### PR TITLE
Fix silent validation failure when saving custom reports with invalid settings

### DIFF
--- a/frontend/src/components/reports/CustomReportForm.tsx
+++ b/frontend/src/components/reports/CustomReportForm.tsx
@@ -96,6 +96,23 @@ const customReportSchema = z.object({
   tableColumns: z.array(z.nativeEnum(TableColumn)).optional(),
   sortBy: z.nativeEnum(TableColumn).optional().nullable(),
   sortDirection: z.nativeEnum(SortDirection).optional(),
+}).superRefine((data, ctx) => {
+  if (data.timeframeType === TimeframeType.CUSTOM) {
+    if (!data.customStartDate) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Start date is required for custom timeframe',
+        path: ['customStartDate'],
+      });
+    }
+    if (!data.customEndDate) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'End date is required for custom timeframe',
+        path: ['customEndDate'],
+      });
+    }
+  }
 });
 
 type FormData = z.infer<typeof customReportSchema>;


### PR DESCRIPTION
Reports with CUSTOM timeframe but missing start/end dates could be saved
without error, then fail silently on execution. Added frontend Zod schema
validation to require both dates when CUSTOM is selected, backend
BadRequestException on create/update/execute, and corresponding tests.

https://claude.ai/code/session_013L6zurutY8GqMbnYaZ7fX1