### PR TITLE
fix: skip undefined events in SSE stream to prevent writing invalid data

### DIFF
--- a/backend/src/ai/query/ai-query.controller.ts
+++ b/backend/src/ai/query/ai-query.controller.ts
@@ -51,7 +51,9 @@ export class AiQueryController {
         req.user.id,
         dto.query,
       )) {
-        res.write(`data: ${JSON.stringify(event)}\n\n`);
+        if (event) {
+          res.write(`data: ${JSON.stringify(event)}\n\n`);
+        }
       }
     } catch (error) {
       const message =


### PR DESCRIPTION
The streamQuery controller now guards against undefined/null events from
the async generator, preventing "data: undefined" from being written to
the SSE stream. This fixes two failing tests where bare yield statements
(used to satisfy require-yield) produced undefined values.

https://claude.ai/code/session_01JQFbYQ9fhKuiCobLcHjgQv