### PR TITLE
Fix QIF transfer duplication for investment cash accounts

### DIFF
--- a/backend/src/common/format-currency.util.ts
+++ b/backend/src/common/format-currency.util.ts
@@ -1,4 +1,4 @@
-import { roundToDecimals } from './round.util';
+import { roundToDecimals } from "./round.util";
 
 /**
  * Format a number as currency with the correct decimal places for the given currency code.

--- a/backend/src/common/round.util.spec.ts
+++ b/backend/src/common/round.util.spec.ts
@@ -1,83 +1,83 @@
-import { roundToDecimals } from './round.util';
+import { roundToDecimals } from "./round.util";
 
-describe('roundToDecimals', () => {
-  describe('basic rounding', () => {
-    it('rounds to 2 decimal places', () => {
+describe("roundToDecimals", () => {
+  describe("basic rounding", () => {
+    it("rounds to 2 decimal places", () => {
       expect(roundToDecimals(1.234, 2)).toBe(1.23);
       expect(roundToDecimals(1.235, 2)).toBe(1.24);
       expect(roundToDecimals(1.236, 2)).toBe(1.24);
     });
 
-    it('rounds to 0 decimal places', () => {
+    it("rounds to 0 decimal places", () => {
       expect(roundToDecimals(1.4, 0)).toBe(1);
       expect(roundToDecimals(1.5, 0)).toBe(2);
       expect(roundToDecimals(1.6, 0)).toBe(2);
     });
 
-    it('rounds to 4 decimal places', () => {
+    it("rounds to 4 decimal places", () => {
       expect(roundToDecimals(1.23456, 4)).toBe(1.2346);
       expect(roundToDecimals(1.23454, 4)).toBe(1.2345);
     });
   });
 
-  describe('IEEE 754 midpoint cases (the actual bug)', () => {
-    it('correctly rounds 159.735 to 2dp (10 shares at 15.9735)', () => {
+  describe("IEEE 754 midpoint cases (the actual bug)", () => {
+    it("correctly rounds 159.735 to 2dp (10 shares at 15.9735)", () => {
       // 10 * 15.9735 = 159.735 mathematically, but IEEE 754 stores
       // it as 159.73499999999998... which naive rounding gets wrong
       const total = 10 * 15.9735;
       expect(roundToDecimals(total, 2)).toBe(159.74);
     });
 
-    it('correctly rounds 1.005 to 2dp', () => {
+    it("correctly rounds 1.005 to 2dp", () => {
       expect(roundToDecimals(1.005, 2)).toBe(1.01);
     });
 
-    it('correctly rounds 2.675 to 2dp', () => {
+    it("correctly rounds 2.675 to 2dp", () => {
       expect(roundToDecimals(2.675, 2)).toBe(2.68);
     });
 
-    it('correctly rounds 1.255 to 2dp', () => {
+    it("correctly rounds 1.255 to 2dp", () => {
       expect(roundToDecimals(1.255, 2)).toBe(1.26);
     });
   });
 
-  describe('negative values (round half away from zero)', () => {
-    it('rounds negative midpoints away from zero', () => {
+  describe("negative values (round half away from zero)", () => {
+    it("rounds negative midpoints away from zero", () => {
       expect(roundToDecimals(-1.235, 2)).toBe(-1.24);
       expect(roundToDecimals(-159.735, 2)).toBe(-159.74);
       expect(roundToDecimals(-1.005, 2)).toBe(-1.01);
     });
 
-    it('rounds negative non-midpoints correctly', () => {
+    it("rounds negative non-midpoints correctly", () => {
       expect(roundToDecimals(-1.234, 2)).toBe(-1.23);
       expect(roundToDecimals(-1.236, 2)).toBe(-1.24);
     });
   });
 
-  describe('edge cases', () => {
-    it('handles zero', () => {
+  describe("edge cases", () => {
+    it("handles zero", () => {
       expect(roundToDecimals(0, 2)).toBe(0);
     });
 
-    it('handles integers', () => {
+    it("handles integers", () => {
       expect(roundToDecimals(5, 2)).toBe(5);
     });
 
-    it('handles Infinity', () => {
+    it("handles Infinity", () => {
       expect(roundToDecimals(Infinity, 2)).toBe(Infinity);
       expect(roundToDecimals(-Infinity, 2)).toBe(-Infinity);
     });
 
-    it('handles NaN', () => {
+    it("handles NaN", () => {
       expect(roundToDecimals(NaN, 2)).toBeNaN();
     });
 
-    it('handles very small numbers', () => {
+    it("handles very small numbers", () => {
       expect(roundToDecimals(0.001, 2)).toBe(0);
       expect(roundToDecimals(0.005, 2)).toBe(0.01);
     });
 
-    it('handles 3 decimal places (e.g. BHD)', () => {
+    it("handles 3 decimal places (e.g. BHD)", () => {
       expect(roundToDecimals(1.2345, 3)).toBe(1.235);
       expect(roundToDecimals(1.2344, 3)).toBe(1.234);
     });

--- a/backend/src/common/round.util.ts
+++ b/backend/src/common/round.util.ts
@@ -21,10 +21,7 @@
  *   roundToDecimals(-159.735, 2)      => -159.74  (not -159.73)
  *   roundToDecimals(1.005, 2)         => 1.01     (not 1.00)
  */
-export function roundToDecimals(
-  value: number,
-  decimalPlaces: number,
-): number {
+export function roundToDecimals(value: number, decimalPlaces: number): number {
   if (!isFinite(value)) return value;
   const sign = value < 0 ? -1 : 1;
   const abs = Math.abs(value);
@@ -32,9 +29,7 @@ export function roundToDecimals(
   return (
     sign *
     Number(
-      Math.round(Number(nudged + 'e' + decimalPlaces)) +
-        'e-' +
-        decimalPlaces,
+      Math.round(Number(nudged + "e" + decimalPlaces)) + "e-" + decimalPlaces,
     )
   );
 }

--- a/backend/src/import/import-investment-processor.service.spec.ts
+++ b/backend/src/import/import-investment-processor.service.spec.ts
@@ -1143,13 +1143,15 @@ describe("ImportInvestmentProcessorService", () => {
 
       // Cash transaction saved in the investment account
       const cashTxSave = saveCalls.find(
-        (call: any) => call[0]?.accountId === accountId && call[0]?.amount === 1000,
+        (call: any) =>
+          call[0]?.accountId === accountId && call[0]?.amount === 1000,
       );
       expect(cashTxSave).toBeDefined();
 
       // Linked transaction saved in the transfer account
       const linkedTxSave = saveCalls.find(
-        (call: any) => call[0]?.accountId === "acc-chequing" && call[0]?.amount === -1000,
+        (call: any) =>
+          call[0]?.accountId === "acc-chequing" && call[0]?.amount === -1000,
       );
       expect(linkedTxSave).toBeDefined();
       expect(ctx.affectedAccountIds.has("acc-chequing")).toBe(true);
@@ -1188,12 +1190,14 @@ describe("ImportInvestmentProcessorService", () => {
 
       const saveCalls = ctx.queryRunner.manager.save.mock.calls;
       const cashTxSave = saveCalls.find(
-        (call: any) => call[0]?.accountId === accountId && call[0]?.amount === -500,
+        (call: any) =>
+          call[0]?.accountId === accountId && call[0]?.amount === -500,
       );
       expect(cashTxSave).toBeDefined();
 
       const linkedTxSave = saveCalls.find(
-        (call: any) => call[0]?.accountId === "acc-savings" && call[0]?.amount === 500,
+        (call: any) =>
+          call[0]?.accountId === "acc-savings" && call[0]?.amount === 500,
       );
       expect(linkedTxSave).toBeDefined();
     });
@@ -1269,7 +1273,8 @@ describe("ImportInvestmentProcessorService", () => {
 
       const saveCalls = ctx.queryRunner.manager.save.mock.calls;
       const cashTxSave = saveCalls.find(
-        (call: any) => call[0]?.accountId === "acc-cash" && call[0]?.amount === 750,
+        (call: any) =>
+          call[0]?.accountId === "acc-cash" && call[0]?.amount === 750,
       );
       expect(cashTxSave).toBeDefined();
     });

--- a/backend/src/import/import-investment-processor.service.ts
+++ b/backend/src/import/import-investment-processor.service.ts
@@ -223,10 +223,20 @@ export class ImportInvestmentProcessorService {
         ? TransactionStatus.CLEARED
         : TransactionStatus.UNRECONCILED;
 
-    const transferAccountId: string | null =
+    let transferAccountId: string | null =
       qifTx.isTransfer && qifTx.transferAccount
         ? (ctx.accountMap.get(qifTx.transferAccount) ?? null)
         : null;
+    // Case-insensitive fallback (matches resolveTransactionTarget behavior)
+    if (!transferAccountId && qifTx.isTransfer && qifTx.transferAccount) {
+      const lowerName = qifTx.transferAccount.toLowerCase();
+      for (const [name, id] of ctx.accountMap) {
+        if (id && name.toLowerCase() === lowerName) {
+          transferAccountId = id;
+          break;
+        }
+      }
+    }
 
     // Duplicate detection using the same counting approach as the regular
     // processor: compare how many matching linked transfers already exist in
@@ -236,11 +246,7 @@ export class ImportInvestmentProcessorService {
     if (transferAccountId) {
       const existingCount = await ctx.queryRunner.manager
         .createQueryBuilder(Transaction, "t")
-        .innerJoin(
-          Transaction,
-          "linked",
-          "t.linked_transaction_id = linked.id",
-        )
+        .innerJoin(Transaction, "linked", "t.linked_transaction_id = linked.id")
         .where("t.user_id = :userId", { userId: ctx.userId })
         .andWhere("t.account_id = :accountId", { accountId: cashAccountId })
         .andWhere("t.is_transfer = true")

--- a/backend/src/import/import-regular-processor.service.spec.ts
+++ b/backend/src/import/import-regular-processor.service.spec.ts
@@ -340,14 +340,16 @@ describe("ImportRegularProcessorService", () => {
       // After the first transfer is processed, the DB has 1 existing linked
       // transfer matching the signature. The counting logic should let the
       // second QIF entry through because seenCount (2) > existingCount (1).
+      // QB call sequence per processTransaction:
+      //   1. isDuplicateTransfer linked check
+      //   2. isDuplicateTransfer split-linked check
+      //   3. matchPendingTransfer
+      // So for tx2, the linked check is call 4.
       let qbCallCount = 0;
       ctx.queryRunner.manager.createQueryBuilder.mockImplementation(() => {
         qbCallCount++;
-        // Calls 1-2: isDuplicateTransfer for 1st QIF tx (linked + split-linked)
-        // Calls 3-4: isDuplicateTransfer for 2nd QIF tx (linked + split-linked)
-        // The linked query returns count=1 only for the 2nd tx (after 1st was created)
         const qb = makeMockQueryBuilder(null);
-        if (qbCallCount === 3) {
+        if (qbCallCount === 4) {
           // 2nd tx's linked-transfer check: 1 existing match in DB
           qb.getCount.mockResolvedValue(1);
         }
@@ -1494,6 +1496,43 @@ describe("ImportRegularProcessorService", () => {
         (call: any) => call[1] === pendingSplitTransfer.id,
       );
       expect(pendingUpdate).toBeDefined();
+    });
+  });
+
+  describe("isDuplicateTransfer - case-insensitive account matching", () => {
+    it("should detect duplicate even when transfer account name has different casing", async () => {
+      // Simulates the scenario where the investment processor created a linked
+      // transfer pair (e.g. from XOut processing), and the regular processor
+      // encounters the counterpart with slightly different account name casing.
+      const accountMap = new Map<string, string | null>();
+      accountMap.set("My Investments", "acc-investment-cash");
+      const ctx = makeContext({ accountMap });
+
+      // The linked transfer already exists (created by the investment processor)
+      let qbCallCount = 0;
+      ctx.queryRunner.manager.createQueryBuilder.mockImplementation(() => {
+        qbCallCount++;
+        const qb = makeMockQueryBuilder(null);
+        if (qbCallCount === 1) {
+          // linked-transfer check: 1 existing match
+          qb.getCount.mockResolvedValue(1);
+        }
+        return qb;
+      });
+
+      // Transfer uses different casing than account map key
+      const qifTx = {
+        date: "2025-01-15",
+        amount: 1000,
+        payee: "Transfer from My Investments",
+        isTransfer: true,
+        transferAccount: "my investments", // lowercase
+      };
+
+      await service.processTransaction(ctx, qifTx);
+
+      expect(ctx.importResult.skipped).toBe(1);
+      expect(ctx.importResult.imported).toBe(0);
     });
   });
 

--- a/backend/src/import/import-regular-processor.service.ts
+++ b/backend/src/import/import-regular-processor.service.ts
@@ -115,7 +115,18 @@ export class ImportRegularProcessorService {
     // exist in the DB and how many same-signature QIF entries we have seen in this
     // block; only skip when the seen count does not exceed the existing count.
     if (qifTx.isTransfer && qifTx.transferAccount) {
-      const mappedTransferAccountId = ctx.accountMap.get(qifTx.transferAccount);
+      let mappedTransferAccountId =
+        ctx.accountMap.get(qifTx.transferAccount) ?? undefined;
+      // Case-insensitive fallback (matches resolveTransactionTarget behavior)
+      if (!mappedTransferAccountId) {
+        const lowerName = qifTx.transferAccount.toLowerCase();
+        for (const [name, id] of ctx.accountMap) {
+          if (id && name.toLowerCase() === lowerName) {
+            mappedTransferAccountId = id;
+            break;
+          }
+        }
+      }
       if (mappedTransferAccountId) {
         const existingCount = await ctx.queryRunner.manager
           .createQueryBuilder(Transaction, "t")
@@ -136,13 +147,16 @@ export class ImportRegularProcessorService {
           })
           .getCount();
 
-        if (existingCount > 0) {
-          const sigKey = `linked|${qifTx.date}|${qifTx.amount}|${mappedTransferAccountId}`;
-          const seenSoFar = ctx.transferDupCounts.get(sigKey) || 0;
-          ctx.transferDupCounts.set(sigKey, seenSoFar + 1);
-          if (seenSoFar + 1 <= existingCount) {
-            return true;
-          }
+        // Always count every QIF entry with this signature, even when
+        // existingCount is zero (fresh import). This ensures that when the
+        // next entry with the same signature arrives and finds existingCount=1,
+        // seenSoFar is already 1 so seenSoFar+1=2 > 1 and it is not
+        // incorrectly skipped. Matches processCashTransfer counting logic.
+        const sigKey = `linked|${qifTx.date}|${qifTx.amount}|${mappedTransferAccountId}`;
+        const seenSoFar = ctx.transferDupCounts.get(sigKey) || 0;
+        ctx.transferDupCounts.set(sigKey, seenSoFar + 1);
+        if (existingCount > 0 && seenSoFar + 1 <= existingCount) {
+          return true;
         }
       }
     }
@@ -165,13 +179,12 @@ export class ImportRegularProcessorService {
         .andWhere("t.amount = :amount", { amount: qifTx.amount })
         .getCount();
 
-      if (existingCount > 0) {
-        const sigKey = `split|${qifTx.date}|${qifTx.amount}`;
-        const seenSoFar = ctx.transferDupCounts.get(sigKey) || 0;
-        ctx.transferDupCounts.set(sigKey, seenSoFar + 1);
-        if (seenSoFar + 1 <= existingCount) {
-          return true;
-        }
+      // Always count (same rationale as linked transfers above)
+      const sigKey = `split|${qifTx.date}|${qifTx.amount}`;
+      const seenSoFar = ctx.transferDupCounts.get(sigKey) || 0;
+      ctx.transferDupCounts.set(sigKey, seenSoFar + 1);
+      if (existingCount > 0 && seenSoFar + 1 <= existingCount) {
+        return true;
       }
     }
 


### PR DESCRIPTION
## Summary

- **Fixed counter logic in `isDuplicateTransfer`**: The transfer dedup counter was only incremented when existing DB matches were found (`existingCount > 0`), unlike `processCashTransfer` which always increments. This caused the second of two identical transfers in the same regular account block to be incorrectly skipped as a duplicate during fresh imports.
- **Added case-insensitive account name fallback** to both `isDuplicateTransfer` (regular processor) and `processCashTransfer` (investment processor), matching the existing behavior in `resolveTransactionTarget`. Without this, transfers could be created but not detected as duplicates when account names differed only in casing.
- **Fixed broken test mock** where `matchPendingTransfer`'s QueryBuilder call was intercepting the wrong call index, and added a new test for case-insensitive account matching.

## Test plan

- [x] All 49 regular processor tests pass
- [x] All 57 investment processor tests pass
- [x] All 105 import service tests pass
- [x] Full unit test suite passes (4701 tests across 174 suites)
- [x] ESLint passes
- [ ] Manual test: Import a full Quicken QIF file with investment accounts that have XIn/XOut transfers to bank accounts -- verify transfers appear once (not twice) in the investment cash account

https://claude.ai/code/session_018ukhjpfURxnMvpZcbHPcbc