### PR TITLE
Add inline tool call parsing for OpenAI-compatible providers

### DIFF
--- a/backend/src/ai/providers/openai-compatible.provider.spec.ts
+++ b/backend/src/ai/providers/openai-compatible.provider.spec.ts
@@ -1,6 +1,7 @@
-import type { AiToolStreamChunk } from "./ai-provider.interface";
+import type { AiMessage, AiToolStreamChunk } from "./ai-provider.interface";
 import {
   OpenAiCompatibleProvider,
+  flattenToolMessages,
   parseInlineToolCalls,
 } from "./openai-compatible.provider";
 
@@ -103,6 +104,72 @@ describe("parseInlineToolCalls", () => {
   });
 });
 
+describe("flattenToolMessages", () => {
+  it("passes user messages through untouched", () => {
+    const messages: AiMessage[] = [{ role: "user", content: "hi" }];
+    expect(flattenToolMessages(messages)).toEqual(messages);
+  });
+
+  it("serializes assistant tool calls into plain content", () => {
+    const messages: AiMessage[] = [
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          {
+            id: "call_1",
+            name: "query_transactions",
+            input: { startDate: "2026-03-01" },
+          },
+        ],
+      },
+    ];
+    const out = flattenToolMessages(messages);
+    expect(out).toHaveLength(1);
+    expect(out[0].role).toBe("assistant");
+    // No toolCalls field on output -- Cloudflare rejects it.
+    expect((out[0] as { toolCalls?: unknown }).toolCalls).toBeUndefined();
+    if (out[0].role === "assistant") {
+      const parsed = JSON.parse(out[0].content);
+      expect(parsed.name).toBe("query_transactions");
+      expect(parsed.parameters).toEqual({ startDate: "2026-03-01" });
+    }
+  });
+
+  it("converts tool-result messages into user messages", () => {
+    const messages: AiMessage[] = [
+      {
+        role: "tool",
+        toolCallId: "call_1",
+        name: "query_transactions",
+        content: '{"total":42}',
+      },
+    ];
+    const out = flattenToolMessages(messages);
+    expect(out).toHaveLength(1);
+    expect(out[0].role).toBe("user");
+    if (out[0].role === "user") {
+      expect(out[0].content).toContain("Tool query_transactions result:");
+      expect(out[0].content).toContain('{"total":42}');
+    }
+  });
+
+  it("preserves assistant content alongside tool calls", () => {
+    const messages: AiMessage[] = [
+      {
+        role: "assistant",
+        content: "Let me check.",
+        toolCalls: [{ id: "c1", name: "t", input: {} }],
+      },
+    ];
+    const out = flattenToolMessages(messages);
+    if (out[0].role === "assistant") {
+      expect(out[0].content.startsWith("Let me check.")).toBe(true);
+      expect(out[0].content).toContain('"name":"t"');
+    }
+  });
+});
+
 describe("OpenAiCompatibleProvider", () => {
   let provider: OpenAiCompatibleProvider;
 
@@ -183,6 +250,58 @@ describe("OpenAiCompatibleProvider", () => {
       expect(result.content).toBe("Just a text answer.");
       expect(result.toolCalls).toHaveLength(0);
       expect(result.stopReason).toBe("end_turn");
+    });
+
+    it("flattens prior tool-call / tool-result messages before sending", async () => {
+      mockCreate.mockResolvedValueOnce({
+        choices: [
+          {
+            message: { content: "done.", tool_calls: undefined },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+        model: "llama",
+      });
+
+      await provider.completeWithTools(
+        {
+          systemPrompt: "sys",
+          messages: [
+            { role: "user", content: "hi" },
+            {
+              role: "assistant",
+              content: "",
+              toolCalls: [{ id: "c1", name: "t", input: { a: 1 } }],
+            },
+            {
+              role: "tool",
+              toolCallId: "c1",
+              name: "t",
+              content: '{"ok":true}',
+            },
+          ],
+        },
+        [],
+      );
+
+      const payload = mockCreate.mock.calls[0][0];
+      // No role="tool" messages, no tool_calls on assistant messages.
+      for (const m of payload.messages) {
+        expect(m.role).not.toBe("tool");
+        if (m.role === "assistant") {
+          expect(m.tool_calls).toBeUndefined();
+        }
+      }
+      // Tool result became a user message.
+      const userMessages = payload.messages.filter(
+        (m: { role: string }) => m.role === "user",
+      );
+      expect(
+        userMessages.some((m: { content: string }) =>
+          m.content.includes("Tool t result:"),
+        ),
+      ).toBe(true);
     });
 
     it("does not clobber real structured tool calls", async () => {

--- a/backend/src/ai/providers/openai-compatible.provider.spec.ts
+++ b/backend/src/ai/providers/openai-compatible.provider.spec.ts
@@ -1,36 +1,396 @@
-import { OpenAiCompatibleProvider } from "./openai-compatible.provider";
+import type { AiToolStreamChunk } from "./ai-provider.interface";
+import {
+  OpenAiCompatibleProvider,
+  parseInlineToolCalls,
+} from "./openai-compatible.provider";
 
-jest.mock("openai", () => {
-  return {
-    __esModule: true,
-    default: jest.fn().mockImplementation(() => ({
-      chat: { completions: { create: jest.fn() } },
-      models: { list: jest.fn() },
-    })),
-  };
+const mockCreate = jest.fn();
+const mockListModels = jest.fn().mockResolvedValue({ data: [] });
+
+jest.mock("openai", () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    chat: { completions: { create: mockCreate } },
+    models: { list: mockListModels },
+  })),
+}));
+
+describe("parseInlineToolCalls", () => {
+  it("returns null for plain text", () => {
+    expect(parseInlineToolCalls("I don't know")).toBeNull();
+    expect(parseInlineToolCalls("")).toBeNull();
+  });
+
+  it("parses the Llama-3.1 shape with `arguments`", () => {
+    const text = JSON.stringify({
+      name: "get_spending_by_category",
+      arguments: { startDate: "2026-03-01", topN: "all" },
+    });
+    const result = parseInlineToolCalls(text);
+    expect(result).toHaveLength(1);
+    expect(result![0].name).toBe("get_spending_by_category");
+    expect(result![0].input).toEqual({
+      startDate: "2026-03-01",
+      topN: "all",
+    });
+    expect(result![0].id).toMatch(/^call_inline_/);
+  });
+
+  it("parses the Cloudflare 70B shape with `type: function` and `parameters`", () => {
+    const text = JSON.stringify({
+      type: "function",
+      name: "query_transactions",
+      parameters: { startDate: "2026-03-01", direction: "expenses" },
+    });
+    const result = parseInlineToolCalls(text);
+    expect(result).toHaveLength(1);
+    expect(result![0].name).toBe("query_transactions");
+    expect(result![0].input).toEqual({
+      startDate: "2026-03-01",
+      direction: "expenses",
+    });
+  });
+
+  it("parses the OpenAI-ish nested `function` shape", () => {
+    const text = JSON.stringify({
+      type: "function",
+      function: {
+        name: "get_balance",
+        arguments: JSON.stringify({ accountId: "abc" }),
+      },
+    });
+    const result = parseInlineToolCalls(text);
+    expect(result).toHaveLength(1);
+    expect(result![0].name).toBe("get_balance");
+    expect(result![0].input).toEqual({ accountId: "abc" });
+  });
+
+  it("strips <|python_tag|> prefix", () => {
+    const text = `<|python_tag|>${JSON.stringify({
+      name: "get_balance",
+      arguments: { accountId: "abc" },
+    })}`;
+    const result = parseInlineToolCalls(text);
+    expect(result).toHaveLength(1);
+    expect(result![0].name).toBe("get_balance");
+  });
+
+  it("parses <function=name>{...}</function> wrapper", () => {
+    const text = '<function=get_balance>{"accountId":"abc"}</function>';
+    const result = parseInlineToolCalls(text);
+    expect(result).toHaveLength(1);
+    expect(result![0].name).toBe("get_balance");
+    expect(result![0].input).toEqual({ accountId: "abc" });
+  });
+
+  it("parses arrays of tool calls", () => {
+    const text = JSON.stringify([
+      { name: "a", arguments: { x: 1 } },
+      { name: "b", arguments: { y: 2 } },
+    ]);
+    const result = parseInlineToolCalls(text);
+    expect(result).toHaveLength(2);
+    expect(result![0].name).toBe("a");
+    expect(result![1].name).toBe("b");
+  });
+
+  it("returns null for JSON that is not a tool call", () => {
+    expect(parseInlineToolCalls('{"answer":42}')).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseInlineToolCalls("{ this is not json")).toBeNull();
+  });
 });
 
 describe("OpenAiCompatibleProvider", () => {
-  it("has name openai-compatible", () => {
-    const provider = new OpenAiCompatibleProvider(
+  let provider: OpenAiCompatibleProvider;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    provider = new OpenAiCompatibleProvider(
       "test-key",
-      "https://api.groq.com/openai/v1",
-      "mixtral-8x7b",
+      "https://api.cloudflare.com/client/v4/accounts/abc/ai/v1",
+      "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
     );
+  });
+
+  it("has name openai-compatible", () => {
     expect(provider.name).toBe("openai-compatible");
     expect(provider.supportsStreaming).toBe(true);
     expect(provider.supportsToolUse).toBe(true);
   });
 
-  it("inherits streamWithTools from OpenAiProvider", () => {
-    const provider = new OpenAiCompatibleProvider(
-      "test-key",
-      "https://api.groq.com/openai/v1",
-      "mixtral-8x7b",
-    );
-    // streamWithTools is the realtime feedback path; openai-compatible should
-    // pick it up through inheritance so any OpenAI-API-compatible backend
-    // (Groq, vLLM, LM Studio, etc.) gets streaming for free.
-    expect(typeof provider.streamWithTools).toBe("function");
+  describe("completeWithTools()", () => {
+    it("converts inline JSON tool call text to structured tool calls", async () => {
+      const inlineBlob = JSON.stringify({
+        type: "function",
+        name: "query_transactions",
+        parameters: { startDate: "2026-03-01" },
+      });
+      mockCreate.mockResolvedValueOnce({
+        choices: [
+          {
+            message: { content: inlineBlob, tool_calls: undefined },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 20 },
+        model: "llama",
+      });
+
+      const result = await provider.completeWithTools(
+        {
+          systemPrompt: "sys",
+          messages: [{ role: "user", content: "hi" }],
+        },
+        [
+          {
+            name: "query_transactions",
+            description: "",
+            inputSchema: { type: "object" },
+          },
+        ],
+      );
+
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].name).toBe("query_transactions");
+      expect(result.toolCalls[0].input).toEqual({ startDate: "2026-03-01" });
+      expect(result.content).toBe("");
+      expect(result.stopReason).toBe("tool_use");
+    });
+
+    it("passes through plain text responses unchanged", async () => {
+      mockCreate.mockResolvedValueOnce({
+        choices: [
+          {
+            message: { content: "Just a text answer.", tool_calls: undefined },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 20 },
+        model: "llama",
+      });
+
+      const result = await provider.completeWithTools(
+        {
+          systemPrompt: "sys",
+          messages: [{ role: "user", content: "hi" }],
+        },
+        [],
+      );
+
+      expect(result.content).toBe("Just a text answer.");
+      expect(result.toolCalls).toHaveLength(0);
+      expect(result.stopReason).toBe("end_turn");
+    });
+
+    it("does not clobber real structured tool calls", async () => {
+      mockCreate.mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              content: "",
+              tool_calls: [
+                {
+                  id: "call_1",
+                  type: "function",
+                  function: {
+                    name: "get_balance",
+                    arguments: '{"accountId":"abc"}',
+                  },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 5 },
+        model: "llama",
+      });
+
+      const result = await provider.completeWithTools(
+        {
+          systemPrompt: "sys",
+          messages: [{ role: "user", content: "hi" }],
+        },
+        [],
+      );
+
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].id).toBe("call_1");
+      expect(result.toolCalls[0].name).toBe("get_balance");
+    });
+  });
+
+  describe("streamWithTools()", () => {
+    const makeStream = (
+      chunks: Array<{
+        delta?: { content?: string; tool_calls?: unknown };
+        finish_reason?: string | null;
+        usage?: { prompt_tokens: number; completion_tokens: number };
+        model?: string;
+      }>,
+    ) => ({
+      [Symbol.asyncIterator]: () => {
+        let idx = 0;
+        return {
+          next: () => {
+            if (idx < chunks.length) {
+              const c = chunks[idx++];
+              return Promise.resolve({
+                value: {
+                  choices: [
+                    { delta: c.delta ?? {}, finish_reason: c.finish_reason },
+                  ],
+                  usage: c.usage,
+                  model: c.model,
+                },
+                done: false,
+              });
+            }
+            return Promise.resolve({ value: undefined, done: true });
+          },
+        };
+      },
+    });
+
+    it("buffers JSON-looking text and replaces it with tool calls on done", async () => {
+      const inlineBlob = JSON.stringify({
+        type: "function",
+        name: "query_transactions",
+        parameters: { startDate: "2026-03-01" },
+      });
+      mockCreate.mockResolvedValueOnce(
+        makeStream([
+          { delta: { content: inlineBlob.slice(0, 20) } },
+          { delta: { content: inlineBlob.slice(20) } },
+          {
+            delta: {},
+            finish_reason: "stop",
+            usage: { prompt_tokens: 10, completion_tokens: 30 },
+            model: "llama",
+          },
+        ]),
+      );
+
+      const yielded: AiToolStreamChunk[] = [];
+      for await (const chunk of provider.streamWithTools(
+        {
+          systemPrompt: "sys",
+          messages: [{ role: "user", content: "hi" }],
+        },
+        [],
+      )) {
+        yielded.push(chunk);
+      }
+
+      // Should NOT have surfaced any raw JSON text chunks
+      expect(yielded.filter((c) => c.type === "text")).toHaveLength(0);
+      const done = yielded.find((c) => c.type === "done");
+      expect(done).toBeDefined();
+      if (done && done.type === "done") {
+        expect(done.toolCalls).toHaveLength(1);
+        expect(done.toolCalls[0].name).toBe("query_transactions");
+        expect(done.stopReason).toBe("tool_use");
+        expect(done.content).toBe("");
+      }
+    });
+
+    it("streams plain text normally", async () => {
+      mockCreate.mockResolvedValueOnce(
+        makeStream([
+          { delta: { content: "Hello " } },
+          { delta: { content: "world" } },
+          {
+            delta: {},
+            finish_reason: "stop",
+            usage: { prompt_tokens: 5, completion_tokens: 5 },
+            model: "llama",
+          },
+        ]),
+      );
+
+      const texts: string[] = [];
+      let done: AiToolStreamChunk | undefined;
+      for await (const chunk of provider.streamWithTools(
+        {
+          systemPrompt: "sys",
+          messages: [{ role: "user", content: "hi" }],
+        },
+        [],
+      )) {
+        if (chunk.type === "text") texts.push(chunk.text);
+        else done = chunk;
+      }
+
+      expect(texts.join("")).toBe("Hello world");
+      expect(done).toBeDefined();
+      if (done && done.type === "done") {
+        expect(done.toolCalls).toHaveLength(0);
+      }
+    });
+
+    it("flushes buffered text when JSON-looking content does not parse as a tool call", async () => {
+      // Content starts with `{` but is not a tool call -- e.g. the model is
+      // narrating a code block. We should flush it rather than eating it.
+      mockCreate.mockResolvedValueOnce(
+        makeStream([
+          { delta: { content: '{"answer":' } },
+          { delta: { content: "42}" } },
+          {
+            delta: {},
+            finish_reason: "stop",
+            usage: { prompt_tokens: 5, completion_tokens: 5 },
+            model: "llama",
+          },
+        ]),
+      );
+
+      const texts: string[] = [];
+      let done: AiToolStreamChunk | undefined;
+      for await (const chunk of provider.streamWithTools(
+        {
+          systemPrompt: "sys",
+          messages: [{ role: "user", content: "hi" }],
+        },
+        [],
+      )) {
+        if (chunk.type === "text") texts.push(chunk.text);
+        else done = chunk;
+      }
+
+      expect(texts.join("")).toBe('{"answer":42}');
+      expect(done).toBeDefined();
+      if (done && done.type === "done") {
+        expect(done.toolCalls).toHaveLength(0);
+      }
+    });
+  });
+
+  describe("isAvailable()", () => {
+    it("probes via chat.completions.create instead of models.list", async () => {
+      mockCreate.mockResolvedValueOnce({
+        choices: [{ message: { content: "pong" } }],
+      });
+
+      const result = await provider.isAvailable();
+
+      expect(result).toBe(true);
+      expect(mockListModels).not.toHaveBeenCalled();
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+          max_tokens: 1,
+        }),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    it("returns false when the probe fails", async () => {
+      mockCreate.mockRejectedValueOnce(new Error("Unauthorized"));
+      const result = await provider.isAvailable();
+      expect(result).toBe(false);
+    });
   });
 });

--- a/backend/src/ai/providers/openai-compatible.provider.ts
+++ b/backend/src/ai/providers/openai-compatible.provider.ts
@@ -1,5 +1,6 @@
 import {
   AiCompletionRequest,
+  AiMessage,
   AiToolCall,
   AiToolDefinition,
   AiToolResponse,
@@ -124,6 +125,52 @@ function makeToolCallId(): string {
 }
 
 /**
+ * Flatten OpenAI-style tool-call / tool-result messages into plain
+ * user/assistant turns.
+ *
+ * Cloudflare Workers AI's OpenAI-compatible endpoint (and some other Llama
+ * backends) accept the `tools` parameter on input but reject assistant
+ * messages carrying `tool_calls` and messages with `role: "tool"` with a
+ * bare `400 (no body)`. Since these backends model tool use as
+ * regular-content JSON anyway, we round-trip through that representation:
+ *
+ * - assistant { content, toolCalls } -> assistant { content: "<content?> <json(toolCalls)>" }
+ * - tool      { name, content }      -> user      { content: "Tool <name> result:\n<content>" }
+ */
+export function flattenToolMessages(messages: AiMessage[]): AiMessage[] {
+  const result: AiMessage[] = [];
+  for (const msg of messages) {
+    if (msg.role === "assistant") {
+      if (msg.toolCalls && msg.toolCalls.length > 0) {
+        const serializedCalls = msg.toolCalls
+          .map((tc) =>
+            JSON.stringify({
+              type: "function",
+              name: tc.name,
+              parameters: tc.input,
+            }),
+          )
+          .join("\n");
+        const content = msg.content
+          ? `${msg.content}\n${serializedCalls}`
+          : serializedCalls;
+        result.push({ role: "assistant", content });
+      } else {
+        result.push({ role: "assistant", content: msg.content });
+      }
+    } else if (msg.role === "tool") {
+      result.push({
+        role: "user",
+        content: `Tool ${msg.name} result:\n${msg.content}`,
+      });
+    } else {
+      result.push(msg);
+    }
+  }
+  return result;
+}
+
+/**
  * Detect whether an in-progress stream's leading text looks like it is
  * building a tool-call blob, so we can buffer instead of surfacing raw
  * JSON to the UI.
@@ -150,7 +197,11 @@ export class OpenAiCompatibleProvider extends OpenAiProvider {
     request: AiCompletionRequest,
     tools: AiToolDefinition[],
   ): Promise<AiToolResponse> {
-    const response = await super.completeWithTools(request, tools);
+    const flattened: AiCompletionRequest = {
+      ...request,
+      messages: flattenToolMessages(request.messages),
+    };
+    const response = await super.completeWithTools(flattened, tools);
     if (response.toolCalls.length > 0) return response;
 
     const inline = parseInlineToolCalls(response.content);
@@ -168,7 +219,11 @@ export class OpenAiCompatibleProvider extends OpenAiProvider {
     request: AiCompletionRequest,
     tools: AiToolDefinition[],
   ): AsyncIterable<AiToolStreamChunk> {
-    const source = super.streamWithTools!(request, tools);
+    const flattened: AiCompletionRequest = {
+      ...request,
+      messages: flattenToolMessages(request.messages),
+    };
+    const source = super.streamWithTools!(flattened, tools);
 
     // Buffer text chunks only when the leading content looks like a tool
     // call blob. For normal text responses we still stream token-by-token.

--- a/backend/src/ai/providers/openai-compatible.provider.ts
+++ b/backend/src/ai/providers/openai-compatible.provider.ts
@@ -1,9 +1,265 @@
+import {
+  AiCompletionRequest,
+  AiToolCall,
+  AiToolDefinition,
+  AiToolResponse,
+  AiToolStreamChunk,
+} from "./ai-provider.interface";
 import { OpenAiProvider } from "./openai.provider";
+
+/**
+ * Attempt to extract structured tool calls from assistant text content.
+ *
+ * Some OpenAI-compatible endpoints (notably Cloudflare Workers AI with Llama
+ * 3.x) do not translate Llama-format function calls into the OpenAI
+ * `tool_calls` field and instead leak the raw JSON as text. This helper
+ * tolerantly parses the common shapes so the query engine can still drive a
+ * tool loop.
+ *
+ * Returns `null` if the content does not look like a tool call blob.
+ */
+export function parseInlineToolCalls(text: string): AiToolCall[] | null {
+  if (!text) return null;
+
+  // Strip common wrappers emitted by fine-tuned chat templates. Keep this
+  // conservative: only touch patterns we've seen in the wild.
+  let candidate = text.trim();
+
+  // <|python_tag|>{ ... } (Llama 3.x tool-call chat template)
+  if (candidate.startsWith("<|python_tag|>")) {
+    candidate = candidate.slice("<|python_tag|>".length).trim();
+  }
+
+  // <function=name>{ "arg": "val" }</function>
+  const functionTagMatch = candidate.match(
+    /^<function=([a-zA-Z0-9_-]+)>([\s\S]*?)<\/function>\s*$/,
+  );
+  if (functionTagMatch) {
+    const name = functionTagMatch[1];
+    let input: Record<string, unknown> = {};
+    try {
+      const parsed: unknown = JSON.parse(functionTagMatch[2]);
+      if (parsed && typeof parsed === "object") {
+        input = parsed as Record<string, unknown>;
+      }
+    } catch {
+      return null;
+    }
+    return [{ id: makeToolCallId(), name, input }];
+  }
+
+  // Must at least look like JSON from here on.
+  if (!candidate.startsWith("{") && !candidate.startsWith("[")) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(candidate);
+  } catch {
+    return null;
+  }
+
+  const asArray = Array.isArray(parsed) ? parsed : [parsed];
+  const toolCalls: AiToolCall[] = [];
+  for (const item of asArray) {
+    const tc = normalizeToolCall(item);
+    if (!tc) return null;
+    toolCalls.push(tc);
+  }
+  return toolCalls.length > 0 ? toolCalls : null;
+}
+
+function normalizeToolCall(item: unknown): AiToolCall | null {
+  if (!item || typeof item !== "object") return null;
+  const obj = item as Record<string, unknown>;
+
+  // OpenAI-ish shape: { type: "function", function: { name, arguments } }
+  if (
+    obj.type === "function" &&
+    obj.function &&
+    typeof obj.function === "object"
+  ) {
+    const fn = obj.function as Record<string, unknown>;
+    if (typeof fn.name !== "string") return null;
+    const argsRaw = fn.arguments;
+    let input: Record<string, unknown> = {};
+    if (typeof argsRaw === "string") {
+      try {
+        const a: unknown = JSON.parse(argsRaw);
+        if (a && typeof a === "object") input = a as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    } else if (argsRaw && typeof argsRaw === "object") {
+      input = argsRaw as Record<string, unknown>;
+    }
+    return { id: makeToolCallId(), name: fn.name, input };
+  }
+
+  // Llama-ish shape: { name, arguments | parameters }
+  // Or Cloudflare 70B shape: { type: "function", name, parameters }
+  if (typeof obj.name !== "string") return null;
+  const argsField = obj.arguments ?? obj.parameters;
+  let input: Record<string, unknown> = {};
+  if (typeof argsField === "string") {
+    try {
+      const a: unknown = JSON.parse(argsField);
+      if (a && typeof a === "object") input = a as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  } else if (argsField && typeof argsField === "object") {
+    input = argsField as Record<string, unknown>;
+  } else if (argsField !== undefined) {
+    return null;
+  }
+  return { id: makeToolCallId(), name: obj.name, input };
+}
+
+let toolCallCounter = 0;
+function makeToolCallId(): string {
+  toolCallCounter += 1;
+  return `call_inline_${Date.now()}_${toolCallCounter}`;
+}
+
+/**
+ * Detect whether an in-progress stream's leading text looks like it is
+ * building a tool-call blob, so we can buffer instead of surfacing raw
+ * JSON to the UI.
+ */
+function looksLikeToolCallPrefix(text: string): boolean {
+  const trimmed = text.trimStart();
+  if (!trimmed) return false;
+  return (
+    trimmed.startsWith("{") ||
+    trimmed.startsWith("[") ||
+    trimmed.startsWith("<|python_tag|>") ||
+    trimmed.startsWith("<function=")
+  );
+}
 
 export class OpenAiCompatibleProvider extends OpenAiProvider {
   override readonly name = "openai-compatible";
 
   constructor(apiKey: string, baseUrl: string, model: string) {
     super(apiKey, model, baseUrl);
+  }
+
+  override async completeWithTools(
+    request: AiCompletionRequest,
+    tools: AiToolDefinition[],
+  ): Promise<AiToolResponse> {
+    const response = await super.completeWithTools(request, tools);
+    if (response.toolCalls.length > 0) return response;
+
+    const inline = parseInlineToolCalls(response.content);
+    if (!inline) return response;
+
+    return {
+      ...response,
+      content: "",
+      toolCalls: inline,
+      stopReason: "tool_use",
+    };
+  }
+
+  override async *streamWithTools(
+    request: AiCompletionRequest,
+    tools: AiToolDefinition[],
+  ): AsyncIterable<AiToolStreamChunk> {
+    const source = super.streamWithTools!(request, tools);
+
+    // Buffer text chunks only when the leading content looks like a tool
+    // call blob. For normal text responses we still stream token-by-token.
+    const buffered: string[] = [];
+    let decided: "passthrough" | "buffer" | null = null;
+    let accumulated = "";
+
+    for await (const chunk of source) {
+      if (chunk.type === "text") {
+        accumulated += chunk.text;
+        if (decided === null) {
+          if (looksLikeToolCallPrefix(accumulated)) {
+            decided = "buffer";
+            buffered.push(chunk.text);
+          } else {
+            decided = "passthrough";
+            yield chunk;
+          }
+        } else if (decided === "buffer") {
+          buffered.push(chunk.text);
+        } else {
+          yield chunk;
+        }
+        continue;
+      }
+
+      // chunk.type === "done"
+      if (chunk.toolCalls.length > 0) {
+        // Provider already returned structured tool calls. Flush any text
+        // we buffered (unlikely to matter in practice) and pass done along.
+        if (decided === "buffer") {
+          for (const part of buffered) {
+            yield { type: "text", text: part };
+          }
+        }
+        yield chunk;
+        return;
+      }
+
+      const inline = parseInlineToolCalls(chunk.content);
+      if (inline) {
+        // Swallow the buffered JSON text; replace with synthesized tool
+        // calls so the query engine drives a proper tool loop.
+        yield {
+          type: "done",
+          content: "",
+          toolCalls: inline,
+          usage: chunk.usage,
+          model: chunk.model,
+          stopReason: "tool_use",
+        };
+        return;
+      }
+
+      // Plain text response that happened to start with `{` etc. Flush
+      // buffered text now so the UI still sees it.
+      if (decided === "buffer") {
+        for (const part of buffered) {
+          yield { type: "text", text: part };
+        }
+      }
+      yield chunk;
+      return;
+    }
+  }
+
+  /**
+   * Cloudflare Workers AI (and some other OpenAI-compatible endpoints) do not
+   * implement `GET /models`, so the default `client.models.list()` probe used
+   * by `OpenAiProvider.isAvailable()` returns 404. Use a minimal chat
+   * completion instead -- it exercises the actual code path users care about.
+   */
+  override async isAvailable(): Promise<boolean> {
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 5000);
+      try {
+        await this.client.chat.completions.create(
+          {
+            model: this.modelId,
+            messages: [{ role: "user", content: "ping" }],
+            max_tokens: 1,
+          },
+          { signal: controller.signal },
+        );
+        return true;
+      } finally {
+        clearTimeout(timeout);
+      }
+    } catch {
+      return false;
+    }
   }
 }

--- a/backend/src/ai/query/ai-query.service.ts
+++ b/backend/src/ai/query/ai-query.service.ts
@@ -402,6 +402,7 @@ export class AiQueryService {
           type: "tool_result",
           name: toolCall.name,
           summary: result.summary,
+          isError: result.isError === true,
         };
 
         // Add tool result message with sanitized string values

--- a/backend/src/ai/query/tool-definitions.spec.ts
+++ b/backend/src/ai/query/tool-definitions.spec.ts
@@ -89,7 +89,7 @@ describe("FINANCIAL_TOOLS", () => {
         string,
         Record<string, unknown>
       >;
-      expect(props.topN.type).toBe("number");
+      expect(props.topN.type).toBe("integer");
     });
   });
 

--- a/backend/src/ai/query/tool-definitions.ts
+++ b/backend/src/ai/query/tool-definitions.ts
@@ -41,7 +41,7 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
           type: "string",
           enum: ["expenses", "income", "both"],
           description:
-            "Filter by direction: 'expenses' for negative amounts, 'income' for positive, 'both' for all. Default: both.",
+            "Filter by direction. Must be EXACTLY one of: 'expenses' (outflows/spending), 'income' (inflows/earnings), or 'both' (default). Do not use 'expense', 'all', 'debit', or any variation.",
         },
       },
       required: ["startDate", "endDate"],
@@ -78,8 +78,11 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
           description: "End date (YYYY-MM-DD)",
         },
         topN: {
-          type: "number",
-          description: "Limit to top N categories by amount (default: all)",
+          type: "integer",
+          minimum: 1,
+          maximum: 50,
+          description:
+            'Optional integer between 1 and 50 to limit to the top N categories by amount. MUST be a number like 10 (not a string like "10" or "all"). Omit this field entirely to get all categories.',
         },
       },
       required: ["startDate", "endDate"],
@@ -158,7 +161,8 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
         direction: {
           type: "string",
           enum: ["expenses", "income", "both"],
-          description: "Filter by direction (default: expenses)",
+          description:
+            "Filter by direction. Must be EXACTLY one of: 'expenses' (default), 'income', or 'both'. Do not use 'expense', 'all', or any variation.",
         },
       },
       required: ["period1Start", "period1End", "period2Start", "period2End"],

--- a/backend/src/ai/query/tool-executor.service.spec.ts
+++ b/backend/src/ai/query/tool-executor.service.spec.ts
@@ -244,6 +244,7 @@ describe("ToolExecutorService", () => {
       );
       expect(result.summary).toContain("Invalid input");
       expect(result.sources).toEqual([]);
+      expect(result.isError).toBe(true);
     });
 
     it("rejects missing required fields in tool input (LLM07-F1)", async () => {

--- a/backend/src/ai/query/tool-executor.service.ts
+++ b/backend/src/ai/query/tool-executor.service.ts
@@ -28,6 +28,7 @@ interface ToolResult {
   data: unknown;
   summary: string;
   sources: Array<{ type: string; description: string; dateRange?: string }>;
+  isError?: boolean;
 }
 
 @Injectable()
@@ -68,6 +69,7 @@ export class ToolExecutorService {
         data: { error: validation.error },
         summary: `Invalid input for ${toolName}: ${validation.error}`,
         sources: [],
+        isError: true,
       };
     }
     const validatedInput = validation.data;
@@ -123,6 +125,7 @@ export class ToolExecutorService {
         data: { error: "An error occurred while retrieving data." },
         summary: `Error executing ${toolName}: unable to retrieve data.`,
         sources: [],
+        isError: true,
       };
     }
   }

--- a/backend/src/ai/query/tool-input-schemas.spec.ts
+++ b/backend/src/ai/query/tool-input-schemas.spec.ts
@@ -93,7 +93,7 @@ describe("tool-input-schemas", () => {
         accountNames: ["Checking"],
         searchText: "walmart",
         groupBy: "category",
-        direction: "expense",
+        direction: "expenses",
       });
 
       expect(result.success).toBe(true);
@@ -109,14 +109,39 @@ describe("tool-input-schemas", () => {
       expect(result.success).toBe(false);
     });
 
-    it("rejects invalid direction enum value", () => {
+    it("rejects truly unknown direction enum value", () => {
       const result = queryTransactionsSchema.safeParse({
         startDate: "2026-01-01",
         endDate: "2026-01-31",
-        direction: "credit",
+        direction: "sideways",
       });
 
       expect(result.success).toBe(false);
+    });
+
+    it("normalizes common direction aliases to canonical values", () => {
+      const cases: Array<[string, "expenses" | "income" | "both"]> = [
+        ["expense", "expenses"],
+        ["spending", "expenses"],
+        ["debit", "expenses"],
+        ["EXPENSES", "expenses"],
+        ["earnings", "income"],
+        ["revenue", "income"],
+        ["credit", "income"],
+        ["all", "both"],
+        ["any", "both"],
+      ];
+      for (const [input, expected] of cases) {
+        const result = queryTransactionsSchema.safeParse({
+          startDate: "2026-01-01",
+          endDate: "2026-01-31",
+          direction: input,
+        });
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.direction).toBe(expected);
+        }
+      }
     });
   });
 
@@ -173,6 +198,27 @@ describe("tool-input-schemas", () => {
         startDate: "2026-01-01",
         endDate: "2026-01-31",
         topN: 0,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("coerces numeric string topN to integer", () => {
+      const result = getSpendingByCategorySchema.safeParse({
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+        topN: "10",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.topN).toBe(10);
+      }
+    });
+
+    it("rejects non-numeric string topN like 'all'", () => {
+      const result = getSpendingByCategorySchema.safeParse({
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+        topN: "all",
       });
       expect(result.success).toBe(false);
     });

--- a/backend/src/ai/query/tool-input-schemas.ts
+++ b/backend/src/ai/query/tool-input-schemas.ts
@@ -9,6 +9,54 @@ import { z } from "zod";
 
 const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/;
 
+/**
+ * Direction normalization. The model often sends variants of the same concept
+ * (e.g. "expense" vs "expenses", "all" vs "both"). Normalize these at the
+ * schema boundary so the tool executor gets a consistent canonical value and
+ * the user doesn't see a failed-tool-call for a cosmetic difference.
+ *
+ * Canonical values: "expenses" | "income" | "both"
+ */
+const directionSchema = z.preprocess(
+  (val) => {
+    if (typeof val !== "string") return val;
+    const normalized = val.toLowerCase().trim();
+    // Aliases the model tends to produce.
+    const aliases: Record<string, string> = {
+      expense: "expenses",
+      expenditure: "expenses",
+      expenditures: "expenses",
+      spending: "expenses",
+      out: "expenses",
+      outgoing: "expenses",
+      debit: "expenses",
+      debits: "expenses",
+      earnings: "income",
+      revenue: "income",
+      in: "income",
+      incoming: "income",
+      credit: "income",
+      credits: "income",
+      all: "both",
+      any: "both",
+    };
+    return aliases[normalized] ?? normalized;
+  },
+  z.enum(["expenses", "income", "both"]),
+);
+
+/**
+ * Integer coercion from string. The model sometimes sends topN as "5" or even
+ * "all" (which should be omitted). We coerce clean numeric strings and let
+ * non-numeric values fail validation so the model gets a clear error.
+ */
+const positiveIntSchema = (min: number, max: number) =>
+  z.preprocess(
+    (val) =>
+      typeof val === "string" && /^-?\d+$/.test(val) ? Number(val) : val,
+    z.number().int().min(min).max(max),
+  );
+
 export const queryTransactionsSchema = z.object({
   startDate: z.string().regex(isoDateRegex, "Expected YYYY-MM-DD"),
   endDate: z.string().regex(isoDateRegex, "Expected YYYY-MM-DD"),
@@ -16,7 +64,7 @@ export const queryTransactionsSchema = z.object({
   accountNames: z.array(z.string().max(100)).optional(),
   searchText: z.string().max(200).optional(),
   groupBy: z.enum(["category", "payee", "month", "week"]).optional(),
-  direction: z.enum(["income", "expense", "both"]).optional(),
+  direction: directionSchema.optional(),
 });
 
 export const getAccountBalancesSchema = z.object({
@@ -26,7 +74,7 @@ export const getAccountBalancesSchema = z.object({
 export const getSpendingByCategorySchema = z.object({
   startDate: z.string().regex(isoDateRegex, "Expected YYYY-MM-DD"),
   endDate: z.string().regex(isoDateRegex, "Expected YYYY-MM-DD"),
-  topN: z.number().int().min(1).max(50).optional(),
+  topN: positiveIntSchema(1, 50).optional(),
 });
 
 export const getIncomeSummarySchema = z.object({
@@ -46,7 +94,7 @@ export const comparePeriodsSchema = z.object({
   period2Start: z.string().regex(isoDateRegex, "Expected YYYY-MM-DD"),
   period2End: z.string().regex(isoDateRegex, "Expected YYYY-MM-DD"),
   groupBy: z.enum(["category", "payee"]).optional(),
-  direction: z.enum(["expenses", "income", "all"]).optional(),
+  direction: directionSchema.optional(),
 });
 
 export const getBudgetStatusSchema = z.object({

--- a/frontend/src/components/ai/ChatInterface.tsx
+++ b/frontend/src/components/ai/ChatInterface.tsx
@@ -149,10 +149,14 @@ export function ChatInterface() {
             case 'tool_result': {
               // Backfill the summary onto the most recent matching tool entry
               // (model can call the same tool multiple times in a query).
-              for (let i = toolsUsed.length - 1; i >= 0; i--) {
+              // Find the first entry (by call order) matching the name that
+              // hasn't been resolved yet — this is the call this result
+              // belongs to.
+              for (let i = 0; i < toolsUsed.length; i++) {
                 if (
                   toolsUsed[i].name === event.name &&
-                  !toolsUsed[i].summary
+                  !toolsUsed[i].summary &&
+                  toolsUsed[i].isError === undefined
                 ) {
                   toolsUsed[i] = {
                     ...toolsUsed[i],
@@ -162,19 +166,31 @@ export function ChatInterface() {
                   break;
                 }
               }
-              setThinking((prev) => ({
-                ...prev,
-                tools: prev.tools.map((t) =>
-                  t.name === event.name
-                    ? {
+              setThinking((prev) => {
+                // Update only the first still-running tool with this name so
+                // repeated calls to the same tool don't overwrite each
+                // other's pass/fail state.
+                let updated = false;
+                return {
+                  ...prev,
+                  tools: prev.tools.map((t) => {
+                    if (
+                      !updated &&
+                      t.name === event.name &&
+                      t.status === 'running'
+                    ) {
+                      updated = true;
+                      return {
                         ...t,
                         status: 'done',
                         summary: event.summary,
                         isError: event.isError === true,
-                      }
-                    : t,
-                ),
-              }));
+                      };
+                    }
+                    return t;
+                  }),
+                };
+              });
               break;
             }
 

--- a/frontend/src/components/ai/ChatInterface.tsx
+++ b/frontend/src/components/ai/ChatInterface.tsx
@@ -12,6 +12,7 @@ interface ToolCallRecord {
   name: string;
   summary: string;
   input?: Record<string, unknown>;
+  isError?: boolean;
 }
 
 interface Message {
@@ -31,7 +32,12 @@ interface ThinkingState {
   // backend emits assistant_text deltas. Reset on each new tool_start so the
   // user sees the next "thinking" pass cleanly.
   liveText: string;
-  tools: Array<{ name: string; status: 'running' | 'done'; summary?: string }>;
+  tools: Array<{
+    name: string;
+    status: 'running' | 'done';
+    summary?: string;
+    isError?: boolean;
+  }>;
 }
 
 export function ChatInterface() {
@@ -151,6 +157,7 @@ export function ChatInterface() {
                   toolsUsed[i] = {
                     ...toolsUsed[i],
                     summary: event.summary || '',
+                    isError: event.isError === true,
                   };
                   break;
                 }
@@ -159,7 +166,12 @@ export function ChatInterface() {
                 ...prev,
                 tools: prev.tools.map((t) =>
                   t.name === event.name
-                    ? { ...t, status: 'done', summary: event.summary }
+                    ? {
+                        ...t,
+                        status: 'done',
+                        summary: event.summary,
+                        isError: event.isError === true,
+                      }
                     : t,
                 ),
               }));
@@ -381,6 +393,20 @@ export function ChatInterface() {
                                   className="opacity-75"
                                   fill="currentColor"
                                   d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                                />
+                              </svg>
+                            ) : tool.isError ? (
+                              <svg
+                                className="w-3 h-3 text-red-500"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                strokeWidth={2}
+                                stroke="currentColor"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M6 18L18 6M6 6l12 12"
                                 />
                               </svg>
                             ) : (

--- a/frontend/src/components/ai/ChatMessage.test.tsx
+++ b/frontend/src/components/ai/ChatMessage.test.tsx
@@ -114,6 +114,39 @@ describe('ChatMessage', () => {
       expect(screen.getByText('unknown_tool')).toBeInTheDocument();
     });
 
+    it('shows a success checkmark by default', () => {
+      render(
+        <ChatMessage
+          role="assistant"
+          content="ok"
+          toolsUsed={[{ name: 'query_transactions', summary: 'Found 1' }]}
+        />,
+      );
+      expect(screen.getByLabelText('Tool succeeded')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Tool failed')).not.toBeInTheDocument();
+    });
+
+    it('shows a red X and red-themed container when the tool errored', () => {
+      const { container } = render(
+        <ChatMessage
+          role="assistant"
+          content="ok"
+          toolsUsed={[
+            {
+              name: 'query_transactions',
+              summary: 'Invalid input for query_transactions: ...',
+              isError: true,
+            },
+          ]}
+        />,
+      );
+      expect(screen.getByLabelText('Tool failed')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Tool succeeded')).not.toBeInTheDocument();
+      // The surrounding container uses the red theme.
+      const errored = container.querySelector('.border-red-200');
+      expect(errored).not.toBeNull();
+    });
+
     it('renders all known tool labels correctly', () => {
       const tools = [
         { name: 'query_transactions', expected: 'Transactions' },

--- a/frontend/src/components/ai/ChatMessage.tsx
+++ b/frontend/src/components/ai/ChatMessage.tsx
@@ -6,6 +6,7 @@ interface ToolInfo {
   name: string;
   summary: string;
   input?: Record<string, unknown>;
+  isError?: boolean;
 }
 
 interface SourceInfo {
@@ -39,30 +40,64 @@ function ToolDetails({ tool }: { tool: ToolInfo }) {
   const hasInput = tool.input && Object.keys(tool.input).length > 0;
   const hasSummary = !!tool.summary;
   const hasDetails = hasInput || hasSummary;
+  const isError = !!tool.isError;
+
+  const containerClasses = isError
+    ? 'rounded-lg border border-red-200 dark:border-red-900/50 bg-red-50/60 dark:bg-red-900/20 overflow-hidden'
+    : 'rounded-lg border border-blue-100 dark:border-blue-900/50 bg-blue-50/60 dark:bg-blue-900/20 overflow-hidden';
+  const buttonClasses = isError
+    ? 'w-full flex items-center justify-between gap-2 px-2.5 py-1.5 text-left text-xs text-red-700 dark:text-red-300 hover:bg-red-100/60 dark:hover:bg-red-900/30 disabled:cursor-default disabled:hover:bg-transparent transition-colors'
+    : 'w-full flex items-center justify-between gap-2 px-2.5 py-1.5 text-left text-xs text-blue-700 dark:text-blue-300 hover:bg-blue-100/60 dark:hover:bg-blue-900/30 disabled:cursor-default disabled:hover:bg-transparent transition-colors';
+  const detailsClasses = isError
+    ? 'border-t border-red-200 dark:border-red-900/50 px-2.5 py-2 space-y-2 bg-white/40 dark:bg-black/20'
+    : 'border-t border-blue-100 dark:border-blue-900/50 px-2.5 py-2 space-y-2 bg-white/40 dark:bg-black/20';
+  const labelClasses = isError
+    ? 'text-[10px] uppercase tracking-wide text-red-600 dark:text-red-400 font-semibold mb-0.5'
+    : 'text-[10px] uppercase tracking-wide text-blue-600 dark:text-blue-400 font-semibold mb-0.5';
 
   return (
-    <div className="rounded-lg border border-blue-100 dark:border-blue-900/50 bg-blue-50/60 dark:bg-blue-900/20 overflow-hidden">
+    <div className={containerClasses}>
       <button
         type="button"
         onClick={() => hasDetails && setExpanded((v) => !v)}
         disabled={!hasDetails}
         aria-expanded={expanded}
-        className="w-full flex items-center justify-between gap-2 px-2.5 py-1.5 text-left text-xs text-blue-700 dark:text-blue-300 hover:bg-blue-100/60 dark:hover:bg-blue-900/30 disabled:cursor-default disabled:hover:bg-transparent transition-colors"
+        className={buttonClasses}
       >
         <span className="flex items-center gap-1.5 min-w-0">
-          <svg
-            className="w-3 h-3 flex-shrink-0"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={2}
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M4.5 12.75l6 6 9-13.5"
-            />
-          </svg>
+          {isError ? (
+            <svg
+              className="w-3 h-3 flex-shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              aria-label="Tool failed"
+              role="img"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          ) : (
+            <svg
+              className="w-3 h-3 flex-shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              aria-label="Tool succeeded"
+              role="img"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M4.5 12.75l6 6 9-13.5"
+              />
+            </svg>
+          )}
           <span className="font-medium truncate">{label}</span>
         </span>
         {hasDetails && (
@@ -82,12 +117,10 @@ function ToolDetails({ tool }: { tool: ToolInfo }) {
         )}
       </button>
       {expanded && hasDetails && (
-        <div className="border-t border-blue-100 dark:border-blue-900/50 px-2.5 py-2 space-y-2 bg-white/40 dark:bg-black/20">
+        <div className={detailsClasses}>
           {hasInput && (
             <div>
-              <div className="text-[10px] uppercase tracking-wide text-blue-600 dark:text-blue-400 font-semibold mb-0.5">
-                Input
-              </div>
+              <div className={labelClasses}>Input</div>
               <pre className="text-[11px] text-gray-700 dark:text-gray-200 whitespace-pre-wrap break-words font-mono">
                 {JSON.stringify(tool.input, null, 2)}
               </pre>
@@ -95,9 +128,7 @@ function ToolDetails({ tool }: { tool: ToolInfo }) {
           )}
           {hasSummary && (
             <div>
-              <div className="text-[10px] uppercase tracking-wide text-blue-600 dark:text-blue-400 font-semibold mb-0.5">
-                Result
-              </div>
+              <div className={labelClasses}>Result</div>
               <p className="text-[11px] text-gray-700 dark:text-gray-200 whitespace-pre-wrap break-words">
                 {tool.summary}
               </p>

--- a/frontend/src/types/ai.ts
+++ b/frontend/src/types/ai.ts
@@ -114,6 +114,9 @@ export interface StreamEvent {
   description?: string;
   summary?: string;
   text?: string;
+  // Set on `tool_result` when the tool failed (validation error, exception, etc.)
+  // The UI uses this to render a red X instead of a green checkmark.
+  isError?: boolean;
   // Tool arguments the model passed to the tool. Present on tool_start so
   // the UI can show the user what the model actually queried for.
   input?: Record<string, unknown>;


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for parsing inline JSON tool calls from OpenAI-compatible providers (like Cloudflare Workers AI and Llama-based backends) that emit tool calls as text content rather than structured `tool_calls` fields.

## Key Changes

- **Added `parseInlineToolCalls()` function**: Tolerantly parses multiple JSON tool call formats emitted by different backends:
  - Llama 3.x shape with `arguments` field
  - Cloudflare 70B shape with `type: "function"` and `parameters`
  - OpenAI-style nested `function` objects
  - Handles wrapper formats like `<|python_tag|>` and `<function=name>...</function>`
  - Supports both single objects and arrays of tool calls

- **Added `flattenToolMessages()` function**: Converts tool-call and tool-result messages into plain text representations since some backends reject structured `tool_calls` fields and `role: "tool"` messages:
  - Serializes assistant `toolCalls` into JSON format
  - Converts tool result messages into user messages with descriptive text
  - Preserves assistant content alongside tool calls

- **Enhanced `completeWithTools()` override**: 
  - Flattens messages before sending to the provider
  - Attempts to parse inline tool calls from response content when structured calls aren't present
  - Returns proper `AiToolResponse` with parsed tool calls and `stopReason: "tool_use"`

- **Enhanced `streamWithTools()` override**:
  - Buffers text chunks when content looks like a tool call blob (starts with `{`, `[`, or known wrappers)
  - Streams plain text normally without buffering
  - Flushes buffered content if it doesn't parse as a valid tool call
  - Synthesizes tool calls from inline JSON on stream completion

- **Improved `isAvailable()` probe**: Uses `chat.completions.create()` instead of `models.list()` since many OpenAI-compatible endpoints don't implement the models endpoint

## Implementation Details

- Tool call IDs are generated with a timestamp-based format (`call_inline_<timestamp>_<counter>`) for inline calls
- The implementation is conservative about wrapper detection to avoid false positives
- Buffering logic ensures JSON-looking content that isn't a tool call is still surfaced to the UI
- All message flattening is done before sending to the provider to ensure compatibility

https://claude.ai/code/session_01HZaiCFYgXWtZXpVZ7dLh3y