### PR TITLE
Allow private URLs for self-hosted AI providers

### DIFF
--- a/backend/src/ai/ai.service.spec.ts
+++ b/backend/src/ai/ai.service.spec.ts
@@ -204,6 +204,33 @@ describe("AiService", () => {
       expect(mockEncryptionService.encrypt).not.toHaveBeenCalled();
       expect(mockConfigRepository.save).toHaveBeenCalled();
     });
+
+    it("allows private/local baseUrl for self-hosted providers", async () => {
+      await service.createConfig(userId, {
+        provider: "ollama",
+        baseUrl: "http://192.168.1.100:11434",
+      });
+      expect(mockConfigRepository.save).toHaveBeenCalled();
+    });
+
+    it("rejects private baseUrl for cloud providers", async () => {
+      await expect(
+        service.createConfig(userId, {
+          provider: "anthropic",
+          apiKey: "sk-key",
+          baseUrl: "http://localhost:8080",
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it("rejects invalid URL scheme for self-hosted providers", async () => {
+      await expect(
+        service.createConfig(userId, {
+          provider: "ollama",
+          baseUrl: "ftp://localhost:11434",
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
   });
 
   describe("updateConfig()", () => {

--- a/backend/src/ai/ai.service.ts
+++ b/backend/src/ai/ai.service.ts
@@ -23,7 +23,14 @@ import {
   AiCompletionResponse,
   AiProvider,
 } from "./providers/ai-provider.interface";
-import { validateUrlIsSafe } from "./validators/safe-url.validator";
+import {
+  validateUrlIsSafe,
+  validateUrlBasicSafety,
+} from "./validators/safe-url.validator";
+import {
+  SELF_HOSTED_PROVIDERS,
+  AiProviderType,
+} from "./entities/ai-provider-config.entity";
 
 const DEFAULT_MAX_AI_PROVIDERS_PER_USER = 10;
 
@@ -50,23 +57,44 @@ export class AiService {
         ? envVal
         : DEFAULT_MAX_AI_PROVIDERS_PER_USER;
 
-    // SECURITY: Validate AI_DEFAULT_BASE_URL against SSRF at startup
+    // SECURITY: Validate AI_DEFAULT_BASE_URL at startup.
+    // Self-hosted providers (ollama, openai-compatible) only need basic URL
+    // safety since they are expected to run on private/local networks.
     const defaultBaseUrl = this.configService.get<string>(
       "AI_DEFAULT_BASE_URL",
     );
     if (defaultBaseUrl) {
-      validateUrlIsSafe(defaultBaseUrl).then((isSafe) => {
-        if (isSafe) {
+      const defaultProvider = this.configService.get<string>(
+        "AI_DEFAULT_PROVIDER",
+      );
+      const isSelfHosted = SELF_HOSTED_PROVIDERS.has(
+        defaultProvider as AiProviderType,
+      );
+
+      if (isSelfHosted) {
+        if (validateUrlBasicSafety(defaultBaseUrl)) {
           this.validatedDefaultBaseUrl = defaultBaseUrl;
         } else {
           this.logger.error(
-            `AI_DEFAULT_BASE_URL "${defaultBaseUrl}" failed SSRF validation -- ` +
-              "it points to a private/internal IP or blocked hostname. " +
+            `AI_DEFAULT_BASE_URL "${defaultBaseUrl}" is not a valid HTTP/HTTPS URL. ` +
               "The default AI provider base URL will not be used.",
           );
         }
         this.defaultBaseUrlValidated = true;
-      });
+      } else {
+        validateUrlIsSafe(defaultBaseUrl).then((isSafe) => {
+          if (isSafe) {
+            this.validatedDefaultBaseUrl = defaultBaseUrl;
+          } else {
+            this.logger.error(
+              `AI_DEFAULT_BASE_URL "${defaultBaseUrl}" failed SSRF validation -- ` +
+                "it points to a private/internal IP or blocked hostname. " +
+                "The default AI provider base URL will not be used.",
+            );
+          }
+          this.defaultBaseUrlValidated = true;
+        });
+      }
     } else {
       this.defaultBaseUrlValidated = true;
     }
@@ -94,6 +122,12 @@ export class AiService {
     userId: string,
     dto: CreateAiConfigDto,
   ): Promise<AiProviderConfigResponse> {
+    // Validate baseUrl: self-hosted providers allow private URLs,
+    // cloud providers require full SSRF validation
+    if (dto.baseUrl) {
+      await this.validateBaseUrl(dto.baseUrl, dto.provider);
+    }
+
     const existingCount = await this.configRepository.count({
       where: { userId },
     });
@@ -133,6 +167,12 @@ export class AiService {
     dto: UpdateAiConfigDto,
   ): Promise<AiProviderConfigResponse> {
     const config = await this.getConfig(userId, configId);
+
+    // Validate baseUrl: self-hosted providers allow private URLs,
+    // cloud providers require full SSRF validation
+    if (dto.baseUrl) {
+      await this.validateBaseUrl(dto.baseUrl, config.provider);
+    }
 
     if (dto.displayName !== undefined)
       config.displayName = dto.displayName || null;
@@ -326,6 +366,26 @@ export class AiService {
     }
 
     return config;
+  }
+
+  private async validateBaseUrl(
+    baseUrl: string,
+    provider: AiProviderType,
+  ): Promise<void> {
+    if (SELF_HOSTED_PROVIDERS.has(provider)) {
+      if (!validateUrlBasicSafety(baseUrl)) {
+        throw new BadRequestException(
+          "baseUrl must be a valid HTTP or HTTPS URL",
+        );
+      }
+    } else {
+      const isSafe = await validateUrlIsSafe(baseUrl);
+      if (!isSafe) {
+        throw new BadRequestException(
+          "baseUrl must be a valid HTTP/HTTPS URL pointing to an external host",
+        );
+      }
+    }
   }
 
   private toResponseDto(config: AiProviderConfig): AiProviderConfigResponse {

--- a/backend/src/ai/dto/ai-config.dto.ts
+++ b/backend/src/ai/dto/ai-config.dto.ts
@@ -8,11 +8,9 @@ import {
   MaxLength,
   Min,
   Max,
-  ValidateIf,
 } from "class-validator";
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
-import { IsSafeUrl } from "../validators/safe-url.validator";
 import { IsSafeConfigObject } from "../validators/safe-config-object.validator";
 import {
   AI_PROVIDERS,
@@ -60,13 +58,11 @@ export class CreateAiConfigDto {
   @ApiPropertyOptional({
     example: "https://api.example.com",
     description:
-      "Base URL for the provider (required for Ollama and OpenAI-compatible). Must be a valid external HTTP/HTTPS URL.",
+      "Base URL for the provider (required for Ollama and OpenAI-compatible). Self-hosted providers allow private/local URLs.",
   })
   @IsOptional()
   @IsString()
   @MaxLength(500)
-  @ValidateIf((o) => o.baseUrl !== undefined && o.baseUrl !== "")
-  @IsSafeUrl()
   baseUrl?: string;
 
   @ApiPropertyOptional({
@@ -120,13 +116,11 @@ export class UpdateAiConfigDto {
   @ApiPropertyOptional({
     example: "https://api.example.com",
     description:
-      "Base URL for the provider. Must be a valid external HTTP/HTTPS URL.",
+      "Base URL for the provider. Self-hosted providers allow private/local URLs.",
   })
   @IsOptional()
   @IsString()
   @MaxLength(500)
-  @ValidateIf((o) => o.baseUrl !== undefined && o.baseUrl !== "")
-  @IsSafeUrl()
   baseUrl?: string;
 
   @ApiPropertyOptional({

--- a/backend/src/ai/entities/ai-provider-config.entity.ts
+++ b/backend/src/ai/entities/ai-provider-config.entity.ts
@@ -18,6 +18,12 @@ export const AI_PROVIDERS = [
 
 export type AiProviderType = (typeof AI_PROVIDERS)[number];
 
+/** Providers that are self-hosted and expected to run on private/local networks. */
+export const SELF_HOSTED_PROVIDERS: ReadonlySet<AiProviderType> = new Set([
+  "ollama",
+  "openai-compatible",
+]);
+
 @Entity("ai_provider_configs")
 export class AiProviderConfig {
   @PrimaryGeneratedColumn("uuid")

--- a/backend/src/ai/validators/safe-url.validator.ts
+++ b/backend/src/ai/validators/safe-url.validator.ts
@@ -184,6 +184,27 @@ export async function validateUrlIsSafe(url: string): Promise<boolean> {
   return validator.validate(url);
 }
 
+/**
+ * Lighter validation for self-hosted providers (Ollama, OpenAI-compatible) that are
+ * expected to run on private/local networks. Only checks protocol and rejects
+ * embedded credentials.
+ */
+export function validateUrlBasicSafety(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return false;
+  }
+  if (parsed.username || parsed.password) {
+    return false;
+  }
+  return true;
+}
+
 export function IsSafeUrl(
   validationOptions?: ValidationOptions,
 ): PropertyDecorator {


### PR DESCRIPTION
## Summary
This PR implements differentiated URL validation for AI providers based on whether they are self-hosted or cloud-based. Self-hosted providers (Ollama, OpenAI-compatible) now allow private/local network URLs, while cloud providers continue to require full SSRF validation.

## Key Changes
- **New validation function**: Added `validateUrlBasicSafety()` for lightweight URL validation that only checks protocol (HTTP/HTTPS) and rejects embedded credentials, suitable for self-hosted providers on private networks
- **Provider classification**: Introduced `SELF_HOSTED_PROVIDERS` constant to identify providers that run on private/local networks
- **Conditional validation logic**: 
  - Self-hosted providers use basic safety validation (protocol + credential check)
  - Cloud providers use full SSRF validation to prevent attacks on internal infrastructure
- **Service-level validation**: Moved URL validation from DTO decorators to `validateBaseUrl()` method in `AiService` for both create and update operations, enabling provider-aware validation
- **Updated documentation**: Modified API property descriptions to clarify that self-hosted providers allow private/local URLs
- **Test coverage**: Added tests verifying that private URLs are allowed for self-hosted providers, rejected for cloud providers, and invalid schemes are rejected

## Implementation Details
- Validation is applied at service layer during `createConfig()` and `updateConfig()` operations
- Startup validation of `AI_DEFAULT_BASE_URL` now checks if the default provider is self-hosted before applying appropriate validation
- Removed class-validator decorators (`@IsSafeUrl`, `@ValidateIf`) from DTOs to allow service-layer provider-aware validation
- Error messages distinguish between basic URL format issues and SSRF violations

https://claude.ai/code/session_01RBhqL4nYTtTiMsE2yuhFjq