### PR TITLE
fix: keep AI Assistant queries running after navigating away

### DIFF
--- a/frontend/src/components/ai/ChatInterface.test.tsx
+++ b/frontend/src/components/ai/ChatInterface.test.tsx
@@ -1,7 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@/test/render';
 import { ChatInterface, AI_CHAT_STORAGE_KEY } from './ChatInterface';
+import { useAiChatStore, type ChatMessage } from '@/store/aiChatStore';
 import type { StreamCallbacks } from '@/types/ai';
+
+// The Zustand persist middleware wraps state as { state: {...}, version: 0 }.
+// Helpers let tests seed and inspect the persisted blob without mirroring that
+// shape inline everywhere.
+function seedPersistedMessages(messages: ChatMessage[]) {
+  window.localStorage.setItem(
+    AI_CHAT_STORAGE_KEY,
+    JSON.stringify({ state: { messages }, version: 0 }),
+  );
+  // Push the same messages into the live store so the component renders them
+  // without waiting for rehydration on a remounted store.
+  useAiChatStore.setState({ messages });
+}
+
+function readPersistedMessages(): ChatMessage[] | null {
+  const raw = window.localStorage.getItem(AI_CHAT_STORAGE_KEY);
+  if (!raw) return null;
+  return JSON.parse(raw).state.messages;
+}
 
 // Capture the callbacks from queryStream calls
 let capturedCallbacks: StreamCallbacks | null = null;
@@ -33,10 +53,17 @@ describe('ChatInterface', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedCallbacks = null;
-    // Chat now persists to localStorage. The test setup's mock is shared across
-    // tests, so clear the key to prevent messages from one test bleeding into
-    // the next.
+    // Chat state lives in a Zustand store that survives across tests (singleton)
+    // and persists to a shared localStorage mock — reset both so messages from
+    // one test don't bleed into the next.
     window.localStorage.removeItem(AI_CHAT_STORAGE_KEY);
+    useAiChatStore.setState({
+      messages: [],
+      isLoading: false,
+      thinking: { active: false, message: '', liveText: '', tools: [] },
+      _abortController: null,
+      _activeAssistantId: null,
+    });
   });
 
   it('shows suggested queries when no messages', async () => {
@@ -471,14 +498,11 @@ describe('ChatInterface', () => {
   });
 
   describe('conversation persistence', () => {
-    it('restores prior conversation from localStorage on mount', async () => {
-      window.localStorage.setItem(
-        AI_CHAT_STORAGE_KEY,
-        JSON.stringify([
-          { id: 'user-1', role: 'user', content: 'What did I spend?' },
-          { id: 'assistant-1', role: 'assistant', content: 'You spent $42.' },
-        ]),
-      );
+    it('restores prior conversation from the store on mount', async () => {
+      seedPersistedMessages([
+        { id: 'user-1', role: 'user', content: 'What did I spend?' },
+        { id: 'assistant-1', role: 'assistant', content: 'You spent $42.' },
+      ]);
 
       await renderChat();
 
@@ -495,48 +519,93 @@ describe('ChatInterface', () => {
       fireEvent.change(textarea, { target: { value: 'Balance?' } });
       fireEvent.click(screen.getByTitle('Send'));
 
-      const stored = window.localStorage.getItem(AI_CHAT_STORAGE_KEY);
+      const stored = readPersistedMessages();
       expect(stored).not.toBeNull();
-      const parsed = JSON.parse(stored as string);
-      expect(parsed).toHaveLength(1);
-      expect(parsed[0]).toMatchObject({ role: 'user', content: 'Balance?' });
+      expect(stored).toHaveLength(1);
+      expect(stored?.[0]).toMatchObject({ role: 'user', content: 'Balance?' });
+    });
+
+    it('keeps streaming into the store after the component unmounts', async () => {
+      // Simulates the user navigating away mid-query. The store keeps writing
+      // to messages and localStorage even with no component subscribed, so
+      // when they return the assistant response is fully there.
+      const { unmount } = await renderChat();
+
+      const textarea = screen.getByPlaceholderText(
+        'Ask about your finances...',
+      );
+      fireEvent.change(textarea, { target: { value: 'Q' } });
+      fireEvent.click(screen.getByTitle('Send'));
+
+      // User leaves the AI page
+      unmount();
+
+      // Stream completes in the background
+      act(() => {
+        capturedCallbacks?.onEvent({
+          type: 'content',
+          text: 'Backgrounded answer.',
+        });
+        capturedCallbacks?.onEvent({
+          type: 'done',
+          usage: { inputTokens: 10, outputTokens: 5, toolCalls: 0 },
+        });
+      });
+
+      const stored = readPersistedMessages();
+      expect(stored).toHaveLength(2);
+      expect(stored?.[1]).toMatchObject({
+        role: 'assistant',
+        content: 'Backgrounded answer.',
+        isStreaming: false,
+      });
+
+      // User returns to the AI page — the answer is shown, no spinner.
+      await renderChat();
+      expect(screen.getByText('Backgrounded answer.')).toBeInTheDocument();
+      expect(screen.getByTitle('Send')).toBeInTheDocument();
+      expect(screen.queryByTitle('Cancel')).not.toBeInTheDocument();
     });
 
     it('heals stuck isStreaming flag from an interrupted session', async () => {
+      // Simulate a previous tab that was killed mid-stream — the Zustand
+      // persist middleware would have written messages with isStreaming:true.
       window.localStorage.setItem(
         AI_CHAT_STORAGE_KEY,
-        JSON.stringify([
-          { id: 'user-1', role: 'user', content: 'Q' },
-          {
-            id: 'assistant-1',
-            role: 'assistant',
-            content: 'Partial answer',
-            isStreaming: true,
+        JSON.stringify({
+          state: {
+            messages: [
+              { id: 'user-1', role: 'user', content: 'Q' },
+              {
+                id: 'assistant-1',
+                role: 'assistant',
+                content: 'Partial answer',
+                isStreaming: true,
+              },
+            ],
           },
-        ]),
+          version: 0,
+        }),
       );
+      // Force the store to rehydrate from the seeded payload.
+      await useAiChatStore.persist.rehydrate();
 
       await renderChat();
 
-      // The "Send" button is shown (not the in-flight "Cancel" button),
-      // confirming the restored state isn't treated as an active request.
+      // Send button (not Cancel) confirms the restored state isn't treated
+      // as an in-flight request.
       expect(screen.getByTitle('Send')).toBeInTheDocument();
       expect(screen.queryByTitle('Cancel')).not.toBeInTheDocument();
 
-      const stored = JSON.parse(
-        window.localStorage.getItem(AI_CHAT_STORAGE_KEY) as string,
-      );
-      expect(stored[1].isStreaming).toBe(false);
+      const stored = readPersistedMessages();
+      expect(stored?.[1].isStreaming).toBe(false);
     });
 
     it('clears the conversation when Clear conversation is clicked', async () => {
-      window.localStorage.setItem(
-        AI_CHAT_STORAGE_KEY,
-        JSON.stringify([
-          { id: 'user-1', role: 'user', content: 'Hello' },
-          { id: 'assistant-1', role: 'assistant', content: 'Hi there' },
-        ]),
-      );
+      seedPersistedMessages([
+        { id: 'user-1', role: 'user', content: 'Hello' },
+        { id: 'assistant-1', role: 'assistant', content: 'Hi there' },
+      ]);
 
       await renderChat();
       expect(screen.getByText('Hello')).toBeInTheDocument();
@@ -545,10 +614,7 @@ describe('ChatInterface', () => {
 
       expect(screen.queryByText('Hello')).not.toBeInTheDocument();
       expect(screen.queryByText('Hi there')).not.toBeInTheDocument();
-      const stored = JSON.parse(
-        window.localStorage.getItem(AI_CHAT_STORAGE_KEY) as string,
-      );
-      expect(stored).toEqual([]);
+      expect(readPersistedMessages()).toEqual([]);
     });
 
     it('does not show the conversation header when there are no messages', async () => {

--- a/frontend/src/components/ai/ChatInterface.tsx
+++ b/frontend/src/components/ai/ChatInterface.tsx
@@ -4,65 +4,30 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { aiApi } from '@/lib/ai';
 import { SuggestedQueries } from './SuggestedQueries';
 import { ChatMessage } from './ChatMessage';
-import type { AiStatus, StreamEvent } from '@/types/ai';
-import { useLocalStorage } from '@/hooks/useLocalStorage';
-import toast from 'react-hot-toast';
+import type { AiStatus } from '@/types/ai';
+import {
+  useAiChatStore,
+  AI_CHAT_STORAGE_KEY,
+} from '@/store/aiChatStore';
 import Link from 'next/link';
 
-// Key for persisting the AI conversation in the browser's localStorage.
-// Cleared on logout via authStore so conversations don't leak between accounts.
-export const AI_CHAT_STORAGE_KEY = 'monize:ai-chat-messages';
-
-interface ToolCallRecord {
-  name: string;
-  summary: string;
-  input?: Record<string, unknown>;
-  isError?: boolean;
-}
-
-interface Message {
-  id: string;
-  role: 'user' | 'assistant';
-  content: string;
-  toolsUsed?: ToolCallRecord[];
-  sources?: Array<{ type: string; description: string; dateRange?: string }>;
-  isStreaming?: boolean;
-  error?: string;
-}
-
-interface ThinkingState {
-  active: boolean;
-  message: string;
-  // Live streamed text from the model — accumulates per iteration as the
-  // backend emits assistant_text deltas. Reset on each new tool_start so the
-  // user sees the next "thinking" pass cleanly.
-  liveText: string;
-  tools: Array<{
-    name: string;
-    status: 'running' | 'done';
-    summary?: string;
-    isError?: boolean;
-  }>;
-}
+// Re-exported for tests and other call sites that previously imported the key
+// from the component module.
+export { AI_CHAT_STORAGE_KEY };
 
 export function ChatInterface() {
-  const [messages, setMessages] = useLocalStorage<Message[]>(
-    AI_CHAT_STORAGE_KEY,
-    [],
-  );
+  const messages = useAiChatStore((s) => s.messages);
+  const isLoading = useAiChatStore((s) => s.isLoading);
+  const thinking = useAiChatStore((s) => s.thinking);
+  const submit = useAiChatStore((s) => s.submit);
+  const cancel = useAiChatStore((s) => s.cancel);
+  const clear = useAiChatStore((s) => s.clear);
+
   const [input, setInput] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
   const [aiStatus, setAiStatus] = useState<AiStatus | null>(null);
   const [statusLoading, setStatusLoading] = useState(true);
-  const [thinking, setThinking] = useState<ThinkingState>({
-    active: false,
-    message: '',
-    liveText: '',
-    tools: [],
-  });
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     aiApi.getStatus().then((status) => {
@@ -72,29 +37,6 @@ export function ChatInterface() {
       setStatusLoading(false);
     });
   }, []);
-
-  // If the user navigated away mid-stream, the persisted message will still
-  // be flagged isStreaming and the last assistant entry may be flagged as an
-  // in-flight error. On mount, sanitize those flags so the restored
-  // conversation renders as a completed exchange.
-  useEffect(() => {
-    setMessages((prev) => {
-      if (!prev.some((m) => m.isStreaming)) return prev;
-      return prev.map((m) =>
-        m.isStreaming ? { ...m, isStreaming: false } : m,
-      );
-    });
-    // Run once on mount — setMessages is stable and we only want to heal
-    // flags that were persisted from a previous session.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const handleClearConversation = useCallback(() => {
-    abortControllerRef.current?.abort();
-    setMessages([]);
-    setThinking({ active: false, message: '', liveText: '', tools: [] });
-    setIsLoading(false);
-  }, [setMessages]);
 
   const scrollToBottom = useCallback(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -107,215 +49,13 @@ export function ChatInterface() {
   }, [messages, thinking, scrollToBottom]);
 
   const handleSubmit = useCallback(
-    async (queryText?: string) => {
-      const query = queryText || input.trim();
-      if (!query || isLoading) return;
-
+    (queryText?: string) => {
+      const query = queryText || input;
+      if (!query.trim() || isLoading) return;
       setInput('');
-      setIsLoading(true);
-
-      // Add user message
-      const userMsgId = `user-${Date.now()}`;
-      const assistantMsgId = `assistant-${Date.now()}`;
-
-      setMessages((prev) => [
-        ...prev,
-        { id: userMsgId, role: 'user', content: query },
-      ]);
-
-      setThinking({
-        active: true,
-        message: 'Analyzing your question...',
-        liveText: '',
-        tools: [],
-      });
-
-      const toolsUsed: ToolCallRecord[] = [];
-      let sources: Array<{ type: string; description: string; dateRange?: string }> = [];
-      let contentBuffer = '';
-      let hasStartedContent = false;
-
-      const controller = aiApi.queryStream(query, {
-        onEvent: (event: StreamEvent) => {
-          switch (event.type) {
-            case 'thinking':
-              setThinking((prev) => ({
-                ...prev,
-                message: event.message || 'Thinking...',
-              }));
-              break;
-
-            case 'assistant_text':
-              // Streaming text delta from the model — append to the live
-              // thinking buffer so the user sees realtime feedback while
-              // the model generates its next step.
-              setThinking((prev) => ({
-                ...prev,
-                liveText: prev.liveText + (event.text || ''),
-              }));
-              break;
-
-            case 'tool_start':
-              // The model decided to use a tool. Lock in any live text as
-              // "thinking we already saw" by clearing the buffer for the
-              // next iteration, and add the tool to the indicator list.
-              // Capture the input now so it's available for the expandable
-              // detail view even if the tool result never arrives.
-              toolsUsed.push({
-                name: event.name || '',
-                summary: '',
-                input: event.input,
-              });
-              setThinking((prev) => ({
-                ...prev,
-                message: `Looking up ${event.name?.replace(/_/g, ' ')}...`,
-                liveText: '',
-                tools: [
-                  ...prev.tools,
-                  { name: event.name || '', status: 'running' },
-                ],
-              }));
-              break;
-
-            case 'tool_result': {
-              // Backfill the summary onto the most recent matching tool entry
-              // (model can call the same tool multiple times in a query).
-              // Find the first entry (by call order) matching the name that
-              // hasn't been resolved yet — this is the call this result
-              // belongs to.
-              for (let i = 0; i < toolsUsed.length; i++) {
-                if (
-                  toolsUsed[i].name === event.name &&
-                  !toolsUsed[i].summary &&
-                  toolsUsed[i].isError === undefined
-                ) {
-                  toolsUsed[i] = {
-                    ...toolsUsed[i],
-                    summary: event.summary || '',
-                    isError: event.isError === true,
-                  };
-                  break;
-                }
-              }
-              setThinking((prev) => {
-                // Update only the first still-running tool with this name so
-                // repeated calls to the same tool don't overwrite each
-                // other's pass/fail state.
-                let updated = false;
-                return {
-                  ...prev,
-                  tools: prev.tools.map((t) => {
-                    if (
-                      !updated &&
-                      t.name === event.name &&
-                      t.status === 'running'
-                    ) {
-                      updated = true;
-                      return {
-                        ...t,
-                        status: 'done',
-                        summary: event.summary,
-                        isError: event.isError === true,
-                      };
-                    }
-                    return t;
-                  }),
-                };
-              });
-              break;
-            }
-
-            case 'content':
-              if (!hasStartedContent) {
-                hasStartedContent = true;
-                setThinking({ active: false, message: '', liveText: '', tools: [] });
-                setMessages((prev) => [
-                  ...prev,
-                  {
-                    id: assistantMsgId,
-                    role: 'assistant',
-                    content: event.text || '',
-                    toolsUsed: [...toolsUsed],
-                    isStreaming: true,
-                  },
-                ]);
-              }
-              contentBuffer = event.text || '';
-              setMessages((prev) =>
-                prev.map((m) =>
-                  m.id === assistantMsgId
-                    ? { ...m, content: contentBuffer, toolsUsed: [...toolsUsed] }
-                    : m,
-                ),
-              );
-              break;
-
-            case 'sources':
-              sources = (event.sources as typeof sources) || [];
-              break;
-
-            case 'done':
-              setMessages((prev) =>
-                prev.map((m) =>
-                  m.id === assistantMsgId
-                    ? { ...m, isStreaming: false, sources }
-                    : m,
-                ),
-              );
-              setIsLoading(false);
-              setThinking({ active: false, message: '', liveText: '', tools: [] });
-              break;
-
-            case 'error':
-              setThinking({ active: false, message: '', liveText: '', tools: [] });
-              if (hasStartedContent) {
-                setMessages((prev) =>
-                  prev.map((m) =>
-                    m.id === assistantMsgId
-                      ? { ...m, isStreaming: false, error: event.message as string }
-                      : m,
-                  ),
-                );
-              } else {
-                setMessages((prev) => [
-                  ...prev,
-                  {
-                    id: assistantMsgId,
-                    role: 'assistant',
-                    content: '',
-                    error: (event.message as string) || 'An error occurred',
-                  },
-                ]);
-              }
-              setIsLoading(false);
-              break;
-          }
-        },
-        onDone: () => {
-          setIsLoading(false);
-          setThinking({ active: false, message: '', liveText: '', tools: [] });
-        },
-        onError: (error) => {
-          setThinking({ active: false, message: '', liveText: '', tools: [] });
-          setIsLoading(false);
-          toast.error(error.message || 'Failed to get response');
-          if (!hasStartedContent) {
-            setMessages((prev) => [
-              ...prev,
-              {
-                id: assistantMsgId,
-                role: 'assistant',
-                content: '',
-                error: error.message || 'Failed to connect to the AI service.',
-              },
-            ]);
-          }
-        },
-      });
-
-      abortControllerRef.current = controller;
+      submit(query);
     },
-    [input, isLoading, setMessages],
+    [input, isLoading, submit],
   );
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -323,12 +63,6 @@ export function ChatInterface() {
       e.preventDefault();
       handleSubmit();
     }
-  };
-
-  const handleCancel = () => {
-    abortControllerRef.current?.abort();
-    setIsLoading(false);
-    setThinking({ active: false, message: '', liveText: '', tools: [] });
   };
 
   // Auto-resize textarea
@@ -373,7 +107,7 @@ export function ChatInterface() {
           </p>
           <button
             type="button"
-            onClick={handleClearConversation}
+            onClick={clear}
             className="text-xs text-gray-500 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400 transition-colors"
           >
             Clear conversation
@@ -516,7 +250,7 @@ export function ChatInterface() {
           />
           {isLoading ? (
             <button
-              onClick={handleCancel}
+              onClick={cancel}
               className="flex-shrink-0 p-2.5 rounded-xl bg-red-500 hover:bg-red-600 text-white transition-colors"
               title="Cancel"
             >

--- a/frontend/src/store/aiChatStore.test.ts
+++ b/frontend/src/store/aiChatStore.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  useAiChatStore,
+  AI_CHAT_STORAGE_KEY,
+} from './aiChatStore';
+import type { StreamCallbacks } from '@/types/ai';
+
+let capturedCallbacks: StreamCallbacks | null = null;
+const mockAbortController = { abort: vi.fn() };
+
+vi.mock('@/lib/ai', () => ({
+  aiApi: {
+    queryStream: vi.fn((_query: string, callbacks: StreamCallbacks) => {
+      capturedCallbacks = callbacks;
+      return mockAbortController;
+    }),
+  },
+}));
+
+describe('aiChatStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedCallbacks = null;
+    window.localStorage.removeItem(AI_CHAT_STORAGE_KEY);
+    useAiChatStore.setState({
+      messages: [],
+      isLoading: false,
+      thinking: { active: false, message: '', liveText: '', tools: [] },
+      _abortController: null,
+      _activeAssistantId: null,
+    });
+  });
+
+  describe('submit', () => {
+    it('appends a user message and enters loading state', () => {
+      useAiChatStore.getState().submit('What is my balance?');
+
+      const state = useAiChatStore.getState();
+      expect(state.messages).toHaveLength(1);
+      expect(state.messages[0]).toMatchObject({
+        role: 'user',
+        content: 'What is my balance?',
+      });
+      expect(state.isLoading).toBe(true);
+      expect(state.thinking.active).toBe(true);
+    });
+
+    it('ignores empty/whitespace queries', async () => {
+      const { aiApi } = await import('@/lib/ai');
+      useAiChatStore.getState().submit('   ');
+      expect(aiApi.queryStream).not.toHaveBeenCalled();
+      expect(useAiChatStore.getState().messages).toHaveLength(0);
+    });
+
+    it('ignores submission while another query is in flight', async () => {
+      const { aiApi } = await import('@/lib/ai');
+      useAiChatStore.getState().submit('first');
+      useAiChatStore.getState().submit('second');
+
+      expect(aiApi.queryStream).toHaveBeenCalledTimes(1);
+      expect(useAiChatStore.getState().messages).toHaveLength(1);
+    });
+
+    it('writes streamed content into the assistant message', () => {
+      useAiChatStore.getState().submit('Q');
+
+      capturedCallbacks?.onEvent({ type: 'content', text: 'Answer.' });
+      capturedCallbacks?.onEvent({
+        type: 'done',
+        usage: { inputTokens: 1, outputTokens: 1, toolCalls: 0 },
+      });
+
+      const messages = useAiChatStore.getState().messages;
+      expect(messages).toHaveLength(2);
+      expect(messages[1]).toMatchObject({
+        role: 'assistant',
+        content: 'Answer.',
+        isStreaming: false,
+      });
+      expect(useAiChatStore.getState().isLoading).toBe(false);
+    });
+
+    it('records errors against the assistant message', () => {
+      useAiChatStore.getState().submit('Q');
+
+      capturedCallbacks?.onEvent({
+        type: 'error',
+        message: 'Provider unavailable',
+      });
+
+      const messages = useAiChatStore.getState().messages;
+      expect(messages).toHaveLength(2);
+      expect(messages[1]).toMatchObject({
+        role: 'assistant',
+        error: 'Provider unavailable',
+      });
+      expect(useAiChatStore.getState().isLoading).toBe(false);
+    });
+  });
+
+  describe('cancel', () => {
+    it('aborts the in-flight controller and resets loading state', () => {
+      useAiChatStore.getState().submit('Q');
+      useAiChatStore.getState().cancel();
+
+      expect(mockAbortController.abort).toHaveBeenCalled();
+      expect(useAiChatStore.getState().isLoading).toBe(false);
+      expect(useAiChatStore.getState().thinking.active).toBe(false);
+    });
+
+    it('marks a partial assistant message as no-longer-streaming', () => {
+      useAiChatStore.getState().submit('Q');
+      capturedCallbacks?.onEvent({ type: 'content', text: 'Half-' });
+      useAiChatStore.getState().cancel();
+
+      const messages = useAiChatStore.getState().messages;
+      expect(messages[1]).toMatchObject({
+        role: 'assistant',
+        content: 'Half-',
+        isStreaming: false,
+      });
+    });
+  });
+
+  describe('clear', () => {
+    it('aborts in-flight stream and empties messages', () => {
+      useAiChatStore.getState().submit('Q');
+      useAiChatStore.getState().clear();
+
+      expect(mockAbortController.abort).toHaveBeenCalled();
+      expect(useAiChatStore.getState().messages).toEqual([]);
+      expect(useAiChatStore.getState().isLoading).toBe(false);
+    });
+  });
+
+  describe('persistence', () => {
+    it('writes only messages to localStorage (not transient state)', () => {
+      useAiChatStore.getState().submit('Q');
+
+      const raw = window.localStorage.getItem(AI_CHAT_STORAGE_KEY);
+      expect(raw).not.toBeNull();
+      const persisted = JSON.parse(raw as string);
+      expect(persisted.state).toEqual({
+        messages: [
+          expect.objectContaining({ role: 'user', content: 'Q' }),
+        ],
+      });
+    });
+  });
+
+  describe('_heal', () => {
+    it('clears stuck isStreaming flags from a previous session', () => {
+      useAiChatStore.setState({
+        messages: [
+          { id: 'u', role: 'user', content: 'Q' },
+          {
+            id: 'a',
+            role: 'assistant',
+            content: 'partial',
+            isStreaming: true,
+          },
+        ],
+      });
+
+      useAiChatStore.getState()._heal();
+
+      const messages = useAiChatStore.getState().messages;
+      expect(messages[1].isStreaming).toBe(false);
+    });
+  });
+});

--- a/frontend/src/store/aiChatStore.ts
+++ b/frontend/src/store/aiChatStore.ts
@@ -1,0 +1,373 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { aiApi } from '@/lib/ai';
+import type { StreamEvent } from '@/types/ai';
+
+// Key for persisting the AI conversation in the browser's localStorage.
+// Cleared on logout via authStore so conversations don't leak between accounts.
+export const AI_CHAT_STORAGE_KEY = 'monize:ai-chat-messages';
+
+export interface ToolCallRecord {
+  name: string;
+  summary: string;
+  input?: Record<string, unknown>;
+  isError?: boolean;
+}
+
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  toolsUsed?: ToolCallRecord[];
+  sources?: Array<{ type: string; description: string; dateRange?: string }>;
+  isStreaming?: boolean;
+  error?: string;
+}
+
+export interface ThinkingState {
+  active: boolean;
+  message: string;
+  // Live streamed text from the model — accumulates per iteration as the
+  // backend emits assistant_text deltas. Reset on each new tool_start so the
+  // user sees the next "thinking" pass cleanly.
+  liveText: string;
+  tools: Array<{
+    name: string;
+    status: 'running' | 'done';
+    summary?: string;
+    isError?: boolean;
+  }>;
+}
+
+const IDLE_THINKING: ThinkingState = {
+  active: false,
+  message: '',
+  liveText: '',
+  tools: [],
+};
+
+interface AiChatState {
+  messages: ChatMessage[];
+  isLoading: boolean;
+  thinking: ThinkingState;
+  // Transient (not persisted): tracks the in-flight stream so we can cancel
+  // even after the user navigates away and comes back.
+  _abortController: AbortController | null;
+  // Transient (not persisted): the assistant message id being written by the
+  // current stream. Lets us reattach if the user returns mid-stream.
+  _activeAssistantId: string | null;
+
+  submit: (query: string) => void;
+  cancel: () => void;
+  clear: () => void;
+  // Heal stuck flags from a previous session that was killed mid-stream
+  // (e.g. tab closed). Called once on rehydration.
+  _heal: () => void;
+}
+
+export const useAiChatStore = create<AiChatState>()(
+  persist(
+    (set, get) => ({
+      messages: [],
+      isLoading: false,
+      thinking: IDLE_THINKING,
+      _abortController: null,
+      _activeAssistantId: null,
+
+      submit: (query: string) => {
+        const trimmed = query.trim();
+        if (!trimmed || get().isLoading) return;
+
+        const userMsgId = `user-${Date.now()}`;
+        const assistantMsgId = `assistant-${Date.now()}`;
+
+        set((state) => ({
+          messages: [
+            ...state.messages,
+            { id: userMsgId, role: 'user', content: trimmed },
+          ],
+          isLoading: true,
+          thinking: {
+            active: true,
+            message: 'Analyzing your question...',
+            liveText: '',
+            tools: [],
+          },
+          _activeAssistantId: assistantMsgId,
+        }));
+
+        // Per-request mutable state. Lives in this closure for the lifetime
+        // of the stream, independent of any React component.
+        const toolsUsed: ToolCallRecord[] = [];
+        let sources: ChatMessage['sources'] = [];
+        let contentBuffer = '';
+        let hasStartedContent = false;
+
+        const controller = aiApi.queryStream(trimmed, {
+          onEvent: (event: StreamEvent) => {
+            switch (event.type) {
+              case 'thinking':
+                set((state) => ({
+                  thinking: {
+                    ...state.thinking,
+                    message: event.message || 'Thinking...',
+                  },
+                }));
+                break;
+
+              case 'assistant_text':
+                set((state) => ({
+                  thinking: {
+                    ...state.thinking,
+                    liveText: state.thinking.liveText + (event.text || ''),
+                  },
+                }));
+                break;
+
+              case 'tool_start':
+                toolsUsed.push({
+                  name: event.name || '',
+                  summary: '',
+                  input: event.input,
+                });
+                set((state) => ({
+                  thinking: {
+                    ...state.thinking,
+                    message: `Looking up ${event.name?.replace(/_/g, ' ')}...`,
+                    liveText: '',
+                    tools: [
+                      ...state.thinking.tools,
+                      { name: event.name || '', status: 'running' },
+                    ],
+                  },
+                }));
+                break;
+
+              case 'tool_result': {
+                for (let i = 0; i < toolsUsed.length; i++) {
+                  if (
+                    toolsUsed[i].name === event.name &&
+                    !toolsUsed[i].summary &&
+                    toolsUsed[i].isError === undefined
+                  ) {
+                    toolsUsed[i] = {
+                      ...toolsUsed[i],
+                      summary: event.summary || '',
+                      isError: event.isError === true,
+                    };
+                    break;
+                  }
+                }
+                set((state) => {
+                  let updated = false;
+                  return {
+                    thinking: {
+                      ...state.thinking,
+                      tools: state.thinking.tools.map((t) => {
+                        if (
+                          !updated &&
+                          t.name === event.name &&
+                          t.status === 'running'
+                        ) {
+                          updated = true;
+                          return {
+                            ...t,
+                            status: 'done',
+                            summary: event.summary,
+                            isError: event.isError === true,
+                          };
+                        }
+                        return t;
+                      }),
+                    },
+                  };
+                });
+                break;
+              }
+
+              case 'content':
+                if (!hasStartedContent) {
+                  hasStartedContent = true;
+                  set((state) => ({
+                    thinking: IDLE_THINKING,
+                    messages: [
+                      ...state.messages,
+                      {
+                        id: assistantMsgId,
+                        role: 'assistant',
+                        content: event.text || '',
+                        toolsUsed: [...toolsUsed],
+                        isStreaming: true,
+                      },
+                    ],
+                  }));
+                }
+                contentBuffer = event.text || '';
+                set((state) => ({
+                  messages: state.messages.map((m) =>
+                    m.id === assistantMsgId
+                      ? {
+                          ...m,
+                          content: contentBuffer,
+                          toolsUsed: [...toolsUsed],
+                        }
+                      : m,
+                  ),
+                }));
+                break;
+
+              case 'sources':
+                sources =
+                  (event.sources as ChatMessage['sources']) || [];
+                break;
+
+              case 'done':
+                set((state) => ({
+                  messages: state.messages.map((m) =>
+                    m.id === assistantMsgId
+                      ? { ...m, isStreaming: false, sources }
+                      : m,
+                  ),
+                  isLoading: false,
+                  thinking: IDLE_THINKING,
+                  _abortController: null,
+                  _activeAssistantId: null,
+                }));
+                break;
+
+              case 'error':
+                set((state) => {
+                  const errorMsg = (event.message as string) || 'An error occurred';
+                  if (hasStartedContent) {
+                    return {
+                      messages: state.messages.map((m) =>
+                        m.id === assistantMsgId
+                          ? { ...m, isStreaming: false, error: errorMsg }
+                          : m,
+                      ),
+                      isLoading: false,
+                      thinking: IDLE_THINKING,
+                      _abortController: null,
+                      _activeAssistantId: null,
+                    };
+                  }
+                  return {
+                    messages: [
+                      ...state.messages,
+                      {
+                        id: assistantMsgId,
+                        role: 'assistant',
+                        content: '',
+                        error: errorMsg,
+                      },
+                    ],
+                    isLoading: false,
+                    thinking: IDLE_THINKING,
+                    _abortController: null,
+                    _activeAssistantId: null,
+                  };
+                });
+                break;
+            }
+          },
+          onDone: () => {
+            // Backstop in case the server closes without a 'done' event.
+            if (get().isLoading) {
+              set({
+                isLoading: false,
+                thinking: IDLE_THINKING,
+                _abortController: null,
+                _activeAssistantId: null,
+              });
+            }
+          },
+          onError: (error) => {
+            set((state) => {
+              const errorMsg = error.message || 'Failed to connect to the AI service.';
+              if (!hasStartedContent) {
+                return {
+                  messages: [
+                    ...state.messages,
+                    {
+                      id: assistantMsgId,
+                      role: 'assistant',
+                      content: '',
+                      error: errorMsg,
+                    },
+                  ],
+                  isLoading: false,
+                  thinking: IDLE_THINKING,
+                  _abortController: null,
+                  _activeAssistantId: null,
+                };
+              }
+              return {
+                isLoading: false,
+                thinking: IDLE_THINKING,
+                _abortController: null,
+                _activeAssistantId: null,
+              };
+            });
+          },
+        });
+
+        set({ _abortController: controller });
+      },
+
+      cancel: () => {
+        const { _abortController, _activeAssistantId } = get();
+        _abortController?.abort();
+        set((state) => ({
+          isLoading: false,
+          thinking: IDLE_THINKING,
+          _abortController: null,
+          _activeAssistantId: null,
+          // If we already started writing the assistant message, mark it as
+          // no-longer-streaming so it doesn't render as in-flight on return.
+          messages: _activeAssistantId
+            ? state.messages.map((m) =>
+                m.id === _activeAssistantId
+                  ? { ...m, isStreaming: false }
+                  : m,
+              )
+            : state.messages,
+        }));
+      },
+
+      clear: () => {
+        get()._abortController?.abort();
+        set({
+          messages: [],
+          isLoading: false,
+          thinking: IDLE_THINKING,
+          _abortController: null,
+          _activeAssistantId: null,
+        });
+      },
+
+      _heal: () => {
+        set((state) => {
+          // After rehydration, no stream is actually running — the abort
+          // controller from the previous tab/page is gone. Any persisted
+          // isStreaming flag is stale.
+          if (!state.messages.some((m) => m.isStreaming)) return {};
+          return {
+            messages: state.messages.map((m) =>
+              m.isStreaming ? { ...m, isStreaming: false } : m,
+            ),
+          };
+        });
+      },
+    }),
+    {
+      name: AI_CHAT_STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+      // Only persist the messages — transient UI state (loading, thinking,
+      // abort controller) belongs to the live in-memory session.
+      partialize: (state) => ({ messages: state.messages }),
+      onRehydrateStorage: () => (state) => {
+        state?._heal();
+      },
+    },
+  ),
+);


### PR DESCRIPTION
## Summary

Follow-up to #401. After that PR merged, the conversation was persisted to localStorage but **any in-flight query was effectively killed** when the user navigated away from `/ai`: the fetch kept running, but streaming callbacks were calling `setState` on an unmounted component, so the response never made it into the conversation.

This PR hoists the chat state and streaming machinery into a new Zustand store so an in-flight query keeps writing into `messages` (and localStorage) even with no component mounted. Returning to the AI page reattaches to the live store and shows the in-progress thinking indicator or the now-completed answer.

- New `frontend/src/store/aiChatStore.ts` — holds `messages`, `isLoading`, `thinking`, the abort controller, and the `submit`/`cancel`/`clear` actions. Only `messages` is persisted (via the Zustand `persist` middleware), transient UI state is not.
- `ChatInterface` is now a thin subscriber: it owns the textarea draft and the AI-status fetch, and delegates everything else to the store.
- The `monize:ai-chat-messages` storage key and the `authStore.logout()` cleanup are unchanged — the persist middleware just wraps the payload, and `removeItem` still works.
- Heals stuck `isStreaming` flags on rehydration (for tabs that were killed mid-stream).

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm run test` — all 4602 tests pass, including:
  - 10 new tests in `aiChatStore.test.ts` covering `submit`/`cancel`/`clear`, error handling, persistence, and `_heal`
  - New `ChatInterface` test "keeps streaming into the store after the component unmounts" that directly exercises the navigate-away-mid-query scenario this PR fixes
- [ ] Manual: start a query on `/ai`, navigate to another page before it completes, navigate back — the completed answer should be there

https://claude.ai/code/session_011EuLrUtRrjE4Zf1nKeEUDr