### PR TITLE
fix: update AI service tests to match security-hardened error handling

### DIFF
--- a/backend/src/ai/ai.service.spec.ts
+++ b/backend/src/ai/ai.service.spec.ts
@@ -44,6 +44,7 @@ describe("AiService", () => {
     mockConfigRepository = {
       find: jest.fn().mockResolvedValue([]),
       findOne: jest.fn().mockResolvedValue(null),
+      count: jest.fn().mockResolvedValue(0),
       create: jest.fn().mockImplementation((data) => ({ ...data })),
       save: jest.fn().mockImplementation((data) =>
         Promise.resolve({
@@ -286,7 +287,7 @@ describe("AiService", () => {
 
       const result = await service.testConnection(userId, "config-1");
       expect(result.available).toBe(false);
-      expect(result.error).toBe("Connection refused");
+      expect(result.error).toBe("Connection test failed. Check your provider settings.");
     });
   });
 

--- a/backend/src/ai/dto/ai-config.dto.spec.ts
+++ b/backend/src/ai/dto/ai-config.dto.spec.ts
@@ -33,7 +33,7 @@ describe("CreateAiConfigDto", () => {
   it("accepts valid ollama config without API key", async () => {
     const dto = createDto({
       provider: "ollama",
-      baseUrl: "http://localhost:11434",
+      baseUrl: "http://ollama-server.example.com:11434",
     });
     const errors = await validate(dto);
     expect(errors).toHaveLength(0);

--- a/backend/src/ai/query/ai-query.controller.spec.ts
+++ b/backend/src/ai/query/ai-query.controller.spec.ts
@@ -142,7 +142,7 @@ describe("AiQueryController", () => {
         written[0].replace("data: ", "").replace("\n\n", ""),
       );
       expect(errorEvent.type).toBe("error");
-      expect(errorEvent.message).toBe("Provider crashed");
+      expect(errorEvent.message).toBe("An unexpected error occurred while processing your query.");
       expect(mockRes.end).toHaveBeenCalled();
     });
 
@@ -172,7 +172,7 @@ describe("AiQueryController", () => {
         written[0].replace("data: ", "").replace("\n\n", ""),
       );
       expect(errorEvent.type).toBe("error");
-      expect(errorEvent.message).toBe("Unknown error");
+      expect(errorEvent.message).toBe("An unexpected error occurred while processing your query.");
     });
 
     it("passes query service the correct user ID", async () => {

--- a/backend/src/ai/query/ai-query.service.spec.ts
+++ b/backend/src/ai/query/ai-query.service.spec.ts
@@ -301,7 +301,7 @@ describe("AiQueryService", () => {
 
       const errorEvent = events.find((e) => e.type === "error");
       expect(errorEvent).toBeDefined();
-      expect(errorEvent!.message).toContain("Rate limit exceeded");
+      expect(errorEvent!.message).toContain("The AI provider encountered an error processing your query.");
     });
 
     it("logs usage after successful completion", async () => {


### PR DESCRIPTION
Tests were failing because:
- configRepository.count mock was missing (needed after per-user config limit)
- Tests expected raw error messages but services now return generic messages
  to prevent error leakage (security audit fix)
- Ollama DTO test used localhost URL which is now blocked by SSRF validator

https://claude.ai/code/session_01Qi3pNFdS6Q8bJTFWYnywmE