### PR TITLE
fix: handle QIF dates with apostrophe before 4-digit year (DD/MM'YYYY)

### DIFF
--- a/backend/src/import/qif-parser.spec.ts
+++ b/backend/src/import/qif-parser.spec.ts
@@ -548,6 +548,55 @@ T-50.00
     });
   });
 
+  describe("parseQif - DD/MM'YYYY format with apostrophe before 4-digit year", () => {
+    it("parses date with apostrophe before 4-digit year as DD/MM/YYYY", () => {
+      const qif = `!Type:Bank
+D08/03'2010
+T0.00
+^`;
+      const result = parseQif(qif, "DD/MM/YYYY");
+      expect(result.transactions[0].date).toBe("2010-03-08");
+    });
+
+    it("parses multiple transactions with apostrophe 4-digit year format", () => {
+      const qif = `!Type:Bank
+D08/03'2010
+T150.00
+PCash Deposit
+^
+D11/03'2010
+T521.48
+PNFT Distribution LTD
+^
+D12/03'2010
+T-20.00
+PCash Withdrawal
+^`;
+      const result = parseQif(qif, "DD/MM/YYYY");
+      expect(result.transactions[0].date).toBe("2010-03-08");
+      expect(result.transactions[1].date).toBe("2010-03-11");
+      expect(result.transactions[2].date).toBe("2010-03-12");
+    });
+
+    it("auto-detects DD/MM/YYYY from apostrophe format when day > 12", () => {
+      const qif = `!Type:Bank
+D15/03'2010
+T-50.00
+^`;
+      const result = parseQif(qif);
+      expect(result.detectedDateFormat).toBe("DD/MM/YYYY");
+    });
+
+    it("parses apostrophe 4-digit year with MM/DD/YYYY format", () => {
+      const qif = `!Type:Bank
+D03/15'2010
+T-50.00
+^`;
+      const result = parseQif(qif, "MM/DD/YYYY");
+      expect(result.transactions[0].date).toBe("2010-03-15");
+    });
+  });
+
   describe("parseQif - 2-digit year boundary (year 49 vs 50)", () => {
     it("treats year 50 as 2050", () => {
       const qif = `!Type:Bank

--- a/backend/src/import/qif-parser.ts
+++ b/backend/src/import/qif-parser.ts
@@ -363,11 +363,25 @@ export function parseQif(
   };
 }
 
+function normalizeDateSeparators(dateStr: string): string {
+  // Remove wrapping quotes and trim
+  let normalized = dateStr.replace(/^['"]|['"]$/g, "").trim();
+  // Normalize apostrophe/quote used as date separator to '/'
+  // Handles formats like DD/MM'YYYY and M/D'YY
+  normalized = normalized.replace(/(\d)['"](\d)/g, "$1/$2");
+  return normalized;
+}
+
 function detectDateFormat(dates: string[]): DateFormat {
   if (dates.length === 0) return "MM/DD/YYYY";
 
+  // Normalize separators so apostrophe formats (e.g. DD/MM'YYYY) are handled
+  const normalizedDates = dates.map(normalizeDateSeparators);
+
   // Check for YYYY-MM-DD or YYYY-DD-MM format (ISO-like)
-  const isoMatch = dates[0]?.match(/^(\d{4})[-/](\d{1,2})[-/](\d{1,2})$/);
+  const isoMatch = normalizedDates[0]?.match(
+    /^(\d{4})[-/](\d{1,2})[-/](\d{1,2})$/,
+  );
   if (isoMatch) {
     const [, , part2, part3] = isoMatch;
     const p2 = parseInt(part2);
@@ -379,7 +393,7 @@ function detectDateFormat(dates: string[]): DateFormat {
     if (p3 > 12) return "YYYY-MM-DD";
 
     // Check multiple dates to make a better guess
-    for (const date of dates.slice(0, 10)) {
+    for (const date of normalizedDates.slice(0, 10)) {
       const m = date.match(/^(\d{4})[-/](\d{1,2})[-/](\d{1,2})$/);
       if (m) {
         if (parseInt(m[2]) > 12) return "YYYY-DD-MM";
@@ -392,7 +406,7 @@ function detectDateFormat(dates: string[]): DateFormat {
   }
 
   // Check for MM/DD/YYYY or DD/MM/YYYY format
-  for (const date of dates.slice(0, 10)) {
+  for (const date of normalizedDates.slice(0, 10)) {
     const match = date.match(/^(\d{1,2})[-/](\d{1,2})[-/](\d{2,4})$/);
     if (match) {
       const [, part1, part2] = match;
@@ -411,8 +425,7 @@ function detectDateFormat(dates: string[]): DateFormat {
 }
 
 function parseQifDate(dateStr: string, format?: DateFormat): string {
-  // Remove any quotes
-  dateStr = dateStr.replace(/['"]/g, "").trim();
+  dateStr = normalizeDateSeparators(dateStr);
 
   // Try YYYY-MM-DD or YYYY-DD-MM format (ISO-like)
   let match = dateStr.match(/^(\d{4})[-/](\d{1,2})[-/](\d{1,2})$/);
@@ -455,25 +468,6 @@ function parseQifDate(dateStr: string, format?: DateFormat): string {
     }
 
     return `${year}-${month}-${day}`;
-  }
-
-  // Try alternate format with apostrophe for year: M/D'YY
-  match = dateStr.match(/^(\d{1,2})[-/](\d{1,2})['"]?(\d{2})$/);
-  if (match) {
-    const [, part1, part2, year] = match;
-    const yearNum = parseInt(year);
-    const fullYear = yearNum > 50 ? `19${year}` : `20${year}`;
-
-    let month: string, day: string;
-    if (format === "DD/MM/YYYY") {
-      day = part1.padStart(2, "0");
-      month = part2.padStart(2, "0");
-    } else {
-      month = part1.padStart(2, "0");
-      day = part2.padStart(2, "0");
-    }
-
-    return `${fullYear}-${month}-${day}`;
   }
 
   // Return as-is if can't parse


### PR DESCRIPTION
Normalize apostrophe/quote date separators to '/' early in parsing so formats like 08/03'2010 are correctly handled by both date detection and date parsing. Removes now-redundant apostrophe-specific regex block since normalization covers both 2-digit and 4-digit year cases.

https://claude.ai/code/session_01Cp9XBpoQCrmbJqTe33ufK5