### PR TITLE
Add account grouping by type with collapsible headers and totals

### DIFF
--- a/frontend/src/app/accounts/page.tsx
+++ b/frontend/src/app/accounts/page.tsx
@@ -209,7 +209,7 @@ function AccountsContent() {
           {isLoading ? (
             <LoadingSpinner text="Loading accounts..." />
           ) : (
-            <AccountList accounts={accounts} brokerageMarketValues={brokerageMarketValues} onEdit={openEdit} onRefresh={loadAccounts} />
+            <AccountList accounts={accounts} brokerageMarketValues={brokerageMarketValues} defaultCurrency={defaultCurrency} convertToDefault={convertToDefault} onEdit={openEdit} onRefresh={loadAccounts} />
           )}
         </div>
       </main>

--- a/frontend/src/components/accounts/AccountList.test.tsx
+++ b/frontend/src/components/accounts/AccountList.test.tsx
@@ -101,7 +101,7 @@ describe('AccountList', () => {
       <AccountList
         accounts={[]}
         onEdit={mockOnEdit}
-        onRefresh={mockOnRefresh}
+        defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh}
       />
     );
 
@@ -122,7 +122,7 @@ describe('AccountList', () => {
       <AccountList
         accounts={accounts}
         onEdit={mockOnEdit}
-        onRefresh={mockOnRefresh}
+        defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh}
       />
     );
 
@@ -139,7 +139,7 @@ describe('AccountList', () => {
       <AccountList
         accounts={accounts}
         onEdit={mockOnEdit}
-        onRefresh={mockOnRefresh}
+        defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh}
       />
     );
 
@@ -160,7 +160,7 @@ describe('AccountList', () => {
       <AccountList
         accounts={[closedAccount]}
         onEdit={mockOnEdit}
-        onRefresh={mockOnRefresh}
+        defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh}
       />
     );
 
@@ -188,7 +188,7 @@ describe('AccountList', () => {
       <AccountList
         accounts={accounts}
         onEdit={mockOnEdit}
-        onRefresh={mockOnRefresh}
+        defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh}
       />
     );
 
@@ -218,7 +218,7 @@ describe('AccountList', () => {
       <AccountList
         accounts={accounts}
         onEdit={mockOnEdit}
-        onRefresh={mockOnRefresh}
+        defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh}
       />
     );
 
@@ -237,7 +237,7 @@ describe('AccountList', () => {
       <AccountList
         accounts={accounts}
         onEdit={mockOnEdit}
-        onRefresh={mockOnRefresh}
+        defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh}
       />
     );
 
@@ -274,7 +274,7 @@ describe('AccountList', () => {
       <AccountList
         accounts={accounts}
         onEdit={mockOnEdit}
-        onRefresh={mockOnRefresh}
+        defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh}
       />
     );
 
@@ -291,7 +291,7 @@ describe('AccountList', () => {
       <AccountList
         accounts={[deletableAccount]}
         onEdit={mockOnEdit}
-        onRefresh={mockOnRefresh}
+        defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh}
       />
     );
 
@@ -310,7 +310,7 @@ describe('AccountList', () => {
       <AccountList
         accounts={[account]}
         onEdit={mockOnEdit}
-        onRefresh={mockOnRefresh}
+        defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh}
       />
     );
 
@@ -331,7 +331,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     expect(screen.getByText('Chequing Acct')).toBeInTheDocument();
@@ -357,7 +357,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     expect(screen.getByText('$2500.50')).toBeInTheDocument();
@@ -370,7 +370,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     // Non-default currency appends currency code
@@ -381,7 +381,7 @@ describe('AccountList', () => {
     const account = createAccount({ canDelete: false });
 
     render(
-      <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     expect(screen.queryByText('Delete')).not.toBeInTheDocument();
@@ -394,7 +394,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     expect(screen.getByText('2 of 2 accounts')).toBeInTheDocument();
@@ -419,7 +419,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     // Click the "Closed" status filter button in the segmented control
@@ -441,7 +441,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     expect(screen.getByText('2 of 2 accounts')).toBeInTheDocument();
@@ -461,7 +461,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     const netWorthFilter = screen.getByDisplayValue('Net Worth: All');
@@ -479,7 +479,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     expect(screen.queryByDisplayValue('Net Worth: All')).not.toBeInTheDocument();
@@ -491,7 +491,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     // Filter by closed status when all accounts are active
@@ -512,7 +512,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     // Filter by CHEQUING
@@ -534,7 +534,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     // Click on Balance header to sort
@@ -561,7 +561,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     // Groups are rendered Chequing → Savings regardless of input order.
@@ -581,7 +581,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     // Click on Status header to sort by status
@@ -599,7 +599,7 @@ describe('AccountList', () => {
     const account = createAccount({ currentBalance: 0 });
 
     render(
-      <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     const closeButton = screen.getByRole('button', { name: 'Close' });
@@ -610,7 +610,7 @@ describe('AccountList', () => {
     const account = createAccount({ currentBalance: 0 });
 
     render(
-      <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     // Click Close to open dialog
@@ -636,7 +636,7 @@ describe('AccountList', () => {
     const account = createAccount({ currentBalance: 0 });
 
     render(
-      <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     // Click Close to open dialog
@@ -655,7 +655,7 @@ describe('AccountList', () => {
     const account = createAccount({ canDelete: true });
 
     render(
-      <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     // Click Delete to open dialog
@@ -678,7 +678,7 @@ describe('AccountList', () => {
     const account = createAccount({ canDelete: true });
 
     render(
-      <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     fireEvent.click(screen.getByText('Delete'));
@@ -697,7 +697,7 @@ describe('AccountList', () => {
     });
 
     render(
-      <AccountList accounts={[closedAccount]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[closedAccount]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     fireEvent.click(screen.getByText('Reopen'));
@@ -715,7 +715,7 @@ describe('AccountList', () => {
     const account = createAccount({ accountSubType: null });
 
     render(
-      <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     expect(screen.getByText('Reconcile')).toBeInTheDocument();
@@ -728,7 +728,7 @@ describe('AccountList', () => {
     });
 
     render(
-      <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     expect(screen.queryByText('Reconcile')).not.toBeInTheDocument();
@@ -750,7 +750,7 @@ describe('AccountList', () => {
         accounts={[account]}
         brokerageMarketValues={brokerageMarketValues}
         onEdit={mockOnEdit}
-        onRefresh={mockOnRefresh}
+        defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh}
       />
     );
 
@@ -768,7 +768,7 @@ describe('AccountList', () => {
     });
 
     render(
-      <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     expect(screen.getByText(/Limit:/)).toBeInTheDocument();
@@ -785,7 +785,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     // "Closed" appears both in the status column badge and in the filter bar button
@@ -801,7 +801,7 @@ describe('AccountList', () => {
     });
 
     render(
-      <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     expect(screen.getByText('Reopen')).toBeInTheDocument();
@@ -813,7 +813,7 @@ describe('AccountList', () => {
     const account = createAccount({ currentBalance: 0 });
 
     render(
-      <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Close' }));
@@ -832,7 +832,7 @@ describe('AccountList', () => {
     const account = createAccount({ canDelete: true });
 
     render(
-      <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     fireEvent.click(screen.getByText('Delete'));
@@ -853,7 +853,7 @@ describe('AccountList', () => {
     });
 
     render(
-      <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     fireEvent.click(screen.getByText('Reopen'));
@@ -869,7 +869,7 @@ describe('AccountList', () => {
     const accounts = [createAccount()];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     // The "All" button in the segmented control should have active styling
@@ -884,7 +884,7 @@ describe('AccountList', () => {
     const account = createAccount({ isFavourite: true });
 
     render(
-      <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     // The favourite star icon has aria-label "Favourite"
@@ -911,7 +911,7 @@ describe('AccountList', () => {
       <AccountList
         accounts={[cashAccount, brokerageAccount]}
         onEdit={mockOnEdit}
-        onRefresh={mockOnRefresh}
+        defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh}
       />
     );
 
@@ -939,7 +939,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     expect(screen.getByText('Inv. Cash')).toBeInTheDocument();
@@ -952,7 +952,7 @@ describe('AccountList', () => {
     });
 
     render(
-      <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     expect(screen.getByText('My primary chequing')).toBeInTheDocument();
@@ -964,7 +964,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     // Filter by closed status when all accounts are active to produce empty results
@@ -991,7 +991,7 @@ describe('AccountList', () => {
     ];
 
     render(
-      <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     const typeSelect = screen.getByDisplayValue('All Types') as HTMLSelectElement;
@@ -1012,7 +1012,7 @@ describe('AccountList', () => {
     });
 
     render(
-      <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
     // The approximate conversion indicator
@@ -1044,7 +1044,7 @@ describe('AccountList', () => {
       });
 
       render(
-        <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+        <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
       );
 
       fireEvent.click(screen.getByText('My Brokerage'));
@@ -1060,7 +1060,7 @@ describe('AccountList', () => {
       });
 
       render(
-        <AccountList accounts={[account]} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+        <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
       );
 
       fireEvent.click(screen.getByText('Main Chequing'));
@@ -1078,7 +1078,7 @@ describe('AccountList', () => {
       ];
 
       render(
-        <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+        <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
       );
 
       // Group headers display the account count alongside the type label.
@@ -1110,7 +1110,7 @@ describe('AccountList', () => {
       ];
 
       render(
-        <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+        <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
       );
 
       // Group total: 1000 CAD + (500 USD * 1.4) = 1700 CAD
@@ -1155,7 +1155,7 @@ describe('AccountList', () => {
           accounts={accounts}
           brokerageMarketValues={brokerageMarketValues}
           onEdit={mockOnEdit}
-          onRefresh={mockOnRefresh}
+          defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh}
         />
       );
 
@@ -1194,7 +1194,7 @@ describe('AccountList', () => {
       ];
 
       render(
-        <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+        <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
       );
 
       // CHEQUING group total: 1000 + 500 (future) + 250 = 1750
@@ -1219,7 +1219,7 @@ describe('AccountList', () => {
       ];
 
       render(
-        <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+        <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
       );
 
       expect(screen.getByText('Cheq A')).toBeInTheDocument();
@@ -1244,7 +1244,7 @@ describe('AccountList', () => {
       ];
 
       const { unmount } = render(
-        <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+        <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
       );
 
       const groupRow = document.querySelector<HTMLTableRowElement>(
@@ -1262,7 +1262,7 @@ describe('AccountList', () => {
 
       // Re-render: persisted state means CHEQUING starts collapsed.
       render(
-        <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+        <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
       );
       expect(screen.queryByText('Cheq A')).not.toBeInTheDocument();
     });
@@ -1292,7 +1292,7 @@ describe('AccountList', () => {
       ];
 
       render(
-        <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+        <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
       );
 
       // Within the INVESTMENT group, the brokerage account is rendered

--- a/frontend/src/components/accounts/AccountList.test.tsx
+++ b/frontend/src/components/accounts/AccountList.test.tsx
@@ -748,7 +748,9 @@ describe('AccountList', () => {
       />
     );
 
-    expect(screen.getByText('$12345.67')).toBeInTheDocument();
+    // The market value is shown both on the account row and in the
+    // INVESTMENT group header total, so there are two matching nodes.
+    expect(screen.getAllByText('$12345.67').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('Market value')).toBeInTheDocument();
   });
 
@@ -1076,6 +1078,51 @@ describe('AccountList', () => {
       // Group headers display the account count alongside the type label.
       expect(screen.getByText('2 accounts')).toBeInTheDocument();
       expect(screen.getByText('1 account')).toBeInTheDocument();
+    });
+
+    it('shows the total balance for each group in the default currency', () => {
+      const accounts = [
+        createAccount({
+          id: 'c1',
+          name: 'Cheq A',
+          accountType: 'CHEQUING',
+          currencyCode: 'CAD',
+          currentBalance: 1000,
+          futureTransactionsSum: 500,
+        }),
+        createAccount({
+          id: 'c2',
+          name: 'Cheq B',
+          accountType: 'CHEQUING',
+          currencyCode: 'CAD',
+          currentBalance: 250,
+        }),
+        createAccount({
+          id: 'cc1',
+          name: 'Visa',
+          accountType: 'CREDIT_CARD',
+          currencyCode: 'CAD',
+          currentBalance: -750,
+        }),
+      ];
+
+      render(
+        <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      );
+
+      // CHEQUING group total: 1000 + 500 (future) + 250 = 1750
+      // CREDIT_CARD group total: -750
+      const chequingHeaderRow = Array.from(
+        document.querySelectorAll<HTMLTableRowElement>('tr[aria-expanded]'),
+      ).find((tr) => tr.textContent?.includes('Chequing'));
+      const creditHeaderRow = Array.from(
+        document.querySelectorAll<HTMLTableRowElement>('tr[aria-expanded]'),
+      ).find((tr) => tr.textContent?.includes('Credit Card'));
+
+      expect(chequingHeaderRow).toBeTruthy();
+      expect(creditHeaderRow).toBeTruthy();
+      expect(chequingHeaderRow!.textContent).toContain('$1750.00');
+      expect(creditHeaderRow!.textContent).toContain('$-750.00');
     });
 
     it('collapses a group when its header is clicked and hides the rows', () => {

--- a/frontend/src/components/accounts/AccountList.test.tsx
+++ b/frontend/src/components/accounts/AccountList.test.tsx
@@ -19,10 +19,14 @@ vi.mock('@/hooks/useNumberFormat', () => ({
   }),
 }));
 
+const exchangeMocks = vi.hoisted(() => ({
+  convertToDefault: vi.fn((n: number, _currency?: string) => n),
+}));
+
 vi.mock('@/hooks/useExchangeRates', () => ({
   useExchangeRates: () => ({
     defaultCurrency: 'CAD',
-    convertToDefault: (n: number) => n,
+    convertToDefault: exchangeMocks.convertToDefault,
   }),
 }));
 
@@ -86,6 +90,8 @@ describe('AccountList', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset the exchange-rate mock to a no-op identity for currency conversion.
+    exchangeMocks.convertToDefault.mockImplementation((n: number) => n);
     // Clear localStorage to reset persisted filter/sort/density state
     localStorage.clear();
   });
@@ -1078,6 +1084,41 @@ describe('AccountList', () => {
       // Group headers display the account count alongside the type label.
       expect(screen.getByText('2 accounts')).toBeInTheDocument();
       expect(screen.getByText('1 account')).toBeInTheDocument();
+    });
+
+    it('converts foreign-currency balances into the default currency before summing', () => {
+      // 1 USD = 1.4 CAD; CAD passes through unchanged.
+      exchangeMocks.convertToDefault.mockImplementation((n: number, currency?: string) =>
+        currency === 'USD' ? n * 1.4 : n,
+      );
+
+      const accounts = [
+        createAccount({
+          id: 'cad-1',
+          name: 'CAD Cheq',
+          accountType: 'CHEQUING',
+          currencyCode: 'CAD',
+          currentBalance: 1000,
+        }),
+        createAccount({
+          id: 'usd-1',
+          name: 'USD Cheq',
+          accountType: 'CHEQUING',
+          currencyCode: 'USD',
+          currentBalance: 500,
+        }),
+      ];
+
+      render(
+        <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      );
+
+      // Group total: 1000 CAD + (500 USD * 1.4) = 1700 CAD
+      const chequingHeader = document.querySelector<HTMLTableRowElement>(
+        'tr[aria-expanded]',
+      );
+      expect(chequingHeader).toBeTruthy();
+      expect(chequingHeader!.textContent).toContain('$1700.00');
     });
 
     it('shows the total balance for each group in the default currency', () => {

--- a/frontend/src/components/accounts/AccountList.test.tsx
+++ b/frontend/src/components/accounts/AccountList.test.tsx
@@ -1121,6 +1121,52 @@ describe('AccountList', () => {
       expect(chequingHeader!.textContent).toContain('$1700.00');
     });
 
+    it('converts investment brokerage market values into the default currency before summing', () => {
+      // 1 USD = 1.4 CAD; CAD passes through unchanged.
+      exchangeMocks.convertToDefault.mockImplementation((n: number, currency?: string) =>
+        currency === 'USD' ? n * 1.4 : n,
+      );
+
+      const accounts = [
+        createAccount({
+          id: 'broker-cad',
+          name: 'CAD Brokerage',
+          accountType: 'INVESTMENT',
+          accountSubType: 'INVESTMENT_BROKERAGE',
+          currencyCode: 'CAD',
+          currentBalance: 0,
+        }),
+        createAccount({
+          id: 'broker-usd',
+          name: 'USD Brokerage',
+          accountType: 'INVESTMENT',
+          accountSubType: 'INVESTMENT_BROKERAGE',
+          currencyCode: 'USD',
+          currentBalance: 0,
+        }),
+      ];
+      const brokerageMarketValues = new Map([
+        ['broker-cad', 1000],
+        ['broker-usd', 500],
+      ]);
+
+      render(
+        <AccountList
+          accounts={accounts}
+          brokerageMarketValues={brokerageMarketValues}
+          onEdit={mockOnEdit}
+          onRefresh={mockOnRefresh}
+        />
+      );
+
+      // Group total: 1000 CAD market value + (500 USD market value * 1.4) = 1700 CAD
+      const investmentHeader = document.querySelector<HTMLTableRowElement>(
+        'tr[aria-expanded]',
+      );
+      expect(investmentHeader).toBeTruthy();
+      expect(investmentHeader!.textContent).toContain('$1700.00');
+    });
+
     it('shows the total balance for each group in the default currency', () => {
       const accounts = [
         createAccount({

--- a/frontend/src/components/accounts/AccountList.test.tsx
+++ b/frontend/src/components/accounts/AccountList.test.tsx
@@ -216,11 +216,12 @@ describe('AccountList', () => {
       />
     );
 
-    // Default sort is by name ascending, so Alpha should come first
+    // Default sort is by name ascending, so Alpha should come first.
+    // rows[0] = table header, rows[1] = CHEQUING group header,
+    // rows[2..] = account rows in sorted order.
     const rows = screen.getAllByRole('row');
-    // rows[0] = header, rows[1] = first data row, rows[2] = second data row
-    expect(rows[1]).toHaveTextContent('Alpha Account');
-    expect(rows[2]).toHaveTextContent('Zebra Account');
+    expect(rows[2]).toHaveTextContent('Alpha Account');
+    expect(rows[3]).toHaveTextContent('Zebra Account');
   });
 
   it('density toggle cycles through Normal, Compact, Dense', () => {
@@ -534,19 +535,20 @@ describe('AccountList', () => {
     const balanceHeader = screen.getByText('Balance');
     fireEvent.click(balanceHeader);
 
+    // rows[0] = table header, rows[1] = CHEQUING group header,
+    // followed by account rows sorted by balance ascending.
     const rows = screen.getAllByRole('row');
-    // rows[0] = header, sorted by balance ascending
-    expect(rows[1]).toHaveTextContent('Low Balance');
-    expect(rows[2]).toHaveTextContent('High Balance');
+    expect(rows[2]).toHaveTextContent('Low Balance');
+    expect(rows[3]).toHaveTextContent('High Balance');
 
     // Click again to reverse
     fireEvent.click(balanceHeader);
     const rowsDesc = screen.getAllByRole('row');
-    expect(rowsDesc[1]).toHaveTextContent('High Balance');
-    expect(rowsDesc[2]).toHaveTextContent('Low Balance');
+    expect(rowsDesc[2]).toHaveTextContent('High Balance');
+    expect(rowsDesc[3]).toHaveTextContent('Low Balance');
   });
 
-  it('sorts accounts by type', () => {
+  it('renders account-type groups in the canonical order', () => {
     const accounts = [
       createAccount({ id: 'a1', name: 'Savings Acct', accountType: 'SAVINGS' }),
       createAccount({ id: 'a2', name: 'Chequing Acct', accountType: 'CHEQUING' }),
@@ -556,14 +558,14 @@ describe('AccountList', () => {
       <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
     );
 
-    // Click on Type header to sort by type
-    const typeHeader = screen.getByText('Type');
-    fireEvent.click(typeHeader);
-
+    // Groups are rendered Chequing → Savings regardless of input order.
+    // rows[0] = table header, rows[1] = Chequing group header,
+    // rows[2] = Chequing account, rows[3] = Savings group header, rows[4] = Savings account.
     const rows = screen.getAllByRole('row');
-    // CHEQUING < SAVINGS alphabetically
-    expect(rows[1]).toHaveTextContent('Chequing Acct');
-    expect(rows[2]).toHaveTextContent('Savings Acct');
+    expect(rows[1]).toHaveTextContent('Chequing');
+    expect(rows[2]).toHaveTextContent('Chequing Acct');
+    expect(rows[3]).toHaveTextContent('Savings');
+    expect(rows[4]).toHaveTextContent('Savings Acct');
   });
 
   it('sorts accounts by status', () => {
@@ -580,10 +582,11 @@ describe('AccountList', () => {
     const statusHeader = screen.getByText('Status');
     fireEvent.click(statusHeader);
 
+    // rows[0] = table header, rows[1] = CHEQUING group header (both accounts share the type),
+    // followed by account rows ordered Active before Closed.
     const rows = screen.getAllByRole('row');
-    // Active (0) before Closed (1) ascending
-    expect(rows[1]).toHaveTextContent('Active Acct');
-    expect(rows[2]).toHaveTextContent('Closed Acct');
+    expect(rows[2]).toHaveTextContent('Active Acct');
+    expect(rows[3]).toHaveTextContent('Closed Acct');
   });
 
   it('enables Close button when account balance is zero', () => {
@@ -1055,6 +1058,120 @@ describe('AccountList', () => {
       fireEvent.click(screen.getByText('Main Chequing'));
 
       expect(mockPush).toHaveBeenCalledWith('/transactions?accountId=chequing-1');
+    });
+  });
+
+  describe('grouping by account type', () => {
+    it('renders a group header for each account type with the account count', () => {
+      const accounts = [
+        createAccount({ id: 'c1', name: 'Cheq A', accountType: 'CHEQUING' }),
+        createAccount({ id: 'c2', name: 'Cheq B', accountType: 'CHEQUING' }),
+        createAccount({ id: 's1', name: 'Sav A', accountType: 'SAVINGS' }),
+      ];
+
+      render(
+        <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      );
+
+      // Group headers display the account count alongside the type label.
+      expect(screen.getByText('2 accounts')).toBeInTheDocument();
+      expect(screen.getByText('1 account')).toBeInTheDocument();
+    });
+
+    it('collapses a group when its header is clicked and hides the rows', () => {
+      const accounts = [
+        createAccount({ id: 'c1', name: 'Cheq A', accountType: 'CHEQUING' }),
+        createAccount({ id: 's1', name: 'Sav A', accountType: 'SAVINGS' }),
+      ];
+
+      render(
+        <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      );
+
+      expect(screen.getByText('Cheq A')).toBeInTheDocument();
+
+      const groupRows = Array.from(
+        document.querySelectorAll<HTMLTableRowElement>('tr[aria-expanded]'),
+      );
+      const chequingHeader = groupRows.find((tr) =>
+        tr.textContent?.includes('Chequing'),
+      );
+      expect(chequingHeader).toBeTruthy();
+      fireEvent.click(chequingHeader!);
+
+      // The chequing account row is hidden, but the group header remains.
+      expect(screen.queryByText('Cheq A')).not.toBeInTheDocument();
+      expect(screen.getByText('Sav A')).toBeInTheDocument();
+    });
+
+    it('persists collapsed groups in localStorage', () => {
+      const accounts = [
+        createAccount({ id: 'c1', name: 'Cheq A', accountType: 'CHEQUING' }),
+      ];
+
+      const { unmount } = render(
+        <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      );
+
+      const groupRow = document.querySelector<HTMLTableRowElement>(
+        'tr[aria-expanded]',
+      );
+      expect(groupRow).toBeTruthy();
+      fireEvent.click(groupRow!);
+
+      const stored = JSON.parse(
+        localStorage.getItem('accounts.filter.collapsedGroups') ?? '[]',
+      );
+      expect(stored).toEqual(['CHEQUING']);
+
+      unmount();
+
+      // Re-render: persisted state means CHEQUING starts collapsed.
+      render(
+        <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      );
+      expect(screen.queryByText('Cheq A')).not.toBeInTheDocument();
+    });
+
+    it('keeps linked investment cash and brokerage accounts adjacent', () => {
+      const accounts = [
+        createAccount({
+          id: 'cash-1',
+          name: 'Pair One Cash',
+          accountType: 'INVESTMENT',
+          accountSubType: 'INVESTMENT_CASH',
+          linkedAccountId: 'broker-1',
+        }),
+        createAccount({
+          id: 'lonely',
+          name: 'Solo Investment',
+          accountType: 'INVESTMENT',
+          accountSubType: null,
+        }),
+        createAccount({
+          id: 'broker-1',
+          name: 'Pair One Brokerage',
+          accountType: 'INVESTMENT',
+          accountSubType: 'INVESTMENT_BROKERAGE',
+          linkedAccountId: 'cash-1',
+        }),
+      ];
+
+      render(
+        <AccountList accounts={accounts} onEdit={mockOnEdit} onRefresh={mockOnRefresh} />
+      );
+
+      // Within the INVESTMENT group, the brokerage account is rendered
+      // immediately before its paired cash account, regardless of input order.
+      const rows = screen.getAllByRole('row');
+      const brokerageRow = screen.getByText('Pair One Brokerage').closest('tr');
+      const cashRow = screen.getByText('Pair One Cash').closest('tr');
+      expect(brokerageRow).toBeTruthy();
+      expect(cashRow).toBeTruthy();
+      const brokerageRowIdx = rows.indexOf(brokerageRow as HTMLTableRowElement);
+      const cashRowIdx = rows.indexOf(cashRow as HTMLTableRowElement);
+      expect(brokerageRowIdx).toBeGreaterThan(0);
+      expect(cashRowIdx).toBe(brokerageRowIdx + 1);
     });
   });
 });

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -27,7 +27,22 @@ const STORAGE_KEYS = {
   sortField: 'accounts.filter.sortField',
   sortDirection: 'accounts.filter.sortDirection',
   density: 'accounts.filter.density',
+  collapsedGroups: 'accounts.filter.collapsedGroups',
 };
+
+// Display order for account-type groups: assets first, then liabilities.
+const ACCOUNT_TYPE_ORDER: AccountType[] = [
+  'CHEQUING',
+  'SAVINGS',
+  'CASH',
+  'INVESTMENT',
+  'ASSET',
+  'CREDIT_CARD',
+  'LINE_OF_CREDIT',
+  'LOAN',
+  'MORTGAGE',
+  'OTHER',
+];
 
 // Helper to get stored value
 function getStoredValue<T>(key: string, defaultValue: T): T {
@@ -115,6 +130,24 @@ export function AccountList({ accounts, brokerageMarketValues, onEdit, onRefresh
     getStoredValue<DensityLevel>(STORAGE_KEYS.density, 'normal')
   );
 
+  // Collapsed account-type groups - initialize from localStorage
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<AccountType>>(() => {
+    const stored = getStoredValue<AccountType[]>(STORAGE_KEYS.collapsedGroups, []);
+    return new Set(stored);
+  });
+
+  const toggleGroup = useCallback((type: AccountType) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(type)) {
+        next.delete(type);
+      } else {
+        next.add(type);
+      }
+      return next;
+    });
+  }, []);
+
   // Persist filter/sort changes to localStorage
   useEffect(() => {
     localStorage.setItem(STORAGE_KEYS.showFilters, JSON.stringify(showFilters));
@@ -143,6 +176,13 @@ export function AccountList({ accounts, brokerageMarketValues, onEdit, onRefresh
   useEffect(() => {
     localStorage.setItem(STORAGE_KEYS.density, JSON.stringify(density));
   }, [density]);
+
+  useEffect(() => {
+    localStorage.setItem(
+      STORAGE_KEYS.collapsedGroups,
+      JSON.stringify(Array.from(collapsedGroups)),
+    );
+  }, [collapsedGroups]);
 
   // Long-press handling for context menu on mobile
   const longPressTimer = useRef<NodeJS.Timeout | null>(null);
@@ -258,6 +298,82 @@ export function AccountList({ accounts, brokerageMarketValues, onEdit, onRefresh
     accounts.forEach((a) => map.set(a.id, a.name));
     return map;
   }, [accounts]);
+
+  // Group accounts by account type. Within the INVESTMENT group, ensure linked
+  // brokerage/cash pairs are rendered adjacently (brokerage first).
+  const groupedAccounts = useMemo(() => {
+    const groups = new Map<AccountType, Account[]>();
+    for (const account of filteredAndSortedAccounts) {
+      const existing = groups.get(account.accountType);
+      if (existing) {
+        existing.push(account);
+      } else {
+        groups.set(account.accountType, [account]);
+      }
+    }
+
+    const investments = groups.get('INVESTMENT');
+    if (investments && investments.length > 1) {
+      const byId = new Map(investments.map((a) => [a.id, a]));
+      const placed = new Set<string>();
+      const ordered: Account[] = [];
+      for (const account of investments) {
+        if (placed.has(account.id)) continue;
+        const partner = account.linkedAccountId
+          ? byId.get(account.linkedAccountId)
+          : undefined;
+        if (partner && !placed.has(partner.id)) {
+          // Brokerage first, then its paired cash account.
+          const brokerage =
+            account.accountSubType === 'INVESTMENT_BROKERAGE' ? account : partner;
+          const cash = brokerage === account ? partner : account;
+          ordered.push(brokerage);
+          ordered.push(cash);
+          placed.add(brokerage.id);
+          placed.add(cash.id);
+        } else {
+          ordered.push(account);
+          placed.add(account.id);
+        }
+      }
+      groups.set('INVESTMENT', ordered);
+    }
+
+    const result: { type: AccountType; accounts: Account[] }[] = [];
+    for (const type of ACCOUNT_TYPE_ORDER) {
+      const list = groups.get(type);
+      if (list && list.length > 0) {
+        result.push({ type, accounts: list });
+        groups.delete(type);
+      }
+    }
+    // Append any unrecognised types last (defensive against new enum values).
+    for (const [type, list] of groups) {
+      if (list.length > 0) result.push({ type, accounts: list });
+    }
+    return result;
+  }, [filteredAndSortedAccounts]);
+
+  // Flatten groups into a sequence of header / row entries with stable striping
+  // indices so AccountRow alternation continues to look right across groups.
+  const renderItems = useMemo(() => {
+    type Item =
+      | { kind: 'header'; type: AccountType; count: number; isCollapsed: boolean }
+      | { kind: 'row'; account: Account; index: number };
+    const items: Item[] = [];
+    let rowIndex = 0;
+    for (const { type, accounts: groupAccounts } of groupedAccounts) {
+      const isCollapsed = collapsedGroups.has(type);
+      items.push({ kind: 'header', type, count: groupAccounts.length, isCollapsed });
+      if (!isCollapsed) {
+        for (const account of groupAccounts) {
+          items.push({ kind: 'row', account, index: rowIndex });
+          rowIndex += 1;
+        }
+      }
+    }
+    return items;
+  }, [groupedAccounts, collapsedGroups]);
 
   // Only show the net worth filter when at least one account is excluded
   const hasExcludedAccounts = useMemo(
@@ -540,34 +656,63 @@ export function AccountList({ accounts, brokerageMarketValues, onEdit, onRefresh
             </tr>
           </thead>
           <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
-            {filteredAndSortedAccounts.map((account, index) => (
-              <AccountRow
-                key={account.id}
-                account={account}
-                index={index}
-                density={density}
-                cellPadding={cellPadding}
-                isDeletable={deletableAccounts.has(account.id)}
-                accountNameMap={accountNameMap}
-                brokerageMarketValue={brokerageMarketValues?.get(account.id)}
-                defaultCurrency={defaultCurrency}
-                formatCurrency={formatCurrency}
-                formatCurrencyBase={formatCurrencyBase}
-                convertToDefault={convertToDefault}
-                formatAccountType={formatAccountType}
-                getAccountTypeColor={getAccountTypeColor}
-                onRowClick={handleRowClick}
-                onEdit={onEdit}
-                onReconcile={handleReconcile}
-                onCloseClick={handleCloseClick}
-                onDeleteClick={handleDeleteClick}
-                onReopen={handleReopen}
-                onLongPressStart={handleLongPressStart}
-                onLongPressStartTouch={handleLongPressStart}
-                onLongPressEnd={handleLongPressEnd}
-                onTouchMove={handleTouchMove}
-              />
-            ))}
+            {renderItems.map((item) =>
+              item.kind === 'header' ? (
+                <tr
+                  key={`group-${item.type}`}
+                  className="bg-gray-100 dark:bg-gray-700/40 hover:bg-gray-200 dark:hover:bg-gray-700 cursor-pointer select-none"
+                  onClick={() => toggleGroup(item.type)}
+                  aria-expanded={!item.isCollapsed}
+                >
+                  <td colSpan={5} className={cellPadding}>
+                    <div className="flex items-center gap-2 text-sm">
+                      <svg
+                        className={`w-4 h-4 text-gray-500 dark:text-gray-400 transition-transform ${item.isCollapsed ? '-rotate-90' : ''}`}
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        aria-hidden="true"
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                      </svg>
+                      <span className="font-semibold text-gray-700 dark:text-gray-200">
+                        {formatAccountType(item.type)}
+                      </span>
+                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                        {item.count} {item.count === 1 ? 'account' : 'accounts'}
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                <AccountRow
+                  key={item.account.id}
+                  account={item.account}
+                  index={item.index}
+                  density={density}
+                  cellPadding={cellPadding}
+                  isDeletable={deletableAccounts.has(item.account.id)}
+                  accountNameMap={accountNameMap}
+                  brokerageMarketValue={brokerageMarketValues?.get(item.account.id)}
+                  defaultCurrency={defaultCurrency}
+                  formatCurrency={formatCurrency}
+                  formatCurrencyBase={formatCurrencyBase}
+                  convertToDefault={convertToDefault}
+                  formatAccountType={formatAccountType}
+                  getAccountTypeColor={getAccountTypeColor}
+                  onRowClick={handleRowClick}
+                  onEdit={onEdit}
+                  onReconcile={handleReconcile}
+                  onCloseClick={handleCloseClick}
+                  onDeleteClick={handleDeleteClick}
+                  onReopen={handleReopen}
+                  onLongPressStart={handleLongPressStart}
+                  onLongPressStartTouch={handleLongPressStart}
+                  onLongPressEnd={handleLongPressEnd}
+                  onTouchMove={handleTouchMove}
+                />
+              ),
+            )}
           </tbody>
         </table>
         </div>

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -662,21 +662,21 @@ export function AccountList({ accounts, brokerageMarketValues, onEdit, onRefresh
                 </div>
               </th>
               <th
+                className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 select-none hidden md:table-cell w-1 whitespace-nowrap`}
+                onClick={() => handleSort('status')}
+              >
+                <div className="flex items-center">
+                  Status
+                  <SortIcon field="status" sortField={sortField} sortDirection={sortDirection} />
+                </div>
+              </th>
+              <th
                 className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 select-none`}
                 onClick={() => handleSort('balance')}
               >
                 <div className="flex items-center justify-end">
                   Balance
                   <SortIcon field="balance" sortField={sortField} sortDirection={sortDirection} />
-                </div>
-              </th>
-              <th
-                className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 select-none hidden md:table-cell`}
-                onClick={() => handleSort('status')}
-              >
-                <div className="flex items-center">
-                  Status
-                  <SortIcon field="status" sortField={sortField} sortDirection={sortDirection} />
                 </div>
               </th>
               <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden min-[480px]:table-cell sticky right-0 bg-gray-50 dark:bg-gray-800`}>
@@ -693,36 +693,40 @@ export function AccountList({ accounts, brokerageMarketValues, onEdit, onRefresh
                   onClick={() => toggleGroup(item.type)}
                   aria-expanded={!item.isCollapsed}
                 >
-                  <td colSpan={5} className={cellPadding}>
-                    <div className="flex items-center justify-between gap-3 text-sm">
-                      <div className="flex items-center gap-2 min-w-0">
-                        <svg
-                          className={`w-4 h-4 text-gray-500 dark:text-gray-400 transition-transform ${item.isCollapsed ? '-rotate-90' : ''}`}
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          aria-hidden="true"
-                        >
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                        </svg>
-                        <span className="font-semibold text-gray-700 dark:text-gray-200">
-                          {formatAccountType(item.type)}
-                        </span>
-                        <span className="text-xs text-gray-500 dark:text-gray-400">
-                          {item.count} {item.count === 1 ? 'account' : 'accounts'}
-                        </span>
-                      </div>
-                      <span
-                        className={`font-medium tabular-nums ${
-                          item.total >= 0
-                            ? 'text-gray-700 dark:text-gray-200'
-                            : 'text-red-600 dark:text-red-400'
-                        }`}
+                  <td colSpan={3} className={cellPadding}>
+                    <div className="flex items-center gap-2 min-w-0 text-sm">
+                      <svg
+                        className={`w-4 h-4 text-gray-500 dark:text-gray-400 transition-transform ${item.isCollapsed ? '-rotate-90' : ''}`}
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        aria-hidden="true"
                       >
-                        {formatCurrencyBase(item.total, defaultCurrency)}
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                      </svg>
+                      <span className="font-semibold text-gray-700 dark:text-gray-200">
+                        {formatAccountType(item.type)}
+                      </span>
+                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                        {item.count} {item.count === 1 ? 'account' : 'accounts'}
                       </span>
                     </div>
                   </td>
+                  <td className={`${cellPadding} text-right whitespace-nowrap`}>
+                    <span
+                      className={`text-sm font-medium tabular-nums ${
+                        item.total >= 0
+                          ? 'text-gray-700 dark:text-gray-200'
+                          : 'text-red-600 dark:text-red-400'
+                      }`}
+                    >
+                      {formatCurrencyBase(item.total, defaultCurrency)}
+                    </span>
+                  </td>
+                  <td
+                    className={`${cellPadding} hidden min-[480px]:table-cell sticky right-0 bg-gray-100 dark:bg-gray-700/40`}
+                    aria-hidden="true"
+                  />
                 </tr>
               ) : (
                 <AccountRow

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -354,17 +354,46 @@ export function AccountList({ accounts, brokerageMarketValues, onEdit, onRefresh
     return result;
   }, [filteredAndSortedAccounts]);
 
+  // Per-group total balance, converted into the user's default currency.
+  // Brokerage accounts use their portfolio market value (matching the page
+  // summary calculation) so net-worth math stays consistent with the cards
+  // above the list.
+  const groupTotals = useMemo(() => {
+    const totals = new Map<AccountType, number>();
+    for (const { type, accounts: groupAccounts } of groupedAccounts) {
+      let totalUnits = 0;
+      for (const account of groupAccounts) {
+        const rawBalance =
+          account.accountSubType === 'INVESTMENT_BROKERAGE'
+            ? brokerageMarketValues?.get(account.id) ?? 0
+            : (Number(account.currentBalance) || 0) +
+              (Number(account.futureTransactionsSum) || 0);
+        const converted = convertToDefault(rawBalance, account.currencyCode);
+        // Accumulate in 1/10000 units to avoid floating-point drift.
+        totalUnits += Math.round(converted * 10000);
+      }
+      totals.set(type, totalUnits / 10000);
+    }
+    return totals;
+  }, [groupedAccounts, brokerageMarketValues, convertToDefault]);
+
   // Flatten groups into a sequence of header / row entries with stable striping
   // indices so AccountRow alternation continues to look right across groups.
   const renderItems = useMemo(() => {
     type Item =
-      | { kind: 'header'; type: AccountType; count: number; isCollapsed: boolean }
+      | { kind: 'header'; type: AccountType; count: number; total: number; isCollapsed: boolean }
       | { kind: 'row'; account: Account; index: number };
     const items: Item[] = [];
     let rowIndex = 0;
     for (const { type, accounts: groupAccounts } of groupedAccounts) {
       const isCollapsed = collapsedGroups.has(type);
-      items.push({ kind: 'header', type, count: groupAccounts.length, isCollapsed });
+      items.push({
+        kind: 'header',
+        type,
+        count: groupAccounts.length,
+        total: groupTotals.get(type) ?? 0,
+        isCollapsed,
+      });
       if (!isCollapsed) {
         for (const account of groupAccounts) {
           items.push({ kind: 'row', account, index: rowIndex });
@@ -665,21 +694,32 @@ export function AccountList({ accounts, brokerageMarketValues, onEdit, onRefresh
                   aria-expanded={!item.isCollapsed}
                 >
                   <td colSpan={5} className={cellPadding}>
-                    <div className="flex items-center gap-2 text-sm">
-                      <svg
-                        className={`w-4 h-4 text-gray-500 dark:text-gray-400 transition-transform ${item.isCollapsed ? '-rotate-90' : ''}`}
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        aria-hidden="true"
+                    <div className="flex items-center justify-between gap-3 text-sm">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <svg
+                          className={`w-4 h-4 text-gray-500 dark:text-gray-400 transition-transform ${item.isCollapsed ? '-rotate-90' : ''}`}
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          aria-hidden="true"
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                        </svg>
+                        <span className="font-semibold text-gray-700 dark:text-gray-200">
+                          {formatAccountType(item.type)}
+                        </span>
+                        <span className="text-xs text-gray-500 dark:text-gray-400">
+                          {item.count} {item.count === 1 ? 'account' : 'accounts'}
+                        </span>
+                      </div>
+                      <span
+                        className={`font-medium tabular-nums ${
+                          item.total >= 0
+                            ? 'text-gray-700 dark:text-gray-200'
+                            : 'text-red-600 dark:text-red-400'
+                        }`}
                       >
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                      </svg>
-                      <span className="font-semibold text-gray-700 dark:text-gray-200">
-                        {formatAccountType(item.type)}
-                      </span>
-                      <span className="text-xs text-gray-500 dark:text-gray-400">
-                        {item.count} {item.count === 1 ? 'account' : 'accounts'}
+                        {formatCurrencyBase(item.total, defaultCurrency)}
                       </span>
                     </div>
                   </td>

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -7,7 +7,6 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { Modal } from '@/components/ui/Modal';
 import { accountsApi } from '@/lib/accounts';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
-import { useExchangeRates } from '@/hooks/useExchangeRates';
 import toast from 'react-hot-toast';
 import { getErrorMessage } from '@/lib/errors';
 import { AccountRow } from './AccountRow';
@@ -84,14 +83,15 @@ const getAccountTypeColor = (type: AccountType) => {
 interface AccountListProps {
   accounts: Account[];
   brokerageMarketValues?: Map<string, number>;
+  defaultCurrency: string;
+  convertToDefault: (value: number, fromCurrency: string) => number;
   onEdit: (account: Account) => void;
   onRefresh: () => void;
 }
 
-export function AccountList({ accounts, brokerageMarketValues, onEdit, onRefresh }: AccountListProps) {
+export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, convertToDefault, onEdit, onRefresh }: AccountListProps) {
   const router = useRouter();
   const { formatCurrency: formatCurrencyBase } = useNumberFormat();
-  const { convertToDefault, defaultCurrency } = useExchangeRates();
   const [closeDialogOpen, setCloseDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [accountToClose, setAccountToClose] = useState<Account | null>(null);
@@ -402,7 +402,7 @@ export function AccountList({ accounts, brokerageMarketValues, onEdit, onRefresh
       }
     }
     return items;
-  }, [groupedAccounts, collapsedGroups]);
+  }, [groupedAccounts, collapsedGroups, groupTotals]);
 
   // Only show the net worth filter when at least one account is excluded
   const hasExcludedAccounts = useMemo(

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -689,7 +689,7 @@ export function AccountList({ accounts, brokerageMarketValues, onEdit, onRefresh
               item.kind === 'header' ? (
                 <tr
                   key={`group-${item.type}`}
-                  className="bg-gray-100 dark:bg-gray-700/40 hover:bg-gray-200 dark:hover:bg-gray-700 cursor-pointer select-none"
+                  className="group bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 cursor-pointer select-none"
                   onClick={() => toggleGroup(item.type)}
                   aria-expanded={!item.isCollapsed}
                 >
@@ -724,7 +724,7 @@ export function AccountList({ accounts, brokerageMarketValues, onEdit, onRefresh
                     </span>
                   </td>
                   <td
-                    className={`${cellPadding} hidden min-[480px]:table-cell sticky right-0 bg-gray-100 dark:bg-gray-700/40`}
+                    className="hidden min-[480px]:table-cell sticky right-0 bg-gray-100 dark:bg-gray-800 group-hover:bg-gray-200 dark:group-hover:bg-gray-700"
                     aria-hidden="true"
                   />
                 </tr>

--- a/frontend/src/components/accounts/AccountRow.tsx
+++ b/frontend/src/components/accounts/AccountRow.tsx
@@ -116,6 +116,17 @@ export const AccountRow = memo(function AccountRow({
            formatAccountType(account.accountType)}
         </span>
       </td>
+      <td className={`${cellPadding} whitespace-nowrap hidden md:table-cell w-1`}>
+        <span
+          className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
+            !account.isClosed
+              ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+              : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300'
+          }`}
+        >
+          {!account.isClosed ? 'Active' : 'Closed'}
+        </span>
+      </td>
       <td className={`${cellPadding} whitespace-nowrap text-right ${account.isClosed ? 'opacity-50' : ''}`}>
         {account.accountSubType === 'INVESTMENT_BROKERAGE' && brokerageMarketValue !== undefined ? (
           <>
@@ -161,17 +172,6 @@ export const AccountRow = memo(function AccountRow({
             )}
           </>
         )}
-      </td>
-      <td className={`${cellPadding} whitespace-nowrap hidden md:table-cell`}>
-        <span
-          className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-            !account.isClosed
-              ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
-              : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300'
-          }`}
-        >
-          {!account.isClosed ? 'Active' : 'Closed'}
-        </span>
       </td>
       <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium ${density === 'dense' ? 'space-x-1' : 'space-x-2'} hidden min-[480px]:table-cell sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`} onClick={(e) => e.stopPropagation()}>
         {!account.isClosed ? (


### PR DESCRIPTION
## Summary
This PR refactors the AccountList component to group accounts by account type with collapsible headers that display account counts and group totals. It also updates the component to accept currency conversion as props rather than using the `useExchangeRates` hook directly.

## Key Changes

- **Account Grouping**: Accounts are now grouped by type (CHEQUING, SAVINGS, INVESTMENT, etc.) in a canonical display order, with collapsible group headers showing the account count and total balance for each group.

- **Group Totals**: Each group header displays the sum of all account balances in that group, with proper currency conversion applied. For investment brokerage accounts, market values are used instead of current balance to maintain consistency with net-worth calculations.

- **Collapsible Groups**: Group headers can be clicked to collapse/expand their accounts. The collapsed state is persisted to localStorage.

- **Props Refactoring**: `AccountList` now accepts `defaultCurrency` and `convertToDefault` as explicit props instead of deriving them from the `useExchangeRates` hook. This improves testability and allows callers to control currency conversion behavior.

- **Investment Account Pairing**: Within the INVESTMENT group, linked brokerage/cash account pairs are rendered adjacently with the brokerage account appearing first.

- **Status Column Reordering**: The Status column has been moved to appear before the Balance column in the table header for better visual flow.

- **Test Updates**: All test cases have been updated to pass the new required props and verify the grouping behavior, including tests for group header rendering, currency conversion in group totals, and collapsible functionality.

## Implementation Details

- Group totals use fixed-point arithmetic (1/10000 units) to avoid floating-point precision errors when summing converted balances.
- The render pipeline flattens grouped accounts into a sequence of header and row items with stable striping indices to maintain visual consistency across groups.
- Group collapse state is managed separately from filter/sort state and persisted independently to localStorage.

https://claude.ai/code/session_016joBg56D2tU2hJi8hUV326