### PR TITLE
Remove hardcoded database password fallbacks from standalone scripts

### DIFF
--- a/backend/src/database/add-default-categories.ts
+++ b/backend/src/database/add-default-categories.ts
@@ -3,13 +3,22 @@ import * as dotenv from "dotenv";
 
 dotenv.config();
 
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required environment variable: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
 const dataSource = new DataSource({
   type: "postgres",
   host: process.env.DATABASE_HOST || "localhost",
   port: parseInt(process.env.DATABASE_PORT || "5432"),
-  username: process.env.DATABASE_USER || "monize_user",
-  password: process.env.DATABASE_PASSWORD || "monize_password",
-  database: process.env.DATABASE_NAME || "monize",
+  username: requiredEnv("DATABASE_USER"),
+  password: requiredEnv("DATABASE_PASSWORD"),
+  database: requiredEnv("DATABASE_NAME"),
 });
 
 interface CategoryDef {

--- a/backend/src/database/add-income-categories.ts
+++ b/backend/src/database/add-income-categories.ts
@@ -3,13 +3,22 @@ import * as dotenv from "dotenv";
 
 dotenv.config();
 
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required environment variable: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
 const dataSource = new DataSource({
   type: "postgres",
   host: process.env.DATABASE_HOST || "localhost",
   port: parseInt(process.env.DATABASE_PORT || "5432"),
-  username: process.env.DATABASE_USER || "monize_user",
-  password: process.env.DATABASE_PASSWORD || "monize_password",
-  database: process.env.DATABASE_NAME || "monize",
+  username: requiredEnv("DATABASE_USER"),
+  password: requiredEnv("DATABASE_PASSWORD"),
+  database: requiredEnv("DATABASE_NAME"),
 });
 
 interface CategoryDef {

--- a/backend/src/database/add-skip-price-updates-column.ts
+++ b/backend/src/database/add-skip-price-updates-column.ts
@@ -13,18 +13,23 @@ import * as path from "path";
 
 dotenv.config({ path: path.join(__dirname, "../../../.env") });
 
+function requiredEnv(...names: string[]): string {
+  for (const name of names) {
+    const value = process.env[name];
+    if (value) return value;
+  }
+  console.error(`Missing required environment variable: ${names.join(" or ")}`);
+  process.exit(1);
+}
+
 async function addSkipPriceUpdatesColumn() {
   const dataSource = new DataSource({
     type: "postgres",
     host: process.env.DATABASE_HOST || "localhost",
     port: parseInt(process.env.DATABASE_PORT || "5432"),
-    username:
-      process.env.DATABASE_USER || process.env.POSTGRES_USER || "monize_user",
-    password:
-      process.env.DATABASE_PASSWORD ||
-      process.env.POSTGRES_PASSWORD ||
-      "monize_password",
-    database: process.env.DATABASE_NAME || process.env.POSTGRES_DB || "monize",
+    username: requiredEnv("DATABASE_USER", "POSTGRES_USER"),
+    password: requiredEnv("DATABASE_PASSWORD", "POSTGRES_PASSWORD"),
+    database: requiredEnv("DATABASE_NAME", "POSTGRES_DB"),
   });
 
   await dataSource.initialize();

--- a/backend/src/database/fix-linked-transactions.ts
+++ b/backend/src/database/fix-linked-transactions.ts
@@ -15,18 +15,23 @@ import * as path from "path";
 
 dotenv.config({ path: path.join(__dirname, "../../../.env") });
 
+function requiredEnv(...names: string[]): string {
+  for (const name of names) {
+    const value = process.env[name];
+    if (value) return value;
+  }
+  console.error(`Missing required environment variable: ${names.join(" or ")}`);
+  process.exit(1);
+}
+
 async function fixLinkedTransactions() {
   const dataSource = new DataSource({
     type: "postgres",
     host: process.env.DATABASE_HOST || "localhost",
     port: parseInt(process.env.DATABASE_PORT || "5432"),
-    username:
-      process.env.DATABASE_USER || process.env.POSTGRES_USER || "monize_user",
-    password:
-      process.env.DATABASE_PASSWORD ||
-      process.env.POSTGRES_PASSWORD ||
-      "monize_password",
-    database: process.env.DATABASE_NAME || process.env.POSTGRES_DB || "monize",
+    username: requiredEnv("DATABASE_USER", "POSTGRES_USER"),
+    password: requiredEnv("DATABASE_PASSWORD", "POSTGRES_PASSWORD"),
+    database: requiredEnv("DATABASE_NAME", "POSTGRES_DB"),
   });
 
   await dataSource.initialize();

--- a/backend/src/db-init.ts
+++ b/backend/src/db-init.ts
@@ -2,13 +2,22 @@ import { Client } from "pg";
 import * as fs from "fs";
 import * as path from "path";
 
+function requiredEnv(name: string, fallback?: string): string {
+  const value = process.env[name] || fallback;
+  if (!value) {
+    console.error(`Missing required environment variable: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
 async function initDatabase() {
   const client = new Client({
     host: process.env.DATABASE_HOST || "localhost",
     port: parseInt(process.env.DATABASE_PORT || "5432", 10),
-    user: process.env.DATABASE_USER || "monize_user",
-    password: process.env.DATABASE_PASSWORD || "monize_password",
-    database: process.env.DATABASE_NAME || "monize",
+    user: requiredEnv("DATABASE_USER"),
+    password: requiredEnv("DATABASE_PASSWORD"),
+    database: requiredEnv("DATABASE_NAME"),
   });
 
   try {


### PR DESCRIPTION
Replace fallback credentials ("monize_password", "monize_user") with
required environment variable validation that fails loudly if DATABASE_PASSWORD,
DATABASE_USER, or DATABASE_NAME are not set. This prevents scripts from
silently connecting with well-known default credentials if env vars are
missing in production.

Affected files:
- db-init.ts
- add-default-categories.ts
- add-income-categories.ts
- add-skip-price-updates-column.ts
- fix-linked-transactions.ts

https://claude.ai/code/session_01Knmx7J939ffjBaN9qH5mnR