### PR TITLE
Recover PWA from stale auth state on resume

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Toaster } from 'react-hot-toast';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import { PreferencesLoader } from '@/components/providers/PreferencesLoader';
 import { ServiceWorkerRegistrar } from '@/components/providers/ServiceWorkerRegistrar';
+import { PwaLifecycleHandler } from '@/components/providers/PwaLifecycleHandler';
 import { SwipeShell } from '@/components/layout/SwipeShell';
 import './globals.css';
 
@@ -54,6 +55,7 @@ export default async function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
         <ServiceWorkerRegistrar />
+        <PwaLifecycleHandler />
         <ThemeProvider>
           <PreferencesLoader>
             <SwipeShell httpsHeadersActive={httpsHeadersActive}>

--- a/frontend/src/components/providers/PwaLifecycleHandler.test.tsx
+++ b/frontend/src/components/providers/PwaLifecycleHandler.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@/test/render';
+import { AxiosError, AxiosHeaders } from 'axios';
+import { PwaLifecycleHandler } from './PwaLifecycleHandler';
+
+const mockGetProfile = vi.fn();
+const mockLogout = vi.fn();
+let mockIsAuthenticated = true;
+
+vi.mock('@/lib/auth', () => ({
+  authApi: {
+    getProfile: () => mockGetProfile(),
+  },
+}));
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: {
+    getState: () => ({
+      isAuthenticated: mockIsAuthenticated,
+      logout: mockLogout,
+    }),
+  },
+}));
+
+function setVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', {
+    value: state,
+    configurable: true,
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+function firePageShow(persisted: boolean) {
+  const event = new Event('pageshow') as Event & { persisted: boolean };
+  Object.defineProperty(event, 'persisted', { value: persisted });
+  window.dispatchEvent(event);
+}
+
+describe('PwaLifecycleHandler', () => {
+  let replaceSpy: ReturnType<typeof vi.fn>;
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockIsAuthenticated = true;
+    mockGetProfile.mockResolvedValue({ id: 'u1' });
+
+    originalLocation = window.location;
+    replaceSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, replace: replaceSpy, pathname: '/dashboard' },
+    });
+
+    // Force standalone PWA detection
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+      media: '(display-mode: standalone)',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }) as unknown as typeof window.matchMedia;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('renders nothing', () => {
+    const { container } = render(<PwaLifecycleHandler />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('does not re-validate when resume is fast (< stale threshold)', async () => {
+    render(<PwaLifecycleHandler />);
+
+    setVisibility('hidden');
+    vi.advanceTimersByTime(60_000);
+    setVisibility('visible');
+
+    // Allow the async onResume handler to run
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGetProfile).not.toHaveBeenCalled();
+  });
+
+  it('re-validates auth when resume happens after stale threshold', async () => {
+    render(<PwaLifecycleHandler />);
+
+    setVisibility('hidden');
+    vi.advanceTimersByTime(6 * 60 * 1000);
+    setVisibility('visible');
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGetProfile).toHaveBeenCalled();
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+
+  it('forces hard navigation to /login on 401 during stale resume in standalone PWA', async () => {
+    const error = new AxiosError(
+      'Unauthorized',
+      '401',
+      undefined,
+      undefined,
+      {
+        status: 401,
+        data: {},
+        statusText: 'Unauthorized',
+        headers: {},
+        config: { headers: new AxiosHeaders() },
+      }
+    );
+    mockGetProfile.mockRejectedValue(error);
+
+    render(<PwaLifecycleHandler />);
+
+    setVisibility('hidden');
+    vi.advanceTimersByTime(6 * 60 * 1000);
+    setVisibility('visible');
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockLogout).toHaveBeenCalled();
+    expect(replaceSpy).toHaveBeenCalledWith('/login');
+  });
+
+  it('does not navigate when backend is unreachable (502 / no response)', async () => {
+    const error = new AxiosError('Network Error', 'ERR_NETWORK');
+    mockGetProfile.mockRejectedValue(error);
+
+    render(<PwaLifecycleHandler />);
+
+    setVisibility('hidden');
+    vi.advanceTimersByTime(6 * 60 * 1000);
+    setVisibility('visible');
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+
+  it('always re-validates on BFCache restore (pageshow with persisted=true)', async () => {
+    render(<PwaLifecycleHandler />);
+
+    firePageShow(true);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGetProfile).toHaveBeenCalled();
+  });
+
+  it('ignores pageshow when persisted=false (initial load)', async () => {
+    render(<PwaLifecycleHandler />);
+
+    firePageShow(false);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGetProfile).not.toHaveBeenCalled();
+  });
+
+  it('does not re-validate when not authenticated', async () => {
+    mockIsAuthenticated = false;
+    render(<PwaLifecycleHandler />);
+
+    setVisibility('hidden');
+    vi.advanceTimersByTime(6 * 60 * 1000);
+    setVisibility('visible');
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGetProfile).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/providers/PwaLifecycleHandler.tsx
+++ b/frontend/src/components/providers/PwaLifecycleHandler.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { AxiosError } from 'axios';
+import { useAuthStore } from '@/store/authStore';
+import { authApi } from '@/lib/auth';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('PwaLifecycle');
+
+// If the PWA was hidden longer than this, force a hard reload on resume.
+// iOS frequently keeps the WebView alive in BFCache, which can leave the
+// app stuck on the splash screen with stale auth state when the session
+// has expired. A hard reload guarantees a clean boot.
+const STALE_THRESHOLD_MS = 5 * 60 * 1000;
+
+export function PwaLifecycleHandler() {
+  const lastHiddenAt = useRef<number | null>(null);
+  const revalidating = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const isStandalonePwa = (): boolean => {
+      try {
+        return (
+          window.matchMedia('(display-mode: standalone)').matches ||
+          // iOS Safari standalone flag
+          (window.navigator as Navigator & { standalone?: boolean }).standalone === true
+        );
+      } catch {
+        return false;
+      }
+    };
+
+    const onResume = async (source: 'visibility' | 'pageshow', persisted = false) => {
+      const hiddenAt = lastHiddenAt.current;
+      const hiddenFor = hiddenAt ? Date.now() - hiddenAt : 0;
+      lastHiddenAt.current = null;
+
+      if (revalidating.current) return;
+
+      // pageshow with persisted=true means BFCache restore — JS state is frozen.
+      // Always re-validate in this case regardless of how long it was hidden.
+      const isStaleResume = persisted || hiddenFor >= STALE_THRESHOLD_MS;
+      if (!isStaleResume) return;
+
+      const { isAuthenticated } = useAuthStore.getState();
+      logger.debug(
+        `Resume detected (source=${source}, persisted=${persisted}, hiddenFor=${hiddenFor}ms, auth=${isAuthenticated})`
+      );
+
+      // If the user wasn't authenticated, they're already on a public page —
+      // nothing to do.
+      if (!isAuthenticated) return;
+
+      revalidating.current = true;
+      try {
+        await authApi.getProfile();
+      } catch (error) {
+        const status =
+          error instanceof AxiosError ? error.response?.status : undefined;
+
+        // 502 / network: backend unreachable — let the existing connection
+        // banner handle it. Don't navigate.
+        if (status === 502 || (error instanceof AxiosError && !error.response)) {
+          return;
+        }
+
+        // Genuine auth failure on resume. The 401 interceptor in api.ts will
+        // already trigger logout + redirect on its own, but in PWA standalone
+        // mode `window.location.href` redirects after a BFCache restore can
+        // be unreliable. Force a hard replace to guarantee a clean boot of
+        // the login page.
+        if (isStandalonePwa() && typeof window !== 'undefined') {
+          logger.info('PWA resume with invalid session — forcing reload to /login');
+          useAuthStore.getState().logout();
+          window.location.replace('/login');
+        }
+      } finally {
+        revalidating.current = false;
+      }
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        lastHiddenAt.current = Date.now();
+      } else if (document.visibilityState === 'visible') {
+        void onResume('visibility');
+      }
+    };
+
+    const onPageShow = (event: PageTransitionEvent) => {
+      // persisted=true => restored from BFCache (iOS PWA common case)
+      if (event.persisted) {
+        void onResume('pageshow', true);
+      }
+    };
+
+    const onPageHide = () => {
+      lastHiddenAt.current = Date.now();
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    window.addEventListener('pageshow', onPageShow);
+    window.addEventListener('pagehide', onPageHide);
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      window.removeEventListener('pageshow', onPageShow);
+      window.removeEventListener('pagehide', onPageHide);
+    };
+  }, []);
+
+  return null;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -199,7 +199,12 @@ apiClient.interceptors.response.use(
       }
 
       if (typeof window !== 'undefined' && !window.location.pathname.includes('/login')) {
-        window.location.href = '/login';
+        // Use replace() rather than assigning href so the post-401 page does
+        // not stay in history. On PWAs (especially iOS standalone), an
+        // assigned href can be deferred during BFCache restore and leave the
+        // app stuck on the splash screen until force-quit; replace() is
+        // synchronous and doesn't accumulate a back-button trap.
+        window.location.replace('/login');
       }
       isLoggingOut = false;
     }


### PR DESCRIPTION
When the iOS/Android PWA is suspended in the background and resumed
after the session has expired, the WebView is often kept alive (BFCache
or memory). Pending requests and React state from before suspension
remain "frozen", and the app gets stuck on the iOS-generated splash
screen (Monize logo) instead of routing to the SSO sign-in prompt.
Force-quitting the app is the only way to recover.

Add a PwaLifecycleHandler that listens for visibilitychange and
pageshow (persisted=true) events. On a stale resume it re-validates
the session via getProfile; on auth failure inside a standalone PWA
it forces window.location.replace('/login') so the app boots cleanly
into the login flow.

Also switch the 401 interceptor's redirect from href= to replace() so
the post-expiry page does not linger in history and the navigation is
not deferred during a BFCache restore.