### PR TITLE
fix: resolve 13 unhandled test errors and act() warnings

### DIFF
--- a/frontend/src/app/budgets/[id]/edit/page.test.tsx
+++ b/frontend/src/app/budgets/[id]/edit/page.test.tsx
@@ -200,10 +200,15 @@ describe('BudgetEditPage', () => {
     mockGetSummary.mockResolvedValue(mockSummary);
   });
 
-  it('shows loading spinner initially', () => {
+  it('shows loading spinner initially', async () => {
     render(<BudgetEditPage />);
 
     expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+
+    // Wait for async operations to complete to prevent act() warnings
+    await waitFor(() => {
+      expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+    });
   });
 
   it('renders budget form after loading', async () => {

--- a/frontend/src/app/budgets/[id]/page.test.tsx
+++ b/frontend/src/app/budgets/[id]/page.test.tsx
@@ -179,10 +179,15 @@ describe('BudgetDetailPage', () => {
     mockGetPeriods.mockResolvedValue([]);
   });
 
-  it('shows loading spinner initially', () => {
+  it('shows loading spinner initially', async () => {
     render(<BudgetDetailPage />);
 
     expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+
+    // Wait for async operations to complete to prevent act() warnings
+    await waitFor(() => {
+      expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+    });
   });
 
   it('renders budget dashboard after loading', async () => {

--- a/frontend/src/app/transactions/page.test.tsx
+++ b/frontend/src/app/transactions/page.test.tsx
@@ -133,6 +133,13 @@ vi.mock('@/lib/errors', () => ({
   getErrorMessage: (_error: any, fallback: string) => fallback,
 }));
 
+// Mock budgets API (used for category budget status indicators)
+vi.mock('@/lib/budgets', () => ({
+  budgetsApi: {
+    getCategoryBudgetStatus: vi.fn().mockResolvedValue({}),
+  },
+}));
+
 // Mock child components
 vi.mock('@/components/transactions/TransactionList', () => ({
   TransactionList: (props: any) => (

--- a/frontend/src/components/budgets/BudgetAlertBadge.test.tsx
+++ b/frontend/src/components/budgets/BudgetAlertBadge.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@/test/render';
+import { render, screen, fireEvent, waitFor, act } from '@/test/render';
 import { BudgetAlertBadge } from './BudgetAlertBadge';
 import type { BudgetAlert } from '@/types/budget';
 
@@ -64,18 +64,16 @@ describe('BudgetAlertBadge', () => {
 
   it('renders the bell icon button', async () => {
     render(<BudgetAlertBadge />);
+    await act(async () => {});
 
-    await waitFor(() => {
-      expect(screen.getByTestId('alert-badge-button')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('alert-badge-button')).toBeInTheDocument();
   });
 
   it('fetches alerts on mount', async () => {
     render(<BudgetAlertBadge />);
+    await act(async () => {});
 
-    await waitFor(() => {
-      expect(mockGetAlerts).toHaveBeenCalled();
-    });
+    expect(mockGetAlerts).toHaveBeenCalled();
   });
 
   it('shows unread count badge when there are unread alerts', async () => {
@@ -86,10 +84,9 @@ describe('BudgetAlertBadge', () => {
     ]);
 
     render(<BudgetAlertBadge />);
+    await act(async () => {});
 
-    await waitFor(() => {
-      expect(screen.getByTestId('unread-count')).toHaveTextContent('2');
-    });
+    expect(screen.getByTestId('unread-count')).toHaveTextContent('2');
   });
 
   it('does not show badge when all alerts are read', async () => {
@@ -98,10 +95,9 @@ describe('BudgetAlertBadge', () => {
     ]);
 
     render(<BudgetAlertBadge />);
+    await act(async () => {});
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('unread-count')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByTestId('unread-count')).not.toBeInTheDocument();
   });
 
   it('shows 9+ when there are more than 9 unread alerts', async () => {
@@ -111,20 +107,16 @@ describe('BudgetAlertBadge', () => {
     mockGetAlerts.mockResolvedValue(alerts);
 
     render(<BudgetAlertBadge />);
+    await act(async () => {});
 
-    await waitFor(() => {
-      expect(screen.getByTestId('unread-count')).toHaveTextContent('9+');
-    });
+    expect(screen.getByTestId('unread-count')).toHaveTextContent('9+');
   });
 
   it('opens alert list dropdown when clicked', async () => {
     mockGetAlerts.mockResolvedValue([makeAlert()]);
 
     render(<BudgetAlertBadge />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('alert-badge-button')).toBeInTheDocument();
-    });
+    await act(async () => {});
 
     fireEvent.click(screen.getByTestId('alert-badge-button'));
 
@@ -135,10 +127,7 @@ describe('BudgetAlertBadge', () => {
     mockGetAlerts.mockResolvedValue([makeAlert()]);
 
     render(<BudgetAlertBadge />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('alert-badge-button')).toBeInTheDocument();
-    });
+    await act(async () => {});
 
     fireEvent.click(screen.getByTestId('alert-badge-button'));
     expect(screen.getByTestId('alert-list')).toBeInTheDocument();
@@ -152,10 +141,7 @@ describe('BudgetAlertBadge', () => {
     mockGetAlerts.mockResolvedValue([makeAlert({ id: 'a1', isRead: false })]);
 
     render(<BudgetAlertBadge />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('alert-badge-button')).toBeInTheDocument();
-    });
+    await act(async () => {});
 
     fireEvent.click(screen.getByTestId('alert-badge-button'));
     fireEvent.click(screen.getByTestId('alert-item-a1'));
@@ -172,10 +158,7 @@ describe('BudgetAlertBadge', () => {
     ]);
 
     render(<BudgetAlertBadge />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('alert-badge-button')).toBeInTheDocument();
-    });
+    await act(async () => {});
 
     fireEvent.click(screen.getByTestId('alert-badge-button'));
     fireEvent.click(screen.getByTestId('mark-all-read'));
@@ -189,10 +172,7 @@ describe('BudgetAlertBadge', () => {
     mockGetAlerts.mockResolvedValue([]);
 
     render(<BudgetAlertBadge />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('alert-badge-button')).toBeInTheDocument();
-    });
+    await act(async () => {});
 
     fireEvent.click(screen.getByTestId('alert-badge-button'));
 
@@ -205,10 +185,7 @@ describe('BudgetAlertBadge', () => {
     ]);
 
     render(<BudgetAlertBadge />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('alert-badge-button')).toBeInTheDocument();
-    });
+    await act(async () => {});
 
     fireEvent.click(screen.getByTestId('alert-badge-button'));
     fireEvent.click(screen.getByTestId('alert-item-a1'));
@@ -220,10 +197,7 @@ describe('BudgetAlertBadge', () => {
     mockGetAlerts.mockRejectedValue(new Error('Network error'));
 
     render(<BudgetAlertBadge />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('alert-badge-button')).toBeInTheDocument();
-    });
+    await act(async () => {});
 
     // Should not throw, badge should render without count
     expect(screen.queryByTestId('unread-count')).not.toBeInTheDocument();

--- a/frontend/src/components/layout/AppHeader.test.tsx
+++ b/frontend/src/components/layout/AppHeader.test.tsx
@@ -57,13 +57,9 @@ vi.mock('@/store/authStore', () => ({
   }),
 }));
 
-// Mock budgets API for BudgetAlertBadge
-vi.mock('@/lib/budgets', () => ({
-  budgetsApi: {
-    getAlerts: vi.fn().mockResolvedValue([]),
-    markAlertRead: vi.fn().mockResolvedValue({}),
-    markAllAlertsRead: vi.fn().mockResolvedValue({ updated: 0 }),
-  },
+// Mock BudgetAlertBadge to avoid async act() warnings (tested in its own file)
+vi.mock('@/components/budgets/BudgetAlertBadge', () => ({
+  BudgetAlertBadge: () => <div data-testid="budget-alert-badge" />,
 }));
 
 describe('AppHeader', () => {


### PR DESCRIPTION
- Add missing budgetsApi mock to transactions page test to prevent
  real HTTP requests from getCategoryBudgetStatus leaking through
  jsdom and causing InvalidArgumentError rejections
- Fix act() warnings in BudgetDetailContent and BudgetEditContent
  tests by waiting for async operations to complete before test ends
- Fix act() warnings in BudgetAlertBadge tests by flushing pending
  microtasks from fetchAlerts with await act(async () => {})
- Mock BudgetAlertBadge in AppHeader tests to avoid async side
  effects from the nested component

https://claude.ai/code/session_01CJZ77TsJbFMgSqCDqTSMKm