### PR TITLE
Fix flaky reconcile test by waiting for button enabled state

### DIFF
--- a/frontend/src/app/reconcile/page.test.tsx
+++ b/frontend/src/app/reconcile/page.test.tsx
@@ -266,8 +266,11 @@ describe('ReconcilePage', () => {
       await waitFor(() => expect(screen.getByLabelText('Account')).toBeInTheDocument());
       fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-1' } });
       fireEvent.change(screen.getByLabelText('Statement Ending Balance'), { target: { value: '1500' } });
-      const startButtons = screen.getAllByText('Start Reconciliation');
-      fireEvent.click(startButtons.find(el => el.tagName === 'BUTTON')!);
+      await waitFor(() => {
+        const button = screen.getAllByText('Start Reconciliation').find(el => el.tagName === 'BUTTON');
+        expect(button).not.toBeDisabled();
+      });
+      fireEvent.click(screen.getAllByText('Start Reconciliation').find(el => el.tagName === 'BUTTON')!);
       await waitFor(() => expect(screen.getByText('Statement Balance')).toBeInTheDocument());
     }
 


### PR DESCRIPTION
The "Select All selects all transactions" test failed because fireEvent.change calls didn't always flush React 18 state updates before the Start Reconciliation button was clicked. Added await waitFor to ensure the button is enabled before proceeding.

https://claude.ai/code/session_015Ay5Bkh3y5ReWkSRwqV7EG