### PR TITLE
fix: surface actionable error when Ollama model lacks tool support

### DIFF
--- a/backend/src/ai/providers/ollama.provider.spec.ts
+++ b/backend/src/ai/providers/ollama.provider.spec.ts
@@ -1,4 +1,5 @@
 import type { AiToolStreamChunk } from "./ai-provider.interface";
+import { OllamaModelDoesNotSupportToolsError } from "./ollama.provider";
 
 // Mock the long-running-fetch helper so tests can keep using `global.fetch`.
 // In production, longRunningFetch calls undici.fetch directly with our
@@ -531,6 +532,63 @@ describe("OllamaProvider", () => {
           }
         })(),
       ).rejects.toThrow("Ollama request failed: 503 Service Unavailable");
+    });
+
+    it("throws a typed error when Ollama reports the model does not support tools", async () => {
+      // Ollama returns 400 with this JSON body when the loaded model's
+      // Modelfile template doesn't declare tool support (e.g. the default
+      // deepseek-r1:latest in Ollama's registry).
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        text: () =>
+          Promise.resolve(
+            '{"error":"registry.ollama.ai/library/deepseek-r1:latest does not support tools"}',
+          ),
+      });
+
+      const gen = provider.streamWithTools(
+        { systemPrompt: "test", messages: [{ role: "user", content: "hi" }] },
+        tools,
+      );
+
+      await expect(
+        (async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          for await (const _chunk of gen) {
+            // consume
+          }
+        })(),
+      ).rejects.toBeInstanceOf(OllamaModelDoesNotSupportToolsError);
+    });
+
+    it("includes the model id and remediation advice in the tool-unsupported error", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        text: () =>
+          Promise.resolve(
+            '{"error":"registry.ollama.ai/library/deepseek-r1:latest does not support tools"}',
+          ),
+      });
+
+      const gen = provider.streamWithTools(
+        { systemPrompt: "test", messages: [{ role: "user", content: "hi" }] },
+        tools,
+      );
+
+      await expect(
+        (async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          for await (const _chunk of gen) {
+            // consume
+          }
+        })(),
+        // The provider was instantiated with modelId "llama3" in beforeEach,
+        // so that's the id we expect to see reflected in the error.
+      ).rejects.toThrow(/llama3.*does not support tool use/s);
     });
 
     it("throws when response body is null", async () => {

--- a/backend/src/ai/providers/ollama.provider.ts
+++ b/backend/src/ai/providers/ollama.provider.ts
@@ -20,6 +20,32 @@ import { longRunningFetch } from "./long-running-fetch";
  */
 const PROGRESS_LOG_INTERVAL_MS = 30_000;
 
+/**
+ * Thrown when Ollama rejects a tool-calling request because the loaded model's
+ * Modelfile template does not advertise tool support (e.g. the default
+ * `deepseek-r1:latest` in Ollama's registry, which predates DeepSeek's 0528
+ * tool-calling update). Retrying is pointless — the user needs to switch to
+ * a tool-calling-capable model. The query service surfaces the message of
+ * this error verbatim to the user so they know what action to take.
+ */
+export class OllamaModelDoesNotSupportToolsError extends Error {
+  readonly model: string;
+
+  constructor(model: string) {
+    super(
+      `The Ollama model "${model}" does not support tool use, so the AI ` +
+        `Assistant cannot run queries against your data. DeepSeek-R1 (0528+) ` +
+        `added function calling, but Ollama's default registry templates ` +
+        `still declare no tool support. Switch to a tool-calling-capable ` +
+        `model such as "MFDoom/deepseek-r1-tool-calling", ` +
+        `"okamototk/deepseek-r1", "llama3.1", or "qwen2.5", then update the ` +
+        `Ollama model in your AI provider settings.`,
+    );
+    this.name = "OllamaModelDoesNotSupportToolsError";
+    this.model = model;
+  }
+}
+
 interface OllamaToolCall {
   function: { name: string; arguments: Record<string, unknown> };
 }
@@ -365,6 +391,9 @@ export class OllamaProvider implements AiProvider {
         this.logger.error(
           `streamWithTools non-OK url=${url} status=${response.status} body=${bodyText.substring(0, 500)}`,
         );
+        if (this.isModelDoesNotSupportToolsBody(bodyText)) {
+          throw new OllamaModelDoesNotSupportToolsError(this.modelId);
+        }
         throw new Error(
           `Ollama request failed: ${response.status} ${response.statusText}`,
         );
@@ -470,6 +499,27 @@ export class OllamaProvider implements AiProvider {
       throw error;
     } finally {
       clearTimeout(timeout);
+    }
+  }
+
+  /**
+   * Ollama returns 400 with `{"error":"...does not support tools"}` when the
+   * loaded model's Modelfile template doesn't declare tool support. Match the
+   * stable substring of that message so we can convert it into a typed error
+   * with actionable remediation. Matches both parsed-JSON and raw-text bodies
+   * defensively.
+   */
+  private isModelDoesNotSupportToolsBody(bodyText: string): boolean {
+    if (!bodyText) return false;
+    if (/does not support tools/i.test(bodyText)) return true;
+    try {
+      const parsed = JSON.parse(bodyText) as { error?: unknown };
+      return (
+        typeof parsed.error === "string" &&
+        /does not support tools/i.test(parsed.error)
+      );
+    } catch {
+      return false;
     }
   }
 

--- a/backend/src/ai/query/ai-query.service.spec.ts
+++ b/backend/src/ai/query/ai-query.service.spec.ts
@@ -5,6 +5,7 @@ import { AiService } from "../ai.service";
 import { AiUsageService } from "../ai-usage.service";
 import { FinancialContextBuilder } from "../context/financial-context.builder";
 import { ToolExecutorService } from "./tool-executor.service";
+import { OllamaModelDoesNotSupportToolsError } from "../providers/ollama.provider";
 
 describe("AiQueryService", () => {
   let service: AiQueryService;
@@ -317,6 +318,22 @@ describe("AiQueryService", () => {
       expect(errorEvent!.message).toContain(
         "The AI provider encountered an error processing your query.",
       );
+    });
+
+    it("surfaces OllamaModelDoesNotSupportToolsError message verbatim (retry won't help)", async () => {
+      (mockProvider.completeWithTools as jest.Mock).mockRejectedValueOnce(
+        new OllamaModelDoesNotSupportToolsError("deepseek-r1:latest"),
+      );
+
+      const events = await collectEvents(userId, "Any query");
+
+      const errorEvent = events.find((e) => e.type === "error");
+      expect(errorEvent).toBeDefined();
+      // User needs to know what model to switch to — don't hide behind a
+      // generic "try again" message.
+      expect(errorEvent!.message).toContain("deepseek-r1:latest");
+      expect(errorEvent!.message).toContain("does not support tool use");
+      expect(errorEvent!.message).not.toContain("Please try again");
     });
 
     it("logs usage after successful completion", async () => {

--- a/backend/src/ai/query/ai-query.service.ts
+++ b/backend/src/ai/query/ai-query.service.ts
@@ -9,6 +9,7 @@ import {
   AiProvider,
   AiToolCall,
 } from "../providers/ai-provider.interface";
+import { OllamaModelDoesNotSupportToolsError } from "../providers/ollama.provider";
 import { assessInjectionRisk } from "../context/prompt-injection-detector";
 import { QUERY_SAFETY_REMINDER } from "../context/prompt-templates";
 import { sanitizeToolResultStrings } from "../context/prompt-sanitize";
@@ -310,10 +311,16 @@ export class AiQueryService {
           Date.now() - startTime,
           rawMessage,
         );
+        // For errors the user can act on (e.g. Ollama model lacks tool
+        // support), surface the specific message instead of the generic
+        // "try again" — retrying without changing the model won't help.
+        const userMessage =
+          error instanceof OllamaModelDoesNotSupportToolsError
+            ? error.message
+            : "The AI provider encountered an error processing your query. Please try again.";
         yield {
           type: "error",
-          message:
-            "The AI provider encountered an error processing your query. Please try again.",
+          message: userMessage,
         };
         return;
       }


### PR DESCRIPTION
Ollama returns 400 with body `{"error":"...does not support tools"}`
when the loaded model's Modelfile template doesn't declare tool
support (e.g. the default deepseek-r1:latest in Ollama's registry,
which predates DeepSeek's 0528 tool-calling update). The query
service was swallowing this with a generic "Please try again"
message, which is misleading since retrying without switching
models won't help.

The Ollama provider now detects this specific error body and
throws a typed OllamaModelDoesNotSupportToolsError whose message
names the model and points the user at tool-calling-capable
alternatives (MFDoom/deepseek-r1-tool-calling, okamototk/deepseek-r1,
llama3.1, qwen2.5). The AI query service surfaces that message
verbatim so the user sees the actual remediation.