### PR TITLE
Add CSV export to AI assistant tables and fix account balance calculations

### DIFF
--- a/backend/src/ai/query/tool-executor.service.spec.ts
+++ b/backend/src/ai/query/tool-executor.service.spec.ts
@@ -522,32 +522,28 @@ describe("ToolExecutorService", () => {
       expect(result.sources[0].description).toBe("All account balances");
     });
 
-    it("adds holdings market value to brokerage account balances", async () => {
+    it("shows market value as the per-account balance for INVESTMENT_BROKERAGE accounts", async () => {
       const accountsWithBrokerage = [
         {
           id: "acc-1",
           name: "Checking",
-          accountType: "checking",
+          accountType: "CHEQUING",
+          accountSubType: null,
           currencyCode: "USD",
           currentBalance: "5000.00",
-          excludeFromNetWorth: false,
+          futureTransactionsSum: 0,
         },
         {
           id: "acc-brokerage",
           name: "Brokerage",
           accountType: "INVESTMENT",
+          accountSubType: "INVESTMENT_BROKERAGE",
           currencyCode: "USD",
           currentBalance: "0.00",
-          excludeFromNetWorth: false,
+          futureTransactionsSum: 0,
         },
       ];
       mockAccountsService.findAll.mockResolvedValue(accountsWithBrokerage);
-      mockAccountsService.getSummary.mockResolvedValue({
-        totalAssets: 5000,
-        totalLiabilities: 0,
-        netWorth: 5000,
-        totalAccounts: 2,
-      });
       mockPortfolioService.getAccountMarketValues.mockResolvedValue(
         new Map([["acc-brokerage", 75000]]),
       );
@@ -559,60 +555,52 @@ describe("ToolExecutorService", () => {
       const brokerage = accounts.find((a) => a.name === "Brokerage");
       expect(brokerage).toBeDefined();
       expect(brokerage!.balance).toBe(75000);
-      expect(data.totalAssets).toBe(80000);
-      expect(data.netWorth).toBe(80000);
     });
 
-    it("excludes holdings from totalAssets when account is excludeFromNetWorth", async () => {
-      const accountsWithBrokerage = [
+    it("includes future-dated transactions in non-brokerage account balances", async () => {
+      const accountsWithFuture = [
         {
           id: "acc-1",
           name: "Checking",
-          accountType: "checking",
+          accountType: "CHEQUING",
+          accountSubType: null,
           currencyCode: "USD",
           currentBalance: "5000.00",
-          excludeFromNetWorth: false,
-        },
-        {
-          id: "acc-excluded",
-          name: "Excluded Brokerage",
-          accountType: "INVESTMENT",
-          currencyCode: "USD",
-          currentBalance: "0.00",
-          excludeFromNetWorth: true,
+          futureTransactionsSum: 250,
         },
       ];
-      mockAccountsService.findAll.mockResolvedValue(accountsWithBrokerage);
-      mockAccountsService.getSummary.mockResolvedValue({
-        totalAssets: 5000,
-        totalLiabilities: 0,
-        netWorth: 5000,
-        totalAccounts: 2,
-      });
-      mockPortfolioService.getAccountMarketValues.mockResolvedValue(
-        new Map([["acc-excluded", 50000]]),
-      );
+      mockAccountsService.findAll.mockResolvedValue(accountsWithFuture);
 
       const result = await service.execute(userId, "get_account_balances", {});
       const data = result.data as Record<string, unknown>;
       const accounts = data.accounts as Array<Record<string, unknown>>;
 
-      // The per-account balance still reflects market value
-      const excluded = accounts.find((a) => a.name === "Excluded Brokerage");
-      expect(excluded!.balance).toBe(50000);
-      // But totals respect the excludeFromNetWorth flag
-      expect(data.totalAssets).toBe(5000);
-      expect(data.netWorth).toBe(5000);
+      expect(accounts[0].balance).toBe(5250);
     });
 
-    it("leaves balances untouched when there are no holdings", async () => {
-      // Default mockPortfolioService returns an empty map
+    it("uses getMonthlyNetWorth totals so the AI matches the Net Worth widget and report", async () => {
+      mockNetWorthService.getMonthlyNetWorth.mockResolvedValue([
+        { month: "2026-01", assets: 90000, liabilities: 2500, netWorth: 87500 },
+        { month: "2026-02", assets: 95000, liabilities: 2000, netWorth: 93000 },
+      ]);
+
       const result = await service.execute(userId, "get_account_balances", {});
       const data = result.data as Record<string, unknown>;
-      const accounts = data.accounts as Array<Record<string, unknown>>;
 
-      expect(accounts[0].balance).toBe(5000);
-      expect(data.totalAssets).toBe(20000);
+      expect(data.totalAssets).toBe(95000);
+      expect(data.totalLiabilities).toBe(2000);
+      expect(data.netWorth).toBe(93000);
+    });
+
+    it("returns zeroed totals when there are no net worth snapshots yet", async () => {
+      mockNetWorthService.getMonthlyNetWorth.mockResolvedValue([]);
+
+      const result = await service.execute(userId, "get_account_balances", {});
+      const data = result.data as Record<string, unknown>;
+
+      expect(data.totalAssets).toBe(0);
+      expect(data.totalLiabilities).toBe(0);
+      expect(data.netWorth).toBe(0);
     });
   });
 

--- a/backend/src/ai/query/tool-executor.service.ts
+++ b/backend/src/ai/query/tool-executor.service.ts
@@ -8,7 +8,7 @@ import { NetWorthService } from "../../net-worth/net-worth.service";
 import { BudgetsService } from "../../budgets/budgets.service";
 import { BudgetReportsService } from "../../budgets/budget-reports.service";
 import { PortfolioService } from "../../securities/portfolio.service";
-import { AccountType } from "../../accounts/entities/account.entity";
+import { AccountSubType } from "../../accounts/entities/account.entity";
 import {
   getCurrentMonthPeriodDates,
   getPreviousMonthPeriodDates,
@@ -441,12 +441,10 @@ export class ToolExecutorService {
     const accountNames = input.accountNames as string[] | undefined;
 
     const allAccounts = await this.accountsService.findAll(userId, false);
-    const summary = await this.accountsService.getSummary(userId);
 
-    // Brokerage (and standalone investment) accounts carry securities, not
-    // cash, so `currentBalance` is 0 for them — the real value lives in
-    // `holdings.quantity * latest price`. Pull per-account market values so
-    // both the per-account list and the totals reflect reality.
+    // Brokerage accounts carry securities, not cash, so `currentBalance` is 0
+    // for them — the real value lives in `holdings.quantity * latest price`.
+    // Pull per-account market values to mirror the Account List UI.
     const marketValues =
       await this.portfolioService.getAccountMarketValues(userId);
 
@@ -458,42 +456,45 @@ export class ToolExecutorService {
       );
     }
 
+    // Match the Account List / Account Balances report per-account balance:
+    // - INVESTMENT_BROKERAGE shows market value of holdings
+    // - Every other account shows currentBalance + futureTransactionsSum
     const accountList = accounts.map((a) => {
-      const cashBalance = Number(a.currentBalance);
-      const marketValue = marketValues.get(a.id) ?? 0;
+      const balance =
+        a.accountSubType === AccountSubType.INVESTMENT_BROKERAGE
+          ? (marketValues.get(a.id) ?? 0)
+          : Number(a.currentBalance) + Number(a.futureTransactionsSum ?? 0);
       return {
         name: a.name,
         type: a.accountType,
-        balance: roundMoney(cashBalance + marketValue),
+        balance: roundMoney(balance),
         currency: a.currencyCode,
       };
     });
 
-    // The base summary only sums `currentBalance`, so investment accounts with
-    // holdings contribute 0 to totalAssets / netWorth. Add in each excluded-
-    // from-net-worth-respecting investment account's market value here so the
-    // AI sees accurate totals.
-    let extraInvestmentAssets = 0;
-    for (const account of allAccounts) {
-      if (account.accountType !== AccountType.INVESTMENT) continue;
-      if (account.excludeFromNetWorth) continue;
-      const marketValue = marketValues.get(account.id);
-      if (marketValue) extraInvestmentAssets += marketValue;
-    }
-    const totalAssets = roundMoney(summary.totalAssets + extraInvestmentAssets);
-    const netWorth = roundMoney(totalAssets - summary.totalLiabilities);
+    // Use the same source as the dashboard Net Worth widget and Net Worth
+    // report so all three surfaces agree. getMonthlyNetWorth reads from
+    // monthly_account_balances, respects excludeFromNetWorth, applies
+    // currency conversion to the user's default currency, and handles
+    // brokerage vs standalone investment accounts correctly. The latest
+    // month's snapshot is what the widget/report display as "current".
+    const monthly = await this.netWorthService.getMonthlyNetWorth(userId);
+    const latest = monthly[monthly.length - 1];
+    const totalAssets = roundMoney(latest?.assets ?? 0);
+    const totalLiabilities = roundMoney(latest?.liabilities ?? 0);
+    const netWorth = roundMoney(latest?.netWorth ?? 0);
 
     const data = {
       accounts: accountList,
       totalAssets,
-      totalLiabilities: summary.totalLiabilities,
+      totalLiabilities,
       netWorth,
-      totalAccounts: summary.totalAccounts,
+      totalAccounts: allAccounts.length,
     };
 
     return {
       data,
-      summary: `${accounts.length} accounts. Net worth: ${netWorth.toFixed(2)}, Assets: ${totalAssets.toFixed(2)}, Liabilities: ${summary.totalLiabilities.toFixed(2)}`,
+      summary: `${accounts.length} accounts. Net worth: ${netWorth.toFixed(2)}, Assets: ${totalAssets.toFixed(2)}, Liabilities: ${totalLiabilities.toFixed(2)}`,
       sources: [
         {
           type: "accounts",

--- a/frontend/src/components/ai/AssistantMarkdown.tsx
+++ b/frontend/src/components/ai/AssistantMarkdown.tsx
@@ -2,6 +2,7 @@
 
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { AssistantTable } from './AssistantTable';
 
 interface AssistantMarkdownProps {
   content: string;
@@ -78,11 +79,7 @@ export function AssistantMarkdown({ content }: AssistantMarkdownProps) {
             {children}
           </a>
         ),
-        table: ({ children }) => (
-          <div className="overflow-x-auto my-2">
-            <table className="text-xs border-collapse">{children}</table>
-          </div>
-        ),
+        table: ({ children }) => <AssistantTable>{children}</AssistantTable>,
         th: ({ children }) => (
           <th className="border border-gray-300 dark:border-gray-600 px-2 py-1 font-semibold bg-gray-200/60 dark:bg-gray-800/60 text-left">
             {children}

--- a/frontend/src/components/ai/AssistantTable.test.tsx
+++ b/frontend/src/components/ai/AssistantTable.test.tsx
@@ -66,7 +66,7 @@ describe('AssistantTable', () => {
 
     expect(exportToCsvMock).toHaveBeenCalledTimes(1);
     expect(exportToCsvMock).toHaveBeenCalledWith(
-      'ai-table',
+      'category',
       ['Category', 'Amount'],
       [
         ['Food', '$100'],
@@ -98,9 +98,70 @@ describe('AssistantTable', () => {
     );
 
     expect(exportToCsvMock).toHaveBeenCalledWith(
-      'ai-table',
+      'metric',
       ['Metric', 'Value'],
       [['Net Worth', '$10,000']],
+    );
+  });
+
+  it('uses a preceding heading as the CSV filename', () => {
+    render(
+      <div>
+        <h2>Spending by Category</h2>
+        <AssistantTable>
+          <thead>
+            <tr>
+              <th>Category</th>
+              <th>Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Food</td>
+              <td>$100</td>
+            </tr>
+          </tbody>
+        </AssistantTable>
+      </div>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /download table as csv/i }),
+    );
+
+    expect(exportToCsvMock).toHaveBeenCalledWith(
+      'spending-by-category',
+      ['Category', 'Amount'],
+      [['Food', '$100']],
+    );
+  });
+
+  it('falls back to "ai-table" when neither heading nor header cell is available', () => {
+    render(
+      <AssistantTable>
+        <thead>
+          <tr>
+            <th></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>A</td>
+            <td>B</td>
+          </tr>
+        </tbody>
+      </AssistantTable>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /download table as csv/i }),
+    );
+
+    expect(exportToCsvMock).toHaveBeenCalledWith(
+      'ai-table',
+      ['', ''],
+      [['A', 'B']],
     );
   });
 });

--- a/frontend/src/components/ai/AssistantTable.test.tsx
+++ b/frontend/src/components/ai/AssistantTable.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import { render, screen } from '@/test/render';
+import { AssistantTable } from './AssistantTable';
+
+const exportToCsvMock = vi.fn();
+vi.mock('@/lib/csv-export', () => ({
+  exportToCsv: (...args: unknown[]) => exportToCsvMock(...args),
+}));
+
+describe('AssistantTable', () => {
+  beforeEach(() => {
+    exportToCsvMock.mockReset();
+  });
+
+  it('renders the table content and a download button', () => {
+    render(
+      <AssistantTable>
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th>Amount</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Food</td>
+            <td>$100</td>
+          </tr>
+        </tbody>
+      </AssistantTable>,
+    );
+
+    expect(screen.getByText('Category')).toBeInTheDocument();
+    expect(screen.getByText('Food')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /download table as csv/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('extracts headers and rows from the rendered DOM when exporting', () => {
+    render(
+      <AssistantTable>
+        <thead>
+          <tr>
+            <th> Category </th>
+            <th>Amount</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Food</td>
+            <td>$100</td>
+          </tr>
+          <tr>
+            <td>Gas</td>
+            <td>$50</td>
+          </tr>
+        </tbody>
+      </AssistantTable>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /download table as csv/i }),
+    );
+
+    expect(exportToCsvMock).toHaveBeenCalledTimes(1);
+    expect(exportToCsvMock).toHaveBeenCalledWith(
+      'ai-table',
+      ['Category', 'Amount'],
+      [
+        ['Food', '$100'],
+        ['Gas', '$50'],
+      ],
+    );
+  });
+
+  it('exports row-header cells in the body as part of the row', () => {
+    render(
+      <AssistantTable>
+        <thead>
+          <tr>
+            <th>Metric</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Net Worth</th>
+            <td>$10,000</td>
+          </tr>
+        </tbody>
+      </AssistantTable>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /download table as csv/i }),
+    );
+
+    expect(exportToCsvMock).toHaveBeenCalledWith(
+      'ai-table',
+      ['Metric', 'Value'],
+      [['Net Worth', '$10,000']],
+    );
+  });
+});

--- a/frontend/src/components/ai/AssistantTable.tsx
+++ b/frontend/src/components/ai/AssistantTable.tsx
@@ -8,7 +8,40 @@ interface AssistantTableProps {
   children: ReactNode;
 }
 
+function sanitizeFilename(name: string): string {
+  const cleaned = name
+    .replace(/[^a-z0-9]+/gi, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+  return cleaned.toLowerCase() || 'ai-table';
+}
+
+/**
+ * Derive a filename-appropriate label for the table. Prefers the nearest
+ * preceding heading (matches how the markdown author introduces the table),
+ * then falls back to the first header cell so the CSV name reflects the
+ * table's subject rather than a generic placeholder.
+ */
+function deriveTableName(
+  wrapper: HTMLElement | null,
+  table: HTMLTableElement,
+): string {
+  const heading = wrapper?.previousElementSibling;
+  if (
+    heading &&
+    /^(H[1-6]|P)$/.test(heading.tagName) &&
+    heading.textContent?.trim()
+  ) {
+    return heading.textContent.trim();
+  }
+  const firstHeader = table
+    .querySelector('thead th')
+    ?.textContent?.trim();
+  return firstHeader || '';
+}
+
 export function AssistantTable({ children }: AssistantTableProps) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const tableRef = useRef<HTMLTableElement>(null);
 
   const handleDownload = () => {
@@ -29,11 +62,14 @@ export function AssistantTable({ children }: AssistantTableProps) {
       return;
     }
 
-    exportToCsv('ai-table', headers, rows);
+    const filename = sanitizeFilename(
+      deriveTableName(wrapperRef.current, table),
+    );
+    exportToCsv(filename, headers, rows);
   };
 
   return (
-    <div className="my-2">
+    <div ref={wrapperRef} className="my-2">
       <div className="flex justify-end">
         <button
           type="button"

--- a/frontend/src/components/ai/AssistantTable.tsx
+++ b/frontend/src/components/ai/AssistantTable.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { ReactNode, useRef } from 'react';
+import toast from 'react-hot-toast';
+import { exportToCsv } from '@/lib/csv-export';
+
+interface AssistantTableProps {
+  children: ReactNode;
+}
+
+export function AssistantTable({ children }: AssistantTableProps) {
+  const tableRef = useRef<HTMLTableElement>(null);
+
+  const handleDownload = () => {
+    const table = tableRef.current;
+    if (!table) return;
+
+    const headers = Array.from(table.querySelectorAll('thead th')).map(
+      (th) => th.textContent?.trim() ?? '',
+    );
+    const rows = Array.from(table.querySelectorAll('tbody tr')).map((tr) =>
+      Array.from(tr.querySelectorAll('th, td')).map(
+        (c) => c.textContent?.trim() ?? '',
+      ),
+    );
+
+    if (headers.length === 0 && rows.length === 0) {
+      toast.error('No table data to export');
+      return;
+    }
+
+    exportToCsv('ai-table', headers, rows);
+  };
+
+  return (
+    <div className="my-2">
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={handleDownload}
+          className="p-1 rounded text-gray-500 hover:text-gray-700 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-700 transition-colors"
+          title="Download table as CSV"
+          aria-label="Download table as CSV"
+        >
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+            />
+          </svg>
+        </button>
+      </div>
+      <div className="overflow-x-auto">
+        <table ref={tableRef} className="text-xs border-collapse">
+          {children}
+        </table>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
This PR adds CSV export functionality to AI assistant-generated tables and refactors the account balance calculation logic to align with the dashboard's Net Worth widget and reports.

## Key Changes

### Frontend
- **New `AssistantTable` component** (`frontend/src/components/ai/AssistantTable.tsx`):
  - Wraps markdown-rendered tables with a download button
  - Extracts headers from `<thead>` and rows from `<tbody>` (including row-header cells)
  - Exports table data as CSV using the existing `exportToCsv` utility
  - Includes comprehensive test coverage for various table structures

- **Updated `AssistantMarkdown` component**:
  - Replaced inline table rendering with the new `AssistantTable` component
  - Maintains existing styling while adding export capability

### Backend
- **Refactored `get_account_balances` tool** (`backend/src/ai/query/tool-executor.service.ts`):
  - Changed account balance calculation to match the Account List UI:
    - `INVESTMENT_BROKERAGE` accounts now show market value of holdings
    - Other accounts show `currentBalance + futureTransactionsSum`
  - Replaced `accountsService.getSummary()` with `netWorthService.getMonthlyNetWorth()` for totals
    - Ensures AI sees the same Net Worth figures as the dashboard widget and reports
    - Respects `excludeFromNetWorth` flags and currency conversion
    - Uses the latest monthly snapshot as "current" values
  - Removed dependency on `AccountType` enum, now uses `AccountSubType`

- **Updated test suite** (`backend/src/ai/query/tool-executor.service.spec.ts`):
  - Refactored test data to use correct account type/subtype structure
  - Updated test expectations to reflect new balance calculation logic
  - Added tests for future-dated transactions and net worth snapshot handling
  - Removed tests for `excludeFromNetWorth` flag behavior (now handled by `getMonthlyNetWorth`)

## Notable Implementation Details
- The CSV export extracts data directly from the rendered DOM, making it resilient to markdown rendering variations
- Account balance calculations now have a single source of truth (`getMonthlyNetWorth`), reducing inconsistencies across the UI
- The `AssistantTable` component gracefully handles edge cases like empty tables with user-friendly error messages

https://claude.ai/code/session_01RJGS5mwXMhCAcySzxqJKdv