### PR TITLE
Parallelize quote fetching and improve timeout handling

### DIFF
--- a/backend/src/securities/security-price.service.ts
+++ b/backend/src/securities/security-price.service.ts
@@ -106,23 +106,17 @@ export class SecurityPriceService {
       symbolGroups.set(key, group);
     }
 
-    for (const group of symbolGroups.values()) {
-      const representative = group[0];
-      const yahooSymbol = this.yahooFinance.getYahooSymbol(
-        representative.symbol,
-        representative.exchange,
-      );
-      let quote = await this.yahooFinance.fetchQuote(yahooSymbol);
+    // Fetch all quotes in parallel so one slow symbol doesn't block the others
+    const groups = [...symbolGroups.values()];
+    const quotes = await Promise.all(
+      groups.map((group) =>
+        this.fetchQuoteWithFallback(group[0].symbol, group[0].exchange),
+      ),
+    );
 
-      if (!quote && yahooSymbol === representative.symbol) {
-        const alternateSymbols = this.yahooFinance.getAlternateSymbols(
-          representative.symbol,
-        );
-        for (const altSymbol of alternateSymbols) {
-          quote = await this.yahooFinance.fetchQuote(altSymbol);
-          if (quote) break;
-        }
-      }
+    for (let i = 0; i < groups.length; i++) {
+      const group = groups[i];
+      const quote = quotes[i];
 
       if (!quote || quote.regularMarketPrice === undefined) {
         for (const security of group) {
@@ -199,22 +193,16 @@ export class SecurityPriceService {
     let updated = 0;
     let failed = 0;
 
-    for (const security of securities) {
-      const yahooSymbol = this.yahooFinance.getYahooSymbol(
-        security.symbol,
-        security.exchange,
-      );
-      let quote = await this.yahooFinance.fetchQuote(yahooSymbol);
+    // Fetch all quotes in parallel so one slow symbol doesn't block the others
+    const quotes = await Promise.all(
+      securities.map((security) =>
+        this.fetchQuoteWithFallback(security.symbol, security.exchange),
+      ),
+    );
 
-      if (!quote && yahooSymbol === security.symbol) {
-        const alternateSymbols = this.yahooFinance.getAlternateSymbols(
-          security.symbol,
-        );
-        for (const altSymbol of alternateSymbols) {
-          quote = await this.yahooFinance.fetchQuote(altSymbol);
-          if (quote) break;
-        }
-      }
+    for (let i = 0; i < securities.length; i++) {
+      const security = securities[i];
+      const quote = quotes[i];
 
       if (!quote || quote.regularMarketPrice === undefined) {
         results.push({
@@ -348,6 +336,29 @@ export class SecurityPriceService {
       order: { createdAt: "DESC" },
     });
     return latest?.createdAt ?? null;
+  }
+
+  /**
+   * Fetch a current quote with alternate-symbol fallback.
+   * Tries the primary Yahoo symbol, then Canadian suffix variants (.TO/.V/.CN)
+   * when the security had no exchange-based suffix.
+   */
+  private async fetchQuoteWithFallback(
+    symbol: string,
+    exchange: string | null,
+  ): Promise<YahooQuoteResult | null> {
+    const yahooSymbol = this.yahooFinance.getYahooSymbol(symbol, exchange);
+    let quote = await this.yahooFinance.fetchQuote(yahooSymbol);
+
+    if (!quote && yahooSymbol === symbol) {
+      const alternateSymbols = this.yahooFinance.getAlternateSymbols(symbol);
+      for (const altSymbol of alternateSymbols) {
+        quote = await this.yahooFinance.fetchQuote(altSymbol);
+        if (quote) break;
+      }
+    }
+
+    return quote;
   }
 
   /**

--- a/backend/src/securities/yahoo-finance.service.ts
+++ b/backend/src/securities/yahoo-finance.service.ts
@@ -66,7 +66,7 @@ const YAHOO_SECTOR_NAMES: Record<string, string> = {
 export class YahooFinanceService {
   private readonly logger = new Logger(YahooFinanceService.name);
 
-  private static readonly FETCH_TIMEOUT_MS = 30000;
+  private static readonly FETCH_TIMEOUT_MS = 10000;
   private static readonly USER_AGENT =
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 

--- a/frontend/src/hooks/useInvestmentData.ts
+++ b/frontend/src/hooks/useInvestmentData.ts
@@ -141,9 +141,17 @@ export function useInvestmentData() {
   }, []);
 
   const { isRefreshing: isRefreshingPrices, triggerManualRefresh: handleRefreshPrices, triggerAutoRefresh } = usePriceRefresh({
-    onRefreshComplete: () => {
+    onRefreshComplete: (lastUpdated) => {
       loadAllPortfolioData(selectedAccountIds, currentPage, transactionFilters);
-      loadPriceStatus();
+      // Prefer the refresh result's timestamp: savePriceData UPDATEs existing
+      // rows in place, so the DB-backed lastUpdated (createdAt) wouldn't advance
+      // on same-day refreshes. Fall back to the DB value if the result didn't
+      // carry one (e.g. when no securities to refresh).
+      if (lastUpdated) {
+        setLastPriceUpdate(lastUpdated);
+      } else {
+        loadPriceStatus();
+      }
     },
   });
 

--- a/frontend/src/hooks/usePriceRefresh.test.ts
+++ b/frontend/src/hooks/usePriceRefresh.test.ts
@@ -135,19 +135,24 @@ describe('usePriceRefresh', () => {
     expect(investmentsApi.refreshSelectedPrices).toHaveBeenCalledWith(['s-1']);
   });
 
-  it('calls onRefreshComplete callback', async () => {
+  it('calls onRefreshComplete callback with lastUpdated from the refresh result', async () => {
     const onRefreshComplete = vi.fn();
     vi.mocked(investmentsApi.getPortfolioSummary).mockResolvedValue({
       holdings: [{ securityId: 's-1', quantity: 10 }],
     } as any);
     vi.mocked(investmentsApi.refreshSelectedPrices).mockResolvedValue({
-      updated: 1, failed: 0, totalSecurities: 1, skipped: 0, results: [], lastUpdated: '',
+      updated: 1,
+      failed: 0,
+      totalSecurities: 1,
+      skipped: 0,
+      results: [],
+      lastUpdated: '2026-04-15T14:06:00Z',
     });
 
     const { result } = renderHook(() => usePriceRefresh({ onRefreshComplete }));
     await act(async () => {
       await result.current.triggerManualRefresh();
     });
-    expect(onRefreshComplete).toHaveBeenCalled();
+    expect(onRefreshComplete).toHaveBeenCalledWith('2026-04-15T14:06:00Z');
   });
 });

--- a/frontend/src/hooks/usePriceRefresh.ts
+++ b/frontend/src/hooks/usePriceRefresh.ts
@@ -45,7 +45,7 @@ export function setRefreshInProgress(value: boolean): void {
 }
 
 interface UsePriceRefreshOptions {
-  onRefreshComplete?: () => Promise<void> | void;
+  onRefreshComplete?: (lastUpdated?: string) => Promise<void> | void;
 }
 
 interface UsePriceRefreshReturn {
@@ -81,7 +81,7 @@ export function usePriceRefresh({ onRefreshComplete }: UsePriceRefreshOptions = 
           toast.success(`${result.updated} security price${result.updated !== 1 ? 's' : ''} updated`);
         }
       }
-      await onRefreshComplete?.();
+      await onRefreshComplete?.(result.lastUpdated);
     } catch (error) {
       logger.error('Failed to refresh prices:', error);
       if (!silent) toast.error(getErrorMessage(error, 'Failed to refresh prices'));

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -281,6 +281,66 @@ describe('apiClient', () => {
       expect(mockSetBackendDown).toHaveBeenCalled();
     });
 
+    it('does NOT set backend down on client-side timeout (ECONNABORTED)', async () => {
+      mockSetBackendDown.mockClear();
+      vi.resetModules();
+
+      vi.doMock('@/store/connectionStore', () => ({
+        useConnectionStore: {
+          getState: () => ({
+            setBackendDown: mockSetBackendDown,
+          }),
+        },
+      }));
+
+      const { apiClient: freshClient } = await import('@/lib/api');
+      const interceptors = freshClient.interceptors.response as any;
+      const handlers = interceptors.handlers;
+      const errorHandler = handlers.find((h: any) => h?.rejected);
+
+      const mockError = {
+        code: 'ECONNABORTED',
+        message: 'timeout of 10000ms exceeded',
+        config: {
+          headers: new AxiosHeaders(),
+        },
+        // No response property -- but this is a client-side timeout,
+        // not an actual backend outage.
+      };
+
+      await expect(errorHandler.rejected(mockError)).rejects.toEqual(mockError);
+      expect(mockSetBackendDown).not.toHaveBeenCalled();
+    });
+
+    it('does NOT set backend down on client-side cancellation (ERR_CANCELED)', async () => {
+      mockSetBackendDown.mockClear();
+      vi.resetModules();
+
+      vi.doMock('@/store/connectionStore', () => ({
+        useConnectionStore: {
+          getState: () => ({
+            setBackendDown: mockSetBackendDown,
+          }),
+        },
+      }));
+
+      const { apiClient: freshClient } = await import('@/lib/api');
+      const interceptors = freshClient.interceptors.response as any;
+      const handlers = interceptors.handlers;
+      const errorHandler = handlers.find((h: any) => h?.rejected);
+
+      const mockError = {
+        code: 'ERR_CANCELED',
+        message: 'canceled',
+        config: {
+          headers: new AxiosHeaders(),
+        },
+      };
+
+      await expect(errorHandler.rejected(mockError)).rejects.toEqual(mockError);
+      expect(mockSetBackendDown).not.toHaveBeenCalled();
+    });
+
     it('does not attempt CSRF or token refresh on 502', async () => {
       mockSetBackendDown.mockClear();
       const axiosGetSpy = vi.spyOn(axios, 'get');

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -88,8 +88,16 @@ apiClient.interceptors.response.use(
       _authRetried?: boolean;
     };
 
-    // Handle 502 (backend unavailable) or network errors (no response at all)
-    if (error.response?.status === 502 || !error.response) {
+    // Handle 502 (backend unavailable) or network errors (no response at all).
+    // A client-side timeout (axios code ECONNABORTED / ERR_CANCELED) means the
+    // backend was simply slow to answer this specific request; it does NOT
+    // indicate the backend is down, so skip the banner in that case.
+    const isClientTimeout =
+      error.code === 'ECONNABORTED' || error.code === 'ERR_CANCELED';
+    if (
+      !isClientTimeout &&
+      (error.response?.status === 502 || !error.response)
+    ) {
       const { useConnectionStore } = await import('@/store/connectionStore');
       useConnectionStore.getState().setBackendDown();
       return Promise.reject(error);


### PR DESCRIPTION
## Summary
This PR improves performance and reliability by parallelizing security price quote fetching and refining how client-side timeouts are handled. It also extracts common quote-fetching logic into a reusable method and ensures the UI displays accurate price update timestamps.

## Key Changes

**Backend (Security Price Service)**
- Extracted quote-fetching logic with fallback into a new `fetchQuoteWithFallback()` private method to reduce code duplication
- Parallelized quote fetching in `updateSecurityPrices()` and `updateSelectedSecurityPrices()` using `Promise.all()` instead of sequential awaits
  - Prevents slow symbols from blocking the entire refresh operation
  - Significantly improves performance when refreshing multiple securities
- Reduced Yahoo Finance fetch timeout from 30s to 10s to fail faster on unresponsive requests

**Frontend (API & Connection Handling)**
- Improved error handling in the API response interceptor to distinguish between client-side timeouts and actual backend outages
  - Client-side timeouts (ECONNABORTED, ERR_CANCELED) no longer trigger the "backend down" banner
  - Only genuine backend unavailability (502 or no response) sets the backend-down state
- Updated `usePriceRefresh` hook to pass the refresh result's `lastUpdated` timestamp to the completion callback
  - Ensures UI displays the actual refresh timestamp rather than querying the database
  - Handles same-day refreshes correctly (DB timestamps wouldn't advance on updates)
- Added comprehensive test coverage for timeout and cancellation scenarios

## Implementation Details
- The new `fetchQuoteWithFallback()` method encapsulates the logic for trying primary Yahoo symbols and falling back to Canadian suffix variants (.TO/.V/.CN)
- Parallel fetching maintains the original group/security ordering by using indexed array access
- The timeout distinction prevents false "backend down" alerts during temporary network slowness

https://claude.ai/code/session_01WMw7L4YdBaL4HxkdANUabJ