### PR TITLE
Add realized gains calculation using average-cost method

### DIFF
--- a/backend/src/securities/investment-transactions.controller.spec.ts
+++ b/backend/src/securities/investment-transactions.controller.spec.ts
@@ -30,6 +30,7 @@ describe("InvestmentTransactionsController", () => {
       create: jest.fn(),
       findAll: jest.fn(),
       getSummary: jest.fn(),
+      getRealizedGains: jest.fn(),
       findOne: jest.fn(),
       update: jest.fn(),
       remove: jest.fn(),
@@ -187,6 +188,39 @@ describe("InvestmentTransactionsController", () => {
       await controller.getSummary(req, `${UUID1},${UUID2}`);
 
       expect(service.getSummary).toHaveBeenCalledWith("user-1", [UUID1, UUID2]);
+    });
+  });
+
+  describe("getRealizedGains", () => {
+    it("passes filters through to the service", async () => {
+      const rows = [{ transactionId: "s1", realizedGain: 100 }];
+      service.getRealizedGains.mockResolvedValue(rows);
+
+      const result = await controller.getRealizedGains(
+        req,
+        `${UUID1},${UUID2}`,
+        "2024-01-01",
+        "2024-12-31",
+      );
+
+      expect(service.getRealizedGains).toHaveBeenCalledWith("user-1", {
+        accountIds: [UUID1, UUID2],
+        startDate: "2024-01-01",
+        endDate: "2024-12-31",
+      });
+      expect(result).toEqual(rows);
+    });
+
+    it("rejects invalid UUIDs", () => {
+      expect(() => controller.getRealizedGains(req, "not-a-uuid")).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it("rejects malformed dates", () => {
+      expect(() =>
+        controller.getRealizedGains(req, undefined, "2024/01/01"),
+      ).toThrow(BadRequestException);
     });
   });
 

--- a/backend/src/securities/investment-transactions.controller.ts
+++ b/backend/src/securities/investment-transactions.controller.ts
@@ -178,6 +178,47 @@ export class InvestmentTransactionsController {
     return this.investmentTransactionsService.getSummary(req.user.id, ids);
   }
 
+  @Get("realized-gains")
+  @ApiOperation({
+    summary:
+      "Realized gains for each SELL transaction, using average-cost basis replay",
+  })
+  @ApiQuery({ name: "accountIds", required: false })
+  @ApiQuery({ name: "startDate", required: false })
+  @ApiQuery({ name: "endDate", required: false })
+  @ApiResponse({ status: 200, description: "List of SELLs with realized gain" })
+  getRealizedGains(
+    @Request() req,
+    @Query("accountIds") accountIds?: string,
+    @Query("startDate") startDate?: string,
+    @Query("endDate") endDate?: string,
+  ) {
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+    const ids = accountIds ? accountIds.split(",").filter(Boolean) : undefined;
+    if (ids) {
+      for (const id of ids) {
+        if (!uuidRegex.test(id)) {
+          throw new BadRequestException(`Invalid account UUID: ${id}`);
+        }
+      }
+    }
+    if (startDate !== undefined && !dateRegex.test(startDate)) {
+      throw new BadRequestException("startDate must be in YYYY-MM-DD format");
+    }
+    if (endDate !== undefined && !dateRegex.test(endDate)) {
+      throw new BadRequestException("endDate must be in YYYY-MM-DD format");
+    }
+
+    return this.investmentTransactionsService.getRealizedGains(req.user.id, {
+      accountIds: ids,
+      startDate,
+      endDate,
+    });
+  }
+
   @Get(":id")
   @ApiOperation({ summary: "Get an investment transaction by ID" })
   @ApiResponse({

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -14,6 +14,7 @@ import { AccountSubType } from "../accounts/entities/account.entity";
 import { AccountsService } from "../accounts/accounts.service";
 import { TransactionsService } from "../transactions/transactions.service";
 import { HoldingsService } from "./holdings.service";
+import { PortfolioCalculationService } from "./portfolio-calculation.service";
 import { SecuritiesService } from "./securities.service";
 import { SecurityPriceService } from "./security-price.service";
 import { NetWorthService } from "../net-worth/net-worth.service";
@@ -334,6 +335,10 @@ describe("InvestmentTransactionsService", () => {
         {
           provide: HoldingsService,
           useValue: holdingsService,
+        },
+        {
+          provide: PortfolioCalculationService,
+          useValue: { calculateRealizedGains: jest.fn().mockResolvedValue([]) },
         },
         {
           provide: SecuritiesService,

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -17,6 +17,10 @@ import { UpdateInvestmentTransactionDto } from "./dto/update-investment-transact
 import { AccountsService } from "../accounts/accounts.service";
 import { TransactionsService } from "../transactions/transactions.service";
 import { HoldingsService } from "./holdings.service";
+import {
+  PortfolioCalculationService,
+  RealizedGainEntry,
+} from "./portfolio-calculation.service";
 import { SecuritiesService } from "./securities.service";
 import { SecurityPriceService } from "./security-price.service";
 import { NetWorthService } from "../net-worth/net-worth.service";
@@ -82,6 +86,7 @@ export class InvestmentTransactionsService {
     @Inject(forwardRef(() => TransactionsService))
     private transactionsService: TransactionsService,
     private holdingsService: HoldingsService,
+    private portfolioCalculationService: PortfolioCalculationService,
     private securitiesService: SecuritiesService,
     private securityPriceService: SecurityPriceService,
     private netWorthService: NetWorthService,
@@ -765,6 +770,37 @@ export class InvestmentTransactionsService {
         hasMore: pageNum < totalPages,
       },
     };
+  }
+
+  /**
+   * Return each SELL transaction annotated with cost basis and realized gain,
+   * computed by replaying the user's transaction history under the
+   * average-cost method. Linked brokerage/cash accounts are resolved the same
+   * way as `findAll()` so filtering by either side yields consistent results.
+   */
+  async getRealizedGains(
+    userId: string,
+    opts: {
+      accountIds?: string[];
+      startDate?: string;
+      endDate?: string;
+    } = {},
+  ): Promise<RealizedGainEntry[]> {
+    let accountIds = opts.accountIds;
+    if (accountIds && accountIds.length > 0) {
+      const resolvedIds = new Set<string>(accountIds);
+      const accounts = await this.accountsService.findByIds(userId, accountIds);
+      for (const acct of accounts) {
+        if (acct.linkedAccountId) resolvedIds.add(acct.linkedAccountId);
+      }
+      accountIds = [...resolvedIds];
+    }
+
+    return this.portfolioCalculationService.calculateRealizedGains(userId, {
+      accountIds,
+      startDate: opts.startDate,
+      endDate: opts.endDate,
+    });
   }
 
   async findOne(userId: string, id: string): Promise<InvestmentTransaction> {

--- a/backend/src/securities/portfolio-calculation.service.spec.ts
+++ b/backend/src/securities/portfolio-calculation.service.spec.ts
@@ -1,0 +1,215 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { PortfolioCalculationService } from "./portfolio-calculation.service";
+import { Holding } from "./entities/holding.entity";
+import { SecurityPrice } from "./entities/security-price.entity";
+import {
+  InvestmentTransaction,
+  InvestmentAction,
+} from "./entities/investment-transaction.entity";
+import { Account } from "../accounts/entities/account.entity";
+import { ExchangeRateService } from "../currencies/exchange-rate.service";
+
+describe("PortfolioCalculationService.calculateRealizedGains", () => {
+  let service: PortfolioCalculationService;
+  let txRepo: { find: jest.Mock };
+
+  const userId = "user-1";
+  const accountId = "acct-1";
+  const securityId = "sec-1";
+
+  const makeTx = (overrides: Partial<InvestmentTransaction>) =>
+    ({
+      id: overrides.id ?? "tx",
+      userId,
+      accountId,
+      securityId,
+      action: InvestmentAction.BUY,
+      transactionDate: "2024-01-01",
+      quantity: 0,
+      price: 0,
+      commission: 0,
+      totalAmount: 0,
+      exchangeRate: 1,
+      description: null,
+      createdAt: new Date("2024-01-01"),
+      updatedAt: new Date("2024-01-01"),
+      account: {
+        id: accountId,
+        name: "TFSA",
+        currencyCode: "CAD",
+      } as Partial<Account>,
+      security: {
+        id: securityId,
+        symbol: "ABC",
+        name: "ABC Corp",
+        currencyCode: "CAD",
+      },
+      ...overrides,
+    }) as unknown as InvestmentTransaction;
+
+  beforeEach(async () => {
+    txRepo = { find: jest.fn() };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PortfolioCalculationService,
+        { provide: getRepositoryToken(Holding), useValue: {} },
+        { provide: getRepositoryToken(SecurityPrice), useValue: {} },
+        { provide: getRepositoryToken(InvestmentTransaction), useValue: txRepo },
+        { provide: getRepositoryToken(Account), useValue: {} },
+        { provide: ExchangeRateService, useValue: {} },
+      ],
+    }).compile();
+    service = module.get(PortfolioCalculationService);
+  });
+
+  it("uses average cost at sale time, not quantity * price, as the cost basis", async () => {
+    // Buy 100 @ $50, then sell 100 @ $60. True realized gain = 100 * ($60 - $50) = $1000.
+    // The old buggy formula would have produced cost basis = 100 * $60 = $6000 -> gain near zero.
+    txRepo.find.mockResolvedValue([
+      makeTx({
+        id: "buy",
+        action: InvestmentAction.BUY,
+        transactionDate: "2024-01-10",
+        quantity: 100,
+        price: 50,
+        totalAmount: 5000,
+      }),
+      makeTx({
+        id: "sell",
+        action: InvestmentAction.SELL,
+        transactionDate: "2024-06-10",
+        quantity: 100,
+        price: 60,
+        commission: 10,
+        totalAmount: 5990, // 100 * 60 - 10 commission
+      }),
+    ]);
+
+    const result = await service.calculateRealizedGains(userId);
+
+    expect(result).toHaveLength(1);
+    const sell = result[0];
+    expect(sell.transactionId).toBe("sell");
+    expect(sell.costBasis).toBe(5000);
+    expect(sell.proceeds).toBe(5990); // net of commission
+    expect(sell.realizedGain).toBe(990); // 5990 - 5000
+  });
+
+  it("averages cost across multiple BUYs before a partial SELL", async () => {
+    // Buy 100 @ $50 -> costBasis 5000, qty 100
+    // Buy 100 @ $70 -> costBasis 12000, qty 200, avg = 60
+    // Sell 50 -> cost basis for sold = 50 * 60 = 3000
+    txRepo.find.mockResolvedValue([
+      makeTx({
+        id: "b1",
+        action: InvestmentAction.BUY,
+        transactionDate: "2024-01-10",
+        quantity: 100,
+        price: 50,
+        totalAmount: 5000,
+      }),
+      makeTx({
+        id: "b2",
+        action: InvestmentAction.BUY,
+        transactionDate: "2024-03-10",
+        quantity: 100,
+        price: 70,
+        totalAmount: 7000,
+      }),
+      makeTx({
+        id: "s1",
+        action: InvestmentAction.SELL,
+        transactionDate: "2024-06-10",
+        quantity: 50,
+        price: 80,
+        totalAmount: 4000,
+      }),
+    ]);
+
+    const result = await service.calculateRealizedGains(userId);
+    expect(result).toHaveLength(1);
+    expect(result[0].costBasis).toBe(3000);
+    expect(result[0].realizedGain).toBe(1000);
+  });
+
+  it("filters the output by startDate but still replays history before the range", async () => {
+    txRepo.find.mockResolvedValue([
+      makeTx({
+        id: "b1",
+        action: InvestmentAction.BUY,
+        transactionDate: "2022-01-10", // well before the window
+        quantity: 100,
+        price: 20,
+        totalAmount: 2000,
+      }),
+      makeTx({
+        id: "s1",
+        action: InvestmentAction.SELL,
+        transactionDate: "2024-06-10",
+        quantity: 50,
+        price: 40,
+        totalAmount: 2000,
+      }),
+    ]);
+
+    const result = await service.calculateRealizedGains(userId, {
+      startDate: "2024-01-01",
+      endDate: "2024-12-31",
+    });
+
+    expect(result).toHaveLength(1);
+    // Cost basis from the 2022 BUY at $20/share still applies.
+    expect(result[0].costBasis).toBe(1000); // 50 * 20
+    expect(result[0].realizedGain).toBe(1000); // 2000 - 1000
+  });
+
+  it("converts to account currency using the SELL transaction's exchange rate", async () => {
+    // BUY 10 @ $100 USD with rate 1.3 -> costBasis 1300 CAD
+    // SELL 10 @ $150 USD, totalAmount 1500 USD, rate 1.35 -> proceeds 2025 CAD
+    txRepo.find.mockResolvedValue([
+      makeTx({
+        id: "b1",
+        action: InvestmentAction.BUY,
+        transactionDate: "2024-01-01",
+        quantity: 10,
+        price: 100,
+        totalAmount: 1000,
+        exchangeRate: 1.3,
+      }),
+      makeTx({
+        id: "s1",
+        action: InvestmentAction.SELL,
+        transactionDate: "2024-06-01",
+        quantity: 10,
+        price: 150,
+        totalAmount: 1500,
+        exchangeRate: 1.35,
+      }),
+    ]);
+
+    const result = await service.calculateRealizedGains(userId);
+    expect(result[0].proceeds).toBe(2025); // 1500 * 1.35
+    expect(result[0].costBasis).toBe(1300); // 10 * 100 * 1.3
+    expect(result[0].realizedGain).toBe(725); // 2025 - 1300
+  });
+
+  it("returns zero realized gain when a SELL has no prior position", async () => {
+    txRepo.find.mockResolvedValue([
+      makeTx({
+        id: "orphan-sell",
+        action: InvestmentAction.SELL,
+        transactionDate: "2024-06-01",
+        quantity: 10,
+        price: 50,
+        totalAmount: 500,
+      }),
+    ]);
+
+    const result = await service.calculateRealizedGains(userId);
+    expect(result).toHaveLength(1);
+    expect(result[0].costBasis).toBe(0);
+    expect(result[0].proceeds).toBe(500);
+    expect(result[0].realizedGain).toBe(500);
+  });
+});

--- a/backend/src/securities/portfolio-calculation.service.ts
+++ b/backend/src/securities/portfolio-calculation.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository, In, LessThanOrEqual } from "typeorm";
+import { Repository, In, LessThanOrEqual, FindOptionsWhere } from "typeorm";
 import { Holding } from "./entities/holding.entity";
 import { SecurityPrice } from "./entities/security-price.entity";
 import {
@@ -375,12 +375,7 @@ export class PortfolioCalculationService {
   ): Promise<RealizedGainEntry[]> {
     const { accountIds, startDate, endDate } = opts;
 
-    const where: {
-      userId: string;
-      accountId?: ReturnType<typeof In>;
-      transactionDate?: ReturnType<typeof LessThanOrEqual>;
-    } = { userId };
-
+    const where: FindOptionsWhere<InvestmentTransaction> = { userId };
     if (accountIds && accountIds.length > 0) {
       where.accountId = In(accountIds);
     }

--- a/backend/src/securities/portfolio-calculation.service.ts
+++ b/backend/src/securities/portfolio-calculation.service.ts
@@ -27,6 +27,33 @@ export interface CategorisedAccounts {
 }
 
 /**
+ * A single SELL transaction with the cost basis and realized gain derived
+ * from replaying transaction history up to the sale. All monetary fields
+ * are denominated in the holding account's currency.
+ */
+export interface RealizedGainEntry {
+  transactionId: string;
+  transactionDate: string;
+  accountId: string;
+  accountName: string | null;
+  accountCurrencyCode: string | null;
+  securityId: string;
+  symbol: string | null;
+  securityName: string | null;
+  securityCurrencyCode: string | null;
+  quantity: number;
+  price: number;
+  commission: number;
+  proceeds: number;
+  costBasis: number;
+  realizedGain: number;
+}
+
+function roundMoney(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}
+
+/**
  * Service responsible for the core portfolio value calculations:
  * holdings valuation, account grouping, allocation, TWR, and CAGR.
  *
@@ -321,6 +348,135 @@ export class PortfolioCalculationService {
     }
 
     return result;
+  }
+
+  /**
+   * Replay the user's investment transaction history to compute the realized
+   * gain or loss of each SELL transaction using the average-cost method.
+   *
+   * For every prior BUY/REINVEST/TRANSFER_IN, the running cost basis for that
+   * (account, security) grows by `quantity * price * exchangeRate` (the same
+   * bookkeeping as `calculateCostBasesInAccountCurrency`). A SELL then draws
+   * down cost basis proportionally at the running average cost per share, and
+   * the realized gain is `proceeds - costBasis` — all in the holding account's
+   * currency.
+   *
+   * The entire history is replayed regardless of the requested date range so
+   * SELLs early in the range still see cost basis built up by prior BUYs; only
+   * the returned rows are filtered to the requested window.
+   */
+  async calculateRealizedGains(
+    userId: string,
+    opts: {
+      accountIds?: string[];
+      startDate?: string;
+      endDate?: string;
+    } = {},
+  ): Promise<RealizedGainEntry[]> {
+    const { accountIds, startDate, endDate } = opts;
+
+    const where: {
+      userId: string;
+      accountId?: ReturnType<typeof In>;
+      transactionDate?: ReturnType<typeof LessThanOrEqual>;
+    } = { userId };
+
+    if (accountIds && accountIds.length > 0) {
+      where.accountId = In(accountIds);
+    }
+    if (endDate) {
+      where.transactionDate = LessThanOrEqual(endDate);
+    }
+
+    const transactions = await this.investmentTransactionRepository.find({
+      where,
+      relations: ["security", "account"],
+      order: { transactionDate: "ASC", createdAt: "ASC" },
+    });
+
+    const state = new Map<string, { quantity: number; costBasis: number }>();
+    const results: RealizedGainEntry[] = [];
+
+    for (const tx of transactions) {
+      if (!tx.securityId) continue;
+
+      const key = `${tx.accountId}:${tx.securityId}`;
+      let entry = state.get(key);
+      if (!entry) {
+        entry = { quantity: 0, costBasis: 0 };
+        state.set(key, entry);
+      }
+
+      const quantity = Number(tx.quantity) || 0;
+      const price = Number(tx.price) || 0;
+      const exchangeRate = Number(tx.exchangeRate) || 1;
+
+      switch (tx.action) {
+        case InvestmentAction.BUY:
+        case InvestmentAction.REINVEST:
+        case InvestmentAction.TRANSFER_IN: {
+          entry.costBasis += quantity * price * exchangeRate;
+          entry.quantity += quantity;
+          break;
+        }
+        case InvestmentAction.SELL:
+        case InvestmentAction.TRANSFER_OUT: {
+          const sellQty = Math.min(quantity, entry.quantity);
+          const avgCostPerShare =
+            entry.quantity > 0 ? entry.costBasis / entry.quantity : 0;
+          const costBasisSold = sellQty * avgCostPerShare;
+          entry.costBasis -= costBasisSold;
+          entry.quantity -= sellQty;
+
+          if (tx.action === InvestmentAction.SELL) {
+            // totalAmount is already stored in the security's currency and is
+            // net of commission; multiply by exchangeRate to put both sides of
+            // the gain calculation in the holding account's currency.
+            const proceeds = Number(tx.totalAmount) * exchangeRate;
+            const realizedGain = proceeds - costBasisSold;
+
+            if (!startDate || tx.transactionDate >= startDate) {
+              results.push({
+                transactionId: tx.id,
+                transactionDate: tx.transactionDate,
+                accountId: tx.accountId,
+                accountName: tx.account?.name ?? null,
+                accountCurrencyCode: tx.account?.currencyCode ?? null,
+                securityId: tx.securityId,
+                symbol: tx.security?.symbol ?? null,
+                securityName: tx.security?.name ?? null,
+                securityCurrencyCode: tx.security?.currencyCode ?? null,
+                quantity: Math.abs(quantity),
+                price,
+                commission: Number(tx.commission) || 0,
+                proceeds: roundMoney(proceeds),
+                costBasis: roundMoney(costBasisSold),
+                realizedGain: roundMoney(realizedGain),
+              });
+            }
+          }
+          break;
+        }
+        case InvestmentAction.ADD_SHARES:
+          entry.quantity += quantity;
+          break;
+        case InvestmentAction.REMOVE_SHARES:
+          entry.quantity -= quantity;
+          break;
+        case InvestmentAction.SPLIT: {
+          const splitRatio = quantity || 1;
+          if (splitRatio > 0) entry.quantity *= splitRatio;
+          break;
+        }
+      }
+
+      if (Math.abs(entry.quantity) < 0.0001) {
+        entry.quantity = 0;
+        entry.costBasis = 0;
+      }
+    }
+
+    return results;
   }
 
   /**

--- a/frontend/src/app/transactions/page.test.tsx
+++ b/frontend/src/app/transactions/page.test.tsx
@@ -950,12 +950,19 @@ describe('TransactionsPage', () => {
 
       render(<TransactionsPage />);
 
+      // Wait until the filter panel shows -- that's our signal that accounts
+      // have loaded and filteredAccounts is populated, so the subsequent
+      // loadTransactions re-run has the real account list to work with.
       await waitFor(() => {
-        expect(mockGetDailyBalances).toHaveBeenCalled();
+        expect(screen.getByTestId('filter-panel')).toBeInTheDocument();
+      });
+
+      await waitFor(() => {
+        const latest = mockGetDailyBalances.mock.calls.at(-1)?.[0];
+        expect(latest?.accountIds).toBeDefined();
       });
 
       const callArgs = mockGetDailyBalances.mock.calls.at(-1)?.[0];
-      expect(callArgs).toBeDefined();
       const accountIds = (callArgs.accountIds as string).split(',').sort();
       // acc-4 is a brokerage account in the mock fixtures and must not appear.
       expect(accountIds).not.toContain('acc-4');

--- a/frontend/src/app/transactions/page.test.tsx
+++ b/frontend/src/app/transactions/page.test.tsx
@@ -940,6 +940,29 @@ describe('TransactionsPage', () => {
       expect((callArgs.accountIds as string).split(',')).toEqual(['acc-3']);
     });
 
+    it('excludes brokerage accounts from the chart query when no Show Accounts filter is set (All)', async () => {
+      // Regression: previously the chart fell back to accountIds=undefined
+      // when the Active/Closed/All toggle was on "All", which let the daily
+      // balances API include brokerage accounts. The Account Balances chart
+      // should never surface brokerage accounts here -- they're only
+      // actionable from the Investments page.
+      mockGetAllAccounts.mockResolvedValue(mockAccounts);
+
+      render(<TransactionsPage />);
+
+      await waitFor(() => {
+        expect(mockGetDailyBalances).toHaveBeenCalled();
+      });
+
+      const callArgs = mockGetDailyBalances.mock.calls.at(-1)?.[0];
+      expect(callArgs).toBeDefined();
+      const accountIds = (callArgs.accountIds as string).split(',').sort();
+      // acc-4 is a brokerage account in the mock fixtures and must not appear.
+      expect(accountIds).not.toContain('acc-4');
+      // All non-brokerage accounts (active + closed) should be requested.
+      expect(accountIds).toEqual(['acc-1', 'acc-2', 'acc-3']);
+    });
+
     it('forwards a filter label to Monthly Totals chart built from selected category/payee/tag names', async () => {
       mockGetAllAccounts.mockResolvedValue(mockAccounts);
       mockGetAllCategories.mockResolvedValue(mockCategories);

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -129,7 +129,11 @@ function TransactionsContent() {
       let accountIdsForQuery: string[] | undefined;
       if (filters.filterAccountIds.length > 0) {
         accountIdsForQuery = filters.filterAccountIds;
-      } else if (filters.filterAccountStatus && filters.filteredAccounts.length > 0) {
+      } else if (filters.filteredAccounts.length > 0) {
+        // Always narrow to filteredAccounts (which strips brokerage and
+        // honours the Active/Closed/All toggle). Without this, the "All"
+        // toggle would let the chart query include brokerage accounts whose
+        // balances are not actionable from the Transactions page.
         accountIdsForQuery = filters.filteredAccounts.map(a => a.id);
       }
 
@@ -418,7 +422,7 @@ function TransactionsContent() {
     const f: BulkUpdateFilters = {};
     if (filters.filterAccountIds.length > 0) {
       f.accountIds = filters.filterAccountIds;
-    } else if (filters.filterAccountStatus && filters.filteredAccounts.length > 0) {
+    } else if (filters.filteredAccounts.length > 0) {
       f.accountIds = filters.filteredAccounts.map(a => a.id);
     }
     if (filters.filterCategoryIds.length > 0) f.categoryIds = filters.filterCategoryIds;
@@ -568,7 +572,11 @@ function TransactionsContent() {
       let accountIdsForQuery: string[] | undefined;
       if (filters.filterAccountIds.length > 0) {
         accountIdsForQuery = filters.filterAccountIds;
-      } else if (filters.filterAccountStatus && filters.filteredAccounts.length > 0) {
+      } else if (filters.filteredAccounts.length > 0) {
+        // Always narrow to filteredAccounts (which strips brokerage and
+        // honours the Active/Closed/All toggle). Without this, the "All"
+        // toggle would let the chart query include brokerage accounts whose
+        // balances are not actionable from the Transactions page.
         accountIdsForQuery = filters.filteredAccounts.map(a => a.id);
       }
 

--- a/frontend/src/components/reports/CustomReportViewer.test.tsx
+++ b/frontend/src/components/reports/CustomReportViewer.test.tsx
@@ -380,6 +380,49 @@ describe("CustomReportViewer", () => {
     );
   });
 
+  it("assigns distinct legend swatch colours when data has no colour", async () => {
+    mockGetById.mockResolvedValue({
+      id: "rpt-1",
+      name: "Uncoloured Report",
+      viewType: "PIE_CHART",
+      timeframeType: "LAST_3_MONTHS",
+      groupBy: "CATEGORY",
+      config: {
+        metric: "TOTAL_AMOUNT",
+        direction: "EXPENSES_ONLY",
+        includeTransfers: false,
+      },
+      filters: {},
+    });
+    mockExecute.mockResolvedValue({
+      viewType: "PIE_CHART",
+      groupBy: "CATEGORY",
+      data: [
+        { label: "Food", value: 500, count: 20, id: "cat-1" },
+        { label: "Transport", value: 200, count: 10, id: "cat-2" },
+        { label: "Utilities", value: 150, count: 5, id: "cat-3" },
+      ],
+      summary: { total: 850, count: 35 },
+      timeframe: {
+        label: "Last 3 months",
+        startDate: "2024-10-01",
+        endDate: "2025-01-01",
+      },
+    });
+    render(<CustomReportViewer reportId="rpt-1" />);
+    await waitFor(() => {
+      expect(screen.getByText("Food")).toBeInTheDocument();
+    });
+    const swatches = document.querySelectorAll<HTMLElement>(
+      "button .w-3.h-3.rounded-full",
+    );
+    expect(swatches.length).toBe(3);
+    const colours = Array.from(swatches).map((el) => el.style.backgroundColor);
+    // Each swatch must have a colour, and they must not all be identical.
+    colours.forEach((c) => expect(c).toBeTruthy());
+    expect(new Set(colours).size).toBe(3);
+  });
+
   it("handles execute error gracefully", async () => {
     mockGetById.mockResolvedValue({
       id: "rpt-1",

--- a/frontend/src/components/reports/CustomReportViewer.tsx
+++ b/frontend/src/components/reports/CustomReportViewer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 import Link from 'next/link';
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/Button';
 import { DateInput } from '@/components/ui/DateInput';
 import { Select } from '@/components/ui/Select';
 import { customReportsApi } from '@/lib/custom-reports';
+import { CHART_COLOURS } from '@/lib/chart-colours';
 import {
   CustomReport,
   ReportResult,
@@ -125,6 +126,16 @@ export function CustomReportViewer({ reportId }: CustomReportViewerProps) {
     { value: '', label: 'Use saved timeframe' },
     ...Object.entries(TIMEFRAME_LABELS).map(([value, label]) => ({ value, label })),
   ];
+
+  // Mirror ReportChart's colour assignment so legend swatches match chart slices/bars.
+  const legendData = useMemo(() => {
+    if (!result) return [];
+    let colourIndex = 0;
+    return result.data.map((item) => ({
+      ...item,
+      color: item.color || CHART_COLOURS[colourIndex++ % CHART_COLOURS.length],
+    }));
+  }, [result]);
 
   if (isLoading) {
     return (
@@ -257,10 +268,10 @@ export function CustomReportViewer({ reportId }: CustomReportViewerProps) {
 
           {/* Legend for pie/bar charts */}
           {(result.viewType === ReportViewType.PIE_CHART || result.viewType === ReportViewType.BAR_CHART) &&
-            result.data.length > 0 && (
+            legendData.length > 0 && (
               <div className="mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
                 <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
-                  {result.data.slice(0, 15).map((item, index) => (
+                  {legendData.slice(0, 15).map((item, index) => (
                     <button
                       key={index}
                       onClick={() => item.id && handleDataPointClick(item.id)}
@@ -268,7 +279,7 @@ export function CustomReportViewer({ reportId }: CustomReportViewerProps) {
                     >
                       <div
                         className="w-3 h-3 rounded-full flex-shrink-0"
-                        style={{ backgroundColor: item.color || '#3b82f6' }}
+                        style={{ backgroundColor: item.color }}
                       />
                       <span className="text-gray-600 dark:text-gray-400 truncate">
                         {item.label}

--- a/frontend/src/components/reports/DividendIncomeReport.test.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.test.tsx
@@ -52,11 +52,13 @@ vi.mock('recharts', () => ({
 
 const mockGetTransactions = vi.fn();
 const mockGetInvestmentAccounts = vi.fn();
+const mockGetRealizedGains = vi.fn();
 
 vi.mock('@/lib/investments', () => ({
   investmentsApi: {
     getTransactions: (...args: any[]) => mockGetTransactions(...args),
     getInvestmentAccounts: (...args: any[]) => mockGetInvestmentAccounts(...args),
+    getRealizedGains: (...args: any[]) => mockGetRealizedGains(...args),
   },
 }));
 
@@ -77,6 +79,7 @@ describe('DividendIncomeReport', () => {
   it('shows loading state initially', () => {
     mockGetTransactions.mockReturnValue(new Promise(() => {}));
     mockGetInvestmentAccounts.mockReturnValue(new Promise(() => {}));
+    mockGetRealizedGains.mockReturnValue(new Promise(() => {}));
     render(<DividendIncomeReport />);
     expect(document.querySelector('.animate-pulse')).toBeTruthy();
   });
@@ -84,6 +87,7 @@ describe('DividendIncomeReport', () => {
   it('renders empty state when no income transactions', async () => {
     mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
     mockGetInvestmentAccounts.mockResolvedValue([]);
+    mockGetRealizedGains.mockResolvedValue([]);
     render(<DividendIncomeReport />);
     await waitFor(() => {
       expect(
@@ -92,32 +96,36 @@ describe('DividendIncomeReport', () => {
     });
   });
 
-  it('counts realized gains from SELL transactions toward Capital Gains', async () => {
-    mockGetTransactions.mockResolvedValue({
-      data: [
-        {
-          id: 'tx-sell',
-          transactionDate: '2024-08-10',
-          action: 'SELL',
-          // proceeds = 1200, cost basis = 10 * 100 = 1000, realized gain = 200
-          totalAmount: 1200,
-          quantity: 10,
-          price: 100,
-          accountId: 'acc-1',
-          security: { symbol: 'ABC', name: 'ABC Corp' },
-        },
-      ],
-      pagination: { hasMore: false },
-    });
+  it('folds realized gains from the backend into Capital Gains', async () => {
+    mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
     mockGetInvestmentAccounts.mockResolvedValue([
       { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+    ]);
+    mockGetRealizedGains.mockResolvedValue([
+      {
+        transactionId: 'sell-1',
+        transactionDate: '2024-08-10',
+        accountId: 'acc-1',
+        accountName: 'TFSA',
+        accountCurrencyCode: 'CAD',
+        securityId: 'sec-1',
+        symbol: 'ABC',
+        securityName: 'ABC Corp',
+        securityCurrencyCode: 'CAD',
+        quantity: 10,
+        price: 80,
+        commission: 0,
+        proceeds: 800,
+        costBasis: 500,
+        realizedGain: 300,
+      },
     ]);
     render(<DividendIncomeReport />);
     await waitFor(() => {
       expect(screen.getByText('Capital Gains')).toBeInTheDocument();
     });
-    // Summary card and By Security cell for ABC should both display the $200 realized gain.
-    expect(screen.getAllByText('$200.00').length).toBeGreaterThan(0);
+    // Summary card and By Security cell for ABC should both display the $300 realized gain.
+    expect(screen.getAllByText('$300.00').length).toBeGreaterThan(0);
   });
 
   it('renders summary cards with data', async () => {
@@ -145,6 +153,7 @@ describe('DividendIncomeReport', () => {
     mockGetInvestmentAccounts.mockResolvedValue([
       { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
     ]);
+    mockGetRealizedGains.mockResolvedValue([]);
     render(<DividendIncomeReport />);
     await waitFor(() => {
       expect(screen.getByText('Dividends')).toBeInTheDocument();
@@ -157,6 +166,7 @@ describe('DividendIncomeReport', () => {
   it('renders view type buttons', async () => {
     mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
     mockGetInvestmentAccounts.mockResolvedValue([]);
+    mockGetRealizedGains.mockResolvedValue([]);
     render(<DividendIncomeReport />);
     await waitFor(() => {
       expect(screen.getByText('Monthly')).toBeInTheDocument();

--- a/frontend/src/components/reports/DividendIncomeReport.test.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.test.tsx
@@ -86,8 +86,38 @@ describe('DividendIncomeReport', () => {
     mockGetInvestmentAccounts.mockResolvedValue([]);
     render(<DividendIncomeReport />);
     await waitFor(() => {
-      expect(screen.getByText(/No dividend, interest, or capital gain transactions found/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/No dividend, interest, capital gain, or sell transactions found/),
+      ).toBeInTheDocument();
     });
+  });
+
+  it('counts realized gains from SELL transactions toward Capital Gains', async () => {
+    mockGetTransactions.mockResolvedValue({
+      data: [
+        {
+          id: 'tx-sell',
+          transactionDate: '2024-08-10',
+          action: 'SELL',
+          // proceeds = 1200, cost basis = 10 * 100 = 1000, realized gain = 200
+          totalAmount: 1200,
+          quantity: 10,
+          price: 100,
+          accountId: 'acc-1',
+          security: { symbol: 'ABC', name: 'ABC Corp' },
+        },
+      ],
+      pagination: { hasMore: false },
+    });
+    mockGetInvestmentAccounts.mockResolvedValue([
+      { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+    ]);
+    render(<DividendIncomeReport />);
+    await waitFor(() => {
+      expect(screen.getByText('Capital Gains')).toBeInTheDocument();
+    });
+    // Summary card and By Security cell for ABC should both display the $200 realized gain.
+    expect(screen.getAllByText('$200.00').length).toBeGreaterThan(0);
   });
 
   it('renders summary cards with data', async () => {

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -13,7 +13,7 @@ import {
 } from 'recharts';
 import { format, eachMonthOfInterval } from 'date-fns';
 import { investmentsApi } from '@/lib/investments';
-import { InvestmentTransaction } from '@/types/investment';
+import { InvestmentTransaction, RealizedGainEntry } from '@/types/investment';
 import { Account } from '@/types/account';
 import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
@@ -48,6 +48,7 @@ export function DividendIncomeReport() {
   const { defaultCurrency, convertToDefault } = useExchangeRates();
   const chartRef = useRef<HTMLDivElement>(null);
   const [transactions, setTransactions] = useState<InvestmentTransaction[]>([]);
+  const [realizedGains, setRealizedGains] = useState<RealizedGainEntry[]>([]);
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [selectedAccountId, setSelectedAccountId] = useState<string>('');
   const { dateRange, setDateRange, resolvedRange, isValid } = useDateRange({ defaultRange: '1y', alignment: 'month' });
@@ -77,20 +78,13 @@ export function DividendIncomeReport() {
     return convertToDefault(amount, txCurrency);
   }, [selectedAccountId, accountCurrencyMap, defaultCurrency, convertToDefault]);
 
-  // Realized gain for a SELL transaction = proceeds - cost basis (quantity * price).
-  // Non-SELL actions return 0. Mirrors the formula used by RealizedGainsReport so
-  // the Capital Gains column here reconciles with that report.
-  const getRealizedGain = useCallback((tx: InvestmentTransaction): number => {
-    if (tx.action !== 'SELL') return 0;
-    const proceeds = Math.abs(tx.totalAmount);
-    const costBasis = tx.quantity != null && tx.price != null
-      ? Math.abs(tx.quantity) * Math.abs(tx.price)
-      : proceeds;
-    const gain = proceeds - costBasis;
-    if (selectedAccountId) return gain;
-    const txCurrency = accountCurrencyMap.get(tx.accountId) || defaultCurrency;
-    return convertToDefault(gain, txCurrency);
-  }, [selectedAccountId, accountCurrencyMap, defaultCurrency, convertToDefault]);
+  // Backend already returns each realized gain in the holding account's
+  // currency (cost basis derived via chronological replay). Convert to the
+  // default currency for the All-Accounts view; pass through otherwise.
+  const convertRealized = useCallback((entry: RealizedGainEntry): number => {
+    if (selectedAccountId) return entry.realizedGain;
+    return convertToDefault(entry.realizedGain, entry.accountCurrencyCode || defaultCurrency);
+  }, [selectedAccountId, defaultCurrency, convertToDefault]);
 
   const fmtValue = useCallback((value: number): string => {
     if (isForeign) {
@@ -106,8 +100,14 @@ export function DividendIncomeReport() {
       try {
         const { start, end } = resolvedRange;
 
+        const accountsPromise = investmentsApi.getInvestmentAccounts();
+        const realizedGainsPromise = investmentsApi.getRealizedGains({
+          accountIds: selectedAccountId || undefined,
+          startDate: start || undefined,
+          endDate: end,
+        });
+
         // Paginate through all transactions (API limit is 200 per page)
-        const accountsData = await investmentsApi.getInvestmentAccounts();
         let allTransactions: InvestmentTransaction[] = [];
         let page = 1;
         let hasMore = true;
@@ -124,17 +124,22 @@ export function DividendIncomeReport() {
           page++;
         }
 
-        // Filter to only income transactions. SELL is included so its realized
-        // gain (proceeds - cost basis) contributes to the Capital Gains total.
+        const [accountsData, realizedGainsData] = await Promise.all([
+          accountsPromise,
+          realizedGainsPromise,
+        ]);
+
+        // Dividend / Interest / CAPITAL_GAIN come from the plain transaction
+        // list; SELL realized gains come from the backend replay endpoint.
         const incomeTransactions = allTransactions.filter(
           (tx) =>
             tx.action === 'DIVIDEND' ||
             tx.action === 'INTEREST' ||
-            tx.action === 'CAPITAL_GAIN' ||
-            tx.action === 'SELL'
+            tx.action === 'CAPITAL_GAIN',
         );
 
         setTransactions(incomeTransactions);
+        setRealizedGains(realizedGainsData);
         setAccounts(accountsData);
       } catch (error) {
         logger.error('Failed to load investment transactions:', error);
@@ -171,11 +176,8 @@ export function DividendIncomeReport() {
       });
     });
 
-    // Aggregate transactions
-    transactions.forEach((tx) => {
-      const txDate = parseLocalDate(tx.transactionDate);
+    const getOrCreateBucket = (txDate: Date): MonthlyIncome => {
       const monthKey = format(txDate, 'yyyy-MM');
-
       let bucket = monthMap.get(monthKey);
       if (!bucket) {
         bucket = {
@@ -188,76 +190,78 @@ export function DividendIncomeReport() {
         };
         monthMap.set(monthKey, bucket);
       }
+      return bucket;
+    };
 
-      let contribution = 0;
+    transactions.forEach((tx) => {
+      const bucket = getOrCreateBucket(parseLocalDate(tx.transactionDate));
+      const contribution = getTxAmount(tx);
       switch (tx.action) {
         case 'DIVIDEND':
-          contribution = getTxAmount(tx);
           bucket.dividends += contribution;
           break;
         case 'INTEREST':
-          contribution = getTxAmount(tx);
           bucket.interest += contribution;
           break;
         case 'CAPITAL_GAIN':
-          contribution = getTxAmount(tx);
-          bucket.capitalGains += contribution;
-          break;
-        case 'SELL':
-          contribution = getRealizedGain(tx);
           bucket.capitalGains += contribution;
           break;
       }
       bucket.total += contribution;
     });
 
+    realizedGains.forEach((entry) => {
+      const bucket = getOrCreateBucket(parseLocalDate(entry.transactionDate));
+      const gain = convertRealized(entry);
+      bucket.capitalGains += gain;
+      bucket.total += gain;
+    });
+
     return Array.from(monthMap.values()).sort((a, b) => a.month.localeCompare(b.month));
-  }, [transactions, dateRange, resolvedRange, getTxAmount, getRealizedGain]);
+  }, [transactions, realizedGains, dateRange, resolvedRange, getTxAmount, convertRealized]);
 
   const securityData = useMemo((): SecurityIncome[] => {
     const securityMap = new Map<string, SecurityIncome>();
 
+    const getOrCreateBucket = (symbol: string, name: string): SecurityIncome => {
+      let bucket = securityMap.get(symbol);
+      if (!bucket) {
+        bucket = { symbol, name, dividends: 0, interest: 0, capitalGains: 0, total: 0 };
+        securityMap.set(symbol, bucket);
+      }
+      return bucket;
+    };
+
     transactions.forEach((tx) => {
       const symbol = tx.security?.symbol || 'Unknown';
       const name = tx.security?.name || 'Unknown Security';
-
-      let bucket = securityMap.get(symbol);
-      if (!bucket) {
-        bucket = {
-          symbol,
-          name,
-          dividends: 0,
-          interest: 0,
-          capitalGains: 0,
-          total: 0,
-        };
-        securityMap.set(symbol, bucket);
-      }
-
-      let contribution = 0;
+      const bucket = getOrCreateBucket(symbol, name);
+      const contribution = getTxAmount(tx);
       switch (tx.action) {
         case 'DIVIDEND':
-          contribution = getTxAmount(tx);
           bucket.dividends += contribution;
           break;
         case 'INTEREST':
-          contribution = getTxAmount(tx);
           bucket.interest += contribution;
           break;
         case 'CAPITAL_GAIN':
-          contribution = getTxAmount(tx);
-          bucket.capitalGains += contribution;
-          break;
-        case 'SELL':
-          contribution = getRealizedGain(tx);
           bucket.capitalGains += contribution;
           break;
       }
       bucket.total += contribution;
     });
 
+    realizedGains.forEach((entry) => {
+      const symbol = entry.symbol || 'Unknown';
+      const name = entry.securityName || 'Unknown Security';
+      const bucket = getOrCreateBucket(symbol, name);
+      const gain = convertRealized(entry);
+      bucket.capitalGains += gain;
+      bucket.total += gain;
+    });
+
     return Array.from(securityMap.values()).sort((a, b) => b.total - a.total);
-  }, [transactions, getTxAmount, getRealizedGain]);
+  }, [transactions, realizedGains, getTxAmount, convertRealized]);
 
   const totals = useMemo(() => {
     const dividends = transactions
@@ -266,18 +270,21 @@ export function DividendIncomeReport() {
     const interest = transactions
       .filter((t) => t.action === 'INTEREST')
       .reduce((sum, t) => sum + getTxAmount(t), 0);
-    const capitalGains = transactions.reduce((sum, t) => {
-      if (t.action === 'CAPITAL_GAIN') return sum + getTxAmount(t);
-      if (t.action === 'SELL') return sum + getRealizedGain(t);
-      return sum;
-    }, 0);
+    const manualCapitalGains = transactions
+      .filter((t) => t.action === 'CAPITAL_GAIN')
+      .reduce((sum, t) => sum + getTxAmount(t), 0);
+    const sellRealizedGains = realizedGains.reduce(
+      (sum, entry) => sum + convertRealized(entry),
+      0,
+    );
+    const capitalGains = manualCapitalGains + sellRealizedGains;
     return {
       dividends,
       interest,
       capitalGains,
       total: dividends + interest + capitalGains,
     };
-  }, [transactions, getTxAmount, getRealizedGain]);
+  }, [transactions, realizedGains, getTxAmount, convertRealized]);
 
   const handleExportPdf = async () => {
     const { exportToPdf } = await import('@/lib/pdf-export');
@@ -404,7 +411,7 @@ export function DividendIncomeReport() {
         </div>
       </div>
 
-      {transactions.length === 0 ? (
+      {transactions.length === 0 && realizedGains.length === 0 ? (
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
           <p className="text-gray-500 dark:text-gray-400 text-center py-8">
             No dividend, interest, capital gain, or sell transactions found for this period.

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -77,6 +77,21 @@ export function DividendIncomeReport() {
     return convertToDefault(amount, txCurrency);
   }, [selectedAccountId, accountCurrencyMap, defaultCurrency, convertToDefault]);
 
+  // Realized gain for a SELL transaction = proceeds - cost basis (quantity * price).
+  // Non-SELL actions return 0. Mirrors the formula used by RealizedGainsReport so
+  // the Capital Gains column here reconciles with that report.
+  const getRealizedGain = useCallback((tx: InvestmentTransaction): number => {
+    if (tx.action !== 'SELL') return 0;
+    const proceeds = Math.abs(tx.totalAmount);
+    const costBasis = tx.quantity != null && tx.price != null
+      ? Math.abs(tx.quantity) * Math.abs(tx.price)
+      : proceeds;
+    const gain = proceeds - costBasis;
+    if (selectedAccountId) return gain;
+    const txCurrency = accountCurrencyMap.get(tx.accountId) || defaultCurrency;
+    return convertToDefault(gain, txCurrency);
+  }, [selectedAccountId, accountCurrencyMap, defaultCurrency, convertToDefault]);
+
   const fmtValue = useCallback((value: number): string => {
     if (isForeign) {
       return `${formatCurrencyFull(value, displayCurrency)} ${displayCurrency}`;
@@ -109,9 +124,14 @@ export function DividendIncomeReport() {
           page++;
         }
 
-        // Filter to only income transactions
+        // Filter to only income transactions. SELL is included so its realized
+        // gain (proceeds - cost basis) contributes to the Capital Gains total.
         const incomeTransactions = allTransactions.filter(
-          (tx) => tx.action === 'DIVIDEND' || tx.action === 'INTEREST' || tx.action === 'CAPITAL_GAIN'
+          (tx) =>
+            tx.action === 'DIVIDEND' ||
+            tx.action === 'INTEREST' ||
+            tx.action === 'CAPITAL_GAIN' ||
+            tx.action === 'SELL'
         );
 
         setTransactions(incomeTransactions);
@@ -169,23 +189,30 @@ export function DividendIncomeReport() {
         monthMap.set(monthKey, bucket);
       }
 
-      const amount = getTxAmount(tx);
+      let contribution = 0;
       switch (tx.action) {
         case 'DIVIDEND':
-          bucket.dividends += amount;
+          contribution = getTxAmount(tx);
+          bucket.dividends += contribution;
           break;
         case 'INTEREST':
-          bucket.interest += amount;
+          contribution = getTxAmount(tx);
+          bucket.interest += contribution;
           break;
         case 'CAPITAL_GAIN':
-          bucket.capitalGains += amount;
+          contribution = getTxAmount(tx);
+          bucket.capitalGains += contribution;
+          break;
+        case 'SELL':
+          contribution = getRealizedGain(tx);
+          bucket.capitalGains += contribution;
           break;
       }
-      bucket.total += amount;
+      bucket.total += contribution;
     });
 
     return Array.from(monthMap.values()).sort((a, b) => a.month.localeCompare(b.month));
-  }, [transactions, dateRange, resolvedRange, getTxAmount]);
+  }, [transactions, dateRange, resolvedRange, getTxAmount, getRealizedGain]);
 
   const securityData = useMemo((): SecurityIncome[] => {
     const securityMap = new Map<string, SecurityIncome>();
@@ -207,32 +234,50 @@ export function DividendIncomeReport() {
         securityMap.set(symbol, bucket);
       }
 
-      const amount = getTxAmount(tx);
+      let contribution = 0;
       switch (tx.action) {
         case 'DIVIDEND':
-          bucket.dividends += amount;
+          contribution = getTxAmount(tx);
+          bucket.dividends += contribution;
           break;
         case 'INTEREST':
-          bucket.interest += amount;
+          contribution = getTxAmount(tx);
+          bucket.interest += contribution;
           break;
         case 'CAPITAL_GAIN':
-          bucket.capitalGains += amount;
+          contribution = getTxAmount(tx);
+          bucket.capitalGains += contribution;
+          break;
+        case 'SELL':
+          contribution = getRealizedGain(tx);
+          bucket.capitalGains += contribution;
           break;
       }
-      bucket.total += amount;
+      bucket.total += contribution;
     });
 
     return Array.from(securityMap.values()).sort((a, b) => b.total - a.total);
-  }, [transactions, getTxAmount]);
+  }, [transactions, getTxAmount, getRealizedGain]);
 
   const totals = useMemo(() => {
+    const dividends = transactions
+      .filter((t) => t.action === 'DIVIDEND')
+      .reduce((sum, t) => sum + getTxAmount(t), 0);
+    const interest = transactions
+      .filter((t) => t.action === 'INTEREST')
+      .reduce((sum, t) => sum + getTxAmount(t), 0);
+    const capitalGains = transactions.reduce((sum, t) => {
+      if (t.action === 'CAPITAL_GAIN') return sum + getTxAmount(t);
+      if (t.action === 'SELL') return sum + getRealizedGain(t);
+      return sum;
+    }, 0);
     return {
-      dividends: transactions.filter((t) => t.action === 'DIVIDEND').reduce((sum, t) => sum + getTxAmount(t), 0),
-      interest: transactions.filter((t) => t.action === 'INTEREST').reduce((sum, t) => sum + getTxAmount(t), 0),
-      capitalGains: transactions.filter((t) => t.action === 'CAPITAL_GAIN').reduce((sum, t) => sum + getTxAmount(t), 0),
-      total: transactions.reduce((sum, t) => sum + getTxAmount(t), 0),
+      dividends,
+      interest,
+      capitalGains,
+      total: dividends + interest + capitalGains,
     };
-  }, [transactions, getTxAmount]);
+  }, [transactions, getTxAmount, getRealizedGain]);
 
   const handleExportPdf = async () => {
     const { exportToPdf } = await import('@/lib/pdf-export');
@@ -362,7 +407,7 @@ export function DividendIncomeReport() {
       {transactions.length === 0 ? (
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
           <p className="text-gray-500 dark:text-gray-400 text-center py-8">
-            No dividend, interest, or capital gain transactions found for this period.
+            No dividend, interest, capital gain, or sell transactions found for this period.
           </p>
         </div>
       ) : viewType === 'monthly' ? (
@@ -433,7 +478,7 @@ export function DividendIncomeReport() {
                       {security.interest > 0 ? fmtValue(security.interest) : '-'}
                     </td>
                     <td className="px-4 py-3 text-right text-sm text-purple-600 dark:text-purple-400">
-                      {security.capitalGains > 0 ? fmtValue(security.capitalGains) : '-'}
+                      {security.capitalGains !== 0 ? fmtValue(security.capitalGains) : '-'}
                     </td>
                     <td className="px-4 py-3 text-right text-sm font-medium text-gray-900 dark:text-gray-100">
                       {fmtValue(security.total)}

--- a/frontend/src/components/reports/RealizedGainsReport.test.tsx
+++ b/frontend/src/components/reports/RealizedGainsReport.test.tsx
@@ -49,12 +49,12 @@ vi.mock('recharts', () => ({
   Tooltip: () => null,
 }));
 
-const mockGetTransactions = vi.fn();
+const mockGetRealizedGains = vi.fn();
 const mockGetInvestmentAccounts = vi.fn();
 
 vi.mock('@/lib/investments', () => ({
   investmentsApi: {
-    getTransactions: (...args: any[]) => mockGetTransactions(...args),
+    getRealizedGains: (...args: any[]) => mockGetRealizedGains(...args),
     getInvestmentAccounts: (...args: any[]) => mockGetInvestmentAccounts(...args),
   },
 }));
@@ -68,20 +68,39 @@ vi.mock('@/lib/logger', () => ({
   }),
 }));
 
+const gainEntry = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  transactionId: 'sell-1',
+  transactionDate: '2025-06-15',
+  accountId: 'acc-1',
+  accountName: 'TFSA',
+  accountCurrencyCode: 'CAD',
+  securityId: 'sec-1',
+  symbol: 'AAPL',
+  securityName: 'Apple Inc.',
+  securityCurrencyCode: 'CAD',
+  quantity: 50,
+  price: 110,
+  commission: 0,
+  proceeds: 5500,
+  costBasis: 5000,
+  realizedGain: 500,
+  ...overrides,
+});
+
 describe('RealizedGainsReport', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('shows loading state initially', () => {
-    mockGetTransactions.mockReturnValue(new Promise(() => {}));
+    mockGetRealizedGains.mockReturnValue(new Promise(() => {}));
     mockGetInvestmentAccounts.mockReturnValue(new Promise(() => {}));
     render(<RealizedGainsReport />);
     expect(document.querySelector('.animate-pulse')).toBeTruthy();
   });
 
   it('renders empty state when no sell transactions', async () => {
-    mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
+    mockGetRealizedGains.mockResolvedValue([]);
     mockGetInvestmentAccounts.mockResolvedValue([]);
     render(<RealizedGainsReport />);
     await waitFor(() => {
@@ -89,32 +108,19 @@ describe('RealizedGainsReport', () => {
     });
   });
 
-  it('renders summary cards with sell transaction data', async () => {
-    mockGetTransactions.mockResolvedValue({
-      data: [
-        {
-          id: 'tx-1',
-          transactionDate: '2025-06-15',
-          action: 'SELL',
-          totalAmount: -5000,
-          quantity: -50,
-          price: 100,
-          accountId: 'acc-1',
-          security: { symbol: 'AAPL', name: 'Apple Inc.' },
-        },
-        {
-          id: 'tx-2',
-          transactionDate: '2025-08-20',
-          action: 'SELL',
-          totalAmount: -3000,
-          quantity: -30,
-          price: 100,
-          accountId: 'acc-1',
-          security: { symbol: 'MSFT', name: 'Microsoft Corp.' },
-        },
-      ],
-      pagination: { hasMore: false },
-    });
+  it('renders summary cards with realized gain data', async () => {
+    mockGetRealizedGains.mockResolvedValue([
+      gainEntry(),
+      gainEntry({
+        transactionId: 'sell-2',
+        transactionDate: '2025-08-20',
+        symbol: 'MSFT',
+        securityName: 'Microsoft Corp.',
+        proceeds: 3300,
+        costBasis: 3000,
+        realizedGain: 300,
+      }),
+    ]);
     mockGetInvestmentAccounts.mockResolvedValue([
       { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
     ]);
@@ -128,7 +134,7 @@ describe('RealizedGainsReport', () => {
   });
 
   it('renders view type toggle buttons', async () => {
-    mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
+    mockGetRealizedGains.mockResolvedValue([]);
     mockGetInvestmentAccounts.mockResolvedValue([]);
     render(<RealizedGainsReport />);
     await waitFor(() => {
@@ -138,21 +144,7 @@ describe('RealizedGainsReport', () => {
   });
 
   it('renders chart with gain data', async () => {
-    mockGetTransactions.mockResolvedValue({
-      data: [
-        {
-          id: 'tx-1',
-          transactionDate: '2025-06-15',
-          action: 'SELL',
-          totalAmount: -5500,
-          quantity: -50,
-          price: 100,
-          accountId: 'acc-1',
-          security: { symbol: 'AAPL', name: 'Apple Inc.' },
-        },
-      ],
-      pagination: { hasMore: false },
-    });
+    mockGetRealizedGains.mockResolvedValue([gainEntry()]);
     mockGetInvestmentAccounts.mockResolvedValue([]);
     render(<RealizedGainsReport />);
     await waitFor(() => {
@@ -162,21 +154,7 @@ describe('RealizedGainsReport', () => {
   });
 
   it('renders sell transactions table', async () => {
-    mockGetTransactions.mockResolvedValue({
-      data: [
-        {
-          id: 'tx-1',
-          transactionDate: '2025-06-15',
-          action: 'SELL',
-          totalAmount: -5000,
-          quantity: -50,
-          price: 100,
-          accountId: 'acc-1',
-          security: { symbol: 'AAPL', name: 'Apple Inc.' },
-        },
-      ],
-      pagination: { hasMore: false },
-    });
+    mockGetRealizedGains.mockResolvedValue([gainEntry()]);
     mockGetInvestmentAccounts.mockResolvedValue([]);
     render(<RealizedGainsReport />);
     await waitFor(() => {
@@ -185,13 +163,16 @@ describe('RealizedGainsReport', () => {
     expect(screen.getByText('AAPL')).toBeInTheDocument();
   });
 
-  it('filters transactions by SELL action', async () => {
-    mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
+  it('queries the realized-gains endpoint with the selected date range', async () => {
+    mockGetRealizedGains.mockResolvedValue([]);
     mockGetInvestmentAccounts.mockResolvedValue([]);
     render(<RealizedGainsReport />);
     await waitFor(() => {
-      expect(mockGetTransactions).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'SELL' }),
+      expect(mockGetRealizedGains).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startDate: '2025-01-01',
+          endDate: '2026-01-01',
+        }),
       );
     });
   });

--- a/frontend/src/components/reports/RealizedGainsReport.tsx
+++ b/frontend/src/components/reports/RealizedGainsReport.tsx
@@ -12,7 +12,7 @@ import {
 } from 'recharts';
 import { format } from 'date-fns';
 import { investmentsApi } from '@/lib/investments';
-import { InvestmentTransaction } from '@/types/investment';
+import { RealizedGainEntry } from '@/types/investment';
 import { Account } from '@/types/account';
 import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
@@ -24,8 +24,6 @@ import { exportToCsv } from '@/lib/csv-export';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('RealizedGainsReport');
-
-const MAX_PAGES = 50;
 
 function CustomTooltip({ active, payload, fmtValue }: {
   active?: boolean;
@@ -57,28 +55,23 @@ interface SecurityGain {
 export function RealizedGainsReport() {
   const { formatCurrency: formatCurrencyFull, formatCurrencyAxis } = useNumberFormat();
   const { defaultCurrency, convertToDefault } = useExchangeRates();
-  const [transactions, setTransactions] = useState<InvestmentTransaction[]>([]);
+  const [entries, setEntries] = useState<RealizedGainEntry[]>([]);
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [selectedAccountId, setSelectedAccountId] = useState<string>('');
   const { dateRange, setDateRange, resolvedRange, isValid } = useDateRange({ defaultRange: '1y', alignment: 'month' });
   const [isLoading, setIsLoading] = useState(true);
   const [viewType, setViewType] = useState<'chart' | 'table'>('chart');
 
-  const accountCurrencyMap = useMemo(() => {
-    const map = new Map<string, string>();
-    accounts.forEach((a) => map.set(a.id, a.currencyCode));
-    return map;
-  }, [accounts]);
-
   const selectedAccount = accounts.find((a) => a.id === selectedAccountId);
   const displayCurrency = selectedAccount?.currencyCode || defaultCurrency;
   const isForeign = displayCurrency !== defaultCurrency;
 
-  const getTxAmount = useCallback((amount: number, accountId: string): number => {
+  // Backend returns each figure in the holding account's currency. Convert to
+  // the default currency when viewing All Accounts; otherwise pass through.
+  const toDisplay = useCallback((amount: number, accountCurrencyCode: string | null): number => {
     if (selectedAccountId) return amount;
-    const txCurrency = accountCurrencyMap.get(accountId) || defaultCurrency;
-    return convertToDefault(amount, txCurrency);
-  }, [selectedAccountId, accountCurrencyMap, defaultCurrency, convertToDefault]);
+    return convertToDefault(amount, accountCurrencyCode || defaultCurrency);
+  }, [selectedAccountId, defaultCurrency, convertToDefault]);
 
   const fmtValue = useCallback((value: number): string => {
     if (isForeign) {
@@ -100,26 +93,14 @@ export function RealizedGainsReport() {
       setIsLoading(true);
       try {
         const { start, end } = resolvedRange;
-        const allTransactions: InvestmentTransaction[] = [];
-        let page = 1;
-        let hasMore = true;
-        while (hasMore && page <= MAX_PAGES) {
-          const result = await investmentsApi.getTransactions({
-            accountIds: selectedAccountId || undefined,
-            startDate: start || undefined,
-            endDate: end,
-            action: 'SELL',
-            limit: 200,
-            page,
-          });
-          allTransactions.push(...result.data);
-          hasMore = result.pagination.hasMore;
-          page++;
-        }
-
-        setTransactions(allTransactions);
+        const data = await investmentsApi.getRealizedGains({
+          accountIds: selectedAccountId || undefined,
+          startDate: start || undefined,
+          endDate: end,
+        });
+        setEntries(data);
       } catch (error) {
-        logger.error('Failed to load sell transactions:', error);
+        logger.error('Failed to load realized gains:', error);
       } finally {
         setIsLoading(false);
       }
@@ -130,13 +111,13 @@ export function RealizedGainsReport() {
   const securityGains = useMemo((): SecurityGain[] => {
     const map = new Map<string, SecurityGain>();
 
-    transactions.forEach((tx) => {
-      const symbol = tx.security?.symbol || 'Unknown';
-      const name = tx.security?.name || 'Unknown Security';
+    entries.forEach((entry) => {
+      const symbol = entry.symbol || 'Unknown';
+      const name = entry.securityName || 'Unknown Security';
 
-      let entry = map.get(symbol);
-      if (!entry) {
-        entry = {
+      let bucket = map.get(symbol);
+      if (!bucket) {
+        bucket = {
           symbol,
           name,
           totalProceeds: 0,
@@ -144,22 +125,17 @@ export function RealizedGainsReport() {
           realizedGain: 0,
           transactionCount: 0,
         };
-        map.set(symbol, entry);
+        map.set(symbol, bucket);
       }
 
-      const proceeds = getTxAmount(Math.abs(tx.totalAmount), tx.accountId);
-      const costBasis = tx.quantity && tx.price
-        ? getTxAmount(Math.abs(tx.quantity) * Math.abs(tx.price), tx.accountId)
-        : proceeds;
-
-      entry.totalProceeds += proceeds;
-      entry.totalCostBasis += costBasis;
-      entry.realizedGain += proceeds - costBasis;
-      entry.transactionCount += 1;
+      bucket.totalProceeds += toDisplay(entry.proceeds, entry.accountCurrencyCode);
+      bucket.totalCostBasis += toDisplay(entry.costBasis, entry.accountCurrencyCode);
+      bucket.realizedGain += toDisplay(entry.realizedGain, entry.accountCurrencyCode);
+      bucket.transactionCount += 1;
     });
 
     return Array.from(map.values()).sort((a, b) => b.realizedGain - a.realizedGain);
-  }, [transactions, getTxAmount]);
+  }, [entries, toDisplay]);
 
   const chartData = useMemo(() => {
     return securityGains
@@ -183,24 +159,22 @@ export function RealizedGainsReport() {
     return { totalProceeds, totalCostBasis, totalGain, totalTransactions, gainers, losers };
   }, [securityGains]);
 
-  const sortedTransactions = useMemo(
-    () => [...transactions].sort((a, b) => b.transactionDate.localeCompare(a.transactionDate)),
-    [transactions],
+  const sortedEntries = useMemo(
+    () => [...entries].sort((a, b) => b.transactionDate.localeCompare(a.transactionDate)),
+    [entries],
   );
 
   const getExportData = useCallback(() => {
     const headers = ['Security', 'Date Sold', 'Quantity', 'Proceeds', 'Cost Basis', 'Gain/Loss', 'Return %'];
-    const rows: (string | number)[][] = sortedTransactions.map((tx) => {
-      const proceeds = getTxAmount(Math.abs(tx.totalAmount), tx.accountId);
-      const costBasis = tx.quantity && tx.price
-        ? getTxAmount(Math.abs(tx.quantity) * Math.abs(tx.price), tx.accountId)
-        : proceeds;
-      const gain = proceeds - costBasis;
+    const rows: (string | number)[][] = sortedEntries.map((entry) => {
+      const proceeds = toDisplay(entry.proceeds, entry.accountCurrencyCode);
+      const costBasis = toDisplay(entry.costBasis, entry.accountCurrencyCode);
+      const gain = toDisplay(entry.realizedGain, entry.accountCurrencyCode);
       const returnPct = costBasis !== 0 ? ((gain / costBasis) * 100).toFixed(2) + '%' : '-';
       return [
-        tx.security?.symbol || 'N/A',
-        format(parseLocalDate(tx.transactionDate), 'yyyy-MM-dd'),
-        tx.quantity != null ? Math.abs(tx.quantity) : '',
+        entry.symbol || 'N/A',
+        format(parseLocalDate(entry.transactionDate), 'yyyy-MM-dd'),
+        entry.quantity,
         proceeds,
         costBasis,
         gain,
@@ -208,7 +182,7 @@ export function RealizedGainsReport() {
       ];
     });
     return { headers, rows };
-  }, [sortedTransactions, getTxAmount]);
+  }, [sortedEntries, toDisplay]);
 
   const handleExportCsv = useCallback(() => {
     const { headers, rows } = getExportData();
@@ -328,12 +302,12 @@ export function RealizedGainsReport() {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M3 14h18M3 6h18M3 18h18" />
               </svg>
             </button>
-            <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} disabled={transactions.length === 0} />
+            <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} disabled={entries.length === 0} />
           </div>
         </div>
       </div>
 
-      {transactions.length === 0 ? (
+      {entries.length === 0 ? (
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
           <p className="text-gray-500 dark:text-gray-400 text-center py-8">
             No sell transactions found for this period.
@@ -446,11 +420,11 @@ export function RealizedGainsReport() {
       )}
 
       {/* Individual Transactions */}
-      {transactions.length > 0 && (
+      {entries.length > 0 && (
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 overflow-hidden">
           <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-              Sell Transactions ({transactions.length})
+              Sell Transactions ({entries.length})
             </h3>
           </div>
           <div className="overflow-x-auto">
@@ -470,29 +444,29 @@ export function RealizedGainsReport() {
                     Price
                   </th>
                   <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
-                    Total
+                    Proceeds
                   </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-                {sortedTransactions.map((tx) => (
-                  <tr key={tx.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                {sortedEntries.map((entry) => (
+                  <tr key={entry.transactionId} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
                     <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
-                      {format(parseLocalDate(tx.transactionDate), 'MMM d, yyyy')}
+                      {format(parseLocalDate(entry.transactionDate), 'MMM d, yyyy')}
                     </td>
                     <td className="px-4 py-3">
                       <div className="font-medium text-sm text-gray-900 dark:text-gray-100">
-                        {tx.security?.symbol || 'N/A'}
+                        {entry.symbol || 'N/A'}
                       </div>
                     </td>
                     <td className="px-4 py-3 text-right text-sm text-gray-900 dark:text-gray-100">
-                      {tx.quantity != null ? Math.abs(tx.quantity).toFixed(4) : '-'}
+                      {entry.quantity.toFixed(4)}
                     </td>
                     <td className="px-4 py-3 text-right text-sm text-gray-900 dark:text-gray-100">
-                      {tx.price != null ? fmtValue(tx.price) : '-'}
+                      {fmtValue(entry.price)}
                     </td>
                     <td className="px-4 py-3 text-right text-sm font-medium text-gray-900 dark:text-gray-100">
-                      {fmtValue(Math.abs(tx.totalAmount))}
+                      {fmtValue(toDisplay(entry.proceeds, entry.accountCurrencyCode))}
                     </td>
                   </tr>
                 ))}

--- a/frontend/src/components/transactions/AccountBalancesBarChart.test.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.test.tsx
@@ -5,6 +5,9 @@ import { AccountBalancesBarChart } from './AccountBalancesBarChart';
 // Capture the Bar onClick handler so we can simulate account bar clicks
 // without relying on the real recharts rendering pipeline.
 let capturedBarOnClick: ((entry: any) => void) | undefined;
+// Capture the BarChart onClick so we can simulate clicks anywhere in the
+// tooltip-highlighted column (the whitespace above a bar).
+let capturedBarChartOnClick: ((state: any) => void) | undefined;
 // Capture the YAxis props so we can assert which scale the chart picked.
 let capturedYAxisProps: any;
 // Capture the XAxis props so we can assert label rotation behaviour.
@@ -12,7 +15,8 @@ let capturedXAxisProps: any;
 
 vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
-  BarChart: ({ children }: any) => {
+  BarChart: ({ children, onClick }: any) => {
+    capturedBarChartOnClick = onClick;
     return <div data-testid="bar-chart">{children}</div>;
   },
   Bar: ({ children, onClick }: any) => {
@@ -46,6 +50,7 @@ vi.mock('@/hooks/useNumberFormat', () => ({
 describe('AccountBalancesBarChart', () => {
   beforeEach(() => {
     capturedBarOnClick = undefined;
+    capturedBarChartOnClick = undefined;
     capturedYAxisProps = undefined;
     capturedXAxisProps = undefined;
     mockFormatCurrency.mockImplementation((n: number) => `$${n.toFixed(2)}`);
@@ -307,6 +312,46 @@ describe('AccountBalancesBarChart', () => {
     expect(onAccountClick).toHaveBeenCalledWith('acc-1');
   });
 
+  it('fires onAccountClick from BarChart-level clicks (tooltip-highlighted column)', () => {
+    const onAccountClick = vi.fn();
+    render(
+      <AccountBalancesBarChart
+        data={[
+          { accountId: 'acc-1', accountName: 'Checking', balance: 1000 },
+          { accountId: 'acc-2', accountName: 'Savings', balance: 500 },
+        ]}
+        isLoading={false}
+        onAccountClick={onAccountClick}
+      />,
+    );
+
+    // A click in the column whitespace (above the bar) gives Recharts an
+    // activePayload but no direct Bar hit -- it must still fire the filter.
+    capturedBarChartOnClick?.({
+      activePayload: [
+        { payload: { accountId: 'acc-2', accountName: 'Savings', balance: 500, absBalance: 500 } },
+      ],
+    });
+
+    expect(onAccountClick).toHaveBeenCalledWith('acc-2');
+  });
+
+  it('ignores BarChart clicks outside any active column (no activePayload)', () => {
+    const onAccountClick = vi.fn();
+    render(
+      <AccountBalancesBarChart
+        data={[
+          { accountId: 'acc-1', accountName: 'Checking', balance: 1000 },
+        ]}
+        isLoading={false}
+        onAccountClick={onAccountClick}
+      />,
+    );
+
+    capturedBarChartOnClick?.({});
+    expect(onAccountClick).not.toHaveBeenCalled();
+  });
+
   it('does not call onAccountClick when no accountId is present on the entry', () => {
     const onAccountClick = vi.fn();
     render(
@@ -336,6 +381,7 @@ describe('AccountBalancesBarChart', () => {
     );
 
     expect(capturedBarOnClick).toBeUndefined();
+    expect(capturedBarChartOnClick).toBeUndefined();
   });
 
   it('renders each account name in the x-axis dataset', () => {

--- a/frontend/src/components/transactions/AccountBalancesBarChart.test.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.test.tsx
@@ -7,6 +7,8 @@ import { AccountBalancesBarChart } from './AccountBalancesBarChart';
 let capturedBarOnClick: ((entry: any) => void) | undefined;
 // Capture the YAxis props so we can assert which scale the chart picked.
 let capturedYAxisProps: any;
+// Capture the XAxis props so we can assert label rotation behaviour.
+let capturedXAxisProps: any;
 
 vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
@@ -17,7 +19,10 @@ vi.mock('recharts', () => ({
     capturedBarOnClick = onClick;
     return <div data-testid="bar">{children}</div>;
   },
-  XAxis: () => <div data-testid="x-axis" />,
+  XAxis: (props: any) => {
+    capturedXAxisProps = props;
+    return <div data-testid="x-axis" />;
+  },
   YAxis: (props: any) => {
     capturedYAxisProps = props;
     return <div data-testid="y-axis" />;
@@ -42,6 +47,7 @@ describe('AccountBalancesBarChart', () => {
   beforeEach(() => {
     capturedBarOnClick = undefined;
     capturedYAxisProps = undefined;
+    capturedXAxisProps = undefined;
     mockFormatCurrency.mockImplementation((n: number) => `$${n.toFixed(2)}`);
     mockFormatCurrency.mockClear();
     mockFormatCurrencyAxis.mockClear();
@@ -368,6 +374,32 @@ describe('AccountBalancesBarChart', () => {
     // Average = 50,000, Total = 100,000
     expect(screen.getByText('¥50,000')).toBeInTheDocument();
     expect(screen.getByText('¥100,000')).toBeInTheDocument();
+  });
+
+  describe('x-axis label rotation', () => {
+    const buildAccounts = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        accountId: `a${i + 1}`,
+        accountName: `Account ${i + 1}`,
+        balance: 100 * (i + 1),
+      }));
+
+    it('keeps desktop x-axis labels horizontal at or below 10 accounts', () => {
+      render(<AccountBalancesBarChart data={buildAccounts(10)} isLoading={false} />);
+      expect(capturedXAxisProps.angle).toBe(0);
+      expect(capturedXAxisProps.textAnchor).toBe('middle');
+      expect(capturedXAxisProps.height).toBe(30);
+    });
+
+    it('rotates desktop x-axis labels vertical once account count crosses 10', () => {
+      render(<AccountBalancesBarChart data={buildAccounts(11)} isLoading={false} />);
+      // angle=90 + textAnchor='start' anchors the first character at the tick
+      // and lets the rest of the name hang straight down past the axis.
+      expect(capturedXAxisProps.angle).toBe(90);
+      expect(capturedXAxisProps.textAnchor).toBe('start');
+      // Reserve enough vertical space for the rotated labels.
+      expect(capturedXAxisProps.height).toBeGreaterThan(30);
+    });
   });
 
   it('does not render the tooltip when there is no data', () => {

--- a/frontend/src/components/transactions/AccountBalancesBarChart.test.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.test.tsx
@@ -487,7 +487,7 @@ describe('AccountBalancesBarChart', () => {
       );
 
       // Render the custom tick directly so we can inspect the rendered text.
-      const CustomTick = capturedXAxisProps.tick as React.ReactElement;
+      const CustomTick = capturedXAxisProps.tick as React.ReactElement<any>;
       const { container } = render(
         <svg>
           {React.cloneElement(CustomTick, {
@@ -506,7 +506,7 @@ describe('AccountBalancesBarChart', () => {
 
     it('leaves vertical x-axis labels under 15 characters untouched', () => {
       render(<AccountBalancesBarChart data={buildAccounts(11)} isLoading={false} />);
-      const CustomTick = capturedXAxisProps.tick as React.ReactElement;
+      const CustomTick = capturedXAxisProps.tick as React.ReactElement<any>;
       const { container } = render(
         <svg>
           {React.cloneElement(CustomTick, {

--- a/frontend/src/components/transactions/AccountBalancesBarChart.test.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.test.tsx
@@ -337,7 +337,27 @@ describe('AccountBalancesBarChart', () => {
     expect(onAccountClick).toHaveBeenCalledWith('acc-2');
   });
 
-  it('ignores BarChart clicks outside any active column (no activePayload)', () => {
+  it('fires onAccountClick when only activeLabel is available (column whitespace)', () => {
+    const onAccountClick = vi.fn();
+    render(
+      <AccountBalancesBarChart
+        data={[
+          { accountId: 'acc-1', accountName: 'Checking', balance: 1000 },
+          { accountId: 'acc-2', accountName: 'Savings', balance: 500 },
+        ]}
+        isLoading={false}
+        onAccountClick={onAccountClick}
+      />,
+    );
+
+    // Clicks in the highlighted column sometimes populate activeLabel but
+    // not activePayload; the handler must fall back to a chartData lookup.
+    capturedBarChartOnClick?.({ activeLabel: 'Savings' });
+
+    expect(onAccountClick).toHaveBeenCalledWith('acc-2');
+  });
+
+  it('ignores BarChart clicks outside any active column (no activePayload and no activeLabel)', () => {
     const onAccountClick = vi.fn();
     render(
       <AccountBalancesBarChart

--- a/frontend/src/components/transactions/AccountBalancesBarChart.test.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.test.tsx
@@ -2,19 +2,21 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@/test/render';
 import { AccountBalancesBarChart } from './AccountBalancesBarChart';
 
-// Capture the BarChart onClick handler so we can simulate account bar clicks
+// Capture the Bar onClick handler so we can simulate account bar clicks
 // without relying on the real recharts rendering pipeline.
-let capturedBarChartOnClick: ((state: any) => void) | undefined;
+let capturedBarOnClick: ((entry: any) => void) | undefined;
 // Capture the YAxis props so we can assert which scale the chart picked.
 let capturedYAxisProps: any;
 
 vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
-  BarChart: ({ children, onClick }: any) => {
-    capturedBarChartOnClick = onClick;
+  BarChart: ({ children }: any) => {
     return <div data-testid="bar-chart">{children}</div>;
   },
-  Bar: ({ children }: any) => <div data-testid="bar">{children}</div>,
+  Bar: ({ children, onClick }: any) => {
+    capturedBarOnClick = onClick;
+    return <div data-testid="bar">{children}</div>;
+  },
   XAxis: () => <div data-testid="x-axis" />,
   YAxis: (props: any) => {
     capturedYAxisProps = props;
@@ -38,7 +40,7 @@ vi.mock('@/hooks/useNumberFormat', () => ({
 
 describe('AccountBalancesBarChart', () => {
   beforeEach(() => {
-    capturedBarChartOnClick = undefined;
+    capturedBarOnClick = undefined;
     capturedYAxisProps = undefined;
     mockFormatCurrency.mockImplementation((n: number) => `$${n.toFixed(2)}`);
     mockFormatCurrency.mockClear();
@@ -273,18 +275,33 @@ describe('AccountBalancesBarChart', () => {
       />
     );
 
-    expect(capturedBarChartOnClick).toBeDefined();
+    expect(capturedBarOnClick).toBeDefined();
 
-    capturedBarChartOnClick?.({
-      activePayload: [
-        { payload: { accountId: 'acc-2', accountName: 'Savings', balance: 500, absBalance: 500 } },
-      ],
-    });
+    // Recharts passes the data point directly as the first arg to a Bar's
+    // onClick handler.
+    capturedBarOnClick?.({ accountId: 'acc-2', accountName: 'Savings', balance: 500, absBalance: 500 });
 
     expect(onAccountClick).toHaveBeenCalledWith('acc-2');
   });
 
-  it('does not call onAccountClick when activePayload is missing', () => {
+  it('reads accountId from entry.payload as a fallback', () => {
+    const onAccountClick = vi.fn();
+    render(
+      <AccountBalancesBarChart
+        data={[
+          { accountId: 'acc-1', accountName: 'Checking', balance: 1000 },
+        ]}
+        isLoading={false}
+        onAccountClick={onAccountClick}
+      />
+    );
+
+    capturedBarOnClick?.({ payload: { accountId: 'acc-1' } });
+
+    expect(onAccountClick).toHaveBeenCalledWith('acc-1');
+  });
+
+  it('does not call onAccountClick when no accountId is present on the entry', () => {
     const onAccountClick = vi.fn();
     render(
       <AccountBalancesBarChart
@@ -297,7 +314,7 @@ describe('AccountBalancesBarChart', () => {
       />
     );
 
-    capturedBarChartOnClick?.({});
+    capturedBarOnClick?.({});
     expect(onAccountClick).not.toHaveBeenCalled();
   });
 
@@ -312,7 +329,7 @@ describe('AccountBalancesBarChart', () => {
       />
     );
 
-    expect(capturedBarChartOnClick).toBeUndefined();
+    expect(capturedBarOnClick).toBeUndefined();
   });
 
   it('renders each account name in the x-axis dataset', () => {
@@ -370,7 +387,7 @@ describe('AccountBalancesBarChart', () => {
       />,
     );
     // First render without handler
-    expect(capturedBarChartOnClick).toBeUndefined();
+    expect(capturedBarOnClick).toBeUndefined();
 
     // Re-render with the handler
     const onAccountClick = vi.fn();
@@ -385,11 +402,7 @@ describe('AccountBalancesBarChart', () => {
       />,
     );
 
-    capturedBarChartOnClick?.({
-      activePayload: [
-        { payload: { accountId: 'a1', accountName: 'Checking', balance: 100, absBalance: 100 } },
-      ],
-    });
+    capturedBarOnClick?.({ accountId: 'a1', accountName: 'Checking', balance: 100, absBalance: 100 });
     expect(onAccountClick).toHaveBeenCalledWith('a1');
   });
 });

--- a/frontend/src/components/transactions/AccountBalancesBarChart.test.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@/test/render';
 import { AccountBalancesBarChart } from './AccountBalancesBarChart';
@@ -437,14 +438,66 @@ describe('AccountBalancesBarChart', () => {
       expect(capturedXAxisProps.height).toBe(30);
     });
 
-    it('rotates desktop x-axis labels vertical once account count crosses 10', () => {
+    it('rotates desktop x-axis labels vertical once account count crosses 10 via a custom tick', () => {
       render(<AccountBalancesBarChart data={buildAccounts(11)} isLoading={false} />);
-      // angle=90 + textAnchor='start' anchors the first character at the tick
-      // and lets the rest of the name hang straight down past the axis.
-      expect(capturedXAxisProps.angle).toBe(90);
-      expect(capturedXAxisProps.textAnchor).toBe('start');
+      // A custom tick renderer handles the rotation so the first character
+      // anchors at the axis line (textAnchor='start' + rotate(90)); the
+      // XAxis itself no longer sets angle/textAnchor.
+      expect(capturedXAxisProps.tick).not.toBe(null);
+      expect(typeof capturedXAxisProps.tick).toBe('object');
+      expect(capturedXAxisProps.angle).toBe(0);
+      expect(capturedXAxisProps.textAnchor).toBe('middle');
       // Reserve enough vertical space for the rotated labels.
       expect(capturedXAxisProps.height).toBeGreaterThan(30);
+    });
+
+    it('truncates vertical x-axis labels longer than 20 characters with an ellipsis', () => {
+      render(
+        <AccountBalancesBarChart
+          data={[
+            {
+              accountId: 'a1',
+              accountName: 'A Very Long Account Name That Should Be Truncated',
+              balance: 100,
+            },
+            ...buildAccounts(10),
+          ]}
+          isLoading={false}
+        />,
+      );
+
+      // Render the custom tick directly so we can inspect the rendered text.
+      const CustomTick = capturedXAxisProps.tick as React.ReactElement;
+      const { container } = render(
+        <svg>
+          {React.cloneElement(CustomTick, {
+            x: 0,
+            y: 0,
+            payload: { value: 'A Very Long Account Name That Should Be Truncated' },
+          })}
+        </svg>,
+      );
+
+      const text = container.querySelector('text');
+      expect(text).not.toBeNull();
+      expect(text?.textContent).toBe('A Very Long Account N...');
+      expect(text?.textContent?.length).toBe(23); // 20 chars + "..."
+    });
+
+    it('leaves vertical x-axis labels under 20 characters untouched', () => {
+      render(<AccountBalancesBarChart data={buildAccounts(11)} isLoading={false} />);
+      const CustomTick = capturedXAxisProps.tick as React.ReactElement;
+      const { container } = render(
+        <svg>
+          {React.cloneElement(CustomTick, {
+            x: 0,
+            y: 0,
+            payload: { value: 'Short Name' },
+          })}
+        </svg>,
+      );
+      const text = container.querySelector('text');
+      expect(text?.textContent).toBe('Short Name');
     });
   });
 

--- a/frontend/src/components/transactions/AccountBalancesBarChart.test.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.test.tsx
@@ -451,7 +451,7 @@ describe('AccountBalancesBarChart', () => {
       expect(capturedXAxisProps.height).toBeGreaterThan(30);
     });
 
-    it('truncates vertical x-axis labels longer than 20 characters with an ellipsis', () => {
+    it('truncates vertical x-axis labels longer than 15 characters with an ellipsis', () => {
       render(
         <AccountBalancesBarChart
           data={[
@@ -480,11 +480,11 @@ describe('AccountBalancesBarChart', () => {
 
       const text = container.querySelector('text');
       expect(text).not.toBeNull();
-      expect(text?.textContent).toBe('A Very Long Account N...');
-      expect(text?.textContent?.length).toBe(23); // 20 chars + "..."
+      expect(text?.textContent).toBe('A Very Long Acc...');
+      expect(text?.textContent?.length).toBe(18); // 15 chars + "..."
     });
 
-    it('leaves vertical x-axis labels under 20 characters untouched', () => {
+    it('leaves vertical x-axis labels under 15 characters untouched', () => {
       render(<AccountBalancesBarChart data={buildAccounts(11)} isLoading={false} />);
       const CustomTick = capturedXAxisProps.tick as React.ReactElement;
       const { container } = render(

--- a/frontend/src/components/transactions/AccountBalancesBarChart.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.tsx
@@ -199,11 +199,6 @@ export function AccountBalancesBarChart({
           <BarChart
             data={chartData}
             margin={{ top: 20, right: isMobile ? 16 : 5, left: -10, bottom: 0 }}
-            onClick={onAccountClick ? (state: any) => {
-              const accountId = state?.activePayload?.[0]?.payload?.accountId;
-              if (!accountId) return;
-              onAccountClick(accountId);
-            } : undefined}
             style={onAccountClick ? { cursor: 'pointer' } : undefined}
           >
             <CartesianGrid
@@ -237,6 +232,13 @@ export function AccountBalancesBarChart({
               dataKey="absBalance"
               radius={[4, 4, 0, 0]}
               maxBarSize={50}
+              onClick={onAccountClick ? (entry: any) => {
+                // Recharts passes the data point as the first arg. With Cell
+                // children the BarChart-level onClick can fail to populate
+                // activePayload, so we read accountId straight off the bar.
+                const accountId = entry?.accountId ?? entry?.payload?.accountId;
+                if (accountId) onAccountClick(accountId);
+              } : undefined}
             >
               {chartData.map((entry, index) => (
                 <Cell

--- a/frontend/src/components/transactions/AccountBalancesBarChart.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.tsx
@@ -28,7 +28,7 @@ const DESKTOP_VERTICAL_AXIS_THRESHOLD = 10;
 
 // Cap vertical x-axis labels at this many characters so an extra-long account
 // name can't eat the whole chart height.
-const VERTICAL_LABEL_MAX_LEN = 20;
+const VERTICAL_LABEL_MAX_LEN = 15;
 
 function truncateAccountName(name: string): string {
   return name.length > VERTICAL_LABEL_MAX_LEN
@@ -237,8 +237,8 @@ export function AccountBalancesBarChart({
 
       <div
         ref={chartRef}
-        className="h-72"
-        style={{ minHeight: 288 }}
+        className="h-96"
+        style={{ minHeight: 384 }}
       >
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           <BarChart
@@ -273,7 +273,7 @@ export function AccountBalancesBarChart({
               angle={isMobile ? -35 : 0}
               textAnchor={isMobile ? 'end' : 'middle'}
               tickMargin={isMobile ? 10 : verticalXAxis ? 8 : 0}
-              height={isMobile ? 64 : verticalXAxis ? 150 : 30}
+              height={isMobile ? 64 : verticalXAxis ? 120 : 30}
             />
             <YAxis
               tick={{ fill: '#6b7280', fontSize: 11 }}

--- a/frontend/src/components/transactions/AccountBalancesBarChart.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.tsx
@@ -244,13 +244,18 @@ export function AccountBalancesBarChart({
           <BarChart
             data={chartData}
             margin={{ top: 20, right: isMobile ? 16 : 5, left: -10, bottom: 0 }}
-            // Also fire on clicks anywhere in the tooltip-highlighted column
-            // (not just the bar rect). Recharts puts the column's data point
-            // on state.activePayload whenever the cursor is over an active
-            // tick, so users can click the whitespace above a short bar and
-            // still land on the right account.
+            // Fire on clicks anywhere in the tooltip-highlighted column (not
+            // just the bar rect). Prefer state.activeLabel -- which Recharts
+            // sets to the active category whenever the cursor is in an
+            // active column -- and fall back to activePayload for the direct
+            // bar hit case.
             onClick={onAccountClick ? (state: any) => {
-              const accountId = state?.activePayload?.[0]?.payload?.accountId;
+              const activeName: string | undefined = state?.activeLabel;
+              const fromLabel = activeName
+                ? chartData.find((d) => d.accountName === activeName)?.accountId
+                : undefined;
+              const accountId =
+                fromLabel ?? state?.activePayload?.[0]?.payload?.accountId;
               if (accountId) onAccountClick(accountId);
             } : undefined}
             style={onAccountClick ? { cursor: 'pointer' } : undefined}
@@ -285,7 +290,12 @@ export function AccountBalancesBarChart({
               domain={effectiveScale === 'log' ? ['auto', 'auto'] : undefined}
               allowDataOverflow={false}
             />
-            <Tooltip content={<AccountBalanceTooltip formatCurrency={formatCurrency} />} />
+            <Tooltip
+              content={<AccountBalanceTooltip formatCurrency={formatCurrency} />}
+              // Keep the highlight rect visually present but transparent to
+              // pointer events so clicks fall through to BarChart's onClick.
+              cursor={{ fill: '#e5e7eb', fillOpacity: 0.35, style: { pointerEvents: 'none' } }}
+            />
             <Bar
               dataKey="absBalance"
               radius={[4, 4, 0, 0]}

--- a/frontend/src/components/transactions/AccountBalancesBarChart.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.tsx
@@ -22,6 +22,10 @@ const CHART_TITLE = 'Account Balances';
 // the "auto" mode switches to a log scale so small bars remain visible.
 const AUTO_LOG_RATIO = 50;
 
+// Past this many bars on desktop, x-axis account names are rotated vertical
+// so they stop overlapping each other along the axis.
+const DESKTOP_VERTICAL_AXIS_THRESHOLD = 10;
+
 type ScaleMode = 'auto' | 'linear' | 'log';
 type EffectiveScale = 'linear' | 'log';
 
@@ -119,6 +123,10 @@ export function AccountBalancesBarChart({
   const effectiveScale: EffectiveScale =
     scaleMode === 'auto' ? (autoPrefersLog ? 'log' : 'linear') : scaleMode;
 
+  // Mobile keeps its existing -35° slant; on desktop, switch to fully vertical
+  // labels once the bar count crosses the crowding threshold.
+  const verticalXAxis = !isMobile && chartData.length > DESKTOP_VERTICAL_AXIS_THRESHOLD;
+
   const summary = useMemo(() => {
     if (chartData.length === 0) return null;
     const totalCents = chartData.reduce(
@@ -212,10 +220,14 @@ export function AccountBalancesBarChart({
               tickLine={false}
               axisLine={{ stroke: '#e5e7eb' }}
               interval={isMobile ? 'preserveStartEnd' : 0}
-              angle={isMobile ? -35 : 0}
-              textAnchor={isMobile ? 'end' : 'middle'}
-              tickMargin={isMobile ? 10 : 0}
-              height={isMobile ? 64 : 30}
+              // Rotate desktop labels fully vertical once there are enough
+              // bars to start running into each other. textAnchor='start' with
+              // angle=90 anchors the FIRST character at the tick so the label
+              // hangs straight down from its bar without overlapping the axis.
+              angle={isMobile ? -35 : verticalXAxis ? 90 : 0}
+              textAnchor={isMobile ? 'end' : verticalXAxis ? 'start' : 'middle'}
+              tickMargin={isMobile ? 10 : verticalXAxis ? 8 : 0}
+              height={isMobile ? 64 : verticalXAxis ? 120 : 30}
             />
             <YAxis
               tick={{ fill: '#6b7280', fontSize: 11 }}

--- a/frontend/src/components/transactions/AccountBalancesBarChart.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.tsx
@@ -26,6 +26,43 @@ const AUTO_LOG_RATIO = 50;
 // so they stop overlapping each other along the axis.
 const DESKTOP_VERTICAL_AXIS_THRESHOLD = 10;
 
+// Cap vertical x-axis labels at this many characters so an extra-long account
+// name can't eat the whole chart height.
+const VERTICAL_LABEL_MAX_LEN = 20;
+
+function truncateAccountName(name: string): string {
+  return name.length > VERTICAL_LABEL_MAX_LEN
+    ? `${name.slice(0, VERTICAL_LABEL_MAX_LEN)}...`
+    : name;
+}
+
+// Custom tick used when the x-axis is rotated vertical. textAnchor='start'
+// combined with the 90deg rotation anchors the first character at the tick
+// so the label's visual left edge sits flush with the x-axis line, rather
+// than the label straddling the axis as the default centered tick does.
+function VerticalAccountTick({
+  x,
+  y,
+  payload,
+}: {
+  x?: number;
+  y?: number;
+  payload?: { value?: string };
+}) {
+  return (
+    <g transform={`translate(${x ?? 0},${y ?? 0})`}>
+      <text
+        textAnchor="start"
+        fill="#6b7280"
+        fontSize={12}
+        transform="rotate(90)"
+      >
+        {truncateAccountName(String(payload?.value ?? ''))}
+      </text>
+    </g>
+  );
+}
+
 type ScaleMode = 'auto' | 'linear' | 'log';
 type EffectiveScale = 'linear' | 'log';
 
@@ -225,18 +262,18 @@ export function AccountBalancesBarChart({
             />
             <XAxis
               dataKey="accountName"
-              tick={{ fill: '#6b7280', fontSize: isMobile ? 10 : 12 }}
+              tick={
+                verticalXAxis
+                  ? <VerticalAccountTick />
+                  : { fill: '#6b7280', fontSize: isMobile ? 10 : 12 }
+              }
               tickLine={false}
               axisLine={{ stroke: '#e5e7eb' }}
               interval={isMobile ? 'preserveStartEnd' : 0}
-              // Rotate desktop labels fully vertical once there are enough
-              // bars to start running into each other. textAnchor='start' with
-              // angle=90 anchors the FIRST character at the tick so the label
-              // hangs straight down from its bar without overlapping the axis.
-              angle={isMobile ? -35 : verticalXAxis ? 90 : 0}
-              textAnchor={isMobile ? 'end' : verticalXAxis ? 'start' : 'middle'}
+              angle={isMobile ? -35 : 0}
+              textAnchor={isMobile ? 'end' : 'middle'}
               tickMargin={isMobile ? 10 : verticalXAxis ? 8 : 0}
-              height={isMobile ? 64 : verticalXAxis ? 120 : 30}
+              height={isMobile ? 64 : verticalXAxis ? 150 : 30}
             />
             <YAxis
               tick={{ fill: '#6b7280', fontSize: 11 }}

--- a/frontend/src/components/transactions/AccountBalancesBarChart.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.tsx
@@ -207,6 +207,15 @@ export function AccountBalancesBarChart({
           <BarChart
             data={chartData}
             margin={{ top: 20, right: isMobile ? 16 : 5, left: -10, bottom: 0 }}
+            // Also fire on clicks anywhere in the tooltip-highlighted column
+            // (not just the bar rect). Recharts puts the column's data point
+            // on state.activePayload whenever the cursor is over an active
+            // tick, so users can click the whitespace above a short bar and
+            // still land on the right account.
+            onClick={onAccountClick ? (state: any) => {
+              const accountId = state?.activePayload?.[0]?.payload?.accountId;
+              if (accountId) onAccountClick(accountId);
+            } : undefined}
             style={onAccountClick ? { cursor: 'pointer' } : undefined}
           >
             <CartesianGrid

--- a/frontend/src/components/transactions/AccountBalancesBarChart.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.tsx
@@ -237,8 +237,8 @@ export function AccountBalancesBarChart({
 
       <div
         ref={chartRef}
-        className="h-96"
-        style={{ minHeight: 384 }}
+        className="h-72"
+        style={{ minHeight: 288 }}
       >
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           <BarChart

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
@@ -4,11 +4,18 @@ import { CategoryPayeeBarChart } from './CategoryPayeeBarChart';
 
 // Capture props passed to the recharts primitives we care about so individual
 // tests can assert on axis / label styling (angle, interval, etc.).
-const capturedProps: { xAxis: any; labelList: any } = { xAxis: null, labelList: null };
+const capturedProps: { xAxis: any; labelList: any; barChart: any } = {
+  xAxis: null,
+  labelList: null,
+  barChart: null,
+};
 
 vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
-  BarChart: ({ children }: any) => <div data-testid="bar-chart">{children}</div>,
+  BarChart: ({ children, ...rest }: any) => {
+    capturedProps.barChart = rest;
+    return <div data-testid="bar-chart">{children}</div>;
+  },
   Bar: ({ children }: any) => <div data-testid="bar">{children}</div>,
   XAxis: (props: any) => {
     capturedProps.xAxis = props;
@@ -50,6 +57,7 @@ describe('CategoryPayeeBarChart', () => {
     mockIsMobile.mockReturnValue(false);
     capturedProps.xAxis = null;
     capturedProps.labelList = null;
+    capturedProps.barChart = null;
   });
 
   const buildMonths = (n: number) =>
@@ -232,14 +240,17 @@ describe('CategoryPayeeBarChart', () => {
     it('keeps desktop bar-top labels horizontal when uncrowded (<= 36 months)', () => {
       render(<CategoryPayeeBarChart data={buildMonths(36)} isLoading={false} />);
       expect(capturedProps.labelList.angle).toBe(0);
+      expect(capturedProps.labelList.textAnchor).toBe('middle');
       expect(capturedProps.labelList.offset).toBe(5);
     });
 
-    it('rotates desktop bar-top labels vertical once column count crosses 36', () => {
+    it('rotates desktop bar-top labels vertical once column count crosses 36 and anchors them to sit above the bar', () => {
       render(<CategoryPayeeBarChart data={buildMonths(37)} isLoading={false} />);
       expect(capturedProps.labelList.angle).toBe(-90);
-      expect(capturedProps.labelList.textAnchor).toBe('middle');
-      expect(capturedProps.labelList.offset).toBe(18);
+      // textAnchor='start' (with angle -90) makes rotated text extend upward
+      // from the anchor, so values never overlap the bar they label.
+      expect(capturedProps.labelList.textAnchor).toBe('start');
+      expect(capturedProps.labelList.offset).toBe(6);
       // dominantBaseline is nested inside the style object
       expect(capturedProps.labelList.style).toMatchObject({
         dominantBaseline: 'central',
@@ -250,10 +261,16 @@ describe('CategoryPayeeBarChart', () => {
       mockIsMobile.mockReturnValue(true);
       render(<CategoryPayeeBarChart data={buildMonths(3)} isLoading={false} />);
       expect(capturedProps.labelList.angle).toBe(-90);
-      expect(capturedProps.labelList.offset).toBe(20);
+      expect(capturedProps.labelList.textAnchor).toBe('start');
+      expect(capturedProps.labelList.offset).toBe(8);
       expect(capturedProps.labelList.style).toMatchObject({
         dominantBaseline: 'central',
       });
+    });
+
+    it('reserves extra top margin when bar-top labels are vertical', () => {
+      render(<CategoryPayeeBarChart data={buildMonths(40)} isLoading={false} />);
+      expect(capturedProps.barChart.margin.top).toBe(80);
     });
   });
 });

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
@@ -270,7 +270,7 @@ describe('CategoryPayeeBarChart', () => {
 
     it('reserves extra top margin when bar-top labels are vertical', () => {
       render(<CategoryPayeeBarChart data={buildMonths(40)} isLoading={false} />);
-      expect(capturedProps.barChart.margin.top).toBe(36);
+      expect(capturedProps.barChart.margin.top).toBe(20);
     });
   });
 });

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
@@ -270,7 +270,7 @@ describe('CategoryPayeeBarChart', () => {
 
     it('reserves extra top margin when bar-top labels are vertical', () => {
       render(<CategoryPayeeBarChart data={buildMonths(40)} isLoading={false} />);
-      expect(capturedProps.barChart.margin.top).toBe(80);
+      expect(capturedProps.barChart.margin.top).toBe(36);
     });
   });
 });

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
@@ -151,7 +151,7 @@ export function CategoryPayeeBarChart({
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           <BarChart
             data={chartData}
-            margin={{ top: verticalLabels ? 36 : 20, right: isMobile ? 16 : 5, left: -10, bottom: 0 }}
+            margin={{ top: verticalLabels ? 36 : 12, right: isMobile ? 16 : 5, left: -10, bottom: 0 }}
             onClick={onMonthClick ? (state: any) => {
               const month = state?.activeLabel;
               if (!month) return;

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
@@ -151,7 +151,7 @@ export function CategoryPayeeBarChart({
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           <BarChart
             data={chartData}
-            margin={{ top: verticalLabels ? 36 : 12, right: isMobile ? 16 : 5, left: -10, bottom: 0 }}
+            margin={{ top: verticalLabels ? 20 : 12, right: isMobile ? 16 : 5, left: -10, bottom: 0 }}
             onClick={onMonthClick ? (state: any) => {
               const month = state?.activeLabel;
               if (!month) return;

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
@@ -151,7 +151,7 @@ export function CategoryPayeeBarChart({
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           <BarChart
             data={chartData}
-            margin={{ top: verticalLabels ? 32 : 20, right: isMobile ? 16 : 5, left: -10, bottom: 0 }}
+            margin={{ top: verticalLabels ? 80 : 20, right: isMobile ? 16 : 5, left: -10, bottom: 0 }}
             onClick={onMonthClick ? (state: any) => {
               const month = state?.activeLabel;
               if (!month) return;
@@ -201,8 +201,8 @@ export function CategoryPayeeBarChart({
                 dataKey="total"
                 position="top"
                 angle={verticalLabels ? -90 : 0}
-                offset={isMobile ? 20 : verticalLabels ? 18 : 5}
-                textAnchor="middle"
+                offset={verticalLabels ? (isMobile ? 8 : 6) : 5}
+                textAnchor={verticalLabels ? 'start' : 'middle'}
                 formatter={(value: unknown) =>
                   isMobile
                     ? formatCurrencyAxis(Number(value))

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
@@ -151,7 +151,7 @@ export function CategoryPayeeBarChart({
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           <BarChart
             data={chartData}
-            margin={{ top: verticalLabels ? 80 : 20, right: isMobile ? 16 : 5, left: -10, bottom: 0 }}
+            margin={{ top: verticalLabels ? 36 : 20, right: isMobile ? 16 : 5, left: -10, bottom: 0 }}
             onClick={onMonthClick ? (state: any) => {
               const month = state?.activeLabel;
               if (!month) return;

--- a/frontend/src/lib/investments.ts
+++ b/frontend/src/lib/investments.ts
@@ -6,6 +6,7 @@ import {
   InvestmentTransaction,
   CreateInvestmentTransactionData,
   Holding,
+  RealizedGainEntry,
   Security,
   CreateSecurityData,
   CreateSecurityPriceData,
@@ -81,6 +82,19 @@ export const investmentsApi = {
   }): Promise<PaginatedInvestmentTransactions> => {
     const response = await apiClient.get<PaginatedInvestmentTransactions>(
       '/investment-transactions',
+      { params },
+    );
+    return response.data;
+  },
+
+  // Get realized gains per SELL transaction (proper cost basis via replay)
+  getRealizedGains: async (params?: {
+    accountIds?: string;
+    startDate?: string;
+    endDate?: string;
+  }): Promise<RealizedGainEntry[]> => {
+    const response = await apiClient.get<RealizedGainEntry[]>(
+      '/investment-transactions/realized-gains',
       { params },
     );
     return response.data;

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -210,3 +210,21 @@ export interface PaginatedInvestmentTransactions {
   data: InvestmentTransaction[];
   pagination: InvestmentTransactionPaginationInfo;
 }
+
+export interface RealizedGainEntry {
+  transactionId: string;
+  transactionDate: string;
+  accountId: string;
+  accountName: string | null;
+  accountCurrencyCode: string | null;
+  securityId: string;
+  symbol: string | null;
+  securityName: string | null;
+  securityCurrencyCode: string | null;
+  quantity: number;
+  price: number;
+  commission: number;
+  proceeds: number;
+  costBasis: number;
+  realizedGain: number;
+}


### PR DESCRIPTION
## Summary
Implement a new backend endpoint and service to calculate realized gains for SELL transactions using the average-cost basis method. This replaces the frontend's naive calculation (quantity × price) with proper cost basis tracking by replaying the entire transaction history chronologically.

## Key Changes

### Backend
- **New `calculateRealizedGains()` method** in `PortfolioCalculationService`: Replays all investment transactions for a user to compute cost basis and realized gains for each SELL transaction using average-cost accounting. Handles multiple transaction types (BUY, REINVEST, TRANSFER_IN, SPLIT, etc.) and currency conversion via exchange rates.
- **New `getRealizedGains()` endpoint** in `InvestmentTransactionsController`: Exposes the calculation service with filtering by account IDs and date range. Validates UUID and date formats.
- **New `getRealizedGains()` method** in `InvestmentTransactionsService`: Wraps the portfolio calculation service and resolves linked brokerage/cash accounts.
- **Comprehensive test suite** (`portfolio-calculation.service.spec.ts`): 5 test cases covering single/multiple buys, partial sells, date filtering, currency conversion, and orphaned sells.

### Frontend
- **New `RealizedGainEntry` type** in `types/investment.ts`: Defines the structure returned by the backend endpoint.
- **New `getRealizedGains()` API method** in `lib/investments.ts`: Calls the backend endpoint with optional filters.
- **Updated `RealizedGainsReport` component**: Replaced manual SELL transaction fetching and naive cost basis calculation with direct calls to the new `getRealizedGains()` endpoint. Simplified data aggregation logic.
- **Updated `DividendIncomeReport` component**: Integrated realized gains from the backend endpoint into the Capital Gains bucket alongside CAPITAL_GAIN transactions.
- **Updated tests**: Modified test mocks and assertions to use the new `getRealizedGains()` endpoint instead of filtering raw SELL transactions.

### Bug Fixes
- **Recharts click handlers**: Fixed `AccountBalancesBarChart` to attach `onClick` to the `Bar` component instead of `BarChart` (recharts API change). Updated test to simulate clicks correctly.

## Implementation Details
- **Cost basis replay**: Maintains running state of (quantity, costBasis) per (account, security) pair, processing transactions in chronological order. SELL transactions draw down cost basis at the running average cost per share.
- **Currency handling**: All monetary values are converted to the holding account's currency using the transaction's exchange rate. The backend returns figures already in account currency; the frontend converts to default currency only when viewing all accounts.
- **Date filtering**: The entire transaction history is replayed to ensure SELLs early in a date range still see cost basis from prior BUYs outside the range. Only SELL transactions within the requested date window are returned.
- **Rounding**: Money values are rounded to 4 decimal places to avoid floating-point precision issues.

https://claude.ai/code/session_01RGN6RFbS5o9BzXQQgXqaUh