### PR TITLE
Bump version to 1.9.0 for backend and frontend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monize-backend",
-  "version": "1.8.59",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monize-backend",
-      "version": "1.8.59",
+      "version": "1.9.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.75.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monize-backend",
-  "version": "1.8.59",
+  "version": "1.9.0",
   "description": "Personal Finance Management System - Backend API",
   "author": "",
   "private": true,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monize-frontend",
-  "version": "1.8.59",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monize-frontend",
-      "version": "1.8.59",
+      "version": "1.9.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^5.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monize-frontend",
-  "version": "1.8.59",
+  "version": "1.9.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
This PR updates the version numbers for both the backend and frontend packages from 1.8.59 to 1.9.0, indicating a minor version release.

## Changes
- Updated `backend/package.json` version from 1.8.59 to 1.9.0
- Updated `frontend/package.json` version from 1.8.59 to 1.9.0

## Notes
This is a version bump release. The lockfiles have been automatically updated to reflect the new version metadata.

https://claude.ai/code/session_019GdBJ3z74Z8dwfBhNNNF1P