### PR TITLE
Fix Invalid CSRF token error when using the AI Assistant

### DIFF
--- a/frontend/src/lib/ai.ts
+++ b/frontend/src/lib/ai.ts
@@ -1,3 +1,4 @@
+import Cookies from 'js-cookie';
 import apiClient from './api';
 import type {
   AiProviderConfig,
@@ -57,11 +58,12 @@ export const aiApi = {
   queryStream: (query: string, callbacks: StreamCallbacks): AbortController => {
     const controller = new AbortController();
 
-    // Get CSRF token from cookie
-    const csrfToken = document.cookie
-      .split('; ')
-      .find((row) => row.startsWith('csrf_token='))
-      ?.split('=')[1] || '';
+    // Get CSRF token from cookie. Use js-cookie (not raw document.cookie) so
+    // the value is URL-decoded — the backend stores `${nonce}:${hmac}`, which
+    // Express serializes with `%3A` in place of the colon. Sending the raw
+    // encoded value would fail the backend's timing-safe comparison against
+    // the cookie-parser-decoded cookie.
+    const csrfToken = Cookies.get('csrf_token') || '';
 
     fetch('/api/v1/ai/query/stream', {
       method: 'POST',


### PR DESCRIPTION
The queryStream function read the csrf_token cookie directly from
document.cookie without URL-decoding. The backend generates tokens in
the format `${nonce}:${hmac}`, and Express serializes the colon as
`%3A`, so the raw cookie string contained the encoded form. The
streaming request sent that encoded value in the X-CSRF-Token header,
which never matched the cookie-parser-decoded value on the backend
and failed CsrfGuard's timing-safe comparison.

Use Cookies.get('csrf_token') from js-cookie (consistent with the
axios interceptor in api.ts) so the value is properly URL-decoded
before being sent in the header.