### PR TITLE
Add AI provider cost tracking and estimated usage cost calculation

### DIFF
--- a/backend/src/ai/ai-usage.service.spec.ts
+++ b/backend/src/ai/ai-usage.service.spec.ts
@@ -2,10 +2,12 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { getRepositoryToken } from "@nestjs/typeorm";
 import { AiUsageService } from "./ai-usage.service";
 import { AiUsageLog } from "./entities/ai-usage-log.entity";
+import { AiProviderConfig } from "./entities/ai-provider-config.entity";
 
 describe("AiUsageService", () => {
   let service: AiUsageService;
   let mockRepository: Record<string, jest.Mock>;
+  let mockConfigRepository: Record<string, jest.Mock>;
 
   const mockQueryBuilder = {
     select: jest.fn().mockReturnThis(),
@@ -13,6 +15,7 @@ describe("AiUsageService", () => {
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
     groupBy: jest.fn().mockReturnThis(),
+    addGroupBy: jest.fn().mockReturnThis(),
     getRawMany: jest.fn().mockResolvedValue([]),
     getRawOne: jest.fn().mockResolvedValue({
       totalRequests: "0",
@@ -38,12 +41,20 @@ describe("AiUsageService", () => {
       createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
     };
 
+    mockConfigRepository = {
+      find: jest.fn().mockResolvedValue([]),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AiUsageService,
         {
           provide: getRepositoryToken(AiUsageLog),
           useValue: mockRepository,
+        },
+        {
+          provide: getRepositoryToken(AiProviderConfig),
+          useValue: mockConfigRepository,
         },
       ],
     }).compile();
@@ -105,6 +116,7 @@ describe("AiUsageService", () => {
         totalRequests: 0,
         totalInputTokens: 0,
         totalOutputTokens: 0,
+        totalEstimatedCost: null,
         byProvider: [],
         byFeature: [],
         recentLogs: [],
@@ -141,6 +153,7 @@ describe("AiUsageService", () => {
         inputTokens: 100,
         outputTokens: 50,
         durationMs: 1200,
+        estimatedCost: null,
         createdAt: "2024-06-15T12:00:00.000Z",
       });
     });
@@ -150,6 +163,7 @@ describe("AiUsageService", () => {
         .mockResolvedValueOnce([
           {
             provider: "anthropic",
+            model: "claude-sonnet-4-20250514",
             requests: "5",
             inputTokens: "500",
             outputTokens: "250",
@@ -158,6 +172,8 @@ describe("AiUsageService", () => {
         .mockResolvedValueOnce([
           {
             feature: "categorize",
+            provider: "anthropic",
+            model: "claude-sonnet-4-20250514",
             requests: "3",
             inputTokens: "300",
             outputTokens: "150",
@@ -174,12 +190,14 @@ describe("AiUsageService", () => {
       expect(summary.totalRequests).toBe(5);
       expect(summary.totalInputTokens).toBe(500);
       expect(summary.totalOutputTokens).toBe(250);
+      expect(summary.totalEstimatedCost).toBeNull();
       expect(summary.byProvider).toEqual([
         {
           provider: "anthropic",
           requests: 5,
           inputTokens: 500,
           outputTokens: 250,
+          estimatedCost: null,
         },
       ]);
       expect(summary.byFeature).toEqual([
@@ -188,8 +206,84 @@ describe("AiUsageService", () => {
           requests: 3,
           inputTokens: 300,
           outputTokens: 150,
+          estimatedCost: null,
         },
       ]);
+    });
+
+    it("computes estimated cost from configured rates", async () => {
+      // User configured Anthropic Sonnet with $3 input / $15 output per 1M tokens.
+      mockConfigRepository.find.mockResolvedValueOnce([
+        {
+          provider: "anthropic",
+          model: "claude-sonnet-4-20250514",
+          inputCostPer1M: 3,
+          outputCostPer1M: 15,
+        },
+      ]);
+      mockQueryBuilder.getRawMany
+        .mockResolvedValueOnce([
+          {
+            provider: "anthropic",
+            model: "claude-sonnet-4-20250514",
+            requests: "2",
+            // 1,000,000 input tokens * $3 + 500,000 output tokens * $15 / 1M = $3 + $7.5 = $10.5
+            inputTokens: "1000000",
+            outputTokens: "500000",
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      mockQueryBuilder.getRawOne.mockResolvedValueOnce({
+        totalRequests: "2",
+        totalInputTokens: "1000000",
+        totalOutputTokens: "500000",
+      });
+      mockRepository.find.mockResolvedValueOnce([
+        {
+          id: "log-1",
+          provider: "anthropic",
+          model: "claude-sonnet-4-20250514",
+          feature: "query",
+          inputTokens: 1000000,
+          outputTokens: 500000,
+          durationMs: 1200,
+          createdAt: new Date("2024-06-15T12:00:00Z"),
+        },
+      ]);
+
+      const summary = await service.getUsageSummary("user-1");
+
+      expect(summary.totalEstimatedCost).toBe(10.5);
+      expect(summary.byProvider[0].estimatedCost).toBe(10.5);
+      expect(summary.recentLogs[0].estimatedCost).toBe(10.5);
+    });
+
+    it("returns null cost when provider/model has no configured rate", async () => {
+      mockConfigRepository.find.mockResolvedValueOnce([
+        {
+          provider: "anthropic",
+          model: "claude-opus-4-20250514",
+          inputCostPer1M: 15,
+          outputCostPer1M: 75,
+        },
+      ]);
+      // Log uses a different model than the configured one -- no match, no cost.
+      mockQueryBuilder.getRawMany
+        .mockResolvedValueOnce([
+          {
+            provider: "anthropic",
+            model: "claude-sonnet-4-20250514",
+            requests: "1",
+            inputTokens: "1000",
+            outputTokens: "500",
+          },
+        ])
+        .mockResolvedValueOnce([]);
+
+      const summary = await service.getUsageSummary("user-1");
+
+      expect(summary.totalEstimatedCost).toBeNull();
+      expect(summary.byProvider[0].estimatedCost).toBeNull();
     });
   });
 

--- a/backend/src/ai/ai-usage.service.spec.ts
+++ b/backend/src/ai/ai-usage.service.spec.ts
@@ -116,7 +116,7 @@ describe("AiUsageService", () => {
         totalRequests: 0,
         totalInputTokens: 0,
         totalOutputTokens: 0,
-        totalEstimatedCost: null,
+        totalEstimatedCostByCurrency: {},
         byProvider: [],
         byFeature: [],
         recentLogs: [],
@@ -154,6 +154,7 @@ describe("AiUsageService", () => {
         outputTokens: 50,
         durationMs: 1200,
         estimatedCost: null,
+        costCurrency: null,
         createdAt: "2024-06-15T12:00:00.000Z",
       });
     });
@@ -190,14 +191,14 @@ describe("AiUsageService", () => {
       expect(summary.totalRequests).toBe(5);
       expect(summary.totalInputTokens).toBe(500);
       expect(summary.totalOutputTokens).toBe(250);
-      expect(summary.totalEstimatedCost).toBeNull();
+      expect(summary.totalEstimatedCostByCurrency).toEqual({});
       expect(summary.byProvider).toEqual([
         {
           provider: "anthropic",
           requests: 5,
           inputTokens: 500,
           outputTokens: 250,
-          estimatedCost: null,
+          estimatedCostByCurrency: {},
         },
       ]);
       expect(summary.byFeature).toEqual([
@@ -206,7 +207,7 @@ describe("AiUsageService", () => {
           requests: 3,
           inputTokens: 300,
           outputTokens: 150,
-          estimatedCost: null,
+          estimatedCostByCurrency: {},
         },
       ]);
     });
@@ -219,6 +220,7 @@ describe("AiUsageService", () => {
           model: "claude-sonnet-4-20250514",
           inputCostPer1M: 3,
           outputCostPer1M: 15,
+          costCurrency: "USD",
         },
       ]);
       mockQueryBuilder.getRawMany
@@ -253,18 +255,69 @@ describe("AiUsageService", () => {
 
       const summary = await service.getUsageSummary("user-1");
 
-      expect(summary.totalEstimatedCost).toBe(10.5);
-      expect(summary.byProvider[0].estimatedCost).toBe(10.5);
+      expect(summary.totalEstimatedCostByCurrency).toEqual({ USD: 10.5 });
+      expect(summary.byProvider[0].estimatedCostByCurrency).toEqual({
+        USD: 10.5,
+      });
       expect(summary.recentLogs[0].estimatedCost).toBe(10.5);
+      expect(summary.recentLogs[0].costCurrency).toBe("USD");
     });
 
-    it("returns null cost when provider/model has no configured rate", async () => {
+    it("buckets estimated cost by configured rate currency", async () => {
+      // Two configs with different billing currencies -- costs should not merge.
+      mockConfigRepository.find.mockResolvedValueOnce([
+        {
+          provider: "anthropic",
+          model: "claude-sonnet-4-20250514",
+          inputCostPer1M: 3,
+          outputCostPer1M: 15,
+          costCurrency: "USD",
+        },
+        {
+          provider: "openai",
+          model: "gpt-4o",
+          inputCostPer1M: 2,
+          outputCostPer1M: 8,
+          costCurrency: "EUR",
+        },
+      ]);
+      mockQueryBuilder.getRawMany
+        .mockResolvedValueOnce([
+          {
+            provider: "anthropic",
+            model: "claude-sonnet-4-20250514",
+            requests: "1",
+            // 1M input * $3 + 0 = $3
+            inputTokens: "1000000",
+            outputTokens: "0",
+          },
+          {
+            provider: "openai",
+            model: "gpt-4o",
+            requests: "1",
+            // 1M input * €2 + 0 = €2
+            inputTokens: "1000000",
+            outputTokens: "0",
+          },
+        ])
+        .mockResolvedValueOnce([]);
+
+      const summary = await service.getUsageSummary("user-1");
+
+      expect(summary.totalEstimatedCostByCurrency).toEqual({
+        USD: 3,
+        EUR: 2,
+      });
+    });
+
+    it("returns empty bucket when provider/model has no configured rate", async () => {
       mockConfigRepository.find.mockResolvedValueOnce([
         {
           provider: "anthropic",
           model: "claude-opus-4-20250514",
           inputCostPer1M: 15,
           outputCostPer1M: 75,
+          costCurrency: "USD",
         },
       ]);
       // Log uses a different model than the configured one -- no match, no cost.
@@ -282,8 +335,8 @@ describe("AiUsageService", () => {
 
       const summary = await service.getUsageSummary("user-1");
 
-      expect(summary.totalEstimatedCost).toBeNull();
-      expect(summary.byProvider[0].estimatedCost).toBeNull();
+      expect(summary.totalEstimatedCostByCurrency).toEqual({});
+      expect(summary.byProvider[0].estimatedCostByCurrency).toEqual({});
     });
   });
 

--- a/backend/src/ai/ai-usage.service.ts
+++ b/backend/src/ai/ai-usage.service.ts
@@ -3,7 +3,39 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { LessThan, Repository } from "typeorm";
 import { Cron } from "@nestjs/schedule";
 import { AiUsageLog } from "./entities/ai-usage-log.entity";
+import { AiProviderConfig } from "./entities/ai-provider-config.entity";
 import { AiUsageSummary } from "./dto/ai-response.dto";
+
+interface CostRate {
+  inputCostPer1M: number | null;
+  outputCostPer1M: number | null;
+}
+
+const TOKENS_PER_UNIT = 1_000_000;
+
+function rateKey(provider: string, model: string | null): string {
+  return `${provider}::${model ?? ""}`;
+}
+
+function computeCost(
+  inputTokens: number,
+  outputTokens: number,
+  rate: CostRate | undefined,
+): number | null {
+  if (!rate) return null;
+  if (rate.inputCostPer1M === null && rate.outputCostPer1M === null) {
+    return null;
+  }
+  const inputCost =
+    rate.inputCostPer1M !== null
+      ? (inputTokens / TOKENS_PER_UNIT) * rate.inputCostPer1M
+      : 0;
+  const outputCost =
+    rate.outputCostPer1M !== null
+      ? (outputTokens / TOKENS_PER_UNIT) * rate.outputCostPer1M
+      : 0;
+  return Math.round((inputCost + outputCost) * 10000) / 10000;
+}
 
 interface LogUsageParams {
   userId: string;
@@ -23,6 +55,8 @@ export class AiUsageService {
   constructor(
     @InjectRepository(AiUsageLog)
     private readonly usageLogRepository: Repository<AiUsageLog>,
+    @InjectRepository(AiProviderConfig)
+    private readonly providerConfigRepository: Repository<AiProviderConfig>,
   ) {}
 
   @Cron("0 4 * * *")
@@ -64,85 +98,208 @@ export class AiUsageService {
     userId: string,
     days?: number,
   ): Promise<AiUsageSummary> {
-    const qb = this.usageLogRepository
-      .createQueryBuilder("log")
-      .where("log.user_id = :userId", { userId });
+    const [byProviderModel, byFeatureModel, recentLogs, totals, userConfigs] =
+      await Promise.all([
+        // Group by provider AND model so we can look up per-model cost rates.
+        this.usageLogRepository
+          .createQueryBuilder("log")
+          .select("log.provider", "provider")
+          .addSelect("log.model", "model")
+          .addSelect("COUNT(*)", "requests")
+          .addSelect("SUM(log.input_tokens)", "inputTokens")
+          .addSelect("SUM(log.output_tokens)", "outputTokens")
+          .where("log.user_id = :userId", { userId })
+          .andWhere(
+            days
+              ? "log.created_at >= NOW() - make_interval(days => :days)"
+              : "1=1",
+            { days },
+          )
+          .groupBy("log.provider")
+          .addGroupBy("log.model")
+          .getRawMany(),
 
-    if (days) {
-      qb.andWhere("log.created_at >= NOW() - make_interval(days => :days)", {
-        days,
+        this.usageLogRepository
+          .createQueryBuilder("log")
+          .select("log.feature", "feature")
+          .addSelect("log.provider", "provider")
+          .addSelect("log.model", "model")
+          .addSelect("COUNT(*)", "requests")
+          .addSelect("SUM(log.input_tokens)", "inputTokens")
+          .addSelect("SUM(log.output_tokens)", "outputTokens")
+          .where("log.user_id = :userId", { userId })
+          .andWhere(
+            days
+              ? "log.created_at >= NOW() - make_interval(days => :days)"
+              : "1=1",
+            { days },
+          )
+          .groupBy("log.feature")
+          .addGroupBy("log.provider")
+          .addGroupBy("log.model")
+          .getRawMany(),
+
+        this.usageLogRepository.find({
+          where: { userId },
+          order: { createdAt: "DESC" },
+          take: 20,
+        }),
+
+        this.usageLogRepository
+          .createQueryBuilder("log")
+          .select("COUNT(*)", "totalRequests")
+          .addSelect("COALESCE(SUM(log.input_tokens), 0)", "totalInputTokens")
+          .addSelect("COALESCE(SUM(log.output_tokens), 0)", "totalOutputTokens")
+          .where("log.user_id = :userId", { userId })
+          .andWhere(
+            days
+              ? "log.created_at >= NOW() - make_interval(days => :days)"
+              : "1=1",
+            { days },
+          )
+          .getRawOne(),
+
+        this.providerConfigRepository.find({
+          where: { userId },
+          select: [
+            "provider",
+            "model",
+            "inputCostPer1M",
+            "outputCostPer1M",
+          ] as (keyof AiProviderConfig)[],
+        }),
+      ]);
+
+    // Build (provider, model) -> rate lookup from the user's configured providers.
+    const rateMap = new Map<string, CostRate>();
+    for (const cfg of userConfigs) {
+      rateMap.set(rateKey(cfg.provider, cfg.model), {
+        inputCostPer1M: cfg.inputCostPer1M,
+        outputCostPer1M: cfg.outputCostPer1M,
       });
     }
 
-    const [byProvider, byFeature, recentLogs, totals] = await Promise.all([
-      this.usageLogRepository
-        .createQueryBuilder("log")
-        .select("log.provider", "provider")
-        .addSelect("COUNT(*)", "requests")
-        .addSelect("SUM(log.input_tokens)", "inputTokens")
-        .addSelect("SUM(log.output_tokens)", "outputTokens")
-        .where("log.user_id = :userId", { userId })
-        .andWhere(
-          days
-            ? "log.created_at >= NOW() - make_interval(days => :days)"
-            : "1=1",
-          { days },
-        )
-        .groupBy("log.provider")
-        .getRawMany(),
+    // Collapse (provider, model) aggregates into byProvider, summing cost
+    // across models. If no logs under a provider match a rate, cost stays null.
+    const providerAgg = new Map<
+      string,
+      {
+        provider: string;
+        requests: number;
+        inputTokens: number;
+        outputTokens: number;
+        cost: number;
+        hasCost: boolean;
+      }
+    >();
 
-      this.usageLogRepository
-        .createQueryBuilder("log")
-        .select("log.feature", "feature")
-        .addSelect("COUNT(*)", "requests")
-        .addSelect("SUM(log.input_tokens)", "inputTokens")
-        .addSelect("SUM(log.output_tokens)", "outputTokens")
-        .where("log.user_id = :userId", { userId })
-        .andWhere(
-          days
-            ? "log.created_at >= NOW() - make_interval(days => :days)"
-            : "1=1",
-          { days },
-        )
-        .groupBy("log.feature")
-        .getRawMany(),
+    for (const row of byProviderModel as Record<string, string | null>[]) {
+      const provider = row.provider as string;
+      const model = row.model as string | null;
+      const requests = parseInt(row.requests as string, 10) || 0;
+      const inputTokens = parseInt(row.inputTokens as string, 10) || 0;
+      const outputTokens = parseInt(row.outputTokens as string, 10) || 0;
+      const rate = rateMap.get(rateKey(provider, model));
+      const cost = computeCost(inputTokens, outputTokens, rate);
 
-      this.usageLogRepository.find({
-        where: { userId },
-        order: { createdAt: "DESC" },
-        take: 20,
-      }),
+      const existing = providerAgg.get(provider);
+      if (existing) {
+        existing.requests += requests;
+        existing.inputTokens += inputTokens;
+        existing.outputTokens += outputTokens;
+        if (cost !== null) {
+          existing.cost += cost;
+          existing.hasCost = true;
+        }
+      } else {
+        providerAgg.set(provider, {
+          provider,
+          requests,
+          inputTokens,
+          outputTokens,
+          cost: cost ?? 0,
+          hasCost: cost !== null,
+        });
+      }
+    }
 
-      this.usageLogRepository
-        .createQueryBuilder("log")
-        .select("COUNT(*)", "totalRequests")
-        .addSelect("COALESCE(SUM(log.input_tokens), 0)", "totalInputTokens")
-        .addSelect("COALESCE(SUM(log.output_tokens), 0)", "totalOutputTokens")
-        .where("log.user_id = :userId", { userId })
-        .andWhere(
-          days
-            ? "log.created_at >= NOW() - make_interval(days => :days)"
-            : "1=1",
-          { days },
-        )
-        .getRawOne(),
-    ]);
+    // Same pattern for byFeature.
+    const featureAgg = new Map<
+      string,
+      {
+        feature: string;
+        requests: number;
+        inputTokens: number;
+        outputTokens: number;
+        cost: number;
+        hasCost: boolean;
+      }
+    >();
+
+    for (const row of byFeatureModel as Record<string, string | null>[]) {
+      const feature = row.feature as string;
+      const provider = row.provider as string;
+      const model = row.model as string | null;
+      const requests = parseInt(row.requests as string, 10) || 0;
+      const inputTokens = parseInt(row.inputTokens as string, 10) || 0;
+      const outputTokens = parseInt(row.outputTokens as string, 10) || 0;
+      const rate = rateMap.get(rateKey(provider, model));
+      const cost = computeCost(inputTokens, outputTokens, rate);
+
+      const existing = featureAgg.get(feature);
+      if (existing) {
+        existing.requests += requests;
+        existing.inputTokens += inputTokens;
+        existing.outputTokens += outputTokens;
+        if (cost !== null) {
+          existing.cost += cost;
+          existing.hasCost = true;
+        }
+      } else {
+        featureAgg.set(feature, {
+          feature,
+          requests,
+          inputTokens,
+          outputTokens,
+          cost: cost ?? 0,
+          hasCost: cost !== null,
+        });
+      }
+    }
+
+    // Compute total estimated cost by summing per-provider costs.
+    let totalEstimatedCost: number | null = null;
+    for (const agg of providerAgg.values()) {
+      if (agg.hasCost) {
+        totalEstimatedCost = (totalEstimatedCost ?? 0) + agg.cost;
+      }
+    }
+    if (totalEstimatedCost !== null) {
+      totalEstimatedCost = Math.round(totalEstimatedCost * 10000) / 10000;
+    }
 
     return {
       totalRequests: parseInt(totals.totalRequests, 10) || 0,
       totalInputTokens: parseInt(totals.totalInputTokens, 10) || 0,
       totalOutputTokens: parseInt(totals.totalOutputTokens, 10) || 0,
-      byProvider: byProvider.map((row: Record<string, string>) => ({
-        provider: row.provider,
-        requests: parseInt(row.requests, 10) || 0,
-        inputTokens: parseInt(row.inputTokens, 10) || 0,
-        outputTokens: parseInt(row.outputTokens, 10) || 0,
+      totalEstimatedCost,
+      byProvider: Array.from(providerAgg.values()).map((agg) => ({
+        provider: agg.provider,
+        requests: agg.requests,
+        inputTokens: agg.inputTokens,
+        outputTokens: agg.outputTokens,
+        estimatedCost: agg.hasCost
+          ? Math.round(agg.cost * 10000) / 10000
+          : null,
       })),
-      byFeature: byFeature.map((row: Record<string, string>) => ({
-        feature: row.feature,
-        requests: parseInt(row.requests, 10) || 0,
-        inputTokens: parseInt(row.inputTokens, 10) || 0,
-        outputTokens: parseInt(row.outputTokens, 10) || 0,
+      byFeature: Array.from(featureAgg.values()).map((agg) => ({
+        feature: agg.feature,
+        requests: agg.requests,
+        inputTokens: agg.inputTokens,
+        outputTokens: agg.outputTokens,
+        estimatedCost: agg.hasCost
+          ? Math.round(agg.cost * 10000) / 10000
+          : null,
       })),
       recentLogs: recentLogs.map((log) => ({
         id: log.id,
@@ -152,6 +309,11 @@ export class AiUsageService {
         inputTokens: log.inputTokens,
         outputTokens: log.outputTokens,
         durationMs: log.durationMs,
+        estimatedCost: computeCost(
+          log.inputTokens,
+          log.outputTokens,
+          rateMap.get(rateKey(log.provider, log.model)),
+        ),
         createdAt: log.createdAt.toISOString(),
       })),
     };

--- a/backend/src/ai/ai-usage.service.ts
+++ b/backend/src/ai/ai-usage.service.ts
@@ -4,11 +4,15 @@ import { LessThan, Repository } from "typeorm";
 import { Cron } from "@nestjs/schedule";
 import { AiUsageLog } from "./entities/ai-usage-log.entity";
 import { AiProviderConfig } from "./entities/ai-provider-config.entity";
-import { AiUsageSummary } from "./dto/ai-response.dto";
+import {
+  AiUsageSummary,
+  EstimatedCostByCurrency,
+} from "./dto/ai-response.dto";
 
 interface CostRate {
   inputCostPer1M: number | null;
   outputCostPer1M: number | null;
+  currency: string;
 }
 
 const TOKENS_PER_UNIT = 1_000_000;
@@ -35,6 +39,15 @@ function computeCost(
       ? (outputTokens / TOKENS_PER_UNIT) * rate.outputCostPer1M
       : 0;
   return Math.round((inputCost + outputCost) * 10000) / 10000;
+}
+
+function addCostToBucket(
+  bucket: EstimatedCostByCurrency,
+  currency: string,
+  cost: number,
+): void {
+  const prev = bucket[currency] ?? 0;
+  bucket[currency] = Math.round((prev + cost) * 10000) / 10000;
 }
 
 interface LogUsageParams {
@@ -166,6 +179,7 @@ export class AiUsageService {
             "model",
             "inputCostPer1M",
             "outputCostPer1M",
+            "costCurrency",
           ] as (keyof AiProviderConfig)[],
         }),
       ]);
@@ -176,11 +190,12 @@ export class AiUsageService {
       rateMap.set(rateKey(cfg.provider, cfg.model), {
         inputCostPer1M: cfg.inputCostPer1M,
         outputCostPer1M: cfg.outputCostPer1M,
+        currency: cfg.costCurrency || "USD",
       });
     }
 
-    // Collapse (provider, model) aggregates into byProvider, summing cost
-    // across models. If no logs under a provider match a rate, cost stays null.
+    // Collapse (provider, model) aggregates into byProvider, bucketing costs
+    // by each config's cost currency so we can display/convert per-currency.
     const providerAgg = new Map<
       string,
       {
@@ -188,8 +203,7 @@ export class AiUsageService {
         requests: number;
         inputTokens: number;
         outputTokens: number;
-        cost: number;
-        hasCost: boolean;
+        costs: EstimatedCostByCurrency;
       }
     >();
 
@@ -202,24 +216,22 @@ export class AiUsageService {
       const rate = rateMap.get(rateKey(provider, model));
       const cost = computeCost(inputTokens, outputTokens, rate);
 
-      const existing = providerAgg.get(provider);
-      if (existing) {
-        existing.requests += requests;
-        existing.inputTokens += inputTokens;
-        existing.outputTokens += outputTokens;
-        if (cost !== null) {
-          existing.cost += cost;
-          existing.hasCost = true;
-        }
-      } else {
-        providerAgg.set(provider, {
+      let existing = providerAgg.get(provider);
+      if (!existing) {
+        existing = {
           provider,
-          requests,
-          inputTokens,
-          outputTokens,
-          cost: cost ?? 0,
-          hasCost: cost !== null,
-        });
+          requests: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          costs: {},
+        };
+        providerAgg.set(provider, existing);
+      }
+      existing.requests += requests;
+      existing.inputTokens += inputTokens;
+      existing.outputTokens += outputTokens;
+      if (cost !== null && rate) {
+        addCostToBucket(existing.costs, rate.currency, cost);
       }
     }
 
@@ -231,8 +243,7 @@ export class AiUsageService {
         requests: number;
         inputTokens: number;
         outputTokens: number;
-        cost: number;
-        hasCost: boolean;
+        costs: EstimatedCostByCurrency;
       }
     >();
 
@@ -246,76 +257,68 @@ export class AiUsageService {
       const rate = rateMap.get(rateKey(provider, model));
       const cost = computeCost(inputTokens, outputTokens, rate);
 
-      const existing = featureAgg.get(feature);
-      if (existing) {
-        existing.requests += requests;
-        existing.inputTokens += inputTokens;
-        existing.outputTokens += outputTokens;
-        if (cost !== null) {
-          existing.cost += cost;
-          existing.hasCost = true;
-        }
-      } else {
-        featureAgg.set(feature, {
+      let existing = featureAgg.get(feature);
+      if (!existing) {
+        existing = {
           feature,
-          requests,
-          inputTokens,
-          outputTokens,
-          cost: cost ?? 0,
-          hasCost: cost !== null,
-        });
+          requests: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          costs: {},
+        };
+        featureAgg.set(feature, existing);
+      }
+      existing.requests += requests;
+      existing.inputTokens += inputTokens;
+      existing.outputTokens += outputTokens;
+      if (cost !== null && rate) {
+        addCostToBucket(existing.costs, rate.currency, cost);
       }
     }
 
-    // Compute total estimated cost by summing per-provider costs.
-    let totalEstimatedCost: number | null = null;
+    // Sum all provider buckets to produce the totals-by-currency.
+    const totalEstimatedCostByCurrency: EstimatedCostByCurrency = {};
     for (const agg of providerAgg.values()) {
-      if (agg.hasCost) {
-        totalEstimatedCost = (totalEstimatedCost ?? 0) + agg.cost;
+      for (const [currency, amount] of Object.entries(agg.costs)) {
+        addCostToBucket(totalEstimatedCostByCurrency, currency, amount);
       }
-    }
-    if (totalEstimatedCost !== null) {
-      totalEstimatedCost = Math.round(totalEstimatedCost * 10000) / 10000;
     }
 
     return {
       totalRequests: parseInt(totals.totalRequests, 10) || 0,
       totalInputTokens: parseInt(totals.totalInputTokens, 10) || 0,
       totalOutputTokens: parseInt(totals.totalOutputTokens, 10) || 0,
-      totalEstimatedCost,
+      totalEstimatedCostByCurrency,
       byProvider: Array.from(providerAgg.values()).map((agg) => ({
         provider: agg.provider,
         requests: agg.requests,
         inputTokens: agg.inputTokens,
         outputTokens: agg.outputTokens,
-        estimatedCost: agg.hasCost
-          ? Math.round(agg.cost * 10000) / 10000
-          : null,
+        estimatedCostByCurrency: agg.costs,
       })),
       byFeature: Array.from(featureAgg.values()).map((agg) => ({
         feature: agg.feature,
         requests: agg.requests,
         inputTokens: agg.inputTokens,
         outputTokens: agg.outputTokens,
-        estimatedCost: agg.hasCost
-          ? Math.round(agg.cost * 10000) / 10000
-          : null,
+        estimatedCostByCurrency: agg.costs,
       })),
-      recentLogs: recentLogs.map((log) => ({
-        id: log.id,
-        provider: log.provider,
-        model: log.model,
-        feature: log.feature,
-        inputTokens: log.inputTokens,
-        outputTokens: log.outputTokens,
-        durationMs: log.durationMs,
-        estimatedCost: computeCost(
-          log.inputTokens,
-          log.outputTokens,
-          rateMap.get(rateKey(log.provider, log.model)),
-        ),
-        createdAt: log.createdAt.toISOString(),
-      })),
+      recentLogs: recentLogs.map((log) => {
+        const rate = rateMap.get(rateKey(log.provider, log.model));
+        const cost = computeCost(log.inputTokens, log.outputTokens, rate);
+        return {
+          id: log.id,
+          provider: log.provider,
+          model: log.model,
+          feature: log.feature,
+          inputTokens: log.inputTokens,
+          outputTokens: log.outputTokens,
+          durationMs: log.durationMs,
+          estimatedCost: cost,
+          costCurrency: cost !== null && rate ? rate.currency : null,
+          createdAt: log.createdAt.toISOString(),
+        };
+      }),
     };
   }
 }

--- a/backend/src/ai/ai.service.spec.ts
+++ b/backend/src/ai/ai.service.spec.ts
@@ -36,6 +36,7 @@ describe("AiService", () => {
     config.config = {};
     config.inputCostPer1M = null;
     config.outputCostPer1M = null;
+    config.costCurrency = "USD";
     config.createdAt = new Date("2024-01-01");
     config.updatedAt = new Date("2024-01-01");
     Object.assign(config, overrides);

--- a/backend/src/ai/ai.service.spec.ts
+++ b/backend/src/ai/ai.service.spec.ts
@@ -34,6 +34,8 @@ describe("AiService", () => {
     config.apiKeyEnc = "encrypted-key";
     config.baseUrl = null;
     config.config = {};
+    config.inputCostPer1M = null;
+    config.outputCostPer1M = null;
     config.createdAt = new Date("2024-01-01");
     config.updatedAt = new Date("2024-01-01");
     Object.assign(config, overrides);

--- a/backend/src/ai/ai.service.ts
+++ b/backend/src/ai/ai.service.ts
@@ -147,6 +147,7 @@ export class AiService {
       config: dto.config || {},
       inputCostPer1M: dto.inputCostPer1M ?? null,
       outputCostPer1M: dto.outputCostPer1M ?? null,
+      costCurrency: dto.costCurrency || "USD",
       isActive: true,
     });
 
@@ -187,6 +188,7 @@ export class AiService {
       config.inputCostPer1M = dto.inputCostPer1M;
     if (dto.outputCostPer1M !== undefined)
       config.outputCostPer1M = dto.outputCostPer1M;
+    if (dto.costCurrency !== undefined) config.costCurrency = dto.costCurrency;
 
     if (dto.apiKey !== undefined) {
       if (dto.apiKey) {
@@ -409,6 +411,7 @@ export class AiService {
       config: config.config,
       inputCostPer1M: config.inputCostPer1M,
       outputCostPer1M: config.outputCostPer1M,
+      costCurrency: config.costCurrency ?? "USD",
       createdAt: config.createdAt.toISOString(),
       updatedAt: config.updatedAt.toISOString(),
     };

--- a/backend/src/ai/ai.service.ts
+++ b/backend/src/ai/ai.service.ts
@@ -145,6 +145,8 @@ export class AiService {
       baseUrl: dto.baseUrl || null,
       priority: dto.priority ?? 0,
       config: dto.config || {},
+      inputCostPer1M: dto.inputCostPer1M ?? null,
+      outputCostPer1M: dto.outputCostPer1M ?? null,
       isActive: true,
     });
 
@@ -181,6 +183,10 @@ export class AiService {
     if (dto.priority !== undefined) config.priority = dto.priority;
     if (dto.isActive !== undefined) config.isActive = dto.isActive;
     if (dto.config !== undefined) config.config = dto.config;
+    if (dto.inputCostPer1M !== undefined)
+      config.inputCostPer1M = dto.inputCostPer1M;
+    if (dto.outputCostPer1M !== undefined)
+      config.outputCostPer1M = dto.outputCostPer1M;
 
     if (dto.apiKey !== undefined) {
       if (dto.apiKey) {
@@ -401,6 +407,8 @@ export class AiService {
       apiKeyMasked,
       baseUrl: config.baseUrl,
       config: config.config,
+      inputCostPer1M: config.inputCostPer1M,
+      outputCostPer1M: config.outputCostPer1M,
       createdAt: config.createdAt.toISOString(),
       updatedAt: config.updatedAt.toISOString(),
     };

--- a/backend/src/ai/dto/ai-config.dto.spec.ts
+++ b/backend/src/ai/dto/ai-config.dto.spec.ts
@@ -201,6 +201,36 @@ describe("CreateAiConfigDto", () => {
     const errors = await validate(dto);
     expect(errors).toHaveLength(0);
   });
+
+  it("accepts valid input and output cost rates", async () => {
+    const dto = createDto({
+      provider: "anthropic",
+      inputCostPer1M: 3,
+      outputCostPer1M: 15,
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("rejects negative cost rates", async () => {
+    const dto = createDto({
+      provider: "anthropic",
+      inputCostPer1M: -1,
+    });
+    const errors = await validate(dto);
+    const costErrors = errors.find((e) => e.property === "inputCostPer1M");
+    expect(costErrors).toBeDefined();
+  });
+
+  it("allows null cost rates (for clearing)", async () => {
+    const dto = createDto({
+      provider: "anthropic",
+      inputCostPer1M: null,
+      outputCostPer1M: null,
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
 });
 
 describe("UpdateAiConfigDto", () => {

--- a/backend/src/ai/dto/ai-config.dto.spec.ts
+++ b/backend/src/ai/dto/ai-config.dto.spec.ts
@@ -231,6 +231,18 @@ describe("CreateAiConfigDto", () => {
     const errors = await validate(dto);
     expect(errors).toHaveLength(0);
   });
+
+  it("accepts a valid ISO 4217 cost currency", async () => {
+    const dto = createDto({ provider: "anthropic", costCurrency: "EUR" });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("rejects lowercase or non-ISO currency codes", async () => {
+    const dto = createDto({ provider: "anthropic", costCurrency: "usd" });
+    const errors = await validate(dto);
+    expect(errors.find((e) => e.property === "costCurrency")).toBeDefined();
+  });
 });
 
 describe("UpdateAiConfigDto", () => {

--- a/backend/src/ai/dto/ai-config.dto.ts
+++ b/backend/src/ai/dto/ai-config.dto.ts
@@ -6,6 +6,7 @@ import {
   IsIn,
   IsObject,
   IsNumber,
+  Matches,
   MaxLength,
   Min,
   Max,
@@ -106,6 +107,18 @@ export class CreateAiConfigDto {
   @Min(0)
   @Max(1000000)
   outputCostPer1M?: number | null;
+
+  @ApiPropertyOptional({
+    example: "USD",
+    description:
+      "ISO 4217 currency code for the cost rates (e.g. USD, EUR). Defaults to USD.",
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[A-Z]{3}$/, {
+    message: "costCurrency must be a 3-letter ISO 4217 currency code",
+  })
+  costCurrency?: string;
 }
 
 export class UpdateAiConfigDto {
@@ -193,4 +206,16 @@ export class UpdateAiConfigDto {
   @Min(0)
   @Max(1000000)
   outputCostPer1M?: number | null;
+
+  @ApiPropertyOptional({
+    example: "USD",
+    description:
+      "ISO 4217 currency code for the cost rates (e.g. USD, EUR).",
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[A-Z]{3}$/, {
+    message: "costCurrency must be a 3-letter ISO 4217 currency code",
+  })
+  costCurrency?: string;
 }

--- a/backend/src/ai/dto/ai-config.dto.ts
+++ b/backend/src/ai/dto/ai-config.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsIn,
   IsObject,
+  IsNumber,
   MaxLength,
   Min,
   Max,
@@ -83,6 +84,28 @@ export class CreateAiConfigDto {
   @IsObject()
   @IsSafeConfigObject()
   config?: Record<string, unknown>;
+
+  @ApiPropertyOptional({
+    example: 3,
+    description:
+      "User-defined input cost per 1,000,000 tokens (for usage cost estimation). Set to null to clear.",
+  })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 4 })
+  @Min(0)
+  @Max(1000000)
+  inputCostPer1M?: number | null;
+
+  @ApiPropertyOptional({
+    example: 15,
+    description:
+      "User-defined output cost per 1,000,000 tokens (for usage cost estimation). Set to null to clear.",
+  })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 4 })
+  @Min(0)
+  @Max(1000000)
+  outputCostPer1M?: number | null;
 }
 
 export class UpdateAiConfigDto {
@@ -148,4 +171,26 @@ export class UpdateAiConfigDto {
   @IsObject()
   @IsSafeConfigObject()
   config?: Record<string, unknown>;
+
+  @ApiPropertyOptional({
+    example: 3,
+    description:
+      "User-defined input cost per 1,000,000 tokens (for usage cost estimation). Pass null to clear.",
+  })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 4 })
+  @Min(0)
+  @Max(1000000)
+  inputCostPer1M?: number | null;
+
+  @ApiPropertyOptional({
+    example: 15,
+    description:
+      "User-defined output cost per 1,000,000 tokens (for usage cost estimation). Pass null to clear.",
+  })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 4 })
+  @Min(0)
+  @Max(1000000)
+  outputCostPer1M?: number | null;
 }

--- a/backend/src/ai/dto/ai-response.dto.ts
+++ b/backend/src/ai/dto/ai-response.dto.ts
@@ -10,33 +10,41 @@ export interface AiProviderConfigResponse {
   config: Record<string, unknown>;
   inputCostPer1M: number | null;
   outputCostPer1M: number | null;
+  costCurrency: string;
   createdAt: string;
   updatedAt: string;
 }
+
+/**
+ * Aggregated estimated cost buckets. The key is an ISO 4217 currency code
+ * and the value is the summed cost in that currency. Empty when no matching
+ * configured rates exist for any logs in the bucket.
+ */
+export type EstimatedCostByCurrency = Record<string, number>;
 
 export interface AiUsageSummary {
   totalRequests: number;
   totalInputTokens: number;
   totalOutputTokens: number;
   /**
-   * Sum of estimated costs for logs that have a matching provider+model
-   * configuration with cost rates defined. Null when no matching configured
-   * rates exist for any logs in the period.
+   * Sum of estimated costs keyed by the configured provider's cost currency.
+   * Each entry represents one currency bucket (e.g. USD: 1.23, EUR: 0.45).
+   * Empty when no configured rates match any logs in the period.
    */
-  totalEstimatedCost: number | null;
+  totalEstimatedCostByCurrency: EstimatedCostByCurrency;
   byProvider: Array<{
     provider: string;
     requests: number;
     inputTokens: number;
     outputTokens: number;
-    estimatedCost: number | null;
+    estimatedCostByCurrency: EstimatedCostByCurrency;
   }>;
   byFeature: Array<{
     feature: string;
     requests: number;
     inputTokens: number;
     outputTokens: number;
-    estimatedCost: number | null;
+    estimatedCostByCurrency: EstimatedCostByCurrency;
   }>;
   recentLogs: Array<{
     id: string;
@@ -46,7 +54,10 @@ export interface AiUsageSummary {
     inputTokens: number;
     outputTokens: number;
     durationMs: number;
+    /** Cost value in `costCurrency`, or null when no matching rate is configured. */
     estimatedCost: number | null;
+    /** Currency code of `estimatedCost`, or null when no rate is configured. */
+    costCurrency: string | null;
     createdAt: string;
   }>;
 }

--- a/backend/src/ai/dto/ai-response.dto.ts
+++ b/backend/src/ai/dto/ai-response.dto.ts
@@ -8,6 +8,8 @@ export interface AiProviderConfigResponse {
   apiKeyMasked: string | null;
   baseUrl: string | null;
   config: Record<string, unknown>;
+  inputCostPer1M: number | null;
+  outputCostPer1M: number | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -16,17 +18,25 @@ export interface AiUsageSummary {
   totalRequests: number;
   totalInputTokens: number;
   totalOutputTokens: number;
+  /**
+   * Sum of estimated costs for logs that have a matching provider+model
+   * configuration with cost rates defined. Null when no matching configured
+   * rates exist for any logs in the period.
+   */
+  totalEstimatedCost: number | null;
   byProvider: Array<{
     provider: string;
     requests: number;
     inputTokens: number;
     outputTokens: number;
+    estimatedCost: number | null;
   }>;
   byFeature: Array<{
     feature: string;
     requests: number;
     inputTokens: number;
     outputTokens: number;
+    estimatedCost: number | null;
   }>;
   recentLogs: Array<{
     id: string;
@@ -36,6 +46,7 @@ export interface AiUsageSummary {
     inputTokens: number;
     outputTokens: number;
     durationMs: number;
+    estimatedCost: number | null;
     createdAt: string;
   }>;
 }

--- a/backend/src/ai/entities/ai-provider-config.entity.ts
+++ b/backend/src/ai/entities/ai-provider-config.entity.ts
@@ -9,6 +9,13 @@ import {
 } from "typeorm";
 import { User } from "../../users/entities/user.entity";
 
+const numericTransformer = {
+  to: (value: number | null | undefined): number | null =>
+    value === null || value === undefined ? null : value,
+  from: (value: string | null): number | null =>
+    value === null ? null : Number(value),
+};
+
 export const AI_PROVIDERS = [
   "anthropic",
   "openai",
@@ -64,6 +71,26 @@ export class AiProviderConfig {
 
   @Column({ type: "jsonb", default: {} })
   config: Record<string, unknown>;
+
+  @Column({
+    type: "numeric",
+    precision: 12,
+    scale: 4,
+    name: "input_cost_per_1m",
+    nullable: true,
+    transformer: numericTransformer,
+  })
+  inputCostPer1M: number | null;
+
+  @Column({
+    type: "numeric",
+    precision: 12,
+    scale: 4,
+    name: "output_cost_per_1m",
+    nullable: true,
+    transformer: numericTransformer,
+  })
+  outputCostPer1M: number | null;
 
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;

--- a/backend/src/ai/entities/ai-provider-config.entity.ts
+++ b/backend/src/ai/entities/ai-provider-config.entity.ts
@@ -92,6 +92,14 @@ export class AiProviderConfig {
   })
   outputCostPer1M: number | null;
 
+  @Column({
+    type: "varchar",
+    length: 3,
+    name: "cost_currency",
+    default: "USD",
+  })
+  costCurrency: string;
+
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;
 

--- a/database/migrations/049_ai_provider_costs.sql
+++ b/database/migrations/049_ai_provider_costs.sql
@@ -1,0 +1,8 @@
+-- Add user-defined cost rates to AI provider configurations.
+-- Rates are per 1,000,000 tokens, in the user's chosen currency (typically USD).
+-- Used to calculate estimated costs for the AI Settings Usage dashboard.
+-- Nullable: when null, the UI will display "-" and no cost estimate will be computed.
+
+ALTER TABLE ai_provider_configs
+    ADD COLUMN IF NOT EXISTS input_cost_per_1m NUMERIC(12, 4),
+    ADD COLUMN IF NOT EXISTS output_cost_per_1m NUMERIC(12, 4);

--- a/database/migrations/050_ai_provider_cost_currency.sql
+++ b/database/migrations/050_ai_provider_cost_currency.sql
@@ -1,0 +1,7 @@
+-- Adds the currency associated with the input/output token cost rates on each
+-- AI provider configuration. Defaults to USD because most major AI providers
+-- (Anthropic, OpenAI, etc.) bill in USD. The Usage dashboard uses this to
+-- optionally convert estimated costs into the user's home currency.
+
+ALTER TABLE ai_provider_configs
+    ADD COLUMN IF NOT EXISTS cost_currency VARCHAR(3) NOT NULL DEFAULT 'USD';

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -666,6 +666,7 @@ CREATE TABLE ai_provider_configs (
     config JSONB DEFAULT '{}',           -- Provider-specific settings (temperature, maxTokens, etc.)
     input_cost_per_1m NUMERIC(12, 4),    -- User-defined input cost per 1M tokens (for usage cost estimation)
     output_cost_per_1m NUMERIC(12, 4),   -- User-defined output cost per 1M tokens (for usage cost estimation)
+    cost_currency VARCHAR(3) NOT NULL DEFAULT 'USD', -- ISO 4217 currency of the cost rates
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(user_id, provider, priority)

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -664,6 +664,8 @@ CREATE TABLE ai_provider_configs (
     api_key_enc TEXT,                     -- Encrypted API key (null for Ollama)
     base_url VARCHAR(500),               -- Custom endpoint URL (required for Ollama/compatible)
     config JSONB DEFAULT '{}',           -- Provider-specific settings (temperature, maxTokens, etc.)
+    input_cost_per_1m NUMERIC(12, 4),    -- User-defined input cost per 1M tokens (for usage cost estimation)
+    output_cost_per_1m NUMERIC(12, 4),   -- User-defined output cost per 1M tokens (for usage cost estimation)
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(user_id, provider, priority)

--- a/frontend/src/app/settings/ai/page.tsx
+++ b/frontend/src/app/settings/ai/page.tsx
@@ -115,6 +115,7 @@ function AiSettingsContent() {
         {usage && (
           <UsageDashboard
             usage={usage}
+            configs={configs}
             onPeriodChange={handlePeriodChange}
           />
         )}

--- a/frontend/src/components/settings/ai/ProviderConfigForm.tsx
+++ b/frontend/src/components/settings/ai/ProviderConfigForm.tsx
@@ -14,6 +14,12 @@ import { AI_PROVIDER_LABELS, AI_PROVIDER_DEFAULT_MODELS } from '@/types/ai';
 
 const AI_PROVIDER_TYPES = ['anthropic', 'openai', 'ollama', 'openai-compatible'] as const;
 
+const costField = z
+  .string()
+  .regex(/^(\d+(\.\d{0,4})?)?$/, 'Must be a number with up to 4 decimal places')
+  .optional()
+  .or(z.literal(''));
+
 const providerConfigSchema = z.object({
   provider: z.enum(AI_PROVIDER_TYPES),
   displayName: z.string().max(100, 'Display name must be 100 characters or less').optional().or(z.literal('')),
@@ -21,6 +27,8 @@ const providerConfigSchema = z.object({
   apiKey: z.string().max(500).optional().or(z.literal('')),
   baseUrl: z.string().max(500).optional().or(z.literal('')),
   priority: z.string().regex(/^\d*$/, 'Must be a number'),
+  inputCostPer1M: costField,
+  outputCostPer1M: costField,
 });
 
 type ProviderConfigFormData = z.infer<typeof providerConfigSchema>;
@@ -54,6 +62,8 @@ export function ProviderConfigForm({ isOpen, onClose, onSubmit, editConfig }: Pr
       apiKey: '',
       baseUrl: editConfig?.baseUrl || '',
       priority: String(editConfig?.priority ?? 0),
+      inputCostPer1M: editConfig?.inputCostPer1M != null ? String(editConfig.inputCostPer1M) : '',
+      outputCostPer1M: editConfig?.outputCostPer1M != null ? String(editConfig.outputCostPer1M) : '',
     },
   });
 
@@ -63,10 +73,19 @@ export function ProviderConfigForm({ isOpen, onClose, onSubmit, editConfig }: Pr
   const needsApiKey = provider !== 'ollama';
   const modelSuggestions = AI_PROVIDER_DEFAULT_MODELS[provider] || [];
 
+  const parseCost = (value: string | undefined): number | null => {
+    if (value === undefined || value === '') return null;
+    const parsed = parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+
   const onFormSubmit = async (formData: ProviderConfigFormData) => {
     setError('');
 
     try {
+      const newInputCost = parseCost(formData.inputCostPer1M);
+      const newOutputCost = parseCost(formData.outputCostPer1M);
+
       if (editConfig) {
         const data: UpdateAiProviderConfig = {};
         if (formData.displayName !== (editConfig.displayName || '')) data.displayName = formData.displayName || undefined;
@@ -74,6 +93,8 @@ export function ProviderConfigForm({ isOpen, onClose, onSubmit, editConfig }: Pr
         if (formData.apiKey) data.apiKey = formData.apiKey;
         if (formData.baseUrl !== (editConfig.baseUrl || '')) data.baseUrl = formData.baseUrl || undefined;
         if (formData.priority !== String(editConfig.priority)) data.priority = parseInt(formData.priority, 10) || 0;
+        if (newInputCost !== editConfig.inputCostPer1M) data.inputCostPer1M = newInputCost;
+        if (newOutputCost !== editConfig.outputCostPer1M) data.outputCostPer1M = newOutputCost;
         await onSubmit(data);
       } else {
         const data: CreateAiProviderConfig = {
@@ -83,6 +104,8 @@ export function ProviderConfigForm({ isOpen, onClose, onSubmit, editConfig }: Pr
           ...(formData.apiKey && { apiKey: formData.apiKey }),
           ...(formData.baseUrl && { baseUrl: formData.baseUrl }),
           priority: parseInt(formData.priority, 10) || 0,
+          ...(newInputCost !== null && { inputCostPer1M: newInputCost }),
+          ...(newOutputCost !== null && { outputCostPer1M: newOutputCost }),
         };
         await onSubmit(data);
       }
@@ -169,6 +192,35 @@ export function ProviderConfigForm({ isOpen, onClose, onSubmit, editConfig }: Pr
           <p className="text-xs text-gray-500 dark:text-gray-400 -mt-3">
             Lower number = higher priority. Used for fallback ordering.
           </p>
+
+          <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
+            <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Cost rates (optional)
+            </h3>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+              Enter your provider&apos;s published rates in USD per 1,000,000 tokens to see estimated cost on the Usage dashboard. Leave blank to skip cost estimates.
+            </p>
+            <div className="grid grid-cols-2 gap-3">
+              <Input
+                label="Input $ / 1M tokens"
+                type="number"
+                step="0.0001"
+                min={0}
+                {...register('inputCostPer1M')}
+                error={errors.inputCostPer1M?.message}
+                placeholder="e.g., 3.00"
+              />
+              <Input
+                label="Output $ / 1M tokens"
+                type="number"
+                step="0.0001"
+                min={0}
+                {...register('outputCostPer1M')}
+                error={errors.outputCostPer1M?.message}
+                placeholder="e.g., 15.00"
+              />
+            </div>
+          </div>
 
           {error && (
             <p className="text-sm text-red-600 dark:text-red-400">{error}</p>

--- a/frontend/src/components/settings/ai/ProviderConfigForm.tsx
+++ b/frontend/src/components/settings/ai/ProviderConfigForm.tsx
@@ -20,6 +20,19 @@ const costField = z
   .optional()
   .or(z.literal(''));
 
+// Common billing currencies for AI providers. USD covers Anthropic/OpenAI;
+// the others are included to let users align with locally-billed providers.
+const COST_CURRENCY_OPTIONS = [
+  { value: 'USD', label: 'USD - US Dollar' },
+  { value: 'EUR', label: 'EUR - Euro' },
+  { value: 'GBP', label: 'GBP - British Pound' },
+  { value: 'CAD', label: 'CAD - Canadian Dollar' },
+  { value: 'AUD', label: 'AUD - Australian Dollar' },
+  { value: 'JPY', label: 'JPY - Japanese Yen' },
+  { value: 'CNY', label: 'CNY - Chinese Yuan' },
+  { value: 'INR', label: 'INR - Indian Rupee' },
+];
+
 const providerConfigSchema = z.object({
   provider: z.enum(AI_PROVIDER_TYPES),
   displayName: z.string().max(100, 'Display name must be 100 characters or less').optional().or(z.literal('')),
@@ -29,6 +42,7 @@ const providerConfigSchema = z.object({
   priority: z.string().regex(/^\d*$/, 'Must be a number'),
   inputCostPer1M: costField,
   outputCostPer1M: costField,
+  costCurrency: z.string().regex(/^[A-Z]{3}$/, 'Must be a 3-letter currency code'),
 });
 
 type ProviderConfigFormData = z.infer<typeof providerConfigSchema>;
@@ -64,6 +78,7 @@ export function ProviderConfigForm({ isOpen, onClose, onSubmit, editConfig }: Pr
       priority: String(editConfig?.priority ?? 0),
       inputCostPer1M: editConfig?.inputCostPer1M != null ? String(editConfig.inputCostPer1M) : '',
       outputCostPer1M: editConfig?.outputCostPer1M != null ? String(editConfig.outputCostPer1M) : '',
+      costCurrency: editConfig?.costCurrency || 'USD',
     },
   });
 
@@ -95,6 +110,7 @@ export function ProviderConfigForm({ isOpen, onClose, onSubmit, editConfig }: Pr
         if (formData.priority !== String(editConfig.priority)) data.priority = parseInt(formData.priority, 10) || 0;
         if (newInputCost !== editConfig.inputCostPer1M) data.inputCostPer1M = newInputCost;
         if (newOutputCost !== editConfig.outputCostPer1M) data.outputCostPer1M = newOutputCost;
+        if (formData.costCurrency !== editConfig.costCurrency) data.costCurrency = formData.costCurrency;
         await onSubmit(data);
       } else {
         const data: CreateAiProviderConfig = {
@@ -106,6 +122,7 @@ export function ProviderConfigForm({ isOpen, onClose, onSubmit, editConfig }: Pr
           priority: parseInt(formData.priority, 10) || 0,
           ...(newInputCost !== null && { inputCostPer1M: newInputCost }),
           ...(newOutputCost !== null && { outputCostPer1M: newOutputCost }),
+          costCurrency: formData.costCurrency,
         };
         await onSubmit(data);
       }
@@ -198,11 +215,11 @@ export function ProviderConfigForm({ isOpen, onClose, onSubmit, editConfig }: Pr
               Cost rates (optional)
             </h3>
             <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
-              Enter your provider&apos;s published rates in USD per 1,000,000 tokens to see estimated cost on the Usage dashboard. Leave blank to skip cost estimates.
+              Enter your provider&apos;s published rates per 1,000,000 tokens to see estimated cost on the Usage dashboard. Leave blank to skip cost estimates.
             </p>
             <div className="grid grid-cols-2 gap-3">
               <Input
-                label="Input $ / 1M tokens"
+                label="Input cost / 1M tokens"
                 type="number"
                 step="0.0001"
                 min={0}
@@ -211,7 +228,7 @@ export function ProviderConfigForm({ isOpen, onClose, onSubmit, editConfig }: Pr
                 placeholder="e.g., 3.00"
               />
               <Input
-                label="Output $ / 1M tokens"
+                label="Output cost / 1M tokens"
                 type="number"
                 step="0.0001"
                 min={0}
@@ -219,6 +236,17 @@ export function ProviderConfigForm({ isOpen, onClose, onSubmit, editConfig }: Pr
                 error={errors.outputCostPer1M?.message}
                 placeholder="e.g., 15.00"
               />
+            </div>
+            <div className="mt-3">
+              <Select
+                label="Rate Currency"
+                {...register('costCurrency')}
+                options={COST_CURRENCY_OPTIONS}
+                error={errors.costCurrency?.message}
+              />
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                If this differs from your home currency, the Usage dashboard can convert costs using your saved exchange rates.
+              </p>
             </div>
           </div>
 

--- a/frontend/src/components/settings/ai/ProviderList.test.tsx
+++ b/frontend/src/components/settings/ai/ProviderList.test.tsx
@@ -46,6 +46,8 @@ const mockConfig: AiProviderConfig = {
   apiKeyMasked: '****abcd',
   baseUrl: null,
   config: {},
+  inputCostPer1M: null,
+  outputCostPer1M: null,
   createdAt: '2024-01-01T00:00:00.000Z',
   updatedAt: '2024-01-01T00:00:00.000Z',
 };

--- a/frontend/src/components/settings/ai/ProviderList.test.tsx
+++ b/frontend/src/components/settings/ai/ProviderList.test.tsx
@@ -48,6 +48,7 @@ const mockConfig: AiProviderConfig = {
   config: {},
   inputCostPer1M: null,
   outputCostPer1M: null,
+  costCurrency: 'USD',
   createdAt: '2024-01-01T00:00:00.000Z',
   updatedAt: '2024-01-01T00:00:00.000Z',
 };

--- a/frontend/src/components/settings/ai/ProviderList.tsx
+++ b/frontend/src/components/settings/ai/ProviderList.tsx
@@ -134,10 +134,15 @@ export function ProviderList({ configs, encryptionAvailable, onConfigsChanged, h
                       Priority: {config.priority}
                     </span>
                   </div>
-                  <div className="mt-1 flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
+                  <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
                     {config.model && <span>Model: {config.model}</span>}
                     {config.apiKeyMasked && <span>Key: {config.apiKeyMasked}</span>}
                     {config.baseUrl && <span className="truncate max-w-xs">URL: {config.baseUrl}</span>}
+                    {(config.inputCostPer1M != null || config.outputCostPer1M != null) && (
+                      <span>
+                        Cost/1M: ${config.inputCostPer1M ?? 0} in / ${config.outputCostPer1M ?? 0} out
+                      </span>
+                    )}
                   </div>
                 </div>
                 <div className="flex items-center gap-2">

--- a/frontend/src/components/settings/ai/ProviderList.tsx
+++ b/frontend/src/components/settings/ai/ProviderList.tsx
@@ -140,7 +140,7 @@ export function ProviderList({ configs, encryptionAvailable, onConfigsChanged, h
                     {config.baseUrl && <span className="truncate max-w-xs">URL: {config.baseUrl}</span>}
                     {(config.inputCostPer1M != null || config.outputCostPer1M != null) && (
                       <span>
-                        Cost/1M: ${config.inputCostPer1M ?? 0} in / ${config.outputCostPer1M ?? 0} out
+                        Cost/1M ({config.costCurrency}): {config.inputCostPer1M ?? 0} in / {config.outputCostPer1M ?? 0} out
                       </span>
                     )}
                   </div>

--- a/frontend/src/components/settings/ai/UsageDashboard.test.tsx
+++ b/frontend/src/components/settings/ai/UsageDashboard.test.tsx
@@ -1,7 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@/test/render';
 import { UsageDashboard } from './UsageDashboard';
-import type { AiUsageSummary } from '@/types/ai';
+import type { AiUsageSummary, AiProviderConfig } from '@/types/ai';
+
+const noConfigs: AiProviderConfig[] = [];
+
+function makeConfig(overrides: Partial<AiProviderConfig> = {}): AiProviderConfig {
+  return {
+    id: 'config-1',
+    provider: 'anthropic',
+    displayName: null,
+    isActive: true,
+    priority: 0,
+    model: null,
+    apiKeyMasked: null,
+    baseUrl: null,
+    config: {},
+    inputCostPer1M: null,
+    outputCostPer1M: null,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
 
 const emptyUsage: AiUsageSummary = {
   totalRequests: 0,
@@ -48,7 +69,7 @@ describe('UsageDashboard', () => {
   });
 
   it('renders summary cards', () => {
-    render(<UsageDashboard usage={populatedUsage} onPeriodChange={onPeriodChange} />);
+    render(<UsageDashboard usage={populatedUsage} configs={noConfigs} onPeriodChange={onPeriodChange} />);
     expect(screen.getByText('Total Requests')).toBeInTheDocument();
     expect(screen.getByText('42')).toBeInTheDocument();
     expect(screen.getByText('5,000')).toBeInTheDocument();
@@ -56,7 +77,7 @@ describe('UsageDashboard', () => {
   });
 
   it('renders period selector buttons', () => {
-    render(<UsageDashboard usage={emptyUsage} onPeriodChange={onPeriodChange} />);
+    render(<UsageDashboard usage={emptyUsage} configs={noConfigs} onPeriodChange={onPeriodChange} />);
     expect(screen.getByText('7 days')).toBeInTheDocument();
     expect(screen.getByText('30 days')).toBeInTheDocument();
     expect(screen.getByText('90 days')).toBeInTheDocument();
@@ -64,43 +85,71 @@ describe('UsageDashboard', () => {
   });
 
   it('calls onPeriodChange when period button clicked', () => {
-    render(<UsageDashboard usage={emptyUsage} onPeriodChange={onPeriodChange} />);
+    render(<UsageDashboard usage={emptyUsage} configs={noConfigs} onPeriodChange={onPeriodChange} />);
     fireEvent.click(screen.getByText('7 days'));
     expect(onPeriodChange).toHaveBeenCalledWith(7);
   });
 
-  it('renders by-provider table when data exists', () => {
-    render(<UsageDashboard usage={populatedUsage} onPeriodChange={onPeriodChange} />);
+  it('renders by-provider table with friendly labels when no display name is configured', () => {
+    render(<UsageDashboard usage={populatedUsage} configs={noConfigs} onPeriodChange={onPeriodChange} />);
     expect(screen.getByText('By Provider')).toBeInTheDocument();
-    expect(screen.getAllByText('anthropic').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText('openai')).toBeInTheDocument();
+    expect(screen.getAllByText('Anthropic (Claude)').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('OpenAI (GPT)')).toBeInTheDocument();
+  });
+
+  it('uses display name from configured provider when available', () => {
+    const configs = [
+      makeConfig({
+        id: 'c-1',
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-20250514',
+        displayName: 'My Claude API',
+      }),
+    ];
+    render(<UsageDashboard usage={populatedUsage} configs={configs} onPeriodChange={onPeriodChange} />);
+    // By-provider row uses the single-config display name.
+    expect(screen.getAllByText('My Claude API').length).toBeGreaterThanOrEqual(1);
+    // Unconfigured provider still falls back to the friendly label.
+    expect(screen.getByText('OpenAI (GPT)')).toBeInTheDocument();
+  });
+
+  it('falls back to provider label when multiple configs share a provider type', () => {
+    const configs = [
+      makeConfig({ id: 'c-1', provider: 'anthropic', model: 'claude-sonnet-4-20250514', displayName: 'Claude Sonnet' }),
+      makeConfig({ id: 'c-2', provider: 'anthropic', model: 'claude-haiku-4-20250414', displayName: 'Claude Haiku' }),
+    ];
+    render(<UsageDashboard usage={populatedUsage} configs={configs} onPeriodChange={onPeriodChange} />);
+    // By-provider row uses the fallback label since there are two anthropic configs.
+    expect(screen.getAllByText('Anthropic (Claude)').length).toBeGreaterThanOrEqual(1);
+    // Recent Activity row matches (provider, model) exactly, so it uses the specific config's name.
+    expect(screen.getByText('Claude Sonnet')).toBeInTheDocument();
   });
 
   it('renders recent activity table when logs exist', () => {
-    render(<UsageDashboard usage={populatedUsage} onPeriodChange={onPeriodChange} />);
+    render(<UsageDashboard usage={populatedUsage} configs={noConfigs} onPeriodChange={onPeriodChange} />);
     expect(screen.getByText('Recent Activity')).toBeInTheDocument();
     expect(screen.getByText('categorize')).toBeInTheDocument();
     expect(screen.getByText('1200ms')).toBeInTheDocument();
   });
 
   it('shows empty state when no usage data', () => {
-    render(<UsageDashboard usage={emptyUsage} onPeriodChange={onPeriodChange} />);
+    render(<UsageDashboard usage={emptyUsage} configs={noConfigs} onPeriodChange={onPeriodChange} />);
     expect(screen.getByText(/no usage data yet/i)).toBeInTheDocument();
   });
 
   it('shows estimated cost in summary card', () => {
-    render(<UsageDashboard usage={populatedUsage} onPeriodChange={onPeriodChange} />);
+    render(<UsageDashboard usage={populatedUsage} configs={noConfigs} onPeriodChange={onPeriodChange} />);
     expect(screen.getByText('Est. Cost')).toBeInTheDocument();
     expect(screen.getByText('$12.34')).toBeInTheDocument();
   });
 
   it('shows dash for estimated cost when no rates configured', () => {
-    render(<UsageDashboard usage={emptyUsage} onPeriodChange={onPeriodChange} />);
+    render(<UsageDashboard usage={emptyUsage} configs={noConfigs} onPeriodChange={onPeriodChange} />);
     expect(screen.getByText(/set rates on a provider/i)).toBeInTheDocument();
   });
 
   it('does not show provider table when empty', () => {
-    render(<UsageDashboard usage={emptyUsage} onPeriodChange={onPeriodChange} />);
+    render(<UsageDashboard usage={emptyUsage} configs={noConfigs} onPeriodChange={onPeriodChange} />);
     expect(screen.queryByText('By Provider')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/settings/ai/UsageDashboard.test.tsx
+++ b/frontend/src/components/settings/ai/UsageDashboard.test.tsx
@@ -1,7 +1,32 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@/test/render';
-import { UsageDashboard } from './UsageDashboard';
 import type { AiUsageSummary, AiProviderConfig } from '@/types/ai';
+
+// Mock the stores/hooks the dashboard reads for currency conversion.
+// By default the user's home currency is USD and conversion is 1:1, so the
+// tests that don't care about conversion behave the same as before.
+let mockHomeCurrency = 'USD';
+vi.mock('@/store/preferencesStore', () => ({
+  usePreferencesStore: (selector: (state: unknown) => unknown) =>
+    selector({ preferences: { defaultCurrency: mockHomeCurrency } }),
+}));
+
+vi.mock('@/hooks/useExchangeRates', () => ({
+  useExchangeRates: () => ({
+    convert: (amount: number, from: string, to?: string) => {
+      if (!to || from === to) return amount;
+      // Simple fake rate: EUR->USD = 1.1.
+      if (from === 'EUR' && to === 'USD') return amount * 1.1;
+      if (from === 'USD' && to === 'EUR') return amount / 1.1;
+      return amount;
+    },
+    defaultCurrency: mockHomeCurrency,
+  }),
+}));
+
+// Import after mocks are registered.
+// eslint-disable-next-line import/first
+import { UsageDashboard } from './UsageDashboard';
 
 const noConfigs: AiProviderConfig[] = [];
 
@@ -18,6 +43,7 @@ function makeConfig(overrides: Partial<AiProviderConfig> = {}): AiProviderConfig
     config: {},
     inputCostPer1M: null,
     outputCostPer1M: null,
+    costCurrency: 'USD',
     createdAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z',
     ...overrides,
@@ -28,7 +54,7 @@ const emptyUsage: AiUsageSummary = {
   totalRequests: 0,
   totalInputTokens: 0,
   totalOutputTokens: 0,
-  totalEstimatedCost: null,
+  totalEstimatedCostByCurrency: {},
   byProvider: [],
   byFeature: [],
   recentLogs: [],
@@ -38,13 +64,31 @@ const populatedUsage: AiUsageSummary = {
   totalRequests: 42,
   totalInputTokens: 5000,
   totalOutputTokens: 2500,
-  totalEstimatedCost: 12.34,
+  totalEstimatedCostByCurrency: { USD: 12.34 },
   byProvider: [
-    { provider: 'anthropic', requests: 30, inputTokens: 3500, outputTokens: 1800, estimatedCost: 10 },
-    { provider: 'openai', requests: 12, inputTokens: 1500, outputTokens: 700, estimatedCost: 2.34 },
+    {
+      provider: 'anthropic',
+      requests: 30,
+      inputTokens: 3500,
+      outputTokens: 1800,
+      estimatedCostByCurrency: { USD: 10 },
+    },
+    {
+      provider: 'openai',
+      requests: 12,
+      inputTokens: 1500,
+      outputTokens: 700,
+      estimatedCostByCurrency: { USD: 2.34 },
+    },
   ],
   byFeature: [
-    { feature: 'categorize', requests: 25, inputTokens: 3000, outputTokens: 1500, estimatedCost: 8.5 },
+    {
+      feature: 'categorize',
+      requests: 25,
+      inputTokens: 3000,
+      outputTokens: 1500,
+      estimatedCostByCurrency: { USD: 8.5 },
+    },
   ],
   recentLogs: [
     {
@@ -56,6 +100,7 @@ const populatedUsage: AiUsageSummary = {
       outputTokens: 50,
       durationMs: 1200,
       estimatedCost: 0.0012,
+      costCurrency: 'USD',
       createdAt: '2024-06-15T12:00:00.000Z',
     },
   ],
@@ -66,6 +111,7 @@ describe('UsageDashboard', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockHomeCurrency = 'USD';
   });
 
   it('renders summary cards', () => {
@@ -107,9 +153,7 @@ describe('UsageDashboard', () => {
       }),
     ];
     render(<UsageDashboard usage={populatedUsage} configs={configs} onPeriodChange={onPeriodChange} />);
-    // By-provider row uses the single-config display name.
     expect(screen.getAllByText('My Claude API').length).toBeGreaterThanOrEqual(1);
-    // Unconfigured provider still falls back to the friendly label.
     expect(screen.getByText('OpenAI (GPT)')).toBeInTheDocument();
   });
 
@@ -119,9 +163,7 @@ describe('UsageDashboard', () => {
       makeConfig({ id: 'c-2', provider: 'anthropic', model: 'claude-haiku-4-20250414', displayName: 'Claude Haiku' }),
     ];
     render(<UsageDashboard usage={populatedUsage} configs={configs} onPeriodChange={onPeriodChange} />);
-    // By-provider row uses the fallback label since there are two anthropic configs.
     expect(screen.getAllByText('Anthropic (Claude)').length).toBeGreaterThanOrEqual(1);
-    // Recent Activity row matches (provider, model) exactly, so it uses the specific config's name.
     expect(screen.getByText('Claude Sonnet')).toBeInTheDocument();
   });
 
@@ -139,7 +181,8 @@ describe('UsageDashboard', () => {
 
   it('shows estimated cost in summary card', () => {
     render(<UsageDashboard usage={populatedUsage} configs={noConfigs} onPeriodChange={onPeriodChange} />);
-    expect(screen.getByText('Est. Cost')).toBeInTheDocument();
+    // "Est. Cost" appears in the summary card and in each table header, so assert at least one exists.
+    expect(screen.getAllByText('Est. Cost').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('$12.34')).toBeInTheDocument();
   });
 
@@ -151,5 +194,36 @@ describe('UsageDashboard', () => {
   it('does not show provider table when empty', () => {
     render(<UsageDashboard usage={emptyUsage} configs={noConfigs} onPeriodChange={onPeriodChange} />);
     expect(screen.queryByText('By Provider')).not.toBeInTheDocument();
+  });
+
+  it('does not show the currency toggle when all costs are in the home currency', () => {
+    render(<UsageDashboard usage={populatedUsage} configs={noConfigs} onPeriodChange={onPeriodChange} />);
+    expect(screen.queryByText(/In provider currency/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the currency toggle and switches between home and provider currency', () => {
+    const foreignUsage: AiUsageSummary = {
+      ...populatedUsage,
+      totalEstimatedCostByCurrency: { EUR: 10 },
+      byProvider: [
+        {
+          provider: 'anthropic',
+          requests: 30,
+          inputTokens: 3500,
+          outputTokens: 1800,
+          estimatedCostByCurrency: { EUR: 10 },
+        },
+      ],
+      recentLogs: [],
+    };
+    render(<UsageDashboard usage={foreignUsage} configs={noConfigs} onPeriodChange={onPeriodChange} />);
+
+    // Home currency (USD) mode is the default: EUR 10 -> USD 11 via the fake rate.
+    // Appears in both the summary card and the byProvider row.
+    expect(screen.getAllByText('$11.00').length).toBeGreaterThanOrEqual(1);
+
+    // Switch to provider currency and assert euros now show up.
+    fireEvent.click(screen.getByText('In provider currency'));
+    expect(screen.getAllByText(/€\s?10\.00/).length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/frontend/src/components/settings/ai/UsageDashboard.test.tsx
+++ b/frontend/src/components/settings/ai/UsageDashboard.test.tsx
@@ -7,6 +7,7 @@ const emptyUsage: AiUsageSummary = {
   totalRequests: 0,
   totalInputTokens: 0,
   totalOutputTokens: 0,
+  totalEstimatedCost: null,
   byProvider: [],
   byFeature: [],
   recentLogs: [],
@@ -16,12 +17,13 @@ const populatedUsage: AiUsageSummary = {
   totalRequests: 42,
   totalInputTokens: 5000,
   totalOutputTokens: 2500,
+  totalEstimatedCost: 12.34,
   byProvider: [
-    { provider: 'anthropic', requests: 30, inputTokens: 3500, outputTokens: 1800 },
-    { provider: 'openai', requests: 12, inputTokens: 1500, outputTokens: 700 },
+    { provider: 'anthropic', requests: 30, inputTokens: 3500, outputTokens: 1800, estimatedCost: 10 },
+    { provider: 'openai', requests: 12, inputTokens: 1500, outputTokens: 700, estimatedCost: 2.34 },
   ],
   byFeature: [
-    { feature: 'categorize', requests: 25, inputTokens: 3000, outputTokens: 1500 },
+    { feature: 'categorize', requests: 25, inputTokens: 3000, outputTokens: 1500, estimatedCost: 8.5 },
   ],
   recentLogs: [
     {
@@ -32,6 +34,7 @@ const populatedUsage: AiUsageSummary = {
       inputTokens: 100,
       outputTokens: 50,
       durationMs: 1200,
+      estimatedCost: 0.0012,
       createdAt: '2024-06-15T12:00:00.000Z',
     },
   ],
@@ -83,6 +86,17 @@ describe('UsageDashboard', () => {
   it('shows empty state when no usage data', () => {
     render(<UsageDashboard usage={emptyUsage} onPeriodChange={onPeriodChange} />);
     expect(screen.getByText(/no usage data yet/i)).toBeInTheDocument();
+  });
+
+  it('shows estimated cost in summary card', () => {
+    render(<UsageDashboard usage={populatedUsage} onPeriodChange={onPeriodChange} />);
+    expect(screen.getByText('Est. Cost')).toBeInTheDocument();
+    expect(screen.getByText('$12.34')).toBeInTheDocument();
+  });
+
+  it('shows dash for estimated cost when no rates configured', () => {
+    render(<UsageDashboard usage={emptyUsage} onPeriodChange={onPeriodChange} />);
+    expect(screen.getByText(/set rates on a provider/i)).toBeInTheDocument();
   });
 
   it('does not show provider table when empty', () => {

--- a/frontend/src/components/settings/ai/UsageDashboard.tsx
+++ b/frontend/src/components/settings/ai/UsageDashboard.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { useState } from 'react';
-import type { AiUsageSummary } from '@/types/ai';
+import type { AiUsageSummary, AiProviderConfig, AiProviderType } from '@/types/ai';
+import { AI_PROVIDER_LABELS } from '@/types/ai';
 
 interface UsageDashboardProps {
   usage: AiUsageSummary;
+  configs: AiProviderConfig[];
   onPeriodChange: (days?: number) => void;
 }
 
@@ -26,7 +28,47 @@ function formatCost(cost: number | null): string {
   return cost === null ? '-' : costFormatter.format(cost);
 }
 
-export function UsageDashboard({ usage, onPeriodChange }: UsageDashboardProps) {
+function providerLabel(provider: string): string {
+  return AI_PROVIDER_LABELS[provider as AiProviderType] ?? provider;
+}
+
+/**
+ * Resolve a log's provider+model to the user's display name.
+ * Falls back to the human-readable provider label, then the raw type.
+ */
+function resolveLogName(
+  provider: string,
+  model: string,
+  configs: AiProviderConfig[],
+): string {
+  const exact = configs.find(
+    (c) => c.provider === provider && c.model === model && c.displayName,
+  );
+  if (exact?.displayName) return exact.displayName;
+  const byProvider = configs.find(
+    (c) => c.provider === provider && c.displayName,
+  );
+  if (byProvider?.displayName) return byProvider.displayName;
+  return providerLabel(provider);
+}
+
+/**
+ * Resolve a provider-level aggregation row's display name.
+ * If the user has exactly one config for that provider, use its display name.
+ * Otherwise fall back to the human-readable provider label.
+ */
+function resolveProviderName(
+  provider: string,
+  configs: AiProviderConfig[],
+): string {
+  const matches = configs.filter((c) => c.provider === provider);
+  if (matches.length === 1 && matches[0].displayName) {
+    return matches[0].displayName;
+  }
+  return providerLabel(provider);
+}
+
+export function UsageDashboard({ usage, configs, onPeriodChange }: UsageDashboardProps) {
   const [selectedPeriod, setSelectedPeriod] = useState<number | undefined>(30);
 
   const handlePeriodChange = (days: number | undefined) => {
@@ -109,7 +151,7 @@ export function UsageDashboard({ usage, onPeriodChange }: UsageDashboardProps) {
               <tbody>
                 {usage.byProvider.map((row) => (
                   <tr key={row.provider} className="border-b border-gray-100 dark:border-gray-700/50">
-                    <td className="py-2 text-gray-900 dark:text-white">{row.provider}</td>
+                    <td className="py-2 text-gray-900 dark:text-white">{resolveProviderName(row.provider, configs)}</td>
                     <td className="py-2 text-right text-gray-600 dark:text-gray-300">{row.requests.toLocaleString()}</td>
                     <td className="py-2 text-right text-gray-600 dark:text-gray-300">{row.inputTokens.toLocaleString()}</td>
                     <td className="py-2 text-right text-gray-600 dark:text-gray-300">{row.outputTokens.toLocaleString()}</td>
@@ -144,7 +186,7 @@ export function UsageDashboard({ usage, onPeriodChange }: UsageDashboardProps) {
                     <td className="py-2 text-gray-600 dark:text-gray-300">
                       {new Date(log.createdAt).toLocaleDateString()}
                     </td>
-                    <td className="py-2 text-gray-900 dark:text-white">{log.provider}</td>
+                    <td className="py-2 text-gray-900 dark:text-white">{resolveLogName(log.provider, log.model, configs)}</td>
                     <td className="py-2 text-gray-600 dark:text-gray-300">{log.feature}</td>
                     <td className="py-2 text-right text-gray-600 dark:text-gray-300">
                       {(log.inputTokens + log.outputTokens).toLocaleString()}

--- a/frontend/src/components/settings/ai/UsageDashboard.tsx
+++ b/frontend/src/components/settings/ai/UsageDashboard.tsx
@@ -1,8 +1,15 @@
 'use client';
 
-import { useState } from 'react';
-import type { AiUsageSummary, AiProviderConfig, AiProviderType } from '@/types/ai';
+import { useMemo, useState } from 'react';
+import type {
+  AiUsageSummary,
+  AiProviderConfig,
+  AiProviderType,
+  EstimatedCostByCurrency,
+} from '@/types/ai';
 import { AI_PROVIDER_LABELS } from '@/types/ai';
+import { useExchangeRates } from '@/hooks/useExchangeRates';
+import { usePreferencesStore } from '@/store/preferencesStore';
 
 interface UsageDashboardProps {
   usage: AiUsageSummary;
@@ -17,25 +24,31 @@ const PERIOD_OPTIONS = [
   { label: 'All time', value: undefined },
 ];
 
-const costFormatter = new Intl.NumberFormat(undefined, {
-  style: 'currency',
-  currency: 'USD',
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 4,
-});
-
-function formatCost(cost: number | null): string {
-  return cost === null ? '-' : costFormatter.format(cost);
+function currencyFormatter(currency: string): Intl.NumberFormat {
+  // Guard against any invalid currency code; fall back to USD so formatting
+  // never throws for users with exotic codes.
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 4,
+    });
+  } catch {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 4,
+    });
+  }
 }
 
 function providerLabel(provider: string): string {
   return AI_PROVIDER_LABELS[provider as AiProviderType] ?? provider;
 }
 
-/**
- * Resolve a log's provider+model to the user's display name.
- * Falls back to the human-readable provider label, then the raw type.
- */
+/** Resolve a log's provider+model to the user's display name. */
 function resolveLogName(
   provider: string,
   model: string,
@@ -52,11 +65,7 @@ function resolveLogName(
   return providerLabel(provider);
 }
 
-/**
- * Resolve a provider-level aggregation row's display name.
- * If the user has exactly one config for that provider, use its display name.
- * Otherwise fall back to the human-readable provider label.
- */
+/** Display name for a provider-level aggregation row. */
 function resolveProviderName(
   provider: string,
   configs: AiProviderConfig[],
@@ -68,13 +77,75 @@ function resolveProviderName(
   return providerLabel(provider);
 }
 
+/** True when the per-currency bucket contains at least one positive amount. */
+function hasAnyCost(bucket: EstimatedCostByCurrency): boolean {
+  return Object.values(bucket).some((v) => v > 0);
+}
+
 export function UsageDashboard({ usage, configs, onPeriodChange }: UsageDashboardProps) {
   const [selectedPeriod, setSelectedPeriod] = useState<number | undefined>(30);
+  const [showInHomeCurrency, setShowInHomeCurrency] = useState(true);
+  const { convert } = useExchangeRates();
+  const homeCurrency =
+    usePreferencesStore((state) => state.preferences?.defaultCurrency) || 'USD';
 
   const handlePeriodChange = (days: number | undefined) => {
     setSelectedPeriod(days);
     onPeriodChange(days);
   };
+
+  // Collect all distinct cost currencies that appear in the response so we
+  // can decide whether to show the currency-mode toggle.
+  const currenciesInUse = useMemo(() => {
+    const set = new Set<string>();
+    Object.keys(usage.totalEstimatedCostByCurrency).forEach((c) => set.add(c));
+    usage.byProvider.forEach((row) =>
+      Object.keys(row.estimatedCostByCurrency).forEach((c) => set.add(c)),
+    );
+    usage.recentLogs.forEach((log) => {
+      if (log.costCurrency) set.add(log.costCurrency);
+    });
+    return set;
+  }, [usage]);
+
+  const hasForeignCurrency = useMemo(() => {
+    for (const c of currenciesInUse) {
+      if (c !== homeCurrency) return true;
+    }
+    return false;
+  }, [currenciesInUse, homeCurrency]);
+
+  // Format a bucket either as a single converted home-currency amount or as
+  // one line per provider currency.
+  const renderBucket = (bucket: EstimatedCostByCurrency): string => {
+    if (!hasAnyCost(bucket)) return '-';
+    if (showInHomeCurrency || !hasForeignCurrency) {
+      let total = 0;
+      for (const [currency, amount] of Object.entries(bucket)) {
+        total += convert(amount, currency, homeCurrency);
+      }
+      return currencyFormatter(homeCurrency).format(total);
+    }
+    return Object.entries(bucket)
+      .filter(([, amount]) => amount > 0)
+      .map(([currency, amount]) => currencyFormatter(currency).format(amount))
+      .join(' + ');
+  };
+
+  const renderLogCost = (
+    cost: number | null,
+    costCurrency: string | null,
+  ): string => {
+    if (cost === null || !costCurrency) return '-';
+    if (showInHomeCurrency) {
+      return currencyFormatter(homeCurrency).format(
+        convert(cost, costCurrency, homeCurrency),
+      );
+    }
+    return currencyFormatter(costCurrency).format(cost);
+  };
+
+  const totalHasCost = hasAnyCost(usage.totalEstimatedCostByCurrency);
 
   return (
     <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 mb-6">
@@ -96,6 +167,35 @@ export function UsageDashboard({ usage, configs, onPeriodChange }: UsageDashboar
           ))}
         </div>
       </div>
+
+      {hasForeignCurrency && (
+        <div className="flex justify-end mb-3">
+          <div className="inline-flex rounded-md border border-gray-200 dark:border-gray-700 text-xs overflow-hidden">
+            <button
+              type="button"
+              onClick={() => setShowInHomeCurrency(true)}
+              className={`px-3 py-1 ${
+                showInHomeCurrency
+                  ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300'
+                  : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700'
+              }`}
+            >
+              In {homeCurrency}
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowInHomeCurrency(false)}
+              className={`px-3 py-1 ${
+                !showInHomeCurrency
+                  ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300'
+                  : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700'
+              }`}
+            >
+              In provider currency
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Summary Cards */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
@@ -123,9 +223,9 @@ export function UsageDashboard({ usage, configs, onPeriodChange }: UsageDashboar
         >
           <p className="text-xs text-gray-500 dark:text-gray-400">Est. Cost</p>
           <p className="text-2xl font-bold text-gray-900 dark:text-white">
-            {formatCost(usage.totalEstimatedCost)}
+            {totalHasCost ? renderBucket(usage.totalEstimatedCostByCurrency) : '-'}
           </p>
-          {usage.totalEstimatedCost === null && (
+          {!totalHasCost && (
             <p className="text-[10px] text-gray-400 dark:text-gray-500 mt-1">
               Set rates on a provider to enable
             </p>
@@ -155,7 +255,7 @@ export function UsageDashboard({ usage, configs, onPeriodChange }: UsageDashboar
                     <td className="py-2 text-right text-gray-600 dark:text-gray-300">{row.requests.toLocaleString()}</td>
                     <td className="py-2 text-right text-gray-600 dark:text-gray-300">{row.inputTokens.toLocaleString()}</td>
                     <td className="py-2 text-right text-gray-600 dark:text-gray-300">{row.outputTokens.toLocaleString()}</td>
-                    <td className="py-2 text-right text-gray-600 dark:text-gray-300">{formatCost(row.estimatedCost)}</td>
+                    <td className="py-2 text-right text-gray-600 dark:text-gray-300">{renderBucket(row.estimatedCostByCurrency)}</td>
                   </tr>
                 ))}
               </tbody>
@@ -195,7 +295,7 @@ export function UsageDashboard({ usage, configs, onPeriodChange }: UsageDashboar
                       {log.durationMs}ms
                     </td>
                     <td className="py-2 text-right text-gray-600 dark:text-gray-300">
-                      {formatCost(log.estimatedCost)}
+                      {renderLogCost(log.estimatedCost, log.costCurrency)}
                     </td>
                   </tr>
                 ))}

--- a/frontend/src/components/settings/ai/UsageDashboard.tsx
+++ b/frontend/src/components/settings/ai/UsageDashboard.tsx
@@ -15,6 +15,17 @@ const PERIOD_OPTIONS = [
   { label: 'All time', value: undefined },
 ];
 
+const costFormatter = new Intl.NumberFormat(undefined, {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 4,
+});
+
+function formatCost(cost: number | null): string {
+  return cost === null ? '-' : costFormatter.format(cost);
+}
+
 export function UsageDashboard({ usage, onPeriodChange }: UsageDashboardProps) {
   const [selectedPeriod, setSelectedPeriod] = useState<number | undefined>(30);
 
@@ -45,7 +56,7 @@ export function UsageDashboard({ usage, onPeriodChange }: UsageDashboardProps) {
       </div>
 
       {/* Summary Cards */}
-      <div className="grid grid-cols-3 gap-4 mb-6">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
         <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4">
           <p className="text-xs text-gray-500 dark:text-gray-400">Total Requests</p>
           <p className="text-2xl font-bold text-gray-900 dark:text-white">
@@ -64,6 +75,20 @@ export function UsageDashboard({ usage, onPeriodChange }: UsageDashboardProps) {
             {usage.totalOutputTokens.toLocaleString()}
           </p>
         </div>
+        <div
+          className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4"
+          title="Estimated using the cost rates you configured on each provider. Excludes any activity where no matching rate is set."
+        >
+          <p className="text-xs text-gray-500 dark:text-gray-400">Est. Cost</p>
+          <p className="text-2xl font-bold text-gray-900 dark:text-white">
+            {formatCost(usage.totalEstimatedCost)}
+          </p>
+          {usage.totalEstimatedCost === null && (
+            <p className="text-[10px] text-gray-400 dark:text-gray-500 mt-1">
+              Set rates on a provider to enable
+            </p>
+          )}
+        </div>
       </div>
 
       {/* By Provider */}
@@ -78,6 +103,7 @@ export function UsageDashboard({ usage, onPeriodChange }: UsageDashboardProps) {
                   <th className="pb-2 font-medium text-right">Requests</th>
                   <th className="pb-2 font-medium text-right">Input Tokens</th>
                   <th className="pb-2 font-medium text-right">Output Tokens</th>
+                  <th className="pb-2 font-medium text-right">Est. Cost</th>
                 </tr>
               </thead>
               <tbody>
@@ -87,6 +113,7 @@ export function UsageDashboard({ usage, onPeriodChange }: UsageDashboardProps) {
                     <td className="py-2 text-right text-gray-600 dark:text-gray-300">{row.requests.toLocaleString()}</td>
                     <td className="py-2 text-right text-gray-600 dark:text-gray-300">{row.inputTokens.toLocaleString()}</td>
                     <td className="py-2 text-right text-gray-600 dark:text-gray-300">{row.outputTokens.toLocaleString()}</td>
+                    <td className="py-2 text-right text-gray-600 dark:text-gray-300">{formatCost(row.estimatedCost)}</td>
                   </tr>
                 ))}
               </tbody>
@@ -108,6 +135,7 @@ export function UsageDashboard({ usage, onPeriodChange }: UsageDashboardProps) {
                   <th className="pb-2 font-medium">Feature</th>
                   <th className="pb-2 font-medium text-right">Tokens</th>
                   <th className="pb-2 font-medium text-right">Duration</th>
+                  <th className="pb-2 font-medium text-right">Est. Cost</th>
                 </tr>
               </thead>
               <tbody>
@@ -123,6 +151,9 @@ export function UsageDashboard({ usage, onPeriodChange }: UsageDashboardProps) {
                     </td>
                     <td className="py-2 text-right text-gray-600 dark:text-gray-300">
                       {log.durationMs}ms
+                    </td>
+                    <td className="py-2 text-right text-gray-600 dark:text-gray-300">
+                      {formatCost(log.estimatedCost)}
                     </td>
                   </tr>
                 ))}

--- a/frontend/src/types/ai.ts
+++ b/frontend/src/types/ai.ts
@@ -10,6 +10,8 @@ export interface AiProviderConfig {
   apiKeyMasked: string | null;
   baseUrl: string | null;
   config: Record<string, unknown>;
+  inputCostPer1M: number | null;
+  outputCostPer1M: number | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -22,6 +24,8 @@ export interface CreateAiProviderConfig {
   baseUrl?: string;
   priority?: number;
   config?: Record<string, unknown>;
+  inputCostPer1M?: number | null;
+  outputCostPer1M?: number | null;
 }
 
 export interface UpdateAiProviderConfig {
@@ -32,23 +36,28 @@ export interface UpdateAiProviderConfig {
   priority?: number;
   isActive?: boolean;
   config?: Record<string, unknown>;
+  inputCostPer1M?: number | null;
+  outputCostPer1M?: number | null;
 }
 
 export interface AiUsageSummary {
   totalRequests: number;
   totalInputTokens: number;
   totalOutputTokens: number;
+  totalEstimatedCost: number | null;
   byProvider: Array<{
     provider: string;
     requests: number;
     inputTokens: number;
     outputTokens: number;
+    estimatedCost: number | null;
   }>;
   byFeature: Array<{
     feature: string;
     requests: number;
     inputTokens: number;
     outputTokens: number;
+    estimatedCost: number | null;
   }>;
   recentLogs: Array<{
     id: string;
@@ -58,6 +67,7 @@ export interface AiUsageSummary {
     inputTokens: number;
     outputTokens: number;
     durationMs: number;
+    estimatedCost: number | null;
     createdAt: string;
   }>;
 }

--- a/frontend/src/types/ai.ts
+++ b/frontend/src/types/ai.ts
@@ -12,6 +12,7 @@ export interface AiProviderConfig {
   config: Record<string, unknown>;
   inputCostPer1M: number | null;
   outputCostPer1M: number | null;
+  costCurrency: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -26,6 +27,7 @@ export interface CreateAiProviderConfig {
   config?: Record<string, unknown>;
   inputCostPer1M?: number | null;
   outputCostPer1M?: number | null;
+  costCurrency?: string;
 }
 
 export interface UpdateAiProviderConfig {
@@ -38,26 +40,33 @@ export interface UpdateAiProviderConfig {
   config?: Record<string, unknown>;
   inputCostPer1M?: number | null;
   outputCostPer1M?: number | null;
+  costCurrency?: string;
 }
+
+/**
+ * Aggregated estimated cost keyed by ISO 4217 currency code.
+ * Empty when no configured rates match any logs.
+ */
+export type EstimatedCostByCurrency = Record<string, number>;
 
 export interface AiUsageSummary {
   totalRequests: number;
   totalInputTokens: number;
   totalOutputTokens: number;
-  totalEstimatedCost: number | null;
+  totalEstimatedCostByCurrency: EstimatedCostByCurrency;
   byProvider: Array<{
     provider: string;
     requests: number;
     inputTokens: number;
     outputTokens: number;
-    estimatedCost: number | null;
+    estimatedCostByCurrency: EstimatedCostByCurrency;
   }>;
   byFeature: Array<{
     feature: string;
     requests: number;
     inputTokens: number;
     outputTokens: number;
-    estimatedCost: number | null;
+    estimatedCostByCurrency: EstimatedCostByCurrency;
   }>;
   recentLogs: Array<{
     id: string;
@@ -68,6 +77,7 @@ export interface AiUsageSummary {
     outputTokens: number;
     durationMs: number;
     estimatedCost: number | null;
+    costCurrency: string | null;
     createdAt: string;
   }>;
 }


### PR DESCRIPTION
## Summary
This PR adds support for tracking and calculating estimated costs for AI provider usage. Users can now configure cost rates (per 1M tokens) for each AI provider/model combination, and the system will calculate and display estimated costs in the usage dashboard.

## Key Changes

### Backend
- **Cost Rate Configuration**: Added `inputCostPer1M` and `outputCostPer1M` fields to `AiProviderConfig` entity with numeric precision (12,4) for accurate cost calculations
- **Cost Calculation Logic**: Implemented `computeCost()` utility function that calculates estimated costs based on token counts and configured rates, with proper null handling
- **Enhanced Usage Summary**: Modified `getUsageSummary()` to:
  - Fetch user-configured cost rates from the database
  - Group logs by provider AND model (not just provider) to enable per-model rate lookups
  - Calculate estimated costs for each provider, feature, and individual log entry
  - Return `totalEstimatedCost` aggregated across all providers
- **API DTOs**: Added cost rate fields to `CreateAiConfigDto` and `UpdateAiConfigDto` with validation (0-1000000 range, max 4 decimal places)
- **Database Migration**: Added migration script to add the two new nullable numeric columns to `ai_provider_configs` table

### Frontend
- **Provider Config Form**: Added optional cost rate input fields with validation (regex for decimal format, up to 4 places)
- **Usage Dashboard**: 
  - Added "Est. Cost" summary card showing total estimated cost with helpful tooltip
  - Extended provider and feature tables to display `estimatedCost` column
  - Added cost formatter utility using `Intl.NumberFormat` for USD currency display
  - Shows "-" when cost is null (no matching rate configured)
- **Type Updates**: Updated `AiProviderConfig` and related interfaces to include cost rate fields

### Testing
- Added comprehensive test cases for cost computation with various scenarios:
  - Valid cost rates calculation
  - Null handling when no rates configured
  - Mismatched provider/model (no cost when rate doesn't match)
- Updated existing test mocks and fixtures to include the new cost fields

## Implementation Details
- Cost rates are user-defined and optional; when not set, cost estimates display as "-"
- Costs are calculated per-log and aggregated at provider/feature level
- The system uses a `rateMap` keyed by `provider::model` to enable precise per-model cost lookups
- Costs are rounded to 4 decimal places for precision
- Only logs with matching configured rates contribute to total estimated cost

https://claude.ai/code/session_015ENiF5ehhnTc6mPyZk96qh