### PR TITLE
Fix flaky Select All/Select None reconcile tests

### DIFF
--- a/frontend/src/app/reconcile/page.test.tsx
+++ b/frontend/src/app/reconcile/page.test.tsx
@@ -317,13 +317,17 @@ describe('ReconcilePage', () => {
     it('Select All selects all transactions', async () => {
       await advanceToReconcileStep();
       fireEvent.click(screen.getByText('Select All'));
-      screen.getAllByRole('checkbox').forEach(cb => expect(cb).toBeChecked());
+      await waitFor(() => {
+        screen.getAllByRole('checkbox').forEach(cb => expect(cb).toBeChecked());
+      });
     });
 
     it('Select None deselects all transactions', async () => {
       await advanceToReconcileStep();
       fireEvent.click(screen.getByText('Select None'));
-      screen.getAllByRole('checkbox').forEach(cb => expect(cb).not.toBeChecked());
+      await waitFor(() => {
+        screen.getAllByRole('checkbox').forEach(cb => expect(cb).not.toBeChecked());
+      });
     });
 
     it('calculates difference correctly', async () => {


### PR DESCRIPTION
Wrap checkbox assertions in waitFor() to handle React state update
timing. The assertions were racing against the re-render triggered by
setSelectedTransactionIds, causing intermittent failures.

https://claude.ai/code/session_01QtJ4wm6bQjRFPaSvveuU3s