### PR TITLE
AI tool defaults + category parsing + account filters + chart fix

### DIFF
--- a/backend/src/accounts/accounts.service.ts
+++ b/backend/src/accounts/accounts.service.ts
@@ -820,28 +820,42 @@ export class AccountsService {
   async getLlmBalances(
     userId: string,
     accountNames?: string[],
+    status: "open" | "closed" | "all" = "open",
+    accountTypes?: AccountType[],
   ): Promise<{
     accounts: Array<{
       name: string;
       type: AccountType;
       balance: number;
       currency: string;
+      isClosed: boolean;
     }>;
     totalAssets: number;
     totalLiabilities: number;
     netWorth: number;
     totalAccounts: number;
   }> {
-    const allAccounts = await this.findAll(userId, false);
+    // findAll(userId, true) returns every account; we then narrow by status
+    // so "open" / "closed" / "all" all go through a single query path.
+    const allAccounts = await this.findAll(userId, true);
     const marketValues =
       await this.portfolioService.getAccountMarketValues(userId);
 
     let accounts = allAccounts;
+    if (status === "open") {
+      accounts = accounts.filter((a) => !a.isClosed);
+    } else if (status === "closed") {
+      accounts = accounts.filter((a) => a.isClosed);
+    }
+
+    if (accountTypes && accountTypes.length > 0) {
+      const typeSet = new Set(accountTypes);
+      accounts = accounts.filter((a) => typeSet.has(a.accountType));
+    }
+
     if (accountNames && accountNames.length > 0) {
       const lowerNames = new Set(accountNames.map((n) => n.toLowerCase()));
-      accounts = allAccounts.filter((a) =>
-        lowerNames.has(a.name.toLowerCase()),
-      );
+      accounts = accounts.filter((a) => lowerNames.has(a.name.toLowerCase()));
     }
 
     const roundMoney = (v: number): number => Math.round(v * 100) / 100;
@@ -856,6 +870,7 @@ export class AccountsService {
         type: a.accountType,
         balance: roundMoney(balance),
         currency: a.currencyCode,
+        isClosed: a.isClosed,
       };
     });
 

--- a/backend/src/ai/query/tool-definitions.spec.ts
+++ b/backend/src/ai/query/tool-definitions.spec.ts
@@ -77,6 +77,40 @@ describe("FINANCIAL_TOOLS", () => {
       )!;
       expect(tool.inputSchema.required).toBeUndefined();
     });
+
+    it("supports status filter with open/closed/all", () => {
+      const tool = FINANCIAL_TOOLS.find(
+        (t) => t.name === "get_account_balances",
+      )!;
+      const props = tool.inputSchema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.status.enum).toEqual(["open", "closed", "all"]);
+    });
+
+    it("exposes every AccountType in the accountTypes enum", () => {
+      const tool = FINANCIAL_TOOLS.find(
+        (t) => t.name === "get_account_balances",
+      )!;
+      const props = tool.inputSchema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      const items = props.accountTypes.items as Record<string, unknown>;
+      expect(items.enum).toEqual([
+        "CHEQUING",
+        "SAVINGS",
+        "CREDIT_CARD",
+        "LOAN",
+        "MORTGAGE",
+        "INVESTMENT",
+        "CASH",
+        "LINE_OF_CREDIT",
+        "ASSET",
+        "OTHER",
+      ]);
+    });
   });
 
   describe("get_spending_by_category", () => {

--- a/backend/src/ai/query/tool-definitions.spec.ts
+++ b/backend/src/ai/query/tool-definitions.spec.ts
@@ -1,8 +1,8 @@
 import { FINANCIAL_TOOLS } from "./tool-definitions";
 
 describe("FINANCIAL_TOOLS", () => {
-  it("defines exactly 12 tools", () => {
-    expect(FINANCIAL_TOOLS).toHaveLength(12);
+  it("defines exactly 13 tools", () => {
+    expect(FINANCIAL_TOOLS).toHaveLength(13);
   });
 
   it("has unique tool names", () => {
@@ -13,6 +13,7 @@ describe("FINANCIAL_TOOLS", () => {
   const expectedTools = [
     "query_transactions",
     "get_account_balances",
+    "get_categories",
     "get_spending_by_category",
     "get_income_summary",
     "get_net_worth_history",
@@ -110,6 +111,32 @@ describe("FINANCIAL_TOOLS", () => {
         "ASSET",
         "OTHER",
       ]);
+    });
+  });
+
+  describe("get_categories", () => {
+    it("has no required fields (type defaults to all)", () => {
+      const tool = FINANCIAL_TOOLS.find((t) => t.name === "get_categories")!;
+      expect(tool.inputSchema.required).toBeUndefined();
+    });
+
+    it("supports type filter with expense/income/all", () => {
+      const tool = FINANCIAL_TOOLS.find((t) => t.name === "get_categories")!;
+      const props = tool.inputSchema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.type.enum).toEqual(["expense", "income", "all"]);
+    });
+
+    it("exposes an optional search parameter", () => {
+      const tool = FINANCIAL_TOOLS.find((t) => t.name === "get_categories")!;
+      const props = tool.inputSchema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.search).toBeDefined();
+      expect(props.search.type).toBe("string");
     });
   });
 

--- a/backend/src/ai/query/tool-definitions.spec.ts
+++ b/backend/src/ai/query/tool-definitions.spec.ts
@@ -34,11 +34,11 @@ describe("FINANCIAL_TOOLS", () => {
   });
 
   describe("query_transactions", () => {
-    it("requires startDate and endDate", () => {
+    it("has no required fields (dates default to last 30 days)", () => {
       const tool = FINANCIAL_TOOLS.find(
         (t) => t.name === "query_transactions",
       )!;
-      expect(tool.inputSchema.required).toEqual(["startDate", "endDate"]);
+      expect(tool.inputSchema.required).toBeUndefined();
     });
 
     it("supports groupBy with valid enum values", () => {
@@ -80,11 +80,11 @@ describe("FINANCIAL_TOOLS", () => {
   });
 
   describe("get_spending_by_category", () => {
-    it("requires startDate and endDate", () => {
+    it("has no required fields (dates default to last 30 days, topN to 10)", () => {
       const tool = FINANCIAL_TOOLS.find(
         (t) => t.name === "get_spending_by_category",
       )!;
-      expect(tool.inputSchema.required).toEqual(["startDate", "endDate"]);
+      expect(tool.inputSchema.required).toBeUndefined();
     });
 
     it("supports topN parameter", () => {
@@ -122,14 +122,9 @@ describe("FINANCIAL_TOOLS", () => {
   });
 
   describe("compare_periods", () => {
-    it("requires all four period boundary dates", () => {
+    it("has no required fields (defaults to previous month vs current month-to-date)", () => {
       const tool = FINANCIAL_TOOLS.find((t) => t.name === "compare_periods")!;
-      expect(tool.inputSchema.required).toEqual([
-        "period1Start",
-        "period1End",
-        "period2Start",
-        "period2End",
-      ]);
+      expect(tool.inputSchema.required).toBeUndefined();
     });
 
     it("supports groupBy with category and payee", () => {
@@ -225,9 +220,9 @@ describe("FINANCIAL_TOOLS", () => {
   });
 
   describe("get_transfers", () => {
-    it("requires startDate and endDate", () => {
+    it("has no required fields (dates default to last 30 days)", () => {
       const tool = FINANCIAL_TOOLS.find((t) => t.name === "get_transfers")!;
-      expect(tool.inputSchema.required).toEqual(["startDate", "endDate"]);
+      expect(tool.inputSchema.required).toBeUndefined();
     });
 
     it("supports optional accountNames filter", () => {

--- a/backend/src/ai/query/tool-definitions.ts
+++ b/backend/src/ai/query/tool-definitions.ts
@@ -10,11 +10,13 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
       properties: {
         startDate: {
           type: "string",
-          description: "Start date in YYYY-MM-DD format",
+          description:
+            "Start date in YYYY-MM-DD format. Omit to default to 30 days ago.",
         },
         endDate: {
           type: "string",
-          description: "End date in YYYY-MM-DD format",
+          description:
+            "End date in YYYY-MM-DD format. Omit to default to today.",
         },
         categoryNames: {
           type: "array",
@@ -44,7 +46,6 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
             "Filter by direction. Must be EXACTLY one of: 'expenses' (outflows/spending), 'income' (inflows/earnings), or 'both' (default). Do not use 'expense', 'all', 'debit', or any variation.",
         },
       },
-      required: ["startDate", "endDate"],
     },
   },
   {
@@ -71,21 +72,21 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
       properties: {
         startDate: {
           type: "string",
-          description: "Start date (YYYY-MM-DD)",
+          description:
+            "Start date (YYYY-MM-DD). Omit to default to 30 days ago.",
         },
         endDate: {
           type: "string",
-          description: "End date (YYYY-MM-DD)",
+          description: "End date (YYYY-MM-DD). Omit to default to today.",
         },
         topN: {
           type: "integer",
           minimum: 1,
           maximum: 50,
           description:
-            'Optional integer between 1 and 50 to limit to the top N categories by amount. MUST be a number like 10 (not a string like "10" or "all"). Omit this field entirely to get all categories.',
+            'Integer between 1 and 50 to limit to the top N categories by amount. MUST be a number like 10 (not a string like "10" or "all"). Omit to default to 10.',
         },
       },
-      required: ["startDate", "endDate"],
     },
   },
   {
@@ -97,11 +98,12 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
       properties: {
         startDate: {
           type: "string",
-          description: "Start date (YYYY-MM-DD)",
+          description:
+            "Start date (YYYY-MM-DD). Omit to default to 30 days ago.",
         },
         endDate: {
           type: "string",
-          description: "End date (YYYY-MM-DD)",
+          description: "End date (YYYY-MM-DD). Omit to default to today.",
         },
         groupBy: {
           type: "string",
@@ -109,7 +111,6 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
           description: "How to group income (default: category)",
         },
       },
-      required: ["startDate", "endDate"],
     },
   },
   {
@@ -133,25 +134,29 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
   {
     name: "compare_periods",
     description:
-      "Compare spending or income between two time periods. Returns a side-by-side comparison showing absolute and percentage changes. Use for questions like 'compare this month vs last month'.",
+      "Compare spending or income between two time periods. Returns a side-by-side comparison showing absolute and percentage changes. Use for questions like 'compare this month vs last month'. If any of the four date fields are omitted, defaults to the previous full month (period1) vs the current month-to-date (period2).",
     inputSchema: {
       type: "object",
       properties: {
         period1Start: {
           type: "string",
-          description: "First period start date (YYYY-MM-DD)",
+          description:
+            "First period start date (YYYY-MM-DD). Omit to default to the start of last month.",
         },
         period1End: {
           type: "string",
-          description: "First period end date (YYYY-MM-DD)",
+          description:
+            "First period end date (YYYY-MM-DD). Omit to default to the last day of last month.",
         },
         period2Start: {
           type: "string",
-          description: "Second period start date (YYYY-MM-DD)",
+          description:
+            "Second period start date (YYYY-MM-DD). Omit to default to the start of the current month.",
         },
         period2End: {
           type: "string",
-          description: "Second period end date (YYYY-MM-DD)",
+          description:
+            "Second period end date (YYYY-MM-DD). Omit to default to today.",
         },
         groupBy: {
           type: "string",
@@ -165,7 +170,6 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
             "Filter by direction. Must be EXACTLY one of: 'expenses' (default), 'income', or 'both'. Do not use 'expense', 'all', or any variation.",
         },
       },
-      required: ["period1Start", "period1End", "period2Start", "period2End"],
     },
   },
   {
@@ -250,11 +254,12 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
       properties: {
         startDate: {
           type: "string",
-          description: "Start date (YYYY-MM-DD)",
+          description:
+            "Start date (YYYY-MM-DD). Omit to default to 30 days ago.",
         },
         endDate: {
           type: "string",
-          description: "End date (YYYY-MM-DD)",
+          description: "End date (YYYY-MM-DD). Omit to default to today.",
         },
         accountNames: {
           type: "array",
@@ -263,7 +268,6 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
             "Optional: filter to specific account names. Use exact names from the user's account list.",
         },
       },
-      required: ["startDate", "endDate"],
     },
   },
   {

--- a/backend/src/ai/query/tool-definitions.ts
+++ b/backend/src/ai/query/tool-definitions.ts
@@ -90,6 +90,27 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
     },
   },
   {
+    name: "get_categories",
+    description:
+      "List the user's categories with their hierarchy (parent names) and transaction counts. Use this for questions like 'what categories do I have', 'list my income categories', or 'do I have a category for groceries'. Returns a flat list with each category's parent name so hierarchy is visible without nested JSON. Do not use this to query spending amounts -- use get_spending_by_category for that.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        type: {
+          type: "string",
+          enum: ["expense", "income", "all"],
+          description:
+            "Filter by category type. 'expense' returns only expense categories, 'income' returns only income categories, 'all' returns both. Defaults to 'all'.",
+        },
+        search: {
+          type: "string",
+          description:
+            "Optional case-insensitive substring match on category name. If a matching category is a subcategory, its parent is included so the hierarchy stays visible.",
+        },
+      },
+    },
+  },
+  {
     name: "get_spending_by_category",
     description:
       "Get a breakdown of spending (expenses) by category for a given date range. Returns each category with its total amount, percentage of total spending, and transaction count. Sorted by amount descending.",

--- a/backend/src/ai/query/tool-definitions.ts
+++ b/backend/src/ai/query/tool-definitions.ts
@@ -22,7 +22,7 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
           type: "array",
           items: { type: "string" },
           description:
-            'Filter by category names (e.g., ["Groceries", "Dining Out"]). Use exact names from the user\'s category list.',
+            'Filter by category names (e.g., ["Groceries", "Dining Out"]). Use exact names from the user\'s category list. To target a subcategory unambiguously, use "Parent: Child" notation (e.g., "Food: Dining Out"). If any name cannot be resolved the tool returns an error -- call get_categories first if unsure.',
         },
         accountNames: {
           type: "array",

--- a/backend/src/ai/query/tool-definitions.ts
+++ b/backend/src/ai/query/tool-definitions.ts
@@ -60,6 +60,32 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
           items: { type: "string" },
           description: "Optional: filter to specific account names",
         },
+        status: {
+          type: "string",
+          enum: ["open", "closed", "all"],
+          description:
+            "Which accounts to include by status. 'open' returns only active accounts, 'closed' returns only closed accounts, 'all' returns both. Defaults to 'open'.",
+        },
+        accountTypes: {
+          type: "array",
+          items: {
+            type: "string",
+            enum: [
+              "CHEQUING",
+              "SAVINGS",
+              "CREDIT_CARD",
+              "LOAN",
+              "MORTGAGE",
+              "INVESTMENT",
+              "CASH",
+              "LINE_OF_CREDIT",
+              "ASSET",
+              "OTHER",
+            ],
+          },
+          description:
+            "Optional: filter to specific account types. Values must be UPPER_SNAKE_CASE exactly as listed. Omit to include all account types.",
+        },
       },
     },
   },

--- a/backend/src/ai/query/tool-definitions.ts
+++ b/backend/src/ai/query/tool-definitions.ts
@@ -240,7 +240,7 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
           type: "string",
           enum: ["account", "date", "security", "action"],
           description:
-            "Optional: group the results by account name, transaction date, security symbol, or action type.",
+            "Group the results by account name, transaction date, security symbol, or action type. Defaults to 'security' when omitted.",
         },
       },
     },

--- a/backend/src/ai/query/tool-executor.service.spec.ts
+++ b/backend/src/ai/query/tool-executor.service.spec.ts
@@ -207,9 +207,39 @@ describe("ToolExecutorService", () => {
     it("get_account_balances delegates to accounts.getLlmBalances", async () => {
       const result = await service.execute(userId, "get_account_balances", {});
 
-      expect(accounts.getLlmBalances).toHaveBeenCalledWith(userId, undefined);
+      expect(accounts.getLlmBalances).toHaveBeenCalledWith(
+        userId,
+        undefined,
+        "open",
+        undefined,
+      );
       expect(result.sources[0].type).toBe("accounts");
       expect(result.summary).toContain("Net worth");
+    });
+
+    it("get_account_balances passes status and accountTypes through", async () => {
+      await service.execute(userId, "get_account_balances", {
+        status: "closed",
+        accountTypes: ["CHEQUING", "SAVINGS"],
+      });
+
+      expect(accounts.getLlmBalances).toHaveBeenCalledWith(
+        userId,
+        undefined,
+        "closed",
+        ["CHEQUING", "SAVINGS"],
+      );
+    });
+
+    it("get_account_balances supports 'all' status", async () => {
+      await service.execute(userId, "get_account_balances", { status: "all" });
+
+      expect(accounts.getLlmBalances).toHaveBeenCalledWith(
+        userId,
+        undefined,
+        "all",
+        undefined,
+      );
     });
 
     it("get_spending_by_category delegates to analytics.getLlmSpendingByCategory", async () => {

--- a/backend/src/ai/query/tool-executor.service.spec.ts
+++ b/backend/src/ai/query/tool-executor.service.spec.ts
@@ -57,7 +57,9 @@ describe("ToolExecutorService", () => {
         totalOutbound: 0,
         transferCount: 0,
       }),
-      resolveLlmCategoryIds: jest.fn().mockResolvedValue(["cat-1"]),
+      resolveLlmCategoryIds: jest
+        .fn()
+        .mockResolvedValue({ categoryIds: ["cat-1"], unresolved: [] }),
     };
 
     categories = {
@@ -220,6 +222,23 @@ describe("ToolExecutorService", () => {
         userId,
         expect.objectContaining({ categoryIds: ["cat-1"] }),
       );
+    });
+
+    it("query_transactions returns an error when a category name cannot be resolved", async () => {
+      analytics.resolveLlmCategoryIds.mockResolvedValueOnce({
+        categoryIds: [],
+        unresolved: ["Bogus"],
+      });
+
+      const result = await service.execute(userId, "query_transactions", {
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+        categoryNames: ["Bogus"],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.summary).toContain("Bogus");
+      expect(analytics.getLlmQueryTransactions).not.toHaveBeenCalled();
     });
 
     it("get_account_balances delegates to accounts.getLlmBalances", async () => {

--- a/backend/src/ai/query/tool-executor.service.spec.ts
+++ b/backend/src/ai/query/tool-executor.service.spec.ts
@@ -228,6 +228,17 @@ describe("ToolExecutorService", () => {
       expect(result.sources[0].type).toBe("spending");
     });
 
+    it("get_spending_by_category defaults topN to 10 and fills in dates when omitted", async () => {
+      await service.execute(userId, "get_spending_by_category", {});
+
+      expect(analytics.getLlmSpendingByCategory).toHaveBeenCalledWith(
+        userId,
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        10,
+      );
+    });
+
     it("get_income_summary delegates to analytics.getLlmIncomeSummary", async () => {
       const result = await service.execute(userId, "get_income_summary", {
         startDate: "2026-01-01",
@@ -286,6 +297,22 @@ describe("ToolExecutorService", () => {
         direction: "expenses",
       });
       expect(result.sources[0].type).toBe("comparison");
+    });
+
+    it("compare_periods fills in all four dates when omitted", async () => {
+      await service.execute(userId, "compare_periods", {});
+
+      expect(analytics.getLlmPeriodComparison).toHaveBeenCalledWith(
+        userId,
+        expect.objectContaining({
+          period1Start: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+          period1End: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+          period2Start: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+          period2End: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+          groupBy: "category",
+          direction: "expenses",
+        }),
+      );
     });
 
     it("get_portfolio_summary delegates to portfolioService.getLlmSummary", async () => {
@@ -384,6 +411,28 @@ describe("ToolExecutorService", () => {
       expect(result.sources[0].type).toBe("transfers");
     });
 
+    it("get_transfers applies default date range when omitted", async () => {
+      await service.execute(userId, "get_transfers", {});
+
+      expect(analytics.getTransfersByAccount).toHaveBeenCalledWith(
+        userId,
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        undefined,
+      );
+    });
+
+    it("get_income_summary applies default date range when omitted", async () => {
+      await service.execute(userId, "get_income_summary", {});
+
+      expect(analytics.getLlmIncomeSummary).toHaveBeenCalledWith(
+        userId,
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        "category",
+      );
+    });
+
     it("get_budget_status delegates to budgetReports.getLlmBudgetStatus", async () => {
       const result = await service.execute(userId, "get_budget_status", {});
 
@@ -442,11 +491,17 @@ describe("ToolExecutorService", () => {
       expect(analytics.getLlmQueryTransactions).not.toHaveBeenCalled();
     });
 
-    it("rejects missing required fields", async () => {
+    it("applies default date range when startDate and endDate are omitted", async () => {
       const result = await service.execute(userId, "query_transactions", {});
 
-      expect(result.isError).toBe(true);
-      expect(result.summary).toContain("Invalid input");
+      expect(result.isError).toBeUndefined();
+      expect(analytics.getLlmQueryTransactions).toHaveBeenCalledWith(
+        userId,
+        expect.objectContaining({
+          startDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+          endDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        }),
+      );
     });
 
     it("allows valid input and delegates to the analytics service", async () => {

--- a/backend/src/ai/query/tool-executor.service.spec.ts
+++ b/backend/src/ai/query/tool-executor.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { ToolExecutorService } from "./tool-executor.service";
 import { AccountsService } from "../../accounts/accounts.service";
+import { CategoriesService } from "../../categories/categories.service";
 import { TransactionAnalyticsService } from "../../transactions/transaction-analytics.service";
 import { NetWorthService } from "../../net-worth/net-worth.service";
 import { BudgetReportsService } from "../../budgets/budget-reports.service";
@@ -15,6 +16,7 @@ describe("ToolExecutorService", () => {
   let budgetReports: Record<string, jest.Mock>;
   let portfolio: Record<string, jest.Mock>;
   let investmentTransactions: Record<string, jest.Mock>;
+  let categories: Record<string, jest.Mock>;
 
   const userId = "user-1";
 
@@ -56,6 +58,21 @@ describe("ToolExecutorService", () => {
         transferCount: 0,
       }),
       resolveLlmCategoryIds: jest.fn().mockResolvedValue(["cat-1"]),
+    };
+
+    categories = {
+      getLlmCategories: jest.fn().mockResolvedValue({
+        categories: [
+          {
+            id: "cat-1",
+            name: "Groceries",
+            parentName: "Food",
+            isIncome: false,
+            transactionCount: 12,
+          },
+        ],
+        totalCount: 1,
+      }),
     };
 
     accounts = {
@@ -140,6 +157,7 @@ describe("ToolExecutorService", () => {
       providers: [
         ToolExecutorService,
         { provide: AccountsService, useValue: accounts },
+        { provide: CategoriesService, useValue: categories },
         { provide: TransactionAnalyticsService, useValue: analytics },
         { provide: NetWorthService, useValue: netWorth },
         { provide: BudgetReportsService, useValue: budgetReports },
@@ -240,6 +258,29 @@ describe("ToolExecutorService", () => {
         "all",
         undefined,
       );
+    });
+
+    it("get_categories delegates to categoriesService.getLlmCategories", async () => {
+      const result = await service.execute(userId, "get_categories", {});
+
+      expect(categories.getLlmCategories).toHaveBeenCalledWith(userId, {
+        type: undefined,
+        search: undefined,
+      });
+      expect(result.sources[0].type).toBe("categories");
+      expect(result.summary).toContain("categor");
+    });
+
+    it("get_categories passes type and search through", async () => {
+      await service.execute(userId, "get_categories", {
+        type: "expense",
+        search: "groc",
+      });
+
+      expect(categories.getLlmCategories).toHaveBeenCalledWith(userId, {
+        type: "expense",
+        search: "groc",
+      });
     });
 
     it("get_spending_by_category delegates to analytics.getLlmSpendingByCategory", async () => {

--- a/backend/src/ai/query/tool-executor.service.spec.ts
+++ b/backend/src/ai/query/tool-executor.service.spec.ts
@@ -396,6 +396,17 @@ describe("ToolExecutorService", () => {
       expect(result.sources[0].dateRange).toBe("all dates");
     });
 
+    it("query_investment_transactions defaults groupBy to 'security' when omitted", async () => {
+      await service.execute(userId, "query_investment_transactions", {});
+
+      expect(
+        investmentTransactions.getLlmInvestmentTransactions,
+      ).toHaveBeenCalledWith(
+        userId,
+        expect.objectContaining({ groupBy: "security" }),
+      );
+    });
+
     it("get_transfers delegates to analytics.getTransfersByAccount", async () => {
       const result = await service.execute(userId, "get_transfers", {
         startDate: "2026-01-01",

--- a/backend/src/ai/query/tool-executor.service.ts
+++ b/backend/src/ai/query/tool-executor.service.ts
@@ -399,7 +399,8 @@ export class ToolExecutorService {
     const accountNames = input.accountNames as string[] | undefined;
     const symbols = input.symbols as string[] | undefined;
     const actions = input.actions as InvestmentAction[] | undefined;
-    const groupBy = input.groupBy as LlmInvestmentTxGroupBy | undefined;
+    const groupBy =
+      (input.groupBy as LlmInvestmentTxGroupBy | undefined) ?? "security";
 
     const accountIds = await this.resolveAccountIds(userId, accountNames);
 

--- a/backend/src/ai/query/tool-executor.service.ts
+++ b/backend/src/ai/query/tool-executor.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Inject, forwardRef, Logger } from "@nestjs/common";
 import { AccountsService } from "../../accounts/accounts.service";
 import { AccountType } from "../../accounts/entities/account.entity";
+import { CategoriesService } from "../../categories/categories.service";
 import { TransactionAnalyticsService } from "../../transactions/transaction-analytics.service";
 import { NetWorthService } from "../../net-worth/net-worth.service";
 import { BudgetReportsService } from "../../budgets/budget-reports.service";
@@ -33,6 +34,8 @@ export class ToolExecutorService {
   constructor(
     @Inject(forwardRef(() => AccountsService))
     private readonly accountsService: AccountsService,
+    @Inject(forwardRef(() => CategoriesService))
+    private readonly categoriesService: CategoriesService,
     @Inject(forwardRef(() => TransactionAnalyticsService))
     private readonly analyticsService: TransactionAnalyticsService,
     @Inject(forwardRef(() => NetWorthService))
@@ -76,6 +79,9 @@ export class ToolExecutorService {
           break;
         case "get_account_balances":
           result = await this.getAccountBalances(userId, validatedInput);
+          break;
+        case "get_categories":
+          result = await this.getCategories(userId, validatedInput);
           break;
         case "get_spending_by_category":
           result = await this.getSpendingByCategory(userId, validatedInput);
@@ -237,6 +243,36 @@ export class ToolExecutorService {
           description,
         },
       ],
+    };
+  }
+
+  private async getCategories(
+    userId: string,
+    input: Record<string, unknown>,
+  ): Promise<ToolResult> {
+    const type = input.type as "expense" | "income" | "all" | undefined;
+    const search = input.search as string | undefined;
+
+    const data = await this.categoriesService.getLlmCategories(userId, {
+      type,
+      search,
+    });
+
+    const effectiveType = type ?? "all";
+    const descriptionParts: string[] = [];
+    if (effectiveType !== "all") descriptionParts.push(effectiveType);
+    if (search) descriptionParts.push(`matching "${search}"`);
+    const description =
+      descriptionParts.length > 0
+        ? `Categories (${descriptionParts.join(", ")})`
+        : "All categories";
+
+    return {
+      data,
+      summary: `${data.totalCount} categor${data.totalCount === 1 ? "y" : "ies"}${
+        descriptionParts.length > 0 ? ` ${descriptionParts.join(", ")}` : ""
+      }.`,
+      sources: [{ type: "categories", description }],
     };
   }
 

--- a/backend/src/ai/query/tool-executor.service.ts
+++ b/backend/src/ai/query/tool-executor.service.ts
@@ -12,6 +12,11 @@ import { InvestmentAction } from "../../securities/entities/investment-transacti
 import { validateToolInput } from "./tool-input-schemas";
 import { executeCalculation, CalculateInput } from "./calculate-tool";
 import { sanitizePromptValue } from "../../common/sanitization.util";
+import {
+  DEFAULT_TOP_N,
+  getDefaultComparePeriods,
+  getDefaultDateRange,
+} from "../../common/tool-schemas";
 
 interface ToolResult {
   data: unknown;
@@ -149,8 +154,9 @@ export class ToolExecutorService {
     userId: string,
     input: Record<string, unknown>,
   ): Promise<ToolResult> {
-    const startDate = input.startDate as string;
-    const endDate = input.endDate as string;
+    const defaults = getDefaultDateRange();
+    const startDate = (input.startDate as string) ?? defaults.startDate;
+    const endDate = (input.endDate as string) ?? defaults.endDate;
     const categoryNames = input.categoryNames as string[] | undefined;
     const accountNames = input.accountNames as string[] | undefined;
     const searchText = input.searchText as string | undefined;
@@ -224,9 +230,10 @@ export class ToolExecutorService {
     userId: string,
     input: Record<string, unknown>,
   ): Promise<ToolResult> {
-    const startDate = input.startDate as string;
-    const endDate = input.endDate as string;
-    const topN = input.topN as number | undefined;
+    const defaults = getDefaultDateRange();
+    const startDate = (input.startDate as string) ?? defaults.startDate;
+    const endDate = (input.endDate as string) ?? defaults.endDate;
+    const topN = (input.topN as number | undefined) ?? DEFAULT_TOP_N;
 
     const data = await this.analyticsService.getLlmSpendingByCategory(
       userId,
@@ -252,8 +259,9 @@ export class ToolExecutorService {
     userId: string,
     input: Record<string, unknown>,
   ): Promise<ToolResult> {
-    const startDate = input.startDate as string;
-    const endDate = input.endDate as string;
+    const defaults = getDefaultDateRange();
+    const startDate = (input.startDate as string) ?? defaults.startDate;
+    const endDate = (input.endDate as string) ?? defaults.endDate;
     const groupBy =
       (input.groupBy as "category" | "payee" | "month") || "category";
 
@@ -318,10 +326,20 @@ export class ToolExecutorService {
     userId: string,
     input: Record<string, unknown>,
   ): Promise<ToolResult> {
-    const p1Start = input.period1Start as string;
-    const p1End = input.period1End as string;
-    const p2Start = input.period2Start as string;
-    const p2End = input.period2End as string;
+    // All-or-nothing defaults: if any of the four dates is missing, fall
+    // back to "previous month vs current month-to-date". Mixing caller
+    // dates with computed ones would compare unrelated windows.
+    const hasAllPeriods = Boolean(
+      input.period1Start &&
+      input.period1End &&
+      input.period2Start &&
+      input.period2End,
+    );
+    const defaults = hasAllPeriods ? null : getDefaultComparePeriods();
+    const p1Start = (input.period1Start as string) ?? defaults!.period1Start;
+    const p1End = (input.period1End as string) ?? defaults!.period1End;
+    const p2Start = (input.period2Start as string) ?? defaults!.period2Start;
+    const p2End = (input.period2End as string) ?? defaults!.period2End;
     const groupBy = (input.groupBy as "category" | "payee") || "category";
     const direction =
       (input.direction as "expenses" | "income" | "both") || "expenses";
@@ -430,8 +448,9 @@ export class ToolExecutorService {
     userId: string,
     input: Record<string, unknown>,
   ): Promise<ToolResult> {
-    const startDate = input.startDate as string;
-    const endDate = input.endDate as string;
+    const defaults = getDefaultDateRange();
+    const startDate = (input.startDate as string) ?? defaults.startDate;
+    const endDate = (input.endDate as string) ?? defaults.endDate;
     const accountNames = input.accountNames as string[] | undefined;
     const accountIds = await this.resolveAccountIds(userId, accountNames);
 

--- a/backend/src/ai/query/tool-executor.service.ts
+++ b/backend/src/ai/query/tool-executor.service.ts
@@ -181,9 +181,29 @@ export class ToolExecutorService {
       | undefined;
 
     const accountIds = await this.resolveAccountIds(userId, accountNames);
-    const categoryIds = categoryNames
-      ? await this.analyticsService.resolveLlmCategoryIds(userId, categoryNames)
-      : undefined;
+    let categoryIds: string[] | undefined;
+    if (categoryNames && categoryNames.length > 0) {
+      const resolved = await this.analyticsService.resolveLlmCategoryIds(
+        userId,
+        categoryNames,
+      );
+      if (resolved.unresolved.length > 0) {
+        // Fail loudly instead of silently dropping the filter -- otherwise
+        // the user sees "all transactions" when they asked for a specific
+        // (mistyped or subcategory-shaped) category.
+        const list = resolved.unresolved.join(", ");
+        return {
+          data: {
+            error: `Unknown categor${resolved.unresolved.length === 1 ? "y" : "ies"}: ${list}. Call get_categories to look up valid names; subcategories can be referenced as "Parent: Child".`,
+            unresolvedCategoryNames: resolved.unresolved,
+          },
+          summary: `Could not resolve categor${resolved.unresolved.length === 1 ? "y" : "ies"}: ${list}.`,
+          sources: [],
+          isError: true,
+        };
+      }
+      categoryIds = resolved.categoryIds;
+    }
 
     const data = await this.analyticsService.getLlmQueryTransactions(userId, {
       startDate,

--- a/backend/src/ai/query/tool-executor.service.ts
+++ b/backend/src/ai/query/tool-executor.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Inject, forwardRef, Logger } from "@nestjs/common";
 import { AccountsService } from "../../accounts/accounts.service";
+import { AccountType } from "../../accounts/entities/account.entity";
 import { TransactionAnalyticsService } from "../../transactions/transaction-analytics.service";
 import { NetWorthService } from "../../net-worth/net-worth.service";
 import { BudgetReportsService } from "../../budgets/budget-reports.service";
@@ -206,11 +207,26 @@ export class ToolExecutorService {
     input: Record<string, unknown>,
   ): Promise<ToolResult> {
     const accountNames = input.accountNames as string[] | undefined;
+    const status =
+      (input.status as "open" | "closed" | "all" | undefined) ?? "open";
+    const accountTypes = input.accountTypes as AccountType[] | undefined;
 
     const data = await this.accountsService.getLlmBalances(
       userId,
       accountNames,
+      status,
+      accountTypes,
     );
+
+    const filterDescParts: string[] = [];
+    if (accountNames?.length) filterDescParts.push(accountNames.join(", "));
+    if (accountTypes?.length) filterDescParts.push(accountTypes.join(", "));
+    const descriptionBase =
+      filterDescParts.length > 0
+        ? `Balances for ${filterDescParts.join("; ")}`
+        : "All account balances";
+    const description =
+      status === "open" ? descriptionBase : `${descriptionBase} (${status})`;
 
     return {
       data,
@@ -218,9 +234,7 @@ export class ToolExecutorService {
       sources: [
         {
           type: "accounts",
-          description: accountNames
-            ? `Balances for ${accountNames.join(", ")}`
-            : "All account balances",
+          description,
         },
       ],
     };

--- a/backend/src/ai/query/tool-input-schemas.spec.ts
+++ b/backend/src/ai/query/tool-input-schemas.spec.ts
@@ -52,12 +52,13 @@ describe("tool-input-schemas", () => {
       }
     });
 
-    it("returns error when required fields are missing", () => {
+    it("accepts empty input (dates are optional; handler applies defaults)", () => {
       const result = validateToolInput("query_transactions", {});
 
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error).toContain("Invalid input");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.startDate).toBeUndefined();
+        expect(result.data.endDate).toBeUndefined();
       }
     });
 
@@ -172,11 +173,16 @@ describe("tool-input-schemas", () => {
   });
 
   describe("getSpendingByCategorySchema", () => {
-    it("validates required date fields", () => {
+    it("accepts date fields", () => {
       const result = getSpendingByCategorySchema.safeParse({
         startDate: "2026-01-01",
         endDate: "2026-01-31",
       });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts empty input (dates are optional)", () => {
+      const result = getSpendingByCategorySchema.safeParse({});
       expect(result.success).toBe(true);
     });
 
@@ -284,13 +290,18 @@ describe("tool-input-schemas", () => {
       expect(result.success).toBe(true);
     });
 
-    it("rejects missing period dates", () => {
+    it("accepts missing period dates (handler applies defaults)", () => {
       const result = comparePeriodsSchema.safeParse({
         period1Start: "2025-12-01",
         period1End: "2025-12-31",
-        // Missing period2Start and period2End
+        // period2Start and period2End omitted; defaulted in the executor
       });
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts empty input (dates are optional)", () => {
+      const result = comparePeriodsSchema.safeParse({});
+      expect(result.success).toBe(true);
     });
 
     it("accepts optional groupBy and direction", () => {
@@ -427,11 +438,11 @@ describe("tool-input-schemas", () => {
       expect(result.success).toBe(true);
     });
 
-    it("rejects missing required date fields", () => {
+    it("accepts missing date fields (handler applies defaults)", () => {
       const result = getTransfersSchema.safeParse({
         accountNames: ["Chequing"],
       });
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
     });
 
     it("rejects invalid date format", () => {

--- a/backend/src/ai/query/tool-input-schemas.spec.ts
+++ b/backend/src/ai/query/tool-input-schemas.spec.ts
@@ -170,6 +170,42 @@ describe("tool-input-schemas", () => {
       });
       expect(result.success).toBe(false);
     });
+
+    it("accepts the three status values", () => {
+      for (const status of ["open", "closed", "all"]) {
+        const result = getAccountBalancesSchema.safeParse({ status });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it("rejects unknown status values", () => {
+      const result = getAccountBalancesSchema.safeParse({ status: "archived" });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts accountTypes filter", () => {
+      const result = getAccountBalancesSchema.safeParse({
+        accountTypes: ["CHEQUING", "SAVINGS"],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("uppercases accountTypes inputs via preprocess", () => {
+      const result = getAccountBalancesSchema.safeParse({
+        accountTypes: ["chequing", " savings "],
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.accountTypes).toEqual(["CHEQUING", "SAVINGS"]);
+      }
+    });
+
+    it("rejects an unknown account type", () => {
+      const result = getAccountBalancesSchema.safeParse({
+        accountTypes: ["NOT_REAL"],
+      });
+      expect(result.success).toBe(false);
+    });
   });
 
   describe("getSpendingByCategorySchema", () => {

--- a/backend/src/ai/query/tool-input-schemas.spec.ts
+++ b/backend/src/ai/query/tool-input-schemas.spec.ts
@@ -2,6 +2,7 @@ import {
   validateToolInput,
   queryTransactionsSchema,
   getAccountBalancesSchema,
+  getCategoriesSchema,
   getSpendingByCategorySchema,
   getIncomeSummarySchema,
   getNetWorthHistorySchema,
@@ -203,6 +204,37 @@ describe("tool-input-schemas", () => {
     it("rejects an unknown account type", () => {
       const result = getAccountBalancesSchema.safeParse({
         accountTypes: ["NOT_REAL"],
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("getCategoriesSchema", () => {
+    it("accepts empty input", () => {
+      const result = getCategoriesSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts all three type values", () => {
+      for (const type of ["expense", "income", "all"]) {
+        const result = getCategoriesSchema.safeParse({ type });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it("rejects unknown type values", () => {
+      const result = getCategoriesSchema.safeParse({ type: "transfer" });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a search string", () => {
+      const result = getCategoriesSchema.safeParse({ search: "food" });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects a search string over 100 chars", () => {
+      const result = getCategoriesSchema.safeParse({
+        search: "a".repeat(101),
       });
       expect(result.success).toBe(false);
     });

--- a/backend/src/ai/query/tool-input-schemas.ts
+++ b/backend/src/ai/query/tool-input-schemas.ts
@@ -48,6 +48,11 @@ export const getAccountBalancesSchema = z.object({
   accountTypes: z.array(accountTypeSchema).max(10).optional(),
 });
 
+export const getCategoriesSchema = z.object({
+  type: z.enum(["expense", "income", "all"]).optional(),
+  search: z.string().max(100).optional(),
+});
+
 export const getSpendingByCategorySchema = z.object({
   startDate: isoDateSchema.optional(),
   endDate: isoDateSchema.optional(),
@@ -146,6 +151,7 @@ export const renderChartSchema = z.object({
 export const toolInputSchemas: Record<string, z.ZodSchema> = {
   query_transactions: queryTransactionsSchema,
   get_account_balances: getAccountBalancesSchema,
+  get_categories: getCategoriesSchema,
   get_spending_by_category: getSpendingByCategorySchema,
   get_income_summary: getIncomeSummarySchema,
   get_net_worth_history: getNetWorthHistorySchema,

--- a/backend/src/ai/query/tool-input-schemas.ts
+++ b/backend/src/ai/query/tool-input-schemas.ts
@@ -26,8 +26,26 @@ export const queryTransactionsSchema = z.object({
   direction: directionSchema.optional(),
 });
 
+const accountTypeSchema = z.preprocess(
+  (val) => (typeof val === "string" ? val.toUpperCase().trim() : val),
+  z.enum([
+    "CHEQUING",
+    "SAVINGS",
+    "CREDIT_CARD",
+    "LOAN",
+    "MORTGAGE",
+    "INVESTMENT",
+    "CASH",
+    "LINE_OF_CREDIT",
+    "ASSET",
+    "OTHER",
+  ]),
+);
+
 export const getAccountBalancesSchema = z.object({
   accountNames: z.array(z.string().max(100)).optional(),
+  status: z.enum(["open", "closed", "all"]).optional(),
+  accountTypes: z.array(accountTypeSchema).max(10).optional(),
 });
 
 export const getSpendingByCategorySchema = z.object({

--- a/backend/src/ai/query/tool-input-schemas.ts
+++ b/backend/src/ai/query/tool-input-schemas.ts
@@ -17,8 +17,8 @@ import {
  */
 
 export const queryTransactionsSchema = z.object({
-  startDate: isoDateSchema,
-  endDate: isoDateSchema,
+  startDate: isoDateSchema.optional(),
+  endDate: isoDateSchema.optional(),
   categoryNames: z.array(z.string().max(100)).optional(),
   accountNames: z.array(z.string().max(100)).optional(),
   searchText: z.string().max(200).optional(),
@@ -31,14 +31,14 @@ export const getAccountBalancesSchema = z.object({
 });
 
 export const getSpendingByCategorySchema = z.object({
-  startDate: isoDateSchema,
-  endDate: isoDateSchema,
+  startDate: isoDateSchema.optional(),
+  endDate: isoDateSchema.optional(),
   topN: positiveIntSchema(1, 50).optional(),
 });
 
 export const getIncomeSummarySchema = z.object({
-  startDate: isoDateSchema,
-  endDate: isoDateSchema,
+  startDate: isoDateSchema.optional(),
+  endDate: isoDateSchema.optional(),
   groupBy: z.enum(["category", "payee", "month"]).optional(),
 });
 
@@ -48,10 +48,10 @@ export const getNetWorthHistorySchema = z.object({
 });
 
 export const comparePeriodsSchema = z.object({
-  period1Start: isoDateSchema,
-  period1End: isoDateSchema,
-  period2Start: isoDateSchema,
-  period2End: isoDateSchema,
+  period1Start: isoDateSchema.optional(),
+  period1End: isoDateSchema.optional(),
+  period2Start: isoDateSchema.optional(),
+  period2End: isoDateSchema.optional(),
   groupBy: z.enum(["category", "payee"]).optional(),
   direction: directionSchema.optional(),
 });
@@ -89,8 +89,8 @@ export const queryInvestmentTransactionsSchema = z.object({
 });
 
 export const getTransfersSchema = z.object({
-  startDate: isoDateSchema,
-  endDate: isoDateSchema,
+  startDate: isoDateSchema.optional(),
+  endDate: isoDateSchema.optional(),
   accountNames: z.array(z.string().max(100)).optional(),
 });
 

--- a/backend/src/categories/categories.service.spec.ts
+++ b/backend/src/categories/categories.service.spec.ts
@@ -594,6 +594,112 @@ describe("CategoriesService", () => {
     });
   });
 
+  describe("getLlmCategories", () => {
+    const expense1 = {
+      ...mockCategory,
+      id: "c1",
+      name: "Food",
+      parentId: null,
+      transactionCount: 5,
+    } as any;
+    const expense2 = {
+      ...mockCategory,
+      id: "c2",
+      name: "Groceries",
+      parentId: "c1",
+      transactionCount: 3,
+    } as any;
+    const expense3 = {
+      ...mockCategory,
+      id: "c3",
+      name: "Rent",
+      parentId: null,
+      transactionCount: 1,
+    } as any;
+    const income1 = {
+      ...mockCategory,
+      id: "c4",
+      name: "Salary",
+      parentId: null,
+      isIncome: true,
+      transactionCount: 2,
+    } as any;
+
+    const allCategories = [expense1, expense2, expense3, income1];
+
+    const stubFindAll = () => {
+      jest.spyOn(service, "findAll").mockResolvedValue(allCategories as any);
+    };
+
+    it("defaults to type='all' and no search", async () => {
+      stubFindAll();
+
+      const result = await service.getLlmCategories("user-1");
+
+      expect(result.totalCount).toBe(4);
+      const names = result.categories.map((c) => c.name);
+      expect(names).toContain("Food");
+      expect(names).toContain("Groceries");
+      expect(names).toContain("Rent");
+      expect(names).toContain("Salary");
+    });
+
+    it("includes parentName for subcategories", async () => {
+      stubFindAll();
+
+      const result = await service.getLlmCategories("user-1");
+
+      const groceries = result.categories.find((c) => c.name === "Groceries");
+      expect(groceries?.parentName).toBe("Food");
+      const food = result.categories.find((c) => c.name === "Food");
+      expect(food?.parentName).toBeNull();
+    });
+
+    it("filters by expense type", async () => {
+      stubFindAll();
+
+      const result = await service.getLlmCategories("user-1", {
+        type: "expense",
+      });
+
+      expect(result.totalCount).toBe(3);
+      expect(result.categories.every((c) => !c.isIncome)).toBe(true);
+    });
+
+    it("filters by income type", async () => {
+      stubFindAll();
+
+      const result = await service.getLlmCategories("user-1", {
+        type: "income",
+      });
+
+      expect(result.totalCount).toBe(1);
+      expect(result.categories[0].name).toBe("Salary");
+    });
+
+    it("search includes matched subcategory's parent", async () => {
+      stubFindAll();
+
+      const result = await service.getLlmCategories("user-1", {
+        search: "groceries",
+      });
+
+      const names = result.categories.map((c) => c.name);
+      expect(names).toEqual(expect.arrayContaining(["Food", "Groceries"]));
+      expect(names).not.toContain("Rent");
+    });
+
+    it("search is case-insensitive", async () => {
+      stubFindAll();
+
+      const result = await service.getLlmCategories("user-1", {
+        search: "RENT",
+      });
+
+      expect(result.categories.map((c) => c.name)).toEqual(["Rent"]);
+    });
+  });
+
   describe("findOne", () => {
     it("returns category when found and belongs to user", async () => {
       categoriesRepository.findOne.mockResolvedValue(mockCategory);

--- a/backend/src/categories/categories.service.ts
+++ b/backend/src/categories/categories.service.ts
@@ -214,6 +214,83 @@ export class CategoriesService {
     return this.resolveEffectiveColors(categories);
   }
 
+  /**
+   * LLM-friendly category listing: returns a flat list with parent names so
+   * the model can understand hierarchy without parsing nested JSON. Used by
+   * both the AI Assistant and the MCP server to keep response shapes in sync.
+   *
+   * - `type` narrows to expense or income categories; 'all' (default)
+   *   returns both.
+   * - `search` is a case-insensitive substring match on category name. If the
+   *   matching category is a subcategory, its parent is included so the LLM
+   *   sees the hierarchy context.
+   */
+  async getLlmCategories(
+    userId: string,
+    options: {
+      type?: "expense" | "income" | "all";
+      search?: string;
+    } = {},
+  ): Promise<{
+    categories: Array<{
+      id: string;
+      name: string;
+      parentName: string | null;
+      isIncome: boolean;
+      transactionCount: number;
+    }>;
+    totalCount: number;
+  }> {
+    const type = options.type ?? "all";
+    const search = options.search?.trim().toLowerCase();
+
+    const all = await this.findAll(userId, false);
+    const byId = new Map(all.map((c) => [c.id, c]));
+
+    let filtered = all;
+    if (type !== "all") {
+      const wantIncome = type === "income";
+      filtered = filtered.filter((c) => c.isIncome === wantIncome);
+    }
+
+    if (search) {
+      const matchIds = new Set(
+        filtered
+          .filter((c) => c.name.toLowerCase().includes(search))
+          .map((c) => c.id),
+      );
+      // Include parents of matched subcategories so hierarchy stays intact.
+      for (const id of Array.from(matchIds)) {
+        const cat = byId.get(id);
+        if (cat?.parentId) matchIds.add(cat.parentId);
+      }
+      filtered = filtered.filter((c) => matchIds.has(c.id));
+    }
+
+    const categories = filtered
+      .map((c) => ({
+        id: c.id,
+        name: c.name,
+        parentName: c.parentId ? (byId.get(c.parentId)?.name ?? null) : null,
+        isIncome: c.isIncome,
+        transactionCount: c.transactionCount,
+      }))
+      .sort((a, b) => {
+        // Parents first, then children, both alphabetized
+        const aKey = a.parentName ?? a.name;
+        const bKey = b.parentName ?? b.name;
+        if (aKey !== bKey) return aKey.localeCompare(bKey);
+        if (a.parentName === null && b.parentName !== null) return -1;
+        if (a.parentName !== null && b.parentName === null) return 1;
+        return a.name.localeCompare(b.name);
+      });
+
+    return {
+      categories,
+      totalCount: categories.length,
+    };
+  }
+
   async findOne(
     userId: string,
     id: string,

--- a/backend/src/common/tool-schemas.spec.ts
+++ b/backend/src/common/tool-schemas.spec.ts
@@ -1,0 +1,108 @@
+import {
+  DEFAULT_LOOKBACK_DAYS,
+  DEFAULT_TOP_N,
+  getDefaultComparePeriods,
+  getDefaultDateRange,
+  getDefaultPreviousMonth,
+} from "./tool-schemas";
+
+describe("tool-schemas defaults", () => {
+  const ymdRegex = /^\d{4}-\d{2}-\d{2}$/;
+  const ymRegex = /^\d{4}-\d{2}$/;
+
+  describe("getDefaultDateRange()", () => {
+    it("returns today's date for endDate", () => {
+      const today = new Date();
+      const y = today.getFullYear();
+      const m = String(today.getMonth() + 1).padStart(2, "0");
+      const d = String(today.getDate()).padStart(2, "0");
+      const expected = `${y}-${m}-${d}`;
+
+      const { endDate } = getDefaultDateRange();
+
+      expect(endDate).toBe(expected);
+    });
+
+    it("returns a startDate roughly DEFAULT_LOOKBACK_DAYS ago by default", () => {
+      const { startDate, endDate } = getDefaultDateRange();
+
+      const startMs = new Date(startDate + "T00:00:00").getTime();
+      const endMs = new Date(endDate + "T00:00:00").getTime();
+      const daysDiff = Math.round((endMs - startMs) / (1000 * 60 * 60 * 24));
+
+      expect(daysDiff).toBe(DEFAULT_LOOKBACK_DAYS);
+    });
+
+    it("honors a custom lookback window", () => {
+      const { startDate, endDate } = getDefaultDateRange(7);
+      const startMs = new Date(startDate + "T00:00:00").getTime();
+      const endMs = new Date(endDate + "T00:00:00").getTime();
+      const daysDiff = Math.round((endMs - startMs) / (1000 * 60 * 60 * 24));
+
+      expect(daysDiff).toBe(7);
+    });
+
+    it("returns YYYY-MM-DD strings for both ends", () => {
+      const { startDate, endDate } = getDefaultDateRange();
+      expect(startDate).toMatch(ymdRegex);
+      expect(endDate).toMatch(ymdRegex);
+    });
+  });
+
+  describe("getDefaultComparePeriods()", () => {
+    it("returns period1 as the previous full calendar month", () => {
+      const { period1Start, period1End } = getDefaultComparePeriods();
+
+      const now = new Date();
+      const expectedStart = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+      const expectedEnd = new Date(now.getFullYear(), now.getMonth(), 0);
+
+      const fmt = (d: Date) =>
+        `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
+      expect(period1Start).toBe(fmt(expectedStart));
+      expect(period1End).toBe(fmt(expectedEnd));
+    });
+
+    it("returns period2 as the current month-to-date", () => {
+      const { period2Start, period2End } = getDefaultComparePeriods();
+      const now = new Date();
+      const expectedStart = new Date(now.getFullYear(), now.getMonth(), 1);
+
+      const fmt = (d: Date) =>
+        `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
+      expect(period2Start).toBe(fmt(expectedStart));
+      expect(period2End).toBe(fmt(now));
+    });
+
+    it("returns YYYY-MM-DD strings for all four fields", () => {
+      const periods = getDefaultComparePeriods();
+      expect(periods.period1Start).toMatch(ymdRegex);
+      expect(periods.period1End).toMatch(ymdRegex);
+      expect(periods.period2Start).toMatch(ymdRegex);
+      expect(periods.period2End).toMatch(ymdRegex);
+    });
+  });
+
+  describe("getDefaultPreviousMonth()", () => {
+    it("returns the previous calendar month in YYYY-MM", () => {
+      const now = new Date();
+      const prev = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+      const expected = `${prev.getFullYear()}-${String(prev.getMonth() + 1).padStart(2, "0")}`;
+
+      expect(getDefaultPreviousMonth()).toBe(expected);
+    });
+
+    it("returns a YYYY-MM formatted string", () => {
+      expect(getDefaultPreviousMonth()).toMatch(ymRegex);
+    });
+  });
+
+  describe("constants", () => {
+    it("exposes sensible default values", () => {
+      expect(DEFAULT_LOOKBACK_DAYS).toBe(30);
+      expect(DEFAULT_TOP_N).toBe(10);
+    });
+  });
+});

--- a/backend/src/common/tool-schemas.ts
+++ b/backend/src/common/tool-schemas.ts
@@ -60,3 +60,73 @@ export const positiveIntSchema = (min: number, max: number) =>
       typeof val === "string" && /^-?\d+$/.test(val) ? Number(val) : val,
     z.number().int().min(min).max(max),
   );
+
+/**
+ * Defaults applied when an LLM omits parameters that would otherwise be
+ * required. Centralized here so the AI Assistant and the MCP server
+ * fall back to the same values.
+ */
+export const DEFAULT_LOOKBACK_DAYS = 30;
+export const DEFAULT_TOP_N = 10;
+
+/**
+ * Format a local Date as YYYY-MM-DD using local-time components.
+ * Defaults work with calendar dates from the server's perspective,
+ * so local components avoid an off-by-one shift that UTC formatting
+ * would introduce in non-UTC timezones.
+ */
+function localYMD(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Return a {startDate, endDate} pair covering the last `lookbackDays`
+ * days (inclusive of today). Used when the model omits a date range.
+ */
+export function getDefaultDateRange(
+  lookbackDays: number = DEFAULT_LOOKBACK_DAYS,
+): { startDate: string; endDate: string } {
+  const end = new Date();
+  const start = new Date();
+  start.setDate(start.getDate() - lookbackDays);
+  return { startDate: localYMD(start), endDate: localYMD(end) };
+}
+
+/**
+ * Return the four dates needed to compare the previous full month
+ * against the current month-to-date. Used when the model omits any
+ * period in compare_periods -- treated as all-or-nothing because
+ * mixing user-supplied dates with computed ones would be surprising.
+ */
+export function getDefaultComparePeriods(): {
+  period1Start: string;
+  period1End: string;
+  period2Start: string;
+  period2End: string;
+} {
+  const now = new Date();
+  const currentStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const prevStart = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  // Day 0 of the current month = last day of the previous month
+  const prevEnd = new Date(now.getFullYear(), now.getMonth(), 0);
+  return {
+    period1Start: localYMD(prevStart),
+    period1End: localYMD(prevEnd),
+    period2Start: localYMD(currentStart),
+    period2End: localYMD(now),
+  };
+}
+
+/**
+ * Return the previous complete calendar month in YYYY-MM format.
+ * Used as the default for monthly_comparison so reports run against
+ * a month that has already closed.
+ */
+export function getDefaultPreviousMonth(): string {
+  const now = new Date();
+  const prev = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  return `${prev.getFullYear()}-${String(prev.getMonth() + 1).padStart(2, "0")}`;
+}

--- a/backend/src/mcp/tools/accounts.tool.spec.ts
+++ b/backend/src/mcp/tools/accounts.tool.spec.ts
@@ -33,7 +33,7 @@ describe("McpAccountsTools", () => {
   });
 
   describe("get_account_balances", () => {
-    it("delegates to accountsService.getLlmBalances", async () => {
+    it("delegates to accountsService.getLlmBalances (service applies 'open' default)", async () => {
       resolve.mockReturnValue({ userId: "u1", scopes: "read" });
       accountsService.getLlmBalances.mockResolvedValue({
         accounts: [],
@@ -48,11 +48,37 @@ describe("McpAccountsTools", () => {
         { sessionId: "s1" },
       );
 
-      expect(accountsService.getLlmBalances).toHaveBeenCalledWith("u1", [
-        "Checking",
-      ]);
+      expect(accountsService.getLlmBalances).toHaveBeenCalledWith(
+        "u1",
+        ["Checking"],
+        undefined,
+        undefined,
+      );
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed.netWorth).toBe(1000);
+    });
+
+    it("passes status and accountTypes filters through", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      accountsService.getLlmBalances.mockResolvedValue({
+        accounts: [],
+        totalAssets: 0,
+        totalLiabilities: 0,
+        netWorth: 0,
+        totalAccounts: 0,
+      });
+
+      await handlers["get_account_balances"](
+        { status: "closed", accountTypes: ["CHEQUING", "SAVINGS"] },
+        { sessionId: "s1" },
+      );
+
+      expect(accountsService.getLlmBalances).toHaveBeenCalledWith(
+        "u1",
+        undefined,
+        "closed",
+        ["CHEQUING", "SAVINGS"],
+      );
     });
   });
 

--- a/backend/src/mcp/tools/accounts.tool.ts
+++ b/backend/src/mcp/tools/accounts.tool.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { AccountsService } from "../../accounts/accounts.service";
+import { AccountType } from "../../accounts/entities/account.entity";
 import {
   UserContextResolver,
   requireScope,
@@ -112,6 +113,19 @@ export class McpAccountsTools {
             .describe(
               "Optional: filter to specific account names. Omit to cover all accounts.",
             ),
+          status: z
+            .enum(["open", "closed", "all"])
+            .optional()
+            .describe(
+              "Which accounts to include by status. Defaults to 'open'.",
+            ),
+          accountTypes: z
+            .array(z.nativeEnum(AccountType))
+            .max(10)
+            .optional()
+            .describe(
+              "Optional: filter to specific account types (CHEQUING, SAVINGS, CREDIT_CARD, LOAN, MORTGAGE, INVESTMENT, CASH, LINE_OF_CREDIT, ASSET, OTHER). Omit to include all types.",
+            ),
         },
       },
       async (args, extra) => {
@@ -121,9 +135,12 @@ export class McpAccountsTools {
         if (check.error) return check.result;
 
         try {
+          // Service owns the "open" default so it stays in one place.
           const data = await this.accountsService.getLlmBalances(
             ctx.userId,
             args.accountNames,
+            args.status,
+            args.accountTypes,
           );
           return toolResult(data);
         } catch (err: unknown) {

--- a/backend/src/mcp/tools/categories.tool.spec.ts
+++ b/backend/src/mcp/tools/categories.tool.spec.ts
@@ -10,8 +10,7 @@ describe("McpCategoriesTools", () => {
 
   beforeEach(() => {
     categoriesService = {
-      getTree: jest.fn(),
-      findByType: jest.fn(),
+      getLlmCategories: jest.fn(),
     };
 
     tool = new McpCategoriesTools(categoriesService as any);
@@ -31,53 +30,60 @@ describe("McpCategoriesTools", () => {
   });
 
   describe("get_categories", () => {
-    it("should return error when no user context", async () => {
+    it("returns error when no user context", async () => {
       resolve.mockReturnValue(undefined);
       const result = await handlers["get_categories"]({}, { sessionId: "s1" });
       expect(result.isError).toBe(true);
     });
 
-    it("should return full tree when no type filter", async () => {
+    it("delegates to categoriesService.getLlmCategories with no filters", async () => {
       resolve.mockReturnValue({ userId: "u1", scopes: "read" });
-      categoriesService.getTree.mockResolvedValue([{ id: "c1", name: "Food" }]);
+      categoriesService.getLlmCategories.mockResolvedValue({
+        categories: [
+          {
+            id: "c1",
+            name: "Food",
+            parentName: null,
+            isIncome: false,
+            transactionCount: 0,
+          },
+        ],
+        totalCount: 1,
+      });
 
       const result = await handlers["get_categories"]({}, { sessionId: "s1" });
-      expect(categoriesService.getTree).toHaveBeenCalledWith("u1");
+      expect(categoriesService.getLlmCategories).toHaveBeenCalledWith("u1", {
+        type: undefined,
+        search: undefined,
+      });
       const parsed = JSON.parse(result.content[0].text);
-      expect(parsed[0].name).toBe("Food");
+      expect(parsed.totalCount).toBe(1);
+      expect(parsed.categories[0].name).toBe("Food");
     });
 
-    it("should filter by income type", async () => {
+    it("passes type and search filters through", async () => {
       resolve.mockReturnValue({ userId: "u1", scopes: "read" });
-      categoriesService.findByType.mockResolvedValue([
-        { id: "c2", name: "Salary" },
-      ]);
-
-      const result = await handlers["get_categories"](
-        { type: "income" },
-        { sessionId: "s1" },
-      );
-      expect(categoriesService.findByType).toHaveBeenCalledWith("u1", true);
-      const parsed = JSON.parse(result.content[0].text);
-      expect(parsed[0].name).toBe("Salary");
-    });
-
-    it("should filter by expense type", async () => {
-      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
-      categoriesService.findByType.mockResolvedValue([
-        { id: "c3", name: "Rent" },
-      ]);
+      categoriesService.getLlmCategories.mockResolvedValue({
+        categories: [],
+        totalCount: 0,
+      });
 
       await handlers["get_categories"](
-        { type: "expense" },
+        { type: "income", search: "salary" },
         { sessionId: "s1" },
       );
-      expect(categoriesService.findByType).toHaveBeenCalledWith("u1", false);
+
+      expect(categoriesService.getLlmCategories).toHaveBeenCalledWith("u1", {
+        type: "income",
+        search: "salary",
+      });
     });
 
-    it("should handle service errors", async () => {
+    it("handles service errors", async () => {
       resolve.mockReturnValue({ userId: "u1", scopes: "read" });
-      categoriesService.getTree.mockRejectedValue(new Error("DB fail"));
+      categoriesService.getLlmCategories.mockRejectedValue(
+        new Error("DB fail"),
+      );
 
       const result = await handlers["get_categories"]({}, { sessionId: "s1" });
       expect(result.isError).toBe(true);

--- a/backend/src/mcp/tools/categories.tool.ts
+++ b/backend/src/mcp/tools/categories.tool.ts
@@ -18,12 +18,22 @@ export class McpCategoriesTools {
     server.registerTool(
       "get_categories",
       {
-        description: "Get full category tree or filter by type",
+        description:
+          "List the user's categories with their hierarchy (parent names) and transaction counts. Optionally filter by type or search by name. Returns the same shape as the AI Assistant's get_categories tool.",
         inputSchema: {
           type: z
-            .enum(["income", "expense"])
+            .enum(["expense", "income", "all"])
             .optional()
-            .describe("Filter by income or expense categories"),
+            .describe(
+              "Filter by category type. Defaults to 'all' when omitted.",
+            ),
+          search: z
+            .string()
+            .max(100)
+            .optional()
+            .describe(
+              "Optional case-insensitive substring match on category name. Matched subcategories' parents are included so hierarchy stays visible.",
+            ),
         },
       },
       async (args, extra) => {
@@ -33,15 +43,11 @@ export class McpCategoriesTools {
         if (check.error) return check.result;
 
         try {
-          if (args.type) {
-            const categories = await this.categoriesService.findByType(
-              ctx.userId,
-              args.type === "income",
-            );
-            return toolResult(categories);
-          }
-          const tree = await this.categoriesService.getTree(ctx.userId);
-          return toolResult(tree);
+          const data = await this.categoriesService.getLlmCategories(
+            ctx.userId,
+            { type: args.type, search: args.search },
+          );
+          return toolResult(data);
         } catch (err: unknown) {
           return safeToolError(err);
         }

--- a/backend/src/mcp/tools/investments.tool.spec.ts
+++ b/backend/src/mcp/tools/investments.tool.spec.ts
@@ -159,7 +159,7 @@ describe("McpInvestmentsTools", () => {
       expect(parsed.groups[0].key).toBe("AAPL");
     });
 
-    it("passes undefined filters when no args provided", async () => {
+    it("defaults groupBy to 'security' and leaves other filters undefined when no args provided", async () => {
       resolve.mockReturnValue({ userId: "u1", scopes: "read" });
       investmentTransactionsService.getLlmInvestmentTransactions.mockResolvedValue(
         {
@@ -185,7 +185,7 @@ describe("McpInvestmentsTools", () => {
         accountIds: undefined,
         symbols: undefined,
         actions: undefined,
-        groupBy: undefined,
+        groupBy: "security",
       });
     });
 

--- a/backend/src/mcp/tools/investments.tool.ts
+++ b/backend/src/mcp/tools/investments.tool.ts
@@ -95,7 +95,7 @@ export class McpInvestmentsTools {
             .enum(["account", "date", "security", "action"])
             .optional()
             .describe(
-              "Optional grouping: by account name, transaction date, security symbol, or action type.",
+              "Grouping: by account name, transaction date, security symbol, or action type. Defaults to 'security' when omitted.",
             ),
         },
       },
@@ -115,7 +115,9 @@ export class McpInvestmentsTools {
                 accountIds: args.accountIds,
                 symbols: args.symbols,
                 actions: args.actions,
-                groupBy: args.groupBy as LlmInvestmentTxGroupBy | undefined,
+                groupBy:
+                  (args.groupBy as LlmInvestmentTxGroupBy | undefined) ??
+                  "security",
               },
             );
           return toolResult(result);

--- a/backend/src/mcp/tools/reports.tool.spec.ts
+++ b/backend/src/mcp/tools/reports.tool.spec.ts
@@ -129,6 +129,22 @@ describe("McpReportsTools", () => {
       );
       expect(reportsService.getIncomeBySource).toHaveBeenCalled();
     });
+
+    it("applies default dates when omitted", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "reports" });
+      reportsService.getSpendingByCategory.mockResolvedValue({ data: [] });
+
+      await handlers["generate_report"](
+        { type: "spending_by_category" },
+        { sessionId: "s1" },
+      );
+
+      expect(reportsService.getSpendingByCategory).toHaveBeenCalledWith(
+        "u1",
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      );
+    });
   });
 
   describe("monthly_comparison", () => {
@@ -185,6 +201,18 @@ describe("McpReportsTools", () => {
       );
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("An error occurred");
+    });
+
+    it("defaults month to the previous calendar month when omitted", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "reports" });
+      reportsService.getMonthlyComparison.mockResolvedValue({});
+
+      await handlers["monthly_comparison"]({}, { sessionId: "s1" });
+
+      expect(reportsService.getMonthlyComparison).toHaveBeenCalledWith(
+        "u1",
+        expect.stringMatching(/^\d{4}-\d{2}$/),
+      );
     });
   });
 

--- a/backend/src/mcp/tools/reports.tool.ts
+++ b/backend/src/mcp/tools/reports.tool.ts
@@ -9,6 +9,10 @@ import {
   toolError,
   safeToolError,
 } from "../mcp-context";
+import {
+  getDefaultDateRange,
+  getDefaultPreviousMonth,
+} from "../../common/tool-schemas";
 
 @Injectable()
 export class McpReportsTools {
@@ -29,8 +33,16 @@ export class McpReportsTools {
               "income_by_source",
             ])
             .describe("Report type"),
-          startDate: z.string().max(10).describe("Start date (YYYY-MM-DD)"),
-          endDate: z.string().max(10).describe("End date (YYYY-MM-DD)"),
+          startDate: z
+            .string()
+            .max(10)
+            .optional()
+            .describe("Start date (YYYY-MM-DD). Defaults to 30 days ago."),
+          endDate: z
+            .string()
+            .max(10)
+            .optional()
+            .describe("End date (YYYY-MM-DD). Defaults to today."),
         },
       },
       async (args, extra) => {
@@ -40,41 +52,44 @@ export class McpReportsTools {
         if (check.error) return check.result;
 
         try {
+          const defaults = getDefaultDateRange();
+          const startDate = args.startDate ?? defaults.startDate;
+          const endDate = args.endDate ?? defaults.endDate;
           let data: any;
           switch (args.type) {
             case "spending_by_category":
               data = await this.reportsService.getSpendingByCategory(
                 ctx.userId,
-                args.startDate,
-                args.endDate,
+                startDate,
+                endDate,
               );
               break;
             case "spending_by_payee":
               data = await this.reportsService.getSpendingByPayee(
                 ctx.userId,
-                args.startDate,
-                args.endDate,
+                startDate,
+                endDate,
               );
               break;
             case "income_vs_expenses":
               data = await this.reportsService.getIncomeVsExpenses(
                 ctx.userId,
-                args.startDate,
-                args.endDate,
+                startDate,
+                endDate,
               );
               break;
             case "monthly_trend":
               data = await this.reportsService.getMonthlySpendingTrend(
                 ctx.userId,
-                args.startDate,
-                args.endDate,
+                startDate,
+                endDate,
               );
               break;
             case "income_by_source":
               data = await this.reportsService.getIncomeBySource(
                 ctx.userId,
-                args.startDate,
-                args.endDate,
+                startDate,
+                endDate,
               );
               break;
           }
@@ -94,7 +109,10 @@ export class McpReportsTools {
           month: z
             .string()
             .max(7)
-            .describe("Month to compare in YYYY-MM format (e.g., 2026-01)"),
+            .optional()
+            .describe(
+              "Month to compare in YYYY-MM format (e.g., 2026-01). Defaults to the previous complete month.",
+            ),
         },
       },
       async (args, extra) => {
@@ -106,7 +124,7 @@ export class McpReportsTools {
         try {
           const data = await this.reportsService.getMonthlyComparison(
             ctx.userId,
-            args.month,
+            args.month ?? getDefaultPreviousMonth(),
           );
           return toolResult(data);
         } catch (err: unknown) {

--- a/backend/src/mcp/tools/transactions.tool.spec.ts
+++ b/backend/src/mcp/tools/transactions.tool.spec.ts
@@ -74,6 +74,26 @@ describe("McpTransactionsTools", () => {
         }),
       );
     });
+
+    it("fills in default dates when startDate/endDate are omitted", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      analyticsService.getLlmQueryTransactions.mockResolvedValue({
+        totalIncome: 0,
+        totalExpenses: 0,
+        netCashFlow: 0,
+        transactionCount: 0,
+      });
+
+      await handlers["query_transactions"]({}, { sessionId: "s1" });
+
+      expect(analyticsService.getLlmQueryTransactions).toHaveBeenCalledWith(
+        "u1",
+        expect.objectContaining({
+          startDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+          endDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        }),
+      );
+    });
   });
 
   describe("get_spending_by_category", () => {
@@ -96,6 +116,23 @@ describe("McpTransactionsTools", () => {
         5,
       );
     });
+
+    it("defaults topN to 10 and fills in dates when omitted", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      analyticsService.getLlmSpendingByCategory.mockResolvedValue({
+        categories: [],
+        totalSpending: 0,
+      });
+
+      await handlers["get_spending_by_category"]({}, { sessionId: "s1" });
+
+      expect(analyticsService.getLlmSpendingByCategory).toHaveBeenCalledWith(
+        "u1",
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        10,
+      );
+    });
   });
 
   describe("get_income_summary", () => {
@@ -116,6 +153,24 @@ describe("McpTransactionsTools", () => {
         "u1",
         "2026-01-01",
         "2026-01-31",
+        "category",
+      );
+    });
+
+    it("fills in default dates when omitted", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      analyticsService.getLlmIncomeSummary.mockResolvedValue({
+        items: [],
+        totalIncome: 0,
+        groupedBy: "category",
+      });
+
+      await handlers["get_income_summary"]({}, { sessionId: "s1" });
+
+      expect(analyticsService.getLlmIncomeSummary).toHaveBeenCalledWith(
+        "u1",
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
         "category",
       );
     });
@@ -147,6 +202,29 @@ describe("McpTransactionsTools", () => {
         expect.objectContaining({
           period1Start: "2025-12-01",
           period2Start: "2026-01-01",
+        }),
+      );
+    });
+
+    it("fills in all four dates when omitted", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      analyticsService.getLlmPeriodComparison.mockResolvedValue({
+        period1: { start: "", end: "", total: 0 },
+        period2: { start: "", end: "", total: 0 },
+        totalChange: 0,
+        totalChangePercent: 0,
+        comparison: [],
+      });
+
+      await handlers["compare_periods"]({}, { sessionId: "s1" });
+
+      expect(analyticsService.getLlmPeriodComparison).toHaveBeenCalledWith(
+        "u1",
+        expect.objectContaining({
+          period1Start: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+          period1End: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+          period2Start: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+          period2End: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
         }),
       );
     });
@@ -218,6 +296,25 @@ describe("McpTransactionsTools", () => {
         "2026-01-01",
         "2026-01-31",
         ["00000000-0000-0000-0000-000000000001"],
+      );
+    });
+
+    it("fills in default dates when omitted", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      analyticsService.getTransfersByAccount.mockResolvedValue({
+        accounts: [],
+        totalInbound: 0,
+        totalOutbound: 0,
+        transferCount: 0,
+      });
+
+      await handlers["get_transfers"]({}, { sessionId: "s1" });
+
+      expect(analyticsService.getTransfersByAccount).toHaveBeenCalledWith(
+        "u1",
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        undefined,
       );
     });
   });

--- a/backend/src/mcp/tools/transactions.tool.ts
+++ b/backend/src/mcp/tools/transactions.tool.ts
@@ -13,6 +13,11 @@ import {
 } from "../mcp-context";
 import { McpWriteLimiter } from "../mcp-write-limiter";
 import { stripHtml } from "../../common/sanitization.util";
+import {
+  DEFAULT_TOP_N,
+  getDefaultComparePeriods,
+  getDefaultDateRange,
+} from "../../common/tool-schemas";
 
 @Injectable()
 export class McpTransactionsTools {
@@ -149,8 +154,16 @@ export class McpTransactionsTools {
         description:
           "Search and aggregate transaction data. Returns totals, counts, and optional grouped breakdowns (category, payee, year, month, week) - never individual transaction details. Returns the same shape as the AI Assistant's query_transactions tool.",
         inputSchema: {
-          startDate: z.string().max(10).describe("Start date (YYYY-MM-DD)"),
-          endDate: z.string().max(10).describe("End date (YYYY-MM-DD)"),
+          startDate: z
+            .string()
+            .max(10)
+            .optional()
+            .describe("Start date (YYYY-MM-DD). Defaults to 30 days ago."),
+          endDate: z
+            .string()
+            .max(10)
+            .optional()
+            .describe("End date (YYYY-MM-DD). Defaults to today."),
           accountIds: z
             .array(z.string().uuid())
             .max(50)
@@ -183,11 +196,12 @@ export class McpTransactionsTools {
         if (check.error) return check.result;
 
         try {
+          const defaults = getDefaultDateRange();
           const data = await this.analyticsService.getLlmQueryTransactions(
             ctx.userId,
             {
-              startDate: args.startDate,
-              endDate: args.endDate,
+              startDate: args.startDate ?? defaults.startDate,
+              endDate: args.endDate ?? defaults.endDate,
               accountIds: args.accountIds,
               categoryIds: args.categoryIds,
               searchText: args.searchText,
@@ -208,15 +222,25 @@ export class McpTransactionsTools {
         description:
           "Spending breakdown by category for a date range. Returns each category with total amount, percentage of total spending, and transaction count. Sorted by amount descending. Returns the same shape as the AI Assistant's get_spending_by_category tool.",
         inputSchema: {
-          startDate: z.string().max(10).describe("Start date (YYYY-MM-DD)"),
-          endDate: z.string().max(10).describe("End date (YYYY-MM-DD)"),
+          startDate: z
+            .string()
+            .max(10)
+            .optional()
+            .describe("Start date (YYYY-MM-DD). Defaults to 30 days ago."),
+          endDate: z
+            .string()
+            .max(10)
+            .optional()
+            .describe("End date (YYYY-MM-DD). Defaults to today."),
           topN: z
             .number()
             .int()
             .min(1)
             .max(50)
             .optional()
-            .describe("Limit to top N categories by amount"),
+            .describe(
+              `Limit to top N categories by amount. Defaults to ${DEFAULT_TOP_N}.`,
+            ),
         },
       },
       async (args, extra) => {
@@ -226,11 +250,12 @@ export class McpTransactionsTools {
         if (check.error) return check.result;
 
         try {
+          const defaults = getDefaultDateRange();
           const data = await this.analyticsService.getLlmSpendingByCategory(
             ctx.userId,
-            args.startDate,
-            args.endDate,
-            args.topN,
+            args.startDate ?? defaults.startDate,
+            args.endDate ?? defaults.endDate,
+            args.topN ?? DEFAULT_TOP_N,
           );
           return toolResult(data);
         } catch (err: unknown) {
@@ -245,8 +270,16 @@ export class McpTransactionsTools {
         description:
           "Income summary for a date range, grouped by category, payee, or month. Returns the same shape as the AI Assistant's get_income_summary tool.",
         inputSchema: {
-          startDate: z.string().max(10).describe("Start date (YYYY-MM-DD)"),
-          endDate: z.string().max(10).describe("End date (YYYY-MM-DD)"),
+          startDate: z
+            .string()
+            .max(10)
+            .optional()
+            .describe("Start date (YYYY-MM-DD). Defaults to 30 days ago."),
+          endDate: z
+            .string()
+            .max(10)
+            .optional()
+            .describe("End date (YYYY-MM-DD). Defaults to today."),
           groupBy: z
             .enum(["category", "payee", "month"])
             .optional()
@@ -260,10 +293,11 @@ export class McpTransactionsTools {
         if (check.error) return check.result;
 
         try {
+          const defaults = getDefaultDateRange();
           const data = await this.analyticsService.getLlmIncomeSummary(
             ctx.userId,
-            args.startDate,
-            args.endDate,
+            args.startDate ?? defaults.startDate,
+            args.endDate ?? defaults.endDate,
             args.groupBy ?? "category",
           );
           return toolResult(data);
@@ -277,24 +311,34 @@ export class McpTransactionsTools {
       "compare_periods",
       {
         description:
-          "Compare spending or income between two time periods. Returns side-by-side comparison showing absolute and percentage changes per group. Returns the same shape as the AI Assistant's compare_periods tool.",
+          "Compare spending or income between two time periods. Returns side-by-side comparison showing absolute and percentage changes per group. If any of the four period dates are omitted, defaults to the previous full month (period1) vs the current month-to-date (period2). Returns the same shape as the AI Assistant's compare_periods tool.",
         inputSchema: {
           period1Start: z
             .string()
             .max(10)
-            .describe("First period start (YYYY-MM-DD)"),
+            .optional()
+            .describe(
+              "First period start (YYYY-MM-DD). Defaults to the start of last month.",
+            ),
           period1End: z
             .string()
             .max(10)
-            .describe("First period end (YYYY-MM-DD)"),
+            .optional()
+            .describe(
+              "First period end (YYYY-MM-DD). Defaults to the last day of last month.",
+            ),
           period2Start: z
             .string()
             .max(10)
-            .describe("Second period start (YYYY-MM-DD)"),
+            .optional()
+            .describe(
+              "Second period start (YYYY-MM-DD). Defaults to the start of the current month.",
+            ),
           period2End: z
             .string()
             .max(10)
-            .describe("Second period end (YYYY-MM-DD)"),
+            .optional()
+            .describe("Second period end (YYYY-MM-DD). Defaults to today."),
           groupBy: z
             .enum(["category", "payee"])
             .optional()
@@ -312,13 +356,20 @@ export class McpTransactionsTools {
         if (check.error) return check.result;
 
         try {
+          const hasAllPeriods = Boolean(
+            args.period1Start &&
+            args.period1End &&
+            args.period2Start &&
+            args.period2End,
+          );
+          const defaults = hasAllPeriods ? null : getDefaultComparePeriods();
           const data = await this.analyticsService.getLlmPeriodComparison(
             ctx.userId,
             {
-              period1Start: args.period1Start,
-              period1End: args.period1End,
-              period2Start: args.period2Start,
-              period2End: args.period2End,
+              period1Start: args.period1Start ?? defaults!.period1Start,
+              period1End: args.period1End ?? defaults!.period1End,
+              period2Start: args.period2Start ?? defaults!.period2Start,
+              period2End: args.period2End ?? defaults!.period2End,
               groupBy: args.groupBy,
               direction: args.direction,
             },
@@ -336,8 +387,16 @@ export class McpTransactionsTools {
         description:
           "Get transfer activity between the user's own accounts for a date range. Returns per-account inbound, outbound, net, and count. Transfers are deliberately excluded from other transaction queries because they net to zero across accounts. Returns the same shape as the AI Assistant's get_transfers tool.",
         inputSchema: {
-          startDate: z.string().max(10).describe("Start date (YYYY-MM-DD)"),
-          endDate: z.string().max(10).describe("End date (YYYY-MM-DD)"),
+          startDate: z
+            .string()
+            .max(10)
+            .optional()
+            .describe("Start date (YYYY-MM-DD). Defaults to 30 days ago."),
+          endDate: z
+            .string()
+            .max(10)
+            .optional()
+            .describe("End date (YYYY-MM-DD). Defaults to today."),
           accountIds: z
             .array(z.string().uuid())
             .max(50)
@@ -354,10 +413,11 @@ export class McpTransactionsTools {
         if (check.error) return check.result;
 
         try {
+          const defaults = getDefaultDateRange();
           const result = await this.analyticsService.getTransfersByAccount(
             ctx.userId,
-            args.startDate,
-            args.endDate,
+            args.startDate ?? defaults.startDate,
+            args.endDate ?? defaults.endDate,
             args.accountIds,
           );
           return toolResult(result);

--- a/backend/src/transactions/transaction-analytics.service.spec.ts
+++ b/backend/src/transactions/transaction-analytics.service.spec.ts
@@ -1541,4 +1541,94 @@ describe("TransactionAnalyticsService", () => {
       });
     });
   });
+
+  describe("resolveLlmCategoryIds", () => {
+    const food = { id: "id-food", name: "Food", parentId: null };
+    const dining = { id: "id-dining", name: "Dining Out", parentId: "id-food" };
+    const groceries = {
+      id: "id-groceries",
+      name: "Groceries",
+      parentId: "id-food",
+    };
+    const rent = { id: "id-rent", name: "Rent", parentId: null };
+    const allCategories = [food, dining, groceries, rent];
+
+    beforeEach(() => {
+      // resolveLlmCategoryIds calls categoriesRepository.find twice:
+      // once for the lookup index, once via getAllCategoryIdsWithChildren.
+      categoriesRepository.find.mockResolvedValue(allCategories);
+    });
+
+    it("returns empty result for empty input", async () => {
+      const result = await service.resolveLlmCategoryIds(userId, []);
+      expect(result).toEqual({ categoryIds: [], unresolved: [] });
+    });
+
+    it("matches an exact category name and expands to descendants", async () => {
+      const result = await service.resolveLlmCategoryIds(userId, ["Food"]);
+      expect(result.unresolved).toEqual([]);
+      // Food expands to itself + Dining Out + Groceries
+      expect(result.categoryIds).toEqual(
+        expect.arrayContaining(["id-food", "id-dining", "id-groceries"]),
+      );
+      expect(result.categoryIds).not.toContain("id-rent");
+    });
+
+    it("matches Parent: Child notation for a subcategory", async () => {
+      const result = await service.resolveLlmCategoryIds(userId, [
+        "Food: Dining Out",
+      ]);
+      expect(result.unresolved).toEqual([]);
+      expect(result.categoryIds).toContain("id-dining");
+      // Should not include sibling subcategories of Food
+      expect(result.categoryIds).not.toContain("id-groceries");
+    });
+
+    it("accepts alternate separators (/, >, ->)", async () => {
+      for (const input of [
+        "Food / Dining Out",
+        "Food > Dining Out",
+        "Food -> Dining Out",
+      ]) {
+        const result = await service.resolveLlmCategoryIds(userId, [input]);
+        expect(result.unresolved).toEqual([]);
+        expect(result.categoryIds).toContain("id-dining");
+      }
+    });
+
+    it("is case-insensitive and tolerates extra whitespace", async () => {
+      const result = await service.resolveLlmCategoryIds(userId, [
+        "  food   :   DINING  out  ",
+      ]);
+      expect(result.unresolved).toEqual([]);
+      expect(result.categoryIds).toContain("id-dining");
+    });
+
+    it("falls back to last segment when full Parent: Child key misses", async () => {
+      // "Mystery: Dining Out" — parent doesn't exist but child does
+      const result = await service.resolveLlmCategoryIds(userId, [
+        "Mystery: Dining Out",
+      ]);
+      expect(result.unresolved).toEqual([]);
+      expect(result.categoryIds).toContain("id-dining");
+    });
+
+    it("reports unknown categories in unresolved", async () => {
+      const result = await service.resolveLlmCategoryIds(userId, [
+        "Bogus",
+        "Food",
+      ]);
+      expect(result.unresolved).toEqual(["Bogus"]);
+      expect(result.categoryIds).toContain("id-food");
+    });
+
+    it("returns no IDs when nothing resolves", async () => {
+      const result = await service.resolveLlmCategoryIds(userId, [
+        "Bogus",
+        "AlsoBogus",
+      ]);
+      expect(result.categoryIds).toEqual([]);
+      expect(result.unresolved).toEqual(["Bogus", "AlsoBogus"]);
+    });
+  });
 });

--- a/backend/src/transactions/transaction-analytics.service.ts
+++ b/backend/src/transactions/transaction-analytics.service.ts
@@ -611,31 +611,86 @@ export class TransactionAnalyticsService {
    * Resolve category names plus their descendants to IDs. Shared helper for
    * tool adapters that accept names from LLM input.
    */
+  /**
+   * Resolve LLM-supplied category names into the IDs used by the transaction
+   * filters. Handles three input shapes the model often produces:
+   *   - exact name              -> "Dining Out"
+   *   - parent / child notation -> "Food: Dining Out", "Food / Dining Out",
+   *                                "Food > Dining Out", "Food -> Dining Out"
+   *   - extra whitespace        -> "  food   :  dining out  "
+   *
+   * Returns the matched category IDs (expanded to include descendants so a
+   * filter on "Food" naturally catches its subcategories) plus any names we
+   * could not match. Callers should treat any `unresolved` entry as a hard
+   * failure rather than silently dropping the filter -- otherwise a mistyped
+   * category yields "all transactions" instead of an honest error.
+   */
   async resolveLlmCategoryIds(
     userId: string,
     categoryNames: string[],
-  ): Promise<string[]> {
-    if (categoryNames.length === 0) return [];
+  ): Promise<{ categoryIds: string[]; unresolved: string[] }> {
+    if (categoryNames.length === 0) {
+      return { categoryIds: [], unresolved: [] };
+    }
 
     const allCategories = await this.categoriesRepository.find({
       where: { userId },
-      select: ["id", "name"],
+      select: ["id", "name", "parentId"],
     });
-    const nameMap = new Map(
-      allCategories.map((c) => [c.name.toLowerCase(), c.id]),
-    );
 
-    const matched = categoryNames
-      .map((name) => nameMap.get(name.toLowerCase()))
-      .filter((id): id is string => id !== undefined);
+    const norm = (s: string) => s.toLowerCase().trim().replace(/\s+/g, " ");
+    const SEPARATORS = [":", "/", ">", "->"];
 
-    if (matched.length === 0) return matched;
+    const byId = new Map(allCategories.map((c) => [c.id, c]));
+    const lookup = new Map<string, string>();
+    for (const cat of allCategories) {
+      const childKey = norm(cat.name);
+      if (!lookup.has(childKey)) lookup.set(childKey, cat.id);
 
-    return getAllCategoryIdsWithChildren(
+      if (cat.parentId) {
+        const parent = byId.get(cat.parentId);
+        if (parent) {
+          const parentKey = norm(parent.name);
+          for (const sep of SEPARATORS) {
+            lookup.set(`${parentKey}${sep}${childKey}`, cat.id);
+            lookup.set(`${parentKey} ${sep} ${childKey}`, cat.id);
+          }
+        }
+      }
+    }
+
+    const matched: string[] = [];
+    const unresolved: string[] = [];
+    for (const raw of categoryNames) {
+      const normalized = norm(raw);
+      let id = lookup.get(normalized);
+      if (!id) {
+        // Last-segment fallback: "Food: Dining Out" -> try just "Dining Out"
+        for (const sep of SEPARATORS) {
+          if (normalized.includes(sep)) {
+            const lastSeg = norm(normalized.split(sep).pop() ?? "");
+            const candidate = lastSeg ? lookup.get(lastSeg) : undefined;
+            if (candidate) {
+              id = candidate;
+              break;
+            }
+          }
+        }
+      }
+      if (id) matched.push(id);
+      else unresolved.push(raw);
+    }
+
+    if (matched.length === 0) {
+      return { categoryIds: [], unresolved };
+    }
+
+    const categoryIds = await getAllCategoryIdsWithChildren(
       this.categoriesRepository,
       userId,
       matched,
     );
+    return { categoryIds, unresolved };
   }
 
   /**

--- a/frontend/src/app/categories/page.test.tsx
+++ b/frontend/src/app/categories/page.test.tsx
@@ -334,6 +334,38 @@ describe('CategoriesPage', () => {
     });
   });
 
+  it('search by subcategory name includes the parent so the tree row renders', async () => {
+    mockGetAll.mockResolvedValue(mockCategories);
+    render(<CategoriesPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('category-list')).toBeInTheDocument();
+    });
+    // 'Organic' is a subcategory of 'Groceries' (cat-2). Searching for it
+    // should surface both the subcategory and its parent so the hierarchy
+    // row renders in the tree view.
+    fireEvent.change(screen.getByPlaceholderText('Search categories...'), { target: { value: 'Organic' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('category-cat-4')).toBeInTheDocument();
+      expect(screen.getByTestId('category-cat-2')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('category-cat-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('category-cat-3')).not.toBeInTheDocument();
+  });
+
+  it('search by parent name includes all its subcategories', async () => {
+    mockGetAll.mockResolvedValue(mockCategories);
+    render(<CategoriesPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('category-list')).toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByPlaceholderText('Search categories...'), { target: { value: 'Groceries' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('category-cat-2')).toBeInTheDocument();
+      expect(screen.getByTestId('category-cat-4')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('category-cat-1')).not.toBeInTheDocument();
+  });
+
   it('combines search with type filter', async () => {
     mockGetAll.mockResolvedValue(mockCategories);
     render(<CategoriesPage />);

--- a/frontend/src/app/categories/page.tsx
+++ b/frontend/src/app/categories/page.tsx
@@ -118,9 +118,25 @@ function CategoriesContent() {
 
   const filteredCategories = useMemo(() => {
     if (!searchQuery) return typeFilteredCategories;
-    return typeFilteredCategories.filter((c) =>
-      c.name.toLowerCase().includes(searchQuery.toLowerCase())
+    const query = searchQuery.toLowerCase();
+    // Match on any category whose own name matches. Then also include the
+    // parent of any matched subcategory so the tree row renders, and include
+    // every subcategory of a matched parent so the user can see the whole
+    // branch they were searching for.
+    const byId = new Map(typeFilteredCategories.map((c) => [c.id, c]));
+    const matchedIds = new Set(
+      typeFilteredCategories
+        .filter((c) => c.name.toLowerCase().includes(query))
+        .map((c) => c.id),
     );
+    for (const id of Array.from(matchedIds)) {
+      const cat = byId.get(id);
+      if (cat?.parentId) matchedIds.add(cat.parentId);
+    }
+    for (const c of typeFilteredCategories) {
+      if (c.parentId && matchedIds.has(c.parentId)) matchedIds.add(c.id);
+    }
+    return typeFilteredCategories.filter((c) => matchedIds.has(c.id));
   }, [typeFilteredCategories, searchQuery]);
 
   const handleSort = useCallback((field: SortField) => {

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
@@ -2,16 +2,32 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@/test/render';
 import { CategoryPayeeBarChart } from './CategoryPayeeBarChart';
 
+// Capture props passed to the recharts primitives we care about so individual
+// tests can assert on axis / label styling (angle, interval, etc.).
+const capturedProps: { xAxis: any; labelList: any } = { xAxis: null, labelList: null };
+
 vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
   BarChart: ({ children }: any) => <div data-testid="bar-chart">{children}</div>,
   Bar: ({ children }: any) => <div data-testid="bar">{children}</div>,
-  XAxis: () => <div data-testid="x-axis" />,
+  XAxis: (props: any) => {
+    capturedProps.xAxis = props;
+    return <div data-testid="x-axis" />;
+  },
   YAxis: () => <div data-testid="y-axis" />,
   CartesianGrid: () => <div data-testid="cartesian-grid" />,
   Tooltip: () => <div data-testid="tooltip" />,
-  LabelList: () => <div data-testid="label-list" />,
+  LabelList: (props: any) => {
+    capturedProps.labelList = props;
+    return <div data-testid="label-list" />;
+  },
   Cell: () => <div data-testid="cell" />,
+}));
+
+// Control the mobile breakpoint deterministically from tests.
+const mockIsMobile = vi.fn(() => false);
+vi.mock('@/hooks/useIsMobile', () => ({
+  useIsMobile: () => mockIsMobile(),
 }));
 
 // Use vi.fn() so individual tests can override the implementation to simulate
@@ -31,7 +47,17 @@ describe('CategoryPayeeBarChart', () => {
     // Reset to default USD-like 2-decimal behaviour before each test
     mockFormatCurrency.mockImplementation((n: number) => `$${n.toFixed(2)}`);
     mockFormatCurrency.mockClear();
+    mockIsMobile.mockReturnValue(false);
+    capturedProps.xAxis = null;
+    capturedProps.labelList = null;
   });
+
+  const buildMonths = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      month: `${2020 + Math.floor(i / 12)}-${String((i % 12) + 1).padStart(2, '0')}`,
+      total: -100,
+      count: 1,
+    }));
 
   it('renders loading state with title and pulse skeleton', () => {
     render(<CategoryPayeeBarChart data={[]} isLoading={true} />);
@@ -190,5 +216,44 @@ describe('CategoryPayeeBarChart', () => {
     expect(screen.getByText('BD150.000')).toBeInTheDocument();
     // Total = 300 => BD300.000
     expect(screen.getByText('BD300.000')).toBeInTheDocument();
+  });
+
+  describe('label crowding behaviour', () => {
+    it('always lets the X-axis skip ticks when crowded (preserveStartEnd)', () => {
+      render(<CategoryPayeeBarChart data={buildMonths(48)} isLoading={false} />);
+      expect(capturedProps.xAxis.interval).toBe('preserveStartEnd');
+    });
+
+    it('also lets the X-axis skip ticks when not crowded', () => {
+      render(<CategoryPayeeBarChart data={buildMonths(6)} isLoading={false} />);
+      expect(capturedProps.xAxis.interval).toBe('preserveStartEnd');
+    });
+
+    it('keeps desktop bar-top labels horizontal when uncrowded (<= 36 months)', () => {
+      render(<CategoryPayeeBarChart data={buildMonths(36)} isLoading={false} />);
+      expect(capturedProps.labelList.angle).toBe(0);
+      expect(capturedProps.labelList.offset).toBe(5);
+    });
+
+    it('rotates desktop bar-top labels vertical once column count crosses 36', () => {
+      render(<CategoryPayeeBarChart data={buildMonths(37)} isLoading={false} />);
+      expect(capturedProps.labelList.angle).toBe(-90);
+      expect(capturedProps.labelList.textAnchor).toBe('middle');
+      expect(capturedProps.labelList.offset).toBe(12);
+      // dominantBaseline is nested inside the style object
+      expect(capturedProps.labelList.style).toMatchObject({
+        dominantBaseline: 'central',
+      });
+    });
+
+    it('leaves mobile bar-top labels vertical regardless of column count', () => {
+      mockIsMobile.mockReturnValue(true);
+      render(<CategoryPayeeBarChart data={buildMonths(3)} isLoading={false} />);
+      expect(capturedProps.labelList.angle).toBe(-90);
+      expect(capturedProps.labelList.offset).toBe(14);
+      expect(capturedProps.labelList.style).toMatchObject({
+        dominantBaseline: 'central',
+      });
+    });
   });
 });

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
@@ -239,7 +239,7 @@ describe('CategoryPayeeBarChart', () => {
       render(<CategoryPayeeBarChart data={buildMonths(37)} isLoading={false} />);
       expect(capturedProps.labelList.angle).toBe(-90);
       expect(capturedProps.labelList.textAnchor).toBe('middle');
-      expect(capturedProps.labelList.offset).toBe(12);
+      expect(capturedProps.labelList.offset).toBe(18);
       // dominantBaseline is nested inside the style object
       expect(capturedProps.labelList.style).toMatchObject({
         dominantBaseline: 'central',
@@ -250,7 +250,7 @@ describe('CategoryPayeeBarChart', () => {
       mockIsMobile.mockReturnValue(true);
       render(<CategoryPayeeBarChart data={buildMonths(3)} isLoading={false} />);
       expect(capturedProps.labelList.angle).toBe(-90);
-      expect(capturedProps.labelList.offset).toBe(14);
+      expect(capturedProps.labelList.offset).toBe(20);
       expect(capturedProps.labelList.style).toMatchObject({
         dominantBaseline: 'central',
       });

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
@@ -201,7 +201,7 @@ export function CategoryPayeeBarChart({
                 dataKey="total"
                 position="top"
                 angle={verticalLabels ? -90 : 0}
-                offset={isMobile ? 14 : verticalLabels ? 12 : 5}
+                offset={isMobile ? 20 : verticalLabels ? 18 : 5}
                 textAnchor="middle"
                 formatter={(value: unknown) =>
                   isMobile

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
@@ -20,6 +20,9 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import { ChartDownloadButton } from '@/components/ui/ChartDownloadButton';
 
 const CHART_TITLE = 'Monthly Totals';
+// Desktop goes vertical on the bar-top labels and widens the top margin only
+// once the column count crosses this threshold (3 years of monthly buckets).
+const DESKTOP_CROWDED_THRESHOLD = 36;
 
 interface CategoryPayeeBarChartProps {
   data: MonthlyTotal[];
@@ -94,6 +97,9 @@ export function CategoryPayeeBarChart({
     });
   }, [data]);
 
+  const isCrowded = chartData.length > DESKTOP_CROWDED_THRESHOLD;
+  const verticalLabels = isMobile || isCrowded;
+
   const summary = useMemo(() => {
     if (chartData.length === 0) return null;
     const total = chartData.reduce((sum, d) => sum + d.total, 0);
@@ -145,7 +151,7 @@ export function CategoryPayeeBarChart({
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           <BarChart
             data={chartData}
-            margin={{ top: isMobile ? 32 : 20, right: isMobile ? 16 : 5, left: -10, bottom: 0 }}
+            margin={{ top: verticalLabels ? 32 : 20, right: isMobile ? 16 : 5, left: -10, bottom: 0 }}
             onClick={onMonthClick ? (state: any) => {
               const month = state?.activeLabel;
               if (!month) return;
@@ -166,7 +172,7 @@ export function CategoryPayeeBarChart({
               tickLine={false}
               axisLine={{ stroke: '#e5e7eb' }}
               tickFormatter={(value: string) => format(parseLocalDate(`${value}-01`), 'MMM yy')}
-              interval={isMobile ? 'preserveStartEnd' : 0}
+              interval="preserveStartEnd"
               angle={isMobile ? -35 : 0}
               textAnchor={isMobile ? 'end' : 'middle'}
               tickMargin={isMobile ? 10 : 0}
@@ -194,8 +200,9 @@ export function CategoryPayeeBarChart({
               <LabelList
                 dataKey="total"
                 position="top"
-                angle={isMobile ? -90 : 0}
-                offset={isMobile ? 14 : 5}
+                angle={verticalLabels ? -90 : 0}
+                offset={isMobile ? 14 : verticalLabels ? 12 : 5}
+                textAnchor="middle"
                 formatter={(value: unknown) =>
                   isMobile
                     ? formatCurrencyAxis(Number(value))
@@ -205,7 +212,7 @@ export function CategoryPayeeBarChart({
                   fill: '#6b7280',
                   fontSize: isMobile ? 10 : 11,
                   fontWeight: 500,
-                  ...(isMobile && { dominantBaseline: 'central' as const }),
+                  ...(verticalLabels && { dominantBaseline: 'central' as const }),
                 }}
               />
             </Bar>


### PR DESCRIPTION
## Summary

This branch bundles a series of AI Assistant / MCP improvements and two unrelated UI fixes. All AI-visible tools share a single domain-service implementation per `CLAUDE.md`'s "shared AI tools" rule — the AI executor and MCP handlers are thin adapters.

### 1. Sensible defaults for AI + MCP tool parameters (`f62c278`)

Tools that previously required date ranges (or `topN`) now fall back to sensible defaults in the handler so the LLM doesn't fail validation when it omits them.

- `query_transactions` / `get_spending_by_category` / `get_income_summary` / `get_transfers` / `generate_report`: default to the last 30 days
- `get_spending_by_category.topN`: defaults to 10
- `compare_periods`: defaults to previous full month vs current month-to-date (all-or-nothing fallback)
- `monthly_comparison.month`: defaults to the previous complete month

Defaults are centralized in `backend/src/common/tool-schemas.ts` (`getDefaultDateRange`, `getDefaultComparePeriods`, `getDefaultPreviousMonth`, `DEFAULT_TOP_N`). Zod validation relaxed accordingly; tool descriptions advertise the defaults.

### 2. `query_investment_transactions` defaults `groupBy` to `security` (`ee15cec`)

Per-ticker is the most useful default breakdown for "what did I buy this year" questions. Applied on both AI + MCP.

### 3. `get_account_balances` gains `status` + `accountTypes` filters (`0a7a771`)

- `status`: `"open" | "closed" | "all"` — defaults to `"open"`. Single source of truth in `AccountsService.getLlmBalances`.
- `accountTypes`: optional array of `AccountType` enum values (defaults to all types).
- Response entries now carry `isClosed` so the LLM can distinguish closed accounts when `"all"` / `"closed"` is selected.
- MCP adapter passes caller's value straight through so the `"open"` default lives in one place only.

### 4. New shared `get_categories` tool + frontend subcategory-search fix (`710bf92`)

**Backend:** `CategoriesService.getLlmCategories` is a new shared method. Both AI + MCP delegate to it. Returns a flat list with `parentName`, `isIncome`, and `transactionCount` plus a `totalCount`. Filters: `type: "expense" | "income" | "all"` (defaults `"all"`), and case-insensitive `search` on name. Matched subcategories pull in their parent so hierarchy stays visible.

**Frontend (unrelated fix):** Tools → Categories search previously filtered only top-level rows, so searching for a subcategory returned an empty tree. The filter now:
- includes the parent of any matching subcategory (so its tree row renders)
- includes every subcategory of a matching parent (so the branch you searched for actually appears)

### 5. `query_transactions` category parsing (`7d8f95d`)

`resolveLlmCategoryIds` used to do a case-insensitive exact lookup on the leaf name, then silently drop any miss. Combined, that meant `"Food: Dining Out"` never matched anything and the executor sent an empty category filter — producing "all transactions" instead of the subcategory the user asked about.

The resolver now:
- builds a richer lookup that includes Parent/Child variants for every subcategory (`:`, `/`, `>`, `->`; with and without spaces around the separator)
- falls back to the last segment when a Parent/Child key misses (so `"Mystery: Dining Out"` still resolves)
- normalizes whitespace and case
- returns `{ categoryIds, unresolved }`

`ToolExecutorService.queryTransactions` returns an `isError` result when any name fails to resolve, telling the model which names were wrong and pointing it at `get_categories`. The `query_transactions` tool description advertises the `"Parent: Child"` notation and fail-loud behavior.

### 6. Monthly Totals chart label collision fix (`4019e69`, `fa97ead`) — unrelated UI

On desktop the chart drew every X-axis tick and every bar-top value horizontally. At ~12+ months the labels overran each other and collided with neighbouring bars.

- X-axis now uses `interval="preserveStartEnd"` on both breakpoints so Recharts drops ticks it can't fit.
- Bar-top values rotate to `-90°` on desktop once `chartData.length > 36` (matching existing mobile behavior); `textAnchor="middle"` + `dominantBaseline: 'central'` keep them centered over each bar at any width.
- Chart top margin widens to 32 whenever labels go vertical.
- Vertical-label `offset` bumped (desktop crowded 12→18, mobile 14→20) so the currency symbol at the bottom of the rotated text clears the bar top.
- Uncrowded desktop (≤36 months) is unchanged.

## Test plan

- [x] `npm run lint`, `npm run type-check`, and targeted `npm run test` clean in `backend/` and `frontend/`
- [x] New unit tests for `getDefaultDateRange`, `getDefaultComparePeriods`, `getDefaultPreviousMonth`
- [x] AI executor + MCP handler tests cover every default added (empty-input calls route to the service with computed defaults)
- [x] 9 new resolver tests cover exact-match + descendants, all four separators, whitespace tolerance, last-segment fallback, and mixed / all-unresolved cases
- [x] Executor error-path test for an unresolved category name
- [x] `getLlmCategories` tests cover `type='all'` default, hierarchy `parentName`, search-pulls-in-parent, case insensitivity
- [x] MCP `get_categories` tests cover filters, defaults, and error path
- [x] Frontend `CategoriesPage` tests: subcategory-search shows parent, parent-search shows subcategories
- [x] `CategoryPayeeBarChart` tests cover `interval="preserveStartEnd"`, the 36-month threshold, and mobile staying vertical
- [ ] Manual smoke test: call each updated tool with no arguments via the AI Assistant and MCP client; verify real data comes back instead of a validation error
- [ ] Manual smoke test: load Tools → Categories, search for a subcategory name; verify the branch (parent + subcategory) renders
- [ ] Manual smoke test: load the transactions page with a 48-month range; verify X-axis drops ticks and bar-top values read vertically with the currency symbol clear of the bar

https://claude.ai/code/session_01PYU22ZFHCaYzy5GYzsjPzQ