### PR TITLE
Switch chart click-to-navigate from element-level to chart-level onClick

### DIFF
--- a/frontend/src/components/reports/CashFlowReport.test.tsx
+++ b/frontend/src/components/reports/CashFlowReport.test.tsx
@@ -37,17 +37,15 @@ vi.mock("recharts", () => ({
   ResponsiveContainer: ({ children }: any) => (
     <div data-testid="responsive-container">{children}</div>
   ),
-  BarChart: ({ children }: any) => (
-    <div data-testid="bar-chart">{children}</div>
+  BarChart: ({ children, onClick }: any) => (
+    <div
+      data-testid="bar-chart"
+      onClick={() => onClick?.({ activeLabel: "Jul" })}
+    >
+      {children}
+    </div>
   ),
-  Bar: ({ onClick, dataKey }: any) => (
-    <button
-      data-testid={`bar-${dataKey}`}
-      onClick={() =>
-        onClick?.({ monthStart: "2024-07-01", monthEnd: "2024-07-31" })
-      }
-    />
-  ),
+  Bar: ({ dataKey }: any) => <div data-testid={`bar-${dataKey}`} />,
   XAxis: () => null,
   YAxis: () => null,
   CartesianGrid: () => null,
@@ -185,7 +183,7 @@ describe("CashFlowReport", () => {
     await waitFor(() => {
       expect(screen.getByTestId("bar-chart")).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByTestId("bar-Income"));
+    fireEvent.click(screen.getByTestId("bar-chart"));
     expect(mockPush).toHaveBeenCalledWith(
       "/transactions?startDate=2024-07-01&endDate=2024-07-31",
     );

--- a/frontend/src/components/reports/CashFlowReport.tsx
+++ b/frontend/src/components/reports/CashFlowReport.tsx
@@ -113,11 +113,14 @@ export function CashFlowReport() {
     if (isValid) loadData();
   }, [isValid, loadData]);
 
-  const handleBarClick = (data: Record<string, unknown>) => {
-    const monthStart = data?.monthStart as string | undefined;
-    const monthEnd = data?.monthEnd as string | undefined;
-    if (monthStart && monthEnd) {
-      router.push(`/transactions?startDate=${monthStart}&endDate=${monthEnd}`);
+  const handleChartClick = (state: any) => {
+    const label = state?.activeLabel;
+    if (!label) return;
+    const item = monthlyData.find((d) => d.name === label);
+    if (item?.monthStart && item?.monthEnd) {
+      router.push(
+        `/transactions?startDate=${item.monthStart}&endDate=${item.monthEnd}`,
+      );
     }
   };
 
@@ -245,6 +248,8 @@ export function CashFlowReport() {
             <BarChart
               data={monthlyData}
               margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
+              onClick={handleChartClick}
+              style={{ cursor: "pointer" }}
             >
               <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
               <XAxis dataKey="name" tick={{ fontSize: 12 }} />
@@ -260,16 +265,12 @@ export function CashFlowReport() {
                 fill="#22c55e"
                 name="Inflows"
                 radius={[4, 4, 0, 0]}
-                cursor="pointer"
-                onClick={handleBarClick}
               />
               <Bar
                 dataKey="Expenses"
                 fill="#ef4444"
                 name="Outflows"
                 radius={[4, 4, 0, 0]}
-                cursor="pointer"
-                onClick={handleBarClick}
               />
             </BarChart>
           </ResponsiveContainer>

--- a/frontend/src/components/reports/IncomeVsExpensesReport.test.tsx
+++ b/frontend/src/components/reports/IncomeVsExpensesReport.test.tsx
@@ -37,17 +37,15 @@ vi.mock("recharts", () => ({
   ResponsiveContainer: ({ children }: any) => (
     <div data-testid="responsive-container">{children}</div>
   ),
-  BarChart: ({ children }: any) => (
-    <div data-testid="bar-chart">{children}</div>
+  BarChart: ({ children, onClick }: any) => (
+    <div
+      data-testid="bar-chart"
+      onClick={() => onClick?.({ activeLabel: "Jan" })}
+    >
+      {children}
+    </div>
   ),
-  Bar: ({ onClick, dataKey }: any) => (
-    <button
-      data-testid={`bar-${dataKey}`}
-      onClick={() =>
-        onClick?.({ monthStart: "2024-01-01", monthEnd: "2024-01-31" })
-      }
-    />
-  ),
+  Bar: ({ dataKey }: any) => <div data-testid={`bar-${dataKey}`} />,
   XAxis: () => null,
   YAxis: () => null,
   CartesianGrid: () => null,
@@ -164,7 +162,7 @@ describe("IncomeVsExpensesReport", () => {
     await waitFor(() => {
       expect(screen.getByTestId("bar-chart")).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByTestId("bar-Income"));
+    fireEvent.click(screen.getByTestId("bar-chart"));
     expect(mockPush).toHaveBeenCalledWith(
       "/transactions?startDate=2024-01-01&endDate=2024-01-31",
     );

--- a/frontend/src/components/reports/IncomeVsExpensesReport.tsx
+++ b/frontend/src/components/reports/IncomeVsExpensesReport.tsx
@@ -105,11 +105,14 @@ export function IncomeVsExpensesReport() {
     if (isValid) loadData();
   }, [isValid, loadData]);
 
-  const handleBarClick = (data: Record<string, unknown>) => {
-    const monthStart = data?.monthStart as string | undefined;
-    const monthEnd = data?.monthEnd as string | undefined;
-    if (monthStart && monthEnd) {
-      router.push(`/transactions?startDate=${monthStart}&endDate=${monthEnd}`);
+  const handleChartClick = (state: any) => {
+    const label = state?.activeLabel;
+    if (!label) return;
+    const item = chartData.find((d) => d.name === label);
+    if (item?.monthStart && item?.monthEnd) {
+      router.push(
+        `/transactions?startDate=${item.monthStart}&endDate=${item.monthEnd}`,
+      );
     }
   };
 
@@ -188,6 +191,8 @@ export function IncomeVsExpensesReport() {
                 <BarChart
                   data={chartData}
                   margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
+                  onClick={handleChartClick}
+                  style={{ cursor: "pointer" }}
                 >
                   <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
                   <XAxis dataKey="name" tick={{ fontSize: 12 }} />
@@ -202,22 +207,16 @@ export function IncomeVsExpensesReport() {
                     dataKey="Income"
                     fill="#22c55e"
                     radius={[4, 4, 0, 0]}
-                    cursor="pointer"
-                    onClick={handleBarClick}
                   />
                   <Bar
                     dataKey="Expenses"
                     fill="#ef4444"
                     radius={[4, 4, 0, 0]}
-                    cursor="pointer"
-                    onClick={handleBarClick}
                   />
                   <Bar
                     dataKey="Savings"
                     fill="#3b82f6"
                     radius={[4, 4, 0, 0]}
-                    cursor="pointer"
-                    onClick={handleBarClick}
                   />
                 </BarChart>
               </ResponsiveContainer>

--- a/frontend/src/components/reports/MonthlySpendingTrendReport.test.tsx
+++ b/frontend/src/components/reports/MonthlySpendingTrendReport.test.tsx
@@ -37,19 +37,15 @@ vi.mock("recharts", () => ({
   ResponsiveContainer: ({ children }: any) => (
     <div data-testid="responsive-container">{children}</div>
   ),
-  LineChart: ({ children }: any) => (
-    <div data-testid="line-chart">{children}</div>
+  LineChart: ({ children, onClick }: any) => (
+    <div
+      data-testid="line-chart"
+      onClick={() => onClick?.({ activeLabel: "Jan" })}
+    >
+      {children}
+    </div>
   ),
-  Line: ({ activeDot, dataKey }: any) => (
-    <button
-      data-testid={`line-dot-${dataKey}`}
-      onClick={(e) =>
-        activeDot?.onClick?.(e, {
-          payload: { monthStart: "2024-01-01", monthEnd: "2024-01-31" },
-        })
-      }
-    />
-  ),
+  Line: ({ dataKey }: any) => <div data-testid={`line-dot-${dataKey}`} />,
   XAxis: () => null,
   YAxis: () => null,
   CartesianGrid: () => null,
@@ -146,7 +142,7 @@ describe("MonthlySpendingTrendReport", () => {
     await waitFor(() => {
       expect(screen.getByTestId("line-chart")).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByTestId("line-dot-Expenses"));
+    fireEvent.click(screen.getByTestId("line-chart"));
     expect(mockPush).toHaveBeenCalledWith(
       "/transactions?startDate=2024-01-01&endDate=2024-01-31",
     );

--- a/frontend/src/components/reports/MonthlySpendingTrendReport.tsx
+++ b/frontend/src/components/reports/MonthlySpendingTrendReport.tsx
@@ -95,14 +95,14 @@ export function MonthlySpendingTrendReport() {
     return { totalExpenses, totalIncome, avgExpenses, avgIncome };
   }, [chartData]);
 
-  const handleDotClick = (
-    _event: unknown,
-    payload: { payload?: { monthStart?: string; monthEnd?: string } },
-  ) => {
-    const monthStart = payload?.payload?.monthStart;
-    const monthEnd = payload?.payload?.monthEnd;
-    if (monthStart && monthEnd) {
-      router.push(`/transactions?startDate=${monthStart}&endDate=${monthEnd}`);
+  const handleChartClick = (state: any) => {
+    const label = state?.activeLabel;
+    if (!label) return;
+    const item = chartData.find((d) => d.name === label);
+    if (item?.monthStart && item?.monthEnd) {
+      router.push(
+        `/transactions?startDate=${item.monthStart}&endDate=${item.monthEnd}`,
+      );
     }
   };
 
@@ -178,6 +178,8 @@ export function MonthlySpendingTrendReport() {
                 <LineChart
                   data={chartData}
                   margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+                  onClick={handleChartClick}
+                  style={{ cursor: "pointer" }}
                 >
                   <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
                   <XAxis dataKey="name" tick={{ fontSize: 12 }} />
@@ -192,34 +194,16 @@ export function MonthlySpendingTrendReport() {
                     dataKey="Expenses"
                     stroke="#ef4444"
                     strokeWidth={2}
-                    dot={{
-                      fill: "#ef4444",
-                      strokeWidth: 2,
-                      r: 4,
-                      cursor: "pointer",
-                    }}
-                    activeDot={{
-                      r: 6,
-                      cursor: "pointer",
-                      onClick: handleDotClick,
-                    }}
+                    dot={{ fill: "#ef4444", strokeWidth: 2, r: 4 }}
+                    activeDot={{ r: 6 }}
                   />
                   <Line
                     type="monotone"
                     dataKey="Income"
                     stroke="#22c55e"
                     strokeWidth={2}
-                    dot={{
-                      fill: "#22c55e",
-                      strokeWidth: 2,
-                      r: 4,
-                      cursor: "pointer",
-                    }}
-                    activeDot={{
-                      r: 6,
-                      cursor: "pointer",
-                      onClick: handleDotClick,
-                    }}
+                    dot={{ fill: "#22c55e", strokeWidth: 2, r: 4 }}
+                    activeDot={{ r: 6 }}
                   />
                 </LineChart>
               </ResponsiveContainer>


### PR DESCRIPTION
Use BarChart/LineChart onClick with activeLabel instead of individual Bar onClick or Line activeDot onClick, so clicking anywhere in the chart area for a month navigates to transactions — not just on the bar or dot itself.