### PR TITLE
Fix future-dated transactions when submitting late in negative-UTC zones

### DIFF
--- a/backend/src/accounts/accounts.service.ts
+++ b/backend/src/accounts/accounts.service.ts
@@ -208,7 +208,9 @@ export class AccountsService {
     // Batch check deletability: count transactions + investment transactions per account in 2 queries
     const accountIds = accounts.map((a) => a.id);
 
-    const [txCounts, invTxCounts, futureSums] = await Promise.all([
+    const today = todayYMD();
+
+    const [txCounts, invTxCounts, futureSums, currentSums] = await Promise.all([
       this.transactionRepository
         .createQueryBuilder("t")
         .select("t.accountId", "accountId")
@@ -232,8 +234,26 @@ export class AccountsService {
            AND (t.status IS NULL OR t.status != 'VOID')
            AND t.parent_transaction_id IS NULL
          GROUP BY t.account_id`,
-        [accountIds, todayYMD()],
+        [accountIds, today],
       ) as Promise<Array<{ accountId: string; futureSum: string }>>,
+      // Compute currentBalance live rather than trusting the stored column.
+      // The stored value can lag the TZ-aware definition of "today" (e.g.
+      // after a timezone change, or after a future-dated create that ran
+      // under the old server-UTC logic), and if it does, adding it to the
+      // live futureTransactionsSum below would double-count any transactions
+      // that wandered across the boundary.
+      this.dataSource.query(
+        `SELECT a.id as "accountId",
+                COALESCE(a.opening_balance, 0) + COALESCE(SUM(t.amount), 0) as "currentBalance"
+         FROM accounts a
+         LEFT JOIN transactions t ON t.account_id = a.id
+           AND (t.status IS NULL OR t.status != 'VOID')
+           AND t.parent_transaction_id IS NULL
+           AND t.transaction_date <= $2
+         WHERE a.id = ANY($1)
+         GROUP BY a.id, a.opening_balance`,
+        [accountIds, today],
+      ) as Promise<Array<{ accountId: string; currentBalance: string }>>,
     ]);
 
     const txCountMap = new Map<string, number>();
@@ -248,9 +268,16 @@ export class AccountsService {
         row.accountId,
         Math.round(Number(row.futureSum) * 10000) / 10000,
       );
+    const currentBalanceMap = new Map<string, number>();
+    for (const row of currentSums)
+      currentBalanceMap.set(
+        row.accountId,
+        Math.round(Number(row.currentBalance) * 10000) / 10000,
+      );
 
     return accounts.map((account) => ({
       ...account,
+      currentBalance: currentBalanceMap.get(account.id) ?? account.currentBalance,
       canDelete:
         !(txCountMap.get(account.id) || 0) &&
         !(invTxCountMap.get(account.id) || 0),

--- a/backend/src/accounts/accounts.service.ts
+++ b/backend/src/accounts/accounts.service.ts
@@ -793,6 +793,31 @@ export class AccountsService {
   }
 
   /**
+   * Projected balance: opening balance plus every non-void, non-child
+   * transaction regardless of date. Derived live from raw transactions so
+   * the result does not depend on the stored `account.currentBalance`
+   * column, which can lag the TZ-aware "today" after a timezone change or
+   * a future-dated create that ran under the old server-UTC logic.
+   */
+  async getProjectedBalance(
+    userId: string,
+    accountId: string,
+  ): Promise<number> {
+    const result: { balance: string }[] = await this.dataSource.query(
+      `SELECT COALESCE(a.opening_balance, 0) + COALESCE(SUM(t.amount), 0) AS balance
+         FROM accounts a
+         LEFT JOIN transactions t ON t.account_id = a.id
+           AND t.user_id = $2
+           AND (t.status IS NULL OR t.status != 'VOID')
+           AND t.parent_transaction_id IS NULL
+        WHERE a.id = $1 AND a.user_id = $2
+        GROUP BY a.id, a.opening_balance`,
+      [accountId, userId],
+    );
+    return Math.round(Number(result?.[0]?.balance ?? 0) * 10000) / 10000;
+  }
+
+  /**
    * Get account summary statistics for a user
    */
   async getSummary(userId: string): Promise<{

--- a/backend/src/accounts/accounts.service.ts
+++ b/backend/src/accounts/accounts.service.ts
@@ -228,11 +228,11 @@ export class AccountsService {
                 COALESCE(SUM(t.amount), 0) as "futureSum"
          FROM transactions t
          WHERE t.account_id = ANY($1)
-           AND t.transaction_date > CURRENT_DATE
+           AND t.transaction_date > $2
            AND (t.status IS NULL OR t.status != 'VOID')
            AND t.parent_transaction_id IS NULL
          GROUP BY t.account_id`,
-        [accountIds],
+        [accountIds, todayYMD()],
       ) as Promise<Array<{ accountId: string; futureSum: string }>>,
     ]);
 
@@ -733,13 +733,19 @@ export class AccountsService {
        WHERE t.account_id = $1
          AND (t.status IS NULL OR t.status != 'VOID')
          AND t.parent_transaction_id IS NULL
-         AND t.transaction_date <= CURRENT_DATE`;
+         AND t.transaction_date <= $3`;
 
+    const today = todayYMD();
     const result: { balance: string }[] = queryRunner
-      ? await queryRunner.query(balanceSql, [accountId, account.openingBalance])
+      ? await queryRunner.query(balanceSql, [
+          accountId,
+          account.openingBalance,
+          today,
+        ])
       : await this.dataSource.query(balanceSql, [
           accountId,
           account.openingBalance,
+          today,
         ]);
 
     const newBalance =

--- a/backend/src/accounts/accounts.service.ts
+++ b/backend/src/accounts/accounts.service.ts
@@ -28,7 +28,7 @@ import {
   MortgageAmortizationResult,
 } from "./mortgage-amortization.util";
 import { Cron } from "@nestjs/schedule";
-import { formatDateYMD, todayYMD } from "../common/date-utils";
+import { formatDateYMD, todayInTimezone, todayYMD } from "../common/date-utils";
 import { ActionHistoryService } from "../action-history/action-history.service";
 
 @Injectable()
@@ -1125,57 +1125,97 @@ export class AccountsService {
   }
 
   /**
-   * Daily cron job to apply balance effects for transactions whose dates
-   * have become due. Recalculates currentBalance from source of truth
-   * for any account that has transactions dated today.
+   * Hourly cron that rolls deferred balance effects into currentBalance as
+   * transactions become due. "Due" is evaluated per-user in their local
+   * timezone: an EDT user's midnight is 04:00 UTC, so we re-check every
+   * hour and process each timezone as its local day rolls over.
+   *
+   * Running hourly (and re-applying if a user has already been processed
+   * that day) is idempotent because recalculation derives currentBalance
+   * from scratch against transaction_date <= local_today.
    */
-  @Cron("0 0 * * *")
+  @Cron("0 * * * *")
   async applyDueTransactionBalances(): Promise<void> {
-    this.logger.log("Running daily deferred transaction balance application");
-
     try {
-      // Find all accounts that have non-void transactions dated today
-      const accountRows: { account_id: string }[] = await this.dataSource.query(
-        `SELECT DISTINCT account_id
-           FROM transactions
-           WHERE transaction_date::DATE = CURRENT_DATE
-             AND (status IS NULL OR status != 'VOID')
-             AND parent_transaction_id IS NULL`,
-      );
-
-      if (accountRows.length === 0) {
-        this.logger.log("No accounts with transactions due today");
-        return;
-      }
-
-      const accountIds = accountRows.map((r) => r.account_id);
-      const balances: { account_id: string; balance: string }[] =
+      // Group users by their effective timezone. LEFT JOIN keeps users
+      // without a preferences row -- they fall back to UTC.
+      const userRows: { user_id: string; timezone: string | null }[] =
         await this.dataSource.query(
-          `SELECT a.id as account_id,
-                  COALESCE(a.opening_balance, 0) + COALESCE(SUM(t.amount), 0) as balance
-           FROM accounts a
-           LEFT JOIN transactions t ON t.account_id = a.id
-             AND (t.status IS NULL OR t.status != 'VOID')
-             AND t.parent_transaction_id IS NULL
-             AND t.transaction_date <= CURRENT_DATE
-           WHERE a.id = ANY($1)
-           GROUP BY a.id, a.opening_balance`,
-          [accountIds],
+          `SELECT u.id as user_id, p.timezone
+             FROM users u
+             LEFT JOIN user_preferences p ON p.user_id = u.id`,
         );
 
-      for (const row of balances) {
-        const newBalance = Math.round(Number(row.balance) * 10000) / 10000;
-        await this.accountsRepository.update(row.account_id, {
-          currentBalance: newBalance,
-        });
+      if (userRows.length === 0) return;
+
+      const userIdsByTz = new Map<string, string[]>();
+      for (const { user_id, timezone } of userRows) {
+        const normalised = timezone?.trim();
+        const tz =
+          normalised && normalised !== "browser" ? normalised : "UTC";
+        const list = userIdsByTz.get(tz) ?? [];
+        list.push(user_id);
+        userIdsByTz.set(tz, list);
       }
 
-      this.logger.log(
-        `Applied deferred balances for ${accountRows.length} account(s)`,
-      );
+      let totalApplied = 0;
+
+      for (const [tz, userIds] of userIdsByTz) {
+        const today = todayInTimezone(tz);
+        if (!today) {
+          this.logger.warn(
+            `Skipping ${userIds.length} user(s) with invalid timezone "${tz}"`,
+          );
+          continue;
+        }
+
+        const accountRows: { account_id: string }[] =
+          await this.dataSource.query(
+            `SELECT DISTINCT t.account_id
+               FROM transactions t
+               JOIN accounts a ON a.id = t.account_id
+               WHERE a.user_id = ANY($1)
+                 AND t.transaction_date = $2
+                 AND (t.status IS NULL OR t.status != 'VOID')
+                 AND t.parent_transaction_id IS NULL`,
+            [userIds, today],
+          );
+
+        if (accountRows.length === 0) continue;
+
+        const accountIds = accountRows.map((r) => r.account_id);
+        const balances: { account_id: string; balance: string }[] =
+          await this.dataSource.query(
+            `SELECT a.id as account_id,
+                    COALESCE(a.opening_balance, 0) + COALESCE(SUM(t.amount), 0) as balance
+               FROM accounts a
+               LEFT JOIN transactions t ON t.account_id = a.id
+                 AND (t.status IS NULL OR t.status != 'VOID')
+                 AND t.parent_transaction_id IS NULL
+                 AND t.transaction_date <= $2
+               WHERE a.id = ANY($1)
+               GROUP BY a.id, a.opening_balance`,
+            [accountIds, today],
+          );
+
+        for (const row of balances) {
+          const newBalance = Math.round(Number(row.balance) * 10000) / 10000;
+          await this.accountsRepository.update(row.account_id, {
+            currentBalance: newBalance,
+          });
+        }
+
+        totalApplied += balances.length;
+      }
+
+      if (totalApplied > 0) {
+        this.logger.log(
+          `Applied deferred balances for ${totalApplied} account(s)`,
+        );
+      }
     } catch (error) {
       this.logger.error(
-        `Failed to apply deferred transaction balances: ${error.message}`,
+        `Failed to apply deferred transaction balances: ${(error as Error).message}`,
       );
     }
   }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -16,7 +16,9 @@ import { DemoModeGuard } from "./common/guards/demo-mode.guard";
 import { MustChangePasswordGuard } from "./auth/guards/must-change-password.guard";
 import { PatScopeGuard } from "./auth/guards/pat-scope.guard";
 import { CsrfRefreshInterceptor } from "./common/interceptors/csrf-refresh.interceptor";
+import { RequestContextInterceptor } from "./common/interceptors/request-context.interceptor";
 import { DemoModeModule } from "./common/demo-mode.module";
+import { UserPreference } from "./users/entities/user-preference.entity";
 
 import { AuthModule } from "./auth/auth.module";
 import { UsersModule } from "./users/users.module";
@@ -91,6 +93,10 @@ import { UpdatesModule } from "./updates/updates.module";
     // Demo mode (global — available to all modules)
     DemoModeModule,
 
+    // UserPreference repo for RequestContextInterceptor (resolves the
+    // authenticated user's timezone on every request).
+    TypeOrmModule.forFeature([UserPreference]),
+
     // Feature modules
     HealthModule,
     AuthModule,
@@ -124,6 +130,7 @@ import { UpdatesModule } from "./updates/updates.module";
     { provide: APP_GUARD, useClass: MustChangePasswordGuard },
     { provide: APP_GUARD, useClass: PatScopeGuard },
     { provide: APP_GUARD, useClass: DemoModeGuard },
+    { provide: APP_INTERCEPTOR, useClass: RequestContextInterceptor },
     { provide: APP_INTERCEPTOR, useClass: CsrfRefreshInterceptor },
     {
       provide: APP_INTERCEPTOR,

--- a/backend/src/common/date-utils.ts
+++ b/backend/src/common/date-utils.ts
@@ -1,3 +1,5 @@
+import { getRequestTimezone } from "./request-context";
+
 /**
  * Format a Date object as YYYY-MM-DD string using UTC components.
  * Replaces the common `date.toISOString().split("T")[0]` pattern.
@@ -13,11 +15,39 @@ export function formatDateYMD(date: Date): string {
 }
 
 /**
- * Return today's date as a YYYY-MM-DD string (local time).
- * Uses local date components because "today" is relative to the
- * server's local timezone, not UTC.
+ * Compute today's date as YYYY-MM-DD in the given IANA timezone.
+ * Returns null if the timezone is invalid.
+ */
+export function todayInTimezone(timezone: string): string | null {
+  try {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(new Date());
+    const y = parts.find((p) => p.type === "year")?.value;
+    const m = parts.find((p) => p.type === "month")?.value;
+    const d = parts.find((p) => p.type === "day")?.value;
+    if (!y || !m || !d) return null;
+    return `${y}-${m}-${d}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return today's date as a YYYY-MM-DD string.
+ * If a request-scoped timezone is set (via RequestContextInterceptor),
+ * returns today in that timezone. Otherwise falls back to the server's
+ * local date.
  */
 export function todayYMD(): string {
+  const tz = getRequestTimezone();
+  if (tz) {
+    const inTz = todayInTimezone(tz);
+    if (inTz) return inTz;
+  }
   const now = new Date();
   const y = now.getFullYear();
   const m = String(now.getMonth() + 1).padStart(2, "0");

--- a/backend/src/common/interceptors/request-context.interceptor.ts
+++ b/backend/src/common/interceptors/request-context.interceptor.ts
@@ -1,0 +1,85 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Observable, from, switchMap } from "rxjs";
+import { Repository } from "typeorm";
+import { Request } from "express";
+import { UserPreference } from "../../users/entities/user-preference.entity";
+import { requestContextStorage } from "../request-context";
+
+/**
+ * Populates the request-scoped RequestContext with the authenticated user's
+ * effective timezone so server-side "today" calculations respect the user's
+ * local date, not the server's.
+ *
+ * Resolution order:
+ *   1. user_preferences.timezone, if it is a real IANA name (anything other
+ *      than the sentinel "browser" or blank).
+ *   2. X-Client-Timezone header (sent by the frontend axios interceptor).
+ *   3. Unset -- downstream code falls back to the server's local date.
+ *
+ * The context is entered around next.handle() so all async work kicked off
+ * by the controller inherits the ALS scope.
+ */
+@Injectable()
+export class RequestContextInterceptor implements NestInterceptor {
+  constructor(
+    @InjectRepository(UserPreference)
+    private readonly preferencesRepository: Repository<UserPreference>,
+  ) {}
+
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<unknown> | Promise<Observable<unknown>> {
+    if (context.getType() !== "http") {
+      return next.handle();
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const userId: string | undefined = (
+      request as unknown as { user?: { id?: string } }
+    ).user?.id;
+
+    const rawHeader = request.headers["x-client-timezone"];
+    const headerTz =
+      typeof rawHeader === "string" && rawHeader.trim().length > 0
+        ? rawHeader.trim()
+        : undefined;
+
+    return from(this.resolveTimezone(userId, headerTz)).pipe(
+      switchMap(
+        (timezone) =>
+          new Observable<unknown>((subscriber) => {
+            requestContextStorage.run({ userId, timezone }, () => {
+              next.handle().subscribe({
+                next: (value) => subscriber.next(value),
+                error: (err) => subscriber.error(err),
+                complete: () => subscriber.complete(),
+              });
+            });
+          }),
+      ),
+    );
+  }
+
+  private async resolveTimezone(
+    userId: string | undefined,
+    headerTz: string | undefined,
+  ): Promise<string | undefined> {
+    if (userId) {
+      const pref = await this.preferencesRepository.findOne({
+        where: { userId },
+      });
+      const stored = pref?.timezone?.trim();
+      if (stored && stored !== "browser") {
+        return stored;
+      }
+    }
+    return headerTz;
+  }
+}

--- a/backend/src/common/request-context.ts
+++ b/backend/src/common/request-context.ts
@@ -1,0 +1,16 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface RequestContext {
+  userId?: string;
+  timezone?: string;
+}
+
+export const requestContextStorage = new AsyncLocalStorage<RequestContext>();
+
+export function getRequestContext(): RequestContext | undefined {
+  return requestContextStorage.getStore();
+}
+
+export function getRequestTimezone(): string | undefined {
+  return requestContextStorage.getStore()?.timezone;
+}

--- a/backend/src/transactions/transactions.service.spec.ts
+++ b/backend/src/transactions/transactions.service.spec.ts
@@ -96,6 +96,7 @@ describe("TransactionsService", () => {
       findOne: jest.fn().mockResolvedValue(mockAccount),
       updateBalance: jest.fn().mockResolvedValue(mockAccount),
       recalculateCurrentBalance: jest.fn().mockResolvedValue(mockAccount),
+      getProjectedBalance: jest.fn().mockResolvedValue(0),
     };
 
     payeesService = {
@@ -1445,6 +1446,7 @@ describe("TransactionsService", () => {
         ...mockAccount,
         currentBalance: 950,
       });
+      accountsService.getProjectedBalance.mockResolvedValue(950);
 
       const result = await service.findAll("user-1", ["account-1"]);
 
@@ -1476,6 +1478,7 @@ describe("TransactionsService", () => {
         ...mockAccount,
         currentBalance: 13000,
       });
+      accountsService.getProjectedBalance.mockResolvedValue(3000);
 
       const result = await service.findAll("user-1", ["account-1"]);
 
@@ -1519,6 +1522,7 @@ describe("TransactionsService", () => {
         ...mockAccount,
         currentBalance: 800,
       });
+      accountsService.getProjectedBalance.mockResolvedValue(800);
 
       const result = await service.findAll(
         "user-1",
@@ -2387,6 +2391,7 @@ describe("TransactionsService", () => {
           ...mockAccount,
           currentBalance: 1000,
         });
+        accountsService.getProjectedBalance.mockResolvedValue(1000);
 
         const result = await service.findAll(
           "user-1",
@@ -2417,6 +2422,7 @@ describe("TransactionsService", () => {
           ...mockAccount,
           currentBalance: 1000,
         });
+        accountsService.getProjectedBalance.mockResolvedValue(1000);
 
         const result = await service.findAll(
           "user-1",
@@ -2448,6 +2454,7 @@ describe("TransactionsService", () => {
           ...mockAccount,
           currentBalance: 1000,
         });
+        accountsService.getProjectedBalance.mockResolvedValue(1500);
 
         const result = await service.findAll(
           "user-1",
@@ -2491,6 +2498,7 @@ describe("TransactionsService", () => {
           ...mockAccount,
           currentBalance: 1000,
         });
+        accountsService.getProjectedBalance.mockResolvedValue(1000);
 
         const result = await service.findAll(
           "user-1",
@@ -2536,6 +2544,7 @@ describe("TransactionsService", () => {
           ...mockAccount,
           currentBalance: 1000,
         });
+        accountsService.getProjectedBalance.mockResolvedValue(1000);
 
         await service.findAll(
           "user-1",
@@ -2583,6 +2592,7 @@ describe("TransactionsService", () => {
           ...mockAccount,
           currentBalance: 1000,
         });
+        accountsService.getProjectedBalance.mockResolvedValue(1000);
 
         const result = await service.findAll(
           "user-1",
@@ -2634,6 +2644,7 @@ describe("TransactionsService", () => {
           ...mockAccount,
           currentBalance: 1000,
         });
+        accountsService.getProjectedBalance.mockResolvedValue(1000);
 
         const result = await service.findAll("user-1", ["account-1"]);
 
@@ -2656,6 +2667,7 @@ describe("TransactionsService", () => {
           ...mockAccount,
           currentBalance: 8000,
         });
+        accountsService.getProjectedBalance.mockResolvedValue(3000);
 
         const result = await service.findAll("user-1", ["account-1"]);
 
@@ -2687,6 +2699,7 @@ describe("TransactionsService", () => {
           ...mockAccount,
           currentBalance: 2000,
         });
+        accountsService.getProjectedBalance.mockResolvedValue(2000);
 
         const result = await service.findAll(
           "user-1",

--- a/backend/src/transactions/transactions.service.spec.ts
+++ b/backend/src/transactions/transactions.service.spec.ts
@@ -22,6 +22,7 @@ import { isTransactionInFuture } from "../common/date-utils";
 
 jest.mock("../common/date-utils", () => ({
   isTransactionInFuture: jest.fn().mockReturnValue(false),
+  todayYMD: jest.fn().mockReturnValue("2026-01-01"),
 }));
 
 const mockedIsTransactionInFuture =

--- a/backend/src/transactions/transactions.service.spec.ts
+++ b/backend/src/transactions/transactions.service.spec.ts
@@ -1500,11 +1500,8 @@ describe("TransactionsService", () => {
       };
       const mockQb = createMockQueryBuilder();
       mockQb.getManyAndCount.mockResolvedValue([[mockTx], 51]);
-      // Future sum query (no future transactions)
-      const futureQb = createMockQueryBuilder();
-      futureQb.getRawOne.mockResolvedValue({ sum: 0 });
       // For the sum of previous pages queries:
-      // 1st = main query, 2nd = futureQuery, 3rd = previousPagesQuery, 4th = sumResult query
+      // 1st = main query, 2nd = previousPagesQuery, 3rd = sumResult query
       const sumQb = createMockQueryBuilder({
         setParameters: jest.fn().mockReturnThis(),
       });
@@ -1514,7 +1511,6 @@ describe("TransactionsService", () => {
       previousPagesQb.getParameters.mockReturnValue({ userId: "user-1" });
       transactionsRepository.createQueryBuilder
         .mockReturnValueOnce(mockQb)
-        .mockReturnValueOnce(futureQb)
         .mockReturnValueOnce(previousPagesQb)
         .mockReturnValueOnce(sumQb);
       investmentTxRepository.find.mockResolvedValue([]);
@@ -2373,17 +2369,12 @@ describe("TransactionsService", () => {
         const mockQb = createMockQueryBuilder();
         mockQb.getManyAndCount.mockResolvedValue([[mockTx], 1]);
 
-        // computeProjectedBalance: future sum QB
-        const futureQb = createMockQueryBuilder();
-        futureQb.getRawOne.mockResolvedValue({ sum: 0 });
-
         // sumAfterEndDate QB
         const sumAfterQb = createMockQueryBuilder();
         sumAfterQb.getRawOne.mockResolvedValue({ sum: -300 });
 
         transactionsRepository.createQueryBuilder
           .mockReturnValueOnce(mockQb)
-          .mockReturnValueOnce(futureQb)
           .mockReturnValueOnce(sumAfterQb);
 
         investmentTxRepository.find.mockResolvedValue([]);
@@ -2409,13 +2400,7 @@ describe("TransactionsService", () => {
         const mockQb = createMockQueryBuilder();
         mockQb.getManyAndCount.mockResolvedValue([[mockTx], 1]);
 
-        // computeProjectedBalance: future sum QB
-        const futureQb = createMockQueryBuilder();
-        futureQb.getRawOne.mockResolvedValue({ sum: 0 });
-
-        transactionsRepository.createQueryBuilder
-          .mockReturnValueOnce(mockQb)
-          .mockReturnValueOnce(futureQb);
+        transactionsRepository.createQueryBuilder.mockReturnValueOnce(mockQb);
 
         investmentTxRepository.find.mockResolvedValue([]);
         accountsService.findOne.mockResolvedValue({
@@ -2438,15 +2423,11 @@ describe("TransactionsService", () => {
         const mockQb = createMockQueryBuilder();
         mockQb.getManyAndCount.mockResolvedValue([[mockTx], 1]);
 
-        const futureQb = createMockQueryBuilder();
-        futureQb.getRawOne.mockResolvedValue({ sum: 500 });
-
         const sumAfterQb = createMockQueryBuilder();
         sumAfterQb.getRawOne.mockResolvedValue({ sum: 200 });
 
         transactionsRepository.createQueryBuilder
           .mockReturnValueOnce(mockQb)
-          .mockReturnValueOnce(futureQb)
           .mockReturnValueOnce(sumAfterQb);
 
         investmentTxRepository.find.mockResolvedValue([]);
@@ -2472,9 +2453,6 @@ describe("TransactionsService", () => {
         const mockQb = createMockQueryBuilder();
         mockQb.getManyAndCount.mockResolvedValue([[mockTx], 100]);
 
-        const futureQb = createMockQueryBuilder();
-        futureQb.getRawOne.mockResolvedValue({ sum: 0 });
-
         const sumAfterQb = createMockQueryBuilder();
         sumAfterQb.getRawOne.mockResolvedValue({ sum: -300 });
 
@@ -2488,7 +2466,6 @@ describe("TransactionsService", () => {
 
         transactionsRepository.createQueryBuilder
           .mockReturnValueOnce(mockQb)
-          .mockReturnValueOnce(futureQb)
           .mockReturnValueOnce(sumAfterQb)
           .mockReturnValueOnce(prevPagesQb)
           .mockReturnValueOnce(sumQb);
@@ -2520,9 +2497,6 @@ describe("TransactionsService", () => {
         const mockQb = createMockQueryBuilder();
         mockQb.getManyAndCount.mockResolvedValue([[mockTx], 100]);
 
-        const futureQb = createMockQueryBuilder();
-        futureQb.getRawOne.mockResolvedValue({ sum: 0 });
-
         const sumAfterQb = createMockQueryBuilder();
         sumAfterQb.getRawOne.mockResolvedValue({ sum: 0 });
 
@@ -2534,7 +2508,6 @@ describe("TransactionsService", () => {
 
         transactionsRepository.createQueryBuilder
           .mockReturnValueOnce(mockQb)
-          .mockReturnValueOnce(futureQb)
           .mockReturnValueOnce(sumAfterQb)
           .mockReturnValueOnce(prevPagesQb)
           .mockReturnValueOnce(sumQb);
@@ -2572,9 +2545,6 @@ describe("TransactionsService", () => {
         const mockQb = createMockQueryBuilder();
         mockQb.getManyAndCount.mockResolvedValue([[mockTx], 100]);
 
-        const futureQb = createMockQueryBuilder();
-        futureQb.getRawOne.mockResolvedValue({ sum: 0 });
-
         const prevPagesQb = createMockQueryBuilder();
         const sumQb = createMockQueryBuilder({
           setParameters: jest.fn().mockReturnThis(),
@@ -2583,7 +2553,6 @@ describe("TransactionsService", () => {
 
         transactionsRepository.createQueryBuilder
           .mockReturnValueOnce(mockQb)
-          .mockReturnValueOnce(futureQb)
           .mockReturnValueOnce(prevPagesQb)
           .mockReturnValueOnce(sumQb);
 
@@ -2679,9 +2648,6 @@ describe("TransactionsService", () => {
         const mockQb = createMockQueryBuilder();
         mockQb.getManyAndCount.mockResolvedValue([[mockTx], 100]);
 
-        const futureQb = createMockQueryBuilder();
-        futureQb.getRawOne.mockResolvedValue({ sum: 0 });
-
         const prevPagesQb = createMockQueryBuilder();
         const sumQb = createMockQueryBuilder({
           setParameters: jest.fn().mockReturnThis(),
@@ -2690,7 +2656,6 @@ describe("TransactionsService", () => {
 
         transactionsRepository.createQueryBuilder
           .mockReturnValueOnce(mockQb)
-          .mockReturnValueOnce(futureQb)
           .mockReturnValueOnce(prevPagesQb)
           .mockReturnValueOnce(sumQb);
 

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -842,13 +842,21 @@ export class TransactionsService {
     const account = await this.accountsService.findOne(userId, accountId);
     const currentBalance = Number(account.currentBalance) || 0;
 
+    // Filter shape must match AccountsService.findAll's futureTransactionsSum
+    // query so the projected balance here equals the "current + future" figure
+    // shown on the account list. Differences would desync the running balance
+    // in TransactionList (which subtracts each listed row from startingBalance)
+    // from the account totals displayed elsewhere.
     const futureResult = await this.transactionsRepository
       .createQueryBuilder("t")
       .select("COALESCE(SUM(t.amount), 0)", "sum")
       .where("t.userId = :userId", { userId })
       .andWhere("t.accountId = :accountId", { accountId })
       .andWhere("t.transactionDate > :today", { today: todayYMD() })
-      .andWhere("t.status != :void", { void: TransactionStatus.VOID })
+      .andWhere("(t.status IS NULL OR t.status != :void)", {
+        void: TransactionStatus.VOID,
+      })
+      .andWhere("t.parentTransactionId IS NULL")
       .getRawOne();
 
     return currentBalance + (Number(futureResult?.sum) || 0);

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -833,33 +833,33 @@ export class TransactionsService {
   }
 
   /**
-   * Compute projected balance (current balance + future non-void transactions).
+   * Compute the account's projected balance -- opening balance plus every
+   * non-void, non-child transaction, regardless of date.
+   *
+   * Derived from raw transactions rather than `account.currentBalance +
+   * futureTransactionsSum` because the stored `currentBalance` can be out
+   * of step with the TZ-aware "today" after a timezone change or a
+   * future-dated create that ran under the old server-UTC logic (in which
+   * case currentBalance already contains a row that futureTransactionsSum
+   * also counts, double-counting once the two are added). Computing the
+   * full sum sidesteps any disagreement about where "today" sits.
    */
   private async computeProjectedBalance(
     userId: string,
     accountId: string,
   ): Promise<number> {
-    const account = await this.accountsService.findOne(userId, accountId);
-    const currentBalance = Number(account.currentBalance) || 0;
-
-    // Filter shape must match AccountsService.findAll's futureTransactionsSum
-    // query so the projected balance here equals the "current + future" figure
-    // shown on the account list. Differences would desync the running balance
-    // in TransactionList (which subtracts each listed row from startingBalance)
-    // from the account totals displayed elsewhere.
-    const futureResult = await this.transactionsRepository
-      .createQueryBuilder("t")
-      .select("COALESCE(SUM(t.amount), 0)", "sum")
-      .where("t.userId = :userId", { userId })
-      .andWhere("t.accountId = :accountId", { accountId })
-      .andWhere("t.transactionDate > :today", { today: todayYMD() })
-      .andWhere("(t.status IS NULL OR t.status != :void)", {
-        void: TransactionStatus.VOID,
-      })
-      .andWhere("t.parentTransactionId IS NULL")
-      .getRawOne();
-
-    return currentBalance + (Number(futureResult?.sum) || 0);
+    const result: { balance: string }[] = await this.dataSource.query(
+      `SELECT COALESCE(a.opening_balance, 0) + COALESCE(SUM(t.amount), 0) AS balance
+         FROM accounts a
+         LEFT JOIN transactions t ON t.account_id = a.id
+           AND t.user_id = $2
+           AND (t.status IS NULL OR t.status != 'VOID')
+           AND t.parent_transaction_id IS NULL
+        WHERE a.id = $1 AND a.user_id = $2
+        GROUP BY a.id, a.opening_balance`,
+      [accountId, userId],
+    );
+    return Math.round(Number(result?.[0]?.balance ?? 0) * 10000) / 10000;
   }
 
   /**

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -833,33 +833,15 @@ export class TransactionsService {
   }
 
   /**
-   * Compute the account's projected balance -- opening balance plus every
-   * non-void, non-child transaction, regardless of date.
-   *
-   * Derived from raw transactions rather than `account.currentBalance +
-   * futureTransactionsSum` because the stored `currentBalance` can be out
-   * of step with the TZ-aware "today" after a timezone change or a
-   * future-dated create that ran under the old server-UTC logic (in which
-   * case currentBalance already contains a row that futureTransactionsSum
-   * also counts, double-counting once the two are added). Computing the
-   * full sum sidesteps any disagreement about where "today" sits.
+   * Thin delegate to AccountsService.getProjectedBalance -- kept here so the
+   * paging helpers below stay readable. See that method for why balance is
+   * derived live rather than from the stored currentBalance column.
    */
   private async computeProjectedBalance(
     userId: string,
     accountId: string,
   ): Promise<number> {
-    const result: { balance: string }[] = await this.dataSource.query(
-      `SELECT COALESCE(a.opening_balance, 0) + COALESCE(SUM(t.amount), 0) AS balance
-         FROM accounts a
-         LEFT JOIN transactions t ON t.account_id = a.id
-           AND t.user_id = $2
-           AND (t.status IS NULL OR t.status != 'VOID')
-           AND t.parent_transaction_id IS NULL
-        WHERE a.id = $1 AND a.user_id = $2
-        GROUP BY a.id, a.opening_balance`,
-      [accountId, userId],
-    );
-    return Math.round(Number(result?.[0]?.balance ?? 0) * 10000) / 10000;
+    return this.accountsService.getProjectedBalance(userId, accountId);
   }
 
   /**

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -32,7 +32,7 @@ import {
   BulkDeleteResult,
 } from "./transaction-bulk-update.service";
 import { BulkUpdateDto, BulkDeleteDto } from "./dto/bulk-update.dto";
-import { isTransactionInFuture } from "../common/date-utils";
+import { isTransactionInFuture, todayYMD } from "../common/date-utils";
 import { ActionHistoryService } from "../action-history/action-history.service";
 import { getAllCategoryIdsWithChildren } from "../common/category-tree.util";
 
@@ -842,15 +842,12 @@ export class TransactionsService {
     const account = await this.accountsService.findOne(userId, accountId);
     const currentBalance = Number(account.currentBalance) || 0;
 
-    const now = new Date();
-    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
-
     const futureResult = await this.transactionsRepository
       .createQueryBuilder("t")
       .select("COALESCE(SUM(t.amount), 0)", "sum")
       .where("t.userId = :userId", { userId })
       .andWhere("t.accountId = :accountId", { accountId })
-      .andWhere("t.transactionDate > :today", { today })
+      .andWhere("t.transactionDate > :today", { today: todayYMD() })
       .andWhere("t.status != :void", { void: TransactionStatus.VOID })
       .getRawOne();
 

--- a/frontend/src/components/transactions/TransactionList.tsx
+++ b/frontend/src/components/transactions/TransactionList.tsx
@@ -299,8 +299,12 @@ export function TransactionList({
     return map;
   }, [transactions]);
 
-  // Calculate running balances using the backend-provided starting
-  // balance and display amounts (which may be filtered split totals).
+  // Calculate running balances using the backend-provided starting balance
+  // and display amounts (which may be filtered split totals). The row for
+  // each transaction still displays a running balance, but VOID transactions
+  // and split children (parentTransactionId != null) contribute 0 to the
+  // cumulative sum so the math matches the backend's balance calculations
+  // (which exclude both from currentBalance and futureTransactionsSum).
   const runningBalances = useMemo(() => {
     const safeStart = Number(startingBalance);
     if (isNaN(safeStart) || transactions.length === 0) {
@@ -311,10 +315,14 @@ export function TransactionList({
     let cumulativeCents = 0;
 
     for (const tx of transactions) {
-      const raw = displayAmounts.get(tx.id) ?? Number(tx.amount);
-      const amount = isNaN(raw) ? 0 : raw;
       balances.set(tx.id, Math.round((safeStart * 10000) - cumulativeCents) / 10000);
-      cumulativeCents += Math.round(amount * 10000);
+      const affectsBalance =
+        tx.status !== TransactionStatus.VOID && !tx.parentTransactionId;
+      if (affectsBalance) {
+        const raw = displayAmounts.get(tx.id) ?? Number(tx.amount);
+        const amount = isNaN(raw) ? 0 : raw;
+        cumulativeCents += Math.round(amount * 10000);
+      }
     }
 
     return balances;

--- a/frontend/src/components/transactions/TransactionList.tsx
+++ b/frontend/src/components/transactions/TransactionList.tsx
@@ -12,6 +12,7 @@ import { TransactionRow } from './TransactionRow';
 import { TransactionActionSheet } from './TransactionActionSheet';
 import { useDateFormat } from '@/hooks/useDateFormat';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { getLocalDateString } from '@/lib/utils';
 import { DensityLevel, nextDensity } from '@/hooks/useTableDensity';
 
 interface TransactionListProps {
@@ -258,10 +259,13 @@ export function TransactionList({
     }
   }, [onRefresh, onTransactionUpdate]);
 
-  // Find the index where future transactions end and today/past begin
-  // Transactions are sorted DESC by date, so future ones come first
+  // Find the index where future transactions end and today/past begin.
+  // Transactions are sorted DESC by date, so future ones come first.
+  // "Today" is the user's local date -- using toISOString() would return
+  // the UTC date and mis-classify a tomorrow-local-dated transaction as
+  // past for users west of UTC in the late evening.
   const futureBoundaryIndex = useMemo(() => {
-    const today = new Date().toISOString().slice(0, 10);
+    const today = getLocalDateString();
     for (let i = 0; i < transactions.length; i++) {
       if (transactions[i].transactionDate <= today) {
         return i;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -15,12 +15,29 @@ export const apiClient = axios.create({
   withCredentials: true,
 });
 
-// Request interceptor to add CSRF token
+function detectBrowserTimezone(): string | undefined {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Request interceptor to add CSRF token and the browser's timezone so the
+// backend can compute "today" in the user's local timezone rather than the
+// server's (which would misclassify late-evening tomorrow-dated transactions
+// for users west of UTC).
 apiClient.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
     const csrfToken = Cookies.get('csrf_token');
     if (csrfToken && config.headers) {
       config.headers['X-CSRF-Token'] = csrfToken;
+    }
+    if (config.headers && !config.headers['X-Client-Timezone']) {
+      const tz = detectBrowserTimezone();
+      if (tz) {
+        config.headers['X-Client-Timezone'] = tz;
+      }
     }
     logger.debug(`${config.method?.toUpperCase()} ${config.url}`);
     return config;


### PR DESCRIPTION
When an EDT user creates a transaction dated tomorrow at ~9pm local, the
frontend boundary (new Date().toISOString().slice(0,10)) returns the UTC
date, which is already tomorrow, so the transaction renders below the
"future" divider. In parallel, the backend uses Postgres CURRENT_DATE in
the future-sum and recalculation queries. If that session's date differs
from Node's todayYMD() (which drives isTransactionInFuture), the same
transaction can land in both currentBalance and futureTransactionsSum,
double-counting it in the displayed total.

Use the browser-local date in TransactionList, and parameterize the two
balance-related backend queries with todayYMD() so the "today" cutoff
stays consistent with the branch decision in create/update.