### PR TITLE
Migrate 7 form components from useState to Zod + react-hook-form

### DIFF
--- a/frontend/src/components/auth/TwoFactorVerify.tsx
+++ b/frontend/src/components/auth/TwoFactorVerify.tsx
@@ -1,12 +1,23 @@
 'use client';
 
 import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import '@/lib/zodConfig';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
 import toast from 'react-hot-toast';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { authApi } from '@/lib/auth';
 import { getErrorMessage } from '@/lib/errors';
 import { User } from '@/types/auth';
+
+const verifySchema = z.object({
+  code: z.string().length(6, 'Code must be exactly 6 digits').regex(/^\d{6}$/, 'Code must be 6 digits'),
+  rememberDevice: z.boolean(),
+});
+
+type VerifyFormData = z.infer<typeof verifySchema>;
 
 interface TwoFactorVerifyProps {
   tempToken: string;
@@ -15,23 +26,36 @@ interface TwoFactorVerifyProps {
 }
 
 export function TwoFactorVerify({ tempToken, onVerified, onCancel }: TwoFactorVerifyProps) {
-  const [code, setCode] = useState('');
-  const [rememberDevice, setRememberDevice] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (code.length !== 6) return;
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+  } = useForm<VerifyFormData>({
+    resolver: zodResolver(verifySchema),
+    defaultValues: {
+      code: '',
+      rememberDevice: false,
+    },
+  });
+
+  const codeValue = watch('code');
+  const codeRef = register('code');
+
+  const onSubmit = async (formData: VerifyFormData) => {
+    if (formData.code.length !== 6) return;
 
     setIsLoading(true);
     try {
-      const response = await authApi.verify2FA(tempToken, code, rememberDevice);
+      const response = await authApi.verify2FA(tempToken, formData.code, formData.rememberDevice);
       if (response.user) {
         onVerified(response.user);
       }
     } catch (error) {
       toast.error(getErrorMessage(error, 'Invalid verification code'));
-      setCode('');
+      setValue('code', '');
     } finally {
       setIsLoading(false);
     }
@@ -53,24 +77,27 @@ export function TwoFactorVerify({ tempToken, onVerified, onCancel }: TwoFactorVe
         </p>
       </div>
 
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
         <Input
           label="Verification Code"
           type="text"
           inputMode="numeric"
           autoComplete="one-time-code"
           maxLength={6}
-          value={code}
-          onChange={(e) => setCode(e.target.value.replace(/\D/g, ''))}
           placeholder="000000"
           autoFocus
+          {...codeRef}
+          onChange={(e) => {
+            const filtered = e.target.value.replace(/\D/g, '');
+            e.target.value = filtered;
+            codeRef.onChange(e);
+          }}
         />
 
         <label className="flex items-center gap-2 cursor-pointer">
           <input
             type="checkbox"
-            checked={rememberDevice}
-            onChange={(e) => setRememberDevice(e.target.checked)}
+            {...register('rememberDevice')}
             className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700"
           />
           <span className="text-sm text-gray-600 dark:text-gray-400">
@@ -83,7 +110,7 @@ export function TwoFactorVerify({ tempToken, onVerified, onCancel }: TwoFactorVe
           variant="primary"
           size="lg"
           isLoading={isLoading}
-          disabled={code.length !== 6}
+          disabled={codeValue.length !== 6}
           className="w-full"
         >
           Verify

--- a/frontend/src/components/settings/ApiAccessSection.test.tsx
+++ b/frontend/src/components/settings/ApiAccessSection.test.tsx
@@ -164,7 +164,7 @@ describe('ApiAccessSection', () => {
     fireEvent.click(getFormSubmitButton());
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('Token name is required');
+      expect(screen.getByText('Token name is required')).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/settings/SecuritySection.test.tsx
+++ b/frontend/src/components/settings/SecuritySection.test.tsx
@@ -128,7 +128,7 @@ describe('SecuritySection', () => {
     fireEvent.submit(screen.getByRole('button', { name: 'Change Password' }));
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('New passwords do not match');
+      expect(screen.getByText('New passwords do not match')).toBeInTheDocument();
     });
   });
 
@@ -243,7 +243,7 @@ describe('SecuritySection', () => {
     fireEvent.submit(screen.getByRole('button', { name: 'Change Password' }));
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('Password must be at least 8 characters');
+      expect(screen.getByText('Password must be at least 8 characters')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
Replace manual useState form field management with Zod schemas and
react-hook-form in BudgetForm, BudgetCategoryForm, SecuritySection
(password change), ProviderConfigForm, ApiAccessSection (token
creation), TwoFactorSetup, and TwoFactorVerify. Validation errors
now display inline instead of via toast. Updated 3 affected tests
to check for inline error messages.

https://claude.ai/code/session_0176FhwWYAHFzAV69ZcWAQu4