### PR TITLE
Aggregate holdings by security across accounts

### DIFF
--- a/frontend/src/components/reports/InvestmentPerformanceReport.test.tsx
+++ b/frontend/src/components/reports/InvestmentPerformanceReport.test.tsx
@@ -83,6 +83,8 @@ describe('InvestmentPerformanceReport', () => {
       holdings: [
         {
           id: 'h-1',
+          securityId: 'sec-vfv',
+          accountId: 'acc-1',
           symbol: 'VFV',
           name: 'Vanguard S&P 500',
           quantity: 100,
@@ -90,6 +92,7 @@ describe('InvestmentPerformanceReport', () => {
           currentPrice: 100,
           marketValue: 10000,
           costBasis: 9000,
+          costBasisAccountCurrency: 9000,
           gainLoss: 1000,
           gainLossPercent: 11.11,
           currencyCode: 'CAD',
@@ -128,6 +131,8 @@ describe('InvestmentPerformanceReport', () => {
       holdings: [
         {
           id: 'h-1',
+          securityId: 'sec-xic',
+          accountId: 'acc-1',
           symbol: 'XIC',
           name: 'iShares S&P/TSX',
           quantity: 50,
@@ -135,6 +140,7 @@ describe('InvestmentPerformanceReport', () => {
           currentPrice: 35,
           marketValue: 1750,
           costBasis: 1500,
+          costBasisAccountCurrency: 1500,
           gainLoss: 250,
           gainLossPercent: 16.67,
           currencyCode: 'CAD',

--- a/frontend/src/components/reports/InvestmentPerformanceReport.tsx
+++ b/frontend/src/components/reports/InvestmentPerformanceReport.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import {
   Tooltip,
   ResponsiveContainer,
@@ -17,16 +17,18 @@ import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { CHART_COLOURS } from '@/lib/chart-colours';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { createLogger } from '@/lib/logger';
+import { aggregateHoldingsBySecurity, AggregatedHolding } from '@/lib/aggregate-holdings';
 
 const logger = createLogger('InvestmentPerformanceReport');
 
 export function InvestmentPerformanceReport() {
-  const { formatCurrencyCompact: formatCurrency, formatCurrency: formatCurrencyFull } = useNumberFormat();
+  const { formatCurrency: formatCurrencyFull } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
   const chartRef = useRef<HTMLDivElement>(null);
   const [portfolio, setPortfolio] = useState<PortfolioSummary | null>(null);
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [selectedAccountId, setSelectedAccountId] = useState<string>('');
+  const [expandedSecurityId, setExpandedSecurityId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [viewType, setViewType] = useState<'performance' | 'allocation'>('performance');
 
@@ -91,7 +93,7 @@ export function InvestmentPerformanceReport() {
     if (isForeignSummary) {
       return `${formatCurrencyFull(value, summaryCurrency)} ${summaryCurrency}`;
     }
-    return formatCurrency(value);
+    return formatCurrencyFull(value);
   };
 
   const fmtHolding = (value: number | null, currencyCode: string) => {
@@ -99,19 +101,33 @@ export function InvestmentPerformanceReport() {
     if (currencyCode && currencyCode !== defaultCurrency) {
       return `${formatCurrencyFull(value, currencyCode)} ${currencyCode}`;
     }
-    return formatCurrency(value);
+    return formatCurrencyFull(value);
   };
 
-  const holdingsData = useMemo(() => {
+  const accountNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    accounts.forEach((a) => map.set(a.id, a.name.replace(/ - (Brokerage|Cash)$/, '')));
+    return map;
+  }, [accounts]);
+
+  const aggregatedHoldings = useMemo((): AggregatedHolding[] => {
     if (!portfolio) return [];
-    return portfolio.holdings
+    return aggregateHoldingsBySecurity(portfolio.holdings).sort((a, b) => {
+      if (a.marketValue === null && b.marketValue === null) return 0;
+      if (a.marketValue === null) return 1;
+      if (b.marketValue === null) return -1;
+      return b.marketValue - a.marketValue;
+    });
+  }, [portfolio]);
+
+  const holdingsData = useMemo(() => {
+    return aggregatedHoldings
       .filter((h) => h.marketValue && h.marketValue > 0)
-      .sort((a, b) => (b.marketValue || 0) - (a.marketValue || 0))
       .map((h, index) => ({
         ...h,
         color: CHART_COLOURS[index % CHART_COLOURS.length],
       }));
-  }, [portfolio]);
+  }, [aggregatedHoldings]);
 
   const allocationData = useMemo(() => {
     if (!portfolio) return [];
@@ -129,10 +145,10 @@ export function InvestmentPerformanceReport() {
           <p className="font-medium text-gray-900 dark:text-gray-100">{data.name}</p>
           <p className="text-sm text-gray-600 dark:text-gray-400">{data.symbol}</p>
           <p className="text-sm text-gray-900 dark:text-gray-100 mt-1">
-            Value: {formatCurrency(data.marketValue || 0)}
+            Value: {fmtHolding(data.marketValue, data.currencyCode)}
           </p>
           <p className={`text-sm ${(data.gainLoss || 0) >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-            Gain/Loss: {formatCurrency(data.gainLoss || 0)} ({formatPercent(data.gainLossPercent || 0)})
+            Gain/Loss: {fmtHolding(data.gainLoss, data.currencyCode)} ({formatPercent(data.gainLossPercent || 0)})
           </p>
         </div>
       );
@@ -151,7 +167,7 @@ export function InvestmentPerformanceReport() {
     ] : undefined;
 
     const headers = ['Security', 'Shares', 'Avg Cost', 'Price', 'Market Value', 'Gain/Loss', 'Return'];
-    const rows = portfolio ? portfolio.holdings.map((h) => [
+    const rows = aggregatedHoldings.map((h) => [
       `${h.symbol} - ${h.name}`,
       h.quantity.toFixed(4),
       fmtHolding(h.averageCost, h.currencyCode),
@@ -159,11 +175,11 @@ export function InvestmentPerformanceReport() {
       fmtHolding(h.marketValue, h.currencyCode),
       fmtHolding(h.gainLoss, h.currencyCode),
       h.gainLossPercent !== null ? formatPercent(h.gainLossPercent) : 'N/A',
-    ]) : [];
+    ]);
 
     const legendItems = holdingsData.map((h) => ({
       color: h.color,
-      label: `${h.symbol} - ${formatCurrency(h.marketValue || 0)}`,
+      label: `${h.symbol} - ${fmtHolding(h.marketValue, h.currencyCode)}`,
     }));
 
     await exportToPdf({
@@ -183,7 +199,7 @@ export function InvestmentPerformanceReport() {
         <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
           <p className="font-medium text-gray-900 dark:text-gray-100">{data.name}</p>
           <p className="text-sm text-gray-600 dark:text-gray-400">
-            {formatCurrency(data.value)} ({data.percentage.toFixed(1)}%)
+            {formatCurrencyFull(data.value)} ({data.percentage.toFixed(1)}%)
           </p>
         </div>
       );
@@ -355,36 +371,89 @@ export function InvestmentPerformanceReport() {
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-                  {portfolio.holdings.map((holding) => (
-                    <tr key={holding.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
-                      <td className="px-4 py-3">
-                        <div className="font-medium text-gray-900 dark:text-gray-100">
-                          {holding.symbol}
-                        </div>
-                        <div className="text-sm text-gray-500 dark:text-gray-400">
-                          {holding.name}
-                        </div>
-                      </td>
-                      <td className="px-4 py-3 text-right text-sm text-gray-900 dark:text-gray-100">
-                        {holding.quantity.toFixed(4)}
-                      </td>
-                      <td className="px-4 py-3 text-right text-sm text-gray-900 dark:text-gray-100">
-                        {fmtHolding(holding.averageCost, holding.currencyCode)}
-                      </td>
-                      <td className="px-4 py-3 text-right text-sm text-gray-900 dark:text-gray-100">
-                        {fmtHolding(holding.currentPrice, holding.currencyCode)}
-                      </td>
-                      <td className="px-4 py-3 text-right text-sm font-medium text-gray-900 dark:text-gray-100">
-                        {fmtHolding(holding.marketValue, holding.currencyCode)}
-                      </td>
-                      <td className={`px-4 py-3 text-right text-sm ${(holding.gainLoss || 0) >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                        {fmtHolding(holding.gainLoss, holding.currencyCode)}
-                      </td>
-                      <td className={`px-4 py-3 text-right text-sm font-medium ${(holding.gainLossPercent || 0) >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                        {holding.gainLossPercent !== null ? formatPercent(holding.gainLossPercent) : 'N/A'}
-                      </td>
-                    </tr>
-                  ))}
+                  {aggregatedHoldings.map((holding) => {
+                    const isExpandable = holding.accountBreakdowns.length > 1;
+                    const isExpanded = expandedSecurityId === holding.securityId;
+                    return (
+                      <React.Fragment key={holding.securityId}>
+                        <tr
+                          className={`hover:bg-gray-50 dark:hover:bg-gray-700/50 ${isExpandable ? 'cursor-pointer' : ''}`}
+                          onClick={isExpandable ? () => setExpandedSecurityId(isExpanded ? null : holding.securityId) : undefined}
+                        >
+                          <td className="px-4 py-3">
+                            <div className="flex items-center gap-2">
+                              <div>
+                                <div className="font-medium text-gray-900 dark:text-gray-100">
+                                  {holding.symbol}
+                                </div>
+                                <div className="text-sm text-gray-500 dark:text-gray-400">
+                                  {holding.name}
+                                  {isExpandable && (
+                                    <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">
+                                      ({holding.accountBreakdowns.length} accounts)
+                                    </span>
+                                  )}
+                                </div>
+                              </div>
+                              {isExpandable && (
+                                <svg
+                                  className={`w-4 h-4 text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                >
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                                </svg>
+                              )}
+                            </div>
+                          </td>
+                          <td className="px-4 py-3 text-right text-sm text-gray-900 dark:text-gray-100">
+                            {holding.quantity.toFixed(4)}
+                          </td>
+                          <td className="px-4 py-3 text-right text-sm text-gray-900 dark:text-gray-100">
+                            {fmtHolding(holding.averageCost, holding.currencyCode)}
+                          </td>
+                          <td className="px-4 py-3 text-right text-sm text-gray-900 dark:text-gray-100">
+                            {fmtHolding(holding.currentPrice, holding.currencyCode)}
+                          </td>
+                          <td className="px-4 py-3 text-right text-sm font-medium text-gray-900 dark:text-gray-100">
+                            {fmtHolding(holding.marketValue, holding.currencyCode)}
+                          </td>
+                          <td className={`px-4 py-3 text-right text-sm ${(holding.gainLoss || 0) >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                            {fmtHolding(holding.gainLoss, holding.currencyCode)}
+                          </td>
+                          <td className={`px-4 py-3 text-right text-sm font-medium ${(holding.gainLossPercent || 0) >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                            {holding.gainLossPercent !== null ? formatPercent(holding.gainLossPercent) : 'N/A'}
+                          </td>
+                        </tr>
+                        {isExpanded && holding.accountBreakdowns.map((sub) => (
+                          <tr key={sub.id} className="bg-gray-50/70 dark:bg-gray-900/20">
+                            <td className="px-4 py-2 pl-10 text-sm text-gray-600 dark:text-gray-400">
+                              {accountNameById.get(sub.accountId) || 'Unknown account'}
+                            </td>
+                            <td className="px-4 py-2 text-right text-sm text-gray-600 dark:text-gray-400">
+                              {sub.quantity.toFixed(4)}
+                            </td>
+                            <td className="px-4 py-2 text-right text-sm text-gray-600 dark:text-gray-400">
+                              {fmtHolding(sub.averageCost, sub.currencyCode)}
+                            </td>
+                            <td className="px-4 py-2 text-right text-sm text-gray-600 dark:text-gray-400">
+                              {fmtHolding(sub.currentPrice, sub.currencyCode)}
+                            </td>
+                            <td className="px-4 py-2 text-right text-sm text-gray-600 dark:text-gray-400">
+                              {fmtHolding(sub.marketValue, sub.currencyCode)}
+                            </td>
+                            <td className={`px-4 py-2 text-right text-sm ${(sub.gainLoss || 0) >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                              {fmtHolding(sub.gainLoss, sub.currencyCode)}
+                            </td>
+                            <td className={`px-4 py-2 text-right text-sm ${(sub.gainLossPercent || 0) >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                              {sub.gainLossPercent !== null ? formatPercent(sub.gainLossPercent) : 'N/A'}
+                            </td>
+                          </tr>
+                        ))}
+                      </React.Fragment>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>
@@ -442,7 +511,7 @@ export function InvestmentPerformanceReport() {
                   </div>
                   <div className="text-right">
                     <div className="font-medium text-gray-900 dark:text-gray-100">
-                      {formatCurrency(item.value)}
+                      {formatCurrencyFull(item.value)}
                     </div>
                     <div className="text-sm text-gray-500 dark:text-gray-400">
                       {item.percentage.toFixed(1)}%

--- a/frontend/src/components/reports/SecurityPerformanceReport.test.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.test.tsx
@@ -36,6 +36,7 @@ const mockGetSecurities = vi.fn();
 const mockGetPortfolioSummary = vi.fn();
 const mockGetSecurityPrices = vi.fn();
 const mockGetTransactions = vi.fn();
+const mockGetInvestmentAccounts = vi.fn();
 
 vi.mock('@/lib/investments', () => ({
   investmentsApi: {
@@ -43,6 +44,7 @@ vi.mock('@/lib/investments', () => ({
     getPortfolioSummary: (...args: any[]) => mockGetPortfolioSummary(...args),
     getSecurityPrices: (...args: any[]) => mockGetSecurityPrices(...args),
     getTransactions: (...args: any[]) => mockGetTransactions(...args),
+    getInvestmentAccounts: (...args: any[]) => mockGetInvestmentAccounts(...args),
   },
 }));
 
@@ -83,11 +85,15 @@ const mockHoldings = [
 describe('SecurityPerformanceReport', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetInvestmentAccounts.mockResolvedValue([
+      { id: 'acc-1', name: 'Brokerage 1', currencyCode: 'USD' },
+    ]);
   });
 
   it('shows loading state initially', () => {
     mockGetSecurities.mockReturnValue(new Promise(() => {}));
     mockGetPortfolioSummary.mockReturnValue(new Promise(() => {}));
+    mockGetInvestmentAccounts.mockReturnValue(new Promise(() => {}));
     render(<SecurityPerformanceReport />);
     expect(document.querySelector('.animate-pulse')).toBeTruthy();
   });

--- a/frontend/src/components/reports/SecurityPerformanceReport.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.tsx
@@ -14,11 +14,13 @@ import {
 import { format, differenceInDays } from 'date-fns';
 import { investmentsApi } from '@/lib/investments';
 import { Security, SecurityPrice, InvestmentTransaction, HoldingWithMarketValue } from '@/types/investment';
+import { Account } from '@/types/account';
 import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { createLogger } from '@/lib/logger';
+import { aggregateHoldingsBySecurity } from '@/lib/aggregate-holdings';
 
 const logger = createLogger('SecurityPerformanceReport');
 
@@ -41,6 +43,7 @@ export function SecurityPerformanceReport() {
   const [prices, setPrices] = useState<SecurityPrice[]>([]);
   const [transactions, setTransactions] = useState<InvestmentTransaction[]>([]);
   const [holdings, setHoldings] = useState<HoldingWithMarketValue[]>([]);
+  const [accounts, setAccounts] = useState<Account[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingDetail, setIsLoadingDetail] = useState(false);
   const [viewType, setViewType] = useState<'chart' | 'transactions' | 'dividends'>('chart');
@@ -49,12 +52,14 @@ export function SecurityPerformanceReport() {
   useEffect(() => {
     const load = async () => {
       try {
-        const [secs, summary] = await Promise.all([
+        const [secs, summary, accts] = await Promise.all([
           investmentsApi.getSecurities(),
           investmentsApi.getPortfolioSummary(),
+          investmentsApi.getInvestmentAccounts(),
         ]);
         setSecurities(secs.filter((s) => s.isActive));
         setHoldings(summary.holdings);
+        setAccounts(accts);
       } catch (error) {
         logger.error('Failed to load securities:', error);
       } finally {
@@ -65,6 +70,12 @@ export function SecurityPerformanceReport() {
   }, []);
 
   const selectedSecurity = securities.find((s) => s.id === selectedSecurityId);
+
+  const accountNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    accounts.forEach((a) => map.set(a.id, a.name.replace(/ - (Brokerage|Cash)$/, '')));
+    return map;
+  }, [accounts]);
 
   // Load detail when security selected
   useEffect(() => {
@@ -110,7 +121,13 @@ export function SecurityPerformanceReport() {
     };
     loadDetail();
   }, [selectedSecurityId, securities]);
-  const selectedHolding = holdings.find((h) => h.securityId === selectedSecurityId);
+  const selectedHolding = useMemo(() => {
+    if (!selectedSecurityId) return null;
+    const matches = holdings.filter((h) => h.securityId === selectedSecurityId);
+    if (matches.length === 0) return null;
+    const [aggregated] = aggregateHoldingsBySecurity(matches);
+    return aggregated;
+  }, [holdings, selectedSecurityId]);
 
   // Performance stats
   const stats = useMemo(() => {
@@ -145,6 +162,7 @@ export function SecurityPerformanceReport() {
       quantity: selectedHolding.quantity,
       averageCost: selectedHolding.averageCost,
       currentPrice: selectedHolding.currentPrice,
+      accountCount: selectedHolding.accountBreakdowns.length,
     };
   }, [selectedHolding, transactions]);
 
@@ -218,9 +236,10 @@ export function SecurityPerformanceReport() {
       chartContainer = chartRef.current;
     } else if (viewType === 'transactions') {
       tableData = {
-        headers: ['Date', 'Action', 'Shares', 'Price', 'Total'],
+        headers: ['Date', 'Account', 'Action', 'Shares', 'Price', 'Total'],
         rows: tradeTx.map((tx) => [
           format(parseLocalDate(tx.transactionDate), 'MMM d, yyyy'),
+          accountNameById.get(tx.accountId) || '-',
           tx.action,
           tx.quantity != null ? String(tx.quantity) : '-',
           tx.price != null ? formatCurrencyFull(tx.price, displayCurrency) : '-',
@@ -230,13 +249,14 @@ export function SecurityPerformanceReport() {
     } else {
       const totalDividends = dividendTx.reduce((sum, tx) => sum + Math.abs(tx.totalAmount), 0);
       tableData = {
-        headers: ['Date', 'Type', 'Amount'],
+        headers: ['Date', 'Account', 'Type', 'Amount'],
         rows: dividendTx.map((tx) => [
           format(parseLocalDate(tx.transactionDate), 'MMM d, yyyy'),
+          accountNameById.get(tx.accountId) || '-',
           tx.action,
           formatCurrencyFull(Math.abs(tx.totalAmount), displayCurrency),
         ]),
-        totalRow: ['Total Dividends', '', formatCurrencyFull(totalDividends, displayCurrency)],
+        totalRow: ['Total Dividends', '', '', formatCurrencyFull(totalDividends, displayCurrency)],
       };
     }
 
@@ -367,6 +387,9 @@ export function SecurityPerformanceReport() {
                 </div>
                 <div className="text-xs text-gray-400 dark:text-gray-500 mt-1">
                   {stats.quantity} shares @ {formatCurrencyFull(stats.currentPrice ?? 0, displayCurrency)}
+                  {stats.accountCount > 1 && (
+                    <span className="ml-1">across {stats.accountCount} accounts</span>
+                  )}
                 </div>
               </div>
               <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
@@ -502,6 +525,7 @@ export function SecurityPerformanceReport() {
                     <thead className="bg-gray-50 dark:bg-gray-900/50">
                       <tr>
                         <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Date</th>
+                        <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Account</th>
                         <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Action</th>
                         <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Shares</th>
                         <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Price</th>
@@ -513,6 +537,9 @@ export function SecurityPerformanceReport() {
                         <tr key={tx.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
                           <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
                             {format(parseLocalDate(tx.transactionDate), 'MMM d, yyyy')}
+                          </td>
+                          <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">
+                            {accountNameById.get(tx.accountId) || '-'}
                           </td>
                           <td className="px-4 py-3 text-sm">
                             <span className={`px-2 py-0.5 text-xs font-medium rounded ${
@@ -557,6 +584,7 @@ export function SecurityPerformanceReport() {
                     <thead className="bg-gray-50 dark:bg-gray-900/50">
                       <tr>
                         <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Date</th>
+                        <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Account</th>
                         <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Type</th>
                         <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Amount</th>
                       </tr>
@@ -566,6 +594,9 @@ export function SecurityPerformanceReport() {
                         <tr key={tx.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
                           <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
                             {format(parseLocalDate(tx.transactionDate), 'MMM d, yyyy')}
+                          </td>
+                          <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">
+                            {accountNameById.get(tx.accountId) || '-'}
                           </td>
                           <td className="px-4 py-3 text-sm">
                             <span className="px-2 py-0.5 text-xs font-medium rounded bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
@@ -580,7 +611,7 @@ export function SecurityPerformanceReport() {
                     </tbody>
                     <tfoot className="bg-gray-50 dark:bg-gray-900/50">
                       <tr>
-                        <td className="px-4 py-3 text-sm font-bold text-gray-900 dark:text-gray-100" colSpan={2}>
+                        <td className="px-4 py-3 text-sm font-bold text-gray-900 dark:text-gray-100" colSpan={3}>
                           Total Dividends
                         </td>
                         <td className="px-4 py-3 text-sm text-right font-bold text-green-600 dark:text-green-400">

--- a/frontend/src/components/reports/SecurityTypeAllocationReport.tsx
+++ b/frontend/src/components/reports/SecurityTypeAllocationReport.tsx
@@ -16,6 +16,7 @@ import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { createLogger } from '@/lib/logger';
+import { aggregateHoldingsBySecurity, AggregatedHolding } from '@/lib/aggregate-holdings';
 
 const logger = createLogger('SecurityTypeAllocationReport');
 
@@ -44,7 +45,7 @@ interface TypeAllocation {
   percentage: number;
   count: number;
   color: string;
-  holdings: HoldingWithMarketValue[];
+  holdings: AggregatedHolding[];
 }
 
 function getColor(type: string, index: number): string {
@@ -121,20 +122,21 @@ export function SecurityTypeAllocationReport() {
   };
 
   const allocationData = useMemo((): TypeAllocation[] => {
-    const typeMap = new Map<string, { totalValue: number; count: number; holdings: HoldingWithMarketValue[] }>();
+    // Aggregate holdings by security first so the same symbol held across
+    // multiple accounts appears as a single row under its security type.
+    const aggregated = aggregateHoldingsBySecurity(holdings);
 
-    holdings.forEach((h) => {
+    const typeMap = new Map<string, { totalValue: number; holdings: AggregatedHolding[] }>();
+    aggregated.forEach((h) => {
       const type = h.securityType || 'OTHER';
-      const marketValue = h.marketValue ?? 0;
-      const converted = convertToDefault(marketValue, h.currencyCode);
+      const converted = convertToDefault(h.marketValue ?? 0, h.currencyCode);
 
       let existing = typeMap.get(type);
       if (!existing) {
-        existing = { totalValue: 0, count: 0, holdings: [] };
+        existing = { totalValue: 0, holdings: [] };
         typeMap.set(type, existing);
       }
       existing.totalValue += converted;
-      existing.count += 1;
       existing.holdings.push(h);
     });
 
@@ -147,9 +149,13 @@ export function SecurityTypeAllocationReport() {
         label: TYPE_LABELS[type] || type,
         totalValue: data.totalValue,
         percentage: totalValue > 0 ? (data.totalValue / totalValue) * 100 : 0,
-        count: data.count,
+        count: data.holdings.length,
         color: getColor(type, colorIndex++),
-        holdings: data.holdings,
+        holdings: data.holdings.sort(
+          (a, b) =>
+            convertToDefault(b.marketValue ?? 0, b.currencyCode) -
+            convertToDefault(a.marketValue ?? 0, a.currencyCode),
+        ),
       }))
       .sort((a, b) => b.totalValue - a.totalValue);
   }, [holdings, convertToDefault]);
@@ -375,9 +381,14 @@ export function SecurityTypeAllocationReport() {
                     </td>
                   </tr>
                   {expandedType === item.type && item.holdings.map((h) => (
-                    <tr key={h.id} className="bg-gray-50/50 dark:bg-gray-900/20">
+                    <tr key={h.securityId} className="bg-gray-50/50 dark:bg-gray-900/20">
                       <td className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 pl-10">
                         {h.symbol} - {h.name}
+                        {h.accountBreakdowns.length > 1 && (
+                          <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">
+                            ({h.accountBreakdowns.length} accounts)
+                          </span>
+                        )}
                       </td>
                       <td className="px-4 py-2 text-sm text-right text-gray-600 dark:text-gray-400">
                         {formatCurrencyFull(convertToDefault(h.marketValue ?? 0, h.currencyCode), defaultCurrency)}

--- a/frontend/src/lib/aggregate-holdings.ts
+++ b/frontend/src/lib/aggregate-holdings.ts
@@ -1,0 +1,62 @@
+import { HoldingWithMarketValue } from '@/types/investment';
+
+export interface AggregatedHolding extends HoldingWithMarketValue {
+  /** Per-account breakdown for this security across the filtered account set. */
+  accountBreakdowns: HoldingWithMarketValue[];
+}
+
+/**
+ * Group holdings by security, summing quantities, cost basis and market values
+ * across accounts. Average cost is recomputed from the aggregated totals so
+ * cross-account rollups remain self-consistent. All input holdings for a given
+ * security are assumed to share the same security currency (backend invariant).
+ *
+ * The aggregated row exposes `accountBreakdowns` so callers can render a
+ * per-account drill-down without re-fetching.
+ */
+export function aggregateHoldingsBySecurity(
+  holdings: HoldingWithMarketValue[],
+): AggregatedHolding[] {
+  const map = new Map<string, AggregatedHolding>();
+
+  for (const h of holdings) {
+    const existing = map.get(h.securityId);
+    if (!existing) {
+      map.set(h.securityId, { ...h, accountBreakdowns: [h] });
+      continue;
+    }
+
+    const totalQuantity = Number(existing.quantity) + Number(h.quantity);
+    const totalCostBasis = Number(existing.costBasis) + Number(h.costBasis);
+    const totalCostBasisAccountCurrency =
+      Number(existing.costBasisAccountCurrency) +
+      Number(h.costBasisAccountCurrency);
+    const existingMv = existing.marketValue;
+    const addMv = h.marketValue;
+    const totalMarketValue =
+      existingMv === null && addMv === null
+        ? null
+        : (existingMv ?? 0) + (addMv ?? 0);
+    const gainLoss =
+      totalMarketValue !== null ? totalMarketValue - totalCostBasis : null;
+    const gainLossPercent =
+      gainLoss !== null && totalCostBasis > 0
+        ? (gainLoss / totalCostBasis) * 100
+        : null;
+    const averageCost = totalQuantity > 0 ? totalCostBasis / totalQuantity : 0;
+
+    map.set(h.securityId, {
+      ...existing,
+      quantity: totalQuantity,
+      averageCost,
+      costBasis: totalCostBasis,
+      costBasisAccountCurrency: totalCostBasisAccountCurrency,
+      marketValue: totalMarketValue,
+      gainLoss,
+      gainLossPercent,
+      accountBreakdowns: [...existing.accountBreakdowns, h],
+    });
+  }
+
+  return Array.from(map.values());
+}


### PR DESCRIPTION
## Summary
This PR introduces security-level aggregation for investment holdings, allowing users to see consolidated views of securities held across multiple accounts while maintaining the ability to drill down into per-account details.

## Key Changes

- **New aggregation utility** (`aggregate-holdings.ts`): Created `aggregateHoldingsBySecurity()` function that groups holdings by security ID, summing quantities and market values across accounts while recomputing average cost from aggregated totals. Exposes `accountBreakdowns` array for per-account drill-down without re-fetching.

- **InvestmentPerformanceReport enhancements**:
  - Integrated security aggregation to show consolidated holdings in the main table
  - Added expandable rows for securities held in multiple accounts, displaying account-level details with proper indentation
  - Added `expandedSecurityId` state to manage expansion UI
  - Created `accountNameById` map to display clean account names in breakdowns
  - Fixed currency formatting to use `formatCurrencyFull` consistently instead of the removed `formatCurrencyCompact`
  - Updated export functionality to work with aggregated holdings

- **SecurityPerformanceReport enhancements**:
  - Integrated aggregation when selecting a security to show consolidated holding data
  - Added account column to transaction and dividend tables
  - Updated stats display to show account count when security is held across multiple accounts
  - Fetches investment accounts on load to support account name mapping

- **SecurityTypeAllocationReport enhancements**:
  - Aggregates holdings by security before grouping by type, ensuring same symbol held across accounts appears as single row
  - Updated type allocation data structure to use `AggregatedHolding` type
  - Displays account count indicator for securities held in multiple accounts

- **Test updates**: Updated test fixtures to include new required fields (`securityId`, `accountId`, `costBasisAccountCurrency`)

## Implementation Details

- The aggregation preserves all original holding data in `accountBreakdowns` for detailed views
- Average cost is recomputed from aggregated totals to maintain self-consistency
- Null market values are handled correctly during aggregation
- UI uses collapsible rows with visual indicators (chevron icons) for expandable securities
- Account names are cleaned by removing " - (Brokerage|Cash)" suffix for display

https://claude.ai/code/session_01Y62yKPc6oEAoFAsDDJm6G5