### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - run: npm install
@@ -33,15 +33,15 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - run: npm install
       - run: npm run test:unit -- --coverage
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: backend-unit-coverage
           path: backend/coverage/
@@ -75,8 +75,8 @@ jobs:
       JWT_SECRET: test-jwt-secret-for-ci-minimum-32-characters-long
       NODE_ENV: test
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - run: npm install
@@ -90,8 +90,8 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - run: npm install
@@ -105,15 +105,15 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - run: npm install
       - run: npm run test:cov
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: frontend-coverage
           path: frontend/coverage/
@@ -122,8 +122,8 @@ jobs:
     name: NPM Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - run: cd backend && npm install && npm audit --audit-level=high
@@ -133,7 +133,7 @@ jobs:
     name: Bearer Security Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Bearer
         uses: bearer/bearer-action@v2
         with:
@@ -165,11 +165,11 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -271,8 +271,8 @@ jobs:
   #     NODE_ENV: development
   #     PUBLIC_APP_URL: http://localhost:3001
   #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-node@v4
+  #     - uses: actions/checkout@v6
+  #     - uses: actions/setup-node@v6
   #       with:
   #         node-version: 24
   #     - name: Create .env for Docker Compose
@@ -302,7 +302,7 @@ jobs:
   #       run: npx playwright test --project=chromium
   #     - name: Upload test report
   #       if: always()
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v7
   #       with:
   #         name: e2e-report
   #         path: e2e/playwright-report/


### PR DESCRIPTION
## Summary
Updated GitHub Actions workflow dependencies to their latest major versions to benefit from security patches, performance improvements, and new features.

## Key Changes
- **actions/checkout**: v4 → v6
- **actions/setup-node**: v4 → v6
- **actions/upload-artifact**: v4 → v7

These upgrades were applied consistently across all workflow jobs:
- Backend build and test jobs
- Frontend build and test jobs
- NPM audit job
- Bearer security scan job
- Release/publish job
- Commented-out e2e test job (for future use)

## Notable Details
- All Node.js version configurations remain at v24
- No changes to workflow logic or job structure
- Upgrades applied uniformly across both active and commented-out workflow sections to maintain consistency

https://claude.ai/code/session_01MjNv6RTDXjQsb2jYuuJPDz