### PR TITLE
Add numeric validation constraints for amount and balance fields

### DIFF
--- a/backend/src/accounts/dto/create-account.dto.ts
+++ b/backend/src/accounts/dto/create-account.dto.ts
@@ -102,6 +102,8 @@ export class CreateAccountDto {
   })
   @IsOptional()
   @IsNumber({ maxDecimalPlaces: 4 })
+  @Min(-999999999999)
+  @Max(999999999999)
   openingBalance?: number;
 
   @ApiPropertyOptional({

--- a/backend/src/scheduled-transactions/dto/create-scheduled-transaction-split.dto.ts
+++ b/backend/src/scheduled-transactions/dto/create-scheduled-transaction-split.dto.ts
@@ -6,6 +6,8 @@ import {
   IsArray,
   ValidateIf,
   MaxLength,
+  Min,
+  Max,
 } from "class-validator";
 import { ApiPropertyOptional } from "@nestjs/swagger";
 import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
@@ -29,7 +31,9 @@ export class CreateScheduledTransactionSplitDto {
   @ValidateIf((o) => !o.categoryId)
   transferAccountId?: string;
 
-  @IsNumber()
+  @IsNumber({ maxDecimalPlaces: 4 })
+  @Min(-999999999999)
+  @Max(999999999999)
   amount: number;
 
   @IsOptional()

--- a/backend/src/scheduled-transactions/dto/create-scheduled-transaction.dto.ts
+++ b/backend/src/scheduled-transactions/dto/create-scheduled-transaction.dto.ts
@@ -10,6 +10,7 @@ import {
   ArrayMaxSize,
   ValidateNested,
   Min,
+  Max,
   MaxLength,
 } from "class-validator";
 import { Type } from "class-transformer";
@@ -50,7 +51,9 @@ export class CreateScheduledTransactionDto {
   @IsUUID()
   categoryId?: string;
 
-  @IsNumber()
+  @IsNumber({ maxDecimalPlaces: 4 })
+  @Min(-999999999999)
+  @Max(999999999999)
   amount: number;
 
   @IsString()


### PR DESCRIPTION
## Summary
This PR adds comprehensive numeric validation constraints to amount and balance fields across the scheduled transactions and accounts modules. The changes ensure that numeric values are properly validated with decimal place limits and reasonable min/max bounds.

## Key Changes
- **Scheduled Transaction Split DTO**: Added `@Min()` and `@Max()` validators to the `amount` field, and updated `@IsNumber()` to enforce a maximum of 4 decimal places
- **Scheduled Transaction DTO**: Added `@Min()` and `@Max()` validators to the `amount` field, and updated `@IsNumber()` to enforce a maximum of 4 decimal places
- **Create Account DTO**: Added `@Min()` and `@Max()` validators to the `openingBalance` field (which already had the 4 decimal place constraint)

## Implementation Details
- All numeric fields are now constrained to a range of `-999999999999` to `999999999999`
- All numeric fields enforce a maximum of 4 decimal places via `@IsNumber({ maxDecimalPlaces: 4 })`
- These constraints provide consistent validation across financial transaction and account creation endpoints
- The bounds allow for reasonable financial values while preventing overflow and precision issues

https://claude.ai/code/session_01XE4ravkQyrtujc7F2k96Dq