### PR TITLE
feat: persist AI Assistant conversation history in localStorage

### DIFF
--- a/frontend/src/components/ai/ChatInterface.test.tsx
+++ b/frontend/src/components/ai/ChatInterface.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@/test/render';
-import { ChatInterface } from './ChatInterface';
+import { ChatInterface, AI_CHAT_STORAGE_KEY } from './ChatInterface';
 import type { StreamCallbacks } from '@/types/ai';
 
 // Capture the callbacks from queryStream calls
@@ -33,6 +33,10 @@ describe('ChatInterface', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedCallbacks = null;
+    // Chat now persists to localStorage. The test setup's mock is shared across
+    // tests, so clear the key to prevent messages from one test bleeding into
+    // the next.
+    window.localStorage.removeItem(AI_CHAT_STORAGE_KEY);
   });
 
   it('shows suggested queries when no messages', async () => {
@@ -464,5 +468,95 @@ describe('ChatInterface', () => {
     fireEvent.click(screen.getByTitle('Send'));
 
     expect(aiApi.queryStream).not.toHaveBeenCalled();
+  });
+
+  describe('conversation persistence', () => {
+    it('restores prior conversation from localStorage on mount', async () => {
+      window.localStorage.setItem(
+        AI_CHAT_STORAGE_KEY,
+        JSON.stringify([
+          { id: 'user-1', role: 'user', content: 'What did I spend?' },
+          { id: 'assistant-1', role: 'assistant', content: 'You spent $42.' },
+        ]),
+      );
+
+      await renderChat();
+
+      expect(screen.getByText('What did I spend?')).toBeInTheDocument();
+      expect(screen.getByText('You spent $42.')).toBeInTheDocument();
+    });
+
+    it('persists new messages to localStorage', async () => {
+      await renderChat();
+
+      const textarea = screen.getByPlaceholderText(
+        'Ask about your finances...',
+      );
+      fireEvent.change(textarea, { target: { value: 'Balance?' } });
+      fireEvent.click(screen.getByTitle('Send'));
+
+      const stored = window.localStorage.getItem(AI_CHAT_STORAGE_KEY);
+      expect(stored).not.toBeNull();
+      const parsed = JSON.parse(stored as string);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0]).toMatchObject({ role: 'user', content: 'Balance?' });
+    });
+
+    it('heals stuck isStreaming flag from an interrupted session', async () => {
+      window.localStorage.setItem(
+        AI_CHAT_STORAGE_KEY,
+        JSON.stringify([
+          { id: 'user-1', role: 'user', content: 'Q' },
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            content: 'Partial answer',
+            isStreaming: true,
+          },
+        ]),
+      );
+
+      await renderChat();
+
+      // The "Send" button is shown (not the in-flight "Cancel" button),
+      // confirming the restored state isn't treated as an active request.
+      expect(screen.getByTitle('Send')).toBeInTheDocument();
+      expect(screen.queryByTitle('Cancel')).not.toBeInTheDocument();
+
+      const stored = JSON.parse(
+        window.localStorage.getItem(AI_CHAT_STORAGE_KEY) as string,
+      );
+      expect(stored[1].isStreaming).toBe(false);
+    });
+
+    it('clears the conversation when Clear conversation is clicked', async () => {
+      window.localStorage.setItem(
+        AI_CHAT_STORAGE_KEY,
+        JSON.stringify([
+          { id: 'user-1', role: 'user', content: 'Hello' },
+          { id: 'assistant-1', role: 'assistant', content: 'Hi there' },
+        ]),
+      );
+
+      await renderChat();
+      expect(screen.getByText('Hello')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('Clear conversation'));
+
+      expect(screen.queryByText('Hello')).not.toBeInTheDocument();
+      expect(screen.queryByText('Hi there')).not.toBeInTheDocument();
+      const stored = JSON.parse(
+        window.localStorage.getItem(AI_CHAT_STORAGE_KEY) as string,
+      );
+      expect(stored).toEqual([]);
+    });
+
+    it('does not show the conversation header when there are no messages', async () => {
+      await renderChat();
+      expect(
+        screen.queryByText('Conversation saved in your browser'),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Clear conversation')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/ai/ChatInterface.tsx
+++ b/frontend/src/components/ai/ChatInterface.tsx
@@ -5,8 +5,13 @@ import { aiApi } from '@/lib/ai';
 import { SuggestedQueries } from './SuggestedQueries';
 import { ChatMessage } from './ChatMessage';
 import type { AiStatus, StreamEvent } from '@/types/ai';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 import toast from 'react-hot-toast';
 import Link from 'next/link';
+
+// Key for persisting the AI conversation in the browser's localStorage.
+// Cleared on logout via authStore so conversations don't leak between accounts.
+export const AI_CHAT_STORAGE_KEY = 'monize:ai-chat-messages';
 
 interface ToolCallRecord {
   name: string;
@@ -41,7 +46,10 @@ interface ThinkingState {
 }
 
 export function ChatInterface() {
-  const [messages, setMessages] = useState<Message[]>([]);
+  const [messages, setMessages] = useLocalStorage<Message[]>(
+    AI_CHAT_STORAGE_KEY,
+    [],
+  );
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [aiStatus, setAiStatus] = useState<AiStatus | null>(null);
@@ -64,6 +72,29 @@ export function ChatInterface() {
       setStatusLoading(false);
     });
   }, []);
+
+  // If the user navigated away mid-stream, the persisted message will still
+  // be flagged isStreaming and the last assistant entry may be flagged as an
+  // in-flight error. On mount, sanitize those flags so the restored
+  // conversation renders as a completed exchange.
+  useEffect(() => {
+    setMessages((prev) => {
+      if (!prev.some((m) => m.isStreaming)) return prev;
+      return prev.map((m) =>
+        m.isStreaming ? { ...m, isStreaming: false } : m,
+      );
+    });
+    // Run once on mount — setMessages is stable and we only want to heal
+    // flags that were persisted from a previous session.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleClearConversation = useCallback(() => {
+    abortControllerRef.current?.abort();
+    setMessages([]);
+    setThinking({ active: false, message: '', liveText: '', tools: [] });
+    setIsLoading(false);
+  }, [setMessages]);
 
   const scrollToBottom = useCallback(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -284,7 +315,7 @@ export function ChatInterface() {
 
       abortControllerRef.current = controller;
     },
-    [input, isLoading],
+    [input, isLoading, setMessages],
   );
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -331,6 +362,22 @@ export function ChatInterface() {
               </p>
             </div>
           </div>
+        </div>
+      )}
+
+      {/* Conversation header with clear action */}
+      {messages.length > 0 && (
+        <div className="flex items-center justify-between px-2 pb-2 border-b border-gray-200 dark:border-gray-700">
+          <p className="text-xs text-gray-400 dark:text-gray-500">
+            Conversation saved in your browser
+          </p>
+          <button
+            type="button"
+            onClick={handleClearConversation}
+            className="text-xs text-gray-500 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400 transition-colors"
+          >
+            Clear conversation
+          </button>
         </div>
       )}
 

--- a/frontend/src/store/authStore.test.ts
+++ b/frontend/src/store/authStore.test.ts
@@ -57,6 +57,19 @@ describe('authStore', () => {
       expect(state.error).toBeNull();
       expect(state.isLoading).toBe(false);
     });
+
+    it('clears persisted AI chat history so it does not leak across accounts', () => {
+      window.localStorage.setItem(
+        'monize:ai-chat-messages',
+        JSON.stringify([{ id: '1', role: 'user', content: 'private' }]),
+      );
+
+      useAuthStore.getState().logout();
+
+      expect(
+        window.localStorage.getItem('monize:ai-chat-messages'),
+      ).toBeNull();
+    });
   });
 
   describe('setUser', () => {

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -58,6 +58,14 @@ export const useAuthStore = create<AuthState>()(
         import('@/store/preferencesStore').then(({ usePreferencesStore }) => {
           usePreferencesStore.getState().clearPreferences();
         });
+        // SECURITY: Clear AI chat history so conversations don't leak across accounts
+        try {
+          if (typeof window !== 'undefined') {
+            window.localStorage.removeItem('monize:ai-chat-messages');
+          }
+        } catch {
+          // localStorage unavailable — nothing to do
+        }
         set({
           user: null,
           token: null,


### PR DESCRIPTION
The AI Assistant chat now survives navigation away from the page. Messages are
stored in the browser's localStorage under 'monize:ai-chat-messages' via the
existing useLocalStorage hook, and are cleared on logout so conversations don't
leak across accounts. A "Clear conversation" action lets users start fresh, and
stuck isStreaming flags from interrupted sessions are healed on mount so a
restored conversation renders as completed.

https://claude.ai/code/session_011EuLrUtRrjE4Zf1nKeEUDr