### PR TITLE
Claude/ai startup validator and once bill cleanup

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -41,6 +41,7 @@
         "rxjs": "^7.8.2",
         "typeorm": "^0.3.28",
         "ua-parser-js": "^2.0.9",
+        "undici": "^8.0.2",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -9522,6 +9523,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.0.2.tgz",
+      "integrity": "sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -62,6 +62,7 @@
     "rxjs": "^7.8.2",
     "typeorm": "^0.3.28",
     "ua-parser-js": "^2.0.9",
+    "undici": "^8.0.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/backend/src/ai/ai-startup.validator.spec.ts
+++ b/backend/src/ai/ai-startup.validator.spec.ts
@@ -1,0 +1,186 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigService } from "@nestjs/config";
+import { Logger } from "@nestjs/common";
+import { AiStartupValidator } from "./ai-startup.validator";
+import { AiProviderFactory } from "./ai-provider.factory";
+import { AiEncryptionService } from "./ai-encryption.service";
+
+describe("AiStartupValidator", () => {
+  let validator: AiStartupValidator;
+  let mockProviderFactory: { createProvider: jest.Mock };
+  let mockEncryptionService: { encrypt: jest.Mock; isConfigured: jest.Mock };
+  let mockConfigService: { get: jest.Mock };
+  let logSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    mockProviderFactory = {
+      createProvider: jest.fn(),
+    };
+
+    mockEncryptionService = {
+      encrypt: jest.fn().mockReturnValue("encrypted-default"),
+      isConfigured: jest.fn().mockReturnValue(true),
+    };
+
+    mockConfigService = {
+      get: jest.fn().mockReturnValue(undefined),
+    };
+
+    logSpy = jest.spyOn(Logger.prototype, "log").mockImplementation();
+    warnSpy = jest.spyOn(Logger.prototype, "warn").mockImplementation();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AiStartupValidator,
+        { provide: AiProviderFactory, useValue: mockProviderFactory },
+        { provide: AiEncryptionService, useValue: mockEncryptionService },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    validator = module.get<AiStartupValidator>(AiStartupValidator);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("onApplicationBootstrap()", () => {
+    it("logs and skips when AI_DEFAULT_PROVIDER is not set", async () => {
+      await validator.onApplicationBootstrap();
+
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("No system-default AI provider configured"),
+      );
+      expect(mockProviderFactory.createProvider).not.toHaveBeenCalled();
+    });
+
+    it("validates the system default provider and logs success", async () => {
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === "AI_DEFAULT_PROVIDER") return "anthropic";
+        if (key === "AI_DEFAULT_MODEL") return "claude-sonnet-4-20250514";
+        if (key === "AI_DEFAULT_API_KEY") return "sk-default";
+        return undefined;
+      });
+
+      const isAvailable = jest.fn().mockResolvedValue(true);
+      mockProviderFactory.createProvider.mockReturnValue({ isAvailable });
+
+      await validator.onApplicationBootstrap();
+
+      expect(mockEncryptionService.encrypt).toHaveBeenCalledWith("sk-default");
+      expect(mockProviderFactory.createProvider).toHaveBeenCalledTimes(1);
+      expect(mockProviderFactory.createProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "anthropic",
+          model: "claude-sonnet-4-20250514",
+          apiKeyEnc: "encrypted-default",
+        }),
+      );
+      expect(isAvailable).toHaveBeenCalled();
+
+      const successCall = logSpy.mock.calls.find((c) =>
+        String(c[0]).startsWith("AI provider OK:"),
+      );
+      expect(successCall).toBeDefined();
+      expect(successCall![0]).toContain("anthropic:claude-sonnet-4-20250514");
+    });
+
+    it("logs a warning when the provider is unreachable", async () => {
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === "AI_DEFAULT_PROVIDER") return "anthropic";
+        return undefined;
+      });
+
+      mockProviderFactory.createProvider.mockReturnValue({
+        isAvailable: jest.fn().mockResolvedValue(false),
+      });
+
+      await validator.onApplicationBootstrap();
+
+      const failureCall = warnSpy.mock.calls.find((c) =>
+        String(c[0]).startsWith("AI provider FAILED:"),
+      );
+      expect(failureCall).toBeDefined();
+      expect(failureCall![0]).toContain("anthropic");
+    });
+
+    it("captures the error message when isAvailable throws", async () => {
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === "AI_DEFAULT_PROVIDER") return "anthropic";
+        return undefined;
+      });
+
+      mockProviderFactory.createProvider.mockReturnValue({
+        isAvailable: jest.fn().mockRejectedValue(new Error("Boom")),
+      });
+
+      await validator.onApplicationBootstrap();
+
+      const failureCall = warnSpy.mock.calls.find((c) =>
+        String(c[0]).startsWith("AI provider FAILED:"),
+      );
+      expect(failureCall).toBeDefined();
+      expect(failureCall![0]).toContain("Boom");
+    });
+
+    it("captures the error message when createProvider throws", async () => {
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === "AI_DEFAULT_PROVIDER") return "openai-compatible";
+        return undefined;
+      });
+
+      mockProviderFactory.createProvider.mockImplementation(() => {
+        throw new Error("baseUrl is required");
+      });
+
+      await validator.onApplicationBootstrap();
+
+      const failureCall = warnSpy.mock.calls.find((c) =>
+        String(c[0]).startsWith("AI provider FAILED:"),
+      );
+      expect(failureCall).toBeDefined();
+      expect(failureCall![0]).toContain("baseUrl is required");
+    });
+
+    it("does not encrypt the default API key when encryption is not configured", async () => {
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === "AI_DEFAULT_PROVIDER") return "anthropic";
+        if (key === "AI_DEFAULT_API_KEY") return "sk-default";
+        return undefined;
+      });
+      mockEncryptionService.isConfigured.mockReturnValue(false);
+
+      mockProviderFactory.createProvider.mockReturnValue({
+        isAvailable: jest.fn().mockResolvedValue(true),
+      });
+
+      await validator.onApplicationBootstrap();
+
+      expect(mockEncryptionService.encrypt).not.toHaveBeenCalled();
+      expect(mockProviderFactory.createProvider).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKeyEnc: null }),
+      );
+    });
+
+    it("omits the model from the label when AI_DEFAULT_MODEL is unset", async () => {
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === "AI_DEFAULT_PROVIDER") return "ollama";
+        return undefined;
+      });
+
+      mockProviderFactory.createProvider.mockReturnValue({
+        isAvailable: jest.fn().mockResolvedValue(true),
+      });
+
+      await validator.onApplicationBootstrap();
+
+      const successCall = logSpy.mock.calls.find((c) =>
+        String(c[0]).startsWith("AI provider OK:"),
+      );
+      expect(successCall).toBeDefined();
+      expect(successCall![0]).toMatch(/AI provider OK: ollama$/);
+    });
+  });
+});

--- a/backend/src/ai/ai-startup.validator.ts
+++ b/backend/src/ai/ai-startup.validator.ts
@@ -1,0 +1,82 @@
+import { Injectable, Logger, OnApplicationBootstrap } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import {
+  AiProviderConfig,
+  AiProviderType,
+} from "./entities/ai-provider-config.entity";
+import { AiProviderFactory } from "./ai-provider.factory";
+import { AiEncryptionService } from "./ai-encryption.service";
+
+/**
+ * Validates connectivity to the system-default AI provider on backend startup
+ * and logs the result. The system default is configured via the AI_DEFAULT_*
+ * env vars; if none is set, validation is skipped.
+ *
+ * Failures are logged as warnings but never abort startup.
+ */
+@Injectable()
+export class AiStartupValidator implements OnApplicationBootstrap {
+  private readonly logger = new Logger(AiStartupValidator.name);
+
+  constructor(
+    private readonly providerFactory: AiProviderFactory,
+    private readonly encryptionService: AiEncryptionService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    const config = this.buildSystemDefaultConfig();
+
+    if (!config) {
+      this.logger.log(
+        "No system-default AI provider configured (AI_DEFAULT_PROVIDER unset); skipping startup validation.",
+      );
+      return;
+    }
+
+    const label = this.formatLabel(config);
+    this.logger.log(`Validating connection to AI provider: ${label}`);
+
+    try {
+      const provider = this.providerFactory.createProvider(config);
+      const available = await provider.isAvailable();
+      if (available) {
+        this.logger.log(`AI provider OK: ${label}`);
+      } else {
+        this.logger.warn(`AI provider FAILED: ${label}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`AI provider FAILED: ${label} -- ${message}`);
+    }
+  }
+
+  private formatLabel(config: AiProviderConfig): string {
+    return config.model
+      ? `${config.provider}:${config.model}`
+      : config.provider;
+  }
+
+  private buildSystemDefaultConfig(): AiProviderConfig | null {
+    const provider = this.configService.get<string>("AI_DEFAULT_PROVIDER");
+    if (!provider) return null;
+
+    const config = new AiProviderConfig();
+    config.provider = provider as AiProviderType;
+    config.model = this.configService.get<string>("AI_DEFAULT_MODEL") || null;
+    config.baseUrl =
+      this.configService.get<string>("AI_DEFAULT_BASE_URL") || null;
+    config.isActive = true;
+    config.priority = 0;
+    config.config = {};
+    config.displayName = "System Default";
+    config.apiKeyEnc = null;
+
+    const defaultApiKey = this.configService.get<string>("AI_DEFAULT_API_KEY");
+    if (defaultApiKey && this.encryptionService.isConfigured()) {
+      config.apiKeyEnc = this.encryptionService.encrypt(defaultApiKey);
+    }
+
+    return config;
+  }
+}

--- a/backend/src/ai/ai.module.ts
+++ b/backend/src/ai/ai.module.ts
@@ -12,6 +12,7 @@ import { AiService } from "./ai.service";
 import { AiUsageService } from "./ai-usage.service";
 import { AiEncryptionService } from "./ai-encryption.service";
 import { AiProviderFactory } from "./ai-provider.factory";
+import { AiStartupValidator } from "./ai-startup.validator";
 import { AiController } from "./ai.controller";
 import { FinancialContextBuilder } from "./context/financial-context.builder";
 import { AiQueryService } from "./query/ai-query.service";
@@ -52,6 +53,7 @@ import { BudgetsModule } from "../budgets/budgets.module";
     AiUsageService,
     AiEncryptionService,
     AiProviderFactory,
+    AiStartupValidator,
     FinancialContextBuilder,
     AiQueryService,
     ToolExecutorService,

--- a/backend/src/ai/providers/ai-provider.interface.ts
+++ b/backend/src/ai/providers/ai-provider.interface.ts
@@ -62,6 +62,23 @@ export interface AiToolResponse {
   stopReason: "end_turn" | "tool_use" | "max_tokens";
 }
 
+/**
+ * Streaming chunk produced by `streamWithTools()`. Providers emit zero or more
+ * `text` chunks as the model generates output, followed by exactly one `done`
+ * chunk that carries the fully-assembled tool calls (if any), final usage
+ * counters, model id, and stop reason.
+ */
+export type AiToolStreamChunk =
+  | { type: "text"; text: string }
+  | {
+      type: "done";
+      content: string;
+      toolCalls: AiToolCall[];
+      usage: { inputTokens: number; outputTokens: number };
+      model: string;
+      stopReason: "end_turn" | "tool_use" | "max_tokens";
+    };
+
 export interface AiProvider {
   readonly name: string;
   readonly supportsStreaming: boolean;
@@ -75,6 +92,17 @@ export interface AiProvider {
     request: AiCompletionRequest,
     tools: AiToolDefinition[],
   ): Promise<AiToolResponse>;
+
+  /**
+   * Streaming variant of `completeWithTools()` that yields the model's text
+   * output incrementally so the caller can surface realtime feedback.
+   * Optional — providers that haven't implemented it will fall back to
+   * `completeWithTools()` in the query service.
+   */
+  streamWithTools?(
+    request: AiCompletionRequest,
+    tools: AiToolDefinition[],
+  ): AsyncIterable<AiToolStreamChunk>;
 
   isAvailable(): Promise<boolean>;
 }

--- a/backend/src/ai/providers/anthropic.provider.spec.ts
+++ b/backend/src/ai/providers/anthropic.provider.spec.ts
@@ -1,4 +1,5 @@
 import { AnthropicProvider } from "./anthropic.provider";
+import type { AiToolStreamChunk } from "./ai-provider.interface";
 
 const mockCreate = jest.fn().mockResolvedValue({
   content: [{ type: "text", text: "Hello from Claude" }],
@@ -233,6 +234,208 @@ describe("AnthropicProvider", () => {
           content: '{"balance": 5000}',
         },
       ]);
+    });
+  });
+
+  describe("streamWithTools()", () => {
+    type AnthropicEvent = Record<string, unknown>;
+    type FinalMessage = Record<string, unknown>;
+
+    const buildStream = (
+      events: AnthropicEvent[],
+      finalMessage: FinalMessage,
+    ) => {
+      const stream = {
+        [Symbol.asyncIterator]: () => {
+          let idx = 0;
+          return {
+            next: () => {
+              if (idx < events.length) {
+                return Promise.resolve({ value: events[idx++], done: false });
+              }
+              return Promise.resolve({ value: undefined, done: true });
+            },
+          };
+        },
+        finalMessage: jest.fn().mockResolvedValue(finalMessage),
+      };
+      return stream;
+    };
+
+    const tools = [
+      {
+        name: "get_account_balances",
+        description: "Get balances",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ];
+
+    it("yields text deltas as text chunks then a done chunk with end_turn", async () => {
+      mockStream.mockReturnValueOnce(
+        buildStream(
+          [
+            {
+              type: "content_block_start",
+              index: 0,
+              content_block: { type: "text", text: "" },
+            },
+            {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "text_delta", text: "Your " },
+            },
+            {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "text_delta", text: "balance is $5,000." },
+            },
+            { type: "content_block_stop", index: 0 },
+            { type: "message_stop" },
+          ],
+          {
+            content: [{ type: "text", text: "Your balance is $5,000." }],
+            usage: { input_tokens: 30, output_tokens: 12 },
+            model: "claude-sonnet-4-20250514",
+            stop_reason: "end_turn",
+          },
+        ),
+      );
+
+      const chunks: AiToolStreamChunk[] = [];
+      for await (const chunk of provider.streamWithTools(
+        {
+          systemPrompt: "Be brief.",
+          messages: [{ role: "user", content: "balance?" }],
+        },
+        tools,
+      )) {
+        chunks.push(chunk);
+      }
+
+      expect(
+        chunks
+          .filter((c) => c.type === "text")
+          .map((c) => (c.type === "text" ? c.text : "")),
+      ).toEqual(["Your ", "balance is $5,000."]);
+      const doneChunk = chunks[chunks.length - 1];
+      expect(doneChunk.type).toBe("done");
+      if (doneChunk.type === "done") {
+        expect(doneChunk.content).toBe("Your balance is $5,000.");
+        expect(doneChunk.toolCalls).toEqual([]);
+        expect(doneChunk.stopReason).toBe("end_turn");
+        expect(doneChunk.usage.inputTokens).toBe(30);
+        expect(doneChunk.usage.outputTokens).toBe(12);
+      }
+    });
+
+    it("emits accumulated tool calls from finalMessage with tool_use stop reason", async () => {
+      mockStream.mockReturnValueOnce(
+        buildStream(
+          [
+            {
+              type: "content_block_start",
+              index: 0,
+              content_block: { type: "text", text: "" },
+            },
+            {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "text_delta", text: "Let me check." },
+            },
+            { type: "content_block_stop", index: 0 },
+            {
+              type: "content_block_start",
+              index: 1,
+              content_block: {
+                type: "tool_use",
+                id: "tu_1",
+                name: "get_account_balances",
+                input: {},
+              },
+            },
+            {
+              type: "content_block_delta",
+              index: 1,
+              delta: { type: "input_json_delta", partial_json: '{"days":' },
+            },
+            {
+              type: "content_block_delta",
+              index: 1,
+              delta: { type: "input_json_delta", partial_json: "30}" },
+            },
+            { type: "content_block_stop", index: 1 },
+            { type: "message_stop" },
+          ],
+          {
+            content: [
+              { type: "text", text: "Let me check." },
+              {
+                type: "tool_use",
+                id: "tu_1",
+                name: "get_account_balances",
+                input: { days: 30 },
+              },
+            ],
+            usage: { input_tokens: 25, output_tokens: 18 },
+            model: "claude-sonnet-4-20250514",
+            stop_reason: "tool_use",
+          },
+        ),
+      );
+
+      const chunks: AiToolStreamChunk[] = [];
+      for await (const chunk of provider.streamWithTools(
+        {
+          systemPrompt: "test",
+          messages: [{ role: "user", content: "balance?" }],
+        },
+        tools,
+      )) {
+        chunks.push(chunk);
+      }
+
+      const doneChunk = chunks[chunks.length - 1];
+      expect(doneChunk.type).toBe("done");
+      if (doneChunk.type === "done") {
+        expect(doneChunk.stopReason).toBe("tool_use");
+        expect(doneChunk.toolCalls).toEqual([
+          { id: "tu_1", name: "get_account_balances", input: { days: 30 } },
+        ]);
+        expect(doneChunk.content).toBe("Let me check.");
+      }
+    });
+
+    it("maps stop_reason max_tokens correctly", async () => {
+      mockStream.mockReturnValueOnce(
+        buildStream(
+          [
+            {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "text_delta", text: "truncated" },
+            },
+          ],
+          {
+            content: [{ type: "text", text: "truncated" }],
+            usage: { input_tokens: 10, output_tokens: 4096 },
+            model: "claude-sonnet-4-20250514",
+            stop_reason: "max_tokens",
+          },
+        ),
+      );
+
+      const chunks: AiToolStreamChunk[] = [];
+      for await (const chunk of provider.streamWithTools(
+        { systemPrompt: "test", messages: [{ role: "user", content: "hi" }] },
+        tools,
+      )) {
+        chunks.push(chunk);
+      }
+
+      const doneChunk = chunks[chunks.length - 1];
+      if (doneChunk.type === "done") {
+        expect(doneChunk.stopReason).toBe("max_tokens");
+      }
     });
   });
 

--- a/backend/src/ai/providers/anthropic.provider.spec.ts
+++ b/backend/src/ai/providers/anthropic.provider.spec.ts
@@ -65,6 +65,19 @@ describe("AnthropicProvider", () => {
     expect(provider.supportsToolUse).toBe(true);
   });
 
+  it("constructs the SDK client with the long-running fetch wrapper", () => {
+    // Regression: the SDK uses Node fetch (undici) under the hood, which
+    // defaults bodyTimeout to 5 minutes. The provider must inject the
+    // long-running fetch wrapper so SDK calls inherit disabled timeouts.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Anthropic = require("@anthropic-ai/sdk").default;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { longRunningFetch } = require("./long-running-fetch");
+    expect(Anthropic).toHaveBeenCalledWith(
+      expect.objectContaining({ fetch: longRunningFetch }),
+    );
+  });
+
   describe("complete()", () => {
     it("returns formatted response", async () => {
       const result = await provider.complete({

--- a/backend/src/ai/providers/anthropic.provider.ts
+++ b/backend/src/ai/providers/anthropic.provider.ts
@@ -6,6 +6,7 @@ import {
   AiStreamChunk,
   AiToolDefinition,
   AiToolResponse,
+  AiToolStreamChunk,
   AiMessage,
 } from "./ai-provider.interface";
 
@@ -196,6 +197,87 @@ export class AnthropicProvider implements AiProvider {
       },
       model: response.model,
       provider: this.name,
+      stopReason,
+    };
+  }
+
+  async *streamWithTools(
+    request: AiCompletionRequest,
+    tools: AiToolDefinition[],
+  ): AsyncIterable<AiToolStreamChunk> {
+    const stream = this.client.messages.stream({
+      model: this.modelId,
+      max_tokens: request.maxTokens || 4096,
+      system: request.systemPrompt,
+      messages: this.toAnthropicMessages(request.messages),
+      tools: tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        input_schema: tool.inputSchema as Anthropic.Tool.InputSchema,
+      })),
+      ...(request.temperature !== undefined && {
+        temperature: request.temperature,
+      }),
+    });
+
+    let accumulatedContent = "";
+    // Per content block index: tool-use metadata + accumulated JSON arg string
+    const toolBlocks = new Map<
+      number,
+      { id: string; name: string; jsonBuffer: string }
+    >();
+
+    for await (const event of stream) {
+      if (event.type === "content_block_start") {
+        if (event.content_block.type === "tool_use") {
+          toolBlocks.set(event.index, {
+            id: event.content_block.id,
+            name: event.content_block.name,
+            jsonBuffer: "",
+          });
+        }
+      } else if (event.type === "content_block_delta") {
+        if (event.delta.type === "text_delta") {
+          accumulatedContent += event.delta.text;
+          yield { type: "text", text: event.delta.text };
+        } else if (event.delta.type === "input_json_delta") {
+          const block = toolBlocks.get(event.index);
+          if (block) {
+            block.jsonBuffer += event.delta.partial_json;
+          }
+        }
+      }
+    }
+
+    // Use the SDK helper to get the final message with all metadata.
+    const finalMessage = await stream.finalMessage();
+
+    const toolCalls = finalMessage.content
+      .filter(
+        (block): block is Anthropic.ToolUseBlock => block.type === "tool_use",
+      )
+      .map((block) => ({
+        id: block.id,
+        name: block.name,
+        input: block.input as Record<string, unknown>,
+      }));
+
+    const stopReason: "end_turn" | "tool_use" | "max_tokens" =
+      finalMessage.stop_reason === "tool_use"
+        ? "tool_use"
+        : finalMessage.stop_reason === "max_tokens"
+          ? "max_tokens"
+          : "end_turn";
+
+    yield {
+      type: "done",
+      content: accumulatedContent,
+      toolCalls,
+      usage: {
+        inputTokens: finalMessage.usage.input_tokens,
+        outputTokens: finalMessage.usage.output_tokens,
+      },
+      model: finalMessage.model,
       stopReason,
     };
   }

--- a/backend/src/ai/providers/anthropic.provider.ts
+++ b/backend/src/ai/providers/anthropic.provider.ts
@@ -9,6 +9,7 @@ import {
   AiToolStreamChunk,
   AiMessage,
 } from "./ai-provider.interface";
+import { longRunningFetch } from "./long-running-fetch";
 
 export class AnthropicProvider implements AiProvider {
   readonly name = "anthropic";
@@ -19,7 +20,12 @@ export class AnthropicProvider implements AiProvider {
   private readonly modelId: string;
 
   constructor(apiKey: string, model?: string) {
-    this.client = new Anthropic({ apiKey });
+    this.client = new Anthropic({
+      apiKey,
+      // Inject our long-running fetch wrapper so SDK calls inherit the
+      // disabled bodyTimeout/headersTimeout. See long-running-fetch.ts.
+      fetch: longRunningFetch,
+    });
     this.modelId = model || "claude-sonnet-4-20250514";
   }
 

--- a/backend/src/ai/providers/long-running-fetch.spec.ts
+++ b/backend/src/ai/providers/long-running-fetch.spec.ts
@@ -1,81 +1,95 @@
+// Mock undici BEFORE importing the helper, so the helper picks up our mocks.
+const mockUndiciFetch = jest.fn();
+const mockAgentInstances: Array<{ options: unknown; dispatch: jest.Mock }> = [];
+
+jest.mock("undici", () => {
+  return {
+    Agent: jest.fn().mockImplementation((options: unknown) => {
+      const instance = { options, dispatch: jest.fn() };
+      mockAgentInstances.push(instance);
+      return instance;
+    }),
+    fetch: mockUndiciFetch,
+  };
+});
+
 import { longRunningAgent, longRunningFetch } from "./long-running-fetch";
 
 describe("long-running-fetch", () => {
+  beforeEach(() => {
+    mockUndiciFetch.mockReset();
+    mockUndiciFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+    });
+  });
+
   describe("longRunningAgent", () => {
-    it("is configured with disabled body and headers timeouts", () => {
-      // The Agent itself doesn't expose its options publicly, but its
-      // existence + correct shape is what matters for the type system.
-      // The behavioral verification is via the spec below that asserts
-      // longRunningFetch passes it as the dispatcher option.
-      expect(longRunningAgent).toBeDefined();
-      expect(typeof longRunningAgent.dispatch).toBe("function");
+    it("is constructed with body and headers timeouts disabled", () => {
+      // The Agent mock captured the constructor options at module load time.
+      const constructed = mockAgentInstances[0];
+      expect(constructed).toBeDefined();
+      expect(constructed.options).toEqual({
+        bodyTimeout: 0,
+        headersTimeout: 0,
+      });
+    });
+
+    it("is the same instance the helper exports", () => {
+      // Sanity check: longRunningAgent is the mocked Agent instance.
+      expect(longRunningAgent).toBe(mockAgentInstances[0]);
     });
   });
 
   describe("longRunningFetch", () => {
-    let originalFetch: typeof fetch;
-
-    beforeEach(() => {
-      originalFetch = global.fetch;
-    });
-
-    afterEach(() => {
-      global.fetch = originalFetch;
-    });
-
-    it("invokes global fetch with the long-running dispatcher injected", async () => {
-      const mockFetch = jest
-        .fn()
-        .mockResolvedValue(new Response("ok", { status: 200 }));
-      global.fetch = mockFetch as unknown as typeof fetch;
-
+    it("calls undici.fetch (not global fetch) with the long-running dispatcher", async () => {
       await longRunningFetch("https://example.test/api", {
         method: "POST",
         body: JSON.stringify({ ping: true }),
       });
 
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-      const [url, init] = mockFetch.mock.calls[0];
+      expect(mockUndiciFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockUndiciFetch.mock.calls[0];
       expect(url).toBe("https://example.test/api");
       expect(init.method).toBe("POST");
-      // The dispatcher option must be the shared long-running agent
-      expect((init as { dispatcher?: unknown }).dispatcher).toBe(
-        longRunningAgent,
-      );
+      expect(init.dispatcher).toBe(longRunningAgent);
     });
 
     it("passes through caller-provided init options", async () => {
-      const mockFetch = jest
-        .fn()
-        .mockResolvedValue(new Response("ok", { status: 200 }));
-      global.fetch = mockFetch as unknown as typeof fetch;
-
       const headers = { "X-Custom": "value" };
       await longRunningFetch("https://example.test/api", {
         method: "GET",
         headers,
       });
 
-      const [, init] = mockFetch.mock.calls[0];
+      const [, init] = mockUndiciFetch.mock.calls[0];
       expect(init.method).toBe("GET");
       expect(init.headers).toBe(headers);
-      expect((init as { dispatcher?: unknown }).dispatcher).toBe(
-        longRunningAgent,
-      );
+      expect(init.dispatcher).toBe(longRunningAgent);
     });
 
     it("works without any caller-provided init", async () => {
-      const mockFetch = jest
-        .fn()
-        .mockResolvedValue(new Response("ok", { status: 200 }));
-      global.fetch = mockFetch as unknown as typeof fetch;
-
       await longRunningFetch("https://example.test/api");
 
-      const [, init] = mockFetch.mock.calls[0];
-      expect((init as { dispatcher?: unknown }).dispatcher).toBe(
-        longRunningAgent,
-      );
+      const [, init] = mockUndiciFetch.mock.calls[0];
+      expect(init.dispatcher).toBe(longRunningAgent);
+    });
+
+    it("does not call globalThis.fetch", async () => {
+      // Critical regression: globalThis.fetch (Node's built-in) silently
+      // ignores or rejects an Agent instance from a separately-installed
+      // undici package. The helper must call undici.fetch directly.
+      const globalFetchSpy = jest.fn();
+      const originalGlobalFetch = global.fetch;
+      global.fetch = globalFetchSpy as unknown as typeof fetch;
+      try {
+        await longRunningFetch("https://example.test/api");
+        expect(globalFetchSpy).not.toHaveBeenCalled();
+        expect(mockUndiciFetch).toHaveBeenCalled();
+      } finally {
+        global.fetch = originalGlobalFetch;
+      }
     });
 
     it("matches the global fetch signature", () => {

--- a/backend/src/ai/providers/long-running-fetch.spec.ts
+++ b/backend/src/ai/providers/long-running-fetch.spec.ts
@@ -1,0 +1,87 @@
+import { longRunningAgent, longRunningFetch } from "./long-running-fetch";
+
+describe("long-running-fetch", () => {
+  describe("longRunningAgent", () => {
+    it("is configured with disabled body and headers timeouts", () => {
+      // The Agent itself doesn't expose its options publicly, but its
+      // existence + correct shape is what matters for the type system.
+      // The behavioral verification is via the spec below that asserts
+      // longRunningFetch passes it as the dispatcher option.
+      expect(longRunningAgent).toBeDefined();
+      expect(typeof longRunningAgent.dispatch).toBe("function");
+    });
+  });
+
+  describe("longRunningFetch", () => {
+    let originalFetch: typeof fetch;
+
+    beforeEach(() => {
+      originalFetch = global.fetch;
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it("invokes global fetch with the long-running dispatcher injected", async () => {
+      const mockFetch = jest
+        .fn()
+        .mockResolvedValue(new Response("ok", { status: 200 }));
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      await longRunningFetch("https://example.test/api", {
+        method: "POST",
+        body: JSON.stringify({ ping: true }),
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://example.test/api");
+      expect(init.method).toBe("POST");
+      // The dispatcher option must be the shared long-running agent
+      expect((init as { dispatcher?: unknown }).dispatcher).toBe(
+        longRunningAgent,
+      );
+    });
+
+    it("passes through caller-provided init options", async () => {
+      const mockFetch = jest
+        .fn()
+        .mockResolvedValue(new Response("ok", { status: 200 }));
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      const headers = { "X-Custom": "value" };
+      await longRunningFetch("https://example.test/api", {
+        method: "GET",
+        headers,
+      });
+
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init.method).toBe("GET");
+      expect(init.headers).toBe(headers);
+      expect((init as { dispatcher?: unknown }).dispatcher).toBe(
+        longRunningAgent,
+      );
+    });
+
+    it("works without any caller-provided init", async () => {
+      const mockFetch = jest
+        .fn()
+        .mockResolvedValue(new Response("ok", { status: 200 }));
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      await longRunningFetch("https://example.test/api");
+
+      const [, init] = mockFetch.mock.calls[0];
+      expect((init as { dispatcher?: unknown }).dispatcher).toBe(
+        longRunningAgent,
+      );
+    });
+
+    it("matches the global fetch signature", () => {
+      // Compile-time check: longRunningFetch must be assignable to typeof fetch
+      const f: typeof fetch = longRunningFetch;
+      expect(typeof f).toBe("function");
+    });
+  });
+});

--- a/backend/src/ai/providers/long-running-fetch.ts
+++ b/backend/src/ai/providers/long-running-fetch.ts
@@ -1,4 +1,4 @@
-import { Agent } from "undici";
+import { Agent, fetch as undiciFetch } from "undici";
 
 /**
  * Shared dispatcher used for long-running AI provider requests.
@@ -21,12 +21,25 @@ export const longRunningAgent = new Agent({
 });
 
 /**
- * fetch wrapper that injects {@link longRunningAgent} as the dispatcher.
- * Use this when constructing AI SDK clients that take a `fetch` option,
- * so the SDK's internal HTTP calls inherit the disabled timeouts.
+ * fetch wrapper that calls undici's fetch directly with our long-running
+ * dispatcher. We MUST call `undici.fetch` (from the npm package) rather
+ * than `globalThis.fetch` — Node bundles its own internal copy of undici,
+ * and its built-in fetch silently ignores or rejects a `dispatcher` option
+ * that came from a separately-installed undici package, because the two
+ * `Agent` classes have different internal identities. Using undici's own
+ * fetch guarantees the dispatcher is honored.
+ *
+ * The signature is widened to `typeof fetch` so SDK clients (Anthropic,
+ * OpenAI) that accept a `fetch` option can use this drop-in replacement.
+ * undici's Response type is structurally compatible with the global one
+ * but TS sees them as distinct (Symbol.dispose), so we cast through
+ * unknown.
  */
-export const longRunningFetch: typeof fetch = (input, init) =>
-  fetch(input, {
+export const longRunningFetch: typeof fetch = ((
+  input: Parameters<typeof undiciFetch>[0],
+  init?: Parameters<typeof undiciFetch>[1],
+) =>
+  undiciFetch(input, {
     ...init,
     dispatcher: longRunningAgent,
-  } as RequestInit);
+  })) as unknown as typeof fetch;

--- a/backend/src/ai/providers/long-running-fetch.ts
+++ b/backend/src/ai/providers/long-running-fetch.ts
@@ -1,0 +1,32 @@
+import { Agent } from "undici";
+
+/**
+ * Shared dispatcher used for long-running AI provider requests.
+ *
+ * Node's built-in fetch (undici under the hood) defaults `bodyTimeout` and
+ * `headersTimeout` to 5 minutes. That's far too aggressive for CPU-only
+ * inference on slow hardware (e.g. an Intel N100), where the gap between
+ * the request and the first generated token can easily exceed 5 minutes
+ * for a cold model with a long financial-context prompt. When the timer
+ * fires, undici aborts the stream and the caller sees a generic
+ * "fetch failed" error.
+ *
+ * Setting both timeouts to 0 disables them entirely. The provider code
+ * still caps the total request time with its own AbortController, so a
+ * runaway request can't hang forever.
+ */
+export const longRunningAgent = new Agent({
+  bodyTimeout: 0,
+  headersTimeout: 0,
+});
+
+/**
+ * fetch wrapper that injects {@link longRunningAgent} as the dispatcher.
+ * Use this when constructing AI SDK clients that take a `fetch` option,
+ * so the SDK's internal HTTP calls inherit the disabled timeouts.
+ */
+export const longRunningFetch: typeof fetch = (input, init) =>
+  fetch(input, {
+    ...init,
+    dispatcher: longRunningAgent,
+  } as RequestInit);

--- a/backend/src/ai/providers/ollama.provider.spec.ts
+++ b/backend/src/ai/providers/ollama.provider.spec.ts
@@ -1,4 +1,5 @@
 import { OllamaProvider } from "./ollama.provider";
+import type { AiToolStreamChunk } from "./ai-provider.interface";
 
 describe("OllamaProvider", () => {
   let provider: OllamaProvider;
@@ -176,29 +177,38 @@ describe("OllamaProvider", () => {
       },
     ];
 
-    it("returns tool calls when model invokes tools", async () => {
-      const mockResponse = {
+    /**
+     * Helper: build a mock fetch Response whose body streams the given NDJSON
+     * chunks. Used by both completeWithTools() (which now delegates internally
+     * to streamWithTools()) and the dedicated streamWithTools() tests below.
+     */
+    const mockStreamingFetch = (ndjsonLines: string[]) => {
+      const encoder = new TextEncoder();
+      let readIdx = 0;
+      return jest.fn().mockResolvedValue({
         ok: true,
-        json: () =>
-          Promise.resolve({
-            message: {
-              role: "assistant",
-              content: "",
-              tool_calls: [
-                {
-                  function: {
-                    name: "get_account_balances",
-                    arguments: {},
-                  },
-                },
-              ],
+        body: {
+          getReader: () => ({
+            read: () => {
+              if (readIdx < ndjsonLines.length) {
+                return Promise.resolve({
+                  value: encoder.encode(ndjsonLines[readIdx++]),
+                  done: false,
+                });
+              }
+              return Promise.resolve({ value: undefined, done: true });
             },
-            done: true,
-            prompt_eval_count: 50,
-            eval_count: 10,
+            releaseLock: jest.fn(),
           }),
-      };
-      global.fetch = jest.fn().mockResolvedValue(mockResponse);
+        },
+      });
+    };
+
+    it("returns tool calls when model invokes tools", async () => {
+      global.fetch = mockStreamingFetch([
+        '{"message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"get_account_balances","arguments":{}}}]},"done":false}\n',
+        '{"message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":50,"eval_count":10}\n',
+      ]);
 
       const result = await provider.completeWithTools(
         {
@@ -223,22 +233,16 @@ describe("OllamaProvider", () => {
           body: expect.stringContaining('"tools"'),
         }),
       );
+      // Must use stream:true now that completeWithTools delegates to streamWithTools
+      const bodyArg = (global.fetch as jest.Mock).mock.calls[0][1].body;
+      expect(bodyArg).toContain('"stream":true');
     });
 
     it("returns end_turn when model responds without tool calls", async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            message: {
-              role: "assistant",
-              content: "Your total balance is $5,000.",
-            },
-            done: true,
-            prompt_eval_count: 100,
-            eval_count: 20,
-          }),
-      });
+      global.fetch = mockStreamingFetch([
+        '{"message":{"role":"assistant","content":"Your total balance is $5,000."},"done":false}\n',
+        '{"message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":100,"eval_count":20}\n',
+      ]);
 
       const result = await provider.completeWithTools(
         {
@@ -251,6 +255,8 @@ describe("OllamaProvider", () => {
       expect(result.stopReason).toBe("end_turn");
       expect(result.toolCalls).toHaveLength(0);
       expect(result.content).toBe("Your total balance is $5,000.");
+      expect(result.usage.inputTokens).toBe(100);
+      expect(result.usage.outputTokens).toBe(20);
     });
 
     it("throws on non-ok response", async () => {
@@ -269,6 +275,197 @@ describe("OllamaProvider", () => {
           tools,
         ),
       ).rejects.toThrow("Ollama request failed: 500 Internal Server Error");
+    });
+  });
+
+  describe("streamWithTools()", () => {
+    const tools = [
+      {
+        name: "get_account_balances",
+        description: "Get account balances",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ];
+
+    const mockStreamingFetch = (ndjsonLines: string[]) => {
+      const encoder = new TextEncoder();
+      let readIdx = 0;
+      return jest.fn().mockResolvedValue({
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: () => {
+              if (readIdx < ndjsonLines.length) {
+                return Promise.resolve({
+                  value: encoder.encode(ndjsonLines[readIdx++]),
+                  done: false,
+                });
+              }
+              return Promise.resolve({ value: undefined, done: true });
+            },
+            releaseLock: jest.fn(),
+          }),
+        },
+      });
+    };
+
+    it("yields a text chunk per content delta then a done chunk", async () => {
+      global.fetch = mockStreamingFetch([
+        '{"message":{"content":"Looking "},"done":false}\n',
+        '{"message":{"content":"at "},"done":false}\n',
+        '{"message":{"content":"your data."},"done":false}\n',
+        '{"message":{"content":""},"done":true,"prompt_eval_count":42,"eval_count":7}\n',
+      ]);
+
+      const chunks: AiToolStreamChunk[] = [];
+      for await (const chunk of provider.streamWithTools(
+        {
+          systemPrompt: "Be brief.",
+          messages: [{ role: "user", content: "What's up?" }],
+        },
+        tools,
+      )) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toHaveLength(4);
+      expect(chunks[0]).toEqual({ type: "text", text: "Looking " });
+      expect(chunks[1]).toEqual({ type: "text", text: "at " });
+      expect(chunks[2]).toEqual({ type: "text", text: "your data." });
+
+      const doneChunk = chunks[3];
+      expect(doneChunk.type).toBe("done");
+      if (doneChunk.type === "done") {
+        expect(doneChunk.content).toBe("Looking at your data.");
+        expect(doneChunk.toolCalls).toEqual([]);
+        expect(doneChunk.stopReason).toBe("end_turn");
+        expect(doneChunk.usage.inputTokens).toBe(42);
+        expect(doneChunk.usage.outputTokens).toBe(7);
+        expect(doneChunk.model).toBe("llama3");
+      }
+    });
+
+    it("collects tool calls across chunks and reports tool_use stop reason", async () => {
+      global.fetch = mockStreamingFetch([
+        '{"message":{"content":"I need to check that."},"done":false}\n',
+        '{"message":{"content":"","tool_calls":[{"function":{"name":"get_transactions","arguments":{"days":30}}}]},"done":false}\n',
+        '{"message":{"content":""},"done":true,"prompt_eval_count":100,"eval_count":15}\n',
+      ]);
+
+      const chunks: AiToolStreamChunk[] = [];
+      for await (const chunk of provider.streamWithTools(
+        { systemPrompt: "test", messages: [{ role: "user", content: "hi" }] },
+        tools,
+      )) {
+        chunks.push(chunk);
+      }
+
+      const doneChunk = chunks[chunks.length - 1];
+      expect(doneChunk.type).toBe("done");
+      if (doneChunk.type === "done") {
+        expect(doneChunk.stopReason).toBe("tool_use");
+        expect(doneChunk.toolCalls).toHaveLength(1);
+        expect(doneChunk.toolCalls[0].name).toBe("get_transactions");
+        expect(doneChunk.toolCalls[0].input).toEqual({ days: 30 });
+        expect(doneChunk.toolCalls[0].id).toBeDefined();
+        expect(doneChunk.content).toBe("I need to check that.");
+      }
+    });
+
+    it("handles fragmented NDJSON spread across reads", async () => {
+      // Split a JSON line across two reads to verify the line buffer handles partial input.
+      const encoder = new TextEncoder();
+      const firstChunk = '{"message":{"content":"par';
+      const secondChunk =
+        'tial"},"done":false}\n{"message":{"content":""},"done":true}\n';
+      let readIdx = 0;
+      const reads = [firstChunk, secondChunk];
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: () => {
+              if (readIdx < reads.length) {
+                return Promise.resolve({
+                  value: encoder.encode(reads[readIdx++]),
+                  done: false,
+                });
+              }
+              return Promise.resolve({ value: undefined, done: true });
+            },
+            releaseLock: jest.fn(),
+          }),
+        },
+      });
+
+      const textChunks: string[] = [];
+      for await (const chunk of provider.streamWithTools(
+        { systemPrompt: "test", messages: [{ role: "user", content: "hi" }] },
+        tools,
+      )) {
+        if (chunk.type === "text") textChunks.push(chunk.text);
+      }
+      expect(textChunks.join("")).toBe("partial");
+    });
+
+    it("sends tools and stream:true in request body", async () => {
+      global.fetch = mockStreamingFetch([
+        '{"message":{"content":""},"done":true}\n',
+      ]);
+
+      const gen = provider.streamWithTools(
+        { systemPrompt: "test", messages: [{ role: "user", content: "hi" }] },
+        tools,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _chunk of gen) {
+        // consume
+      }
+
+      const bodyArg = (global.fetch as jest.Mock).mock.calls[0][1].body;
+      expect(bodyArg).toContain('"tools"');
+      expect(bodyArg).toContain('"stream":true');
+      expect(bodyArg).toContain('"get_account_balances"');
+    });
+
+    it("throws on non-ok response", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: "Service Unavailable",
+      });
+
+      const gen = provider.streamWithTools(
+        { systemPrompt: "test", messages: [{ role: "user", content: "hi" }] },
+        tools,
+      );
+
+      await expect(
+        (async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          for await (const _chunk of gen) {
+            // consume
+          }
+        })(),
+      ).rejects.toThrow("Ollama request failed: 503 Service Unavailable");
+    });
+
+    it("throws when response body is null", async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, body: null });
+
+      const gen = provider.streamWithTools(
+        { systemPrompt: "test", messages: [{ role: "user", content: "hi" }] },
+        tools,
+      );
+
+      await expect(
+        (async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          for await (const _chunk of gen) {
+            // consume
+          }
+        })(),
+      ).rejects.toThrow("No response body from Ollama");
     });
   });
 

--- a/backend/src/ai/providers/ollama.provider.spec.ts
+++ b/backend/src/ai/providers/ollama.provider.spec.ts
@@ -1,6 +1,25 @@
-import { OllamaProvider } from "./ollama.provider";
 import type { AiToolStreamChunk } from "./ai-provider.interface";
-import { longRunningAgent } from "./long-running-fetch";
+
+// Mock the long-running-fetch helper so tests can keep using `global.fetch`.
+// In production, longRunningFetch calls undici.fetch directly with our
+// long-running dispatcher (so timeouts are disabled). For tests, we route
+// it through globalThis.fetch so the existing test setups (which assign
+// jest.fn() to global.fetch) keep working unchanged.
+const mockLongRunningFetch = jest.fn(
+  async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ) => global.fetch(input, init),
+);
+jest.mock("./long-running-fetch", () => ({
+  longRunningAgent: { __mock: "agent" },
+  longRunningFetch: (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ) => mockLongRunningFetch(input, init),
+}));
+
+import { OllamaProvider } from "./ollama.provider";
 
 describe("OllamaProvider", () => {
   let provider: OllamaProvider;
@@ -78,9 +97,12 @@ describe("OllamaProvider", () => {
       ).rejects.toThrow("Ollama request failed: 500 Internal Server Error");
     });
 
-    it("passes the long-running undici dispatcher to fetch", async () => {
-      // Regression: see streamWithTools spec for context. complete() also
-      // makes a long-running fetch and must inject the same dispatcher.
+    it("calls longRunningFetch (not raw global fetch) so undici timeouts are disabled", async () => {
+      // Regression: Node's globalThis.fetch silently rejects an Agent from a
+      // separately-installed undici package because the two Agent classes
+      // have different identities. The provider must call longRunningFetch
+      // which uses undici.fetch directly so the dispatcher is honored.
+      mockLongRunningFetch.mockClear();
       const encoder = new TextEncoder();
       global.fetch = jest.fn().mockResolvedValue({
         ok: true,
@@ -105,8 +127,11 @@ describe("OllamaProvider", () => {
         messages: [{ role: "user", content: "hi" }],
       });
 
-      const initArg = (global.fetch as jest.Mock).mock.calls[0][1];
-      expect(initArg.dispatcher).toBe(longRunningAgent);
+      expect(mockLongRunningFetch).toHaveBeenCalledTimes(1);
+      expect(mockLongRunningFetch).toHaveBeenCalledWith(
+        "http://localhost:11434/api/chat",
+        expect.objectContaining({ method: "POST" }),
+      );
     });
   });
 
@@ -460,14 +485,12 @@ describe("OllamaProvider", () => {
       expect(bodyArg).toContain('"get_account_balances"');
     });
 
-    it("passes the long-running undici dispatcher to fetch", async () => {
+    it("calls longRunningFetch (not raw global fetch) so undici timeouts are disabled", async () => {
       // Regression: Node fetch (undici) defaults bodyTimeout to 5 minutes,
-      // which kills slow CPU inference. The Ollama provider must inject the
-      // shared longRunningAgent dispatcher so the request can run for as
-      // long as the model needs to produce its first token.
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { longRunningAgent } = require("./long-running-fetch");
-
+      // which kills slow CPU inference. The Ollama provider must call
+      // longRunningFetch (which uses undici.fetch directly) instead of
+      // globalThis.fetch, so the long-running dispatcher is honored.
+      mockLongRunningFetch.mockClear();
       global.fetch = mockStreamingFetch([
         '{"message":{"content":""},"done":true}\n',
       ]);
@@ -481,8 +504,11 @@ describe("OllamaProvider", () => {
         // consume
       }
 
-      const initArg = (global.fetch as jest.Mock).mock.calls[0][1];
-      expect(initArg.dispatcher).toBe(longRunningAgent);
+      expect(mockLongRunningFetch).toHaveBeenCalledTimes(1);
+      expect(mockLongRunningFetch).toHaveBeenCalledWith(
+        "http://localhost:11434/api/chat",
+        expect.objectContaining({ method: "POST" }),
+      );
     });
 
     it("throws on non-ok response", async () => {

--- a/backend/src/ai/providers/ollama.provider.spec.ts
+++ b/backend/src/ai/providers/ollama.provider.spec.ts
@@ -1,5 +1,6 @@
 import { OllamaProvider } from "./ollama.provider";
 import type { AiToolStreamChunk } from "./ai-provider.interface";
+import { longRunningAgent } from "./long-running-fetch";
 
 describe("OllamaProvider", () => {
   let provider: OllamaProvider;
@@ -75,6 +76,37 @@ describe("OllamaProvider", () => {
           messages: [{ role: "user", content: "hi" }],
         }),
       ).rejects.toThrow("Ollama request failed: 500 Internal Server Error");
+    });
+
+    it("passes the long-running undici dispatcher to fetch", async () => {
+      // Regression: see streamWithTools spec for context. complete() also
+      // makes a long-running fetch and must inject the same dispatcher.
+      const encoder = new TextEncoder();
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: jest
+              .fn()
+              .mockResolvedValueOnce({
+                value: encoder.encode(
+                  '{"message":{"content":""},"done":true}\n',
+                ),
+                done: false,
+              })
+              .mockResolvedValueOnce({ value: undefined, done: true }),
+            releaseLock: jest.fn(),
+          }),
+        },
+      });
+
+      await provider.complete({
+        systemPrompt: "test",
+        messages: [{ role: "user", content: "hi" }],
+      });
+
+      const initArg = (global.fetch as jest.Mock).mock.calls[0][1];
+      expect(initArg.dispatcher).toBe(longRunningAgent);
     });
   });
 
@@ -426,6 +458,31 @@ describe("OllamaProvider", () => {
       expect(bodyArg).toContain('"tools"');
       expect(bodyArg).toContain('"stream":true');
       expect(bodyArg).toContain('"get_account_balances"');
+    });
+
+    it("passes the long-running undici dispatcher to fetch", async () => {
+      // Regression: Node fetch (undici) defaults bodyTimeout to 5 minutes,
+      // which kills slow CPU inference. The Ollama provider must inject the
+      // shared longRunningAgent dispatcher so the request can run for as
+      // long as the model needs to produce its first token.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { longRunningAgent } = require("./long-running-fetch");
+
+      global.fetch = mockStreamingFetch([
+        '{"message":{"content":""},"done":true}\n',
+      ]);
+
+      const gen = provider.streamWithTools(
+        { systemPrompt: "test", messages: [{ role: "user", content: "hi" }] },
+        tools,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _chunk of gen) {
+        // consume
+      }
+
+      const initArg = (global.fetch as jest.Mock).mock.calls[0][1];
+      expect(initArg.dispatcher).toBe(longRunningAgent);
     });
 
     it("throws on non-ok response", async () => {

--- a/backend/src/ai/providers/ollama.provider.ts
+++ b/backend/src/ai/providers/ollama.provider.ts
@@ -9,7 +9,7 @@ import {
   AiMessage,
 } from "./ai-provider.interface";
 import { randomUUID } from "crypto";
-import { longRunningAgent } from "./long-running-fetch";
+import { longRunningFetch } from "./long-running-fetch";
 
 interface OllamaToolCall {
   function: { name: string; arguments: Record<string, unknown> };
@@ -53,12 +53,10 @@ export class OllamaProvider implements AiProvider {
     const timeout = setTimeout(() => controller.abort(), 20 * 60 * 1000); // 20 minutes for CPU inference
 
     try {
-      const response = await fetch(`${this.baseUrl}/api/chat`, {
+      const response = await longRunningFetch(`${this.baseUrl}/api/chat`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         signal: controller.signal,
-        // @ts-expect-error — `dispatcher` is an undici-specific option not in lib.dom types
-        dispatcher: longRunningAgent,
         body: JSON.stringify({
           model: this.modelId,
           messages,
@@ -142,12 +140,10 @@ export class OllamaProvider implements AiProvider {
     const timeout = setTimeout(() => controller.abort(), 20 * 60 * 1000);
 
     try {
-      const response = await fetch(`${this.baseUrl}/api/chat`, {
+      const response = await longRunningFetch(`${this.baseUrl}/api/chat`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         signal: controller.signal,
-        // @ts-expect-error — `dispatcher` is an undici-specific option not in lib.dom types
-        dispatcher: longRunningAgent,
         body: JSON.stringify({
           model: this.modelId,
           messages,
@@ -264,12 +260,10 @@ export class OllamaProvider implements AiProvider {
     const timeout = setTimeout(() => controller.abort(), 20 * 60 * 1000); // 20 minutes for CPU inference
 
     try {
-      const response = await fetch(`${this.baseUrl}/api/chat`, {
+      const response = await longRunningFetch(`${this.baseUrl}/api/chat`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         signal: controller.signal,
-        // @ts-expect-error — `dispatcher` is an undici-specific option not in lib.dom types
-        dispatcher: longRunningAgent,
         body: JSON.stringify({
           model: this.modelId,
           messages,

--- a/backend/src/ai/providers/ollama.provider.ts
+++ b/backend/src/ai/providers/ollama.provider.ts
@@ -5,6 +5,7 @@ import {
   AiStreamChunk,
   AiToolDefinition,
   AiToolResponse,
+  AiToolStreamChunk,
   AiMessage,
 } from "./ai-provider.interface";
 import { randomUUID } from "crypto";
@@ -205,6 +206,40 @@ export class OllamaProvider implements AiProvider {
     request: AiCompletionRequest,
     tools: AiToolDefinition[],
   ): Promise<AiToolResponse> {
+    let content = "";
+    let toolCalls: {
+      id: string;
+      name: string;
+      input: Record<string, unknown>;
+    }[] = [];
+    let usage = { inputTokens: 0, outputTokens: 0 };
+    let stopReason: "end_turn" | "tool_use" | "max_tokens" = "end_turn";
+
+    for await (const chunk of this.streamWithTools(request, tools)) {
+      if (chunk.type === "text") {
+        content += chunk.text;
+      } else {
+        content = chunk.content;
+        toolCalls = chunk.toolCalls;
+        usage = chunk.usage;
+        stopReason = chunk.stopReason;
+      }
+    }
+
+    return {
+      content,
+      toolCalls,
+      usage,
+      model: this.modelId,
+      provider: this.name,
+      stopReason,
+    };
+  }
+
+  async *streamWithTools(
+    request: AiCompletionRequest,
+    tools: AiToolDefinition[],
+  ): AsyncIterable<AiToolStreamChunk> {
     const messages = this.toOllamaMessages(
       request.messages,
       request.systemPrompt,
@@ -219,11 +254,12 @@ export class OllamaProvider implements AiProvider {
       },
     }));
 
+    // H14: Timeout covers both fetch and stream consumption
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 10 * 60 * 1000);
-    let response: Response;
+    const timeout = setTimeout(() => controller.abort(), 15 * 60 * 1000); // 15 minutes for CPU inference
+
     try {
-      response = await fetch(`${this.baseUrl}/api/chat`, {
+      const response = await fetch(`${this.baseUrl}/api/chat`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         signal: controller.signal,
@@ -231,43 +267,91 @@ export class OllamaProvider implements AiProvider {
           model: this.modelId,
           messages,
           tools: ollamaTools,
-          stream: false,
+          stream: true,
           ...(request.temperature !== undefined && {
             options: { temperature: request.temperature },
           }),
         }),
       });
+
+      if (!response.ok) {
+        throw new Error(
+          `Ollama request failed: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error("No response body from Ollama");
+      }
+
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let accumulatedContent = "";
+      const accumulatedToolCalls: {
+        id: string;
+        name: string;
+        input: Record<string, unknown>;
+      }[] = [];
+      let promptTokens = 0;
+      let outputTokens = 0;
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() || "";
+
+          for (const line of lines) {
+            if (!line.trim()) continue;
+            let chunk: OllamaChatResponse;
+            try {
+              chunk = JSON.parse(line) as OllamaChatResponse;
+            } catch {
+              continue;
+            }
+
+            const delta = chunk.message?.content;
+            if (delta) {
+              accumulatedContent += delta;
+              yield { type: "text", text: delta };
+            }
+
+            // Ollama emits tool_calls in any chunk; collect them as they appear.
+            if (chunk.message?.tool_calls) {
+              for (const tc of chunk.message.tool_calls) {
+                accumulatedToolCalls.push({
+                  id: randomUUID(),
+                  name: tc.function.name,
+                  input: tc.function.arguments,
+                });
+              }
+            }
+
+            if (chunk.done) {
+              promptTokens = chunk.prompt_eval_count || 0;
+              outputTokens = chunk.eval_count || 0;
+            }
+          }
+        }
+      } finally {
+        reader.releaseLock();
+      }
+
+      yield {
+        type: "done",
+        content: accumulatedContent,
+        toolCalls: accumulatedToolCalls,
+        usage: { inputTokens: promptTokens, outputTokens },
+        model: this.modelId,
+        stopReason: accumulatedToolCalls.length > 0 ? "tool_use" : "end_turn",
+      };
     } finally {
       clearTimeout(timeout);
     }
-
-    if (!response.ok) {
-      throw new Error(
-        `Ollama request failed: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    const data = (await response.json()) as OllamaChatResponse;
-
-    const toolCalls = (data.message?.tool_calls || []).map((tc) => ({
-      id: randomUUID(),
-      name: tc.function.name,
-      input: tc.function.arguments,
-    }));
-
-    const hasToolCalls = toolCalls.length > 0;
-
-    return {
-      content: data.message?.content || "",
-      toolCalls,
-      usage: {
-        inputTokens: data.prompt_eval_count || 0,
-        outputTokens: data.eval_count || 0,
-      },
-      model: this.modelId,
-      provider: this.name,
-      stopReason: hasToolCalls ? "tool_use" : "end_turn",
-    };
   }
 
   private toOllamaMessages(

--- a/backend/src/ai/providers/ollama.provider.ts
+++ b/backend/src/ai/providers/ollama.provider.ts
@@ -9,6 +9,7 @@ import {
   AiMessage,
 } from "./ai-provider.interface";
 import { randomUUID } from "crypto";
+import { longRunningAgent } from "./long-running-fetch";
 
 interface OllamaToolCall {
   function: { name: string; arguments: Record<string, unknown> };
@@ -49,13 +50,15 @@ export class OllamaProvider implements AiProvider {
 
     // H14: Timeout covers both fetch and stream consumption
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 10 * 60 * 1000); // 10 minutes for CPU inference
+    const timeout = setTimeout(() => controller.abort(), 20 * 60 * 1000); // 20 minutes for CPU inference
 
     try {
       const response = await fetch(`${this.baseUrl}/api/chat`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         signal: controller.signal,
+        // @ts-expect-error — `dispatcher` is an undici-specific option not in lib.dom types
+        dispatcher: longRunningAgent,
         body: JSON.stringify({
           model: this.modelId,
           messages,
@@ -136,13 +139,15 @@ export class OllamaProvider implements AiProvider {
 
     // H14: Timeout covers both fetch and stream consumption
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 10 * 60 * 1000);
+    const timeout = setTimeout(() => controller.abort(), 20 * 60 * 1000);
 
     try {
       const response = await fetch(`${this.baseUrl}/api/chat`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         signal: controller.signal,
+        // @ts-expect-error — `dispatcher` is an undici-specific option not in lib.dom types
+        dispatcher: longRunningAgent,
         body: JSON.stringify({
           model: this.modelId,
           messages,
@@ -256,13 +261,15 @@ export class OllamaProvider implements AiProvider {
 
     // H14: Timeout covers both fetch and stream consumption
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 15 * 60 * 1000); // 15 minutes for CPU inference
+    const timeout = setTimeout(() => controller.abort(), 20 * 60 * 1000); // 20 minutes for CPU inference
 
     try {
       const response = await fetch(`${this.baseUrl}/api/chat`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         signal: controller.signal,
+        // @ts-expect-error — `dispatcher` is an undici-specific option not in lib.dom types
+        dispatcher: longRunningAgent,
         body: JSON.stringify({
           model: this.modelId,
           messages,

--- a/backend/src/ai/providers/openai-compatible.provider.spec.ts
+++ b/backend/src/ai/providers/openai-compatible.provider.spec.ts
@@ -21,4 +21,16 @@ describe("OpenAiCompatibleProvider", () => {
     expect(provider.supportsStreaming).toBe(true);
     expect(provider.supportsToolUse).toBe(true);
   });
+
+  it("inherits streamWithTools from OpenAiProvider", () => {
+    const provider = new OpenAiCompatibleProvider(
+      "test-key",
+      "https://api.groq.com/openai/v1",
+      "mixtral-8x7b",
+    );
+    // streamWithTools is the realtime feedback path; openai-compatible should
+    // pick it up through inheritance so any OpenAI-API-compatible backend
+    // (Groq, vLLM, LM Studio, etc.) gets streaming for free.
+    expect(typeof provider.streamWithTools).toBe("function");
+  });
 });

--- a/backend/src/ai/providers/openai.provider.spec.ts
+++ b/backend/src/ai/providers/openai.provider.spec.ts
@@ -1,4 +1,5 @@
 import { OpenAiProvider } from "./openai.provider";
+import type { AiToolStreamChunk } from "./ai-provider.interface";
 
 const mockCreate = jest.fn();
 const mockListModels = jest.fn().mockResolvedValue({ data: [] });
@@ -314,6 +315,247 @@ describe("OpenAiProvider", () => {
       expect(messages[3].role).toBe("tool");
       expect(messages[3].tool_call_id).toBe("call_1");
       expect(messages[3].content).toBe('{"balance": 5000}');
+    });
+  });
+
+  describe("streamWithTools()", () => {
+    type Chunk = Record<string, unknown>;
+
+    const mockStreamReturn = (chunks: Chunk[]) => {
+      mockCreate.mockResolvedValueOnce({
+        [Symbol.asyncIterator]: () => {
+          let idx = 0;
+          return {
+            next: () => {
+              if (idx < chunks.length) {
+                return Promise.resolve({ value: chunks[idx++], done: false });
+              }
+              return Promise.resolve({ value: undefined, done: true });
+            },
+          };
+        },
+      });
+    };
+
+    const tools = [
+      {
+        name: "get_balance",
+        description: "Get balance",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ];
+
+    it("yields text deltas as text chunks then a done chunk with end_turn", async () => {
+      mockStreamReturn([
+        {
+          model: "gpt-4o",
+          choices: [{ delta: { content: "Your " }, finish_reason: null }],
+        },
+        {
+          model: "gpt-4o",
+          choices: [
+            { delta: { content: "balance is $5,000." }, finish_reason: null },
+          ],
+        },
+        { model: "gpt-4o", choices: [{ delta: {}, finish_reason: "stop" }] },
+        {
+          model: "gpt-4o",
+          choices: [],
+          usage: { prompt_tokens: 30, completion_tokens: 12 },
+        },
+      ]);
+
+      const chunks: AiToolStreamChunk[] = [];
+      for await (const chunk of provider.streamWithTools(
+        {
+          systemPrompt: "Be brief.",
+          messages: [{ role: "user", content: "balance?" }],
+        },
+        tools,
+      )) {
+        chunks.push(chunk);
+      }
+
+      const textChunks = chunks.filter((c) => c.type === "text");
+      expect(textChunks).toHaveLength(2);
+      expect((textChunks[0] as { text: string }).text).toBe("Your ");
+      expect((textChunks[1] as { text: string }).text).toBe(
+        "balance is $5,000.",
+      );
+
+      const doneChunk = chunks[chunks.length - 1];
+      expect(doneChunk.type).toBe("done");
+      if (doneChunk.type === "done") {
+        expect(doneChunk.content).toBe("Your balance is $5,000.");
+        expect(doneChunk.toolCalls).toEqual([]);
+        expect(doneChunk.stopReason).toBe("end_turn");
+        expect(doneChunk.usage.inputTokens).toBe(30);
+        expect(doneChunk.usage.outputTokens).toBe(12);
+        expect(doneChunk.model).toBe("gpt-4o");
+      }
+    });
+
+    it("accumulates incrementally streamed tool call args by index", async () => {
+      // OpenAI streams tool call args as JSON deltas spread across chunks.
+      mockStreamReturn([
+        {
+          model: "gpt-4o",
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_abc",
+                    function: { name: "get_balance", arguments: "" },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          model: "gpt-4o",
+          choices: [
+            {
+              delta: {
+                tool_calls: [{ index: 0, function: { arguments: '{"days":' } }],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          model: "gpt-4o",
+          choices: [
+            {
+              delta: {
+                tool_calls: [{ index: 0, function: { arguments: "30}" } }],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          model: "gpt-4o",
+          choices: [{ delta: {}, finish_reason: "tool_calls" }],
+        },
+        {
+          model: "gpt-4o",
+          choices: [],
+          usage: { prompt_tokens: 25, completion_tokens: 18 },
+        },
+      ]);
+
+      const chunks: AiToolStreamChunk[] = [];
+      for await (const chunk of provider.streamWithTools(
+        {
+          systemPrompt: "test",
+          messages: [{ role: "user", content: "balance?" }],
+        },
+        tools,
+      )) {
+        chunks.push(chunk);
+      }
+
+      const doneChunk = chunks[chunks.length - 1];
+      expect(doneChunk.type).toBe("done");
+      if (doneChunk.type === "done") {
+        expect(doneChunk.stopReason).toBe("tool_use");
+        expect(doneChunk.toolCalls).toEqual([
+          { id: "call_abc", name: "get_balance", input: { days: 30 } },
+        ]);
+      }
+    });
+
+    it("falls back to empty input on malformed tool call JSON", async () => {
+      mockStreamReturn([
+        {
+          model: "gpt-4o",
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_bad",
+                    function: { name: "get_balance", arguments: "{not json" },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          model: "gpt-4o",
+          choices: [{ delta: {}, finish_reason: "tool_calls" }],
+        },
+      ]);
+
+      const chunks: AiToolStreamChunk[] = [];
+      for await (const chunk of provider.streamWithTools(
+        { systemPrompt: "test", messages: [{ role: "user", content: "hi" }] },
+        tools,
+      )) {
+        chunks.push(chunk);
+      }
+
+      const doneChunk = chunks[chunks.length - 1];
+      if (doneChunk.type === "done") {
+        expect(doneChunk.toolCalls).toEqual([
+          { id: "call_bad", name: "get_balance", input: {} },
+        ]);
+      }
+    });
+
+    it("maps finish_reason length to max_tokens", async () => {
+      mockStreamReturn([
+        {
+          model: "gpt-4o",
+          choices: [{ delta: { content: "Truncated" }, finish_reason: null }],
+        },
+        {
+          model: "gpt-4o",
+          choices: [{ delta: {}, finish_reason: "length" }],
+        },
+      ]);
+
+      const chunks: AiToolStreamChunk[] = [];
+      for await (const chunk of provider.streamWithTools(
+        { systemPrompt: "test", messages: [{ role: "user", content: "hi" }] },
+        tools,
+      )) {
+        chunks.push(chunk);
+      }
+
+      const doneChunk = chunks[chunks.length - 1];
+      if (doneChunk.type === "done") {
+        expect(doneChunk.stopReason).toBe("max_tokens");
+        expect(doneChunk.content).toBe("Truncated");
+      }
+    });
+
+    it("requests stream:true and passes tools in the body", async () => {
+      mockStreamReturn([
+        { model: "gpt-4o", choices: [{ delta: {}, finish_reason: "stop" }] },
+      ]);
+
+      const gen = provider.streamWithTools(
+        { systemPrompt: "test", messages: [{ role: "user", content: "hi" }] },
+        tools,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _chunk of gen) {
+        // consume
+      }
+
+      const callArg = mockCreate.mock.calls[0][0];
+      expect(callArg.stream).toBe(true);
+      expect(callArg.tools).toBeDefined();
+      expect(callArg.tools[0].function.name).toBe("get_balance");
+      expect(callArg.stream_options).toEqual({ include_usage: true });
     });
   });
 

--- a/backend/src/ai/providers/openai.provider.spec.ts
+++ b/backend/src/ai/providers/openai.provider.spec.ts
@@ -43,6 +43,19 @@ describe("OpenAiProvider", () => {
     expect(provider.supportsToolUse).toBe(true);
   });
 
+  it("constructs the SDK client with the long-running fetch wrapper", () => {
+    // Regression: the SDK uses Node fetch (undici) under the hood, which
+    // defaults bodyTimeout to 5 minutes. The provider must inject the
+    // long-running fetch wrapper so SDK calls inherit disabled timeouts.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const OpenAI = require("openai").default;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { longRunningFetch } = require("./long-running-fetch");
+    expect(OpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ fetch: longRunningFetch }),
+    );
+  });
+
   describe("complete()", () => {
     it("returns formatted response", async () => {
       const result = await provider.complete({

--- a/backend/src/ai/providers/openai.provider.ts
+++ b/backend/src/ai/providers/openai.provider.ts
@@ -6,6 +6,7 @@ import {
   AiStreamChunk,
   AiToolDefinition,
   AiToolResponse,
+  AiToolStreamChunk,
   AiMessage,
 } from "./ai-provider.interface";
 
@@ -195,6 +196,111 @@ export class OpenAiProvider implements AiProvider {
       },
       model: response.model,
       provider: this.name,
+      stopReason,
+    };
+  }
+
+  async *streamWithTools(
+    request: AiCompletionRequest,
+    tools: AiToolDefinition[],
+  ): AsyncIterable<AiToolStreamChunk> {
+    const messages = this.toOpenAiMessages(
+      request.messages,
+      request.systemPrompt,
+    );
+
+    const stream = await this.client.chat.completions.create({
+      model: this.modelId,
+      messages,
+      max_tokens: request.maxTokens || 4096,
+      stream: true,
+      stream_options: { include_usage: true },
+      tools: tools.map((tool) => ({
+        type: "function" as const,
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.inputSchema,
+        },
+      })),
+      ...(request.temperature !== undefined && {
+        temperature: request.temperature,
+      }),
+    });
+
+    let accumulatedContent = "";
+    // Per choice index → per tool-call index → accumulator
+    const toolBuffers = new Map<
+      number,
+      { id: string; name: string; argsBuffer: string }
+    >();
+    let finishReason: string | null = null;
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let modelId = this.modelId;
+
+    for await (const chunk of stream) {
+      if (chunk.model) modelId = chunk.model;
+      if (chunk.usage) {
+        inputTokens = chunk.usage.prompt_tokens || 0;
+        outputTokens = chunk.usage.completion_tokens || 0;
+      }
+
+      const choice = chunk.choices[0];
+      if (!choice) continue;
+
+      const delta = choice.delta;
+      if (delta?.content) {
+        accumulatedContent += delta.content;
+        yield { type: "text", text: delta.content };
+      }
+
+      if (delta?.tool_calls) {
+        for (const tcDelta of delta.tool_calls) {
+          const idx = tcDelta.index;
+          let buffer = toolBuffers.get(idx);
+          if (!buffer) {
+            buffer = { id: "", name: "", argsBuffer: "" };
+            toolBuffers.set(idx, buffer);
+          }
+          if (tcDelta.id) buffer.id = tcDelta.id;
+          if (tcDelta.function?.name) buffer.name = tcDelta.function.name;
+          if (tcDelta.function?.arguments) {
+            buffer.argsBuffer += tcDelta.function.arguments;
+          }
+        }
+      }
+
+      if (choice.finish_reason) {
+        finishReason = choice.finish_reason;
+      }
+    }
+
+    const toolCalls = Array.from(toolBuffers.values()).map((buf) => {
+      let input: Record<string, unknown> = {};
+      try {
+        input = buf.argsBuffer
+          ? (JSON.parse(buf.argsBuffer) as Record<string, unknown>)
+          : {};
+      } catch {
+        input = {};
+      }
+      return { id: buf.id, name: buf.name, input };
+    });
+
+    const stopReason: "end_turn" | "tool_use" | "max_tokens" =
+      finishReason === "tool_calls"
+        ? "tool_use"
+        : finishReason === "length"
+          ? "max_tokens"
+          : "end_turn";
+
+    yield {
+      type: "done",
+      content: accumulatedContent,
+      toolCalls,
+      usage: { inputTokens, outputTokens },
+      model: modelId,
       stopReason,
     };
   }

--- a/backend/src/ai/providers/openai.provider.ts
+++ b/backend/src/ai/providers/openai.provider.ts
@@ -9,6 +9,7 @@ import {
   AiToolStreamChunk,
   AiMessage,
 } from "./ai-provider.interface";
+import { longRunningFetch } from "./long-running-fetch";
 
 export class OpenAiProvider implements AiProvider {
   readonly name: string = "openai";
@@ -22,6 +23,9 @@ export class OpenAiProvider implements AiProvider {
     this.client = new OpenAI({
       apiKey,
       ...(baseUrl && { baseURL: baseUrl }),
+      // Inject our long-running fetch wrapper so SDK calls inherit the
+      // disabled bodyTimeout/headersTimeout. See long-running-fetch.ts.
+      fetch: longRunningFetch,
     });
     this.modelId = model || "gpt-4o";
   }

--- a/backend/src/ai/query/ai-query.controller.spec.ts
+++ b/backend/src/ai/query/ai-query.controller.spec.ts
@@ -206,5 +206,140 @@ describe("AiQueryController", () => {
         "My spending?",
       );
     });
+
+    it("emits SSE comment heartbeats every 15s during quiet streams", async () => {
+      // The Next.js dev proxy uses undici with a 5 min default bodyTimeout.
+      // Heartbeats keep the upstream stream alive when the model is silent
+      // for long stretches (e.g. CPU-only Ollama generating tokens).
+      jest.useFakeTimers();
+      try {
+        // A stream that yields nothing for a while, then ends — gives the
+        // heartbeat interval room to fire before the generator resolves.
+        let resolveStream: () => void;
+        const blocker = new Promise<void>((resolve) => {
+          resolveStream = resolve;
+        });
+        mockQueryService.executeQueryStream.mockReturnValue(
+          (async function* () {
+            await blocker;
+            if (false as boolean) yield { type: "noop" };
+          })(),
+        );
+
+        const written: string[] = [];
+        const mockRes = {
+          setHeader: jest.fn(),
+          flushHeaders: jest.fn(),
+          write: jest.fn((data: string) => written.push(data)),
+          end: jest.fn(),
+          on: jest.fn(),
+          writableEnded: false,
+        };
+
+        const streamPromise = controller.streamQuery(
+          mockRequest,
+          { query: "slow query" },
+          mockRes as any,
+        );
+
+        // Advance through three heartbeat intervals (45 s)
+        await jest.advanceTimersByTimeAsync(15_000);
+        await jest.advanceTimersByTimeAsync(15_000);
+        await jest.advanceTimersByTimeAsync(15_000);
+
+        const heartbeatLines = written.filter((line) =>
+          line.startsWith(": heartbeat"),
+        );
+        expect(heartbeatLines.length).toBeGreaterThanOrEqual(3);
+
+        // Release the stream so the controller finishes
+        resolveStream!();
+        await streamPromise;
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("clears the heartbeat interval after stream completes", async () => {
+      jest.useFakeTimers();
+      try {
+        const events = [{ type: "content", text: "done" }];
+        mockQueryService.executeQueryStream.mockReturnValue(
+          (async function* () {
+            for (const event of events) {
+              yield event;
+            }
+          })(),
+        );
+
+        const written: string[] = [];
+        const mockRes = {
+          setHeader: jest.fn(),
+          flushHeaders: jest.fn(),
+          write: jest.fn((data: string) => written.push(data)),
+          end: jest.fn(),
+          on: jest.fn(),
+          writableEnded: false,
+        };
+
+        await controller.streamQuery(
+          mockRequest,
+          { query: "fast" },
+          mockRes as any,
+        );
+
+        // Advance well past the heartbeat interval; nothing new should be
+        // written because the interval was cleared in the finally block.
+        const writesBefore = written.length;
+        await jest.advanceTimersByTimeAsync(60_000);
+        expect(written.length).toBe(writesBefore);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("does not write a heartbeat after the response is ended", async () => {
+      jest.useFakeTimers();
+      try {
+        let resolveStream: () => void;
+        const blocker = new Promise<void>((resolve) => {
+          resolveStream = resolve;
+        });
+        mockQueryService.executeQueryStream.mockReturnValue(
+          (async function* () {
+            await blocker;
+            if (false as boolean) yield { type: "noop" };
+          })(),
+        );
+
+        const written: string[] = [];
+        const mockRes = {
+          setHeader: jest.fn(),
+          flushHeaders: jest.fn(),
+          write: jest.fn((data: string) => written.push(data)),
+          end: jest.fn(),
+          on: jest.fn(),
+          writableEnded: true, // simulate response already closed
+        };
+
+        const streamPromise = controller.streamQuery(
+          mockRequest,
+          { query: "slow" },
+          mockRes as any,
+        );
+
+        await jest.advanceTimersByTimeAsync(30_000);
+        // Heartbeat callback skips writing when writableEnded === true
+        const heartbeatLines = written.filter((line) =>
+          line.startsWith(": heartbeat"),
+        );
+        expect(heartbeatLines).toHaveLength(0);
+
+        resolveStream!();
+        await streamPromise;
+      } finally {
+        jest.useRealTimers();
+      }
+    });
   });
 });

--- a/backend/src/ai/query/ai-query.controller.ts
+++ b/backend/src/ai/query/ai-query.controller.ts
@@ -52,6 +52,18 @@ export class AiQueryController {
     const abortController = new AbortController();
     res.on("close", () => abortController.abort());
 
+    // Send a periodic SSE comment as a keepalive. The Next.js dev proxy uses
+    // undici, whose `bodyTimeout` defaults to 5 minutes — without this, an
+    // idle interval (e.g. while a slow CPU model is generating tokens) will
+    // terminate the upstream stream and surface as "Error in input stream"
+    // in the browser. Comment lines (`: ...`) are silently ignored by SSE
+    // consumers but reset the body timeout.
+    const heartbeat = setInterval(() => {
+      if (!abortController.signal.aborted && !res.writableEnded) {
+        res.write(`: heartbeat ${Date.now()}\n\n`);
+      }
+    }, 15_000);
+
     try {
       for await (const event of this.queryService.executeQueryStream(
         req.user.id,
@@ -71,6 +83,8 @@ export class AiQueryController {
           `data: ${JSON.stringify({ type: "error", message: "An unexpected error occurred while processing your query." })}\n\n`,
         );
       }
+    } finally {
+      clearInterval(heartbeat);
     }
 
     if (!abortController.signal.aborted) {

--- a/backend/src/ai/query/ai-query.service.spec.ts
+++ b/backend/src/ai/query/ai-query.service.spec.ts
@@ -585,4 +585,251 @@ describe("AiQueryService", () => {
       );
     });
   });
+
+  // ==========================================================================
+  // Streaming-with-tools path
+  //
+  // When the configured provider implements `streamWithTools()` (Ollama,
+  // Anthropic, OpenAI, openai-compatible), the query service uses it
+  // preferentially so the model's text deltas are surfaced live as
+  // `assistant_text` events. The tests below cover that path with a
+  // dedicated mock provider whose stream mock supplies a sequence of chunks.
+  // ==========================================================================
+  describe("executeQueryStream() — streaming provider path", () => {
+    /**
+     * Build a streamWithTools mock that yields the supplied chunks. The mock
+     * is shaped like an async iterable so the service's `for await` loop
+     * consumes it the same way it would a real provider.
+     */
+    function makeStreamingProvider(
+      chunkSequences: Array<Array<Record<string, unknown>>>,
+    ): {
+      name: string;
+      supportsToolUse: boolean;
+      streamWithTools: jest.Mock;
+    } {
+      const streamWithTools = jest.fn();
+      for (const chunks of chunkSequences) {
+        streamWithTools.mockReturnValueOnce({
+          [Symbol.asyncIterator]: () => {
+            let i = 0;
+            return {
+              next: () =>
+                i < chunks.length
+                  ? Promise.resolve({ value: chunks[i++], done: false })
+                  : Promise.resolve({ value: undefined, done: true }),
+            };
+          },
+        });
+      }
+      return {
+        name: "ollama",
+        supportsToolUse: true,
+        streamWithTools,
+      };
+    }
+
+    it("emits assistant_text events for each text chunk before final content", async () => {
+      const streamingProvider = makeStreamingProvider([
+        [
+          { type: "text", text: "Looking " },
+          { type: "text", text: "at " },
+          { type: "text", text: "your accounts." },
+          {
+            type: "done",
+            content: "Looking at your accounts.",
+            toolCalls: [],
+            usage: { inputTokens: 50, outputTokens: 10 },
+            model: "llama3",
+            stopReason: "end_turn",
+          },
+        ],
+      ]);
+      mockAiService.getToolUseProvider.mockResolvedValueOnce(streamingProvider);
+
+      const events = await collectEvents(userId, "What are my balances?");
+
+      const textEvents = events.filter((e) => e.type === "assistant_text");
+      expect(textEvents.map((e) => e.text)).toEqual([
+        "Looking ",
+        "at ",
+        "your accounts.",
+      ]);
+
+      const contentEvent = events.find((e) => e.type === "content");
+      expect(contentEvent).toBeDefined();
+      expect(contentEvent!.text).toBe("Looking at your accounts.");
+
+      const doneEvent = events.find((e) => e.type === "done");
+      expect(doneEvent).toBeDefined();
+      expect((doneEvent!.usage as { inputTokens: number }).inputTokens).toBe(
+        50,
+      );
+    });
+
+    it("processes tool calls between streaming iterations", async () => {
+      const streamingProvider = makeStreamingProvider([
+        [
+          { type: "text", text: "Let me check that for you." },
+          {
+            type: "done",
+            content: "Let me check that for you.",
+            toolCalls: [
+              { id: "tc-1", name: "get_account_balances", input: {} },
+            ],
+            usage: { inputTokens: 80, outputTokens: 20 },
+            model: "llama3",
+            stopReason: "tool_use",
+          },
+        ],
+        [
+          { type: "text", text: "Your balance " },
+          { type: "text", text: "is $5,000." },
+          {
+            type: "done",
+            content: "Your balance is $5,000.",
+            toolCalls: [],
+            usage: { inputTokens: 150, outputTokens: 25 },
+            model: "llama3",
+            stopReason: "end_turn",
+          },
+        ],
+      ]);
+      mockAiService.getToolUseProvider.mockResolvedValueOnce(streamingProvider);
+
+      const events = await collectEvents(userId, "What's my balance?");
+
+      // Two iterations of assistant_text with a tool execution between them
+      const textEvents = events.filter((e) => e.type === "assistant_text");
+      expect(textEvents.map((e) => e.text)).toEqual([
+        "Let me check that for you.",
+        "Your balance ",
+        "is $5,000.",
+      ]);
+
+      const toolStartEvent = events.find((e) => e.type === "tool_start");
+      expect(toolStartEvent).toBeDefined();
+      expect(toolStartEvent!.name).toBe("get_account_balances");
+
+      const toolResultEvent = events.find((e) => e.type === "tool_result");
+      expect(toolResultEvent).toBeDefined();
+
+      const contentEvent = events.find((e) => e.type === "content");
+      expect(contentEvent!.text).toBe("Your balance is $5,000.");
+
+      // streamWithTools called twice, completeWithTools never
+      expect(streamingProvider.streamWithTools).toHaveBeenCalledTimes(2);
+
+      // Total input/output tokens should aggregate across both iterations
+      const doneEvent = events.find((e) => e.type === "done");
+      expect((doneEvent!.usage as { inputTokens: number }).inputTokens).toBe(
+        230,
+      );
+      expect((doneEvent!.usage as { outputTokens: number }).outputTokens).toBe(
+        45,
+      );
+      expect((doneEvent!.usage as { toolCalls: number }).toolCalls).toBe(1);
+    });
+
+    it("yields error event when streaming provider throws mid-iteration", async () => {
+      const streamingProvider = {
+        name: "ollama",
+        supportsToolUse: true,
+        streamWithTools: jest.fn().mockReturnValue({
+          [Symbol.asyncIterator]: () => ({
+            next: () => Promise.reject(new Error("connection reset")),
+          }),
+        }),
+      };
+      mockAiService.getToolUseProvider.mockResolvedValueOnce(streamingProvider);
+
+      const events = await collectEvents(userId, "What's up?");
+
+      const errorEvent = events.find((e) => e.type === "error");
+      expect(errorEvent).toBeDefined();
+      expect(errorEvent!.message).toContain("AI provider encountered an error");
+    });
+
+    it("falls back to completeWithTools when provider lacks streamWithTools", async () => {
+      // Default mockProvider in this suite only has completeWithTools.
+      // Verify the fallback emits a single assistant_text with the full text
+      // so the UI still shows live feedback before the final content event.
+      const events = await collectEvents(userId, "How am I doing?");
+
+      const textEvents = events.filter((e) => e.type === "assistant_text");
+      expect(textEvents).toHaveLength(1);
+      expect(textEvents[0].text).toBe("Here is your financial summary.");
+      expect(mockProvider.completeWithTools).toHaveBeenCalled();
+    });
+
+    it("emits no assistant_text in fallback path when content is empty", async () => {
+      (mockProvider.completeWithTools as jest.Mock).mockResolvedValueOnce({
+        content: "",
+        toolCalls: [],
+        usage: { inputTokens: 10, outputTokens: 0 },
+        model: "claude-sonnet-4-20250514",
+        provider: "anthropic",
+        stopReason: "end_turn",
+      });
+
+      const events = await collectEvents(userId, "ping");
+
+      const textEvents = events.filter((e) => e.type === "assistant_text");
+      expect(textEvents).toHaveLength(0);
+    });
+
+    it("yields error when provider has neither streamWithTools nor completeWithTools", async () => {
+      mockAiService.getToolUseProvider.mockResolvedValueOnce({
+        name: "broken",
+        supportsToolUse: true,
+      });
+
+      const events = await collectEvents(userId, "ping");
+      const errorEvent = events.find((e) => e.type === "error");
+      expect(errorEvent).toBeDefined();
+    });
+  });
+
+  // ==========================================================================
+  // executeQuery() aggregation when the streaming path is in use
+  // ==========================================================================
+  describe("executeQuery() with streaming provider", () => {
+    it("joins assistant_text deltas via the final content event", async () => {
+      mockAiService.getToolUseProvider.mockResolvedValueOnce({
+        name: "ollama",
+        supportsToolUse: true,
+        streamWithTools: jest.fn().mockReturnValue({
+          [Symbol.asyncIterator]: () => {
+            const chunks = [
+              { type: "text", text: "Hello " },
+              { type: "text", text: "world." },
+              {
+                type: "done",
+                content: "Hello world.",
+                toolCalls: [],
+                usage: { inputTokens: 5, outputTokens: 3 },
+                model: "llama3",
+                stopReason: "end_turn",
+              },
+            ];
+            let i = 0;
+            return {
+              next: () =>
+                i < chunks.length
+                  ? Promise.resolve({ value: chunks[i++], done: false })
+                  : Promise.resolve({ value: undefined, done: true }),
+            };
+          },
+        }),
+      });
+
+      const result = await service.executeQuery(userId, "ping");
+      // executeQuery joins all `content` events into the final answer.
+      // The streaming path emits a single canonical `content` event after
+      // the assistant_text deltas, so the answer matches the joined text.
+      expect(result.answer).toBe("Hello world.");
+      expect(result.usage.inputTokens).toBe(5);
+      expect(result.usage.outputTokens).toBe(3);
+    });
+  });
 });

--- a/backend/src/ai/query/ai-query.service.ts
+++ b/backend/src/ai/query/ai-query.service.ts
@@ -4,7 +4,11 @@ import { AiUsageService } from "../ai-usage.service";
 import { FinancialContextBuilder } from "../context/financial-context.builder";
 import { ToolExecutorService } from "./tool-executor.service";
 import { FINANCIAL_TOOLS } from "./tool-definitions";
-import { AiMessage, AiProvider } from "../providers/ai-provider.interface";
+import {
+  AiMessage,
+  AiProvider,
+  AiToolCall,
+} from "../providers/ai-provider.interface";
 import { assessInjectionRisk } from "../context/prompt-injection-detector";
 import { QUERY_SAFETY_REMINDER } from "../context/prompt-templates";
 import { sanitizeToolResultStrings } from "../context/prompt-sanitize";
@@ -16,12 +20,15 @@ const MAX_TOOL_CALLS = 15;
 
 /**
  * LLM04-F2: Overall query timeout in milliseconds.
- * This is independent of the per-provider timeout (e.g., Ollama's 10-min timeout).
- * The Ollama provider timeout remains untouched so scheduled tasks
+ * This is independent of the per-provider timeout (e.g., Ollama's 15-min
+ * timeout). The Ollama provider timeout remains untouched so scheduled tasks
  * (insights/forecasts) that call the provider directly can still use the
  * full provider timeout window.
+ *
+ * Bumped from 5 min to 20 min so slow CPU-only Ollama inference can finish
+ * a multi-step query.
  */
-const QUERY_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const QUERY_TIMEOUT_MS = 20 * 60 * 1000; // 20 minutes
 
 /** LLM04-F3: Maximum cumulative input tokens before aborting the query. */
 const MAX_INPUT_TOKENS = 200_000;
@@ -39,6 +46,7 @@ export interface QueryResult {
 export interface StreamEvent {
   type:
     | "thinking"
+    | "assistant_text"
     | "tool_start"
     | "tool_result"
     | "content"
@@ -201,17 +209,63 @@ export class AiQueryService {
         break;
       }
 
-      let response;
+      let iterationContent = "";
+      let iterationToolCalls: AiToolCall[] = [];
+      let iterationStopReason: "end_turn" | "tool_use" | "max_tokens" =
+        "end_turn";
+      let iterationModel = "unknown";
+      let iterationInputTokens = 0;
+      let iterationOutputTokens = 0;
+
       try {
-        response = await provider.completeWithTools!(
-          {
-            systemPrompt,
-            messages,
-            maxTokens: 4096,
-            temperature: 0.1,
-          },
-          FINANCIAL_TOOLS,
-        );
+        if (provider.streamWithTools) {
+          // Streaming path: emit assistant_text deltas as the model generates
+          // them so the UI shows the thinking in realtime.
+          for await (const chunk of provider.streamWithTools(
+            {
+              systemPrompt,
+              messages,
+              maxTokens: 4096,
+              temperature: 0.1,
+            },
+            FINANCIAL_TOOLS,
+          )) {
+            if (chunk.type === "text") {
+              yield { type: "assistant_text", text: chunk.text };
+            } else {
+              iterationContent = chunk.content;
+              iterationToolCalls = chunk.toolCalls;
+              iterationStopReason = chunk.stopReason;
+              iterationModel = chunk.model;
+              iterationInputTokens = chunk.usage.inputTokens;
+              iterationOutputTokens = chunk.usage.outputTokens;
+            }
+          }
+        } else if (provider.completeWithTools) {
+          // Non-streaming fallback for providers that don't implement
+          // streamWithTools yet. Emit the full text as a single delta so
+          // the UI still shows the thinking buffer populated.
+          const response = await provider.completeWithTools(
+            {
+              systemPrompt,
+              messages,
+              maxTokens: 4096,
+              temperature: 0.1,
+            },
+            FINANCIAL_TOOLS,
+          );
+          iterationContent = response.content;
+          iterationToolCalls = response.toolCalls;
+          iterationStopReason = response.stopReason;
+          iterationModel = response.model;
+          iterationInputTokens = response.usage.inputTokens;
+          iterationOutputTokens = response.usage.outputTokens;
+          if (iterationContent) {
+            yield { type: "assistant_text", text: iterationContent };
+          }
+        } else {
+          throw new Error("Configured AI provider does not support tool use");
+        }
       } catch (error) {
         const rawMessage =
           error instanceof Error ? error.message : "AI provider error";
@@ -226,15 +280,16 @@ export class AiQueryService {
         return;
       }
 
-      totalInputTokens += response.usage.inputTokens;
-      totalOutputTokens += response.usage.outputTokens;
+      totalInputTokens += iterationInputTokens;
+      totalOutputTokens += iterationOutputTokens;
 
       if (
-        response.stopReason !== "tool_use" ||
-        response.toolCalls.length === 0
+        iterationStopReason !== "tool_use" ||
+        iterationToolCalls.length === 0
       ) {
-        // Final answer
-        yield { type: "content", text: response.content };
+        // Final answer — emit canonical content event so the UI promotes the
+        // streamed thinking text into the assistant message bubble.
+        yield { type: "content", text: iterationContent };
 
         if (allSources.length > 0) {
           yield { type: "sources", sources: allSources };
@@ -244,7 +299,7 @@ export class AiQueryService {
         await this.logUsage(
           userId,
           provider.name,
-          response.model,
+          iterationModel,
           totalInputTokens,
           totalOutputTokens,
           durationMs,
@@ -264,12 +319,12 @@ export class AiQueryService {
       // Process tool calls
       const assistantMessage: AiMessage = {
         role: "assistant",
-        content: response.content,
-        toolCalls: response.toolCalls,
+        content: iterationContent,
+        toolCalls: iterationToolCalls,
       };
       messages.push(assistantMessage);
 
-      for (const toolCall of response.toolCalls) {
+      for (const toolCall of iterationToolCalls) {
         totalToolCalls++;
 
         yield {

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
@@ -1208,21 +1208,93 @@ describe("ScheduledTransactionsService", () => {
       );
     });
 
-    it("should deactivate ONCE frequency after posting", async () => {
+    it("should delete ONCE frequency after posting", async () => {
       const scheduled = makeScheduled({ frequency: "ONCE" });
       stubFindOne(scheduled);
       const overrideQb = mockQueryBuilder(null);
       overrideQb.getOne.mockResolvedValue(null);
       overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
       accountsRepo.findOne.mockResolvedValue(null);
+      mockQueryRunner.manager.delete = jest
+        .fn()
+        .mockResolvedValue({ affected: 1 });
+
+      const result = await service.post(userId, stId);
+
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(
+        ScheduledTransaction,
+        stId,
+      );
+      expect(mockQueryRunner.manager.update).not.toHaveBeenCalled();
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("should still create the underlying transaction when deleting a ONCE", async () => {
+      const scheduled = makeScheduled({ frequency: "ONCE" });
+      stubFindOne(scheduled);
+      const overrideQb = mockQueryBuilder(null);
+      overrideQb.getOne.mockResolvedValue(null);
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+      accountsRepo.findOne.mockResolvedValue(null);
+      mockQueryRunner.manager.delete = jest
+        .fn()
+        .mockResolvedValue({ affected: 1 });
 
       await service.post(userId, stId);
 
-      expect(mockQueryRunner.manager.update).toHaveBeenCalledWith(
+      expect(transactionsService.create).toHaveBeenCalledWith(
+        userId,
+        expect.objectContaining({ accountId: "acc-1", amount: -1200 }),
+      );
+    });
+
+    it("should remove a stored override before deleting a ONCE", async () => {
+      const scheduled = makeScheduled({ frequency: "ONCE" });
+      stubFindOne(scheduled);
+      const storedOverride = {
+        id: "ovr-1",
+        amount: null,
+        description: null,
+        isSplit: null,
+        categoryId: null,
+        splits: null,
+      };
+      const overrideQb = mockQueryBuilder(null);
+      overrideQb.getOne.mockResolvedValue(storedOverride);
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+      accountsRepo.findOne.mockResolvedValue(null);
+      mockQueryRunner.manager.delete = jest
+        .fn()
+        .mockResolvedValue({ affected: 1 });
+
+      await service.post(userId, stId);
+
+      expect(mockQueryRunner.manager.remove).toHaveBeenCalledWith(
+        storedOverride,
+      );
+      expect(mockQueryRunner.manager.delete).toHaveBeenCalledWith(
         ScheduledTransaction,
         stId,
-        expect.objectContaining({ isActive: false }),
       );
+    });
+
+    it("should not call findOne after deleting a ONCE (would 404)", async () => {
+      const scheduled = makeScheduled({ frequency: "ONCE" });
+      stubFindOne(scheduled);
+      const overrideQb = mockQueryBuilder(null);
+      overrideQb.getOne.mockResolvedValue(null);
+      overridesRepo.createQueryBuilder.mockReturnValue(overrideQb);
+      accountsRepo.findOne.mockResolvedValue(null);
+      mockQueryRunner.manager.delete = jest
+        .fn()
+        .mockResolvedValue({ affected: 1 });
+
+      // findOne is called once at the start of post() to load the entity.
+      // It must NOT be called a second time after the row is deleted.
+      await service.post(userId, stId);
+
+      expect(scheduledRepo.findOne).toHaveBeenCalledTimes(1);
     });
 
     it("should advance nextDueDate for recurring frequency", async () => {

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -635,7 +635,7 @@ export class ScheduledTransactionsService {
     userId: string,
     id: string,
     postDto?: PostScheduledTransactionDto,
-  ): Promise<ScheduledTransaction> {
+  ): Promise<ScheduledTransaction | null> {
     const scheduled = await this.findOne(userId, id);
 
     const nextDueDateStr =
@@ -765,51 +765,52 @@ export class ScheduledTransactionsService {
         await queryRunner.manager.remove(storedOverride);
       }
 
-      // H10: Calculate next due date once and reuse
-      const newNextDueDate =
-        scheduled.frequency === "ONCE"
-          ? null
-          : this.calculateNextDueDate(
-              new Date(scheduled.nextDueDate),
-              scheduled.frequency,
-            );
+      if (scheduled.frequency === "ONCE") {
+        // One-time bill or deposit: remove the scheduled transaction entirely
+        // after posting so it disappears from the Bills & Deposits page.
+        // Splits and overrides are cleaned up via ON DELETE CASCADE.
+        await queryRunner.manager.delete(ScheduledTransaction, id);
 
-      if (newNextDueDate) {
-        const newNextDueDateStr = formatDateYMD(newNextDueDate);
-        await queryRunner.manager
-          .createQueryBuilder()
-          .delete()
-          .from(ScheduledTransactionOverride)
-          .where("scheduledTransactionId = :id", { id })
-          .andWhere("originalDate < :newNextDueDate", {
-            newNextDueDate: newNextDueDateStr,
-          })
-          .execute();
+        await queryRunner.commitTransaction();
+        return null;
       }
+
+      // Recurring frequency: advance nextDueDate, prune stale overrides,
+      // decrement occurrencesRemaining, deactivate if past endDate.
+      const newNextDueDate = this.calculateNextDueDate(
+        new Date(scheduled.nextDueDate),
+        scheduled.frequency,
+      );
+      const newNextDueDateStr = formatDateYMD(newNextDueDate);
+
+      await queryRunner.manager
+        .createQueryBuilder()
+        .delete()
+        .from(ScheduledTransactionOverride)
+        .where("scheduledTransactionId = :id", { id })
+        .andWhere("originalDate < :newNextDueDate", {
+          newNextDueDate: newNextDueDateStr,
+        })
+        .execute();
 
       const updateFields: Record<string, any> = {
         lastPostedDate: new Date(),
+        nextDueDate: newNextDueDateStr,
       };
 
-      if (scheduled.frequency === "ONCE") {
-        updateFields.isActive = false;
-      } else if (newNextDueDate) {
-        updateFields.nextDueDate = formatDateYMD(newNextDueDate);
-
-        if (
-          scheduled.occurrencesRemaining !== null &&
-          scheduled.occurrencesRemaining > 0
-        ) {
-          const newRemaining = scheduled.occurrencesRemaining - 1;
-          updateFields.occurrencesRemaining = newRemaining;
-          if (newRemaining === 0) {
-            updateFields.isActive = false;
-          }
-        }
-
-        if (scheduled.endDate && newNextDueDate > new Date(scheduled.endDate)) {
+      if (
+        scheduled.occurrencesRemaining !== null &&
+        scheduled.occurrencesRemaining > 0
+      ) {
+        const newRemaining = scheduled.occurrencesRemaining - 1;
+        updateFields.occurrencesRemaining = newRemaining;
+        if (newRemaining === 0) {
           updateFields.isActive = false;
         }
+      }
+
+      if (scheduled.endDate && newNextDueDate > new Date(scheduled.endDate)) {
+        updateFields.isActive = false;
       }
 
       await queryRunner.manager.update(ScheduledTransaction, id, updateFields);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1915,9 +1915,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.0.tgz",
-      "integrity": "sha512-OZIbODWWAi0epQRCRjNe1VO45LOFBzgiyqmTLzIqWq6u1wrxKnAyz1HH6tgY/Mc81YzIjRPoYsPAEr4QV4l9TA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
+      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1931,9 +1931,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.0.tgz",
-      "integrity": "sha512-/JZsqKzKt01IFoiLLAzlNqys7qk2F3JkcUhj50zuRhKDQkZNOz9E5N6wAQWprXdsvjRP4lTFj+/+36NSv5AwhQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
+      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
       "cpu": [
         "arm64"
       ],
@@ -1947,9 +1947,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.0.tgz",
-      "integrity": "sha512-/hV8erWq4SNlVgglUiW5UmQ5Hwy5EW/AbbXlJCn6zkfKxTy/E/U3V8U1Ocm2YCTUoFgQdoMxRyRMOW5jYy4ygg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
       "cpu": [
         "x64"
       ],
@@ -1963,11 +1963,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.0.tgz",
-      "integrity": "sha512-GkjL/Q7MWOwqWR9zoxu1TIHzkOI2l2BHCf7FzeQG87zPgs+6WDh+oC9Sw9ARuuL/FUk6JNCgKRkA6rEQYadUaw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1979,11 +1982,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.0.tgz",
-      "integrity": "sha512-1ffhC6KY5qWLg5miMlKJp3dZbXelEfjuXt1qcp5WzSCQy36CV3y+JT7OC1WSFKizGQCDOcQbfkH/IjZP3cdRNA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1995,11 +2001,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.0.tgz",
-      "integrity": "sha512-FmbDcZQ8yJRq93EJSL6xaE0KK/Rslraf8fj1uViGxg7K4CKBCRYSubILJPEhjSgZurpcPQq12QNOJQ0DRJl6Hg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2011,11 +2020,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.0.tgz",
-      "integrity": "sha512-HzjIHVkmGAwRbh/vzvoBWWEbb8BBZPxBvVbDQDvzHSf3D8RP/4vjw7MNLDXFF9Q1WEzeQyEj2zdxBtVAHu5Oyw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2027,9 +2039,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.0.tgz",
-      "integrity": "sha512-UMiFNQf5H7+1ZsZPxEsA064WEuFbRNq/kEXyepbCnSErp4f5iut75dBA8UeerFIG3vDaQNOfCpevnERPp2V+nA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
       "cpu": [
         "arm64"
       ],
@@ -2043,9 +2055,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.0.tgz",
-      "integrity": "sha512-DRrNJKW+/eimrZgdhVN1uvkN1OI4j6Lpefwr44jKQ0YQzztlmOBUUzHuV5GxOMPK3nmodAYElUVCY8ZXo/IWeA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
       "cpu": [
         "x64"
       ],
@@ -7717,12 +7729,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.0.tgz",
-      "integrity": "sha512-NLBVrJy1pbV1Yn00L5sU4vFyAHt5XuSjzrNyFnxo6Com0M0KrL6hHM5B99dbqXb2bE9pm4Ow3Zl1xp6HVY9edQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
+      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.0",
+        "@next/env": "16.2.3",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -7736,14 +7748,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.0",
-        "@next/swc-darwin-x64": "16.2.0",
-        "@next/swc-linux-arm64-gnu": "16.2.0",
-        "@next/swc-linux-arm64-musl": "16.2.0",
-        "@next/swc-linux-x64-gnu": "16.2.0",
-        "@next/swc-linux-x64-musl": "16.2.0",
-        "@next/swc-win32-arm64-msvc": "16.2.0",
-        "@next/swc-win32-x64-msvc": "16.2.0",
+        "@next/swc-darwin-arm64": "16.2.3",
+        "@next/swc-darwin-x64": "16.2.3",
+        "@next/swc-linux-arm64-gnu": "16.2.3",
+        "@next/swc-linux-arm64-musl": "16.2.3",
+        "@next/swc-linux-x64-gnu": "16.2.3",
+        "@next/swc-linux-x64-musl": "16.2.3",
+        "@next/swc-win32-arm64-msvc": "16.2.3",
+        "@next/swc-win32-x64-msvc": "16.2.3",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/frontend/src/components/ai/ChatInterface.test.tsx
+++ b/frontend/src/components/ai/ChatInterface.test.tsx
@@ -319,6 +319,113 @@ describe('ChatInterface', () => {
       });
     });
 
+    it('shows live streamed text from assistant_text events in the thinking panel', async () => {
+      await renderChat();
+
+      const textarea = screen.getByPlaceholderText(
+        'Ask about your finances...',
+      );
+      fireEvent.change(textarea, { target: { value: 'Test' } });
+      fireEvent.click(screen.getByTitle('Send'));
+
+      // Simulate three text deltas streaming in
+      act(() => {
+        capturedCallbacks?.onEvent({ type: 'assistant_text', text: 'Looking ' });
+      });
+      act(() => {
+        capturedCallbacks?.onEvent({ type: 'assistant_text', text: 'at ' });
+      });
+      act(() => {
+        capturedCallbacks?.onEvent({
+          type: 'assistant_text',
+          text: 'your accounts.',
+        });
+      });
+
+      await waitFor(() => {
+        // Live thinking text accumulates the deltas
+        expect(
+          screen.getByText('Looking at your accounts.'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('clears the live thinking text when a new tool_start fires', async () => {
+      await renderChat();
+
+      const textarea = screen.getByPlaceholderText(
+        'Ask about your finances...',
+      );
+      fireEvent.change(textarea, { target: { value: 'Test' } });
+      fireEvent.click(screen.getByTitle('Send'));
+
+      act(() => {
+        capturedCallbacks?.onEvent({
+          type: 'assistant_text',
+          text: 'I will check the database.',
+        });
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('I will check the database.'),
+        ).toBeInTheDocument();
+      });
+
+      // Tool start should reset the live text buffer for the next iteration
+      act(() => {
+        capturedCallbacks?.onEvent({
+          type: 'tool_start',
+          name: 'get_account_balances',
+        });
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText('I will check the database.'),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('promotes streamed text to a finalized message bubble on content event', async () => {
+      await renderChat();
+
+      const textarea = screen.getByPlaceholderText(
+        'Ask about your finances...',
+      );
+      fireEvent.change(textarea, { target: { value: 'Test' } });
+      fireEvent.click(screen.getByTitle('Send'));
+
+      act(() => {
+        capturedCallbacks?.onEvent({
+          type: 'assistant_text',
+          text: 'Your balance is $5,000.',
+        });
+      });
+
+      // The streamed text appears live in the thinking panel
+      await waitFor(() => {
+        expect(
+          screen.getByText('Your balance is $5,000.'),
+        ).toBeInTheDocument();
+      });
+
+      // The final content event finalizes it; the same text now lives in
+      // the proper assistant message bubble (still in the document).
+      act(() => {
+        capturedCallbacks?.onEvent({
+          type: 'content',
+          text: 'Your balance is $5,000.',
+        });
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Your balance is $5,000.'),
+        ).toBeInTheDocument();
+      });
+    });
+
     it('finishes loading after done event', async () => {
       await renderChat();
 

--- a/frontend/src/components/ai/ChatInterface.tsx
+++ b/frontend/src/components/ai/ChatInterface.tsx
@@ -21,6 +21,10 @@ interface Message {
 interface ThinkingState {
   active: boolean;
   message: string;
+  // Live streamed text from the model — accumulates per iteration as the
+  // backend emits assistant_text deltas. Reset on each new tool_start so the
+  // user sees the next "thinking" pass cleanly.
+  liveText: string;
   tools: Array<{ name: string; status: 'running' | 'done'; summary?: string }>;
 }
 
@@ -33,6 +37,7 @@ export function ChatInterface() {
   const [thinking, setThinking] = useState<ThinkingState>({
     active: false,
     message: '',
+    liveText: '',
     tools: [],
   });
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -75,7 +80,12 @@ export function ChatInterface() {
         { id: userMsgId, role: 'user', content: query },
       ]);
 
-      setThinking({ active: true, message: 'Analyzing your question...', tools: [] });
+      setThinking({
+        active: true,
+        message: 'Analyzing your question...',
+        liveText: '',
+        tools: [],
+      });
 
       const toolsUsed: Array<{ name: string; summary: string }> = [];
       let sources: Array<{ type: string; description: string; dateRange?: string }> = [];
@@ -92,10 +102,24 @@ export function ChatInterface() {
               }));
               break;
 
+            case 'assistant_text':
+              // Streaming text delta from the model — append to the live
+              // thinking buffer so the user sees realtime feedback while
+              // the model generates its next step.
+              setThinking((prev) => ({
+                ...prev,
+                liveText: prev.liveText + (event.text || ''),
+              }));
+              break;
+
             case 'tool_start':
+              // The model decided to use a tool. Lock in any live text as
+              // "thinking we already saw" by clearing the buffer for the
+              // next iteration, and add the tool to the indicator list.
               setThinking((prev) => ({
                 ...prev,
                 message: `Looking up ${event.name?.replace(/_/g, ' ')}...`,
+                liveText: '',
                 tools: [
                   ...prev.tools,
                   { name: event.name || '', status: 'running' },
@@ -121,7 +145,7 @@ export function ChatInterface() {
             case 'content':
               if (!hasStartedContent) {
                 hasStartedContent = true;
-                setThinking({ active: false, message: '', tools: [] });
+                setThinking({ active: false, message: '', liveText: '', tools: [] });
                 setMessages((prev) => [
                   ...prev,
                   {
@@ -133,7 +157,7 @@ export function ChatInterface() {
                   },
                 ]);
               }
-              contentBuffer += event.text || '';
+              contentBuffer = event.text || '';
               setMessages((prev) =>
                 prev.map((m) =>
                   m.id === assistantMsgId
@@ -156,11 +180,11 @@ export function ChatInterface() {
                 ),
               );
               setIsLoading(false);
-              setThinking({ active: false, message: '', tools: [] });
+              setThinking({ active: false, message: '', liveText: '', tools: [] });
               break;
 
             case 'error':
-              setThinking({ active: false, message: '', tools: [] });
+              setThinking({ active: false, message: '', liveText: '', tools: [] });
               if (hasStartedContent) {
                 setMessages((prev) =>
                   prev.map((m) =>
@@ -186,10 +210,10 @@ export function ChatInterface() {
         },
         onDone: () => {
           setIsLoading(false);
-          setThinking({ active: false, message: '', tools: [] });
+          setThinking({ active: false, message: '', liveText: '', tools: [] });
         },
         onError: (error) => {
-          setThinking({ active: false, message: '', tools: [] });
+          setThinking({ active: false, message: '', liveText: '', tools: [] });
           setIsLoading(false);
           toast.error(error.message || 'Failed to get response');
           if (!hasStartedContent) {
@@ -221,7 +245,7 @@ export function ChatInterface() {
   const handleCancel = () => {
     abortControllerRef.current?.abort();
     setIsLoading(false);
-    setThinking({ active: false, message: '', tools: [] });
+    setThinking({ active: false, message: '', liveText: '', tools: [] });
   };
 
   // Auto-resize textarea
@@ -303,6 +327,11 @@ export function ChatInterface() {
                       </svg>
                       {thinking.message}
                     </div>
+                    {thinking.liveText && (
+                      <div className="mt-2 text-sm text-gray-600 dark:text-gray-300 italic whitespace-pre-wrap break-words">
+                        {thinking.liveText}
+                      </div>
+                    )}
                     {thinking.tools.length > 0 && (
                       <div className="mt-2 space-y-1">
                         {thinking.tools.map((tool, i) => (

--- a/frontend/src/lib/scheduled-transactions.ts
+++ b/frontend/src/lib/scheduled-transactions.ts
@@ -67,9 +67,11 @@ export const scheduledTransactionsApi = {
     invalidateCache('scheduled:');
   },
 
-  // Post scheduled transaction (create actual transaction and advance)
-  post: async (id: string, data?: PostScheduledTransactionData): Promise<ScheduledTransaction> => {
-    const response = await apiClient.post<ScheduledTransaction>(
+  // Post scheduled transaction (create actual transaction and advance).
+  // Returns null when the scheduled transaction was a one-time entry and was
+  // deleted as part of the post.
+  post: async (id: string, data?: PostScheduledTransactionData): Promise<ScheduledTransaction | null> => {
+    const response = await apiClient.post<ScheduledTransaction | null>(
       `/scheduled-transactions/${id}/post`,
       data || {},
     );

--- a/frontend/src/types/ai.ts
+++ b/frontend/src/types/ai.ts
@@ -100,7 +100,15 @@ export interface QueryResult {
 }
 
 export interface StreamEvent {
-  type: 'thinking' | 'tool_start' | 'tool_result' | 'content' | 'sources' | 'done' | 'error';
+  type:
+    | 'thinking'
+    | 'assistant_text'
+    | 'tool_start'
+    | 'tool_result'
+    | 'content'
+    | 'sources'
+    | 'done'
+    | 'error';
   message?: string;
   name?: string;
   description?: string;


### PR DESCRIPTION
## Summary

Two unrelated changes bundled on one branch:

### 1. Validate AI provider connectivity on backend startup

Adds `AiStartupValidator` (`OnApplicationBootstrap`) which probes the system-default AI provider on boot so misconfigurations are visible in the logs immediately rather than at first user request.

- Builds a synthetic `AiProviderConfig` from the `AI_DEFAULT_*` env vars
- Hands it to the existing `AiProviderFactory` (so encryption, baseUrl handling, and model defaulting use the same path as runtime)
- Calls `provider.isAvailable()` — a cheap, time-bounded probe (`models.list()` for cloud providers, `GET /api/tags` for Ollama)
- Logs `AI provider OK: <provider:model>` on success or `AI provider FAILED: ... -- <reason>` on failure
- Skipped silently when `AI_DEFAULT_PROVIDER` is unset — never aborts startup

Per-user provider configs are intentionally **not** validated on startup (would be slow and noisy with multiple users).

**Files**
- `backend/src/ai/ai-startup.validator.ts` (new)
- `backend/src/ai/ai-startup.validator.spec.ts` (new, 7 tests)
- `backend/src/ai/ai.module.ts` (register provider)

### 2. Delete one-time bills and deposits after they're posted

Previously, posting a scheduled transaction with `frequency = ONCE` flipped `isActive = false` but left the row in the database, so it lingered on the **Bills & Deposits** page indefinitely. Now the row is deleted as part of the post.

- Deletion happens inside the same `QueryRunner` transaction as the override cleanup, so it's atomic with the posting bookkeeping
- Splits, split tags, and overrides are removed automatically via the existing `ON DELETE CASCADE` constraints — no schema change required
- The actual posted `Transaction` row in the `transactions` table remains as the source of truth for what happened
- Loan-recalc tail is skipped for ONCE (loan payments are always recurring, and the row no longer exists to recalc against)
- `post()` return type widens to `ScheduledTransaction | null` (returns `null` after deletion). Frontend API client signature updated to match — no call sites consume the response, so the Bills page needs no further changes

**Files**
- `backend/src/scheduled-transactions/scheduled-transactions.service.ts`
- `backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts` (replaced 1 test, added 3)
- `frontend/src/lib/scheduled-transactions.ts`

#### Migration note

Any existing posted-but-still-present ONCE rows from before this change won't be cleaned up automatically. If you want them gone, run:

```sql
DELETE FROM scheduled_transactions
WHERE frequency = 'ONCE' AND is_active = false AND last_posted_date IS NOT NULL;
