### PR TITLE
Hide 2FA settings for SSO users and clear 2FA config on OIDC login

### DIFF
--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -687,6 +687,20 @@ describe("AuthService", () => {
         "User not found",
       );
     });
+
+    it("throws BadRequestException for SSO users", async () => {
+      usersRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        authProvider: "oidc",
+      });
+
+      await expect(service.setup2FA("user-1")).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.setup2FA("user-1")).rejects.toThrow(
+        "Two-factor authentication is not available for SSO accounts",
+      );
+    });
   });
 
   // ---------------------------------------------------------------
@@ -1382,6 +1396,66 @@ describe("AuthService", () => {
 
       expect(result.firstName).toBe("John");
       expect(result.lastName).toBe("Michael Doe");
+    });
+
+    it("clears 2FA config for SSO users who have it", async () => {
+      const userWith2FA = {
+        ...mockUser,
+        id: "oidc-2fa",
+        oidcSubject: "oidc-sub-2fa",
+        authProvider: "oidc",
+        twoFactorSecret: "encrypted-secret",
+        pendingTwoFactorSecret: "pending-secret",
+        backupCodes: '["code1","code2"]',
+      };
+      usersRepository.findOne.mockResolvedValue(userWith2FA);
+      usersRepository.save.mockImplementation((u) => u);
+      preferencesRepository.findOne.mockResolvedValue({
+        userId: "oidc-2fa",
+        twoFactorEnabled: true,
+      });
+      preferencesRepository.save.mockImplementation((p) => p);
+      trustedDevicesRepository.delete.mockResolvedValue({ affected: 2 });
+
+      const result = await service.findOrCreateOidcUser({
+        sub: "oidc-sub-2fa",
+        email: "test@example.com",
+        email_verified: true,
+      });
+
+      expect(result.twoFactorSecret).toBeNull();
+      expect(result.pendingTwoFactorSecret).toBeNull();
+      expect(result.backupCodes).toBeNull();
+      expect(preferencesRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ twoFactorEnabled: false }),
+      );
+      expect(trustedDevicesRepository.delete).toHaveBeenCalledWith({
+        userId: "oidc-2fa",
+      });
+    });
+
+    it("does not clear 2FA config when SSO user has no 2FA", async () => {
+      const userWithout2FA = {
+        ...mockUser,
+        id: "oidc-no2fa",
+        oidcSubject: "oidc-sub-no2fa",
+        authProvider: "oidc",
+        twoFactorSecret: null,
+        pendingTwoFactorSecret: null,
+        backupCodes: null,
+      };
+      usersRepository.findOne.mockResolvedValue(userWithout2FA);
+      usersRepository.save.mockImplementation((u) => u);
+
+      await service.findOrCreateOidcUser({
+        sub: "oidc-sub-no2fa",
+        email: "test@example.com",
+        email_verified: true,
+      });
+
+      // preferencesRepository.findOne should NOT be called for 2FA cleanup
+      // (only the lastLogin save should happen)
+      expect(trustedDevicesRepository.delete).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -417,6 +417,12 @@ export class AuthService {
       throw new NotFoundException("User not found");
     }
 
+    if (user.authProvider === "oidc") {
+      throw new BadRequestException(
+        "Two-factor authentication is not available for SSO accounts",
+      );
+    }
+
     const secret = otplib.generateSecret();
     const otpauthUrl = otplib.generateURI({
       secret,
@@ -668,6 +674,28 @@ export class AuthService {
       if (needsUpdate) {
         await this.usersRepository.save(user);
       }
+    }
+
+    // Strip any 2FA config from SSO users -- 2FA is managed by the identity provider
+    if (
+      user.twoFactorSecret ||
+      user.pendingTwoFactorSecret ||
+      user.backupCodes
+    ) {
+      user.twoFactorSecret = null;
+      user.pendingTwoFactorSecret = null;
+      user.backupCodes = null;
+      this.logger.log(`Cleared 2FA config for SSO user ${user.id}`);
+
+      const preferences = await this.preferencesRepository.findOne({
+        where: { userId: user.id },
+      });
+      if (preferences && preferences.twoFactorEnabled) {
+        preferences.twoFactorEnabled = false;
+        await this.preferencesRepository.save(preferences);
+      }
+
+      await this.trustedDevicesRepository.delete({ userId: user.id });
     }
 
     // Update last login

--- a/frontend/src/components/settings/SecuritySection.test.tsx
+++ b/frontend/src/components/settings/SecuritySection.test.tsx
@@ -879,6 +879,44 @@ describe('SecuritySection', () => {
     expect(screen.queryByText(/Single Sign-On \(SSO\)/)).not.toBeInTheDocument();
   });
 
+  // --- SSO users: 2FA settings hidden ---
+  it('hides 2FA controls for SSO users but keeps heading and explanation', () => {
+    const oidcUser = { ...mockUser, authProvider: 'oidc' as const };
+
+    render(
+      <SecuritySection
+        user={oidcUser}
+        preferences={mockPreferences}
+        force2fa={false}
+        onPreferencesUpdated={mockOnPreferencesUpdated}
+      />
+    );
+
+    expect(screen.getByText('Two-Factor Authentication')).toBeInTheDocument();
+    expect(screen.getByText(/not available for SSO accounts/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Enable 2FA' })).not.toBeInTheDocument();
+  });
+
+  it('hides 2FA controls for SSO users even when 2FA was previously enabled', () => {
+    const oidcUser = { ...mockUser, authProvider: 'oidc' as const };
+    const prefsWith2fa = { ...mockPreferences, twoFactorEnabled: true };
+
+    render(
+      <SecuritySection
+        user={oidcUser}
+        preferences={prefsWith2fa}
+        force2fa={false}
+        onPreferencesUpdated={mockOnPreferencesUpdated}
+      />
+    );
+
+    expect(screen.getByText('Two-Factor Authentication')).toBeInTheDocument();
+    expect(screen.getByText(/not available for SSO accounts/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Disable 2FA' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Backup Codes')).not.toBeInTheDocument();
+    expect(screen.queryByText('Trusted Devices')).not.toBeInTheDocument();
+  });
+
   // --- 2FA disable error handling ---
   it('shows error toast when disable 2FA API fails', async () => {
     const prefsWith2fa = { ...mockPreferences, twoFactorEnabled: true };

--- a/frontend/src/components/settings/SecuritySection.tsx
+++ b/frontend/src/components/settings/SecuritySection.tsx
@@ -131,10 +131,10 @@ export function SecuritySection({ user, preferences, force2fa, onPreferencesUpda
   };
 
   useEffect(() => {
-    if (twoFactorEnabled && user.hasPassword) {
+    if (twoFactorEnabled && user.hasPassword && user.authProvider !== 'oidc') {
       loadTrustedDevices();
     }
-  }, [twoFactorEnabled, user.hasPassword]);
+  }, [twoFactorEnabled, user.hasPassword, user.authProvider]);
 
   const handleRevokeDevice = async (id: string) => {
     try {
@@ -205,50 +205,53 @@ export function SecuritySection({ user, preferences, force2fa, onPreferencesUpda
         <h3 className="text-md font-medium text-gray-900 dark:text-gray-100 mb-3">
           Two-Factor Authentication
         </h3>
-        {user.authProvider === 'oidc' && (
-          <div className="mb-3 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+        {user.authProvider === 'oidc' ? (
+          <div className="p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
             <p className="text-sm text-blue-700 dark:text-blue-300">
-              Two-factor authentication only applies to password-based logins. When using Single Sign-On (SSO), authentication security is managed by your identity provider.
+              Two-factor authentication is not available for SSO accounts. Authentication security is managed by your identity provider.
             </p>
-          </div>
-        )}
-        {twoFactorEnabled ? (
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400">
-                Enabled
-              </span>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                Your account is protected with TOTP verification.
-              </p>
-            </div>
-            {force2fa ? (
-              <p className="text-xs text-gray-500 dark:text-gray-400 italic">
-                Required by administrator
-              </p>
-            ) : (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setShowTwoFactorDisable(true)}
-              >
-                Disable 2FA
-              </Button>
-            )}
           </div>
         ) : (
-          <div className="flex items-center justify-between">
-            <p className="text-sm text-gray-500 dark:text-gray-400">
-              Add an extra layer of security to your account.
-            </p>
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={() => setShowTwoFactorSetup(true)}
-            >
-              Enable 2FA
-            </Button>
-          </div>
+          <>
+            {twoFactorEnabled ? (
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400">
+                    Enabled
+                  </span>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    Your account is protected with TOTP verification.
+                  </p>
+                </div>
+                {force2fa ? (
+                  <p className="text-xs text-gray-500 dark:text-gray-400 italic">
+                    Required by administrator
+                  </p>
+                ) : (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setShowTwoFactorDisable(true)}
+                  >
+                    Disable 2FA
+                  </Button>
+                )}
+              </div>
+            ) : (
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Add an extra layer of security to your account.
+                </p>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() => setShowTwoFactorSetup(true)}
+                >
+                  Enable 2FA
+                </Button>
+              </div>
+            )}
+          </>
         )}
       </div>
 
@@ -342,7 +345,7 @@ export function SecuritySection({ user, preferences, force2fa, onPreferencesUpda
       </Modal>
 
       {/* Backup Codes */}
-      {twoFactorEnabled && (
+      {twoFactorEnabled && user.authProvider !== 'oidc' && (
         <div className="border-t border-gray-200 dark:border-gray-700 mt-6 pt-6">
           <div className="flex items-center justify-between">
             <div>
@@ -377,7 +380,7 @@ export function SecuritySection({ user, preferences, force2fa, onPreferencesUpda
       </Modal>
 
       {/* Trusted Devices */}
-      {twoFactorEnabled && (
+      {twoFactorEnabled && user.authProvider !== 'oidc' && (
         <div className="border-t border-gray-200 dark:border-gray-700 mt-6 pt-6">
           <div className="flex items-center justify-between mb-3">
             <h3 className="text-md font-medium text-gray-900 dark:text-gray-100">


### PR DESCRIPTION
SSO users authenticate through their identity provider, so 2FA settings are irrelevant. The 2FA section heading and explanation are preserved, but all controls (enable/disable, backup codes, trusted devices) are hidden. On the backend, any existing 2FA config is automatically cleared when a user logs in via OIDC, and the setup2FA endpoint now rejects SSO users with a clear error message.

https://claude.ai/code/session_01YGatBUAEAxwXzeiECDfbB2