### PR TITLE
Add password verification to 2FA setup flow

### DIFF
--- a/backend/src/ai/dto/ai-config.dto.ts
+++ b/backend/src/ai/dto/ai-config.dto.ts
@@ -15,6 +15,7 @@ import {
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
 import { IsSafeConfigObject } from "../validators/safe-config-object.validator";
+import { IsSafeProviderBaseUrl } from "../validators/safe-url.validator";
 import {
   AI_PROVIDERS,
   AiProviderType,
@@ -66,6 +67,7 @@ export class CreateAiConfigDto {
   @IsOptional()
   @IsString()
   @MaxLength(500)
+  @IsSafeProviderBaseUrl()
   baseUrl?: string;
 
   @ApiPropertyOptional({
@@ -158,6 +160,7 @@ export class UpdateAiConfigDto {
   @IsOptional()
   @IsString()
   @MaxLength(500)
+  @IsSafeProviderBaseUrl()
   baseUrl?: string;
 
   @ApiPropertyOptional({
@@ -267,6 +270,7 @@ export class TestAiConfigDto {
   @IsOptional()
   @IsString()
   @MaxLength(500)
+  @IsSafeProviderBaseUrl()
   baseUrl?: string;
 
   @ApiPropertyOptional({

--- a/backend/src/ai/validators/safe-url.validator.ts
+++ b/backend/src/ai/validators/safe-url.validator.ts
@@ -1,11 +1,16 @@
 import {
   registerDecorator,
+  ValidationArguments,
   ValidationOptions,
   ValidatorConstraint,
   ValidatorConstraintInterface,
 } from "class-validator";
 import * as dns from "dns";
 import * as net from "net";
+import {
+  AiProviderType,
+  SELF_HOSTED_PROVIDERS,
+} from "../entities/ai-provider-config.entity";
 
 const BLOCKED_HOSTNAMES = new Set([
   "localhost",
@@ -215,6 +220,72 @@ export function IsSafeUrl(
       options: validationOptions,
       constraints: [],
       validator: IsSafeUrlConstraint,
+    });
+  };
+}
+
+/**
+ * SSRF guard for AI provider baseUrl values. Dispatches on the sibling
+ * `provider` field: cloud providers get the strict IsSafeUrl check (blocks
+ * private IPs, metadata endpoints, DNS-rebinding) while self-hosted providers
+ * (ollama, openai-compatible) intentionally allow private/local URLs since
+ * they run on LAN.
+ */
+@ValidatorConstraint({ async: true })
+export class IsSafeProviderBaseUrlConstraint implements ValidatorConstraintInterface {
+  private lastMessage = "baseUrl must be a valid HTTP/HTTPS URL";
+
+  async validate(value: unknown, args: ValidationArguments): Promise<boolean> {
+    if (typeof value !== "string" || value.length === 0) return false;
+
+    const provider = (args.object as { provider?: AiProviderType }).provider;
+
+    // No provider in the DTO means we can't pick the right policy at the
+    // validation layer (e.g. UpdateAiConfigDto, where provider is immutable
+    // and not echoed in the request). Fall back to basic safety here and let
+    // the service layer run provider-aware validation against the stored row.
+    if (!provider) {
+      if (!validateUrlBasicSafety(value)) {
+        this.lastMessage =
+          "baseUrl must be a valid HTTP/HTTPS URL without embedded credentials";
+        return false;
+      }
+      return true;
+    }
+
+    if (SELF_HOSTED_PROVIDERS.has(provider)) {
+      if (!validateUrlBasicSafety(value)) {
+        this.lastMessage =
+          "baseUrl must be a valid HTTP/HTTPS URL without embedded credentials";
+        return false;
+      }
+      return true;
+    }
+
+    const strict = new IsSafeUrlConstraint();
+    const ok = await strict.validate(value);
+    if (!ok) {
+      this.lastMessage =
+        "baseUrl must be a valid HTTP/HTTPS URL pointing to an external host";
+    }
+    return ok;
+  }
+
+  defaultMessage(): string {
+    return this.lastMessage;
+  }
+}
+
+export function IsSafeProviderBaseUrl(
+  validationOptions?: ValidationOptions,
+): PropertyDecorator {
+  return function (object: object, propertyName: string | symbol) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName: String(propertyName),
+      options: validationOptions,
+      constraints: [],
+      validator: IsSafeProviderBaseUrlConstraint,
     });
   };
 }

--- a/backend/src/auth/auth-email.service.spec.ts
+++ b/backend/src/auth/auth-email.service.spec.ts
@@ -4,6 +4,7 @@ import { BadRequestException } from "@nestjs/common";
 import * as bcrypt from "bcryptjs";
 import { AuthEmailService } from "./auth-email.service";
 import { User } from "../users/entities/user.entity";
+import { TrustedDevice } from "../users/entities/trusted-device.entity";
 import { PasswordBreachService } from "./password-breach.service";
 import { TokenService } from "./token.service";
 import { hashToken } from "./crypto.util";
@@ -11,6 +12,7 @@ import { hashToken } from "./crypto.util";
 describe("AuthEmailService", () => {
   let service: AuthEmailService;
   let usersRepository: Record<string, jest.Mock>;
+  let trustedDevicesRepository: Record<string, jest.Mock>;
   let passwordBreachService: { isBreached: jest.Mock };
   let tokenService: { revokeAllUserRefreshTokens: jest.Mock };
 
@@ -31,6 +33,10 @@ describe("AuthEmailService", () => {
       createQueryBuilder: jest.fn(),
     };
 
+    trustedDevicesRepository = {
+      delete: jest.fn(),
+    };
+
     passwordBreachService = {
       isBreached: jest.fn(),
     };
@@ -45,6 +51,10 @@ describe("AuthEmailService", () => {
         {
           provide: getRepositoryToken(User),
           useValue: usersRepository,
+        },
+        {
+          provide: getRepositoryToken(TrustedDevice),
+          useValue: trustedDevicesRepository,
         },
         {
           provide: PasswordBreachService,

--- a/backend/src/auth/auth-email.service.ts
+++ b/backend/src/auth/auth-email.service.ts
@@ -10,6 +10,7 @@ import * as bcrypt from "bcryptjs";
 import * as crypto from "crypto";
 
 import { User } from "../users/entities/user.entity";
+import { TrustedDevice } from "../users/entities/trusted-device.entity";
 import { hashToken } from "./crypto.util";
 import { PasswordBreachService } from "./password-breach.service";
 import { TokenService } from "./token.service";
@@ -30,6 +31,8 @@ export class AuthEmailService implements OnModuleDestroy {
   constructor(
     @InjectRepository(User)
     private usersRepository: Repository<User>,
+    @InjectRepository(TrustedDevice)
+    private trustedDevicesRepository: Repository<TrustedDevice>,
     private passwordBreachService: PasswordBreachService,
     private tokenService: TokenService,
   ) {
@@ -114,6 +117,9 @@ export class AuthEmailService implements OnModuleDestroy {
     const userId = result.raw?.[0]?.id;
     if (userId) {
       await this.tokenService.revokeAllUserRefreshTokens(userId);
+      // SECURITY: Revoke trusted devices so a stolen trusted-device cookie
+      // cannot bypass 2FA after a password reset.
+      await this.trustedDevicesRepository.delete({ userId });
     }
   }
 

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -986,7 +986,7 @@ describe("AuthController", () => {
   });
 
   describe("setup2FA", () => {
-    it("delegates to authService.setup2FA with user id", async () => {
+    it("delegates to authService.setup2FA with user id and password", async () => {
       const setupResult = {
         secret: "JBSWY3DPEHPK3PXP",
         qrCodeDataUrl: "data:image/png;base64,abc123",
@@ -994,9 +994,14 @@ describe("AuthController", () => {
       authService.setup2FA.mockResolvedValue(setupResult);
       const reqWithUser = { user: { id: "user-1" } };
 
-      const result = await controller.setup2FA(reqWithUser);
+      const result = await controller.setup2FA(reqWithUser, {
+        currentPassword: "correct-password",
+      });
 
-      expect(authService.setup2FA).toHaveBeenCalledWith("user-1");
+      expect(authService.setup2FA).toHaveBeenCalledWith(
+        "user-1",
+        "correct-password",
+      );
       expect(result).toEqual(setupResult);
     });
   });

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -36,6 +36,7 @@ import { ForgotPasswordDto } from "./dto/forgot-password.dto";
 import { ResetPasswordDto } from "./dto/reset-password.dto";
 import { VerifyTotpDto } from "./dto/verify-totp.dto";
 import { Setup2faDto } from "./dto/setup-2fa.dto";
+import { Setup2faInitDto } from "./dto/setup-2fa-init.dto";
 import { passwordResetTemplate } from "../notifications/email-templates";
 import { SkipCsrf } from "../common/decorators/skip-csrf.decorator";
 import { SkipPasswordCheck } from "./decorators/skip-password-check.decorator";
@@ -113,6 +114,50 @@ export class AuthController {
       // the user through the normal 2FA flow on this login.
       return undefined;
     }
+  }
+
+  /**
+   * Decide whether the OIDC provider actually performed multi-factor auth.
+   * Matches RFC 8176 "amr" values that imply a second factor, plus a small
+   * set of well-known multi-factor "acr" strings. When neither claim is
+   * present we treat it as "MFA not proven".
+   */
+  private oidcProvedMfa(amr: string[] | undefined, acr: string | undefined) {
+    const mfaAmrValues = new Set([
+      "mfa",
+      "otp",
+      "totp",
+      "hwk",
+      "swk",
+      "sms",
+      "tel",
+      "pop",
+      "fpt",
+      "face",
+      "iris",
+      "retina",
+      "vbm",
+      "wia",
+      "kba",
+    ]);
+    if (amr?.some((v) => mfaAmrValues.has(v.toLowerCase()))) {
+      // "pwd" + a second factor is the normal case; the presence of any
+      // second-factor value on top of the password is enough.
+      return true;
+    }
+    if (acr) {
+      const lower = acr.toLowerCase();
+      if (
+        lower.includes("mfa") ||
+        lower.endsWith(":2") ||
+        lower.endsWith("/2") ||
+        lower === "2" ||
+        /loa[-_]?[234]/.test(lower)
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private getAccessCookieOptions() {
@@ -317,6 +362,18 @@ export class AuthController {
         nonce,
       );
 
+      // SECURITY: When FORCE_2FA is enabled, app-level 2FA is unavailable for
+      // OIDC users (2FA is delegated to the identity provider). To still
+      // honor the admin's "require MFA for everyone" intent, require the IdP
+      // to assert MFA via RFC 8176 "amr" or a multi-factor "acr" value.
+      if (this.force2fa && !this.oidcProvedMfa(tokenSet.amr, tokenSet.acr)) {
+        this.logger.warn(
+          `OIDC login rejected: FORCE_2FA is enabled but IdP did not assert MFA (amr=${JSON.stringify(tokenSet.amr)}, acr=${tokenSet.acr})`,
+        );
+        res.redirect(`${frontendUrl}/auth/callback?error=mfa_required`);
+        return;
+      }
+
       // Get user info from OIDC provider
       const userInfo = await this.oidcService.getUserInfo(
         tokenSet.access_token,
@@ -516,10 +573,11 @@ export class AuthController {
   @Post("2fa/setup")
   @UseGuards(AuthGuard("jwt"))
   @DemoRestricted()
+  @Throttle({ default: { ttl: 900000, limit: 5 } })
   @ApiBearerAuth()
   @ApiOperation({ summary: "Generate QR code and secret for 2FA setup" })
-  async setup2FA(@Request() req) {
-    return this.authService.setup2FA(req.user.id);
+  async setup2FA(@Request() req, @Body() dto: Setup2faInitDto) {
+    return this.authService.setup2FA(req.user.id, dto.currentPassword);
   }
 
   @Post("2fa/confirm-setup")

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -678,8 +678,9 @@ describe("AuthService", () => {
     it("generates secret, QR code, and stores encrypted secret", async () => {
       usersRepository.findOne.mockResolvedValue({ ...mockUser });
       usersRepository.save.mockImplementation((u) => u);
+      jest.spyOn(bcrypt, "compare").mockResolvedValueOnce(true as never);
 
-      const result = await service.setup2FA("user-1");
+      const result = await service.setup2FA("user-1", "correct-password");
 
       expect(result.secret).toBe("TESTSECRET");
       expect(result.qrCodeDataUrl).toBe("data:image/png;base64,mockqrcode");
@@ -702,10 +703,10 @@ describe("AuthService", () => {
     it("throws NotFoundException when user not found", async () => {
       usersRepository.findOne.mockResolvedValue(null);
 
-      await expect(service.setup2FA("nonexistent")).rejects.toThrow(
+      await expect(service.setup2FA("nonexistent", "pw")).rejects.toThrow(
         NotFoundException,
       );
-      await expect(service.setup2FA("nonexistent")).rejects.toThrow(
+      await expect(service.setup2FA("nonexistent", "pw")).rejects.toThrow(
         "User not found",
       );
     });
@@ -716,12 +717,22 @@ describe("AuthService", () => {
         authProvider: "oidc",
       });
 
-      await expect(service.setup2FA("user-1")).rejects.toThrow(
+      await expect(service.setup2FA("user-1", "pw")).rejects.toThrow(
         BadRequestException,
       );
-      await expect(service.setup2FA("user-1")).rejects.toThrow(
+      await expect(service.setup2FA("user-1", "pw")).rejects.toThrow(
         "Two-factor authentication is not available for SSO accounts",
       );
+    });
+
+    it("rejects when current password does not match", async () => {
+      usersRepository.findOne.mockResolvedValue({ ...mockUser });
+      jest.spyOn(bcrypt, "compare").mockResolvedValueOnce(false as never);
+
+      await expect(service.setup2FA("user-1", "wrong")).rejects.toThrow(
+        "Current password is incorrect",
+      );
+      expect(usersRepository.save).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -565,8 +565,8 @@ export class AuthService {
     );
   }
 
-  async setup2FA(userId: string) {
-    return this.twoFactorService.setup2FA(userId);
+  async setup2FA(userId: string, currentPassword: string) {
+    return this.twoFactorService.setup2FA(userId, currentPassword);
   }
 
   async confirmSetup2FA(userId: string, code: string) {

--- a/backend/src/auth/dto/setup-2fa-init.dto.ts
+++ b/backend/src/auth/dto/setup-2fa-init.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, MaxLength } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+
+/**
+ * Body for POST /auth/2fa/setup. The current password must be re-verified
+ * before we generate (and display) a new TOTP secret, so a session-hijacker
+ * cannot force-enroll their own authenticator and lock out the real user.
+ */
+export class Setup2faInitDto {
+  @ApiProperty({ description: "Current account password" })
+  @IsString()
+  @MaxLength(128)
+  currentPassword: string;
+}

--- a/backend/src/auth/oidc/oidc.service.ts
+++ b/backend/src/auth/oidc/oidc.service.ts
@@ -5,6 +5,10 @@ import * as client from "openid-client";
 export interface OidcTokenResult {
   access_token: string;
   sub: string;
+  /** "amr" (Authentication Methods References) claim from the ID token. */
+  amr?: string[];
+  /** "acr" (Authentication Context Class Reference) claim from the ID token. */
+  acr?: string;
 }
 
 @Injectable()
@@ -111,9 +115,18 @@ export class OidcService implements OnModuleInit {
       throw new Error("No subject claim in ID token");
     }
 
+    const rawAmr = (claims as Record<string, unknown>).amr;
+    const amr = Array.isArray(rawAmr)
+      ? rawAmr.filter((v): v is string => typeof v === "string")
+      : undefined;
+    const rawAcr = (claims as Record<string, unknown>).acr;
+    const acr = typeof rawAcr === "string" ? rawAcr : undefined;
+
     return {
       access_token: tokens.access_token,
       sub: claims.sub,
+      amr,
+      acr,
     };
   }
 

--- a/backend/src/auth/two-factor.service.spec.ts
+++ b/backend/src/auth/two-factor.service.spec.ts
@@ -397,8 +397,9 @@ describe("TwoFactorService", () => {
   describe("setup2FA", () => {
     it("should generate a secret and QR code for a local user", async () => {
       usersRepository.findOne.mockResolvedValue({ ...mockUser });
+      jest.spyOn(bcrypt, "compare").mockResolvedValueOnce(true as never);
 
-      const result = await service.setup2FA("user-1");
+      const result = await service.setup2FA("user-1", "correct-password");
 
       expect(result.secret).toBe("TESTSECRET");
       expect(result.qrCodeDataUrl).toBe("data:image/png;base64,mockqrcode");
@@ -409,7 +410,7 @@ describe("TwoFactorService", () => {
     it("should throw NotFoundException for unknown user", async () => {
       usersRepository.findOne.mockResolvedValue(null);
 
-      await expect(service.setup2FA("nonexistent")).rejects.toThrow(
+      await expect(service.setup2FA("nonexistent", "pw")).rejects.toThrow(
         NotFoundException,
       );
     });
@@ -420,9 +421,19 @@ describe("TwoFactorService", () => {
         authProvider: "oidc",
       });
 
-      await expect(service.setup2FA("user-1")).rejects.toThrow(
+      await expect(service.setup2FA("user-1", "pw")).rejects.toThrow(
         BadRequestException,
       );
+    });
+
+    it("should reject incorrect current password", async () => {
+      usersRepository.findOne.mockResolvedValue({ ...mockUser });
+      jest.spyOn(bcrypt, "compare").mockResolvedValueOnce(false as never);
+
+      await expect(
+        service.setup2FA("user-1", "wrong-password"),
+      ).rejects.toThrow(UnauthorizedException);
+      expect(usersRepository.save).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/auth/two-factor.service.ts
+++ b/backend/src/auth/two-factor.service.ts
@@ -271,7 +271,7 @@ export class TwoFactorService {
     }
   }
 
-  async setup2FA(userId: string) {
+  async setup2FA(userId: string, currentPassword: string) {
     const user = await this.usersRepository.findOne({
       where: { id: userId },
     });
@@ -284,6 +284,25 @@ export class TwoFactorService {
       throw new BadRequestException(
         "Two-factor authentication is not available for SSO accounts",
       );
+    }
+
+    // SECURITY: Re-verify the current password before generating (and
+    // displaying) a new TOTP secret. Without this a session-hijacker could
+    // force-enroll their own authenticator and lock out the real user.
+    if (!user.passwordHash) {
+      throw new BadRequestException(
+        "Two-factor authentication requires an account password",
+      );
+    }
+    const isPasswordValid = await bcrypt.compare(
+      currentPassword,
+      user.passwordHash,
+    );
+    if (!isPasswordValid) {
+      this.logger.warn(
+        `2FA setup refused: invalid password for user ${userId}`,
+      );
+      throw new UnauthorizedException("Current password is incorrect");
     }
 
     const secret = otplib.generateSecret();

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -2,6 +2,7 @@ import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { User } from "./entities/user.entity";
 import { UserPreference } from "./entities/user-preference.entity";
+import { TrustedDevice } from "./entities/trusted-device.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
 import { PersonalAccessToken } from "../auth/entities/personal-access-token.entity";
 import { UsersService } from "./users.service";
@@ -13,6 +14,7 @@ import { PasswordBreachService } from "../auth/password-breach.service";
     TypeOrmModule.forFeature([
       User,
       UserPreference,
+      TrustedDevice,
       RefreshToken,
       PersonalAccessToken,
     ]),

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -11,6 +11,7 @@ import * as bcrypt from "bcryptjs";
 import { UsersService } from "./users.service";
 import { User } from "./entities/user.entity";
 import { UserPreference } from "./entities/user-preference.entity";
+import { TrustedDevice } from "./entities/trusted-device.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
 import { PersonalAccessToken } from "../auth/entities/personal-access-token.entity";
 import { PasswordBreachService } from "../auth/password-breach.service";
@@ -21,6 +22,7 @@ describe("UsersService", () => {
   let preferencesRepository: Record<string, jest.Mock>;
   let refreshTokensRepository: Record<string, jest.Mock>;
   let patRepository: Record<string, jest.Mock>;
+  let trustedDevicesRepository: Record<string, jest.Mock>;
   let passwordBreachService: { isBreached: jest.Mock };
   let mockQueryRunner: Record<string, jest.Mock>;
 
@@ -79,6 +81,10 @@ describe("UsersService", () => {
       update: jest.fn(),
     };
 
+    trustedDevicesRepository = {
+      delete: jest.fn(),
+    };
+
     passwordBreachService = {
       isBreached: jest.fn().mockResolvedValue(false),
     };
@@ -111,6 +117,10 @@ describe("UsersService", () => {
         {
           provide: getRepositoryToken(PersonalAccessToken),
           useValue: patRepository,
+        },
+        {
+          provide: getRepositoryToken(TrustedDevice),
+          useValue: trustedDevicesRepository,
         },
         { provide: DataSource, useValue: mockDataSource },
         { provide: PasswordBreachService, useValue: passwordBreachService },

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -12,6 +12,7 @@ import { Repository, DataSource } from "typeorm";
 import * as bcrypt from "bcryptjs";
 import { User } from "./entities/user.entity";
 import { UserPreference } from "./entities/user-preference.entity";
+import { TrustedDevice } from "./entities/trusted-device.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
 import { PersonalAccessToken } from "../auth/entities/personal-access-token.entity";
 import { UpdateProfileDto } from "./dto/update-profile.dto";
@@ -33,6 +34,8 @@ export class UsersService {
     private refreshTokensRepository: Repository<RefreshToken>,
     @InjectRepository(PersonalAccessToken)
     private patRepository: Repository<PersonalAccessToken>,
+    @InjectRepository(TrustedDevice)
+    private trustedDevicesRepository: Repository<TrustedDevice>,
     private dataSource: DataSource,
     private passwordBreachService: PasswordBreachService,
   ) {}
@@ -238,6 +241,10 @@ export class UsersService {
       { userId, isRevoked: false },
       { isRevoked: true },
     );
+
+    // SECURITY: Revoke trusted devices so a stolen trusted-device cookie
+    // cannot bypass 2FA after the user rotates their password.
+    await this.trustedDevicesRepository.delete({ userId });
   }
 
   async deleteAccount(

--- a/frontend/src/components/auth/TwoFactorSetup.test.tsx
+++ b/frontend/src/components/auth/TwoFactorSetup.test.tsx
@@ -17,6 +17,12 @@ vi.mock('@/lib/auth', () => ({
   },
 }));
 
+async function submitPasswordStep(password = 'correct-password') {
+  const passwordInput = screen.getByLabelText('Current password');
+  fireEvent.change(passwordInput, { target: { value: password } });
+  fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+}
+
 describe('TwoFactorSetup', () => {
   const onComplete = vi.fn();
   const onSkip = vi.fn();
@@ -25,41 +31,42 @@ describe('TwoFactorSetup', () => {
     vi.clearAllMocks();
   });
 
-  it('shows loading state on mount while fetching setup data', async () => {
-    const { authApi } = await import('@/lib/auth');
-    vi.mocked(authApi.setup2FA).mockReturnValue(new Promise(() => {})); // never resolves
-
+  it('shows password prompt before fetching setup data', async () => {
     render(<TwoFactorSetup onComplete={onComplete} />);
 
-    // Should show a spinner (the loading div contains animate-spin)
-    expect(document.querySelector('.animate-spin')).toBeInTheDocument();
+    expect(screen.getByText('Confirm your password')).toBeInTheDocument();
+    expect(screen.getByLabelText('Current password')).toBeInTheDocument();
   });
 
-  it('displays QR code after setup data loads', async () => {
+  it('calls setup2FA with the password and displays QR code after confirmation', async () => {
     const { authApi } = await import('@/lib/auth');
     vi.mocked(authApi.setup2FA).mockResolvedValue(mockSetupData);
 
     render(<TwoFactorSetup onComplete={onComplete} />);
+    await submitPasswordStep('my-password');
 
     await waitFor(() => {
       expect(screen.getByAltText('2FA QR Code')).toBeInTheDocument();
     });
-
+    expect(authApi.setup2FA).toHaveBeenCalledWith('my-password');
     const qrImage = screen.getByAltText('2FA QR Code') as HTMLImageElement;
     expect(qrImage.src).toBe(mockSetupData.qrCodeDataUrl);
   });
 
-  it('shows error state when setup fails', async () => {
+  it('shows error toast and stays on password step when password is wrong', async () => {
     const { authApi } = await import('@/lib/auth');
     vi.mocked(authApi.setup2FA).mockRejectedValue({
-      response: { data: { message: 'Setup failed' } },
+      response: { data: { message: 'Current password is incorrect' } },
     });
 
     render(<TwoFactorSetup onComplete={onComplete} />);
+    await submitPasswordStep('wrong');
 
     await waitFor(() => {
-      expect(screen.getByText('Failed to load 2FA setup. Please try again.')).toBeInTheDocument();
+      expect(toast.error).toHaveBeenCalledWith('Current password is incorrect');
     });
+    expect(screen.getByText('Confirm your password')).toBeInTheDocument();
+    expect(screen.queryByAltText('2FA QR Code')).not.toBeInTheDocument();
   });
 
   it('toggles manual key display when clicked', async () => {
@@ -67,6 +74,7 @@ describe('TwoFactorSetup', () => {
     vi.mocked(authApi.setup2FA).mockResolvedValue(mockSetupData);
 
     render(<TwoFactorSetup onComplete={onComplete} />);
+    await submitPasswordStep();
 
     await waitFor(() => {
       expect(screen.getByText("Can't scan? Enter key manually")).toBeInTheDocument();
@@ -85,6 +93,7 @@ describe('TwoFactorSetup', () => {
     vi.mocked(authApi.setup2FA).mockResolvedValue(mockSetupData);
 
     render(<TwoFactorSetup onComplete={onComplete} />);
+    await submitPasswordStep();
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText('000000')).toBeInTheDocument();
@@ -104,6 +113,7 @@ describe('TwoFactorSetup', () => {
     });
 
     render(<TwoFactorSetup onComplete={onComplete} />);
+    await submitPasswordStep();
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText('000000')).toBeInTheDocument();
@@ -143,6 +153,7 @@ describe('TwoFactorSetup', () => {
     });
 
     render(<TwoFactorSetup onComplete={onComplete} />);
+    await submitPasswordStep();
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText('000000')).toBeInTheDocument();
@@ -166,6 +177,7 @@ describe('TwoFactorSetup', () => {
     });
 
     render(<TwoFactorSetup onComplete={onComplete} />);
+    await submitPasswordStep();
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText('000000')).toBeInTheDocument();
@@ -180,16 +192,10 @@ describe('TwoFactorSetup', () => {
     });
   });
 
-  it('shows skip button when onSkip is provided and not forced', async () => {
-    const { authApi } = await import('@/lib/auth');
-    vi.mocked(authApi.setup2FA).mockResolvedValue(mockSetupData);
-
+  it('shows skip button on password step when onSkip is provided and not forced', async () => {
     render(<TwoFactorSetup onComplete={onComplete} onSkip={onSkip} isForced={false} />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Skip for now')).toBeInTheDocument();
-    });
-
+    expect(screen.getByText('Skip for now')).toBeInTheDocument();
     fireEvent.click(screen.getByText('Skip for now'));
     expect(onSkip).toHaveBeenCalled();
   });
@@ -199,6 +205,7 @@ describe('TwoFactorSetup', () => {
     vi.mocked(authApi.setup2FA).mockResolvedValue(mockSetupData);
 
     render(<TwoFactorSetup onComplete={onComplete} onSkip={onSkip} isForced={true} />);
+    await submitPasswordStep();
 
     await waitFor(() => {
       expect(screen.getByText('Verify and Enable')).toBeInTheDocument();

--- a/frontend/src/components/auth/TwoFactorSetup.tsx
+++ b/frontend/src/components/auth/TwoFactorSetup.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import '@/lib/zodConfig';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -19,6 +19,12 @@ const totpCodeSchema = z.object({
 
 type TotpCodeFormData = z.infer<typeof totpCodeSchema>;
 
+const passwordSchema = z.object({
+  currentPassword: z.string().min(1, 'Password is required').max(128),
+});
+
+type PasswordFormData = z.infer<typeof passwordSchema>;
+
 interface TwoFactorSetupProps {
   onComplete: () => void;
   onSkip?: () => void;
@@ -27,7 +33,6 @@ interface TwoFactorSetupProps {
 
 export function TwoFactorSetup({ onComplete, onSkip, isForced }: TwoFactorSetupProps) {
   const [setupData, setSetupData] = useState<TwoFactorSetupResponse | null>(null);
-  const [isSettingUp, setIsSettingUp] = useState(true);
   const [showManualKey, setShowManualKey] = useState(false);
   const [backupCodes, setBackupCodes] = useState<string[] | null>(null);
 
@@ -47,19 +52,23 @@ export function TwoFactorSetup({ onComplete, onSkip, isForced }: TwoFactorSetupP
   const codeValue = watch('code');
   const codeRef = register('code');
 
-  useEffect(() => {
-    const initSetup = async () => {
-      try {
-        const data = await authApi.setup2FA();
-        setSetupData(data);
-      } catch (error) {
-        toast.error(getErrorMessage(error, 'Failed to initialize 2FA setup'));
-      } finally {
-        setIsSettingUp(false);
-      }
-    };
-    initSetup();
-  }, []);
+  const {
+    register: registerPassword,
+    handleSubmit: handlePasswordSubmit,
+    formState: { errors: passwordErrors, isSubmitting: isPasswordSubmitting },
+  } = useForm<PasswordFormData>({
+    resolver: zodResolver(passwordSchema),
+    defaultValues: { currentPassword: '' },
+  });
+
+  const onPasswordSubmit = async (data: PasswordFormData) => {
+    try {
+      const setup = await authApi.setup2FA(data.currentPassword);
+      setSetupData(setup);
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Current password is incorrect'));
+    }
+  };
 
   const onSubmit = async (formData: TotpCodeFormData) => {
     try {
@@ -83,19 +92,46 @@ export function TwoFactorSetup({ onComplete, onSkip, isForced }: TwoFactorSetupP
     return <BackupCodesDisplay codes={backupCodes} onDone={onComplete} />;
   }
 
-  if (isSettingUp) {
-    return (
-      <div className="flex justify-center py-8">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-      </div>
-    );
-  }
-
   if (!setupData) {
     return (
-      <div className="text-center py-4">
-        <p className="text-red-600 dark:text-red-400">Failed to load 2FA setup. Please try again.</p>
-      </div>
+      <form onSubmit={handlePasswordSubmit(onPasswordSubmit)} className="space-y-4">
+        <div className="text-center">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            Confirm your password
+          </h3>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            Re-enter your current password to start two-factor authentication setup.
+          </p>
+        </div>
+
+        <Input
+          label="Current password"
+          type="password"
+          autoComplete="current-password"
+          error={passwordErrors.currentPassword?.message}
+          {...registerPassword('currentPassword')}
+        />
+
+        <Button
+          type="submit"
+          variant="primary"
+          size="lg"
+          isLoading={isPasswordSubmitting}
+          className="w-full"
+        >
+          Continue
+        </Button>
+
+        {onSkip && !isForced && (
+          <button
+            type="button"
+            onClick={onSkip}
+            className="w-full text-center text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+          >
+            Skip for now
+          </button>
+        )}
+      </form>
     );
   }
 

--- a/frontend/src/lib/auth.test.ts
+++ b/frontend/src/lib/auth.test.ts
@@ -66,10 +66,10 @@ describe('authApi', () => {
     });
   });
 
-  it('setup2FA posts to /auth/2fa/setup', async () => {
+  it('setup2FA posts to /auth/2fa/setup with current password', async () => {
     vi.mocked(apiClient.post).mockResolvedValue({ data: { qrCodeDataUrl: 'data:image' } });
-    const result = await authApi.setup2FA();
-    expect(apiClient.post).toHaveBeenCalledWith('/auth/2fa/setup');
+    const result = await authApi.setup2FA('correct-password');
+    expect(apiClient.post).toHaveBeenCalledWith('/auth/2fa/setup', { currentPassword: 'correct-password' });
     expect(result.qrCodeDataUrl).toBeDefined();
   });
 

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -55,8 +55,8 @@ export const authApi = {
     return response.data;
   },
 
-  setup2FA: async (): Promise<TwoFactorSetupResponse> => {
-    const response = await apiClient.post<TwoFactorSetupResponse>('/auth/2fa/setup');
+  setup2FA: async (currentPassword: string): Promise<TwoFactorSetupResponse> => {
+    const response = await apiClient.post<TwoFactorSetupResponse>('/auth/2fa/setup', { currentPassword });
     return response.data;
   },
 


### PR DESCRIPTION
## Summary
This PR adds a password verification step to the two-factor authentication setup flow as a security measure. Before generating and displaying a new TOTP secret, users must re-enter their current password to prevent session hijackers from force-enrolling their own authenticator.

## Key Changes

**Frontend:**
- Modified `TwoFactorSetup` component to display a password confirmation form before showing the QR code
- Added `passwordSchema` validation using Zod for the password input
- Removed automatic setup initialization on mount; now triggered after password verification
- Updated tests to include password submission step in all relevant test cases
- Updated `authApi.setup2FA()` to accept and send the current password to the backend

**Backend:**
- Added `Setup2faInitDto` to validate the current password in the request body
- Modified `setup2FA()` endpoint to require password verification via `@Body() dto: Setup2faInitDto`
- Added password validation in `TwoFactorService.setup2FA()` using bcrypt comparison
- Returns `UnauthorizedException` if the password doesn't match
- Added rate limiting (`@Throttle`) to the setup endpoint (5 requests per 15 minutes)
- Updated OIDC service to extract and return `amr` (Authentication Methods References) and `acr` (Authentication Context Class Reference) claims
- Added OIDC MFA validation in auth controller to enforce FORCE_2FA requirement for OIDC users

**Additional Security Improvements:**
- Added `IsSafeProviderBaseUrl` validator for AI provider configuration to prevent SSRF attacks
- Validator dispatches on provider type: cloud providers get strict checks while self-hosted providers allow private/local URLs
- Updated test suites to mock password verification and validate the new flow

## Implementation Details
- Password verification happens before TOTP secret generation, preventing unauthorized 2FA enrollment
- The password is sent in the request body (not as a URL parameter) for security
- Rate limiting prevents brute force attempts on the setup endpoint
- OIDC users with FORCE_2FA enabled must have their identity provider assert MFA via standard claims

https://claude.ai/code/session_01LNiebCCvNbgCarGLcTJvvC