### PR TITLE
Fix date import parsing for apostrophe-separated dates with spaces

### DIFF
--- a/backend/src/import/qif-parser.spec.ts
+++ b/backend/src/import/qif-parser.spec.ts
@@ -546,6 +546,31 @@ T-50.00
       const result = parseQif(qif, "DD/MM/YYYY");
       expect(result.transactions[0].date).toBe("2026-03-15");
     });
+
+    it("parses date with space after apostrophe before single-digit year (M/D' Y)", () => {
+      const qif = `!Type:Bank
+D3/12' 0
+T-50.00
+^
+D4/14' 0
+T-100.00
+^
+D3/11' 1
+T-75.00
+^
+D4/21' 1
+T-200.00
+^
+D3/11' 2
+T-150.00
+^`;
+      const result = parseQif(qif, "MM/DD/YYYY");
+      expect(result.transactions[0].date).toBe("2000-03-12");
+      expect(result.transactions[1].date).toBe("2000-04-14");
+      expect(result.transactions[2].date).toBe("2001-03-11");
+      expect(result.transactions[3].date).toBe("2001-04-21");
+      expect(result.transactions[4].date).toBe("2002-03-11");
+    });
   });
 
   describe("parseQif - DD/MM'YYYY format with apostrophe before 4-digit year", () => {

--- a/backend/src/import/qif-parser.ts
+++ b/backend/src/import/qif-parser.ts
@@ -450,8 +450,8 @@ function normalizeDateSeparators(dateStr: string): string {
   // Remove wrapping quotes and trim
   let normalized = dateStr.replace(/^['"]|['"]$/g, "").trim();
   // Normalize apostrophe/quote used as date separator to '/'
-  // Handles formats like DD/MM'YYYY and M/D'YY
-  normalized = normalized.replace(/(\d)['"](\d)/g, "$1/$2");
+  // Handles formats like DD/MM'YYYY, M/D'YY, and M/D' Y (space-padded single-digit year)
+  normalized = normalized.replace(/(\d)\s*['"]\s*(\d)/g, "$1/$2");
   // Strip spaces around date separators (Quicken pads single-digit days: "2/ 4/19")
   normalized = normalized.replace(/\s*([/-])\s*/g, "$1");
   return normalized;
@@ -492,7 +492,7 @@ function detectDateFormat(dates: string[]): DateFormat {
 
   // Check for MM/DD/YYYY or DD/MM/YYYY format
   for (const date of normalizedDates) {
-    const match = date.match(/^(\d{1,2})[-/](\d{1,2})[-/](\d{2,4})$/);
+    const match = date.match(/^(\d{1,2})[-/](\d{1,2})[-/](\d{1,4})$/);
     if (match) {
       const [, part1, part2] = match;
       const p1 = parseInt(part1);
@@ -530,16 +530,16 @@ function parseQifDate(dateStr: string, format?: DateFormat): string {
     return `${year}-${month}-${day}`;
   }
 
-  // Try MM/DD/YYYY or DD/MM/YYYY format
-  match = dateStr.match(/^(\d{1,2})[-/](\d{1,2})[-/](\d{2,4})$/);
+  // Try MM/DD/YYYY or DD/MM/YYYY format (1-4 digit years)
+  match = dateStr.match(/^(\d{1,2})[-/](\d{1,2})[-/](\d{1,4})$/);
   if (match) {
     const [, part1, part2, yearRaw] = match;
     let year = yearRaw;
 
-    // Convert 2-digit year to 4-digit
-    if (year.length === 2) {
+    // Convert 1 or 2-digit year to 4-digit
+    if (year.length <= 2) {
       const yearNum = parseInt(year);
-      year = yearNum > 50 ? `19${year}` : `20${year}`;
+      year = yearNum > 50 ? `19${year.padStart(2, "0")}` : `20${year.padStart(2, "0")}`;
     }
 
     let month: string, day: string;


### PR DESCRIPTION
Handle QIF dates like "3/11' 2" where the year is a single digit with a
space after the apostrophe. The apostrophe normalization regex now allows
optional whitespace around the apostrophe/quote separator, and the year
matching accepts 1-digit years (e.g., ' 0 for 2000, ' 1 for 2001).

https://claude.ai/code/session_016qV7rhygAxSsCHhv5qoW3z