### PR TITLE
Simplify Quote Provider label and remove override helper text

### DIFF
--- a/frontend/src/components/securities/SecurityForm.test.tsx
+++ b/frontend/src/components/securities/SecurityForm.test.tsx
@@ -167,8 +167,8 @@ describe('SecurityForm', () => {
     fireEvent.click(screen.getByText('Lookup'));
 
     await waitFor(() => {
-      // Quote Provider Override select should have been updated to MSN Money.
-      const providerSelect = screen.getByLabelText('Quote Provider Override') as HTMLSelectElement;
+      // Quote Provider select should have been updated to MSN Money.
+      const providerSelect = screen.getByLabelText('Quote Provider') as HTMLSelectElement;
       expect(providerSelect.value).toBe('msn');
     });
 
@@ -199,7 +199,7 @@ describe('SecurityForm', () => {
       expect(investmentsApi.lookupSecurityCandidates).toHaveBeenCalled();
     });
 
-    const providerSelect = screen.getByLabelText('Quote Provider Override') as HTMLSelectElement;
+    const providerSelect = screen.getByLabelText('Quote Provider') as HTMLSelectElement;
     expect(providerSelect.value).toBe('');
   });
 

--- a/frontend/src/components/securities/SecurityForm.tsx
+++ b/frontend/src/components/securities/SecurityForm.tsx
@@ -335,7 +335,7 @@ export function SecurityForm({ security, onSubmit, onCancel, onDirtyChange, subm
 
       <div>
         <Select
-          label="Quote Provider Override"
+          label="Quote Provider"
           options={[
             { value: '', label: `Use default (${userDefaultProvider === 'msn' ? 'MSN Money' : 'Yahoo Finance'})` },
             ...quoteProviderOverrideOptions.slice(1),
@@ -348,9 +348,6 @@ export function SecurityForm({ security, onSubmit, onCancel, onDirtyChange, subm
           }
           error={errors.quoteProvider?.message}
         />
-        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-          Override the provider for this security. Leave on default to use your preferences.
-        </p>
         {watch('quoteProvider') === 'msn' && msnReady === false && (
           <p
             role="alert"


### PR DESCRIPTION
## Summary
This PR simplifies the Quote Provider field by removing the "Override" terminology from the label and eliminating the helper text that explained the override behavior.

## Key Changes
- Renamed the form field label from "Quote Provider Override" to "Quote Provider" for clarity and simplicity
- Removed the helper text paragraph that explained the override functionality ("Override the provider for this security. Leave on default to use your preferences.")
- Updated corresponding test assertions to match the new label text

## Implementation Details
The change maintains all existing functionality while improving the user interface clarity. The field still allows users to override the default quote provider per security, but the UI now presents it more simply without the explicit "Override" language. The default option text still clearly indicates that leaving it on default will use the user's preferences.

https://claude.ai/code/session_01QktJFaV4icnjeyWZbfHANC