### PR TITLE
Fix Quicken full import to prompt for security symbol mapping

### DIFF
--- a/backend/src/import/dto/import.dto.ts
+++ b/backend/src/import/dto/import.dto.ts
@@ -357,6 +357,17 @@ export class ImportQifMultiAccountDto {
   })
   @MaxLength(20)
   dateFormat?: string;
+
+  @ApiPropertyOptional({
+    description: "Security mappings for investment transactions",
+    type: [SecurityMappingDto],
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(500)
+  @ValidateNested({ each: true })
+  @Type(() => SecurityMappingDto)
+  securityMappings?: SecurityMappingDto[];
 }
 
 export class ParsedQifMultiAccountResponseDto {
@@ -390,6 +401,12 @@ export class ParsedQifMultiAccountResponseDto {
 
   @ApiProperty()
   totalTransactionCount: number;
+
+  @ApiProperty({
+    type: [String],
+    description: "Unique securities found across investment account blocks",
+  })
+  securities: string[];
 
   @ApiProperty({ description: "Detected date format" })
   detectedDateFormat: string;

--- a/backend/src/import/import.service.ts
+++ b/backend/src/import/import.service.ts
@@ -156,6 +156,14 @@ export class ImportService {
       0,
     );
 
+    // Collect unique securities across all investment account blocks
+    const allSecurities = new Set<string>();
+    for (const block of result.accountBlocks) {
+      for (const sec of block.securities) {
+        allSecurities.add(sec);
+      }
+    }
+
     return {
       isMultiAccount: result.isMultiAccount,
       categoryDefs: result.categoryDefs.map((c) => ({
@@ -169,6 +177,7 @@ export class ImportService {
       })),
       accounts,
       totalTransactionCount,
+      securities: Array.from(allSecurities).sort(),
       detectedDateFormat: result.detectedDateFormat,
       sampleDates: result.sampleDates,
     };
@@ -261,7 +270,38 @@ export class ImportService {
         tagMap,
       );
 
-      // Step 5: Import transactions per account block
+      // Step 5: Build security map from user-provided security mappings
+      const { securityMap, securitiesToCreate } =
+        this.buildSecurityMappings(dto.securityMappings);
+
+      // Create any new securities that the user requested
+      if (securitiesToCreate.length > 0) {
+        // Use the first investment account as the reference for security creation
+        const firstInvestmentBlock = result.accountBlocks.find(
+          (b) => b.accountType === "INVESTMENT",
+        );
+        const refAccountId = firstInvestmentBlock
+          ? accountNameToId.get(firstInvestmentBlock.accountName)
+          : undefined;
+        const refAccount = refAccountId
+          ? await queryRunner.manager.findOne(Account, {
+              where: { id: refAccountId },
+            })
+          : undefined;
+
+        if (refAccount) {
+          await this.entityCreator.createSecurities(
+            queryRunner,
+            userId,
+            securitiesToCreate,
+            securityMap,
+            refAccount,
+            importResult,
+          );
+        }
+      }
+
+      // Step 6: Import transactions per account block
       for (const block of result.accountBlocks) {
         const accountId = accountNameToId.get(block.accountName);
         if (!accountId) {
@@ -296,7 +336,7 @@ export class ImportService {
           categoryMap,
           accountMap,
           loanCategoryMap: new Map(),
-          securityMap: new Map(),
+          securityMap,
           tagMap,
           importStartTime,
           dateCounters: new Map(),

--- a/frontend/src/app/import/page.tsx
+++ b/frontend/src/app/import/page.tsx
@@ -120,6 +120,9 @@ function ImportContent() {
             categoryMappings={wizard.categoryMappings}
             shouldShowMapAccounts={wizard.shouldShowMapAccounts}
             setStep={wizard.setStep}
+            isMultiAccountImport={!!wizard.multiAccountData}
+            isLoading={wizard.isLoading}
+            onMultiAccountImport={wizard.handleMultiAccountImport}
           />
         );
 
@@ -170,6 +173,7 @@ function ImportContent() {
             isLoading={wizard.isLoading}
             onImport={wizard.handleMultiAccountImport}
             setStep={wizard.setStep}
+            hasSecuritiesToMap={wizard.securityMappings.length > 0}
           />
         ) : null;
 
@@ -211,7 +215,8 @@ function ImportContent() {
                 if (s === 'mapSecurities' && wizard.securityMappings.length === 0) return false;
                 if (s === 'mapAccounts' && !wizard.shouldShowMapAccounts) return false;
                 if (s === 'multiAccountReview' && !wizard.multiAccountData) return false;
-                if (wizard.multiAccountData && ['selectAccount', 'mapCategories', 'mapSecurities', 'mapAccounts', 'review'].includes(s)) return false;
+                if (wizard.multiAccountData && ['selectAccount', 'mapCategories', 'mapAccounts', 'review'].includes(s)) return false;
+                if (wizard.multiAccountData && s === 'mapSecurities' && wizard.securityMappings.length === 0) return false;
                 return true;
               });
 

--- a/frontend/src/components/import/MapSecuritiesStep.tsx
+++ b/frontend/src/components/import/MapSecuritiesStep.tsx
@@ -5,7 +5,7 @@ import { Select } from '@/components/ui/Select';
 import { Input } from '@/components/ui/Input';
 import { SecurityMapping } from '@/lib/import';
 
-type ImportStep = 'upload' | 'selectAccount' | 'mapCategories' | 'mapSecurities' | 'mapAccounts' | 'review' | 'complete';
+type ImportStep = 'upload' | 'selectAccount' | 'mapCategories' | 'mapSecurities' | 'mapAccounts' | 'review' | 'multiAccountReview' | 'complete';
 
 interface MapSecuritiesStepProps {
   securityMappings: SecurityMapping[];
@@ -18,6 +18,9 @@ interface MapSecuritiesStepProps {
   categoryMappings: { length: number };
   shouldShowMapAccounts: boolean;
   setStep: (step: ImportStep) => void;
+  isMultiAccountImport?: boolean;
+  isLoading?: boolean;
+  onMultiAccountImport?: () => void;
 }
 
 export function MapSecuritiesStep({
@@ -31,6 +34,9 @@ export function MapSecuritiesStep({
   categoryMappings,
   shouldShowMapAccounts,
   setStep,
+  isMultiAccountImport = false,
+  isLoading = false,
+  onMultiAccountImport,
 }: MapSecuritiesStepProps) {
   const readyCount = securityMappings.filter((m) => m.securityId || (m.createNew && m.securityName)).length;
   const needsAttentionCount = securityMappings.length - readyCount;
@@ -140,7 +146,9 @@ export function MapSecuritiesStep({
           <Button
             variant="outline"
             onClick={() => {
-              if (categoryMappings.length > 0) {
+              if (isMultiAccountImport) {
+                setStep('multiAccountReview');
+              } else if (categoryMappings.length > 0) {
                 setStep('mapCategories');
               } else {
                 setStep('selectAccount');
@@ -149,17 +157,26 @@ export function MapSecuritiesStep({
           >
             Back
           </Button>
-          <Button
-            onClick={() => {
-              if (shouldShowMapAccounts) {
-                setStep('mapAccounts');
-              } else {
-                setStep('review');
-              }
-            }}
-          >
-            Next
-          </Button>
+          {isMultiAccountImport ? (
+            <Button
+              onClick={onMultiAccountImport}
+              isLoading={isLoading}
+            >
+              Import All
+            </Button>
+          ) : (
+            <Button
+              onClick={() => {
+                if (shouldShowMapAccounts) {
+                  setStep('mapAccounts');
+                } else {
+                  setStep('review');
+                }
+              }}
+            >
+              Next
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/import/MultiAccountReviewStep.test.tsx
+++ b/frontend/src/components/import/MultiAccountReviewStep.test.tsx
@@ -18,6 +18,7 @@ const defaultMultiAccountData: ParsedQifMultiAccountResponse = {
     { accountName: 'Credit Card', accountType: 'CCard', transactionCount: 12, dateRange: { start: '2025-02-01', end: '2025-06-15' } },
   ],
   totalTransactionCount: 17,
+  securities: [],
   detectedDateFormat: 'MM/DD/YYYY' as DateFormat,
   sampleDates: ['01/15/2025', '02/20/2025'],
 };
@@ -36,6 +37,7 @@ describe('MultiAccountReviewStep', () => {
     isLoading: false,
     onImport: vi.fn(),
     setStep: vi.fn(),
+    hasSecuritiesToMap: false,
   };
 
   beforeEach(() => {

--- a/frontend/src/components/import/MultiAccountReviewStep.tsx
+++ b/frontend/src/components/import/MultiAccountReviewStep.tsx
@@ -15,6 +15,7 @@ interface MultiAccountReviewStepProps {
   isLoading: boolean;
   onImport: () => void;
   setStep: (step: ImportStep) => void;
+  hasSecuritiesToMap: boolean;
 }
 
 export function MultiAccountReviewStep({
@@ -27,6 +28,7 @@ export function MultiAccountReviewStep({
   isLoading,
   onImport,
   setStep,
+  hasSecuritiesToMap,
 }: MultiAccountReviewStepProps) {
   const { categoryDefs, tagDefs = [], accounts, totalTransactionCount } = multiAccountData;
   const incomeCategories = categoryDefs.filter((c) => c.isIncome);
@@ -169,6 +171,15 @@ export function MultiAccountReviewStep({
         </div>
       )}
 
+      {/* Securities notice */}
+      {hasSecuritiesToMap && (
+        <div className="mb-6 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+          <p className="text-sm text-amber-800 dark:text-amber-300">
+            This file contains {multiAccountData.securities.length} securit{multiAccountData.securities.length !== 1 ? 'ies' : 'y'} that need to be mapped before import.
+          </p>
+        </div>
+      )}
+
       {/* Actions */}
       <div className="flex justify-between pt-4">
         <Button
@@ -178,12 +189,18 @@ export function MultiAccountReviewStep({
         >
           Back
         </Button>
-        <Button
-          onClick={onImport}
-          isLoading={isLoading}
-        >
-          Import All
-        </Button>
+        {hasSecuritiesToMap ? (
+          <Button onClick={() => setStep('mapSecurities')}>
+            Next: Map Securities
+          </Button>
+        ) : (
+          <Button
+            onClick={onImport}
+            isLoading={isLoading}
+          >
+            Import All
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/hooks/useImportWizard.ts
+++ b/frontend/src/hooks/useImportWizard.ts
@@ -389,6 +389,16 @@ export function useImportWizard() {
               if (multiResult.detectedDateFormat) {
                 setDateFormat(multiResult.detectedDateFormat);
               }
+              // Build security mappings if the file contains investment securities
+              if (multiResult.securities && multiResult.securities.length > 0) {
+                const newSecMappings = buildSecurityMappings(
+                  new Set(multiResult.securities),
+                  securities,
+                );
+                setSecurityMappings(newSecMappings);
+              } else {
+                setSecurityMappings([]);
+              }
               setStep('multiAccountReview');
               setIsLoading(false);
               return;
@@ -703,6 +713,7 @@ export function useImportWizard() {
         content: multiAccountContent,
         currencyCode: multiAccountCurrency,
         dateFormat,
+        securityMappings: securityMappings.length > 0 ? securityMappings : undefined,
       });
 
       setImportResult(result);

--- a/frontend/src/lib/import.ts
+++ b/frontend/src/lib/import.ts
@@ -267,6 +267,7 @@ export interface ParsedQifMultiAccountResponse {
     dateRange: { start: string; end: string };
   }>;
   totalTransactionCount: number;
+  securities: string[];
   detectedDateFormat: DateFormat;
   sampleDates: string[];
 }
@@ -275,6 +276,7 @@ export interface ImportQifMultiAccountRequest {
   content: string;
   currencyCode: string;
   dateFormat?: DateFormat;
+  securityMappings?: SecurityMapping[];
 }
 
 export const importApi = {


### PR DESCRIPTION
Previously, the multi-account QIF import auto-generated security symbols
from the first letter of each word. Now it collects securities from the
parsed file, shows the MapSecuritiesStep for user confirmation/lookup
(same as singular QIF import), and passes the mappings to the backend.

https://claude.ai/code/session_01CficLv9Cvf21nJMJDriNYC