### PR TITLE
Use vertical x-axis labels on mobile Account Balances chart

### DIFF
--- a/frontend/src/components/transactions/AccountBalancesBarChart.test.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.test.tsx
@@ -48,6 +48,12 @@ vi.mock('@/hooks/useNumberFormat', () => ({
   }),
 }));
 
+// Control the mobile breakpoint deterministically from tests.
+const mockIsMobile = vi.fn(() => false);
+vi.mock('@/hooks/useIsMobile', () => ({
+  useIsMobile: () => mockIsMobile(),
+}));
+
 describe('AccountBalancesBarChart', () => {
   beforeEach(() => {
     capturedBarOnClick = undefined;
@@ -57,6 +63,7 @@ describe('AccountBalancesBarChart', () => {
     mockFormatCurrency.mockImplementation((n: number) => `$${n.toFixed(2)}`);
     mockFormatCurrency.mockClear();
     mockFormatCurrencyAxis.mockClear();
+    mockIsMobile.mockReturnValue(false);
   });
 
   it('renders loading state with title and pulse skeleton', () => {
@@ -518,6 +525,18 @@ describe('AccountBalancesBarChart', () => {
       );
       const text = container.querySelector('text');
       expect(text?.textContent).toBe('Short Name');
+    });
+
+    it('uses vertical x-axis labels on mobile regardless of account count', () => {
+      mockIsMobile.mockReturnValue(true);
+      render(<AccountBalancesBarChart data={buildAccounts(3)} isLoading={false} />);
+      // Mobile should use the same custom-tick vertical format as the dense
+      // desktop view, not the previous slanted label style.
+      expect(typeof capturedXAxisProps.tick).toBe('object');
+      expect(capturedXAxisProps.angle).toBe(0);
+      expect(capturedXAxisProps.textAnchor).toBe('middle');
+      expect(capturedXAxisProps.interval).toBe(0);
+      expect(capturedXAxisProps.height).toBeGreaterThan(30);
     });
   });
 

--- a/frontend/src/components/transactions/AccountBalancesBarChart.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.tsx
@@ -160,9 +160,9 @@ export function AccountBalancesBarChart({
   const effectiveScale: EffectiveScale =
     scaleMode === 'auto' ? (autoPrefersLog ? 'log' : 'linear') : scaleMode;
 
-  // Mobile keeps its existing -35° slant; on desktop, switch to fully vertical
-  // labels once the bar count crosses the crowding threshold.
-  const verticalXAxis = !isMobile && chartData.length > DESKTOP_VERTICAL_AXIS_THRESHOLD;
+  // Mobile always uses fully vertical labels (matching desktop's dense view);
+  // desktop switches to vertical once the bar count crosses the crowding threshold.
+  const verticalXAxis = isMobile || chartData.length > DESKTOP_VERTICAL_AXIS_THRESHOLD;
 
   const summary = useMemo(() => {
     if (chartData.length === 0) return null;
@@ -270,15 +270,15 @@ export function AccountBalancesBarChart({
               tick={
                 verticalXAxis
                   ? <VerticalAccountTick />
-                  : { fill: '#6b7280', fontSize: isMobile ? 10 : 12 }
+                  : { fill: '#6b7280', fontSize: 12 }
               }
               tickLine={false}
               axisLine={{ stroke: '#e5e7eb' }}
-              interval={isMobile ? 'preserveStartEnd' : 0}
-              angle={isMobile ? -35 : 0}
-              textAnchor={isMobile ? 'end' : 'middle'}
-              tickMargin={isMobile ? 10 : verticalXAxis ? 8 : 0}
-              height={isMobile ? 64 : verticalXAxis ? 120 : 30}
+              interval={0}
+              angle={0}
+              textAnchor="middle"
+              tickMargin={verticalXAxis ? 8 : 0}
+              height={verticalXAxis ? 120 : 30}
             />
             <YAxis
               tick={{ fill: '#6b7280', fontSize: 11 }}


### PR DESCRIPTION
Mobile now uses the same 90-degree rotated custom tick as the desktop
dense view, replacing the previous -35-degree slanted labels. This
keeps account names fully readable without overlapping each other on
narrow screens.

https://claude.ai/code/session_01KzTiLA2wyGXKoDzXq3hgt9