### PR TITLE
Add upstream update check with admin notification banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,16 @@ DEMO_MODE=false
 # AI_MAX_PROVIDERS_PER_USER=10
 
 # ==============================================
+# Update Checks
+# ==============================================
+
+# Controls whether the backend periodically polls GitHub for new Monize
+# releases and shows admin users an in-app "update available" banner.
+# Set to 'false' to disable the check entirely (no outbound calls to
+# api.github.com). Default: true.
+# UPDATE_CHECK_ENABLED=true
+
+# ==============================================
 # Frontend - Local Development Only
 # ==============================================
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -41,6 +41,7 @@ import { BudgetsModule } from "./budgets/budgets.module";
 import { TagsModule } from "./tags/tags.module";
 import { BackupModule } from "./backup/backup.module";
 import { ActionHistoryModule } from "./action-history/action-history.module";
+import { UpdatesModule } from "./updates/updates.module";
 
 @Module({
   imports: [
@@ -114,6 +115,7 @@ import { ActionHistoryModule } from "./action-history/action-history.module";
     TagsModule,
     BackupModule,
     ActionHistoryModule,
+    UpdatesModule,
   ],
   providers: [
     { provide: APP_FILTER, useClass: GlobalExceptionFilter },

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -912,9 +912,7 @@ describe("AuthController", () => {
       // the plaintext is not leaked.
       expect(res.cookie).toHaveBeenCalledWith(
         "trusted_device",
-        expect.stringMatching(
-          /^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/i,
-        ),
+        expect.stringMatching(/^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/i),
         expect.objectContaining({
           httpOnly: true,
           sameSite: "lax",

--- a/backend/src/updates/updates.controller.spec.ts
+++ b/backend/src/updates/updates.controller.spec.ts
@@ -1,0 +1,42 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { UpdatesController } from "./updates.controller";
+import { UpdatesService } from "./updates.service";
+
+describe("UpdatesController", () => {
+  let controller: UpdatesController;
+  let mockService: Partial<Record<keyof UpdatesService, jest.Mock>>;
+  const mockReq = { user: { id: "user-1" } };
+
+  beforeEach(async () => {
+    mockService = {
+      getStatus: jest.fn(),
+      dismiss: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UpdatesController],
+      providers: [
+        {
+          provide: UpdatesService,
+          useValue: mockService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<UpdatesController>(UpdatesController);
+  });
+
+  it("getStatus delegates to service with the request user id", () => {
+    mockService.getStatus!.mockReturnValue("status");
+    const result = controller.getStatus(mockReq);
+    expect(result).toBe("status");
+    expect(mockService.getStatus).toHaveBeenCalledWith("user-1");
+  });
+
+  it("dismiss delegates to service with the request user id", () => {
+    mockService.dismiss!.mockReturnValue("dismissed");
+    const result = controller.dismiss(mockReq);
+    expect(result).toBe("dismissed");
+    expect(mockService.dismiss).toHaveBeenCalledWith("user-1");
+  });
+});

--- a/backend/src/updates/updates.controller.ts
+++ b/backend/src/updates/updates.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Request,
+  UseGuards,
+} from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { Roles } from "../auth/decorators/roles.decorator";
+import { RolesGuard } from "../auth/guards/roles.guard";
+import { UpdateStatus, UpdatesService } from "./updates.service";
+
+@ApiTags("Updates")
+@ApiBearerAuth()
+@Controller("updates")
+@UseGuards(AuthGuard("jwt"), RolesGuard)
+@Roles("admin")
+export class UpdatesController {
+  constructor(private readonly updatesService: UpdatesService) {}
+
+  @Get("status")
+  @ApiOperation({
+    summary:
+      "Get upstream update status (admin only). Returns current vs. latest GitHub release.",
+  })
+  getStatus(@Request() req): Promise<UpdateStatus> {
+    return this.updatesService.getStatus(req.user.id);
+  }
+
+  @Post("dismiss")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary:
+      "Dismiss the update banner for the current latest version (admin only).",
+  })
+  dismiss(@Request() req) {
+    return this.updatesService.dismiss(req.user.id);
+  }
+}

--- a/backend/src/updates/updates.module.ts
+++ b/backend/src/updates/updates.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { UserPreference } from "../users/entities/user-preference.entity";
+import { UpdatesController } from "./updates.controller";
+import { UpdatesService } from "./updates.service";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([UserPreference])],
+  controllers: [UpdatesController],
+  providers: [UpdatesService],
+  exports: [UpdatesService],
+})
+export class UpdatesModule {}

--- a/backend/src/updates/updates.service.spec.ts
+++ b/backend/src/updates/updates.service.spec.ts
@@ -162,6 +162,28 @@ describe("UpdatesService", () => {
       expect(status.error).toBe("unreachable");
       expect(status.updateAvailable).toBe(false);
     });
+
+    it("handles non-Error throwables in the catch branch", async () => {
+      fetchMock.mockRejectedValueOnce("string-thrown-value");
+
+      await service.refreshLatestRelease();
+      preferencesRepo.findOne.mockResolvedValue(null);
+
+      const status = await service.getStatus("user-1");
+      expect(status.error).toBe("unreachable");
+    });
+
+    it("falls back to tag_name when release.name is empty", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockOkResponse(buildRelease({ name: "" })),
+      );
+
+      await service.refreshLatestRelease();
+      preferencesRepo.findOne.mockResolvedValue(null);
+
+      const status = await service.getStatus("user-1");
+      expect(status.releaseName).toBe("v99.0.0");
+    });
   });
 
   describe("getStatus dismissal flag", () => {
@@ -231,6 +253,36 @@ describe("UpdatesService", () => {
       const result = await service.dismiss("user-1");
       expect(result).toEqual({ dismissed: false, version: null });
       expect(preferencesRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("enabled lifecycle", () => {
+    it("onModuleInit triggers an initial refresh in the background", async () => {
+      fetchMock.mockResolvedValueOnce(mockOkResponse(buildRelease()));
+
+      service.onModuleInit();
+
+      // onModuleInit is fire-and-forget; wait a tick for the microtask queue
+      // so the kicked-off refresh can complete.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.github.com/repos/kenlasko/monize/releases/latest",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "User-Agent": "Monize-UpdateCheck",
+          }),
+        }),
+      );
+    });
+
+    it("scheduledRefresh hits GitHub when enabled", async () => {
+      fetchMock.mockResolvedValueOnce(mockOkResponse(buildRelease()));
+
+      await service.scheduledRefresh();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/backend/src/updates/updates.service.spec.ts
+++ b/backend/src/updates/updates.service.spec.ts
@@ -1,0 +1,289 @@
+import { ConfigService } from "@nestjs/config";
+import { Test, TestingModule } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { UserPreference } from "../users/entities/user-preference.entity";
+import {
+  UpdatesService,
+  isNewerVersion,
+  parseVersion,
+} from "./updates.service";
+
+// The service reads its own "current version" from backend/package.json at
+// module load time. Grab it here so assertions stay in sync if the repo
+// version bumps.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const currentVersion = (require("../../package.json") as { version: string })
+  .version;
+
+describe("version helpers", () => {
+  it("parses semver strings with and without v prefix", () => {
+    expect(parseVersion("1.2.3")).toEqual([1, 2, 3]);
+    expect(parseVersion("v10.20.30")).toEqual([10, 20, 30]);
+    expect(parseVersion("garbage")).toBeNull();
+  });
+
+  it("returns true only when latest is strictly newer", () => {
+    expect(isNewerVersion("1.2.3", "1.2.4")).toBe(true);
+    expect(isNewerVersion("1.2.3", "1.3.0")).toBe(true);
+    expect(isNewerVersion("1.2.3", "2.0.0")).toBe(true);
+    expect(isNewerVersion("1.2.3", "1.2.3")).toBe(false);
+    expect(isNewerVersion("1.2.3", "1.2.2")).toBe(false);
+    expect(isNewerVersion("1.2.3", "not-a-version")).toBe(false);
+  });
+});
+
+describe("UpdatesService", () => {
+  let service: UpdatesService;
+  let preferencesRepo: Record<string, jest.Mock>;
+  let configGet: jest.Mock;
+  let originalFetch: typeof fetch;
+  let fetchMock: jest.Mock;
+
+  const buildRelease = (overrides: Partial<Record<string, unknown>> = {}) => ({
+    tag_name: "v99.0.0",
+    name: "Monize 99.0.0",
+    html_url: "https://github.com/kenlasko/monize/releases/tag/v99.0.0",
+    published_at: "2026-01-01T00:00:00Z",
+    draft: false,
+    prerelease: false,
+    ...overrides,
+  });
+
+  const mockOkResponse = (body: unknown) =>
+    ({
+      ok: true,
+      status: 200,
+      json: async () => body,
+    }) as unknown as Response;
+
+  const mockErrorResponse = (status: number) =>
+    ({
+      ok: false,
+      status,
+      json: async () => ({}),
+    }) as unknown as Response;
+
+  beforeEach(async () => {
+    preferencesRepo = {
+      findOne: jest.fn(),
+      save: jest.fn().mockImplementation((p) => p),
+    };
+    configGet = jest.fn().mockReturnValue(undefined);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UpdatesService,
+        {
+          provide: getRepositoryToken(UserPreference),
+          useValue: preferencesRepo,
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: configGet },
+        },
+      ],
+    }).compile();
+
+    service = module.get<UpdatesService>(UpdatesService);
+
+    originalFetch = global.fetch;
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  describe("refreshLatestRelease", () => {
+    it("populates cache with latest release data", async () => {
+      fetchMock.mockResolvedValueOnce(mockOkResponse(buildRelease()));
+
+      await service.refreshLatestRelease();
+      preferencesRepo.findOne.mockResolvedValue(null);
+
+      const status = await service.getStatus("user-1");
+      expect(status.latestVersion).toBe("99.0.0");
+      expect(status.releaseUrl).toBe(
+        "https://github.com/kenlasko/monize/releases/tag/v99.0.0",
+      );
+      expect(status.releaseName).toBe("Monize 99.0.0");
+      expect(status.updateAvailable).toBe(true);
+      expect(status.error).toBeNull();
+      expect(status.checkedAt).not.toBeNull();
+    });
+
+    it("reports updateAvailable=false when upstream is same or older", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockOkResponse(buildRelease({ tag_name: `v${currentVersion}` })),
+      );
+
+      await service.refreshLatestRelease();
+      preferencesRepo.findOne.mockResolvedValue(null);
+
+      const status = await service.getStatus("user-1");
+      expect(status.updateAvailable).toBe(false);
+      expect(status.dismissed).toBe(false);
+    });
+
+    it("ignores draft/prerelease entries but still records checkedAt", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockOkResponse(buildRelease({ prerelease: true })),
+      );
+
+      await service.refreshLatestRelease();
+      preferencesRepo.findOne.mockResolvedValue(null);
+
+      const status = await service.getStatus("user-1");
+      expect(status.latestVersion).toBeNull();
+      expect(status.updateAvailable).toBe(false);
+      expect(status.checkedAt).not.toBeNull();
+    });
+
+    it("surfaces GitHub non-200 as error without throwing", async () => {
+      fetchMock.mockResolvedValueOnce(mockErrorResponse(429));
+
+      await service.refreshLatestRelease();
+      preferencesRepo.findOne.mockResolvedValue(null);
+
+      const status = await service.getStatus("user-1");
+      expect(status.error).toBe("github_status_429");
+      expect(status.updateAvailable).toBe(false);
+    });
+
+    it("surfaces network failures as error=unreachable", async () => {
+      fetchMock.mockRejectedValueOnce(new Error("getaddrinfo ENOTFOUND"));
+
+      await service.refreshLatestRelease();
+      preferencesRepo.findOne.mockResolvedValue(null);
+
+      const status = await service.getStatus("user-1");
+      expect(status.error).toBe("unreachable");
+      expect(status.updateAvailable).toBe(false);
+    });
+  });
+
+  describe("getStatus dismissal flag", () => {
+    it("marks dismissed when preferences.dismissedUpdateVersion matches latest", async () => {
+      fetchMock.mockResolvedValueOnce(mockOkResponse(buildRelease()));
+      await service.refreshLatestRelease();
+
+      preferencesRepo.findOne.mockResolvedValueOnce({
+        userId: "user-1",
+        dismissedUpdateVersion: "99.0.0",
+      });
+
+      const status = await service.getStatus("user-1");
+      expect(status.updateAvailable).toBe(true);
+      expect(status.dismissed).toBe(true);
+    });
+
+    it("does not mark dismissed when stored version is older than latest", async () => {
+      fetchMock.mockResolvedValueOnce(mockOkResponse(buildRelease()));
+      await service.refreshLatestRelease();
+
+      preferencesRepo.findOne.mockResolvedValueOnce({
+        userId: "user-1",
+        dismissedUpdateVersion: "98.0.0",
+      });
+
+      const status = await service.getStatus("user-1");
+      expect(status.updateAvailable).toBe(true);
+      expect(status.dismissed).toBe(false);
+    });
+  });
+
+  describe("dismiss", () => {
+    it("saves latestVersion to user preferences when they exist", async () => {
+      fetchMock.mockResolvedValueOnce(mockOkResponse(buildRelease()));
+      await service.refreshLatestRelease();
+
+      const existingPrefs = {
+        userId: "user-1",
+        dismissedUpdateVersion: null as string | null,
+      };
+      preferencesRepo.findOne.mockResolvedValueOnce(existingPrefs);
+
+      const result = await service.dismiss("user-1");
+      expect(result).toEqual({ dismissed: true, version: "99.0.0" });
+      expect(preferencesRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ dismissedUpdateVersion: "99.0.0" }),
+      );
+    });
+
+    it("creates preferences row if none exists", async () => {
+      fetchMock.mockResolvedValueOnce(mockOkResponse(buildRelease()));
+      await service.refreshLatestRelease();
+      preferencesRepo.findOne.mockResolvedValueOnce(null);
+
+      const result = await service.dismiss("user-1");
+      expect(result).toEqual({ dismissed: true, version: "99.0.0" });
+      expect(preferencesRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "user-1",
+          dismissedUpdateVersion: "99.0.0",
+        }),
+      );
+    });
+
+    it("is a no-op when no latest release has been fetched", async () => {
+      const result = await service.dismiss("user-1");
+      expect(result).toEqual({ dismissed: false, version: null });
+      expect(preferencesRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("disabled via UPDATE_CHECK_ENABLED=false", () => {
+    it("skips onModuleInit refresh and returns disabled status", async () => {
+      configGet.mockReturnValueOnce("false");
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          UpdatesService,
+          {
+            provide: getRepositoryToken(UserPreference),
+            useValue: preferencesRepo,
+          },
+          {
+            provide: ConfigService,
+            useValue: { get: configGet },
+          },
+        ],
+      }).compile();
+
+      const disabledService = module.get<UpdatesService>(UpdatesService);
+      disabledService.onModuleInit();
+
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      const status = await disabledService.getStatus("user-1");
+      expect(status.disabled).toBe(true);
+      expect(status.updateAvailable).toBe(false);
+      expect(status.latestVersion).toBeNull();
+    });
+
+    it("scheduledRefresh is a no-op when disabled", async () => {
+      configGet.mockReturnValueOnce("false");
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          UpdatesService,
+          {
+            provide: getRepositoryToken(UserPreference),
+            useValue: preferencesRepo,
+          },
+          {
+            provide: ConfigService,
+            useValue: { get: configGet },
+          },
+        ],
+      }).compile();
+
+      const disabledService = module.get<UpdatesService>(UpdatesService);
+      await disabledService.scheduledRefresh();
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/updates/updates.service.ts
+++ b/backend/src/updates/updates.service.ts
@@ -1,0 +1,260 @@
+import { Injectable, Logger, OnModuleInit } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Cron, CronExpression } from "@nestjs/schedule";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { UserPreference } from "../users/entities/user-preference.entity";
+
+// Version comes from the backend package.json at build/run time. Using require
+// keeps the read synchronous and avoids ESM import-assertion issues.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const backendPkg = require("../../package.json") as { version: string };
+
+const GITHUB_LATEST_RELEASE_URL =
+  "https://api.github.com/repos/kenlasko/monize/releases/latest";
+const FETCH_TIMEOUT_MS = 10_000;
+
+interface GithubRelease {
+  tag_name: string;
+  name: string;
+  html_url: string;
+  published_at: string;
+  draft: boolean;
+  prerelease: boolean;
+}
+
+interface LatestReleaseCache {
+  latestVersion: string | null;
+  releaseUrl: string | null;
+  releaseName: string | null;
+  publishedAt: string | null;
+  checkedAt: string | null;
+  error: string | null;
+}
+
+export interface UpdateStatus {
+  currentVersion: string;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+  releaseUrl: string | null;
+  releaseName: string | null;
+  publishedAt: string | null;
+  checkedAt: string | null;
+  dismissed: boolean;
+  disabled: boolean;
+  error: string | null;
+}
+
+/**
+ * Parse a version string like "1.8.40" or "v1.8.40" into [major, minor, patch].
+ * Returns null if the string does not match that shape.
+ */
+export function parseVersion(version: string): [number, number, number] | null {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)/.exec(version.trim());
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+/**
+ * Returns true if `latest` is strictly newer than `current`. Both must parse
+ * into major.minor.patch; otherwise returns false (treat as "no update").
+ */
+export function isNewerVersion(current: string, latest: string): boolean {
+  const c = parseVersion(current);
+  const l = parseVersion(latest);
+  if (!c || !l) return false;
+  for (let i = 0; i < 3; i++) {
+    if (l[i] > c[i]) return true;
+    if (l[i] < c[i]) return false;
+  }
+  return false;
+}
+
+@Injectable()
+export class UpdatesService implements OnModuleInit {
+  private readonly logger = new Logger(UpdatesService.name);
+  private readonly currentVersion: string = backendPkg.version;
+  private readonly enabled: boolean;
+
+  private cache: LatestReleaseCache = {
+    latestVersion: null,
+    releaseUrl: null,
+    releaseName: null,
+    publishedAt: null,
+    checkedAt: null,
+    error: null,
+  };
+
+  constructor(
+    @InjectRepository(UserPreference)
+    private readonly preferencesRepository: Repository<UserPreference>,
+    private readonly configService: ConfigService,
+  ) {
+    // Default enabled; disable with UPDATE_CHECK_ENABLED=false.
+    const flag = this.configService.get<string>("UPDATE_CHECK_ENABLED");
+    this.enabled = flag === undefined ? true : flag !== "false";
+  }
+
+  onModuleInit(): void {
+    if (!this.enabled) {
+      this.logger.log(
+        "Upstream update check disabled via UPDATE_CHECK_ENABLED",
+      );
+      return;
+    }
+    // Non-blocking startup refresh so the cache is populated as early as possible.
+    void this.refreshLatestRelease();
+  }
+
+  @Cron(CronExpression.EVERY_12_HOURS)
+  async scheduledRefresh(): Promise<void> {
+    if (!this.enabled) return;
+    await this.refreshLatestRelease();
+  }
+
+  /**
+   * Fetch the latest release from GitHub and update the in-memory cache.
+   * Network / rate-limit failures are logged and surfaced via `cache.error`
+   * rather than thrown — the endpoint stays available.
+   */
+  async refreshLatestRelease(): Promise<void> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const response = await fetch(GITHUB_LATEST_RELEASE_URL, {
+        headers: {
+          Accept: "application/vnd.github+json",
+          "User-Agent": "Monize-UpdateCheck",
+        },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        this.logger.warn(
+          `GitHub releases API returned status ${response.status}; skipping update`,
+        );
+        this.cache = {
+          ...this.cache,
+          checkedAt: new Date().toISOString(),
+          error: `github_status_${response.status}`,
+        };
+        return;
+      }
+
+      const release = (await response.json()) as GithubRelease;
+      if (release.draft || release.prerelease) {
+        this.logger.debug(
+          `Latest GitHub release ${release.tag_name} is draft/prerelease; ignoring`,
+        );
+        this.cache = {
+          ...this.cache,
+          checkedAt: new Date().toISOString(),
+          error: null,
+        };
+        return;
+      }
+
+      this.cache = {
+        latestVersion: release.tag_name.replace(/^v/, ""),
+        releaseUrl: release.html_url,
+        releaseName: release.name || release.tag_name,
+        publishedAt: release.published_at,
+        checkedAt: new Date().toISOString(),
+        error: null,
+      };
+      this.logger.log(
+        `Latest upstream release: ${this.cache.latestVersion} (current: ${this.currentVersion})`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Failed to refresh latest release from GitHub: ${message}`,
+      );
+      this.cache = {
+        ...this.cache,
+        checkedAt: new Date().toISOString(),
+        error: "unreachable",
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async getStatus(userId: string): Promise<UpdateStatus> {
+    if (!this.enabled) {
+      return {
+        currentVersion: this.currentVersion,
+        latestVersion: null,
+        updateAvailable: false,
+        releaseUrl: null,
+        releaseName: null,
+        publishedAt: null,
+        checkedAt: null,
+        dismissed: false,
+        disabled: true,
+        error: null,
+      };
+    }
+
+    const {
+      latestVersion,
+      releaseUrl,
+      releaseName,
+      publishedAt,
+      checkedAt,
+      error,
+    } = this.cache;
+
+    const updateAvailable =
+      !!latestVersion && isNewerVersion(this.currentVersion, latestVersion);
+
+    let dismissed = false;
+    if (updateAvailable && latestVersion) {
+      const prefs = await this.preferencesRepository.findOne({
+        where: { userId },
+      });
+      dismissed = prefs?.dismissedUpdateVersion === latestVersion;
+    }
+
+    return {
+      currentVersion: this.currentVersion,
+      latestVersion,
+      updateAvailable,
+      releaseUrl,
+      releaseName,
+      publishedAt,
+      checkedAt,
+      dismissed,
+      disabled: false,
+      error,
+    };
+  }
+
+  /**
+   * Record that the user has dismissed the banner for the current latest
+   * version. Stored on user_preferences so it survives across devices and
+   * re-appears automatically when a newer upstream release is detected.
+   */
+  async dismiss(
+    userId: string,
+  ): Promise<{ dismissed: boolean; version: string | null }> {
+    const latestVersion = this.cache.latestVersion;
+    if (!latestVersion) {
+      return { dismissed: false, version: null };
+    }
+
+    const prefs = await this.preferencesRepository.findOne({
+      where: { userId },
+    });
+    if (prefs) {
+      prefs.dismissedUpdateVersion = latestVersion;
+      await this.preferencesRepository.save(prefs);
+    } else {
+      const created = new UserPreference();
+      created.userId = userId;
+      created.dismissedUpdateVersion = latestVersion;
+      await this.preferencesRepository.save(created);
+    }
+    return { dismissed: true, version: latestVersion };
+  }
+}

--- a/backend/src/users/entities/user-preference.entity.ts
+++ b/backend/src/users/entities/user-preference.entity.ts
@@ -77,6 +77,14 @@ export class UserPreference {
   })
   preferredExchanges: string[];
 
+  @Column({
+    name: "dismissed_update_version",
+    type: "varchar",
+    length: 50,
+    nullable: true,
+  })
+  dismissedUpdateVersion: string | null;
+
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;
 

--- a/database/migrations/052_dismissed_update_version.sql
+++ b/database/migrations/052_dismissed_update_version.sql
@@ -1,0 +1,7 @@
+-- Add dismissed_update_version column to user_preferences so admins can dismiss
+-- the "upstream update available" banner on a per-version basis. When a new
+-- upstream release is detected, the stored version no longer matches the latest
+-- and the banner re-appears.
+
+ALTER TABLE user_preferences
+  ADD COLUMN IF NOT EXISTS dismissed_update_version VARCHAR(50);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -491,6 +491,7 @@ CREATE TABLE user_preferences (
     show_created_at BOOLEAN DEFAULT false,
     time_format VARCHAR(10) DEFAULT '24h',
     preferred_exchanges TEXT[] DEFAULT '{}',
+    dismissed_update_version VARCHAR(50),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -237,12 +237,12 @@ function SettingsContent() {
                 <DangerZoneSection user={user} />
               </div>
             )}
+
+            <p className="text-center text-xs text-gray-400 dark:text-gray-500 mt-8 mb-4">
+              v{process.env.NEXT_PUBLIC_APP_VERSION}
+            </p>
           </div>
         </div>
-
-        <p className="text-center text-xs text-gray-400 dark:text-gray-500 mt-8 mb-4">
-          v{process.env.NEXT_PUBLIC_APP_VERSION}
-        </p>
       </main>
     </PageLayout>
   );

--- a/frontend/src/components/layout/SwipeShell.test.tsx
+++ b/frontend/src/components/layout/SwipeShell.test.tsx
@@ -37,6 +37,13 @@ vi.mock('./SwipeIndicator', () => ({
   ),
 }));
 
+// Mock UpdateAvailableBanner
+vi.mock('./UpdateAvailableBanner', () => ({
+  UpdateAvailableBanner: () => (
+    <div data-testid="update-available-banner">UpdateAvailableBanner</div>
+  ),
+}));
+
 describe('SwipeShell', () => {
   it('renders AppHeader and children on app pages', () => {
     mockPathname = '/dashboard';

--- a/frontend/src/components/layout/SwipeShell.tsx
+++ b/frontend/src/components/layout/SwipeShell.tsx
@@ -7,6 +7,7 @@ import { BackendDownBanner } from './BackendDownBanner';
 import { DemoModeBanner } from './DemoModeBanner';
 import { HttpWarningBanner } from './HttpWarningBanner';
 import { SwipeIndicator } from './SwipeIndicator';
+import { UpdateAvailableBanner } from './UpdateAvailableBanner';
 import { useSwipeNavigation } from '@/hooks/useSwipeNavigation';
 
 const AUTH_ROUTES = ['/login', '/register', '/forgot-password', '/reset-password', '/setup-2fa', '/change-password'];
@@ -38,6 +39,7 @@ export function SwipeShell({ children, httpsHeadersActive = false }: SwipeShellP
       <HttpWarningBanner httpsHeadersActive={httpsHeadersActive} />
       <BackendDownBanner httpsHeadersActive={httpsHeadersActive} />
       <DemoModeBanner />
+      <UpdateAvailableBanner />
       <SwipeIndicator currentIndex={currentIndex} totalPages={totalPages} isSwipePage={isSwipePage} />
       <div ref={contentRef}>
         {children}

--- a/frontend/src/components/layout/UpdateAvailableBanner.test.tsx
+++ b/frontend/src/components/layout/UpdateAvailableBanner.test.tsx
@@ -126,6 +126,59 @@ describe('UpdateAvailableBanner', () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it('silently swallows a failed getStatus call and renders nothing', async () => {
+    useAuthStore.setState({ user: adminUser, isAuthenticated: true });
+    vi.mocked(updatesApi.getStatus).mockRejectedValueOnce(new Error('boom'));
+
+    const { container } = await renderBanner();
+
+    await waitFor(() => {
+      expect(updatesApi.getStatus).toHaveBeenCalled();
+    });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('falls back to a generic message when latestVersion is missing', async () => {
+    useAuthStore.setState({ user: adminUser, isAuthenticated: true });
+    vi.mocked(updatesApi.getStatus).mockResolvedValue({
+      ...baseStatus,
+      latestVersion: null,
+    });
+
+    await renderBanner();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/A new version of Monize is available/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('un-hides the banner if dismiss fails so the user can retry', async () => {
+    useAuthStore.setState({ user: adminUser, isAuthenticated: true });
+    vi.mocked(updatesApi.getStatus).mockResolvedValue(baseStatus);
+    vi.mocked(updatesApi.dismiss).mockRejectedValueOnce(new Error('boom'));
+
+    await renderBanner();
+
+    const dismissButton = await screen.findByRole('button', {
+      name: /dismiss update notification/i,
+    });
+
+    await act(async () => {
+      fireEvent.click(dismissButton);
+    });
+
+    await waitFor(() => {
+      expect(updatesApi.dismiss).toHaveBeenCalledTimes(1);
+    });
+
+    // After the failed dismiss, the banner should be visible again.
+    expect(
+      screen.getByText(/Monize v1\.9\.0 is available/),
+    ).toBeInTheDocument();
+  });
+
   it('hides the banner and calls dismiss when the user clicks Dismiss', async () => {
     useAuthStore.setState({ user: adminUser, isAuthenticated: true });
     vi.mocked(updatesApi.getStatus).mockResolvedValue(baseStatus);

--- a/frontend/src/components/layout/UpdateAvailableBanner.test.tsx
+++ b/frontend/src/components/layout/UpdateAvailableBanner.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, act, fireEvent } from '@/test/render';
+import { UpdateAvailableBanner } from './UpdateAvailableBanner';
+import { useAuthStore } from '@/store/authStore';
+import { updatesApi, UpdateStatus } from '@/lib/updatesApi';
+import type { User } from '@/types/auth';
+
+vi.mock('@/lib/updatesApi', () => ({
+  updatesApi: {
+    getStatus: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+const adminUser: User = {
+  id: 'admin-1',
+  email: 'admin@example.com',
+  authProvider: 'local',
+  hasPassword: true,
+  role: 'admin',
+  isActive: true,
+  mustChangePassword: false,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+const regularUser: User = { ...adminUser, id: 'user-1', role: 'user' };
+
+const baseStatus: UpdateStatus = {
+  currentVersion: '1.8.40',
+  latestVersion: '1.9.0',
+  updateAvailable: true,
+  releaseUrl: 'https://github.com/kenlasko/monize/releases/tag/v1.9.0',
+  releaseName: 'Monize 1.9.0',
+  publishedAt: '2026-02-01T00:00:00Z',
+  checkedAt: '2026-02-02T00:00:00Z',
+  dismissed: false,
+  disabled: false,
+  error: null,
+};
+
+async function renderBanner() {
+  let result: ReturnType<typeof render>;
+  await act(async () => {
+    result = render(<UpdateAvailableBanner />);
+  });
+  return result!;
+}
+
+describe('UpdateAvailableBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.setState({
+      user: null,
+      isAuthenticated: false,
+    });
+  });
+
+  it('renders nothing for non-admin users even if an update is available', async () => {
+    useAuthStore.setState({ user: regularUser, isAuthenticated: true });
+    vi.mocked(updatesApi.getStatus).mockResolvedValue(baseStatus);
+
+    const { container } = await renderBanner();
+
+    expect(container.firstChild).toBeNull();
+    expect(updatesApi.getStatus).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing when not authenticated', async () => {
+    vi.mocked(updatesApi.getStatus).mockResolvedValue(baseStatus);
+
+    const { container } = await renderBanner();
+
+    expect(container.firstChild).toBeNull();
+    expect(updatesApi.getStatus).not.toHaveBeenCalled();
+  });
+
+  it('renders banner with latest version and release notes link for admin with available update', async () => {
+    useAuthStore.setState({ user: adminUser, isAuthenticated: true });
+    vi.mocked(updatesApi.getStatus).mockResolvedValue(baseStatus);
+
+    await renderBanner();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Monize v1\.9\.0 is available/),
+      ).toBeInTheDocument();
+    });
+
+    const link = screen.getByRole('link', { name: /release notes/i });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://github.com/kenlasko/monize/releases/tag/v1.9.0',
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders nothing when updateAvailable is false', async () => {
+    useAuthStore.setState({ user: adminUser, isAuthenticated: true });
+    vi.mocked(updatesApi.getStatus).mockResolvedValue({
+      ...baseStatus,
+      updateAvailable: false,
+    });
+
+    const { container } = await renderBanner();
+
+    await waitFor(() => {
+      expect(updatesApi.getStatus).toHaveBeenCalled();
+    });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when the user has already dismissed this version', async () => {
+    useAuthStore.setState({ user: adminUser, isAuthenticated: true });
+    vi.mocked(updatesApi.getStatus).mockResolvedValue({
+      ...baseStatus,
+      dismissed: true,
+    });
+
+    const { container } = await renderBanner();
+
+    await waitFor(() => {
+      expect(updatesApi.getStatus).toHaveBeenCalled();
+    });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('hides the banner and calls dismiss when the user clicks Dismiss', async () => {
+    useAuthStore.setState({ user: adminUser, isAuthenticated: true });
+    vi.mocked(updatesApi.getStatus).mockResolvedValue(baseStatus);
+    vi.mocked(updatesApi.dismiss).mockResolvedValue({
+      dismissed: true,
+      version: '1.9.0',
+    });
+
+    await renderBanner();
+
+    const dismissButton = await screen.findByRole('button', {
+      name: /dismiss update notification/i,
+    });
+
+    await act(async () => {
+      fireEvent.click(dismissButton);
+    });
+
+    await waitFor(() => {
+      expect(updatesApi.dismiss).toHaveBeenCalledTimes(1);
+    });
+
+    expect(
+      screen.queryByText(/Monize v1\.9\.0 is available/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/UpdateAvailableBanner.tsx
+++ b/frontend/src/components/layout/UpdateAvailableBanner.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAuthStore } from '@/store/authStore';
+import { updatesApi, UpdateStatus } from '@/lib/updatesApi';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('UpdateAvailableBanner');
+
+/**
+ * Admin-only banner that alerts operators when a newer Monize release is
+ * available upstream on GitHub. Dismissal is stored per-version on the user's
+ * preferences, so a dismissed banner re-appears once the next release lands.
+ */
+export function UpdateAvailableBanner() {
+  const user = useAuthStore((s) => s.user);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const [status, setStatus] = useState<UpdateStatus | null>(null);
+  const [hidden, setHidden] = useState(false);
+
+  const isAdmin = isAuthenticated && user?.role === 'admin';
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    let cancelled = false;
+
+    updatesApi
+      .getStatus()
+      .then((s) => {
+        if (!cancelled) setStatus(s);
+      })
+      .catch((err) => {
+        // Silent failure — the banner is non-critical and should never surface
+        // an error toast to the user. We still log it for debugging.
+        logger.debug('Failed to fetch update status', err);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAdmin]);
+
+  if (!isAdmin || !status || hidden) return null;
+  if (!status.updateAvailable || status.dismissed) return null;
+
+  const handleDismiss = async () => {
+    setHidden(true);
+    try {
+      await updatesApi.dismiss();
+    } catch (err) {
+      // If the dismiss call fails, un-hide so the user can try again next load.
+      // No toast — silent recovery.
+      logger.debug('Failed to dismiss update banner', err);
+      setHidden(false);
+    }
+  };
+
+  const label = status.latestVersion
+    ? `Monize v${status.latestVersion} is available`
+    : 'A new version of Monize is available';
+
+  return (
+    <div className="bg-blue-50 dark:bg-blue-900/30 border-b border-blue-200 dark:border-blue-800 px-4 py-2 text-center text-sm text-blue-800 dark:text-blue-200 flex items-center justify-center gap-3">
+      <span>
+        <span className="font-semibold">{label}</span>
+        {status.currentVersion && (
+          <span className="ml-1 text-blue-700/80 dark:text-blue-300/80">
+            (running v{status.currentVersion})
+          </span>
+        )}
+      </span>
+      {status.releaseUrl && (
+        <a
+          href={status.releaseUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline font-medium hover:text-blue-900 dark:hover:text-blue-100"
+        >
+          Release notes
+        </a>
+      )}
+      <button
+        type="button"
+        onClick={handleDismiss}
+        aria-label="Dismiss update notification"
+        className="ml-2 text-blue-700/70 dark:text-blue-300/70 hover:text-blue-900 dark:hover:text-blue-100"
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/lib/updatesApi.test.ts
+++ b/frontend/src/lib/updatesApi.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the axios client so we test updatesApi in isolation without
+// dragging in interceptors, cookies, or the auth store.
+vi.mock('./api', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+import apiClient from './api';
+import { updatesApi } from './updatesApi';
+
+describe('updatesApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getStatus calls GET /updates/status and unwraps data', async () => {
+    const payload = {
+      currentVersion: '1.8.40',
+      latestVersion: '1.9.0',
+      updateAvailable: true,
+      releaseUrl: 'https://github.com/kenlasko/monize/releases/tag/v1.9.0',
+      releaseName: 'Monize 1.9.0',
+      publishedAt: '2026-02-01T00:00:00Z',
+      checkedAt: '2026-02-02T00:00:00Z',
+      dismissed: false,
+      disabled: false,
+      error: null,
+    };
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: payload });
+
+    const result = await updatesApi.getStatus();
+
+    expect(apiClient.get).toHaveBeenCalledWith('/updates/status');
+    expect(result).toEqual(payload);
+  });
+
+  it('dismiss calls POST /updates/dismiss and unwraps data', async () => {
+    const payload = { dismissed: true, version: '1.9.0' };
+    vi.mocked(apiClient.post).mockResolvedValueOnce({ data: payload });
+
+    const result = await updatesApi.dismiss();
+
+    expect(apiClient.post).toHaveBeenCalledWith('/updates/dismiss');
+    expect(result).toEqual(payload);
+  });
+
+  it('getStatus propagates errors from the axios client', async () => {
+    vi.mocked(apiClient.get).mockRejectedValueOnce(new Error('network'));
+
+    await expect(updatesApi.getStatus()).rejects.toThrow('network');
+  });
+
+  it('dismiss propagates errors from the axios client', async () => {
+    vi.mocked(apiClient.post).mockRejectedValueOnce(new Error('boom'));
+
+    await expect(updatesApi.dismiss()).rejects.toThrow('boom');
+  });
+});

--- a/frontend/src/lib/updatesApi.ts
+++ b/frontend/src/lib/updatesApi.ts
@@ -1,0 +1,31 @@
+import apiClient from './api';
+
+export interface UpdateStatus {
+  currentVersion: string;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+  releaseUrl: string | null;
+  releaseName: string | null;
+  publishedAt: string | null;
+  checkedAt: string | null;
+  dismissed: boolean;
+  disabled: boolean;
+  error: string | null;
+}
+
+export interface DismissResult {
+  dismissed: boolean;
+  version: string | null;
+}
+
+export const updatesApi = {
+  getStatus: async (): Promise<UpdateStatus> => {
+    const response = await apiClient.get<UpdateStatus>('/updates/status');
+    return response.data;
+  },
+
+  dismiss: async (): Promise<DismissResult> => {
+    const response = await apiClient.post<DismissResult>('/updates/dismiss');
+    return response.data;
+  },
+};


### PR DESCRIPTION
## Summary
Adds a system for checking GitHub releases and notifying admins when a newer version of Monize is available. The feature includes a backend service that periodically polls GitHub, stores dismissal preferences per-version, and a frontend banner that displays the update notification to admin users only.

## Key Changes

**Backend:**
- New `UpdatesService` that fetches the latest release from GitHub API every 12 hours
  - Parses semantic versions and compares current vs. latest
  - Caches release metadata (version, URL, name, published date)
  - Handles network failures and rate limits gracefully without throwing
  - Respects `UPDATE_CHECK_ENABLED` config flag (defaults to enabled)
- New `UpdatesController` with two admin-only endpoints:
  - `GET /updates/status` — returns current version, latest version, and dismissal state
  - `POST /updates/dismiss` — records that the user dismissed this version
- Added `dismissedUpdateVersion` column to `user_preferences` table to persist dismissals per-version
- New `UpdatesModule` integrated into `AppModule`
- Comprehensive test coverage for version parsing, comparison, GitHub API interaction, and error handling

**Frontend:**
- New `UpdateAvailableBanner` component that:
  - Only renders for authenticated admin users
  - Fetches update status on mount
  - Shows release name, current version, and link to release notes
  - Allows users to dismiss the banner (stored server-side)
  - Silently handles API failures without surfacing errors
  - Re-appears automatically when a newer version is detected
- New `updatesApi` client module for API communication
- Integrated banner into `SwipeShell` layout
- Comprehensive test coverage for all user interactions and edge cases

**Database:**
- Migration adding `dismissed_update_version` VARCHAR(50) column to `user_preferences`
- Updated schema.sql to reflect the new column

## Implementation Details

- Version comparison uses semantic versioning (major.minor.patch) with strict "newer" semantics
- GitHub API calls include a 10-second timeout and proper User-Agent header
- Draft and prerelease versions are ignored but still update the `checkedAt` timestamp
- Dismissal is per-version: when a new upstream release is detected, the banner reappears automatically
- All network/API errors are logged but don't throw — the feature degrades gracefully
- Admin-only access is enforced via `@Roles("admin")` decorator on controller endpoints

https://claude.ai/code/session_01Ub2euaQnw7UbULz8kVpKA8