### PR TITLE
Add query_investment_transactions tool for LLM/AI consumers

### DIFF
--- a/backend/src/ai/query/tool-definitions.spec.ts
+++ b/backend/src/ai/query/tool-definitions.spec.ts
@@ -1,8 +1,8 @@
 import { FINANCIAL_TOOLS } from "./tool-definitions";
 
 describe("FINANCIAL_TOOLS", () => {
-  it("defines exactly 11 tools", () => {
-    expect(FINANCIAL_TOOLS).toHaveLength(11);
+  it("defines exactly 12 tools", () => {
+    expect(FINANCIAL_TOOLS).toHaveLength(12);
   });
 
   it("has unique tool names", () => {
@@ -18,6 +18,7 @@ describe("FINANCIAL_TOOLS", () => {
     "get_net_worth_history",
     "compare_periods",
     "get_portfolio_summary",
+    "query_investment_transactions",
     "get_transfers",
     "get_budget_status",
     "calculate",
@@ -159,6 +160,67 @@ describe("FINANCIAL_TOOLS", () => {
       >;
       expect(props.accountNames).toBeDefined();
       expect(props.accountNames.type).toBe("array");
+    });
+  });
+
+  describe("query_investment_transactions", () => {
+    it("has no required fields", () => {
+      const tool = FINANCIAL_TOOLS.find(
+        (t) => t.name === "query_investment_transactions",
+      )!;
+      expect(tool.inputSchema.required).toBeUndefined();
+    });
+
+    it("supports groupBy with account, date, security, and action", () => {
+      const tool = FINANCIAL_TOOLS.find(
+        (t) => t.name === "query_investment_transactions",
+      )!;
+      const props = tool.inputSchema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.groupBy.enum).toEqual([
+        "account",
+        "date",
+        "security",
+        "action",
+      ]);
+    });
+
+    it("exposes the full set of investment actions in the actions enum", () => {
+      const tool = FINANCIAL_TOOLS.find(
+        (t) => t.name === "query_investment_transactions",
+      )!;
+      const props = tool.inputSchema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      const items = props.actions.items as Record<string, unknown>;
+      expect(items.enum).toEqual([
+        "BUY",
+        "SELL",
+        "DIVIDEND",
+        "INTEREST",
+        "CAPITAL_GAIN",
+        "SPLIT",
+        "TRANSFER_IN",
+        "TRANSFER_OUT",
+        "REINVEST",
+        "ADD_SHARES",
+        "REMOVE_SHARES",
+      ]);
+    });
+
+    it("supports optional accountNames and symbols array filters", () => {
+      const tool = FINANCIAL_TOOLS.find(
+        (t) => t.name === "query_investment_transactions",
+      )!;
+      const props = tool.inputSchema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.accountNames.type).toBe("array");
+      expect(props.symbols.type).toBe("array");
     });
   });
 

--- a/backend/src/ai/query/tool-definitions.ts
+++ b/backend/src/ai/query/tool-definitions.ts
@@ -185,6 +185,63 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
     },
   },
   {
+    name: "query_investment_transactions",
+    description:
+      "Query the user's brokerage investment-account transactions (buys, sells, dividends, interest, capital gains, splits, transfers, reinvestments, share adjustments). Returns aggregate totals (count, total amount, total commission, action breakdown) and a capped list of matching transactions. Optionally group the results by account, date, security (symbol), or transaction type (action). Use this for questions like 'what did I buy last month', 'show my AAPL trades', 'how much did I pay in commissions', or 'what dividends did I receive'. Do not use for the current portfolio holdings or unrealized gains — use get_portfolio_summary for that.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        startDate: {
+          type: "string",
+          description: "Optional start date (YYYY-MM-DD).",
+        },
+        endDate: {
+          type: "string",
+          description: "Optional end date (YYYY-MM-DD).",
+        },
+        accountNames: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Optional: filter to specific investment account names. Use exact names from the user's account list.",
+        },
+        symbols: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            'Optional: filter to specific security ticker symbols (e.g., ["AAPL", "MSFT"]). Case insensitive.',
+        },
+        actions: {
+          type: "array",
+          items: {
+            type: "string",
+            enum: [
+              "BUY",
+              "SELL",
+              "DIVIDEND",
+              "INTEREST",
+              "CAPITAL_GAIN",
+              "SPLIT",
+              "TRANSFER_IN",
+              "TRANSFER_OUT",
+              "REINVEST",
+              "ADD_SHARES",
+              "REMOVE_SHARES",
+            ],
+          },
+          description:
+            "Optional: filter to specific transaction types. Values must be UPPER_SNAKE_CASE exactly as listed.",
+        },
+        groupBy: {
+          type: "string",
+          enum: ["account", "date", "security", "action"],
+          description:
+            "Optional: group the results by account name, transaction date, security symbol, or action type.",
+        },
+      },
+    },
+  },
+  {
     name: "get_transfers",
     description:
       "Get transfer activity between the user's own accounts for a date range. Returns per-account inbound (money received from another account), outbound (money sent to another account), net movement, and transfer count. Transfers are deliberately excluded from spending and income tools because they net to zero across accounts; use this tool for questions like 'how much did I move into my savings', 'what went out of chequing to other accounts', or 'what are my transfers between accounts'.",

--- a/backend/src/ai/query/tool-executor.service.spec.ts
+++ b/backend/src/ai/query/tool-executor.service.spec.ts
@@ -5,6 +5,7 @@ import { TransactionAnalyticsService } from "../../transactions/transaction-anal
 import { NetWorthService } from "../../net-worth/net-worth.service";
 import { BudgetReportsService } from "../../budgets/budget-reports.service";
 import { PortfolioService } from "../../securities/portfolio.service";
+import { InvestmentTransactionsService } from "../../securities/investment-transactions.service";
 
 describe("ToolExecutorService", () => {
   let service: ToolExecutorService;
@@ -13,6 +14,7 @@ describe("ToolExecutorService", () => {
   let netWorth: Record<string, jest.Mock>;
   let budgetReports: Record<string, jest.Mock>;
   let portfolio: Record<string, jest.Mock>;
+  let investmentTransactions: Record<string, jest.Mock>;
 
   const userId = "user-1";
 
@@ -104,6 +106,20 @@ describe("ToolExecutorService", () => {
       }),
     };
 
+    investmentTransactions = {
+      getLlmInvestmentTransactions: jest.fn().mockResolvedValue({
+        transactionCount: 3,
+        totalAmount: 2325,
+        totalCommission: 19.98,
+        totalQuantity: 15,
+        actionCounts: { BUY: 1, SELL: 1, DIVIDEND: 1 },
+        groupedBy: null,
+        groups: null,
+        transactions: [],
+        truncatedTransactionList: false,
+      }),
+    };
+
     portfolio = {
       getLlmSummary: jest.fn().mockResolvedValue({
         holdingCount: 0,
@@ -128,6 +144,10 @@ describe("ToolExecutorService", () => {
         { provide: NetWorthService, useValue: netWorth },
         { provide: BudgetReportsService, useValue: budgetReports },
         { provide: PortfolioService, useValue: portfolio },
+        {
+          provide: InvestmentTransactionsService,
+          useValue: investmentTransactions,
+        },
       ],
     }).compile();
 
@@ -273,6 +293,80 @@ describe("ToolExecutorService", () => {
 
       expect(portfolio.getLlmSummary).toHaveBeenCalledWith(userId, undefined);
       expect(result.sources[0].type).toBe("portfolio");
+    });
+
+    it("query_investment_transactions delegates to investmentTransactions.getLlmInvestmentTransactions", async () => {
+      investmentTransactions.getLlmInvestmentTransactions.mockResolvedValueOnce(
+        {
+          transactionCount: 3,
+          totalAmount: 2325,
+          totalCommission: 19.98,
+          totalQuantity: 15,
+          actionCounts: { BUY: 1, SELL: 1 },
+          groupedBy: "security",
+          groups: [
+            {
+              key: "AAPL",
+              transactionCount: 3,
+              totalQuantity: 15,
+              totalAmount: 2325,
+              totalCommission: 19.98,
+            },
+          ],
+          transactions: [],
+          truncatedTransactionList: false,
+        },
+      );
+      const result = await service.execute(
+        userId,
+        "query_investment_transactions",
+        {
+          startDate: "2026-01-01",
+          endDate: "2026-03-31",
+          symbols: ["AAPL"],
+          actions: ["BUY", "SELL"],
+          groupBy: "security",
+        },
+      );
+
+      expect(
+        investmentTransactions.getLlmInvestmentTransactions,
+      ).toHaveBeenCalledWith(userId, {
+        startDate: "2026-01-01",
+        endDate: "2026-03-31",
+        accountIds: undefined,
+        symbols: ["AAPL"],
+        actions: ["BUY", "SELL"],
+        groupBy: "security",
+      });
+      expect(result.sources[0].type).toBe("investment_transactions");
+      expect(result.sources[0].dateRange).toBe("2026-01-01 to 2026-03-31");
+      expect(result.summary).toContain("3 investment transactions");
+      expect(result.summary).toContain("grouped by security");
+    });
+
+    it("query_investment_transactions resolves account names to IDs", async () => {
+      await service.execute(userId, "query_investment_transactions", {
+        accountNames: ["Checking"],
+      });
+
+      expect(accounts.findAll).toHaveBeenCalledWith(userId, false);
+      expect(
+        investmentTransactions.getLlmInvestmentTransactions,
+      ).toHaveBeenCalledWith(
+        userId,
+        expect.objectContaining({ accountIds: ["acc-1"] }),
+      );
+    });
+
+    it("query_investment_transactions handles all-dates summary", async () => {
+      const result = await service.execute(
+        userId,
+        "query_investment_transactions",
+        {},
+      );
+
+      expect(result.sources[0].dateRange).toBe("all dates");
     });
 
     it("get_transfers delegates to analytics.getTransfersByAccount", async () => {

--- a/backend/src/ai/query/tool-executor.service.ts
+++ b/backend/src/ai/query/tool-executor.service.ts
@@ -4,6 +4,11 @@ import { TransactionAnalyticsService } from "../../transactions/transaction-anal
 import { NetWorthService } from "../../net-worth/net-worth.service";
 import { BudgetReportsService } from "../../budgets/budget-reports.service";
 import { PortfolioService } from "../../securities/portfolio.service";
+import {
+  InvestmentTransactionsService,
+  LlmInvestmentTxGroupBy,
+} from "../../securities/investment-transactions.service";
+import { InvestmentAction } from "../../securities/entities/investment-transaction.entity";
 import { validateToolInput } from "./tool-input-schemas";
 import { executeCalculation, CalculateInput } from "./calculate-tool";
 import { sanitizePromptValue } from "../../common/sanitization.util";
@@ -29,6 +34,7 @@ export class ToolExecutorService {
     @Inject(forwardRef(() => BudgetReportsService))
     private readonly budgetReportsService: BudgetReportsService,
     private readonly portfolioService: PortfolioService,
+    private readonly investmentTransactionsService: InvestmentTransactionsService,
   ) {}
 
   async execute(
@@ -79,6 +85,12 @@ export class ToolExecutorService {
           break;
         case "get_portfolio_summary":
           result = await this.getPortfolioSummary(userId, validatedInput);
+          break;
+        case "query_investment_transactions":
+          result = await this.queryInvestmentTransactions(
+            userId,
+            validatedInput,
+          );
           break;
         case "get_transfers":
           result = await this.getTransfers(userId, validatedInput);
@@ -355,6 +367,60 @@ export class ToolExecutorService {
           description: accountNames
             ? `Portfolio summary for ${accountNames.join(", ")}`
             : "Portfolio summary across all investment accounts",
+        },
+      ],
+    };
+  }
+
+  private async queryInvestmentTransactions(
+    userId: string,
+    input: Record<string, unknown>,
+  ): Promise<ToolResult> {
+    const startDate = input.startDate as string | undefined;
+    const endDate = input.endDate as string | undefined;
+    const accountNames = input.accountNames as string[] | undefined;
+    const symbols = input.symbols as string[] | undefined;
+    const actions = input.actions as InvestmentAction[] | undefined;
+    const groupBy = input.groupBy as LlmInvestmentTxGroupBy | undefined;
+
+    const accountIds = await this.resolveAccountIds(userId, accountNames);
+
+    const data =
+      await this.investmentTransactionsService.getLlmInvestmentTransactions(
+        userId,
+        { startDate, endDate, accountIds, symbols, actions, groupBy },
+      );
+
+    const rangeParts: string[] = [];
+    if (startDate && endDate) rangeParts.push(`${startDate} to ${endDate}`);
+    else if (startDate) rangeParts.push(`from ${startDate}`);
+    else if (endDate) rangeParts.push(`through ${endDate}`);
+    const range = rangeParts.length > 0 ? rangeParts[0] : "all dates";
+
+    const filterDescParts: string[] = [];
+    if (accountNames?.length) filterDescParts.push(accountNames.join(", "));
+    if (symbols?.length) filterDescParts.push(symbols.join(", "));
+    if (actions?.length) filterDescParts.push(actions.join(", "));
+    const filterDesc =
+      filterDescParts.length > 0 ? ` (${filterDescParts.join("; ")})` : "";
+
+    const summaryParts = [
+      `${data.transactionCount} investment transaction${data.transactionCount === 1 ? "" : "s"}${filterDesc}`,
+      `total amount ${data.totalAmount.toFixed(2)}`,
+      `commissions ${data.totalCommission.toFixed(2)}`,
+    ];
+    if (groupBy && data.groups) {
+      summaryParts.push(`grouped by ${groupBy} (${data.groups.length} groups)`);
+    }
+
+    return {
+      data,
+      summary: `${summaryParts.join(", ")}.`,
+      sources: [
+        {
+          type: "investment_transactions",
+          description: `Investment transactions${filterDesc}`,
+          dateRange: range,
         },
       ],
     };

--- a/backend/src/ai/query/tool-input-schemas.spec.ts
+++ b/backend/src/ai/query/tool-input-schemas.spec.ts
@@ -7,6 +7,7 @@ import {
   getNetWorthHistorySchema,
   comparePeriodsSchema,
   getPortfolioSummarySchema,
+  queryInvestmentTransactionsSchema,
   getTransfersSchema,
   getBudgetStatusSchema,
   calculateSchema,
@@ -323,6 +324,88 @@ describe("tool-input-schemas", () => {
         accountNames: ["a".repeat(101)],
       });
       expect(result.success).toBe(false);
+    });
+  });
+
+  describe("queryInvestmentTransactionsSchema", () => {
+    it("accepts empty input (all filters optional)", () => {
+      const result = queryInvestmentTransactionsSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts all optional filters", () => {
+      const result = queryInvestmentTransactionsSchema.safeParse({
+        startDate: "2026-01-01",
+        endDate: "2026-03-31",
+        accountNames: ["Brokerage"],
+        symbols: ["AAPL", "MSFT"],
+        actions: ["BUY", "SELL", "DIVIDEND"],
+        groupBy: "security",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("uppercases action inputs via preprocess", () => {
+      const result = queryInvestmentTransactionsSchema.safeParse({
+        actions: ["buy", " sell ", "Dividend"],
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.actions).toEqual(["BUY", "SELL", "DIVIDEND"]);
+      }
+    });
+
+    it("rejects an unknown action value", () => {
+      const result = queryInvestmentTransactionsSchema.safeParse({
+        actions: ["NOT_REAL"],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects an invalid groupBy value", () => {
+      const result = queryInvestmentTransactionsSchema.safeParse({
+        groupBy: "category",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects an invalid date format", () => {
+      const result = queryInvestmentTransactionsSchema.safeParse({
+        startDate: "Jan 1 2026",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects empty symbol strings", () => {
+      const result = queryInvestmentTransactionsSchema.safeParse({
+        symbols: [""],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects symbols longer than 20 chars", () => {
+      const result = queryInvestmentTransactionsSchema.safeParse({
+        symbols: ["a".repeat(21)],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts every groupBy enum value", () => {
+      for (const groupBy of ["account", "date", "security", "action"]) {
+        const result = queryInvestmentTransactionsSchema.safeParse({ groupBy });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it("routes through validateToolInput", () => {
+      const result = validateToolInput("query_investment_transactions", {
+        symbols: ["aapl"],
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // symbols not uppercased by schema; preprocessing only applies to actions
+        expect(result.data.symbols).toEqual(["aapl"]);
+      }
     });
   });
 

--- a/backend/src/ai/query/tool-input-schemas.ts
+++ b/backend/src/ai/query/tool-input-schemas.ts
@@ -60,6 +60,34 @@ export const getPortfolioSummarySchema = z.object({
   accountNames: z.array(z.string().max(100)).optional(),
 });
 
+export const INVESTMENT_ACTIONS = [
+  "BUY",
+  "SELL",
+  "DIVIDEND",
+  "INTEREST",
+  "CAPITAL_GAIN",
+  "SPLIT",
+  "TRANSFER_IN",
+  "TRANSFER_OUT",
+  "REINVEST",
+  "ADD_SHARES",
+  "REMOVE_SHARES",
+] as const;
+
+const investmentActionSchema = z.preprocess(
+  (val) => (typeof val === "string" ? val.toUpperCase().trim() : val),
+  z.enum(INVESTMENT_ACTIONS),
+);
+
+export const queryInvestmentTransactionsSchema = z.object({
+  startDate: isoDateSchema.optional(),
+  endDate: isoDateSchema.optional(),
+  accountNames: z.array(z.string().max(100)).max(50).optional(),
+  symbols: z.array(z.string().min(1).max(20)).max(50).optional(),
+  actions: z.array(investmentActionSchema).max(11).optional(),
+  groupBy: z.enum(["account", "date", "security", "action"]).optional(),
+});
+
 export const getTransfersSchema = z.object({
   startDate: isoDateSchema,
   endDate: isoDateSchema,
@@ -105,6 +133,7 @@ export const toolInputSchemas: Record<string, z.ZodSchema> = {
   get_net_worth_history: getNetWorthHistorySchema,
   compare_periods: comparePeriodsSchema,
   get_portfolio_summary: getPortfolioSummarySchema,
+  query_investment_transactions: queryInvestmentTransactionsSchema,
   get_transfers: getTransfersSchema,
   get_budget_status: getBudgetStatusSchema,
   calculate: calculateSchema,

--- a/backend/src/mcp/tools/investments.tool.spec.ts
+++ b/backend/src/mcp/tools/investments.tool.spec.ts
@@ -5,6 +5,7 @@ describe("McpInvestmentsTools", () => {
   let tool: McpInvestmentsTools;
   let portfolioService: Record<string, jest.Mock>;
   let holdingsService: Record<string, jest.Mock>;
+  let investmentTransactionsService: Record<string, jest.Mock>;
   let server: { registerTool: jest.Mock };
   let resolve: jest.MockedFunction<UserContextResolver>;
   const handlers: Record<string, (...args: any[]) => any> = {};
@@ -19,9 +20,14 @@ describe("McpInvestmentsTools", () => {
       findAll: jest.fn(),
     };
 
+    investmentTransactionsService = {
+      getLlmInvestmentTransactions: jest.fn(),
+    };
+
     tool = new McpInvestmentsTools(
       portfolioService as any,
       holdingsService as any,
+      investmentTransactionsService as any,
     );
 
     server = {
@@ -34,8 +40,8 @@ describe("McpInvestmentsTools", () => {
     tool.register(server as any, resolve);
   });
 
-  it("should register 2 tools", () => {
-    expect(server.registerTool).toHaveBeenCalledTimes(2);
+  it("should register 3 tools", () => {
+    expect(server.registerTool).toHaveBeenCalledTimes(3);
   });
 
   describe("get_portfolio_summary", () => {
@@ -88,6 +94,112 @@ describe("McpInvestmentsTools", () => {
       expect(portfolioService.getLlmSummary).toHaveBeenCalledWith("u1", [
         "00000000-0000-0000-0000-000000000001",
       ]);
+    });
+  });
+
+  describe("query_investment_transactions", () => {
+    it("returns error when no user context", async () => {
+      resolve.mockReturnValue(undefined);
+      const result = await handlers["query_investment_transactions"](
+        {},
+        { sessionId: "s1" },
+      );
+      expect(result.isError).toBe(true);
+    });
+
+    it("delegates to shared getLlmInvestmentTransactions with all filters", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      investmentTransactionsService.getLlmInvestmentTransactions.mockResolvedValue(
+        {
+          transactionCount: 2,
+          totalAmount: 1000,
+          totalCommission: 9.99,
+          totalQuantity: 10,
+          actionCounts: { BUY: 2 },
+          groupedBy: "security",
+          groups: [
+            {
+              key: "AAPL",
+              transactionCount: 2,
+              totalQuantity: 10,
+              totalAmount: 1000,
+              totalCommission: 9.99,
+            },
+          ],
+          transactions: [],
+          truncatedTransactionList: false,
+        },
+      );
+
+      const result = await handlers["query_investment_transactions"](
+        {
+          startDate: "2026-01-01",
+          endDate: "2026-03-31",
+          accountIds: ["00000000-0000-0000-0000-000000000001"],
+          symbols: ["AAPL"],
+          actions: ["BUY"],
+          groupBy: "security",
+        },
+        { sessionId: "s1" },
+      );
+
+      expect(
+        investmentTransactionsService.getLlmInvestmentTransactions,
+      ).toHaveBeenCalledWith("u1", {
+        startDate: "2026-01-01",
+        endDate: "2026-03-31",
+        accountIds: ["00000000-0000-0000-0000-000000000001"],
+        symbols: ["AAPL"],
+        actions: ["BUY"],
+        groupBy: "security",
+      });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.transactionCount).toBe(2);
+      expect(parsed.groupedBy).toBe("security");
+      expect(parsed.groups[0].key).toBe("AAPL");
+    });
+
+    it("passes undefined filters when no args provided", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      investmentTransactionsService.getLlmInvestmentTransactions.mockResolvedValue(
+        {
+          transactionCount: 0,
+          totalAmount: 0,
+          totalCommission: 0,
+          totalQuantity: 0,
+          actionCounts: {},
+          groupedBy: null,
+          groups: null,
+          transactions: [],
+          truncatedTransactionList: false,
+        },
+      );
+
+      await handlers["query_investment_transactions"]({}, { sessionId: "s1" });
+
+      expect(
+        investmentTransactionsService.getLlmInvestmentTransactions,
+      ).toHaveBeenCalledWith("u1", {
+        startDate: undefined,
+        endDate: undefined,
+        accountIds: undefined,
+        symbols: undefined,
+        actions: undefined,
+        groupBy: undefined,
+      });
+    });
+
+    it("returns a safe error on service failure", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      investmentTransactionsService.getLlmInvestmentTransactions.mockRejectedValue(
+        new Error("boom"),
+      );
+
+      const result = await handlers["query_investment_transactions"](
+        {},
+        { sessionId: "s1" },
+      );
+      expect(result.isError).toBe(true);
     });
   });
 

--- a/backend/src/mcp/tools/investments.tool.ts
+++ b/backend/src/mcp/tools/investments.tool.ts
@@ -4,6 +4,11 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { PortfolioService } from "../../securities/portfolio.service";
 import { HoldingsService } from "../../securities/holdings.service";
 import {
+  InvestmentTransactionsService,
+  LlmInvestmentTxGroupBy,
+} from "../../securities/investment-transactions.service";
+import { InvestmentAction } from "../../securities/entities/investment-transaction.entity";
+import {
   UserContextResolver,
   requireScope,
   toolResult,
@@ -16,6 +21,7 @@ export class McpInvestmentsTools {
   constructor(
     private readonly portfolioService: PortfolioService,
     private readonly holdingsService: HoldingsService,
+    private readonly investmentTransactionsService: InvestmentTransactionsService,
   ) {}
 
   register(server: McpServer, resolve: UserContextResolver) {
@@ -46,6 +52,73 @@ export class McpInvestmentsTools {
             args.accountIds,
           );
           return toolResult(summary);
+        } catch (err: unknown) {
+          return safeToolError(err);
+        }
+      },
+    );
+
+    server.registerTool(
+      "query_investment_transactions",
+      {
+        description:
+          "Query brokerage investment-account transactions (buys, sells, dividends, interest, capital gains, splits, transfers, reinvestments, share adjustments). Filter by account, security symbol, action, and date; optionally group by account, date, security, or action. Returns the same compact, LLM-friendly shape as the AI Assistant's tool.",
+        inputSchema: {
+          startDate: z
+            .string()
+            .max(10)
+            .optional()
+            .describe("Optional start date (YYYY-MM-DD)"),
+          endDate: z
+            .string()
+            .max(10)
+            .optional()
+            .describe("Optional end date (YYYY-MM-DD)"),
+          accountIds: z
+            .array(z.string().uuid())
+            .max(50)
+            .optional()
+            .describe("Optional investment account IDs."),
+          symbols: z
+            .array(z.string().min(1).max(20))
+            .max(50)
+            .optional()
+            .describe("Optional security ticker symbols (case insensitive)."),
+          actions: z
+            .array(z.nativeEnum(InvestmentAction))
+            .max(11)
+            .optional()
+            .describe(
+              "Optional transaction types (BUY, SELL, DIVIDEND, INTEREST, CAPITAL_GAIN, SPLIT, TRANSFER_IN, TRANSFER_OUT, REINVEST, ADD_SHARES, REMOVE_SHARES).",
+            ),
+          groupBy: z
+            .enum(["account", "date", "security", "action"])
+            .optional()
+            .describe(
+              "Optional grouping: by account name, transaction date, security symbol, or action type.",
+            ),
+        },
+      },
+      async (args, extra) => {
+        const ctx = resolve(extra.sessionId);
+        if (!ctx) return toolError("No user context");
+        const check = requireScope(ctx.scopes, "read");
+        if (check.error) return check.result;
+
+        try {
+          const result =
+            await this.investmentTransactionsService.getLlmInvestmentTransactions(
+              ctx.userId,
+              {
+                startDate: args.startDate,
+                endDate: args.endDate,
+                accountIds: args.accountIds,
+                symbols: args.symbols,
+                actions: args.actions,
+                groupBy: args.groupBy as LlmInvestmentTxGroupBy | undefined,
+              },
+            );
+          return toolResult(result);
         } catch (err: unknown) {
           return safeToolError(err);
         }

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -2435,6 +2435,258 @@ describe("InvestmentTransactionsService", () => {
     });
   });
 
+  describe("getLlmInvestmentTransactions", () => {
+    const buy = {
+      ...mockBuyTransaction,
+      action: InvestmentAction.BUY,
+      transactionDate: "2026-03-10",
+      quantity: 10,
+      price: 150,
+      commission: 9.99,
+      totalAmount: 1509.99,
+      account: { ...mockInvestmentAccount, currencyCode: "USD" },
+      security: mockSecurity,
+    };
+    const sell = {
+      ...mockSellTransaction,
+      action: InvestmentAction.SELL,
+      transactionDate: "2026-03-20",
+      quantity: 5,
+      price: 160,
+      commission: 9.99,
+      totalAmount: 790.01,
+      account: { ...mockInvestmentAccount, currencyCode: "USD" },
+      security: mockSecurity,
+    };
+    const dividend = {
+      ...mockDividendTransaction,
+      action: InvestmentAction.DIVIDEND,
+      transactionDate: "2026-03-15",
+      quantity: null,
+      price: null,
+      commission: 0,
+      totalAmount: 25,
+      account: { ...mockInvestmentAccount, currencyCode: "USD" },
+      security: mockSecurity,
+    };
+
+    it("returns aggregate totals, action counts, and transactions list", async () => {
+      const rows = [sell, dividend, buy];
+      const mockQB = createMockQueryBuilder(rows, rows.length);
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        mockQB,
+      );
+
+      const result = await service.getLlmInvestmentTransactions(userId, {});
+
+      expect(result.transactionCount).toBe(3);
+      expect(result.totalAmount).toBeCloseTo(2325, 2);
+      expect(result.totalCommission).toBeCloseTo(19.98, 2);
+      expect(result.totalQuantity).toBeCloseTo(15, 8);
+      expect(result.actionCounts).toEqual({ BUY: 1, SELL: 1, DIVIDEND: 1 });
+      expect(result.groupedBy).toBeNull();
+      expect(result.groups).toBeNull();
+      expect(result.truncatedTransactionList).toBe(false);
+      expect(result.transactions).toHaveLength(3);
+      expect(result.transactions[0]).toEqual({
+        transactionDate: "2026-03-20",
+        action: "SELL",
+        accountName: "Brokerage Account",
+        symbol: "AAPL",
+        securityName: "Apple Inc.",
+        quantity: 5,
+        price: 160,
+        commission: 9.99,
+        totalAmount: 790.01,
+        currency: "USD",
+        description: "Sell AAPL",
+      });
+    });
+
+    it("applies date, symbol, action and accountId filters", async () => {
+      const mockQB = createMockQueryBuilder([], 0);
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        mockQB,
+      );
+      accountsService.findByIds.mockResolvedValue([
+        { ...mockInvestmentAccount, linkedAccountId: cashAccountId },
+      ]);
+
+      await service.getLlmInvestmentTransactions(userId, {
+        startDate: "2026-01-01",
+        endDate: "2026-03-31",
+        accountIds: [accountId],
+        symbols: ["aapl"],
+        actions: [InvestmentAction.BUY, InvestmentAction.SELL],
+      });
+
+      expect(accountsService.findByIds).toHaveBeenCalledWith(userId, [
+        accountId,
+      ]);
+      // Base userId filter + 5 andWhere calls (accountIds, startDate, endDate, symbols, actions)
+      expect(mockQB.andWhere).toHaveBeenCalledWith(
+        "it.accountId IN (:...allIds)",
+        { allIds: expect.arrayContaining([accountId, cashAccountId]) },
+      );
+      expect(mockQB.andWhere).toHaveBeenCalledWith(
+        "it.transactionDate >= :startDate",
+        { startDate: "2026-01-01" },
+      );
+      expect(mockQB.andWhere).toHaveBeenCalledWith(
+        "it.transactionDate <= :endDate",
+        { endDate: "2026-03-31" },
+      );
+      expect(mockQB.andWhere).toHaveBeenCalledWith(
+        "UPPER(security.symbol) IN (:...upperSymbols)",
+        { upperSymbols: ["AAPL"] },
+      );
+      expect(mockQB.andWhere).toHaveBeenCalledWith(
+        "it.action IN (:...actions)",
+        { actions: [InvestmentAction.BUY, InvestmentAction.SELL] },
+      );
+    });
+
+    it("groups by security symbol with per-group totals", async () => {
+      const tsla = {
+        ...buy,
+        id: "tx-tsla",
+        totalAmount: 500,
+        quantity: 2,
+        commission: 1,
+        security: { ...mockSecurity, id: "sec-tsla", symbol: "TSLA" },
+      };
+      const rows = [buy, sell, dividend, tsla];
+      const mockQB = createMockQueryBuilder(rows, rows.length);
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        mockQB,
+      );
+
+      const result = await service.getLlmInvestmentTransactions(userId, {
+        groupBy: "security",
+      });
+
+      expect(result.groupedBy).toBe("security");
+      expect(result.groups).not.toBeNull();
+      const aapl = result.groups!.find((g) => g.key === "AAPL");
+      const tslaGroup = result.groups!.find((g) => g.key === "TSLA");
+      expect(aapl).toBeDefined();
+      expect(tslaGroup).toBeDefined();
+      expect(aapl!.transactionCount).toBe(3);
+      expect(aapl!.totalAmount).toBeCloseTo(2325, 2);
+      expect(aapl!.totalCommission).toBeCloseTo(19.98, 2);
+      expect(aapl!.totalQuantity).toBeCloseTo(15, 8);
+      expect(tslaGroup!.transactionCount).toBe(1);
+      expect(tslaGroup!.totalAmount).toBeCloseTo(500, 2);
+      // Sorted by totalAmount descending (non-date grouping)
+      expect(result.groups![0].key).toBe("AAPL");
+    });
+
+    it("groups by date with date-descending ordering", async () => {
+      const rows = [buy, sell, dividend];
+      const mockQB = createMockQueryBuilder(rows, rows.length);
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        mockQB,
+      );
+
+      const result = await service.getLlmInvestmentTransactions(userId, {
+        groupBy: "date",
+      });
+
+      expect(result.groupedBy).toBe("date");
+      expect(result.groups!.map((g) => g.key)).toEqual([
+        "2026-03-20",
+        "2026-03-15",
+        "2026-03-10",
+      ]);
+    });
+
+    it("groups by action type", async () => {
+      const rows = [buy, sell, dividend];
+      const mockQB = createMockQueryBuilder(rows, rows.length);
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        mockQB,
+      );
+
+      const result = await service.getLlmInvestmentTransactions(userId, {
+        groupBy: "action",
+      });
+
+      expect(result.groupedBy).toBe("action");
+      expect(new Set(result.groups!.map((g) => g.key))).toEqual(
+        new Set(["BUY", "SELL", "DIVIDEND"]),
+      );
+    });
+
+    it("groups by account name", async () => {
+      const otherAccountTx = {
+        ...buy,
+        id: "tx-other",
+        accountId: "acc-2",
+        account: {
+          ...mockInvestmentAccount,
+          id: "acc-2",
+          name: "TFSA",
+        },
+      };
+      const rows = [buy, otherAccountTx];
+      const mockQB = createMockQueryBuilder(rows, rows.length);
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        mockQB,
+      );
+
+      const result = await service.getLlmInvestmentTransactions(userId, {
+        groupBy: "account",
+      });
+
+      expect(result.groupedBy).toBe("account");
+      expect(new Set(result.groups!.map((g) => g.key))).toEqual(
+        new Set(["Brokerage Account", "TFSA"]),
+      );
+    });
+
+    it("truncates the transactions list at 100 but preserves full aggregate totals", async () => {
+      const rows = Array.from({ length: 150 }, (_, i) => ({
+        ...buy,
+        id: `tx-${i}`,
+        totalAmount: 10,
+        commission: 1,
+        quantity: 1,
+      }));
+      const mockQB = createMockQueryBuilder(rows, rows.length);
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        mockQB,
+      );
+
+      const result = await service.getLlmInvestmentTransactions(userId, {});
+
+      expect(result.transactionCount).toBe(150);
+      expect(result.transactions).toHaveLength(100);
+      expect(result.truncatedTransactionList).toBe(true);
+      expect(result.totalAmount).toBeCloseTo(1500, 2);
+      expect(result.totalCommission).toBeCloseTo(150, 2);
+    });
+
+    it("handles empty result set cleanly", async () => {
+      const mockQB = createMockQueryBuilder([], 0);
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        mockQB,
+      );
+
+      const result = await service.getLlmInvestmentTransactions(userId, {
+        groupBy: "action",
+      });
+
+      expect(result.transactionCount).toBe(0);
+      expect(result.totalAmount).toBe(0);
+      expect(result.totalCommission).toBe(0);
+      expect(result.totalQuantity).toBe(0);
+      expect(result.actionCounts).toEqual({});
+      expect(result.groups).toEqual([]);
+      expect(result.transactions).toEqual([]);
+      expect(result.truncatedTransactionList).toBe(false);
+    });
+  });
+
   describe("removeAll", () => {
     it("deletes all transactions, holdings, and resets account balances", async () => {
       const transactions = [mockBuyTransaction, mockSellTransaction];

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -31,6 +31,42 @@ import { Account, AccountSubType } from "../accounts/entities/account.entity";
 import { isTransactionInFuture } from "../common/date-utils";
 import { ActionHistoryService } from "../action-history/action-history.service";
 
+export type LlmInvestmentTxGroupBy = "account" | "date" | "security" | "action";
+
+export interface LlmInvestmentTxRow {
+  transactionDate: string;
+  action: string;
+  accountName: string | null;
+  symbol: string | null;
+  securityName: string | null;
+  quantity: number | null;
+  price: number | null;
+  commission: number;
+  totalAmount: number;
+  currency: string | null;
+  description: string | null;
+}
+
+export interface LlmInvestmentTxGroup {
+  key: string;
+  transactionCount: number;
+  totalQuantity: number;
+  totalAmount: number;
+  totalCommission: number;
+}
+
+export interface LlmInvestmentTransactionsResult {
+  transactionCount: number;
+  totalAmount: number;
+  totalCommission: number;
+  totalQuantity: number;
+  actionCounts: Record<string, number>;
+  groupedBy: LlmInvestmentTxGroupBy | null;
+  groups: LlmInvestmentTxGroup[] | null;
+  transactions: LlmInvestmentTxRow[];
+  truncatedTransactionList: boolean;
+}
+
 @Injectable()
 export class InvestmentTransactionsService {
   private readonly logger = new Logger(InvestmentTransactionsService.name);
@@ -1149,6 +1185,185 @@ export class InvestmentTransactionsService {
       beforeData,
       description: `Deleted ${beforeData.action} transaction`,
     });
+  }
+
+  /**
+   * Compact investment-transaction query for LLM / AI consumers. Called by
+   * both the AI Assistant's tool executor and the MCP server's
+   * `query_investment_transactions` tool so the two surfaces return the same
+   * shape. Monetary values are rounded to 4 decimals, quantities to 8.
+   *
+   * Filters: account, security symbol, action, and date range.
+   * Grouping: by account, date, security (symbol), or action. When grouped,
+   * each bucket carries per-group totals; when not grouped, a capped list of
+   * the most recent matching transactions is returned alongside aggregate
+   * totals so the LLM can cite individual rows.
+   */
+  async getLlmInvestmentTransactions(
+    userId: string,
+    options: {
+      startDate?: string;
+      endDate?: string;
+      accountIds?: string[];
+      symbols?: string[];
+      actions?: InvestmentAction[];
+      groupBy?: LlmInvestmentTxGroupBy;
+    },
+  ): Promise<LlmInvestmentTransactionsResult> {
+    const query = this.investmentTransactionsRepository
+      .createQueryBuilder("it")
+      .leftJoinAndSelect("it.account", "account")
+      .leftJoinAndSelect("it.security", "security")
+      .where("it.userId = :userId", { userId });
+
+    if (options.accountIds && options.accountIds.length > 0) {
+      const resolvedIds = new Set<string>(options.accountIds);
+      const accounts = await this.accountsService.findByIds(
+        userId,
+        options.accountIds,
+      );
+      for (const acct of accounts) {
+        if (acct.linkedAccountId) resolvedIds.add(acct.linkedAccountId);
+      }
+      const allIds = [...resolvedIds];
+      query.andWhere("it.accountId IN (:...allIds)", { allIds });
+    }
+
+    if (options.startDate) {
+      query.andWhere("it.transactionDate >= :startDate", {
+        startDate: options.startDate,
+      });
+    }
+    if (options.endDate) {
+      query.andWhere("it.transactionDate <= :endDate", {
+        endDate: options.endDate,
+      });
+    }
+    if (options.symbols && options.symbols.length > 0) {
+      const upperSymbols = options.symbols.map((s) => s.toUpperCase());
+      query.andWhere("UPPER(security.symbol) IN (:...upperSymbols)", {
+        upperSymbols,
+      });
+    }
+    if (options.actions && options.actions.length > 0) {
+      query.andWhere("it.action IN (:...actions)", {
+        actions: options.actions,
+      });
+    }
+
+    query.orderBy("it.transactionDate", "DESC");
+
+    const rows = await query.getMany();
+
+    const round4 = (n: number): number => Math.round(n * 10000) / 10000;
+    const round8 = (n: number): number => Math.round(n * 1e8) / 1e8;
+
+    let totalAmountScaled = 0;
+    let totalCommissionScaled = 0;
+    let totalQuantityScaled = 0;
+    const actionCounts: Record<string, number> = {};
+
+    for (const r of rows) {
+      totalAmountScaled += Math.round(Number(r.totalAmount) * 10000);
+      totalCommissionScaled += Math.round(Number(r.commission || 0) * 10000);
+      if (r.quantity !== null && r.quantity !== undefined) {
+        totalQuantityScaled += Math.round(Number(r.quantity) * 1e8);
+      }
+      actionCounts[r.action] = (actionCounts[r.action] || 0) + 1;
+    }
+
+    const MAX_LISTED = 100;
+    const transactions: LlmInvestmentTxRow[] = rows
+      .slice(0, MAX_LISTED)
+      .map((r) => ({
+        transactionDate: r.transactionDate,
+        action: r.action,
+        accountName: r.account?.name ?? null,
+        symbol: r.security?.symbol ?? null,
+        securityName: r.security?.name ?? null,
+        quantity:
+          r.quantity !== null && r.quantity !== undefined
+            ? round8(Number(r.quantity))
+            : null,
+        price:
+          r.price !== null && r.price !== undefined
+            ? round4(Number(r.price))
+            : null,
+        commission: round4(Number(r.commission || 0)),
+        totalAmount: round4(Number(r.totalAmount)),
+        currency: r.account?.currencyCode ?? null,
+        description: r.description ?? null,
+      }));
+
+    let groups: LlmInvestmentTxGroup[] | null = null;
+    if (options.groupBy) {
+      const buckets = new Map<
+        string,
+        {
+          amountScaled: number;
+          commissionScaled: number;
+          quantityScaled: number;
+          count: number;
+        }
+      >();
+      for (const r of rows) {
+        const key = this.getLlmInvestmentGroupKey(r, options.groupBy);
+        const b = buckets.get(key) ?? {
+          amountScaled: 0,
+          commissionScaled: 0,
+          quantityScaled: 0,
+          count: 0,
+        };
+        b.amountScaled += Math.round(Number(r.totalAmount) * 10000);
+        b.commissionScaled += Math.round(Number(r.commission || 0) * 10000);
+        if (r.quantity !== null && r.quantity !== undefined) {
+          b.quantityScaled += Math.round(Number(r.quantity) * 1e8);
+        }
+        b.count += 1;
+        buckets.set(key, b);
+      }
+      groups = [...buckets.entries()]
+        .map(([key, b]) => ({
+          key,
+          transactionCount: b.count,
+          totalQuantity: round8(b.quantityScaled / 1e8),
+          totalAmount: round4(b.amountScaled / 10000),
+          totalCommission: round4(b.commissionScaled / 10000),
+        }))
+        .sort((a, b) =>
+          options.groupBy === "date"
+            ? b.key.localeCompare(a.key)
+            : b.totalAmount - a.totalAmount,
+        );
+    }
+
+    return {
+      transactionCount: rows.length,
+      totalAmount: round4(totalAmountScaled / 10000),
+      totalCommission: round4(totalCommissionScaled / 10000),
+      totalQuantity: round8(totalQuantityScaled / 1e8),
+      actionCounts,
+      groupedBy: options.groupBy ?? null,
+      groups,
+      transactions,
+      truncatedTransactionList: rows.length > MAX_LISTED,
+    };
+  }
+
+  private getLlmInvestmentGroupKey(
+    row: InvestmentTransaction,
+    groupBy: LlmInvestmentTxGroupBy,
+  ): string {
+    switch (groupBy) {
+      case "account":
+        return row.account?.name ?? row.accountId;
+      case "date":
+        return row.transactionDate;
+      case "security":
+        return row.security?.symbol ?? "(no security)";
+      case "action":
+        return row.action;
+    }
   }
 
   async getSummary(userId: string, accountIds?: string[]) {


### PR DESCRIPTION
## Summary
Adds a new `query_investment_transactions` tool that provides a compact, LLM-friendly interface for querying investment account transactions. This tool is exposed through both the AI Assistant's tool executor and the MCP server, enabling consistent transaction querying across surfaces.

## Key Changes

- **New service method**: `getLlmInvestmentTransactions()` in `InvestmentTransactionsService`
  - Supports filtering by date range, account IDs, security symbols, and transaction actions
  - Supports optional grouping by account, date, security symbol, or action type
  - Returns aggregate totals (count, amount, commission, quantity) and action breakdowns
  - Caps transaction list at 100 rows while preserving full aggregate totals
  - Implements precision rounding (4 decimals for monetary values, 8 for quantities)

- **New type exports** from `InvestmentTransactionsService`:
  - `LlmInvestmentTxGroupBy`: grouping dimension type
  - `LlmInvestmentTxRow`: individual transaction row shape
  - `LlmInvestmentTxGroup`: grouped result with per-group totals
  - `LlmInvestmentTransactionsResult`: complete result shape

- **Tool executor integration**: `ToolExecutorService.queryInvestmentTransactions()`
  - Resolves account names to IDs
  - Formats date ranges and filter descriptions for LLM context
  - Delegates to the shared service method

- **MCP server tool**: `McpInvestmentsTools.query_investment_transactions`
  - Registers the tool with the MCP server
  - Enforces read scope requirement
  - Returns results in the same shape as the AI Assistant tool

- **Input validation**: `queryInvestmentTransactionsSchema` in `tool-input-schemas.ts`
  - Validates all optional filters (dates, symbols, actions, groupBy)
  - Preprocesses action inputs to uppercase
  - Enforces symbol length and array size limits

- **Tool definition**: Added to `FINANCIAL_TOOLS` array with comprehensive documentation

## Notable Implementation Details

- **Linked account resolution**: When filtering by account IDs, the method automatically includes linked cash accounts to capture related transactions
- **Grouping logic**: Date grouping sorts descending by date; other groupings sort by total amount descending
- **Precision handling**: Uses scaled integer arithmetic internally to avoid floating-point precision issues, then rounds results appropriately
- **Empty result handling**: Gracefully handles zero-transaction results with empty arrays and zero totals
- **Comprehensive test coverage**: 258 lines of test specs covering all filtering, grouping, truncation, and edge cases

https://claude.ai/code/session_01FHSmbs69nes8ENerjykvKh