### PR TITLE
Defer auto-post when override moves next occurrence forward

### DIFF
--- a/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
@@ -504,6 +504,25 @@ describe("ScheduledTransactionsService", () => {
       expect(callArgs.where.isActive).toBe(true);
       expect(result).toEqual(due);
     });
+
+    it("should defer transactions whose override moved the next occurrence forward", async () => {
+      const candidate = makeScheduled({ id: "st-postponed" });
+      scheduledRepo.find.mockResolvedValue([candidate]);
+
+      // First createQueryBuilder call: postponed-id lookup -> returns this id
+      // Second: moved-earlier lookup -> returns []
+      const postponedQb = mockQueryBuilder(null);
+      postponedQb.getRawMany.mockResolvedValue([{ id: "st-postponed" }]);
+      const earlierQb = mockQueryBuilder(null);
+      earlierQb.getRawMany.mockResolvedValue([]);
+      overridesRepo.createQueryBuilder
+        .mockReturnValueOnce(postponedQb)
+        .mockReturnValueOnce(earlierQb);
+
+      const result = await service.findDue(userId);
+
+      expect(result).toEqual([]);
+    });
   });
 
   // ==================== findUpcoming ====================
@@ -1922,6 +1941,30 @@ describe("ScheduledTransactionsService", () => {
           transactionDate: "2025-03-12",
         }),
       );
+    });
+
+    it("should NOT auto-post when an override moves the next occurrence forward", async () => {
+      const scheduled = makeScheduled({
+        id: "st-postponed",
+        autoPost: true,
+        nextDueDate: new Date("2026-04-26"),
+      });
+      scheduledRepo.find.mockResolvedValue([scheduled]);
+
+      // Postponed-id lookup returns this transaction; the moved-earlier
+      // lookup returns nothing.
+      const postponedQb = mockQueryBuilder(null);
+      postponedQb.getRawMany.mockResolvedValue([{ id: "st-postponed" }]);
+      const earlierQb = mockQueryBuilder(null);
+      earlierQb.getRawMany.mockResolvedValue([]);
+      overridesRepo.createQueryBuilder
+        .mockReturnValueOnce(postponedQb)
+        .mockReturnValueOnce(earlierQb);
+
+      await service.processAutoPostTransactions();
+
+      expect(transactionsService.create).not.toHaveBeenCalled();
+      expect(transactionsService.createTransfer).not.toHaveBeenCalled();
     });
 
     it("should use override date as transaction date in post()", async () => {

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -60,8 +60,8 @@ export class ScheduledTransactionsService {
     try {
       const today = todayYMD();
 
-      // Find transactions due by their base nextDueDate
-      const dueByDate = await this.scheduledTransactionsRepository.find({
+      // Find candidates whose base nextDueDate is on/before today.
+      const candidates = await this.scheduledTransactionsRepository.find({
         where: {
           isActive: true,
           autoPost: true,
@@ -79,6 +79,14 @@ export class ScheduledTransactionsService {
         ],
         order: { nextDueDate: "ASC" },
       });
+
+      // Defer candidates whose next occurrence has an override pushing the
+      // effective date past today (e.g. user moved the 26th to the 27th).
+      const postponedIds = await this.findPostponedIds(
+        candidates.map((t) => t.id),
+        today,
+      );
+      const dueByDate = candidates.filter((t) => !postponedIds.has(t.id));
 
       // Find transactions with overrides that moved the date earlier
       const overrideDueIds = await this.overridesRepository
@@ -151,6 +159,27 @@ export class ScheduledTransactionsService {
     } catch (error) {
       this.logger.error("Auto-post processing failed", error.stack);
     }
+  }
+
+  private async findPostponedIds(
+    candidateIds: string[],
+    today: string,
+  ): Promise<Set<string>> {
+    if (candidateIds.length === 0) {
+      return new Set();
+    }
+
+    const rows = await this.overridesRepository
+      .createQueryBuilder("o")
+      .innerJoin("o.scheduledTransaction", "st")
+      .where("o.scheduledTransactionId IN (:...ids)", { ids: candidateIds })
+      .andWhere("o.originalDate = st.nextDueDate")
+      .andWhere("o.overrideDate > :today", { today })
+      .select("o.scheduledTransactionId", "id")
+      .distinct(true)
+      .getRawMany();
+
+    return new Set(rows.map((r) => r.id as string));
   }
 
   async create(
@@ -384,7 +413,7 @@ export class ScheduledTransactionsService {
   async findDue(userId: string): Promise<ScheduledTransaction[]> {
     const today = todayYMD();
 
-    const dueByDate = await this.scheduledTransactionsRepository.find({
+    const candidates = await this.scheduledTransactionsRepository.find({
       where: {
         userId,
         isActive: true,
@@ -401,6 +430,14 @@ export class ScheduledTransactionsService {
       ],
       order: { nextDueDate: "ASC" },
     });
+
+    // Defer candidates whose next occurrence has an override pushing the
+    // effective date past today.
+    const postponedIds = await this.findPostponedIds(
+      candidates.map((t) => t.id),
+      today,
+    );
+    const dueByDate = candidates.filter((t) => !postponedIds.has(t.id));
 
     // Also find transactions with overrides that moved the date earlier
     const overrideDueIds = await this.overridesRepository


### PR DESCRIPTION
The auto-post cron and findDue() picked up scheduled transactions whose
base nextDueDate was on/before today without checking whether an override
had pushed the next occurrence to a later date. As a result, editing the
upcoming iteration to a later day (e.g. 26th -> 27th) still triggered
auto-entry on the original date.

Filter candidates against overrides whose originalDate equals the base
nextDueDate and whose overrideDate is in the future, deferring those
transactions until the override date arrives.