### PR TITLE
fix: address security findings from code review

### DIFF
--- a/backend/src/auth/auth-email.service.spec.ts
+++ b/backend/src/auth/auth-email.service.spec.ts
@@ -60,6 +60,10 @@ describe("AuthEmailService", () => {
     service = module.get<AuthEmailService>(AuthEmailService);
   });
 
+  afterEach(() => {
+    service.onModuleDestroy();
+  });
+
   describe("generateResetToken", () => {
     it("should return user and token when user exists with password", async () => {
       const user = { ...mockUser };
@@ -309,6 +313,45 @@ describe("AuthEmailService", () => {
       expect(service.checkForgotPasswordEmailLimit("user2@example.com")).toBe(
         true,
       );
+    });
+  });
+
+  describe("cleanup", () => {
+    it("should remove expired entries when cleanup runs", () => {
+      // Add entries
+      service.checkForgotPasswordEmailLimit("expired@example.com");
+      service.checkForgotPasswordEmailLimit("fresh@example.com");
+
+      // Advance time so the first entry expires
+      const realDateNow = Date.now;
+      const originalNow = Date.now();
+      Date.now = jest
+        .fn()
+        .mockReturnValue(originalNow + 60 * 60 * 1000 + 1);
+
+      try {
+        // Add a fresh entry at the new time
+        service.checkForgotPasswordEmailLimit("fresh@example.com");
+
+        // Trigger cleanup via the internal method
+        (service as any).cleanupExpiredAttempts();
+
+        // expired@example.com should be cleaned up, fresh should remain
+        // Verify by checking that expired@example.com starts fresh (allowed)
+        // and reaches limit normally
+        const result =
+          service.checkForgotPasswordEmailLimit("expired@example.com");
+        expect(result).toBe(true);
+      } finally {
+        Date.now = realDateNow;
+      }
+    });
+
+    it("should clear interval on module destroy", () => {
+      const clearIntervalSpy = jest.spyOn(global, "clearInterval");
+      service.onModuleDestroy();
+      expect(clearIntervalSpy).toHaveBeenCalled();
+      clearIntervalSpy.mockRestore();
     });
   });
 });

--- a/backend/src/auth/auth-email.service.ts
+++ b/backend/src/auth/auth-email.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, BadRequestException, Logger } from "@nestjs/common";
+import {
+  Injectable,
+  BadRequestException,
+  Logger,
+  OnModuleDestroy,
+} from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import * as bcrypt from "bcryptjs";
@@ -10,7 +15,7 @@ import { PasswordBreachService } from "./password-breach.service";
 import { TokenService } from "./token.service";
 
 @Injectable()
-export class AuthEmailService {
+export class AuthEmailService implements OnModuleDestroy {
   private readonly logger = new Logger(AuthEmailService.name);
 
   // M7: Per-email rate limiting for forgot-password
@@ -20,13 +25,37 @@ export class AuthEmailService {
   >();
   private readonly FORGOT_PASSWORD_EMAIL_LIMIT = 3;
   private readonly FORGOT_PASSWORD_EMAIL_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+  private readonly cleanupInterval: ReturnType<typeof setInterval>;
 
   constructor(
     @InjectRepository(User)
     private usersRepository: Repository<User>,
     private passwordBreachService: PasswordBreachService,
     private tokenService: TokenService,
-  ) {}
+  ) {
+    // Periodically prune expired entries to prevent unbounded memory growth.
+    // unref() ensures the timer does not prevent Node.js process shutdown.
+    this.cleanupInterval = setInterval(
+      () => this.cleanupExpiredAttempts(),
+      this.FORGOT_PASSWORD_EMAIL_WINDOW_MS,
+    );
+    if (this.cleanupInterval.unref) {
+      this.cleanupInterval.unref();
+    }
+  }
+
+  onModuleDestroy() {
+    clearInterval(this.cleanupInterval);
+  }
+
+  private cleanupExpiredAttempts(): void {
+    const now = Date.now();
+    for (const [email, record] of this.forgotPasswordAttempts) {
+      if (now - record.windowStart > this.FORGOT_PASSWORD_EMAIL_WINDOW_MS) {
+        this.forgotPasswordAttempts.delete(email);
+      }
+    }
+  }
 
   async generateResetToken(
     email: string,

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -70,6 +70,7 @@ import { NotificationsModule } from "../notifications/notifications.module";
     OidcService,
     PatService,
     PasswordBreachService,
+    JwtModule,
   ],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -22,7 +22,10 @@ import { LoginDto } from "./dto/login.dto";
 import { derivePurposeKey, hashToken } from "./crypto.util";
 import { PasswordBreachService } from "./password-breach.service";
 import { EmailService } from "../notifications/email.service";
-import { accountLockedTemplate } from "../notifications/email-templates";
+import {
+  accountLockedTemplate,
+  oidcLinkTemplate,
+} from "../notifications/email-templates";
 import { TokenService } from "./token.service";
 import { TwoFactorService } from "./two-factor.service";
 import { AuthEmailService } from "./auth-email.service";
@@ -463,18 +466,7 @@ export class AuthService {
         this.configService.get<string>("PUBLIC_APP_URL") ||
         "http://localhost:3000";
       const confirmUrl = `${frontendUrl}/api/v1/auth/oidc/confirm-link?token=${linkToken}`;
-      const safeName = user.firstName || "there";
-      const html = `
-        <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-          <h2 style="color: #1f2937;">Link Your SSO Account</h2>
-          <p style="color: #374151;">Hi ${safeName},</p>
-          <p style="color: #374151;">Someone attempted to sign in via SSO with an email that matches your existing Monize account. To link your SSO identity to this account, click the button below:</p>
-          <p style="text-align: center; margin: 24px 0;">
-            <a href="${confirmUrl}" style="background-color: #2563eb; color: #ffffff; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-weight: 600;">Confirm Account Link</a>
-          </p>
-          <p style="color: #6b7280; font-size: 14px;">If you did not initiate this request, you can safely ignore this email. The link expires in 1 hour.</p>
-          <p style="color: #6b7280; font-size: 14px; margin-top: 24px;">-- Monize</p>
-        </div>`;
+      const html = oidcLinkTemplate(user.firstName || "", confirmUrl);
       await this.emailService.sendMail(
         user.email,
         "Monize: Confirm SSO Account Link",

--- a/backend/src/auth/oidc/oidc.service.ts
+++ b/backend/src/auth/oidc/oidc.service.ts
@@ -138,6 +138,50 @@ export class OidcService implements OnModuleInit {
   }
 
   /**
+   * Verify an OIDC ID token's claims without full JWKS signature verification.
+   * Checks that the token is a valid JWT, issued by the configured provider,
+   * intended for our client, not expired, and belongs to the expected subject.
+   */
+  verifyIdTokenClaims(
+    idToken: string,
+    expectedSubject: string,
+  ): boolean {
+    try {
+      const parts = idToken.split(".");
+      if (parts.length !== 3) return false;
+
+      const payload = JSON.parse(
+        Buffer.from(parts[1], "base64url").toString("utf-8"),
+      );
+
+      // Verify issuer matches configured OIDC provider
+      if (this.config) {
+        const expectedIssuer = this.config.serverMetadata().issuer;
+        if (payload.iss !== expectedIssuer) return false;
+      }
+
+      // Verify audience includes our client ID
+      const clientId = this.configService.get<string>("OIDC_CLIENT_ID");
+      if (clientId) {
+        const aud = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+        if (!aud.includes(clientId)) return false;
+      }
+
+      // Verify token is not expired (with 60s clock skew tolerance)
+      if (payload.exp && payload.exp < Math.floor(Date.now() / 1000) - 60) {
+        return false;
+      }
+
+      // Verify subject matches the expected OIDC subject
+      if (payload.sub !== expectedSubject) return false;
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Generate a random state value for CSRF protection
    */
   generateState(): string {

--- a/backend/src/backup/backup.module.ts
+++ b/backend/src/backup/backup.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { BackupController } from "./backup.controller";
 import { BackupService } from "./backup.service";
 import { User } from "../users/entities/user.entity";
+import { AuthModule } from "../auth/auth.module";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User]), AuthModule],
   controllers: [BackupController],
   providers: [BackupService],
 })

--- a/backend/src/backup/backup.service.spec.ts
+++ b/backend/src/backup/backup.service.spec.ts
@@ -10,6 +10,7 @@ import { gzipSync, gunzipSync } from "zlib";
 import { PassThrough } from "stream";
 import { BackupService, RestoreBackupInput } from "./backup.service";
 import { User } from "../users/entities/user.entity";
+import { OidcService } from "../auth/oidc/oidc.service";
 import * as bcrypt from "bcryptjs";
 
 jest.mock("bcryptjs");
@@ -32,6 +33,56 @@ describe("BackupService", () => {
     passwordHash: "hashed-password",
   };
 
+  // Known columns per table for schema validation mock. When insertRows()
+  // queries information_schema.columns, the mock returns these so that
+  // column-name validation does not strip legitimate backup data.
+  const schemaColumns: Record<string, string[]> = {
+    categories: ["id", "user_id", "name", "parent_id", "type", "icon", "color", "is_active", "sort_order", "created_at", "updated_at"],
+    accounts: ["id", "user_id", "name", "type", "currency_code", "current_balance", "opening_balance", "is_active", "institution", "account_number", "notes", "sort_order", "linked_account_id", "source_account_id", "scheduled_transaction_id", "principal_category_id", "interest_category_id", "asset_category_id", "interest_rate", "loan_amount", "original_term_months", "loan_start_date", "maturity_date", "payment_amount", "payment_frequency", "compounding_frequency", "amortization_months", "extra_payment", "asset_value", "asset_date", "depreciation_rate", "appreciation_rate", "created_at", "updated_at"],
+    payees: ["id", "user_id", "name", "default_category_id", "created_at", "updated_at"],
+    tags: ["id", "user_id", "name", "color", "created_at", "updated_at"],
+    transactions: ["id", "user_id", "account_id", "amount", "transaction_date", "payee_id", "category_id", "memo", "is_reconciled", "check_number", "type", "linked_transaction_id", "parent_transaction_id", "is_split", "created_at", "updated_at"],
+    transaction_splits: ["id", "transaction_id", "amount", "category_id", "memo", "transfer_account_id", "created_at", "updated_at"],
+    transaction_tags: ["transaction_id", "tag_id"],
+    transaction_split_tags: ["transaction_split_id", "tag_id"],
+    securities: ["id", "user_id", "symbol", "name", "type", "exchange", "currency_code", "sector_weightings", "skip_price_updates", "data_source", "created_at", "updated_at"],
+    security_prices: ["id", "security_id", "date", "close_price", "created_at"],
+    holdings: ["id", "user_id", "account_id", "security_id", "quantity", "cost_basis", "created_at", "updated_at"],
+    investment_transactions: ["id", "user_id", "account_id", "security_id", "type", "quantity", "price", "amount", "commission", "transaction_date", "memo", "created_at", "updated_at"],
+    user_preferences: ["id", "user_id", "key", "value", "created_at", "updated_at"],
+    user_currency_preferences: ["id", "user_id", "currency_code", "decimal_places", "created_at", "updated_at"],
+    scheduled_transactions: ["id", "user_id", "account_id", "amount", "payee_id", "category_id", "memo", "frequency", "start_date", "end_date", "next_due_date", "is_active", "type", "created_at", "updated_at"],
+    scheduled_transaction_splits: ["id", "scheduled_transaction_id", "amount", "category_id", "memo", "transfer_account_id", "created_at", "updated_at"],
+    scheduled_transaction_overrides: ["id", "scheduled_transaction_id", "original_date", "new_date", "skip", "created_at", "updated_at"],
+    budgets: ["id", "user_id", "name", "period_type", "currency_code", "is_active", "created_at", "updated_at"],
+    budget_categories: ["id", "budget_id", "category_id", "amount", "created_at", "updated_at"],
+    budget_periods: ["id", "budget_id", "start_date", "end_date", "created_at", "updated_at"],
+    budget_period_categories: ["id", "budget_period_id", "category_id", "budgeted", "actual", "created_at", "updated_at"],
+    budget_alerts: ["id", "budget_id", "type", "threshold", "created_at", "updated_at"],
+    custom_reports: ["id", "user_id", "name", "config", "created_at", "updated_at"],
+    import_column_mappings: ["id", "user_id", "name", "mappings", "created_at", "updated_at"],
+    monthly_account_balances: ["id", "account_id", "year_month", "balance", "created_at", "updated_at"],
+    payee_aliases: ["id", "user_id", "payee_id", "alias", "created_at", "updated_at"],
+    currencies: ["code", "name", "symbol", "decimal_places", "is_active", "created_by_user_id", "created_at", "updated_at"],
+  };
+
+  function mockQueryHandler(sql: string, params?: unknown[]) {
+    if (typeof sql === "string" && sql.includes("information_schema.columns")) {
+      // Extract table name from params (insertRows) or from the SQL itself (ensureCurrenciesExist)
+      let tableName: string | undefined;
+      if (Array.isArray(params) && params.length > 0) {
+        tableName = params[0] as string;
+      } else if (sql.includes("'currencies'")) {
+        tableName = "currencies";
+      }
+      const cols = tableName && schemaColumns[tableName] ? schemaColumns[tableName] : [];
+      return Promise.resolve(
+        cols.map((col) => ({ column_name: col, data_type: "text" })),
+      );
+    }
+    return Promise.resolve([]);
+  }
+
   beforeEach(async () => {
     mockQueryRunner = {
       connect: jest.fn(),
@@ -39,7 +90,7 @@ describe("BackupService", () => {
       commitTransaction: jest.fn(),
       rollbackTransaction: jest.fn(),
       release: jest.fn(),
-      query: jest.fn().mockResolvedValue([]),
+      query: jest.fn().mockImplementation(mockQueryHandler),
     };
 
     mockDataSource = {
@@ -61,6 +112,13 @@ describe("BackupService", () => {
         {
           provide: DataSource,
           useValue: mockDataSource,
+        },
+        {
+          provide: OidcService,
+          useValue: {
+            enabled: true,
+            verifyIdTokenClaims: jest.fn().mockReturnValue(true),
+          },
         },
       ],
     }).compile();
@@ -556,6 +614,7 @@ describe("BackupService", () => {
         ...mockUser,
         authProvider: "oidc",
         passwordHash: null,
+        oidcSubject: "oidc-sub-123",
       });
 
       const result = await service.restoreData(

--- a/backend/src/backup/backup.service.ts
+++ b/backend/src/backup/backup.service.ts
@@ -10,6 +10,7 @@ import { Repository, DataSource } from "typeorm";
 import * as bcrypt from "bcryptjs";
 import { createGzip, gunzipSync } from "zlib";
 import { User } from "../users/entities/user.entity";
+import { OidcService } from "../auth/oidc/oidc.service";
 
 export interface RestoreBackupInput {
   compressedData: Buffer;
@@ -59,6 +60,7 @@ export class BackupService {
     @InjectRepository(User)
     private readonly usersRepository: Repository<User>,
     private readonly dataSource: DataSource,
+    private readonly oidcService: OidcService,
   ) {}
 
   async streamExport(
@@ -473,6 +475,18 @@ export class BackupService {
           "OIDC re-authentication is required to confirm restore",
         );
       }
+      if (
+        !user.oidcSubject ||
+        !this.oidcService.enabled ||
+        !this.oidcService.verifyIdTokenClaims(
+          input.oidcIdToken,
+          user.oidcSubject,
+        )
+      ) {
+        throw new UnauthorizedException(
+          "Invalid OIDC token: the token must be a valid ID token from your SSO provider",
+        );
+      }
     } else if (user.passwordHash) {
       if (!input.password) {
         throw new UnauthorizedException(
@@ -769,10 +783,29 @@ export class BackupService {
 
     // First, restore user-created currencies from the backup (ON CONFLICT DO NOTHING)
     if (data.currencies) {
+      // Validate column names against the actual currencies table schema to
+      // prevent SQL injection via crafted backup data with malicious keys.
+      const currencySchemaResult = await queryRunner.query(
+        `SELECT column_name FROM information_schema.columns
+         WHERE table_name = 'currencies' AND table_schema = 'public'`,
+      );
+      const validCurrencyColumns = new Set<string>(
+        currencySchemaResult.map(
+          (r: { column_name: string }) => r.column_name,
+        ),
+      );
+
       for (const row of data.currencies) {
         const filteredRow = { ...row };
         filteredRow.created_by_user_id = userId;
         delete filteredRow.created_at;
+
+        // Strip column names not in the actual table schema
+        for (const key of Object.keys(filteredRow)) {
+          if (!validCurrencyColumns.has(key)) {
+            delete filteredRow[key];
+          }
+        }
 
         const columns = Object.keys(filteredRow);
         const values = Object.values(filteredRow).map((v) =>
@@ -878,16 +911,23 @@ export class BackupService {
     };
     const columnsToDefer = deferredFkColumns[table] ?? [];
 
-    // Detect native PostgreSQL array columns (e.g. TEXT[]) so we can pass
-    // JS arrays directly to the pg driver instead of JSON-stringifying them.
-    // JSONB columns still need JSON.stringify; only native array columns differ.
-    const arrayColResult = await queryRunner.query(
-      `SELECT column_name FROM information_schema.columns
-       WHERE table_name = $1 AND data_type = 'ARRAY'`,
+    // Fetch all valid column names for this table from the schema. This serves
+    // two purposes: (1) detect native PostgreSQL array columns so we can pass JS
+    // arrays directly to the pg driver, and (2) validate that column names from
+    // the user-uploaded backup are real columns, preventing SQL injection via
+    // crafted column names with embedded double-quote characters.
+    const schemaColResult = await queryRunner.query(
+      `SELECT column_name, data_type FROM information_schema.columns
+       WHERE table_name = $1 AND table_schema = 'public'`,
       [table],
     );
+    const validColumns = new Set<string>(
+      schemaColResult.map((r: { column_name: string }) => r.column_name),
+    );
     const pgArrayColumns = new Set<string>(
-      arrayColResult.map((r: { column_name: string }) => r.column_name),
+      schemaColResult
+        .filter((r: { data_type: string }) => r.data_type === "ARRAY")
+        .map((r: { column_name: string }) => r.column_name),
     );
 
     let count = 0;
@@ -908,6 +948,14 @@ export class BackupService {
         delete filteredRow[col];
       }
 
+      // Strip any column names not present in the actual table schema to
+      // prevent SQL injection via crafted backup data with malicious keys.
+      for (const key of Object.keys(filteredRow)) {
+        if (!validColumns.has(key)) {
+          delete filteredRow[key];
+        }
+      }
+
       const columns = Object.keys(filteredRow);
       // Stringify object/array values for JSONB columns -- PostgreSQL requires
       // JSON text, not native JS objects, in parameterised queries. Native
@@ -925,7 +973,6 @@ export class BackupService {
         continue;
       }
 
-      // Use quoted identifiers for column names (safe since they come from DB export)
       const columnList = columns.map((c) => `"${c}"`).join(", ");
       const placeholders = columns.map((_, i) => `$${i + 1}`).join(", ");
 

--- a/backend/src/common/guards/csrf.guard.spec.ts
+++ b/backend/src/common/guards/csrf.guard.spec.ts
@@ -1,6 +1,7 @@
 import { ExecutionContext, ForbiddenException } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { ConfigService } from "@nestjs/config";
+import { JwtService } from "@nestjs/jwt";
 import { Test, TestingModule } from "@nestjs/testing";
 import { CsrfGuard } from "./csrf.guard";
 import { SKIP_CSRF_KEY } from "../decorators/skip-csrf.decorator";
@@ -27,6 +28,12 @@ describe("CsrfGuard", () => {
             get: jest.fn().mockReturnValue(undefined),
           },
         },
+        {
+          provide: JwtService,
+          useValue: {
+            decode: jest.fn().mockReturnValue(null),
+          },
+        },
       ],
     }).compile();
 
@@ -38,16 +45,12 @@ describe("CsrfGuard", () => {
     method?: string;
     cookies?: Record<string, string>;
     headers?: Record<string, string>;
-    user?: { id: string };
   }): ExecutionContext {
     const request: Record<string, unknown> = {
       method: overrides.method ?? "POST",
       cookies: overrides.cookies ?? {},
       headers: overrides.headers ?? {},
     };
-    if (overrides.user) {
-      request.user = overrides.user;
-    }
 
     return {
       switchToHttp: () => ({
@@ -191,11 +194,14 @@ describe("CsrfGuard", () => {
     const jwtSecret = "test-secret-key-32-chars-minimum!!";
     const userId = "user-123";
     let hmacGuard: CsrfGuard;
-    // The guard now derives a purpose-specific key from JWT_SECRET
+    let mockJwtService: { decode: jest.Mock };
     let derivedCsrfKey: string;
 
     beforeEach(async () => {
       derivedCsrfKey = derivePurposeKey(jwtSecret, "csrf-token");
+      mockJwtService = {
+        decode: jest.fn().mockReturnValue({ sub: userId }),
+      };
 
       const module: TestingModule = await Test.createTestingModule({
         providers: [
@@ -212,19 +218,36 @@ describe("CsrfGuard", () => {
               get: jest.fn().mockReturnValue(jwtSecret),
             },
           },
+          {
+            provide: JwtService,
+            useValue: mockJwtService,
+          },
         ],
       }).compile();
 
       hmacGuard = module.get<CsrfGuard>(CsrfGuard);
     });
 
-    it("accepts valid HMAC-bound token for the correct user", () => {
+    it("accepts valid HMAC-bound token when JWT is in cookie", () => {
+      const token = generateCsrfToken(userId, derivedCsrfKey);
+      const context = createMockContext({
+        method: "POST",
+        cookies: { csrf_token: token, auth_token: "fake-jwt" },
+        headers: { "x-csrf-token": token },
+      });
+
+      expect(hmacGuard.canActivate(context)).toBe(true);
+    });
+
+    it("accepts valid HMAC-bound token when JWT is in Authorization header", () => {
       const token = generateCsrfToken(userId, derivedCsrfKey);
       const context = createMockContext({
         method: "POST",
         cookies: { csrf_token: token },
-        headers: { "x-csrf-token": token },
-        user: { id: userId },
+        headers: {
+          "x-csrf-token": token,
+          authorization: "Bearer fake-jwt",
+        },
       });
 
       expect(hmacGuard.canActivate(context)).toBe(true);
@@ -232,11 +255,12 @@ describe("CsrfGuard", () => {
 
     it("rejects HMAC-bound token for a different user", () => {
       const token = generateCsrfToken(userId, derivedCsrfKey);
+      mockJwtService.decode.mockReturnValue({ sub: "different-user" });
+
       const context = createMockContext({
         method: "POST",
-        cookies: { csrf_token: token },
+        cookies: { csrf_token: token, auth_token: "fake-jwt" },
         headers: { "x-csrf-token": token },
-        user: { id: "different-user" },
       });
 
       expect(() => hmacGuard.canActivate(context)).toThrow(
@@ -250,9 +274,8 @@ describe("CsrfGuard", () => {
       const tampered = `${parts[0]}:${"f".repeat(64)}`;
       const context = createMockContext({
         method: "POST",
-        cookies: { csrf_token: tampered },
+        cookies: { csrf_token: tampered, auth_token: "fake-jwt" },
         headers: { "x-csrf-token": tampered },
-        user: { id: userId },
       });
 
       expect(() => hmacGuard.canActivate(context)).toThrow(
@@ -260,17 +283,30 @@ describe("CsrfGuard", () => {
       );
     });
 
-    it("skips HMAC verification when no session is available", () => {
-      // No user on the request means sessionId is undefined
+    it("skips HMAC verification when no JWT is present", () => {
       const token = "plain-token-no-colon";
       const context = createMockContext({
         method: "POST",
         cookies: { csrf_token: token },
         headers: { "x-csrf-token": token },
-        // no user
       });
 
       // Should pass the double-submit check without HMAC verification
+      expect(hmacGuard.canActivate(context)).toBe(true);
+    });
+
+    it("skips HMAC verification when JWT decode fails", () => {
+      mockJwtService.decode.mockImplementation(() => {
+        throw new Error("invalid token");
+      });
+
+      const token = "plain-token-no-colon";
+      const context = createMockContext({
+        method: "POST",
+        cookies: { csrf_token: token, auth_token: "bad-jwt" },
+        headers: { "x-csrf-token": token },
+      });
+
       expect(hmacGuard.canActivate(context)).toBe(true);
     });
   });

--- a/backend/src/common/guards/csrf.guard.ts
+++ b/backend/src/common/guards/csrf.guard.ts
@@ -6,6 +6,7 @@ import {
 } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { ConfigService } from "@nestjs/config";
+import { JwtService } from "@nestjs/jwt";
 import * as crypto from "crypto";
 import { SKIP_CSRF_KEY } from "../decorators/skip-csrf.decorator";
 import { verifyCsrfToken } from "../csrf.util";
@@ -18,6 +19,7 @@ export class CsrfGuard implements CanActivate {
   constructor(
     private reflector: Reflector,
     private configService: ConfigService,
+    private jwtService: JwtService,
   ) {
     const jwtSecret = this.configService.get<string>("JWT_SECRET");
     this.csrfKey = jwtSecret ? derivePurposeKey(jwtSecret, "csrf-token") : "";
@@ -64,16 +66,41 @@ export class CsrfGuard implements CanActivate {
       throw new ForbiddenException("Invalid CSRF token");
     }
 
-    // XC-F1: Always verify HMAC session binding when session info is available.
-    // Tokens are always generated with HMAC binding (nonce:hmac format),
-    // so we unconditionally verify rather than checking for ":" in the token.
-    const sessionId = request.user?.id;
-    if (sessionId && this.csrfKey) {
-      if (!verifyCsrfToken(headerToken, sessionId, this.csrfKey)) {
-        throw new ForbiddenException("Invalid CSRF token");
+    // Verify HMAC session binding by extracting the user ID directly from the
+    // JWT token. This guard runs as a global guard before the route-level JWT
+    // guard, so request.user is not yet populated. We decode the JWT here to
+    // get the session ID for HMAC verification. If the token is missing or
+    // invalid, we skip the HMAC check (the JWT guard will reject later).
+    if (this.csrfKey) {
+      const sessionId = this.extractSessionId(request);
+      if (sessionId) {
+        if (!verifyCsrfToken(headerToken, sessionId, this.csrfKey)) {
+          throw new ForbiddenException("Invalid CSRF token");
+        }
       }
     }
 
     return true;
+  }
+
+  private extractSessionId(request: any): string | null {
+    // Try auth_token cookie first, then Authorization header
+    const token =
+      request.cookies?.["auth_token"] ||
+      this.extractBearerToken(request.headers?.["authorization"]);
+
+    if (!token) return null;
+
+    try {
+      const payload = this.jwtService.decode(token);
+      return payload?.sub || null;
+    } catch {
+      return null;
+    }
+  }
+
+  private extractBearerToken(header: string | undefined): string | null {
+    if (!header?.startsWith("Bearer ")) return null;
+    return header.slice(7);
   }
 }

--- a/backend/src/notifications/email-templates.ts
+++ b/backend/src/notifications/email-templates.ts
@@ -353,6 +353,26 @@ export function budgetMonthlySummaryTemplate(
   `;
 }
 
+export function oidcLinkTemplate(
+  firstName: string,
+  confirmUrl: string,
+): string {
+  const safeName = escapeHtml(firstName || "there");
+  const safeUrl = escapeHtml(confirmUrl);
+  return `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+      <h2 style="color: #1f2937;">Link Your SSO Account</h2>
+      <p style="color: #374151;">Hi ${safeName},</p>
+      <p style="color: #374151;">Someone attempted to sign in via SSO with an email that matches your existing Monize account. To link your SSO identity to this account, click the button below:</p>
+      <p style="text-align: center; margin: 24px 0;">
+        <a href="${safeUrl}" style="background-color: #2563eb; color: #ffffff; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-weight: 600;">Confirm Account Link</a>
+      </p>
+      <p style="color: #6b7280; font-size: 14px;">If you did not initiate this request, you can safely ignore this email. The link expires in 1 hour.</p>
+      <p style="color: #6b7280; font-size: 14px; margin-top: 24px;">-- Monize</p>
+    </div>
+  `;
+}
+
 export function accountLockedTemplate(firstName: string): string {
   const safeName = escapeHtml(firstName || "there");
   return `


### PR DESCRIPTION
- Fix HTML injection in OIDC link email by moving template to email-templates.ts with escapeHtml()
- Validate backup restore column names against information_schema to prevent SQL injection via crafted backup files
- Add OIDC ID token claim verification (issuer, audience, subject, expiry) in backup restore re-authentication
- Fix CSRF HMAC session binding dead code by extracting user ID from JWT directly in the guard instead of relying on request.user
- Add periodic cleanup for forgot-password rate limit Map to prevent unbounded memory growth