### PR TITLE
Add currency-aware formatting to balance history and cash flow forecast charts

### DIFF
--- a/backend/src/accounts/accounts.service.ts
+++ b/backend/src/accounts/accounts.service.ts
@@ -832,7 +832,14 @@ export class AccountsService {
     startDate?: string,
     endDate?: string,
     accountIds?: string[],
-  ): Promise<Array<{ date: string; balance: number }>> {
+  ): Promise<
+    Array<{
+      date: string;
+      balance: number;
+      accountId: string;
+      currencyCode: string;
+    }>
+  > {
     const end = endDate || todayYMD();
     const start =
       startDate ||
@@ -845,10 +852,14 @@ export class AccountsService {
     const accountIdsParam =
       accountIds && accountIds.length > 0 ? accountIds : null;
 
-    const rows: Array<{ date: string; balance: string }> =
-      await this.dataSource.query(
-        `WITH target_accounts AS (
-          SELECT id, opening_balance
+    const rows: Array<{
+      date: string;
+      balance: string;
+      account_id: string;
+      currency_code: string;
+    }> = await this.dataSource.query(
+      `WITH target_accounts AS (
+          SELECT id, opening_balance, currency_code
           FROM accounts
           WHERE user_id = $1
             AND ($2::UUID[] IS NULL OR id = ANY($2::UUID[]))
@@ -878,6 +889,7 @@ export class AccountsService {
         account_daily AS (
           SELECT d.dt::DATE as date,
                  ta.id as account_id,
+                 ta.currency_code,
                  (ta.opening_balance + COALESCE(pp.total, 0) +
                    COALESCE(SUM(dtx.total) OVER (
                      PARTITION BY ta.id ORDER BY d.dt
@@ -889,16 +901,17 @@ export class AccountsService {
           LEFT JOIN pre_period pp ON pp.account_id = ta.id
           LEFT JOIN daily_tx dtx ON dtx.account_id = ta.id AND dtx.tx_date = d.dt::DATE
         )
-        SELECT date::TEXT, SUM(balance)::NUMERIC as balance
+        SELECT date::TEXT, balance::NUMERIC, account_id, currency_code
         FROM account_daily
-        GROUP BY date
-        ORDER BY date`,
-        [userId, accountIdsParam, start, end],
-      );
+        ORDER BY date, account_id`,
+      [userId, accountIdsParam, start, end],
+    );
 
     return rows.map((r) => ({
       date: r.date,
       balance: Number(r.balance),
+      accountId: r.account_id,
+      currencyCode: r.currency_code,
     }));
   }
 

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -29,6 +29,7 @@ import { Payee } from '@/types/payee';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useDateFormat } from '@/hooks/useDateFormat';
 import { usePreferencesStore } from '@/store/preferencesStore';
+import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useFormModal } from '@/hooks/useFormModal';
 import { Modal } from '@/components/ui/Modal';
 import { UnsavedChangesDialog } from '@/components/ui/UnsavedChangesDialog';
@@ -56,11 +57,13 @@ function TransactionsContent() {
   const router = useRouter();
   const { formatDate } = useDateFormat();
   const weekStartsOn = (usePreferencesStore((s) => s.preferences?.weekStartsOn) ?? 1) as 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  const defaultCurrency = usePreferencesStore((s) => s.preferences?.defaultCurrency) || 'CAD';
+  const { convertToDefault } = useExchangeRates();
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [payees, setPayees] = useState<Payee[]>([]);
-  const [dailyBalances, setDailyBalances] = useState<Array<{ date: string; balance: number }>>([]);
+  const [dailyBalances, setDailyBalances] = useState<Array<{ date: string; balance: number; accountId: string; currencyCode: string }>>([]);
   const [monthlyTotals, setMonthlyTotals] = useState<MonthlyTotal[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const { showForm, editingItem: editingTransaction, openCreate, openEdit, close, modalProps, setFormDirty, unsavedChangesDialog, formSubmitRef } = useFormModal<Transaction>();
@@ -135,7 +138,7 @@ function TransactionsContent() {
           }).catch(() => [] as MonthlyTotal[])
         : accountsApi.getDailyBalances(
             Object.keys(chartParams).length > 0 ? chartParams : undefined,
-          ).catch(() => [] as Array<{ date: string; balance: number }>);
+          ).catch(() => [] as Array<{ date: string; balance: number; accountId: string; currencyCode: string }>);
 
       const [transactionsResponse, chartResult] = await Promise.all([
         transactionsApi.getAll({
@@ -160,7 +163,7 @@ function TransactionsContent() {
         setMonthlyTotals(chartResult as MonthlyTotal[]);
         setDailyBalances([]);
       } else {
-        setDailyBalances(chartResult as Array<{ date: string; balance: number }>);
+        setDailyBalances(chartResult as Array<{ date: string; balance: number; accountId: string; currencyCode: string }>);
         setMonthlyTotals([]);
       }
 
@@ -334,6 +337,27 @@ function TransactionsContent() {
     return f;
   }, [filters.filterAccountIds, filters.filterAccountStatus, filters.filteredAccounts, filters.filterCategoryIds, filters.filterPayeeIds, filters.filterStartDate, filters.filterEndDate, filters.filterSearch]);
 
+  // Derive chart currency and aggregate per-account daily balances
+  const { chartBalances, chartCurrency } = useMemo(() => {
+    if (dailyBalances.length === 0) return { chartBalances: [] as Array<{ date: string; balance: number }>, chartCurrency: defaultCurrency };
+
+    const currencies = new Set(dailyBalances.map((r) => r.currencyCode));
+    const isSingleCurrency = currencies.size === 1;
+    const displayCurrency = isSingleCurrency ? [...currencies][0] : defaultCurrency;
+
+    const byDate = new Map<string, number>();
+    for (const row of dailyBalances) {
+      const amount = isSingleCurrency ? row.balance : convertToDefault(row.balance, row.currencyCode);
+      byDate.set(row.date, (byDate.get(row.date) ?? 0) + amount);
+    }
+
+    const aggregated = [...byDate.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, balance]) => ({ date, balance }));
+
+    return { chartBalances: aggregated, chartCurrency: displayCurrency };
+  }, [dailyBalances, defaultCurrency, convertToDefault]);
+
   const selection = useTransactionSelection(
     transactions,
     pagination?.total ?? 0,
@@ -374,7 +398,7 @@ function TransactionsContent() {
             filters.setFilterTimePeriod('custom');
           }} />
         ) : (
-          <BalanceHistoryChart data={dailyBalances} isLoading={isLoading} />
+          <BalanceHistoryChart data={chartBalances} isLoading={isLoading} currencyCode={chartCurrency} />
         )}
 
         {/* Form Modal */}

--- a/frontend/src/components/bills/CashFlowForecastChart.test.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.test.tsx
@@ -13,10 +13,22 @@ vi.mock('recharts', () => ({
   ReferenceLine: () => <div data-testid="reference-line" />,
 }));
 
+const mockFormatCurrencyCompact = vi.fn((n: number, _code?: string) => `$${n.toFixed(0)}`);
+const mockFormatCurrencyAxis = vi.fn((n: number, _code?: string) => `$${n}`);
+
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
-    formatCurrencyCompact: (n: number) => `$${n.toFixed(0)}`,
-    formatCurrencyAxis: (n: number) => `$${n}`,
+    formatCurrencyCompact: mockFormatCurrencyCompact,
+    formatCurrencyAxis: mockFormatCurrencyAxis,
+  }),
+}));
+
+const mockConvertToDefault = vi.fn((amount: number, _currency: string) => amount * 1.35);
+
+vi.mock('@/hooks/useExchangeRates', () => ({
+  useExchangeRates: () => ({
+    convertToDefault: mockConvertToDefault,
+    defaultCurrency: 'CAD',
   }),
 }));
 
@@ -39,6 +51,16 @@ vi.mock('@/lib/forecast', () => ({
     year: '1Y',
   },
 }));
+
+const makeAccount = (overrides: Record<string, any> = {}) => ({
+  id: 'a1',
+  name: 'Checking',
+  isClosed: false,
+  accountType: 'CHEQUING',
+  accountSubType: null,
+  currencyCode: 'CAD',
+  ...overrides,
+}) as any;
 
 describe('CashFlowForecastChart', () => {
   beforeEach(() => {
@@ -76,12 +98,8 @@ describe('CashFlowForecastChart', () => {
   });
 
   it('shows "No scheduled transactions" when accounts exist but no scheduled transactions', () => {
-    const accounts = [
-      { id: 'a1', name: 'Checking', isClosed: false, accountType: 'CHEQUING', accountSubType: null },
-    ] as any[];
-
     render(
-      <CashFlowForecastChart scheduledTransactions={[]} accounts={accounts} isLoading={false} />
+      <CashFlowForecastChart scheduledTransactions={[]} accounts={[makeAccount()]} isLoading={false} />
     );
     expect(screen.getByText('No scheduled transactions')).toBeInTheDocument();
   });
@@ -118,7 +136,7 @@ describe('CashFlowForecastChart', () => {
     });
 
     render(
-      <CashFlowForecastChart scheduledTransactions={[{} as any]} accounts={[{ id: 'a1', name: 'Checking', isClosed: false, accountType: 'CHEQUING', accountSubType: null } as any]} isLoading={false} />
+      <CashFlowForecastChart scheduledTransactions={[{} as any]} accounts={[makeAccount()]} isLoading={false} />
     );
     expect(screen.getByText('Starting')).toBeInTheDocument();
     expect(screen.getByText('Ending')).toBeInTheDocument();
@@ -136,7 +154,7 @@ describe('CashFlowForecastChart', () => {
     mockBuildForecast.mockReturnValue(forecastData);
 
     render(
-      <CashFlowForecastChart scheduledTransactions={[{} as any]} accounts={[{ id: 'a1', name: 'Checking', isClosed: false, accountType: 'CHEQUING', accountSubType: null } as any]} isLoading={false} />
+      <CashFlowForecastChart scheduledTransactions={[{} as any]} accounts={[makeAccount()]} isLoading={false} />
     );
     expect(screen.getByText('2 scheduled transactions in forecast')).toBeInTheDocument();
   });
@@ -155,7 +173,7 @@ describe('CashFlowForecastChart', () => {
     });
 
     render(
-      <CashFlowForecastChart scheduledTransactions={[{} as any]} accounts={[{ id: 'a1', name: 'Checking', isClosed: false, accountType: 'CHEQUING', accountSubType: null } as any]} isLoading={false} />
+      <CashFlowForecastChart scheduledTransactions={[{} as any]} accounts={[makeAccount()]} isLoading={false} />
     );
     expect(screen.getByText('Lowest')).toBeInTheDocument();
     expect(screen.getByText('!')).toBeInTheDocument();
@@ -175,7 +193,7 @@ describe('CashFlowForecastChart', () => {
     });
 
     render(
-      <CashFlowForecastChart scheduledTransactions={[{} as any]} accounts={[{ id: 'a1', name: 'Checking', isClosed: false, accountType: 'CHEQUING', accountSubType: null } as any]} isLoading={false} />
+      <CashFlowForecastChart scheduledTransactions={[{} as any]} accounts={[makeAccount()]} isLoading={false} />
     );
     expect(screen.getByText('No upcoming transactions in this period - showing current balance')).toBeInTheDocument();
   });
@@ -191,9 +209,9 @@ describe('CashFlowForecastChart', () => {
 
   it('shows accounts in the account selector dropdown', () => {
     const accounts = [
-      { id: 'a1', name: 'Checking', isClosed: false, accountType: 'CHEQUING', accountSubType: null },
-      { id: 'a2', name: 'Savings', isClosed: false, accountType: 'SAVINGS', accountSubType: null },
-    ] as any[];
+      makeAccount({ id: 'a1', name: 'Checking' }),
+      makeAccount({ id: 'a2', name: 'Savings', accountType: 'SAVINGS' }),
+    ];
 
     render(
       <CashFlowForecastChart scheduledTransactions={[]} accounts={accounts} isLoading={false} />
@@ -204,11 +222,11 @@ describe('CashFlowForecastChart', () => {
 
   it('filters out closed and asset/investment accounts from selector', () => {
     const accounts = [
-      { id: 'a1', name: 'Checking', isClosed: false, accountType: 'CHEQUING', accountSubType: null },
-      { id: 'a2', name: 'Closed Account', isClosed: true, accountType: 'CHEQUING', accountSubType: null },
-      { id: 'a3', name: 'House', isClosed: false, accountType: 'ASSET', accountSubType: null },
-      { id: 'a4', name: 'Brokerage', isClosed: false, accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_BROKERAGE' },
-    ] as any[];
+      makeAccount({ id: 'a1', name: 'Checking' }),
+      makeAccount({ id: 'a2', name: 'Closed Account', isClosed: true }),
+      makeAccount({ id: 'a3', name: 'House', accountType: 'ASSET' }),
+      makeAccount({ id: 'a4', name: 'Brokerage', accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_BROKERAGE' }),
+    ];
 
     render(
       <CashFlowForecastChart scheduledTransactions={[]} accounts={accounts} isLoading={false} />
@@ -219,9 +237,7 @@ describe('CashFlowForecastChart', () => {
   });
 
   it('passes futureTransactions to buildForecast', () => {
-    const accounts = [
-      { id: 'a1', name: 'Checking', isClosed: false, accountType: 'CHEQUING', accountSubType: null },
-    ] as any[];
+    const accounts = [makeAccount()];
     const futureTransactions = [
       { id: 'ft-1', accountId: 'a1', name: 'Future Bill', amount: -500, date: '2026-03-01' },
     ];
@@ -241,13 +257,12 @@ describe('CashFlowForecastChart', () => {
       expect.anything(),
       expect.anything(),
       futureTransactions,
+      undefined, // no conversion needed for single-currency
     );
   });
 
   it('defaults futureTransactions to empty array when not provided', () => {
-    const accounts = [
-      { id: 'a1', name: 'Checking', isClosed: false, accountType: 'CHEQUING', accountSubType: null },
-    ] as any[];
+    const accounts = [makeAccount()];
 
     render(
       <CashFlowForecastChart scheduledTransactions={[]} accounts={accounts} isLoading={false} />
@@ -259,6 +274,108 @@ describe('CashFlowForecastChart', () => {
       expect.anything(),
       expect.anything(),
       [],
+      undefined, // no conversion needed for single-currency
     );
+  });
+
+  describe('currency-aware formatting', () => {
+    it('uses account currency for single-currency accounts', () => {
+      mockFormatCurrencyCompact.mockClear();
+      const accounts = [makeAccount({ currencyCode: 'USD' })];
+
+      const forecastData = [
+        { label: 'Today', balance: 1000, transactions: [] },
+        { label: 'Tomorrow', balance: 800, transactions: [{ amount: -200, name: 'Bill' }] },
+      ];
+      mockBuildForecast.mockReturnValue(forecastData);
+      mockGetForecastSummary.mockReturnValue({
+        startingBalance: 1000,
+        endingBalance: 800,
+        minBalance: 800,
+        goesNegative: false,
+      });
+
+      render(
+        <CashFlowForecastChart scheduledTransactions={[{} as any]} accounts={accounts} isLoading={false} />
+      );
+
+      // Summary footer calls formatCurrencyCompact with the account's currency
+      const usdCalls = mockFormatCurrencyCompact.mock.calls.filter(
+        ([, code]) => code === 'USD',
+      );
+      expect(usdCalls.length).toBeGreaterThan(0);
+    });
+
+    it('uses default currency when accounts have mixed currencies', () => {
+      mockFormatCurrencyCompact.mockClear();
+      const accounts = [
+        makeAccount({ id: 'a1', currencyCode: 'USD' }),
+        makeAccount({ id: 'a2', name: 'Euro Account', currencyCode: 'EUR' }),
+      ];
+
+      const forecastData = [
+        { label: 'Today', balance: 2700, transactions: [] },
+        { label: 'Tomorrow', balance: 2500, transactions: [{ amount: -200, name: 'Bill' }] },
+      ];
+      mockBuildForecast.mockReturnValue(forecastData);
+      mockGetForecastSummary.mockReturnValue({
+        startingBalance: 2700,
+        endingBalance: 2500,
+        minBalance: 2500,
+        goesNegative: false,
+      });
+
+      render(
+        <CashFlowForecastChart scheduledTransactions={[{} as any]} accounts={accounts} isLoading={false} />
+      );
+
+      // With mixed currencies, should format in default currency (CAD)
+      const cadCalls = mockFormatCurrencyCompact.mock.calls.filter(
+        ([, code]) => code === 'CAD',
+      );
+      expect(cadCalls.length).toBeGreaterThan(0);
+    });
+
+    it('passes convertToDefault to buildForecast when currencies are mixed', () => {
+      const accounts = [
+        makeAccount({ id: 'a1', currencyCode: 'USD' }),
+        makeAccount({ id: 'a2', name: 'Euro Account', currencyCode: 'EUR' }),
+      ];
+
+      render(
+        <CashFlowForecastChart scheduledTransactions={[]} accounts={accounts} isLoading={false} />
+      );
+
+      // Should pass the conversion function as 6th argument
+      expect(mockBuildForecast).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        mockConvertToDefault,
+      );
+    });
+
+    it('does not pass convertToDefault when all accounts share one currency', () => {
+      const accounts = [
+        makeAccount({ id: 'a1', currencyCode: 'USD' }),
+        makeAccount({ id: 'a2', name: 'Savings', currencyCode: 'USD' }),
+      ];
+
+      render(
+        <CashFlowForecastChart scheduledTransactions={[]} accounts={accounts} isLoading={false} />
+      );
+
+      // Should pass undefined as 6th argument (no conversion needed)
+      expect(mockBuildForecast).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        undefined,
+      );
+    });
   });
 });

--- a/frontend/src/components/bills/CashFlowForecastChart.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useCallback } from 'react';
 import {
   LineChart,
   Line,
@@ -23,6 +23,7 @@ import {
   FORECAST_PERIOD_LABELS,
 } from '@/lib/forecast';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useExchangeRates } from '@/hooks/useExchangeRates';
 
 interface CashFlowForecastChartProps {
   scheduledTransactions: ScheduledTransaction[];
@@ -112,7 +113,8 @@ export function CashFlowForecastChart({
   futureTransactions = [],
   isLoading,
 }: CashFlowForecastChartProps) {
-  const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis } = useNumberFormat();
+  const { formatCurrencyCompact, formatCurrencyAxis } = useNumberFormat();
+  const { convertToDefault, defaultCurrency } = useExchangeRates();
   const [selectedPeriod, setSelectedPeriod] = useState<ForecastPeriod>(() => getStoredPeriod());
   const [selectedAccountId, setSelectedAccountId] = useState<string>(() => getStoredAccountId());
 
@@ -136,9 +138,34 @@ export function CashFlowForecastChart({
     ];
   }, [accounts]);
 
+  // Determine display currency from selected accounts
+  const { chartCurrency, needsConversion } = useMemo(() => {
+    const targetAccounts = selectedAccountId === 'all'
+      ? accounts.filter(a => !a.isClosed)
+      : accounts.filter(a => a.id === selectedAccountId);
+    const currencies = new Set(targetAccounts.map(a => a.currencyCode));
+    return {
+      chartCurrency: currencies.size === 1 ? [...currencies][0] : defaultCurrency,
+      needsConversion: currencies.size > 1,
+    };
+  }, [accounts, selectedAccountId, defaultCurrency]);
+
+  const formatCurrency = useCallback(
+    (value: number) => formatCurrencyCompact(value, chartCurrency),
+    [formatCurrencyCompact, chartCurrency],
+  );
+
+  const formatAxis = useCallback(
+    (value: number) => formatCurrencyAxis(value, chartCurrency),
+    [formatCurrencyAxis, chartCurrency],
+  );
+
   const forecastData = useMemo(() => {
-    return buildForecast(accounts, scheduledTransactions, selectedPeriod, selectedAccountId, futureTransactions);
-  }, [accounts, scheduledTransactions, selectedPeriod, selectedAccountId, futureTransactions]);
+    return buildForecast(
+      accounts, scheduledTransactions, selectedPeriod, selectedAccountId, futureTransactions,
+      needsConversion ? convertToDefault : undefined,
+    );
+  }, [accounts, scheduledTransactions, selectedPeriod, selectedAccountId, futureTransactions, needsConversion, convertToDefault]);
 
   const summary = useMemo(() => {
     return getForecastSummary(forecastData);
@@ -232,7 +259,7 @@ export function CashFlowForecastChart({
             <LineChart data={forecastData} margin={{ left: 0, right: 8, top: 5, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" className="dark:stroke-gray-700" />
               <XAxis dataKey="label" tick={{ fill: '#6b7280', fontSize: 12 }} tickLine={false} axisLine={{ stroke: '#e5e7eb' }} interval="preserveStartEnd" />
-              <YAxis tick={{ fill: '#6b7280', fontSize: 11 }} tickLine={false} axisLine={false} tickFormatter={formatCurrencyAxis} width={45} domain={['auto', 'auto']} />
+              <YAxis tick={{ fill: '#6b7280', fontSize: 11 }} tickLine={false} axisLine={false} tickFormatter={formatAxis} width={45} domain={['auto', 'auto']} />
               <Tooltip content={<CashFlowTooltip formatCurrency={formatCurrency} />} />
               <ReferenceLine y={0} stroke="#ef4444" strokeDasharray="5 5" strokeOpacity={0.5} />
               <Line type="monotone" dataKey="balance" stroke="#9ca3af" strokeWidth={2} dot={false} strokeDasharray="5 5" />
@@ -264,7 +291,7 @@ export function CashFlowForecastChart({
                 tick={{ fill: '#6b7280', fontSize: 11 }}
                 tickLine={false}
                 axisLine={false}
-                tickFormatter={formatCurrencyAxis}
+                tickFormatter={formatAxis}
                 width={45}
                 domain={['auto', 'auto']}
               />
@@ -294,7 +321,7 @@ export function CashFlowForecastChart({
                   const { cx, cy } = props;
                   if (props.index === minBalanceIndex) {
                     const color = summary.minBalance < 0 ? '#ef4444' : '#f59e0b';
-                    const label = formatCurrencyAxis(summary.minBalance);
+                    const label = formatAxis(summary.minBalance);
                     const labelWidth = label.length * 7 + 14;
                     const labelHeight = 22;
                     const arrowSize = 5;

--- a/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
@@ -13,10 +13,13 @@ vi.mock('recharts', () => ({
   ReferenceLine: () => <div data-testid="reference-line" />,
 }));
 
+const mockFormatCurrencyCompact = vi.fn((n: number, _code?: string) => `$${n.toFixed(0)}`);
+const mockFormatCurrencyAxis = vi.fn((n: number, _code?: string) => `$${n}`);
+
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
-    formatCurrencyCompact: (n: number) => `$${n.toFixed(0)}`,
-    formatCurrencyAxis: (n: number) => `$${n}`,
+    formatCurrencyCompact: mockFormatCurrencyCompact,
+    formatCurrencyAxis: mockFormatCurrencyAxis,
   }),
 }));
 
@@ -70,5 +73,26 @@ describe('BalanceHistoryChart', () => {
 
     expect(screen.getByText('Lowest')).toBeInTheDocument();
     expect(screen.getByText('!')).toBeInTheDocument();
+  });
+
+  it('passes currencyCode to formatting functions', () => {
+    mockFormatCurrencyCompact.mockClear();
+
+    render(
+      <BalanceHistoryChart
+        data={[
+          { date: '2025-01-01', balance: 500 },
+          { date: '2025-01-02', balance: 600 },
+        ]}
+        isLoading={false}
+        currencyCode="EUR"
+      />
+    );
+
+    // Summary footer calls formatCurrency (which wraps formatCurrencyCompact with currencyCode)
+    const eurCalls = mockFormatCurrencyCompact.mock.calls.filter(
+      ([, code]) => code === 'EUR',
+    );
+    expect(eurCalls.length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/components/transactions/BalanceHistoryChart.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
   LineChart,
   Line,
@@ -18,6 +18,7 @@ import { useNumberFormat } from '@/hooks/useNumberFormat';
 interface BalanceHistoryChartProps {
   data: Array<{ date: string; balance: number }>;
   isLoading: boolean;
+  currencyCode?: string;
 }
 
 interface ChartPoint {
@@ -60,8 +61,19 @@ function BalanceTooltip({
 export function BalanceHistoryChart({
   data,
   isLoading,
+  currencyCode,
 }: BalanceHistoryChartProps) {
-  const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis } = useNumberFormat();
+  const { formatCurrencyCompact, formatCurrencyAxis } = useNumberFormat();
+
+  const formatCurrency = useCallback(
+    (value: number) => formatCurrencyCompact(value, currencyCode),
+    [formatCurrencyCompact, currencyCode],
+  );
+
+  const formatAxis = useCallback(
+    (value: number) => formatCurrencyAxis(value, currencyCode),
+    [formatCurrencyAxis, currencyCode],
+  );
 
   const { chartData, monthTicks } = useMemo(() => {
     if (data.length === 0) return { chartData: [], monthTicks: [] };
@@ -147,7 +159,7 @@ export function BalanceHistoryChart({
               tick={{ fill: '#6b7280', fontSize: 11 }}
               tickLine={false}
               axisLine={false}
-              tickFormatter={formatCurrencyAxis}
+              tickFormatter={formatAxis}
               width={45}
               domain={['auto', 'auto']}
             />

--- a/frontend/src/lib/accounts.ts
+++ b/frontend/src/lib/accounts.ts
@@ -105,13 +105,13 @@ export const accountsApi = {
     invalidateCache('accounts:');
   },
 
-  // Get daily running balances for accounts
+  // Get daily running balances for accounts (per-account rows with currency)
   getDailyBalances: async (params?: {
     startDate?: string;
     endDate?: string;
     accountIds?: string;
-  }): Promise<Array<{ date: string; balance: number }>> => {
-    const response = await apiClient.get<Array<{ date: string; balance: number }>>(
+  }): Promise<Array<{ date: string; balance: number; accountId: string; currencyCode: string }>> => {
+    const response = await apiClient.get<Array<{ date: string; balance: number; accountId: string; currencyCode: string }>>(
       '/accounts/daily-balances',
       { params },
     );

--- a/frontend/src/lib/forecast.test.ts
+++ b/frontend/src/lib/forecast.test.ts
@@ -985,6 +985,93 @@ describe('buildForecast', () => {
       expect(result[0].balance).toBe(1000);
     });
   });
+
+  // --- Currency conversion via convertAmount ---
+  describe('convertAmount parameter', () => {
+    it('converts starting balances when convertAmount is provided', () => {
+      const accounts = [
+        makeAccount({ id: 'acc-1', currentBalance: 1000, currencyCode: 'USD' }),
+        makeAccount({ id: 'acc-2', currentBalance: 500, currencyCode: 'EUR' }),
+      ];
+      // USD*1.35, EUR*1.50 -> 1350 + 750 = 2100
+      const convertAmount = (amount: number, currency: string) => {
+        if (currency === 'USD') return amount * 1.35;
+        if (currency === 'EUR') return amount * 1.50;
+        return amount;
+      };
+      const result = buildForecast(accounts, [], 'week', 'all', [], convertAmount);
+      expect(result[0].balance).toBe(2100);
+    });
+
+    it('converts transaction amounts through convertAmount', () => {
+      const accounts = [
+        makeAccount({ id: 'acc-1', currentBalance: 1000, currencyCode: 'USD' }),
+      ];
+      const transactions = [makeScheduled({
+        nextDueDate: '2025-01-20',
+        amount: -500,
+        frequency: 'ONCE',
+        accountId: 'acc-1',
+      })];
+      // USD*2 -> starting 2000, tx -1000 -> 1000
+      const convertAmount = (amount: number, currency: string) => {
+        if (currency === 'USD') return amount * 2;
+        return amount;
+      };
+      const result = buildForecast(accounts, transactions, 'month', 'all', [], convertAmount);
+      const jan20 = result.find(dp => dp.date === '2025-01-20');
+      expect(jan20?.balance).toBe(1000);
+    });
+
+    it('does not convert when convertAmount is undefined', () => {
+      const accounts = [
+        makeAccount({ id: 'acc-1', currentBalance: 1000, currencyCode: 'USD' }),
+        makeAccount({ id: 'acc-2', currentBalance: 500, currencyCode: 'EUR' }),
+      ];
+      const result = buildForecast(accounts, [], 'week', 'all', [], undefined);
+      // Raw sum without conversion
+      expect(result[0].balance).toBe(1500);
+    });
+
+    it('converts future transaction amounts through convertAmount', () => {
+      const accounts = [
+        makeAccount({ id: 'acc-1', currentBalance: 1000, currencyCode: 'USD' }),
+      ];
+      const futureTransactions: FutureTransaction[] = [
+        { id: 'ft-1', accountId: 'acc-1', name: 'Future Bill', amount: -200, date: '2025-01-20' },
+      ];
+      // USD*1.5 -> starting 1500, tx -300 -> 1200
+      const convertAmount = (amount: number, currency: string) => {
+        if (currency === 'USD') return amount * 1.5;
+        return amount;
+      };
+      const result = buildForecast(accounts, [], 'month', 'all', futureTransactions, convertAmount);
+      const jan20 = result.find(dp => dp.date === '2025-01-20');
+      expect(jan20?.balance).toBe(1200);
+    });
+
+    it('converts inbound transfer amounts using destination account currency', () => {
+      const accounts = [
+        makeAccount({ id: 'acc-2', currentBalance: 500, currencyCode: 'EUR' }),
+      ];
+      const transactions = [makeScheduled({
+        nextDueDate: '2025-01-20',
+        amount: -100,
+        frequency: 'ONCE',
+        isTransfer: true,
+        transferAccountId: 'acc-2',
+        accountId: 'acc-1',
+      })];
+      // EUR*2 -> starting 1000, inbound transfer +100 converted -> +200 -> 1200
+      const convertAmount = (amount: number, currency: string) => {
+        if (currency === 'EUR') return amount * 2;
+        return amount;
+      };
+      const result = buildForecast(accounts, transactions, 'month', 'acc-2', [], convertAmount);
+      const jan20 = result.find(dp => dp.date === '2025-01-20');
+      expect(jan20?.balance).toBe(1200);
+    });
+  });
 });
 
 describe('getForecastSummary', () => {

--- a/frontend/src/lib/forecast.ts
+++ b/frontend/src/lib/forecast.ts
@@ -232,7 +232,8 @@ export function buildForecast(
   transactions: ScheduledTransaction[],
   period: ForecastPeriod,
   accountId: string | 'all',
-  futureTransactions: FutureTransaction[] = []
+  futureTransactions: FutureTransaction[] = [],
+  convertAmount?: (amount: number, currencyCode: string) => number,
 ): ForecastDataPoint[] {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -261,8 +262,18 @@ export function buildForecast(
     targetAccountIds.has(ft.accountId) && ft.date > todayKey
   );
 
+  // Build account currency lookup for converting transaction amounts
+  const accountCurrencyMap = new Map(targetAccounts.map(a => [a.id, a.currencyCode]));
+  const conv = (amount: number, acctId: string): number => {
+    if (!convertAmount) return amount;
+    const currency = accountCurrencyMap.get(acctId);
+    return currency ? convertAmount(amount, currency) : amount;
+  };
+
   const startingBalance = targetAccounts.reduce(
-    (sum, acc) => sum + Number(acc.currentBalance),
+    (sum, acc) => sum + (convertAmount
+      ? convertAmount(Number(acc.currentBalance), acc.currencyCode)
+      : Number(acc.currentBalance)),
     0
   );
 
@@ -287,7 +298,7 @@ export function buildForecast(
     const existing = transactionsByDate.get(ft.date) || [];
     existing.push({
       name: ft.name,
-      amount: ft.amount,
+      amount: conv(ft.amount, ft.accountId),
       scheduledTransactionId: ft.id,
     });
     transactionsByDate.set(ft.date, existing);
@@ -296,11 +307,12 @@ export function buildForecast(
   for (const tx of relevantTransactions) {
     const occurrences = generateOccurrences(tx, today, endDate);
     const isInbound = inboundTransferIds.has(tx.id);
+    const txAccountId = isInbound ? (tx.transferAccountId ?? tx.accountId) : tx.accountId;
     for (const occ of occurrences) {
       const existing = transactionsByDate.get(occ.date) || [];
       existing.push({
         name: tx.name,
-        amount: isInbound ? -occ.amount : occ.amount,
+        amount: conv(isInbound ? -occ.amount : occ.amount, txAccountId),
         scheduledTransactionId: tx.id,
       });
       transactionsByDate.set(occ.date, existing);


### PR DESCRIPTION
Return per-account daily balances with currency codes from the backend instead of pre-summed aggregates. Frontend now detects mixed currencies and converts to the user's default currency via exchange rates, or displays in the native currency when all selected accounts share one.