### PR TITLE
Add DISABLE_HTTPS_HEADERS env var for plain HTTP deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,10 @@ PUBLIC_APP_URL=http://localhost:3001
 # CORS allowed origin (should match PUBLIC_APP_URL)
 CORS_ORIGIN=http://localhost:3001
 
+# Set to 'true' if accessing Monize directly via HTTP without a reverse proxy.
+# Disables Cross-Origin-Opener-Policy and Strict-Transport-Security headers.
+# DISABLE_HTTPS_HEADERS=false
+
 # ==============================================
 # Authentication
 # ==============================================

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -44,11 +44,17 @@ async function bootstrap() {
   app.use(cookieParser());
 
   // Security middleware
+  const disableHttpsHeaders =
+    process.env.DISABLE_HTTPS_HEADERS === "true";
   app.use(
     helmet({
       frameguard: { action: "deny" },
-      hsts: { maxAge: 63072000, includeSubDomains: true, preload: true },
-      crossOriginOpenerPolicy: { policy: "same-origin" },
+      hsts: disableHttpsHeaders
+        ? false
+        : { maxAge: 63072000, includeSubDomains: true, preload: true },
+      crossOriginOpenerPolicy: disableHttpsHeaders
+        ? false
+        : { policy: "same-origin" },
       crossOriginResourcePolicy: { policy: "same-origin" },
       contentSecurityPolicy: {
         directives: {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -70,6 +70,8 @@ services:
       AI_DEFAULT_MODEL: ${AI_DEFAULT_MODEL:-}
       AI_DEFAULT_API_KEY: ${AI_DEFAULT_API_KEY:-}
       AI_DEFAULT_BASE_URL: ${AI_DEFAULT_BASE_URL:-}
+      # HTTP mode (optional)
+      DISABLE_HTTPS_HEADERS: ${DISABLE_HTTPS_HEADERS:-false}
     volumes:
       - ./backend:/app
       - ./database/schema.sql:/app/schema.sql:ro
@@ -95,6 +97,7 @@ services:
       NODE_ENV: ${NODE_ENV:-development}
       INTERNAL_API_URL: http://backend:3000
       PUBLIC_APP_URL: http://localhost:3001
+      DISABLE_HTTPS_HEADERS: ${DISABLE_HTTPS_HEADERS:-false}
     volumes:
       - ./frontend:/app
       - /app/node_modules

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -70,6 +70,8 @@ services:
       AI_DEFAULT_MODEL: ${AI_DEFAULT_MODEL:-}
       AI_DEFAULT_API_KEY: ${AI_DEFAULT_API_KEY:-}
       AI_DEFAULT_BASE_URL: ${AI_DEFAULT_BASE_URL:-}
+      # HTTP mode (optional)
+      DISABLE_HTTPS_HEADERS: ${DISABLE_HTTPS_HEADERS:-false}
     networks:
       - monize-network
     healthcheck:
@@ -98,6 +100,7 @@ services:
       NODE_ENV: production
       INTERNAL_API_URL: http://backend:3000
       PUBLIC_APP_URL: ${PUBLIC_APP_URL}
+      DISABLE_HTTPS_HEADERS: ${DISABLE_HTTPS_HEADERS:-false}
     ports:
       - "${FRONTEND_PORT:-3000}:3000"
     networks:

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -12,21 +12,22 @@ const nextConfig = {
   // API proxying and CSP are handled by proxy.ts at runtime
   // This allows INTERNAL_API_URL to be set at container start, not build time
   async headers() {
-    return [
-      {
-        source: '/(.*)',
-        headers: [
-          { key: 'X-Content-Type-Options', value: 'nosniff' },
-          { key: 'X-Frame-Options', value: 'DENY' },
-          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
-          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
-          // CSP is set dynamically in proxy.ts with per-request nonces
-          { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
-          { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
-          { key: 'Cross-Origin-Resource-Policy', value: 'same-origin' },
-        ],
-      },
+    const disableHttpsHeaders = process.env.DISABLE_HTTPS_HEADERS === 'true';
+    const securityHeaders = [
+      { key: 'X-Content-Type-Options', value: 'nosniff' },
+      { key: 'X-Frame-Options', value: 'DENY' },
+      { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+      { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+      // CSP is set dynamically in proxy.ts with per-request nonces
+      { key: 'Cross-Origin-Resource-Policy', value: 'same-origin' },
     ];
+    if (!disableHttpsHeaders) {
+      securityHeaders.push(
+        { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+        { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
+      );
+    }
+    return [{ source: '/(.*)', headers: securityHeaders }];
   },
 };
 


### PR DESCRIPTION
Users deploying Monize in Docker without a reverse proxy can set DISABLE_HTTPS_HEADERS=true to disable the Cross-Origin-Opener-Policy and Strict-Transport-Security headers that prevent HTTP access.

https://claude.ai/code/session_01VukEfm62Park5ZtvQdvZES