### PR TITLE
Add get_transfers AI tool for account-to-account movement visibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,12 @@ database/
 - Organize by feature/domain, not by type
 - Always update `database/schema.sql` alongside any migration
 
+### Shared AI tools (AI Assistant + MCP server)
+- Every AI tool that reads or aggregates data must share its implementation between the AI Assistant (`backend/src/ai/query/tool-executor.service.ts`) and the MCP server (`backend/src/mcp/tools/*.tool.ts`).
+- Put the shared logic on the relevant domain service (e.g., `PortfolioService.getLlmSummary`, `TransactionAnalyticsService.getTransfersByAccount`). The two tool layers become thin adapters that call it.
+- Both surfaces must return the same data shape. The AI tool executor wraps it with `{ summary, sources }`; MCP just `toolResult(data)`s it.
+- Adding a new AI tool means wiring it into both layers in the same PR -- never ship a tool to only one of the two.
+
 ### Code Style
 - No emojis in code, comments, or documentation
 - Immutability always -- never mutate objects or arrays

--- a/backend/src/ai/context/prompt-templates.ts
+++ b/backend/src/ai/context/prompt-templates.ts
@@ -16,6 +16,7 @@ IMPORTANT RULES:
 10. Amounts in the data use this convention: positive = income/inflow, negative = expense/outflow. When presenting expenses to the user, show them as positive numbers (e.g., "You spent $500 on groceries") unless showing net cash flow.
 11. Use the exact account names and category names from the user's data when calling tools.
 12. For period comparisons, always label which period is which clearly (e.g., "January 2026" vs "February 2026").
+13. Transfers between the user's own accounts are deliberately excluded from query_transactions, get_spending_by_category, get_income_summary, and compare_periods so those results reflect only real spending and income. For questions about money moved between accounts (e.g., "how much did I move into savings", "what went out of chequing to other accounts"), call get_transfers instead.
 
 MATH ACCURACY RULES:
 13. Never perform arithmetic yourself (addition, subtraction, multiplication, division, percentages). Use the calculate tool instead. Tool results include pre-computed totals, percentages, and changes -- always use those values directly.

--- a/backend/src/ai/context/prompt-templates.ts
+++ b/backend/src/ai/context/prompt-templates.ts
@@ -17,6 +17,7 @@ IMPORTANT RULES:
 11. Use the exact account names and category names from the user's data when calling tools.
 12. For period comparisons, always label which period is which clearly (e.g., "January 2026" vs "February 2026").
 13. Transfers between the user's own accounts are deliberately excluded from query_transactions, get_spending_by_category, get_income_summary, and compare_periods so those results reflect only real spending and income. For questions about money moved between accounts (e.g., "how much did I move into savings", "what went out of chequing to other accounts"), call get_transfers instead.
+14. Investment data lives in a separate tool. For questions about holdings, positions, portfolio value, gain/loss, or asset allocation (e.g., "what stocks do I own", "how is my portfolio doing", "what's my allocation"), call get_portfolio_summary. Brokerage accounts in get_account_balances only show the aggregate market value -- get_portfolio_summary is the only tool that returns individual holdings.
 
 MATH ACCURACY RULES:
 13. Never perform arithmetic yourself (addition, subtraction, multiplication, division, percentages). Use the calculate tool instead. Tool results include pre-computed totals, percentages, and changes -- always use those values directly.

--- a/backend/src/ai/query/tool-definitions.spec.ts
+++ b/backend/src/ai/query/tool-definitions.spec.ts
@@ -1,8 +1,8 @@
 import { FINANCIAL_TOOLS } from "./tool-definitions";
 
 describe("FINANCIAL_TOOLS", () => {
-  it("defines exactly 9 tools", () => {
-    expect(FINANCIAL_TOOLS).toHaveLength(9);
+  it("defines exactly 10 tools", () => {
+    expect(FINANCIAL_TOOLS).toHaveLength(10);
   });
 
   it("has unique tool names", () => {
@@ -17,6 +17,7 @@ describe("FINANCIAL_TOOLS", () => {
     "get_income_summary",
     "get_net_worth_history",
     "compare_periods",
+    "get_transfers",
     "get_budget_status",
     "calculate",
     "render_chart",
@@ -136,6 +137,23 @@ describe("FINANCIAL_TOOLS", () => {
         Record<string, unknown>
       >;
       expect(props.groupBy.enum).toEqual(["category", "payee"]);
+    });
+  });
+
+  describe("get_transfers", () => {
+    it("requires startDate and endDate", () => {
+      const tool = FINANCIAL_TOOLS.find((t) => t.name === "get_transfers")!;
+      expect(tool.inputSchema.required).toEqual(["startDate", "endDate"]);
+    });
+
+    it("supports optional accountNames filter", () => {
+      const tool = FINANCIAL_TOOLS.find((t) => t.name === "get_transfers")!;
+      const props = tool.inputSchema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.accountNames).toBeDefined();
+      expect(props.accountNames.type).toBe("array");
     });
   });
 

--- a/backend/src/ai/query/tool-definitions.spec.ts
+++ b/backend/src/ai/query/tool-definitions.spec.ts
@@ -1,8 +1,8 @@
 import { FINANCIAL_TOOLS } from "./tool-definitions";
 
 describe("FINANCIAL_TOOLS", () => {
-  it("defines exactly 10 tools", () => {
-    expect(FINANCIAL_TOOLS).toHaveLength(10);
+  it("defines exactly 11 tools", () => {
+    expect(FINANCIAL_TOOLS).toHaveLength(11);
   });
 
   it("has unique tool names", () => {
@@ -17,6 +17,7 @@ describe("FINANCIAL_TOOLS", () => {
     "get_income_summary",
     "get_net_worth_history",
     "compare_periods",
+    "get_portfolio_summary",
     "get_transfers",
     "get_budget_status",
     "calculate",
@@ -137,6 +138,27 @@ describe("FINANCIAL_TOOLS", () => {
         Record<string, unknown>
       >;
       expect(props.groupBy.enum).toEqual(["category", "payee"]);
+    });
+  });
+
+  describe("get_portfolio_summary", () => {
+    it("has no required fields", () => {
+      const tool = FINANCIAL_TOOLS.find(
+        (t) => t.name === "get_portfolio_summary",
+      )!;
+      expect(tool.inputSchema.required).toBeUndefined();
+    });
+
+    it("supports optional accountNames filter", () => {
+      const tool = FINANCIAL_TOOLS.find(
+        (t) => t.name === "get_portfolio_summary",
+      )!;
+      const props = tool.inputSchema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.accountNames).toBeDefined();
+      expect(props.accountNames.type).toBe("array");
     });
   });
 

--- a/backend/src/ai/query/tool-definitions.ts
+++ b/backend/src/ai/query/tool-definitions.ts
@@ -169,6 +169,31 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
     },
   },
   {
+    name: "get_transfers",
+    description:
+      "Get transfer activity between the user's own accounts for a date range. Returns per-account inbound (money received from another account), outbound (money sent to another account), net movement, and transfer count. Transfers are deliberately excluded from spending and income tools because they net to zero across accounts; use this tool for questions like 'how much did I move into my savings', 'what went out of chequing to other accounts', or 'what are my transfers between accounts'.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        startDate: {
+          type: "string",
+          description: "Start date (YYYY-MM-DD)",
+        },
+        endDate: {
+          type: "string",
+          description: "End date (YYYY-MM-DD)",
+        },
+        accountNames: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Optional: filter to specific account names. Use exact names from the user's account list.",
+        },
+      },
+      required: ["startDate", "endDate"],
+    },
+  },
+  {
     name: "get_budget_status",
     description:
       "Get budget status for a specific period. Returns total budgeted vs actual spending, per-category breakdowns, spending velocity, safe daily spend, and health score. Use for questions like 'how am I doing on my budget?', 'which categories am I overspending in?', or 'how much can I still spend this month?'.",

--- a/backend/src/ai/query/tool-definitions.ts
+++ b/backend/src/ai/query/tool-definitions.ts
@@ -169,6 +169,22 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
     },
   },
   {
+    name: "get_portfolio_summary",
+    description:
+      "Get the user's investment holdings and portfolio performance. Returns each held security (symbol, name, security type, quantity, cost basis, current market value, unrealized gain/loss, and percent return) plus portfolio-wide totals (total holdings value, total cost basis, total portfolio value, total unrealized gain/loss, time-weighted return, CAGR) and asset allocation percentages. Holdings are sorted by market value descending. Use this for questions like 'what stocks do I own', 'how is my portfolio performing', 'what's my asset allocation', or 'how much have I made on <symbol>'. Market values come from the latest stored security prices -- they may be a day or two stale if price updates haven't run.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        accountNames: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Optional: filter to specific investment account names. Use exact names from the user's account list. Omit to cover all investment accounts.",
+        },
+      },
+    },
+  },
+  {
     name: "get_transfers",
     description:
       "Get transfer activity between the user's own accounts for a date range. Returns per-account inbound (money received from another account), outbound (money sent to another account), net movement, and transfer count. Transfers are deliberately excluded from spending and income tools because they net to zero across accounts; use this tool for questions like 'how much did I move into my savings', 'what went out of chequing to other accounts', or 'what are my transfers between accounts'.",

--- a/backend/src/ai/query/tool-executor.service.spec.ts
+++ b/backend/src/ai/query/tool-executor.service.spec.ts
@@ -64,6 +64,7 @@ describe("ToolExecutorService", () => {
       select: jest.fn().mockReturnThis(),
       addSelect: jest.fn().mockReturnThis(),
       groupBy: jest.fn().mockReturnThis(),
+      addGroupBy: jest.fn().mockReturnThis(),
       orderBy: jest.fn().mockReturnThis(),
       getRawMany: jest.fn().mockResolvedValue([]),
     };
@@ -198,6 +199,16 @@ describe("ToolExecutorService", () => {
       expect(result.data).toBeDefined();
       expect(result.summary).toContain("Net worth history");
       expect(result.sources[0].type).toBe("net_worth");
+    });
+
+    it("routes to get_transfers tool", async () => {
+      const result = await service.execute(userId, "get_transfers", {
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+      });
+
+      expect(result.data).toBeDefined();
+      expect(result.sources[0].type).toBe("transfers");
     });
 
     it("routes to compare_periods tool", async () => {
@@ -882,6 +893,120 @@ describe("ToolExecutorService", () => {
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
         "NOT EXISTS (SELECT 1 FROM investment_transactions it WHERE it.transaction_id = t.id)",
       );
+    });
+  });
+
+  describe("get_transfers", () => {
+    it("filters transactions to transfers in the requested date range", async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValueOnce([]);
+
+      await service.execute(userId, "get_transfers", {
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+      });
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        "t.isTransfer = true",
+      );
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        "t.transactionDate >= :startDate",
+        { startDate: "2026-01-01" },
+      );
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        "t.transactionDate <= :endDate",
+        { endDate: "2026-01-31" },
+      );
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        "t.status != 'VOID'",
+      );
+    });
+
+    it("aggregates inbound and outbound amounts per account", async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValueOnce([
+        {
+          accountName: "Checking",
+          currencyCode: "USD",
+          inbound: "0",
+          outbound: "1500",
+          count: "3",
+        },
+        {
+          accountName: "Savings",
+          currencyCode: "USD",
+          inbound: "1500",
+          outbound: "0",
+          count: "3",
+        },
+      ]);
+
+      const result = await service.execute(userId, "get_transfers", {
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+      });
+
+      const data = result.data as Record<string, unknown>;
+      const accounts = data.accounts as Array<Record<string, unknown>>;
+      expect(accounts).toHaveLength(2);
+      expect(accounts[0]).toMatchObject({
+        accountName: "Checking",
+        inbound: 0,
+        outbound: 1500,
+        net: -1500,
+        transferCount: 3,
+      });
+      expect(accounts[1]).toMatchObject({
+        accountName: "Savings",
+        inbound: 1500,
+        outbound: 0,
+        net: 1500,
+        transferCount: 3,
+      });
+      expect(data.totalInbound).toBe(1500);
+      expect(data.totalOutbound).toBe(1500);
+      expect(data.transferCount).toBe(6);
+    });
+
+    it("resolves accountNames filter to account IDs", async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValueOnce([]);
+
+      await service.execute(userId, "get_transfers", {
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+        accountNames: ["Savings"],
+      });
+
+      expect(mockAccountsService.findAll).toHaveBeenCalledWith(userId, false);
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        "t.accountId IN (:...accountIds)",
+        { accountIds: ["acc-2"] },
+      );
+    });
+
+    it("produces a human-readable summary and source metadata", async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValueOnce([
+        {
+          accountName: "Savings",
+          currencyCode: "USD",
+          inbound: "500",
+          outbound: "0",
+          count: "1",
+        },
+      ]);
+
+      const result = await service.execute(userId, "get_transfers", {
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+        accountNames: ["Savings"],
+      });
+
+      expect(result.summary).toContain("1 transfer transactions");
+      expect(result.summary).toContain("Inbound: 500.00");
+      expect(result.sources).toHaveLength(1);
+      expect(result.sources[0]).toMatchObject({
+        type: "transfers",
+        description: "Transfer activity for Savings",
+        dateRange: "2026-01-01 to 2026-01-31",
+      });
     });
   });
 

--- a/backend/src/ai/query/tool-executor.service.spec.ts
+++ b/backend/src/ai/query/tool-executor.service.spec.ts
@@ -91,6 +91,12 @@ describe("ToolExecutorService", () => {
         transactionCount: 45,
         byCurrency: { USD: { income: 5000, expenses: -3000 } },
       }),
+      getTransfersByAccount: jest.fn().mockResolvedValue({
+        accounts: [],
+        totalInbound: 0,
+        totalOutbound: 0,
+        transferCount: 0,
+      }),
     };
 
     mockNetWorthService = {
@@ -112,6 +118,19 @@ describe("ToolExecutorService", () => {
 
     mockPortfolioService = {
       getAccountMarketValues: jest.fn().mockResolvedValue(new Map()),
+      getLlmSummary: jest.fn().mockResolvedValue({
+        holdingCount: 0,
+        totalCashValue: 0,
+        totalHoldingsValue: 0,
+        totalCostBasis: 0,
+        totalPortfolioValue: 0,
+        totalGainLoss: 0,
+        totalGainLossPercent: 0,
+        timeWeightedReturn: null,
+        cagr: null,
+        holdings: [],
+        allocation: [],
+      }),
     };
 
     mockTransactionRepo = {
@@ -209,6 +228,13 @@ describe("ToolExecutorService", () => {
 
       expect(result.data).toBeDefined();
       expect(result.sources[0].type).toBe("transfers");
+    });
+
+    it("routes to get_portfolio_summary tool", async () => {
+      const result = await service.execute(userId, "get_portfolio_summary", {});
+
+      expect(result.data).toBeDefined();
+      expect(result.sources[0].type).toBe("portfolio");
     });
 
     it("routes to compare_periods tool", async () => {
@@ -897,77 +923,57 @@ describe("ToolExecutorService", () => {
   });
 
   describe("get_transfers", () => {
-    it("filters transactions to transfers in the requested date range", async () => {
-      mockQueryBuilder.getRawMany.mockResolvedValueOnce([]);
-
-      await service.execute(userId, "get_transfers", {
-        startDate: "2026-01-01",
-        endDate: "2026-01-31",
+    it("delegates to the shared analytics service", async () => {
+      mockAnalyticsService.getTransfersByAccount.mockResolvedValueOnce({
+        accounts: [
+          {
+            accountName: "Checking",
+            currency: "USD",
+            inbound: 0,
+            outbound: 1500,
+            net: -1500,
+            transferCount: 3,
+          },
+          {
+            accountName: "Savings",
+            currency: "USD",
+            inbound: 1500,
+            outbound: 0,
+            net: 1500,
+            transferCount: 3,
+          },
+        ],
+        totalInbound: 1500,
+        totalOutbound: 1500,
+        transferCount: 6,
       });
-
-      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        "t.isTransfer = true",
-      );
-      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        "t.transactionDate >= :startDate",
-        { startDate: "2026-01-01" },
-      );
-      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        "t.transactionDate <= :endDate",
-        { endDate: "2026-01-31" },
-      );
-      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        "t.status != 'VOID'",
-      );
-    });
-
-    it("aggregates inbound and outbound amounts per account", async () => {
-      mockQueryBuilder.getRawMany.mockResolvedValueOnce([
-        {
-          accountName: "Checking",
-          currencyCode: "USD",
-          inbound: "0",
-          outbound: "1500",
-          count: "3",
-        },
-        {
-          accountName: "Savings",
-          currencyCode: "USD",
-          inbound: "1500",
-          outbound: "0",
-          count: "3",
-        },
-      ]);
 
       const result = await service.execute(userId, "get_transfers", {
         startDate: "2026-01-01",
         endDate: "2026-01-31",
       });
 
+      expect(mockAnalyticsService.getTransfersByAccount).toHaveBeenCalledWith(
+        userId,
+        "2026-01-01",
+        "2026-01-31",
+        undefined,
+      );
+
       const data = result.data as Record<string, unknown>;
-      const accounts = data.accounts as Array<Record<string, unknown>>;
-      expect(accounts).toHaveLength(2);
-      expect(accounts[0]).toMatchObject({
-        accountName: "Checking",
-        inbound: 0,
-        outbound: 1500,
-        net: -1500,
-        transferCount: 3,
-      });
-      expect(accounts[1]).toMatchObject({
-        accountName: "Savings",
-        inbound: 1500,
-        outbound: 0,
-        net: 1500,
-        transferCount: 3,
-      });
+      expect((data.accounts as unknown[]).length).toBe(2);
       expect(data.totalInbound).toBe(1500);
       expect(data.totalOutbound).toBe(1500);
       expect(data.transferCount).toBe(6);
     });
 
-    it("resolves accountNames filter to account IDs", async () => {
-      mockQueryBuilder.getRawMany.mockResolvedValueOnce([]);
+    it("resolves accountNames to IDs before delegating", async () => {
+      mockAnalyticsService.getTransfersByAccount.mockResolvedValueOnce({
+        accounts: [],
+        totalInbound: 0,
+        totalOutbound: 0,
+        transferCount: 0,
+      });
 
       await service.execute(userId, "get_transfers", {
         startDate: "2026-01-01",
@@ -976,22 +982,30 @@ describe("ToolExecutorService", () => {
       });
 
       expect(mockAccountsService.findAll).toHaveBeenCalledWith(userId, false);
-      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        "t.accountId IN (:...accountIds)",
-        { accountIds: ["acc-2"] },
+      expect(mockAnalyticsService.getTransfersByAccount).toHaveBeenCalledWith(
+        userId,
+        "2026-01-01",
+        "2026-01-31",
+        ["acc-2"],
       );
     });
 
     it("produces a human-readable summary and source metadata", async () => {
-      mockQueryBuilder.getRawMany.mockResolvedValueOnce([
-        {
-          accountName: "Savings",
-          currencyCode: "USD",
-          inbound: "500",
-          outbound: "0",
-          count: "1",
-        },
-      ]);
+      mockAnalyticsService.getTransfersByAccount.mockResolvedValueOnce({
+        accounts: [
+          {
+            accountName: "Savings",
+            currency: "USD",
+            inbound: 500,
+            outbound: 0,
+            net: 500,
+            transferCount: 1,
+          },
+        ],
+        totalInbound: 500,
+        totalOutbound: 0,
+        transferCount: 1,
+      });
 
       const result = await service.execute(userId, "get_transfers", {
         startDate: "2026-01-01",
@@ -1007,6 +1021,89 @@ describe("ToolExecutorService", () => {
         description: "Transfer activity for Savings",
         dateRange: "2026-01-01 to 2026-01-31",
       });
+    });
+  });
+
+  describe("get_portfolio_summary", () => {
+    it("delegates to the shared portfolio LLM summary method", async () => {
+      mockPortfolioService.getLlmSummary.mockResolvedValueOnce({
+        holdingCount: 2,
+        totalCashValue: 100,
+        totalHoldingsValue: 9900,
+        totalCostBasis: 9000,
+        totalPortfolioValue: 10000,
+        totalGainLoss: 900,
+        totalGainLossPercent: 10,
+        timeWeightedReturn: 8.5,
+        cagr: 7.2,
+        holdings: [
+          {
+            symbol: "AAPL",
+            name: "Apple Inc.",
+            securityType: "STOCK",
+            currency: "USD",
+            quantity: 10,
+            averageCost: 150,
+            costBasis: 1500,
+            marketValue: 1800,
+            gainLoss: 300,
+            gainLossPercent: 20,
+          },
+        ],
+        allocation: [
+          {
+            name: "AAPL",
+            symbol: "AAPL",
+            type: "security",
+            value: 1800,
+            percentage: 18,
+          },
+        ],
+      });
+
+      const result = await service.execute(userId, "get_portfolio_summary", {});
+
+      expect(mockPortfolioService.getLlmSummary).toHaveBeenCalledWith(
+        userId,
+        undefined,
+      );
+      const data = result.data as Record<string, unknown>;
+      expect(data.totalPortfolioValue).toBe(10000);
+      expect(data.totalGainLoss).toBe(900);
+      expect((data.holdings as unknown[]).length).toBe(1);
+      expect(result.sources[0].type).toBe("portfolio");
+    });
+
+    it("resolves accountNames to IDs before delegating", async () => {
+      await service.execute(userId, "get_portfolio_summary", {
+        accountNames: ["Checking"],
+      });
+
+      expect(mockAccountsService.findAll).toHaveBeenCalledWith(userId, false);
+      expect(mockPortfolioService.getLlmSummary).toHaveBeenCalledWith(userId, [
+        "acc-1",
+      ]);
+    });
+
+    it("formats gain/loss with a + sign when positive", async () => {
+      mockPortfolioService.getLlmSummary.mockResolvedValueOnce({
+        holdingCount: 1,
+        totalCashValue: 0,
+        totalHoldingsValue: 1200,
+        totalCostBasis: 1000,
+        totalPortfolioValue: 1200,
+        totalGainLoss: 200,
+        totalGainLossPercent: 20,
+        timeWeightedReturn: null,
+        cagr: null,
+        holdings: [],
+        allocation: [],
+      });
+
+      const result = await service.execute(userId, "get_portfolio_summary", {});
+
+      expect(result.summary).toContain("+200.00");
+      expect(result.summary).toContain("+20.00%");
     });
   });
 

--- a/backend/src/ai/query/tool-executor.service.ts
+++ b/backend/src/ai/query/tool-executor.service.ts
@@ -126,6 +126,9 @@ export class ToolExecutorService {
         case "compare_periods":
           result = await this.comparePeriods(userId, validatedInput);
           break;
+        case "get_transfers":
+          result = await this.getTransfers(userId, validatedInput);
+          break;
         case "get_budget_status":
           result = await this.getBudgetStatus(userId, validatedInput);
           break;
@@ -826,6 +829,89 @@ export class ToolExecutorService {
     }
 
     return items.map((r) => ({ label: r.label, total: r.total }));
+  }
+
+  private async getTransfers(
+    userId: string,
+    input: Record<string, unknown>,
+  ): Promise<ToolResult> {
+    const startDate = input.startDate as string;
+    const endDate = input.endDate as string;
+    const accountNames = input.accountNames as string[] | undefined;
+    const accountIds = await this.resolveAccountIds(userId, accountNames);
+
+    // Transfers are stored as two linked transactions (one per side). A row
+    // with amount > 0 represents money received into that account; amount < 0
+    // represents money sent out. We aggregate per account so the answer
+    // mirrors "money in / money out" as the user thinks about it.
+    const qb = this.transactionRepo
+      .createQueryBuilder("t")
+      .leftJoin("t.account", "transferAccount")
+      .select("transferAccount.name", "accountName")
+      .addSelect("t.currencyCode", "currencyCode")
+      .addSelect(
+        "SUM(CASE WHEN t.amount > 0 THEN t.amount ELSE 0 END)",
+        "inbound",
+      )
+      .addSelect(
+        "SUM(CASE WHEN t.amount < 0 THEN ABS(t.amount) ELSE 0 END)",
+        "outbound",
+      )
+      .addSelect("COUNT(*)", "count")
+      .where("t.userId = :userId", { userId })
+      .andWhere("t.isTransfer = true")
+      .andWhere("t.transactionDate >= :startDate", { startDate })
+      .andWhere("t.transactionDate <= :endDate", { endDate })
+      .andWhere("t.status != 'VOID'")
+      .groupBy("transferAccount.id")
+      .addGroupBy("transferAccount.name")
+      .addGroupBy("t.currencyCode")
+      .orderBy("transferAccount.name", "ASC");
+
+    if (accountIds && accountIds.length > 0) {
+      qb.andWhere("t.accountId IN (:...accountIds)", { accountIds });
+    }
+
+    const rows = await qb.getRawMany();
+
+    const accounts = rows.map((r) => {
+      const inbound = roundMoney(Number(r.inbound) || 0);
+      const outbound = roundMoney(Number(r.outbound) || 0);
+      return {
+        accountName: r.accountName,
+        currency: r.currencyCode,
+        inbound,
+        outbound,
+        net: roundMoney(inbound - outbound),
+        transferCount: Number(r.count) || 0,
+      };
+    });
+
+    // totalInbound and totalOutbound count both sides of every transfer, so
+    // when no account filter is applied they're equal (modulo multi-currency
+    // conversions). That's intentional -- it lets the user see gross movement.
+    const totalInbound = sumMoney(accounts.map((a) => a.inbound));
+    const totalOutbound = sumMoney(accounts.map((a) => a.outbound));
+    const transferCount = accounts.reduce((s, a) => s + a.transferCount, 0);
+
+    return {
+      data: {
+        accounts,
+        totalInbound,
+        totalOutbound,
+        transferCount,
+      },
+      summary: `${transferCount} transfer transactions across ${accounts.length} account${accounts.length === 1 ? "" : "s"} from ${startDate} to ${endDate}. Inbound: ${totalInbound.toFixed(2)}, Outbound: ${totalOutbound.toFixed(2)}.`,
+      sources: [
+        {
+          type: "transfers",
+          description: accountNames
+            ? `Transfer activity for ${accountNames.join(", ")}`
+            : "Transfer activity across all accounts",
+          dateRange: `${startDate} to ${endDate}`,
+        },
+      ],
+    };
   }
 
   private async getBudgetStatus(

--- a/backend/src/ai/query/tool-executor.service.ts
+++ b/backend/src/ai/query/tool-executor.service.ts
@@ -126,6 +126,9 @@ export class ToolExecutorService {
         case "compare_periods":
           result = await this.comparePeriods(userId, validatedInput);
           break;
+        case "get_portfolio_summary":
+          result = await this.getPortfolioSummary(userId, validatedInput);
+          break;
         case "get_transfers":
           result = await this.getTransfers(userId, validatedInput);
           break;
@@ -831,6 +834,30 @@ export class ToolExecutorService {
     return items.map((r) => ({ label: r.label, total: r.total }));
   }
 
+  private async getPortfolioSummary(
+    userId: string,
+    input: Record<string, unknown>,
+  ): Promise<ToolResult> {
+    const accountNames = input.accountNames as string[] | undefined;
+    const accountIds = await this.resolveAccountIds(userId, accountNames);
+
+    const data = await this.portfolioService.getLlmSummary(userId, accountIds);
+
+    const sign = data.totalGainLoss >= 0 ? "+" : "";
+    return {
+      data,
+      summary: `${data.holdingCount} holding${data.holdingCount === 1 ? "" : "s"}, total portfolio value ${data.totalPortfolioValue.toFixed(2)}, unrealized gain/loss ${sign}${data.totalGainLoss.toFixed(2)} (${sign}${data.totalGainLossPercent.toFixed(2)}%).`,
+      sources: [
+        {
+          type: "portfolio",
+          description: accountNames
+            ? `Portfolio summary for ${accountNames.join(", ")}`
+            : "Portfolio summary across all investment accounts",
+        },
+      ],
+    };
+  }
+
   private async getTransfers(
     userId: string,
     input: Record<string, unknown>,
@@ -840,68 +867,16 @@ export class ToolExecutorService {
     const accountNames = input.accountNames as string[] | undefined;
     const accountIds = await this.resolveAccountIds(userId, accountNames);
 
-    // Transfers are stored as two linked transactions (one per side). A row
-    // with amount > 0 represents money received into that account; amount < 0
-    // represents money sent out. We aggregate per account so the answer
-    // mirrors "money in / money out" as the user thinks about it.
-    const qb = this.transactionRepo
-      .createQueryBuilder("t")
-      .leftJoin("t.account", "transferAccount")
-      .select("transferAccount.name", "accountName")
-      .addSelect("t.currencyCode", "currencyCode")
-      .addSelect(
-        "SUM(CASE WHEN t.amount > 0 THEN t.amount ELSE 0 END)",
-        "inbound",
-      )
-      .addSelect(
-        "SUM(CASE WHEN t.amount < 0 THEN ABS(t.amount) ELSE 0 END)",
-        "outbound",
-      )
-      .addSelect("COUNT(*)", "count")
-      .where("t.userId = :userId", { userId })
-      .andWhere("t.isTransfer = true")
-      .andWhere("t.transactionDate >= :startDate", { startDate })
-      .andWhere("t.transactionDate <= :endDate", { endDate })
-      .andWhere("t.status != 'VOID'")
-      .groupBy("transferAccount.id")
-      .addGroupBy("transferAccount.name")
-      .addGroupBy("t.currencyCode")
-      .orderBy("transferAccount.name", "ASC");
-
-    if (accountIds && accountIds.length > 0) {
-      qb.andWhere("t.accountId IN (:...accountIds)", { accountIds });
-    }
-
-    const rows = await qb.getRawMany();
-
-    const accounts = rows.map((r) => {
-      const inbound = roundMoney(Number(r.inbound) || 0);
-      const outbound = roundMoney(Number(r.outbound) || 0);
-      return {
-        accountName: r.accountName,
-        currency: r.currencyCode,
-        inbound,
-        outbound,
-        net: roundMoney(inbound - outbound),
-        transferCount: Number(r.count) || 0,
-      };
-    });
-
-    // totalInbound and totalOutbound count both sides of every transfer, so
-    // when no account filter is applied they're equal (modulo multi-currency
-    // conversions). That's intentional -- it lets the user see gross movement.
-    const totalInbound = sumMoney(accounts.map((a) => a.inbound));
-    const totalOutbound = sumMoney(accounts.map((a) => a.outbound));
-    const transferCount = accounts.reduce((s, a) => s + a.transferCount, 0);
+    const data = await this.analyticsService.getTransfersByAccount(
+      userId,
+      startDate,
+      endDate,
+      accountIds,
+    );
 
     return {
-      data: {
-        accounts,
-        totalInbound,
-        totalOutbound,
-        transferCount,
-      },
-      summary: `${transferCount} transfer transactions across ${accounts.length} account${accounts.length === 1 ? "" : "s"} from ${startDate} to ${endDate}. Inbound: ${totalInbound.toFixed(2)}, Outbound: ${totalOutbound.toFixed(2)}.`,
+      data,
+      summary: `${data.transferCount} transfer transactions across ${data.accounts.length} account${data.accounts.length === 1 ? "" : "s"} from ${startDate} to ${endDate}. Inbound: ${data.totalInbound.toFixed(2)}, Outbound: ${data.totalOutbound.toFixed(2)}.`,
       sources: [
         {
           type: "transfers",

--- a/backend/src/ai/query/tool-input-schemas.spec.ts
+++ b/backend/src/ai/query/tool-input-schemas.spec.ts
@@ -6,6 +6,7 @@ import {
   getIncomeSummarySchema,
   getNetWorthHistorySchema,
   comparePeriodsSchema,
+  getTransfersSchema,
   getBudgetStatusSchema,
   calculateSchema,
   renderChartSchema,
@@ -300,6 +301,49 @@ describe("tool-input-schemas", () => {
         direction: "income",
       });
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe("getTransfersSchema", () => {
+    it("accepts valid input with only required fields", () => {
+      const result = getTransfersSchema.safeParse({
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts optional accountNames filter", () => {
+      const result = getTransfersSchema.safeParse({
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+        accountNames: ["Chequing", "Savings"],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects missing required date fields", () => {
+      const result = getTransfersSchema.safeParse({
+        accountNames: ["Chequing"],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid date format", () => {
+      const result = getTransfersSchema.safeParse({
+        startDate: "not-a-date",
+        endDate: "2026-01-31",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects account names over 100 chars", () => {
+      const result = getTransfersSchema.safeParse({
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+        accountNames: ["a".repeat(101)],
+      });
+      expect(result.success).toBe(false);
     });
   });
 

--- a/backend/src/ai/query/tool-input-schemas.spec.ts
+++ b/backend/src/ai/query/tool-input-schemas.spec.ts
@@ -6,6 +6,7 @@ import {
   getIncomeSummarySchema,
   getNetWorthHistorySchema,
   comparePeriodsSchema,
+  getPortfolioSummarySchema,
   getTransfersSchema,
   getBudgetStatusSchema,
   calculateSchema,
@@ -301,6 +302,27 @@ describe("tool-input-schemas", () => {
         direction: "income",
       });
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe("getPortfolioSummarySchema", () => {
+    it("accepts empty input", () => {
+      const result = getPortfolioSummarySchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts accountNames filter", () => {
+      const result = getPortfolioSummarySchema.safeParse({
+        accountNames: ["Brokerage", "TFSA"],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects account names over 100 chars", () => {
+      const result = getPortfolioSummarySchema.safeParse({
+        accountNames: ["a".repeat(101)],
+      });
+      expect(result.success).toBe(false);
     });
   });
 

--- a/backend/src/ai/query/tool-input-schemas.ts
+++ b/backend/src/ai/query/tool-input-schemas.ts
@@ -56,6 +56,12 @@ export const comparePeriodsSchema = z.object({
   direction: directionSchema.optional(),
 });
 
+export const getTransfersSchema = z.object({
+  startDate: isoDateSchema,
+  endDate: isoDateSchema,
+  accountNames: z.array(z.string().max(100)).optional(),
+});
+
 export const getBudgetStatusSchema = z.object({
   period: z.string().max(20).optional(),
   budgetName: z.string().max(100).optional(),
@@ -94,6 +100,7 @@ export const toolInputSchemas: Record<string, z.ZodSchema> = {
   get_income_summary: getIncomeSummarySchema,
   get_net_worth_history: getNetWorthHistorySchema,
   compare_periods: comparePeriodsSchema,
+  get_transfers: getTransfersSchema,
   get_budget_status: getBudgetStatusSchema,
   calculate: calculateSchema,
   render_chart: renderChartSchema,

--- a/backend/src/ai/query/tool-input-schemas.ts
+++ b/backend/src/ai/query/tool-input-schemas.ts
@@ -56,6 +56,10 @@ export const comparePeriodsSchema = z.object({
   direction: directionSchema.optional(),
 });
 
+export const getPortfolioSummarySchema = z.object({
+  accountNames: z.array(z.string().max(100)).optional(),
+});
+
 export const getTransfersSchema = z.object({
   startDate: isoDateSchema,
   endDate: isoDateSchema,
@@ -100,6 +104,7 @@ export const toolInputSchemas: Record<string, z.ZodSchema> = {
   get_income_summary: getIncomeSummarySchema,
   get_net_worth_history: getNetWorthHistorySchema,
   compare_periods: comparePeriodsSchema,
+  get_portfolio_summary: getPortfolioSummarySchema,
   get_transfers: getTransfersSchema,
   get_budget_status: getBudgetStatusSchema,
   calculate: calculateSchema,

--- a/backend/src/mcp/tools/investments.tool.spec.ts
+++ b/backend/src/mcp/tools/investments.tool.spec.ts
@@ -12,6 +12,7 @@ describe("McpInvestmentsTools", () => {
   beforeEach(() => {
     portfolioService = {
       getPortfolioSummary: jest.fn(),
+      getLlmSummary: jest.fn(),
     };
 
     holdingsService = {
@@ -47,19 +48,46 @@ describe("McpInvestmentsTools", () => {
       expect(result.isError).toBe(true);
     });
 
-    it("should return portfolio summary", async () => {
+    it("should return portfolio summary via shared getLlmSummary", async () => {
       resolve.mockReturnValue({ userId: "u1", scopes: "read" });
-      portfolioService.getPortfolioSummary.mockResolvedValue({
-        totalValue: 10000,
-        totalGain: 500,
+      portfolioService.getLlmSummary.mockResolvedValue({
+        holdingCount: 2,
+        totalPortfolioValue: 10000,
+        totalGainLoss: 500,
+        holdings: [],
+        allocation: [],
       });
 
       const result = await handlers["get_portfolio_summary"](
         {},
         { sessionId: "s1" },
       );
+      expect(portfolioService.getLlmSummary).toHaveBeenCalledWith(
+        "u1",
+        undefined,
+      );
       const parsed = JSON.parse(result.content[0].text);
-      expect(parsed.totalValue).toBe(10000);
+      expect(parsed.totalPortfolioValue).toBe(10000);
+      expect(parsed.totalGainLoss).toBe(500);
+    });
+
+    it("passes accountIds filter through to getLlmSummary", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      portfolioService.getLlmSummary.mockResolvedValue({
+        holdingCount: 0,
+        totalPortfolioValue: 0,
+        totalGainLoss: 0,
+        holdings: [],
+        allocation: [],
+      });
+
+      await handlers["get_portfolio_summary"](
+        { accountIds: ["00000000-0000-0000-0000-000000000001"] },
+        { sessionId: "s1" },
+      );
+      expect(portfolioService.getLlmSummary).toHaveBeenCalledWith("u1", [
+        "00000000-0000-0000-0000-000000000001",
+      ]);
     });
   });
 

--- a/backend/src/mcp/tools/investments.tool.ts
+++ b/backend/src/mcp/tools/investments.tool.ts
@@ -23,18 +23,27 @@ export class McpInvestmentsTools {
       "get_portfolio_summary",
       {
         description:
-          "Get investment portfolio overview with holdings, gains/losses, and allocation",
-        inputSchema: {},
+          "Get investment portfolio overview with holdings, gains/losses, and allocation. Returns the same compact, LLM-friendly shape as the AI Assistant's tool.",
+        inputSchema: {
+          accountIds: z
+            .array(z.string().uuid())
+            .max(50)
+            .optional()
+            .describe(
+              "Optional investment account IDs to filter to. Omit to cover all investment accounts.",
+            ),
+        },
       },
-      async (_args, extra) => {
+      async (args, extra) => {
         const ctx = resolve(extra.sessionId);
         if (!ctx) return toolError("No user context");
         const check = requireScope(ctx.scopes, "read");
         if (check.error) return check.result;
 
         try {
-          const summary = await this.portfolioService.getPortfolioSummary(
+          const summary = await this.portfolioService.getLlmSummary(
             ctx.userId,
+            args.accountIds,
           );
           return toolResult(summary);
         } catch (err: unknown) {

--- a/backend/src/mcp/tools/transactions.tool.spec.ts
+++ b/backend/src/mcp/tools/transactions.tool.spec.ts
@@ -5,6 +5,7 @@ import { MCP_DAILY_WRITE_LIMIT } from "../mcp-write-limiter";
 describe("McpTransactionsTools", () => {
   let tool: McpTransactionsTools;
   let transactionsService: Record<string, jest.Mock>;
+  let analyticsService: Record<string, jest.Mock>;
   let accountsService: Record<string, jest.Mock>;
   let server: { registerTool: jest.Mock };
   let resolve: jest.MockedFunction<UserContextResolver>;
@@ -17,12 +18,17 @@ describe("McpTransactionsTools", () => {
       update: jest.fn(),
     };
 
+    analyticsService = {
+      getTransfersByAccount: jest.fn(),
+    };
+
     accountsService = {
       findOne: jest.fn(),
     };
 
     tool = new McpTransactionsTools(
       transactionsService as any,
+      analyticsService as any,
       accountsService as any,
     );
 
@@ -36,8 +42,78 @@ describe("McpTransactionsTools", () => {
     tool.register(server as any, resolve);
   });
 
-  it("should register 3 tools", () => {
-    expect(server.registerTool).toHaveBeenCalledTimes(3);
+  it("should register 4 tools", () => {
+    expect(server.registerTool).toHaveBeenCalledTimes(4);
+  });
+
+  describe("get_transfers", () => {
+    it("delegates to shared analytics service", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      analyticsService.getTransfersByAccount.mockResolvedValue({
+        accounts: [
+          {
+            accountName: "Savings",
+            currency: "USD",
+            inbound: 1500,
+            outbound: 0,
+            net: 1500,
+            transferCount: 3,
+          },
+        ],
+        totalInbound: 1500,
+        totalOutbound: 0,
+        transferCount: 3,
+      });
+
+      const result = await handlers["get_transfers"](
+        { startDate: "2026-01-01", endDate: "2026-01-31" },
+        { sessionId: "s1" },
+      );
+
+      expect(analyticsService.getTransfersByAccount).toHaveBeenCalledWith(
+        "u1",
+        "2026-01-01",
+        "2026-01-31",
+        undefined,
+      );
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.totalInbound).toBe(1500);
+      expect(parsed.accounts).toHaveLength(1);
+    });
+
+    it("requires read scope", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "write" });
+      const result = await handlers["get_transfers"](
+        { startDate: "2026-01-01", endDate: "2026-01-31" },
+        { sessionId: "s1" },
+      );
+      expect(result.isError).toBe(true);
+    });
+
+    it("passes accountIds filter through", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      analyticsService.getTransfersByAccount.mockResolvedValue({
+        accounts: [],
+        totalInbound: 0,
+        totalOutbound: 0,
+        transferCount: 0,
+      });
+
+      await handlers["get_transfers"](
+        {
+          startDate: "2026-01-01",
+          endDate: "2026-01-31",
+          accountIds: ["00000000-0000-0000-0000-000000000001"],
+        },
+        { sessionId: "s1" },
+      );
+      expect(analyticsService.getTransfersByAccount).toHaveBeenCalledWith(
+        "u1",
+        "2026-01-01",
+        "2026-01-31",
+        ["00000000-0000-0000-0000-000000000001"],
+      );
+    });
   });
 
   describe("search_transactions", () => {
@@ -380,6 +456,7 @@ describe("McpTransactionsTools", () => {
       // and manually filling up the limiter
       const freshTool = new McpTransactionsTools(
         transactionsService as any,
+        analyticsService as any,
         accountsService as any,
       );
       const freshHandlers: Record<string, (...args: any[]) => any> = {};
@@ -432,6 +509,7 @@ describe("McpTransactionsTools", () => {
 
       const freshTool = new McpTransactionsTools(
         transactionsService as any,
+        analyticsService as any,
         accountsService as any,
       );
       const freshHandlers: Record<string, (...args: any[]) => any> = {};

--- a/backend/src/mcp/tools/transactions.tool.ts
+++ b/backend/src/mcp/tools/transactions.tool.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { TransactionsService } from "../../transactions/transactions.service";
+import { TransactionAnalyticsService } from "../../transactions/transaction-analytics.service";
 import { AccountsService } from "../../accounts/accounts.service";
 import {
   UserContextResolver,
@@ -19,6 +20,7 @@ export class McpTransactionsTools {
 
   constructor(
     private readonly transactionsService: TransactionsService,
+    private readonly analyticsService: TransactionAnalyticsService,
     private readonly accountsService: AccountsService,
   ) {}
 
@@ -135,6 +137,43 @@ export class McpTransactionsTools {
             total: result.pagination.total,
             hasMore: result.pagination.hasMore,
           });
+        } catch (err: unknown) {
+          return safeToolError(err);
+        }
+      },
+    );
+
+    server.registerTool(
+      "get_transfers",
+      {
+        description:
+          "Get transfer activity between the user's own accounts for a date range. Returns per-account inbound, outbound, net, and count. Transfers are deliberately excluded from other transaction queries because they net to zero across accounts. Returns the same shape as the AI Assistant's get_transfers tool.",
+        inputSchema: {
+          startDate: z.string().max(10).describe("Start date (YYYY-MM-DD)"),
+          endDate: z.string().max(10).describe("End date (YYYY-MM-DD)"),
+          accountIds: z
+            .array(z.string().uuid())
+            .max(50)
+            .optional()
+            .describe(
+              "Optional account IDs to filter to. Omit to cover all accounts.",
+            ),
+        },
+      },
+      async (args, extra) => {
+        const ctx = resolve(extra.sessionId);
+        if (!ctx) return toolError("No user context");
+        const check = requireScope(ctx.scopes, "read");
+        if (check.error) return check.result;
+
+        try {
+          const result = await this.analyticsService.getTransfersByAccount(
+            ctx.userId,
+            args.startDate,
+            args.endDate,
+            args.accountIds,
+          );
+          return toolResult(result);
         } catch (err: unknown) {
           return safeToolError(err);
         }

--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -1257,6 +1257,146 @@ describe("PortfolioService", () => {
     });
   });
 
+  describe("getLlmSummary", () => {
+    it("maps raw holdings into the compact LLM shape and rounds monetary and percentage values", async () => {
+      const getPortfolioSummary = jest
+        .spyOn(service, "getPortfolioSummary")
+        .mockResolvedValue({
+          totalCashValue: 100.12345,
+          totalHoldingsValue: 9900.56789,
+          totalCostBasis: 9000.1234,
+          totalNetInvested: 9000,
+          totalPortfolioValue: 10000.6913,
+          totalGainLoss: 900.5544,
+          totalGainLossPercent: 10.123456,
+          timeWeightedReturn: 8.56789,
+          cagr: null,
+          holdings: [
+            {
+              id: "h1",
+              accountId: "a1",
+              securityId: "s1",
+              symbol: "AAPL",
+              name: "Apple Inc.",
+              securityType: "STOCK",
+              currencyCode: "USD",
+              quantity: 10,
+              averageCost: 150.0,
+              costBasis: 1500.0,
+              costBasisAccountCurrency: 1500.0,
+              currentPrice: 180.0,
+              marketValue: 1800.12345,
+              gainLoss: 300.12345,
+              gainLossPercent: 20.567,
+            },
+          ],
+          holdingsByAccount: [],
+          allocation: [
+            {
+              name: "AAPL",
+              symbol: "AAPL",
+              type: "security",
+              value: 1800.12345,
+              percentage: 18.56789,
+            },
+          ],
+        });
+
+      const result = await service.getLlmSummary("user-1");
+
+      expect(getPortfolioSummary).toHaveBeenCalledWith("user-1", undefined);
+      expect(result.holdingCount).toBe(1);
+      expect(result.totalCashValue).toBe(100.1235);
+      expect(result.totalHoldingsValue).toBe(9900.5679);
+      expect(result.totalPortfolioValue).toBe(10000.6913);
+      expect(result.totalGainLoss).toBe(900.5544);
+      expect(result.totalGainLossPercent).toBe(10.12);
+      expect(result.timeWeightedReturn).toBe(8.57);
+      expect(result.cagr).toBeNull();
+      expect(result.holdings[0]).toMatchObject({
+        symbol: "AAPL",
+        name: "Apple Inc.",
+        securityType: "STOCK",
+        currency: "USD",
+        quantity: 10,
+        averageCost: 150,
+        costBasis: 1500,
+        marketValue: 1800.1235,
+        gainLoss: 300.1235,
+        gainLossPercent: 20.57,
+      });
+      expect(result.allocation[0]).toMatchObject({
+        name: "AAPL",
+        symbol: "AAPL",
+        type: "security",
+        value: 1800.1235,
+        percentage: 18.57,
+      });
+    });
+
+    it("passes accountIds filter through to getPortfolioSummary", async () => {
+      const spy = jest.spyOn(service, "getPortfolioSummary").mockResolvedValue({
+        totalCashValue: 0,
+        totalHoldingsValue: 0,
+        totalCostBasis: 0,
+        totalNetInvested: 0,
+        totalPortfolioValue: 0,
+        totalGainLoss: 0,
+        totalGainLossPercent: 0,
+        timeWeightedReturn: null,
+        cagr: null,
+        holdings: [],
+        holdingsByAccount: [],
+        allocation: [],
+      });
+
+      await service.getLlmSummary("user-1", ["acc-1", "acc-2"]);
+
+      expect(spy).toHaveBeenCalledWith("user-1", ["acc-1", "acc-2"]);
+    });
+
+    it("preserves null averageCost", async () => {
+      jest.spyOn(service, "getPortfolioSummary").mockResolvedValue({
+        totalCashValue: 0,
+        totalHoldingsValue: 100,
+        totalCostBasis: 0,
+        totalNetInvested: 0,
+        totalPortfolioValue: 100,
+        totalGainLoss: 0,
+        totalGainLossPercent: 0,
+        timeWeightedReturn: null,
+        cagr: null,
+        holdings: [
+          {
+            id: "h1",
+            accountId: "a1",
+            securityId: "s1",
+            symbol: "ACB",
+            name: "Aurora",
+            securityType: "STOCK",
+            currencyCode: "CAD",
+            quantity: 5,
+            averageCost: null as unknown as number,
+            costBasis: 0,
+            costBasisAccountCurrency: 0,
+            currentPrice: 20,
+            marketValue: 100,
+            gainLoss: null,
+            gainLossPercent: null,
+          },
+        ],
+        holdingsByAccount: [],
+        allocation: [],
+      });
+
+      const result = await service.getLlmSummary("user-1");
+
+      expect(result.holdings[0].averageCost).toBeNull();
+      expect(result.holdings[0].gainLoss).toBeNull();
+      expect(result.holdings[0].gainLossPercent).toBeNull();
+    });
+  });
+
   describe("getTopMovers", () => {
     describe("when user has active holdings with price history", () => {
       beforeEach(() => {

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -90,6 +90,47 @@ export interface AssetAllocation {
   totalValue: number;
 }
 
+/**
+ * Compact portfolio view shared by the AI Assistant's tool executor and the
+ * MCP server. Mirrors `PortfolioSummary` but drops internal UUIDs, rounds
+ * monetary and percentage values, and keeps only the fields the model needs
+ * to answer holdings questions.
+ */
+export interface LlmPortfolioHolding {
+  symbol: string;
+  name: string;
+  securityType: string;
+  currency: string;
+  quantity: number;
+  averageCost: number | null;
+  costBasis: number;
+  marketValue: number | null;
+  gainLoss: number | null;
+  gainLossPercent: number | null;
+}
+
+export interface LlmPortfolioAllocation {
+  name: string;
+  symbol: string | null;
+  type: "cash" | "security";
+  value: number;
+  percentage: number;
+}
+
+export interface LlmPortfolioSummary {
+  holdingCount: number;
+  totalCashValue: number;
+  totalHoldingsValue: number;
+  totalCostBasis: number;
+  totalPortfolioValue: number;
+  totalGainLoss: number;
+  totalGainLossPercent: number;
+  timeWeightedReturn: number | null;
+  cagr: number | null;
+  holdings: LlmPortfolioHolding[];
+  allocation: LlmPortfolioAllocation[];
+}
+
 @Injectable()
 export class PortfolioService {
   constructor(
@@ -275,6 +316,65 @@ export class PortfolioService {
       cagr,
       holdings: sortedHoldings,
       holdingsByAccount,
+      allocation,
+    };
+  }
+
+  /**
+   * Compact portfolio summary for LLM / AI consumers. Called by both the AI
+   * Assistant's tool executor and the MCP server's `get_portfolio_summary`
+   * tool so the two surfaces return the same shape. Monetary values are
+   * rounded to 4 decimal places; percentages to 2.
+   */
+  async getLlmSummary(
+    userId: string,
+    accountIds?: string[],
+  ): Promise<LlmPortfolioSummary> {
+    const summary = await this.getPortfolioSummary(userId, accountIds);
+
+    const roundMoney = (v: number | null | undefined): number =>
+      v === null || v === undefined ? 0 : Math.round(Number(v) * 10000) / 10000;
+    const roundMoneyNullable = (v: number | null | undefined): number | null =>
+      v === null || v === undefined
+        ? null
+        : Math.round(Number(v) * 10000) / 10000;
+    const roundPct = (v: number | null | undefined): number | null =>
+      v === null || v === undefined ? null : Math.round(Number(v) * 100) / 100;
+
+    const holdings: LlmPortfolioHolding[] = summary.holdings.map((h) => ({
+      symbol: h.symbol,
+      name: h.name,
+      securityType: h.securityType,
+      currency: h.currencyCode,
+      quantity: h.quantity,
+      averageCost: roundMoneyNullable(h.averageCost),
+      costBasis: roundMoney(h.costBasis),
+      marketValue: roundMoneyNullable(h.marketValue),
+      gainLoss: roundMoneyNullable(h.gainLoss),
+      gainLossPercent: roundPct(h.gainLossPercent),
+    }));
+
+    const allocation: LlmPortfolioAllocation[] = summary.allocation.map(
+      (a) => ({
+        name: a.name,
+        symbol: a.symbol,
+        type: a.type,
+        value: roundMoney(a.value),
+        percentage: roundPct(a.percentage) ?? 0,
+      }),
+    );
+
+    return {
+      holdingCount: holdings.length,
+      totalCashValue: roundMoney(summary.totalCashValue),
+      totalHoldingsValue: roundMoney(summary.totalHoldingsValue),
+      totalCostBasis: roundMoney(summary.totalCostBasis),
+      totalPortfolioValue: roundMoney(summary.totalPortfolioValue),
+      totalGainLoss: roundMoney(summary.totalGainLoss),
+      totalGainLossPercent: roundPct(summary.totalGainLossPercent) ?? 0,
+      timeWeightedReturn: roundPct(summary.timeWeightedReturn),
+      cagr: roundPct(summary.cagr),
+      holdings,
       allocation,
     };
   }

--- a/backend/src/transactions/transaction-analytics.service.spec.ts
+++ b/backend/src/transactions/transaction-analytics.service.spec.ts
@@ -38,6 +38,7 @@ describe("TransactionAnalyticsService", () => {
       }),
       leftJoin: jest.fn().mockReturnValue(mockQueryBuilder),
       groupBy: jest.fn().mockReturnValue(mockQueryBuilder),
+      addGroupBy: jest.fn().mockReturnValue(mockQueryBuilder),
       orderBy: jest.fn().mockReturnValue(mockQueryBuilder),
       setParameter: jest.fn().mockReturnValue(mockQueryBuilder),
       getRawMany: jest.fn().mockResolvedValue([]),
@@ -949,6 +950,96 @@ describe("TransactionAnalyticsService", () => {
         expect(ids).not.toContain("cat-2");
         expect(ids).not.toContain("cat-2-child");
       });
+    });
+  });
+
+  describe("getTransfersByAccount", () => {
+    it("filters to transfer rows in the requested date range", async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValue([]);
+
+      await service.getTransfersByAccount(userId, "2026-01-01", "2026-01-31");
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        "t.isTransfer = true",
+      );
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        "t.transactionDate >= :startDate",
+        { startDate: "2026-01-01" },
+      );
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        "t.transactionDate <= :endDate",
+        { endDate: "2026-01-31" },
+      );
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        "t.status != 'VOID'",
+      );
+    });
+
+    it("aggregates inbound, outbound, net, and count per account", async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValue([
+        {
+          accountName: "Chequing",
+          currencyCode: "USD",
+          inbound: "0",
+          outbound: "1500",
+          count: "3",
+        },
+        {
+          accountName: "Savings",
+          currencyCode: "USD",
+          inbound: "1500",
+          outbound: "0",
+          count: "3",
+        },
+      ]);
+
+      const result = await service.getTransfersByAccount(
+        userId,
+        "2026-01-01",
+        "2026-01-31",
+      );
+
+      expect(result.accounts).toHaveLength(2);
+      expect(result.accounts[0]).toMatchObject({
+        accountName: "Chequing",
+        currency: "USD",
+        inbound: 0,
+        outbound: 1500,
+        net: -1500,
+        transferCount: 3,
+      });
+      expect(result.totalInbound).toBe(1500);
+      expect(result.totalOutbound).toBe(1500);
+      expect(result.transferCount).toBe(6);
+    });
+
+    it("applies accountIds filter when provided", async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValue([]);
+
+      await service.getTransfersByAccount(userId, "2026-01-01", "2026-01-31", [
+        "acc-1",
+        "acc-2",
+      ]);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        "t.accountId IN (:...accountIds)",
+        { accountIds: ["acc-1", "acc-2"] },
+      );
+    });
+
+    it("returns zeroed totals when there are no transfers", async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValue([]);
+
+      const result = await service.getTransfersByAccount(
+        userId,
+        "2026-01-01",
+        "2026-01-31",
+      );
+
+      expect(result.accounts).toEqual([]);
+      expect(result.totalInbound).toBe(0);
+      expect(result.totalOutbound).toBe(0);
+      expect(result.transferCount).toBe(0);
     });
   });
 

--- a/backend/src/transactions/transaction-analytics.service.ts
+++ b/backend/src/transactions/transaction-analytics.service.ts
@@ -5,6 +5,22 @@ import { Transaction } from "./entities/transaction.entity";
 import { Category } from "../categories/entities/category.entity";
 import { getAllCategoryIdsWithChildren } from "../common/category-tree.util";
 
+export interface TransferAccountSummary {
+  accountName: string;
+  currency: string;
+  inbound: number;
+  outbound: number;
+  net: number;
+  transferCount: number;
+}
+
+export interface TransfersByAccountResult {
+  accounts: TransferAccountSummary[];
+  totalInbound: number;
+  totalOutbound: number;
+  transferCount: number;
+}
+
 @Injectable()
 export class TransactionAnalyticsService {
   constructor(
@@ -13,6 +29,76 @@ export class TransactionAnalyticsService {
     @InjectRepository(Category)
     private categoriesRepository: Repository<Category>,
   ) {}
+
+  /**
+   * Per-account transfer activity between the user's own accounts for a date
+   * range. Shared by the AI Assistant's tool executor and the MCP server so
+   * both surfaces return the same shape. `inbound` counts positive-sign
+   * transfer rows (money received), `outbound` counts the absolute value of
+   * negative-sign rows (money sent). When no account filter is applied,
+   * `totalInbound` equals `totalOutbound` (modulo multi-currency conversions)
+   * because every transfer is stored as two linked rows, one on each side.
+   */
+  async getTransfersByAccount(
+    userId: string,
+    startDate: string,
+    endDate: string,
+    accountIds?: string[],
+  ): Promise<TransfersByAccountResult> {
+    const qb = this.transactionsRepository
+      .createQueryBuilder("t")
+      .leftJoin("t.account", "transferAccount")
+      .select("transferAccount.name", "accountName")
+      .addSelect("t.currencyCode", "currencyCode")
+      .addSelect(
+        "SUM(CASE WHEN t.amount > 0 THEN t.amount ELSE 0 END)",
+        "inbound",
+      )
+      .addSelect(
+        "SUM(CASE WHEN t.amount < 0 THEN ABS(t.amount) ELSE 0 END)",
+        "outbound",
+      )
+      .addSelect("COUNT(*)", "count")
+      .where("t.userId = :userId", { userId })
+      .andWhere("t.isTransfer = true")
+      .andWhere("t.transactionDate >= :startDate", { startDate })
+      .andWhere("t.transactionDate <= :endDate", { endDate })
+      .andWhere("t.status != 'VOID'")
+      .groupBy("transferAccount.id")
+      .addGroupBy("transferAccount.name")
+      .addGroupBy("t.currencyCode")
+      .orderBy("transferAccount.name", "ASC");
+
+    if (accountIds && accountIds.length > 0) {
+      qb.andWhere("t.accountId IN (:...accountIds)", { accountIds });
+    }
+
+    const rows = await qb.getRawMany();
+
+    const roundMoney = (v: number): number => Math.round(v * 10000) / 10000;
+    const sumMoney = (values: number[]): number =>
+      values.reduce((s, v) => s + Math.round(v * 10000), 0) / 10000;
+
+    const accounts: TransferAccountSummary[] = rows.map((r) => {
+      const inbound = roundMoney(Number(r.inbound) || 0);
+      const outbound = roundMoney(Number(r.outbound) || 0);
+      return {
+        accountName: r.accountName,
+        currency: r.currencyCode,
+        inbound,
+        outbound,
+        net: roundMoney(inbound - outbound),
+        transferCount: Number(r.count) || 0,
+      };
+    });
+
+    return {
+      accounts,
+      totalInbound: sumMoney(accounts.map((a) => a.inbound)),
+      totalOutbound: sumMoney(accounts.map((a) => a.outbound)),
+      transferCount: accounts.reduce((s, a) => s + a.transferCount, 0),
+    };
+  }
 
   async getSummary(
     userId: string,


### PR DESCRIPTION
The AI Assistant previously excluded transfers from every query tool so
spending and income summaries only reflected real outflows and inflows.
That exclusion made it impossible to answer questions like "how much did
I move into savings last month" or "what went out of chequing to other
accounts".

Adds a dedicated `get_transfers` tool that aggregates transfer
transactions per account (inbound, outbound, net, count) for a date
range, with an optional accountNames filter. Keeps transfers out of the
existing spending/income tools so those totals stay accurate, and
updates the system prompt to route transfer questions to the new tool.

https://claude.ai/code/session_016L6ZciMC1HxrksvyAPwXrE