### PR TITLE
Add accountId to uncategorized report, reorder filters, fix tests

### DIFF
--- a/backend/src/built-in-reports/built-in-reports.service.spec.ts
+++ b/backend/src/built-in-reports/built-in-reports.service.spec.ts
@@ -1666,6 +1666,7 @@ describe("BuiltInReportsService", () => {
             payee_name: "Unknown Shop",
             description: "Misc purchase",
             account_name: "Checking",
+            account_id: "acc-1",
           },
         ])
         .mockResolvedValueOnce([
@@ -1689,6 +1690,7 @@ describe("BuiltInReportsService", () => {
       // EUR->USD rate 1.1, so -50 EUR = -55 USD
       expect(result.transactions[0].amount).toBeCloseTo(-55, 5);
       expect(result.transactions[0].payeeName).toBe("Unknown Shop");
+      expect(result.transactions[0].accountId).toBe("acc-1");
     });
 
     it("calculates summary totals across multiple currencies", async () => {

--- a/backend/src/built-in-reports/data-quality-reports.service.spec.ts
+++ b/backend/src/built-in-reports/data-quality-reports.service.spec.ts
@@ -75,6 +75,7 @@ describe("DataQualityReportsService", () => {
           payee_name: "Coffee Shop",
           description: "Morning coffee",
           account_name: "Checking",
+          account_id: "acc-1",
         },
         {
           id: "tx-2",
@@ -84,6 +85,7 @@ describe("DataQualityReportsService", () => {
           payee_name: null,
           description: null,
           account_name: "Savings",
+          account_id: "acc-2",
         },
       ]);
       transactionsRepository.query.mockResolvedValueOnce([
@@ -109,9 +111,11 @@ describe("DataQualityReportsService", () => {
       expect(result.transactions[0].payeeName).toBe("Coffee Shop");
       expect(result.transactions[0].description).toBe("Morning coffee");
       expect(result.transactions[0].accountName).toBe("Checking");
+      expect(result.transactions[0].accountId).toBe("acc-1");
 
       expect(result.transactions[1].payeeName).toBeNull();
       expect(result.transactions[1].description).toBeNull();
+      expect(result.transactions[1].accountId).toBe("acc-2");
     });
 
     it("calculates summary from multiple currency rows", async () => {
@@ -174,6 +178,7 @@ describe("DataQualityReportsService", () => {
           payee_name: "Euro Store",
           description: null,
           account_name: "Euro Account",
+          account_id: "acc-1",
         },
       ]);
       transactionsRepository.query.mockResolvedValueOnce([]);
@@ -282,6 +287,7 @@ describe("DataQualityReportsService", () => {
           payee_name: "Store",
           description: null,
           account_name: "Checking",
+          account_id: "acc-1",
         },
       ]);
       transactionsRepository.query.mockResolvedValueOnce([]);

--- a/backend/src/built-in-reports/data-quality-reports.service.ts
+++ b/backend/src/built-in-reports/data-quality-reports.service.ts
@@ -37,7 +37,8 @@ export class DataQualityReportsService {
         t.amount,
         COALESCE(p.name, t.payee_name) as payee_name,
         t.description,
-        a.name as account_name
+        a.name as account_name,
+        t.account_id
       FROM transactions t
       LEFT JOIN payees p ON p.id = t.payee_id
       LEFT JOIN accounts a ON a.id = t.account_id
@@ -75,6 +76,7 @@ export class DataQualityReportsService {
       payee_name: string | null;
       description: string | null;
       account_name: string | null;
+      account_id: string;
     }
 
     const rows: RawUncategorizedTx[] = await this.transactionsRepository.query(
@@ -96,6 +98,7 @@ export class DataQualityReportsService {
       payeeName: row.payee_name,
       description: row.description,
       accountName: row.account_name,
+      accountId: row.account_id,
     }));
 
     let summaryQuery = `

--- a/backend/src/built-in-reports/dto/uncategorized-transactions.dto.ts
+++ b/backend/src/built-in-reports/dto/uncategorized-transactions.dto.ts
@@ -18,6 +18,9 @@ export class UncategorizedTransactionItem {
 
   @ApiProperty({ nullable: true })
   accountName: string | null;
+
+  @ApiProperty()
+  accountId: string;
 }
 
 export class UncategorizedTransactionsSummary {

--- a/frontend/src/components/reports/UncategorizedTransactionsReport.test.tsx
+++ b/frontend/src/components/reports/UncategorizedTransactionsReport.test.tsx
@@ -92,6 +92,7 @@ describe("UncategorizedTransactionsReport", () => {
           payeeName: "Unknown Store",
           description: "Card payment",
           accountName: "Chequing",
+          accountId: "acc-1",
           amount: -50.0,
         },
       ],
@@ -138,6 +139,7 @@ describe("UncategorizedTransactionsReport", () => {
           payeeName: "Store A",
           description: "",
           accountName: "Chequing",
+          accountId: "acc-1",
           amount: -50,
         },
         {
@@ -146,6 +148,7 @@ describe("UncategorizedTransactionsReport", () => {
           payeeName: "Employer",
           description: "",
           accountName: "Chequing",
+          accountId: "acc-1",
           amount: 200,
         },
       ],
@@ -175,6 +178,7 @@ describe("UncategorizedTransactionsReport", () => {
           payeeName: "Store A",
           description: "",
           accountName: "Chequing",
+          accountId: "acc-1",
           amount: -50,
         },
         {
@@ -183,6 +187,7 @@ describe("UncategorizedTransactionsReport", () => {
           payeeName: "Employer",
           description: "",
           accountName: "Chequing",
+          accountId: "acc-1",
           amount: 200,
         },
       ],
@@ -212,6 +217,7 @@ describe("UncategorizedTransactionsReport", () => {
           payeeName: "Alpha",
           description: "",
           accountName: "Chequing",
+          accountId: "acc-1",
           amount: -50,
         },
         {
@@ -220,6 +226,7 @@ describe("UncategorizedTransactionsReport", () => {
           payeeName: "Beta",
           description: "",
           accountName: "Savings",
+          accountId: "acc-2",
           amount: -100,
         },
       ],
@@ -251,6 +258,7 @@ describe("UncategorizedTransactionsReport", () => {
           payeeName: "Store A",
           description: "",
           accountName: "Chequing",
+          accountId: "acc-1",
           amount: -50,
         },
         {
@@ -259,6 +267,7 @@ describe("UncategorizedTransactionsReport", () => {
           payeeName: "Store B",
           description: "",
           accountName: "Chequing",
+          accountId: "acc-1",
           amount: -100,
         },
       ],
@@ -278,7 +287,7 @@ describe("UncategorizedTransactionsReport", () => {
     expect(screen.getByText("Store B")).toBeInTheDocument();
   });
 
-  it("navigates to transactions with search on row click", async () => {
+  it("navigates to transactions with uncategorized and account filters on row click", async () => {
     mockGetUncategorizedTransactions.mockResolvedValue({
       transactions: [
         {
@@ -287,6 +296,7 @@ describe("UncategorizedTransactionsReport", () => {
           payeeName: "Store A",
           description: "desc",
           accountName: "Chequing",
+          accountId: "acc-1",
           amount: -50,
         },
       ],
@@ -303,7 +313,72 @@ describe("UncategorizedTransactionsReport", () => {
       expect(screen.getByText("Store A")).toBeInTheDocument();
     });
     fireEvent.click(screen.getByText("Store A"));
-    expect(mockPush).toHaveBeenCalledWith("/transactions?search=Store%20A");
+    expect(mockPush).toHaveBeenCalledWith(
+      "/transactions?categoryIds=uncategorized&accountIds=acc-1&search=Store+A"
+    );
+  });
+
+  it("navigates using description when payeeName is null", async () => {
+    mockGetUncategorizedTransactions.mockResolvedValue({
+      transactions: [
+        {
+          id: "tx-1",
+          transactionDate: "2025-02-15",
+          payeeName: null,
+          description: "Wire transfer",
+          accountName: "Chequing",
+          accountId: "acc-1",
+          amount: -75,
+        },
+      ],
+      summary: {
+        totalCount: 1,
+        expenseCount: 1,
+        expenseTotal: 75,
+        incomeCount: 0,
+        incomeTotal: 0,
+      },
+    });
+    render(<UncategorizedTransactionsReport />);
+    await waitFor(() => {
+      expect(screen.getByText("Wire transfer")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Wire transfer"));
+    expect(mockPush).toHaveBeenCalledWith(
+      "/transactions?categoryIds=uncategorized&accountIds=acc-1&search=Wire+transfer"
+    );
+  });
+
+  it("navigates without search param when payeeName and description are null", async () => {
+    mockGetUncategorizedTransactions.mockResolvedValue({
+      transactions: [
+        {
+          id: "tx-1",
+          transactionDate: "2025-02-15",
+          payeeName: null,
+          description: null,
+          accountName: "Chequing",
+          accountId: "acc-1",
+          amount: 25,
+        },
+      ],
+      summary: {
+        totalCount: 1,
+        expenseCount: 0,
+        expenseTotal: 0,
+        incomeCount: 1,
+        incomeTotal: 25,
+      },
+    });
+    render(<UncategorizedTransactionsReport />);
+    await waitFor(() => {
+      const unknowns = screen.getAllByText("Unknown");
+      expect(unknowns.length).toBeGreaterThanOrEqual(1);
+    });
+    fireEvent.click(screen.getAllByText("Unknown")[0]);
+    expect(mockPush).toHaveBeenCalledWith(
+      "/transactions?categoryIds=uncategorized&accountIds=acc-1"
+    );
   });
 
   it("renders transaction without payeeName", async () => {
@@ -315,6 +390,7 @@ describe("UncategorizedTransactionsReport", () => {
           payeeName: null,
           description: null,
           accountName: null,
+          accountId: "acc-1",
           amount: 25,
         },
       ],
@@ -340,6 +416,7 @@ describe("UncategorizedTransactionsReport", () => {
       payeeName: `Payee ${i}`,
       description: "",
       accountName: "Chequing",
+      accountId: "acc-1",
       amount: -10,
     }));
     mockGetUncategorizedTransactions.mockResolvedValue({

--- a/frontend/src/components/reports/UncategorizedTransactionsReport.tsx
+++ b/frontend/src/components/reports/UncategorizedTransactionsReport.tsx
@@ -82,7 +82,12 @@ export function UncategorizedTransactionsReport() {
   }, [reportData, filterType, sortField, sortOrder]);
 
   const handleTransactionClick = (tx: UncategorizedTransactionItem) => {
-    router.push(`/transactions?search=${encodeURIComponent(tx.payeeName || tx.description || '')}`);
+    const params = new URLSearchParams();
+    params.set('categoryIds', 'uncategorized');
+    params.set('accountIds', tx.accountId);
+    const search = tx.payeeName || tx.description;
+    if (search) params.set('search', search);
+    router.push(`/transactions?${params.toString()}`);
   };
 
   const handleSort = (field: SortField) => {

--- a/frontend/src/components/settings/PreferencesSection.test.tsx
+++ b/frontend/src/components/settings/PreferencesSection.test.tsx
@@ -153,7 +153,7 @@ describe('PreferencesSection', () => {
     render(<PreferencesSection preferences={mockPreferences} onPreferencesUpdated={mockOnPreferencesUpdated} />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Default Currency')).toBeInTheDocument();
+      expect(screen.getByText('USD - US Dollar')).toBeInTheDocument();
     });
 
     fireEvent.change(screen.getByLabelText('Default Currency'), { target: { value: 'USD' } });

--- a/frontend/src/components/transactions/TransactionFilterPanel.tsx
+++ b/frontend/src/components/transactions/TransactionFilterPanel.tsx
@@ -192,6 +192,24 @@ export function TransactionFilterPanel({
                   </button>
                 </span>
               ))}
+              {/* Payee chips - Purple */}
+              {selectedPayees.map(payee => (
+                <span
+                  key={`payee-${payee.id}`}
+                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-200 whitespace-nowrap"
+                >
+                  {payee.name}
+                  <button
+                    onClick={() => handleArrayFilterChange(setFilterPayeeIds, filterPayeeIds.filter(id => id !== payee.id))}
+                    className="ml-0.5 -mr-1 p-0.5 rounded-full inline-flex items-center justify-center hover:bg-purple-200 dark:hover:bg-purple-800"
+                    aria-label={`Remove ${payee.name} filter`}
+                  >
+                    <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </span>
+              ))}
               {/* Category chips - Blue with color dot */}
               {selectedCategories.map(cat => (
                 <span
@@ -209,24 +227,6 @@ export function TransactionFilterPanel({
                     onClick={() => handleArrayFilterChange(setFilterCategoryIds, filterCategoryIds.filter(id => id !== cat.id))}
                     className="ml-0.5 -mr-1 p-0.5 rounded-full inline-flex items-center justify-center hover:bg-blue-200 dark:hover:bg-blue-800"
                     aria-label={`Remove ${cat.name} filter`}
-                  >
-                    <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                  </button>
-                </span>
-              ))}
-              {/* Payee chips - Purple */}
-              {selectedPayees.map(payee => (
-                <span
-                  key={`payee-${payee.id}`}
-                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-200 whitespace-nowrap"
-                >
-                  {payee.name}
-                  <button
-                    onClick={() => handleArrayFilterChange(setFilterPayeeIds, filterPayeeIds.filter(id => id !== payee.id))}
-                    className="ml-0.5 -mr-1 p-0.5 rounded-full inline-flex items-center justify-center hover:bg-purple-200 dark:hover:bg-purple-800"
-                    aria-label={`Remove ${payee.name} filter`}
                   >
                     <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -340,19 +340,19 @@ export function TransactionFilterPanel({
                 />
 
                 <MultiSelect
-                  label="Categories"
-                  options={categoryFilterOptions}
-                  value={filterCategoryIds}
-                  onChange={(values) => handleArrayFilterChange(setFilterCategoryIds, values)}
-                  placeholder="All categories"
-                />
-
-                <MultiSelect
                   label="Payees"
                   options={payeeFilterOptions}
                   value={filterPayeeIds}
                   onChange={(values) => handleArrayFilterChange(setFilterPayeeIds, values)}
                   placeholder="All payees"
+                />
+
+                <MultiSelect
+                  label="Categories"
+                  options={categoryFilterOptions}
+                  value={filterCategoryIds}
+                  onChange={(values) => handleArrayFilterChange(setFilterCategoryIds, values)}
+                  placeholder="All categories"
                 />
               </div>
 

--- a/frontend/src/components/transactions/TransactionForm.test.tsx
+++ b/frontend/src/components/transactions/TransactionForm.test.tsx
@@ -404,6 +404,14 @@ describe('TransactionForm', () => {
   // Existing tests (preserved)
   // =========================================================================
 
+  it('fetches accounts including closed accounts on mount', async () => {
+    render(<TransactionForm onSuccess={mockOnSuccess} onCancel={mockOnCancel} />);
+
+    await waitFor(() => {
+      expect(mockAccountsGetAll).toHaveBeenCalledWith(true);
+    });
+  });
+
   it('renders form with mode selector buttons', async () => {
     render(<TransactionForm onSuccess={mockOnSuccess} onCancel={mockOnCancel} />);
 

--- a/frontend/src/types/built-in-reports.ts
+++ b/frontend/src/types/built-in-reports.ts
@@ -227,6 +227,7 @@ export interface UncategorizedTransactionItem {
   payeeName: string | null;
   description: string | null;
   accountName: string | null;
+  accountId: string;
 }
 
 export interface UncategorizedTransactionsResponse {


### PR DESCRIPTION
- Add accountId to uncategorized transactions report response so clicking a row navigates with categoryIds=uncategorized and accountIds filters for more precise transaction lookup
- Reorder transaction filter panel: Payees before Categories (both in expanded dropdowns and collapsed chips)
- Add navigation edge case tests for description fallback and missing search params
- Fix PreferencesSection test race condition: wait for currency options to load before changing select value
- Add accountId to all mock data across backend and frontend tests