### PR TITLE
feat: detect backend unavailability with banner, prevent false logout

### DIFF
--- a/frontend/src/app/accounts/page.test.tsx
+++ b/frontend/src/app/accounts/page.test.tsx
@@ -26,6 +26,7 @@ vi.mock('@/lib/logger', () => ({
 // Mock errors
 vi.mock('@/lib/errors', () => ({
   getErrorMessage: vi.fn((_e: any, fallback: string) => fallback),
+  showErrorToast: vi.fn(),
 }));
 
 // Mock auth store
@@ -303,10 +304,11 @@ describe('AccountsPage', () => {
   });
 
   it('handles API error gracefully', async () => {
+    const { showErrorToast } = await import('@/lib/errors');
     mockGetAll.mockRejectedValueOnce(new Error('Network error'));
     render(<AccountsPage />);
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('Failed to load accounts');
+      expect(showErrorToast).toHaveBeenCalledWith(expect.any(Error), 'Failed to load accounts');
     });
   });
 

--- a/frontend/src/app/accounts/page.tsx
+++ b/frontend/src/app/accounts/page.tsx
@@ -22,7 +22,7 @@ import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { createLogger } from '@/lib/logger';
-import { getErrorMessage } from '@/lib/errors';
+import { showErrorToast } from '@/lib/errors';
 
 const logger = createLogger('Accounts');
 
@@ -52,7 +52,7 @@ function AccountsContent() {
       setAccounts(data);
       setPortfolioSummary(portfolio);
     } catch (error) {
-      toast.error(getErrorMessage(error, 'Failed to load accounts'));
+      showErrorToast(error, 'Failed to load accounts');
       logger.error(error);
     } finally {
       setIsLoading(false);
@@ -99,7 +99,7 @@ function AccountsContent() {
       close();
       loadAccounts();
     } catch (error) {
-      toast.error(getErrorMessage(error, `Failed to ${editingItem ? 'update' : 'create'} account`));
+      showErrorToast(error, `Failed to ${editingItem ? 'update' : 'create'} account`);
       throw error;
     }
   };

--- a/frontend/src/app/transactions/page.test.tsx
+++ b/frontend/src/app/transactions/page.test.tsx
@@ -135,6 +135,7 @@ vi.mock('@/lib/constants', () => ({
 
 vi.mock('@/lib/errors', () => ({
   getErrorMessage: (_error: any, fallback: string) => fallback,
+  showErrorToast: vi.fn(),
 }));
 
 // Mock budgets API (used for category budget status indicators)
@@ -427,23 +428,25 @@ describe('TransactionsPage', () => {
     });
 
     it('shows error toast when loading fails', async () => {
+      const { showErrorToast } = await import('@/lib/errors');
       mockGetAll.mockRejectedValue(new Error('Network error'));
       mockGetSummary.mockRejectedValue(new Error('Network error'));
 
       render(<TransactionsPage />);
 
       await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith('Failed to load transactions');
+        expect(showErrorToast).toHaveBeenCalledWith(expect.any(Error), 'Failed to load transactions');
       });
     });
 
     it('shows error toast when static data loading fails', async () => {
+      const { showErrorToast } = await import('@/lib/errors');
       mockGetAllAccounts.mockRejectedValue(new Error('Error'));
 
       render(<TransactionsPage />);
 
       await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith('Failed to load form data');
+        expect(showErrorToast).toHaveBeenCalledWith(expect.any(Error), 'Failed to load form data');
       });
     });
   });
@@ -728,8 +731,9 @@ describe('TransactionsPage', () => {
 
       fireEvent.click(screen.getByTestId('payee-click-btn'));
 
+      const { showErrorToast } = await import('@/lib/errors');
       await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith('Failed to load payee details');
+        expect(showErrorToast).toHaveBeenCalledWith(expect.any(Error), 'Failed to load payee details');
       });
     });
   });

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -37,7 +37,7 @@ import { PageHeader } from '@/components/layout/PageHeader';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { createLogger } from '@/lib/logger';
-import { getErrorMessage } from '@/lib/errors';
+import { showErrorToast } from '@/lib/errors';
 import { PAGE_SIZE } from '@/lib/constants';
 import { budgetsApi } from '@/lib/budgets';
 import { CategoryBudgetStatus } from '@/types/budget';
@@ -99,7 +99,7 @@ function TransactionsContent() {
       setPayees(payeesData);
       staticDataLoaded.current = true;
     } catch (error) {
-      toast.error(getErrorMessage(error, 'Failed to load form data'));
+      showErrorToast(error, 'Failed to load form data');
       logger.error(error);
     }
   }, []);
@@ -180,7 +180,7 @@ function TransactionsContent() {
         budgetsApi.getCategoryBudgetStatus(categoryIds).then(setBudgetStatusMap).catch(() => {});
       }
     } catch (error) {
-      toast.error(getErrorMessage(error, 'Failed to load transactions'));
+      showErrorToast(error, 'Failed to load transactions');
       logger.error(error);
     } finally {
       setIsLoading(false);
@@ -281,7 +281,7 @@ function TransactionsContent() {
       setEditingPayee(payee);
       setShowPayeeForm(true);
     } catch (error) {
-      toast.error(getErrorMessage(error, 'Failed to load payee details'));
+      showErrorToast(error, 'Failed to load payee details');
       logger.error(error);
     }
   };
@@ -300,7 +300,7 @@ function TransactionsContent() {
       setEditingPayee(undefined);
       setPayees(prev => prev.map(p => p.id === updated.id ? updated : p));
     } catch (error) {
-      toast.error(getErrorMessage(error, 'Failed to update payee'));
+      showErrorToast(error, 'Failed to update payee');
     }
   };
 

--- a/frontend/src/components/layout/BackendDownBanner.test.tsx
+++ b/frontend/src/components/layout/BackendDownBanner.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { render, screen } from '@/test/render';
+import { BackendDownBanner } from './BackendDownBanner';
+import { useConnectionStore } from '@/store/connectionStore';
+
+describe('BackendDownBanner', () => {
+  beforeEach(() => {
+    useConnectionStore.setState({ isBackendDown: false, downSince: null });
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when backend is up', () => {
+    const { container } = render(<BackendDownBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders banner when backend is down', () => {
+    useConnectionStore.setState({ isBackendDown: true, downSince: Date.now() });
+    render(<BackendDownBanner />);
+    expect(screen.getByText('Connection Lost')).toBeInTheDocument();
+  });
+
+  it('displays retry message when down', () => {
+    useConnectionStore.setState({ isBackendDown: true, downSince: Date.now() });
+    render(<BackendDownBanner />);
+    expect(
+      screen.getByText(/Unable to reach the server\. Retrying automatically/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders Connection Lost label in bold', () => {
+    useConnectionStore.setState({ isBackendDown: true, downSince: Date.now() });
+    render(<BackendDownBanner />);
+    const label = screen.getByText('Connection Lost');
+    expect(label.tagName).toBe('SPAN');
+    expect(label.className).toContain('font-semibold');
+  });
+
+  it('uses red color scheme', () => {
+    useConnectionStore.setState({ isBackendDown: true, downSince: Date.now() });
+    const { container } = render(<BackendDownBanner />);
+    const banner = container.firstChild as HTMLElement;
+    expect(banner.className).toContain('bg-red-50');
+    expect(banner.className).toContain('text-red-800');
+  });
+
+  it('polls health endpoint every 5 seconds when down', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('fetch failed'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    useConnectionStore.setState({ isBackendDown: true, downSince: Date.now() });
+    render(<BackendDownBanner />);
+
+    // No fetch yet (first poll is after interval)
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Advance 5 seconds -- first poll
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/health/live', { cache: 'no-store' });
+
+    // Advance another 5 seconds -- second poll
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not poll when backend is up', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<BackendDownBanner />);
+
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reloads the page when health check succeeds', async () => {
+    const reloadMock = vi.fn();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload: reloadMock },
+      writable: true,
+    });
+
+    useConnectionStore.setState({ isBackendDown: true, downSince: Date.now() });
+    render(<BackendDownBanner />);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(reloadMock).toHaveBeenCalled();
+  });
+
+  it('continues polling when health check returns non-ok', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+    vi.stubGlobal('fetch', fetchMock);
+    const reloadMock = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload: reloadMock },
+      writable: true,
+    });
+
+    useConnectionStore.setState({ isBackendDown: true, downSince: Date.now() });
+    render(<BackendDownBanner />);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(reloadMock).not.toHaveBeenCalled();
+
+    // Continues polling
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('cleans up interval on unmount', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('fetch failed'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    useConnectionStore.setState({ isBackendDown: true, downSince: Date.now() });
+    const { unmount } = render(<BackendDownBanner />);
+
+    unmount();
+
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/layout/BackendDownBanner.tsx
+++ b/frontend/src/components/layout/BackendDownBanner.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useConnectionStore } from '@/store/connectionStore';
+
+const POLL_INTERVAL_MS = 5000;
+
+export function BackendDownBanner() {
+  const isBackendDown = useConnectionStore((s) => s.isBackendDown);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!isBackendDown) {
+      return;
+    }
+
+    async function pollHealth() {
+      try {
+        const res = await fetch('/api/v1/health/live', { cache: 'no-store' });
+        if (res.ok) {
+          // Backend is back -- full reload to refetch all data and auth state
+          window.location.reload();
+        }
+      } catch {
+        // Still unreachable
+      }
+    }
+
+    timerRef.current = setInterval(pollHealth, POLL_INTERVAL_MS);
+
+    return () => {
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [isBackendDown]);
+
+  if (!isBackendDown) return null;
+
+  return (
+    <div className="bg-red-50 dark:bg-red-900/30 border-b border-red-200 dark:border-red-800 px-4 py-2 text-center text-sm text-red-800 dark:text-red-200">
+      <span className="font-semibold">Connection Lost</span>
+      {' \u2014 '}
+      Unable to reach the server. Retrying automatically...
+    </div>
+  );
+}

--- a/frontend/src/components/layout/SwipeShell.test.tsx
+++ b/frontend/src/components/layout/SwipeShell.test.tsx
@@ -14,6 +14,11 @@ vi.mock('./AppHeader', () => ({
   AppHeader: () => <div data-testid="app-header">AppHeader</div>,
 }));
 
+// Mock BackendDownBanner
+vi.mock('./BackendDownBanner', () => ({
+  BackendDownBanner: () => <div data-testid="backend-down-banner">BackendDownBanner</div>,
+}));
+
 // Mock SwipeIndicator
 vi.mock('./SwipeIndicator', () => ({
   SwipeIndicator: (props: any) => (
@@ -62,5 +67,17 @@ describe('SwipeShell', () => {
     const { container } = render(<SwipeShell><p>Content</p></SwipeShell>);
     const wrapper = container.firstChild as HTMLElement;
     expect(wrapper.className).toContain('overflow-x-hidden');
+  });
+
+  it('renders BackendDownBanner on app pages', () => {
+    mockPathname = '/dashboard';
+    render(<SwipeShell><p>Content</p></SwipeShell>);
+    expect(screen.getByTestId('backend-down-banner')).toBeInTheDocument();
+  });
+
+  it('renders BackendDownBanner on auth routes', () => {
+    mockPathname = '/login';
+    render(<SwipeShell><p>Login form</p></SwipeShell>);
+    expect(screen.getByTestId('backend-down-banner')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/layout/SwipeShell.tsx
+++ b/frontend/src/components/layout/SwipeShell.tsx
@@ -3,6 +3,7 @@
 import { ReactNode } from 'react';
 import { usePathname } from 'next/navigation';
 import { AppHeader } from './AppHeader';
+import { BackendDownBanner } from './BackendDownBanner';
 import { DemoModeBanner } from './DemoModeBanner';
 import { SwipeIndicator } from './SwipeIndicator';
 import { useSwipeNavigation } from '@/hooks/useSwipeNavigation';
@@ -20,12 +21,18 @@ export function SwipeShell({ children }: SwipeShellProps) {
   const isAuthRoute = AUTH_ROUTES.some(r => pathname === r || pathname.startsWith(r + '/'));
 
   if (isAuthRoute) {
-    return <>{children}</>;
+    return (
+      <>
+        <BackendDownBanner />
+        {children}
+      </>
+    );
   }
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 overflow-x-hidden">
       <AppHeader />
+      <BackendDownBanner />
       <DemoModeBanner />
       <SwipeIndicator currentIndex={currentIndex} totalPages={totalPages} isSwipePage={isSwipePage} />
       <div ref={contentRef}>

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -26,6 +26,15 @@ vi.mock('@/lib/logger', () => ({
   }),
 }));
 
+const mockSetBackendDown = vi.fn();
+vi.mock('@/store/connectionStore', () => ({
+  useConnectionStore: {
+    getState: () => ({
+      setBackendDown: mockSetBackendDown,
+    }),
+  },
+}));
+
 describe('apiClient', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -210,6 +219,110 @@ describe('apiClient', () => {
       };
 
       await expect(errorHandler.rejected(mockError)).rejects.toEqual(mockError);
+    });
+
+    it('sets backend down on 502 response and rejects', async () => {
+      mockSetBackendDown.mockClear();
+      vi.resetModules();
+
+      vi.doMock('@/store/connectionStore', () => ({
+        useConnectionStore: {
+          getState: () => ({
+            setBackendDown: mockSetBackendDown,
+          }),
+        },
+      }));
+
+      const { apiClient: freshClient } = await import('@/lib/api');
+      const interceptors = freshClient.interceptors.response as any;
+      const handlers = interceptors.handlers;
+      const errorHandler = handlers.find((h: any) => h?.rejected);
+
+      const mockError = {
+        response: {
+          status: 502,
+          data: { error: 'Backend unavailable' },
+        },
+        config: {
+          headers: new AxiosHeaders(),
+        },
+      };
+
+      await expect(errorHandler.rejected(mockError)).rejects.toEqual(mockError);
+      expect(mockSetBackendDown).toHaveBeenCalled();
+    });
+
+    it('sets backend down on network error (no response) and rejects', async () => {
+      mockSetBackendDown.mockClear();
+      vi.resetModules();
+
+      vi.doMock('@/store/connectionStore', () => ({
+        useConnectionStore: {
+          getState: () => ({
+            setBackendDown: mockSetBackendDown,
+          }),
+        },
+      }));
+
+      const { apiClient: freshClient } = await import('@/lib/api');
+      const interceptors = freshClient.interceptors.response as any;
+      const handlers = interceptors.handlers;
+      const errorHandler = handlers.find((h: any) => h?.rejected);
+
+      const mockError = {
+        message: 'Network Error',
+        config: {
+          headers: new AxiosHeaders(),
+        },
+        // No response property -- network-level failure
+      };
+
+      await expect(errorHandler.rejected(mockError)).rejects.toEqual(mockError);
+      expect(mockSetBackendDown).toHaveBeenCalled();
+    });
+
+    it('does not attempt CSRF or token refresh on 502', async () => {
+      mockSetBackendDown.mockClear();
+      const axiosGetSpy = vi.spyOn(axios, 'get');
+      const axiosPostSpy = vi.spyOn(axios, 'post');
+
+      vi.resetModules();
+
+      vi.doMock('@/store/connectionStore', () => ({
+        useConnectionStore: {
+          getState: () => ({
+            setBackendDown: mockSetBackendDown,
+          }),
+        },
+      }));
+
+      const { apiClient: freshClient } = await import('@/lib/api');
+      const interceptors = freshClient.interceptors.response as any;
+      const handlers = interceptors.handlers;
+      const errorHandler = handlers.find((h: any) => h?.rejected);
+
+      const mockError = {
+        response: {
+          status: 502,
+          data: { error: 'Backend unavailable' },
+        },
+        config: {
+          headers: new AxiosHeaders(),
+        },
+      };
+
+      try {
+        await errorHandler.rejected(mockError);
+      } catch {
+        // Expected
+      }
+
+      // Should not have attempted CSRF refresh or token refresh
+      expect(axiosGetSpy).not.toHaveBeenCalledWith('/api/v1/auth/csrf-refresh', expect.anything());
+      expect(axiosPostSpy).not.toHaveBeenCalledWith('/api/v1/auth/refresh', expect.anything(), expect.anything());
+
+      axiosGetSpy.mockRestore();
+      axiosPostSpy.mockRestore();
     });
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -88,6 +88,13 @@ apiClient.interceptors.response.use(
       _authRetried?: boolean;
     };
 
+    // Handle 502 (backend unavailable) or network errors (no response at all)
+    if (error.response?.status === 502 || !error.response) {
+      const { useConnectionStore } = await import('@/store/connectionStore');
+      useConnectionStore.getState().setBackendDown();
+      return Promise.reject(error);
+    }
+
     // Handle 403 CSRF errors — attempt transparent refresh and retry
     if (
       error.response?.status === 403 &&

--- a/frontend/src/lib/errors.test.ts
+++ b/frontend/src/lib/errors.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AxiosError, AxiosHeaders } from 'axios';
+import toast from 'react-hot-toast';
+import { showErrorToast, getErrorMessage } from './errors';
+
+describe('showErrorToast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('suppresses toast on 502 AxiosError', () => {
+    const error = new AxiosError('Bad Gateway', '502', undefined, undefined, {
+      status: 502,
+      data: { error: 'Backend unavailable' },
+      statusText: 'Bad Gateway',
+      headers: {},
+      config: { headers: new AxiosHeaders() },
+    });
+
+    showErrorToast(error, 'Something failed');
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('suppresses toast on network error (no response)', () => {
+    const error = new AxiosError('Network Error');
+    // Network errors have no response property
+
+    showErrorToast(error, 'Something failed');
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('shows toast for non-502 AxiosError', () => {
+    const error = new AxiosError('Not Found', '404', undefined, undefined, {
+      status: 404,
+      data: { message: 'Resource not found' },
+      statusText: 'Not Found',
+      headers: {},
+      config: { headers: new AxiosHeaders() },
+    });
+
+    showErrorToast(error, 'Fallback message');
+
+    expect(toast.error).toHaveBeenCalledWith('Resource not found');
+  });
+
+  it('shows toast with fallback for AxiosError without server message', () => {
+    const error = new AxiosError('Server Error', '500', undefined, undefined, {
+      status: 500,
+      data: {},
+      statusText: 'Internal Server Error',
+      headers: {},
+      config: { headers: new AxiosHeaders() },
+    });
+
+    showErrorToast(error, 'Something went wrong');
+
+    expect(toast.error).toHaveBeenCalledWith('Something went wrong');
+  });
+
+  it('shows toast for generic Error', () => {
+    const error = new Error('Unexpected failure');
+
+    showErrorToast(error, 'Fallback');
+
+    expect(toast.error).toHaveBeenCalledWith('Unexpected failure');
+  });
+
+  it('shows toast with fallback for unknown error types', () => {
+    showErrorToast('string error', 'Fallback message');
+
+    expect(toast.error).toHaveBeenCalledWith('Fallback message');
+  });
+});
+
+describe('getErrorMessage', () => {
+  it('extracts message from AxiosError response', () => {
+    const error = new AxiosError('Bad Request', '400', undefined, undefined, {
+      status: 400,
+      data: { message: 'Validation failed' },
+      statusText: 'Bad Request',
+      headers: {},
+      config: { headers: new AxiosHeaders() },
+    });
+
+    expect(getErrorMessage(error, 'Fallback')).toBe('Validation failed');
+  });
+
+  it('returns fallback when AxiosError has no message in response', () => {
+    const error = new AxiosError('Server Error', '500', undefined, undefined, {
+      status: 500,
+      data: {},
+      statusText: 'Internal Server Error',
+      headers: {},
+      config: { headers: new AxiosHeaders() },
+    });
+
+    expect(getErrorMessage(error, 'Fallback')).toBe('Fallback');
+  });
+
+  it('extracts message from generic Error', () => {
+    expect(getErrorMessage(new Error('Something broke'), 'Fallback')).toBe('Something broke');
+  });
+
+  it('returns fallback for unknown error types', () => {
+    expect(getErrorMessage(42, 'Fallback')).toBe('Fallback');
+    expect(getErrorMessage(null, 'Fallback')).toBe('Fallback');
+  });
+});

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -1,4 +1,15 @@
 import { AxiosError } from 'axios';
+import toast from 'react-hot-toast';
+
+/**
+ * Shows an error toast unless the error is a 502 / network error (handled by BackendDownBanner).
+ */
+export function showErrorToast(error: unknown, fallback: string): void {
+  if (error instanceof AxiosError && (error.response?.status === 502 || !error.response)) {
+    return;
+  }
+  toast.error(getErrorMessage(error, fallback));
+}
 
 /**
  * Extracts a user-friendly error message from an error caught in a try/catch block.

--- a/frontend/src/store/authStore.test.ts
+++ b/frontend/src/store/authStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useAuthStore } from './authStore';
 
 describe('authStore', () => {
@@ -113,6 +113,131 @@ describe('authStore', () => {
       // Access the persist API to check partialize config
       const persistOptions = (store as any).persist;
       expect(persistOptions).toBeDefined();
+    });
+  });
+
+  describe('rehydration 502 handling', () => {
+    it('keeps authenticated state on 502 error and sets backend down', async () => {
+      const { AxiosError, AxiosHeaders } = await import('axios');
+      const { useConnectionStore } = await import('@/store/connectionStore');
+      useConnectionStore.setState({ isBackendDown: false, downSince: null });
+
+      // Simulate: user was authenticated, profile fetch returns 502
+      useAuthStore.setState({
+        isAuthenticated: true,
+        user: null,
+        _hasHydrated: false,
+        isLoading: true,
+      });
+
+      const error502 = new AxiosError('Bad Gateway', '502', undefined, undefined, {
+        status: 502,
+        data: { error: 'Backend unavailable' },
+        statusText: 'Bad Gateway',
+        headers: {},
+        config: { headers: new AxiosHeaders() },
+      });
+
+      // Access the persist config to get the onRehydrateStorage callback
+      const persistApi = (useAuthStore as any).persist;
+      const options = persistApi.getOptions();
+      const onRehydrate = options.onRehydrateStorage();
+
+      // Mock the auth module to return 502
+      vi.doMock('@/lib/auth', () => ({
+        authApi: {
+          getProfile: vi.fn().mockRejectedValue(error502),
+        },
+      }));
+
+      // Call onRehydrate with the current state
+      onRehydrate(useAuthStore.getState());
+
+      // Wait for async operations (dynamic import + catch handler)
+      await new Promise(r => setTimeout(r, 50));
+
+      const state = useAuthStore.getState();
+      expect(state.isAuthenticated).toBe(true);
+      expect(state._hasHydrated).toBe(true);
+      expect(useConnectionStore.getState().isBackendDown).toBe(true);
+
+      vi.doUnmock('@/lib/auth');
+    });
+
+    it('logs out on non-502 error during rehydration', async () => {
+      const { AxiosError, AxiosHeaders } = await import('axios');
+
+      useAuthStore.setState({
+        isAuthenticated: true,
+        user: null,
+        _hasHydrated: false,
+        isLoading: true,
+      });
+
+      const error401 = new AxiosError('Unauthorized', '401', undefined, undefined, {
+        status: 401,
+        data: { message: 'Session expired' },
+        statusText: 'Unauthorized',
+        headers: {},
+        config: { headers: new AxiosHeaders() },
+      });
+
+      const persistApi = (useAuthStore as any).persist;
+      const options = persistApi.getOptions();
+      const onRehydrate = options.onRehydrateStorage();
+
+      vi.doMock('@/lib/auth', () => ({
+        authApi: {
+          getProfile: vi.fn().mockRejectedValue(error401),
+        },
+      }));
+
+      onRehydrate(useAuthStore.getState());
+
+      await new Promise(r => setTimeout(r, 50));
+
+      const state = useAuthStore.getState();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state._hasHydrated).toBe(true);
+
+      vi.doUnmock('@/lib/auth');
+    });
+
+    it('keeps authenticated state on network error (no response)', async () => {
+      const { AxiosError } = await import('axios');
+      const { useConnectionStore } = await import('@/store/connectionStore');
+      useConnectionStore.setState({ isBackendDown: false, downSince: null });
+
+      useAuthStore.setState({
+        isAuthenticated: true,
+        user: null,
+        _hasHydrated: false,
+        isLoading: true,
+      });
+
+      // Network error: AxiosError with no response
+      const networkError = new AxiosError('Network Error');
+
+      const persistApi = (useAuthStore as any).persist;
+      const options = persistApi.getOptions();
+      const onRehydrate = options.onRehydrateStorage();
+
+      vi.doMock('@/lib/auth', () => ({
+        authApi: {
+          getProfile: vi.fn().mockRejectedValue(networkError),
+        },
+      }));
+
+      onRehydrate(useAuthStore.getState());
+
+      await new Promise(r => setTimeout(r, 50));
+
+      const state = useAuthStore.getState();
+      expect(state.isAuthenticated).toBe(true);
+      expect(state._hasHydrated).toBe(true);
+      expect(useConnectionStore.getState().isBackendDown).toBe(true);
+
+      vi.doUnmock('@/lib/auth');
     });
   });
 });

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { AxiosError } from 'axios';
 import { User } from '@/types/auth';
 import { clearAllCache } from '@/lib/apiCache';
 
@@ -88,10 +89,23 @@ export const useAuthStore = create<AuthState>()(
             authApi.getProfile().then((user: User) => {
               state.setUser(user);
               state.setHasHydrated(true);
-            }).catch(() => {
-              // Profile fetch failed (session expired) — log out
-              state.logout();
-              state.setHasHydrated(true);
+            }).catch((error: unknown) => {
+              const status = error instanceof AxiosError ? error.response?.status : undefined;
+              if (status === 502 || (error instanceof AxiosError && !error.response)) {
+                // Backend unreachable -- keep isAuthenticated from localStorage so the app
+                // shell renders with the BackendDownBanner visible. This is safe because:
+                // (a) all API calls fail with 502 during downtime (no data access)
+                // (b) window.location.reload() on recovery forces full re-auth via getProfile()
+                // (c) if JWT/refresh token expired, the 401 interceptor triggers logout
+                import('@/store/connectionStore').then(({ useConnectionStore }) => {
+                  useConnectionStore.getState().setBackendDown();
+                });
+                state.setHasHydrated(true);
+              } else {
+                // Genuine auth failure (401, etc.) — log out
+                state.logout();
+                state.setHasHydrated(true);
+              }
             });
           });
         } else {

--- a/frontend/src/store/connectionStore.test.ts
+++ b/frontend/src/store/connectionStore.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useConnectionStore } from './connectionStore';
+
+describe('connectionStore', () => {
+  beforeEach(() => {
+    useConnectionStore.setState({ isBackendDown: false, downSince: null });
+  });
+
+  it('initializes with backend up', () => {
+    const state = useConnectionStore.getState();
+    expect(state.isBackendDown).toBe(false);
+    expect(state.downSince).toBeNull();
+  });
+
+  it('sets backend down with timestamp', () => {
+    const before = Date.now();
+    useConnectionStore.getState().setBackendDown();
+    const state = useConnectionStore.getState();
+    expect(state.isBackendDown).toBe(true);
+    expect(state.downSince).toBeGreaterThanOrEqual(before);
+    expect(state.downSince).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('guards against redundant setBackendDown calls', () => {
+    useConnectionStore.getState().setBackendDown();
+    const firstDownSince = useConnectionStore.getState().downSince;
+
+    // Second call should be a no-op (guard prevents redundant updates)
+    useConnectionStore.getState().setBackendDown();
+    const secondDownSince = useConnectionStore.getState().downSince;
+
+    expect(secondDownSince).toBe(firstDownSince);
+  });
+
+  it('sets backend up and clears timestamp', () => {
+    useConnectionStore.getState().setBackendDown();
+    expect(useConnectionStore.getState().isBackendDown).toBe(true);
+
+    useConnectionStore.getState().setBackendUp();
+    const state = useConnectionStore.getState();
+    expect(state.isBackendDown).toBe(false);
+    expect(state.downSince).toBeNull();
+  });
+
+  it('allows setting down again after recovery', () => {
+    useConnectionStore.getState().setBackendDown();
+    useConnectionStore.getState().setBackendUp();
+    useConnectionStore.getState().setBackendDown();
+
+    expect(useConnectionStore.getState().isBackendDown).toBe(true);
+    expect(useConnectionStore.getState().downSince).not.toBeNull();
+  });
+});

--- a/frontend/src/store/connectionStore.ts
+++ b/frontend/src/store/connectionStore.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand';
+
+interface ConnectionState {
+  isBackendDown: boolean;
+  downSince: number | null;
+  setBackendDown: () => void;
+  setBackendUp: () => void;
+}
+
+export const useConnectionStore = create<ConnectionState>()((set, get) => ({
+  isBackendDown: false,
+  downSince: null,
+  setBackendDown: () => {
+    if (get().isBackendDown) return;
+    set({ isBackendDown: true, downSince: Date.now() });
+  },
+  setBackendUp: () => {
+    set({ isBackendDown: false, downSince: null });
+  },
+}));


### PR DESCRIPTION
When the backend becomes unreachable (502 or network error), the app now shows a persistent red "Connection Lost" banner instead of logging the user out. Health polling auto-detects recovery and triggers a full page reload to restore all data.

- Add connectionStore (Zustand) to track backend-down state
- Add BackendDownBanner with 5s health polling via raw fetch
- Add 502/network error detection in axios response interceptor
- Prevent authStore rehydration from logging out on 502
- Add showErrorToast helper to suppress toasts during outages
- Mount banner in SwipeShell for both auth and app routes
- Migrate accounts/transactions pages to showErrorToast
- Full test coverage across all new and modified modules