### PR TITLE
Fix brokerage account display on dashboard favourites

### DIFF
--- a/frontend/src/components/dashboard/FavouriteAccounts.tsx
+++ b/frontend/src/components/dashboard/FavouriteAccounts.tsx
@@ -73,12 +73,11 @@ export function FavouriteAccounts({ accounts, brokerageMarketValues, isLoading, 
 
       try {
         await accountsApi.reorderFavourites(reordered.map((a) => a.id));
-        onAccountsChanged?.();
       } catch {
         setLocalOrder(null);
       }
     },
-    [accounts, effectiveLocalOrder, onAccountsChanged],
+    [accounts, effectiveLocalOrder],
   );
 
   if (isLoading) {


### PR DESCRIPTION
## Summary
- **Market value**: Brokerage accounts in dashboard favourites now show their actual market value (from portfolio summary) instead of zero (`currentBalance` is always 0 for brokerage accounts since value is tracked via holdings)
- **Navigation**: Clicking a brokerage favourite now navigates to `/investments?accountId=...` instead of `/transactions`, since brokerage accounts have no regular transactions
- **Reorder flicker**: Reordering favourites no longer triggers a full dashboard reload; the optimistic local state already keeps the UI in sync

## Test plan
- [x] FavouriteAccounts tests pass (22 tests) -- includes new tests for market value display and brokerage navigation
- [x] Dashboard page tests pass (14 tests)
- [x] BalanceHistoryChart tests pass (8 tests) -- fixed date-sensitive test
- [ ] Manual: Add a brokerage account to favourites, verify market value displays with "Market value" label
- [ ] Manual: Click a brokerage favourite, verify it navigates to Investments page filtered to that account
- [ ] Manual: Click a regular favourite, verify it still navigates to Transactions page
- [ ] Manual: Reorder favourites, verify no page flash/refresh

https://claude.ai/code/session_01CmdhBvtoxr7we5KkkDs2W2