### PR TITLE
Fix SMTP configuration to properly handle TLS modes

### DIFF
--- a/backend/src/notifications/email.service.spec.ts
+++ b/backend/src/notifications/email.service.spec.ts
@@ -24,7 +24,6 @@ describe("EmailService", () => {
             SMTP_HOST: "smtp.example.com",
             SMTP_USER: "user@example.com",
             SMTP_PASSWORD: "password123",
-            SMTP_SECURE: "false",
             SMTP_PORT: 587,
             EMAIL_FROM: "noreply@monize.app",
           };
@@ -43,10 +42,13 @@ describe("EmailService", () => {
       service.onModuleInit();
     });
 
-    it("configures transport on init", () => {
+    it("configures transport with STARTTLS on port 587", () => {
       expect(nodemailer.createTransport).toHaveBeenCalledWith(
         expect.objectContaining({
           host: "smtp.example.com",
+          port: 587,
+          secure: false,
+          requireTLS: true,
           auth: { user: "user@example.com", pass: "password123" },
         }),
       );
@@ -82,6 +84,48 @@ describe("EmailService", () => {
 
       const result = await service.verifyConnection();
       expect(result).toBe(false);
+    });
+  });
+
+  describe("when SMTP is configured with port 465", () => {
+    beforeEach(async () => {
+      (nodemailer.createTransport as jest.Mock).mockClear();
+      configService = {
+        get: jest.fn().mockImplementation((key: string, defaultVal?: any) => {
+          const config: Record<string, any> = {
+            SMTP_HOST: "smtp.example.com",
+            SMTP_USER: "user@example.com",
+            SMTP_PASSWORD: "password123",
+            SMTP_PORT: 465,
+            EMAIL_FROM: "noreply@monize.app",
+          };
+          return config[key] ?? defaultVal;
+        }),
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          EmailService,
+          { provide: ConfigService, useValue: configService },
+        ],
+      }).compile();
+
+      service = module.get<EmailService>(EmailService);
+      service.onModuleInit();
+    });
+
+    it("configures transport with implicit TLS on port 465", () => {
+      expect(nodemailer.createTransport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          host: "smtp.example.com",
+          port: 465,
+          secure: true,
+          auth: { user: "user@example.com", pass: "password123" },
+        }),
+      );
+      expect(nodemailer.createTransport).not.toHaveBeenCalledWith(
+        expect.objectContaining({ requireTLS: true }),
+      );
     });
   });
 

--- a/backend/src/notifications/email.service.ts
+++ b/backend/src/notifications/email.service.ts
@@ -21,19 +21,23 @@ export class EmailService implements OnModuleInit {
       return;
     }
 
-    const secure =
-      this.configService.get<string>("SMTP_SECURE", "false") === "true";
-    const port = this.configService.get<number>(
-      "SMTP_PORT",
-      secure ? 465 : 587,
-    );
+    const port = this.configService.get<number>("SMTP_PORT", 587);
+    // Port 465 uses implicit TLS; port 587 uses STARTTLS (secure must be false)
+    const secure = port === 465;
 
-    this.transporter = nodemailer.createTransport({
+    const transportOptions: Record<string, unknown> = {
       host,
       port,
       secure,
       auth: { user, pass: password },
-    });
+    };
+
+    // For port 587, require STARTTLS upgrade (don't fall back to plaintext)
+    if (!secure) {
+      transportOptions.requireTLS = true;
+    }
+
+    this.transporter = nodemailer.createTransport(transportOptions);
 
     this.configured = true;
     this.logger.log("SMTP email transport configured");


### PR DESCRIPTION
## Summary
Updated the email service SMTP configuration to automatically determine the correct TLS mode based on the port number, removing the need for a separate `SMTP_SECURE` environment variable.

## Key Changes
- **Removed `SMTP_SECURE` config variable**: The TLS mode is now derived from the port number, which is the standard SMTP convention
- **Port 465 (implicit TLS)**: Automatically sets `secure: true` for direct TLS connections
- **Port 587 (STARTTLS)**: Automatically sets `secure: false` and adds `requireTLS: true` to enforce TLS upgrade and prevent plaintext fallback
- **Updated tests**: Added comprehensive test coverage for both port 465 and 587 configurations with their respective TLS settings

## Implementation Details
- The `secure` flag is now determined by checking if `port === 465`
- For non-secure connections (port 587), `requireTLS: true` is added to the transport options to ensure the connection upgrades to TLS and doesn't fall back to plaintext
- This follows SMTP best practices where port 465 uses implicit TLS and port 587 uses explicit STARTTLS

https://claude.ai/code/session_0189vW4TKC13Sv43e1sq6Qjm