### PR TITLE
Allow negative intermediate holdings during transaction edits

### DIFF
--- a/backend/src/securities/holdings.service.spec.ts
+++ b/backend/src/securities/holdings.service.spec.ts
@@ -515,6 +515,78 @@ describe("HoldingsService", () => {
       // The tiny residual (0.00005) should be snapped to exactly 0
       expect(result.quantity).toBe(0);
     });
+
+    it("rejects when selling more than held by default", async () => {
+      const existingHolding = {
+        id: "hold-1",
+        accountId: "acc-1",
+        securityId: "sec-1",
+        quantity: 0,
+        averageCost: 150,
+      };
+      holdingsRepository.findOne.mockResolvedValue(existingHolding);
+
+      await expect(
+        service.createOrUpdate("user-1", "acc-1", "sec-1", -100, 150),
+      ).rejects.toThrow(/Insufficient shares/);
+    });
+
+    it("allows negative intermediate state when allowNegative=true", async () => {
+      const existingHolding = {
+        id: "hold-1",
+        accountId: "acc-1",
+        securityId: "sec-1",
+        quantity: 0,
+        averageCost: 150,
+      };
+      holdingsRepository.findOne.mockResolvedValue(existingHolding);
+      holdingsRepository.save.mockImplementation((data) =>
+        Promise.resolve(data),
+      );
+
+      const result = await service.createOrUpdate(
+        "user-1",
+        "acc-1",
+        "sec-1",
+        -100,
+        150,
+        undefined,
+        true,
+      );
+
+      expect(result.quantity).toBe(-100);
+    });
+
+    it("does not update averageCost while running quantity stays non-positive", async () => {
+      // Reverse of a past BUY can leave quantity at -100 with the original
+      // avg cost of 50. Applying a new BUY(150 @ 60) bringing quantity to 50
+      // should inherit the new trade's price as the avg cost rather than
+      // producing a distorted blended value.
+      const existingHolding = {
+        id: "hold-1",
+        accountId: "acc-1",
+        securityId: "sec-1",
+        quantity: -100,
+        averageCost: 50,
+      };
+      holdingsRepository.findOne.mockResolvedValue(existingHolding);
+      holdingsRepository.save.mockImplementation((data) =>
+        Promise.resolve(data),
+      );
+
+      const result = await service.createOrUpdate(
+        "user-1",
+        "acc-1",
+        "sec-1",
+        150,
+        60,
+        undefined,
+        true,
+      );
+
+      expect(result.quantity).toBe(50);
+      expect(result.averageCost).toBe(60);
+    });
   });
 
   describe("updateHolding", () => {
@@ -1262,6 +1334,201 @@ describe("HoldingsService", () => {
         }),
       );
       expect(result.holdingsCreated).toBe(1);
+    });
+  });
+
+  describe("validateNoNegativeHoldingsHistory", () => {
+    it("returns silently when user has no brokerage accounts", async () => {
+      accountsRepository.find.mockResolvedValue([]);
+
+      await expect(
+        service.validateNoNegativeHoldingsHistory("user-1"),
+      ).resolves.toBeUndefined();
+      expect(investmentTransactionsRepository.find).not.toHaveBeenCalled();
+    });
+
+    it("allows a buy-then-sell sequence that ends at zero", async () => {
+      accountsRepository.find.mockResolvedValue([mockAccount]);
+      investmentTransactionsRepository.find.mockResolvedValue([
+        {
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: InvestmentAction.BUY,
+          quantity: 100,
+          transactionDate: "2024-01-01",
+          security: { symbol: "AAPL" },
+        },
+        {
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: InvestmentAction.SELL,
+          quantity: 100,
+          transactionDate: "2024-06-01",
+          security: { symbol: "AAPL" },
+        },
+      ]);
+
+      await expect(
+        service.validateNoNegativeHoldingsHistory("user-1"),
+      ).resolves.toBeUndefined();
+    });
+
+    it("throws when a SELL at some date would drop holdings below zero", async () => {
+      accountsRepository.find.mockResolvedValue([mockAccount]);
+      investmentTransactionsRepository.find.mockResolvedValue([
+        {
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: InvestmentAction.BUY,
+          quantity: 50,
+          transactionDate: "2024-01-01",
+          security: { symbol: "AAPL" },
+        },
+        {
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: InvestmentAction.SELL,
+          quantity: 100,
+          transactionDate: "2024-06-01",
+          security: { symbol: "AAPL" },
+        },
+      ]);
+
+      await expect(
+        service.validateNoNegativeHoldingsHistory("user-1"),
+      ).rejects.toThrow(/negative/i);
+    });
+
+    it("does not count a later BUY to cover an earlier oversold SELL", async () => {
+      // Transactions are ordered by date, so an oversell on 2024-06-01 must
+      // throw even though a subsequent BUY on 2024-09-01 would restore the
+      // final balance.
+      accountsRepository.find.mockResolvedValue([mockAccount]);
+      investmentTransactionsRepository.find.mockResolvedValue([
+        {
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: InvestmentAction.BUY,
+          quantity: 10,
+          transactionDate: "2024-01-01",
+          security: { symbol: "AAPL" },
+        },
+        {
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: InvestmentAction.SELL,
+          quantity: 50,
+          transactionDate: "2024-06-01",
+          security: { symbol: "AAPL" },
+        },
+        {
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: InvestmentAction.BUY,
+          quantity: 100,
+          transactionDate: "2024-09-01",
+          security: { symbol: "AAPL" },
+        },
+      ]);
+
+      await expect(
+        service.validateNoNegativeHoldingsHistory("user-1"),
+      ).rejects.toThrow(/AAPL/);
+    });
+
+    it("tracks different securities independently", async () => {
+      accountsRepository.find.mockResolvedValue([mockAccount]);
+      investmentTransactionsRepository.find.mockResolvedValue([
+        {
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: InvestmentAction.BUY,
+          quantity: 100,
+          transactionDate: "2024-01-01",
+          security: { symbol: "AAPL" },
+        },
+        {
+          accountId: "acc-1",
+          securityId: "sec-2",
+          action: InvestmentAction.SELL,
+          quantity: 10,
+          transactionDate: "2024-02-01",
+          security: { symbol: "MSFT" },
+        },
+      ]);
+
+      await expect(
+        service.validateNoNegativeHoldingsHistory("user-1"),
+      ).rejects.toThrow(/MSFT/);
+    });
+
+    it("applies SPLIT as a multiplier on running quantity", async () => {
+      accountsRepository.find.mockResolvedValue([mockAccount]);
+      investmentTransactionsRepository.find.mockResolvedValue([
+        {
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: InvestmentAction.BUY,
+          quantity: 10,
+          transactionDate: "2024-01-01",
+          security: { symbol: "AAPL" },
+        },
+        {
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: InvestmentAction.SPLIT,
+          quantity: 4,
+          transactionDate: "2024-02-01",
+          security: { symbol: "AAPL" },
+        },
+        {
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: InvestmentAction.SELL,
+          quantity: 30,
+          transactionDate: "2024-03-01",
+          security: { symbol: "AAPL" },
+        },
+      ]);
+
+      // After BUY 10 + 4-for-1 SPLIT = 40 shares, SELL 30 leaves 10. Valid.
+      await expect(
+        service.validateNoNegativeHoldingsHistory("user-1"),
+      ).resolves.toBeUndefined();
+    });
+
+    it("ignores DIVIDEND/INTEREST/CAPITAL_GAIN transactions", async () => {
+      accountsRepository.find.mockResolvedValue([mockAccount]);
+      investmentTransactionsRepository.find.mockResolvedValue([
+        {
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: InvestmentAction.BUY,
+          quantity: 10,
+          transactionDate: "2024-01-01",
+          security: { symbol: "AAPL" },
+        },
+        {
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: InvestmentAction.DIVIDEND,
+          quantity: 0,
+          transactionDate: "2024-02-01",
+          security: { symbol: "AAPL" },
+        },
+        {
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: InvestmentAction.SELL,
+          quantity: 10,
+          transactionDate: "2024-03-01",
+          security: { symbol: "AAPL" },
+        },
+      ]);
+
+      await expect(
+        service.validateNoNegativeHoldingsHistory("user-1"),
+      ).resolves.toBeUndefined();
     });
   });
 

--- a/backend/src/securities/holdings.service.spec.ts
+++ b/backend/src/securities/holdings.service.spec.ts
@@ -1497,6 +1497,43 @@ describe("HoldingsService", () => {
       ).resolves.toBeUndefined();
     });
 
+    it("limits validation to the supplied accountIds", async () => {
+      // A pre-existing oversold state in an unrelated account should not
+      // block an edit scoped to a specific account.
+      accountsRepository.find.mockResolvedValue([mockAccount, mockAccount2]);
+      investmentTransactionsRepository.find.mockResolvedValue([
+        // Only the transactions for acc-1 are returned because we query
+        // with accountId IN (...) filtered to the scoped list.
+        {
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: InvestmentAction.BUY,
+          quantity: 10,
+          transactionDate: "2024-01-01",
+          security: { symbol: "AAPL" },
+        },
+      ]);
+
+      await expect(
+        service.validateNoNegativeHoldingsHistory(
+          "user-1",
+          undefined,
+          ["acc-1"],
+        ),
+      ).resolves.toBeUndefined();
+
+      // The scoped list must be passed through to the query, not the
+      // broader account lookup.
+      expect(accountsRepository.find).not.toHaveBeenCalled();
+      expect(investmentTransactionsRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            userId: "user-1",
+          }),
+        }),
+      );
+    });
+
     it("ignores DIVIDEND/INTEREST/CAPITAL_GAIN transactions", async () => {
       accountsRepository.find.mockResolvedValue([mockAccount]);
       investmentTransactionsRepository.find.mockResolvedValue([

--- a/backend/src/securities/holdings.service.ts
+++ b/backend/src/securities/holdings.service.ts
@@ -90,6 +90,7 @@ export class HoldingsService {
     quantityChange: number,
     pricePerShare: number,
     queryRunner?: QueryRunner,
+    allowNegative: boolean = false,
   ): Promise<Holding> {
     // Verify account ownership
     await this.accountsService.findOne(userId, accountId);
@@ -123,18 +124,28 @@ export class HoldingsService {
       const newQuantity = currentQuantity + quantityChange;
 
       if (quantityChange > 0) {
-        // Buying shares - calculate new average cost
-        const totalCostBefore = currentQuantity * currentAvgCost;
-        const totalCostAdded = quantityChange * pricePerShare;
-        const newAvgCost = (totalCostBefore + totalCostAdded) / newQuantity;
-        holding.averageCost = newAvgCost;
-      } else {
-        // Selling shares - keep same average cost
-        // Average cost doesn't change when selling
+        if (currentQuantity <= 0 && newQuantity > 0) {
+          // Coming out of a zero-or-negative balance (e.g. reverse-apply
+          // of a past buy): treat this purchase as establishing the new
+          // cost basis rather than blending against a phantom negative
+          // cost basis.
+          holding.averageCost = pricePerShare;
+        } else if (currentQuantity > 0 && newQuantity > 0) {
+          // Blend the purchase into existing positive holdings.
+          const totalCostBefore = currentQuantity * currentAvgCost;
+          const totalCostAdded = quantityChange * pricePerShare;
+          const newAvgCost = (totalCostBefore + totalCostAdded) / newQuantity;
+          holding.averageCost = newAvgCost;
+        }
       }
 
-      // Guard against negative holdings from overselling
-      if (newQuantity < -0.00000001) {
+      // Guard against negative holdings from overselling. Skipped when
+      // allowNegative is true, which the investment-transaction update and
+      // remove flows use to permit intermediate negative states during
+      // reverse/re-apply. The caller is responsible for running
+      // validateHoldingsHistory afterward so oversells at any historical
+      // date are still caught.
+      if (!allowNegative && newQuantity < -0.00000001) {
         throw new BadRequestException(
           `Insufficient shares: cannot reduce by ${Math.abs(quantityChange)}, only ${currentQuantity} held`,
         );
@@ -154,6 +165,7 @@ export class HoldingsService {
     quantityDelta: number,
     price: number,
     queryRunner?: QueryRunner,
+    allowNegative: boolean = false,
   ): Promise<Holding> {
     return this.createOrUpdate(
       userId,
@@ -162,6 +174,7 @@ export class HoldingsService {
       quantityDelta,
       price,
       queryRunner,
+      allowNegative,
     );
   }
 
@@ -242,6 +255,96 @@ export class HoldingsService {
     }
 
     await this.holdingsRepository.remove(holding);
+  }
+
+  /**
+   * Replay the user's investment transactions in chronological order and
+   * throw BadRequestException if any (account, security) pair would have a
+   * negative running quantity at any date. Used after editing or deleting a
+   * past investment transaction to ensure the change does not retroactively
+   * cause an oversell on any historical date.
+   */
+  async validateNoNegativeHoldingsHistory(
+    userId: string,
+    queryRunner?: QueryRunner,
+  ): Promise<void> {
+    const accountsRepo = queryRunner
+      ? queryRunner.manager.getRepository(Account)
+      : this.accountsRepository;
+    const txRepo = queryRunner
+      ? queryRunner.manager.getRepository(InvestmentTransaction)
+      : this.investmentTransactionsRepository;
+
+    const investmentAccounts = await accountsRepo.find({
+      where: {
+        userId,
+        accountType: AccountType.INVESTMENT,
+      },
+    });
+
+    const eligibleAccountIds = investmentAccounts
+      .filter(
+        (a) =>
+          a.accountSubType === AccountSubType.INVESTMENT_BROKERAGE ||
+          !a.accountSubType,
+      )
+      .map((a) => a.id);
+
+    if (eligibleAccountIds.length === 0) {
+      return;
+    }
+
+    const transactions = await txRepo.find({
+      where: {
+        userId,
+        accountId: In(eligibleAccountIds),
+      },
+      relations: ["security"],
+      order: {
+        transactionDate: "ASC",
+        createdAt: "ASC",
+      },
+    });
+
+    const balances = new Map<string, number>();
+
+    for (const tx of transactions) {
+      if (!tx.securityId) continue;
+
+      const key = `${tx.accountId}:${tx.securityId}`;
+      const current = balances.get(key) || 0;
+      const quantity = Number(tx.quantity) || 0;
+
+      let next = current;
+      switch (tx.action) {
+        case InvestmentAction.BUY:
+        case InvestmentAction.REINVEST:
+        case InvestmentAction.TRANSFER_IN:
+        case InvestmentAction.ADD_SHARES:
+          next = current + quantity;
+          break;
+        case InvestmentAction.SELL:
+        case InvestmentAction.TRANSFER_OUT:
+        case InvestmentAction.REMOVE_SHARES:
+          next = current - quantity;
+          break;
+        case InvestmentAction.SPLIT:
+          next = current * quantity;
+          break;
+        default:
+          continue;
+      }
+
+      if (next < -0.00000001) {
+        const symbol = tx.security?.symbol || "this security";
+        throw new BadRequestException(
+          `This change would cause holdings of ${symbol} to go negative on ${tx.transactionDate}. ` +
+            `A ${tx.action} transaction on that date would reduce the balance below zero.`,
+        );
+      }
+
+      balances.set(key, next);
+    }
   }
 
   /**

--- a/backend/src/securities/holdings.service.ts
+++ b/backend/src/securities/holdings.service.ts
@@ -264,9 +264,22 @@ export class HoldingsService {
    * past investment transaction to ensure the change does not retroactively
    * cause an oversell on any historical date.
    */
+  /**
+   * Replay a user's investment transactions in chronological order and
+   * throw BadRequestException if any (account, security) pair would have a
+   * negative running quantity at any date. Used after editing or deleting a
+   * past investment transaction to ensure the change does not retroactively
+   * cause an oversell on any historical date.
+   *
+   * When `accountIds` is provided, only those accounts are validated. The
+   * caller should pass the accounts touched by the edit so pre-existing
+   * inconsistencies in unrelated accounts (for example, from historical
+   * imports) don't get blamed on this change.
+   */
   async validateNoNegativeHoldingsHistory(
     userId: string,
     queryRunner?: QueryRunner,
+    accountIds?: string[],
   ): Promise<void> {
     const accountsRepo = queryRunner
       ? queryRunner.manager.getRepository(Account)
@@ -275,20 +288,25 @@ export class HoldingsService {
       ? queryRunner.manager.getRepository(InvestmentTransaction)
       : this.investmentTransactionsRepository;
 
-    const investmentAccounts = await accountsRepo.find({
-      where: {
-        userId,
-        accountType: AccountType.INVESTMENT,
-      },
-    });
+    let eligibleAccountIds: string[];
+    if (accountIds && accountIds.length > 0) {
+      eligibleAccountIds = accountIds;
+    } else {
+      const investmentAccounts = await accountsRepo.find({
+        where: {
+          userId,
+          accountType: AccountType.INVESTMENT,
+        },
+      });
 
-    const eligibleAccountIds = investmentAccounts
-      .filter(
-        (a) =>
-          a.accountSubType === AccountSubType.INVESTMENT_BROKERAGE ||
-          !a.accountSubType,
-      )
-      .map((a) => a.id);
+      eligibleAccountIds = investmentAccounts
+        .filter(
+          (a) =>
+            a.accountSubType === AccountSubType.INVESTMENT_BROKERAGE ||
+            !a.accountSubType,
+        )
+        .map((a) => a.id);
+    }
 
     if (eligibleAccountIds.length === 0) {
       return;

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -225,6 +225,7 @@ describe("InvestmentTransactionsService", () => {
       updateHolding: jest.fn().mockResolvedValue(undefined),
       adjustQuantity: jest.fn().mockResolvedValue(undefined),
       removeAllForUser: jest.fn().mockResolvedValue(5),
+      validateNoNegativeHoldingsHistory: jest.fn().mockResolvedValue(undefined),
     };
 
     securitiesService = {
@@ -429,6 +430,7 @@ describe("InvestmentTransactionsService", () => {
         10,
         150,
         expect.anything(),
+        false,
       );
     });
 
@@ -521,6 +523,7 @@ describe("InvestmentTransactionsService", () => {
         -5,
         160,
         expect.anything(),
+        false,
       );
     });
 
@@ -732,6 +735,7 @@ describe("InvestmentTransactionsService", () => {
         2,
         150,
         expect.anything(),
+        false,
       );
       // No cash transaction for REINVEST
       expect(transactionRepository.create).not.toHaveBeenCalled();
@@ -778,6 +782,7 @@ describe("InvestmentTransactionsService", () => {
         20,
         100,
         expect.anything(),
+        false,
       );
       expect(transactionRepository.create).not.toHaveBeenCalled();
     });
@@ -822,6 +827,7 @@ describe("InvestmentTransactionsService", () => {
         -10,
         100,
         expect.anything(),
+        false,
       );
       expect(transactionRepository.create).not.toHaveBeenCalled();
     });
@@ -1570,6 +1576,7 @@ describe("InvestmentTransactionsService", () => {
         -10, // Reverse: remove original 10 shares
         150,
         expect.anything(),
+        true,
       );
 
       // Then apply new effects
@@ -1580,7 +1587,70 @@ describe("InvestmentTransactionsService", () => {
         expect.any(Number), // New quantity applied
         expect.any(Number),
         expect.anything(),
+        true,
       );
+    });
+
+    it("allows editing a past transaction when current holdings are zero", async () => {
+      // Regression: previously the update flow rejected any edit to a past
+      // BUY transaction when current holdings were zero because reversing
+      // the original BUY drove the running balance negative. The fix passes
+      // allowNegative=true through reverse+apply and validates the full
+      // history after instead.
+      const existingTx = { ...mockBuyTransaction };
+      const firstFindQB = createMockQueryBuilder(existingTx);
+      const secondFindQB = createMockQueryBuilder({
+        ...existingTx,
+        quantity: 15,
+        totalAmount: 2259.99,
+      });
+
+      investmentTransactionsRepository.createQueryBuilder
+        .mockReturnValueOnce(firstFindQB)
+        .mockReturnValueOnce(secondFindQB);
+
+      transactionRepository.findOne.mockResolvedValue({
+        id: cashTransactionId,
+        userId,
+        accountId: cashAccountId,
+        amount: -1509.99,
+      });
+
+      await expect(
+        service.update(userId, transactionId, { quantity: 15 }),
+      ).resolves.toBeDefined();
+
+      expect(
+        holdingsService.validateNoNegativeHoldingsHistory,
+      ).toHaveBeenCalledWith(userId, expect.anything());
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+      expect(mockQueryRunner.rollbackTransaction).not.toHaveBeenCalled();
+    });
+
+    it("rolls back when the edit would cause negative holdings on some date", async () => {
+      const existingTx = { ...mockBuyTransaction };
+      const firstFindQB = createMockQueryBuilder(existingTx);
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValueOnce(
+        firstFindQB,
+      );
+
+      transactionRepository.findOne.mockResolvedValue({
+        id: cashTransactionId,
+        userId,
+        accountId: cashAccountId,
+        amount: -1509.99,
+      });
+
+      holdingsService.validateNoNegativeHoldingsHistory.mockRejectedValueOnce(
+        new BadRequestException("Negative holdings of AAPL on 2024-06-01"),
+      );
+
+      await expect(
+        service.update(userId, transactionId, { quantity: 1 }),
+      ).rejects.toThrow(/Negative holdings/);
+
+      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+      expect(mockQueryRunner.commitTransaction).not.toHaveBeenCalled();
     });
 
     it("recalculates totalAmount when quantity changes", async () => {
@@ -1967,6 +2037,7 @@ describe("InvestmentTransactionsService", () => {
         -10,
         150,
         expect.anything(),
+        true,
       );
 
       // Should delete cash transaction and reverse balance
@@ -2005,6 +2076,7 @@ describe("InvestmentTransactionsService", () => {
         5, // Add back the sold shares
         160,
         expect.anything(),
+        true,
       );
     });
 
@@ -2031,6 +2103,7 @@ describe("InvestmentTransactionsService", () => {
         -3,
         150,
         expect.anything(),
+        true,
       );
     });
 
@@ -2057,6 +2130,7 @@ describe("InvestmentTransactionsService", () => {
         -20,
         100,
         expect.anything(),
+        true,
       );
     });
 
@@ -2083,6 +2157,7 @@ describe("InvestmentTransactionsService", () => {
         10,
         100,
         expect.anything(),
+        true,
       );
     });
 

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -1622,7 +1622,7 @@ describe("InvestmentTransactionsService", () => {
 
       expect(
         holdingsService.validateNoNegativeHoldingsHistory,
-      ).toHaveBeenCalledWith(userId, expect.anything());
+      ).toHaveBeenCalledWith(userId, expect.anything(), [accountId]);
       expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
       expect(mockQueryRunner.rollbackTransaction).not.toHaveBeenCalled();
     });

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -469,6 +469,7 @@ export class InvestmentTransactionsService {
     queryRunner: QueryRunner,
     userId: string,
     transaction: InvestmentTransaction,
+    allowNegative: boolean = false,
   ): Promise<void> {
     if (isTransactionInFuture(transaction.transactionDate)) {
       return;
@@ -504,6 +505,7 @@ export class InvestmentTransactionsService {
           Number(quantity),
           Number(price),
           queryRunner,
+          allowNegative,
         );
         cashTransactionId = await this.createCashTransactionInTransaction(
           queryRunner,
@@ -522,6 +524,7 @@ export class InvestmentTransactionsService {
           -Number(quantity),
           Number(price),
           queryRunner,
+          allowNegative,
         );
         cashTransactionId = await this.createCashTransactionInTransaction(
           queryRunner,
@@ -553,6 +556,7 @@ export class InvestmentTransactionsService {
             Number(quantity),
             Number(price),
             queryRunner,
+            allowNegative,
           );
         }
         break;
@@ -592,6 +596,7 @@ export class InvestmentTransactionsService {
             Number(quantity),
             Number(price),
             queryRunner,
+            allowNegative,
           );
         }
         break;
@@ -605,6 +610,7 @@ export class InvestmentTransactionsService {
             -Number(quantity),
             Number(price),
             queryRunner,
+            allowNegative,
           );
         }
         break;
@@ -853,11 +859,21 @@ export class InvestmentTransactionsService {
       const saved = await queryRunner.manager.save(transaction);
       savedId = saved.id;
 
-      // Apply the new transaction effects
+      // Apply the new transaction effects. Allow intermediate negative
+      // holdings so editing a past transaction is not blocked by the
+      // current (possibly zero) balance. Correctness is enforced by the
+      // history check below, which replays all transactions in
+      // chronological order.
       await this.processTransactionEffectsInTransaction(
         queryRunner,
         userId,
         saved,
+        true,
+      );
+
+      await this.holdingsService.validateNoNegativeHoldingsHistory(
+        userId,
+        queryRunner,
       );
 
       await queryRunner.commitTransaction();
@@ -942,6 +958,12 @@ export class InvestmentTransactionsService {
       );
     }
 
+    // Reversing a past transaction can make the running Holding balance
+    // temporarily negative (e.g. reversing a BUY when the user has since
+    // sold the position). Allow that intermediate state; the update/remove
+    // callers validate the full transaction history before commit.
+    const allowNegative = true;
+
     switch (action) {
       case InvestmentAction.BUY:
         if (securityId) {
@@ -952,6 +974,7 @@ export class InvestmentTransactionsService {
             -Number(quantity),
             Number(price),
             queryRunner,
+            allowNegative,
           );
         }
         break;
@@ -965,6 +988,7 @@ export class InvestmentTransactionsService {
             Number(quantity),
             Number(price),
             queryRunner,
+            allowNegative,
           );
         }
         break;
@@ -983,6 +1007,7 @@ export class InvestmentTransactionsService {
             -Number(quantity),
             Number(price),
             queryRunner,
+            allowNegative,
           );
         }
         break;
@@ -996,6 +1021,7 @@ export class InvestmentTransactionsService {
             -Number(quantity),
             Number(price),
             queryRunner,
+            allowNegative,
           );
         }
         break;
@@ -1009,6 +1035,7 @@ export class InvestmentTransactionsService {
             Number(quantity),
             Number(price),
             queryRunner,
+            allowNegative,
           );
         }
         break;
@@ -1066,6 +1093,11 @@ export class InvestmentTransactionsService {
       );
 
       await queryRunner.manager.remove(transaction);
+
+      await this.holdingsService.validateNoNegativeHoldingsHistory(
+        userId,
+        queryRunner,
+      );
 
       await queryRunner.commitTransaction();
     } catch (error) {

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -862,8 +862,8 @@ export class InvestmentTransactionsService {
       // Apply the new transaction effects. Allow intermediate negative
       // holdings so editing a past transaction is not blocked by the
       // current (possibly zero) balance. Correctness is enforced by the
-      // history check below, which replays all transactions in
-      // chronological order.
+      // history check below, which replays the affected accounts'
+      // transactions in chronological order.
       await this.processTransactionEffectsInTransaction(
         queryRunner,
         userId,
@@ -871,9 +871,17 @@ export class InvestmentTransactionsService {
         true,
       );
 
+      // Scope validation to the accounts this edit could have affected
+      // (old account + new account if it changed). Validating every
+      // account would falsely blame this edit for pre-existing oversold
+      // states elsewhere in the user's data.
+      const affectedAccountIds = Array.from(
+        new Set([accountId, saved.accountId].filter(Boolean) as string[]),
+      );
       await this.holdingsService.validateNoNegativeHoldingsHistory(
         userId,
         queryRunner,
+        affectedAccountIds,
       );
 
       await queryRunner.commitTransaction();
@@ -1097,6 +1105,7 @@ export class InvestmentTransactionsService {
       await this.holdingsService.validateNoNegativeHoldingsHistory(
         userId,
         queryRunner,
+        [accountId],
       );
 
       await queryRunner.commitTransaction();

--- a/frontend/src/app/investments/page.tsx
+++ b/frontend/src/app/investments/page.tsx
@@ -23,6 +23,7 @@ import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useInvestmentData } from '@/hooks/useInvestmentData';
 import { useOnUndoRedo } from '@/hooks/useOnUndoRedo';
 import { Account } from '@/types/account';
+import { buildAccountFilterLabel } from '@/lib/account-utils';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { PAGE_SIZE } from '@/lib/constants';
 import { formatRelativeTime } from '@/lib/format';
@@ -124,6 +125,15 @@ function InvestmentsContent() {
     return account.name;
   };
 
+  // Summary/allocation/chart titles show which accounts the filter covers.
+  const accountFilterLabel = useMemo(() => {
+    return buildAccountFilterLabel(
+      data.selectedAccountIds,
+      data.selectableAccounts,
+      (a) => getAccountDisplayName(a as Account),
+    );
+  }, [data.selectedAccountIds, data.selectableAccounts]);
+
   return (
     <PageLayout>
       <main className="px-4 sm:px-6 lg:px-12 pt-6 pb-8">
@@ -192,6 +202,7 @@ function InvestmentsContent() {
                   ? data.accounts.find(a => a.id === data.selectedAccountIds[0])?.currencyCode ?? null
                   : null
               }
+              titleSuffix={accountFilterLabel}
             />
             <AssetAllocationChart
               allocation={data.portfolioSummary ? { allocation: data.portfolioSummary.allocation, totalValue: data.portfolioSummary.totalPortfolioValue } : null}
@@ -202,6 +213,7 @@ function InvestmentsContent() {
                   : null
               }
               holdingsByAccount={data.portfolioSummary?.holdingsByAccount}
+              titleSuffix={accountFilterLabel}
             />
           </div>
 
@@ -214,6 +226,7 @@ function InvestmentsContent() {
                   ? data.accounts.find(a => a.id === data.selectedAccountIds[0])?.currencyCode ?? null
                   : null
               }
+              titleSuffix={accountFilterLabel}
             />
           </div>
 

--- a/frontend/src/components/investments/AssetAllocationChart.tsx
+++ b/frontend/src/components/investments/AssetAllocationChart.tsx
@@ -45,6 +45,7 @@ interface AssetAllocationChartProps {
   isLoading: boolean;
   singleAccountCurrency?: string | null;
   holdingsByAccount?: AccountHoldings[];
+  titleSuffix?: string;
 }
 
 export function AssetAllocationChart({
@@ -52,6 +53,7 @@ export function AssetAllocationChart({
   isLoading,
   singleAccountCurrency,
   holdingsByAccount,
+  titleSuffix,
 }: AssetAllocationChartProps) {
   const { formatCurrencyCompact: formatCurrency } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
@@ -92,7 +94,7 @@ export function AssetAllocationChart({
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-          Asset Allocation
+          Asset Allocation{titleSuffix ? ` (${titleSuffix})` : ''}
         </h3>
         <div className="h-64 flex items-center justify-center">
           <div className="animate-pulse w-48 h-48 rounded-full bg-gray-200 dark:bg-gray-700" />
@@ -105,7 +107,7 @@ export function AssetAllocationChart({
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-          Asset Allocation
+          Asset Allocation{titleSuffix ? ` (${titleSuffix})` : ''}
         </h3>
         <p className="text-gray-500 dark:text-gray-400">
           No allocation data available.

--- a/frontend/src/components/investments/AssetAllocationChart.tsx
+++ b/frontend/src/components/investments/AssetAllocationChart.tsx
@@ -119,7 +119,7 @@ export function AssetAllocationChart({
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
       <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-        Asset Allocation
+        Asset Allocation{titleSuffix ? ` (${titleSuffix})` : ''}
       </h3>
       <div className="h-64">
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -26,9 +26,10 @@ const DAILY_RANGES = new Set(['1w', '1m', '3m', 'ytd', '1y']);
 interface InvestmentValueChartProps {
   accountIds?: string[];
   displayCurrency?: string | null;
+  titleSuffix?: string;
 }
 
-export function InvestmentValueChart({ accountIds, displayCurrency }: InvestmentValueChartProps) {
+export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix }: InvestmentValueChartProps) {
   const { formatCurrencyCompact, formatCurrencyAxis } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
   const [chartPoints, setChartPoints] = useState<Array<{ name: string; Value: number }>>([]);
@@ -160,7 +161,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency }: Investment
       {/* Header with title and date range buttons */}
       <div className="flex flex-wrap items-center justify-between gap-4 mb-4">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-          Portfolio Value Over Time
+          Portfolio Value Over Time{titleSuffix ? ` (${titleSuffix})` : ''}
         </h3>
         <DateRangeSelector
           ranges={['1w', '1m', '3m', 'ytd', '1y', '2y', '5y', 'all']}

--- a/frontend/src/components/investments/PortfolioSummaryCard.tsx
+++ b/frontend/src/components/investments/PortfolioSummaryCard.tsx
@@ -29,12 +29,14 @@ interface PortfolioSummaryCardProps {
   summary: PortfolioSummary | null;
   isLoading: boolean;
   singleAccountCurrency?: string | null;
+  titleSuffix?: string;
 }
 
 export function PortfolioSummaryCard({
   summary,
   isLoading,
   singleAccountCurrency,
+  titleSuffix,
 }: PortfolioSummaryCardProps) {
   const { formatCurrency } = useNumberFormat();
   const { convertToDefault, defaultCurrency } = useExchangeRates();
@@ -113,7 +115,7 @@ export function PortfolioSummaryCard({
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-          Portfolio Summary
+          Portfolio Summary{titleSuffix ? ` (${titleSuffix})` : ''}
         </h3>
         <div className="space-y-3">
           {[1, 2, 3, 4, 5].map((i) => (
@@ -131,7 +133,7 @@ export function PortfolioSummaryCard({
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-          Portfolio Summary
+          Portfolio Summary{titleSuffix ? ` (${titleSuffix})` : ''}
         </h3>
         <p className="text-gray-500 dark:text-gray-400">
           No investment data available.

--- a/frontend/src/components/investments/PortfolioSummaryCard.tsx
+++ b/frontend/src/components/investments/PortfolioSummaryCard.tsx
@@ -150,7 +150,7 @@ export function PortfolioSummaryCard({
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
       <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-        Portfolio Summary
+        Portfolio Summary{titleSuffix ? ` (${titleSuffix})` : ''}
       </h3>
 
       <div className="space-y-4">

--- a/frontend/src/hooks/useInvestmentData.ts
+++ b/frontend/src/hooks/useInvestmentData.ts
@@ -395,6 +395,9 @@ export function useInvestmentData() {
   const handleCashFormSuccess = () => {
     closeCash();
     loadCashTransactions(cashAccountIds, cashCurrentPage, cashFiltersObj);
+    // The portfolio summary drives the Holdings by Account section's cash
+    // balances, so refresh it when a cash transaction changes.
+    loadPortfolioSummary(selectedAccountIds);
   };
 
   const refreshCashTransactions = useCallback(() => {

--- a/frontend/src/lib/account-utils.test.ts
+++ b/frontend/src/lib/account-utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { buildAccountDropdownOptions, formatAccountType, isInvestmentBrokerageAccount } from './account-utils';
+import {
+  buildAccountDropdownOptions,
+  buildAccountFilterLabel,
+  formatAccountType,
+  isInvestmentBrokerageAccount,
+} from './account-utils';
 import { Account } from '@/types/account';
 
 function makeAccount(overrides: Partial<Account> & { id: string; name: string }): Account {
@@ -202,5 +207,65 @@ describe('isInvestmentBrokerageAccount', () => {
   it('returns false for null subtype', () => {
     const account = makeAccount({ id: '1', name: 'Regular' });
     expect(isInvestmentBrokerageAccount(account)).toBe(false);
+  });
+});
+
+describe('buildAccountFilterLabel', () => {
+  const accounts = [
+    { id: '1', name: 'Alpha' },
+    { id: '2', name: 'Beta' },
+    { id: '3', name: 'Gamma' },
+    { id: '4', name: 'Delta' },
+  ];
+
+  it('returns "All Accounts" when no selection is applied', () => {
+    expect(buildAccountFilterLabel([], accounts)).toBe('All Accounts');
+  });
+
+  it('returns "All Accounts" when every account is selected', () => {
+    expect(
+      buildAccountFilterLabel(['1', '2', '3', '4'], accounts),
+    ).toBe('All Accounts');
+  });
+
+  it('returns "All Accounts" when the available account list is empty', () => {
+    expect(buildAccountFilterLabel(['1'], [])).toBe('All Accounts');
+  });
+
+  it('lists selected names when half or fewer are selected', () => {
+    expect(buildAccountFilterLabel(['1', '2'], accounts)).toBe('Alpha, Beta');
+  });
+
+  it('lists a single selected name', () => {
+    expect(buildAccountFilterLabel(['3'], accounts)).toBe('Gamma');
+  });
+
+  it('inverts to "All but ..." when more than half are selected', () => {
+    expect(
+      buildAccountFilterLabel(['1', '2', '3'], accounts),
+    ).toBe('All but Delta');
+  });
+
+  it('inverts to "All but ..." with multiple unselected names', () => {
+    const five = [...accounts, { id: '5', name: 'Epsilon' }];
+    // 3 of 5 is more than half (3 > 2.5), so invert.
+    expect(buildAccountFilterLabel(['1', '2', '3'], five)).toBe(
+      'All but Delta, Epsilon',
+    );
+  });
+
+  it('uses the display-name override when provided', () => {
+    const brokerages = [
+      { id: '1', name: 'TFSA - Brokerage' },
+      { id: '2', name: 'RRSP - Brokerage' },
+    ];
+    const result = buildAccountFilterLabel(['1'], brokerages, (a) =>
+      a.name.replace(' - Brokerage', ''),
+    );
+    expect(result).toBe('TFSA');
+  });
+
+  it('ignores selections for accounts not in the available list', () => {
+    expect(buildAccountFilterLabel(['99'], accounts)).toBe('All Accounts');
   });
 });

--- a/frontend/src/lib/account-utils.ts
+++ b/frontend/src/lib/account-utils.ts
@@ -69,3 +69,40 @@ export const formatAccountType = (type: AccountType): string => {
 export const isInvestmentBrokerageAccount = (account: Account): boolean => {
   return account.accountSubType === 'INVESTMENT_BROKERAGE';
 };
+
+/**
+ * Build a human-readable label describing which accounts are currently in
+ * a filter, for use in section headers.
+ *
+ * - No selection (or empty): "All Accounts"
+ * - Selection covers more than half of the available accounts: "All but X, Y"
+ *   (names are the accounts that are NOT selected)
+ * - Otherwise: "X, Y" (names are the accounts that ARE selected)
+ */
+export function buildAccountFilterLabel(
+  selectedIds: string[],
+  availableAccounts: { id: string; name: string }[],
+  getDisplayName: (account: { id: string; name: string }) => string = (a) => a.name,
+): string {
+  if (availableAccounts.length === 0 || selectedIds.length === 0) {
+    return 'All Accounts';
+  }
+
+  const selectedSet = new Set(selectedIds);
+  const selected = availableAccounts.filter((a) => selectedSet.has(a.id));
+
+  if (selected.length === 0) {
+    return 'All Accounts';
+  }
+
+  if (selected.length === availableAccounts.length) {
+    return 'All Accounts';
+  }
+
+  if (selected.length > availableAccounts.length / 2) {
+    const unselected = availableAccounts.filter((a) => !selectedSet.has(a.id));
+    return `All but ${unselected.map(getDisplayName).join(', ')}`;
+  }
+
+  return selected.map(getDisplayName).join(', ');
+}


### PR DESCRIPTION
## Summary
This PR adds support for editing and deleting past investment transactions without being blocked by current zero or negative holdings. It introduces a validation mechanism that replays transaction history to ensure no oversells occur at any historical date, while allowing intermediate negative states during the edit/delete process.

## Key Changes

### Backend - Holdings Service
- Added `allowNegative` parameter to `createOrUpdate()` and `updateHolding()` methods to permit temporary negative balances during transaction reversals
- Improved average cost calculation logic:
  - When transitioning from zero/negative to positive holdings, use the new trade's price as the cost basis (rather than blending with phantom negative costs)
  - Only blend costs when both current and new quantities are positive
- Added new `validateNoNegativeHoldingsHistory()` method that:
  - Replays all investment transactions in chronological order for a user
  - Tracks running quantities per (account, security) pair
  - Throws `BadRequestException` if any transaction would drive holdings negative at that date
  - Supports filtering to specific accounts to avoid false positives from pre-existing inconsistencies
  - Handles SPLIT transactions as multipliers and ignores non-quantity-affecting actions (DIVIDEND, INTEREST, CAPITAL_GAIN)

### Backend - Investment Transactions Service
- Modified `processTransactionEffectsInTransaction()` to accept `allowNegative` parameter and pass it through to holdings updates
- Updated `update()` method to:
  - Pass `allowNegative=true` when reversing and re-applying transaction effects
  - Call `validateNoNegativeHoldingsHistory()` after applying changes, scoped to affected accounts only
  - Rollback the transaction if validation fails
- Updated `remove()` method to use `allowNegative=true` when reversing transaction effects

### Frontend - Account Utilities
- Added `buildAccountFilterLabel()` utility function that generates human-readable labels for account filters:
  - Returns "All Accounts" when no filter or all accounts selected
  - Shows selected account names when ≤50% selected
  - Shows "All but X, Y" when >50% selected (inverted display)
  - Supports custom display name formatting

### Frontend - Investment Pages
- Updated investment page components to display account filter labels in section headers:
  - `PortfolioSummaryCard` and `AssetAllocationChart` now accept optional `titleSuffix` prop
  - `InvestmentValueChart` accepts optional `titleSuffix` prop
  - Main investments page computes and passes the filter label to relevant components

## Notable Implementation Details

- The `allowNegative` flag is only used during the reverse-and-reapply flow in transaction edits/deletes; normal transaction creation still rejects oversells immediately
- Historical validation is scoped to affected accounts to avoid false failures from pre-existing data inconsistencies in unrelated accounts
- The validation replays transactions in chronological order (by `transactionDate`, then `createdAt`) to catch oversells at the exact date they would occur
- Average cost recalculation prevents distorted blended values when coming out of negative balances (e.g., reversing a past buy then applying a new buy)

https://claude.ai/code/session_018pKzdFnWVPCnssoqdMwc3Y