### PR TITLE
Add OCI image annotations to Docker build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,16 @@ jobs:
             GIT_SHA=${{ steps.meta.outputs.git_sha }}
             BUILD_DATE=${{ steps.meta.outputs.build_date }}
             VERSION=${{ steps.version.outputs.version }}
+          annotations: |
+            index:org.opencontainers.image.title=Monize Backend
+            index:org.opencontainers.image.description=Backend for Monize, a self-hosted personal finance app
+            index:org.opencontainers.image.source=https://github.com/kenlasko/monize
+            index:org.opencontainers.image.url=https://github.com/kenlasko/monize
+            index:org.opencontainers.image.authors=ken.lasko@gmail.com
+            index:org.opencontainers.image.vendor=Ken Lasko
+            index:org.opencontainers.image.revision=${{ steps.meta.outputs.git_sha }}
+            index:org.opencontainers.image.created=${{ steps.meta.outputs.build_date }}
+            index:org.opencontainers.image.version=${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -247,6 +257,16 @@ jobs:
             GIT_SHA=${{ steps.meta.outputs.git_sha }}
             BUILD_DATE=${{ steps.meta.outputs.build_date }}
             VERSION=${{ steps.version.outputs.version }}
+          annotations: |
+            index:org.opencontainers.image.title=Monize Frontend
+            index:org.opencontainers.image.description=Frontend for Monize, a self-hosted personal finance app
+            index:org.opencontainers.image.source=https://github.com/kenlasko/monize
+            index:org.opencontainers.image.url=https://github.com/kenlasko/monize
+            index:org.opencontainers.image.authors=ken.lasko@gmail.com
+            index:org.opencontainers.image.vendor=Ken Lasko
+            index:org.opencontainers.image.revision=${{ steps.meta.outputs.git_sha }}
+            index:org.opencontainers.image.created=${{ steps.meta.outputs.build_date }}
+            index:org.opencontainers.image.version=${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary
This PR adds Open Container Initiative (OCI) image annotations to the Docker build steps in the CI workflow for both the backend and frontend services. These annotations provide standardized metadata about the container images.

## Key Changes
- Added OCI image annotations to the backend Docker build step, including:
  - Image title, description, and source repository information
  - Author and vendor metadata
  - Git revision and build date
  - Version information

- Added identical OCI image annotations to the frontend Docker build step with appropriate service-specific titles and descriptions

## Implementation Details
The annotations follow the OCI Image Spec standard format using the `index:` prefix, which ensures they are applied to the image index/manifest. Each annotation includes:
- **title**: Service name (Backend/Frontend)
- **description**: Purpose and context of the service
- **source/url**: Links to the GitHub repository
- **authors/vendor**: Attribution information
- **revision**: Git SHA from the build metadata
- **created**: Build timestamp
- **version**: Version number from the version step output

These annotations improve image discoverability and provide consumers with standardized metadata about the container images.

https://claude.ai/code/session_01WsdKJUApRf5ZBLoCCfsx2C