### PR TITLE
feat(accounts): send email reminders for upcoming mortgage renewals

### DIFF
--- a/backend/src/accounts/accounts.module.ts
+++ b/backend/src/accounts/accounts.module.ts
@@ -4,6 +4,8 @@ import { Account } from "./entities/account.entity";
 import { Transaction } from "../transactions/entities/transaction.entity";
 import { InvestmentTransaction } from "../securities/entities/investment-transaction.entity";
 import { Category } from "../categories/entities/category.entity";
+import { User } from "../users/entities/user.entity";
+import { UserPreference } from "../users/entities/user-preference.entity";
 import { AccountsService } from "./accounts.service";
 import { AccountExportService } from "./account-export.service";
 import { LoanMortgageAccountService } from "./loan-mortgage-account.service";
@@ -15,6 +17,7 @@ import { CategoriesModule } from "../categories/categories.module";
 import { ScheduledTransactionsModule } from "../scheduled-transactions/scheduled-transactions.module";
 import { NetWorthModule } from "../net-worth/net-worth.module";
 import { ActionHistoryModule } from "../action-history/action-history.module";
+import { NotificationsModule } from "../notifications/notifications.module";
 
 @Module({
   imports: [
@@ -23,11 +26,14 @@ import { ActionHistoryModule } from "../action-history/action-history.module";
       Transaction,
       InvestmentTransaction,
       Category,
+      User,
+      UserPreference,
     ]),
     forwardRef(() => CategoriesModule),
     forwardRef(() => ScheduledTransactionsModule),
     forwardRef(() => NetWorthModule),
     ActionHistoryModule,
+    NotificationsModule,
   ],
   providers: [
     AccountsService,

--- a/backend/src/accounts/mortgage-reminder.service.spec.ts
+++ b/backend/src/accounts/mortgage-reminder.service.spec.ts
@@ -1,11 +1,19 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { getRepositoryToken } from "@nestjs/typeorm";
+import { ConfigService } from "@nestjs/config";
 import { MortgageReminderService } from "./mortgage-reminder.service";
 import { Account, AccountType } from "./entities/account.entity";
+import { User } from "../users/entities/user.entity";
+import { UserPreference } from "../users/entities/user-preference.entity";
+import { EmailService } from "../notifications/email.service";
 
 describe("MortgageReminderService", () => {
   let service: MortgageReminderService;
   let accountsRepository: Record<string, jest.Mock>;
+  let usersRepository: Record<string, jest.Mock>;
+  let preferencesRepository: Record<string, jest.Mock>;
+  let emailService: Record<string, jest.Mock>;
+  let configService: Record<string, jest.Mock>;
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -25,9 +33,39 @@ describe("MortgageReminderService", () => {
     termEndDate: daysFromNow(30),
   };
 
+  const mockUser: Partial<User> = {
+    id: "user-1",
+    email: "user1@example.com",
+    firstName: "Alice",
+  };
+
+  const mockPrefsEmailEnabled: Partial<UserPreference> = {
+    userId: "user-1",
+    notificationEmail: true,
+  };
+
   beforeEach(async () => {
     accountsRepository = {
       find: jest.fn().mockResolvedValue([]),
+    };
+
+    usersRepository = {
+      findOne: jest.fn(),
+    };
+
+    preferencesRepository = {
+      findOne: jest.fn(),
+    };
+
+    emailService = {
+      getStatus: jest.fn().mockReturnValue({ configured: true }),
+      sendMail: jest.fn().mockResolvedValue(undefined),
+    };
+
+    configService = {
+      get: jest
+        .fn()
+        .mockImplementation((_key: string, fallback: string) => fallback),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -37,6 +75,16 @@ describe("MortgageReminderService", () => {
           provide: getRepositoryToken(Account),
           useValue: accountsRepository,
         },
+        {
+          provide: getRepositoryToken(User),
+          useValue: usersRepository,
+        },
+        {
+          provide: getRepositoryToken(UserPreference),
+          useValue: preferencesRepository,
+        },
+        { provide: EmailService, useValue: emailService },
+        { provide: ConfigService, useValue: configService },
       ],
     }).compile();
 
@@ -99,12 +147,175 @@ describe("MortgageReminderService", () => {
       accountsRepository.find.mockResolvedValue([]);
 
       await expect(service.checkMortgageRenewals()).resolves.not.toThrow();
+      expect(emailService.sendMail).not.toHaveBeenCalled();
     });
 
     it("processes upcoming renewals", async () => {
       accountsRepository.find.mockResolvedValue([mockMortgage]);
+      preferencesRepository.findOne.mockResolvedValue(mockPrefsEmailEnabled);
+      usersRepository.findOne.mockResolvedValue(mockUser);
 
       await expect(service.checkMortgageRenewals()).resolves.not.toThrow();
+    });
+
+    it("skips sending emails when SMTP is not configured", async () => {
+      emailService.getStatus.mockReturnValue({ configured: false });
+      accountsRepository.find.mockResolvedValue([mockMortgage]);
+
+      await service.checkMortgageRenewals();
+
+      expect(preferencesRepository.findOne).not.toHaveBeenCalled();
+      expect(emailService.sendMail).not.toHaveBeenCalled();
+    });
+
+    it("sends an email when a user has a renewal and email notifications enabled", async () => {
+      accountsRepository.find.mockResolvedValue([mockMortgage]);
+      preferencesRepository.findOne.mockResolvedValue(mockPrefsEmailEnabled);
+      usersRepository.findOne.mockResolvedValue(mockUser);
+
+      await service.checkMortgageRenewals();
+
+      expect(emailService.sendMail).toHaveBeenCalledTimes(1);
+      const [to, subject, html] = emailService.sendMail.mock.calls[0];
+      expect(to).toBe("user1@example.com");
+      expect(subject).toBe("Monize: 1 upcoming mortgage renewal");
+      expect(html).toContain("Home Mortgage");
+      expect(html).toContain("Hi Alice,");
+    });
+
+    it("uses plural subject for multiple mortgages", async () => {
+      const secondMortgage = {
+        ...mockMortgage,
+        id: "mort-2",
+        name: "Cottage Mortgage",
+        termEndDate: daysFromNow(45),
+      };
+      accountsRepository.find.mockResolvedValue([mockMortgage, secondMortgage]);
+      preferencesRepository.findOne.mockResolvedValue(mockPrefsEmailEnabled);
+      usersRepository.findOne.mockResolvedValue(mockUser);
+
+      await service.checkMortgageRenewals();
+
+      expect(emailService.sendMail).toHaveBeenCalledTimes(1);
+      const [, subject, html] = emailService.sendMail.mock.calls[0];
+      expect(subject).toBe("Monize: 2 upcoming mortgage renewals");
+      expect(html).toContain("Home Mortgage");
+      expect(html).toContain("Cottage Mortgage");
+    });
+
+    it("groups mortgages by user into a single email", async () => {
+      const mortgageUser1A = mockMortgage;
+      const mortgageUser1B = {
+        ...mockMortgage,
+        id: "mort-1b",
+        name: "Cottage Mortgage",
+      };
+      const mortgageUser2 = {
+        ...mockMortgage,
+        id: "mort-2",
+        userId: "user-2",
+        name: "Investment Mortgage",
+      };
+      accountsRepository.find.mockResolvedValue([
+        mortgageUser1A,
+        mortgageUser1B,
+        mortgageUser2,
+      ]);
+      preferencesRepository.findOne.mockResolvedValue(mockPrefsEmailEnabled);
+      usersRepository.findOne.mockImplementation((query) => {
+        const id = query.where.id;
+        if (id === "user-1") return Promise.resolve(mockUser);
+        if (id === "user-2")
+          return Promise.resolve({
+            id: "user-2",
+            email: "user2@example.com",
+            firstName: "Bob",
+          });
+        return Promise.resolve(null);
+      });
+
+      await service.checkMortgageRenewals();
+
+      expect(emailService.sendMail).toHaveBeenCalledTimes(2);
+      const recipients = emailService.sendMail.mock.calls
+        .map((c) => c[0])
+        .sort();
+      expect(recipients).toEqual(["user1@example.com", "user2@example.com"]);
+    });
+
+    it("skips user when notificationEmail preference is disabled", async () => {
+      accountsRepository.find.mockResolvedValue([mockMortgage]);
+      preferencesRepository.findOne.mockResolvedValue({
+        userId: "user-1",
+        notificationEmail: false,
+      });
+
+      await service.checkMortgageRenewals();
+
+      expect(usersRepository.findOne).not.toHaveBeenCalled();
+      expect(emailService.sendMail).not.toHaveBeenCalled();
+    });
+
+    it("sends when preferences row is missing (default on)", async () => {
+      accountsRepository.find.mockResolvedValue([mockMortgage]);
+      preferencesRepository.findOne.mockResolvedValue(null);
+      usersRepository.findOne.mockResolvedValue(mockUser);
+
+      await service.checkMortgageRenewals();
+
+      expect(emailService.sendMail).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips user when no user record is found", async () => {
+      accountsRepository.find.mockResolvedValue([mockMortgage]);
+      preferencesRepository.findOne.mockResolvedValue(mockPrefsEmailEnabled);
+      usersRepository.findOne.mockResolvedValue(null);
+
+      await service.checkMortgageRenewals();
+
+      expect(emailService.sendMail).not.toHaveBeenCalled();
+    });
+
+    it("skips user when user has no email address", async () => {
+      accountsRepository.find.mockResolvedValue([mockMortgage]);
+      preferencesRepository.findOne.mockResolvedValue(mockPrefsEmailEnabled);
+      usersRepository.findOne.mockResolvedValue({
+        id: "user-1",
+        email: null,
+        firstName: "Alice",
+      });
+
+      await service.checkMortgageRenewals();
+
+      expect(emailService.sendMail).not.toHaveBeenCalled();
+    });
+
+    it("continues processing remaining users when one send fails", async () => {
+      const mortgageUser2 = {
+        ...mockMortgage,
+        id: "mort-2",
+        userId: "user-2",
+        name: "Investment Mortgage",
+      };
+      accountsRepository.find.mockResolvedValue([mockMortgage, mortgageUser2]);
+      preferencesRepository.findOne.mockResolvedValue(mockPrefsEmailEnabled);
+      usersRepository.findOne.mockImplementation((query) => {
+        const id = query.where.id;
+        if (id === "user-1") return Promise.resolve(mockUser);
+        if (id === "user-2")
+          return Promise.resolve({
+            id: "user-2",
+            email: "user2@example.com",
+            firstName: "Bob",
+          });
+        return Promise.resolve(null);
+      });
+      emailService.sendMail
+        .mockRejectedValueOnce(new Error("SMTP send failed"))
+        .mockResolvedValueOnce(undefined);
+
+      await expect(service.checkMortgageRenewals()).resolves.not.toThrow();
+      expect(emailService.sendMail).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/backend/src/accounts/mortgage-reminder.service.ts
+++ b/backend/src/accounts/mortgage-reminder.service.ts
@@ -2,15 +2,21 @@ import { Injectable, Logger } from "@nestjs/common";
 import { Cron, CronExpression } from "@nestjs/schedule";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository, IsNull, Not } from "typeorm";
+import { ConfigService } from "@nestjs/config";
 import { Account, AccountType } from "./entities/account.entity";
+import { User } from "../users/entities/user.entity";
+import { UserPreference } from "../users/entities/user-preference.entity";
+import { EmailService } from "../notifications/email.service";
+import { mortgageReminderTemplate } from "../notifications/email-templates";
 import { formatDateYMD } from "../common/date-utils";
 
 /**
  * Service for handling mortgage term renewal reminders
  *
- * Runs daily to check for mortgages with term end dates approaching
- * and logs reminders. When a full notification system is implemented,
- * this will create actual user notifications.
+ * Runs daily to check for mortgages with term end dates approaching and
+ * sends an email reminder to each affected user (respecting their
+ * notificationEmail preference). Also logs each detected renewal so ops
+ * can see what was processed even when SMTP is unavailable.
  */
 @Injectable()
 export class MortgageReminderService {
@@ -19,6 +25,12 @@ export class MortgageReminderService {
   constructor(
     @InjectRepository(Account)
     private accountsRepository: Repository<Account>,
+    @InjectRepository(User)
+    private usersRepository: Repository<User>,
+    @InjectRepository(UserPreference)
+    private preferencesRepository: Repository<UserPreference>,
+    private emailService: EmailService,
+    private configService: ConfigService,
   ) {}
 
   /**
@@ -41,20 +53,80 @@ export class MortgageReminderService {
         `Mortgage renewal reminder: ${mortgage.name} (User: ${mortgage.userId}) ` +
           `- Term ends in ${daysUntilRenewal} days on ${formatDateYMD(mortgage.termEndDate!)}`,
       );
-
-      // TODO: When notification system is implemented, create a notification here
-      // await this.notificationsService.create({
-      //   userId: mortgage.userId,
-      //   type: 'MORTGAGE_RENEWAL',
-      //   title: 'Mortgage Term Renewal Approaching',
-      //   message: `Your mortgage term for "${mortgage.name}" ends on ${mortgage.termEndDate.toLocaleDateString()}. Contact your lender to discuss renewal options.`,
-      //   accountId: mortgage.id,
-      //   expiresAt: new Date(mortgage.termEndDate.getTime() + 30 * 24 * 60 * 60 * 1000), // Expire 30 days after term end
-      // });
     }
 
     this.logger.log(
       `Found ${upcomingRenewals.length} mortgage(s) with upcoming renewals`,
+    );
+
+    if (!this.emailService.getStatus().configured) {
+      this.logger.debug(
+        "SMTP not configured, skipping mortgage renewal emails",
+      );
+      return;
+    }
+
+    // Group mortgages by userId so each user receives a single email
+    const mortgagesByUser = new Map<string, Account[]>();
+    for (const mortgage of upcomingRenewals) {
+      const existing = mortgagesByUser.get(mortgage.userId) || [];
+      existing.push(mortgage);
+      mortgagesByUser.set(mortgage.userId, existing);
+    }
+
+    const appUrl = this.configService.get<string>(
+      "PUBLIC_APP_URL",
+      "http://localhost:3000",
+    );
+    let sentCount = 0;
+    let skipCount = 0;
+
+    for (const [userId, mortgages] of mortgagesByUser) {
+      try {
+        const prefs = await this.preferencesRepository.findOne({
+          where: { userId },
+        });
+        if (prefs && !prefs.notificationEmail) {
+          skipCount++;
+          continue;
+        }
+
+        const user = await this.usersRepository.findOne({
+          where: { id: userId },
+        });
+        if (!user || !user.email) {
+          skipCount++;
+          continue;
+        }
+
+        const mortgageData = mortgages.map((m) => ({
+          name: m.name,
+          termEndDate: formatDateYMD(m.termEndDate!),
+          daysUntilRenewal: this.getDaysUntilDate(m.termEndDate!),
+        }));
+
+        const html = mortgageReminderTemplate(
+          user.firstName || "",
+          mortgageData,
+          appUrl,
+        );
+        const subject =
+          mortgages.length === 1
+            ? "Monize: 1 upcoming mortgage renewal"
+            : `Monize: ${mortgages.length} upcoming mortgage renewals`;
+
+        await this.emailService.sendMail(user.email, subject, html);
+        sentCount++;
+      } catch (error) {
+        this.logger.error(
+          `Failed to send mortgage reminder to user ${userId}`,
+          error instanceof Error ? error.stack : error,
+        );
+      }
+    }
+
+    this.logger.log(
+      `Mortgage reminders complete: ${sentCount} sent, ${skipCount} skipped`,
     );
   }
 

--- a/backend/src/notifications/email-templates.spec.ts
+++ b/backend/src/notifications/email-templates.spec.ts
@@ -3,6 +3,7 @@ import {
   billReminderTemplate,
   passwordResetTemplate,
   budgetMonthlySummaryTemplate,
+  mortgageReminderTemplate,
 } from "./email-templates";
 
 describe("Email Templates", () => {
@@ -648,6 +649,156 @@ describe("Email Templates", () => {
 
       expect(html).toContain("#dc2626");
       expect(html).toContain("40/100");
+    });
+  });
+
+  describe("mortgageReminderTemplate()", () => {
+    const sampleMortgages = [
+      {
+        name: "Home Mortgage",
+        termEndDate: "2026-06-15",
+        daysUntilRenewal: 45,
+      },
+      {
+        name: "Cottage Mortgage",
+        termEndDate: "2026-05-01",
+        daysUntilRenewal: 15,
+      },
+    ];
+
+    it("renders the greeting with the provided name", () => {
+      const html = mortgageReminderTemplate(
+        "Alice",
+        sampleMortgages,
+        "https://monize.app",
+      );
+
+      expect(html).toContain("Hi Alice,");
+    });
+
+    it("renders mortgage rows with name, term end date, and days", () => {
+      const html = mortgageReminderTemplate(
+        "Alice",
+        sampleMortgages,
+        "https://monize.app",
+      );
+
+      expect(html).toContain("Home Mortgage");
+      expect(html).toContain("2026-06-15");
+      expect(html).toContain("45 days");
+      expect(html).toContain("Cottage Mortgage");
+      expect(html).toContain("2026-05-01");
+      expect(html).toContain("15 days");
+    });
+
+    it("includes the Mortgage Renewal Reminder heading", () => {
+      const html = mortgageReminderTemplate(
+        "Alice",
+        sampleMortgages,
+        "https://monize.app",
+      );
+
+      expect(html).toContain("Mortgage Renewal Reminder");
+    });
+
+    it("uses plural grammar for multiple mortgages", () => {
+      const html = mortgageReminderTemplate(
+        "Alice",
+        sampleMortgages,
+        "https://monize.app",
+      );
+
+      expect(html).toContain("2 mortgages");
+    });
+
+    it("uses singular grammar for a single mortgage", () => {
+      const html = mortgageReminderTemplate(
+        "Alice",
+        [sampleMortgages[0]],
+        "https://monize.app",
+      );
+
+      expect(html).toContain("1 mortgage with an upcoming term renewal");
+    });
+
+    it("uses singular day for 1 day remaining", () => {
+      const html = mortgageReminderTemplate(
+        "Alice",
+        [{ name: "Home", termEndDate: "2026-04-17", daysUntilRenewal: 1 }],
+        "https://monize.app",
+      );
+
+      expect(html).toContain("1 day<");
+      expect(html).not.toContain("1 days");
+    });
+
+    it("uses red color for mortgages within 30 days", () => {
+      const html = mortgageReminderTemplate(
+        "Alice",
+        [{ name: "Urgent", termEndDate: "2026-05-01", daysUntilRenewal: 15 }],
+        "https://monize.app",
+      );
+
+      expect(html).toContain("#dc2626");
+    });
+
+    it("uses amber color for mortgages between 31 and 60 days", () => {
+      const html = mortgageReminderTemplate(
+        "Alice",
+        [{ name: "Soon", termEndDate: "2026-06-15", daysUntilRenewal: 45 }],
+        "https://monize.app",
+      );
+
+      expect(html).toContain("#d97706");
+    });
+
+    it("includes the appUrl link to the accounts page", () => {
+      const html = mortgageReminderTemplate(
+        "Alice",
+        sampleMortgages,
+        "https://monize.app",
+      );
+
+      expect(html).toContain('href="https://monize.app/accounts"');
+      expect(html).toContain("View Accounts");
+    });
+
+    it('falls back to "there" when firstName is empty', () => {
+      const html = mortgageReminderTemplate(
+        "",
+        sampleMortgages,
+        "https://monize.app",
+      );
+
+      expect(html).toContain("Hi there,");
+    });
+
+    it("escapes HTML in mortgage names", () => {
+      const html = mortgageReminderTemplate(
+        "Alice",
+        [
+          {
+            name: '<script>alert("xss")</script>',
+            termEndDate: "2026-06-15",
+            daysUntilRenewal: 45,
+          },
+        ],
+        "https://monize.app",
+      );
+
+      expect(html).not.toContain("<script>");
+      expect(html).toContain("&lt;script&gt;");
+    });
+
+    it("escapes HTML in firstName", () => {
+      const html = mortgageReminderTemplate(
+        '<img src=x onerror="alert(1)">',
+        sampleMortgages,
+        "https://monize.app",
+      );
+
+      expect(html).not.toContain("<img");
+      expect(html).toContain("&lt;img");
     });
   });
 });

--- a/backend/src/notifications/email-templates.ts
+++ b/backend/src/notifications/email-templates.ts
@@ -74,6 +74,52 @@ export function billReminderTemplate(
   `;
 }
 
+interface MortgageReminderData {
+  name: string;
+  termEndDate: string;
+  daysUntilRenewal: number;
+}
+
+export function mortgageReminderTemplate(
+  firstName: string,
+  mortgages: MortgageReminderData[],
+  appUrl: string,
+): string {
+  const safeName = escapeHtml(firstName || "there");
+  const mortgageRows = mortgages
+    .map(
+      (m) =>
+        `<tr>
+          <td style="padding: 10px 12px; border-bottom: 1px solid #e5e7eb;">${escapeHtml(m.name)}</td>
+          <td style="padding: 10px 12px; border-bottom: 1px solid #e5e7eb;">${escapeHtml(m.termEndDate)}</td>
+          <td style="padding: 10px 12px; border-bottom: 1px solid #e5e7eb; text-align: right; color: ${m.daysUntilRenewal <= 30 ? "#dc2626" : "#d97706"}; font-weight: 500;">${m.daysUntilRenewal} day${m.daysUntilRenewal === 1 ? "" : "s"}</td>
+        </tr>`,
+    )
+    .join("");
+
+  return `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+      <h2 style="color: #1f2937;">Mortgage Renewal Reminder</h2>
+      <p style="color: #374151;">Hi ${safeName},</p>
+      <p style="color: #374151;">You have ${mortgages.length} mortgage${mortgages.length === 1 ? "" : "s"} with an upcoming term renewal. Contact your lender to discuss renewal options before the term ends:</p>
+      <table style="width: 100%; border-collapse: collapse; margin: 16px 0; border: 1px solid #e5e7eb; border-radius: 8px;">
+        <thead>
+          <tr style="background: #f3f4f6;">
+            <th style="padding: 10px 12px; text-align: left; font-weight: 600; color: #374151;">Mortgage</th>
+            <th style="padding: 10px 12px; text-align: left; font-weight: 600; color: #374151;">Term End Date</th>
+            <th style="padding: 10px 12px; text-align: right; font-weight: 600; color: #374151;">Time Remaining</th>
+          </tr>
+        </thead>
+        <tbody>${mortgageRows}</tbody>
+      </table>
+      <p style="margin-top: 20px;">
+        <a href="${appUrl}/accounts" style="display: inline-block; padding: 10px 20px; background: #2563eb; color: #ffffff; border-radius: 6px; text-decoration: none; font-weight: 500;">View Accounts</a>
+      </p>
+      <p style="color: #6b7280; font-size: 14px; margin-top: 24px;">-- Monize</p>
+    </div>
+  `;
+}
+
 interface BudgetAlertData {
   title: string;
   message: string;


### PR DESCRIPTION
MortgageReminderService previously only logged upcoming renewals; now it
sends a grouped email to each affected user through the existing
EmailService, mirroring the BillReminderService pattern and respecting
each user's notificationEmail preference.

https://claude.ai/code/session_01K4BcqCgxtMyqZUqj7iBmEg