### PR TITLE
Fix AI chart tooltip dark mode and add PNG download

### DIFF
--- a/frontend/src/components/ai/ResultChart.test.tsx
+++ b/frontend/src/components/ai/ResultChart.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { act, fireEvent } from '@testing-library/react';
 import { render, screen } from '@/test/render';
 import { ResultChart } from './ResultChart';
 
@@ -24,6 +25,11 @@ vi.mock('recharts', () => ({
     <div data-testid="area-chart">{children}</div>
   ),
   Area: () => null,
+}));
+
+const captureSvgAsImageMock = vi.fn();
+vi.mock('@/lib/pdf-export-charts', () => ({
+  captureSvgAsImage: (...args: unknown[]) => captureSvgAsImageMock(...args),
 }));
 
 const sampleData = [
@@ -87,5 +93,48 @@ describe('ResultChart', () => {
     );
     expect(screen.getByText('Single')).toBeInTheDocument();
     expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+  });
+
+  it('renders a download button', () => {
+    render(<ResultChart type="bar" title="Test" data={sampleData} />);
+    expect(
+      screen.getByRole('button', { name: /download chart as png/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('triggers a PNG download when the download button is clicked', async () => {
+    captureSvgAsImageMock.mockResolvedValueOnce({
+      dataUrl: 'data:image/png;base64,AAAA',
+      width: 400,
+      height: 256,
+    });
+
+    const clickSpy = vi.fn();
+    const originalCreateElement = document.createElement.bind(document);
+    const createElementSpy = vi
+      .spyOn(document, 'createElement')
+      .mockImplementation((tag: string) => {
+        const el = originalCreateElement(tag) as HTMLElement;
+        if (tag === 'a') {
+          (el as HTMLAnchorElement).click = clickSpy;
+        }
+        return el;
+      });
+
+    render(
+      <ResultChart type="bar" title="My Spending Report" data={sampleData} />,
+    );
+
+    const button = screen.getByRole('button', {
+      name: /download chart as png/i,
+    });
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(captureSvgAsImageMock).toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalled();
+
+    createElementSpy.mockRestore();
   });
 });

--- a/frontend/src/components/ai/ResultChart.tsx
+++ b/frontend/src/components/ai/ResultChart.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useRef, useState } from 'react';
+import toast from 'react-hot-toast';
 import {
   BarChart,
   Bar,
@@ -14,6 +16,7 @@ import {
   AreaChart,
   Area,
 } from 'recharts';
+import { captureSvgAsImage } from '@/lib/pdf-export-charts';
 
 const COLORS = [
   '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6',
@@ -64,15 +67,69 @@ function ChartTooltip({
   );
 }
 
+function sanitizeFilename(name: string): string {
+  const cleaned = name.replace(/[^a-z0-9]+/gi, '-').replace(/^-+|-+$/g, '');
+  return cleaned.toLowerCase() || 'chart';
+}
+
 export function ResultChart({ type, title, data }: ResultChartProps) {
+  const chartRef = useRef<HTMLDivElement>(null);
+  const [isDownloading, setIsDownloading] = useState(false);
+
   if (!data || data.length === 0) return null;
+
+  async function handleDownload() {
+    if (!chartRef.current || isDownloading) return;
+    setIsDownloading(true);
+    try {
+      const captured = await captureSvgAsImage(chartRef.current);
+      if (!captured) {
+        toast.error('Unable to capture chart image');
+        return;
+      }
+      const link = document.createElement('a');
+      link.href = captured.dataUrl;
+      link.download = `${sanitizeFilename(title)}.png`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } catch {
+      toast.error('Failed to download chart');
+    } finally {
+      setIsDownloading(false);
+    }
+  }
 
   return (
     <div className="mt-3 p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
-      <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
-        {title}
-      </h4>
-      <div className="h-64">
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          {title}
+        </h4>
+        <button
+          type="button"
+          onClick={handleDownload}
+          disabled={isDownloading}
+          className="p-1 rounded text-gray-500 hover:text-gray-700 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          title="Download chart as PNG"
+          aria-label="Download chart as PNG"
+        >
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+            />
+          </svg>
+        </button>
+      </div>
+      <div ref={chartRef} className="h-64">
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           {type === 'pie' ? (
             <PieChart>

--- a/frontend/src/components/ai/ResultChart.tsx
+++ b/frontend/src/components/ai/ResultChart.tsx
@@ -36,6 +36,34 @@ function formatCurrency(value: number | undefined): string {
   return `$${value.toLocaleString(undefined, { minimumFractionDigits: 2 })}`;
 }
 
+function ChartTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: Array<{ name?: string; value?: number; payload?: { label?: string } }>;
+  label?: string;
+}) {
+  if (!active || !payload || payload.length === 0) return null;
+  const heading = label ?? payload[0]?.payload?.label ?? payload[0]?.name;
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
+      {heading && (
+        <p className="font-medium text-gray-900 dark:text-gray-100">{heading}</p>
+      )}
+      {payload.map((entry, index) => (
+        <p
+          key={`tooltip-${index}`}
+          className="text-sm text-blue-600 dark:text-blue-400"
+        >
+          {formatCurrency(entry.value)}
+        </p>
+      ))}
+    </div>
+  );
+}
+
 export function ResultChart({ type, title, data }: ResultChartProps) {
   if (!data || data.length === 0) return null;
 
@@ -66,14 +94,14 @@ export function ResultChart({ type, title, data }: ResultChartProps) {
                   />
                 ))}
               </Pie>
-              <Tooltip formatter={formatCurrency} />
+              <Tooltip content={<ChartTooltip />} />
             </PieChart>
           ) : type === 'area' || type === 'line' ? (
             <AreaChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="label" tick={{ fontSize: 12 }} />
               <YAxis tick={{ fontSize: 12 }} />
-              <Tooltip formatter={formatCurrency} />
+              <Tooltip content={<ChartTooltip />} />
               <Area
                 type="monotone"
                 dataKey="value"
@@ -86,7 +114,7 @@ export function ResultChart({ type, title, data }: ResultChartProps) {
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="label" tick={{ fontSize: 12 }} />
               <YAxis tick={{ fontSize: 12 }} />
-              <Tooltip formatter={formatCurrency} />
+              <Tooltip content={<ChartTooltip />} />
               <Bar dataKey="value" radius={[4, 4, 0, 0]}>
                 {data.map((_, index) => (
                   <Cell


### PR DESCRIPTION
## Summary

Two changes to the AI-generated charts rendered by `ResultChart.tsx`:

1. **Fix: tooltips now respect dark mode.** Previously the charts used recharts' default `<Tooltip>`, which has a hardcoded white background — making values unreadable against light text in dark mode. Replaced it with a custom `ChartTooltip` that uses the same Tailwind `dark:` class pattern already used by the dashboard charts (`NetWorthChart`, `ExpensesPieChart`, `IncomeExpensesBarChart`, `BalanceHistoryChart`).

2. **Feature: charts are now downloadable as PNG.** Added a small download icon button next to each chart title. Clicking it captures the rendered SVG and saves it as a high-resolution PNG, reusing the existing `captureSvgAsImage` utility from `pdf-export-charts.ts` that already powers PDF report export (white background, text forced to dark gray for readability regardless of theme). The filename is derived from the chart title, sanitized to kebab-case.

## Changes

**Tooltip fix (`ResultChart.tsx`)**
- New `ChartTooltip` component using `bg-white dark:bg-gray-800`, `border-gray-200 dark:border-gray-700`, `text-gray-900 dark:text-gray-100`, and `text-blue-600 dark:text-blue-400`
- Wired into all three chart variants (pie, area/line, bar) via `<Tooltip content={<ChartTooltip />} />`

**Download feature (`ResultChart.tsx`)**
- `useRef` on the chart container so the rendered SVG can be located
- `handleDownload` calls `captureSvgAsImage` and triggers a standard anchor-click download
- `isDownloading` state disables the button while capture is in flight
- Toast on failure via `react-hot-toast` (consistent with `ExportDropdown`)
- `sanitizeFilename` converts titles like "My Spending Report" to `my-spending-report.png`

**No new dependencies** — everything uses the native Canvas API plus the already-installed `react-hot-toast`.

## Test plan

- [x] `npm run test` — 11/11 ResultChart tests pass (9 existing + 2 new: download button renders; clicking it calls `captureSvgAsImage` and triggers the anchor click)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [ ] Manual: verify tooltip readability in dark mode on pie, bar, and line/area AI charts
- [ ] Manual: verify downloaded PNG renders with a white background and readable text regardless of active theme

https://claude.ai/code/session_01JShmqSp3qhTsCsRuWj31nt