### PR TITLE
Add comprehensive Monize wiki documentation

### DIFF
--- a/wiki/Accounts.md
+++ b/wiki/Accounts.md
@@ -1,0 +1,196 @@
+# Accounts
+
+Monize supports a wide variety of account types to represent your complete financial picture. This page covers creating, managing, and organizing your accounts.
+
+---
+
+## Table of Contents
+
+- [Account Types](#account-types)
+- [Creating an Account](#creating-an-account)
+- [Account List](#account-list)
+- [Editing and Closing Accounts](#editing-and-closing-accounts)
+- [Account Reconciliation](#account-reconciliation)
+- [Favourite Accounts](#favourite-accounts)
+- [Investment Account Pairs](#investment-account-pairs)
+- [Multi-Currency Accounts](#multi-currency-accounts)
+
+---
+
+## Account Types
+
+Monize supports 10 account types:
+
+| Account Type | Description | Typical Use |
+|-------------|-------------|-------------|
+| **Chequing** | Checking or current account | Day-to-day banking |
+| **Savings** | Savings account | Emergency fund, short-term savings |
+| **Credit Card** | Credit card account | Credit card spending and payments |
+| **Loan** | Installment loan | Personal loans, auto loans |
+| **Mortgage** | Mortgage account | Home mortgage tracking |
+| **Investment** | Brokerage account | Stocks, ETFs, mutual funds |
+| **Cash** | Cash wallet or petty cash | Physical cash tracking |
+| **Line of Credit** | Line of credit | Revolving credit facilities |
+| **Asset** | Asset tracking | Property, vehicles, collectibles |
+| **Other** | Miscellaneous | Any account that does not fit other types |
+
+### Account Type Details
+
+**Credit Card** accounts include a credit limit field. The available credit is calculated as `credit limit - current balance`.
+
+**Loan and Mortgage** accounts support interest rate tracking. Mortgage accounts include Canadian-specific settings for amortization.
+
+**Investment** accounts are always created as a linked pair -- a brokerage account (for holding securities) and a cash account (for the cash balance within the brokerage). See [Investment Account Pairs](#investment-account-pairs) for details.
+
+**Asset** accounts are used to track the value of physical assets like property or vehicles. Transactions on asset accounts represent changes in value.
+
+---
+
+## Creating an Account
+
+1. Navigate to **Accounts** from the top navigation bar
+2. Click the **Create Account** button
+3. Fill in the account form:
+
+![Create Account Form](images/create-account-form.png)
+<!-- Screenshot: The account creation form showing all fields -->
+
+### Required Fields
+
+| Field | Description |
+|-------|-------------|
+| **Account Name** | A descriptive name for the account |
+| **Account Type** | Select from the available types |
+| **Currency** | The currency this account operates in |
+
+### Optional Fields
+
+| Field | Description |
+|-------|-------------|
+| **Opening Balance** | The starting balance (defaults to 0) |
+| **Opening Date** | The date of the opening balance |
+| **Credit Limit** | For credit cards only |
+| **Interest Rate** | For savings, loans, and mortgages |
+| **Notes** | Any additional notes about the account |
+
+4. Click **Save** to create the account
+
+> **Tip:** When importing from Microsoft Money, you do not need to create accounts manually if you plan to create them during the import process. However, creating accounts first gives you more control over the exact names, types, and opening balances.
+
+---
+
+## Account List
+
+The Accounts page displays all your accounts organized by type.
+
+![Accounts List](images/accounts-list.png)
+<!-- Screenshot: The accounts list page showing accounts grouped by type with balances -->
+
+Each account entry shows:
+
+- **Account name**
+- **Account type** indicator
+- **Current balance** in the account's currency
+- **Currency code** (if different from your home currency)
+- **Actions** -- Edit, close, or delete
+
+### Summary Card
+
+At the top of the accounts page, a summary card shows:
+
+- **Total assets** -- Sum of all positive-balance accounts
+- **Total liabilities** -- Sum of all debt accounts
+- **Net worth** -- Assets minus liabilities
+
+### Filtering
+
+You can toggle between:
+- **Active accounts** -- Currently in use
+- **All accounts** -- Including closed/archived accounts
+
+---
+
+## Editing and Closing Accounts
+
+### Editing
+
+Click the edit button on any account to modify its details. All fields from account creation can be updated.
+
+### Closing Accounts
+
+When an account is no longer active (e.g., you closed a bank account), you can close it in Monize:
+
+1. Click the edit button on the account
+2. Toggle the **Closed** switch
+3. Click **Save**
+
+Closed accounts are hidden from the active accounts view and from transaction dropdowns, but their historical data is preserved for reporting.
+
+### Deleting Accounts
+
+Accounts can only be deleted if they have no transactions. If an account has transactions, you must either delete the transactions first or close the account instead.
+
+---
+
+## Account Reconciliation
+
+Reconciliation helps you verify that your Monize records match your bank statement.
+
+![Reconciliation](images/account-reconciliation.png)
+<!-- Screenshot: The reconciliation screen showing cleared and unreconciled transactions -->
+
+### How to Reconcile
+
+1. Navigate to the account you want to reconcile
+2. Click **Reconcile**
+3. Enter the **statement ending balance** and **statement date** from your bank
+4. Review each transaction:
+   - **Cleared** transactions match your bank statement
+   - **Unreconciled** transactions have not yet appeared on a statement
+5. Mark transactions as cleared by clicking on them
+6. When the difference is zero, click **Finish Reconciling**
+
+### Transaction Status
+
+| Status | Meaning |
+|--------|---------|
+| **Unreconciled** | New transaction, not yet on a statement |
+| **Cleared** | Matches a bank statement entry |
+| **Reconciled** | Previously cleared and locked |
+| **Void** | Cancelled transaction |
+
+---
+
+## Favourite Accounts
+
+Mark accounts as favourites to have them displayed on the Dashboard:
+
+1. In the account list, click the star icon next to an account
+2. The account will appear in the Favourite Accounts widget on the Dashboard
+
+---
+
+## Investment Account Pairs
+
+When you create an **Investment** type account, Monize automatically creates two linked accounts:
+
+1. **Brokerage Account** -- Holds your securities (stocks, ETFs, mutual funds, etc.)
+2. **Cash Account** -- Tracks the cash balance within the brokerage
+
+These are linked internally. When you buy securities, the cash balance decreases. When you sell or receive dividends, the cash balance increases.
+
+The cash account is hidden from the main account list but is accessible through the investment interface. For more details, see [Investments](Investments.md).
+
+> **Important for Microsoft Money users:** In Microsoft Money, investment accounts contain both securities and cash in a single account. In Monize, these are split into two linked accounts. When importing, the QIF parser handles this automatically -- the "Investment" export maps to the brokerage account and the "Regular" export maps to the cash account.
+
+---
+
+## Multi-Currency Accounts
+
+Each account has a designated currency. If you have accounts in different currencies:
+
+- Transactions in that account are recorded in the account's currency
+- The Dashboard and reports convert balances to your home currency using the latest exchange rates
+- Cross-currency transfers record both amounts and the effective exchange rate
+
+For more details, see [Currency Management](Currency-Management.md).

--- a/wiki/Bills-and-Deposits.md
+++ b/wiki/Bills-and-Deposits.md
@@ -1,0 +1,167 @@
+# Bills and Deposits
+
+The Bills & Deposits feature lets you schedule recurring transactions so you never miss a payment or forget about regular income.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Creating a Scheduled Transaction](#creating-a-scheduled-transaction)
+- [Frequency Options](#frequency-options)
+- [Bills List](#bills-list)
+- [Auto-Posting](#auto-posting)
+- [Overriding Individual Occurrences](#overriding-individual-occurrences)
+- [Cash Flow Forecast](#cash-flow-forecast)
+- [Loan Payment Scheduling](#loan-payment-scheduling)
+
+---
+
+## Overview
+
+Bills & Deposits manages your recurring financial obligations and expected income. It displays upcoming transactions, provides a cash flow forecast, and can automatically post transactions on their due dates.
+
+![Bills and Deposits Page](images/bills-deposits-page.png)
+<!-- Screenshot: The bills and deposits page showing the list of scheduled transactions with next due dates and amounts -->
+
+---
+
+## Creating a Scheduled Transaction
+
+1. Navigate to **Bills & Deposits** from the top navigation bar
+2. Click **Add Scheduled Transaction**
+3. Fill in the form:
+
+![Scheduled Transaction Form](images/scheduled-transaction-form.png)
+<!-- Screenshot: The scheduled transaction creation form showing all fields -->
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| **Account** | Yes | Which account this transaction uses |
+| **Payee** | No | Who the transaction is with |
+| **Amount** | Yes | Transaction amount |
+| **Category** | No | Expense or income category |
+| **Frequency** | Yes | How often the transaction recurs |
+| **Start Date** | Yes | When the recurring schedule begins |
+| **End Date** | No | When to stop recurring (optional) |
+| **Total Occurrences** | No | Maximum number of occurrences (alternative to end date) |
+| **Reminder Days** | No | How many days before due date to show a reminder |
+| **Auto-Post** | No | Whether to automatically create the transaction on the due date |
+| **Memo** | No | Additional notes |
+
+### Split Scheduled Transactions
+
+Like regular transactions, scheduled transactions support splits across multiple categories. Click **Split** in the form to add multiple category/amount rows.
+
+### Transfer Scheduling
+
+You can schedule recurring transfers between accounts (e.g., a monthly transfer from chequing to savings). Select a **Transfer to** account instead of a category.
+
+---
+
+## Frequency Options
+
+| Frequency | Description |
+|-----------|-------------|
+| **Once** | A single future transaction (useful for reminders) |
+| **Daily** | Every day |
+| **Weekly** | Once per week on a specific day |
+| **Bi-Weekly** | Every two weeks |
+| **Monthly** | Once per month on a specific date |
+| **Quarterly** | Every three months |
+| **Yearly** | Once per year |
+
+---
+
+## Bills List
+
+The Bills & Deposits page shows all scheduled transactions with:
+
+| Column | Description |
+|--------|-------------|
+| **Description/Payee** | Who or what the transaction is for |
+| **Account** | The account involved |
+| **Amount** | The scheduled amount |
+| **Frequency** | How often it recurs |
+| **Next Due Date** | When the next occurrence is due |
+| **Status** | Active, paused, or completed |
+
+![Bills List](images/bills-list.png)
+<!-- Screenshot: The bills list showing multiple scheduled transactions with their frequencies and next due dates -->
+
+---
+
+## Auto-Posting
+
+When auto-posting is enabled for a scheduled transaction, Monize automatically creates the transaction on its due date without any manual intervention.
+
+### How It Works
+
+1. Each day, the system checks for scheduled transactions that are due
+2. If auto-post is enabled, the transaction is created in the designated account
+3. The next occurrence date is calculated based on the frequency
+4. If the total occurrences limit is reached, the scheduled transaction is marked as completed
+
+### When to Use Auto-Posting
+
+- **Fixed-amount bills** (e.g., rent, subscription services) -- The amount is the same each time
+- **Regular transfers** (e.g., monthly savings contribution) -- Predictable, consistent amounts
+
+### When NOT to Use Auto-Posting
+
+- **Variable-amount bills** (e.g., utilities, credit card payments) -- Use reminders instead and enter the actual amount manually
+
+---
+
+## Overriding Individual Occurrences
+
+You can modify or skip individual occurrences of a scheduled transaction without changing the overall schedule.
+
+### Modifying an Occurrence
+
+1. In the bills list, find the scheduled transaction
+2. Click on the specific upcoming occurrence
+3. Change the date, amount, or category for this occurrence only
+4. Click **Save Override**
+
+The override only affects that single occurrence. All other future occurrences follow the original schedule.
+
+### Skipping an Occurrence
+
+If a recurring bill does not apply for a particular period (e.g., a holiday causes a payment to be skipped):
+
+1. Select the occurrence
+2. Choose **Skip this occurrence**
+3. The next occurrence continues as normal
+
+---
+
+## Cash Flow Forecast
+
+The bills system provides a cash flow forecast showing your expected account balances based on scheduled transactions.
+
+![Cash Flow Forecast](images/cash-flow-forecast.png)
+<!-- Screenshot: The cash flow forecast showing projected balances over the next 30-60 days -->
+
+This helps you:
+- Anticipate when account balances will be low
+- Plan for upcoming large expenses
+- Ensure sufficient funds for automatic payments
+
+---
+
+## Loan Payment Scheduling
+
+For loan and mortgage accounts, scheduled transactions can be set up to track regular payments.
+
+### Setting Up Loan Payments
+
+1. Create a scheduled transaction with the loan payment amount
+2. Set the **category** to the loan account (this creates a transfer to the loan)
+3. Set the appropriate frequency (typically monthly)
+
+This ensures each payment is recorded as a transfer to the loan account, properly reducing the outstanding balance.
+
+> **Note:** When importing from Microsoft Money, loan payment categories are automatically detected and mapped to the corresponding loan accounts. See [Importing from Microsoft Money](Importing-from-Microsoft-Money.md) for details.

--- a/wiki/Categories-and-Payees.md
+++ b/wiki/Categories-and-Payees.md
@@ -1,0 +1,153 @@
+# Categories and Payees
+
+Categories and payees are the organizational backbone of your financial data. Categories classify *what* the money was for, while payees track *who* the money went to or came from.
+
+---
+
+## Table of Contents
+
+- [Categories](#categories)
+  - [Category Hierarchy](#category-hierarchy)
+  - [Managing Categories](#managing-categories)
+  - [Income vs Expense Categories](#income-vs-expense-categories)
+  - [System Categories](#system-categories)
+- [Payees](#payees)
+  - [Managing Payees](#managing-payees)
+  - [Default Categories](#default-categories)
+  - [Payee Auto-Complete](#payee-auto-complete)
+  - [Most Used and Recently Used](#most-used-and-recently-used)
+
+---
+
+## Categories
+
+Categories are used to classify transactions by purpose (e.g., "Groceries," "Rent," "Salary"). They form a hierarchical tree structure with parent and child categories.
+
+### Category Hierarchy
+
+Categories support parent-child relationships for detailed tracking:
+
+```
+Food & Dining (parent)
+  |- Groceries (child)
+  |- Restaurants (child)
+  |- Coffee Shops (child)
+
+Housing (parent)
+  |- Rent (child)
+  |- Utilities (child)
+  |- Maintenance (child)
+```
+
+When viewing reports, you can see totals at the parent level (all "Food & Dining") or drill down to individual children (just "Groceries").
+
+### Managing Categories
+
+Navigate to **Tools > Categories** to access the category management page.
+
+![Categories Page](images/categories-page.png)
+<!-- Screenshot: The categories management page showing the hierarchical list of categories with edit/delete buttons -->
+
+#### Creating a Category
+
+1. Click **Add Category**
+2. Enter the category details:
+
+| Field | Description |
+|-------|-------------|
+| **Name** | Category name (e.g., "Groceries") |
+| **Parent** | Optional parent category for nesting |
+| **Type** | Income or Expense |
+| **Colour** | Visual colour for reports and charts |
+
+3. Click **Save**
+
+#### Editing a Category
+
+Click the edit button next to any category to modify its name, parent, type, or colour.
+
+#### Deleting a Category
+
+Categories can only be deleted if no transactions reference them. If transactions use the category, you must reassign them first or choose to merge the category into another one.
+
+### Income vs Expense Categories
+
+Each category is marked as either **Income** or **Expense**:
+
+- **Income categories** -- Salary, freelance income, investment returns, etc.
+- **Expense categories** -- Groceries, rent, utilities, entertainment, etc.
+
+This classification determines how transactions are counted in reports (income vs. expenses charts).
+
+### System Categories
+
+Monize includes a set of default system categories that cannot be deleted. These provide a starting point and cover common financial categories. You can rename them or add child categories to customize them for your needs.
+
+---
+
+## Payees
+
+Payees represent the people, businesses, or entities you transact with. Every transaction can optionally be assigned a payee.
+
+### Managing Payees
+
+Navigate to **Tools > Payees** to access the payee management page.
+
+![Payees Page](images/payees-page.png)
+<!-- Screenshot: The payees management page showing a list of payees with default categories and transaction counts -->
+
+#### Creating a Payee
+
+1. Click **Add Payee**
+2. Enter the payee details:
+
+| Field | Description |
+|-------|-------------|
+| **Name** | Payee name (e.g., "Amazon", "City Hydro") |
+| **Default Category** | Auto-assigned category for new transactions with this payee |
+| **Notes** | Optional notes about the payee |
+
+3. Click **Save**
+
+Payees can also be created inline when creating a transaction -- if you type a name that does not exist, you can create it on the fly.
+
+#### Editing a Payee
+
+Click the edit button next to any payee to modify its name, default category, or notes.
+
+#### Merging Payees
+
+If you have duplicate payees (e.g., "Amazon" and "Amazon.com"), you can merge them by renaming one to match the other. All transactions will be reassigned to the surviving payee.
+
+#### Deleting a Payee
+
+Payees can be deleted. Transactions that referenced the deleted payee will have their payee field cleared.
+
+### Default Categories
+
+One of the most powerful features of payees is the **default category**. When you assign a default category to a payee:
+
+1. The next time you create a transaction for that payee, the category is automatically filled in
+2. This saves time and ensures consistent categorization
+3. You can always override the default for individual transactions
+
+For example, if you set "Loblaws" with a default category of "Groceries," every new transaction to Loblaws will automatically be categorized as Groceries.
+
+### Payee Auto-Complete
+
+When typing a payee name in the transaction form, Monize provides auto-complete suggestions based on:
+
+1. **Existing payees** matching your typed text
+2. **Most frequently used** payees appearing first
+3. **Recently used** payees given priority
+
+This makes data entry faster and more consistent.
+
+### Most Used and Recently Used
+
+The payee system tracks usage statistics to improve the auto-complete experience:
+
+- **Most Used** -- Payees with the highest transaction count appear first in suggestions
+- **Recently Used** -- Payees from recent transactions are prioritized for quick access
+
+These statistics are computed efficiently using a single database query that includes the default category information.

--- a/wiki/Currency-Management.md
+++ b/wiki/Currency-Management.md
@@ -1,0 +1,126 @@
+# Currency Management
+
+Monize supports multiple currencies for international users or anyone with accounts in different currencies.
+
+---
+
+## Table of Contents
+
+- [Supported Currencies](#supported-currencies)
+- [Home Currency](#home-currency)
+- [Exchange Rates](#exchange-rates)
+- [Cross-Currency Transfers](#cross-currency-transfers)
+- [Currency in Reports](#currency-in-reports)
+- [Investment Securities and Currency](#investment-securities-and-currency)
+
+---
+
+## Supported Currencies
+
+Monize includes 8 currencies out of the box:
+
+| Code | Currency | Symbol |
+|------|----------|--------|
+| **USD** | US Dollar | $ |
+| **CAD** | Canadian Dollar | CA$ |
+| **EUR** | Euro | EUR |
+| **GBP** | British Pound | GBP |
+| **JPY** | Japanese Yen | JPY |
+| **CHF** | Swiss Franc | CHF |
+| **AUD** | Australian Dollar | A$ |
+| **CNY** | Chinese Yuan | CNY |
+
+### Managing Currencies
+
+Navigate to **Tools > Currencies** to view and manage currencies.
+
+![Currencies Page](images/currencies-page.png)
+<!-- Screenshot: The currencies management page showing the list of currencies with exchange rates -->
+
+---
+
+## Home Currency
+
+Your home currency is the primary currency used for:
+
+- **Dashboard totals** -- All account balances are converted to your home currency
+- **Net worth calculations** -- All assets and liabilities are expressed in your home currency
+- **Reports** -- Financial reports use your home currency for aggregation
+
+Set your home currency in **Settings** during initial setup or at any time.
+
+---
+
+## Exchange Rates
+
+### Automatic Updates
+
+Exchange rates are updated automatically on a daily basis. The system fetches the latest rates and stores them historically, allowing for accurate conversion at any point in time.
+
+### Historical Rates
+
+When you import data or need to view past reports, Monize uses the exchange rate that was in effect on the transaction date, not today's rate. This ensures historical accuracy.
+
+### Manual Rate Entry
+
+In some cases (particularly with imported data), you may need to manually adjust an exchange rate for a specific transaction. This is especially common with cross-currency transfers imported from Microsoft Money, where the QIF format does not include exchange rate information.
+
+---
+
+## Cross-Currency Transfers
+
+When you transfer money between accounts that use different currencies, Monize handles the conversion:
+
+### How It Works
+
+1. You create a transfer from Account A (e.g., USD) to Account B (e.g., CAD)
+2. Enter the amount in the source account's currency
+3. The destination amount is calculated based on the exchange rate
+4. Both transactions are linked
+
+### During Import
+
+Cross-currency transfers imported from QIF files require special handling because the QIF format does not record exchange rate information:
+
+1. The first side of the transfer is imported as a pending transaction
+2. When the other account's file is imported, the system matches the pending transfer
+3. You may need to manually adjust the destination amount to match the actual exchange rate used
+
+This is noted in the transaction with a memo: *"PENDING IMPORT: Amount may need adjustment..."*
+
+---
+
+## Currency in Reports
+
+### Conversion for Reports
+
+All reports automatically convert amounts to your home currency using:
+
+- The exchange rate on the transaction date for historical accuracy
+- The latest rate for current balance reports
+
+### Multi-Currency Accounts in Reports
+
+When a report includes accounts in different currencies, the amounts are all converted to your home currency before aggregation. This means:
+
+- A spending report correctly compares a $100 USD purchase with a $130 CAD purchase
+- Net worth reports accurately combine assets across currencies
+
+---
+
+## Investment Securities and Currency
+
+Securities trade in specific currencies based on their exchange:
+
+| Exchange | Currency |
+|----------|----------|
+| NYSE, NASDAQ, AMEX | USD |
+| TSX, TSX-V, NEO, CSE | CAD |
+| LSE, LON | GBP |
+| XETRA, FRA, EPA, AMS | EUR |
+| TYO | JPY |
+| HKG | HKD |
+| SHA, SHE | CNY |
+| ASX | AUD |
+
+If you hold securities that trade in a different currency than your investment account, the market values are converted to the account's currency for display, and to your home currency for portfolio totals.

--- a/wiki/Dashboard.md
+++ b/wiki/Dashboard.md
@@ -1,0 +1,127 @@
+# Dashboard
+
+The Dashboard is your financial command center -- a single-page overview of your accounts, spending, income, net worth, and upcoming bills.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Favourite Accounts](#favourite-accounts)
+- [Upcoming Bills](#upcoming-bills)
+- [Getting Started Widget](#getting-started-widget)
+- [Top Movers](#top-movers)
+- [Expenses Pie Chart](#expenses-pie-chart)
+- [Income vs Expenses Bar Chart](#income-vs-expenses-bar-chart)
+- [Net Worth Chart](#net-worth-chart)
+
+---
+
+## Overview
+
+When you log in, the Dashboard is the first page you see. It provides a comprehensive snapshot of your financial health using interactive charts and summary widgets.
+
+![Dashboard Overview](images/dashboard-overview.png)
+<!-- Screenshot: Full dashboard page showing all widgets - favourite accounts at top, charts below -->
+
+---
+
+## Favourite Accounts
+
+The top section of the dashboard displays your favourite accounts as summary cards. Each card shows:
+
+- **Account name** and type
+- **Current balance** in the account's currency
+- Quick access to account transactions
+
+To mark an account as a favourite, go to **Accounts** and toggle the star icon on any account.
+
+![Favourite Accounts](images/dashboard-favourite-accounts.png)
+<!-- Screenshot: The favourite accounts cards at the top of the dashboard showing account names and balances -->
+
+---
+
+## Upcoming Bills
+
+This widget shows your scheduled bills and deposits that are coming due, ordered by date. Each entry shows:
+
+- **Payee name** or transaction description
+- **Due date** and how many days until due
+- **Amount** of the scheduled transaction
+- **Account** the transaction will be posted to
+
+This helps you anticipate upcoming cash flow needs and ensure sufficient funds are available.
+
+![Upcoming Bills](images/dashboard-upcoming-bills.png)
+<!-- Screenshot: The upcoming bills widget showing a list of bills with dates, amounts, and accounts -->
+
+---
+
+## Getting Started Widget
+
+For new users, a Getting Started widget provides guidance on initial setup tasks:
+
+- Creating accounts
+- Adding transactions
+- Setting up scheduled bills
+- Importing data
+
+This widget disappears once you have completed the basic setup steps.
+
+---
+
+## Top Movers
+
+If you have investment accounts, the Top Movers widget shows the securities in your portfolio with the largest daily price changes (both gains and losses). This gives you a quick view of which investments are moving the most.
+
+![Top Movers](images/dashboard-top-movers.png)
+<!-- Screenshot: The top movers widget showing securities with daily price changes, green for gains and red for losses -->
+
+> **Note:** This widget only appears if you have at least one investment account with holdings.
+
+---
+
+## Expenses Pie Chart
+
+A pie chart breaks down your spending over the last 30 days by category. This provides an instant visual of where your money is going.
+
+- Hover over a segment to see the category name and amount
+- Categories are colour-coded for easy identification
+- The chart includes expense categories only (income is excluded)
+
+![Expenses Pie Chart](images/dashboard-expenses-pie.png)
+<!-- Screenshot: The pie chart showing expense breakdown by category with a legend -->
+
+---
+
+## Income vs Expenses Bar Chart
+
+This bar chart compares your monthly income and expenses over the last 12 months. Each month shows:
+
+- A **green bar** for total income
+- A **red bar** for total expenses
+- The visual difference helps you see months where you spent more than you earned
+
+![Income vs Expenses Chart](images/dashboard-income-expenses-bar.png)
+<!-- Screenshot: Bar chart with green (income) and red (expense) bars side by side for each month -->
+
+---
+
+## Net Worth Chart
+
+The Net Worth chart tracks your total net worth over time, calculated monthly. It shows:
+
+- **Total assets** (all positive-balance accounts plus investment market values)
+- **Total liabilities** (credit cards, loans, mortgages, lines of credit)
+- **Net worth** (assets minus liabilities)
+
+The chart provides a clear trend line showing whether your financial position is improving over time.
+
+![Net Worth Chart](images/dashboard-net-worth.png)
+<!-- Screenshot: Line chart showing net worth trend over the past 12 months -->
+
+---
+
+## Refreshing Data
+
+Investment prices and exchange rates can be refreshed manually from the dashboard using the refresh button. Prices are also updated automatically on weekdays at 5 PM EST.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,164 @@
+# Getting Started
+
+This guide walks you through setting up Monize and getting your financial data organized.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [First-Time Setup](#first-time-setup)
+- [Creating Your First Account](#creating-your-first-account)
+- [Navigating the Application](#navigating-the-application)
+- [Next Steps](#next-steps)
+
+---
+
+## Prerequisites
+
+Before installing Monize, ensure you have:
+
+- **Docker** and **Docker Compose** installed on your server
+- A minimum of 1 GB RAM available
+- A modern web browser (Chrome, Firefox, Safari, or Edge)
+
+---
+
+## Installation
+
+### Using Docker Compose (Recommended)
+
+1. Clone the repository:
+
+```bash
+git clone https://github.com/your-repo/monize.git
+cd monize
+```
+
+2. Create a `.env` file with your configuration:
+
+```bash
+# Required
+JWT_SECRET=your-secret-key-minimum-32-characters-long
+
+# Database (defaults shown)
+POSTGRES_USER=monize
+POSTGRES_PASSWORD=your-database-password
+POSTGRES_DB=monize
+
+# Optional: Email notifications
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your-email@example.com
+SMTP_PASS=your-email-password
+```
+
+> **Important:** The `JWT_SECRET` must be at least 32 characters long. The application will refuse to start with a shorter secret.
+
+3. Start the application:
+
+```bash
+docker compose up -d
+```
+
+4. Access Monize at `http://localhost:3001`
+
+### Using Kubernetes (Helm)
+
+Helm charts are provided in the `helm/` directory for Kubernetes deployments. Refer to the Helm README for detailed configuration options.
+
+---
+
+## First-Time Setup
+
+### Registration
+
+When you first access Monize, you will be presented with the login page.
+
+![Login Page](images/login-page.png)
+<!-- Screenshot: The login page showing email/password fields and the Register link -->
+
+1. Click **Register** to create your account
+2. Enter your **first name**, **email address**, and **password**
+3. Click **Register** to complete account creation
+4. You will be redirected to the dashboard
+
+![Registration Page](images/registration-page.png)
+<!-- Screenshot: The registration form with first name, email, and password fields -->
+
+### Setting Your Home Currency
+
+After registration, navigate to **Settings** (gear icon in the top-right corner) to configure your home currency. This is the primary currency used for reporting and net worth calculations.
+
+![Settings Page](images/settings-page.png)
+<!-- Screenshot: The settings page showing currency selection and user preferences -->
+
+---
+
+## Creating Your First Account
+
+1. Navigate to **Accounts** from the top navigation bar
+2. Click **Create Account**
+3. Fill in the account details:
+   - **Account Name** -- A descriptive name (e.g., "Main Chequing")
+   - **Account Type** -- Select from the available types (see [Accounts](Accounts.md) for details)
+   - **Currency** -- The currency this account operates in
+   - **Opening Balance** -- The starting balance as of a specific date
+4. Click **Save**
+
+![Create Account Form](images/create-account-form.png)
+<!-- Screenshot: The account creation form showing name, type, currency, and opening balance fields -->
+
+---
+
+## Navigating the Application
+
+The main navigation bar provides access to all major features:
+
+![Navigation Bar](images/navigation-bar.png)
+<!-- Screenshot: The top navigation bar showing all menu items -->
+
+### Primary Navigation
+
+| Menu Item | Description |
+|-----------|-------------|
+| **Transactions** | View, search, and manage all transactions |
+| **Accounts** | Manage your accounts and view balances |
+| **Investments** | Track your investment portfolio |
+| **Bills & Deposits** | Manage scheduled and recurring transactions |
+| **Reports** | Access built-in and custom reports |
+
+### Tools Menu
+
+Click the **Tools** dropdown to access additional features:
+
+| Tool | Description |
+|------|-------------|
+| **Categories** | Manage income and expense categories |
+| **Payees** | Manage payee records |
+| **Securities** | Manage investment securities |
+| **Currencies** | View and manage currencies and exchange rates |
+| **Import Transactions** | Import QIF files from Microsoft Money or other software |
+
+![Tools Dropdown](images/tools-dropdown.png)
+<!-- Screenshot: The Tools dropdown menu showing Categories, Payees, Securities, Currencies, and Import Transactions -->
+
+### User Menu
+
+The top-right corner shows your name and provides access to:
+
+- **Settings** -- Configure preferences, two-factor authentication, and trusted devices
+- **Logout** -- Sign out of the application
+
+---
+
+## Next Steps
+
+Once you have Monize installed and your first account created, here are recommended next steps:
+
+1. **Migrating from Microsoft Money?** Follow the detailed [Importing from Microsoft Money](Importing-from-Microsoft-Money.md) guide
+2. **Set up your categories** -- Customize the default categories in [Categories and Payees](Categories-and-Payees.md)
+3. **Add your accounts** -- Create all your financial accounts in [Accounts](Accounts.md)
+4. **Schedule recurring transactions** -- Set up your bills and regular deposits in [Bills and Deposits](Bills-and-Deposits.md)
+5. **Explore reports** -- Check out the [Reports](Reports.md) section to see what insights are available

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,71 @@
+# Monize Wiki
+
+Welcome to the Monize wiki -- your comprehensive guide to managing personal finances with Monize, a modern replacement for Microsoft Money.
+
+![Monize Logo](images/monize-logo.png)
+<!-- Screenshot: The Monize logo or application header -->
+
+---
+
+## Table of Contents
+
+### Getting Started
+- [Getting Started](Getting-Started.md) -- Installation, first-time setup, and initial configuration
+- [Importing from Microsoft Money](Importing-from-Microsoft-Money.md) -- Complete migration guide from Microsoft Money
+
+### Core Features
+- [Dashboard](Dashboard.md) -- Your financial overview at a glance
+- [Accounts](Accounts.md) -- Managing bank accounts, credit cards, loans, and assets
+- [Transactions](Transactions.md) -- Recording, searching, and managing transactions
+- [Investments](Investments.md) -- Portfolio tracking, securities, and investment transactions
+- [Bills and Deposits](Bills-and-Deposits.md) -- Scheduled and recurring transactions
+
+### Organization and Reporting
+- [Categories and Payees](Categories-and-Payees.md) -- Organizing your financial data
+- [Reports](Reports.md) -- Built-in and custom financial reports
+- [Currency Management](Currency-Management.md) -- Multi-currency support and exchange rates
+
+### Administration
+- [Settings and Security](Settings-and-Security.md) -- User preferences, two-factor authentication, and security
+
+---
+
+## What is Monize?
+
+Monize is a self-hosted, web-based personal finance management application. It provides a full suite of tools for tracking your income, expenses, investments, and net worth -- all from a modern, responsive web interface.
+
+### Key Features
+
+- **Multi-Account Support** -- Track chequing, savings, credit cards, loans, mortgages, investments, cash, lines of credit, and assets
+- **Investment Portfolio Tracking** -- Full brokerage account support with automatic price updates from Yahoo Finance
+- **Recurring Transactions** -- Schedule bills, deposits, and transfers with flexible recurrence options
+- **Comprehensive Reporting** -- 15+ built-in reports plus a custom report builder with charts
+- **Multi-Currency** -- Support for 8+ currencies with automatic exchange rate updates
+- **QIF Import** -- Import your data from Microsoft Money, Quicken, and other QIF-compatible software
+- **Security** -- Two-factor authentication, refresh token rotation, rate limiting, and comprehensive security headers
+- **Self-Hosted** -- Your financial data stays on your own server
+- **Progressive Web App** -- Installable on mobile devices for native app-like experience
+
+### Technology Stack
+
+| Component | Technology |
+|-----------|------------|
+| Frontend  | Next.js (React), Tailwind CSS |
+| Backend   | NestJS (Node.js/TypeScript) |
+| Database  | PostgreSQL 16 |
+| Deployment | Docker Compose, Kubernetes (Helm) |
+
+---
+
+## Quick Navigation
+
+| I want to... | Go to... |
+|--------------|----------|
+| Set up Monize for the first time | [Getting Started](Getting-Started.md) |
+| Migrate from Microsoft Money | [Importing from Microsoft Money](Importing-from-Microsoft-Money.md) |
+| Understand the dashboard | [Dashboard](Dashboard.md) |
+| Create and manage accounts | [Accounts](Accounts.md) |
+| Track my investments | [Investments](Investments.md) |
+| Set up recurring bills | [Bills and Deposits](Bills-and-Deposits.md) |
+| Run financial reports | [Reports](Reports.md) |
+| Configure security settings | [Settings and Security](Settings-and-Security.md) |

--- a/wiki/Importing-from-Microsoft-Money.md
+++ b/wiki/Importing-from-Microsoft-Money.md
@@ -1,0 +1,666 @@
+# Importing from Microsoft Money
+
+This is the complete guide to migrating your financial data from Microsoft Money to Monize. It covers exporting from Microsoft Money, preparing your data, and importing into Monize with the recommended order to ensure transfers and investment data are handled correctly.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Part 1: Preparing Microsoft Money for Export](#part-1-preparing-microsoft-money-for-export)
+- [Part 2: Exporting from Microsoft Money](#part-2-exporting-from-microsoft-money)
+  - [Exporting Regular Accounts](#exporting-regular-accounts)
+  - [Exporting Investment Accounts](#exporting-investment-accounts)
+  - [File Naming Convention](#file-naming-convention)
+- [Part 3: Recommended Import Order](#part-3-recommended-import-order)
+- [Part 4: Importing into Monize Step by Step](#part-4-importing-into-monize-step-by-step)
+  - [Step 1: Upload QIF Files](#step-1-upload-qif-files)
+  - [Step 2: Select Destination Account](#step-2-select-destination-account)
+  - [Step 3: Map Categories](#step-3-map-categories)
+  - [Step 4: Map Securities](#step-4-map-securities)
+  - [Step 5: Map Transfer Accounts](#step-5-map-transfer-accounts)
+  - [Step 6: Review and Import](#step-6-review-and-import)
+  - [Step 7: Import Complete](#step-7-import-complete)
+- [Part 5: Post-Import Steps](#part-5-post-import-steps)
+- [Part 6: Troubleshooting](#part-6-troubleshooting)
+- [Part 7: What Cannot Be Imported](#part-7-what-cannot-be-imported)
+
+---
+
+## Overview
+
+Microsoft Money uses QIF (Quicken Interchange Format) for data export. Monize includes a comprehensive QIF import wizard that handles:
+
+- Regular banking transactions (chequing, savings, credit cards)
+- Investment transactions (buy, sell, dividends, splits, reinvestments)
+- Split transactions (multiple categories per transaction)
+- Account-to-account transfers
+- Category creation and mapping
+- Security creation and mapping
+- Multi-currency accounts
+
+The import process is designed for bulk operations -- you can import multiple QIF files at once, and the system intelligently coordinates between files to link transfers, reuse categories, and handle cross-references.
+
+---
+
+## Part 1: Preparing Microsoft Money for Export
+
+Before exporting, take these preparatory steps in Microsoft Money to ensure a clean migration.
+
+### 1.1 Note Your Account Details
+
+Create a spreadsheet or list with the following for each account:
+
+| Detail | Example |
+|--------|---------|
+| Account Name | "Main Chequing" |
+| Account Type | Chequing, Savings, Credit Card, Investment, etc. |
+| Currency | USD, CAD, GBP, etc. |
+| Opening Balance | $1,234.56 |
+| Opening Balance Date | January 1, 2005 |
+
+> **Why this matters:** The opening balance and date are critical. For imported accounts to show the correct current balance, the opening balance must be set to the balance as of the first transaction date in the QIF file. Microsoft Money often includes an "Opening Balance" transaction in the QIF export, which Monize detects automatically. However, having this information written down gives you a fallback if the auto-detection does not match.
+
+### 1.2 Clean Up Special Characters
+
+Microsoft Money allows emoji-like icons in category names, payee names, and account names. These icons export as garbled characters in QIF format.
+
+**Before exporting:**
+1. Go through your **Categories** and remove any icons or special characters from names
+2. Go through your **Payees** and clean up names
+3. Go through your **Account** names and ensure they use only standard characters
+
+![Microsoft Money Categories](images/ms-money-categories.png)
+<!-- Screenshot: Microsoft Money category list - if you have a screenshot of MS Money's category editor, place it here -->
+
+### 1.3 Open Closed Accounts (if needed)
+
+If you have closed accounts in Microsoft Money that you want to import, you may need to temporarily reopen them -- Microsoft Money may not allow exporting closed accounts.
+
+### 1.4 Make a List of All Accounts
+
+Microsoft Money exports one account at a time, so make a checklist:
+
+```
+[ ] Main Chequing (Regular)
+[ ] Savings (Regular)
+[ ] Visa Credit Card (Regular)
+[ ] Emergency Fund (Regular)
+[ ] RRSP Brokerage (Investment)
+[ ] RRSP Brokerage (Regular - for cash transactions)
+[ ] TFSA Brokerage (Investment)
+[ ] TFSA Brokerage (Regular - for cash transactions)
+[ ] Home (Asset)
+```
+
+> **Important for Investment Accounts:** Each investment account requires TWO exports -- one as "Investment" type (for securities transactions) and one as "Regular" type (for cash transactions). Mark both on your checklist.
+
+---
+
+## Part 2: Exporting from Microsoft Money
+
+### Exporting Regular Accounts
+
+Follow these steps for each chequing, savings, credit card, cash, line of credit, and asset account:
+
+**Step 1:** Open Microsoft Money and load your `.mny` file
+
+**Step 2:** Go to **File > Export**
+
+![MS Money File Menu](images/ms-money-file-export.png)
+<!-- Screenshot: Microsoft Money File menu with Export highlighted -->
+
+**Step 3:** In the export dialog, select **Loose QIF** format
+
+![MS Money Export Format](images/ms-money-export-format.png)
+<!-- Screenshot: The Microsoft Money export format selection dialog showing "Loose QIF" selected -->
+
+> **Always choose "Loose QIF"** -- it carries more information than "Strict QIF," including split transaction details and transfer references.
+
+**Step 4:** Choose a save location (Desktop is easiest) and name the file after the account
+
+**Step 5:** Select **Regular** as the account type
+
+![MS Money Account Type](images/ms-money-account-type-regular.png)
+<!-- Screenshot: The Microsoft Money export dialog showing "Regular" account type selected -->
+
+**Step 6:** Select the specific account to export from the account list
+
+**Step 7:** Click **Continue** to export
+
+**Step 8:** Check the account off your list and repeat for the next account
+
+### Exporting Investment Accounts
+
+Investment accounts in Microsoft Money contain two types of data:
+- **Investment transactions** (buy, sell, dividend, etc.)
+- **Cash transactions** (deposits, withdrawals, fees)
+
+You must export each investment account **twice**.
+
+#### Export 1: Investment Transactions
+
+1. Go to **File > Export**
+2. Select **Loose QIF**
+3. Name the file with the account name and "-Investment" suffix (e.g., `RRSP-Investment.qif`)
+4. Select **Investment** as the account type
+5. Select the specific investment account
+6. Click **Continue**
+
+![MS Money Investment Export](images/ms-money-export-investment.png)
+<!-- Screenshot: The Microsoft Money export dialog showing "Investment" account type selected and an investment account highlighted -->
+
+#### Export 2: Cash Transactions
+
+1. Go to **File > Export** again
+2. Select **Loose QIF**
+3. Name the file with the account name and "-Regular" suffix (e.g., `RRSP-Regular.qif`)
+4. Select **Regular** as the account type
+5. Select the same investment account
+6. Click **Continue**
+
+### File Naming Convention
+
+Use a consistent naming convention to keep your exports organized. Here is a recommended approach:
+
+```
+01-Asset-Home.qif
+02-Chequing-Main.qif
+03-Chequing-Joint.qif
+04-Savings-Emergency.qif
+05-Savings-USD.qif
+06-CreditCard-Visa.qif
+07-CreditCard-Mastercard.qif
+08-RRSP-Investment.qif
+09-RRSP-Regular.qif
+10-TFSA-Investment.qif
+11-TFSA-Regular.qif
+```
+
+The numeric prefix ensures the files sort in your intended import order. Investment account pairs should be adjacent.
+
+> **Tip:** Keep the filenames matching (or close to) the account names in Microsoft Money. Monize attempts to auto-match QIF files to accounts by filename, so closer names mean less manual mapping during import.
+
+---
+
+## Part 3: Recommended Import Order
+
+The order in which you import your QIF files matters. Monize handles transfers between accounts by matching pending transactions from previously imported files. Importing in the right order ensures transfers are linked correctly and reduces manual cleanup.
+
+### Recommended Order
+
+Import your accounts in this order:
+
+```
+1. Asset Accounts
+      |
+2. Bank Accounts (Home Currency)
+      |
+3. Bank Accounts (Foreign Currency)
+      |
+4. Credit Card Accounts
+      |
+5. Investment Cash Accounts (-Regular exports)
+      |
+6. Investment Brokerage Accounts (-Investment exports)
+      |
+7. Line of Credit / Loan Accounts
+```
+
+### Why This Order?
+
+| Order | Account Type | Reason |
+|-------|-------------|--------|
+| **1** | **Asset Accounts** | Assets rarely have transfers to other accounts. Import them first to establish any asset-related categories. |
+| **2** | **Bank Accounts (Home Currency)** | These are your primary accounts and typically the source/destination of most transfers. Importing them early means subsequent imports can link transfers to these accounts. |
+| **3** | **Bank Accounts (Foreign Currency)** | Foreign currency accounts may have transfers to/from home currency accounts. Importing after home currency accounts ensures the other side of cross-currency transfers already exists. |
+| **4** | **Credit Card Accounts** | Credit card payments typically come from bank accounts (already imported). The import will match these transfers to the existing bank transactions. |
+| **5** | **Investment Cash Accounts** | Import the "-Regular" (cash) QIF files for investment accounts next. These contain deposits/withdrawals to the investment account's cash balance, often transferred from bank accounts (already imported). |
+| **6** | **Investment Brokerage Accounts** | Import the "-Investment" QIF files last among the investment pair. These contain buy/sell/dividend transactions. Monize automatically creates the corresponding cash-side transactions in the linked cash account. |
+| **7** | **Line of Credit / Loan Accounts** | These typically receive payments from bank accounts. Import them last to maximize transfer matching. |
+
+### Bulk Import
+
+Monize supports importing multiple QIF files in a single bulk operation. When you select multiple files:
+
+1. Files are processed sequentially in the order listed
+2. Categories, payees, and accounts created in file 1 are available for file 2, and so on
+3. Transfer matching happens across all files in the batch
+
+**The best approach is to select ALL your QIF files at once** and let Monize process them in order. Use the numeric filename prefix (from the naming convention above) to ensure they sort correctly.
+
+---
+
+## Part 4: Importing into Monize Step by Step
+
+Navigate to **Tools > Import Transactions** to begin the import process.
+
+### Step 1: Upload QIF Files
+
+The upload step presents a drag-and-drop area where you can select your QIF files.
+
+![Upload Step](images/import-upload-step.png)
+<!-- Screenshot: The import upload step showing the drag-and-drop area with "Click to select QIF file(s)" text -->
+
+1. Click the upload area or drag your QIF files onto it
+2. You can select **multiple files** at once for bulk import
+3. Monize parses each file and extracts metadata:
+   - Account type detected from the QIF header
+   - Number of transactions
+   - Date range of transactions
+   - Categories found
+   - Transfer accounts referenced
+   - Securities found (for investment files)
+
+After parsing, you advance to account selection.
+
+> **Pre-Selection:** If you navigate to the import page from a specific account, that account is pre-selected. A blue banner shows "Importing to: [Account Name]".
+
+### Step 2: Select Destination Account
+
+For each QIF file, you need to specify which Monize account the transactions should be imported into.
+
+![Select Account Step](images/import-select-account.png)
+<!-- Screenshot: The select account step showing the file info box (filename, transaction count, date range, detected type) and the account dropdown -->
+
+#### File Information
+
+A gray information box shows:
+- **File:** The filename being imported
+- **Transactions:** Number of transactions found
+- **Date Range:** Earliest to latest transaction dates
+- **Detected Type:** Account type identified from the QIF header (e.g., Bank, Investment, Credit Card)
+
+#### Selecting an Account
+
+Choose from the **"Import into account"** dropdown. The dropdown shows all compatible accounts:
+- For **investment QIF files** (detected type: Investment), only brokerage accounts are shown
+- For **regular QIF files**, all non-brokerage accounts are shown
+
+> **Auto-Matching:** Monize attempts to match QIF filenames to account names automatically. If a match is found, it is pre-selected in the dropdown.
+
+#### Creating a New Account
+
+If the destination account does not exist yet:
+
+1. Click **"+ Create new account"**
+2. Fill in:
+   - **Account name** (e.g., "My Chequing")
+   - **Account type** (Chequing, Savings, Credit Card, etc.)
+   - **Currency** (USD, CAD, etc.)
+3. Click **Create**
+
+![Create Account During Import](images/import-create-account.png)
+<!-- Screenshot: The inline account creation form during import showing name, type, and currency fields -->
+
+The new account is created immediately and auto-selected as the destination.
+
+> **Investment accounts:** When you create an Investment type account during import, both the brokerage and linked cash accounts are created automatically.
+
+#### Date Format
+
+If the detected date format does not look correct (e.g., dates seem to be swapped between MM/DD and DD/MM), you can override the date format using the date format dropdown. Monize supports:
+- MM/DD/YYYY (US format)
+- DD/MM/YYYY (International format)
+- YYYY-MM-DD (ISO format)
+
+### Step 3: Map Categories
+
+If the QIF file contains category references, you need to map them to Monize categories.
+
+![Map Categories Step](images/import-map-categories.png)
+<!-- Screenshot: The map categories step showing unmatched categories (amber), auto-matched categories (green, collapsed), and loan categories (blue, collapsed) -->
+
+#### Understanding the Display
+
+Categories are displayed in three groups:
+
+1. **Needs Attention** (amber/yellow border) -- Categories that could not be auto-matched. These require your input.
+2. **Auto-Matched to Categories** (green, collapsed by default) -- Categories that Monize matched to existing categories. Click to expand and verify.
+3. **Auto-Matched to Loan Accounts** (blue, collapsed by default) -- Categories that match loan or mortgage account names, indicating loan payments.
+
+#### Summary Badges
+
+At the top of the list, badges summarize the mapping status:
+- **Amber badge:** "[X] need attention" -- categories requiring manual mapping
+- **Green badge:** "[X] matched to categories" -- successfully auto-matched
+- **Blue badge:** "[X] matched to loans" -- matched to loan accounts
+
+#### Mapping a Category
+
+For each unmatched category, you can:
+
+**Option A: Map to an existing category**
+- Select from the dropdown of existing Monize categories
+
+**Option B: Create a new category**
+- Enter a new category name
+- Optionally select a parent category
+- The category is created during import
+
+**Option C: Skip the category**
+- Leave unmapped (select "Skip") to import transactions without a category
+- You can categorize them later in the Transactions page
+
+#### Loan Category Detection
+
+If a QIF category name matches an existing loan or mortgage account name, Monize detects it as a loan payment. These transactions are imported as transfers to the loan account rather than regular categorized transactions.
+
+If the loan account does not exist yet, you can create it during this step.
+
+### Step 4: Map Securities
+
+This step appears only when importing investment QIF files that contain security references.
+
+![Map Securities Step](images/import-map-securities.png)
+<!-- Screenshot: The map securities step showing security mapping rows with lookup buttons, existing security dropdowns, and new security creation fields -->
+
+#### Security Lookup
+
+Monize can look up securities automatically:
+- Click **"Lookup"** next to any security to search by name/symbol
+- A bulk lookup runs automatically for all securities when you first reach this step
+- Lookup results include the security name, symbol, type, and exchange
+
+#### Mapping a Security
+
+For each security, you can:
+
+**Option A: Map to an existing security**
+- Select from the "Map to existing" dropdown
+
+**Option B: Create a new security**
+- Enter the **symbol** (e.g., "AAPL")
+- Enter the **name** (e.g., "Apple Inc.")
+- Select the **type** (Stock, ETF, Mutual Fund, Bond, GIC, Cash, Other)
+- Enter the **exchange** (e.g., "NYSE", "TSX")
+
+#### Row Status Indicators
+
+Each security row is colour-coded:
+- **Green border** -- Ready to import (mapped to existing or new security details filled in)
+- **Amber border** -- Needs attention (no mapping selected)
+
+### Step 5: Map Transfer Accounts
+
+This step appears when the QIF file references transfers to other accounts (e.g., `[Savings Account]` notation in QIF).
+
+> **Note:** This step is skipped for investment QIF files. Investment transfers are handled automatically through the linked cash account.
+
+![Map Transfer Accounts Step](images/import-map-accounts.png)
+<!-- Screenshot: The map transfer accounts step showing account mapping rows with existing account dropdown and new account creation fields -->
+
+#### Mapping a Transfer Account
+
+For each referenced transfer account:
+
+**Option A: Map to an existing account**
+- Select from the "Map to existing" dropdown
+
+**Option B: Create a new account**
+- Enter the account name
+- Select the account type
+- Select the currency
+
+> **Tip:** If you are importing all files in bulk, transfers between imported accounts are linked automatically. You only need to map accounts that are not part of the current import batch.
+
+### Step 6: Review and Import
+
+The review step shows a summary of everything that will happen during import.
+
+![Review Step](images/import-review-step.png)
+<!-- Screenshot: The review step showing the summary of files, transaction counts, categories, accounts, and securities to be created -->
+
+#### Single File Import Summary
+
+- **File:** filename.qif
+- **Transactions to import:** [count]
+- **Target account:** [account name]
+
+#### Bulk Import Summary
+
+- **Files to Import:** List of each file with transaction count and target account
+- **Total:** [X] files, [Y] transactions
+
+#### Entity Creation Summary
+
+- **Categories:** Total, mapped, new to create, mapped to loans, new loans to create
+- **Transfer Accounts:** Total, mapped, new to create
+- **Securities:** Total, mapped, new to create
+
+#### Executing the Import
+
+Click **"Import Transactions"** to begin. The button shows a loading spinner while processing.
+
+For bulk imports, files are processed sequentially. Entities created in earlier files (categories, accounts, payees, securities) are available for subsequent files.
+
+> **Important:** The import runs inside a database transaction. If an error occurs, changes are rolled back -- no partial imports.
+
+### Step 7: Import Complete
+
+After successful import, the complete step shows detailed results.
+
+![Import Complete](images/import-complete-step.png)
+<!-- Screenshot: The import complete step showing the green checkmark, summary statistics, and per-file results -->
+
+#### Results Displayed
+
+| Metric | Description |
+|--------|-------------|
+| **Imported** | Number of transactions successfully imported |
+| **Skipped** | Number of duplicate transfers skipped (already existed) |
+| **Errors** | Number of transactions that failed to import |
+| **Categories created** | New categories added |
+| **Accounts created** | New accounts added |
+| **Payees created** | New payees added |
+| **Securities created** | New securities added |
+
+#### Per-File Results (Bulk Import)
+
+For bulk imports, each file shows its individual results with success/error indicators:
+- Green background for files with no errors
+- Red background for files with errors, including the first 3 error messages
+
+#### Next Steps
+
+After import, you have two options:
+- **"View Investments"** / **"View Transactions"** -- Go directly to see your imported data
+- **"Import More Files"** -- Return to the upload step for additional imports
+
+---
+
+## Part 5: Post-Import Steps
+
+After importing all your data, take these steps to verify and finalize your migration.
+
+### 5.1 Verify Account Balances
+
+Compare each account's current balance in Monize against your Microsoft Money records. If balances do not match:
+
+1. Check the opening balance -- it should match the balance as of the first transaction date
+2. Look for missing or duplicate transactions
+3. Check that transfers between accounts were matched correctly (not doubled)
+
+### 5.2 Review Cross-Currency Transfers
+
+Cross-currency transfers from Microsoft Money may need manual adjustment because the QIF format does not include exchange rate information. Look for transactions with a memo containing *"PENDING IMPORT"* and update the amounts to reflect the actual exchange rates.
+
+### 5.3 Verify Investment Holdings
+
+1. Navigate to **Investments**
+2. Check that each holding shows the correct quantity and cost basis
+3. Compare against your Microsoft Money portfolio summary
+4. If any securities were auto-created (marked with `*` suffix), update their symbols and names
+
+### 5.4 Set Up Security Price Updates
+
+Auto-created securities during import have price updates disabled by default. For each security:
+
+1. Navigate to **Tools > Securities**
+2. Edit each security to ensure the correct symbol, exchange, and type
+3. Price updates will start automatically once the security has a valid symbol
+
+### 5.5 Review Categories
+
+Navigate to **Tools > Categories** and review the category hierarchy. Categories imported from Microsoft Money use the QIF naming convention (with `/` separating parent and child). You may want to reorganize or rename them.
+
+### 5.6 Set Up Scheduled Transactions
+
+QIF export from Microsoft Money does **not** include scheduled/recurring transactions. You must recreate these manually:
+
+1. Navigate to **Bills & Deposits**
+2. Create each recurring bill and deposit
+3. See [Bills and Deposits](Bills-and-Deposits.md) for details
+
+### 5.7 Check for Uncategorized Transactions
+
+Run the **Uncategorized Transactions** report (**Reports > Uncategorized Transactions**) to find any transactions that were imported without a category. Assign categories as needed.
+
+### 5.8 Verify Net Worth
+
+Navigate to the Dashboard and check the Net Worth chart. Monize automatically calculates monthly net worth snapshots after import. Compare the trend against your Microsoft Money net worth report.
+
+---
+
+## Part 6: Troubleshooting
+
+### Common Issues
+
+#### "Account type mismatch" Error
+
+**Cause:** Trying to import an Investment QIF file into a non-brokerage account, or a Regular QIF file into a brokerage account.
+
+**Solution:** Make sure you select the correct account type:
+- Investment QIF files (-Investment) go into brokerage accounts
+- Regular QIF files (-Regular or standard banking) go into non-brokerage accounts
+
+#### Dates Appear Wrong
+
+**Cause:** The date format was detected incorrectly (e.g., MM/DD was interpreted as DD/MM).
+
+**Solution:**
+1. Go back to the Select Account step
+2. Change the date format dropdown to the correct format
+3. The file will be re-parsed with the new format
+
+#### Duplicate Transactions After Import
+
+**Cause:** Importing the same file twice, or transfer transactions appearing in both accounts.
+
+**Solution:**
+- Monize skips duplicate transfers when importing the second account
+- If duplicates still appear, use the **Duplicate Transaction Finder** report to identify and remove them
+- For future imports, always import all related files in a single bulk operation
+
+#### Transfer Not Linked Between Accounts
+
+**Cause:** The transfer accounts were not mapped correctly, or the files were imported in separate sessions.
+
+**Solution:**
+- When possible, import all files at once using bulk import
+- Check that account names in QIF match the Monize account names
+- Manually link unmatched transfers by editing the transactions
+
+#### Investment Securities Not Found
+
+**Cause:** Microsoft Money does not include a security master list in QIF exports.
+
+**Solution:**
+1. During the Map Securities step, use the "Lookup" button to search for each security
+2. If lookup fails, manually enter the symbol, name, type, and exchange
+3. After import, edit any auto-created securities (with `*` suffix) in **Tools > Securities**
+
+#### Opening Balance Incorrect
+
+**Cause:** Microsoft Money's opening balance transaction may not match the expected starting point.
+
+**Solution:**
+1. Navigate to **Accounts**
+2. Edit the account
+3. Adjust the opening balance and opening date to match your records
+4. The current balance will be recalculated
+
+#### Cross-Currency Transfer Amounts Wrong
+
+**Cause:** QIF files do not contain exchange rate information.
+
+**Solution:**
+1. Search transactions for "PENDING IMPORT" in the memo field
+2. Edit each flagged transaction
+3. Adjust the amount in the destination account to match the actual transfer amount
+4. This correctly sets the effective exchange rate
+
+#### Import Times Out
+
+**Cause:** Very large QIF files (near the 10 MB limit or files with thousands of transactions).
+
+**Solution:**
+- The import has a 5-minute timeout
+- If a single file is too large, try splitting it into smaller date ranges in Microsoft Money
+- Contact Microsoft Money support resources about the historical 500-transaction limit per QIF export
+
+---
+
+## Part 7: What Cannot Be Imported
+
+The QIF format and Microsoft Money export have limitations. The following data must be recreated manually in Monize:
+
+| Data Type | Status | Notes |
+|-----------|--------|-------|
+| **Account balances** | Auto-detected | Extracted from QIF "Opening Balance" record |
+| **Transactions** | Imported | All regular and investment transactions |
+| **Categories** | Imported | Created during import mapping |
+| **Payees** | Imported | Created automatically from QIF data |
+| **Securities** | Imported | Created during import mapping |
+| **Scheduled transactions** | Not exported | Must be recreated in Bills & Deposits |
+| **Budgets** | Not exported | Monize does not currently have a budget feature |
+| **Reports** | Not applicable | Monize has its own reporting system |
+| **Loan amortization** | Not exported | Loan payment transactions are imported, but amortization schedules must be set up manually |
+| **Account numbers** | Not in QIF | QIF format does not include account numbers |
+| **Cheque images** | Not in QIF | Physical cheque images cannot be exported |
+| **Online banking links** | Not applicable | Monize does not use online banking connections |
+| **Planner/forecast data** | Not exported | Financial plans must be recreated |
+| **Invoices/customers** | Not exported | Business data is not supported |
+
+---
+
+## Quick Reference Card
+
+### Export from Microsoft Money
+
+1. **File > Export > Loose QIF**
+2. One file per account
+3. Investment accounts need two exports (Investment + Regular)
+4. Name files with numeric prefix for sort order
+
+### Import into Monize
+
+1. **Tools > Import Transactions**
+2. Select all files at once for bulk import
+3. Map accounts, categories, securities, and transfer accounts
+4. Review and click "Import Transactions"
+
+### Recommended Import Order
+
+```
+1. Asset accounts
+2. Home currency bank accounts
+3. Foreign currency bank accounts
+4. Credit card accounts
+5. Investment cash accounts (-Regular files)
+6. Investment brokerage accounts (-Investment files)
+7. Line of credit / loan accounts
+```
+
+### After Import Checklist
+
+```
+[ ] Verify all account balances match Microsoft Money
+[ ] Fix cross-currency transfer amounts ("PENDING IMPORT" memos)
+[ ] Verify investment holdings and cost basis
+[ ] Update auto-created securities with correct symbols
+[ ] Recreate scheduled transactions (bills and deposits)
+[ ] Run "Uncategorized Transactions" report and fix gaps
+[ ] Review category hierarchy and reorganize if needed
+[ ] Check net worth trend on Dashboard
+```

--- a/wiki/Investments.md
+++ b/wiki/Investments.md
@@ -1,0 +1,215 @@
+# Investments
+
+Monize provides comprehensive investment portfolio tracking with automatic price updates, cost basis calculation, and performance reporting.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Investment Account Structure](#investment-account-structure)
+- [Portfolio View](#portfolio-view)
+- [Investment Transaction Types](#investment-transaction-types)
+- [Creating Investment Transactions](#creating-investment-transactions)
+- [Securities Management](#securities-management)
+- [Price Updates](#price-updates)
+- [Holdings and Cost Basis](#holdings-and-cost-basis)
+- [Importing Investment Data](#importing-investment-data)
+
+---
+
+## Overview
+
+The Investments page gives you a complete picture of your investment portfolio, including current market values, unrealized gains/losses, and daily price movements.
+
+![Investments Page](images/investments-page.png)
+<!-- Screenshot: The investments page showing portfolio summary, holdings list, and account selection -->
+
+---
+
+## Investment Account Structure
+
+Investment accounts in Monize are composed of two linked accounts:
+
+| Component | Purpose |
+|-----------|---------|
+| **Brokerage Account** | Holds your securities (stocks, ETFs, mutual funds, bonds) |
+| **Cash Account** | Tracks the cash balance within the brokerage |
+
+When you create an investment account, both components are created automatically. The cash account is hidden from the main Accounts list but is managed through the Investments interface.
+
+### How It Works
+
+- **Buying securities** decreases the cash balance and adds to holdings
+- **Selling securities** increases the cash balance and reduces holdings
+- **Dividends** increase the cash balance
+- **Transfers** move cash in or out of the investment account
+
+> **Microsoft Money users:** In Microsoft Money, the cash and securities are combined in a single investment account. Monize separates these for cleaner transaction tracking, but the import process handles this mapping automatically.
+
+---
+
+## Portfolio View
+
+The portfolio view shows all your investment holdings grouped by account.
+
+![Portfolio Holdings](images/portfolio-holdings.png)
+<!-- Screenshot: The portfolio view showing holdings grouped by account with market values, gains, and percentages -->
+
+### Portfolio Summary
+
+At the top, a summary card shows:
+
+- **Total Market Value** -- Current value of all investment holdings
+- **Total Cost Basis** -- What you paid for all holdings
+- **Total Unrealized Gain/Loss** -- The difference (both dollar and percentage)
+- **Cash Balances** -- Total cash across all investment accounts
+
+### Holdings List
+
+Each holding displays:
+
+| Column | Description |
+|--------|-------------|
+| **Security** | Name and symbol of the security |
+| **Quantity** | Number of shares/units held |
+| **Average Cost** | Your average cost per share |
+| **Current Price** | Latest market price |
+| **Market Value** | Current total value (quantity x current price) |
+| **Unrealized Gain/Loss** | Difference from cost basis (both $ and %) |
+
+Holdings are colour-coded: green for gains, red for losses.
+
+---
+
+## Investment Transaction Types
+
+Monize supports 9 investment transaction types:
+
+| Action | Description | Cash Impact |
+|--------|-------------|-------------|
+| **Buy** | Purchase securities | Cash decreases |
+| **Sell** | Sell securities | Cash increases |
+| **Dividend** | Cash dividend received | Cash increases |
+| **Interest** | Interest income received | Cash increases |
+| **Capital Gain** | Realized or unrealized capital gains | Cash increases |
+| **Reinvest** | Dividend reinvested as additional shares | No cash change |
+| **Split** | Stock split adjustment | No cash change |
+| **Transfer In** | Securities moved in from another account | No cash change |
+| **Transfer Out** | Securities moved out to another account | No cash change |
+
+---
+
+## Creating Investment Transactions
+
+1. Navigate to **Investments**
+2. Select the brokerage account
+3. Click **Add Transaction**
+4. Select the transaction type (Buy, Sell, Dividend, etc.)
+5. Fill in the details:
+
+![Investment Transaction Form](images/investment-transaction-form.png)
+<!-- Screenshot: The investment transaction form showing security selection, action type, quantity, price, and commission fields -->
+
+### Transaction Fields
+
+| Field | Description |
+|-------|-------------|
+| **Date** | Transaction date |
+| **Action** | Transaction type (Buy, Sell, etc.) |
+| **Security** | The security involved |
+| **Quantity** | Number of shares/units |
+| **Price** | Price per share/unit |
+| **Commission** | Any trading commission or fee |
+| **Total** | Calculated total (quantity x price + commission) |
+| **Description** | Optional notes |
+
+---
+
+## Securities Management
+
+Securities represent the stocks, ETFs, mutual funds, bonds, and other instruments you trade.
+
+### Accessing Securities
+
+Navigate to **Tools > Securities** to manage your security master list.
+
+![Securities List](images/securities-list.png)
+<!-- Screenshot: The securities management page showing a list of securities with symbols, names, types, and exchanges -->
+
+### Security Fields
+
+| Field | Description |
+|-------|-------------|
+| **Symbol** | Ticker symbol (e.g., AAPL, VGRO.TO) |
+| **Name** | Full name (e.g., Apple Inc.) |
+| **Type** | STOCK, ETF, MUTUAL_FUND, BOND, GIC, CASH, or OTHER |
+| **Exchange** | Stock exchange (NYSE, NASDAQ, TSX, etc.) |
+| **Currency** | The currency the security trades in |
+
+### Adding Securities
+
+Securities can be added:
+- Manually from the Securities page
+- During import (mapped or auto-created from QIF data)
+- Automatically when creating investment transactions
+
+---
+
+## Price Updates
+
+Security prices are updated automatically and can also be refreshed manually.
+
+### Automatic Updates
+
+- **Schedule:** Weekdays (Monday-Friday) at 5:00 PM EST
+- **Source:** Yahoo Finance
+- **Data:** Daily OHLCV (Open, High, Low, Close, Volume)
+
+### Manual Refresh
+
+Click the **Refresh Prices** button on the Investments page or Dashboard to trigger an immediate price update.
+
+### Historical Prices
+
+When you import investment data or add a new security, Monize automatically backfills historical prices (up to 10 years). This ensures accurate portfolio valuation for historical reporting.
+
+---
+
+## Holdings and Cost Basis
+
+Monize tracks your cost basis using the **average cost method**.
+
+### How Average Cost Works
+
+1. When you **buy** shares, the total cost is added to your cost basis
+2. The average cost per share is: `total cost basis / total shares held`
+3. When you **sell** shares, the cost basis for the sold shares is calculated using the average cost
+4. **Reinvested dividends** add to both quantity and cost basis
+
+### Example
+
+| Transaction | Shares | Price | Total Cost | Total Shares | Avg Cost |
+|------------|--------|-------|------------|--------------|----------|
+| Buy 100 | 100 | $10 | $1,000 | 100 | $10.00 |
+| Buy 50 | 50 | $12 | $1,600 | 150 | $10.67 |
+| Sell 75 | -75 | $15 | $800 | 75 | $10.67 |
+
+### Zero Holdings
+
+When all shares of a security are sold, the holding is removed from your portfolio. If you buy the same security again, a new cost basis starts from that purchase.
+
+---
+
+## Importing Investment Data
+
+Importing investment data from Microsoft Money requires special handling. See the [Importing from Microsoft Money](Importing-from-Microsoft-Money.md) guide for complete details.
+
+### Key Points
+
+- Microsoft Money exports investment accounts as two separate QIF files: "Investment" type for securities transactions and "Regular" type for cash transactions
+- Import the investment brokerage file first, then the cash file
+- Securities must be mapped to existing records or created during import
+- Monize automatically creates the linked cash transactions when importing investment QIF files
+
+For the recommended import order, see [Recommended Import Order](Importing-from-Microsoft-Money.md#recommended-import-order).

--- a/wiki/Reports.md
+++ b/wiki/Reports.md
@@ -1,0 +1,190 @@
+# Reports
+
+Monize includes 15+ built-in reports and a custom report builder for analyzing your financial data in depth.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Built-In Reports](#built-in-reports)
+- [Custom Report Builder](#custom-report-builder)
+- [Chart Types](#chart-types)
+- [Report Filters](#report-filters)
+- [Saving and Favouriting Reports](#saving-and-favouriting-reports)
+
+---
+
+## Overview
+
+Navigate to **Reports** from the top navigation bar to access the reporting system. The Reports page lists all built-in reports and any custom reports you have created.
+
+![Reports Page](images/reports-page.png)
+<!-- Screenshot: The reports page showing the list of available built-in and custom reports -->
+
+---
+
+## Built-In Reports
+
+### Spending Reports
+
+| Report | Description |
+|--------|-------------|
+| **Spending by Category** | Breaks down your expenses by category for a selected time period |
+| **Spending by Payee** | Shows your top spending recipients |
+| **Monthly Spending Trend** | Tracks how your spending changes month over month |
+| **Weekend vs Weekday** | Compares spending patterns between weekdays and weekends |
+| **Spending Anomalies** | Identifies unusual transactions that deviate from normal patterns |
+| **Recurring Expenses** | Analyzes your regular, repeating expenses |
+
+![Spending by Category Report](images/report-spending-category.png)
+<!-- Screenshot: The spending by category report showing a pie chart and table breakdown of expenses -->
+
+### Income Reports
+
+| Report | Description |
+|--------|-------------|
+| **Income by Source** | Categorizes your income streams |
+| **Income vs Expenses** | Monthly comparison of income and expenses |
+| **Cash Flow** | Shows net money flow (income minus expenses) by period |
+
+![Income vs Expenses Report](images/report-income-expenses.png)
+<!-- Screenshot: The income vs expenses report showing monthly bars with totals -->
+
+### Comparison Reports
+
+| Report | Description |
+|--------|-------------|
+| **Year over Year** | Compares spending and income across different years |
+
+### Tax and Compliance
+
+| Report | Description |
+|--------|-------------|
+| **Tax Summary** | Groups transactions by tax-relevant categories |
+
+### Data Quality
+
+| Report | Description |
+|--------|-------------|
+| **Uncategorized Transactions** | Lists transactions without a category assigned |
+| **Duplicate Transaction Finder** | Identifies potential duplicate entries |
+
+### Billing and Payment
+
+| Report | Description |
+|--------|-------------|
+| **Bill Payment History** | Tracks your scheduled transaction payment patterns |
+
+### Net Worth
+
+| Report | Description |
+|--------|-------------|
+| **Net Worth Report** | Historical monthly snapshots of your assets, liabilities, and net worth |
+
+![Net Worth Report](images/report-net-worth.png)
+<!-- Screenshot: The net worth report showing a line chart with assets, liabilities, and net worth over time -->
+
+---
+
+## Custom Report Builder
+
+Create your own reports with flexible filtering, grouping, and visualization options.
+
+1. Navigate to **Reports**
+2. Click **Create Custom Report**
+3. Configure the report parameters
+
+![Custom Report Builder](images/custom-report-builder.png)
+<!-- Screenshot: The custom report builder showing all configuration options -->
+
+### Report Configuration
+
+| Setting | Options |
+|---------|---------|
+| **Name** | A descriptive name for your report |
+| **Timeframe** | Date range for the report data |
+| **Group By** | Category, Payee, Month, Week, or Day |
+| **Direction** | Income only, Expenses only, or Both |
+| **Metric** | Total amount, Transaction count, or Average amount |
+| **Chart Type** | Table, Line, Bar, Pie, or Area chart |
+| **Sorting** | Sort by name, amount, count, or date |
+
+### Report Filters
+
+| Filter | Description |
+|--------|-------------|
+| **Accounts** | Include only specific accounts |
+| **Categories** | Filter to specific categories |
+| **Payees** | Filter to specific payees |
+| **Search Text** | Free-text filter on transaction details |
+
+---
+
+## Chart Types
+
+Custom reports support five visualization types:
+
+### Table
+
+A tabular view showing rows of data with columns for the grouped dimension and selected metrics.
+
+![Table Chart](images/report-chart-table.png)
+<!-- Screenshot: A report displayed as a data table -->
+
+### Line Chart
+
+A trend line connecting data points over time. Best for showing changes over months, weeks, or days.
+
+### Bar Chart
+
+Vertical bars comparing values across groups. Best for category or payee comparisons.
+
+### Pie Chart
+
+A circular chart showing proportional breakdown. Best for understanding the composition of spending or income.
+
+### Area Chart
+
+Similar to a line chart but with the area below filled in. Effective for showing cumulative trends.
+
+---
+
+## Report Filters
+
+### Filtering from Reports to Transactions
+
+When viewing a report, you can click on any data point (a bar, pie segment, or table row) to navigate directly to the Transactions page with filters pre-applied. This allows you to drill down from a high-level summary to the individual transactions that make up that figure.
+
+### Date Range Selection
+
+Reports support flexible date ranges:
+
+- **This Month** / **Last Month**
+- **This Quarter** / **Last Quarter**
+- **This Year** / **Last Year**
+- **Last 30 Days** / **Last 90 Days** / **Last 12 Months**
+- **Custom Range** -- Select specific start and end dates
+
+---
+
+## Saving and Favouriting Reports
+
+### Saving Custom Reports
+
+Custom reports are saved automatically when you create them. They appear in the Reports list alongside the built-in reports.
+
+### Favouriting Reports
+
+Mark frequently used reports as favourites for quick access:
+
+1. On the Reports page, click the star icon next to a report
+2. Favourite reports appear at the top of the list
+
+### Editing Custom Reports
+
+Click the edit button on any custom report to modify its configuration. Built-in reports cannot be edited, but you can create a custom report with similar parameters if you need a variation.
+
+### Deleting Custom Reports
+
+Custom reports can be deleted from the Reports page. Built-in reports cannot be deleted.

--- a/wiki/Settings-and-Security.md
+++ b/wiki/Settings-and-Security.md
@@ -1,0 +1,196 @@
+# Settings and Security
+
+Monize provides comprehensive security features and configurable user preferences.
+
+---
+
+## Table of Contents
+
+- [User Settings](#user-settings)
+- [Two-Factor Authentication (2FA)](#two-factor-authentication-2fa)
+- [Trusted Devices](#trusted-devices)
+- [Password Management](#password-management)
+- [Single Sign-On (OIDC)](#single-sign-on-oidc)
+- [Security Architecture](#security-architecture)
+- [Admin Features](#admin-features)
+
+---
+
+## User Settings
+
+Navigate to **Settings** (gear icon in the top-right corner) to configure your preferences.
+
+![Settings Page](images/settings-overview.png)
+<!-- Screenshot: The settings page showing display preferences, home currency, and security options -->
+
+### Display Preferences
+
+| Setting | Description |
+|---------|-------------|
+| **Home Currency** | Primary currency for reporting and dashboard totals |
+| **Date Format** | How dates are displayed throughout the application |
+| **Number Format** | Decimal and thousands separator preferences |
+| **Theme** | Light or dark mode |
+| **Email Notifications** | Toggle email notifications for bills and reminders |
+
+---
+
+## Two-Factor Authentication (2FA)
+
+Monize supports Time-based One-Time Password (TOTP) authentication for an additional layer of security.
+
+### Setting Up 2FA
+
+1. Navigate to **Settings**
+2. Click **Enable Two-Factor Authentication**
+3. Scan the QR code with your authenticator app (Google Authenticator, Authy, 1Password, etc.)
+4. Enter the 6-digit verification code to confirm setup
+5. **Save your backup codes** in a secure location
+
+![2FA Setup](images/2fa-setup.png)
+<!-- Screenshot: The 2FA setup page showing the QR code and verification input -->
+
+### Logging in with 2FA
+
+After enabling 2FA:
+
+1. Enter your email and password as normal
+2. You will be prompted for a 6-digit TOTP code
+3. Enter the code from your authenticator app
+4. Optionally check "Trust this device" to skip 2FA on this device for future logins
+
+### Disabling 2FA
+
+1. Navigate to **Settings**
+2. Click **Disable Two-Factor Authentication**
+3. Enter your current TOTP code to confirm
+
+---
+
+## Trusted Devices
+
+When logging in with 2FA, you can mark a device as "trusted" to skip the TOTP prompt on future logins from that device.
+
+### Managing Trusted Devices
+
+1. Navigate to **Settings**
+2. Scroll to the **Trusted Devices** section
+3. View all currently trusted devices
+4. Click **Remove** to revoke trust for any device
+
+![Trusted Devices](images/trusted-devices.png)
+<!-- Screenshot: The trusted devices section showing a list of devices with remove buttons -->
+
+> **Security Note:** Trusted device tokens are stored as SHA-256 hashes in the database. The actual token is stored only in the browser cookie.
+
+---
+
+## Password Management
+
+### Changing Your Password
+
+1. Navigate to **Settings** or **Change Password**
+2. Enter your current password
+3. Enter and confirm your new password
+4. Click **Save**
+
+Password changes immediately revoke all existing refresh tokens, logging you out of all other sessions.
+
+### Forgot Password
+
+1. On the login page, click **Forgot Password**
+2. Enter your email address
+3. Check your email for a reset link
+4. Click the link and set a new password
+
+> **Security Note:** Password reset tokens are hashed with SHA-256 before being stored in the database. The token expires after a set time period.
+
+---
+
+## Single Sign-On (OIDC)
+
+Monize supports OpenID Connect (OIDC) for single sign-on integration with identity providers.
+
+### Supported Providers
+
+- Authentik
+- Authelia
+- Pocket-ID
+- Any OpenID Connect-compatible provider
+
+### Configuration
+
+OIDC is configured via environment variables:
+
+```bash
+OIDC_ISSUER=https://your-identity-provider.com
+OIDC_CLIENT_ID=monize
+OIDC_CLIENT_SECRET=your-client-secret
+OIDC_REDIRECT_URI=http://localhost:3001/auth/callback
+```
+
+When OIDC is configured, a "Sign in with SSO" button appears on the login page.
+
+![OIDC Login](images/oidc-login.png)
+<!-- Screenshot: The login page showing the "Sign in with SSO" button below the standard login form -->
+
+---
+
+## Security Architecture
+
+Monize implements comprehensive security measures:
+
+### Authentication
+
+| Feature | Implementation |
+|---------|---------------|
+| **Password Hashing** | bcrypt with salt rounds |
+| **Access Tokens** | JWT with 15-minute expiry |
+| **Refresh Tokens** | 7-day rotating tokens with family-based replay detection |
+| **TOTP Encryption** | Per-user unique salt (not shared secret) |
+| **Rate Limiting** | 100 req/min global, 3-5 per 15 min on auth endpoints |
+
+### Data Protection
+
+| Feature | Implementation |
+|---------|---------------|
+| **User Isolation** | All database queries filter by userId |
+| **Input Validation** | DTO validation with whitelist mode (rejects unknown fields) |
+| **SQL Injection** | Parameterized queries via TypeORM |
+| **XSS Protection** | No dangerouslySetInnerHTML, HTML escaping in emails |
+| **CSRF** | Token validation with httpOnly cookies |
+
+### HTTP Security Headers
+
+| Header | Value |
+|--------|-------|
+| **Content-Security-Policy** | Restrictive CSP with style-src and script-src whitelist |
+| **Strict-Transport-Security** | max-age=31536000; includeSubDomains |
+| **X-Content-Type-Options** | nosniff |
+| **X-Frame-Options** | DENY |
+| **Referrer-Policy** | strict-origin-when-cross-origin |
+| **Cross-Origin-Opener-Policy** | same-origin |
+| **Cross-Origin-Resource-Policy** | same-origin |
+| **Permissions-Policy** | Restrictive policy |
+
+---
+
+## Admin Features
+
+Users with the **admin** role have access to additional features.
+
+### User Management
+
+Navigate to **Admin > User Management** to manage application users.
+
+![User Management](images/admin-user-management.png)
+<!-- Screenshot: The admin user management page showing a list of users with roles and actions -->
+
+Admin capabilities:
+
+- View all registered users
+- Change user roles (user/admin)
+- Disable or enable user accounts
+- Reset user passwords
+
+> **Note:** The admin section only appears in the navigation if your user account has the admin role.

--- a/wiki/Transactions.md
+++ b/wiki/Transactions.md
@@ -1,0 +1,180 @@
+# Transactions
+
+Transactions are the core of your financial data in Monize. This page covers creating, searching, filtering, and managing transactions.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Creating a Transaction](#creating-a-transaction)
+- [Transaction List](#transaction-list)
+- [Searching and Filtering](#searching-and-filtering)
+- [Split Transactions](#split-transactions)
+- [Transfers Between Accounts](#transfers-between-accounts)
+- [Editing and Deleting Transactions](#editing-and-deleting-transactions)
+- [Transaction Status](#transaction-status)
+
+---
+
+## Overview
+
+The Transactions page provides a comprehensive view of all your financial transactions across all accounts. It supports advanced filtering, search, and density controls for efficient data management.
+
+![Transactions Page](images/transactions-page.png)
+<!-- Screenshot: The transactions page showing the list, filter panel, and summary card -->
+
+---
+
+## Creating a Transaction
+
+1. Navigate to **Transactions**
+2. Click **Add Transaction** (or use the quick-add button)
+3. Fill in the transaction form:
+
+![Transaction Form](images/transaction-form.png)
+<!-- Screenshot: The transaction creation form showing all fields -->
+
+### Transaction Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| **Date** | Yes | The date of the transaction |
+| **Account** | Yes | Which account this transaction belongs to |
+| **Payee** | No | Who the transaction was with |
+| **Amount** | Yes | The transaction amount (negative for expenses, positive for income) |
+| **Category** | No | The expense or income category |
+| **Memo** | No | Additional notes or description |
+| **Reference** | No | Cheque number or reference code |
+| **Status** | No | Unreconciled, Cleared, or Reconciled |
+
+### Quick Payee Creation
+
+If the payee does not exist, you can create a new one directly from the transaction form without leaving the page.
+
+---
+
+## Transaction List
+
+The transaction list displays your transactions in a table with the following columns:
+
+| Column | Description |
+|--------|-------------|
+| **Date** | Transaction date |
+| **Account** | Account name |
+| **Payee** | Who the transaction was with |
+| **Category** | Assigned category (or "Split" if multiple categories) |
+| **Memo** | Transaction notes |
+| **Amount** | Transaction amount (red for expenses, green for income) |
+| **Balance** | Running balance for the account |
+| **Status** | Reconciliation status indicator |
+
+### Display Density
+
+You can adjust the display density to fit more or fewer transactions on screen:
+
+- **Compact** -- Smaller rows, more transactions visible
+- **Normal** -- Default spacing
+- **Comfortable** -- Larger rows, easier to read
+
+### Pagination
+
+Transactions are paginated at 50 per page. Use the pagination controls at the bottom of the list to navigate between pages.
+
+---
+
+## Searching and Filtering
+
+The filter panel provides powerful options for finding specific transactions.
+
+![Transaction Filters](images/transaction-filters.png)
+<!-- Screenshot: The filter panel showing account, category, payee, date range, and search filters -->
+
+### Available Filters
+
+| Filter | Description |
+|--------|-------------|
+| **Accounts** | Filter by one or more accounts |
+| **Account Status** | Show active or archived accounts |
+| **Categories** | Filter by one or more categories |
+| **Payees** | Filter by one or more payees |
+| **Date Range** | Set start and end dates |
+| **Search** | Free-text search across payee, memo, and reference fields |
+
+### Filter Persistence
+
+Your filter selections are saved in your browser's local storage, so they persist between sessions. When navigating from a report, the report's filters are applied via URL parameters and override your saved filters temporarily.
+
+---
+
+## Split Transactions
+
+A split transaction distributes a single payment across multiple categories. For example, a supermarket purchase might be split between "Groceries" and "Household Supplies."
+
+### Creating a Split
+
+1. In the transaction form, click **Split**
+2. Add multiple category/amount rows
+3. Each row has its own category, amount, and optional memo
+4. The split amounts must total the transaction amount
+5. Click **Save**
+
+![Split Transaction](images/split-transaction.png)
+<!-- Screenshot: The split transaction interface showing multiple category/amount rows -->
+
+Split transactions display "Split" in the category column of the transaction list. Click on the transaction to see the full breakdown.
+
+---
+
+## Transfers Between Accounts
+
+Transfers move money between your accounts (e.g., from chequing to savings).
+
+### Creating a Transfer
+
+1. In the transaction form, select the **source account**
+2. Instead of choosing a category, select **Transfer to account**
+3. Choose the **destination account**
+4. Enter the amount
+5. Click **Save**
+
+Monize creates two linked transactions -- one in each account. The source account shows a withdrawal and the destination shows a deposit.
+
+### Cross-Currency Transfers
+
+If the source and destination accounts are in different currencies, you may need to adjust the exchange rate or amounts after import. See [Currency Management](Currency-Management.md) for details.
+
+---
+
+## Editing and Deleting Transactions
+
+### Editing
+
+Click on any transaction in the list to open it in the edit form. Modify any field and click **Save**.
+
+### Voiding
+
+Voiding a transaction reverses its effect on the account balance but preserves the record for audit purposes. The transaction amount is set to zero and the status changes to **Void**.
+
+### Deleting
+
+Deleting permanently removes a transaction. This action cannot be undone. The account balance is adjusted accordingly.
+
+> **Caution:** If the transaction is part of a linked transfer, deleting it will also affect the linked transaction in the other account.
+
+---
+
+## Transaction Status
+
+Each transaction has a reconciliation status:
+
+| Status | Icon | Description |
+|--------|------|-------------|
+| **Unreconciled** | (blank) | New transaction, not yet verified against a statement |
+| **Cleared** | C | Verified to match a bank statement entry |
+| **Reconciled** | R | Locked as part of a completed reconciliation |
+| **Void** | V | Cancelled, zero-amount record preserved |
+
+The status flow is typically: **Unreconciled** -> **Cleared** -> **Reconciled**
+
+You can change the status from the transaction list by clicking the status indicator, or during the account reconciliation process. See [Account Reconciliation](Accounts.md#account-reconciliation) for details.

--- a/wiki/images/SCREENSHOT-GUIDE.md
+++ b/wiki/images/SCREENSHOT-GUIDE.md
@@ -1,0 +1,141 @@
+# Screenshot Guide
+
+This document lists all the placeholder screenshots referenced in the wiki pages. Use this as a checklist for capturing the actual screenshots.
+
+Save all screenshots as PNG files in this `images/` directory with the exact filenames listed below.
+
+---
+
+## General Application
+
+| Filename | Page | What to Capture |
+|----------|------|-----------------|
+| `monize-logo.png` | Home | The Monize logo (can copy from frontend/public/icons/) |
+| `login-page.png` | Getting Started | Login page with email/password fields and Register link |
+| `registration-page.png` | Getting Started | Registration form with first name, email, password fields |
+| `navigation-bar.png` | Getting Started | Top nav bar showing Transactions, Accounts, Investments, Bills & Deposits, Reports |
+| `tools-dropdown.png` | Getting Started | Tools dropdown expanded showing Categories, Payees, Securities, Currencies, Import |
+| `settings-page.png` | Getting Started | Settings page with currency, date format, and theme options |
+
+## Dashboard
+
+| Filename | Page | What to Capture |
+|----------|------|-----------------|
+| `dashboard-overview.png` | Dashboard | Full dashboard page with all widgets visible |
+| `dashboard-favourite-accounts.png` | Dashboard | Favourite account cards showing names and balances |
+| `dashboard-upcoming-bills.png` | Dashboard | Upcoming bills widget with dates and amounts |
+| `dashboard-top-movers.png` | Dashboard | Top movers widget with securities and daily changes |
+| `dashboard-expenses-pie.png` | Dashboard | Expense breakdown pie chart by category |
+| `dashboard-income-expenses-bar.png` | Dashboard | Monthly income vs expenses bar chart |
+| `dashboard-net-worth.png` | Dashboard | Net worth trend line chart |
+
+## Accounts
+
+| Filename | Page | What to Capture |
+|----------|------|-----------------|
+| `create-account-form.png` | Accounts | Account creation form with all fields visible |
+| `accounts-list.png` | Accounts | Accounts list page grouped by type with balances |
+| `account-reconciliation.png` | Accounts | Reconciliation screen with cleared/unreconciled transactions |
+
+## Transactions
+
+| Filename | Page | What to Capture |
+|----------|------|-----------------|
+| `transactions-page.png` | Transactions | Full transactions page with list, filters, and summary |
+| `transaction-form.png` | Transactions | Transaction creation form with all fields |
+| `transaction-filters.png` | Transactions | Filter panel with account, category, payee, date, search |
+| `split-transaction.png` | Transactions | Split transaction interface with multiple category/amount rows |
+
+## Investments
+
+| Filename | Page | What to Capture |
+|----------|------|-----------------|
+| `investments-page.png` | Investments | Full investments page with portfolio summary and holdings |
+| `portfolio-holdings.png` | Investments | Holdings list grouped by account with values and gains |
+| `investment-transaction-form.png` | Investments | Investment transaction form (Buy/Sell) with fields |
+| `securities-list.png` | Investments | Securities management page with list of securities |
+
+## Bills and Deposits
+
+| Filename | Page | What to Capture |
+|----------|------|-----------------|
+| `bills-deposits-page.png` | Bills & Deposits | Bills page with list of scheduled transactions |
+| `scheduled-transaction-form.png` | Bills & Deposits | Scheduled transaction creation form |
+| `bills-list.png` | Bills & Deposits | Bills list showing frequencies and next due dates |
+| `cash-flow-forecast.png` | Bills & Deposits | Cash flow forecast projection |
+
+## Reports
+
+| Filename | Page | What to Capture |
+|----------|------|-----------------|
+| `reports-page.png` | Reports | Reports list page showing built-in and custom reports |
+| `report-spending-category.png` | Reports | Spending by Category report with pie chart |
+| `report-income-expenses.png` | Reports | Income vs Expenses report with bar chart |
+| `report-net-worth.png` | Reports | Net Worth report with trend line |
+| `custom-report-builder.png` | Reports | Custom report builder configuration form |
+| `report-chart-table.png` | Reports | A report displayed in table format |
+
+## Categories and Payees
+
+| Filename | Page | What to Capture |
+|----------|------|-----------------|
+| `categories-page.png` | Categories & Payees | Category management page with hierarchical list |
+| `payees-page.png` | Categories & Payees | Payee management page with list and default categories |
+
+## Currency Management
+
+| Filename | Page | What to Capture |
+|----------|------|-----------------|
+| `currencies-page.png` | Currency Management | Currencies page with exchange rates |
+
+## Settings and Security
+
+| Filename | Page | What to Capture |
+|----------|------|-----------------|
+| `settings-overview.png` | Settings & Security | Settings page with all preference sections |
+| `2fa-setup.png` | Settings & Security | 2FA setup page with QR code |
+| `trusted-devices.png` | Settings & Security | Trusted devices list with remove buttons |
+| `oidc-login.png` | Settings & Security | Login page with SSO button (requires OIDC config) |
+| `admin-user-management.png` | Settings & Security | Admin user management page |
+
+## Import Process (Most Important!)
+
+| Filename | Page | What to Capture |
+|----------|------|-----------------|
+| `import-upload-step.png` | Importing from MS Money | Upload step with drag-drop area |
+| `import-select-account.png` | Importing from MS Money | Select account step with file info and dropdown |
+| `import-create-account.png` | Importing from MS Money | Inline account creation form during import |
+| `import-map-categories.png` | Importing from MS Money | Map categories step with unmatched (amber) and matched (green) |
+| `import-map-securities.png` | Importing from MS Money | Map securities step with lookup and creation fields |
+| `import-map-accounts.png` | Importing from MS Money | Map transfer accounts step |
+| `import-review-step.png` | Importing from MS Money | Review step with full summary |
+| `import-complete-step.png` | Importing from MS Money | Import complete with green checkmark and statistics |
+
+## Microsoft Money Screenshots (Optional)
+
+These are screenshots of Microsoft Money itself. If you have access to Microsoft Money, capture these to help users who are exporting:
+
+| Filename | Page | What to Capture |
+|----------|------|-----------------|
+| `ms-money-categories.png` | Importing from MS Money | MS Money category list/editor |
+| `ms-money-file-export.png` | Importing from MS Money | MS Money File menu with Export option |
+| `ms-money-export-format.png` | Importing from MS Money | MS Money export dialog - format selection (Loose QIF) |
+| `ms-money-account-type-regular.png` | Importing from MS Money | MS Money export dialog - Regular type selected |
+| `ms-money-export-investment.png` | Importing from MS Money | MS Money export dialog - Investment type selected |
+
+---
+
+## Total Screenshots Needed: 52
+
+- General Application: 6
+- Dashboard: 7
+- Accounts: 3
+- Transactions: 4
+- Investments: 4
+- Bills and Deposits: 4
+- Reports: 6
+- Categories and Payees: 2
+- Currency Management: 1
+- Settings and Security: 5
+- Import Process: 8
+- Microsoft Money (optional): 5


### PR DESCRIPTION
Create 12 wiki pages covering all major application features with placeholder
screenshots. Includes a detailed Microsoft Money migration guide with
step-by-step export instructions, recommended import order (assets first,
then home currency bank accounts, foreign currency accounts, credit cards,
investment cash accounts, investment brokerage accounts, and finally
loans/lines of credit), complete walkthrough of the 7-step QIF import wizard,
post-import verification checklist, and troubleshooting guide. Also includes
a screenshot guide listing all 52 screenshots needed with descriptions.

https://claude.ai/code/session_01CoEoKnnpF75W4Q6EzaWF6i