### PR TITLE
Fix ambiguous text query in InvestmentTransactionList filter test

### DIFF
--- a/frontend/src/components/investments/InvestmentTransactionList.test.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionList.test.tsx
@@ -218,8 +218,8 @@ describe('InvestmentTransactionList', () => {
       />
     );
     fireEvent.click(screen.getByText('Filter'));
-    expect(screen.getByText('Symbol')).toBeInTheDocument();
-    expect(screen.getByText('Action')).toBeInTheDocument();
+    expect(screen.getByText('Symbol', { selector: 'label' })).toBeInTheDocument();
+    expect(screen.getByText('Action', { selector: 'label' })).toBeInTheDocument();
     expect(screen.getByText('From')).toBeInTheDocument();
     expect(screen.getByText('To')).toBeInTheDocument();
   });


### PR DESCRIPTION
Use { selector: 'label' } for 'Symbol' and 'Action' queries to
disambiguate between filter bar labels and table column headers.

https://claude.ai/code/session_01WJ11a8m1MKXKvKZDFhBP97