### PR TITLE
Add amount from/to filters to transactions

### DIFF
--- a/backend/src/transactions/transaction-analytics.service.spec.ts
+++ b/backend/src/transactions/transaction-analytics.service.spec.ts
@@ -1082,4 +1082,156 @@ describe("TransactionAnalyticsService", () => {
       );
     });
   });
+
+  describe("amount range filter", () => {
+    describe("getSummary", () => {
+      it("applies amountFrom filter when provided", async () => {
+        await service.getSummary(
+          userId,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          -100.5,
+        );
+
+        expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+          "transaction.amount >= :amountFrom",
+          { amountFrom: -100.5 },
+        );
+      });
+
+      it("applies amountTo filter when provided", async () => {
+        await service.getSummary(
+          userId,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          500.25,
+        );
+
+        expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+          "transaction.amount <= :amountTo",
+          { amountTo: 500.25 },
+        );
+      });
+
+      it("applies both amountFrom and amountTo when provided", async () => {
+        await service.getSummary(
+          userId,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          10,
+          200,
+        );
+
+        expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+          "transaction.amount >= :amountFrom",
+          { amountFrom: 10 },
+        );
+        expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+          "transaction.amount <= :amountTo",
+          { amountTo: 200 },
+        );
+      });
+
+      it("does not apply amount filters when not provided", async () => {
+        await service.getSummary(userId);
+
+        expect(mockQueryBuilder.andWhere).not.toHaveBeenCalledWith(
+          "transaction.amount >= :amountFrom",
+          expect.anything(),
+        );
+        expect(mockQueryBuilder.andWhere).not.toHaveBeenCalledWith(
+          "transaction.amount <= :amountTo",
+          expect.anything(),
+        );
+      });
+    });
+
+    describe("getMonthlyTotals", () => {
+      it("applies amountFrom filter when provided", async () => {
+        await service.getMonthlyTotals(
+          userId,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          -50,
+        );
+
+        expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+          "transaction.amount >= :amountFrom",
+          { amountFrom: -50 },
+        );
+      });
+
+      it("applies amountTo filter when provided", async () => {
+        await service.getMonthlyTotals(
+          userId,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          1000,
+        );
+
+        expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+          "transaction.amount <= :amountTo",
+          { amountTo: 1000 },
+        );
+      });
+
+      it("applies both amount filters together", async () => {
+        await service.getMonthlyTotals(
+          userId,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          -100,
+          500,
+        );
+
+        expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+          "transaction.amount >= :amountFrom",
+          { amountFrom: -100 },
+        );
+        expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+          "transaction.amount <= :amountTo",
+          { amountTo: 500 },
+        );
+      });
+
+      it("does not apply amount filters when not provided", async () => {
+        await service.getMonthlyTotals(userId);
+
+        expect(mockQueryBuilder.andWhere).not.toHaveBeenCalledWith(
+          "transaction.amount >= :amountFrom",
+          expect.anything(),
+        );
+        expect(mockQueryBuilder.andWhere).not.toHaveBeenCalledWith(
+          "transaction.amount <= :amountTo",
+          expect.anything(),
+        );
+      });
+    });
+  });
 });

--- a/backend/src/transactions/transaction-analytics.service.ts
+++ b/backend/src/transactions/transaction-analytics.service.ts
@@ -22,6 +22,8 @@ export class TransactionAnalyticsService {
     categoryIds?: string[],
     payeeIds?: string[],
     search?: string,
+    amountFrom?: number,
+    amountTo?: number,
   ): Promise<{
     totalIncome: number;
     totalExpenses: number;
@@ -159,6 +161,16 @@ export class TransactionAnalyticsService {
       );
     }
 
+    if (amountFrom !== undefined) {
+      queryBuilder.andWhere("transaction.amount >= :amountFrom", {
+        amountFrom,
+      });
+    }
+
+    if (amountTo !== undefined) {
+      queryBuilder.andWhere("transaction.amount <= :amountTo", { amountTo });
+    }
+
     // When category filter joins splits, use the split amount for split
     // transactions so we only count the matching split, not the full parent.
     const amountExpr = splitsCategoryJoin
@@ -230,6 +242,8 @@ export class TransactionAnalyticsService {
     categoryIds?: string[],
     payeeIds?: string[],
     search?: string,
+    amountFrom?: number,
+    amountTo?: number,
   ): Promise<Array<{ month: string; total: number; count: number }>> {
     const queryBuilder = this.transactionsRepository
       .createQueryBuilder("transaction")
@@ -345,6 +359,16 @@ export class TransactionAnalyticsService {
         "(transaction.description ILIKE :search OR transaction.payeeName ILIKE :search OR splits.memo ILIKE :search)",
         { search: searchPattern },
       );
+    }
+
+    if (amountFrom !== undefined) {
+      queryBuilder.andWhere("transaction.amount >= :amountFrom", {
+        amountFrom,
+      });
+    }
+
+    if (amountTo !== undefined) {
+      queryBuilder.andWhere("transaction.amount <= :amountTo", { amountTo });
     }
 
     // When category filter joins splits, use the split amount for split

--- a/backend/src/transactions/transactions.controller.spec.ts
+++ b/backend/src/transactions/transactions.controller.spec.ts
@@ -84,6 +84,8 @@ describe("TransactionsController", () => {
         false,
         undefined,
         undefined,
+        undefined,
+        undefined,
       );
     });
 
@@ -110,6 +112,8 @@ describe("TransactionsController", () => {
         false,
         undefined,
         undefined,
+        undefined,
+        undefined,
       );
     });
 
@@ -128,6 +132,8 @@ describe("TransactionsController", () => {
         undefined,
         undefined,
         false,
+        undefined,
+        undefined,
         undefined,
         undefined,
       );
@@ -162,6 +168,8 @@ describe("TransactionsController", () => {
         false,
         undefined,
         undefined,
+        undefined,
+        undefined,
       );
     });
 
@@ -193,6 +201,8 @@ describe("TransactionsController", () => {
         undefined,
         undefined,
         true,
+        undefined,
+        undefined,
         undefined,
         undefined,
       );
@@ -230,6 +240,8 @@ describe("TransactionsController", () => {
         false,
         "grocery",
         uuid3,
+        undefined,
+        undefined,
       );
     });
 
@@ -685,6 +697,8 @@ describe("TransactionsController", () => {
         undefined,
         undefined,
         undefined,
+        undefined,
+        undefined,
       );
     });
 
@@ -707,6 +721,8 @@ describe("TransactionsController", () => {
         undefined,
         undefined,
         undefined,
+        undefined,
+        undefined,
       );
     });
 
@@ -719,6 +735,284 @@ describe("TransactionsController", () => {
     it("rejects invalid UUID in summary accountIds", () => {
       expect(() =>
         controller.getSummary(mockReq, undefined, "bad-uuid"),
+      ).toThrow(BadRequestException);
+    });
+
+    it("parses amountFrom and amountTo as floats for summary", async () => {
+      mockService.getSummary.mockResolvedValue({});
+
+      await controller.getSummary(
+        mockReq,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "10.50",
+        "99.99",
+      );
+
+      expect(mockService.getSummary).toHaveBeenCalledWith(
+        "user-1",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        10.5,
+        99.99,
+      );
+    });
+
+    it("rejects non-numeric amountFrom in summary", () => {
+      expect(() =>
+        controller.getSummary(
+          mockReq,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          "abc",
+        ),
+      ).toThrow(BadRequestException);
+    });
+
+    it("rejects non-numeric amountTo in summary", () => {
+      expect(() =>
+        controller.getSummary(
+          mockReq,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          "xyz",
+        ),
+      ).toThrow(BadRequestException);
+    });
+  });
+
+  describe("findAll() amount filters", () => {
+    it("parses amountFrom and amountTo as floats", async () => {
+      mockService.findAll.mockResolvedValue({ data: [], total: 0 });
+
+      await controller.findAll(
+        mockReq,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "-100.50",
+        "500.25",
+      );
+
+      expect(mockService.findAll).toHaveBeenCalledWith(
+        "user-1",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        false,
+        undefined,
+        undefined,
+        -100.5,
+        500.25,
+      );
+    });
+
+    it("passes undefined when amountFrom and amountTo are not provided", async () => {
+      mockService.findAll.mockResolvedValue({ data: [], total: 0 });
+
+      await controller.findAll(mockReq);
+
+      const call = mockService.findAll.mock.calls[0];
+      expect(call[11]).toBeUndefined(); // amountFrom
+      expect(call[12]).toBeUndefined(); // amountTo
+    });
+
+    it("rejects non-numeric amountFrom", () => {
+      expect(() =>
+        controller.findAll(
+          mockReq,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          "not-a-number",
+        ),
+      ).toThrow(BadRequestException);
+    });
+
+    it("rejects non-numeric amountTo", () => {
+      expect(() =>
+        controller.findAll(
+          mockReq,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          "not-a-number",
+        ),
+      ).toThrow(BadRequestException);
+    });
+
+    it("allows only amountFrom without amountTo", async () => {
+      mockService.findAll.mockResolvedValue({ data: [], total: 0 });
+
+      await controller.findAll(
+        mockReq,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "50",
+      );
+
+      const call = mockService.findAll.mock.calls[0];
+      expect(call[11]).toBe(50); // amountFrom
+      expect(call[12]).toBeUndefined(); // amountTo
+    });
+
+    it("allows only amountTo without amountFrom", async () => {
+      mockService.findAll.mockResolvedValue({ data: [], total: 0 });
+
+      await controller.findAll(
+        mockReq,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "200",
+      );
+
+      const call = mockService.findAll.mock.calls[0];
+      expect(call[11]).toBeUndefined(); // amountFrom
+      expect(call[12]).toBe(200); // amountTo
+    });
+  });
+
+  describe("getMonthlyTotals() amount filters", () => {
+    it("parses amountFrom and amountTo as floats for monthly totals", async () => {
+      mockService.getMonthlyTotals = jest.fn().mockResolvedValue([]);
+
+      await controller.getMonthlyTotals(
+        mockReq,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "-50",
+        "1000",
+      );
+
+      expect(mockService.getMonthlyTotals).toHaveBeenCalledWith(
+        "user-1",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        -50,
+        1000,
+      );
+    });
+
+    it("rejects non-numeric amountFrom in monthly totals", () => {
+      expect(() =>
+        controller.getMonthlyTotals(
+          mockReq,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          "abc",
+        ),
+      ).toThrow(BadRequestException);
+    });
+
+    it("rejects non-numeric amountTo in monthly totals", () => {
+      expect(() =>
+        controller.getMonthlyTotals(
+          mockReq,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          "xyz",
+        ),
       ).toThrow(BadRequestException);
     });
   });

--- a/backend/src/transactions/transactions.controller.ts
+++ b/backend/src/transactions/transactions.controller.ts
@@ -127,6 +127,16 @@ export class TransactionsController {
       "Search text to filter by description, payee name, or split memo",
   })
   @ApiQuery({
+    name: "amountFrom",
+    required: false,
+    description: "Filter by minimum amount (inclusive)",
+  })
+  @ApiQuery({
+    name: "amountTo",
+    required: false,
+    description: "Filter by maximum amount (inclusive)",
+  })
+  @ApiQuery({
     name: "targetTransactionId",
     required: false,
     description:
@@ -153,6 +163,8 @@ export class TransactionsController {
     includeInvestmentBrokerage?: boolean,
     @Query("search") search?: string,
     @Query("targetTransactionId") targetTransactionId?: string,
+    @Query("amountFrom") amountFrom?: string,
+    @Query("amountTo") amountTo?: string,
   ) {
     // Validate pagination parameters
     if (page !== undefined) {
@@ -182,6 +194,18 @@ export class TransactionsController {
     // Truncate search to prevent excessive ILIKE query length
     const sanitizedSearch = search ? search.slice(0, 200) : undefined;
 
+    const parsedAmountFrom =
+      amountFrom !== undefined ? parseFloat(amountFrom) : undefined;
+    if (parsedAmountFrom !== undefined && isNaN(parsedAmountFrom)) {
+      throw new BadRequestException("amountFrom must be a number");
+    }
+
+    const parsedAmountTo =
+      amountTo !== undefined ? parseFloat(amountTo) : undefined;
+    if (parsedAmountTo !== undefined && isNaN(parsedAmountTo)) {
+      throw new BadRequestException("amountTo must be a number");
+    }
+
     return this.transactionsService.findAll(
       req.user.id,
       parseIds(accountIds, accountId),
@@ -194,6 +218,8 @@ export class TransactionsController {
       includeInvestmentBrokerage === true,
       sanitizedSearch,
       targetTransactionId,
+      parsedAmountFrom,
+      parsedAmountTo,
     );
   }
 
@@ -245,6 +271,16 @@ export class TransactionsController {
     description:
       "Search text to filter by description, payee name, or split memo",
   })
+  @ApiQuery({
+    name: "amountFrom",
+    required: false,
+    description: "Filter by minimum amount (inclusive)",
+  })
+  @ApiQuery({
+    name: "amountTo",
+    required: false,
+    description: "Filter by maximum amount (inclusive)",
+  })
   @ApiResponse({
     status: 200,
     description: "Transaction summary retrieved successfully",
@@ -261,9 +297,23 @@ export class TransactionsController {
     @Query("payeeId") payeeId?: string,
     @Query("payeeIds") payeeIds?: string,
     @Query("search") search?: string,
+    @Query("amountFrom") amountFrom?: string,
+    @Query("amountTo") amountTo?: string,
   ) {
     validateDateParam(startDate, "startDate");
     validateDateParam(endDate, "endDate");
+
+    const parsedAmountFrom =
+      amountFrom !== undefined ? parseFloat(amountFrom) : undefined;
+    if (parsedAmountFrom !== undefined && isNaN(parsedAmountFrom)) {
+      throw new BadRequestException("amountFrom must be a number");
+    }
+
+    const parsedAmountTo =
+      amountTo !== undefined ? parseFloat(amountTo) : undefined;
+    if (parsedAmountTo !== undefined && isNaN(parsedAmountTo)) {
+      throw new BadRequestException("amountTo must be a number");
+    }
 
     return this.transactionsService.getSummary(
       req.user.id,
@@ -273,6 +323,8 @@ export class TransactionsController {
       parseCategoryIds(categoryIds ?? categoryId),
       parseIds(payeeIds, payeeId),
       search,
+      parsedAmountFrom,
+      parsedAmountTo,
     );
   }
 
@@ -310,6 +362,16 @@ export class TransactionsController {
     description:
       "Search text to filter by description, payee name, or split memo",
   })
+  @ApiQuery({
+    name: "amountFrom",
+    required: false,
+    description: "Filter by minimum amount (inclusive)",
+  })
+  @ApiQuery({
+    name: "amountTo",
+    required: false,
+    description: "Filter by maximum amount (inclusive)",
+  })
   @ApiResponse({
     status: 200,
     description: "Monthly totals retrieved successfully",
@@ -323,9 +385,23 @@ export class TransactionsController {
     @Query("categoryIds") categoryIds?: string,
     @Query("payeeIds") payeeIds?: string,
     @Query("search") search?: string,
+    @Query("amountFrom") amountFrom?: string,
+    @Query("amountTo") amountTo?: string,
   ) {
     validateDateParam(startDate, "startDate");
     validateDateParam(endDate, "endDate");
+
+    const parsedAmountFrom =
+      amountFrom !== undefined ? parseFloat(amountFrom) : undefined;
+    if (parsedAmountFrom !== undefined && isNaN(parsedAmountFrom)) {
+      throw new BadRequestException("amountFrom must be a number");
+    }
+
+    const parsedAmountTo =
+      amountTo !== undefined ? parseFloat(amountTo) : undefined;
+    if (parsedAmountTo !== undefined && isNaN(parsedAmountTo)) {
+      throw new BadRequestException("amountTo must be a number");
+    }
 
     return this.transactionsService.getMonthlyTotals(
       req.user.id,
@@ -335,6 +411,8 @@ export class TransactionsController {
       parseCategoryIds(categoryIds),
       parseUuids(payeeIds),
       search,
+      parsedAmountFrom,
+      parsedAmountTo,
     );
   }
 

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -191,6 +191,8 @@ export class TransactionsService {
     includeInvestmentBrokerage: boolean = false,
     search?: string,
     targetTransactionId?: string,
+    amountFrom?: number,
+    amountTo?: number,
   ): Promise<PaginatedTransactions> {
     let safePage = Math.max(1, page);
     const safeLimit = Math.min(200, Math.max(1, limit));
@@ -261,6 +263,16 @@ export class TransactionsService {
         "(transaction.description ILIKE :search OR transaction.payeeName ILIKE :search OR splits.memo ILIKE :search)",
         { search: searchPattern },
       );
+    }
+
+    if (amountFrom !== undefined) {
+      queryBuilder.andWhere("transaction.amount >= :amountFrom", {
+        amountFrom,
+      });
+    }
+
+    if (amountTo !== undefined) {
+      queryBuilder.andWhere("transaction.amount <= :amountTo", { amountTo });
     }
 
     if (targetTransactionId) {
@@ -977,6 +989,8 @@ export class TransactionsService {
     categoryIds?: string[],
     payeeIds?: string[],
     search?: string,
+    amountFrom?: number,
+    amountTo?: number,
   ) {
     return this.analyticsService.getSummary(
       userId,
@@ -986,6 +1000,8 @@ export class TransactionsService {
       categoryIds,
       payeeIds,
       search,
+      amountFrom,
+      amountTo,
     );
   }
 
@@ -997,6 +1013,8 @@ export class TransactionsService {
     categoryIds?: string[],
     payeeIds?: string[],
     search?: string,
+    amountFrom?: number,
+    amountTo?: number,
   ) {
     return this.analyticsService.getMonthlyTotals(
       userId,
@@ -1006,6 +1024,8 @@ export class TransactionsService {
       categoryIds,
       payeeIds,
       search,
+      amountFrom,
+      amountTo,
     );
   }
 

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -127,6 +127,9 @@ function TransactionsContent() {
       if (filters.filterEndDate) chartParams.endDate = filters.filterEndDate;
       if (filters.filterAccountIds.length > 0) chartParams.accountIds = filters.filterAccountIds.join(',');
 
+      const parsedAmountFrom = filters.filterAmountFrom ? parseFloat(filters.filterAmountFrom) : undefined;
+      const parsedAmountTo = filters.filterAmountTo ? parseFloat(filters.filterAmountTo) : undefined;
+
       const chartPromise = hasCategoryOrPayeeFilter
         ? transactionsApi.getMonthlyTotals({
             accountIds: accountIdsForQuery,
@@ -135,6 +138,8 @@ function TransactionsContent() {
             categoryIds: filters.filterCategoryIds.length > 0 ? filters.filterCategoryIds : undefined,
             payeeIds: filters.filterPayeeIds.length > 0 ? filters.filterPayeeIds : undefined,
             search: filters.filterSearch || undefined,
+            amountFrom: parsedAmountFrom,
+            amountTo: parsedAmountTo,
           }).catch(() => [] as MonthlyTotal[])
         : accountsApi.getDailyBalances(
             Object.keys(chartParams).length > 0 ? chartParams : undefined,
@@ -151,6 +156,8 @@ function TransactionsContent() {
           page,
           limit: PAGE_SIZE,
           targetTransactionId: targetTransactionId || undefined,
+          amountFrom: parsedAmountFrom,
+          amountTo: parsedAmountTo,
         }),
         chartPromise,
       ]);
@@ -188,7 +195,7 @@ function TransactionsContent() {
     } finally {
       setIsLoading(false);
     }
-  }, [filters.filterAccountIds, filters.filterAccountStatus, filters.filteredAccounts, filters.filterCategoryIds, filters.filterPayeeIds, filters.filterStartDate, filters.filterEndDate, filters.filterSearch]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [filters.filterAccountIds, filters.filterAccountStatus, filters.filteredAccounts, filters.filterCategoryIds, filters.filterPayeeIds, filters.filterStartDate, filters.filterEndDate, filters.filterSearch, filters.filterAmountFrom, filters.filterAmountTo]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const loadData = useCallback(async (page: number = filters.currentPage) => {
     await loadTransactions(page);
@@ -226,6 +233,8 @@ function TransactionsContent() {
         startDate: filters.filterStartDate,
         endDate: filters.filterEndDate,
         search: filters.filterSearch,
+        amountFrom: filters.filterAmountFrom,
+        amountTo: filters.filterAmountTo,
       }, wasFilterChange);
     }
 
@@ -237,7 +246,7 @@ function TransactionsContent() {
     } else {
       loadTransactions(page);
     }
-  }, [filters.currentPage, filters.filterAccountIds, filters.filterCategoryIds, filters.filterPayeeIds, filters.filterStartDate, filters.filterEndDate, filters.filterSearch, filters.updateUrl, loadTransactions, filters.filtersInitialized]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [filters.currentPage, filters.filterAccountIds, filters.filterCategoryIds, filters.filterPayeeIds, filters.filterStartDate, filters.filterEndDate, filters.filterSearch, filters.filterAmountFrom, filters.filterAmountTo, filters.updateUrl, loadTransactions, filters.filtersInitialized]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Patch popstate handler to skip when modals open
   useEffect(() => {
@@ -334,8 +343,10 @@ function TransactionsContent() {
     if (filters.filterStartDate) f.startDate = filters.filterStartDate;
     if (filters.filterEndDate) f.endDate = filters.filterEndDate;
     if (filters.filterSearch) f.search = filters.filterSearch;
+    if (filters.filterAmountFrom) f.amountFrom = parseFloat(filters.filterAmountFrom);
+    if (filters.filterAmountTo) f.amountTo = parseFloat(filters.filterAmountTo);
     return f;
-  }, [filters.filterAccountIds, filters.filterAccountStatus, filters.filteredAccounts, filters.filterCategoryIds, filters.filterPayeeIds, filters.filterStartDate, filters.filterEndDate, filters.filterSearch]);
+  }, [filters.filterAccountIds, filters.filterAccountStatus, filters.filteredAccounts, filters.filterCategoryIds, filters.filterPayeeIds, filters.filterStartDate, filters.filterEndDate, filters.filterSearch, filters.filterAmountFrom, filters.filterAmountTo]);
 
   // Derive chart currency and aggregate per-account daily balances
   const { chartBalances, chartCurrency } = useMemo(() => {
@@ -442,6 +453,8 @@ function TransactionsContent() {
           searchInput={filters.searchInput}
           filterAccountStatus={filters.filterAccountStatus}
           filterTimePeriod={filters.filterTimePeriod}
+          filterAmountFrom={filters.filterAmountFrom}
+          filterAmountTo={filters.filterAmountTo}
           weekStartsOn={weekStartsOn}
           handleArrayFilterChange={filters.handleArrayFilterChange}
           handleFilterChange={filters.handleFilterChange}
@@ -454,6 +467,8 @@ function TransactionsContent() {
           setFilterEndDate={filters.setFilterEndDate}
           setFilterSearch={filters.setFilterSearch}
           setFilterTimePeriod={filters.setFilterTimePeriod}
+          setFilterAmountFrom={filters.setFilterAmountFrom}
+          setFilterAmountTo={filters.setFilterAmountTo}
           filtersExpanded={filters.filtersExpanded}
           setFiltersExpanded={filters.setFiltersExpanded}
           activeFilterCount={filters.activeFilterCount}

--- a/frontend/src/components/transactions/TransactionFilterPanel.test.tsx
+++ b/frontend/src/components/transactions/TransactionFilterPanel.test.tsx
@@ -77,6 +77,10 @@ describe('TransactionFilterPanel', () => {
     setFilterEndDate: vi.fn(),
     setFilterSearch: vi.fn(),
     setFilterTimePeriod: vi.fn(),
+    filterAmountFrom: '',
+    filterAmountTo: '',
+    setFilterAmountFrom: vi.fn(),
+    setFilterAmountTo: vi.fn(),
     filtersExpanded: false,
     setFiltersExpanded: vi.fn(),
     activeFilterCount: 0,
@@ -1460,6 +1464,166 @@ describe('TransactionFilterPanel', () => {
 
       const select = screen.getByLabelText('Time Period');
       expect(select).toHaveValue('this_week');
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // Amount filter tests
+  // ----------------------------------------------------------------
+
+  describe('amount filters', () => {
+    it('renders Amount From and Amount To inputs when expanded', () => {
+      render(
+        <TransactionFilterPanel
+          {...defaultProps}
+          filtersExpanded={true}
+        />
+      );
+
+      expect(screen.getByLabelText('Amount From')).toBeInTheDocument();
+      expect(screen.getByLabelText('Amount To')).toBeInTheDocument();
+    });
+
+    it('amount inputs are in overflow-hidden container when collapsed', () => {
+      const { container } = render(
+        <TransactionFilterPanel
+          {...defaultProps}
+          filtersExpanded={false}
+        />
+      );
+
+      // The inputs are in the DOM but inside a container with overflow-hidden
+      expect(screen.getByLabelText('Amount From')).toBeInTheDocument();
+      const overflowDiv = container.querySelector('.overflow-hidden');
+      expect(overflowDiv).toBeInTheDocument();
+    });
+
+    it('displays current amount filter values', () => {
+      render(
+        <TransactionFilterPanel
+          {...defaultProps}
+          filtersExpanded={true}
+          filterAmountFrom="10.50"
+          filterAmountTo="99.99"
+        />
+      );
+
+      expect(screen.getByLabelText('Amount From')).toHaveValue(10.5);
+      expect(screen.getByLabelText('Amount To')).toHaveValue(99.99);
+    });
+
+    it('calls handleFilterChange with setFilterAmountFrom when Amount From changes', () => {
+      render(
+        <TransactionFilterPanel
+          {...defaultProps}
+          filtersExpanded={true}
+        />
+      );
+
+      const amountFromInput = screen.getByLabelText('Amount From');
+      fireEvent.change(amountFromInput, { target: { value: '25' } });
+
+      expect(defaultProps.handleFilterChange).toHaveBeenCalledWith(
+        defaultProps.setFilterAmountFrom,
+        '25',
+      );
+    });
+
+    it('calls handleFilterChange with setFilterAmountTo when Amount To changes', () => {
+      render(
+        <TransactionFilterPanel
+          {...defaultProps}
+          filtersExpanded={true}
+        />
+      );
+
+      const amountToInput = screen.getByLabelText('Amount To');
+      fireEvent.change(amountToInput, { target: { value: '500' } });
+
+      expect(defaultProps.handleFilterChange).toHaveBeenCalledWith(
+        defaultProps.setFilterAmountTo,
+        '500',
+      );
+    });
+
+    it('shows amount range chip when collapsed with both amountFrom and amountTo', () => {
+      render(
+        <TransactionFilterPanel
+          {...defaultProps}
+          filtersExpanded={false}
+          activeFilterCount={2}
+          filterAmountFrom="10"
+          filterAmountTo="100"
+        />
+      );
+
+      expect(screen.getByText('10 - 100')).toBeInTheDocument();
+    });
+
+    it('shows "From" chip when only amountFrom is set', () => {
+      render(
+        <TransactionFilterPanel
+          {...defaultProps}
+          filtersExpanded={false}
+          activeFilterCount={1}
+          filterAmountFrom="50"
+          filterAmountTo=""
+        />
+      );
+
+      expect(screen.getByText('From 50')).toBeInTheDocument();
+    });
+
+    it('shows "Up to" chip when only amountTo is set', () => {
+      render(
+        <TransactionFilterPanel
+          {...defaultProps}
+          filtersExpanded={false}
+          activeFilterCount={1}
+          filterAmountFrom=""
+          filterAmountTo="200"
+        />
+      );
+
+      expect(screen.getByText('Up to 200')).toBeInTheDocument();
+    });
+
+    it('clears both amount filters when chip remove button is clicked', () => {
+      render(
+        <TransactionFilterPanel
+          {...defaultProps}
+          filtersExpanded={false}
+          activeFilterCount={2}
+          filterAmountFrom="10"
+          filterAmountTo="100"
+        />
+      );
+
+      const removeButton = screen.getByLabelText('Remove amount filter');
+      fireEvent.click(removeButton);
+
+      expect(defaultProps.handleFilterChange).toHaveBeenCalledWith(
+        defaultProps.setFilterAmountFrom,
+        '',
+      );
+      expect(defaultProps.handleFilterChange).toHaveBeenCalledWith(
+        defaultProps.setFilterAmountTo,
+        '',
+      );
+    });
+
+    it('does not show amount chip when both values are empty', () => {
+      render(
+        <TransactionFilterPanel
+          {...defaultProps}
+          filtersExpanded={false}
+          activeFilterCount={0}
+          filterAmountFrom=""
+          filterAmountTo=""
+        />
+      );
+
+      expect(screen.queryByLabelText('Remove amount filter')).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/transactions/TransactionFilterPanel.tsx
+++ b/frontend/src/components/transactions/TransactionFilterPanel.tsx
@@ -19,6 +19,8 @@ interface TransactionFilterPanelProps {
   searchInput: string;
   filterAccountStatus: 'active' | 'closed' | '';
   filterTimePeriod: string;
+  filterAmountFrom: string;
+  filterAmountTo: string;
   weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   handleArrayFilterChange: <T>(setter: (value: T) => void, value: T) => void;
   handleFilterChange: (setter: (value: string) => void, value: string) => void;
@@ -31,6 +33,8 @@ interface TransactionFilterPanelProps {
   setFilterEndDate: (value: string) => void;
   setFilterSearch: (value: string) => void;
   setFilterTimePeriod: (value: string) => void;
+  setFilterAmountFrom: (value: string) => void;
+  setFilterAmountTo: (value: string) => void;
   filtersExpanded: boolean;
   setFiltersExpanded: (value: boolean) => void;
   activeFilterCount: number;
@@ -57,6 +61,8 @@ export function TransactionFilterPanel({
   searchInput,
   filterAccountStatus,
   filterTimePeriod,
+  filterAmountFrom,
+  filterAmountTo,
   weekStartsOn,
   handleArrayFilterChange,
   handleFilterChange,
@@ -69,6 +75,8 @@ export function TransactionFilterPanel({
   setFilterEndDate,
   setFilterSearch,
   setFilterTimePeriod,
+  setFilterAmountFrom,
+  setFilterAmountTo,
   filtersExpanded,
   setFiltersExpanded,
   activeFilterCount,
@@ -256,6 +264,28 @@ export function TransactionFilterPanel({
                   </button>
                 </span>
               )}
+              {/* Amount range chip - Teal */}
+              {(filterAmountFrom || filterAmountTo) && (
+                <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-teal-100 dark:bg-teal-900 text-teal-800 dark:text-teal-200 whitespace-nowrap">
+                  {filterAmountFrom && filterAmountTo
+                    ? `${filterAmountFrom} - ${filterAmountTo}`
+                    : filterAmountFrom
+                      ? `From ${filterAmountFrom}`
+                      : `Up to ${filterAmountTo}`}
+                  <button
+                    onClick={() => {
+                      handleFilterChange(setFilterAmountFrom, '');
+                      handleFilterChange(setFilterAmountTo, '');
+                    }}
+                    className="ml-0.5 -mr-1 p-0.5 rounded-full inline-flex items-center justify-center hover:bg-teal-200 dark:hover:bg-teal-800"
+                    aria-label="Remove amount filter"
+                  >
+                    <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </span>
+              )}
               {/* Search chip - Gray */}
               {filterSearch && (
                 <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200 whitespace-nowrap">
@@ -356,8 +386,8 @@ export function TransactionFilterPanel({
                 />
               </div>
 
-              {/* Second row: Time period, dates, and search */}
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mt-4">
+              {/* Second row: Time period, dates, amount range, and search */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4 mt-4">
                 <Select
                   label="Time Period"
                   options={TIME_PERIOD_OPTIONS}
@@ -395,6 +425,24 @@ export function TransactionFilterPanel({
                       setFilterTimePeriod('custom');
                     }
                   }}
+                />
+
+                <Input
+                  label="Amount From"
+                  type="number"
+                  step="0.01"
+                  value={filterAmountFrom}
+                  onChange={(e) => handleFilterChange(setFilterAmountFrom, e.target.value)}
+                  placeholder="Min"
+                />
+
+                <Input
+                  label="Amount To"
+                  type="number"
+                  step="0.01"
+                  value={filterAmountTo}
+                  onChange={(e) => handleFilterChange(setFilterAmountTo, e.target.value)}
+                  placeholder="Max"
                 />
 
                 <Input

--- a/frontend/src/hooks/useTransactionFilters.ts
+++ b/frontend/src/hooks/useTransactionFilters.ts
@@ -19,6 +19,8 @@ const STORAGE_KEYS = {
   endDate: 'transactions.filter.endDate',
   search: 'transactions.filter.search',
   timePeriod: 'transactions.filter.timePeriod',
+  amountFrom: 'transactions.filter.amountFrom',
+  amountTo: 'transactions.filter.amountTo',
 };
 
 // Helper to get filter values as array
@@ -87,6 +89,8 @@ export function useTransactionFilters({ accounts, categories, payees, weekStarts
   const [filterSearch, setFilterSearch] = useState<string>('');
   const [searchInput, setSearchInput] = useState<string>('');
   const [filterTimePeriod, setFilterTimePeriod] = useState<string>('');
+  const [filterAmountFrom, setFilterAmountFrom] = useState<string>('');
+  const [filterAmountTo, setFilterAmountTo] = useState<string>('');
   const searchDebounceRef = useRef<NodeJS.Timeout | null>(null);
   const [filtersInitialized, setFiltersInitialized] = useState(false);
   const [filtersExpanded, setFiltersExpanded] = useState(true);
@@ -109,6 +113,8 @@ export function useTransactionFilters({ accounts, categories, payees, weekStarts
     startDate: string;
     endDate: string;
     search: string;
+    amountFrom: string;
+    amountTo: string;
   }, push: boolean = false) => {
     const params = new URLSearchParams();
     if (page > 1) params.set('page', page.toString());
@@ -118,6 +124,8 @@ export function useTransactionFilters({ accounts, categories, payees, weekStarts
     if (filters.startDate) params.set('startDate', filters.startDate);
     if (filters.endDate) params.set('endDate', filters.endDate);
     if (filters.search) params.set('search', filters.search);
+    if (filters.amountFrom) params.set('amountFrom', filters.amountFrom);
+    if (filters.amountTo) params.set('amountTo', filters.amountTo);
 
     const queryString = params.toString();
     const newUrl = queryString ? `/transactions?${queryString}` : '/transactions';
@@ -231,8 +239,10 @@ export function useTransactionFilters({ accounts, categories, payees, weekStarts
     if (filterStartDate) count++;
     if (filterEndDate) count++;
     if (filterSearch) count++;
+    if (filterAmountFrom) count++;
+    if (filterAmountTo) count++;
     return count;
-  }, [filterAccountIds, filterCategoryIds, filterPayeeIds, filterStartDate, filterEndDate, filterSearch]);
+  }, [filterAccountIds, filterCategoryIds, filterPayeeIds, filterStartDate, filterEndDate, filterSearch, filterAmountFrom, filterAmountTo]);
 
   // Auto-collapse filters when there are active filters, expand when none
   useEffect(() => {
@@ -252,7 +262,9 @@ export function useTransactionFilters({ accounts, categories, payees, weekStarts
       searchParams.has('payeeIds') ||
       searchParams.has('startDate') ||
       searchParams.has('endDate') ||
-      searchParams.has('search');
+      searchParams.has('search') ||
+      searchParams.has('amountFrom') ||
+      searchParams.has('amountTo');
 
     const getAccountIds = () => {
       const ids = searchParams.get('accountIds');
@@ -280,6 +292,8 @@ export function useTransactionFilters({ accounts, categories, payees, weekStarts
     const initialSearch = getFilterValue(STORAGE_KEYS.search, searchParams.get('search'), hasAnyUrlParams);
     setFilterSearch(initialSearch);
     setSearchInput(initialSearch);
+    setFilterAmountFrom(getFilterValue(STORAGE_KEYS.amountFrom, searchParams.get('amountFrom'), hasAnyUrlParams));
+    setFilterAmountTo(getFilterValue(STORAGE_KEYS.amountTo, searchParams.get('amountTo'), hasAnyUrlParams));
     if (hasAnyUrlParams) {
       setFilterTimePeriod((initialStartDate || initialEndDate) ? 'custom' : '');
     } else {
@@ -303,7 +317,9 @@ export function useTransactionFilters({ accounts, categories, payees, weekStarts
     localStorage.setItem(STORAGE_KEYS.endDate, filterEndDate);
     localStorage.setItem(STORAGE_KEYS.search, filterSearch);
     localStorage.setItem(STORAGE_KEYS.timePeriod, filterTimePeriod);
-  }, [filterAccountIds, filterCategoryIds, filterPayeeIds, filterStartDate, filterEndDate, filterSearch, filterTimePeriod, filtersInitialized]);
+    localStorage.setItem(STORAGE_KEYS.amountFrom, filterAmountFrom);
+    localStorage.setItem(STORAGE_KEYS.amountTo, filterAmountTo);
+  }, [filterAccountIds, filterCategoryIds, filterPayeeIds, filterStartDate, filterEndDate, filterSearch, filterTimePeriod, filterAmountFrom, filterAmountTo, filtersInitialized]);
 
   // Helper to update array filter and mark as filter change
   const handleArrayFilterChange = useCallback(<T,>(setter: (value: T) => void, value: T) => {
@@ -351,6 +367,8 @@ export function useTransactionFilters({ accounts, categories, payees, weekStarts
       const search = params.get('search') || '';
       setFilterSearch(search);
       setSearchInput(search);
+      setFilterAmountFrom(params.get('amountFrom') || '');
+      setFilterAmountTo(params.get('amountTo') || '');
       const hasDateParams = params.has('startDate') || params.has('endDate');
       setFilterTimePeriod(hasDateParams ? 'custom' : '');
       const pageParam = params.get('page');
@@ -402,6 +420,8 @@ export function useTransactionFilters({ accounts, categories, payees, weekStarts
     setFilterEndDate('');
     setFilterSearch('');
     setFilterTimePeriod('');
+    setFilterAmountFrom('');
+    setFilterAmountTo('');
     localStorage.removeItem(STORAGE_KEYS.accountIds);
     localStorage.removeItem(STORAGE_KEYS.categoryIds);
     localStorage.removeItem(STORAGE_KEYS.payeeIds);
@@ -409,6 +429,8 @@ export function useTransactionFilters({ accounts, categories, payees, weekStarts
     localStorage.removeItem(STORAGE_KEYS.endDate);
     localStorage.removeItem(STORAGE_KEYS.search);
     localStorage.removeItem(STORAGE_KEYS.timePeriod);
+    localStorage.removeItem(STORAGE_KEYS.amountFrom);
+    localStorage.removeItem(STORAGE_KEYS.amountTo);
     router.replace('/transactions', { scroll: false });
   }, [router]);
 
@@ -430,6 +452,8 @@ export function useTransactionFilters({ accounts, categories, payees, weekStarts
     filterSearch, setFilterSearch,
     searchInput,
     filterTimePeriod, setFilterTimePeriod,
+    filterAmountFrom, setFilterAmountFrom,
+    filterAmountTo, setFilterAmountTo,
     filtersInitialized,
     filtersExpanded, setFiltersExpanded,
     activeFilterCount,

--- a/frontend/src/lib/transactions.ts
+++ b/frontend/src/lib/transactions.ts
@@ -73,6 +73,8 @@ export const transactionsApi = {
     limit?: number;
     search?: string;
     targetTransactionId?: string;
+    amountFrom?: number;
+    amountTo?: number;
   }): Promise<PaginatedTransactions> => {
     const apiParams = {
       ...buildFilterParams(params),
@@ -82,6 +84,8 @@ export const transactionsApi = {
       limit: params?.limit,
       search: params?.search,
       targetTransactionId: params?.targetTransactionId,
+      amountFrom: params?.amountFrom,
+      amountTo: params?.amountTo,
     };
 
     const response = await apiClient.get<PaginatedTransactions>('/transactions', {
@@ -153,12 +157,16 @@ export const transactionsApi = {
     payeeId?: string;
     payeeIds?: string[];
     search?: string;
+    amountFrom?: number;
+    amountTo?: number;
   }): Promise<TransactionSummary> => {
     const apiParams = {
       ...buildFilterParams(params),
       startDate: params?.startDate,
       endDate: params?.endDate,
       search: params?.search,
+      amountFrom: params?.amountFrom,
+      amountTo: params?.amountTo,
     };
 
     const response = await apiClient.get<TransactionSummary>('/transactions/summary', {
@@ -176,12 +184,16 @@ export const transactionsApi = {
     categoryIds?: string[];
     payeeIds?: string[];
     search?: string;
+    amountFrom?: number;
+    amountTo?: number;
   }): Promise<MonthlyTotal[]> => {
     const apiParams = {
       ...buildFilterParams(params),
       startDate: params?.startDate,
       endDate: params?.endDate,
       search: params?.search,
+      amountFrom: params?.amountFrom,
+      amountTo: params?.amountTo,
     };
 
     const response = await apiClient.get<MonthlyTotal[]>('/transactions/monthly-totals', {

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -166,6 +166,8 @@ export interface BulkUpdateFilters {
   categoryIds?: string[];
   payeeIds?: string[];
   search?: string;
+  amountFrom?: number;
+  amountTo?: number;
 }
 
 export interface BulkUpdateData {


### PR DESCRIPTION
Add amountFrom and amountTo query parameters to filter transactions by amount range across findAll, getSummary, and getMonthlyTotals endpoints. Includes filter panel UI with number inputs, URL/localStorage persistence, collapsed filter chips, and comprehensive test coverage.