### PR TITLE
fix: add git pull --rebase before push in version bump step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add backend/package.json backend/package-lock.json frontend/package.json frontend/package-lock.json
           git commit -m "chore: bump version to ${{ steps.version.outputs.version }} [skip ci]"
+          git pull --rebase
           git push
 
       - name: Create GitHub release


### PR DESCRIPTION
The version bump push was failing because the remote main branch
had commits not present in the checkout (e.g., from a prior run's
version bump). Rebasing before push resolves the conflict.

https://claude.ai/code/session_01XUZ4QrEAB9jCppYBt2zAhw