### PR TITLE
Fix mobile overflow by making density button icon-only on small screens

### DIFF
--- a/frontend/src/components/transactions/TransactionList.tsx
+++ b/frontend/src/components/transactions/TransactionList.tsx
@@ -646,10 +646,10 @@ export function TransactionList({
             className="inline-flex items-center px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 rounded flex-shrink-0"
             title="Toggle row density"
           >
-            <svg className="w-4 h-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="w-4 h-4 sm:mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
             </svg>
-            {density === 'normal' ? 'Normal' : density === 'compact' ? 'Compact' : 'Dense'}
+            <span className="hidden sm:inline">{density === 'normal' ? 'Normal' : density === 'compact' ? 'Compact' : 'Dense'}</span>
           </button>
         );
         const showPagination = currentPage !== undefined && totalPages !== undefined && totalPages > 1 && totalItems !== undefined && pageSize !== undefined && onPageChange;


### PR DESCRIPTION
Hide the text label ("Normal"/"Compact"/"Dense") on mobile viewports using
hidden sm:inline, keeping just the icon. This prevents the density button
from competing with pagination nav buttons for horizontal space.

https://claude.ai/code/session_015wDt95QKfnkjnnq6UWAuwU