### PR TITLE
fix: include brokerage holdings in AI account balance queries

### DIFF
--- a/backend/src/ai/ai.module.ts
+++ b/backend/src/ai/ai.module.ts
@@ -29,6 +29,7 @@ import { CategoriesModule } from "../categories/categories.module";
 import { TransactionsModule } from "../transactions/transactions.module";
 import { NetWorthModule } from "../net-worth/net-worth.module";
 import { BudgetsModule } from "../budgets/budgets.module";
+import { SecuritiesModule } from "../securities/securities.module";
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { BudgetsModule } from "../budgets/budgets.module";
     forwardRef(() => TransactionsModule),
     forwardRef(() => NetWorthModule),
     forwardRef(() => BudgetsModule),
+    SecuritiesModule,
   ],
   providers: [
     AiService,

--- a/backend/src/ai/query/tool-executor-budget.spec.ts
+++ b/backend/src/ai/query/tool-executor-budget.spec.ts
@@ -7,6 +7,7 @@ import { TransactionAnalyticsService } from "../../transactions/transaction-anal
 import { NetWorthService } from "../../net-worth/net-worth.service";
 import { BudgetsService } from "../../budgets/budgets.service";
 import { BudgetReportsService } from "../../budgets/budget-reports.service";
+import { PortfolioService } from "../../securities/portfolio.service";
 import { Transaction } from "../../transactions/entities/transaction.entity";
 import { Category } from "../../categories/entities/category.entity";
 import {
@@ -195,6 +196,12 @@ describe("ToolExecutorService - get_budget_status", () => {
         },
         { provide: BudgetsService, useValue: mockBudgetsService },
         { provide: BudgetReportsService, useValue: mockBudgetReportsService },
+        {
+          provide: PortfolioService,
+          useValue: {
+            getAccountMarketValues: jest.fn().mockResolvedValue(new Map()),
+          },
+        },
         {
           provide: getRepositoryToken(Transaction),
           useValue: {

--- a/backend/src/ai/query/tool-executor.service.spec.ts
+++ b/backend/src/ai/query/tool-executor.service.spec.ts
@@ -7,6 +7,7 @@ import { TransactionAnalyticsService } from "../../transactions/transaction-anal
 import { NetWorthService } from "../../net-worth/net-worth.service";
 import { BudgetsService } from "../../budgets/budgets.service";
 import { BudgetReportsService } from "../../budgets/budget-reports.service";
+import { PortfolioService } from "../../securities/portfolio.service";
 import { Transaction } from "../../transactions/entities/transaction.entity";
 import { Category } from "../../categories/entities/category.entity";
 
@@ -18,6 +19,7 @@ describe("ToolExecutorService", () => {
   let mockNetWorthService: Record<string, jest.Mock>;
   let mockBudgetsService: Record<string, jest.Mock>;
   let mockBudgetReportsService: Record<string, jest.Mock>;
+  let mockPortfolioService: Record<string, jest.Mock>;
   let mockTransactionRepo: Record<string, jest.Mock>;
   let mockCategoryRepo: Record<string, jest.Mock>;
   let mockQueryBuilder: Record<string, jest.Mock>;
@@ -107,6 +109,10 @@ describe("ToolExecutorService", () => {
       getHealthScore: jest.fn().mockResolvedValue(null),
     };
 
+    mockPortfolioService = {
+      getAccountMarketValues: jest.fn().mockResolvedValue(new Map()),
+    };
+
     mockTransactionRepo = {
       createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
     };
@@ -127,6 +133,7 @@ describe("ToolExecutorService", () => {
         { provide: NetWorthService, useValue: mockNetWorthService },
         { provide: BudgetsService, useValue: mockBudgetsService },
         { provide: BudgetReportsService, useValue: mockBudgetReportsService },
+        { provide: PortfolioService, useValue: mockPortfolioService },
         {
           provide: getRepositoryToken(Transaction),
           useValue: mockTransactionRepo,
@@ -476,6 +483,99 @@ describe("ToolExecutorService", () => {
       const result = await service.execute(userId, "get_account_balances", {});
 
       expect(result.sources[0].description).toBe("All account balances");
+    });
+
+    it("adds holdings market value to brokerage account balances", async () => {
+      const accountsWithBrokerage = [
+        {
+          id: "acc-1",
+          name: "Checking",
+          accountType: "checking",
+          currencyCode: "USD",
+          currentBalance: "5000.00",
+          excludeFromNetWorth: false,
+        },
+        {
+          id: "acc-brokerage",
+          name: "Brokerage",
+          accountType: "INVESTMENT",
+          currencyCode: "USD",
+          currentBalance: "0.00",
+          excludeFromNetWorth: false,
+        },
+      ];
+      mockAccountsService.findAll.mockResolvedValue(accountsWithBrokerage);
+      mockAccountsService.getSummary.mockResolvedValue({
+        totalAssets: 5000,
+        totalLiabilities: 0,
+        netWorth: 5000,
+        totalAccounts: 2,
+      });
+      mockPortfolioService.getAccountMarketValues.mockResolvedValue(
+        new Map([["acc-brokerage", 75000]]),
+      );
+
+      const result = await service.execute(userId, "get_account_balances", {});
+      const data = result.data as Record<string, unknown>;
+      const accounts = data.accounts as Array<Record<string, unknown>>;
+
+      const brokerage = accounts.find((a) => a.name === "Brokerage");
+      expect(brokerage).toBeDefined();
+      expect(brokerage!.balance).toBe(75000);
+      expect(data.totalAssets).toBe(80000);
+      expect(data.netWorth).toBe(80000);
+    });
+
+    it("excludes holdings from totalAssets when account is excludeFromNetWorth", async () => {
+      const accountsWithBrokerage = [
+        {
+          id: "acc-1",
+          name: "Checking",
+          accountType: "checking",
+          currencyCode: "USD",
+          currentBalance: "5000.00",
+          excludeFromNetWorth: false,
+        },
+        {
+          id: "acc-excluded",
+          name: "Excluded Brokerage",
+          accountType: "INVESTMENT",
+          currencyCode: "USD",
+          currentBalance: "0.00",
+          excludeFromNetWorth: true,
+        },
+      ];
+      mockAccountsService.findAll.mockResolvedValue(accountsWithBrokerage);
+      mockAccountsService.getSummary.mockResolvedValue({
+        totalAssets: 5000,
+        totalLiabilities: 0,
+        netWorth: 5000,
+        totalAccounts: 2,
+      });
+      mockPortfolioService.getAccountMarketValues.mockResolvedValue(
+        new Map([["acc-excluded", 50000]]),
+      );
+
+      const result = await service.execute(userId, "get_account_balances", {});
+      const data = result.data as Record<string, unknown>;
+      const accounts = data.accounts as Array<Record<string, unknown>>;
+
+      // The per-account balance still reflects market value
+      const excluded = accounts.find((a) => a.name === "Excluded Brokerage");
+      expect(excluded!.balance).toBe(50000);
+      // But totals respect the excludeFromNetWorth flag
+      expect(data.totalAssets).toBe(5000);
+      expect(data.netWorth).toBe(5000);
+    });
+
+    it("leaves balances untouched when there are no holdings", async () => {
+      // Default mockPortfolioService returns an empty map
+      const result = await service.execute(userId, "get_account_balances", {});
+      const data = result.data as Record<string, unknown>;
+      const accounts = data.accounts as Array<Record<string, unknown>>;
+
+      expect(accounts[0].balance).toBe(5000);
+      expect(data.totalAssets).toBe(20000);
     });
   });
 

--- a/backend/src/ai/query/tool-executor.service.ts
+++ b/backend/src/ai/query/tool-executor.service.ts
@@ -7,6 +7,8 @@ import { TransactionAnalyticsService } from "../../transactions/transaction-anal
 import { NetWorthService } from "../../net-worth/net-worth.service";
 import { BudgetsService } from "../../budgets/budgets.service";
 import { BudgetReportsService } from "../../budgets/budget-reports.service";
+import { PortfolioService } from "../../securities/portfolio.service";
+import { AccountType } from "../../accounts/entities/account.entity";
 import {
   getCurrentMonthPeriodDates,
   getPreviousMonthPeriodDates,
@@ -48,6 +50,7 @@ export class ToolExecutorService {
     private readonly budgetsService: BudgetsService,
     @Inject(forwardRef(() => BudgetReportsService))
     private readonly budgetReportsService: BudgetReportsService,
+    private readonly portfolioService: PortfolioService,
     @InjectRepository(Transaction)
     private readonly transactionRepo: Repository<Transaction>,
     @InjectRepository(Category)
@@ -360,6 +363,13 @@ export class ToolExecutorService {
     const allAccounts = await this.accountsService.findAll(userId, false);
     const summary = await this.accountsService.getSummary(userId);
 
+    // Brokerage (and standalone investment) accounts carry securities, not
+    // cash, so `currentBalance` is 0 for them — the real value lives in
+    // `holdings.quantity * latest price`. Pull per-account market values so
+    // both the per-account list and the totals reflect reality.
+    const marketValues =
+      await this.portfolioService.getAccountMarketValues(userId);
+
     let accounts = allAccounts;
     if (accountNames && accountNames.length > 0) {
       const lowerNames = new Set(accountNames.map((n) => n.toLowerCase()));
@@ -368,24 +378,42 @@ export class ToolExecutorService {
       );
     }
 
-    const accountList = accounts.map((a) => ({
-      name: a.name,
-      type: a.accountType,
-      balance: Number(a.currentBalance),
-      currency: a.currencyCode,
-    }));
+    const accountList = accounts.map((a) => {
+      const cashBalance = Number(a.currentBalance);
+      const marketValue = marketValues.get(a.id) ?? 0;
+      return {
+        name: a.name,
+        type: a.accountType,
+        balance: cashBalance + marketValue,
+        currency: a.currencyCode,
+      };
+    });
+
+    // The base summary only sums `currentBalance`, so investment accounts with
+    // holdings contribute 0 to totalAssets / netWorth. Add in each excluded-
+    // from-net-worth-respecting investment account's market value here so the
+    // AI sees accurate totals.
+    let extraInvestmentAssets = 0;
+    for (const account of allAccounts) {
+      if (account.accountType !== AccountType.INVESTMENT) continue;
+      if (account.excludeFromNetWorth) continue;
+      const marketValue = marketValues.get(account.id);
+      if (marketValue) extraInvestmentAssets += marketValue;
+    }
+    const totalAssets = summary.totalAssets + extraInvestmentAssets;
+    const netWorth = totalAssets - summary.totalLiabilities;
 
     const data = {
       accounts: accountList,
-      totalAssets: summary.totalAssets,
+      totalAssets,
       totalLiabilities: summary.totalLiabilities,
-      netWorth: summary.netWorth,
+      netWorth,
       totalAccounts: summary.totalAccounts,
     };
 
     return {
       data,
-      summary: `${accounts.length} accounts. Net worth: ${summary.netWorth.toFixed(2)}, Assets: ${summary.totalAssets.toFixed(2)}, Liabilities: ${summary.totalLiabilities.toFixed(2)}`,
+      summary: `${accounts.length} accounts. Net worth: ${netWorth.toFixed(2)}, Assets: ${totalAssets.toFixed(2)}, Liabilities: ${summary.totalLiabilities.toFixed(2)}`,
       sources: [
         {
           type: "accounts",

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -488,6 +488,64 @@ export class PortfolioService {
   }
 
   /**
+   * Compute per-account holdings market value in each account's own currency.
+   *
+   * Lightweight alternative to getPortfolioSummary() for callers that only need
+   * "how much are the holdings worth in this account?" without TWR/CAGR/cost
+   * basis. Useful for balance-style queries where an account's current balance
+   * should reflect its holdings, not just the cash side.
+   *
+   * Only brokerage and standalone investment accounts contribute; cash-only
+   * accounts are omitted. Accounts whose holdings have no current price are
+   * also omitted (caller should treat "missing" as "no market-value info
+   * available" rather than zero).
+   */
+  async getAccountMarketValues(userId: string): Promise<Map<string, number>> {
+    const accounts = await this.getInvestmentAccounts(userId);
+    const { holdingsAccountIds } =
+      this.calculationService.categoriseAccounts(accounts);
+    if (holdingsAccountIds.length === 0) return new Map();
+
+    const holdings = await this.holdingsRepository.find({
+      where: { accountId: In(holdingsAccountIds) },
+      relations: ["security"],
+    });
+    if (holdings.length === 0) return new Map();
+
+    const securityIds = [...new Set(holdings.map((h) => h.securityId))];
+    const priceMap = await this.getLatestPrices(securityIds);
+
+    const accountCurrency = new Map<string, string>();
+    for (const a of accounts) accountCurrency.set(a.id, a.currencyCode);
+
+    const rateCache = new Map<string, number>();
+    const result = new Map<string, number>();
+    for (const h of holdings) {
+      if (Math.abs(Number(h.quantity)) < 0.0001) continue;
+      const price = priceMap.get(h.securityId);
+      if (price == null) continue;
+
+      const marketValue = Number(h.quantity) * price;
+      const securityCurrency = h.security.currencyCode;
+      const acctCurrency = accountCurrency.get(h.accountId) ?? securityCurrency;
+
+      const valueInAccountCurrency =
+        await this.calculationService.convertToDefault(
+          marketValue,
+          securityCurrency,
+          acctCurrency,
+          rateCache,
+        );
+
+      result.set(
+        h.accountId,
+        (result.get(h.accountId) ?? 0) + valueInAccountCurrency,
+      );
+    }
+    return result;
+  }
+
+  /**
    * Get asset allocation breakdown
    * Note: This now just extracts the pre-computed allocation from getPortfolioSummary
    * to maintain backwards compatibility. Prefer using summary.allocation directly.

--- a/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
@@ -134,27 +134,33 @@ describe('BalanceHistoryChart', () => {
   });
 
   it('shows Current as today balance and Ending as last future data point', () => {
-    // All values must be unique to avoid getByText collisions
-    // Data: start=2000, dip=1500, current(today)=1800, ending=1900
-    // Min balance = 1500
-    render(
-      <BalanceHistoryChart
-        data={[
-          { date: '2026-03-01', balance: 2000 },
-          { date: '2026-03-10', balance: 1500 },
-          { date: '2026-04-01', balance: 1800 },
-          { date: '2026-04-15', balance: 1900 },
-        ]}
-        isLoading={false}
-      />
-    );
+    // Lock "today" so the test is not date-dependent. With today = 2026-04-10,
+    // data: start=2000, dip=1500, current(today-anchor=2026-04-01)=1800, ending=1900.
+    // Min balance = 1500.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-04-10T12:00:00Z'));
+    try {
+      render(
+        <BalanceHistoryChart
+          data={[
+            { date: '2026-03-01', balance: 2000 },
+            { date: '2026-03-10', balance: 1500 },
+            { date: '2026-04-01', balance: 1800 },
+            { date: '2026-04-15', balance: 1900 },
+          ]}
+          isLoading={false}
+        />
+      );
 
-    expect(screen.getByText('Ending')).toBeInTheDocument();
-    // Starting = 2000, Current = 1800 (today or before), Ending = 1900, Min = 1500
-    expect(screen.getByText('$2000.00')).toBeInTheDocument();
-    expect(screen.getByText('$1800.00')).toBeInTheDocument();
-    expect(screen.getByText('$1900.00')).toBeInTheDocument();
-    expect(screen.getByText('$1500.00')).toBeInTheDocument();
+      expect(screen.getByText('Ending')).toBeInTheDocument();
+      // Starting = 2000, Current = 1800 (today or before), Ending = 1900, Min = 1500
+      expect(screen.getByText('$2000.00')).toBeInTheDocument();
+      expect(screen.getByText('$1800.00')).toBeInTheDocument();
+      expect(screen.getByText('$1900.00')).toBeInTheDocument();
+      expect(screen.getByText('$1500.00')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('passes currencyCode to formatting functions', () => {


### PR DESCRIPTION
## Summary

When the AI is asked about brokerage account balances it returned 0, even when the account held significant positions. The `get_account_balances` tool read only `accounts.currentBalance`, which is never updated for holdings-driven accounts — the real value lives in `holdings.quantity * latest price`. `totalAssets` and `netWorth` also understated reality by the holdings market value.

- Added `PortfolioService.getAccountMarketValues(userId)` — a lightweight per-account holdings valuation that skips TWR/CAGR/cost-basis work
- Updated `ToolExecutorService.getAccountBalances` to augment each investment account's balance with its market value and recompute `totalAssets` / `netWorth` while still honouring `excludeFromNetWorth`
- Wired `SecuritiesModule` into `AiModule` (no circular dep: securities doesn't import ai)

## Test plan

- [x] `npm run test:unit` (backend) — 5191/5191 pass
- [x] `npx tsc --noEmit` clean
- [x] New unit tests for brokerage with holdings, `excludeFromNetWorth` brokerage, and no-holdings regression
- [ ] Manual: ask the AI "What's my brokerage balance?" and verify it returns the market value, not 0

https://claude.ai/code/session_011EuLrUtRrjE4Zf1nKeEUDr