### PR TITLE
Remove Beta badges from AI features

### DIFF
--- a/frontend/src/app/ai/page.tsx
+++ b/frontend/src/app/ai/page.tsx
@@ -12,7 +12,6 @@ export default function AiPage() {
         <main className="px-4 sm:px-6 lg:px-12 pt-6 pb-8">
           <PageHeader
             title="AI Assistant"
-            badge="Beta"
             subtitle="Ask questions about your finances in natural language"
             helpUrl="https://github.com/kenlasko/monize/wiki/AI"
           />

--- a/frontend/src/app/insights/page.tsx
+++ b/frontend/src/app/insights/page.tsx
@@ -12,7 +12,6 @@ export default function InsightsPage() {
         <main className="px-4 sm:px-6 lg:px-12 pt-6 pb-8">
           <PageHeader
             title="Spending Insights"
-            badge="Beta"
             subtitle="AI-powered analysis of your spending patterns and anomalies"
           />
           <div className="max-w-4xl mx-auto">

--- a/frontend/src/app/settings/ai/page.tsx
+++ b/frontend/src/app/settings/ai/page.tsx
@@ -87,7 +87,6 @@ function AiSettingsContent() {
 
         <PageHeader
           title="AI Settings"
-          badge="Beta"
           subtitle="Configure AI providers for intelligent financial features"
         />
 

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -32,7 +32,7 @@ const ALL_SETTINGS_SECTIONS: readonly (SettingsSection & { demoVisible?: boolean
   { id: 'notifications', label: 'Notifications', demoVisible: true },
   { id: 'security', label: 'Security' },
   { id: 'api-access', label: 'API Access' },
-  { id: 'ai-settings', label: 'AI Settings', href: '/settings/ai', badge: 'Beta' },
+  { id: 'ai-settings', label: 'AI Settings', href: '/settings/ai' },
   { id: 'backup-restore', label: 'Backup & Restore' },
   { id: 'auto-backup', label: 'Automatic Backup' },
   { id: 'danger-zone', label: 'Danger Zone' },
@@ -207,11 +207,8 @@ function SettingsContent() {
                   href="/settings/ai"
                   className="block bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg p-6 mb-6 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
                 >
-                  <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1 flex items-center">
+                  <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">
                     AI Settings
-                    <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300">
-                      Beta
-                    </span>
                   </h2>
                   <p className="text-sm text-gray-500 dark:text-gray-400">
                     Configure AI providers, manage API keys, and view usage statistics.

--- a/frontend/src/components/dashboard/InsightsWidget.tsx
+++ b/frontend/src/components/dashboard/InsightsWidget.tsx
@@ -38,11 +38,6 @@ export function InsightsWidget({ isLoading: parentLoading }: InsightsWidgetProps
   }, [parentLoading]);
 
   const sectionTitle = 'Spending Insights';
-  const betaBadge = (
-    <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300">
-      Beta
-    </span>
-  );
 
   if (isLoading || parentLoading) {
     return (
@@ -52,7 +47,6 @@ export function InsightsWidget({ isLoading: parentLoading }: InsightsWidgetProps
           className="text-lg font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors mb-4"
         >
           {sectionTitle}
-          {betaBadge}
         </button>
         <div className="animate-pulse space-y-3">
           {[1, 2, 3].map((i) => (
@@ -71,7 +65,6 @@ export function InsightsWidget({ isLoading: parentLoading }: InsightsWidgetProps
           className="text-lg font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors mb-4"
         >
           {sectionTitle}
-          {betaBadge}
         </button>
         <p className="text-gray-500 dark:text-gray-400 text-sm">
           No insights available. Visit the Insights page to generate your first analysis.
@@ -94,7 +87,6 @@ export function InsightsWidget({ isLoading: parentLoading }: InsightsWidgetProps
           className="text-lg font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
         >
           {sectionTitle}
-          {betaBadge}
         </button>
         <span className="text-sm text-gray-500 dark:text-gray-400">
           {insights.length} active

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -28,13 +28,10 @@ const toolsLinks: { href: string; label: string; badge?: string }[] = [
   { href: '/import', label: 'Import Transactions' },
 ];
 
-const aiLinks: { href: string; label: string; badge?: string }[] = [
-  { href: '/insights', label: 'Insights', badge: 'Beta' },
-  { href: '/ai', label: 'AI Assistant', badge: 'Beta' },
+const aiLinks: { href: string; label: string }[] = [
+  { href: '/insights', label: 'Insights' },
+  { href: '/ai', label: 'AI Assistant' },
 ];
-
-const BETA_BADGE_CLASSES =
-  'ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300';
 
 export function AppHeader() {
   const router = useRouter();
@@ -144,9 +141,8 @@ export function AppHeader() {
                     <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
 
                     {/* AI section header */}
-                    <div className="px-4 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider flex items-center">
+                    <div className="px-4 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                       AI
-                      <span className={BETA_BADGE_CLASSES}>Beta</span>
                     </div>
 
                     {/* AI links */}
@@ -161,7 +157,6 @@ export function AppHeader() {
                         }`}
                       >
                         {link.label}
-                        {link.badge && <span className={BETA_BADGE_CLASSES}>{link.badge}</span>}
                       </button>
                     ))}
 
@@ -265,7 +260,6 @@ export function AppHeader() {
                   }`}
                 >
                   AI
-                  <span className={BETA_BADGE_CLASSES}>Beta</span>
                   <svg
                     className={`w-4 h-4 transition-transform ${aiOpen ? 'rotate-180' : ''}`}
                     fill="none"
@@ -293,7 +287,6 @@ export function AppHeader() {
                           }`}
                         >
                           {link.label}
-                          {link.badge && <span className={BETA_BADGE_CLASSES}>{link.badge}</span>}
                         </button>
                       ))}
                     </div>

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -10,15 +10,13 @@ interface PageHeaderProps {
   actions?: ReactNode;
   /** URL to the wiki help page for this feature */
   helpUrl?: string;
-  /** Optional badge (e.g. "Beta") shown next to the title */
-  badge?: string;
 }
 
 /**
  * Inline page header with title, subtitle, and action buttons.
  * Renders directly in the content area without a separate background bar.
  */
-export function PageHeader({ title, subtitle, actions, helpUrl, badge }: PageHeaderProps) {
+export function PageHeader({ title, subtitle, actions, helpUrl }: PageHeaderProps) {
   return (
     <div className={`${actions ? 'flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4' : ''} mb-6`}>
       <div>
@@ -26,11 +24,6 @@ export function PageHeader({ title, subtitle, actions, helpUrl, badge }: PageHea
           <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
             {title}
           </h1>
-          {badge && (
-            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300">
-              {badge}
-            </span>
-          )}
           {helpUrl && (
             <a
               href={helpUrl}

--- a/frontend/src/components/settings/SettingsNav.tsx
+++ b/frontend/src/components/settings/SettingsNav.tsx
@@ -9,12 +9,7 @@ export interface SettingsSection {
   readonly label: string;
   /** If set, renders as a navigation link instead of a scroll-to button */
   readonly href?: string;
-  /** Optional badge (e.g. "Beta") shown next to the label */
-  readonly badge?: string;
 }
-
-const BETA_BADGE_CLASSES =
-  'ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300';
 
 interface SettingsNavProps {
   readonly sections: readonly SettingsSection[];
@@ -81,7 +76,6 @@ export function SettingsNav({
               >
                 <span className="inline-flex items-center">
                   {section.label}
-                  {section.badge && <span className={BETA_BADGE_CLASSES}>{section.badge}</span>}
                 </span>
                 <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
               </Link>
@@ -104,7 +98,6 @@ export function SettingsNav({
               aria-selected={isActive}
             >
               {section.label}
-              {section.badge && <span className={BETA_BADGE_CLASSES}>{section.badge}</span>}
             </button>
           );
         })}
@@ -138,7 +131,6 @@ export function SettingsNav({
                 >
                   <span className="inline-flex items-center">
                     {section.label}
-                    {section.badge && <span className={BETA_BADGE_CLASSES}>{section.badge}</span>}
                   </span>
                   <ArrowTopRightOnSquareIcon className="h-4 w-4 opacity-50" />
                 </Link>
@@ -160,7 +152,6 @@ export function SettingsNav({
                 `}
               >
                 {section.label}
-                {section.badge && <span className={BETA_BADGE_CLASSES}>{section.badge}</span>}
               </button>
             </li>
           );


### PR DESCRIPTION
## Summary
This PR removes all "Beta" badges from AI-related features across the application, indicating that these features are no longer in beta status.

## Key Changes
- **AppHeader.tsx**: Removed `BETA_BADGE_CLASSES` constant and all badge rendering from AI section links in both desktop and mobile navigation menus
- **PageHeader.tsx**: Removed the optional `badge` prop from the component interface and its rendering logic
- **SettingsNav.tsx**: Removed `BETA_BADGE_CLASSES` constant and badge rendering from settings navigation items
- **InsightsWidget.tsx**: Removed the `betaBadge` element from the "Spending Insights" widget title
- **settings/page.tsx**: Removed `badge: 'Beta'` from the AI Settings section configuration and removed badge rendering from the AI Settings card
- **ai/page.tsx**: Removed `badge="Beta"` prop from PageHeader component
- **insights/page.tsx**: Removed `badge="Beta"` prop from PageHeader component
- **settings/ai/page.tsx**: Removed `badge="Beta"` prop from PageHeader component

## Implementation Details
The changes maintain all existing functionality while simplifying the UI by removing beta status indicators. The removal is consistent across all components that previously displayed these badges, including navigation headers, page headers, and widget titles.

https://claude.ai/code/session_01SjRABbLsDYTJnGkA1EbiQU