### PR TITLE
Fix stale closure issues with preferredExchanges dependency

### DIFF
--- a/frontend/src/components/dashboard/FavouriteAccounts.tsx
+++ b/frontend/src/components/dashboard/FavouriteAccounts.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Account } from '@/types/account';
 import { usePreferencesStore } from '@/store/preferencesStore';
@@ -28,7 +28,7 @@ interface FavouriteAccountsProps {
   onAccountsChanged?: () => void;
 }
 
-export function FavouriteAccounts({ accounts, brokerageMarketValues, isLoading, onAccountsChanged }: FavouriteAccountsProps) {
+export function FavouriteAccounts({ accounts, brokerageMarketValues, isLoading, onAccountsChanged: _onAccountsChanged }: FavouriteAccountsProps) {
   const router = useRouter();
   const { preferences } = usePreferencesStore();
   const { formatCurrency: formatCurrencyBase } = useNumberFormat();

--- a/frontend/src/components/securities/SecurityForm.tsx
+++ b/frontend/src/components/securities/SecurityForm.tsx
@@ -54,7 +54,8 @@ const securityTypeOptions = [
 
 export function SecurityForm({ security, onSubmit, onCancel, onDirtyChange, submitRef }: SecurityFormProps) {
   const { defaultCurrency } = useNumberFormat();
-  const preferredExchanges = usePreferencesStore((s) => s.preferences?.preferredExchanges) || [];
+  const rawPreferredExchanges = usePreferencesStore((s) => s.preferences?.preferredExchanges);
+  const preferredExchanges = useMemo(() => rawPreferredExchanges || [], [rawPreferredExchanges]);
   const [isLookingUp, setIsLookingUp] = useState(false);
   const [hasLookupResult, setHasLookupResult] = useState(false);
   const [currencies, setCurrencies] = useState<CurrencyInfo[]>([]);

--- a/frontend/src/hooks/useImportWizard.ts
+++ b/frontend/src/hooks/useImportWizard.ts
@@ -71,7 +71,8 @@ export function useImportWizard() {
   const searchParams = useSearchParams();
   const preselectedAccountId = searchParams.get('accountId');
   const defaultCurrency = usePreferencesStore((s) => s.preferences?.defaultCurrency) || 'USD';
-  const preferredExchanges = usePreferencesStore((s) => s.preferences?.preferredExchanges) || [];
+  const rawPreferredExchanges = usePreferencesStore((s) => s.preferences?.preferredExchanges);
+  const preferredExchanges = useMemo(() => rawPreferredExchanges || [], [rawPreferredExchanges]);
 
   const [step, setStep] = useState<ImportStep>('upload');
   const [importFiles, setImportFiles] = useState<ImportFileData[]>([]);
@@ -318,7 +319,7 @@ export function useImportWizard() {
     };
 
     runBulkLookup();
-  }, [step, initialLookupDone, securityMappings]);
+  }, [step, initialLookupDone, securityMappings, preferredExchanges]);
 
   const handleFileSelect = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;


### PR DESCRIPTION
## Summary
This PR fixes stale closure issues in hooks and components that use `preferredExchanges` from the preferences store by properly memoizing the value and including it in dependency arrays.

## Key Changes
- **useImportWizard.ts**: Wrapped `preferredExchanges` with `useMemo` to ensure stable reference and added it to the `runBulkLookup` effect dependency array to prevent stale closures
- **SecurityForm.tsx**: Applied the same `useMemo` pattern to `preferredExchanges` for consistency
- **FavouriteAccounts.tsx**: Removed unused `useRef` import and prefixed unused `onAccountsChanged` prop with underscore to follow linting conventions

## Implementation Details
The core issue was that `preferredExchanges` was being derived directly from the store selector without memoization, causing the reference to change on every render. This led to stale closures in effects that depended on this value. By wrapping it with `useMemo` and properly declaring it as a dependency, we ensure effects only re-run when the actual value changes, not on every render.

https://claude.ai/code/session_01Hsod6gaJaauNu6LQHGuNaD