### PR TITLE
Add Remember Me feature with configurable session duration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,10 @@ REGISTRATION_ENABLED=true
 # Force all local users to set up 2FA
 FORCE_2FA=false
 
+# Number of days the "Remember Me" session lasts (default: 30)
+# Without "Remember Me", sessions last 1 day.
+# REMEMBER_ME_DAYS=30
+
 # ==============================================
 # OIDC / OpenID Connect (Optional)
 # ==============================================

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -10,6 +10,7 @@ import { AuthService } from "./auth.service";
 import { OidcService } from "./oidc/oidc.service";
 import { EmailService } from "../notifications/email.service";
 import { DemoModeService } from "../common/demo-mode.service";
+import { TokenService } from "./token.service";
 
 jest.mock("openid-client", () => ({}));
 
@@ -126,6 +127,14 @@ describe("AuthController", () => {
         { provide: ConfigService, useValue: configService },
         { provide: EmailService, useValue: emailService },
         { provide: DemoModeService, useValue: demoModeService },
+        {
+          provide: TokenService,
+          useValue: {
+            getRefreshExpiryMs: jest
+              .fn()
+              .mockReturnValue(7 * 24 * 60 * 60 * 1000),
+          },
+        },
       ],
     }).compile();
 
@@ -159,6 +168,14 @@ describe("AuthController", () => {
           { provide: ConfigService, useValue: configService },
           { provide: EmailService, useValue: emailService },
           { provide: DemoModeService, useValue: demoModeService },
+          {
+            provide: TokenService,
+            useValue: {
+              getRefreshExpiryMs: jest
+                .fn()
+                .mockReturnValue(7 * 24 * 60 * 60 * 1000),
+            },
+          },
         ],
       }).compile();
 
@@ -196,6 +213,14 @@ describe("AuthController", () => {
           { provide: ConfigService, useValue: configService },
           { provide: EmailService, useValue: emailService },
           { provide: DemoModeService, useValue: demoModeService },
+          {
+            provide: TokenService,
+            useValue: {
+              getRefreshExpiryMs: jest
+                .fn()
+                .mockReturnValue(7 * 24 * 60 * 60 * 1000),
+            },
+          },
         ],
       }).compile();
 
@@ -265,6 +290,14 @@ describe("AuthController", () => {
           { provide: ConfigService, useValue: configService },
           { provide: EmailService, useValue: emailService },
           { provide: DemoModeService, useValue: demoModeService },
+          {
+            provide: TokenService,
+            useValue: {
+              getRefreshExpiryMs: jest
+                .fn()
+                .mockReturnValue(7 * 24 * 60 * 60 * 1000),
+            },
+          },
         ],
       }).compile();
 
@@ -330,6 +363,34 @@ describe("AuthController", () => {
         expect.any(Object),
       );
       expect(res.json).toHaveBeenCalledWith({ user: loginResult.user });
+    });
+
+    it("passes rememberMe from login result to refresh cookie options", async () => {
+      const loginResult = {
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+        user: { id: "user-1", email: "test@example.com" },
+        rememberMe: true,
+      };
+      authService.login.mockResolvedValue(loginResult);
+      const res = mockRes();
+      const expressReq = {
+        cookies: {},
+        headers: { "user-agent": "TestBrowser/1.0" },
+      } as any;
+      const dto = {
+        email: "test@example.com",
+        password: "password",
+        rememberMe: true,
+      };
+
+      await controller.login(dto as any, expressReq, res as any);
+
+      // refresh_token cookie should have maxAge set
+      const refreshCookieCall = res.cookie.mock.calls.find(
+        (call: any[]) => call[0] === "refresh_token",
+      );
+      expect(refreshCookieCall[2]).toHaveProperty("maxAge");
     });
   });
 
@@ -460,6 +521,14 @@ describe("AuthController", () => {
           { provide: ConfigService, useValue: configService },
           { provide: EmailService, useValue: emailService },
           { provide: DemoModeService, useValue: demoModeService },
+          {
+            provide: TokenService,
+            useValue: {
+              getRefreshExpiryMs: jest
+                .fn()
+                .mockReturnValue(7 * 24 * 60 * 60 * 1000),
+            },
+          },
         ],
       }).compile();
 

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -27,6 +27,7 @@ import { Throttle } from "@nestjs/throttler";
 import { Response, Request as ExpressRequest } from "express";
 
 import { AuthService } from "./auth.service";
+import { TokenService } from "./token.service";
 import { OidcService } from "./oidc/oidc.service";
 import { EmailService } from "../notifications/email.service";
 import { RegisterDto } from "./dto/register.dto";
@@ -58,6 +59,7 @@ export class AuthController {
     private configService: ConfigService,
     private emailService: EmailService,
     private demoModeService: DemoModeService,
+    private tokenService: TokenService,
   ) {
     // Default to true if not explicitly set to 'false'
     const localAuthSetting = this.configService.get<string>(
@@ -89,12 +91,12 @@ export class AuthController {
     };
   }
 
-  private getRefreshCookieOptions() {
+  private getRefreshCookieOptions(rememberMe?: boolean) {
     return {
       httpOnly: true,
       secure: this.isProduction,
       sameSite: "strict" as const,
-      maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+      maxAge: this.tokenService.getRefreshExpiryMs(rememberMe),
       path: "/",
     };
   }
@@ -104,9 +106,14 @@ export class AuthController {
     accessToken: string,
     refreshToken: string,
     userId: string,
+    rememberMe?: boolean,
   ) {
     res.cookie("auth_token", accessToken, this.getAccessCookieOptions());
-    res.cookie("refresh_token", refreshToken, this.getRefreshCookieOptions());
+    res.cookie(
+      "refresh_token",
+      refreshToken,
+      this.getRefreshCookieOptions(rememberMe),
+    );
     res.cookie(
       "csrf_token",
       generateCsrfToken(userId, this.authService.getCsrfKey()),
@@ -195,6 +202,7 @@ export class AuthController {
       result.accessToken!,
       result.refreshToken!,
       result.user!.id,
+      result.rememberMe,
     );
     res.json({ user: result.user });
   }
@@ -427,6 +435,7 @@ export class AuthController {
       result.accessToken,
       result.refreshToken,
       result.user.id,
+      result.rememberMe,
     );
 
     if (result.trustedDeviceToken) {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -122,7 +122,7 @@ export class AuthService {
     trustedDeviceToken?: string,
     userAgent?: string,
   ) {
-    const { email: rawEmail, password } = loginDto;
+    const { email: rawEmail, password, rememberMe } = loginDto;
     const email = rawEmail.toLowerCase().trim();
 
     const user = await this.usersRepository.findOne({
@@ -215,17 +215,23 @@ export class AuthService {
           user.lastLogin = new Date();
           await this.usersRepository.save(user);
           const { accessToken, refreshToken } =
-            await this.tokenService.generateTokenPair(user);
+            await this.tokenService.generateTokenPair(user, rememberMe);
           this.logger.log(
             `Login successful (trusted device) for user ${user.id}`,
           );
-          return { user: this.sanitizeUser(user), accessToken, refreshToken };
+          return {
+            user: this.sanitizeUser(user),
+            accessToken,
+            refreshToken,
+            rememberMe,
+          };
         }
       }
 
       // Return a temporary token for 2FA verification
+      // Encode rememberMe in the temp token so it survives the 2FA step
       const tempToken = this.jwtService.sign(
-        { sub: user.id, type: "2fa_pending" },
+        { sub: user.id, type: "2fa_pending", rememberMe: !!rememberMe },
         { expiresIn: "5m" },
       );
       this.logger.log(`Login requires 2FA for user ${user.id}`);
@@ -237,13 +243,14 @@ export class AuthService {
     await this.usersRepository.save(user);
 
     const { accessToken, refreshToken } =
-      await this.tokenService.generateTokenPair(user);
+      await this.tokenService.generateTokenPair(user, rememberMe);
 
     this.logger.log(`Login successful for user ${user.id}`);
     return {
       user: this.sanitizeUser(user),
       accessToken,
       refreshToken,
+      rememberMe,
     };
   }
 
@@ -534,8 +541,8 @@ export class AuthService {
 
   // --- Delegated methods (preserve public API for controller/strategies) ---
 
-  async generateTokenPair(user: User) {
-    return this.tokenService.generateTokenPair(user);
+  async generateTokenPair(user: User, rememberMe?: boolean) {
+    return this.tokenService.generateTokenPair(user, rememberMe);
   }
 
   async refreshTokens(rawRefreshToken: string) {

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,5 +1,12 @@
-import { IsEmail, IsString, IsNotEmpty, MaxLength } from "class-validator";
-import { ApiProperty } from "@nestjs/swagger";
+import {
+  IsEmail,
+  IsString,
+  IsNotEmpty,
+  MaxLength,
+  IsOptional,
+  IsBoolean,
+} from "class-validator";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 
 export class LoginDto {
   @ApiProperty({ example: "user@example.com" })
@@ -11,4 +18,12 @@ export class LoginDto {
   @IsNotEmpty()
   @MaxLength(128)
   password: string;
+
+  @ApiPropertyOptional({
+    example: false,
+    description: "Extend session to 30 days",
+  })
+  @IsOptional()
+  @IsBoolean()
+  rememberMe?: boolean;
 }

--- a/backend/src/auth/token.service.spec.ts
+++ b/backend/src/auth/token.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { getRepositoryToken } from "@nestjs/typeorm";
 import { JwtService } from "@nestjs/jwt";
+import { ConfigService } from "@nestjs/config";
 import { UnauthorizedException } from "@nestjs/common";
 import { DataSource } from "typeorm";
 import { TokenService } from "./token.service";
@@ -79,10 +80,35 @@ describe("TokenService", () => {
           provide: DataSource,
           useValue: dataSource,
         },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue("30") },
+        },
       ],
     }).compile();
 
     service = module.get<TokenService>(TokenService);
+  });
+
+  describe("getRefreshExpiryMs", () => {
+    it("should return 1-day expiry when rememberMe is false", () => {
+      const result = service.getRefreshExpiryMs(false);
+
+      expect(result).toBe(1 * 24 * 60 * 60 * 1000);
+    });
+
+    it("should return 1-day expiry when rememberMe is undefined", () => {
+      const result = service.getRefreshExpiryMs();
+
+      expect(result).toBe(1 * 24 * 60 * 60 * 1000);
+    });
+
+    it("should return configured REMEMBER_ME_DAYS expiry when rememberMe is true", () => {
+      const result = service.getRefreshExpiryMs(true);
+
+      // ConfigService returns "30", so 30 days
+      expect(result).toBe(30 * 24 * 60 * 60 * 1000);
+    });
   });
 
   describe("generateTokenPair", () => {
@@ -113,6 +139,32 @@ describe("TokenService", () => {
         accessToken: "mock-access-token",
         refreshToken: "mock-random-token-hex",
       });
+    });
+
+    it("should use shorter expiry without rememberMe", async () => {
+      const now = Date.now();
+      jest.spyOn(Date, "now").mockReturnValue(now);
+
+      await service.generateTokenPair(mockUser as any);
+
+      const createCall = refreshTokensRepository.create.mock.calls[0][0];
+      const expectedExpiry = new Date(now + 1 * 24 * 60 * 60 * 1000);
+      expect(createCall.expiresAt).toEqual(expectedExpiry);
+
+      jest.restoreAllMocks();
+    });
+
+    it("should use longer expiry with rememberMe", async () => {
+      const now = Date.now();
+      jest.spyOn(Date, "now").mockReturnValue(now);
+
+      await service.generateTokenPair(mockUser as any, true);
+
+      const createCall = refreshTokensRepository.create.mock.calls[0][0];
+      const expectedExpiry = new Date(now + 30 * 24 * 60 * 60 * 1000);
+      expect(createCall.expiresAt).toEqual(expectedExpiry);
+
+      jest.restoreAllMocks();
     });
   });
 

--- a/backend/src/auth/token.service.ts
+++ b/backend/src/auth/token.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, UnauthorizedException, Logger } from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
+import { ConfigService } from "@nestjs/config";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository, LessThan, DataSource } from "typeorm";
 import { Cron, CronExpression } from "@nestjs/schedule";
@@ -13,17 +14,33 @@ import { hashToken } from "./crypto.util";
 export class TokenService {
   private readonly logger = new Logger(TokenService.name);
   private readonly ACCESS_TOKEN_EXPIRY = "15m";
-  private readonly REFRESH_TOKEN_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+  private readonly REFRESH_TOKEN_EXPIRY_MS = 1 * 24 * 60 * 60 * 1000; // 1 day
+  private readonly REMEMBER_ME_EXPIRY_MS: number;
 
   constructor(
     @InjectRepository(RefreshToken)
     private refreshTokensRepository: Repository<RefreshToken>,
     private jwtService: JwtService,
     private dataSource: DataSource,
-  ) {}
+    private configService: ConfigService,
+  ) {
+    const rememberMeDays = parseInt(
+      this.configService.get<string>("REMEMBER_ME_DAYS", "30"),
+      10,
+    );
+    this.REMEMBER_ME_EXPIRY_MS =
+      (rememberMeDays > 0 ? rememberMeDays : 30) * 24 * 60 * 60 * 1000;
+  }
+
+  getRefreshExpiryMs(rememberMe?: boolean): number {
+    return rememberMe
+      ? this.REMEMBER_ME_EXPIRY_MS
+      : this.REFRESH_TOKEN_EXPIRY_MS;
+  }
 
   async generateTokenPair(
     user: User,
+    rememberMe?: boolean,
   ): Promise<{ accessToken: string; refreshToken: string }> {
     const payload = {
       sub: user.id,
@@ -38,13 +55,14 @@ export class TokenService {
     const rawRefreshToken = crypto.randomBytes(64).toString("hex");
     const tokenHash = hashToken(rawRefreshToken);
     const familyId = crypto.randomUUID();
+    const expiryMs = this.getRefreshExpiryMs(rememberMe);
 
     const refreshTokenEntity = this.refreshTokensRepository.create({
       userId: user.id,
       tokenHash,
       familyId,
       isRevoked: false,
-      expiresAt: new Date(Date.now() + this.REFRESH_TOKEN_EXPIRY_MS),
+      expiresAt: new Date(Date.now() + expiryMs),
       replacedByHash: null,
     });
     await this.refreshTokensRepository.save(refreshTokenEntity);

--- a/backend/src/auth/two-factor.service.ts
+++ b/backend/src/auth/two-factor.service.ts
@@ -226,8 +226,9 @@ export class TwoFactorService {
     await this.usersRepository.save(user);
     this.logger.log(`2FA verification successful for user ${user.id}`);
 
+    const rememberMe = payload.rememberMe === true;
     const { accessToken, refreshToken } =
-      await this.tokenService.generateTokenPair(user);
+      await this.tokenService.generateTokenPair(user, rememberMe);
 
     let trustedDeviceToken: string | undefined;
     if (rememberDevice) {
@@ -243,6 +244,7 @@ export class TwoFactorService {
       accessToken,
       refreshToken,
       trustedDeviceToken,
+      rememberMe,
     };
   }
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -503,6 +503,7 @@ CREATE TABLE refresh_tokens (
     token_hash VARCHAR(64) NOT NULL,
     family_id UUID NOT NULL,
     is_revoked BOOLEAN NOT NULL DEFAULT false,
+    remember_me BOOLEAN NOT NULL DEFAULT false,
     expires_at TIMESTAMP NOT NULL,
     replaced_by_hash VARCHAR(64),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -49,6 +49,7 @@ services:
       LOCAL_AUTH_ENABLED: ${LOCAL_AUTH_ENABLED:-true}
       REGISTRATION_ENABLED: ${REGISTRATION_ENABLED:-true}
       FORCE_2FA: ${FORCE_2FA:-false}
+      REMEMBER_ME_DAYS: ${REMEMBER_ME_DAYS:-30}
       # Demo mode (optional)
       DEMO_MODE: ${DEMO_MODE:-false}
       # OIDC (optional)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,6 +49,7 @@ services:
       LOCAL_AUTH_ENABLED: ${LOCAL_AUTH_ENABLED:-true}
       REGISTRATION_ENABLED: ${REGISTRATION_ENABLED:-true}
       FORCE_2FA: ${FORCE_2FA:-false}
+      REMEMBER_ME_DAYS: ${REMEMBER_ME_DAYS:-30}
       # Demo mode (optional)
       DEMO_MODE: ${DEMO_MODE:-false}
       # OIDC (optional)

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -229,7 +229,7 @@ describe('LoginPage', () => {
     });
 
     await waitFor(() => {
-      expect(authApi.login).toHaveBeenCalledWith({ email: 'test@example.com', password: 'password123' });
+      expect(authApi.login).toHaveBeenCalledWith({ email: 'test@example.com', password: 'password123', rememberMe: false });
     });
 
     await waitFor(() => {

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -23,6 +23,7 @@ const logger = createLogger('Login');
 const loginSchema = z.object({
   email: z.string().email('Please enter a valid email address'),
   password: z.string().min(1, 'Password is required'),
+  rememberMe: z.boolean(),
 });
 
 type LoginFormData = z.infer<typeof loginSchema>;
@@ -58,6 +59,7 @@ export default function LoginPage() {
     formState: { errors },
   } = useForm<LoginFormData>({
     resolver: zodResolver(loginSchema),
+    defaultValues: { rememberMe: false },
   });
 
   // Pre-fill demo credentials when demo mode is active
@@ -239,8 +241,8 @@ export default function LoginPage() {
               <div className="flex items-center">
                 <input
                   id="remember-me"
-                  name="remember-me"
                   type="checkbox"
+                  {...register('rememberMe')}
                   className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded dark:border-gray-600 dark:bg-gray-800"
                 />
                 <label

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,8 @@
+import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-export default function HomePage() {
-  redirect('/login');
+export default async function HomePage() {
+  const cookieStore = await cookies();
+  const hasAuth = cookieStore.get('auth_token')?.value || cookieStore.get('refresh_token')?.value;
+  redirect(hasAuth ? '/dashboard' : '/login');
 }

--- a/frontend/src/components/import/CsvColumnMappingStep.tsx
+++ b/frontend/src/components/import/CsvColumnMappingStep.tsx
@@ -321,19 +321,20 @@ export function CsvColumnMappingStep({
             </div>
           )}
 
+          <div>
+            <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">Payee</label>
+            <select
+              value={columnMapping.payee !== undefined ? String(columnMapping.payee) : ''}
+              onChange={(e) => updateMapping('payee', e.target.value)}
+              className="w-full px-2 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+            >
+              {columnOptions.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </div>
+
           <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">Payee</label>
-              <select
-                value={columnMapping.payee !== undefined ? String(columnMapping.payee) : ''}
-                onChange={(e) => updateMapping('payee', e.target.value)}
-                className="w-full px-2 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
-              >
-                {columnOptions.map((o) => (
-                  <option key={o.value} value={o.value}>{o.label}</option>
-                ))}
-              </select>
-            </div>
             <div>
               <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">Category</label>
               <select
@@ -358,6 +359,9 @@ export function CsvColumnMappingStep({
                 ))}
               </select>
             </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
             <div>
               <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">Memo</label>
               <select

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -31,6 +31,7 @@ export interface AdminUser {
 export interface LoginCredentials {
   email: string;
   password: string;
+  rememberMe?: boolean;
 }
 
 export interface RegisterData {


### PR DESCRIPTION
- Add rememberMe checkbox to login form, wired through DTO, auth service, token service, and 2FA flow
- Configurable REMEMBER_ME_DAYS env var (default 30) for persistent sessions; without Remember Me, refresh tokens expire in 1 day
- Dynamic refresh cookie maxAge based on rememberMe flag
- Root page now checks auth cookies to redirect to /dashboard or /login
- Rearrange CSV import column mapping layout (payee gets full width)
- Add tests for getRefreshExpiryMs, generateTokenPair expiry, and rememberMe cookie propagation