### PR TITLE
Add capital gains tracking with realized + unrealized breakdown

### DIFF
--- a/backend/src/ai/query/tool-definitions.spec.ts
+++ b/backend/src/ai/query/tool-definitions.spec.ts
@@ -1,8 +1,8 @@
 import { FINANCIAL_TOOLS } from "./tool-definitions";
 
 describe("FINANCIAL_TOOLS", () => {
-  it("defines exactly 13 tools", () => {
-    expect(FINANCIAL_TOOLS).toHaveLength(13);
+  it("defines exactly 14 tools", () => {
+    expect(FINANCIAL_TOOLS).toHaveLength(14);
   });
 
   it("has unique tool names", () => {
@@ -20,6 +20,7 @@ describe("FINANCIAL_TOOLS", () => {
     "compare_periods",
     "get_portfolio_summary",
     "query_investment_transactions",
+    "get_capital_gains",
     "get_transfers",
     "get_budget_status",
     "calculate",

--- a/backend/src/ai/query/tool-definitions.ts
+++ b/backend/src/ai/query/tool-definitions.ts
@@ -293,6 +293,43 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
     },
   },
   {
+    name: "get_capital_gains",
+    description:
+      "Get per-period capital gains (realized + unrealized) for the user's investment accounts. Replays transaction history against historical close prices, so the result includes mark-to-market movement on currently-held positions in addition to realized gains from SELLs. Useful for 'how did my portfolio do last year', 'did I have any unrealized losses last month', or 'which securities drove my gains this quarter'. Returns period totals plus a breakdown grouped by month, security, or account. Requires startDate and endDate. All monetary values are in the holding account's currency; when a bucket spans accounts with different currencies its 'currency' field is null and sums are mixed.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        startDate: {
+          type: "string",
+          description: "Start date of the window (YYYY-MM-DD). Required.",
+        },
+        endDate: {
+          type: "string",
+          description: "End date of the window (YYYY-MM-DD). Required.",
+        },
+        accountNames: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Optional: filter to specific investment account names. Use exact names from the user's account list.",
+        },
+        symbols: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Optional: filter to specific security ticker symbols (case insensitive).",
+        },
+        groupBy: {
+          type: "string",
+          enum: ["month", "security", "account"],
+          description:
+            "Bucket the breakdown by month, security (symbol), or account. Defaults to 'month' when omitted.",
+        },
+      },
+      required: ["startDate", "endDate"],
+    },
+  },
+  {
     name: "get_transfers",
     description:
       "Get transfer activity between the user's own accounts for a date range. Returns per-account inbound (money received from another account), outbound (money sent to another account), net movement, and transfer count. Transfers are deliberately excluded from spending and income tools because they net to zero across accounts; use this tool for questions like 'how much did I move into my savings', 'what went out of chequing to other accounts', or 'what are my transfers between accounts'.",

--- a/backend/src/ai/query/tool-executor.service.spec.ts
+++ b/backend/src/ai/query/tool-executor.service.spec.ts
@@ -137,6 +137,32 @@ describe("ToolExecutorService", () => {
         transactions: [],
         truncatedTransactionList: false,
       }),
+      getLlmCapitalGains: jest.fn().mockResolvedValue({
+        startDate: "2024-01-01",
+        endDate: "2024-12-31",
+        totals: {
+          realizedGain: 120,
+          unrealizedGain: 80,
+          totalCapitalGain: 200,
+        },
+        groupedBy: "month",
+        entries: [
+          {
+            month: "2024-06",
+            accountName: null,
+            symbol: null,
+            securityName: null,
+            currency: "CAD",
+            startValue: 1000,
+            endValue: 1200,
+            realizedGain: 0,
+            unrealizedGain: 200,
+            totalCapitalGain: 200,
+          },
+        ],
+        entryCount: 1,
+        truncatedEntryList: false,
+      }),
     };
 
     portfolio = {
@@ -494,6 +520,49 @@ describe("ToolExecutorService", () => {
       ).toHaveBeenCalledWith(
         userId,
         expect.objectContaining({ groupBy: "security" }),
+      );
+    });
+
+    it("get_capital_gains delegates to investmentTransactions.getLlmCapitalGains", async () => {
+      const result = await service.execute(userId, "get_capital_gains", {
+        startDate: "2024-01-01",
+        endDate: "2024-12-31",
+        symbols: ["AAA"],
+        groupBy: "month",
+      });
+
+      expect(investmentTransactions.getLlmCapitalGains).toHaveBeenCalledWith(
+        userId,
+        {
+          startDate: "2024-01-01",
+          endDate: "2024-12-31",
+          accountIds: undefined,
+          symbols: ["AAA"],
+          groupBy: "month",
+        },
+      );
+      expect(result.sources[0].type).toBe("investment_capital_gains");
+      expect(result.sources[0].dateRange).toBe("2024-01-01 to 2024-12-31");
+      expect(result.summary).toContain("capital gains 200.00");
+      expect(result.summary).toContain("realized 120.00");
+      expect(result.summary).toContain("unrealized 80.00");
+      expect(result.summary).toContain("grouped by month");
+    });
+
+    it("get_capital_gains resolves account names and defaults groupBy to 'month'", async () => {
+      await service.execute(userId, "get_capital_gains", {
+        startDate: "2024-01-01",
+        endDate: "2024-12-31",
+        accountNames: ["Checking"],
+      });
+
+      expect(accounts.findAll).toHaveBeenCalledWith(userId, false);
+      expect(investmentTransactions.getLlmCapitalGains).toHaveBeenCalledWith(
+        userId,
+        expect.objectContaining({
+          accountIds: ["acc-1"],
+          groupBy: "month",
+        }),
       );
     });
 

--- a/backend/src/ai/query/tool-executor.service.ts
+++ b/backend/src/ai/query/tool-executor.service.ts
@@ -8,6 +8,7 @@ import { BudgetReportsService } from "../../budgets/budget-reports.service";
 import { PortfolioService } from "../../securities/portfolio.service";
 import {
   InvestmentTransactionsService,
+  LlmCapitalGainsGroupBy,
   LlmInvestmentTxGroupBy,
 } from "../../securities/investment-transactions.service";
 import { InvestmentAction } from "../../securities/entities/investment-transaction.entity";
@@ -103,6 +104,9 @@ export class ToolExecutorService {
             userId,
             validatedInput,
           );
+          break;
+        case "get_capital_gains":
+          result = await this.getCapitalGains(userId, validatedInput);
           break;
         case "get_transfers":
           result = await this.getTransfers(userId, validatedInput);
@@ -510,6 +514,52 @@ export class ToolExecutorService {
           type: "investment_transactions",
           description: `Investment transactions${filterDesc}`,
           dateRange: range,
+        },
+      ],
+    };
+  }
+
+  private async getCapitalGains(
+    userId: string,
+    input: Record<string, unknown>,
+  ): Promise<ToolResult> {
+    const startDate = input.startDate as string;
+    const endDate = input.endDate as string;
+    const accountNames = input.accountNames as string[] | undefined;
+    const symbols = input.symbols as string[] | undefined;
+    const groupBy =
+      (input.groupBy as LlmCapitalGainsGroupBy | undefined) ?? "month";
+
+    const accountIds = await this.resolveAccountIds(userId, accountNames);
+
+    const data = await this.investmentTransactionsService.getLlmCapitalGains(
+      userId,
+      { startDate, endDate, accountIds, symbols, groupBy },
+    );
+
+    const filterParts: string[] = [];
+    if (accountNames?.length) filterParts.push(accountNames.join(", "));
+    if (symbols?.length) filterParts.push(symbols.join(", "));
+    const filterDesc =
+      filterParts.length > 0 ? ` (${filterParts.join("; ")})` : "";
+
+    const summaryParts = [
+      `capital gains ${data.totals.totalCapitalGain.toFixed(2)}${filterDesc}`,
+      `realized ${data.totals.realizedGain.toFixed(2)}`,
+      `unrealized ${data.totals.unrealizedGain.toFixed(2)}`,
+      `grouped by ${groupBy} (${data.entryCount} ${
+        data.entryCount === 1 ? "entry" : "entries"
+      })`,
+    ];
+
+    return {
+      data,
+      summary: `${summaryParts.join(", ")}.`,
+      sources: [
+        {
+          type: "investment_capital_gains",
+          description: `Capital gains${filterDesc}`,
+          dateRange: `${startDate} to ${endDate}`,
         },
       ],
     };

--- a/backend/src/ai/query/tool-input-schemas.ts
+++ b/backend/src/ai/query/tool-input-schemas.ts
@@ -111,6 +111,14 @@ export const queryInvestmentTransactionsSchema = z.object({
   groupBy: z.enum(["account", "date", "security", "action"]).optional(),
 });
 
+export const getCapitalGainsSchema = z.object({
+  startDate: isoDateSchema,
+  endDate: isoDateSchema,
+  accountNames: z.array(z.string().max(100)).max(50).optional(),
+  symbols: z.array(z.string().min(1).max(20)).max(50).optional(),
+  groupBy: z.enum(["month", "security", "account"]).optional(),
+});
+
 export const getTransfersSchema = z.object({
   startDate: isoDateSchema.optional(),
   endDate: isoDateSchema.optional(),
@@ -158,6 +166,7 @@ export const toolInputSchemas: Record<string, z.ZodSchema> = {
   compare_periods: comparePeriodsSchema,
   get_portfolio_summary: getPortfolioSummarySchema,
   query_investment_transactions: queryInvestmentTransactionsSchema,
+  get_capital_gains: getCapitalGainsSchema,
   get_transfers: getTransfersSchema,
   get_budget_status: getBudgetStatusSchema,
   calculate: calculateSchema,

--- a/backend/src/mcp/tools/investments.tool.spec.ts
+++ b/backend/src/mcp/tools/investments.tool.spec.ts
@@ -22,6 +22,7 @@ describe("McpInvestmentsTools", () => {
 
     investmentTransactionsService = {
       getLlmInvestmentTransactions: jest.fn(),
+      getLlmCapitalGains: jest.fn(),
     };
 
     tool = new McpInvestmentsTools(
@@ -40,8 +41,8 @@ describe("McpInvestmentsTools", () => {
     tool.register(server as any, resolve);
   });
 
-  it("should register 3 tools", () => {
-    expect(server.registerTool).toHaveBeenCalledTimes(3);
+  it("should register 4 tools", () => {
+    expect(server.registerTool).toHaveBeenCalledTimes(4);
   });
 
   describe("get_portfolio_summary", () => {
@@ -197,6 +198,109 @@ describe("McpInvestmentsTools", () => {
 
       const result = await handlers["query_investment_transactions"](
         {},
+        { sessionId: "s1" },
+      );
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("get_capital_gains", () => {
+    it("returns error when no user context", async () => {
+      resolve.mockReturnValue(undefined);
+      const result = await handlers["get_capital_gains"](
+        { startDate: "2024-01-01", endDate: "2024-12-31" },
+        { sessionId: "s1" },
+      );
+      expect(result.isError).toBe(true);
+    });
+
+    it("delegates to shared getLlmCapitalGains with all filters", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      investmentTransactionsService.getLlmCapitalGains.mockResolvedValue({
+        startDate: "2024-01-01",
+        endDate: "2024-12-31",
+        totals: {
+          realizedGain: 50,
+          unrealizedGain: 100,
+          totalCapitalGain: 150,
+        },
+        groupedBy: "security",
+        entries: [
+          {
+            month: null,
+            accountName: null,
+            symbol: "AAA",
+            securityName: "Alpha",
+            currency: "CAD",
+            startValue: 1000,
+            endValue: 1100,
+            realizedGain: 50,
+            unrealizedGain: 100,
+            totalCapitalGain: 150,
+          },
+        ],
+        entryCount: 1,
+        truncatedEntryList: false,
+      });
+
+      const result = await handlers["get_capital_gains"](
+        {
+          startDate: "2024-01-01",
+          endDate: "2024-12-31",
+          accountIds: ["00000000-0000-0000-0000-000000000001"],
+          symbols: ["AAA"],
+          groupBy: "security",
+        },
+        { sessionId: "s1" },
+      );
+
+      expect(
+        investmentTransactionsService.getLlmCapitalGains,
+      ).toHaveBeenCalledWith("u1", {
+        startDate: "2024-01-01",
+        endDate: "2024-12-31",
+        accountIds: ["00000000-0000-0000-0000-000000000001"],
+        symbols: ["AAA"],
+        groupBy: "security",
+      });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.totals.totalCapitalGain).toBe(150);
+      expect(parsed.entries[0].symbol).toBe("AAA");
+    });
+
+    it("defaults groupBy to 'month' when omitted", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      investmentTransactionsService.getLlmCapitalGains.mockResolvedValue({
+        startDate: "2024-01-01",
+        endDate: "2024-12-31",
+        totals: { realizedGain: 0, unrealizedGain: 0, totalCapitalGain: 0 },
+        groupedBy: "month",
+        entries: [],
+        entryCount: 0,
+        truncatedEntryList: false,
+      });
+
+      await handlers["get_capital_gains"](
+        { startDate: "2024-01-01", endDate: "2024-12-31" },
+        { sessionId: "s1" },
+      );
+
+      expect(
+        investmentTransactionsService.getLlmCapitalGains,
+      ).toHaveBeenCalledWith(
+        "u1",
+        expect.objectContaining({ groupBy: "month" }),
+      );
+    });
+
+    it("returns a safe error on service failure", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      investmentTransactionsService.getLlmCapitalGains.mockRejectedValue(
+        new Error("boom"),
+      );
+
+      const result = await handlers["get_capital_gains"](
+        { startDate: "2024-01-01", endDate: "2024-12-31" },
         { sessionId: "s1" },
       );
       expect(result.isError).toBe(true);

--- a/backend/src/mcp/tools/investments.tool.ts
+++ b/backend/src/mcp/tools/investments.tool.ts
@@ -5,6 +5,7 @@ import { PortfolioService } from "../../securities/portfolio.service";
 import { HoldingsService } from "../../securities/holdings.service";
 import {
   InvestmentTransactionsService,
+  LlmCapitalGainsGroupBy,
   LlmInvestmentTxGroupBy,
 } from "../../securities/investment-transactions.service";
 import { InvestmentAction } from "../../securities/entities/investment-transaction.entity";
@@ -118,6 +119,65 @@ export class McpInvestmentsTools {
                 groupBy:
                   (args.groupBy as LlmInvestmentTxGroupBy | undefined) ??
                   "security",
+              },
+            );
+          return toolResult(result);
+        } catch (err: unknown) {
+          return safeToolError(err);
+        }
+      },
+    );
+
+    server.registerTool(
+      "get_capital_gains",
+      {
+        description:
+          "Per-period capital gains (realized + unrealized) for the user's investment accounts. Replays transaction history and snapshots positions against historical close prices, so the output includes mark-to-market movement on currently-held positions in addition to realized SELL gains. Requires startDate and endDate. Returns the same compact, LLM-friendly shape as the AI Assistant's tool.",
+        inputSchema: {
+          startDate: z
+            .string()
+            .regex(/^\d{4}-\d{2}-\d{2}$/)
+            .describe("Start date of the window (YYYY-MM-DD)"),
+          endDate: z
+            .string()
+            .regex(/^\d{4}-\d{2}-\d{2}$/)
+            .describe("End date of the window (YYYY-MM-DD)"),
+          accountIds: z
+            .array(z.string().uuid())
+            .max(50)
+            .optional()
+            .describe("Optional investment account IDs."),
+          symbols: z
+            .array(z.string().min(1).max(20))
+            .max(50)
+            .optional()
+            .describe("Optional security ticker symbols (case insensitive)."),
+          groupBy: z
+            .enum(["month", "security", "account"])
+            .optional()
+            .describe(
+              "Bucket the breakdown by month, security, or account. Defaults to 'month' when omitted.",
+            ),
+        },
+      },
+      async (args, extra) => {
+        const ctx = resolve(extra.sessionId);
+        if (!ctx) return toolError("No user context");
+        const check = requireScope(ctx.scopes, "read");
+        if (check.error) return check.result;
+
+        try {
+          const result =
+            await this.investmentTransactionsService.getLlmCapitalGains(
+              ctx.userId,
+              {
+                startDate: args.startDate,
+                endDate: args.endDate,
+                accountIds: args.accountIds,
+                symbols: args.symbols,
+                groupBy:
+                  (args.groupBy as LlmCapitalGainsGroupBy | undefined) ??
+                  "month",
               },
             );
           return toolResult(result);

--- a/backend/src/securities/investment-transactions.controller.spec.ts
+++ b/backend/src/securities/investment-transactions.controller.spec.ts
@@ -31,6 +31,7 @@ describe("InvestmentTransactionsController", () => {
       findAll: jest.fn(),
       getSummary: jest.fn(),
       getRealizedGains: jest.fn(),
+      getCapitalGainsByMonth: jest.fn(),
       findOne: jest.fn(),
       update: jest.fn(),
       remove: jest.fn(),
@@ -220,6 +221,69 @@ describe("InvestmentTransactionsController", () => {
     it("rejects malformed dates", () => {
       expect(() =>
         controller.getRealizedGains(req, undefined, "2024/01/01"),
+      ).toThrow(BadRequestException);
+    });
+  });
+
+  describe("getCapitalGainsByMonth", () => {
+    it("passes startDate, endDate, and account filters through to the service", async () => {
+      const rows = [
+        {
+          month: "2024-06",
+          totalCapitalGain: 250,
+          realizedGain: 0,
+          unrealizedGain: 250,
+        },
+      ];
+      service.getCapitalGainsByMonth.mockResolvedValue(rows);
+
+      const result = await controller.getCapitalGainsByMonth(
+        req,
+        "2024-01-01",
+        "2024-12-31",
+        `${UUID1},${UUID2}`,
+      );
+
+      expect(service.getCapitalGainsByMonth).toHaveBeenCalledWith("user-1", {
+        accountIds: [UUID1, UUID2],
+        startDate: "2024-01-01",
+        endDate: "2024-12-31",
+      });
+      expect(result).toEqual(rows);
+    });
+
+    it("requires startDate", () => {
+      expect(() =>
+        controller.getCapitalGainsByMonth(req, "", "2024-12-31"),
+      ).toThrow(BadRequestException);
+    });
+
+    it("requires endDate", () => {
+      expect(() =>
+        controller.getCapitalGainsByMonth(req, "2024-01-01", ""),
+      ).toThrow(BadRequestException);
+    });
+
+    it("rejects malformed dates", () => {
+      expect(() =>
+        controller.getCapitalGainsByMonth(req, "2024/01/01", "2024-12-31"),
+      ).toThrow(BadRequestException);
+    });
+
+    it("rejects when startDate is after endDate", () => {
+      expect(() =>
+        controller.getCapitalGainsByMonth(req, "2024-12-31", "2024-01-01"),
+      ).toThrow(BadRequestException);
+    });
+
+    it("rejects invalid account UUIDs", () => {
+      expect(() =>
+        controller.getCapitalGainsByMonth(
+          req,
+          "2024-01-01",
+          "2024-12-31",
+          "not-a-uuid",
+        ),
       ).toThrow(BadRequestException);
     });
   });

--- a/backend/src/securities/investment-transactions.controller.ts
+++ b/backend/src/securities/investment-transactions.controller.ts
@@ -219,6 +219,59 @@ export class InvestmentTransactionsController {
     });
   }
 
+  @Get("capital-gains")
+  @ApiOperation({
+    summary:
+      "Per-month capital gains (realized + unrealized) by security across the window",
+    description:
+      "Returns per (account, security, month) capital gain entries combining realized SELL gains and the unrealized mark-to-market change on the position. Requires startDate and endDate.",
+  })
+  @ApiQuery({ name: "accountIds", required: false })
+  @ApiQuery({ name: "startDate", required: true })
+  @ApiQuery({ name: "endDate", required: true })
+  @ApiResponse({
+    status: 200,
+    description: "List of monthly capital gain entries",
+  })
+  getCapitalGainsByMonth(
+    @Request() req,
+    @Query("startDate") startDate: string,
+    @Query("endDate") endDate: string,
+    @Query("accountIds") accountIds?: string,
+  ) {
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+    if (!startDate || !dateRegex.test(startDate)) {
+      throw new BadRequestException(
+        "startDate is required and must be in YYYY-MM-DD format",
+      );
+    }
+    if (!endDate || !dateRegex.test(endDate)) {
+      throw new BadRequestException(
+        "endDate is required and must be in YYYY-MM-DD format",
+      );
+    }
+    if (startDate > endDate) {
+      throw new BadRequestException("startDate must be on or before endDate");
+    }
+
+    const ids = accountIds ? accountIds.split(",").filter(Boolean) : undefined;
+    if (ids) {
+      for (const id of ids) {
+        if (!uuidRegex.test(id)) {
+          throw new BadRequestException(`Invalid account UUID: ${id}`);
+        }
+      }
+    }
+
+    return this.investmentTransactionsService.getCapitalGainsByMonth(
+      req.user.id,
+      { accountIds: ids, startDate, endDate },
+    );
+  }
+
   @Get(":id")
   @ApiOperation({ summary: "Get an investment transaction by ID" })
   @ApiResponse({

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -36,6 +36,7 @@ describe("InvestmentTransactionsService", () => {
   let investmentTransactionsRepository: Record<string, jest.Mock>;
   let transactionRepository: Record<string, jest.Mock>;
   let accountsService: Record<string, jest.Mock>;
+  let portfolioCalculationService: Record<string, jest.Mock>;
   let transactionsService: Record<string, jest.Mock>;
   let holdingsService: Record<string, jest.Mock>;
   let securitiesService: Record<string, jest.Mock>;
@@ -346,7 +347,10 @@ describe("InvestmentTransactionsService", () => {
         },
         {
           provide: PortfolioCalculationService,
-          useValue: { calculateRealizedGains: jest.fn().mockResolvedValue([]) },
+          useValue: (portfolioCalculationService = {
+            calculateRealizedGains: jest.fn().mockResolvedValue([]),
+            calculateCapitalGainsByMonth: jest.fn().mockResolvedValue([]),
+          }),
         },
         {
           provide: SecuritiesService,
@@ -2838,6 +2842,221 @@ describe("InvestmentTransactionsService", () => {
       expect(result.groups).toEqual([]);
       expect(result.transactions).toEqual([]);
       expect(result.truncatedTransactionList).toBe(false);
+    });
+  });
+
+  describe("getLlmCapitalGains", () => {
+    const makeEntry = (
+      overrides: Partial<{
+        month: string;
+        accountId: string;
+        accountName: string | null;
+        accountCurrencyCode: string | null;
+        securityId: string;
+        symbol: string | null;
+        securityName: string | null;
+        startValue: number;
+        endValue: number;
+        realizedGain: number;
+        unrealizedGain: number;
+        totalCapitalGain: number;
+      }>,
+    ) => ({
+      month: "2024-06",
+      accountId: "acc-1",
+      accountName: "TFSA",
+      accountCurrencyCode: "CAD",
+      securityId: "sec-1",
+      symbol: "AAA",
+      securityName: "Alpha",
+      securityCurrencyCode: "CAD",
+      startQuantity: 10,
+      endQuantity: 10,
+      startValue: 1000,
+      endValue: 1100,
+      buys: 0,
+      sells: 0,
+      realizedGain: 0,
+      unrealizedGain: 100,
+      totalCapitalGain: 100,
+      ...overrides,
+    });
+
+    it("aggregates the raw per-(account,security,month) rows into monthly buckets by default", async () => {
+      const raw = [
+        makeEntry({
+          month: "2024-06",
+          symbol: "AAA",
+          securityName: "Alpha",
+          securityId: "sec-1",
+          totalCapitalGain: 100,
+          unrealizedGain: 100,
+          startValue: 1000,
+          endValue: 1100,
+        }),
+        makeEntry({
+          month: "2024-06",
+          symbol: "BBB",
+          securityName: "Beta",
+          securityId: "sec-2",
+          totalCapitalGain: -50,
+          unrealizedGain: -50,
+          startValue: 500,
+          endValue: 450,
+        }),
+        makeEntry({
+          month: "2024-07",
+          symbol: "AAA",
+          securityName: "Alpha",
+          securityId: "sec-1",
+          totalCapitalGain: 200,
+          realizedGain: 120,
+          unrealizedGain: 80,
+          startValue: 1100,
+          endValue: 1300,
+        }),
+      ];
+      (
+        portfolioCalculationService.calculateCapitalGainsByMonth as jest.Mock
+      ).mockResolvedValue(raw);
+
+      const result = await service.getLlmCapitalGains(userId, {
+        startDate: "2024-06-01",
+        endDate: "2024-07-31",
+      });
+
+      expect(result.startDate).toBe("2024-06-01");
+      expect(result.endDate).toBe("2024-07-31");
+      expect(result.groupedBy).toBe("month");
+      expect(result.totals.totalCapitalGain).toBeCloseTo(250, 4);
+      expect(result.totals.realizedGain).toBeCloseTo(120, 4);
+      expect(result.totals.unrealizedGain).toBeCloseTo(130, 4);
+      expect(result.entries).toHaveLength(2);
+      // Sorted by month ascending for the month grouping.
+      expect(result.entries.map((e) => e.month)).toEqual([
+        "2024-06",
+        "2024-07",
+      ]);
+      // June combines Alpha + Beta sums.
+      expect(result.entries[0].totalCapitalGain).toBe(50);
+      expect(result.entries[0].startValue).toBe(1500);
+      expect(result.entries[0].endValue).toBe(1550);
+      // Same account currency across all rows → kept as CAD.
+      expect(result.entries[0].currency).toBe("CAD");
+      expect(result.entryCount).toBe(2);
+      expect(result.truncatedEntryList).toBe(false);
+    });
+
+    it("groups by security when requested and sorts descending by total gain", async () => {
+      (
+        portfolioCalculationService.calculateCapitalGainsByMonth as jest.Mock
+      ).mockResolvedValue([
+        makeEntry({
+          month: "2024-06",
+          symbol: "AAA",
+          securityId: "sec-1",
+          totalCapitalGain: 80,
+          realizedGain: 0,
+          unrealizedGain: 80,
+        }),
+        makeEntry({
+          month: "2024-07",
+          symbol: "AAA",
+          securityId: "sec-1",
+          totalCapitalGain: 120,
+          realizedGain: 60,
+          unrealizedGain: 60,
+        }),
+        makeEntry({
+          month: "2024-06",
+          symbol: "BBB",
+          securityName: "Beta",
+          securityId: "sec-2",
+          totalCapitalGain: -50,
+          realizedGain: 0,
+          unrealizedGain: -50,
+        }),
+      ]);
+
+      const result = await service.getLlmCapitalGains(userId, {
+        startDate: "2024-06-01",
+        endDate: "2024-07-31",
+        groupBy: "security",
+      });
+
+      expect(result.groupedBy).toBe("security");
+      expect(result.entries.map((e) => e.symbol)).toEqual(["AAA", "BBB"]);
+      expect(result.entries[0].totalCapitalGain).toBe(200); // 80 + 120
+      expect(result.entries[0].realizedGain).toBe(60);
+      expect(result.entries[1].totalCapitalGain).toBe(-50);
+    });
+
+    it("flags mixed currencies with a null currency on the bucket", async () => {
+      (
+        portfolioCalculationService.calculateCapitalGainsByMonth as jest.Mock
+      ).mockResolvedValue([
+        makeEntry({ accountCurrencyCode: "CAD", totalCapitalGain: 100 }),
+        makeEntry({
+          accountCurrencyCode: "USD",
+          totalCapitalGain: 50,
+          symbol: "USS",
+          securityId: "sec-us",
+        }),
+      ]);
+
+      const result = await service.getLlmCapitalGains(userId, {
+        startDate: "2024-06-01",
+        endDate: "2024-06-30",
+      });
+
+      expect(result.entries).toHaveLength(1); // single month bucket
+      expect(result.entries[0].currency).toBeNull();
+    });
+
+    it("filters by symbol (case-insensitive) before aggregating", async () => {
+      (
+        portfolioCalculationService.calculateCapitalGainsByMonth as jest.Mock
+      ).mockResolvedValue([
+        makeEntry({ symbol: "AAA", totalCapitalGain: 100 }),
+        makeEntry({
+          symbol: "BBB",
+          securityId: "sec-2",
+          totalCapitalGain: 200,
+        }),
+      ]);
+
+      const result = await service.getLlmCapitalGains(userId, {
+        startDate: "2024-06-01",
+        endDate: "2024-06-30",
+        symbols: ["aaa"],
+      });
+
+      expect(result.entries).toHaveLength(1);
+      expect(result.totals.totalCapitalGain).toBe(100);
+    });
+
+    it("resolves linked brokerage/cash account pairs when an accountId filter is passed", async () => {
+      (accountsService.findByIds as jest.Mock).mockResolvedValue([
+        { id: "brok-1", linkedAccountId: "cash-1" },
+      ]);
+      (
+        portfolioCalculationService.calculateCapitalGainsByMonth as jest.Mock
+      ).mockResolvedValue([]);
+
+      await service.getLlmCapitalGains(userId, {
+        startDate: "2024-06-01",
+        endDate: "2024-06-30",
+        accountIds: ["brok-1"],
+      });
+
+      expect(
+        portfolioCalculationService.calculateCapitalGainsByMonth,
+      ).toHaveBeenCalledWith(
+        userId,
+        expect.objectContaining({
+          accountIds: expect.arrayContaining(["brok-1", "cash-1"]),
+        }),
+      );
     });
   });
 

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -20,6 +20,7 @@ import { HoldingsService } from "./holdings.service";
 import {
   PortfolioCalculationService,
   RealizedGainEntry,
+  CapitalGainEntry,
 } from "./portfolio-calculation.service";
 import { SecuritiesService } from "./securities.service";
 import { SecurityPriceService } from "./security-price.service";
@@ -814,6 +815,40 @@ export class InvestmentTransactionsService {
       startDate: opts.startDate,
       endDate: opts.endDate,
     });
+  }
+
+  /**
+   * Per-month capital gain breakdown (realized + unrealized) per security in
+   * the requested window. Resolves linked brokerage/cash accounts the same way
+   * `findAll()` and `getRealizedGains()` do so callers can filter by either
+   * side and get a consistent picture.
+   */
+  async getCapitalGainsByMonth(
+    userId: string,
+    opts: {
+      accountIds?: string[];
+      startDate: string;
+      endDate: string;
+    },
+  ): Promise<CapitalGainEntry[]> {
+    let accountIds = opts.accountIds;
+    if (accountIds && accountIds.length > 0) {
+      const resolvedIds = new Set<string>(accountIds);
+      const accounts = await this.accountsService.findByIds(userId, accountIds);
+      for (const acct of accounts) {
+        if (acct.linkedAccountId) resolvedIds.add(acct.linkedAccountId);
+      }
+      accountIds = [...resolvedIds];
+    }
+
+    return this.portfolioCalculationService.calculateCapitalGainsByMonth(
+      userId,
+      {
+        accountIds,
+        startDate: opts.startDate,
+        endDate: opts.endDate,
+      },
+    );
   }
 
   async findOne(userId: string, id: string): Promise<InvestmentTransaction> {

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -38,6 +38,40 @@ import { ActionHistoryService } from "../action-history/action-history.service";
 
 export type LlmInvestmentTxGroupBy = "account" | "date" | "security" | "action";
 
+export type LlmCapitalGainsGroupBy = "month" | "security" | "account";
+
+export interface LlmCapitalGainsEntry {
+  month: string | null;
+  accountName: string | null;
+  symbol: string | null;
+  securityName: string | null;
+  /**
+   * Currency the monetary fields are denominated in. `null` when the entry
+   * aggregates rows from multiple accounts with different currencies (the LLM
+   * should then treat the sums as mixed and avoid currency-specific claims).
+   */
+  currency: string | null;
+  startValue: number;
+  endValue: number;
+  realizedGain: number;
+  unrealizedGain: number;
+  totalCapitalGain: number;
+}
+
+export interface LlmCapitalGainsResult {
+  startDate: string;
+  endDate: string;
+  totals: {
+    realizedGain: number;
+    unrealizedGain: number;
+    totalCapitalGain: number;
+  };
+  groupedBy: LlmCapitalGainsGroupBy;
+  entries: LlmCapitalGainsEntry[];
+  entryCount: number;
+  truncatedEntryList: boolean;
+}
+
 export interface LlmInvestmentTxRow {
   transactionDate: string;
   action: string;
@@ -849,6 +883,175 @@ export class InvestmentTransactionsService {
         endDate: opts.endDate,
       },
     );
+  }
+
+  /**
+   * LLM-friendly capital-gains roll-up sharing logic with the report endpoint
+   * and the MCP server. Replays the user's investment history via
+   * PortfolioCalculationService.calculateCapitalGainsByMonth, optionally
+   * narrows by symbol, and aggregates into buckets ('month', 'security', or
+   * 'account') so the assistant gets a compact shape with period totals.
+   *
+   * All monetary values are in the holding account's currency. When a bucket
+   * spans accounts with differing currencies, its `currency` is set to `null`
+   * so callers can tell the sum is mixed.
+   */
+  async getLlmCapitalGains(
+    userId: string,
+    options: {
+      startDate: string;
+      endDate: string;
+      accountIds?: string[];
+      symbols?: string[];
+      groupBy?: LlmCapitalGainsGroupBy;
+    },
+  ): Promise<LlmCapitalGainsResult> {
+    let accountIds = options.accountIds;
+    if (accountIds && accountIds.length > 0) {
+      const resolvedIds = new Set<string>(accountIds);
+      const accounts = await this.accountsService.findByIds(userId, accountIds);
+      for (const acct of accounts) {
+        if (acct.linkedAccountId) resolvedIds.add(acct.linkedAccountId);
+      }
+      accountIds = [...resolvedIds];
+    }
+
+    const raw =
+      await this.portfolioCalculationService.calculateCapitalGainsByMonth(
+        userId,
+        {
+          accountIds,
+          startDate: options.startDate,
+          endDate: options.endDate,
+        },
+      );
+
+    const upperSymbols = options.symbols?.length
+      ? new Set(options.symbols.map((s) => s.toUpperCase()))
+      : null;
+    const filtered = upperSymbols
+      ? raw.filter((e) => e.symbol && upperSymbols.has(e.symbol.toUpperCase()))
+      : raw;
+
+    const groupBy: LlmCapitalGainsGroupBy = options.groupBy ?? "month";
+
+    // Aggregate in integer 1e-4 units so sums stay free of float drift.
+    const round4 = (n: number): number => Math.round(n * 10000) / 10000;
+    interface Bucket {
+      month: string | null;
+      accountName: string | null;
+      symbol: string | null;
+      securityName: string | null;
+      currency: string | null | undefined; // undefined = not seen yet
+      startValueScaled: number;
+      endValueScaled: number;
+      realizedScaled: number;
+      unrealizedScaled: number;
+      totalScaled: number;
+    }
+    const buckets = new Map<string, Bucket>();
+    let totalsRealizedScaled = 0;
+    let totalsUnrealizedScaled = 0;
+    let totalsCapitalScaled = 0;
+
+    for (const e of filtered) {
+      totalsRealizedScaled += Math.round(e.realizedGain * 10000);
+      totalsUnrealizedScaled += Math.round(e.unrealizedGain * 10000);
+      totalsCapitalScaled += Math.round(e.totalCapitalGain * 10000);
+
+      let key: string;
+      let seed: Pick<
+        Bucket,
+        "month" | "accountName" | "symbol" | "securityName"
+      >;
+      if (groupBy === "month") {
+        key = e.month;
+        seed = {
+          month: e.month,
+          accountName: null,
+          symbol: null,
+          securityName: null,
+        };
+      } else if (groupBy === "security") {
+        key = e.symbol ?? `__sec:${e.securityId}`;
+        seed = {
+          month: null,
+          accountName: null,
+          symbol: e.symbol,
+          securityName: e.securityName,
+        };
+      } else {
+        key = e.accountName ?? `__acct:${e.accountId}`;
+        seed = {
+          month: null,
+          accountName: e.accountName,
+          symbol: null,
+          securityName: null,
+        };
+      }
+
+      let b = buckets.get(key);
+      if (!b) {
+        b = {
+          ...seed,
+          currency: undefined,
+          startValueScaled: 0,
+          endValueScaled: 0,
+          realizedScaled: 0,
+          unrealizedScaled: 0,
+          totalScaled: 0,
+        };
+        buckets.set(key, b);
+      }
+
+      // Track currency: consistent → keep it; mixed → null.
+      if (b.currency === undefined) {
+        b.currency = e.accountCurrencyCode;
+      } else if (b.currency !== e.accountCurrencyCode) {
+        b.currency = null;
+      }
+
+      b.startValueScaled += Math.round(e.startValue * 10000);
+      b.endValueScaled += Math.round(e.endValue * 10000);
+      b.realizedScaled += Math.round(e.realizedGain * 10000);
+      b.unrealizedScaled += Math.round(e.unrealizedGain * 10000);
+      b.totalScaled += Math.round(e.totalCapitalGain * 10000);
+    }
+
+    const MAX_ENTRIES = 100;
+    const allEntries: LlmCapitalGainsEntry[] = [...buckets.values()].map(
+      (b) => ({
+        month: b.month,
+        accountName: b.accountName,
+        symbol: b.symbol,
+        securityName: b.securityName,
+        currency: b.currency ?? null,
+        startValue: round4(b.startValueScaled / 10000),
+        endValue: round4(b.endValueScaled / 10000),
+        realizedGain: round4(b.realizedScaled / 10000),
+        unrealizedGain: round4(b.unrealizedScaled / 10000),
+        totalCapitalGain: round4(b.totalScaled / 10000),
+      }),
+    );
+    allEntries.sort((a, b) => {
+      if (groupBy === "month")
+        return (a.month ?? "").localeCompare(b.month ?? "");
+      return b.totalCapitalGain - a.totalCapitalGain;
+    });
+
+    return {
+      startDate: options.startDate,
+      endDate: options.endDate,
+      totals: {
+        realizedGain: round4(totalsRealizedScaled / 10000),
+        unrealizedGain: round4(totalsUnrealizedScaled / 10000),
+        totalCapitalGain: round4(totalsCapitalScaled / 10000),
+      },
+      groupedBy: groupBy,
+      entries: allEntries.slice(0, MAX_ENTRIES),
+      entryCount: allEntries.length,
+      truncatedEntryList: allEntries.length > MAX_ENTRIES,
+    };
   }
 
   async findOne(userId: string, id: string): Promise<InvestmentTransaction> {

--- a/backend/src/securities/portfolio-calculation.service.spec.ts
+++ b/backend/src/securities/portfolio-calculation.service.spec.ts
@@ -216,3 +216,281 @@ describe("PortfolioCalculationService.calculateRealizedGains", () => {
     expect(result[0].realizedGain).toBe(500);
   });
 });
+
+describe("PortfolioCalculationService.calculateCapitalGainsByMonth", () => {
+  let service: PortfolioCalculationService;
+  let txRepo: { find: jest.Mock };
+  let priceRepo: { query: jest.Mock };
+  let exchangeRateService: { getLatestRate: jest.Mock };
+
+  const userId = "user-1";
+  const accountId = "acct-1";
+  const securityId = "sec-1";
+
+  const makeTx = (overrides: Partial<InvestmentTransaction>) =>
+    ({
+      id: overrides.id ?? "tx",
+      userId,
+      accountId,
+      securityId,
+      action: InvestmentAction.BUY,
+      transactionDate: "2024-01-01",
+      quantity: 0,
+      price: 0,
+      commission: 0,
+      totalAmount: 0,
+      exchangeRate: 1,
+      description: null,
+      createdAt: new Date("2024-01-01"),
+      updatedAt: new Date("2024-01-01"),
+      account: {
+        id: accountId,
+        name: "TFSA",
+        currencyCode: "CAD",
+      } as Partial<Account>,
+      security: {
+        id: securityId,
+        symbol: "ABC",
+        name: "ABC Corp",
+        currencyCode: "CAD",
+      },
+      ...overrides,
+    }) as unknown as InvestmentTransaction;
+
+  // Build the rows that getAllPricesForSecurities returns from
+  // security_prices, in the shape the SQL query produces.
+  const priceRows = (
+    rows: Array<{ date: string; price: number; securityId?: string }>,
+  ) =>
+    rows.map((r) => ({
+      security_id: r.securityId ?? securityId,
+      price_date: r.date,
+      close_price: String(r.price),
+    }));
+
+  beforeEach(async () => {
+    txRepo = { find: jest.fn() };
+    priceRepo = { query: jest.fn().mockResolvedValue([]) };
+    exchangeRateService = { getLatestRate: jest.fn().mockResolvedValue(null) };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PortfolioCalculationService,
+        { provide: getRepositoryToken(Holding), useValue: {} },
+        { provide: getRepositoryToken(SecurityPrice), useValue: priceRepo },
+        {
+          provide: getRepositoryToken(InvestmentTransaction),
+          useValue: txRepo,
+        },
+        { provide: getRepositoryToken(Account), useValue: {} },
+        { provide: ExchangeRateService, useValue: exchangeRateService },
+      ],
+    }).compile();
+    service = module.get(PortfolioCalculationService);
+  });
+
+  it("returns an empty array when there are no transactions", async () => {
+    txRepo.find.mockResolvedValue([]);
+    const result = await service.calculateCapitalGainsByMonth(userId, {
+      startDate: "2024-01-01",
+      endDate: "2024-03-31",
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("captures unrealized mark-to-market change for a held position with no SELL", async () => {
+    // Buy 100 shares at $50 in Dec; price climbs $50 -> $55 -> $60 across Jan/Feb.
+    txRepo.find.mockResolvedValue([
+      makeTx({
+        id: "buy",
+        action: InvestmentAction.BUY,
+        transactionDate: "2023-12-15",
+        quantity: 100,
+        price: 50,
+        totalAmount: 5000,
+      }),
+    ]);
+    priceRepo.query.mockResolvedValue(
+      priceRows([
+        { date: "2023-12-31", price: 50 },
+        { date: "2024-01-31", price: 55 },
+        { date: "2024-02-29", price: 60 },
+      ]),
+    );
+
+    const result = await service.calculateCapitalGainsByMonth(userId, {
+      startDate: "2024-01-01",
+      endDate: "2024-02-29",
+    });
+
+    expect(result).toHaveLength(2);
+    const jan = result.find((r) => r.month === "2024-01")!;
+    const feb = result.find((r) => r.month === "2024-02")!;
+    // Jan: (55*100) - (50*100) = +500, all unrealized
+    expect(jan.totalCapitalGain).toBe(500);
+    expect(jan.realizedGain).toBe(0);
+    expect(jan.unrealizedGain).toBe(500);
+    // Feb: (60*100) - (55*100) = +500
+    expect(feb.totalCapitalGain).toBe(500);
+    expect(feb.unrealizedGain).toBe(500);
+  });
+
+  it("decomposes a SELL month into realized + unrealized capital gains", async () => {
+    // Hold 100 shares at avg cost $50 since Dec.
+    // Feb: price goes $50 -> $60, sell 40 shares mid-month at $60 (proceeds 2400),
+    //      end-of-month price = $60. Remaining 60 shares.
+    txRepo.find.mockResolvedValue([
+      makeTx({
+        id: "buy",
+        action: InvestmentAction.BUY,
+        transactionDate: "2023-12-15",
+        quantity: 100,
+        price: 50,
+        totalAmount: 5000,
+      }),
+      makeTx({
+        id: "sell",
+        action: InvestmentAction.SELL,
+        transactionDate: "2024-02-15",
+        quantity: 40,
+        price: 60,
+        totalAmount: 2400,
+      }),
+    ]);
+    priceRepo.query.mockResolvedValue(
+      priceRows([
+        { date: "2024-01-31", price: 50 },
+        { date: "2024-02-29", price: 60 },
+      ]),
+    );
+
+    const result = await service.calculateCapitalGainsByMonth(userId, {
+      startDate: "2024-02-01",
+      endDate: "2024-02-29",
+    });
+
+    expect(result).toHaveLength(1);
+    const feb = result[0];
+    // realized = 40 * (60 - 50) = 400
+    expect(feb.realizedGain).toBe(400);
+    // total = (endValue - startValue) + sells - buys
+    //       = (60*60 - 50*100) + 2400 - 0 = 3600 - 5000 + 2400 = 1000
+    expect(feb.totalCapitalGain).toBe(1000);
+    // unrealized = total - realized = 600 (price gain $50 -> $60 on the 60
+    // shares still held at end of month).
+    expect(feb.unrealizedGain).toBe(600);
+  });
+
+  it("emits negative capital gains when prices fall", async () => {
+    txRepo.find.mockResolvedValue([
+      makeTx({
+        id: "buy",
+        action: InvestmentAction.BUY,
+        transactionDate: "2023-12-15",
+        quantity: 100,
+        price: 50,
+        totalAmount: 5000,
+      }),
+    ]);
+    priceRepo.query.mockResolvedValue(
+      priceRows([
+        { date: "2023-12-31", price: 50 },
+        { date: "2024-01-31", price: 42 },
+      ]),
+    );
+
+    const result = await service.calculateCapitalGainsByMonth(userId, {
+      startDate: "2024-01-01",
+      endDate: "2024-01-31",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].totalCapitalGain).toBe(-800); // (42-50) * 100
+    expect(result[0].unrealizedGain).toBe(-800);
+  });
+
+  it("seeds cost basis from history that predates the requested window", async () => {
+    txRepo.find.mockResolvedValue([
+      makeTx({
+        id: "old-buy",
+        action: InvestmentAction.BUY,
+        transactionDate: "2022-06-01",
+        quantity: 100,
+        price: 20,
+        totalAmount: 2000,
+      }),
+      makeTx({
+        id: "sell",
+        action: InvestmentAction.SELL,
+        transactionDate: "2024-03-15",
+        quantity: 100,
+        price: 30,
+        totalAmount: 3000,
+      }),
+    ]);
+    priceRepo.query.mockResolvedValue(
+      priceRows([
+        { date: "2024-02-29", price: 28 },
+        { date: "2024-03-31", price: 30 },
+      ]),
+    );
+
+    const result = await service.calculateCapitalGainsByMonth(userId, {
+      startDate: "2024-03-01",
+      endDate: "2024-03-31",
+    });
+
+    expect(result).toHaveLength(1);
+    const mar = result[0];
+    // Realized: 100 * (30 - 20) = 1000
+    expect(mar.realizedGain).toBe(1000);
+    // Total: (0 - 28*100) + 3000 - 0 = 200
+    // (start value at Feb-29 close = $2800; end value = 0; cash from sale = $3000)
+    expect(mar.totalCapitalGain).toBe(200);
+    // Unrealized: 200 - 1000 = -800 (the price-driven unrealized gain of $800
+    // from the original $20 cost has been crystallized into realized).
+    expect(mar.unrealizedGain).toBe(-800);
+  });
+
+  it("drops months with no holding and no activity", async () => {
+    txRepo.find.mockResolvedValue([
+      makeTx({
+        id: "buy",
+        action: InvestmentAction.BUY,
+        transactionDate: "2024-02-10",
+        quantity: 10,
+        price: 100,
+        totalAmount: 1000,
+      }),
+      makeTx({
+        id: "sell",
+        action: InvestmentAction.SELL,
+        transactionDate: "2024-02-20",
+        quantity: 10,
+        price: 100,
+        totalAmount: 1000,
+      }),
+    ]);
+    priceRepo.query.mockResolvedValue(
+      priceRows([{ date: "2024-02-29", price: 100 }]),
+    );
+
+    const result = await service.calculateCapitalGainsByMonth(userId, {
+      startDate: "2024-01-01",
+      endDate: "2024-04-30",
+    });
+
+    // Jan: no holding, no activity -> dropped.
+    // Feb: BUY+SELL in the same month -> kept.
+    // Mar/Apr: no holding, no activity -> dropped.
+    expect(result.map((r) => r.month)).toEqual(["2024-02"]);
+  });
+
+  it("returns empty when startDate is after endDate", async () => {
+    txRepo.find.mockResolvedValue([]);
+    const result = await service.calculateCapitalGainsByMonth(userId, {
+      startDate: "2024-12-01",
+      endDate: "2024-01-01",
+    });
+    expect(result).toEqual([]);
+  });
+});

--- a/backend/src/securities/portfolio-calculation.service.ts
+++ b/backend/src/securities/portfolio-calculation.service.ts
@@ -49,8 +49,137 @@ export interface RealizedGainEntry {
   realizedGain: number;
 }
 
+/**
+ * Per-(account, security, month) capital-gain breakdown including both the
+ * realized portion (from SELLs in the month) and the unrealized mark-to-market
+ * change on the position. All monetary values are denominated in the holding
+ * account's currency. The decomposition uses:
+ *
+ *   totalCapitalGain = (endValue - startValue) + sells - buys
+ *   unrealizedGain   = totalCapitalGain - realizedGain
+ *
+ * which is equivalent to "change in market value plus net cash withdrawn from
+ * the position". Months with zero quantity and zero activity are dropped.
+ */
+export interface CapitalGainEntry {
+  month: string;
+  accountId: string;
+  accountName: string | null;
+  accountCurrencyCode: string | null;
+  securityId: string;
+  symbol: string | null;
+  securityName: string | null;
+  securityCurrencyCode: string | null;
+  startQuantity: number;
+  endQuantity: number;
+  startValue: number;
+  endValue: number;
+  buys: number;
+  sells: number;
+  realizedGain: number;
+  unrealizedGain: number;
+  totalCapitalGain: number;
+}
+
 function roundMoney(value: number): number {
   return Math.round(value * 10000) / 10000;
+}
+
+/**
+ * Add `days` to a YYYY-MM-DD date string and return a new YYYY-MM-DD string.
+ * Uses UTC to avoid local-timezone drift when crossing day boundaries.
+ */
+function addDaysIso(iso: string, days: number): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + days);
+  return `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(2, "0")}-${String(dt.getUTCDate()).padStart(2, "0")}`;
+}
+
+interface MonthBucket {
+  month: string; // YYYY-MM
+  monthStart: string; // YYYY-MM-DD (first day of month, clamped to startDate)
+  monthEnd: string; // YYYY-MM-DD (last day of month, clamped to endDate)
+  priceLookupStart: string; // day before monthStart, used to value the
+  // position at the start of the month
+}
+
+/**
+ * Enumerate calendar months covered by [startDate, endDate]. Each entry
+ * carries the YYYY-MM key, the (clamped) start/end day-of-month, and the
+ * day-before-start date used to look up the starting price for the month.
+ */
+function enumerateMonths(startDate: string, endDate: string): MonthBucket[] {
+  const [sy, sm] = startDate.split("-").map(Number);
+  const [ey, em] = endDate.split("-").map(Number);
+  const buckets: MonthBucket[] = [];
+  let y = sy;
+  let m = sm;
+  while (y < ey || (y === ey && m <= em)) {
+    const firstOfMonth = `${y}-${String(m).padStart(2, "0")}-01`;
+    const lastDayNum = new Date(Date.UTC(y, m, 0)).getUTCDate();
+    const lastOfMonth = `${y}-${String(m).padStart(2, "0")}-${String(lastDayNum).padStart(2, "0")}`;
+    const monthStart = firstOfMonth < startDate ? startDate : firstOfMonth;
+    const monthEnd = lastOfMonth > endDate ? endDate : lastOfMonth;
+    buckets.push({
+      month: `${y}-${String(m).padStart(2, "0")}`,
+      monthStart,
+      monthEnd,
+      priceLookupStart: addDaysIso(monthStart, -1),
+    });
+    m++;
+    if (m > 12) {
+      m = 1;
+      y++;
+    }
+  }
+  return buckets;
+}
+
+/**
+ * Apply a single investment transaction to a running { quantity, costBasis }
+ * state in account-currency terms. Used to seed cost basis from history that
+ * predates the requested capital-gains window.
+ */
+function applyTxToState(
+  tx: InvestmentTransaction,
+  state: { quantity: number; costBasis: number },
+): void {
+  const quantity = Number(tx.quantity) || 0;
+  const price = Number(tx.price) || 0;
+  const exchangeRate = Number(tx.exchangeRate) || 1;
+  switch (tx.action) {
+    case InvestmentAction.BUY:
+    case InvestmentAction.REINVEST:
+    case InvestmentAction.TRANSFER_IN:
+      state.costBasis += quantity * price * exchangeRate;
+      state.quantity += quantity;
+      break;
+    case InvestmentAction.SELL:
+    case InvestmentAction.TRANSFER_OUT: {
+      const sellQty = Math.min(quantity, state.quantity);
+      const avgCostPerShare =
+        state.quantity > 0 ? state.costBasis / state.quantity : 0;
+      state.costBasis -= sellQty * avgCostPerShare;
+      state.quantity -= sellQty;
+      break;
+    }
+    case InvestmentAction.ADD_SHARES:
+      state.quantity += quantity;
+      break;
+    case InvestmentAction.REMOVE_SHARES:
+      state.quantity -= quantity;
+      break;
+    case InvestmentAction.SPLIT: {
+      const splitRatio = quantity || 1;
+      if (splitRatio > 0) state.quantity *= splitRatio;
+      break;
+    }
+  }
+  if (Math.abs(state.quantity) < 0.0001) {
+    state.quantity = 0;
+    state.costBasis = 0;
+  }
 }
 
 /**
@@ -475,6 +604,234 @@ export class PortfolioCalculationService {
   }
 
   /**
+   * Compute realized + unrealized capital gains per (account, security, month)
+   * across the requested window. Replays the user's full investment history
+   * to derive cost basis and quantities, then snapshots the position at each
+   * month boundary using historical close prices to capture mark-to-market
+   * changes alongside any realized gains from SELLs in the month.
+   *
+   * Quantities are snapshotted at each month boundary; market values use the
+   * last available close on or before the snapshot date converted to the
+   * holding account's currency at the latest exchange rate. BUYs/SELLs use
+   * their stored historical exchange rate (matching `calculateRealizedGains`).
+   * Months with no holding and no activity are omitted from the result.
+   */
+  async calculateCapitalGainsByMonth(
+    userId: string,
+    opts: {
+      accountIds?: string[];
+      startDate: string;
+      endDate: string;
+      defaultCurrency?: string;
+    },
+  ): Promise<CapitalGainEntry[]> {
+    const { accountIds, startDate, endDate } = opts;
+    if (!startDate || !endDate || startDate > endDate) return [];
+
+    const where: FindOptionsWhere<InvestmentTransaction> = { userId };
+    if (accountIds && accountIds.length > 0) {
+      where.accountId = In(accountIds);
+    }
+    where.transactionDate = LessThanOrEqual(endDate);
+
+    const transactions = await this.investmentTransactionRepository.find({
+      where,
+      relations: ["security", "account"],
+      order: { transactionDate: "ASC", createdAt: "ASC" },
+    });
+
+    if (transactions.length === 0) return [];
+
+    const securityIds = [
+      ...new Set(
+        transactions.filter((t) => t.securityId).map((t) => t.securityId!),
+      ),
+    ];
+    const allPrices = await this.getAllPricesForSecurities(securityIds);
+
+    // Build the ordered list of month buckets to snapshot
+    const months = enumerateMonths(startDate, endDate);
+    if (months.length === 0) return [];
+
+    // Group transactions by (account, security)
+    type GroupKey = string;
+    const groups = new Map<
+      GroupKey,
+      {
+        accountId: string;
+        accountName: string | null;
+        accountCurrencyCode: string | null;
+        securityId: string;
+        symbol: string | null;
+        securityName: string | null;
+        securityCurrencyCode: string | null;
+        txs: InvestmentTransaction[];
+      }
+    >();
+    for (const tx of transactions) {
+      if (!tx.securityId) continue;
+      const key = `${tx.accountId}:${tx.securityId}`;
+      let group = groups.get(key);
+      if (!group) {
+        group = {
+          accountId: tx.accountId,
+          accountName: tx.account?.name ?? null,
+          accountCurrencyCode: tx.account?.currencyCode ?? null,
+          securityId: tx.securityId,
+          symbol: tx.security?.symbol ?? null,
+          securityName: tx.security?.name ?? null,
+          securityCurrencyCode: tx.security?.currencyCode ?? null,
+          txs: [],
+        };
+        groups.set(key, group);
+      }
+      group.txs.push(tx);
+    }
+
+    // Cache FX rates: securityCurrency -> accountCurrency
+    const fxCache = new Map<string, number>();
+    const fxRate = async (
+      from: string | null,
+      to: string | null,
+    ): Promise<number> => {
+      if (!from || !to || from === to) return 1;
+      const cacheKey = `${from}->${to}`;
+      const cached = fxCache.get(cacheKey);
+      if (cached !== undefined) return cached;
+      let rate = await this.exchangeRateService.getLatestRate(from, to);
+      if (rate === null) {
+        const reverse = await this.exchangeRateService.getLatestRate(to, from);
+        rate = reverse !== null ? 1 / reverse : 1;
+      }
+      fxCache.set(cacheKey, rate);
+      return rate;
+    };
+
+    const results: CapitalGainEntry[] = [];
+
+    for (const group of groups.values()) {
+      const txs = group.txs;
+      const state = { quantity: 0, costBasis: 0 };
+      let txIdx = 0;
+      const securityToAccountFx = await fxRate(
+        group.securityCurrencyCode,
+        group.accountCurrencyCode,
+      );
+
+      // Replay any transactions strictly before startDate to seed state.
+      while (
+        txIdx < txs.length &&
+        txs[txIdx].transactionDate < months[0].monthStart
+      ) {
+        applyTxToState(txs[txIdx], state);
+        txIdx++;
+      }
+
+      for (const { month, monthEnd, priceLookupStart } of months) {
+        const startQuantity = state.quantity;
+        const startPrice =
+          this.lookupPrice(group.securityId, priceLookupStart, allPrices) ?? 0;
+        const startValue = startQuantity * startPrice * securityToAccountFx;
+
+        let buys = 0;
+        let sells = 0;
+        let realizedGain = 0;
+
+        while (txIdx < txs.length && txs[txIdx].transactionDate <= monthEnd) {
+          const tx = txs[txIdx];
+          const quantity = Number(tx.quantity) || 0;
+          const price = Number(tx.price) || 0;
+          const exchangeRate = Number(tx.exchangeRate) || 1;
+
+          switch (tx.action) {
+            case InvestmentAction.BUY:
+            case InvestmentAction.REINVEST:
+            case InvestmentAction.TRANSFER_IN: {
+              buys += quantity * price * exchangeRate;
+              state.costBasis += quantity * price * exchangeRate;
+              state.quantity += quantity;
+              break;
+            }
+            case InvestmentAction.SELL:
+            case InvestmentAction.TRANSFER_OUT: {
+              const sellQty = Math.min(quantity, state.quantity);
+              const avgCostPerShare =
+                state.quantity > 0 ? state.costBasis / state.quantity : 0;
+              const costBasisSold = sellQty * avgCostPerShare;
+              state.costBasis -= costBasisSold;
+              state.quantity -= sellQty;
+              if (tx.action === InvestmentAction.SELL) {
+                const proceeds = Number(tx.totalAmount) * exchangeRate;
+                sells += proceeds;
+                realizedGain += proceeds - costBasisSold;
+              }
+              break;
+            }
+            case InvestmentAction.ADD_SHARES:
+              state.quantity += quantity;
+              break;
+            case InvestmentAction.REMOVE_SHARES:
+              state.quantity -= quantity;
+              break;
+            case InvestmentAction.SPLIT: {
+              const splitRatio = quantity || 1;
+              if (splitRatio > 0) state.quantity *= splitRatio;
+              break;
+            }
+          }
+
+          if (Math.abs(state.quantity) < 0.0001) {
+            state.quantity = 0;
+            state.costBasis = 0;
+          }
+          txIdx++;
+        }
+
+        const endQuantity = state.quantity;
+        const endPrice =
+          this.lookupPrice(group.securityId, monthEnd, allPrices) ?? 0;
+        const endValue = endQuantity * endPrice * securityToAccountFx;
+
+        const totalCapitalGain = endValue - startValue + sells - buys;
+        const unrealizedGain = totalCapitalGain - realizedGain;
+
+        const hasActivity =
+          buys !== 0 ||
+          sells !== 0 ||
+          realizedGain !== 0 ||
+          startQuantity !== 0 ||
+          endQuantity !== 0;
+        if (!hasActivity) continue;
+
+        // Suppress vanishingly small float drift to keep the chart clean.
+        const round = (n: number) => (Math.abs(n) < 0.005 ? 0 : roundMoney(n));
+
+        results.push({
+          month,
+          accountId: group.accountId,
+          accountName: group.accountName,
+          accountCurrencyCode: group.accountCurrencyCode,
+          securityId: group.securityId,
+          symbol: group.symbol,
+          securityName: group.securityName,
+          securityCurrencyCode: group.securityCurrencyCode,
+          startQuantity,
+          endQuantity,
+          startValue: round(startValue),
+          endValue: round(endValue),
+          buys: round(buys),
+          sells: round(sells),
+          realizedGain: round(realizedGain),
+          unrealizedGain: round(unrealizedGain),
+          totalCapitalGain: round(totalCapitalGain),
+        });
+      }
+    }
+
+    return results;
+  }
+
+  /**
    * Fetch holdings for the given account IDs, compute per-holding market value,
    * gain/loss, and accumulate totals (converted to defaultCurrency).
    *
@@ -878,7 +1235,7 @@ export class PortfolioCalculationService {
    * Get all historical prices for a list of security IDs, ordered by date.
    * Returns a map of securityId -> sorted array of { date, price }.
    */
-  private async getAllPricesForSecurities(
+  async getAllPricesForSecurities(
     securityIds: string[],
   ): Promise<Map<string, { date: string; price: number }[]>> {
     if (securityIds.length === 0) return new Map();
@@ -910,7 +1267,7 @@ export class PortfolioCalculationService {
   /**
    * Look up the price for a security on or before a given date using binary search.
    */
-  private lookupPrice(
+  lookupPrice(
     securityId: string,
     date: string,
     allPrices: Map<string, { date: string; price: number }[]>,

--- a/frontend/src/app/reports/[reportId]/page.tsx
+++ b/frontend/src/app/reports/[reportId]/page.tsx
@@ -74,7 +74,7 @@ const reportNames: Record<string, string> = {
   'loan-amortization': 'Loan Amortization Schedule',
   // Investment
   'investment-performance': 'Investment Performance',
-  'dividend-income': 'Dividend & Interest Income',
+  'dividend-income': 'Gains, Dividends & Interest',
   'sector-weightings': 'Sector Weightings',
   'realized-gains': 'Realized Gains & Losses',
   'portfolio-value': 'Portfolio Value Over Time',
@@ -121,7 +121,7 @@ const reportDescriptions: Record<string, string> = {
   'debt-payoff-timeline': 'Visualize your debt reduction progress with projections for payoff dates.',
   'loan-amortization': 'Detailed payment schedules for mortgages and loans with principal vs interest breakdown.',
   'investment-performance': 'Track portfolio returns, gains/losses, and asset allocation over time.',
-  'dividend-income': 'Track passive income from dividends, interest, and other investment returns.',
+  'dividend-income': 'Track capital gains and losses (realized + unrealized) alongside dividend and interest income.',
   'sector-weightings': 'Analyze portfolio sector exposure from individual stocks and ETFs.',
   'realized-gains': 'Track realized gains and losses from sold securities for tax planning and performance review.',
   'portfolio-value': 'Visualize your total investment portfolio value with historical trends and period returns.',

--- a/frontend/src/app/reports/page.tsx
+++ b/frontend/src/app/reports/page.tsx
@@ -192,8 +192,8 @@ const reports: Report[] = [
   },
   {
     id: 'dividend-income',
-    name: 'Dividend & Interest Income',
-    description: 'Track passive income from dividends, interest, and other investment returns.',
+    name: 'Gains, Dividends & Interest',
+    description: 'Track capital gains and losses (realized + unrealized) alongside dividend and interest income.',
     category: 'investment',
     color: 'bg-green-600',
     icon: (

--- a/frontend/src/components/investments/InvestmentTransactionForm.test.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.test.tsx
@@ -957,6 +957,16 @@ describe('InvestmentTransactionForm', () => {
         expect(screen.getByText(/100\.0000/)).toBeInTheDocument();
         expect(screen.getByText(/200\.0000/)).toBeInTheDocument();
         expect(screen.getByText(/75\.0000/)).toBeInTheDocument();
+
+        // The unhelpful replay-auto sentence must be gone.
+        expect(
+          screen.queryByText(/replayed automatically/i),
+        ).not.toBeInTheDocument();
+
+        // The "Before (as of ...)" line must render the transaction date using
+        // the user's locale formatting, not the raw YYYY-MM-DD string.
+        expect(screen.queryByText(/as of 2026-01-15/)).not.toBeInTheDocument();
+        expect(screen.getByText(/Before \(as of/i)).toBeInTheDocument();
       } finally {
         asOfMock.mockResolvedValue({ quantity: 0, averageCost: 0 });
       }

--- a/frontend/src/components/investments/InvestmentTransactionForm.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.tsx
@@ -26,6 +26,7 @@ import { getCurrencySymbol, roundToDecimals } from '@/lib/format';
 import { getErrorMessage } from '@/lib/errors';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
+import { useDateFormat } from '@/hooks/useDateFormat';
 import { createLogger } from '@/lib/logger';
 import { useFormSubmitRef } from '@/hooks/useFormSubmitRef';
 import { useFormDirtyNotify } from '@/hooks/useFormDirtyNotify';
@@ -138,6 +139,7 @@ export function InvestmentTransactionForm({
   submitRef,
 }: InvestmentTransactionFormProps) {
   const { defaultCurrency, formatCurrency } = useNumberFormat();
+  const { formatDate } = useDateFormat();
   const [isLoading, setIsLoading] = useState(false);
   const [securities, setSecurities] = useState<Security[]>([]);
   const [securitiesLoaded, setSecuritiesLoaded] = useState(false);
@@ -724,7 +726,7 @@ export function InvestmentTransactionForm({
                 Holding preview
               </div>
               <div>
-                Before (as of {watchedTransactionDate}):{' '}
+                Before (as of {formatDate(watchedTransactionDate)}):{' '}
                 <span className="font-mono">
                   {splitPreview.currentQty.toFixed(4)}
                 </span>{' '}
@@ -748,16 +750,16 @@ export function InvestmentTransactionForm({
                 avg cost
               </div>
               <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                Total cost basis is preserved across the split. Subsequent
-                transactions will be replayed automatically.
+                Total cost basis is preserved across the split.
               </div>
             </div>
           )}
           {!splitPreview && watchedSecurityId && (
             <div className="text-xs text-gray-500 dark:text-gray-400">
               No shares of this security were held in this account on{' '}
-              {watchedTransactionDate}; the split will be recorded but won&apos;t
-              change holdings until shares are added on or before that date.
+              {formatDate(watchedTransactionDate)}; the split will be recorded
+              but won&apos;t change holdings until shares are added on or
+              before that date.
             </div>
           )}
         </div>

--- a/frontend/src/components/reports/DividendIncomeReport.test.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.test.tsx
@@ -18,15 +18,22 @@ vi.mock('@/hooks/useExchangeRates', () => ({
   }),
 }));
 
+// Stable references across re-renders so useEffects keyed on `resolvedRange`
+// identity don't re-fire and bounce the component back into its loading state
+// every time something unrelated changes.
+const STABLE_RESOLVED_RANGE = { start: '2024-01-01', end: '2025-01-01' };
+const STABLE_SET_DATE_RANGE = vi.fn();
+const STABLE_SET_START = vi.fn();
+const STABLE_SET_END = vi.fn();
 vi.mock('@/hooks/useDateRange', () => ({
   useDateRange: () => ({
     dateRange: '1y',
-    setDateRange: vi.fn(),
+    setDateRange: STABLE_SET_DATE_RANGE,
     startDate: '',
-    setStartDate: vi.fn(),
+    setStartDate: STABLE_SET_START,
     endDate: '',
-    setEndDate: vi.fn(),
-    resolvedRange: { start: '2024-01-01', end: '2025-01-01' },
+    setEndDate: STABLE_SET_END,
+    resolvedRange: STABLE_RESOLVED_RANGE,
     isValid: true,
   }),
 }));
@@ -209,6 +216,127 @@ describe('DividendIncomeReport', () => {
       expect(screen.getByText('Monthly')).toBeInTheDocument();
     });
     expect(screen.getByText('By Security')).toBeInTheDocument();
+  });
+
+  it('populates the security filter from loaded data and narrows results when one is picked', async () => {
+    mockGetTransactions.mockResolvedValue({
+      data: [
+        {
+          id: 'tx-1',
+          transactionDate: '2024-06-15',
+          action: 'DIVIDEND',
+          totalAmount: 100,
+          accountId: 'acc-1',
+          securityId: 'sec-a',
+          security: { symbol: 'AAA', name: 'Alpha' },
+        },
+        {
+          id: 'tx-2',
+          transactionDate: '2024-07-15',
+          action: 'DIVIDEND',
+          totalAmount: 30,
+          accountId: 'acc-1',
+          securityId: 'sec-b',
+          security: { symbol: 'BBB', name: 'Beta' },
+        },
+      ],
+      pagination: { hasMore: false },
+    });
+    mockGetInvestmentAccounts.mockResolvedValue([
+      { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+    ]);
+    mockGetCapitalGains.mockResolvedValue([]);
+
+    render(<DividendIncomeReport />);
+
+    const securitySelect = (await screen.findByLabelText('Filter by security')) as HTMLSelectElement;
+    // Options: 'All Securities' + both securities (sorted by symbol).
+    const optionValues = Array.from(securitySelect.options).map((o) => o.value);
+    expect(optionValues).toEqual(['', 'sec-a', 'sec-b']);
+    // Totals aggregate both securities at first (Dividends card).
+    expect(screen.getAllByText('$130.00').length).toBeGreaterThan(0);
+
+    // Pick a security and verify the totals narrow to just that row.
+    fireEvent.change(securitySelect, { target: { value: 'sec-b' } });
+    await waitFor(() => {
+      expect(screen.getAllByText('$30.00').length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText('$130.00')).not.toBeInTheDocument();
+  });
+
+  it('clears the security selection when the account filter changes', async () => {
+    mockGetTransactions.mockResolvedValue({
+      data: [
+        {
+          id: 'tx-1',
+          transactionDate: '2024-06-15',
+          action: 'DIVIDEND',
+          totalAmount: 100,
+          accountId: 'acc-1',
+          securityId: 'sec-a',
+          security: { symbol: 'AAA', name: 'Alpha' },
+        },
+      ],
+      pagination: { hasMore: false },
+    });
+    mockGetInvestmentAccounts.mockResolvedValue([
+      { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+      { id: 'acc-2', name: 'RRSP', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+    ]);
+    mockGetCapitalGains.mockResolvedValue([]);
+
+    render(<DividendIncomeReport />);
+
+    const securitySelect1 = (await screen.findByLabelText('Filter by security')) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(securitySelect1.options.length).toBeGreaterThan(1);
+    });
+    fireEvent.change(securitySelect1, { target: { value: 'sec-a' } });
+    expect(securitySelect1.value).toBe('sec-a');
+
+    const accountSelect = screen.getByLabelText('Filter by account') as HTMLSelectElement;
+    fireEvent.change(accountSelect, { target: { value: 'acc-2' } });
+
+    // Wait out the reload loading state and re-query the security select.
+    await waitFor(async () => {
+      const reloaded = (await screen.findByLabelText('Filter by security')) as HTMLSelectElement;
+      expect(reloaded.value).toBe('');
+    });
+  });
+
+  it('switches the monthly view from chart to table on demand', async () => {
+    mockGetTransactions.mockResolvedValue({
+      data: [
+        {
+          id: 'tx-1',
+          transactionDate: '2024-06-15',
+          action: 'DIVIDEND',
+          totalAmount: 100,
+          accountId: 'acc-1',
+          securityId: 'sec-a',
+          security: { symbol: 'AAA', name: 'Alpha' },
+        },
+      ],
+      pagination: { hasMore: false },
+    });
+    mockGetInvestmentAccounts.mockResolvedValue([
+      { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+    ]);
+    mockGetCapitalGains.mockResolvedValue([]);
+
+    render(<DividendIncomeReport />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Table' }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('bar-chart')).not.toBeInTheDocument();
+    });
+    // The Monthly table has a Month column header.
+    expect(screen.getByText('Month')).toBeInTheDocument();
   });
 
   it('renders series toggles and hides a series when its checkbox is unchecked', async () => {

--- a/frontend/src/components/reports/DividendIncomeReport.test.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.test.tsx
@@ -76,6 +76,11 @@ vi.mock('@/lib/csv-export', () => ({
   exportToCsv: (...args: any[]) => mockExportToCsv(...args),
 }));
 
+const mockExportToPdf = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/lib/pdf-export', () => ({
+  exportToPdf: (...args: any[]) => mockExportToPdf(...args),
+}));
+
 vi.mock('@/lib/logger', () => ({
   createLogger: () => ({
     error: vi.fn(),
@@ -426,6 +431,87 @@ describe('DividendIncomeReport', () => {
 
     const [, headers] = mockExportToCsv.mock.calls[0];
     expect(headers).toEqual(['Month', 'Dividends', 'Interest', 'Total', 'Currency']);
+  });
+
+  it('hands the table data (not the chart container) to the PDF exporter in the monthly table view', async () => {
+    mockGetTransactions.mockResolvedValue({
+      data: [
+        {
+          id: 'tx-1',
+          transactionDate: '2024-06-15',
+          action: 'DIVIDEND',
+          totalAmount: 100,
+          accountId: 'acc-1',
+          securityId: 'sec-a',
+          security: { symbol: 'AAA', name: 'Alpha' },
+        },
+      ],
+      pagination: { hasMore: false },
+    });
+    mockGetInvestmentAccounts.mockResolvedValue([
+      { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+    ]);
+    mockGetCapitalGains.mockResolvedValue([]);
+
+    render(<DividendIncomeReport />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Table' })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Table' }));
+
+    fireEvent.click(await screen.findByRole('button', { name: /^export$/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'PDF' }));
+
+    await waitFor(() => {
+      expect(mockExportToPdf).toHaveBeenCalledTimes(1);
+    });
+    const args = mockExportToPdf.mock.calls[0][0];
+    expect(args.chartContainer).toBeUndefined();
+    expect(args.tableData).toBeDefined();
+    expect(args.tableData.headers).toEqual([
+      'Month',
+      'Dividends',
+      'Interest',
+      'Capital Gains',
+      'Total',
+    ]);
+    expect(args.tableData.rows.length).toBeGreaterThan(0);
+    expect(args.tableData.totalRow?.[0]).toBe('Total');
+  });
+
+  it('hands the chart container to the PDF exporter in the chart view', async () => {
+    mockGetTransactions.mockResolvedValue({
+      data: [
+        {
+          id: 'tx-1',
+          transactionDate: '2024-06-15',
+          action: 'DIVIDEND',
+          totalAmount: 100,
+          accountId: 'acc-1',
+          securityId: 'sec-a',
+          security: { symbol: 'AAA', name: 'Alpha' },
+        },
+      ],
+      pagination: { hasMore: false },
+    });
+    mockGetInvestmentAccounts.mockResolvedValue([
+      { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+    ]);
+    mockGetCapitalGains.mockResolvedValue([]);
+
+    render(<DividendIncomeReport />);
+
+    // Chart view is the default; ExportDropdown collapses to a PDF-only button.
+    const exportPdfBtn = await screen.findByRole('button', { name: /export pdf/i });
+    fireEvent.click(exportPdfBtn);
+
+    await waitFor(() => {
+      expect(mockExportToPdf).toHaveBeenCalledTimes(1);
+    });
+    const args = mockExportToPdf.mock.calls[0][0];
+    expect(args.chartContainer).not.toBeNull();
+    expect(args.tableData).toBeUndefined();
   });
 
   it('writes a by-security CSV with one row per security', async () => {

--- a/frontend/src/components/reports/DividendIncomeReport.test.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.test.tsx
@@ -71,6 +71,11 @@ vi.mock('@/lib/investments', () => ({
   },
 }));
 
+const mockExportToCsv = vi.fn();
+vi.mock('@/lib/csv-export', () => ({
+  exportToCsv: (...args: any[]) => mockExportToCsv(...args),
+}));
+
 vi.mock('@/lib/logger', () => ({
   createLogger: () => ({
     error: vi.fn(),
@@ -339,7 +344,135 @@ describe('DividendIncomeReport', () => {
     expect(screen.getByText('Month')).toBeInTheDocument();
   });
 
-  it('renders series toggles and hides a series when its checkbox is unchecked', async () => {
+  it('offers a CSV export in the monthly table view and writes the visible columns', async () => {
+    mockGetTransactions.mockResolvedValue({
+      data: [
+        {
+          id: 'tx-1',
+          transactionDate: '2024-06-15',
+          action: 'DIVIDEND',
+          totalAmount: 100,
+          accountId: 'acc-1',
+          securityId: 'sec-a',
+          security: { symbol: 'AAA', name: 'Alpha' },
+        },
+      ],
+      pagination: { hasMore: false },
+    });
+    mockGetInvestmentAccounts.mockResolvedValue([
+      { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+    ]);
+    mockGetCapitalGains.mockResolvedValue([]);
+
+    render(<DividendIncomeReport />);
+
+    // No CSV button while the chart view is active.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /export pdf/i })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /^export$/i })).not.toBeInTheDocument();
+
+    // Switch to the monthly table — the dropdown trigger replaces the PDF-only button.
+    fireEvent.click(screen.getByRole('button', { name: 'Table' }));
+    const exportTrigger = await screen.findByRole('button', { name: /^export$/i });
+    fireEvent.click(exportTrigger);
+    fireEvent.click(screen.getByRole('button', { name: 'CSV' }));
+
+    expect(mockExportToCsv).toHaveBeenCalledTimes(1);
+    const [filename, headers, rows] = mockExportToCsv.mock.calls[0];
+    expect(filename).toMatch(/gains-dividends-interest-monthly-all-accounts/);
+    expect(headers).toEqual(['Month', 'Dividends', 'Interest', 'Capital Gains', 'Total', 'Currency']);
+    // The row for June 2024 contains the $100 dividend.
+    const juneRow = rows.find((r: any[]) => r[0] === '2024-06');
+    expect(juneRow).toBeDefined();
+    expect(juneRow[1]).toBe(100); // Dividends
+    expect(juneRow[2]).toBe(0);   // Interest
+    expect(juneRow[3]).toBe(0);   // Capital Gains
+    expect(juneRow[4]).toBe(100); // Total
+    expect(juneRow[5]).toBe('CAD');
+  });
+
+  it('omits hidden series from the CSV export', async () => {
+    mockGetTransactions.mockResolvedValue({
+      data: [
+        {
+          id: 'tx-1',
+          transactionDate: '2024-06-15',
+          action: 'DIVIDEND',
+          totalAmount: 100,
+          accountId: 'acc-1',
+          securityId: 'sec-a',
+          security: { symbol: 'AAA', name: 'Alpha' },
+        },
+      ],
+      pagination: { hasMore: false },
+    });
+    mockGetInvestmentAccounts.mockResolvedValue([
+      { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+    ]);
+    mockGetCapitalGains.mockResolvedValue([]);
+
+    render(<DividendIncomeReport />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Table' })).toBeInTheDocument();
+    });
+    // Turn Capital Gains off, then switch to the table.
+    fireEvent.click(screen.getByRole('button', { name: 'Capital Gains' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Table' }));
+
+    fireEvent.click(await screen.findByRole('button', { name: /^export$/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'CSV' }));
+
+    const [, headers] = mockExportToCsv.mock.calls[0];
+    expect(headers).toEqual(['Month', 'Dividends', 'Interest', 'Total', 'Currency']);
+  });
+
+  it('writes a by-security CSV with one row per security', async () => {
+    mockGetTransactions.mockResolvedValue({
+      data: [
+        {
+          id: 'tx-1',
+          transactionDate: '2024-06-15',
+          action: 'DIVIDEND',
+          totalAmount: 100,
+          accountId: 'acc-1',
+          securityId: 'sec-a',
+          security: { symbol: 'AAA', name: 'Alpha' },
+        },
+      ],
+      pagination: { hasMore: false },
+    });
+    mockGetInvestmentAccounts.mockResolvedValue([
+      { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+    ]);
+    mockGetCapitalGains.mockResolvedValue([]);
+
+    render(<DividendIncomeReport />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'By Security' })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'By Security' }));
+
+    fireEvent.click(await screen.findByRole('button', { name: /^export$/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'CSV' }));
+
+    const [filename, headers, rows] = mockExportToCsv.mock.calls[0];
+    expect(filename).toMatch(/gains-dividends-interest-by-security-all-accounts/);
+    expect(headers).toEqual([
+      'Symbol',
+      'Security',
+      'Dividends',
+      'Interest',
+      'Capital Gains',
+      'Total',
+      'Currency',
+    ]);
+    expect(rows).toEqual([['AAA', 'Alpha', 100, 0, 0, 100, 'CAD']]);
+  });
+
+  it('renders series toggle pills and hides a series when one is clicked', async () => {
     mockGetTransactions.mockResolvedValue({
       data: [
         {
@@ -359,21 +492,24 @@ describe('DividendIncomeReport', () => {
     mockGetCapitalGains.mockResolvedValue([]);
     render(<DividendIncomeReport />);
 
-    // Wait until the chart's Capital Gains bar appears, then toggle it off.
+    // Wait until the chart's Capital Gains bar appears, then toggle it off via
+    // the coloured pill (no checkbox here — it's a toggle button).
     await waitFor(() => {
       expect(screen.getByTestId('bar-Capital Gains')).toBeInTheDocument();
     });
 
-    const checkboxes = screen.getAllByRole('checkbox');
-    // Three series toggles: Dividends, Interest, Capital Gains. All checked by default.
-    expect(checkboxes).toHaveLength(3);
-    const capitalGainsCheckbox = checkboxes[2];
-    fireEvent.click(capitalGainsCheckbox);
+    const capitalGainsToggle = screen.getByRole('button', { name: 'Capital Gains' });
+    expect(capitalGainsToggle.getAttribute('aria-pressed')).toBe('true');
+    fireEvent.click(capitalGainsToggle);
 
     await waitFor(() => {
       expect(screen.queryByTestId('bar-Capital Gains')).not.toBeInTheDocument();
     });
-    // Other bars remain visible.
+    expect(capitalGainsToggle.getAttribute('aria-pressed')).toBe('false');
+    // Other series pills remain in the "on" state and their bars are visible.
+    expect(
+      screen.getByRole('button', { name: 'Dividends' }).getAttribute('aria-pressed'),
+    ).toBe('true');
     expect(screen.getByTestId('bar-Dividends')).toBeInTheDocument();
     expect(screen.getByTestId('bar-Interest')).toBeInTheDocument();
   });

--- a/frontend/src/components/reports/DividendIncomeReport.test.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.test.tsx
@@ -314,6 +314,68 @@ describe('DividendIncomeReport', () => {
     });
   });
 
+  it('renders Start Value and End Value columns in the monthly table, summed across securities', async () => {
+    mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
+    mockGetInvestmentAccounts.mockResolvedValue([
+      { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+    ]);
+    mockGetCapitalGains.mockResolvedValue([
+      // Two securities held through June 2024; Start/End should sum.
+      {
+        month: '2024-06',
+        accountId: 'acc-1',
+        accountName: 'TFSA',
+        accountCurrencyCode: 'CAD',
+        securityId: 'sec-a',
+        symbol: 'AAA',
+        securityName: 'Alpha',
+        securityCurrencyCode: 'CAD',
+        startQuantity: 10,
+        endQuantity: 10,
+        startValue: 1000,
+        endValue: 1200,
+        buys: 0,
+        sells: 0,
+        realizedGain: 0,
+        unrealizedGain: 200,
+        totalCapitalGain: 200,
+      },
+      {
+        month: '2024-06',
+        accountId: 'acc-1',
+        accountName: 'TFSA',
+        accountCurrencyCode: 'CAD',
+        securityId: 'sec-b',
+        symbol: 'BBB',
+        securityName: 'Beta',
+        securityCurrencyCode: 'CAD',
+        startQuantity: 5,
+        endQuantity: 5,
+        startValue: 500,
+        endValue: 450,
+        buys: 0,
+        sells: 0,
+        realizedGain: 0,
+        unrealizedGain: -50,
+        totalCapitalGain: -50,
+      },
+    ]);
+
+    render(<DividendIncomeReport />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Table' })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Table' }));
+
+    // Both columns appear as headers.
+    expect(await screen.findByText('Start Value')).toBeInTheDocument();
+    expect(screen.getByText('End Value')).toBeInTheDocument();
+    // The June row carries the summed Start ($1500) and End ($1650) values.
+    expect(screen.getByText('$1500.00')).toBeInTheDocument();
+    expect(screen.getByText('$1650.00')).toBeInTheDocument();
+  });
+
   it('switches the monthly view from chart to table on demand', async () => {
     mockGetTransactions.mockResolvedValue({
       data: [
@@ -386,15 +448,27 @@ describe('DividendIncomeReport', () => {
     expect(mockExportToCsv).toHaveBeenCalledTimes(1);
     const [filename, headers, rows] = mockExportToCsv.mock.calls[0];
     expect(filename).toMatch(/gains-dividends-interest-monthly-all-accounts/);
-    expect(headers).toEqual(['Month', 'Dividends', 'Interest', 'Capital Gains', 'Total', 'Currency']);
-    // The row for June 2024 contains the $100 dividend.
+    expect(headers).toEqual([
+      'Month',
+      'Start Value',
+      'End Value',
+      'Dividends',
+      'Interest',
+      'Capital Gains',
+      'Total',
+      'Currency',
+    ]);
+    // The row for June 2024 contains the $100 dividend; Start/End Value are
+    // zero here since the mocked data has no capital-gain entries.
     const juneRow = rows.find((r: any[]) => r[0] === '2024-06');
     expect(juneRow).toBeDefined();
-    expect(juneRow[1]).toBe(100); // Dividends
-    expect(juneRow[2]).toBe(0);   // Interest
-    expect(juneRow[3]).toBe(0);   // Capital Gains
-    expect(juneRow[4]).toBe(100); // Total
-    expect(juneRow[5]).toBe('CAD');
+    expect(juneRow[1]).toBe(0);   // Start Value
+    expect(juneRow[2]).toBe(0);   // End Value
+    expect(juneRow[3]).toBe(100); // Dividends
+    expect(juneRow[4]).toBe(0);   // Interest
+    expect(juneRow[5]).toBe(0);   // Capital Gains
+    expect(juneRow[6]).toBe(100); // Total
+    expect(juneRow[7]).toBe('CAD');
   });
 
   it('omits hidden series from the CSV export', async () => {
@@ -430,7 +504,15 @@ describe('DividendIncomeReport', () => {
     fireEvent.click(screen.getByRole('button', { name: 'CSV' }));
 
     const [, headers] = mockExportToCsv.mock.calls[0];
-    expect(headers).toEqual(['Month', 'Dividends', 'Interest', 'Total', 'Currency']);
+    expect(headers).toEqual([
+      'Month',
+      'Start Value',
+      'End Value',
+      'Dividends',
+      'Interest',
+      'Total',
+      'Currency',
+    ]);
   });
 
   it('hands the table data (not the chart container) to the PDF exporter in the monthly table view', async () => {
@@ -471,6 +553,8 @@ describe('DividendIncomeReport', () => {
     expect(args.tableData).toBeDefined();
     expect(args.tableData.headers).toEqual([
       'Month',
+      'Start Value',
+      'End Value',
       'Dividends',
       'Interest',
       'Capital Gains',
@@ -478,6 +562,10 @@ describe('DividendIncomeReport', () => {
     ]);
     expect(args.tableData.rows.length).toBeGreaterThan(0);
     expect(args.tableData.totalRow?.[0]).toBe('Total');
+    // Start/End Value in the footer total row are intentionally blank —
+    // a column sum of point-in-time snapshots would be meaningless.
+    expect(args.tableData.totalRow?.[1]).toBe('');
+    expect(args.tableData.totalRow?.[2]).toBe('');
   });
 
   it('hands the chart container to the PDF exporter in the chart view', async () => {

--- a/frontend/src/components/reports/DividendIncomeReport.test.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@/test/render';
+import { render, screen, waitFor, fireEvent } from '@/test/render';
 import { DividendIncomeReport } from './DividendIncomeReport';
 
 vi.mock('@/hooks/useNumberFormat', () => ({
@@ -42,23 +42,25 @@ vi.mock('@/components/ui/DateRangeSelector', () => ({
 vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
   BarChart: ({ children }: any) => <div data-testid="bar-chart">{children}</div>,
-  Bar: () => null,
+  Bar: ({ name }: any) => <div data-testid={`bar-${name}`} />,
   XAxis: () => null,
   YAxis: () => null,
   CartesianGrid: () => null,
   Tooltip: () => null,
   Legend: () => null,
+  ReferenceLine: () => null,
+  Cell: () => null,
 }));
 
 const mockGetTransactions = vi.fn();
 const mockGetInvestmentAccounts = vi.fn();
-const mockGetRealizedGains = vi.fn();
+const mockGetCapitalGains = vi.fn();
 
 vi.mock('@/lib/investments', () => ({
   investmentsApi: {
     getTransactions: (...args: any[]) => mockGetTransactions(...args),
     getInvestmentAccounts: (...args: any[]) => mockGetInvestmentAccounts(...args),
-    getRealizedGains: (...args: any[]) => mockGetRealizedGains(...args),
+    getCapitalGains: (...args: any[]) => mockGetCapitalGains(...args),
   },
 }));
 
@@ -79,32 +81,31 @@ describe('DividendIncomeReport', () => {
   it('shows loading state initially', () => {
     mockGetTransactions.mockReturnValue(new Promise(() => {}));
     mockGetInvestmentAccounts.mockReturnValue(new Promise(() => {}));
-    mockGetRealizedGains.mockReturnValue(new Promise(() => {}));
+    mockGetCapitalGains.mockReturnValue(new Promise(() => {}));
     render(<DividendIncomeReport />);
     expect(document.querySelector('.animate-pulse')).toBeTruthy();
   });
 
-  it('renders empty state when no income transactions', async () => {
+  it('renders empty state when there is no investment activity', async () => {
     mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
     mockGetInvestmentAccounts.mockResolvedValue([]);
-    mockGetRealizedGains.mockResolvedValue([]);
+    mockGetCapitalGains.mockResolvedValue([]);
     render(<DividendIncomeReport />);
     await waitFor(() => {
       expect(
-        screen.getByText(/No dividend, interest, capital gain, or sell transactions found/),
+        screen.getByText(/No dividends, interest, or capital gain activity/),
       ).toBeInTheDocument();
     });
   });
 
-  it('folds realized gains from the backend into Capital Gains', async () => {
+  it('folds monthly capital gains (realized + unrealized) from the backend into Capital Gains', async () => {
     mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
     mockGetInvestmentAccounts.mockResolvedValue([
       { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
     ]);
-    mockGetRealizedGains.mockResolvedValue([
+    mockGetCapitalGains.mockResolvedValue([
       {
-        transactionId: 'sell-1',
-        transactionDate: '2024-08-10',
+        month: '2024-08',
         accountId: 'acc-1',
         accountName: 'TFSA',
         accountCurrencyCode: 'CAD',
@@ -112,20 +113,56 @@ describe('DividendIncomeReport', () => {
         symbol: 'ABC',
         securityName: 'ABC Corp',
         securityCurrencyCode: 'CAD',
-        quantity: 10,
-        price: 80,
-        commission: 0,
-        proceeds: 800,
-        costBasis: 500,
+        startQuantity: 10,
+        endQuantity: 0,
+        startValue: 800,
+        endValue: 0,
+        buys: 0,
+        sells: 800,
         realizedGain: 300,
+        unrealizedGain: 0,
+        totalCapitalGain: 300,
       },
     ]);
     render(<DividendIncomeReport />);
     await waitFor(() => {
-      expect(screen.getByText('Capital Gains')).toBeInTheDocument();
+      expect(screen.getAllByText('Capital Gains').length).toBeGreaterThan(0);
     });
-    // Summary card and By Security cell for ABC should both display the $300 realized gain.
     expect(screen.getAllByText('$300.00').length).toBeGreaterThan(0);
+  });
+
+  it('shows negative capital gain totals (losses) with red styling', async () => {
+    mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
+    mockGetInvestmentAccounts.mockResolvedValue([
+      { id: 'acc-1', name: 'RRSP', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+    ]);
+    mockGetCapitalGains.mockResolvedValue([
+      {
+        month: '2024-03',
+        accountId: 'acc-1',
+        accountName: 'RRSP',
+        accountCurrencyCode: 'CAD',
+        securityId: 'sec-2',
+        symbol: 'DEF',
+        securityName: 'DEF Corp',
+        securityCurrencyCode: 'CAD',
+        startQuantity: 100,
+        endQuantity: 100,
+        startValue: 5000,
+        endValue: 4500,
+        buys: 0,
+        sells: 0,
+        realizedGain: 0,
+        unrealizedGain: -500,
+        totalCapitalGain: -500,
+      },
+    ]);
+    render(<DividendIncomeReport />);
+    await waitFor(() => {
+      expect(screen.getAllByText('Capital Gains').length).toBeGreaterThan(0);
+    });
+    // Negative total renders as -$500.00 inside the summary card.
+    expect(screen.getAllByText('$-500.00').length).toBeGreaterThan(0);
   });
 
   it('renders summary cards with data', async () => {
@@ -153,24 +190,63 @@ describe('DividendIncomeReport', () => {
     mockGetInvestmentAccounts.mockResolvedValue([
       { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
     ]);
-    mockGetRealizedGains.mockResolvedValue([]);
+    mockGetCapitalGains.mockResolvedValue([]);
     render(<DividendIncomeReport />);
     await waitFor(() => {
-      expect(screen.getByText('Dividends')).toBeInTheDocument();
+      expect(screen.getAllByText('Dividends').length).toBeGreaterThan(0);
     });
-    expect(screen.getByText('Interest')).toBeInTheDocument();
-    expect(screen.getByText('Capital Gains')).toBeInTheDocument();
+    expect(screen.getAllByText('Interest').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Capital Gains').length).toBeGreaterThan(0);
     expect(screen.getByText('Total Income')).toBeInTheDocument();
   });
 
   it('renders view type buttons', async () => {
     mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
     mockGetInvestmentAccounts.mockResolvedValue([]);
-    mockGetRealizedGains.mockResolvedValue([]);
+    mockGetCapitalGains.mockResolvedValue([]);
     render(<DividendIncomeReport />);
     await waitFor(() => {
       expect(screen.getByText('Monthly')).toBeInTheDocument();
     });
     expect(screen.getByText('By Security')).toBeInTheDocument();
+  });
+
+  it('renders series toggles and hides a series when its checkbox is unchecked', async () => {
+    mockGetTransactions.mockResolvedValue({
+      data: [
+        {
+          id: 'tx-1',
+          transactionDate: '2024-06-15',
+          action: 'DIVIDEND',
+          totalAmount: 100,
+          accountId: 'acc-1',
+          security: { symbol: 'VFV', name: 'Vanguard S&P 500' },
+        },
+      ],
+      pagination: { hasMore: false },
+    });
+    mockGetInvestmentAccounts.mockResolvedValue([
+      { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+    ]);
+    mockGetCapitalGains.mockResolvedValue([]);
+    render(<DividendIncomeReport />);
+
+    // Wait until the chart's Capital Gains bar appears, then toggle it off.
+    await waitFor(() => {
+      expect(screen.getByTestId('bar-Capital Gains')).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    // Three series toggles: Dividends, Interest, Capital Gains. All checked by default.
+    expect(checkboxes).toHaveLength(3);
+    const capitalGainsCheckbox = checkboxes[2];
+    fireEvent.click(capitalGainsCheckbox);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('bar-Capital Gains')).not.toBeInTheDocument();
+    });
+    // Other bars remain visible.
+    expect(screen.getByTestId('bar-Dividends')).toBeInTheDocument();
+    expect(screen.getByTestId('bar-Interest')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -61,9 +61,11 @@ export function DividendIncomeReport() {
   const [capitalGains, setCapitalGains] = useState<CapitalGainEntry[]>([]);
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [selectedAccountId, setSelectedAccountId] = useState<string>('');
+  const [selectedSecurityId, setSelectedSecurityId] = useState<string>('');
   const { dateRange, setDateRange, resolvedRange, isValid } = useDateRange({ defaultRange: '1y', alignment: 'month' });
   const [isLoading, setIsLoading] = useState(true);
   const [viewType, setViewType] = useState<'monthly' | 'bySecurity'>('monthly');
+  const [monthlyDisplay, setMonthlyDisplay] = useState<'chart' | 'table'>('chart');
   const [visibleSeries, setVisibleSeries] = useState<Record<SeriesKey, boolean>>({
     dividends: true,
     interest: true,
@@ -76,6 +78,56 @@ export function DividendIncomeReport() {
     accounts.forEach((a) => map.set(a.id, a.currencyCode));
     return map;
   }, [accounts]);
+
+  // Securities present in the currently-loaded (account-filtered) data.
+  // Transactions and capital gains are already narrowed by the backend when an
+  // account is selected, so deriving the list from them naturally hides
+  // securities from other accounts.
+  const availableSecurities = useMemo(() => {
+    const map = new Map<string, { id: string; symbol: string; name: string }>();
+    for (const tx of transactions) {
+      if (!tx.securityId || !tx.security) continue;
+      if (!map.has(tx.securityId)) {
+        map.set(tx.securityId, {
+          id: tx.securityId,
+          symbol: tx.security.symbol,
+          name: tx.security.name,
+        });
+      }
+    }
+    for (const entry of capitalGains) {
+      if (!map.has(entry.securityId)) {
+        map.set(entry.securityId, {
+          id: entry.securityId,
+          symbol: entry.symbol || 'Unknown',
+          name: entry.securityName || 'Unknown Security',
+        });
+      }
+    }
+    return Array.from(map.values()).sort((a, b) => a.symbol.localeCompare(b.symbol));
+  }, [transactions, capitalGains]);
+
+  // Clear the security filter when the account changes or when the selected
+  // security drops out of the available set (e.g. switching to an account
+  // that doesn't hold it).
+  useEffect(() => {
+    if (
+      selectedSecurityId &&
+      !availableSecurities.some((s) => s.id === selectedSecurityId)
+    ) {
+      setSelectedSecurityId('');
+    }
+  }, [selectedSecurityId, availableSecurities]);
+
+  const filteredTransactions = useMemo(() => {
+    if (!selectedSecurityId) return transactions;
+    return transactions.filter((tx) => tx.securityId === selectedSecurityId);
+  }, [transactions, selectedSecurityId]);
+
+  const filteredCapitalGains = useMemo(() => {
+    if (!selectedSecurityId) return capitalGains;
+    return capitalGains.filter((e) => e.securityId === selectedSecurityId);
+  }, [capitalGains, selectedSecurityId]);
 
   // When a single account is selected, show in native currency; otherwise convert to default
   const selectedAccount = accounts.find((a) => a.id === selectedAccountId);
@@ -212,7 +264,7 @@ export function DividendIncomeReport() {
       return bucket;
     };
 
-    transactions.forEach((tx) => {
+    filteredTransactions.forEach((tx) => {
       const bucket = getOrCreateBucket(parseLocalDate(tx.transactionDate));
       const contribution = getTxAmount(tx);
       switch (tx.action) {
@@ -229,7 +281,7 @@ export function DividendIncomeReport() {
       bucket.total += contribution;
     });
 
-    capitalGains.forEach((entry) => {
+    filteredCapitalGains.forEach((entry) => {
       // entry.month is YYYY-MM; create a date in the middle of the month so
       // local-timezone parsing puts it in the right bucket.
       const monthDate = parseLocalDate(`${entry.month}-15`);
@@ -240,7 +292,7 @@ export function DividendIncomeReport() {
     });
 
     return Array.from(monthMap.values()).sort((a, b) => a.month.localeCompare(b.month));
-  }, [transactions, capitalGains, dateRange, resolvedRange, getTxAmount, convertCapitalGain]);
+  }, [filteredTransactions, filteredCapitalGains, dateRange, resolvedRange, getTxAmount, convertCapitalGain]);
 
   const securityData = useMemo((): SecurityIncome[] => {
     const securityMap = new Map<string, SecurityIncome>();
@@ -254,7 +306,7 @@ export function DividendIncomeReport() {
       return bucket;
     };
 
-    transactions.forEach((tx) => {
+    filteredTransactions.forEach((tx) => {
       const symbol = tx.security?.symbol || 'Unknown';
       const name = tx.security?.name || 'Unknown Security';
       const bucket = getOrCreateBucket(symbol, name);
@@ -273,7 +325,7 @@ export function DividendIncomeReport() {
       bucket.total += contribution;
     });
 
-    capitalGains.forEach((entry) => {
+    filteredCapitalGains.forEach((entry) => {
       const symbol = entry.symbol || 'Unknown';
       const name = entry.securityName || 'Unknown Security';
       const bucket = getOrCreateBucket(symbol, name);
@@ -283,19 +335,19 @@ export function DividendIncomeReport() {
     });
 
     return Array.from(securityMap.values()).sort((a, b) => b.total - a.total);
-  }, [transactions, capitalGains, getTxAmount, convertCapitalGain]);
+  }, [filteredTransactions, filteredCapitalGains, getTxAmount, convertCapitalGain]);
 
   const totals = useMemo(() => {
-    const dividends = transactions
+    const dividends = filteredTransactions
       .filter((t) => t.action === 'DIVIDEND')
       .reduce((sum, t) => sum + getTxAmount(t), 0);
-    const interest = transactions
+    const interest = filteredTransactions
       .filter((t) => t.action === 'INTEREST')
       .reduce((sum, t) => sum + getTxAmount(t), 0);
-    const manualCapitalGains = transactions
+    const manualCapitalGains = filteredTransactions
       .filter((t) => t.action === 'CAPITAL_GAIN')
       .reduce((sum, t) => sum + getTxAmount(t), 0);
-    const periodCapitalGains = capitalGains.reduce(
+    const periodCapitalGains = filteredCapitalGains.reduce(
       (sum, entry) => sum + convertCapitalGain(entry),
       0,
     );
@@ -306,7 +358,7 @@ export function DividendIncomeReport() {
       capitalGains: totalGains,
       total: dividends + interest + totalGains,
     };
-  }, [transactions, capitalGains, getTxAmount, convertCapitalGain]);
+  }, [filteredTransactions, filteredCapitalGains, getTxAmount, convertCapitalGain]);
 
   const handleExportPdf = async () => {
     const { exportToPdf } = await import('@/lib/pdf-export');
@@ -409,8 +461,14 @@ export function DividendIncomeReport() {
         <div className="flex flex-wrap gap-3 items-center">
           <select
             value={selectedAccountId}
-            onChange={(e) => setSelectedAccountId(e.target.value)}
+            onChange={(e) => {
+              setSelectedAccountId(e.target.value);
+              // Reset security filter when the account changes so stale
+              // selections can't hide all rows.
+              setSelectedSecurityId('');
+            }}
             className="max-w-48 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm"
+            aria-label="Filter by account"
           >
             <option value="">All Accounts</option>
             {accounts
@@ -421,6 +479,21 @@ export function DividendIncomeReport() {
                   {account.name.replace(/ - (Brokerage|Cash)$/, '')}
                 </option>
               ))}
+          </select>
+          <select
+            value={selectedSecurityId}
+            onChange={(e) => setSelectedSecurityId(e.target.value)}
+            className="max-w-48 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm"
+            aria-label="Filter by security"
+            disabled={availableSecurities.length === 0}
+          >
+            <option value="">All Securities</option>
+            {availableSecurities.map((security) => (
+              <option key={security.id} value={security.id}>
+                {security.symbol}
+                {security.name ? ` — ${security.name}` : ''}
+              </option>
+            ))}
           </select>
           <DateRangeSelector
             ranges={['6m', '1y', '2y', 'all']}
@@ -451,41 +524,69 @@ export function DividendIncomeReport() {
             <ExportDropdown onExportPdf={handleExportPdf} />
           </div>
         </div>
-        {/* Series visibility toggles */}
+        {/* Monthly view sub-controls: chart/table switch + series toggles */}
         {viewType === 'monthly' && (
-          <div className="flex flex-wrap gap-2 mt-3 items-center">
-            <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
-              Show:
-            </span>
-            {(Object.keys(SERIES_COLORS) as SeriesKey[]).map((key) => (
-              <label
-                key={key}
-                className="inline-flex items-center gap-1.5 cursor-pointer text-sm text-gray-700 dark:text-gray-300"
+          <div className="flex flex-wrap gap-4 mt-3 items-center">
+            <div
+              className="inline-flex rounded-md border border-gray-200 dark:border-gray-600 overflow-hidden text-sm"
+              role="group"
+              aria-label="Monthly display mode"
+            >
+              <button
+                onClick={() => setMonthlyDisplay('chart')}
+                className={`px-3 py-1 font-medium transition-colors ${
+                  monthlyDisplay === 'chart'
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+                }`}
               >
-                <input
-                  type="checkbox"
-                  checked={visibleSeries[key]}
-                  onChange={() => toggleSeries(key)}
-                  className="rounded border-gray-300 dark:border-gray-600"
-                />
-                <span
-                  className="inline-block w-3 h-3 rounded-sm"
-                  style={{ backgroundColor: SERIES_COLORS[key].positive }}
-                />
-                {SERIES_COLORS[key].label}
-              </label>
-            ))}
+                Chart
+              </button>
+              <button
+                onClick={() => setMonthlyDisplay('table')}
+                className={`px-3 py-1 font-medium transition-colors ${
+                  monthlyDisplay === 'table'
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+                }`}
+              >
+                Table
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-2 items-center">
+              <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                Show:
+              </span>
+              {(Object.keys(SERIES_COLORS) as SeriesKey[]).map((key) => (
+                <label
+                  key={key}
+                  className="inline-flex items-center gap-1.5 cursor-pointer text-sm text-gray-700 dark:text-gray-300"
+                >
+                  <input
+                    type="checkbox"
+                    checked={visibleSeries[key]}
+                    onChange={() => toggleSeries(key)}
+                    className="rounded border-gray-300 dark:border-gray-600"
+                  />
+                  <span
+                    className="inline-block w-3 h-3 rounded-sm"
+                    style={{ backgroundColor: SERIES_COLORS[key].positive }}
+                  />
+                  {SERIES_COLORS[key].label}
+                </label>
+              ))}
+            </div>
           </div>
         )}
       </div>
 
-      {transactions.length === 0 && capitalGains.length === 0 ? (
+      {filteredTransactions.length === 0 && filteredCapitalGains.length === 0 ? (
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
           <p className="text-gray-500 dark:text-gray-400 text-center py-8">
             No dividends, interest, or capital gain activity found for this period.
           </p>
         </div>
-      ) : viewType === 'monthly' ? (
+      ) : viewType === 'monthly' && monthlyDisplay === 'chart' ? (
         /* Monthly Chart */
         <div ref={chartRef} className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 px-2 py-4 sm:p-6">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
@@ -537,6 +638,89 @@ export function DividendIncomeReport() {
                 )}
               </BarChart>
             </ResponsiveContainer>
+          </div>
+        </div>
+      ) : viewType === 'monthly' ? (
+        /* Monthly Table */
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 overflow-hidden">
+          <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              Monthly Gains, Dividends & Interest
+            </h3>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead className="bg-gray-50 dark:bg-gray-900/50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                    Month
+                  </th>
+                  {visibleSeries.dividends && (
+                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                      Dividends
+                    </th>
+                  )}
+                  {visibleSeries.interest && (
+                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                      Interest
+                    </th>
+                  )}
+                  {visibleSeries.capitalGains && (
+                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                      Capital Gains
+                    </th>
+                  )}
+                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                    Total
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                {monthlyData.map((row) => {
+                  const rowTotal =
+                    (visibleSeries.dividends ? row.dividends : 0) +
+                    (visibleSeries.interest ? row.interest : 0) +
+                    (visibleSeries.capitalGains ? row.capitalGains : 0);
+                  return (
+                    <tr key={row.month} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                      <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">
+                        {row.label}
+                      </td>
+                      {visibleSeries.dividends && (
+                        <td className="px-4 py-3 text-right text-sm text-green-600 dark:text-green-400">
+                          {row.dividends !== 0 ? fmtValue(row.dividends) : '-'}
+                        </td>
+                      )}
+                      {visibleSeries.interest && (
+                        <td className="px-4 py-3 text-right text-sm text-blue-600 dark:text-blue-400">
+                          {row.interest !== 0 ? fmtValue(row.interest) : '-'}
+                        </td>
+                      )}
+                      {visibleSeries.capitalGains && (
+                        <td
+                          className={`px-4 py-3 text-right text-sm ${
+                            row.capitalGains < 0
+                              ? 'text-red-600 dark:text-red-400'
+                              : 'text-purple-600 dark:text-purple-400'
+                          }`}
+                        >
+                          {row.capitalGains !== 0 ? fmtValue(row.capitalGains) : '-'}
+                        </td>
+                      )}
+                      <td
+                        className={`px-4 py-3 text-right text-sm font-medium ${
+                          rowTotal < 0
+                            ? 'text-red-600 dark:text-red-400'
+                            : 'text-gray-900 dark:text-gray-100'
+                        }`}
+                      >
+                        {rowTotal !== 0 ? fmtValue(rowTotal) : '-'}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
           </div>
         </div>
       ) : (

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -33,6 +33,8 @@ type SeriesKey = 'dividends' | 'interest' | 'capitalGains';
 interface MonthlyIncome {
   month: string;
   label: string;
+  startValue: number;
+  endValue: number;
   dividends: number;
   interest: number;
   capitalGains: number;
@@ -154,6 +156,16 @@ export function DividendIncomeReport() {
     return convertToDefault(entry.totalCapitalGain, entry.accountCurrencyCode || defaultCurrency);
   }, [selectedAccountId, defaultCurrency, convertToDefault]);
 
+  // Same conversion as convertCapitalGain but applied to an arbitrary amount
+  // denominated in the entry's account currency (e.g. start/end market values).
+  const convertFromAccountCurrency = useCallback(
+    (amount: number, accountCurrencyCode: string | null): number => {
+      if (selectedAccountId) return amount;
+      return convertToDefault(amount, accountCurrencyCode || defaultCurrency);
+    },
+    [selectedAccountId, defaultCurrency, convertToDefault],
+  );
+
   const fmtValue = useCallback((value: number): string => {
     if (isForeign) {
       return `${formatCurrencyFull(value, displayCurrency)} ${displayCurrency}`;
@@ -241,6 +253,8 @@ export function DividendIncomeReport() {
       monthMap.set(key, {
         month: key,
         label: format(month, 'MMM yyyy'),
+        startValue: 0,
+        endValue: 0,
         dividends: 0,
         interest: 0,
         capitalGains: 0,
@@ -255,6 +269,8 @@ export function DividendIncomeReport() {
         bucket = {
           month: monthKey,
           label: format(txDate, 'MMM yyyy'),
+          startValue: 0,
+          endValue: 0,
           dividends: 0,
           interest: 0,
           capitalGains: 0,
@@ -290,10 +306,20 @@ export function DividendIncomeReport() {
       const gain = convertCapitalGain(entry);
       bucket.capitalGains += gain;
       bucket.total += gain;
+      // Start/end market values sum across securities to give a portfolio
+      // mark-to-market snapshot at each month boundary.
+      bucket.startValue += convertFromAccountCurrency(
+        entry.startValue,
+        entry.accountCurrencyCode,
+      );
+      bucket.endValue += convertFromAccountCurrency(
+        entry.endValue,
+        entry.accountCurrencyCode,
+      );
     });
 
     return Array.from(monthMap.values()).sort((a, b) => a.month.localeCompare(b.month));
-  }, [filteredTransactions, filteredCapitalGains, dateRange, resolvedRange, getTxAmount, convertCapitalGain]);
+  }, [filteredTransactions, filteredCapitalGains, dateRange, resolvedRange, getTxAmount, convertCapitalGain, convertFromAccountCurrency]);
 
   const securityData = useMemo((): SecurityIncome[] => {
     const securityMap = new Map<string, SecurityIncome>();
@@ -404,13 +430,17 @@ export function DividendIncomeReport() {
     // Monthly table export. Respect the series visibility toggles so the CSV
     // matches what the user sees; the Total column reflects only the visible
     // series (same logic as the rendered table).
-    const headers: string[] = ['Month'];
+    const headers: string[] = ['Month', 'Start Value', 'End Value'];
     if (visibleSeries.dividends) headers.push('Dividends');
     if (visibleSeries.interest) headers.push('Interest');
     if (visibleSeries.capitalGains) headers.push('Capital Gains');
     headers.push('Total', 'Currency');
     const rows = monthlyData.map((row) => {
-      const out: (string | number)[] = [row.month];
+      const out: (string | number)[] = [
+        row.month,
+        round4(row.startValue),
+        round4(row.endValue),
+      ];
       let total = 0;
       if (visibleSeries.dividends) {
         out.push(round4(row.dividends));
@@ -465,13 +495,17 @@ export function DividendIncomeReport() {
         ],
       };
     } else if (viewType === 'monthly' && monthlyDisplay === 'table') {
-      const headers: string[] = ['Month'];
+      const headers: string[] = ['Month', 'Start Value', 'End Value'];
       if (visibleSeries.dividends) headers.push('Dividends');
       if (visibleSeries.interest) headers.push('Interest');
       if (visibleSeries.capitalGains) headers.push('Capital Gains');
       headers.push('Total');
       const rows = monthlyData.map((row) => {
-        const out: (string | number)[] = [row.label];
+        const out: (string | number)[] = [
+          row.label,
+          fmtValue(row.startValue),
+          fmtValue(row.endValue),
+        ];
         let rowTotal = 0;
         if (visibleSeries.dividends) {
           out.push(fmtValue(row.dividends));
@@ -489,8 +523,9 @@ export function DividendIncomeReport() {
         return out;
       });
       // Column totals across the whole window, respecting hidden series so the
-      // footer sum matches the visible columns.
-      const totalRow: (string | number)[] = ['Total'];
+      // footer sum matches the visible columns. Start/End values are point-in-
+      // time snapshots so a column sum would be meaningless — leave them blank.
+      const totalRow: (string | number)[] = ['Total', '', ''];
       let grandTotal = 0;
       if (visibleSeries.dividends) {
         totalRow.push(fmtValue(totals.dividends));
@@ -807,6 +842,12 @@ export function DividendIncomeReport() {
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
                     Month
                   </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                    Start Value
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                    End Value
+                  </th>
                   {visibleSeries.dividends && (
                     <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
                       Dividends
@@ -837,6 +878,12 @@ export function DividendIncomeReport() {
                     <tr key={row.month} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
                       <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">
                         {row.label}
+                      </td>
+                      <td className="px-4 py-3 text-right text-sm text-gray-700 dark:text-gray-300">
+                        {row.startValue !== 0 ? fmtValue(row.startValue) : '-'}
+                      </td>
+                      <td className="px-4 py-3 text-right text-sm text-gray-700 dark:text-gray-300">
+                        {row.endValue !== 0 ? fmtValue(row.endValue) : '-'}
                       </td>
                       {visibleSeries.dividends && (
                         <td className="px-4 py-3 text-right text-sm text-green-600 dark:text-green-400">

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -435,6 +435,79 @@ export function DividendIncomeReport() {
     const accountLabel = selectedAccount
       ? selectedAccount.name.replace(/ - (Brokerage|Cash)$/, '')
       : 'All Accounts';
+
+    // Build a PDF table that mirrors what's on screen when the user is in a
+    // table view; fall back to chart capture for the chart view.
+    let tableData: {
+      headers: string[];
+      rows: (string | number)[][];
+      totalRow?: (string | number)[];
+    } | undefined;
+
+    if (viewType === 'bySecurity') {
+      tableData = {
+        headers: ['Symbol', 'Security', 'Dividends', 'Interest', 'Capital Gains', 'Total'],
+        rows: securityData.map((s) => [
+          s.symbol,
+          s.name,
+          fmtValue(s.dividends),
+          fmtValue(s.interest),
+          fmtValue(s.capitalGains),
+          fmtValue(s.total),
+        ]),
+        totalRow: [
+          'Total',
+          '',
+          fmtValue(totals.dividends),
+          fmtValue(totals.interest),
+          fmtValue(totals.capitalGains),
+          fmtValue(totals.total),
+        ],
+      };
+    } else if (viewType === 'monthly' && monthlyDisplay === 'table') {
+      const headers: string[] = ['Month'];
+      if (visibleSeries.dividends) headers.push('Dividends');
+      if (visibleSeries.interest) headers.push('Interest');
+      if (visibleSeries.capitalGains) headers.push('Capital Gains');
+      headers.push('Total');
+      const rows = monthlyData.map((row) => {
+        const out: (string | number)[] = [row.label];
+        let rowTotal = 0;
+        if (visibleSeries.dividends) {
+          out.push(fmtValue(row.dividends));
+          rowTotal += row.dividends;
+        }
+        if (visibleSeries.interest) {
+          out.push(fmtValue(row.interest));
+          rowTotal += row.interest;
+        }
+        if (visibleSeries.capitalGains) {
+          out.push(fmtValue(row.capitalGains));
+          rowTotal += row.capitalGains;
+        }
+        out.push(fmtValue(rowTotal));
+        return out;
+      });
+      // Column totals across the whole window, respecting hidden series so the
+      // footer sum matches the visible columns.
+      const totalRow: (string | number)[] = ['Total'];
+      let grandTotal = 0;
+      if (visibleSeries.dividends) {
+        totalRow.push(fmtValue(totals.dividends));
+        grandTotal += totals.dividends;
+      }
+      if (visibleSeries.interest) {
+        totalRow.push(fmtValue(totals.interest));
+        grandTotal += totals.interest;
+      }
+      if (visibleSeries.capitalGains) {
+        totalRow.push(fmtValue(totals.capitalGains));
+        grandTotal += totals.capitalGains;
+      }
+      totalRow.push(fmtValue(grandTotal));
+      tableData = { headers, rows, totalRow };
+    }
+
     await exportToPdf({
       title: 'Gains, Dividends & Interest',
       subtitle: accountLabel,
@@ -444,7 +517,8 @@ export function DividendIncomeReport() {
         { label: 'Capital Gains', value: fmtValue(totals.capitalGains), color: totals.capitalGains < 0 ? '#dc2626' : '#9333ea' },
         { label: 'Total Income', value: fmtValue(totals.total), color: '#111827' },
       ],
-      chartContainer: chartRef.current,
+      chartContainer: tableData ? undefined : chartRef.current,
+      tableData,
       filename: 'gains-dividends-interest',
     });
   };

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -10,10 +10,12 @@ import {
   Tooltip,
   ResponsiveContainer,
   Legend,
+  ReferenceLine,
+  Cell,
 } from 'recharts';
 import { format, eachMonthOfInterval } from 'date-fns';
 import { investmentsApi } from '@/lib/investments';
-import { InvestmentTransaction, RealizedGainEntry } from '@/types/investment';
+import { InvestmentTransaction, CapitalGainEntry } from '@/types/investment';
 import { Account } from '@/types/account';
 import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
@@ -24,6 +26,8 @@ import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('DividendIncomeReport');
+
+type SeriesKey = 'dividends' | 'interest' | 'capitalGains';
 
 interface MonthlyIncome {
   month: string;
@@ -43,17 +47,28 @@ interface SecurityIncome {
   total: number;
 }
 
+const SERIES_COLORS: Record<SeriesKey, { positive: string; negative: string; label: string }> = {
+  dividends: { positive: '#22c55e', negative: '#22c55e', label: 'Dividends' },
+  interest: { positive: '#3b82f6', negative: '#3b82f6', label: 'Interest' },
+  capitalGains: { positive: '#8b5cf6', negative: '#ef4444', label: 'Capital Gains' },
+};
+
 export function DividendIncomeReport() {
   const { formatCurrency: formatCurrencyFull, formatCurrencyAxis } = useNumberFormat();
   const { defaultCurrency, convertToDefault } = useExchangeRates();
   const chartRef = useRef<HTMLDivElement>(null);
   const [transactions, setTransactions] = useState<InvestmentTransaction[]>([]);
-  const [realizedGains, setRealizedGains] = useState<RealizedGainEntry[]>([]);
+  const [capitalGains, setCapitalGains] = useState<CapitalGainEntry[]>([]);
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [selectedAccountId, setSelectedAccountId] = useState<string>('');
   const { dateRange, setDateRange, resolvedRange, isValid } = useDateRange({ defaultRange: '1y', alignment: 'month' });
   const [isLoading, setIsLoading] = useState(true);
   const [viewType, setViewType] = useState<'monthly' | 'bySecurity'>('monthly');
+  const [visibleSeries, setVisibleSeries] = useState<Record<SeriesKey, boolean>>({
+    dividends: true,
+    interest: true,
+    capitalGains: true,
+  });
 
   // Build account currency lookup
   const accountCurrencyMap = useMemo(() => {
@@ -78,12 +93,12 @@ export function DividendIncomeReport() {
     return convertToDefault(amount, txCurrency);
   }, [selectedAccountId, accountCurrencyMap, defaultCurrency, convertToDefault]);
 
-  // Backend already returns each realized gain in the holding account's
-  // currency (cost basis derived via chronological replay). Convert to the
-  // default currency for the All-Accounts view; pass through otherwise.
-  const convertRealized = useCallback((entry: RealizedGainEntry): number => {
-    if (selectedAccountId) return entry.realizedGain;
-    return convertToDefault(entry.realizedGain, entry.accountCurrencyCode || defaultCurrency);
+  // Backend already returns each capital gain entry in the holding account's
+  // currency. Convert to the default currency for the All-Accounts view; pass
+  // through otherwise.
+  const convertCapitalGain = useCallback((entry: CapitalGainEntry): number => {
+    if (selectedAccountId) return entry.totalCapitalGain;
+    return convertToDefault(entry.totalCapitalGain, entry.accountCurrencyCode || defaultCurrency);
   }, [selectedAccountId, defaultCurrency, convertToDefault]);
 
   const fmtValue = useCallback((value: number): string => {
@@ -101,9 +116,12 @@ export function DividendIncomeReport() {
         const { start, end } = resolvedRange;
 
         const accountsPromise = investmentsApi.getInvestmentAccounts();
-        const realizedGainsPromise = investmentsApi.getRealizedGains({
+        // Capital gains require a window; fall back to a wide window when the
+        // user picks "All Time" so the backend still has bounds to enumerate.
+        const cgStart = start || '1970-01-01';
+        const capitalGainsPromise = investmentsApi.getCapitalGains({
           accountIds: selectedAccountId || undefined,
-          startDate: start || undefined,
+          startDate: cgStart,
           endDate: end,
         });
 
@@ -124,13 +142,14 @@ export function DividendIncomeReport() {
           page++;
         }
 
-        const [accountsData, realizedGainsData] = await Promise.all([
+        const [accountsData, capitalGainsData] = await Promise.all([
           accountsPromise,
-          realizedGainsPromise,
+          capitalGainsPromise,
         ]);
 
-        // Dividend / Interest / CAPITAL_GAIN come from the plain transaction
-        // list; SELL realized gains come from the backend replay endpoint.
+        // Dividend / Interest / CAPITAL_GAIN income comes from the plain
+        // transaction list; SELL realized + unrealized capital gains come from
+        // the new monthly capital gains endpoint.
         const incomeTransactions = allTransactions.filter(
           (tx) =>
             tx.action === 'DIVIDEND' ||
@@ -139,7 +158,7 @@ export function DividendIncomeReport() {
         );
 
         setTransactions(incomeTransactions);
-        setRealizedGains(realizedGainsData);
+        setCapitalGains(capitalGainsData);
         setAccounts(accountsData);
       } catch (error) {
         logger.error('Failed to load investment transactions:', error);
@@ -210,15 +229,18 @@ export function DividendIncomeReport() {
       bucket.total += contribution;
     });
 
-    realizedGains.forEach((entry) => {
-      const bucket = getOrCreateBucket(parseLocalDate(entry.transactionDate));
-      const gain = convertRealized(entry);
+    capitalGains.forEach((entry) => {
+      // entry.month is YYYY-MM; create a date in the middle of the month so
+      // local-timezone parsing puts it in the right bucket.
+      const monthDate = parseLocalDate(`${entry.month}-15`);
+      const bucket = getOrCreateBucket(monthDate);
+      const gain = convertCapitalGain(entry);
       bucket.capitalGains += gain;
       bucket.total += gain;
     });
 
     return Array.from(monthMap.values()).sort((a, b) => a.month.localeCompare(b.month));
-  }, [transactions, realizedGains, dateRange, resolvedRange, getTxAmount, convertRealized]);
+  }, [transactions, capitalGains, dateRange, resolvedRange, getTxAmount, convertCapitalGain]);
 
   const securityData = useMemo((): SecurityIncome[] => {
     const securityMap = new Map<string, SecurityIncome>();
@@ -251,17 +273,17 @@ export function DividendIncomeReport() {
       bucket.total += contribution;
     });
 
-    realizedGains.forEach((entry) => {
+    capitalGains.forEach((entry) => {
       const symbol = entry.symbol || 'Unknown';
       const name = entry.securityName || 'Unknown Security';
       const bucket = getOrCreateBucket(symbol, name);
-      const gain = convertRealized(entry);
+      const gain = convertCapitalGain(entry);
       bucket.capitalGains += gain;
       bucket.total += gain;
     });
 
     return Array.from(securityMap.values()).sort((a, b) => b.total - a.total);
-  }, [transactions, realizedGains, getTxAmount, convertRealized]);
+  }, [transactions, capitalGains, getTxAmount, convertCapitalGain]);
 
   const totals = useMemo(() => {
     const dividends = transactions
@@ -273,18 +295,18 @@ export function DividendIncomeReport() {
     const manualCapitalGains = transactions
       .filter((t) => t.action === 'CAPITAL_GAIN')
       .reduce((sum, t) => sum + getTxAmount(t), 0);
-    const sellRealizedGains = realizedGains.reduce(
-      (sum, entry) => sum + convertRealized(entry),
+    const periodCapitalGains = capitalGains.reduce(
+      (sum, entry) => sum + convertCapitalGain(entry),
       0,
     );
-    const capitalGains = manualCapitalGains + sellRealizedGains;
+    const totalGains = manualCapitalGains + periodCapitalGains;
     return {
       dividends,
       interest,
-      capitalGains,
-      total: dividends + interest + capitalGains,
+      capitalGains: totalGains,
+      total: dividends + interest + totalGains,
     };
-  }, [transactions, realizedGains, getTxAmount, convertRealized]);
+  }, [transactions, capitalGains, getTxAmount, convertCapitalGain]);
 
   const handleExportPdf = async () => {
     const { exportToPdf } = await import('@/lib/pdf-export');
@@ -292,29 +314,43 @@ export function DividendIncomeReport() {
       ? selectedAccount.name.replace(/ - (Brokerage|Cash)$/, '')
       : 'All Accounts';
     await exportToPdf({
-      title: 'Dividend Income',
+      title: 'Gains, Dividends & Interest',
       subtitle: accountLabel,
       summaryCards: [
         { label: 'Dividends', value: fmtValue(totals.dividends), color: '#16a34a' },
         { label: 'Interest', value: fmtValue(totals.interest), color: '#2563eb' },
-        { label: 'Capital Gains', value: fmtValue(totals.capitalGains), color: '#9333ea' },
+        { label: 'Capital Gains', value: fmtValue(totals.capitalGains), color: totals.capitalGains < 0 ? '#dc2626' : '#9333ea' },
         { label: 'Total Income', value: fmtValue(totals.total), color: '#111827' },
       ],
       chartContainer: chartRef.current,
-      filename: 'dividend-income',
+      filename: 'gains-dividends-interest',
     });
   };
 
-  const CustomTooltip = ({ active, payload, label }: { active?: boolean; payload?: Array<{ name: string; value: number; color: string }>; label?: string }) => {
+  const toggleSeries = (key: SeriesKey) => {
+    setVisibleSeries((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const CustomTooltip = ({ active, payload, label }: { active?: boolean; payload?: Array<{ name: string; value: number; color: string; dataKey?: string }>; label?: string }) => {
     if (active && payload && payload.length) {
+      // Recharts can pass a Cell-coloured payload entry; surface signed values
+      // and use the original series colour rather than the per-bar Cell colour.
       return (
         <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
           <p className="font-medium text-gray-900 dark:text-gray-100 mb-1">{label}</p>
-          {payload.map((entry, index) => (
-            <p key={index} className="text-sm" style={{ color: entry.color }}>
-              {entry.name}: {fmtValue(entry.value)}
-            </p>
-          ))}
+          {payload.map((entry, index) => {
+            const seriesKey = entry.dataKey as SeriesKey | undefined;
+            const colour = seriesKey
+              ? entry.value < 0
+                ? SERIES_COLORS[seriesKey].negative
+                : SERIES_COLORS[seriesKey].positive
+              : entry.color;
+            return (
+              <p key={index} className="text-sm" style={{ color: colour }}>
+                {entry.name}: {fmtValue(entry.value)}
+              </p>
+            );
+          })}
         </div>
       );
     }
@@ -332,6 +368,12 @@ export function DividendIncomeReport() {
     );
   }
 
+  // Only stack series where every value is non-negative; once losses appear
+  // we render bars side-by-side so negatives can drop below the zero line
+  // instead of being hidden inside a stack.
+  const hasNegativeCapitalGains = monthlyData.some((m) => m.capitalGains < 0);
+  const stackId = hasNegativeCapitalGains ? undefined : 'a';
+
   return (
     <div className="space-y-6">
       {/* Summary Cards */}
@@ -348,9 +390,9 @@ export function DividendIncomeReport() {
             {fmtValue(totals.interest)}
           </div>
         </div>
-        <div className="bg-purple-50 dark:bg-purple-900/20 rounded-lg p-4">
-          <div className="text-sm text-purple-600 dark:text-purple-400">Capital Gains</div>
-          <div className="text-xl font-bold text-purple-700 dark:text-purple-300">
+        <div className={`rounded-lg p-4 ${totals.capitalGains < 0 ? 'bg-red-50 dark:bg-red-900/20' : 'bg-purple-50 dark:bg-purple-900/20'}`}>
+          <div className={`text-sm ${totals.capitalGains < 0 ? 'text-red-600 dark:text-red-400' : 'text-purple-600 dark:text-purple-400'}`}>Capital Gains</div>
+          <div className={`text-xl font-bold ${totals.capitalGains < 0 ? 'text-red-700 dark:text-red-300' : 'text-purple-700 dark:text-purple-300'}`}>
             {fmtValue(totals.capitalGains)}
           </div>
         </div>
@@ -409,19 +451,45 @@ export function DividendIncomeReport() {
             <ExportDropdown onExportPdf={handleExportPdf} />
           </div>
         </div>
+        {/* Series visibility toggles */}
+        {viewType === 'monthly' && (
+          <div className="flex flex-wrap gap-2 mt-3 items-center">
+            <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Show:
+            </span>
+            {(Object.keys(SERIES_COLORS) as SeriesKey[]).map((key) => (
+              <label
+                key={key}
+                className="inline-flex items-center gap-1.5 cursor-pointer text-sm text-gray-700 dark:text-gray-300"
+              >
+                <input
+                  type="checkbox"
+                  checked={visibleSeries[key]}
+                  onChange={() => toggleSeries(key)}
+                  className="rounded border-gray-300 dark:border-gray-600"
+                />
+                <span
+                  className="inline-block w-3 h-3 rounded-sm"
+                  style={{ backgroundColor: SERIES_COLORS[key].positive }}
+                />
+                {SERIES_COLORS[key].label}
+              </label>
+            ))}
+          </div>
+        )}
       </div>
 
-      {transactions.length === 0 && realizedGains.length === 0 ? (
+      {transactions.length === 0 && capitalGains.length === 0 ? (
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
           <p className="text-gray-500 dark:text-gray-400 text-center py-8">
-            No dividend, interest, capital gain, or sell transactions found for this period.
+            No dividends, interest, or capital gain activity found for this period.
           </p>
         </div>
       ) : viewType === 'monthly' ? (
         /* Monthly Chart */
         <div ref={chartRef} className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 px-2 py-4 sm:p-6">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-            Monthly Income
+            Monthly Gains, Dividends & Interest
           </h3>
           <div className="h-80">
             <ResponsiveContainer width="100%" height="100%" minWidth={0}>
@@ -431,9 +499,42 @@ export function DividendIncomeReport() {
                 <YAxis tickFormatter={formatCurrencyAxis} />
                 <Tooltip content={<CustomTooltip />} />
                 <Legend />
-                <Bar dataKey="dividends" stackId="a" fill="#22c55e" name="Dividends" />
-                <Bar dataKey="interest" stackId="a" fill="#3b82f6" name="Interest" />
-                <Bar dataKey="capitalGains" stackId="a" fill="#8b5cf6" name="Capital Gains" />
+                <ReferenceLine y={0} stroke="#9ca3af" />
+                {visibleSeries.dividends && (
+                  <Bar
+                    dataKey="dividends"
+                    stackId={stackId}
+                    fill={SERIES_COLORS.dividends.positive}
+                    name="Dividends"
+                  />
+                )}
+                {visibleSeries.interest && (
+                  <Bar
+                    dataKey="interest"
+                    stackId={stackId}
+                    fill={SERIES_COLORS.interest.positive}
+                    name="Interest"
+                  />
+                )}
+                {visibleSeries.capitalGains && (
+                  <Bar
+                    dataKey="capitalGains"
+                    stackId={stackId}
+                    fill={SERIES_COLORS.capitalGains.positive}
+                    name="Capital Gains"
+                  >
+                    {monthlyData.map((entry) => (
+                      <Cell
+                        key={entry.month}
+                        fill={
+                          entry.capitalGains < 0
+                            ? SERIES_COLORS.capitalGains.negative
+                            : SERIES_COLORS.capitalGains.positive
+                        }
+                      />
+                    ))}
+                  </Bar>
+                )}
               </BarChart>
             </ResponsiveContainer>
           </div>
@@ -484,10 +585,22 @@ export function DividendIncomeReport() {
                     <td className="px-4 py-3 text-right text-sm text-blue-600 dark:text-blue-400">
                       {security.interest > 0 ? fmtValue(security.interest) : '-'}
                     </td>
-                    <td className="px-4 py-3 text-right text-sm text-purple-600 dark:text-purple-400">
+                    <td
+                      className={`px-4 py-3 text-right text-sm ${
+                        security.capitalGains < 0
+                          ? 'text-red-600 dark:text-red-400'
+                          : 'text-purple-600 dark:text-purple-400'
+                      }`}
+                    >
                       {security.capitalGains !== 0 ? fmtValue(security.capitalGains) : '-'}
                     </td>
-                    <td className="px-4 py-3 text-right text-sm font-medium text-gray-900 dark:text-gray-100">
+                    <td
+                      className={`px-4 py-3 text-right text-sm font-medium ${
+                        security.total < 0
+                          ? 'text-red-600 dark:text-red-400'
+                          : 'text-gray-900 dark:text-gray-100'
+                      }`}
+                    >
                       {fmtValue(security.total)}
                     </td>
                   </tr>

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -23,6 +23,7 @@ import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useDateRange } from '@/hooks/useDateRange';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { exportToCsv } from '@/lib/csv-export';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('DividendIncomeReport');
@@ -360,6 +361,75 @@ export function DividendIncomeReport() {
     };
   }, [filteredTransactions, filteredCapitalGains, getTxAmount, convertCapitalGain]);
 
+  // CSV is only offered when the user is looking at a table. Raw numeric
+  // values (no currency formatting) are written so spreadsheets can sum and
+  // filter them; the currency code goes into a dedicated column.
+  const isTableView =
+    viewType === 'bySecurity' ||
+    (viewType === 'monthly' && monthlyDisplay === 'table');
+
+  const round4 = (n: number) => Math.round(n * 10000) / 10000;
+
+  const handleExportCsv = () => {
+    const accountLabel = selectedAccount
+      ? selectedAccount.name.replace(/ - (Brokerage|Cash)$/, '')
+      : 'all-accounts';
+    const filenameBase = 'gains-dividends-interest';
+    const scope = accountLabel.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+    const currencyCode = displayCurrency;
+
+    if (viewType === 'bySecurity') {
+      const headers = [
+        'Symbol',
+        'Security',
+        'Dividends',
+        'Interest',
+        'Capital Gains',
+        'Total',
+        'Currency',
+      ];
+      const rows = securityData.map((s) => [
+        s.symbol,
+        s.name,
+        round4(s.dividends),
+        round4(s.interest),
+        round4(s.capitalGains),
+        round4(s.total),
+        currencyCode,
+      ]);
+      exportToCsv(`${filenameBase}-by-security-${scope}`, headers, rows);
+      return;
+    }
+
+    // Monthly table export. Respect the series visibility toggles so the CSV
+    // matches what the user sees; the Total column reflects only the visible
+    // series (same logic as the rendered table).
+    const headers: string[] = ['Month'];
+    if (visibleSeries.dividends) headers.push('Dividends');
+    if (visibleSeries.interest) headers.push('Interest');
+    if (visibleSeries.capitalGains) headers.push('Capital Gains');
+    headers.push('Total', 'Currency');
+    const rows = monthlyData.map((row) => {
+      const out: (string | number)[] = [row.month];
+      let total = 0;
+      if (visibleSeries.dividends) {
+        out.push(round4(row.dividends));
+        total += row.dividends;
+      }
+      if (visibleSeries.interest) {
+        out.push(round4(row.interest));
+        total += row.interest;
+      }
+      if (visibleSeries.capitalGains) {
+        out.push(round4(row.capitalGains));
+        total += row.capitalGains;
+      }
+      out.push(round4(total), currencyCode);
+      return out;
+    });
+    exportToCsv(`${filenameBase}-monthly-${scope}`, headers, rows);
+  };
+
   const handleExportPdf = async () => {
     const { exportToPdf } = await import('@/lib/pdf-export');
     const accountLabel = selectedAccount
@@ -521,7 +591,10 @@ export function DividendIncomeReport() {
             >
               By Security
             </button>
-            <ExportDropdown onExportPdf={handleExportPdf} />
+            <ExportDropdown
+              onExportPdf={handleExportPdf}
+              onExportCsv={isTableView ? handleExportCsv : undefined}
+            />
           </div>
         </div>
         {/* Monthly view sub-controls: chart/table switch + series toggles */}
@@ -557,24 +630,29 @@ export function DividendIncomeReport() {
               <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
                 Show:
               </span>
-              {(Object.keys(SERIES_COLORS) as SeriesKey[]).map((key) => (
-                <label
-                  key={key}
-                  className="inline-flex items-center gap-1.5 cursor-pointer text-sm text-gray-700 dark:text-gray-300"
-                >
-                  <input
-                    type="checkbox"
-                    checked={visibleSeries[key]}
-                    onChange={() => toggleSeries(key)}
-                    className="rounded border-gray-300 dark:border-gray-600"
-                  />
-                  <span
-                    className="inline-block w-3 h-3 rounded-sm"
-                    style={{ backgroundColor: SERIES_COLORS[key].positive }}
-                  />
-                  {SERIES_COLORS[key].label}
-                </label>
-              ))}
+              {(Object.keys(SERIES_COLORS) as SeriesKey[]).map((key) => {
+                const active = visibleSeries[key];
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => toggleSeries(key)}
+                    aria-pressed={active}
+                    className={`px-3 py-1 text-sm font-medium rounded-md border transition-colors ${
+                      active
+                        ? 'text-white border-transparent'
+                        : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-600'
+                    }`}
+                    style={
+                      active
+                        ? { backgroundColor: SERIES_COLORS[key].positive }
+                        : undefined
+                    }
+                  >
+                    {SERIES_COLORS[key].label}
+                  </button>
+                );
+              })}
             </div>
           </div>
         )}

--- a/frontend/src/lib/investments.ts
+++ b/frontend/src/lib/investments.ts
@@ -7,6 +7,7 @@ import {
   CreateInvestmentTransactionData,
   Holding,
   RealizedGainEntry,
+  CapitalGainEntry,
   Security,
   CreateSecurityData,
   CreateSecurityPriceData,
@@ -128,6 +129,19 @@ export const investmentsApi = {
   }): Promise<RealizedGainEntry[]> => {
     const response = await apiClient.get<RealizedGainEntry[]>(
       '/investment-transactions/realized-gains',
+      { params },
+    );
+    return response.data;
+  },
+
+  // Per-month capital gain breakdown (realized + unrealized) by security.
+  getCapitalGains: async (params: {
+    accountIds?: string;
+    startDate: string;
+    endDate: string;
+  }): Promise<CapitalGainEntry[]> => {
+    const response = await apiClient.get<CapitalGainEntry[]>(
+      '/investment-transactions/capital-gains',
       { params },
     );
     return response.data;

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -228,3 +228,28 @@ export interface RealizedGainEntry {
   costBasis: number;
   realizedGain: number;
 }
+
+/**
+ * Per-(account, security, month) capital gain entry combining realized SELL
+ * gains with the unrealized mark-to-market change on the position. All values
+ * are in the holding account's currency.
+ */
+export interface CapitalGainEntry {
+  month: string;
+  accountId: string;
+  accountName: string | null;
+  accountCurrencyCode: string | null;
+  securityId: string;
+  symbol: string | null;
+  securityName: string | null;
+  securityCurrencyCode: string | null;
+  startQuantity: number;
+  endQuantity: number;
+  startValue: number;
+  endValue: number;
+  buys: number;
+  sells: number;
+  realizedGain: number;
+  unrealizedGain: number;
+  totalCapitalGain: number;
+}


### PR DESCRIPTION
## Summary
This PR extends the investment reporting system to track capital gains on a monthly basis, decomposing each month's gains into realized portions (from SELL transactions) and unrealized mark-to-market changes on held positions. The frontend report now displays capital gains alongside dividends and interest income, with filtering by security and display options for charts vs. tables.

## Key Changes

### Backend
- **New `CapitalGainEntry` interface** in `portfolio-calculation.service.ts` that captures per-(account, security, month) capital gains including:
  - Realized gains from SELL transactions
  - Unrealized mark-to-market changes (endValue - startValue)
  - Position quantities and market values at month boundaries
  
- **`calculateCapitalGainsByMonth()` method** that:
  - Replays full investment history to derive cost basis and quantities
  - Snapshots positions at each month boundary using historical close prices
  - Converts market values to holding account currency
  - Omits months with zero activity and zero holdings
  
- **Helper utilities** for month enumeration and transaction state application to support the capital gains calculation

- **New API endpoint** `GET /investment-transactions/capital-gains` to expose monthly capital gains data with account and date filtering

- **LLM integration** via `getLlmCapitalGains()` with grouping options (by month, security, or account) for AI assistant queries

- **MCP tool** `get_capital_gains` registered for Claude integration

### Frontend
- **Enhanced `DividendIncomeReport` component** with:
  - Security filtering dropdown populated from loaded transactions and capital gains data
  - Toggle between chart and table views for monthly data
  - Series visibility controls for dividends, interest, and capital gains
  - Color-coded bars (green for gains, red for losses)
  - Reference lines showing portfolio start/end values per month
  
- **Updated data structures** to include `startValue` and `endValue` fields in monthly buckets for mark-to-market tracking

- **Improved test coverage** with stable mock references to prevent unintended re-renders and new test cases for:
  - Negative capital gains (losses) with red styling
  - Monthly capital gains aggregation from backend data
  - Security filtering functionality

### Type Updates
- Renamed `RealizedGainEntry` references to `CapitalGainEntry` where appropriate
- Added `CapitalGainEntry` type to frontend investment types
- Updated API client to call new `getCapitalGains` endpoint

## Implementation Details
- Capital gains calculation uses chronological transaction replay to accurately derive cost basis, matching the approach used for realized gains
- Market values are snapshotted at month boundaries using the last available close price on or before that date
- Currency conversion follows the same pattern as other multi-account views: single-account selections show native currency, all-accounts view converts to default currency
- The decomposition formula: `totalCapitalGain = (endValue - startValue) + sells - buys`, with `unrealizedGain = totalCapitalGain - realizedGain`

https://claude.ai/code/session_01LBtr11xudAYkSkNQ1AZvtq