### PR TITLE
Show failed symbols in price refresh error toast

### DIFF
--- a/frontend/src/hooks/usePriceRefresh.test.ts
+++ b/frontend/src/hooks/usePriceRefresh.test.ts
@@ -193,6 +193,35 @@ describe('usePriceRefresh', () => {
     expect(toast.error).toHaveBeenCalled();
   });
 
+  it('lists failed symbols in the error toast', async () => {
+    vi.mocked(investmentsApi.getSecurities).mockResolvedValue([
+      sec('s-ok'),
+      sec('s-bad-1'),
+      sec('s-bad-2'),
+    ] as any);
+    vi.mocked(investmentsApi.refreshSelectedPrices).mockResolvedValue({
+      updated: 1,
+      failed: 2,
+      totalSecurities: 3,
+      skipped: 0,
+      results: [
+        { symbol: 'GOOD', success: true, price: 100 },
+        { symbol: 'BAD1', success: false, error: 'Not found' },
+        { symbol: 'BAD2', success: false, error: 'Rate limited' },
+      ],
+      lastUpdated: '',
+    });
+
+    const { result } = renderHook(() => usePriceRefresh());
+    await act(async () => {
+      await result.current.triggerManualRefresh();
+    });
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.stringContaining('BAD1, BAD2'),
+      expect.objectContaining({ duration: expect.any(Number) }),
+    );
+  });
+
   it('calls onRefreshComplete callback with lastUpdated from the refresh result', async () => {
     const onRefreshComplete = vi.fn();
     vi.mocked(investmentsApi.getSecurities).mockResolvedValue([sec('s-1')] as any);

--- a/frontend/src/hooks/usePriceRefresh.ts
+++ b/frontend/src/hooks/usePriceRefresh.ts
@@ -89,7 +89,14 @@ export function usePriceRefresh({ onRefreshComplete }: UsePriceRefreshOptions = 
       lastRefreshTimestamp = Date.now();
       if (!silent) {
         if (result.failed > 0) {
-          toast.error(`Prices updated: ${result.updated} succeeded, ${result.failed} failed`);
+          const failedSymbols = result.results
+            .filter((r) => !r.success)
+            .map((r) => r.symbol);
+          const symbolList = failedSymbols.join(', ');
+          toast.error(
+            `Prices updated: ${result.updated} succeeded, ${result.failed} failed${symbolList ? ` (${symbolList})` : ''}`,
+            { duration: 8000 },
+          );
         } else {
           toast.success(`${result.updated} security price${result.updated !== 1 ? 's' : ''} updated`);
         }


### PR DESCRIPTION
## Summary
Enhanced the price refresh error notification to display which symbols failed to update, making it easier for users to identify problematic securities at a glance.

## Key Changes
- Modified the error toast message to include a comma-separated list of failed symbols when price refresh fails
- Increased error toast duration from default to 8 seconds to give users more time to read the detailed error message
- Added test coverage to verify failed symbols are correctly displayed in the error toast

## Implementation Details
- Failed symbols are extracted from the refresh results by filtering for unsuccessful updates and mapping to their symbol names
- The symbol list is conditionally appended to the error message only when there are failed symbols
- Error toast now displays in format: `Prices updated: X succeeded, Y failed (SYMBOL1, SYMBOL2, ...)`

https://claude.ai/code/session_018Q5nUaE1uU1uBVQBfHSBDF