### PR TITLE
Fix false duplicate detection for transfers with same date/amount/account

### DIFF
--- a/backend/src/import/import-context.ts
+++ b/backend/src/import/import-context.ts
@@ -16,6 +16,9 @@ export interface ImportContext {
   dateCounters: Map<string, number>;
   affectedAccountIds: Set<string>;
   importResult: ImportResultDto;
+  /** Tracks how many QIF entries with each transfer signature have been seen in the current block,
+   *  used to distinguish genuinely different transfers that share date/amount/account. */
+  transferDupCounts: Map<string, number>;
 }
 
 /**

--- a/backend/src/import/import-investment-processor.service.spec.ts
+++ b/backend/src/import/import-investment-processor.service.spec.ts
@@ -68,6 +68,7 @@ describe("ImportInvestmentProcessorService", () => {
       dateCounters: new Map(),
       affectedAccountIds: new Set(),
       importResult: makeImportResult(),
+      transferDupCounts: new Map(),
       ...overrides,
     };
   };

--- a/backend/src/import/import-regular-processor.service.spec.ts
+++ b/backend/src/import/import-regular-processor.service.spec.ts
@@ -30,6 +30,7 @@ describe("ImportRegularProcessorService", () => {
       andWhere: jest.fn().mockReturnThis(),
       getOne: jest.fn().mockResolvedValue(result),
       getMany: jest.fn().mockResolvedValue(result ? [result] : []),
+      getCount: jest.fn().mockResolvedValue(result ? 1 : 0),
     };
     return qb;
   };
@@ -75,6 +76,7 @@ describe("ImportRegularProcessorService", () => {
       dateCounters: new Map(),
       affectedAccountIds: new Set(),
       importResult: makeImportResult(),
+      transferDupCounts: new Map(),
       ...overrides,
     };
   };
@@ -324,6 +326,103 @@ describe("ImportRegularProcessorService", () => {
 
       expect(ctx.importResult.skipped).toBe(0);
       expect(ctx.importResult.imported).toBe(1);
+    });
+
+    it("should not skip a second transfer with same date/amount/account but different payee", async () => {
+      // Reproduces GitHub issue #288: two transfers on the same day for the
+      // same amount to the same account (e.g. Manulife $150 and Cris Morley $150
+      // both to Tangerine) should NOT be treated as duplicates of each other.
+      const accountMap = new Map<string, string | null>();
+      accountMap.set("Tangerine", "acc-tangerine");
+      const ctx = makeContext({ accountMap });
+
+      // After the first transfer is processed, the DB has 1 existing linked
+      // transfer matching the signature. The counting logic should let the
+      // second QIF entry through because seenCount (2) > existingCount (1).
+      let qbCallCount = 0;
+      ctx.queryRunner.manager.createQueryBuilder.mockImplementation(() => {
+        qbCallCount++;
+        // Calls 1-2: isDuplicateTransfer for 1st QIF tx (linked + split-linked)
+        // Calls 3-4: isDuplicateTransfer for 2nd QIF tx (linked + split-linked)
+        // The linked query returns count=1 only for the 2nd tx (after 1st was created)
+        const qb = makeMockQueryBuilder(null);
+        if (qbCallCount === 3) {
+          // 2nd tx's linked-transfer check: 1 existing match in DB
+          qb.getCount.mockResolvedValue(1);
+        }
+        return qb;
+      });
+
+      ctx.queryRunner.manager.findOne.mockImplementation(
+        (_entity: any, opts: any) => {
+          if (opts?.where?.id === "acc-tangerine") {
+            return Promise.resolve({
+              id: "acc-tangerine",
+              currencyCode: "CAD",
+            });
+          }
+          return Promise.resolve(null);
+        },
+      );
+
+      const tx1 = {
+        date: "2020-10-05",
+        amount: -150,
+        payee: "Manulife",
+        memo: "Insurance",
+        isTransfer: true,
+        transferAccount: "Tangerine",
+      };
+      const tx2 = {
+        date: "2020-10-05",
+        amount: -150,
+        payee: "Cris Morley",
+        memo: "For Boots",
+        isTransfer: true,
+        transferAccount: "Tangerine",
+      };
+
+      await service.processTransaction(ctx, tx1);
+      await service.processTransaction(ctx, tx2);
+
+      expect(ctx.importResult.imported).toBe(2);
+      expect(ctx.importResult.skipped).toBe(0);
+    });
+
+    it("should correctly skip both sides when processing the other account block", async () => {
+      // When processing the transfer-target account, both incoming transfers
+      // should be detected as duplicates (they were already created as linked txs).
+      const accountMap = new Map<string, string | null>();
+      accountMap.set("Source Account", "acc-source");
+      const ctx = makeContext({ accountMap });
+
+      // Both QIF entries find 2 existing linked transfers in the DB
+      ctx.queryRunner.manager.createQueryBuilder.mockImplementation(() => {
+        const qb = makeMockQueryBuilder(null);
+        qb.getCount.mockResolvedValue(2);
+        return qb;
+      });
+
+      const tx1 = {
+        date: "2020-10-05",
+        amount: 150,
+        payee: "Manulife",
+        isTransfer: true,
+        transferAccount: "Source Account",
+      };
+      const tx2 = {
+        date: "2020-10-05",
+        amount: 150,
+        payee: "Cris Morley",
+        isTransfer: true,
+        transferAccount: "Source Account",
+      };
+
+      await service.processTransaction(ctx, tx1);
+      await service.processTransaction(ctx, tx2);
+
+      expect(ctx.importResult.skipped).toBe(2);
+      expect(ctx.importResult.imported).toBe(0);
     });
   });
 

--- a/backend/src/import/import-regular-processor.service.ts
+++ b/backend/src/import/import-regular-processor.service.ts
@@ -108,11 +108,16 @@ export class ImportRegularProcessorService {
     ctx: ImportContext,
     qifTx: any,
   ): Promise<boolean> {
-    // Check for duplicate linked transfers
+    // Check for duplicate linked transfers using counting to avoid false positives.
+    // Multiple genuinely different transfers can share the same date, amount, and
+    // account pair (e.g. two $150 transfers to the same account on the same day
+    // with different payees). We count how many matching linked transfers already
+    // exist in the DB and how many same-signature QIF entries we have seen in this
+    // block; only skip when the seen count does not exceed the existing count.
     if (qifTx.isTransfer && qifTx.transferAccount) {
       const mappedTransferAccountId = ctx.accountMap.get(qifTx.transferAccount);
       if (mappedTransferAccountId) {
-        const existingLinkedTransfers = await ctx.queryRunner.manager
+        const existingCount = await ctx.queryRunner.manager
           .createQueryBuilder(Transaction, "t")
           .innerJoin(
             Transaction,
@@ -129,17 +134,22 @@ export class ImportRegularProcessorService {
           .andWhere("linked.account_id = :linkedAccountId", {
             linkedAccountId: mappedTransferAccountId,
           })
-          .getOne();
+          .getCount();
 
-        if (existingLinkedTransfers) {
-          return true;
+        if (existingCount > 0) {
+          const sigKey = `linked|${qifTx.date}|${qifTx.amount}|${mappedTransferAccountId}`;
+          const seenSoFar = ctx.transferDupCounts.get(sigKey) || 0;
+          ctx.transferDupCounts.set(sigKey, seenSoFar + 1);
+          if (seenSoFar + 1 <= existingCount) {
+            return true;
+          }
         }
       }
     }
 
-    // Check for split-linked transfers
+    // Check for split-linked transfers (same counting approach)
     if (qifTx.isTransfer) {
-      const existingSplitLinkedTx = await ctx.queryRunner.manager
+      const existingCount = await ctx.queryRunner.manager
         .createQueryBuilder(Transaction, "t")
         .innerJoin(
           TransactionSplit,
@@ -153,10 +163,15 @@ export class ImportRegularProcessorService {
         .andWhere("t.is_transfer = true")
         .andWhere("t.transaction_date = :date", { date: qifTx.date })
         .andWhere("t.amount = :amount", { amount: qifTx.amount })
-        .getOne();
+        .getCount();
 
-      if (existingSplitLinkedTx) {
-        return true;
+      if (existingCount > 0) {
+        const sigKey = `split|${qifTx.date}|${qifTx.amount}`;
+        const seenSoFar = ctx.transferDupCounts.get(sigKey) || 0;
+        ctx.transferDupCounts.set(sigKey, seenSoFar + 1);
+        if (seenSoFar + 1 <= existingCount) {
+          return true;
+        }
       }
     }
 

--- a/backend/src/import/import.service.spec.ts
+++ b/backend/src/import/import.service.spec.ts
@@ -167,6 +167,7 @@ describe("ImportService", () => {
     leftJoinAndSelect: jest.fn().mockReturnThis(),
     getOne: jest.fn().mockResolvedValue(null),
     getMany: jest.fn().mockResolvedValue([]),
+    getCount: jest.fn().mockResolvedValue(0),
     ...overrides,
   });
 
@@ -1620,7 +1621,7 @@ describe("ImportService", () => {
 
         // Simulate an existing linked transfer found via createQueryBuilder
         const mockQb = createMockQueryBuilder({
-          getOne: jest.fn().mockResolvedValue({ id: "existing-transfer" }),
+          getCount: jest.fn().mockResolvedValue(1),
         });
         mockQueryRunner.manager.createQueryBuilder.mockReturnValue(mockQb);
 

--- a/backend/src/import/import.service.ts
+++ b/backend/src/import/import.service.ts
@@ -382,6 +382,7 @@ export class ImportService {
           dateCounters: new Map(),
           affectedAccountIds,
           importResult,
+          transferDupCounts: new Map(),
         };
 
         // Apply opening balance
@@ -1199,6 +1200,7 @@ export class ImportService {
       dateCounters: new Map<string, number>(),
       affectedAccountIds,
       importResult,
+      transferDupCounts: new Map<string, number>(),
     };
 
     try {


### PR DESCRIPTION
isDuplicateTransfer used getOne() which treated any matching linked transfer as a duplicate. When two genuinely different transfers shared the same date, amount, and account pair (e.g. Manulife -$150 and Cris Morley -$150, both to Tangerine on the same day), the second was incorrectly skipped.

Replace the boolean check with a counting approach: count existing linked transfers in the DB and track how many same-signature QIF entries have been seen in the current block. Only skip when seenCount <= existingCount. This correctly handles both the source-side (multiple distinct transfers) and the target-side (skip already-created linked transactions) without depending on payee/memo matching, which avoids the regression where transfers appeared twice when payees differed between sides.