### PR TITLE
Fix dividend yield calculation to aggregate holdings across accounts

### DIFF
--- a/frontend/src/components/reports/DividendYieldGrowthReport.test.tsx
+++ b/frontend/src/components/reports/DividendYieldGrowthReport.test.tsx
@@ -216,4 +216,125 @@ describe('DividendYieldGrowthReport', () => {
       expect(screen.getByText('Dividend Frequency Analysis')).toBeInTheDocument();
     });
   });
+
+  it('aggregates market value across accounts holding the same security', async () => {
+    // Only return transactions for DIVIDEND action so numbers are deterministic
+    mockGetTransactions.mockImplementation(async ({ action }: { action: string }) => {
+      if (action === 'DIVIDEND') {
+        return {
+          data: [
+            {
+              id: 'tx-1',
+              transactionDate: '2025-09-15',
+              action: 'DIVIDEND',
+              totalAmount: 100,
+              accountId: 'acc-1',
+              securityId: 's-1',
+              security: { symbol: 'VFV', name: 'Vanguard S&P 500' },
+            },
+          ],
+          pagination: { hasMore: false },
+        };
+      }
+      return { data: [], pagination: { hasMore: false } };
+    });
+    mockGetInvestmentAccounts.mockResolvedValue([]);
+    mockGetPortfolioSummary.mockResolvedValue({
+      holdings: [
+        { ...mockHoldings[0], id: 'h-1', accountId: 'acc-1', marketValue: 5000 },
+        { ...mockHoldings[0], id: 'h-2', accountId: 'acc-2', marketValue: 5000 },
+      ],
+    });
+    render(<DividendYieldGrowthReport />);
+    await waitFor(() => {
+      expect(screen.getByText('Per-Security Dividend Yield (Trailing 12 Months)')).toBeInTheDocument();
+    });
+    // Market value appears in both the Portfolio Value summary card and the table row
+    expect(screen.getAllByText('$10000.00').length).toBeGreaterThanOrEqual(2);
+    // Yield = 100 / 10000 * 100 = 1.00%. Without aggregation it would be 2.00%.
+    expect(screen.getAllByText('1.00%').length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('2.00%')).not.toBeInTheDocument();
+  });
+
+  it('excludes dividends for securities with no matching holding', async () => {
+    mockGetTransactions.mockImplementation(async ({ action }: { action: string }) => {
+      if (action === 'DIVIDEND') {
+        return {
+          data: [
+            {
+              id: 'tx-ghost',
+              transactionDate: '2025-09-15',
+              action: 'DIVIDEND',
+              totalAmount: 50,
+              accountId: 'acc-1',
+              securityId: 's-ghost',
+              security: null,
+            },
+            {
+              id: 'tx-2',
+              transactionDate: '2025-09-20',
+              action: 'DIVIDEND',
+              totalAmount: 100,
+              accountId: 'acc-1',
+              securityId: 's-1',
+              security: { symbol: 'VFV', name: 'Vanguard S&P 500' },
+            },
+          ],
+          pagination: { hasMore: false },
+        };
+      }
+      return { data: [], pagination: { hasMore: false } };
+    });
+    mockGetInvestmentAccounts.mockResolvedValue([]);
+    mockGetPortfolioSummary.mockResolvedValue({ holdings: mockHoldings });
+    render(<DividendYieldGrowthReport />);
+    await waitFor(() => {
+      expect(screen.getByText('Per-Security Dividend Yield (Trailing 12 Months)')).toBeInTheDocument();
+    });
+    expect(screen.getByText('VFV')).toBeInTheDocument();
+    // The unknown-security fallback name would only appear if an unknown row rendered
+    expect(screen.queryByText('Unknown Security')).not.toBeInTheDocument();
+    // Only the header row and a single VFV data row should be present
+    expect(screen.getAllByRole('row')).toHaveLength(2);
+  });
+
+  it('excludes dividend transactions with no securityId', async () => {
+    mockGetTransactions.mockImplementation(async ({ action }: { action: string }) => {
+      if (action === 'DIVIDEND') {
+        return {
+          data: [
+            {
+              id: 'tx-no-sec',
+              transactionDate: '2025-09-15',
+              action: 'DIVIDEND',
+              totalAmount: 25,
+              accountId: 'acc-1',
+              securityId: null,
+              security: null,
+            },
+            {
+              id: 'tx-2',
+              transactionDate: '2025-09-20',
+              action: 'DIVIDEND',
+              totalAmount: 100,
+              accountId: 'acc-1',
+              securityId: 's-1',
+              security: { symbol: 'VFV', name: 'Vanguard S&P 500' },
+            },
+          ],
+          pagination: { hasMore: false },
+        };
+      }
+      return { data: [], pagination: { hasMore: false } };
+    });
+    mockGetInvestmentAccounts.mockResolvedValue([]);
+    mockGetPortfolioSummary.mockResolvedValue({ holdings: mockHoldings });
+    render(<DividendYieldGrowthReport />);
+    await waitFor(() => {
+      expect(screen.getByText('Per-Security Dividend Yield (Trailing 12 Months)')).toBeInTheDocument();
+    });
+    expect(screen.getByText('VFV')).toBeInTheDocument();
+    expect(screen.queryByText('Unknown Security')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('row')).toHaveLength(2);
+  });
 });

--- a/frontend/src/components/reports/DividendYieldGrowthReport.tsx
+++ b/frontend/src/components/reports/DividendYieldGrowthReport.tsx
@@ -162,35 +162,41 @@ export function DividendYieldGrowthReport() {
     const cutoff = subYears(new Date(), 1);
     const recentTx = transactions.filter((tx) => parseLocalDate(tx.transactionDate) >= cutoff);
 
-    // Aggregate dividends by security
+    // Aggregate dividends by security (skip transactions without a security)
     const dividendMap = new Map<string, { total: number; dates: Date[] }>();
     recentTx.forEach((tx) => {
-      const key = tx.securityId || 'unknown';
-      let existing = dividendMap.get(key);
+      if (!tx.securityId) return;
+      let existing = dividendMap.get(tx.securityId);
       if (!existing) {
         existing = { total: 0, dates: [] };
-        dividendMap.set(key, existing);
+        dividendMap.set(tx.securityId, existing);
       }
       existing.total += getTxAmount(tx);
       existing.dates.push(parseLocalDate(tx.transactionDate));
     });
 
-    // Map holdings to yields
-    const holdingMap = new Map<string, HoldingWithMarketValue>();
-    holdings.forEach((h) => holdingMap.set(h.securityId, h));
+    // Aggregate market value across all accounts holding each security
+    const holdingMap = new Map<string, { symbol: string; name: string; marketValue: number }>();
+    holdings.forEach((h) => {
+      const mv = convertToDefault(h.marketValue ?? 0, h.currencyCode);
+      const existing = holdingMap.get(h.securityId);
+      if (existing) {
+        existing.marketValue += mv;
+      } else {
+        holdingMap.set(h.securityId, { symbol: h.symbol, name: h.name, marketValue: mv });
+      }
+    });
 
     const results: SecurityYield[] = [];
     dividendMap.forEach((data, secId) => {
       const holding = holdingMap.get(secId);
-      const symbol = holding?.symbol || 'Unknown';
-      const name = holding?.name || 'Unknown Security';
-      const mv = holding ? convertToDefault(holding.marketValue ?? 0, holding.currencyCode) : 0;
+      if (!holding) return;
       results.push({
-        symbol,
-        name,
+        symbol: holding.symbol,
+        name: holding.name,
         trailing12mDividends: data.total,
-        marketValue: mv,
-        yield: mv > 0 ? (data.total / mv) * 100 : 0,
+        marketValue: holding.marketValue,
+        yield: holding.marketValue > 0 ? (data.total / holding.marketValue) * 100 : 0,
         frequency: detectFrequency(data.dates),
       });
     });


### PR DESCRIPTION
## Summary
Fixed the dividend yield calculation in the DividendYieldGrowthReport to properly aggregate market values across multiple accounts holding the same security, and to exclude dividends for securities without matching holdings.

## Key Changes
- **Aggregate market value across accounts**: When multiple accounts hold the same security, their market values are now summed together before calculating yield, ensuring accurate yield percentages
- **Skip transactions without securityId**: Dividend transactions missing a `securityId` are now filtered out during aggregation to prevent data integrity issues
- **Exclude orphaned dividends**: Dividends for securities with no matching holding in the portfolio are excluded from results, preventing "Unknown Security" entries
- **Refactored holding aggregation**: Changed `holdingMap` to aggregate market values by security ID rather than storing individual holdings, simplifying the logic and improving correctness

## Implementation Details
- The holding aggregation now converts all market values to the default currency and sums them by security ID
- Early returns are used to skip invalid transactions (missing `securityId`) and dividends without matching holdings
- This prevents incorrect yield calculations that would occur if market values weren't properly aggregated (e.g., 2.00% instead of 1.00% when the same security is held in two accounts)

## Tests Added
Three new test cases verify:
1. Market values are correctly aggregated across accounts holding the same security
2. Dividends for securities with no matching holding are excluded
3. Dividend transactions with no `securityId` are excluded

https://claude.ai/code/session_01PYU22ZFHCaYzy5GYzsjPzQ