### PR TITLE
Harden exception filter for TypeORM errors and refactor QueryBuilder …

### DIFF
--- a/backend/src/common/filters/http-exception.filter.spec.ts
+++ b/backend/src/common/filters/http-exception.filter.spec.ts
@@ -5,6 +5,7 @@ import {
   NotFoundException,
   ForbiddenException,
 } from "@nestjs/common";
+import { QueryFailedError } from "typeorm";
 import { GlobalExceptionFilter } from "./http-exception.filter";
 
 describe("GlobalExceptionFilter", () => {
@@ -152,5 +153,80 @@ describe("GlobalExceptionFilter", () => {
         message: "Internal server error",
       }),
     );
+  });
+
+  describe("QueryFailedError handling", () => {
+    function createQueryFailedError(pgCode: string, detail: string) {
+      const driverError = Object.assign(new Error(detail), { code: pgCode });
+      return new QueryFailedError("SELECT 1", [], driverError as any);
+    }
+
+    it("returns 409 Conflict for unique constraint violations (PG 23505)", () => {
+      const exception = createQueryFailedError(
+        "23505",
+        'duplicate key value violates unique constraint "uq_accounts_name"',
+      );
+
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.CONFLICT);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: HttpStatus.CONFLICT,
+          message: "A record with this value already exists",
+        }),
+      );
+    });
+
+    it("returns 400 Bad Request for foreign key violations (PG 23503)", () => {
+      const exception = createQueryFailedError(
+        "23503",
+        'insert or update on table "transactions" violates foreign key constraint "fk_category"',
+      );
+
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: HttpStatus.BAD_REQUEST,
+          message: "Referenced record does not exist or cannot be removed",
+        }),
+      );
+    });
+
+    it("returns 500 for other database errors", () => {
+      const exception = createQueryFailedError(
+        "42P01",
+        'relation "nonexistent_table" does not exist',
+      );
+
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: "Internal server error",
+        }),
+      );
+    });
+
+    it("never exposes constraint or column names in the response", () => {
+      const exception = createQueryFailedError(
+        "23505",
+        'duplicate key value violates unique constraint "uq_accounts_name" DETAIL: Key (name)=(Checking) already exists',
+      );
+
+      filter.catch(exception, mockHost);
+
+      const jsonCall = mockResponse.json.mock.calls[0][0];
+      const serialized = JSON.stringify(jsonCall);
+      expect(serialized).not.toContain("uq_accounts_name");
+      expect(serialized).not.toContain("constraint");
+      expect(serialized).not.toContain("DETAIL");
+    });
   });
 });

--- a/backend/src/common/filters/http-exception.filter.ts
+++ b/backend/src/common/filters/http-exception.filter.ts
@@ -7,6 +7,7 @@ import {
   Logger,
 } from "@nestjs/common";
 import { Response } from "express";
+import { QueryFailedError } from "typeorm";
 
 @Catch()
 export class GlobalExceptionFilter implements ExceptionFilter {
@@ -39,6 +40,19 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       } else {
         message = exception.message;
       }
+    } else if (exception instanceof QueryFailedError) {
+      const driverError = exception.driverError as { code?: string };
+      if (driverError?.code === "23505") {
+        status = HttpStatus.CONFLICT;
+        message = "A record with this value already exists";
+      } else if (driverError?.code === "23503") {
+        status = HttpStatus.BAD_REQUEST;
+        message = "Referenced record does not exist or cannot be removed";
+      } else {
+        status = HttpStatus.INTERNAL_SERVER_ERROR;
+        message = "Internal server error";
+      }
+      this.logger.error("Database error", exception.stack);
     } else {
       status = HttpStatus.INTERNAL_SERVER_ERROR;
       message = "Internal server error";

--- a/backend/src/transactions/transaction-analytics.service.spec.ts
+++ b/backend/src/transactions/transaction-analytics.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { getRepositoryToken } from "@nestjs/typeorm";
+import { Brackets } from "typeorm";
 import { TransactionAnalyticsService } from "./transaction-analytics.service";
 import { Transaction } from "./entities/transaction.entity";
 import { Category } from "../categories/entities/category.entity";
@@ -14,17 +15,33 @@ describe("TransactionAnalyticsService", () => {
   let mockQueryBuilder: Record<string, jest.Mock>;
 
   beforeEach(async () => {
-    mockQueryBuilder = {
-      select: jest.fn().mockReturnThis(),
-      addSelect: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      leftJoin: jest.fn().mockReturnThis(),
-      groupBy: jest.fn().mockReturnThis(),
-      orderBy: jest.fn().mockReturnThis(),
-      setParameter: jest.fn().mockReturnThis(),
-      getRawMany: jest.fn().mockResolvedValue([]),
+    mockQueryBuilder = {} as Record<string, jest.Mock>;
+    const executeBrackets = (condition: unknown) => {
+      if (condition instanceof Brackets) {
+        (condition as any).whereFactory(mockQueryBuilder);
+      }
     };
+    Object.assign(mockQueryBuilder, {
+      select: jest.fn().mockReturnValue(mockQueryBuilder),
+      addSelect: jest.fn().mockReturnValue(mockQueryBuilder),
+      where: jest.fn().mockImplementation((condition: unknown) => {
+        executeBrackets(condition);
+        return mockQueryBuilder;
+      }),
+      andWhere: jest.fn().mockImplementation((condition: unknown) => {
+        executeBrackets(condition);
+        return mockQueryBuilder;
+      }),
+      orWhere: jest.fn().mockImplementation((condition: unknown) => {
+        executeBrackets(condition);
+        return mockQueryBuilder;
+      }),
+      leftJoin: jest.fn().mockReturnValue(mockQueryBuilder),
+      groupBy: jest.fn().mockReturnValue(mockQueryBuilder),
+      orderBy: jest.fn().mockReturnValue(mockQueryBuilder),
+      setParameter: jest.fn().mockReturnValue(mockQueryBuilder),
+      getRawMany: jest.fn().mockResolvedValue([]),
+    });
 
     transactionsRepository = {
       createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
@@ -373,10 +390,16 @@ describe("TransactionAnalyticsService", () => {
           select: ["id", "parentId"],
         });
 
-        // Should set parameter with parent + all descendants
-        expect(mockQueryBuilder.setParameter).toHaveBeenCalledWith(
-          "summaryCategoryIds",
-          expect.arrayContaining(["cat-1", "cat-1-child", "cat-1-grandchild"]),
+        // Should pass category IDs inline via Brackets
+        expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+          "transaction.categoryId IN (:...summaryCategoryIds)",
+          {
+            summaryCategoryIds: expect.arrayContaining([
+              "cat-1",
+              "cat-1-child",
+              "cat-1-grandchild",
+            ]),
+          },
         );
 
         // Should join splits for category matching
@@ -396,7 +419,11 @@ describe("TransactionAnalyticsService", () => {
           "summaryAccount",
         );
 
+        // Uncategorized condition is now inside a Brackets callback
         expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+          expect.any(Brackets),
+        );
+        expect(mockQueryBuilder.where).toHaveBeenCalledWith(
           expect.stringContaining("transaction.categoryId IS NULL"),
         );
       });
@@ -406,8 +433,12 @@ describe("TransactionAnalyticsService", () => {
           "transfer",
         ]);
 
+        // Transfer condition is now inside a Brackets callback
         expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-          expect.stringContaining("transaction.isTransfer = true"),
+          expect.any(Brackets),
+        );
+        expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+          "transaction.isTransfer = true",
         );
       });
 
@@ -422,15 +453,17 @@ describe("TransactionAnalyticsService", () => {
           "cat-1",
         ]);
 
-        // All three conditions should be OR-ed together
+        // All three conditions should be OR-ed together via Brackets
         expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-          expect.stringContaining(" OR "),
+          expect.any(Brackets),
         );
-
-        // Account join for uncategorized
-        expect(mockQueryBuilder.leftJoin).toHaveBeenCalledWith(
-          "transaction.account",
-          "summaryAccount",
+        // Uncategorized is the first condition (uses where)
+        expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+          expect.stringContaining("transaction.categoryId IS NULL"),
+        );
+        // Transfer and category conditions use orWhere
+        expect(mockQueryBuilder.orWhere).toHaveBeenCalledWith(
+          "transaction.isTransfer = true",
         );
 
         // Splits join for regular categories
@@ -521,11 +554,15 @@ describe("TransactionAnalyticsService", () => {
           "cat-child",
         ]);
 
-        const setParameterCall = mockQueryBuilder.setParameter.mock.calls.find(
-          (call: unknown[]) => call[0] === "summaryCategoryIds",
+        // Find the where call that passes summaryCategoryIds inline
+        const whereCall = mockQueryBuilder.where.mock.calls.find(
+          (call: unknown[]) =>
+            typeof call[0] === "string" &&
+            (call[0] as string).includes("summaryCategoryIds"),
         );
-        expect(setParameterCall).toBeDefined();
-        const ids = setParameterCall[1] as string[];
+        expect(whereCall).toBeDefined();
+        const ids = (whereCall[1] as { summaryCategoryIds: string[] })
+          .summaryCategoryIds;
         // Should be deduplicated (cat-child appears only once)
         const uniqueIds = [...new Set(ids)];
         expect(ids.length).toBe(uniqueIds.length);
@@ -754,9 +791,9 @@ describe("TransactionAnalyticsService", () => {
           "cat-1",
         ]);
 
-        expect(mockQueryBuilder.setParameter).toHaveBeenCalledWith(
-          "summaryCategoryIds",
-          ["cat-1"],
+        expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+          "transaction.categoryId IN (:...summaryCategoryIds)",
+          { summaryCategoryIds: ["cat-1"] },
         );
       });
 
@@ -773,15 +810,17 @@ describe("TransactionAnalyticsService", () => {
           "root",
         ]);
 
-        expect(mockQueryBuilder.setParameter).toHaveBeenCalledWith(
-          "summaryCategoryIds",
-          expect.arrayContaining([
-            "root",
-            "child-1",
-            "child-2",
-            "grandchild-1",
-            "great-grandchild",
-          ]),
+        expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+          "transaction.categoryId IN (:...summaryCategoryIds)",
+          {
+            summaryCategoryIds: expect.arrayContaining([
+              "root",
+              "child-1",
+              "child-2",
+              "grandchild-1",
+              "great-grandchild",
+            ]),
+          },
         );
       });
 
@@ -798,14 +837,16 @@ describe("TransactionAnalyticsService", () => {
           "cat-b",
         ]);
 
-        expect(mockQueryBuilder.setParameter).toHaveBeenCalledWith(
-          "summaryCategoryIds",
-          expect.arrayContaining([
-            "cat-a",
-            "cat-a-child",
-            "cat-b",
-            "cat-b-child",
-          ]),
+        expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+          "transaction.categoryId IN (:...summaryCategoryIds)",
+          {
+            summaryCategoryIds: expect.arrayContaining([
+              "cat-a",
+              "cat-a-child",
+              "cat-b",
+              "cat-b-child",
+            ]),
+          },
         );
       });
 
@@ -821,10 +862,13 @@ describe("TransactionAnalyticsService", () => {
           "cat-1",
         ]);
 
-        const setParameterCall = mockQueryBuilder.setParameter.mock.calls.find(
-          (call: unknown[]) => call[0] === "summaryCategoryIds",
+        const whereCall = mockQueryBuilder.where.mock.calls.find(
+          (call: unknown[]) =>
+            typeof call[0] === "string" &&
+            (call[0] as string).includes("summaryCategoryIds"),
         );
-        const ids = setParameterCall[1] as string[];
+        const ids = (whereCall[1] as { summaryCategoryIds: string[] })
+          .summaryCategoryIds;
         expect(ids).toContain("cat-1");
         expect(ids).toContain("cat-1-child");
         expect(ids).not.toContain("cat-2");
@@ -964,9 +1008,11 @@ describe("TransactionAnalyticsService", () => {
         "cat-1",
       ]);
 
-      expect(mockQueryBuilder.setParameter).toHaveBeenCalledWith(
-        "monthlyCategoryIds",
-        expect.arrayContaining(["cat-1", "cat-child"]),
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+        "transaction.categoryId IN (:...monthlyCategoryIds)",
+        {
+          monthlyCategoryIds: expect.arrayContaining(["cat-1", "cat-child"]),
+        },
       );
     });
 

--- a/backend/src/transactions/transaction-analytics.service.ts
+++ b/backend/src/transactions/transaction-analytics.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
+import { Brackets, Repository } from "typeorm";
 import { Transaction } from "./entities/transaction.entity";
 import { Category } from "../categories/entities/category.entity";
 import { getAllCategoryIdsWithChildren } from "../common/category-tree.util";
@@ -90,37 +90,55 @@ export class TransactionAnalyticsService {
         (id) => id !== "uncategorized" && id !== "transfer",
       );
 
-      const conditions: string[] = [];
+      let hasCondition = false;
 
-      if (hasUncategorized) {
-        conditions.push(
-          "(transaction.categoryId IS NULL AND transaction.isSplit = false AND transaction.isTransfer = false AND summaryAccount.accountType != 'INVESTMENT')",
-        );
-      }
-
-      if (hasTransfer) {
-        conditions.push("transaction.isTransfer = true");
-      }
-
-      if (regularCategoryIds.length > 0) {
-        const uniqueCategoryIds = await getAllCategoryIdsWithChildren(
-          this.categoriesRepository,
-          userId,
-          regularCategoryIds,
-        );
+      if (hasUncategorized || hasTransfer || regularCategoryIds.length > 0) {
+        const uniqueCategoryIds =
+          regularCategoryIds.length > 0
+            ? await getAllCategoryIdsWithChildren(
+                this.categoriesRepository,
+                userId,
+                regularCategoryIds,
+              )
+            : [];
 
         if (uniqueCategoryIds.length > 0) {
           queryBuilder.leftJoin("transaction.splits", "splits");
           splitsCategoryJoin = true;
-          conditions.push(
-            "(transaction.categoryId IN (:...summaryCategoryIds) OR splits.categoryId IN (:...summaryCategoryIds))",
-          );
-          queryBuilder.setParameter("summaryCategoryIds", uniqueCategoryIds);
         }
-      }
 
-      if (conditions.length > 0) {
-        queryBuilder.andWhere(`(${conditions.join(" OR ")})`);
+        queryBuilder.andWhere(
+          new Brackets((qb) => {
+            if (hasUncategorized) {
+              const method = hasCondition ? "orWhere" : "where";
+              hasCondition = true;
+              qb[method](
+                "transaction.categoryId IS NULL AND transaction.isSplit = false AND transaction.isTransfer = false AND summaryAccount.accountType != 'INVESTMENT'",
+              );
+            }
+            if (hasTransfer) {
+              const method = hasCondition ? "orWhere" : "where";
+              hasCondition = true;
+              qb[method]("transaction.isTransfer = true");
+            }
+            if (uniqueCategoryIds.length > 0) {
+              const method = hasCondition ? "orWhere" : "where";
+              hasCondition = true;
+              qb[method](
+                new Brackets((inner) => {
+                  inner
+                    .where(
+                      "transaction.categoryId IN (:...summaryCategoryIds)",
+                      { summaryCategoryIds: uniqueCategoryIds },
+                    )
+                    .orWhere("splits.categoryId IN (:...summaryCategoryIds)", {
+                      summaryCategoryIds: uniqueCategoryIds,
+                    });
+                }),
+              );
+            }
+          }),
+        );
       }
     }
 
@@ -260,37 +278,55 @@ export class TransactionAnalyticsService {
         (id) => id !== "uncategorized" && id !== "transfer",
       );
 
-      const conditions: string[] = [];
+      let hasCondition = false;
 
-      if (hasUncategorized) {
-        conditions.push(
-          "(transaction.categoryId IS NULL AND transaction.isSplit = false AND transaction.isTransfer = false AND summaryAccount.accountType != 'INVESTMENT')",
-        );
-      }
-
-      if (hasTransfer) {
-        conditions.push("transaction.isTransfer = true");
-      }
-
-      if (regularCategoryIds.length > 0) {
-        const uniqueCategoryIds = await getAllCategoryIdsWithChildren(
-          this.categoriesRepository,
-          userId,
-          regularCategoryIds,
-        );
+      if (hasUncategorized || hasTransfer || regularCategoryIds.length > 0) {
+        const uniqueCategoryIds =
+          regularCategoryIds.length > 0
+            ? await getAllCategoryIdsWithChildren(
+                this.categoriesRepository,
+                userId,
+                regularCategoryIds,
+              )
+            : [];
 
         if (uniqueCategoryIds.length > 0) {
           queryBuilder.leftJoin("transaction.splits", "splits");
           splitsCategoryJoin = true;
-          conditions.push(
-            "(transaction.categoryId IN (:...monthlyCategoryIds) OR splits.categoryId IN (:...monthlyCategoryIds))",
-          );
-          queryBuilder.setParameter("monthlyCategoryIds", uniqueCategoryIds);
         }
-      }
 
-      if (conditions.length > 0) {
-        queryBuilder.andWhere(`(${conditions.join(" OR ")})`);
+        queryBuilder.andWhere(
+          new Brackets((qb) => {
+            if (hasUncategorized) {
+              const method = hasCondition ? "orWhere" : "where";
+              hasCondition = true;
+              qb[method](
+                "transaction.categoryId IS NULL AND transaction.isSplit = false AND transaction.isTransfer = false AND summaryAccount.accountType != 'INVESTMENT'",
+              );
+            }
+            if (hasTransfer) {
+              const method = hasCondition ? "orWhere" : "where";
+              hasCondition = true;
+              qb[method]("transaction.isTransfer = true");
+            }
+            if (uniqueCategoryIds.length > 0) {
+              const method = hasCondition ? "orWhere" : "where";
+              hasCondition = true;
+              qb[method](
+                new Brackets((inner) => {
+                  inner
+                    .where(
+                      "transaction.categoryId IN (:...monthlyCategoryIds)",
+                      { monthlyCategoryIds: uniqueCategoryIds },
+                    )
+                    .orWhere("splits.categoryId IN (:...monthlyCategoryIds)", {
+                      monthlyCategoryIds: uniqueCategoryIds,
+                    });
+                }),
+              );
+            }
+          }),
+        );
       }
     }
 

--- a/backend/src/transactions/transaction-bulk-update.service.ts
+++ b/backend/src/transactions/transaction-bulk-update.service.ts
@@ -7,7 +7,7 @@ import {
   Logger,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository, SelectQueryBuilder, DataSource } from "typeorm";
+import { Brackets, Repository, SelectQueryBuilder, DataSource } from "typeorm";
 import { Transaction, TransactionStatus } from "./entities/transaction.entity";
 import { Category } from "../categories/entities/category.entity";
 import { Payee } from "../payees/entities/payee.entity";
@@ -377,37 +377,58 @@ export class TransactionBulkUpdateService {
       (id) => id !== "uncategorized" && id !== "transfer",
     );
 
-    const conditions: string[] = [];
+    let hasCondition = false;
 
-    if (hasUncategorized) {
-      queryBuilder.leftJoin("transaction.account", "filterAccount");
-      conditions.push(
-        "(transaction.categoryId IS NULL AND transaction.isSplit = false AND transaction.isTransfer = false AND filterAccount.accountType != 'INVESTMENT')",
-      );
-    }
+    if (hasUncategorized || hasTransfer || regularCategoryIds.length > 0) {
+      if (hasUncategorized) {
+        queryBuilder.leftJoin("transaction.account", "filterAccount");
+      }
 
-    if (hasTransfer) {
-      conditions.push("transaction.isTransfer = true");
-    }
-
-    if (regularCategoryIds.length > 0) {
-      const uniqueCategoryIds = await getAllCategoryIdsWithChildren(
-        this.categoriesRepository,
-        userId,
-        regularCategoryIds,
-      );
+      const uniqueCategoryIds =
+        regularCategoryIds.length > 0
+          ? await getAllCategoryIdsWithChildren(
+              this.categoriesRepository,
+              userId,
+              regularCategoryIds,
+            )
+          : [];
 
       if (uniqueCategoryIds.length > 0) {
         queryBuilder.leftJoin("transaction.splits", "filterSplits");
-        conditions.push(
-          "(transaction.categoryId IN (:...filterCategoryIds) OR filterSplits.categoryId IN (:...filterCategoryIds))",
-        );
-        queryBuilder.setParameter("filterCategoryIds", uniqueCategoryIds);
       }
-    }
 
-    if (conditions.length > 0) {
-      queryBuilder.andWhere(`(${conditions.join(" OR ")})`);
+      queryBuilder.andWhere(
+        new Brackets((qb) => {
+          if (hasUncategorized) {
+            const method = hasCondition ? "orWhere" : "where";
+            hasCondition = true;
+            qb[method](
+              "transaction.categoryId IS NULL AND transaction.isSplit = false AND transaction.isTransfer = false AND filterAccount.accountType != 'INVESTMENT'",
+            );
+          }
+          if (hasTransfer) {
+            const method = hasCondition ? "orWhere" : "where";
+            hasCondition = true;
+            qb[method]("transaction.isTransfer = true");
+          }
+          if (uniqueCategoryIds.length > 0) {
+            const method = hasCondition ? "orWhere" : "where";
+            hasCondition = true;
+            qb[method](
+              new Brackets((inner) => {
+                inner
+                  .where("transaction.categoryId IN (:...filterCategoryIds)", {
+                    filterCategoryIds: uniqueCategoryIds,
+                  })
+                  .orWhere(
+                    "filterSplits.categoryId IN (:...filterCategoryIds)",
+                    { filterCategoryIds: uniqueCategoryIds },
+                  );
+              }),
+            );
+          }
+        }),
+      );
     }
   }
 }

--- a/backend/src/transactions/transactions.service.spec.ts
+++ b/backend/src/transactions/transactions.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { getRepositoryToken } from "@nestjs/typeorm";
 import { NotFoundException, BadRequestException } from "@nestjs/common";
-import { DataSource } from "typeorm";
+import { Brackets, DataSource } from "typeorm";
 import { TransactionsService } from "./transactions.service";
 import { Transaction, TransactionStatus } from "./entities/transaction.entity";
 import { TransactionSplit } from "./entities/transaction-split.entity";
@@ -891,19 +891,35 @@ describe("TransactionsService", () => {
 
   describe("findAll", () => {
     const createMockQueryBuilder = (overrides?: Record<string, jest.Mock>) => {
-      const mockQb: Record<string, jest.Mock> = {
-        leftJoinAndSelect: jest.fn().mockReturnThis(),
-        leftJoin: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        orderBy: jest.fn().mockReturnThis(),
-        addOrderBy: jest.fn().mockReturnThis(),
-        skip: jest.fn().mockReturnThis(),
-        take: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        setParameter: jest.fn().mockReturnThis(),
+      const mockQb: Record<string, jest.Mock> = {} as Record<string, jest.Mock>;
+      const executeBrackets = (condition: unknown) => {
+        if (condition instanceof Brackets) {
+          (condition as any).whereFactory(mockQb);
+        }
+      };
+      Object.assign(mockQb, {
+        leftJoinAndSelect: jest.fn().mockReturnValue(mockQb),
+        leftJoin: jest.fn().mockReturnValue(mockQb),
+        where: jest.fn().mockImplementation((condition: unknown) => {
+          executeBrackets(condition);
+          return mockQb;
+        }),
+        andWhere: jest.fn().mockImplementation((condition: unknown) => {
+          executeBrackets(condition);
+          return mockQb;
+        }),
+        orWhere: jest.fn().mockImplementation((condition: unknown) => {
+          executeBrackets(condition);
+          return mockQb;
+        }),
+        orderBy: jest.fn().mockReturnValue(mockQb),
+        addOrderBy: jest.fn().mockReturnValue(mockQb),
+        skip: jest.fn().mockReturnValue(mockQb),
+        take: jest.fn().mockReturnValue(mockQb),
+        select: jest.fn().mockReturnValue(mockQb),
+        addSelect: jest.fn().mockReturnValue(mockQb),
+        groupBy: jest.fn().mockReturnValue(mockQb),
+        setParameter: jest.fn().mockReturnValue(mockQb),
         getMany: jest.fn().mockResolvedValue([]),
         getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
         getCount: jest.fn().mockResolvedValue(0),
@@ -911,12 +927,12 @@ describe("TransactionsService", () => {
         getRawOne: jest.fn().mockResolvedValue(null),
         getQuery: jest.fn().mockReturnValue("SELECT 1"),
         getParameters: jest.fn().mockReturnValue({}),
-        limit: jest.fn().mockReturnThis(),
-        update: jest.fn().mockReturnThis(),
-        set: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnValue(mockQb),
+        update: jest.fn().mockReturnValue(mockQb),
+        set: jest.fn().mockReturnValue(mockQb),
         execute: jest.fn().mockResolvedValue({ affected: 0 }),
         ...overrides,
-      };
+      });
       return mockQb;
     };
 
@@ -1050,9 +1066,12 @@ describe("TransactionsService", () => {
       ]);
 
       expect(categoriesRepository.find).toHaveBeenCalled();
-      expect(mockQb.setParameter).toHaveBeenCalledWith(
-        "filterCategoryIds",
-        expect.arrayContaining(["cat-1", "cat-1-child"]),
+      // Category IDs are now passed inline via Brackets
+      expect(mockQb.where).toHaveBeenCalledWith(
+        "transaction.categoryId IN (:...filterCategoryIds)",
+        {
+          filterCategoryIds: expect.arrayContaining(["cat-1", "cat-1-child"]),
+        },
       );
     });
 
@@ -1075,8 +1094,10 @@ describe("TransactionsService", () => {
         "transaction.splits",
         "filterSplits",
       );
-      expect(mockQb.andWhere).toHaveBeenCalledWith(
+      // filterSplits reference is now inside a Brackets callback
+      expect(mockQb.orWhere).toHaveBeenCalledWith(
         expect.stringContaining("filterSplits.categoryId"),
+        expect.anything(),
       );
     });
 
@@ -1090,7 +1111,9 @@ describe("TransactionsService", () => {
         "uncategorized",
       ]);
 
-      expect(mockQb.andWhere).toHaveBeenCalledWith(
+      // Uncategorized condition is now inside a Brackets callback
+      expect(mockQb.andWhere).toHaveBeenCalledWith(expect.any(Brackets));
+      expect(mockQb.where).toHaveBeenCalledWith(
         expect.stringContaining("transaction.categoryId IS NULL"),
       );
     });
@@ -1105,8 +1128,10 @@ describe("TransactionsService", () => {
         "transfer",
       ]);
 
-      expect(mockQb.andWhere).toHaveBeenCalledWith(
-        expect.stringContaining("transaction.isTransfer = true"),
+      // Transfer condition is now inside a Brackets callback
+      expect(mockQb.andWhere).toHaveBeenCalledWith(expect.any(Brackets));
+      expect(mockQb.where).toHaveBeenCalledWith(
+        "transaction.isTransfer = true",
       );
     });
 
@@ -1125,9 +1150,13 @@ describe("TransactionsService", () => {
         "cat-1",
       ]);
 
-      // Should have a combined OR condition containing all three
-      expect(mockQb.andWhere).toHaveBeenCalledWith(
-        expect.stringContaining(" OR "),
+      // All three conditions are combined via Brackets
+      expect(mockQb.andWhere).toHaveBeenCalledWith(expect.any(Brackets));
+      expect(mockQb.where).toHaveBeenCalledWith(
+        expect.stringContaining("transaction.categoryId IS NULL"),
+      );
+      expect(mockQb.orWhere).toHaveBeenCalledWith(
+        "transaction.isTransfer = true",
       );
     });
 
@@ -1864,19 +1893,35 @@ describe("TransactionsService", () => {
 
   describe("getSummary", () => {
     const createMockQueryBuilder = (overrides?: Record<string, jest.Mock>) => {
-      const mockQb: Record<string, jest.Mock> = {
-        leftJoinAndSelect: jest.fn().mockReturnThis(),
-        leftJoin: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        orderBy: jest.fn().mockReturnThis(),
-        addOrderBy: jest.fn().mockReturnThis(),
-        skip: jest.fn().mockReturnThis(),
-        take: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        setParameter: jest.fn().mockReturnThis(),
+      const mockQb: Record<string, jest.Mock> = {} as Record<string, jest.Mock>;
+      const executeBrackets = (condition: unknown) => {
+        if (condition instanceof Brackets) {
+          (condition as any).whereFactory(mockQb);
+        }
+      };
+      Object.assign(mockQb, {
+        leftJoinAndSelect: jest.fn().mockReturnValue(mockQb),
+        leftJoin: jest.fn().mockReturnValue(mockQb),
+        where: jest.fn().mockImplementation((condition: unknown) => {
+          executeBrackets(condition);
+          return mockQb;
+        }),
+        andWhere: jest.fn().mockImplementation((condition: unknown) => {
+          executeBrackets(condition);
+          return mockQb;
+        }),
+        orWhere: jest.fn().mockImplementation((condition: unknown) => {
+          executeBrackets(condition);
+          return mockQb;
+        }),
+        orderBy: jest.fn().mockReturnValue(mockQb),
+        addOrderBy: jest.fn().mockReturnValue(mockQb),
+        skip: jest.fn().mockReturnValue(mockQb),
+        take: jest.fn().mockReturnValue(mockQb),
+        select: jest.fn().mockReturnValue(mockQb),
+        addSelect: jest.fn().mockReturnValue(mockQb),
+        groupBy: jest.fn().mockReturnValue(mockQb),
+        setParameter: jest.fn().mockReturnValue(mockQb),
         getMany: jest.fn().mockResolvedValue([]),
         getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
         getCount: jest.fn().mockResolvedValue(0),
@@ -1884,12 +1929,12 @@ describe("TransactionsService", () => {
         getRawOne: jest.fn().mockResolvedValue(null),
         getQuery: jest.fn().mockReturnValue("SELECT 1"),
         getParameters: jest.fn().mockReturnValue({}),
-        limit: jest.fn().mockReturnThis(),
-        update: jest.fn().mockReturnThis(),
-        set: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnValue(mockQb),
+        update: jest.fn().mockReturnValue(mockQb),
+        set: jest.fn().mockReturnValue(mockQb),
         execute: jest.fn().mockResolvedValue({ affected: 0 }),
         ...overrides,
-      };
+      });
       return mockQb;
     };
 
@@ -1988,7 +2033,9 @@ describe("TransactionsService", () => {
         "transaction.account",
         "summaryAccount",
       );
-      expect(mockQb.andWhere).toHaveBeenCalledWith(
+      // Uncategorized condition is now inside a Brackets callback
+      expect(mockQb.andWhere).toHaveBeenCalledWith(expect.any(Brackets));
+      expect(mockQb.where).toHaveBeenCalledWith(
         expect.stringContaining("transaction.categoryId IS NULL"),
       );
     });
@@ -2002,8 +2049,10 @@ describe("TransactionsService", () => {
         "transfer",
       ]);
 
-      expect(mockQb.andWhere).toHaveBeenCalledWith(
-        expect.stringContaining("transaction.isTransfer = true"),
+      // Transfer condition is now inside a Brackets callback
+      expect(mockQb.andWhere).toHaveBeenCalledWith(expect.any(Brackets));
+      expect(mockQb.where).toHaveBeenCalledWith(
+        "transaction.isTransfer = true",
       );
     });
 
@@ -2024,9 +2073,12 @@ describe("TransactionsService", () => {
         "transaction.splits",
         "splits",
       );
-      expect(mockQb.setParameter).toHaveBeenCalledWith(
-        "summaryCategoryIds",
-        expect.arrayContaining(["cat-1", "cat-child"]),
+      // Category IDs are now passed inline via Brackets
+      expect(mockQb.where).toHaveBeenCalledWith(
+        "transaction.categoryId IN (:...summaryCategoryIds)",
+        {
+          summaryCategoryIds: expect.arrayContaining(["cat-1", "cat-child"]),
+        },
       );
     });
 

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -6,7 +6,7 @@ import {
   Logger,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository, In, DataSource, QueryRunner } from "typeorm";
+import { Brackets, Repository, In, DataSource, QueryRunner } from "typeorm";
 import { Transaction, TransactionStatus } from "./entities/transaction.entity";
 import { TransactionSplit } from "./entities/transaction-split.entity";
 import { Category } from "../categories/entities/category.entity";
@@ -325,38 +325,56 @@ export class TransactionsService {
       (id) => id !== "uncategorized" && id !== "transfer",
     );
 
-    const conditions: string[] = [];
+    let hasCondition = false;
 
-    if (hasUncategorized) {
-      conditions.push(
-        "(transaction.categoryId IS NULL AND transaction.isSplit = false AND transaction.isTransfer = false AND account.accountType != 'INVESTMENT')",
-      );
-    }
-
-    if (hasTransfer) {
-      conditions.push("transaction.isTransfer = true");
-    }
-
-    if (regularCategoryIds.length > 0) {
-      const uniqueCategoryIds = await getAllCategoryIdsWithChildren(
-        this.categoriesRepository,
-        userId,
-        regularCategoryIds,
-      );
+    if (hasUncategorized || hasTransfer || regularCategoryIds.length > 0) {
+      const uniqueCategoryIds =
+        regularCategoryIds.length > 0
+          ? await getAllCategoryIdsWithChildren(
+              this.categoriesRepository,
+              userId,
+              regularCategoryIds,
+            )
+          : [];
 
       if (uniqueCategoryIds.length > 0) {
         // Use a separate join alias for filtering so the main "splits" join
         // (leftJoinAndSelect) still loads ALL splits for display purposes.
         queryBuilder.leftJoin("transaction.splits", "filterSplits");
-        conditions.push(
-          "(transaction.categoryId IN (:...filterCategoryIds) OR filterSplits.categoryId IN (:...filterCategoryIds))",
-        );
-        queryBuilder.setParameter("filterCategoryIds", uniqueCategoryIds);
       }
-    }
 
-    if (conditions.length > 0) {
-      queryBuilder.andWhere(`(${conditions.join(" OR ")})`);
+      queryBuilder.andWhere(
+        new Brackets((qb) => {
+          if (hasUncategorized) {
+            const method = hasCondition ? "orWhere" : "where";
+            hasCondition = true;
+            qb[method](
+              "transaction.categoryId IS NULL AND transaction.isSplit = false AND transaction.isTransfer = false AND account.accountType != 'INVESTMENT'",
+            );
+          }
+          if (hasTransfer) {
+            const method = hasCondition ? "orWhere" : "where";
+            hasCondition = true;
+            qb[method]("transaction.isTransfer = true");
+          }
+          if (uniqueCategoryIds.length > 0) {
+            const method = hasCondition ? "orWhere" : "where";
+            hasCondition = true;
+            qb[method](
+              new Brackets((inner) => {
+                inner
+                  .where("transaction.categoryId IN (:...filterCategoryIds)", {
+                    filterCategoryIds: uniqueCategoryIds,
+                  })
+                  .orWhere(
+                    "filterSplits.categoryId IN (:...filterCategoryIds)",
+                    { filterCategoryIds: uniqueCategoryIds },
+                  );
+              }),
+            );
+          }
+        }),
+      );
     }
   }
 


### PR DESCRIPTION
…to use Brackets

Add specific QueryFailedError handling to GlobalExceptionFilter so database constraint violations return appropriate HTTP status codes (409 for unique, 400 for foreign key) with generic messages, preventing constraint/column name leakage. Replace template-literal conditions.join(" OR ") patterns with TypeORM Brackets API across transaction-analytics, transactions, and transaction-bulk-update services for safer query construction.