### PR TITLE
Mark AI features as Beta

### DIFF
--- a/frontend/src/app/ai/page.tsx
+++ b/frontend/src/app/ai/page.tsx
@@ -12,6 +12,7 @@ export default function AiPage() {
         <main className="px-4 sm:px-6 lg:px-12 pt-6 pb-8">
           <PageHeader
             title="AI Assistant"
+            badge="Beta"
             subtitle="Ask questions about your finances in natural language"
             helpUrl="https://github.com/kenlasko/monize/wiki/AI"
           />

--- a/frontend/src/app/insights/page.tsx
+++ b/frontend/src/app/insights/page.tsx
@@ -12,6 +12,7 @@ export default function InsightsPage() {
         <main className="px-4 sm:px-6 lg:px-12 pt-6 pb-8">
           <PageHeader
             title="Spending Insights"
+            badge="Beta"
             subtitle="AI-powered analysis of your spending patterns and anomalies"
           />
           <div className="max-w-4xl mx-auto">

--- a/frontend/src/app/settings/ai/page.tsx
+++ b/frontend/src/app/settings/ai/page.tsx
@@ -87,6 +87,7 @@ function AiSettingsContent() {
 
         <PageHeader
           title="AI Settings"
+          badge="Beta"
           subtitle="Configure AI providers for intelligent financial features"
         />
 

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -32,7 +32,7 @@ const ALL_SETTINGS_SECTIONS: readonly (SettingsSection & { demoVisible?: boolean
   { id: 'notifications', label: 'Notifications', demoVisible: true },
   { id: 'security', label: 'Security' },
   { id: 'api-access', label: 'API Access' },
-  { id: 'ai-settings', label: 'AI Settings', href: '/settings/ai' },
+  { id: 'ai-settings', label: 'AI Settings', href: '/settings/ai', badge: 'Beta' },
   { id: 'backup-restore', label: 'Backup & Restore' },
   { id: 'auto-backup', label: 'Automatic Backup' },
   { id: 'danger-zone', label: 'Danger Zone' },
@@ -207,8 +207,11 @@ function SettingsContent() {
                   href="/settings/ai"
                   className="block bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg p-6 mb-6 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
                 >
-                  <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">
+                  <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1 flex items-center">
                     AI Settings
+                    <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300">
+                      Beta
+                    </span>
                   </h2>
                   <p className="text-sm text-gray-500 dark:text-gray-400">
                     Configure AI providers, manage API keys, and view usage statistics.

--- a/frontend/src/components/dashboard/InsightsWidget.tsx
+++ b/frontend/src/components/dashboard/InsightsWidget.tsx
@@ -38,6 +38,11 @@ export function InsightsWidget({ isLoading: parentLoading }: InsightsWidgetProps
   }, [parentLoading]);
 
   const sectionTitle = 'Spending Insights';
+  const betaBadge = (
+    <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300">
+      Beta
+    </span>
+  );
 
   if (isLoading || parentLoading) {
     return (
@@ -47,6 +52,7 @@ export function InsightsWidget({ isLoading: parentLoading }: InsightsWidgetProps
           className="text-lg font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors mb-4"
         >
           {sectionTitle}
+          {betaBadge}
         </button>
         <div className="animate-pulse space-y-3">
           {[1, 2, 3].map((i) => (
@@ -65,6 +71,7 @@ export function InsightsWidget({ isLoading: parentLoading }: InsightsWidgetProps
           className="text-lg font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors mb-4"
         >
           {sectionTitle}
+          {betaBadge}
         </button>
         <p className="text-gray-500 dark:text-gray-400 text-sm">
           No insights available. Visit the Insights page to generate your first analysis.
@@ -87,6 +94,7 @@ export function InsightsWidget({ isLoading: parentLoading }: InsightsWidgetProps
           className="text-lg font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
         >
           {sectionTitle}
+          {betaBadge}
         </button>
         <span className="text-sm text-gray-500 dark:text-gray-400">
           {insights.length} active

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -28,10 +28,13 @@ const toolsLinks: { href: string; label: string; badge?: string }[] = [
   { href: '/import', label: 'Import Transactions' },
 ];
 
-const aiLinks = [
-  { href: '/insights', label: 'Insights' },
-  { href: '/ai', label: 'AI Assistant' },
+const aiLinks: { href: string; label: string; badge?: string }[] = [
+  { href: '/insights', label: 'Insights', badge: 'Beta' },
+  { href: '/ai', label: 'AI Assistant', badge: 'Beta' },
 ];
+
+const BETA_BADGE_CLASSES =
+  'ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300';
 
 export function AppHeader() {
   const router = useRouter();
@@ -141,8 +144,9 @@ export function AppHeader() {
                     <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
 
                     {/* AI section header */}
-                    <div className="px-4 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    <div className="px-4 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider flex items-center">
                       AI
+                      <span className={BETA_BADGE_CLASSES}>Beta</span>
                     </div>
 
                     {/* AI links */}
@@ -157,6 +161,7 @@ export function AppHeader() {
                         }`}
                       >
                         {link.label}
+                        {link.badge && <span className={BETA_BADGE_CLASSES}>{link.badge}</span>}
                       </button>
                     ))}
 
@@ -260,6 +265,7 @@ export function AppHeader() {
                   }`}
                 >
                   AI
+                  <span className={BETA_BADGE_CLASSES}>Beta</span>
                   <svg
                     className={`w-4 h-4 transition-transform ${aiOpen ? 'rotate-180' : ''}`}
                     fill="none"
@@ -287,6 +293,7 @@ export function AppHeader() {
                           }`}
                         >
                           {link.label}
+                          {link.badge && <span className={BETA_BADGE_CLASSES}>{link.badge}</span>}
                         </button>
                       ))}
                     </div>

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -10,13 +10,15 @@ interface PageHeaderProps {
   actions?: ReactNode;
   /** URL to the wiki help page for this feature */
   helpUrl?: string;
+  /** Optional badge (e.g. "Beta") shown next to the title */
+  badge?: string;
 }
 
 /**
  * Inline page header with title, subtitle, and action buttons.
  * Renders directly in the content area without a separate background bar.
  */
-export function PageHeader({ title, subtitle, actions, helpUrl }: PageHeaderProps) {
+export function PageHeader({ title, subtitle, actions, helpUrl, badge }: PageHeaderProps) {
   return (
     <div className={`${actions ? 'flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4' : ''} mb-6`}>
       <div>
@@ -24,6 +26,11 @@ export function PageHeader({ title, subtitle, actions, helpUrl }: PageHeaderProp
           <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
             {title}
           </h1>
+          {badge && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300">
+              {badge}
+            </span>
+          )}
           {helpUrl && (
             <a
               href={helpUrl}

--- a/frontend/src/components/settings/SettingsNav.tsx
+++ b/frontend/src/components/settings/SettingsNav.tsx
@@ -9,7 +9,12 @@ export interface SettingsSection {
   readonly label: string;
   /** If set, renders as a navigation link instead of a scroll-to button */
   readonly href?: string;
+  /** Optional badge (e.g. "Beta") shown next to the label */
+  readonly badge?: string;
 }
+
+const BETA_BADGE_CLASSES =
+  'ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300';
 
 interface SettingsNavProps {
   readonly sections: readonly SettingsSection[];
@@ -74,7 +79,10 @@ export function SettingsNav({
                 role="tab"
                 aria-selected={isActive}
               >
-                {section.label}
+                <span className="inline-flex items-center">
+                  {section.label}
+                  {section.badge && <span className={BETA_BADGE_CLASSES}>{section.badge}</span>}
+                </span>
                 <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
               </Link>
             );
@@ -96,6 +104,7 @@ export function SettingsNav({
               aria-selected={isActive}
             >
               {section.label}
+              {section.badge && <span className={BETA_BADGE_CLASSES}>{section.badge}</span>}
             </button>
           );
         })}
@@ -127,7 +136,10 @@ export function SettingsNav({
                     }
                   `}
                 >
-                  {section.label}
+                  <span className="inline-flex items-center">
+                    {section.label}
+                    {section.badge && <span className={BETA_BADGE_CLASSES}>{section.badge}</span>}
+                  </span>
                   <ArrowTopRightOnSquareIcon className="h-4 w-4 opacity-50" />
                 </Link>
               </li>
@@ -148,6 +160,7 @@ export function SettingsNav({
                 `}
               >
                 {section.label}
+                {section.badge && <span className={BETA_BADGE_CLASSES}>{section.badge}</span>}
               </button>
             </li>
           );


### PR DESCRIPTION
Adds a "Beta" badge to the AI Assistant, Spending Insights, and AI Settings pages, the AI dropdown in the header, the dashboard insights widget, and the AI Settings entry in the settings sidebar so users know these features are still being actively developed.