### PR TITLE
Add security lookup picker for multiple candidates

### DIFF
--- a/backend/src/securities/security-price.service.ts
+++ b/backend/src/securities/security-price.service.ts
@@ -670,16 +670,19 @@ export class SecurityPriceService {
       return fetchFromProvider(this.providers.getByName(provider));
     }
 
-    // auto: query every provider in parallel and concatenate results so the
-    // user sees candidates from both Yahoo and MSN in one picker. Order by
-    // the user's default provider first (so that provider's matches show up
-    // at the top of the list).
+    // auto: try the user's primary provider first; only fall back to the
+    // secondary provider when the primary returns no candidates. Mirrors
+    // fetchQuoteWithFallback so lookups respect the same Primary/Secondary
+    // preference used during price refresh.
     const ordered = this.providers.resolveForSecurity(
       { quoteProvider: null },
       ctx.defaultQuoteProvider,
     );
-    const allResults = await Promise.all(ordered.map(fetchFromProvider));
-    return ordered.flatMap((_, i) => allResults[i]);
+    for (const p of ordered) {
+      const results = await fetchFromProvider(p);
+      if (results.length > 0) return results;
+    }
+    return [];
   }
 
   async getLastUpdateTime(): Promise<Date | null> {

--- a/frontend/src/app/import/page.tsx
+++ b/frontend/src/app/import/page.tsx
@@ -124,6 +124,10 @@ function ImportContent() {
             isMultiAccountImport={!!wizard.multiAccountData}
             isLoading={wizard.isLoading}
             onMultiAccountImport={wizard.handleMultiAccountImport}
+            lookupPickerQuery={wizard.lookupPickerQuery}
+            lookupPickerCandidates={wizard.lookupPickerCandidates}
+            handleLookupPickerPick={wizard.handleLookupPickerPick}
+            handleLookupPickerCancel={wizard.handleLookupPickerCancel}
           />
         );
 

--- a/frontend/src/components/import/MapSecuritiesStep.tsx
+++ b/frontend/src/components/import/MapSecuritiesStep.tsx
@@ -7,6 +7,7 @@ import { Combobox } from '@/components/ui/Combobox';
 import { SecurityMapping } from '@/lib/import';
 import { EXCHANGE_OPTIONS } from '@/lib/constants';
 import { usePreferencesStore } from '@/store/preferencesStore';
+import { SecurityLookupPicker, LookupCandidate } from '@/components/securities/SecurityLookupPicker';
 
 type ImportStep = 'upload' | 'selectAccount' | 'mapCategories' | 'mapSecurities' | 'mapAccounts' | 'review' | 'multiAccountReview' | 'complete';
 
@@ -25,6 +26,10 @@ interface MapSecuritiesStepProps {
   isMultiAccountImport?: boolean;
   isLoading?: boolean;
   onMultiAccountImport?: () => void;
+  lookupPickerQuery?: string;
+  lookupPickerCandidates?: LookupCandidate[];
+  handleLookupPickerPick?: (candidate: LookupCandidate) => void;
+  handleLookupPickerCancel?: () => void;
 }
 
 export function MapSecuritiesStep({
@@ -42,12 +47,24 @@ export function MapSecuritiesStep({
   isMultiAccountImport = false,
   isLoading = false,
   onMultiAccountImport,
+  lookupPickerQuery = '',
+  lookupPickerCandidates = [],
+  handleLookupPickerPick,
+  handleLookupPickerCancel,
 }: MapSecuritiesStepProps) {
   const preferredExchanges = usePreferencesStore((s) => s.preferences?.preferredExchanges) || [];
   const readyCount = securityMappings.filter((m) => m.securityId || (m.createNew && m.securityName)).length;
   const needsAttentionCount = securityMappings.length - readyCount;
 
   return (
+    <>
+    <SecurityLookupPicker
+      isOpen={lookupPickerCandidates.length > 0}
+      query={lookupPickerQuery}
+      candidates={lookupPickerCandidates}
+      onPick={(c) => handleLookupPickerPick?.(c)}
+      onCancel={() => handleLookupPickerCancel?.()}
+    />
     <div className="max-w-4xl mx-auto">
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
         <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
@@ -201,5 +218,6 @@ export function MapSecuritiesStep({
         </div>
       </div>
     </div>
+    </>
   );
 }

--- a/frontend/src/hooks/useImportWizard.ts
+++ b/frontend/src/hooks/useImportWizard.ts
@@ -25,6 +25,7 @@ import { getErrorMessage } from '@/lib/errors';
 import { Account, AccountType } from '@/types/account';
 import { Category } from '@/types/category';
 import { Security } from '@/types/investment';
+import { LookupCandidate } from '@/components/securities/SecurityLookupPicker';
 import { usePreferencesStore } from '@/store/preferencesStore';
 import { createLogger } from '@/lib/logger';
 import {
@@ -98,6 +99,9 @@ export function useImportWizard() {
   const [lookupLoadingIndex, setLookupLoadingIndex] = useState<number | null>(null);
   const [initialLookupDone, setInitialLookupDone] = useState(false);
   const [bulkLookupInProgress, setBulkLookupInProgress] = useState(false);
+  const [lookupPickerRowIndex, setLookupPickerRowIndex] = useState<number | null>(null);
+  const [lookupPickerQuery, setLookupPickerQuery] = useState<string>('');
+  const [lookupPickerCandidates, setLookupPickerCandidates] = useState<LookupCandidate[]>([]);
   const [showCreateAccount, setShowCreateAccount] = useState(false);
   const [newAccountName, setNewAccountName] = useState('');
   const [newAccountType, setNewAccountType] = useState<string>('CHEQUING');
@@ -680,6 +684,39 @@ export function useImportWizard() {
     });
   };
 
+  const applyLookupResultToMapping = useCallback(
+    (index: number, result: LookupCandidate) => {
+      const existingSecurity = findMatchingSecurityBySymbol(result.symbol, securities);
+      const resolvedCurrency =
+        result.currencyCode ||
+        getCurrencyFromExchange(result.exchange) ||
+        defaultCurrency;
+      setSecurityMappings((prev) => {
+        const updated = [...prev];
+        updated[index] = {
+          ...updated[index],
+          securityId: undefined,
+          createNew: result.symbol,
+          securityName: result.name,
+          securityType: result.securityType || 'STOCK',
+          exchange: result.exchange || undefined,
+          currencyCode: resolvedCurrency,
+        };
+        return updated;
+      });
+
+      const details = [`Symbol: ${result.symbol}`, `Name: ${result.name}`];
+      if (result.exchange) details.push(`Exchange: ${result.exchange}`);
+      details.push(`Currency: ${resolvedCurrency}`);
+      if (existingSecurity) {
+        toast.success(`Found (exists in database): ${details.join(', ')}`);
+      } else {
+        toast.success(`Found: ${details.join(', ')}`);
+      }
+    },
+    [securities, defaultCurrency],
+  );
+
   const handleSecurityLookup = async (index: number, query: string, exchange?: string) => {
     if (!query || query.length < 2) {
       toast.error('Enter at least 2 characters to lookup');
@@ -695,37 +732,15 @@ export function useImportWizard() {
 
     setLookupLoadingIndex(index);
     try {
-      const result = await investmentsApi.lookupSecurity(query, exchanges);
-      if (result) {
-        const existingSecurity = findMatchingSecurityBySymbol(result.symbol, securities);
-        const resolvedCurrency =
-          result.currencyCode ||
-          getCurrencyFromExchange(result.exchange) ||
-          defaultCurrency;
-        setSecurityMappings((prev) => {
-          const updated = [...prev];
-          updated[index] = {
-            ...updated[index],
-            securityId: undefined,
-            createNew: result.symbol,
-            securityName: result.name,
-            securityType: result.securityType || 'STOCK',
-            exchange: result.exchange || undefined,
-            currencyCode: resolvedCurrency,
-          };
-          return updated;
-        });
-
-        const details = [`Symbol: ${result.symbol}`, `Name: ${result.name}`];
-        if (result.exchange) details.push(`Exchange: ${result.exchange}`);
-        details.push(`Currency: ${resolvedCurrency}`);
-        if (existingSecurity) {
-          toast.success(`Found (exists in database): ${details.join(', ')}`);
-        } else {
-          toast.success(`Found: ${details.join(', ')}`);
-        }
-      } else {
+      const candidates = await investmentsApi.lookupSecurityCandidates(query, exchanges);
+      if (candidates.length === 0) {
         toast.error(`No security found for "${query}"`);
+      } else if (candidates.length === 1) {
+        applyLookupResultToMapping(index, candidates[0]);
+      } else {
+        setLookupPickerRowIndex(index);
+        setLookupPickerQuery(query);
+        setLookupPickerCandidates(candidates);
       }
     } catch (error) {
       logger.error('Security lookup failed:', error);
@@ -734,6 +749,24 @@ export function useImportWizard() {
       setLookupLoadingIndex(null);
     }
   };
+
+  const handleLookupPickerPick = useCallback(
+    (candidate: LookupCandidate) => {
+      if (lookupPickerRowIndex !== null) {
+        applyLookupResultToMapping(lookupPickerRowIndex, candidate);
+      }
+      setLookupPickerRowIndex(null);
+      setLookupPickerQuery('');
+      setLookupPickerCandidates([]);
+    },
+    [lookupPickerRowIndex, applyLookupResultToMapping],
+  );
+
+  const handleLookupPickerCancel = useCallback(() => {
+    setLookupPickerRowIndex(null);
+    setLookupPickerQuery('');
+    setLookupPickerCandidates([]);
+  }, []);
 
   const handleMultiAccountImport = async () => {
     if (!multiAccountContent || !multiAccountData) return;
@@ -995,6 +1028,9 @@ export function useImportWizard() {
     setAccountMappings([]);
     setSecurityMappings([]);
     setInitialLookupDone(false);
+    setLookupPickerRowIndex(null);
+    setLookupPickerQuery('');
+    setLookupPickerCandidates([]);
     setFileType('qif');
     setMultiAccountData(null);
     setMultiAccountContent('');
@@ -1013,6 +1049,7 @@ export function useImportWizard() {
     handleAccountMappingChange, handleSecurityMappingChange, handleSecurityLookup,
     isLoading, importResult, bulkImportResult, handleImport, handleFileSelect, handleImportMore,
     lookupLoadingIndex, bulkLookupInProgress,
+    lookupPickerQuery, lookupPickerCandidates, handleLookupPickerPick, handleLookupPickerCancel,
     showCreateAccount, setShowCreateAccount, creatingForFileIndex, setCreatingForFileIndex,
     newAccountName, setNewAccountName, newAccountType, setNewAccountType, newAccountCurrency, setNewAccountCurrency,
     isCreatingAccount, handleCreateAccount,


### PR DESCRIPTION
## Summary
Enhanced the security lookup workflow to handle multiple candidate results by introducing a picker UI component. When a security lookup returns multiple candidates, users can now select the correct one from a modal dialog instead of automatically applying the first result.

## Key Changes
- **New state management**: Added three new state variables to `useImportWizard` hook to track the lookup picker state:
  - `lookupPickerRowIndex`: tracks which security mapping row initiated the lookup
  - `lookupPickerQuery`: stores the search query
  - `lookupPickerCandidates`: stores the list of candidate securities returned

- **Refactored lookup logic**: Extracted the result application logic into a new `applyLookupResultToMapping` callback function to avoid duplication between single and multiple candidate scenarios

- **Updated API call**: Changed from `lookupSecurity()` (single result) to `lookupSecurityCandidates()` (multiple results) to get all matching candidates

- **Conditional picker display**: 
  - If 0 candidates: show error toast
  - If 1 candidate: automatically apply it (preserves existing behavior)
  - If multiple candidates: display picker modal for user selection

- **New handler functions**: Added `handleLookupPickerPick` and `handleLookupPickerCancel` callbacks to manage picker interactions

- **UI integration**: Integrated `SecurityLookupPicker` component into `MapSecuritiesStep` and wired up all necessary props from the import page

- **Backend optimization**: Modified `SecurityPriceService.lookupSecurityCandidates()` to use a fallback strategy (try primary provider first, then secondary) instead of querying all providers in parallel, ensuring consistent behavior with the price refresh workflow

## Notable Details
- The picker state is properly reset when the import wizard is reset
- The implementation maintains backward compatibility by automatically applying single results
- Currency resolution and security type handling remain consistent with the previous implementation

https://claude.ai/code/session_01Cszc3AGxxgd4mhcidYbM5a