### PR TITLE
fix(accounts): count linked brokerage/cash pairs as one account

### DIFF
--- a/frontend/src/app/accounts/page.test.tsx
+++ b/frontend/src/app/accounts/page.test.tsx
@@ -327,6 +327,19 @@ describe('AccountsPage', () => {
     });
   });
 
+  it('counts linked brokerage/cash pair as a single account in the Total Active Accounts widget', async () => {
+    mockGetAll.mockResolvedValue([
+      { id: 'acc-1', name: 'Checking', accountType: 'CHECKING', accountSubType: null, currencyCode: 'USD', currentBalance: 5000, isClosed: false, canDelete: true, linkedAccountId: null },
+      { id: 'acc-brokerage', name: 'Brokerage', accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_BROKERAGE', currencyCode: 'USD', currentBalance: 0, isClosed: false, canDelete: false, linkedAccountId: 'acc-cash' },
+      { id: 'acc-cash', name: 'Brokerage Cash', accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_CASH', currencyCode: 'USD', currentBalance: 5000, isClosed: false, canDelete: false, linkedAccountId: 'acc-brokerage' },
+    ]);
+    render(<AccountsPage />);
+    await waitFor(() => {
+      // 1 chequing + 1 linked brokerage/cash pair = 2, not 3.
+      expect(screen.getByTestId('summary-Total Active Accounts')).toHaveTextContent('2');
+    });
+  });
+
   it('does not double-count investment cash in brokerage and linked cash account', async () => {
     mockGetAll.mockResolvedValue([
       { id: 'acc-brokerage', name: 'My Investments - Brokerage', accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_BROKERAGE', currencyCode: 'USD', currentBalance: 0, isClosed: false, canDelete: false, linkedAccountId: 'acc-cash' },

--- a/frontend/src/app/accounts/page.tsx
+++ b/frontend/src/app/accounts/page.tsx
@@ -147,8 +147,21 @@ function AccountsContent() {
       }
     });
 
+    // Count a linked brokerage/cash pair as a single logical account.
+    const activeIds = new Set(activeAccounts.map((a) => a.id));
+    const counted = new Set<string>();
+    let accountCount = 0;
+    for (const a of activeAccounts) {
+      if (counted.has(a.id)) continue;
+      counted.add(a.id);
+      if (a.linkedAccountId && activeIds.has(a.linkedAccountId)) {
+        counted.add(a.linkedAccountId);
+      }
+      accountCount += 1;
+    }
+
     const totalBalance = totalAssets - totalLiabilities;
-    return { totalBalance, totalAssets, totalLiabilities, accountCount: activeAccounts.length };
+    return { totalBalance, totalAssets, totalLiabilities, accountCount };
   };
 
   const summary = calculateSummary();

--- a/frontend/src/components/accounts/AccountList.test.tsx
+++ b/frontend/src/components/accounts/AccountList.test.tsx
@@ -1229,5 +1229,55 @@ describe('AccountList', () => {
       expect(brokerageRowIdx).toBeGreaterThan(0);
       expect(cashRowIdx).toBe(brokerageRowIdx + 1);
     });
+
+    it('counts a linked brokerage/cash pair as a single investment account', () => {
+      const accounts = [
+        createAccount({
+          id: 'broker-1',
+          name: 'Pair One Brokerage',
+          accountType: 'INVESTMENT',
+          accountSubType: 'INVESTMENT_BROKERAGE',
+          linkedAccountId: 'cash-1',
+        }),
+        createAccount({
+          id: 'cash-1',
+          name: 'Pair One Cash',
+          accountType: 'INVESTMENT',
+          accountSubType: 'INVESTMENT_CASH',
+          linkedAccountId: 'broker-1',
+        }),
+        createAccount({
+          id: 'broker-2',
+          name: 'Pair Two Brokerage',
+          accountType: 'INVESTMENT',
+          accountSubType: 'INVESTMENT_BROKERAGE',
+          linkedAccountId: 'cash-2',
+        }),
+        createAccount({
+          id: 'cash-2',
+          name: 'Pair Two Cash',
+          accountType: 'INVESTMENT',
+          accountSubType: 'INVESTMENT_CASH',
+          linkedAccountId: 'broker-2',
+        }),
+        createAccount({
+          id: 'solo',
+          name: 'Solo Investment',
+          accountType: 'INVESTMENT',
+          accountSubType: null,
+        }),
+      ];
+
+      render(
+        <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
+      );
+
+      // Two linked pairs + one standalone account = 3 logical investment accounts.
+      const investmentHeader = document.querySelector<HTMLTableRowElement>(
+        'tr[aria-expanded]',
+      );
+      expect(investmentHeader).toBeTruthy();
+      expect(investmentHeader!.textContent).toContain('3 accounts');
+    });
   });
 });

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -369,10 +369,26 @@ export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, 
     let rowIndex = 0;
     for (const { type, accounts: groupAccounts } of groupedAccounts) {
       const isCollapsed = collapsedGroups.has(type);
+      // For investments, a linked brokerage/cash pair represents one logical
+      // account, so collapse pairs into a single count.
+      let count = groupAccounts.length;
+      if (type === 'INVESTMENT') {
+        const idsInGroup = new Set(groupAccounts.map((a) => a.id));
+        const counted = new Set<string>();
+        count = 0;
+        for (const account of groupAccounts) {
+          if (counted.has(account.id)) continue;
+          counted.add(account.id);
+          if (account.linkedAccountId && idsInGroup.has(account.linkedAccountId)) {
+            counted.add(account.linkedAccountId);
+          }
+          count += 1;
+        }
+      }
       items.push({
         kind: 'header',
         type,
-        count: groupAccounts.length,
+        count,
         total: groupTotals.get(type) ?? 0,
         isCollapsed,
       });


### PR DESCRIPTION
In the Accounts page Investment group header, a brokerage and its
linked cash account are now counted as a single logical account
instead of two.

https://claude.ai/code/session_01MbMrrpcBToEqbWEQouX66h