### PR TITLE
Consolidate asset allocation slices per security across accounts

### DIFF
--- a/backend/src/securities/portfolio-calculation.service.ts
+++ b/backend/src/securities/portfolio-calculation.service.ts
@@ -794,32 +794,61 @@ export class PortfolioCalculationService {
       });
     }
 
-    let colorIndex = 0;
+    // Consolidate holdings by security so the same security held across
+    // multiple accounts appears as a single allocation slice.
+    const consolidated = new Map<
+      string,
+      {
+        name: string;
+        symbol: string;
+        currencyCode: string;
+        value: number;
+      }
+    >();
+
     for (const holding of sortedHoldings) {
-      if (holding.marketValue !== null && holding.marketValue > 0) {
-        const originalHolding = holdings.find((h) => h.id === holding.id);
-        const holdingCurrency =
-          originalHolding?.security?.currencyCode || defaultCurrency;
-        const convertedValue = await this.convertToDefault(
-          holding.marketValue,
-          holdingCurrency,
-          defaultCurrency,
-          rateCache,
-        );
-        allocation.push({
+      if (holding.marketValue === null || holding.marketValue <= 0) continue;
+      const originalHolding = holdings.find((h) => h.id === holding.id);
+      const holdingCurrency =
+        originalHolding?.security?.currencyCode || defaultCurrency;
+      const convertedValue = await this.convertToDefault(
+        holding.marketValue,
+        holdingCurrency,
+        defaultCurrency,
+        rateCache,
+      );
+      const existing = consolidated.get(holding.securityId);
+      if (existing) {
+        existing.value += convertedValue;
+      } else {
+        consolidated.set(holding.securityId, {
           name: holding.name,
           symbol: holding.symbol,
-          type: "security",
-          value: convertedValue,
-          percentage:
-            totalPortfolioValue > 0
-              ? (convertedValue / totalPortfolioValue) * 100
-              : 0,
-          color: colors[colorIndex % colors.length],
           currencyCode: holdingCurrency,
+          value: convertedValue,
         });
-        colorIndex++;
       }
+    }
+
+    const consolidatedItems = [...consolidated.values()].sort(
+      (a, b) => b.value - a.value,
+    );
+
+    let colorIndex = 0;
+    for (const item of consolidatedItems) {
+      allocation.push({
+        name: item.name,
+        symbol: item.symbol,
+        type: "security",
+        value: item.value,
+        percentage:
+          totalPortfolioValue > 0
+            ? (item.value / totalPortfolioValue) * 100
+            : 0,
+        color: colors[colorIndex % colors.length],
+        currencyCode: item.currencyCode,
+      });
+      colorIndex++;
     }
 
     allocation.sort((a, b) => b.value - a.value);

--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -432,6 +432,53 @@ describe("PortfolioService", () => {
       });
     });
 
+    describe("when the same security is held in multiple accounts", () => {
+      beforeEach(() => {
+        prefRepository.findOne.mockResolvedValue(mockPref);
+        accountsRepository.find.mockResolvedValue([
+          mockBrokerageAccount,
+          mockCashAccount,
+          mockStandaloneAccount,
+        ]);
+        // VFV held in both the brokerage and standalone accounts
+        holdingsRepository.find.mockResolvedValue([
+          mockHoldingVFV,
+          {
+            id: "hold-4",
+            accountId: "acct-standalone-1",
+            securityId: "sec-2",
+            quantity: 25 as any,
+            averageCost: 82 as any,
+            security: mockSecurityVFV as any,
+            account: mockStandaloneAccount as any,
+          },
+        ]);
+        securityPriceRepository.query.mockResolvedValue([
+          { security_id: "sec-2", close_price: "95", price_date: "2026-02-07" },
+        ]);
+        exchangeRateService.getLatestRate.mockResolvedValue(null);
+      });
+
+      it("consolidates the security into a single allocation slice", async () => {
+        const result = await service.getPortfolioSummary(userId);
+
+        const vfvAllocs = result.allocation.filter(
+          (a) => a.symbol === "VFV.TO",
+        );
+        expect(vfvAllocs).toHaveLength(1);
+        // Combined market value: 50*95 + 25*95 = 4750 + 2375 = 7125
+        expect(vfvAllocs[0].value).toBe(7125);
+      });
+
+      it("retains per-account holdings in holdingsByAccount", async () => {
+        const result = await service.getPortfolioSummary(userId);
+
+        // The underlying holdings are still split per account
+        expect(result.holdingsByAccount).toHaveLength(2);
+        expect(result.holdings).toHaveLength(2);
+      });
+    });
+
     describe("when user has standalone investment accounts", () => {
       beforeEach(() => {
         prefRepository.findOne.mockResolvedValue(mockPref);


### PR DESCRIPTION
The Investments page asset allocation chart iterated over per-account
holdings, so a security held in more than one account showed up as two
or more pie slices. Aggregate by securityId in buildAllocation so each
security renders once with its combined market value, while holdings
and holdingsByAccount remain per-account.

https://claude.ai/code/session_01Cnog9Em5jiCwY1cyY5rSfL