### PR TITLE
Add ON DELETE CASCADE to securities.user_id foreign key

### DIFF
--- a/database/migrations/051_cascade_securities_user.sql
+++ b/database/migrations/051_cascade_securities_user.sql
@@ -1,0 +1,11 @@
+-- Adds ON DELETE CASCADE to the securities.user_id foreign key so that
+-- deleting a user removes their associated securities along with all the
+-- other per-user data. Previously the constraint was NO ACTION, which
+-- blocked user deletion whenever the user owned any securities.
+
+ALTER TABLE securities
+    DROP CONSTRAINT IF EXISTS securities_user_id_fkey;
+
+ALTER TABLE securities
+    ADD CONSTRAINT securities_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -378,7 +378,7 @@ CREATE INDEX idx_sched_txn_overrides_orig ON scheduled_transaction_overrides(sch
 -- Securities (stocks, bonds, mutual funds, ETFs)
 CREATE TABLE securities (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    user_id UUID NOT NULL REFERENCES users(id),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     symbol VARCHAR(20) NOT NULL, -- ticker symbol (unique per user)
     name VARCHAR(255) NOT NULL,
     security_type VARCHAR(50), -- 'STOCK', 'ETF', 'MUTUAL_FUND', 'BOND', etc


### PR DESCRIPTION
## Summary
Updates the foreign key constraint on the `securities.user_id` column to use `ON DELETE CASCADE` instead of the previous `NO ACTION` behavior. This allows users to be deleted without being blocked by existing securities records.

## Changes
- Modified the `securities` table's `user_id` foreign key constraint to cascade deletes from the `users` table
- Added migration `051_cascade_securities_user.sql` to alter the existing constraint in the database
- Updated `schema.sql` to reflect the new constraint definition for future schema generation

## Details
Previously, the `NO ACTION` constraint prevented user deletion whenever a user owned any securities. With this change, deleting a user will automatically remove all associated securities along with other per-user data, enabling proper user cleanup and account deletion workflows.

https://claude.ai/code/session_01LeAZWaJvDNMt2mcvWujfCv