### PR TITLE
Handle XIn/XOut as cash transfers in investment account imports

### DIFF
--- a/backend/src/import/import-investment-processor.service.spec.ts
+++ b/backend/src/import/import-investment-processor.service.spec.ts
@@ -27,6 +27,18 @@ describe("ImportInvestmentProcessorService", () => {
     securitiesCreated: 0,
   });
 
+  const makeMockQueryBuilder = (countResult = 0, oneResult: any = null) => {
+    const qb: Record<string, jest.Mock> = {
+      innerJoin: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockResolvedValue(oneResult),
+      getCount: jest.fn().mockResolvedValue(countResult),
+    };
+    return qb;
+  };
+
   const makeMockManager = () => ({
     save: jest.fn().mockImplementation((entity: any) => {
       if (!entity.id) {
@@ -37,6 +49,7 @@ describe("ImportInvestmentProcessorService", () => {
     findOne: jest.fn().mockResolvedValue(null),
     update: jest.fn().mockResolvedValue({ affected: 1 }),
     create: jest.fn().mockImplementation((_cls: any, data: any) => data),
+    createQueryBuilder: jest.fn().mockReturnValue(makeMockQueryBuilder()),
   });
 
   const makeMockQueryRunner = () => {
@@ -996,12 +1009,42 @@ describe("ImportInvestmentProcessorService", () => {
       await testActionMapping("CvrShrt", InvestmentAction.BUY);
     });
 
-    it("maps XIn to TRANSFER_IN", async () => {
-      await testActionMapping("XIn", InvestmentAction.TRANSFER_IN);
+    it("XIn is handled as a cash transfer, not an investment transaction", async () => {
+      // XIn bypasses the actionMap and is processed by processCashTransfer,
+      // so no InvestmentTransaction record is created.
+      const ctx = makeContext();
+      const qifTx = {
+        action: "XIn",
+        date: "2025-01-15",
+        amount: 500,
+      };
+
+      await service.processTransaction(ctx, qifTx);
+
+      const saveCalls = ctx.queryRunner.manager.save.mock.calls;
+      const investmentTxSave = saveCalls.find(
+        (call: any) => call[0] instanceof InvestmentTransaction,
+      );
+      expect(investmentTxSave).toBeUndefined();
+      expect(ctx.importResult.imported).toBe(1);
     });
 
-    it("maps XOut to TRANSFER_OUT", async () => {
-      await testActionMapping("XOut", InvestmentAction.TRANSFER_OUT);
+    it("XOut is handled as a cash transfer, not an investment transaction", async () => {
+      const ctx = makeContext();
+      const qifTx = {
+        action: "XOut",
+        date: "2025-01-15",
+        amount: -200,
+      };
+
+      await service.processTransaction(ctx, qifTx);
+
+      const saveCalls = ctx.queryRunner.manager.save.mock.calls;
+      const investmentTxSave = saveCalls.find(
+        (call: any) => call[0] instanceof InvestmentTransaction,
+      );
+      expect(investmentTxSave).toBeUndefined();
+      expect(ctx.importResult.imported).toBe(1);
     });
 
     it("maps RtrnCap to DIVIDEND", async () => {
@@ -1046,6 +1089,259 @@ describe("ImportInvestmentProcessorService", () => {
 
     it("maps Cash to INTEREST", async () => {
       await testActionMapping("Cash", InvestmentAction.INTEREST);
+    });
+  });
+
+  describe("XIn / XOut cash transfers", () => {
+    it("XIn creates a cash transaction and a linked transaction in the transfer account", async () => {
+      const accountMap = new Map<string, string | null>();
+      accountMap.set("Chequing", "acc-chequing");
+      const ctx = makeContext({ accountMap });
+
+      ctx.queryRunner.manager.findOne.mockImplementation(
+        (_entity: any, opts: any) => {
+          if (opts?.where?.id === "acc-chequing") {
+            return Promise.resolve({
+              id: "acc-chequing",
+              currencyCode: "USD",
+              currentBalance: 5000,
+            });
+          }
+          if (opts?.where?.id === accountId) {
+            return Promise.resolve({
+              id: accountId,
+              currencyCode: "USD",
+              currentBalance: 0,
+            });
+          }
+          return Promise.resolve(null);
+        },
+      );
+
+      const qifTx = {
+        action: "XIn",
+        date: "2025-01-15",
+        amount: 1000,
+        payee: "Transfer",
+        memo: "Cash in",
+        isTransfer: true,
+        transferAccount: "Chequing",
+        cleared: true,
+      };
+
+      await service.processTransaction(ctx, qifTx);
+
+      expect(ctx.importResult.imported).toBe(1);
+      expect(ctx.importResult.skipped).toBe(0);
+
+      // No InvestmentTransaction should be created
+      const saveCalls = ctx.queryRunner.manager.save.mock.calls;
+      const investmentTxSave = saveCalls.find(
+        (call: any) => call[0] instanceof InvestmentTransaction,
+      );
+      expect(investmentTxSave).toBeUndefined();
+
+      // Cash transaction saved in the investment account
+      const cashTxSave = saveCalls.find(
+        (call: any) => call[0]?.accountId === accountId && call[0]?.amount === 1000,
+      );
+      expect(cashTxSave).toBeDefined();
+
+      // Linked transaction saved in the transfer account
+      const linkedTxSave = saveCalls.find(
+        (call: any) => call[0]?.accountId === "acc-chequing" && call[0]?.amount === -1000,
+      );
+      expect(linkedTxSave).toBeDefined();
+      expect(ctx.affectedAccountIds.has("acc-chequing")).toBe(true);
+    });
+
+    it("XOut creates a cash transaction and a linked transaction in the transfer account", async () => {
+      const accountMap = new Map<string, string | null>();
+      accountMap.set("Savings", "acc-savings");
+      const ctx = makeContext({ accountMap });
+
+      ctx.queryRunner.manager.findOne.mockImplementation(
+        (_entity: any, opts: any) => {
+          if (opts?.where?.id === "acc-savings") {
+            return Promise.resolve({
+              id: "acc-savings",
+              currencyCode: "USD",
+              currentBalance: 2000,
+            });
+          }
+          return Promise.resolve(null);
+        },
+      );
+
+      const qifTx = {
+        action: "XOut",
+        date: "2025-01-20",
+        amount: -500,
+        payee: "Withdrawal",
+        isTransfer: true,
+        transferAccount: "Savings",
+      };
+
+      await service.processTransaction(ctx, qifTx);
+
+      expect(ctx.importResult.imported).toBe(1);
+
+      const saveCalls = ctx.queryRunner.manager.save.mock.calls;
+      const cashTxSave = saveCalls.find(
+        (call: any) => call[0]?.accountId === accountId && call[0]?.amount === -500,
+      );
+      expect(cashTxSave).toBeDefined();
+
+      const linkedTxSave = saveCalls.find(
+        (call: any) => call[0]?.accountId === "acc-savings" && call[0]?.amount === 500,
+      );
+      expect(linkedTxSave).toBeDefined();
+    });
+
+    it("XIn with no transfer account creates only a cash transaction", async () => {
+      const ctx = makeContext();
+
+      const qifTx = {
+        action: "XIn",
+        date: "2025-02-01",
+        amount: 200,
+        isTransfer: false,
+      };
+
+      await service.processTransaction(ctx, qifTx);
+
+      expect(ctx.importResult.imported).toBe(1);
+
+      const saveCalls = ctx.queryRunner.manager.save.mock.calls;
+      // Only the cash TX and the balance update (via findOne/update) -- no linked TX
+      const txSaves = saveCalls.filter(
+        (call: any) => call[0]?.accountId === accountId,
+      );
+      expect(txSaves.length).toBe(1);
+    });
+
+    it("XIn for brokerage account routes cash to the linked cash account", async () => {
+      const accountMap = new Map<string, string | null>();
+      accountMap.set("Chequing", "acc-chequing");
+      const ctx = makeContext({
+        accountMap,
+        account: {
+          id: accountId,
+          currencyCode: "USD",
+          accountSubType: AccountSubType.INVESTMENT_BROKERAGE,
+          linkedAccountId: "acc-cash",
+          name: "My Brokerage",
+        } as any,
+      });
+
+      ctx.queryRunner.manager.findOne.mockImplementation(
+        (_entity: any, opts: any) => {
+          if (opts?.where?.id === "acc-cash") {
+            return Promise.resolve({
+              id: "acc-cash",
+              currencyCode: "USD",
+              currentBalance: 0,
+            });
+          }
+          if (opts?.where?.id === "acc-chequing") {
+            return Promise.resolve({
+              id: "acc-chequing",
+              currencyCode: "USD",
+              currentBalance: 5000,
+            });
+          }
+          return Promise.resolve(null);
+        },
+      );
+
+      const qifTx = {
+        action: "XIn",
+        date: "2025-03-01",
+        amount: 750,
+        isTransfer: true,
+        transferAccount: "Chequing",
+      };
+
+      await service.processTransaction(ctx, qifTx);
+
+      expect(ctx.importResult.imported).toBe(1);
+      expect(ctx.affectedAccountIds.has("acc-cash")).toBe(true);
+
+      const saveCalls = ctx.queryRunner.manager.save.mock.calls;
+      const cashTxSave = saveCalls.find(
+        (call: any) => call[0]?.accountId === "acc-cash" && call[0]?.amount === 750,
+      );
+      expect(cashTxSave).toBeDefined();
+    });
+
+    it("duplicate XIn is skipped using counting when already exists in DB", async () => {
+      // If a matching linked transfer already exists (e.g. from a prior import
+      // of the counterpart account), the XIn should be skipped.
+      const accountMap = new Map<string, string | null>();
+      accountMap.set("Chequing", "acc-chequing");
+      const ctx = makeContext({ accountMap });
+
+      // Duplicate detection query returns count=1 (already imported once)
+      ctx.queryRunner.manager.createQueryBuilder.mockReturnValue(
+        makeMockQueryBuilder(1),
+      );
+
+      const qifTx = {
+        action: "XIn",
+        date: "2025-01-15",
+        amount: 300,
+        isTransfer: true,
+        transferAccount: "Chequing",
+      };
+
+      await service.processTransaction(ctx, qifTx);
+
+      expect(ctx.importResult.skipped).toBe(1);
+      expect(ctx.importResult.imported).toBe(0);
+    });
+
+    it("two XIn transfers with same signature are not both skipped (counting logic)", async () => {
+      // Two genuine XIn transfers on the same day for the same amount from the
+      // same account should both be imported even when the second one finds
+      // existingCount=1 in the DB (the record created by the first XIn).
+      // The "always count" logic ensures seenSoFar=1 by the time the second
+      // XIn runs, so seenSoFar+1=2 > existingCount=1 → not skipped.
+      const accountMap = new Map<string, string | null>();
+      accountMap.set("Chequing", "acc-chequing");
+      const ctx = makeContext({ accountMap });
+
+      let qbCallCount = 0;
+      ctx.queryRunner.manager.createQueryBuilder.mockImplementation(() => {
+        qbCallCount++;
+        const qb = makeMockQueryBuilder(0);
+        // 1st XIn: existingCount=0 (DB empty). Counter bumped to 1.
+        // 2nd XIn: existingCount=1 (1st XIn created a linked TX). Counter
+        //   is already 1, so seenSoFar+1=2 > 1 → not skipped.
+        if (qbCallCount === 2) {
+          qb.getCount.mockResolvedValue(1);
+        }
+        return qb;
+      });
+
+      ctx.queryRunner.manager.findOne.mockResolvedValue({
+        id: "acc-chequing",
+        currencyCode: "USD",
+        currentBalance: 0,
+      });
+
+      const qifTx = {
+        action: "XIn",
+        date: "2025-01-15",
+        amount: 300,
+        isTransfer: true,
+        transferAccount: "Chequing",
+      };
+
+      await service.processTransaction(ctx, { ...qifTx });
+      await service.processTransaction(ctx, { ...qifTx });
+
+      expect(ctx.importResult.imported).toBe(2);
+      expect(ctx.importResult.skipped).toBe(0);
     });
   });
 });

--- a/backend/src/import/import-investment-processor.service.ts
+++ b/backend/src/import/import-investment-processor.service.ts
@@ -18,6 +18,15 @@ export class ImportInvestmentProcessorService {
   private readonly logger = new Logger(ImportInvestmentProcessorService.name);
 
   async processTransaction(ctx: ImportContext, qifTx: any): Promise<void> {
+    // XIn/XOut are cash-only transfers between the investment account and
+    // another account; they carry no security data and must be handled as
+    // regular linked transactions rather than investment transactions.
+    const qifActionRaw = (qifTx.action || "").toLowerCase();
+    if (qifActionRaw === "xin" || qifActionRaw === "xout") {
+      await this.processCashTransfer(ctx, qifTx);
+      return;
+    }
+
     const actionMap: Record<string, InvestmentAction> = {
       buy: InvestmentAction.BUY,
       sell: InvestmentAction.SELL,
@@ -182,6 +191,125 @@ export class ImportInvestmentProcessorService {
 
     ctx.securityMap.set(securityName, savedSecurity.id);
     return savedSecurity.id;
+  }
+
+  private async processCashTransfer(
+    ctx: ImportContext,
+    qifTx: any,
+  ): Promise<void> {
+    // Determine the cash account to credit/debit.
+    // For brokerage accounts with a linked cash account, cash goes there.
+    let cashAccountId = ctx.accountId;
+    let cashCurrencyCode = ctx.account.currencyCode;
+    if (
+      ctx.account.accountSubType === AccountSubType.INVESTMENT_BROKERAGE &&
+      ctx.account.linkedAccountId
+    ) {
+      cashAccountId = ctx.account.linkedAccountId;
+      ctx.affectedAccountIds.add(cashAccountId);
+      const linkedAccount = await ctx.queryRunner.manager.findOne(Account, {
+        where: { id: ctx.account.linkedAccountId },
+      });
+      if (linkedAccount) {
+        cashCurrencyCode = linkedAccount.currencyCode;
+      }
+    }
+
+    const cashAmount = qifTx.amount || 0;
+    const status = qifTx.reconciled
+      ? TransactionStatus.RECONCILED
+      : qifTx.cleared
+        ? TransactionStatus.CLEARED
+        : TransactionStatus.UNRECONCILED;
+
+    const transferAccountId: string | null =
+      qifTx.isTransfer && qifTx.transferAccount
+        ? (ctx.accountMap.get(qifTx.transferAccount) ?? null)
+        : null;
+
+    // Duplicate detection using the same counting approach as the regular
+    // processor: compare how many matching linked transfers already exist in
+    // the DB against how many same-signature entries we have seen so far in
+    // this import block, and only skip when the seen count does not exceed
+    // the existing count.
+    if (transferAccountId) {
+      const existingCount = await ctx.queryRunner.manager
+        .createQueryBuilder(Transaction, "t")
+        .innerJoin(
+          Transaction,
+          "linked",
+          "t.linked_transaction_id = linked.id",
+        )
+        .where("t.user_id = :userId", { userId: ctx.userId })
+        .andWhere("t.account_id = :accountId", { accountId: cashAccountId })
+        .andWhere("t.is_transfer = true")
+        .andWhere("t.transaction_date = :date", { date: qifTx.date })
+        .andWhere("t.amount = :amount", { amount: cashAmount })
+        .andWhere("linked.account_id = :linkedAccountId", {
+          linkedAccountId: transferAccountId,
+        })
+        .getCount();
+
+      // Always count every QIF entry with this signature, including ones where
+      // existingCount is zero (i.e. a fresh import where this QIF entry itself
+      // creates the first DB record). This ensures that when the next entry
+      // with the same signature arrives and finds existingCount=1, seenSoFar
+      // is already 1 so seenSoFar+1=2 > 1 and it is not incorrectly skipped.
+      const sigKey = `xfer|${qifTx.date}|${cashAmount}|${transferAccountId}`;
+      const seenSoFar = ctx.transferDupCounts.get(sigKey) || 0;
+      ctx.transferDupCounts.set(sigKey, seenSoFar + 1);
+      if (existingCount > 0 && seenSoFar + 1 <= existingCount) {
+        ctx.importResult.skipped++;
+        return;
+      }
+    }
+
+    const cashTx = ctx.queryRunner.manager.create(Transaction, {
+      userId: ctx.userId,
+      accountId: cashAccountId,
+      transactionDate: qifTx.date,
+      amount: cashAmount,
+      payeeName: qifTx.payee || null,
+      description: qifTx.memo || null,
+      status,
+      currencyCode: cashCurrencyCode,
+      isTransfer: !!transferAccountId,
+    });
+    const savedCashTx = await ctx.queryRunner.manager.save(cashTx);
+    await updateAccountBalance(ctx.queryRunner, cashAccountId, cashAmount);
+
+    if (transferAccountId) {
+      ctx.affectedAccountIds.add(transferAccountId);
+      const linkedAmount = -cashAmount;
+      const targetAccount = await ctx.queryRunner.manager.findOne(Account, {
+        where: { id: transferAccountId },
+      });
+
+      const linkedTx = ctx.queryRunner.manager.create(Transaction, {
+        userId: ctx.userId,
+        accountId: transferAccountId,
+        transactionDate: qifTx.date,
+        amount: linkedAmount,
+        payeeName: qifTx.payee || `Transfer from ${ctx.account.name}`,
+        description: qifTx.memo || null,
+        status,
+        currencyCode: targetAccount?.currencyCode || cashCurrencyCode,
+        isTransfer: true,
+        linkedTransactionId: savedCashTx.id,
+      });
+      const savedLinkedTx = await ctx.queryRunner.manager.save(linkedTx);
+
+      await ctx.queryRunner.manager.update(Transaction, savedCashTx.id, {
+        linkedTransactionId: savedLinkedTx.id,
+      });
+      await updateAccountBalance(
+        ctx.queryRunner,
+        transferAccountId,
+        linkedAmount,
+      );
+    }
+
+    ctx.importResult.imported++;
   }
 
   private async processCashTransaction(

--- a/backend/src/import/import-regular-processor.service.spec.ts
+++ b/backend/src/import/import-regular-processor.service.spec.ts
@@ -25,6 +25,7 @@ describe("ImportRegularProcessorService", () => {
   const makeMockQueryBuilder = (result: any = null) => {
     const qb: Record<string, jest.Mock> = {
       innerJoin: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
       leftJoinAndSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
@@ -423,6 +424,99 @@ describe("ImportRegularProcessorService", () => {
 
       expect(ctx.importResult.skipped).toBe(2);
       expect(ctx.importResult.imported).toBe(0);
+    });
+
+    it("should not delete a prior split transaction when a second split transaction shares the same transfer account", async () => {
+      // Reproduces a bug where two split transactions with the same date/amount
+      // and a common transfer split (e.g. both have [Accounts Rec] -76.00) caused
+      // the second import to steal the linked transaction from the first and then
+      // delete the first parent transaction as a phantom placeholder.
+      //
+      // Both transactions have amount -100 with splits:
+      //   TX1: [Personal Care -24, [Accounts Rec] -76]
+      //   TX2: [[Accounts Rec] -76, Personal Care -24]  (same splits, reversed order)
+      //
+      // Expected: both imported (imported=2), TX1 is NOT deleted.
+      const accountMap = new Map<string, string | null>();
+      accountMap.set("Accounts Rec", "acc-rec");
+      const ctx = makeContext({ accountMap });
+
+      // isDuplicateTransfer returns false for split transactions (isTransfer is
+      // false on the parent). processSplitTransfer uses getOne, not getCount.
+      // Return null from all query builders so no existing linked tx is found
+      // (simulating a fresh import where neither TX has been stored yet).
+      ctx.queryRunner.manager.createQueryBuilder.mockReturnValue(
+        makeMockQueryBuilder(null),
+      );
+
+      // findOne: return the target account for balance updates
+      ctx.queryRunner.manager.findOne.mockImplementation(
+        (_entity: any, opts: any) => {
+          if (opts?.where?.id === "acc-rec") {
+            return Promise.resolve({
+              id: "acc-rec",
+              currencyCode: "CAD",
+              currentBalance: 0,
+            });
+          }
+          if (opts?.where?.id === ctx.accountId) {
+            return Promise.resolve({
+              id: ctx.accountId,
+              currencyCode: "CAD",
+              currentBalance: 0,
+            });
+          }
+          return Promise.resolve(null);
+        },
+      );
+
+      const tx1 = {
+        date: "2022-06-01",
+        amount: -100,
+        payee: "Galib Shariff Prof",
+        memo: "Physio - Dan",
+        reconciled: true,
+        splits: [
+          {
+            category: "Personal Care:Massage - Physio - Chiro",
+            amount: -24,
+          },
+          {
+            isTransfer: true,
+            transferAccount: "Accounts Rec",
+            amount: -76,
+          },
+        ],
+      };
+      const tx2 = {
+        date: "2022-06-01",
+        amount: -100,
+        payee: "Galib Shariff Prof",
+        memo: "Physio - Dan",
+        reconciled: true,
+        splits: [
+          {
+            isTransfer: true,
+            transferAccount: "Accounts Rec",
+            amount: -76,
+          },
+          {
+            category: "Personal Care:Massage - Physio - Chiro",
+            amount: -24,
+          },
+        ],
+      };
+
+      await service.processTransaction(ctx, tx1);
+      await service.processTransaction(ctx, tx2);
+
+      expect(ctx.importResult.imported).toBe(2);
+      expect(ctx.importResult.skipped).toBe(0);
+
+      // Verify TX1 was not deleted: the delete mock should not have been
+      // called with the ID of the transaction saved during TX1's processing.
+      const deleteCalls = ctx.queryRunner.manager.delete.mock.calls;
+      expect(deleteCalls.length).toBe(0);
     });
   });
 

--- a/backend/src/import/import-regular-processor.service.ts
+++ b/backend/src/import/import-regular-processor.service.ts
@@ -442,8 +442,18 @@ export class ImportRegularProcessorService {
     // Exclude transactions already linked to the current transaction (savedTx)
     // to prevent a second split transfer from matching the linked transaction
     // created by a prior split transfer in the same parent transaction.
+    // Only match transactions that are either unlinked or linked to a simple
+    // (non-split) placeholder in the current account. This prevents stealing
+    // a linked transaction that already belongs to another split parent
+    // transaction imported earlier in the same block.
     const existingLinkedTx = await ctx.queryRunner.manager
       .createQueryBuilder(Transaction, "t")
+      .leftJoin(
+        Transaction,
+        "placeholder",
+        "placeholder.id = t.linked_transaction_id AND placeholder.account_id = :currentAccountId AND placeholder.is_split = false",
+        { currentAccountId: ctx.accountId },
+      )
       .where("t.user_id = :userId", { userId: ctx.userId })
       .andWhere("t.account_id = :accountId", {
         accountId: splitTransferAccountId,
@@ -452,8 +462,7 @@ export class ImportRegularProcessorService {
       .andWhere("t.amount = :amount", { amount: linkedAmount })
       .andWhere("t.is_transfer = true")
       .andWhere(
-        "(t.linked_transaction_id IS NULL OR t.linked_transaction_id != :currentTxId)",
-        { currentTxId: savedTx.id },
+        "(t.linked_transaction_id IS NULL OR placeholder.id IS NOT NULL)",
       )
       .getOne();
 


### PR DESCRIPTION
## Summary
This PR refactors the handling of XIn/XOut transactions in investment account imports to treat them as cash-only transfers rather than investment transactions. It also fixes a bug in split transaction processing where linked transactions could be incorrectly reassigned between split parents.

## Key Changes

### Investment Account Processing (import-investment-processor.service.ts)
- **XIn/XOut routing**: Added early detection of XIn/XOut actions to route them to a new `processCashTransfer()` method instead of the investment transaction pipeline
- **Cash transfer handling**: Implemented `processCashTransfer()` to:
  - Create cash transactions (not investment transactions) for XIn/XOut
  - Support linked transfers between the investment account and other accounts
  - Route cash to the linked cash account for brokerage accounts
  - Implement duplicate detection using a counting mechanism to handle multiple transfers with identical signatures
  - Update account balances for both the investment account and transfer account

### Regular Transaction Processing (import-regular-processor.service.ts)
- **Split transfer linking fix**: Modified `matchPendingTransfer()` to prevent a second split transaction from stealing the linked transaction of a prior split transaction
- **Query refinement**: Added a `leftJoin` condition to only match unlinked transactions or those linked to simple (non-split) placeholders in the current account
- This prevents the bug where two split transactions with the same date/amount and a common transfer split would cause the first transaction to be incorrectly deleted

### Test Coverage
- Updated XIn/XOut test cases to verify they create cash transactions, not investment transactions
- Added comprehensive test suite for XIn/XOut cash transfers covering:
  - Basic XIn/XOut with transfer accounts
  - Brokerage accounts with linked cash accounts
  - Duplicate detection and handling of multiple transfers with identical signatures
  - Edge cases like transfers without target accounts
- Added regression test for split transaction linking bug

## Implementation Details
- XIn/XOut duplicate detection uses a signature-based counting approach (`transferDupCounts` map) to handle multiple identical transfers in a single import block
- Cash transfers maintain bidirectional linking between the investment account transaction and the transfer account transaction
- The fix for split transactions uses a conditional `leftJoin` to distinguish between unlinked transactions and those linked to split parents vs. simple placeholders

https://claude.ai/code/session_01JyuiatnDyHXHknZXmFdGgk