### PR TITLE
Fix PWA fullscreen on Android notch devices and show currency decimals on charts

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -28,9 +28,21 @@
 /* Dark mode variant */
 @variant dark (&:where(.dark, .dark *));
 
-/* Base styles */
+/* Base styles -- extend background behind display cutouts */
+html {
+  @apply bg-gray-50;
+}
+
+.dark html {
+  @apply bg-gray-900;
+}
+
 body {
   @apply bg-gray-50 text-gray-900;
+  padding-top: env(safe-area-inset-top);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 .dark body {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -17,6 +17,7 @@ export const viewport: Viewport = {
   ],
   width: 'device-width',
   initialScale: 1,
+  viewportFit: 'cover',
 };
 
 export const metadata: Metadata = {
@@ -24,7 +25,7 @@ export const metadata: Metadata = {
   description: 'Track your finances with ease',
   appleWebApp: {
     capable: true,
-    statusBarStyle: 'default',
+    statusBarStyle: 'black-translucent',
     title: 'Monize',
   },
   icons: {

--- a/frontend/src/app/manifest.ts
+++ b/frontend/src/app/manifest.ts
@@ -6,7 +6,7 @@ export default function manifest(): MetadataRoute.Manifest {
     short_name: 'Monize',
     description: 'Track your finances, manage budgets, and monitor investments',
     start_url: '/',
-    display: 'fullscreen',
+    display: 'standalone',
     background_color: '#ffffff',
     theme_color: '#10b981',
     orientation: 'portrait-primary',

--- a/frontend/src/components/bills/CashFlowForecastChart.test.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.test.tsx
@@ -13,12 +13,12 @@ vi.mock('recharts', () => ({
   ReferenceLine: () => <div data-testid="reference-line" />,
 }));
 
-const mockFormatCurrencyCompact = vi.fn((n: number, _code?: string) => `$${n.toFixed(0)}`);
+const mockFormatCurrency = vi.fn((n: number, _code?: string) => `$${n.toFixed(2)}`);
 const mockFormatCurrencyAxis = vi.fn((n: number, _code?: string) => `$${n}`);
 
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
-    formatCurrencyCompact: mockFormatCurrencyCompact,
+    formatCurrency: mockFormatCurrency,
     formatCurrencyAxis: mockFormatCurrencyAxis,
   }),
 }));
@@ -141,9 +141,9 @@ describe('CashFlowForecastChart', () => {
     expect(screen.getByText('Starting')).toBeInTheDocument();
     expect(screen.getByText('Ending')).toBeInTheDocument();
     expect(screen.getByText('Min Balance')).toBeInTheDocument();
-    expect(screen.getByText('$1000')).toBeInTheDocument();
-    expect(screen.getByText('$750')).toBeInTheDocument();
-    expect(screen.getByText('$650')).toBeInTheDocument();
+    expect(screen.getByText('$1000.00')).toBeInTheDocument();
+    expect(screen.getByText('$750.00')).toBeInTheDocument();
+    expect(screen.getByText('$650.00')).toBeInTheDocument();
   });
 
   it('shows scheduled transaction count when forecasted transactions exist', () => {
@@ -280,7 +280,7 @@ describe('CashFlowForecastChart', () => {
 
   describe('currency-aware formatting', () => {
     it('uses account currency for single-currency accounts', () => {
-      mockFormatCurrencyCompact.mockClear();
+      mockFormatCurrency.mockClear();
       const accounts = [makeAccount({ currencyCode: 'USD' })];
 
       const forecastData = [
@@ -300,14 +300,14 @@ describe('CashFlowForecastChart', () => {
       );
 
       // Summary footer calls formatCurrencyCompact with the account's currency
-      const usdCalls = mockFormatCurrencyCompact.mock.calls.filter(
+      const usdCalls = mockFormatCurrency.mock.calls.filter(
         ([, code]) => code === 'USD',
       );
       expect(usdCalls.length).toBeGreaterThan(0);
     });
 
     it('uses default currency when accounts have mixed currencies', () => {
-      mockFormatCurrencyCompact.mockClear();
+      mockFormatCurrency.mockClear();
       const accounts = [
         makeAccount({ id: 'a1', currencyCode: 'USD' }),
         makeAccount({ id: 'a2', name: 'Euro Account', currencyCode: 'EUR' }),
@@ -330,7 +330,7 @@ describe('CashFlowForecastChart', () => {
       );
 
       // With mixed currencies, should format in default currency (CAD)
-      const cadCalls = mockFormatCurrencyCompact.mock.calls.filter(
+      const cadCalls = mockFormatCurrency.mock.calls.filter(
         ([, code]) => code === 'CAD',
       );
       expect(cadCalls.length).toBeGreaterThan(0);

--- a/frontend/src/components/bills/CashFlowForecastChart.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.tsx
@@ -113,7 +113,7 @@ export function CashFlowForecastChart({
   futureTransactions = [],
   isLoading,
 }: CashFlowForecastChartProps) {
-  const { formatCurrencyCompact, formatCurrencyAxis } = useNumberFormat();
+  const { formatCurrency: formatCurrencyFull, formatCurrencyAxis } = useNumberFormat();
   const { convertToDefault, defaultCurrency } = useExchangeRates();
   const [selectedPeriod, setSelectedPeriod] = useState<ForecastPeriod>(() => getStoredPeriod());
   const [selectedAccountId, setSelectedAccountId] = useState<string>(() => getStoredAccountId());
@@ -151,8 +151,8 @@ export function CashFlowForecastChart({
   }, [accounts, selectedAccountId, defaultCurrency]);
 
   const formatCurrency = useCallback(
-    (value: number) => formatCurrencyCompact(value, chartCurrency),
-    [formatCurrencyCompact, chartCurrency],
+    (value: number) => formatCurrencyFull(value, chartCurrency),
+    [formatCurrencyFull, chartCurrency],
   );
 
   const formatAxis = useCallback(

--- a/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
@@ -13,12 +13,12 @@ vi.mock('recharts', () => ({
   ReferenceLine: () => <div data-testid="reference-line" />,
 }));
 
-const mockFormatCurrencyCompact = vi.fn((n: number, _code?: string) => `$${n.toFixed(0)}`);
+const mockFormatCurrency = vi.fn((n: number, _code?: string) => `$${n.toFixed(2)}`);
 const mockFormatCurrencyAxis = vi.fn((n: number, _code?: string) => `$${n}`);
 
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
-    formatCurrencyCompact: mockFormatCurrencyCompact,
+    formatCurrency: mockFormatCurrency,
     formatCurrencyAxis: mockFormatCurrencyAxis,
   }),
 }));
@@ -55,9 +55,9 @@ describe('BalanceHistoryChart', () => {
     expect(screen.getByText('Starting')).toBeInTheDocument();
     expect(screen.getByText('Current')).toBeInTheDocument();
     expect(screen.getByText('Min Balance')).toBeInTheDocument();
-    expect(screen.getByText('$1000')).toBeInTheDocument();
-    expect(screen.getByText('$900')).toBeInTheDocument();
-    expect(screen.getByText('$750')).toBeInTheDocument();
+    expect(screen.getByText('$1000.00')).toBeInTheDocument();
+    expect(screen.getByText('$900.00')).toBeInTheDocument();
+    expect(screen.getByText('$750.00')).toBeInTheDocument();
   });
 
   it('shows "Lowest" label and warning when balance goes negative', () => {
@@ -129,14 +129,14 @@ describe('BalanceHistoryChart', () => {
 
     expect(screen.getByText('Ending')).toBeInTheDocument();
     // Starting = 2000, Current = 1800 (today or before), Ending = 1900, Min = 1500
-    expect(screen.getByText('$2000')).toBeInTheDocument();
-    expect(screen.getByText('$1800')).toBeInTheDocument();
-    expect(screen.getByText('$1900')).toBeInTheDocument();
-    expect(screen.getByText('$1500')).toBeInTheDocument();
+    expect(screen.getByText('$2000.00')).toBeInTheDocument();
+    expect(screen.getByText('$1800.00')).toBeInTheDocument();
+    expect(screen.getByText('$1900.00')).toBeInTheDocument();
+    expect(screen.getByText('$1500.00')).toBeInTheDocument();
   });
 
   it('passes currencyCode to formatting functions', () => {
-    mockFormatCurrencyCompact.mockClear();
+    mockFormatCurrency.mockClear();
 
     render(
       <BalanceHistoryChart
@@ -149,8 +149,8 @@ describe('BalanceHistoryChart', () => {
       />
     );
 
-    // Summary footer calls formatCurrency (which wraps formatCurrencyCompact with currencyCode)
-    const eurCalls = mockFormatCurrencyCompact.mock.calls.filter(
+    // Summary footer calls formatCurrency with currencyCode
+    const eurCalls = mockFormatCurrency.mock.calls.filter(
       ([, code]) => code === 'EUR',
     );
     expect(eurCalls.length).toBeGreaterThan(0);

--- a/frontend/src/components/transactions/BalanceHistoryChart.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.tsx
@@ -63,11 +63,11 @@ export function BalanceHistoryChart({
   isLoading,
   currencyCode,
 }: BalanceHistoryChartProps) {
-  const { formatCurrencyCompact, formatCurrencyAxis } = useNumberFormat();
+  const { formatCurrency: formatCurrencyFull, formatCurrencyAxis } = useNumberFormat();
 
   const formatCurrency = useCallback(
-    (value: number) => formatCurrencyCompact(value, currencyCode),
-    [formatCurrencyCompact, currencyCode],
+    (value: number) => formatCurrencyFull(value, currencyCode),
+    [formatCurrencyFull, currencyCode],
   );
 
   const formatAxis = useCallback(


### PR DESCRIPTION
Add viewport-fit=cover and safe-area-inset padding so the PWA extends behind the camera cutout instead of leaving a black bar. Switch manifest display to standalone for more reliable edge-to-edge rendering.

Use full-precision formatCurrency instead of formatCurrencyCompact on the Balance History and Cash Flow Forecast charts so values respect the currency's native decimal places (e.g. 2 for USD/CAD, 0 for JPY).