### PR TITLE
Harden QIF import input validation and field length safety

### DIFF
--- a/backend/src/import/dto/import.dto.ts
+++ b/backend/src/import/dto/import.dto.ts
@@ -6,12 +6,15 @@ import {
   IsArray,
   ValidateNested,
   MaxLength,
+  IsNotEmpty,
+  IsIn,
 } from "class-validator";
 import { Type } from "class-transformer";
 
 export class ParseQifDto {
   @ApiProperty({ description: "QIF file content as string" })
   @IsString()
+  @IsNotEmpty()
   @MaxLength(10_000_000) // ~10MB limit, matches Express body parser
   content: string;
 }
@@ -89,8 +92,18 @@ export class AccountMappingDto {
 
   @ApiPropertyOptional({ description: "Account type for new account" })
   @IsOptional()
-  @IsString()
-  @MaxLength(50)
+  @IsIn([
+    "CHEQUING",
+    "SAVINGS",
+    "CREDIT_CARD",
+    "LOAN",
+    "MORTGAGE",
+    "INVESTMENT",
+    "CASH",
+    "LINE_OF_CREDIT",
+    "ASSET",
+    "OTHER",
+  ])
   accountType?: string;
 
   @ApiPropertyOptional({
@@ -127,11 +140,10 @@ export class SecurityMappingDto {
 
   @ApiPropertyOptional({
     description:
-      "Security type for new security (STOCK, ETF, MUTUAL_FUND, BOND, OPTION, CRYPTO, OTHER)",
+      "Security type for new security (STOCK, ETF, MUTUAL_FUND, BOND, GIC, CASH, OTHER)",
   })
   @IsOptional()
-  @IsString()
-  @MaxLength(50)
+  @IsIn(["STOCK", "ETF", "MUTUAL_FUND", "BOND", "GIC", "CASH", "OTHER"])
   securityType?: string;
 
   @ApiPropertyOptional({
@@ -154,6 +166,7 @@ export class SecurityMappingDto {
 export class ImportQifDto {
   @ApiProperty({ description: "QIF file content as string" })
   @IsString()
+  @IsNotEmpty()
   @MaxLength(10_000_000) // ~10MB limit, matches Express body parser
   content: string;
 
@@ -191,8 +204,7 @@ export class ImportQifDto {
       "Date format to use for parsing (MM/DD/YYYY, DD/MM/YYYY, YYYY-MM-DD, YYYY-DD-MM)",
   })
   @IsOptional()
-  @IsString()
-  @MaxLength(50)
+  @IsIn(["MM/DD/YYYY", "DD/MM/YYYY", "YYYY-MM-DD", "YYYY-DD-MM"])
   dateFormat?: string;
 }
 

--- a/backend/src/import/import.service.ts
+++ b/backend/src/import/import.service.ts
@@ -13,7 +13,7 @@ import { ExchangeRateService } from "../currencies/exchange-rate.service";
 import { Account, AccountSubType } from "../accounts/entities/account.entity";
 import { Category } from "../categories/entities/category.entity";
 import { Payee } from "../payees/entities/payee.entity";
-import { parseQif, validateQifContent } from "./qif-parser";
+import { parseQif, validateQifContent, DateFormat } from "./qif-parser";
 import {
   ImportQifDto,
   ParsedQifResponseDto,
@@ -105,7 +105,7 @@ export class ImportService {
       throw new BadRequestException("Account not found");
     }
 
-    const result = parseQif(dto.content, dto.dateFormat as any);
+    const result = parseQif(dto.content, dto.dateFormat as DateFormat);
 
     // Validate QIF type matches destination account type
     const isQifInvestment = result.accountType === "INVESTMENT";


### PR DESCRIPTION
- Add @IsNotEmpty() on content fields in ParseQifDto and ImportQifDto
- Validate dateFormat against supported enum values via @IsIn()
- Validate accountType and securityType against allowed values via @IsIn()
- Add field length truncation in QIF parser to match DB column limits
  (payee: 255, referenceNumber: 100, memo: 5000, category: 255, security: 255)
- Replace unsafe `as any` cast on dateFormat with proper DateFormat type
- Document file upload security audit findings in CLAUDE.md

https://claude.ai/code/session_01SxHBGwMr3o8oPzDAZZaACf