### PR TITLE
Fix alias buttons submitting the payee form and closing the modal

### DIFF
--- a/frontend/src/components/payees/PayeeAliasManager.tsx
+++ b/frontend/src/components/payees/PayeeAliasManager.tsx
@@ -95,6 +95,7 @@ export function PayeeAliasManager({ payeeId }: PayeeAliasManagerProps) {
                 {alias.alias}
               </span>
               <button
+                type="button"
                 onClick={() => handleRemove(alias)}
                 className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 text-sm"
                 title="Remove alias"
@@ -121,6 +122,7 @@ export function PayeeAliasManager({ payeeId }: PayeeAliasManagerProps) {
           />
         </div>
         <Button
+          type="button"
           variant="secondary"
           size="sm"
           onClick={handleAdd}


### PR DESCRIPTION
The Remove and Add buttons in PayeeAliasManager lacked type="button", so they defaulted to type="submit" inside the PayeeForm <form> element. This caused the payee form to submit (and the modal to close) whenever an alias was added or removed.

https://claude.ai/code/session_01W51ZXB91qabxAUiA6ZNpPL