### PR TITLE
Increase share price precision from 4 to 6 decimal places

### DIFF
--- a/backend/src/securities/dto/create-investment-transaction.dto.ts
+++ b/backend/src/securities/dto/create-investment-transaction.dto.ts
@@ -49,7 +49,7 @@ export class CreateInvestmentTransactionDto {
 
   @ApiProperty({ required: false, description: "Price per share" })
   @IsOptional()
-  @IsNumber({ maxDecimalPlaces: 4 })
+  @IsNumber({ maxDecimalPlaces: 6 })
   @Min(0)
   price?: number;
 

--- a/backend/src/securities/entities/holding.entity.ts
+++ b/backend/src/securities/entities/holding.entity.ts
@@ -35,7 +35,7 @@ export class Holding {
   @Column({
     type: "decimal",
     precision: 20,
-    scale: 4,
+    scale: 6,
     name: "average_cost",
     nullable: true,
   })

--- a/backend/src/securities/entities/investment-transaction.entity.ts
+++ b/backend/src/securities/entities/investment-transaction.entity.ts
@@ -87,7 +87,7 @@ export class InvestmentTransaction {
   quantity: number | null;
 
   @ApiProperty({ example: 150.25, description: "Price per share" })
-  @Column({ type: "decimal", precision: 20, scale: 4, nullable: true })
+  @Column({ type: "decimal", precision: 20, scale: 6, nullable: true })
   price: number | null;
 
   @ApiProperty({ example: 9.99, description: "Commission or fee" })

--- a/backend/src/securities/entities/security-price.entity.ts
+++ b/backend/src/securities/entities/security-price.entity.ts
@@ -29,7 +29,7 @@ export class SecurityPrice {
   @Column({
     type: "decimal",
     precision: 20,
-    scale: 4,
+    scale: 6,
     name: "open_price",
     nullable: true,
   })
@@ -39,7 +39,7 @@ export class SecurityPrice {
   @Column({
     type: "decimal",
     precision: 20,
-    scale: 4,
+    scale: 6,
     name: "high_price",
     nullable: true,
   })
@@ -49,14 +49,14 @@ export class SecurityPrice {
   @Column({
     type: "decimal",
     precision: 20,
-    scale: 4,
+    scale: 6,
     name: "low_price",
     nullable: true,
   })
   lowPrice: number;
 
   @ApiProperty()
-  @Column({ type: "decimal", precision: 20, scale: 4, name: "close_price" })
+  @Column({ type: "decimal", precision: 20, scale: 6, name: "close_price" })
   closePrice: number;
 
   @ApiProperty({ required: false })

--- a/database/migrations/029_share_price_6_decimals.sql
+++ b/database/migrations/029_share_price_6_decimals.sql
@@ -1,0 +1,14 @@
+-- Increase share price precision from 4 to 6 decimal places
+-- Affects: security_prices (OHLC), investment_transactions (price), holdings (average_cost)
+
+ALTER TABLE security_prices
+    ALTER COLUMN open_price TYPE NUMERIC(20, 6),
+    ALTER COLUMN high_price TYPE NUMERIC(20, 6),
+    ALTER COLUMN low_price TYPE NUMERIC(20, 6),
+    ALTER COLUMN close_price TYPE NUMERIC(20, 6);
+
+ALTER TABLE holdings
+    ALTER COLUMN average_cost TYPE NUMERIC(20, 6);
+
+ALTER TABLE investment_transactions
+    ALTER COLUMN price TYPE NUMERIC(20, 6);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -344,10 +344,10 @@ CREATE TABLE security_prices (
     id BIGSERIAL PRIMARY KEY,
     security_id UUID NOT NULL REFERENCES securities(id) ON DELETE CASCADE,
     price_date DATE NOT NULL,
-    open_price NUMERIC(20, 4),
-    high_price NUMERIC(20, 4),
-    low_price NUMERIC(20, 4),
-    close_price NUMERIC(20, 4) NOT NULL,
+    open_price NUMERIC(20, 6),
+    high_price NUMERIC(20, 6),
+    low_price NUMERIC(20, 6),
+    close_price NUMERIC(20, 6) NOT NULL,
     volume BIGINT,
     source VARCHAR(50), -- API source
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -363,7 +363,7 @@ CREATE TABLE holdings (
     account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
     security_id UUID NOT NULL REFERENCES securities(id),
     quantity NUMERIC(20, 8) NOT NULL DEFAULT 0,
-    average_cost NUMERIC(20, 4), -- average cost per unit
+    average_cost NUMERIC(20, 6), -- average cost per unit
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(account_id, security_id)
@@ -397,7 +397,7 @@ CREATE TABLE investment_transactions (
     action investment_action NOT NULL,
     transaction_date DATE NOT NULL,
     quantity NUMERIC(20, 8),
-    price NUMERIC(20, 4),
+    price NUMERIC(20, 6),
     commission NUMERIC(20, 4) DEFAULT 0,
     total_amount NUMERIC(20, 4) NOT NULL,
     description TEXT,

--- a/frontend/src/components/investments/InvestmentTransactionForm.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.tsx
@@ -376,7 +376,7 @@ export function InvestmentTransactionForm({
             prefix={currencySymbol}
             value={watchedPrice || undefined}
             onChange={(value) => setValue('price', value, { shouldValidate: true })}
-            decimalPlaces={5}
+            decimalPlaces={6}
             min={0}
             error={errors.price?.message}
           />
@@ -440,7 +440,7 @@ export function InvestmentTransactionForm({
           </div>
           {needsQuantityPrice && (
             <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              {watchedQuantity} shares @ {currencySymbol}{watchedPrice.toFixed(5)}
+              {watchedQuantity} shares @ {currencySymbol}{watchedPrice.toFixed(6)}
               {watchedCommission > 0 && ` ${watchedAction === 'SELL' ? '-' : '+'} ${formatCurrency(watchedCommission, transactionCurrency)} commission`}
             </div>
           )}


### PR DESCRIPTION
Allows entering and saving share prices with up to 6 decimals of precision
across the full stack: database columns (security_prices OHLC, holdings
average_cost, investment_transactions price), backend entity scales and
DTO validation, and frontend input/display formatting.

https://claude.ai/code/session_01VcVvcNCQWeebswKqw23j4d