### PR TITLE
Fix PWA app header and bottom bar visibility on mobile devices

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -17,6 +17,7 @@ export const viewport: Viewport = {
   ],
   width: 'device-width',
   initialScale: 1,
+  viewportFit: 'cover',
 };
 
 export const metadata: Metadata = {
@@ -24,7 +25,7 @@ export const metadata: Metadata = {
   description: 'Track your finances with ease',
   appleWebApp: {
     capable: true,
-    statusBarStyle: 'default',
+    statusBarStyle: 'black-translucent',
     title: 'Monize',
   },
   icons: {

--- a/frontend/src/app/manifest.ts
+++ b/frontend/src/app/manifest.ts
@@ -6,7 +6,7 @@ export default function manifest(): MetadataRoute.Manifest {
     short_name: 'Monize',
     description: 'Track your finances, manage budgets, and monitor investments',
     start_url: '/',
-    display: 'standalone',
+    display: 'fullscreen',
     background_color: '#ffffff',
     theme_color: '#10b981',
     orientation: 'portrait-primary',

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -82,7 +82,7 @@ export function AppHeader() {
   };
 
   return (
-    <header className="bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50">
+    <header className="bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50" style={{ paddingTop: 'env(safe-area-inset-top)' }}>
       <div className="px-4 sm:px-6 lg:px-12">
         <div className="flex justify-between h-16">
           <div className="flex items-center">

--- a/frontend/src/components/layout/SwipeShell.tsx
+++ b/frontend/src/components/layout/SwipeShell.tsx
@@ -24,7 +24,7 @@ export function SwipeShell({ children }: SwipeShellProps) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 overflow-x-hidden">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 overflow-x-hidden" style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}>
       <AppHeader />
       <DemoModeBanner />
       <SwipeIndicator currentIndex={currentIndex} totalPages={totalPages} isSwipePage={isSwipePage} />


### PR DESCRIPTION
Enable edge-to-edge display so the app extends behind the system status
bar and home indicator, hiding them as before. Changes:
- Add viewport-fit=cover to extend content into safe areas
- Switch iOS status bar to black-translucent (transparent overlay)
- Change manifest display from standalone to fullscreen
- Add safe-area-inset padding to AppHeader (top) and SwipeShell (bottom)

https://claude.ai/code/session_01WGgniAnuBNXMpMqnWVHSRQ