### PR TITLE
Increase rate limit for security lookup endpoint to 60/min

### DIFF
--- a/backend/src/securities/securities.controller.ts
+++ b/backend/src/securities/securities.controller.ts
@@ -101,7 +101,7 @@ export class SecuritiesController {
   }
 
   @Get("lookup")
-  @Throttle({ default: { ttl: 60000, limit: 10 } }) // L2: 10 lookups per minute
+  @Throttle({ default: { ttl: 60000, limit: 60 } }) // L2: 60 lookups per minute
   @ApiOperation({ summary: "Lookup security info from Yahoo Finance" })
   @ApiQuery({
     name: "q",


### PR DESCRIPTION
## Summary
Increased the throttle rate limit for the security lookup endpoint from 10 to 60 requests per minute to accommodate higher query volumes.

## Changes
- Updated the `@Throttle` decorator on the `GET /lookup` endpoint in `SecuritiesController`
  - Changed limit from 10 to 60 requests per minute
  - TTL remains at 60000ms (1 minute)
  - Updated inline comment to reflect new limit

## Details
This change allows the Yahoo Finance security lookup endpoint to handle 6x more requests within the same time window, improving the user experience for applications that need to perform frequent security lookups while still maintaining rate limiting protection.

https://claude.ai/code/session_01H43cYJ5mTmthfCezihKjD3