### PR TITLE
Fix exchange rate refresh to save both directions and fix currency symbol overlap

### DIFF
--- a/backend/src/currencies/currencies.controller.ts
+++ b/backend/src/currencies/currencies.controller.ts
@@ -133,10 +133,8 @@ export class CurrenciesController {
   }
 
   @Post("exchange-rates/refresh")
-  @UseGuards(RolesGuard)
-  @Roles("admin")
   @ApiOperation({
-    summary: "Manually trigger exchange rate refresh (admin only)",
+    summary: "Manually trigger exchange rate refresh",
   })
   @ApiResponse({ status: 201, description: "Refresh summary" })
   refreshRates(): Promise<RateRefreshSummary> {

--- a/backend/src/currencies/exchange-rate.service.spec.ts
+++ b/backend/src/currencies/exchange-rate.service.spec.ts
@@ -262,16 +262,24 @@ describe("ExchangeRateService", () => {
         regularMarketPrice: 1.4,
       });
 
-      const existingRate = { ...mockExchangeRate };
-      exchangeRateRepository.findOne.mockResolvedValue(existingRate);
+      // Return a fresh copy for each findOne call so mutations don't bleed
+      exchangeRateRepository.findOne.mockImplementation(() => ({
+        ...mockExchangeRate,
+      }));
       exchangeRateRepository.save.mockImplementation((data) => data);
 
       const result = await service.refreshAllRates();
 
       expect(result.updated).toBe(1);
-      // Save should be called with updated rate value
+      // Save should be called with both forward and inverse rates
       expect(exchangeRateRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({ rate: 1.4, source: "yahoo_finance" }),
+      );
+      expect(exchangeRateRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rate: Math.round((1 / 1.4) * 10000) / 10000,
+          source: "yahoo_finance",
+        }),
       );
     });
 

--- a/backend/src/currencies/exchange-rate.service.ts
+++ b/backend/src/currencies/exchange-rate.service.ts
@@ -164,9 +164,25 @@ export class ExchangeRateService implements OnModuleInit {
   }
 
   /**
-   * Save or update an exchange rate for a given date
+   * Save or update an exchange rate for a given date,
+   * and also save the inverse rate for the reverse pair.
    */
   private async saveRate(
+    from: string,
+    to: string,
+    rate: number,
+    date: Date,
+  ): Promise<ExchangeRate> {
+    const result = await this.saveOneDirection(from, to, rate, date);
+
+    // Also save the inverse rate so both directions stay current
+    const inverseRate = Math.round((1 / rate) * 10000) / 10000;
+    await this.saveOneDirection(to, from, inverseRate, date);
+
+    return result;
+  }
+
+  private async saveOneDirection(
     from: string,
     to: string,
     rate: number,

--- a/frontend/src/app/currencies/page.tsx
+++ b/frontend/src/app/currencies/page.tsx
@@ -119,8 +119,8 @@ function CurrenciesContent() {
       } else {
         toast.success(`Exchange rates refreshed: ${updated} pairs updated`);
       }
-      // Reload rates into the UI so the list reflects updated values
-      await refreshRates();
+      // Reload rates and currency data so the list reflects updated values
+      await Promise.all([refreshRates(), loadData()]);
     } catch (error) {
       toast.error(getErrorMessage(error, 'Failed to refresh exchange rates'));
     } finally {

--- a/frontend/src/components/ui/CurrencyInput.tsx
+++ b/frontend/src/components/ui/CurrencyInput.tsx
@@ -252,7 +252,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
             onFocus={handleFocus}
             disabled={disabled}
             style={{
-              paddingLeft: prefix ? '1.75rem' : undefined,
+              paddingLeft: prefix ? `${1.15 + prefix.length * 0.6}rem` : undefined,
               paddingRight: allowCalculator ? '2.25rem' : undefined,
             }}
             className={cn(


### PR DESCRIPTION
- Save inverse rate (1/rate) when refreshing exchange rates so both directions (e.g. USD->CAD and CAD->USD) stay current from a single Yahoo Finance fetch
- Remove admin-only restriction from exchange rate refresh endpoint
- Reload currency data after rate refresh so UI reflects updated values
- Scale CurrencyInput prefix padding dynamically based on symbol length to prevent multi-char symbols (e.g. CHF) from overlapping numbers