### PR TITLE
Add MSN provider status check and warning in SecurityForm

### DIFF
--- a/frontend/src/components/securities/SecurityForm.test.tsx
+++ b/frontend/src/components/securities/SecurityForm.test.tsx
@@ -32,6 +32,10 @@ vi.mock('@/lib/investments', () => ({
   investmentsApi: {
     lookupSecurity: vi.fn().mockResolvedValue(null),
     lookupSecurityCandidates: vi.fn().mockResolvedValue([]),
+    getProviderStatus: vi.fn().mockResolvedValue({
+      yahoo: { ready: true },
+      msn: { ready: true },
+    }),
   },
 }));
 

--- a/frontend/src/components/securities/SecurityForm.tsx
+++ b/frontend/src/components/securities/SecurityForm.tsx
@@ -79,9 +79,17 @@ export function SecurityForm({ security, onSubmit, onCancel, onDirtyChange, subm
   const [lookupProvider, setLookupProvider] = useState<'auto' | 'yahoo' | 'msn'>('auto');
   const [pickerQuery, setPickerQuery] = useState<string>('');
   const [pickerCandidates, setPickerCandidates] = useState<LookupCandidate[]>([]);
+  const [msnReady, setMsnReady] = useState<boolean | null>(null);
 
   useEffect(() => {
     exchangeRatesApi.getCurrencies().then(setCurrencies).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    investmentsApi
+      .getProviderStatus()
+      .then((status) => setMsnReady(status.msn.ready))
+      .catch(() => setMsnReady(null));
   }, []);
 
   const currencyOptions = useMemo(() => {
@@ -343,6 +351,18 @@ export function SecurityForm({ security, onSubmit, onCancel, onDirtyChange, subm
         <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
           Override the provider for this security. Leave on default to use your preferences.
         </p>
+        {watch('quoteProvider') === 'msn' && msnReady === false && (
+          <p
+            role="alert"
+            className="text-sm text-red-600 dark:text-red-400 mt-2"
+            data-testid="msn-not-configured-error"
+          >
+            MSN is selected as the default quote provider, but{' '}
+            <code>MSN_API_KEY</code> is not configured on the server. MSN
+            quotes will fail until an administrator sets the env var and
+            restarts the backend.
+          </p>
+        )}
       </div>
 
       {watch('quoteProvider') === 'msn' && (


### PR DESCRIPTION
## Summary
Added functionality to check the MSN quote provider's configuration status and display a warning to users when MSN is selected but not properly configured on the server.

## Key Changes
- Added `msnReady` state to track MSN provider availability
- Added `useEffect` hook to fetch provider status from `investmentsApi.getProviderStatus()` on component mount
- Added conditional alert message that displays when MSN is selected as the quote provider but `MSN_API_KEY` is not configured on the server
- Updated test mocks to include `getProviderStatus` with default ready states for both Yahoo and MSN providers

## Implementation Details
- The provider status is fetched once on component initialization and cached in state
- The warning message is only displayed when `watch('quoteProvider') === 'msn'` AND `msnReady === false`
- The alert uses semantic HTML with `role="alert"` for accessibility
- Includes a `data-testid` attribute for testing purposes
- Error handling gracefully sets `msnReady` to `null` if the API call fails

https://claude.ai/code/session_01G6oR8YXG9B6cAQahREccbs