### PR TITLE
Add PDF export option to all reports

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,8 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "js-cookie": "^3.0.5",
+        "jspdf": "^4.2.1",
+        "jspdf-autotable": "^5.0.7",
         "next": "^16.1.6",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -367,7 +369,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3090,6 +3091,19 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
@@ -3116,6 +3130,13 @@
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -4209,6 +4230,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -4365,6 +4396,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -4510,6 +4561,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4523,6 +4586,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -4907,6 +4980,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5718,6 +5801,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -5727,6 +5821,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -6212,6 +6312,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -6320,6 +6434,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -6955,6 +7075,32 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.7.tgz",
+      "integrity": "sha512-2wr7H6liNDBYNwt25hMQwXkEWFOEopgKIvR1Eukuw6Zmprm/ZcnmLTQEjW7Xx3FCbD3v7pflLcnMAv/h1jFDQw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jspdf": "^2 || ^3 || ^4"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -7867,6 +8013,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7933,6 +8085,13 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8094,6 +8253,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
     },
     "node_modules/react": {
       "version": "19.2.4",
@@ -8271,6 +8440,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -8375,6 +8551,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -8779,6 +8965,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -9050,6 +9246,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -9097,6 +9303,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tiny-invariant": {
@@ -9558,6 +9774,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/victory-vendor": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,8 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "js-cookie": "^3.0.5",
+    "jspdf": "^4.2.1",
+    "jspdf-autotable": "^5.0.7",
     "next": "^16.1.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/frontend/src/components/reports/BillPaymentHistoryReport.tsx
+++ b/frontend/src/components/reports/BillPaymentHistoryReport.tsx
@@ -19,6 +19,7 @@ import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useDateRange } from '@/hooks/useDateRange';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { exportToCsv } from '@/lib/csv-export';
+import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('BillPaymentHistoryReport');
@@ -66,6 +67,26 @@ export function BillPaymentHistoryReport() {
       bp.lastPaymentDate ? format(parseLocalDate(bp.lastPaymentDate), 'yyyy-MM-dd') : '',
     ]);
     exportToCsv('bill-payment-history', headers, rows);
+  };
+
+  const handleExportPdf = async () => {
+    if (!billData) return;
+    const { exportToPdf } = await import('@/lib/pdf-export');
+    const headers = ['Bill', 'Payee', 'Payments', 'Average', 'Total Paid', 'Last Payment'];
+    const rows = billData.billPayments.map((bp) => [
+      bp.scheduledTransactionName,
+      bp.payeeName || '',
+      bp.paymentCount,
+      bp.averagePayment,
+      bp.totalPaid,
+      bp.lastPaymentDate ? format(parseLocalDate(bp.lastPaymentDate), 'yyyy-MM-dd') : '',
+    ]);
+    await exportToPdf({
+      title: 'Bill Payment History',
+      subtitle: `${billData.summary.uniqueBills} bills, ${billData.summary.totalPayments} payments`,
+      tableData: { headers, rows },
+      filename: 'bill-payment-history',
+    });
   };
 
   const CustomTooltip = ({ active, payload, label }: { active?: boolean; payload?: Array<{ value: number }>; label?: string }) => {
@@ -198,16 +219,7 @@ export function BillPaymentHistoryReport() {
             <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
               Payment History by Bill
             </h3>
-            <button
-              onClick={handleExportCsv}
-              className="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5 shrink-0"
-              title="Export to CSV"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-              </svg>
-              CSV
-            </button>
+            <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} />
           </div>
           <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">

--- a/frontend/src/components/reports/LoanAmortizationReport.tsx
+++ b/frontend/src/components/reports/LoanAmortizationReport.tsx
@@ -8,6 +8,7 @@ import { Account } from '@/types/account';
 import { Transaction } from '@/types/transaction';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { exportToCsv } from '@/lib/csv-export';
+import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('LoanAmortizationReport');
@@ -321,6 +322,27 @@ export function LoanAmortizationReport() {
     exportToCsv(`amortization-${accountName}`, headers, rows);
   };
 
+  const handleExportPdf = async () => {
+    const { exportToPdf } = await import('@/lib/pdf-export');
+    const headers = ['#', 'Date', 'Payment', 'Principal', 'Interest', 'Balance', 'Type'];
+    const rows = paymentHistory.map((row) => [
+      row.paymentNumber,
+      format(parseISO(row.date), 'yyyy-MM-dd'),
+      row.payment,
+      row.principal,
+      row.interest,
+      row.balance,
+      row.isProjected ? 'Projected' : 'Actual',
+    ]);
+    const accountName = selectedAccount?.name?.replace(/[^a-zA-Z0-9]/g, '-') || 'loan';
+    await exportToPdf({
+      title: `Loan Amortization - ${selectedAccount?.name || 'Loan'}`,
+      subtitle: summary ? `${historicalCount} payments made, ${formatCurrency(summary.totalInterest)} total interest` : undefined,
+      tableData: { headers, rows },
+      filename: `amortization-${accountName}`,
+    });
+  };
+
   const displayedRows = showAllRows
     ? paymentHistory
     : paymentHistory.slice(0, 24);
@@ -469,16 +491,7 @@ export function LoanAmortizationReport() {
             )}
           </div>
           {paymentHistory.length > 0 && (
-            <button
-              onClick={handleExportCsv}
-              className="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5 shrink-0"
-              title="Export to CSV"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-              </svg>
-              CSV
-            </button>
+            <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} />
           )}
         </div>
 

--- a/frontend/src/components/reports/RecurringExpensesReport.tsx
+++ b/frontend/src/components/reports/RecurringExpensesReport.tsx
@@ -15,6 +15,7 @@ import { RecurringExpenseItem, RecurringExpensesResponse } from '@/types/built-i
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { CHART_COLOURS } from '@/lib/chart-colours';
 import { exportToCsv } from '@/lib/csv-export';
+import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('RecurringExpensesReport');
@@ -63,6 +64,27 @@ export function RecurringExpensesReport() {
       format(new Date(e.lastTransactionDate), 'yyyy-MM-dd'),
     ]);
     exportToCsv('recurring-expenses', headers, rows);
+  };
+
+  const handleExportPdf = async () => {
+    if (!recurringData) return;
+    const { exportToPdf } = await import('@/lib/pdf-export');
+    const headers = ['Payee', 'Category', 'Frequency', 'Count', 'Avg Amount', '6-Mo Total', 'Last Paid'];
+    const rows = recurringData.data.map((e) => [
+      e.payeeName,
+      e.categoryName,
+      e.frequency,
+      e.occurrences,
+      e.averageAmount,
+      e.totalAmount,
+      format(new Date(e.lastTransactionDate), 'yyyy-MM-dd'),
+    ]);
+    await exportToPdf({
+      title: 'Recurring Expenses',
+      subtitle: `${recurringData.summary.uniquePayees} recurring payees identified`,
+      tableData: { headers, rows },
+      filename: 'recurring-expenses',
+    });
   };
 
   const handlePayeeClick = (payeeId: string | null) => {
@@ -204,16 +226,7 @@ export function RecurringExpensesReport() {
               <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
                 All Recurring Expenses
               </h3>
-              <button
-                onClick={handleExportCsv}
-                className="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5 shrink-0"
-                title="Export to CSV"
-              >
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                </svg>
-                CSV
-              </button>
+              <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} />
             </div>
             <div className="overflow-x-auto">
               <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">

--- a/frontend/src/components/reports/ReportChart.tsx
+++ b/frontend/src/components/reports/ReportChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import {
   PieChart,
   Pie,
@@ -20,6 +20,7 @@ import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useDateFormat } from '@/hooks/useDateFormat';
 import { CHART_COLOURS } from '@/lib/chart-colours';
 import { exportToCsv } from '@/lib/csv-export';
+import { ExportDropdown } from '@/components/ui/ExportDropdown';
 
 // Default columns if none specified
 const DEFAULT_TABLE_COLUMNS = [TableColumn.LABEL, TableColumn.VALUE, TableColumn.PERCENTAGE, TableColumn.COUNT];
@@ -31,12 +32,34 @@ interface ReportChartProps {
   onDataPointClick?: (id: string) => void;
   tableColumns?: TableColumn[];
   exportFilename?: string;
+  reportTitle?: string;
+  reportSubtitle?: string;
 }
 
-export function ReportChart({ viewType, data, groupBy, onDataPointClick, tableColumns, exportFilename }: ReportChartProps) {
+function getColumnMap(
+  labelHeader: string,
+  total: number,
+): Record<TableColumn, { header: string; getValue: (item: AggregatedDataPoint) => string | number }> {
+  return {
+    [TableColumn.DATE]: { header: 'Date', getValue: (item) => item.date || '' },
+    [TableColumn.LABEL]: { header: labelHeader, getValue: (item) => item.label },
+    [TableColumn.PAYEE]: { header: 'Payee', getValue: (item) => item.payee || '' },
+    [TableColumn.DESCRIPTION]: { header: 'Description', getValue: (item) => item.description || '' },
+    [TableColumn.MEMO]: { header: 'Memo', getValue: (item) => item.memo || '' },
+    [TableColumn.CATEGORY]: { header: 'Category', getValue: (item) => item.category || '' },
+    [TableColumn.ACCOUNT]: { header: 'Account', getValue: (item) => item.account || '' },
+    [TableColumn.VALUE]: { header: 'Amount', getValue: (item) => item.value },
+    [TableColumn.PERCENTAGE]: { header: '%', getValue: (item) => item.percentage ?? (total > 0 ? Number(((item.value / total) * 100).toFixed(1)) : 0) },
+    [TableColumn.COUNT]: { header: 'Count', getValue: (item) => item.count || 0 },
+    [TableColumn.TAG]: { header: 'Tag', getValue: (item) => item.label || '' },
+  };
+}
+
+export function ReportChart({ viewType, data, groupBy, onDataPointClick, tableColumns, exportFilename, reportTitle, reportSubtitle }: ReportChartProps) {
   const { formatCurrency, formatNumber } = useNumberFormat();
   const { formatDate } = useDateFormat();
   const columns = tableColumns && tableColumns.length > 0 ? tableColumns : DEFAULT_TABLE_COLUMNS;
+  const chartContainerRef = useRef<HTMLDivElement>(null);
 
   // Assign colours to data points without one
   const chartData = useMemo(() => {
@@ -48,6 +71,43 @@ export function ReportChart({ viewType, data, groupBy, onDataPointClick, tableCo
   }, [data]);
 
   const total = chartData.reduce((sum, item) => sum + item.value, 0);
+
+  const labelHeader = groupBy === GroupByType.CATEGORY ? 'Category' :
+                      groupBy === GroupByType.PAYEE ? 'Payee' :
+                      groupBy === GroupByType.NONE ? 'Item' : 'Period';
+
+  const handleExportCsv = () => {
+    const columnMap = getColumnMap(labelHeader, total);
+    const headers = columns.map((col) => columnMap[col]?.header || col);
+    const rows = chartData.map((item) =>
+      columns.map((col) => columnMap[col]?.getValue(item) ?? '')
+    );
+    exportToCsv(exportFilename || 'report', headers, rows);
+  };
+
+  const handleExportPdf = async () => {
+    const { exportToPdf } = await import('@/lib/pdf-export');
+    const columnMap = getColumnMap(labelHeader, total);
+    const headers = columns.map((col) => columnMap[col]?.header || col);
+    const rows = chartData.map((item) =>
+      columns.map((col) => columnMap[col]?.getValue(item) ?? '')
+    );
+    const totalCount = chartData.reduce((sum, item) => sum + (item.count || 0), 0);
+    const totalRow = columns.map((col) => {
+      if (col === TableColumn.LABEL || (col === TableColumn.DATE && !columns.includes(TableColumn.LABEL))) return 'Total';
+      if (col === TableColumn.VALUE) return total;
+      if (col === TableColumn.PERCENTAGE) return '100%';
+      if (col === TableColumn.COUNT) return totalCount || '';
+      return '';
+    });
+    await exportToPdf({
+      title: reportTitle || exportFilename || 'Report',
+      subtitle: reportSubtitle,
+      chartContainer: viewType !== ReportViewType.TABLE ? chartContainerRef.current : null,
+      tableData: { headers, rows, totalRow },
+      filename: exportFilename || 'report',
+    });
+  };
 
   const CustomTooltip = ({
     active,
@@ -78,144 +138,124 @@ export function ReportChart({ viewType, data, groupBy, onDataPointClick, tableCo
 
   const isTimeBased = groupBy === GroupByType.MONTH || groupBy === GroupByType.WEEK || groupBy === GroupByType.DAY;
 
+  const exportBar = (
+    <div className="flex justify-end px-4 py-2">
+      <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} />
+    </div>
+  );
+
   switch (viewType) {
     case ReportViewType.PIE_CHART:
       return (
-        <div className="h-80">
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie
-                data={chartData}
-                cx="50%"
-                cy="50%"
-                innerRadius={60}
-                outerRadius={100}
-                paddingAngle={2}
-                dataKey="value"
-                cursor={onDataPointClick ? 'pointer' : 'default'}
-                onClick={(entry) => entry.id && onDataPointClick?.(entry.id)}
-              >
-                {chartData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip content={<CustomTooltip />} />
-            </PieChart>
-          </ResponsiveContainer>
+        <div>
+          {exportBar}
+          <div ref={chartContainerRef} className="h-80">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={chartData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={60}
+                  outerRadius={100}
+                  paddingAngle={2}
+                  dataKey="value"
+                  cursor={onDataPointClick ? 'pointer' : 'default'}
+                  onClick={(entry) => entry.id && onDataPointClick?.(entry.id)}
+                >
+                  {chartData.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={entry.color} />
+                  ))}
+                </Pie>
+                <Tooltip content={<CustomTooltip />} />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
         </div>
       );
 
     case ReportViewType.BAR_CHART:
       return (
-        <div className="h-80">
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={chartData} margin={{ top: 20, right: 10, left: 0, bottom: 60 }}>
-              <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
-              <XAxis
-                dataKey="label"
-                tick={{ fontSize: 12, fill: 'currentColor' }}
-                angle={-45}
-                textAnchor="end"
-                height={60}
-                interval={0}
-                className="text-gray-600 dark:text-gray-400"
-              />
-              <YAxis
-                tick={{ fontSize: 12, fill: 'currentColor' }}
-                tickFormatter={(value) => formatNumber(value, 0)}
-                className="text-gray-600 dark:text-gray-400"
-              />
-              <Tooltip content={<CustomTooltip />} />
-              <Bar
-                dataKey="value"
-                cursor={onDataPointClick ? 'pointer' : 'default'}
-                onClick={(entry) => entry.id && onDataPointClick?.(entry.id)}
-              >
-                {chartData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+        <div>
+          {exportBar}
+          <div ref={chartContainerRef} className="h-80">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={chartData} margin={{ top: 20, right: 10, left: 0, bottom: 60 }}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
+                <XAxis
+                  dataKey="label"
+                  tick={{ fontSize: 12, fill: 'currentColor' }}
+                  angle={-45}
+                  textAnchor="end"
+                  height={60}
+                  interval={0}
+                  className="text-gray-600 dark:text-gray-400"
+                />
+                <YAxis
+                  tick={{ fontSize: 12, fill: 'currentColor' }}
+                  tickFormatter={(value) => formatNumber(value, 0)}
+                  className="text-gray-600 dark:text-gray-400"
+                />
+                <Tooltip content={<CustomTooltip />} />
+                <Bar
+                  dataKey="value"
+                  cursor={onDataPointClick ? 'pointer' : 'default'}
+                  onClick={(entry) => entry.id && onDataPointClick?.(entry.id)}
+                >
+                  {chartData.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={entry.color} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
         </div>
       );
 
     case ReportViewType.LINE_CHART:
       return (
-        <div className="h-80">
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={chartData} margin={{ top: 20, right: 10, left: 0, bottom: 60 }}>
-              <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
-              <XAxis
-                dataKey="label"
-                tick={{ fontSize: 12, fill: 'currentColor' }}
-                angle={isTimeBased ? -45 : 0}
-                textAnchor={isTimeBased ? 'end' : 'middle'}
-                height={60}
-                interval={isTimeBased ? 'preserveStartEnd' : 0}
-                className="text-gray-600 dark:text-gray-400"
-              />
-              <YAxis
-                tick={{ fontSize: 12, fill: 'currentColor' }}
-                tickFormatter={(value) => formatNumber(value, 0)}
-                className="text-gray-600 dark:text-gray-400"
-              />
-              <Tooltip content={<CustomTooltip />} />
-              <Line
-                type="monotone"
-                dataKey="value"
-                stroke="#3b82f6"
-                strokeWidth={2}
-                dot={{ fill: '#3b82f6', strokeWidth: 2 }}
-                activeDot={{ r: 6 }}
-              />
-            </LineChart>
-          </ResponsiveContainer>
+        <div>
+          {exportBar}
+          <div ref={chartContainerRef} className="h-80">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={chartData} margin={{ top: 20, right: 10, left: 0, bottom: 60 }}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
+                <XAxis
+                  dataKey="label"
+                  tick={{ fontSize: 12, fill: 'currentColor' }}
+                  angle={isTimeBased ? -45 : 0}
+                  textAnchor={isTimeBased ? 'end' : 'middle'}
+                  height={60}
+                  interval={isTimeBased ? 'preserveStartEnd' : 0}
+                  className="text-gray-600 dark:text-gray-400"
+                />
+                <YAxis
+                  tick={{ fontSize: 12, fill: 'currentColor' }}
+                  tickFormatter={(value) => formatNumber(value, 0)}
+                  className="text-gray-600 dark:text-gray-400"
+                />
+                <Tooltip content={<CustomTooltip />} />
+                <Line
+                  type="monotone"
+                  dataKey="value"
+                  stroke="#3b82f6"
+                  strokeWidth={2}
+                  dot={{ fill: '#3b82f6', strokeWidth: 2 }}
+                  activeDot={{ r: 6 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
         </div>
       );
 
     case ReportViewType.TABLE:
     default: {
-      const labelHeader = groupBy === GroupByType.CATEGORY ? 'Category' :
-                          groupBy === GroupByType.PAYEE ? 'Payee' :
-                          groupBy === GroupByType.NONE ? 'Item' : 'Period';
       const totalCount = chartData.reduce((sum, item) => sum + (item.count || 0), 0);
-
-      const handleExportCsv = () => {
-        const columnMap: Record<TableColumn, { header: string; getValue: (item: AggregatedDataPoint) => string | number }> = {
-          [TableColumn.DATE]: { header: 'Date', getValue: (item) => item.date || '' },
-          [TableColumn.LABEL]: { header: labelHeader, getValue: (item) => item.label },
-          [TableColumn.PAYEE]: { header: 'Payee', getValue: (item) => item.payee || '' },
-          [TableColumn.DESCRIPTION]: { header: 'Description', getValue: (item) => item.description || '' },
-          [TableColumn.MEMO]: { header: 'Memo', getValue: (item) => item.memo || '' },
-          [TableColumn.CATEGORY]: { header: 'Category', getValue: (item) => item.category || '' },
-          [TableColumn.ACCOUNT]: { header: 'Account', getValue: (item) => item.account || '' },
-          [TableColumn.VALUE]: { header: 'Amount', getValue: (item) => item.value },
-          [TableColumn.PERCENTAGE]: { header: '%', getValue: (item) => item.percentage ?? (total > 0 ? Number(((item.value / total) * 100).toFixed(1)) : 0) },
-          [TableColumn.COUNT]: { header: 'Count', getValue: (item) => item.count || 0 },
-          [TableColumn.TAG]: { header: 'Tag', getValue: (item) => item.label || '' },
-        };
-        const headers = columns.map((col) => columnMap[col]?.header || col);
-        const rows = chartData.map((item) =>
-          columns.map((col) => columnMap[col]?.getValue(item) ?? '')
-        );
-        exportToCsv(exportFilename || 'report', headers, rows);
-      };
 
       return (
         <div className="overflow-x-auto">
-          <div className="flex justify-end px-4 py-2">
-            <button
-              onClick={handleExportCsv}
-              className="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5"
-              title="Export to CSV"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-              </svg>
-              CSV
-            </button>
-          </div>
+          {exportBar}
           <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
             <thead>
               <tr>

--- a/frontend/src/components/reports/TaxSummaryReport.tsx
+++ b/frontend/src/components/reports/TaxSummaryReport.tsx
@@ -5,6 +5,7 @@ import { builtInReportsApi } from '@/lib/built-in-reports';
 import { TaxSummaryResponse } from '@/types/built-in-reports';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { exportToCsv } from '@/lib/csv-export';
+import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('TaxSummaryReport');
@@ -70,6 +71,33 @@ export function TaxSummaryReport() {
     exportToCsv(`tax-summary-${selectedYear}`, headers, rows);
   };
 
+  const getExportData = () => {
+    const headers = ['Section', 'Category', 'Amount'];
+    const rows: (string | number)[][] = [];
+    for (const item of incomeBySource) {
+      rows.push(['Income', item.name, item.total]);
+    }
+    for (const item of deductibleExpenses) {
+      rows.push(['Potential Deductions', item.name, item.total]);
+    }
+    for (const item of allExpenses) {
+      rows.push(['Expenses', item.name, item.total]);
+    }
+    return { headers, rows };
+  };
+
+  const handleExportPdf = async () => {
+    const { exportToPdf } = await import('@/lib/pdf-export');
+    const { headers, rows } = getExportData();
+    const totalRow: (string | number)[] = ['Totals', '', ''];
+    await exportToPdf({
+      title: `Tax Summary - ${selectedYear}`,
+      subtitle: `Income: ${totals.income} | Expenses: ${totals.expenses} | Deductions: ${totals.deductible}`,
+      tableData: { headers, rows, totalRow },
+      filename: `tax-summary-${selectedYear}`,
+    });
+  };
+
   return (
     <div className="space-y-6">
       {/* Year Selector */}
@@ -89,16 +117,7 @@ export function TaxSummaryReport() {
               ))}
             </select>
           </div>
-          <button
-            onClick={handleExportCsv}
-            className="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5 shrink-0"
-            title="Export to CSV"
-          >
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-            </svg>
-            CSV
-          </button>
+          <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/UncategorizedTransactionsReport.tsx
+++ b/frontend/src/components/reports/UncategorizedTransactionsReport.tsx
@@ -10,6 +10,7 @@ import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useDateRange } from '@/hooks/useDateRange';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { exportToCsv } from '@/lib/csv-export';
+import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('UncategorizedTransactionsReport');
@@ -110,6 +111,24 @@ export function UncategorizedTransactionsReport() {
       tx.amount,
     ]);
     exportToCsv('uncategorized-transactions', headers, rows);
+  };
+
+  const handleExportPdf = async () => {
+    const { exportToPdf } = await import('@/lib/pdf-export');
+    const headers = ['Date', 'Payee', 'Description', 'Account', 'Amount'];
+    const rows = filteredAndSortedTransactions.map((tx) => [
+      format(parseLocalDate(tx.transactionDate), 'yyyy-MM-dd'),
+      tx.payeeName || 'Unknown',
+      tx.description || '',
+      tx.accountName || 'Unknown',
+      tx.amount,
+    ]);
+    await exportToPdf({
+      title: 'Uncategorized Transactions',
+      subtitle: `${filteredAndSortedTransactions.length} transactions`,
+      tableData: { headers, rows },
+      filename: 'uncategorized-transactions',
+    });
   };
 
   const SortIcon = ({ field }: { field: SortField }) => {
@@ -255,16 +274,7 @@ export function UncategorizedTransactionsReport() {
                 Click a transaction to view it in the transactions page
               </p>
             </div>
-            <button
-              onClick={handleExportCsv}
-              className="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5 shrink-0"
-              title="Export to CSV"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-              </svg>
-              CSV
-            </button>
+            <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} />
           </div>
           <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">

--- a/frontend/src/components/ui/ExportDropdown.test.tsx
+++ b/frontend/src/components/ui/ExportDropdown.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@/test/render';
+import { fireEvent, screen } from '@testing-library/react';
+import { ExportDropdown } from './ExportDropdown';
+
+describe('ExportDropdown', () => {
+  it('renders the Export button', () => {
+    render(
+      <ExportDropdown onExportCsv={vi.fn()} onExportPdf={vi.fn()} />,
+    );
+    expect(screen.getByText('Export')).toBeInTheDocument();
+  });
+
+  it('shows dropdown options when clicked', () => {
+    render(
+      <ExportDropdown onExportCsv={vi.fn()} onExportPdf={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText('Export'));
+    expect(screen.getByText('CSV')).toBeInTheDocument();
+    expect(screen.getByText('PDF')).toBeInTheDocument();
+  });
+
+  it('calls onExportCsv when CSV option is clicked', () => {
+    const onExportCsv = vi.fn();
+    render(
+      <ExportDropdown onExportCsv={onExportCsv} onExportPdf={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText('Export'));
+    fireEvent.click(screen.getByText('CSV'));
+    expect(onExportCsv).toHaveBeenCalledOnce();
+  });
+
+  it('calls onExportPdf when PDF option is clicked', async () => {
+    const onExportPdf = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ExportDropdown onExportCsv={vi.fn()} onExportPdf={onExportPdf} />,
+    );
+    fireEvent.click(screen.getByText('Export'));
+    fireEvent.click(screen.getByText('PDF'));
+    expect(onExportPdf).toHaveBeenCalledOnce();
+  });
+
+  it('closes dropdown after selecting an option', () => {
+    render(
+      <ExportDropdown onExportCsv={vi.fn()} onExportPdf={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText('Export'));
+    expect(screen.getByText('CSV')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('CSV'));
+    // Dropdown should be closed - CSV option no longer visible
+    expect(screen.queryByRole('button', { name: 'CSV' })).not.toBeInTheDocument();
+  });
+
+  it('disables the button when disabled prop is true', () => {
+    render(
+      <ExportDropdown onExportCsv={vi.fn()} onExportPdf={vi.fn()} disabled />,
+    );
+    expect(screen.getByTitle('Export report')).toBeDisabled();
+  });
+});

--- a/frontend/src/components/ui/ExportDropdown.tsx
+++ b/frontend/src/components/ui/ExportDropdown.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+interface ExportDropdownProps {
+  onExportCsv: () => void;
+  onExportPdf: () => void;
+  disabled?: boolean;
+}
+
+export function ExportDropdown({ onExportCsv, onExportPdf, disabled }: ExportDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => setIsOpen(false), []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        close();
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen, close]);
+
+  const handleExportCsv = () => {
+    close();
+    onExportCsv();
+  };
+
+  const handleExportPdf = async () => {
+    close();
+    setIsExporting(true);
+    try {
+      await onExportPdf();
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <div ref={dropdownRef} className="relative inline-block">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        disabled={disabled || isExporting}
+        className="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5 disabled:opacity-50"
+        title="Export report"
+      >
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+        </svg>
+        {isExporting ? 'Exporting...' : 'Export'}
+        <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-1 w-36 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg z-50">
+          <button
+            onClick={handleExportCsv}
+            className="w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-t-md flex items-center gap-2"
+          >
+            <svg className="h-4 w-4 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+            CSV
+          </button>
+          <button
+            onClick={handleExportPdf}
+            className="w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-b-md flex items-center gap-2"
+          >
+            <svg className="h-4 w-4 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+            </svg>
+            PDF
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/pdf-export-charts.test.ts
+++ b/frontend/src/lib/pdf-export-charts.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { captureSvgAsImage } from './pdf-export-charts';
+
+describe('captureSvgAsImage', () => {
+  it('returns null when no SVG element is found', async () => {
+    const container = document.createElement('div');
+    const result = await captureSvgAsImage(container);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for empty container', async () => {
+    const container = document.createElement('div');
+    container.innerHTML = '<div>No chart here</div>';
+    const result = await captureSvgAsImage(container);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when SVG has wrong class', async () => {
+    const container = document.createElement('div');
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.classList.add('other-class');
+    container.appendChild(svg);
+    const result = await captureSvgAsImage(container);
+    expect(result).toBeNull();
+  });
+});

--- a/frontend/src/lib/pdf-export-charts.ts
+++ b/frontend/src/lib/pdf-export-charts.ts
@@ -1,0 +1,94 @@
+/**
+ * SVG chart capture utility for PDF export.
+ * Converts Recharts SVG elements to high-resolution PNG images.
+ */
+
+export interface CapturedChart {
+  dataUrl: string;
+  width: number;
+  height: number;
+}
+
+/**
+ * Captures a Recharts SVG element from a container and converts it to a PNG data URL.
+ * Forces a white background regardless of dark mode for print-friendly output.
+ */
+export async function captureSvgAsImage(
+  container: HTMLElement,
+  scale: number = 2,
+): Promise<CapturedChart | null> {
+  const svg = container.querySelector('svg.recharts-surface') as SVGSVGElement | null;
+  if (!svg) return null;
+
+  const svgClone = svg.cloneNode(true) as SVGSVGElement;
+  const svgRect = svg.getBoundingClientRect();
+  const width = svgRect.width;
+  const height = svgRect.height;
+
+  // Ensure the clone has explicit dimensions and a white background
+  svgClone.setAttribute('width', String(width));
+  svgClone.setAttribute('height', String(height));
+  svgClone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+
+  // Add white background rect as the first child
+  const bgRect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+  bgRect.setAttribute('width', '100%');
+  bgRect.setAttribute('height', '100%');
+  bgRect.setAttribute('fill', 'white');
+  svgClone.insertBefore(bgRect, svgClone.firstChild);
+
+  // Force dark-mode text to black for print
+  const textElements = svgClone.querySelectorAll('text, tspan');
+  textElements.forEach((el) => {
+    const elem = el as SVGElement;
+    const fill = elem.getAttribute('fill');
+    if (fill === 'currentColor' || !fill) {
+      elem.setAttribute('fill', '#374151');
+    }
+  });
+
+  // Force grid lines to light gray
+  const lines = svgClone.querySelectorAll('line, path');
+  lines.forEach((el) => {
+    const elem = el as SVGElement;
+    if (elem.classList.contains('stroke-gray-200') || elem.classList.contains('stroke-gray-700')) {
+      elem.setAttribute('stroke', '#e5e7eb');
+      elem.classList.remove('stroke-gray-200', 'stroke-gray-700');
+    }
+  });
+
+  const serializer = new XMLSerializer();
+  const svgString = serializer.serializeToString(svgClone);
+  const svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(svgBlob);
+
+  return new Promise<CapturedChart>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = width * scale;
+      canvas.height = height * scale;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        URL.revokeObjectURL(url);
+        reject(new Error('Failed to get canvas 2d context'));
+        return;
+      }
+      ctx.fillStyle = 'white';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.scale(scale, scale);
+      ctx.drawImage(img, 0, 0, width, height);
+      URL.revokeObjectURL(url);
+      resolve({
+        dataUrl: canvas.toDataURL('image/png'),
+        width,
+        height,
+      });
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('Failed to load SVG image'));
+    };
+    img.src = url;
+  });
+}

--- a/frontend/src/lib/pdf-export-tables.test.ts
+++ b/frontend/src/lib/pdf-export-tables.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockAutoTable } = vi.hoisted(() => ({
+  mockAutoTable: vi.fn(),
+}));
+
+vi.mock('jspdf-autotable', () => ({
+  default: mockAutoTable,
+}));
+
+// Must import AFTER vi.mock
+import { addTableToPdf } from './pdf-export-tables';
+
+describe('addTableToPdf', () => {
+  beforeEach(() => {
+    mockAutoTable.mockClear();
+  });
+
+  it('calls autoTable with correct headers and body', () => {
+    const mockDoc = {
+      lastAutoTable: { finalY: 100 },
+    };
+
+    const headers = ['Name', 'Amount'];
+    const rows = [
+      ['Groceries', 150],
+      ['Rent', 1200],
+    ];
+
+    const result = addTableToPdf(mockDoc as any, headers, rows, { startY: 40 });
+
+    expect(mockAutoTable).toHaveBeenCalledWith(
+      mockDoc,
+      expect.objectContaining({
+        startY: 40,
+        theme: 'grid',
+      }),
+    );
+
+    const callArgs = mockAutoTable.mock.calls[0][1];
+    expect(callArgs.head).toHaveLength(1);
+    expect(callArgs.head[0]).toHaveLength(2);
+    expect(callArgs.body).toHaveLength(2);
+    expect(result).toBe(100);
+  });
+
+  it('adds total row when showTotalRow is true', () => {
+    const mockDoc = {
+      lastAutoTable: { finalY: 120 },
+    };
+
+    addTableToPdf(mockDoc as any, ['Name', 'Amount'], [['A', 10]], {
+      showTotalRow: true,
+      totalRow: ['Total', 10],
+    });
+
+    const callArgs = mockAutoTable.mock.calls[0][1];
+    // Body should have 2 rows: 1 data + 1 total
+    expect(callArgs.body).toHaveLength(2);
+  });
+
+  it('right-aligns numeric headers', () => {
+    const mockDoc = {
+      lastAutoTable: { finalY: 80 },
+    };
+
+    addTableToPdf(mockDoc as any, ['Name', 'Amount', 'Count'], [['A', 100, 5]]);
+
+    const callArgs = mockAutoTable.mock.calls[0][1];
+    const headerRow = callArgs.head[0];
+    // 'Name' should be left-aligned
+    expect(headerRow[0].styles.halign).toBe('left');
+    // 'Amount' should be right-aligned
+    expect(headerRow[1].styles.halign).toBe('right');
+    // 'Count' should be right-aligned
+    expect(headerRow[2].styles.halign).toBe('right');
+  });
+});

--- a/frontend/src/lib/pdf-export-tables.ts
+++ b/frontend/src/lib/pdf-export-tables.ts
@@ -1,0 +1,97 @@
+/**
+ * Table rendering utility for PDF export.
+ * Uses jspdf-autotable to render professional financial tables in PDFs.
+ */
+
+import type jsPDF from 'jspdf';
+import type { CellDef, RowInput } from 'jspdf-autotable';
+import autoTable from 'jspdf-autotable';
+
+export interface PdfTableOptions {
+  startY?: number;
+  fontSize?: number;
+  showTotalRow?: boolean;
+  totalRow?: (string | number)[];
+}
+
+type CellValue = string | number | null | undefined;
+
+/**
+ * Adds a formatted table to a jsPDF document.
+ * Returns the Y position after the table for subsequent content.
+ */
+export function addTableToPdf(
+  doc: jsPDF,
+  headers: string[],
+  rows: CellValue[][],
+  options: PdfTableOptions = {},
+): number {
+  const { startY = 60, fontSize = 9, showTotalRow = false, totalRow } = options;
+
+  const headerRow: CellDef[] = headers.map((h) => ({
+    content: h,
+    styles: {
+      fillColor: [30, 58, 95] as [number, number, number],
+      textColor: [255, 255, 255] as [number, number, number],
+      fontStyle: 'bold' as const,
+      halign: isNumericHeader(h) ? 'right' as const : 'left' as const,
+    },
+  }));
+
+  const bodyRows: RowInput[] = rows.map((row) =>
+    row.map((cell, colIndex) => ({
+      content: cell != null ? cell : '',
+      styles: {
+        halign: isNumericHeader(headers[colIndex]) ? 'right' as const : 'left' as const,
+      },
+    })),
+  );
+
+  if (showTotalRow && totalRow) {
+    const totalRowCells: CellDef[] = totalRow.map((cell, colIndex) => ({
+      content: cell != null ? cell : '',
+      styles: {
+        fontStyle: 'bold' as const,
+        halign: isNumericHeader(headers[colIndex]) ? 'right' as const : 'left' as const,
+        fillColor: [240, 240, 240] as [number, number, number],
+      },
+    }));
+    bodyRows.push(totalRowCells);
+  }
+
+  autoTable(doc, {
+    head: [headerRow],
+    body: bodyRows,
+    startY,
+    theme: 'grid',
+    styles: {
+      fontSize,
+      cellPadding: 3,
+      lineColor: [220, 220, 220],
+      lineWidth: 0.25,
+    },
+    headStyles: {
+      fillColor: [30, 58, 95],
+      textColor: [255, 255, 255],
+      fontStyle: 'bold',
+    },
+    alternateRowStyles: {
+      fillColor: [248, 249, 250],
+    },
+    margin: { left: 14, right: 14 },
+  });
+
+  // Return the final Y position after the table
+  return (doc as jsPDF & { lastAutoTable: { finalY: number } }).lastAutoTable.finalY;
+}
+
+const NUMERIC_HEADERS = new Set([
+  'Amount', 'Value', '%', 'Count', 'Total', 'Balance',
+  'Payment', 'Principal', 'Interest', 'Average', 'Avg Amount',
+  '6-Mo Total', 'Total Paid', 'Payments', 'Total Income',
+  'Total Expenses', 'Total Deductions',
+]);
+
+function isNumericHeader(header: string): boolean {
+  return NUMERIC_HEADERS.has(header);
+}

--- a/frontend/src/lib/pdf-export.test.ts
+++ b/frontend/src/lib/pdf-export.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock jspdf
+const mockSave = vi.fn();
+const mockText = vi.fn();
+const mockAddImage = vi.fn();
+const mockSetFontSize = vi.fn();
+const mockSetFont = vi.fn();
+const mockSetTextColor = vi.fn();
+const mockSetDrawColor = vi.fn();
+const mockSetLineWidth = vi.fn();
+const mockLine = vi.fn();
+const mockAddPage = vi.fn();
+const mockSetPage = vi.fn();
+const mockGetNumberOfPages = vi.fn().mockReturnValue(1);
+
+vi.mock('jspdf', () => {
+  class MockJsPDF {
+    save = mockSave;
+    text = mockText;
+    addImage = mockAddImage;
+    setFontSize = mockSetFontSize;
+    setFont = mockSetFont;
+    setTextColor = mockSetTextColor;
+    setDrawColor = mockSetDrawColor;
+    setLineWidth = mockSetLineWidth;
+    line = mockLine;
+    addPage = mockAddPage;
+    setPage = mockSetPage;
+    getNumberOfPages = mockGetNumberOfPages;
+    internal = {
+      pageSize: { getWidth: () => 297, getHeight: () => 210 },
+    };
+  }
+  return { jsPDF: MockJsPDF };
+});
+
+// Mock chart capture
+vi.mock('./pdf-export-charts', () => ({
+  captureSvgAsImage: vi.fn().mockResolvedValue(null),
+}));
+
+// Mock table rendering
+vi.mock('./pdf-export-tables', () => ({
+  addTableToPdf: vi.fn().mockReturnValue(100),
+}));
+
+describe('exportToPdf', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a PDF with title and saves it', async () => {
+    const { exportToPdf } = await import('./pdf-export');
+
+    await exportToPdf({
+      title: 'Test Report',
+      filename: 'test-report',
+    });
+
+    expect(mockText).toHaveBeenCalledWith('Test Report', expect.any(Number), expect.any(Number));
+    expect(mockSave).toHaveBeenCalledWith('test-report.pdf');
+  });
+
+  it('appends .pdf extension if missing', async () => {
+    const { exportToPdf } = await import('./pdf-export');
+
+    await exportToPdf({
+      title: 'Report',
+      filename: 'my-report',
+    });
+
+    expect(mockSave).toHaveBeenCalledWith('my-report.pdf');
+  });
+
+  it('does not double .pdf extension', async () => {
+    const { exportToPdf } = await import('./pdf-export');
+
+    await exportToPdf({
+      title: 'Report',
+      filename: 'my-report.pdf',
+    });
+
+    expect(mockSave).toHaveBeenCalledWith('my-report.pdf');
+  });
+
+  it('includes subtitle when provided', async () => {
+    const { exportToPdf } = await import('./pdf-export');
+
+    await exportToPdf({
+      title: 'Report',
+      subtitle: 'Jan 2024 - Dec 2024',
+      filename: 'report',
+    });
+
+    expect(mockText).toHaveBeenCalledWith(
+      'Jan 2024 - Dec 2024',
+      expect.any(Number),
+      expect.any(Number),
+    );
+  });
+
+  it('renders table data when provided', async () => {
+    const { exportToPdf } = await import('./pdf-export');
+    const { addTableToPdf } = await import('./pdf-export-tables');
+
+    await exportToPdf({
+      title: 'Report',
+      tableData: {
+        headers: ['Name', 'Value'],
+        rows: [['A', 100]],
+      },
+      filename: 'report',
+    });
+
+    expect(addTableToPdf).toHaveBeenCalled();
+  });
+
+  it('adds page numbers to footer', async () => {
+    const { exportToPdf } = await import('./pdf-export');
+
+    await exportToPdf({
+      title: 'Report',
+      filename: 'report',
+    });
+
+    // Should call setPage for footer
+    expect(mockSetPage).toHaveBeenCalledWith(1);
+    // Should have "Monize" and page number in footer
+    expect(mockText).toHaveBeenCalledWith('Monize', expect.any(Number), expect.any(Number));
+    expect(mockText).toHaveBeenCalledWith(
+      'Page 1 of 1',
+      expect.any(Number),
+      expect.any(Number),
+      expect.objectContaining({ align: 'right' }),
+    );
+  });
+});

--- a/frontend/src/lib/pdf-export.ts
+++ b/frontend/src/lib/pdf-export.ts
@@ -1,0 +1,155 @@
+/**
+ * PDF export utility for report data.
+ * Generates professional financial report PDFs with charts and/or tables.
+ */
+
+import { jsPDF } from 'jspdf';
+import { captureSvgAsImage } from './pdf-export-charts';
+import { addTableToPdf } from './pdf-export-tables';
+
+type CellValue = string | number | null | undefined;
+
+export interface PdfExportOptions {
+  title: string;
+  subtitle?: string;
+  chartContainer?: HTMLElement | null;
+  tableData?: {
+    headers: string[];
+    rows: CellValue[][];
+    totalRow?: (string | number)[];
+  };
+  filename: string;
+}
+
+/**
+ * Generates and downloads a PDF report.
+ * Includes a chart image (if container provided) and/or a data table.
+ */
+export async function exportToPdf(options: PdfExportOptions): Promise<void> {
+  const { title, subtitle, chartContainer, tableData, filename } = options;
+
+  const hasChart = !!chartContainer;
+  const hasTable = tableData && tableData.headers.length > 0;
+
+  // Use landscape for chart-only or chart+table, portrait for table-only
+  const orientation = hasChart ? 'landscape' : 'portrait';
+  const doc = new jsPDF({ orientation, unit: 'mm', format: 'a4' });
+
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const margin = 14;
+
+  // Header
+  addHeader(doc, title, subtitle, pageWidth, margin);
+
+  let currentY = subtitle ? 32 : 26;
+
+  // Chart
+  if (hasChart && chartContainer) {
+    try {
+      const chart = await captureSvgAsImage(chartContainer);
+      if (chart) {
+        const maxWidth = pageWidth - margin * 2;
+        const maxHeight = orientation === 'landscape' ? 120 : 160;
+        const aspectRatio = chart.width / chart.height;
+        let imgWidth = maxWidth;
+        let imgHeight = imgWidth / aspectRatio;
+        if (imgHeight > maxHeight) {
+          imgHeight = maxHeight;
+          imgWidth = imgHeight * aspectRatio;
+        }
+        const xOffset = (pageWidth - imgWidth) / 2;
+        doc.addImage(chart.dataUrl, 'PNG', xOffset, currentY, imgWidth, imgHeight);
+        currentY += imgHeight + 10;
+      }
+    } catch {
+      // Chart capture failed; continue with table only
+    }
+  }
+
+  // Table
+  if (hasTable) {
+    const pageHeight = doc.internal.pageSize.getHeight();
+    // If chart took too much space, add a new page for the table
+    if (hasChart && currentY > pageHeight - 60) {
+      doc.addPage();
+      addHeader(doc, title, subtitle, pageWidth, margin);
+      currentY = subtitle ? 32 : 26;
+    }
+    addTableToPdf(doc, tableData.headers, tableData.rows, {
+      startY: currentY,
+      showTotalRow: !!tableData.totalRow,
+      totalRow: tableData.totalRow,
+    });
+  }
+
+  // Footer on all pages
+  const totalPages = doc.getNumberOfPages();
+  for (let i = 1; i <= totalPages; i++) {
+    doc.setPage(i);
+    addFooter(doc, i, totalPages, pageWidth);
+  }
+
+  const pdfFilename = filename.endsWith('.pdf') ? filename : `${filename}.pdf`;
+  doc.save(pdfFilename);
+}
+
+function addHeader(
+  doc: jsPDF,
+  title: string,
+  subtitle: string | undefined,
+  pageWidth: number,
+  margin: number,
+): void {
+  // Title
+  doc.setFontSize(16);
+  doc.setFont('helvetica', 'bold');
+  doc.setTextColor(30, 58, 95);
+  doc.text(title, margin, 14);
+
+  // Subtitle / date info
+  if (subtitle) {
+    doc.setFontSize(10);
+    doc.setFont('helvetica', 'normal');
+    doc.setTextColor(107, 114, 128);
+    doc.text(subtitle, margin, 22);
+  }
+
+  // Generation timestamp on the right
+  const now = new Date();
+  const timestamp = now.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  doc.setFontSize(8);
+  doc.setFont('helvetica', 'normal');
+  doc.setTextColor(156, 163, 175);
+  doc.text(`Generated: ${timestamp}`, pageWidth - margin, 14, { align: 'right' });
+
+  // Separator line
+  const lineY = subtitle ? 27 : 19;
+  doc.setDrawColor(229, 231, 235);
+  doc.setLineWidth(0.5);
+  doc.line(margin, lineY, pageWidth - margin, lineY);
+}
+
+function addFooter(
+  doc: jsPDF,
+  pageNumber: number,
+  totalPages: number,
+  pageWidth: number,
+): void {
+  const pageHeight = doc.internal.pageSize.getHeight();
+  doc.setFontSize(8);
+  doc.setFont('helvetica', 'normal');
+  doc.setTextColor(156, 163, 175);
+  doc.text('Monize', 14, pageHeight - 8);
+  doc.text(
+    `Page ${pageNumber} of ${totalPages}`,
+    pageWidth - 14,
+    pageHeight - 8,
+    { align: 'right' },
+  );
+}


### PR DESCRIPTION
Client-side PDF generation using jsPDF with SVG-to-canvas chart capture.
Replaces standalone CSV buttons with an Export dropdown offering both
CSV and PDF options across ReportChart and 5 built-in report components.

New files:
- pdf-export.ts: Main orchestrator (title, chart image, table, footer)
- pdf-export-charts.ts: Captures Recharts SVG as high-res PNG
- pdf-export-tables.ts: Professional table layout via jspdf-autotable
- ExportDropdown.tsx: Dropdown UI for CSV/PDF selection

PDF libraries loaded via dynamic import() to avoid impacting initial
bundle size.

https://claude.ai/code/session_01E68tLRcEUkks6cbXi9yaf7