### PR TITLE
Add quick-fill from recent transactions in transaction form

### DIFF
--- a/backend/src/transactions/dto/get-recent-transactions.dto.ts
+++ b/backend/src/transactions/dto/get-recent-transactions.dto.ts
@@ -1,10 +1,18 @@
-import { IsInt, IsOptional, Max, Min } from "class-validator";
+import {
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+} from "class-validator";
 import { Type } from "class-transformer";
 import { ApiPropertyOptional } from "@nestjs/swagger";
 
 export class GetRecentTransactionsDto {
   @ApiPropertyOptional({
-    description: "Number of recent distinct transactions to return",
+    description: "Number of recent transactions to return",
     minimum: 1,
     maximum: 20,
     default: 5,
@@ -15,4 +23,21 @@ export class GetRecentTransactionsDto {
   @Min(1)
   @Max(20)
   limit?: number;
+
+  @ApiPropertyOptional({
+    description:
+      "Restrict results to transactions matching this payee ID. When set, results are returned in raw recency order without dedup.",
+  })
+  @IsOptional()
+  @IsUUID()
+  payeeId?: string;
+
+  @ApiPropertyOptional({
+    description:
+      "Restrict results to transactions whose free-text payeeName matches exactly. Ignored if payeeId is also provided.",
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  payeeName?: string;
 }

--- a/backend/src/transactions/dto/get-recent-transactions.dto.ts
+++ b/backend/src/transactions/dto/get-recent-transactions.dto.ts
@@ -1,0 +1,18 @@
+import { IsInt, IsOptional, Max, Min } from "class-validator";
+import { Type } from "class-transformer";
+import { ApiPropertyOptional } from "@nestjs/swagger";
+
+export class GetRecentTransactionsDto {
+  @ApiPropertyOptional({
+    description: "Number of recent distinct transactions to return",
+    minimum: 1,
+    maximum: 20,
+    default: 5,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(20)
+  limit?: number;
+}

--- a/backend/src/transactions/transactions.controller.spec.ts
+++ b/backend/src/transactions/transactions.controller.spec.ts
@@ -73,7 +73,10 @@ describe("TransactionsController", () => {
       const result = await controller.getRecent(mockReq, {});
 
       expect(result).toEqual(expected);
-      expect(mockService.getRecent).toHaveBeenCalledWith("user-1", 5);
+      expect(mockService.getRecent).toHaveBeenCalledWith("user-1", 5, {
+        payeeId: undefined,
+        payeeName: undefined,
+      });
     });
 
     it("forwards the requested limit when provided", async () => {
@@ -81,7 +84,32 @@ describe("TransactionsController", () => {
 
       await controller.getRecent(mockReq, { limit: 10 });
 
-      expect(mockService.getRecent).toHaveBeenCalledWith("user-1", 10);
+      expect(mockService.getRecent).toHaveBeenCalledWith("user-1", 10, {
+        payeeId: undefined,
+        payeeName: undefined,
+      });
+    });
+
+    it("forwards payeeId for payee-scoped quick-fill", async () => {
+      mockService.getRecent.mockResolvedValue([]);
+
+      await controller.getRecent(mockReq, { payeeId: uuid1 });
+
+      expect(mockService.getRecent).toHaveBeenCalledWith("user-1", 5, {
+        payeeId: uuid1,
+        payeeName: undefined,
+      });
+    });
+
+    it("forwards payeeName when no payeeId is provided", async () => {
+      mockService.getRecent.mockResolvedValue([]);
+
+      await controller.getRecent(mockReq, { payeeName: "Free-text Coffee" });
+
+      expect(mockService.getRecent).toHaveBeenCalledWith("user-1", 5, {
+        payeeId: undefined,
+        payeeName: "Free-text Coffee",
+      });
     });
 
     it("uses authenticated userId, never trusts query params", async () => {
@@ -91,7 +119,10 @@ describe("TransactionsController", () => {
         limit: 5,
       });
 
-      expect(mockService.getRecent).toHaveBeenCalledWith("user-1", 5);
+      expect(mockService.getRecent).toHaveBeenCalledWith("user-1", 5, {
+        payeeId: undefined,
+        payeeName: undefined,
+      });
     });
   });
 

--- a/backend/src/transactions/transactions.controller.spec.ts
+++ b/backend/src/transactions/transactions.controller.spec.ts
@@ -36,6 +36,7 @@ describe("TransactionsController", () => {
       updateTransfer: jest.fn(),
       getSummary: jest.fn(),
       bulkUpdate: jest.fn(),
+      getRecent: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -61,6 +62,36 @@ describe("TransactionsController", () => {
 
       expect(result).toEqual(expected);
       expect(mockService.create).toHaveBeenCalledWith("user-1", dto);
+    });
+  });
+
+  describe("getRecent()", () => {
+    it("delegates to service.getRecent with userId and default limit of 5", async () => {
+      const expected = [{ id: "tx-1" }];
+      mockService.getRecent.mockResolvedValue(expected);
+
+      const result = await controller.getRecent(mockReq, {});
+
+      expect(result).toEqual(expected);
+      expect(mockService.getRecent).toHaveBeenCalledWith("user-1", 5);
+    });
+
+    it("forwards the requested limit when provided", async () => {
+      mockService.getRecent.mockResolvedValue([]);
+
+      await controller.getRecent(mockReq, { limit: 10 });
+
+      expect(mockService.getRecent).toHaveBeenCalledWith("user-1", 10);
+    });
+
+    it("uses authenticated userId, never trusts query params", async () => {
+      mockService.getRecent.mockResolvedValue([]);
+
+      await controller.getRecent({ user: { id: "user-1" } } as any, {
+        limit: 5,
+      });
+
+      expect(mockService.getRecent).toHaveBeenCalledWith("user-1", 5);
     });
   });
 

--- a/backend/src/transactions/transactions.controller.ts
+++ b/backend/src/transactions/transactions.controller.ts
@@ -431,12 +431,23 @@ export class TransactionsController {
   @Get("recent")
   @ApiOperation({
     summary:
-      "Get recent distinct transactions for quick-fill on the new-transaction form",
+      "Get recent transactions for quick-fill. Without a payee filter, returns last-N distinct (deduped by payee+category). With payeeId or payeeName, returns the raw last-N entries for that payee.",
   })
   @ApiQuery({
     name: "limit",
     required: false,
-    description: "Number of recent distinct transactions (1-20, default 5)",
+    description: "Number of recent transactions (1-20, default 5)",
+  })
+  @ApiQuery({
+    name: "payeeId",
+    required: false,
+    description: "Filter to transactions for this payee (UUID); disables dedup",
+  })
+  @ApiQuery({
+    name: "payeeName",
+    required: false,
+    description:
+      "Filter to transactions with this exact free-text payeeName; disables dedup",
   })
   @ApiResponse({
     status: 200,
@@ -444,7 +455,10 @@ export class TransactionsController {
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   getRecent(@Request() req, @Query() query: GetRecentTransactionsDto) {
-    return this.transactionsService.getRecent(req.user.id, query.limit ?? 5);
+    return this.transactionsService.getRecent(req.user.id, query.limit ?? 5, {
+      payeeId: query.payeeId,
+      payeeName: query.payeeName,
+    });
   }
 
   // ==================== Reconciliation Endpoints ====================

--- a/backend/src/transactions/transactions.controller.ts
+++ b/backend/src/transactions/transactions.controller.ts
@@ -30,6 +30,7 @@ import { CreateTransactionSplitDto } from "./dto/create-transaction-split.dto";
 import { UpdateSplitsDto } from "./dto/update-splits.dto";
 import { CreateTransferDto } from "./dto/create-transfer.dto";
 import { UpdateTransferDto } from "./dto/update-transfer.dto";
+import { GetRecentTransactionsDto } from "./dto/get-recent-transactions.dto";
 import { BulkReconcileDto } from "./dto/bulk-reconcile.dto";
 import { BulkUpdateDto, BulkDeleteDto } from "./dto/bulk-update.dto";
 import { MarkClearedDto } from "./dto/mark-cleared.dto";
@@ -425,6 +426,25 @@ export class TransactionsController {
       parsedAmountTo,
       parseUuids(tagIdsParam),
     );
+  }
+
+  @Get("recent")
+  @ApiOperation({
+    summary:
+      "Get recent distinct transactions for quick-fill on the new-transaction form",
+  })
+  @ApiQuery({
+    name: "limit",
+    required: false,
+    description: "Number of recent distinct transactions (1-20, default 5)",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "Recent transactions retrieved successfully",
+  })
+  @ApiResponse({ status: 401, description: "Unauthorized" })
+  getRecent(@Request() req, @Query() query: GetRecentTransactionsDto) {
+    return this.transactionsService.getRecent(req.user.id, query.limit ?? 5);
   }
 
   // ==================== Reconciliation Endpoints ====================

--- a/backend/src/transactions/transactions.service.spec.ts
+++ b/backend/src/transactions/transactions.service.spec.ts
@@ -437,18 +437,57 @@ describe("TransactionsService", () => {
   });
 
   describe("getRecent", () => {
-    it("filters by userId and excludes splits/transfers", async () => {
+    it("filters by userId and excludes transfers, but includes splits", async () => {
       transactionsRepository.find.mockResolvedValue([]);
 
       await service.getRecent("user-1", 5);
 
-      expect(transactionsRepository.find).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { userId: "user-1", isSplit: false, isTransfer: false },
-          order: { transactionDate: "DESC", createdAt: "DESC" },
-          take: 30,
-        }),
+      const call = transactionsRepository.find.mock.calls[0][0];
+      expect(call.where).toEqual({ userId: "user-1", isTransfer: false });
+      expect(call.order).toEqual({
+        transactionDate: "DESC",
+        createdAt: "DESC",
+      });
+      expect(call.take).toBe(30);
+      expect(call.relations).toEqual(
+        expect.arrayContaining([
+          "payee",
+          "category",
+          "account",
+          "tags",
+          "splits",
+          "splits.category",
+          "splits.transferAccount",
+          "splits.tags",
+        ]),
       );
+    });
+
+    it("returns split parents in the result mixed with normals", async () => {
+      const rows = [
+        {
+          id: "s1",
+          payeeId: "p1",
+          payeeName: "A",
+          categoryId: null,
+          isSplit: true,
+          transactionDate: "2026-01-04",
+          splits: [{ id: "sp1", categoryId: "c1", amount: -10 }],
+        },
+        {
+          id: "n1",
+          payeeId: "p2",
+          payeeName: "B",
+          categoryId: "c2",
+          isSplit: false,
+          transactionDate: "2026-01-03",
+        },
+      ];
+      transactionsRepository.find.mockResolvedValue(rows);
+
+      const result = await service.getRecent("user-1", 5);
+
+      expect(result.map((r: any) => r.id)).toEqual(["s1", "n1"]);
     });
 
     it("scopes to payeeId without dedup and uses limit-sized window", async () => {
@@ -483,7 +522,6 @@ describe("TransactionsService", () => {
         expect.objectContaining({
           where: {
             userId: "user-1",
-            isSplit: false,
             isTransfer: false,
             payeeId: "p1",
           },
@@ -502,7 +540,6 @@ describe("TransactionsService", () => {
         expect.objectContaining({
           where: {
             userId: "user-1",
-            isSplit: false,
             isTransfer: false,
             payeeName: "Free-text Coffee",
           },
@@ -522,7 +559,6 @@ describe("TransactionsService", () => {
       const call = transactionsRepository.find.mock.calls[0][0];
       expect(call.where).toEqual({
         userId: "user-1",
-        isSplit: false,
         isTransfer: false,
         payeeId: "p1",
       });

--- a/backend/src/transactions/transactions.service.spec.ts
+++ b/backend/src/transactions/transactions.service.spec.ts
@@ -436,6 +436,168 @@ describe("TransactionsService", () => {
     });
   });
 
+  describe("getRecent", () => {
+    it("filters by userId and excludes splits/transfers", async () => {
+      transactionsRepository.find.mockResolvedValue([]);
+
+      await service.getRecent("user-1", 5);
+
+      expect(transactionsRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: "user-1", isSplit: false, isTransfer: false },
+          order: { transactionDate: "DESC", createdAt: "DESC" },
+          take: 30,
+        }),
+      );
+    });
+
+    it("returns rows in DB order without modification when all distinct", async () => {
+      const rows = [
+        {
+          id: "t1",
+          payeeId: "p1",
+          payeeName: "A",
+          categoryId: "c1",
+          transactionDate: "2026-01-03",
+        },
+        {
+          id: "t2",
+          payeeId: "p2",
+          payeeName: "B",
+          categoryId: "c2",
+          transactionDate: "2026-01-02",
+        },
+        {
+          id: "t3",
+          payeeId: "p3",
+          payeeName: "C",
+          categoryId: "c1",
+          transactionDate: "2026-01-01",
+        },
+      ];
+      transactionsRepository.find.mockResolvedValue(rows);
+
+      const result = await service.getRecent("user-1", 5);
+
+      expect(result).toEqual(rows);
+    });
+
+    it("dedupes by payeeId+categoryId, keeping the most recent", async () => {
+      const rows = [
+        {
+          id: "t1",
+          payeeId: "p1",
+          payeeName: "A",
+          categoryId: "c1",
+          transactionDate: "2026-01-04",
+        },
+        {
+          id: "t2",
+          payeeId: "p1",
+          payeeName: "A",
+          categoryId: "c1",
+          transactionDate: "2026-01-03",
+        },
+        {
+          id: "t3",
+          payeeId: "p2",
+          payeeName: "B",
+          categoryId: "c2",
+          transactionDate: "2026-01-02",
+        },
+        {
+          id: "t4",
+          payeeId: "p1",
+          payeeName: "A",
+          categoryId: "c1",
+          transactionDate: "2026-01-01",
+        },
+      ];
+      transactionsRepository.find.mockResolvedValue(rows);
+
+      const result = await service.getRecent("user-1", 5);
+
+      expect(result.map((r: any) => r.id)).toEqual(["t1", "t3"]);
+    });
+
+    it("dedupes by payeeName when payeeId is null (free-text payee)", async () => {
+      const rows = [
+        {
+          id: "t1",
+          payeeId: null,
+          payeeName: "Free-text",
+          categoryId: "c1",
+          transactionDate: "2026-01-02",
+        },
+        {
+          id: "t2",
+          payeeId: null,
+          payeeName: "Free-text",
+          categoryId: "c1",
+          transactionDate: "2026-01-01",
+        },
+      ];
+      transactionsRepository.find.mockResolvedValue(rows);
+
+      const result = await service.getRecent("user-1", 5);
+
+      expect(result.map((r: any) => r.id)).toEqual(["t1"]);
+    });
+
+    it("treats different categories on same payee as distinct entries", async () => {
+      const rows = [
+        {
+          id: "t1",
+          payeeId: "p1",
+          payeeName: "A",
+          categoryId: "c1",
+          transactionDate: "2026-01-02",
+        },
+        {
+          id: "t2",
+          payeeId: "p1",
+          payeeName: "A",
+          categoryId: "c2",
+          transactionDate: "2026-01-01",
+        },
+      ];
+      transactionsRepository.find.mockResolvedValue(rows);
+
+      const result = await service.getRecent("user-1", 5);
+
+      expect(result.map((r: any) => r.id)).toEqual(["t1", "t2"]);
+    });
+
+    it("caps result at limit even when more distinct rows exist", async () => {
+      const rows = Array.from({ length: 10 }, (_, i) => ({
+        id: `t${i}`,
+        payeeId: `p${i}`,
+        payeeName: `n${i}`,
+        categoryId: `c${i}`,
+        transactionDate: `2026-01-${String(10 - i).padStart(2, "0")}`,
+      }));
+      transactionsRepository.find.mockResolvedValue(rows);
+
+      const result = await service.getRecent("user-1", 3);
+
+      expect(result.map((r: any) => r.id)).toEqual(["t0", "t1", "t2"]);
+    });
+
+    it("clamps limit to [1, 20]", async () => {
+      transactionsRepository.find.mockResolvedValue([]);
+
+      await service.getRecent("user-1", 0);
+      expect(transactionsRepository.find).toHaveBeenLastCalledWith(
+        expect.objectContaining({ take: 6 }),
+      );
+
+      await service.getRecent("user-1", 999);
+      expect(transactionsRepository.find).toHaveBeenLastCalledWith(
+        expect.objectContaining({ take: 120 }),
+      );
+    });
+  });
+
   describe("findOne", () => {
     it("returns transaction when found and belongs to user", async () => {
       const mockTx = {

--- a/backend/src/transactions/transactions.service.spec.ts
+++ b/backend/src/transactions/transactions.service.spec.ts
@@ -451,6 +451,98 @@ describe("TransactionsService", () => {
       );
     });
 
+    it("scopes to payeeId without dedup and uses limit-sized window", async () => {
+      const rows = [
+        {
+          id: "t1",
+          payeeId: "p1",
+          payeeName: "A",
+          categoryId: "c1",
+          transactionDate: "2026-01-04",
+        },
+        {
+          id: "t2",
+          payeeId: "p1",
+          payeeName: "A",
+          categoryId: "c1",
+          transactionDate: "2026-01-03",
+        },
+        {
+          id: "t3",
+          payeeId: "p1",
+          payeeName: "A",
+          categoryId: "c2",
+          transactionDate: "2026-01-02",
+        },
+      ];
+      transactionsRepository.find.mockResolvedValue(rows);
+
+      const result = await service.getRecent("user-1", 5, { payeeId: "p1" });
+
+      expect(transactionsRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            userId: "user-1",
+            isSplit: false,
+            isTransfer: false,
+            payeeId: "p1",
+          },
+          take: 5,
+        }),
+      );
+      expect(result.map((r: any) => r.id)).toEqual(["t1", "t2", "t3"]);
+    });
+
+    it("scopes to payeeName when payeeId is not provided", async () => {
+      transactionsRepository.find.mockResolvedValue([]);
+
+      await service.getRecent("user-1", 5, { payeeName: "Free-text Coffee" });
+
+      expect(transactionsRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            userId: "user-1",
+            isSplit: false,
+            isTransfer: false,
+            payeeName: "Free-text Coffee",
+          },
+          take: 5,
+        }),
+      );
+    });
+
+    it("prefers payeeId over payeeName when both are provided", async () => {
+      transactionsRepository.find.mockResolvedValue([]);
+
+      await service.getRecent("user-1", 5, {
+        payeeId: "p1",
+        payeeName: "ignored",
+      });
+
+      const call = transactionsRepository.find.mock.calls[0][0];
+      expect(call.where).toEqual({
+        userId: "user-1",
+        isSplit: false,
+        isTransfer: false,
+        payeeId: "p1",
+      });
+    });
+
+    it("caps payee-scoped result at limit even when DB returns more", async () => {
+      const rows = Array.from({ length: 8 }, (_, i) => ({
+        id: `t${i}`,
+        payeeId: "p1",
+        payeeName: "A",
+        categoryId: "c1",
+        transactionDate: `2026-01-${String(20 - i).padStart(2, "0")}`,
+      }));
+      transactionsRepository.find.mockResolvedValue(rows);
+
+      const result = await service.getRecent("user-1", 3, { payeeId: "p1" });
+
+      expect(result.map((r: any) => r.id)).toEqual(["t0", "t1", "t2"]);
+    });
+
     it("returns rows in DB order without modification when all distinct", async () => {
       const rows = [
         {

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -220,14 +220,12 @@ export class TransactionsService {
     const isPayeeFiltered = !!(filter?.payeeId || filter?.payeeName);
     // For payee-scoped requests, raw last-N is what's wanted: same payee, just
     // different historical entries. For the unfiltered case we pull a 6x window
-    // so dedup-by-(payee+category) can still yield safeLimit distinct rows.
+    // so dedup can still yield safeLimit distinct rows.
     const window = isPayeeFiltered ? safeLimit : safeLimit * 6;
 
-    const where: Record<string, unknown> = {
-      userId,
-      isSplit: false,
-      isTransfer: false,
-    };
+    // Excludes transfers (those are handled by their own form mode). Splits
+    // ARE included so a user can quick-fill a recurring split entry.
+    const where: Record<string, unknown> = { userId, isTransfer: false };
     if (filter?.payeeId) {
       where.payeeId = filter.payeeId;
     } else if (filter?.payeeName) {
@@ -238,13 +236,25 @@ export class TransactionsService {
       where,
       order: { transactionDate: "DESC", createdAt: "DESC" },
       take: window,
-      relations: ["payee", "category", "account", "tags"],
+      relations: [
+        "payee",
+        "category",
+        "account",
+        "tags",
+        "splits",
+        "splits.category",
+        "splits.transferAccount",
+        "splits.tags",
+      ],
     });
 
     if (isPayeeFiltered) {
       return rows.slice(0, safeLimit);
     }
 
+    // Split parents have categoryId=null (categories live on the splits), so
+    // the dedup key `payeeId|categoryId` collapses to one row per payee for
+    // splits, and to one row per (payee, category) pair for normals.
     const seen = new Set<string>();
     const result: Transaction[] = [];
     for (const row of rows) {

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -211,16 +211,39 @@ export class TransactionsService {
     return result;
   }
 
-  async getRecent(userId: string, limit = 5): Promise<Transaction[]> {
+  async getRecent(
+    userId: string,
+    limit = 5,
+    filter?: { payeeId?: string; payeeName?: string },
+  ): Promise<Transaction[]> {
     const safeLimit = Math.min(20, Math.max(1, Math.floor(limit)));
-    const window = safeLimit * 6;
+    const isPayeeFiltered = !!(filter?.payeeId || filter?.payeeName);
+    // For payee-scoped requests, raw last-N is what's wanted: same payee, just
+    // different historical entries. For the unfiltered case we pull a 6x window
+    // so dedup-by-(payee+category) can still yield safeLimit distinct rows.
+    const window = isPayeeFiltered ? safeLimit : safeLimit * 6;
+
+    const where: Record<string, unknown> = {
+      userId,
+      isSplit: false,
+      isTransfer: false,
+    };
+    if (filter?.payeeId) {
+      where.payeeId = filter.payeeId;
+    } else if (filter?.payeeName) {
+      where.payeeName = filter.payeeName;
+    }
 
     const rows = await this.transactionsRepository.find({
-      where: { userId, isSplit: false, isTransfer: false },
+      where,
       order: { transactionDate: "DESC", createdAt: "DESC" },
       take: window,
       relations: ["payee", "category", "account", "tags"],
     });
+
+    if (isPayeeFiltered) {
+      return rows.slice(0, safeLimit);
+    }
 
     const seen = new Set<string>();
     const result: Transaction[] = [];

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -211,6 +211,30 @@ export class TransactionsService {
     return result;
   }
 
+  async getRecent(userId: string, limit = 5): Promise<Transaction[]> {
+    const safeLimit = Math.min(20, Math.max(1, Math.floor(limit)));
+    const window = safeLimit * 6;
+
+    const rows = await this.transactionsRepository.find({
+      where: { userId, isSplit: false, isTransfer: false },
+      order: { transactionDate: "DESC", createdAt: "DESC" },
+      take: window,
+      relations: ["payee", "category", "account", "tags"],
+    });
+
+    const seen = new Set<string>();
+    const result: Transaction[] = [];
+    for (const row of rows) {
+      const payeeKey = row.payeeId ?? row.payeeName ?? "";
+      const key = `${payeeKey}|${row.categoryId ?? ""}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      result.push(row);
+      if (result.length >= safeLimit) break;
+    }
+    return result;
+  }
+
   async findAll(
     userId: string,
     accountIds?: string[],

--- a/backend/src/users/dto/update-preferences.dto.ts
+++ b/backend/src/users/dto/update-preferences.dto.ts
@@ -150,4 +150,17 @@ export class UpdatePreferencesDto {
   @IsOptional()
   @IsIn(["yahoo", "msn"])
   defaultQuoteProvider?: "yahoo" | "msn";
+
+  @ApiPropertyOptional({
+    description:
+      "Number of entries shown in the recent-transactions quick-fill popover (1-20).",
+    example: 5,
+    minimum: 1,
+    maximum: 20,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(20)
+  recentTransactionsLimit?: number;
 }

--- a/backend/src/users/entities/user-preference.entity.ts
+++ b/backend/src/users/entities/user-preference.entity.ts
@@ -93,6 +93,13 @@ export class UserPreference {
   })
   defaultQuoteProvider: "yahoo" | "msn";
 
+  @Column({
+    name: "recent_transactions_limit",
+    type: "smallint",
+    default: 5,
+  })
+  recentTransactionsLimit: number;
+
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -194,6 +194,9 @@ export class UsersService {
     if (dto.defaultQuoteProvider !== undefined) {
       preferences.defaultQuoteProvider = dto.defaultQuoteProvider;
     }
+    if (dto.recentTransactionsLimit !== undefined) {
+      preferences.recentTransactionsLimit = dto.recentTransactionsLimit;
+    }
 
     return this.preferencesRepository.save(preferences);
   }

--- a/database/migrations/054_recent_transactions_limit.sql
+++ b/database/migrations/054_recent_transactions_limit.sql
@@ -1,0 +1,19 @@
+-- 054: Add per-user limit for the recent-transactions quick-fill popover
+--
+-- Controls how many entries appear in the history button popover next to the
+-- Payee field. Default 5; range 1-20 enforced by check constraint to mirror
+-- the backend DTO validation on GetRecentTransactionsDto.
+
+ALTER TABLE user_preferences
+  ADD COLUMN IF NOT EXISTS recent_transactions_limit SMALLINT NOT NULL DEFAULT 5;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.check_constraints
+    WHERE constraint_name = 'user_preferences_recent_transactions_limit_check'
+  ) THEN
+    ALTER TABLE user_preferences
+      ADD CONSTRAINT user_preferences_recent_transactions_limit_check
+      CHECK (recent_transactions_limit BETWEEN 1 AND 20);
+  END IF;
+END $$;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -497,10 +497,13 @@ CREATE TABLE user_preferences (
     preferred_exchanges TEXT[] DEFAULT '{}',
     dismissed_update_version VARCHAR(50),
     default_quote_provider VARCHAR(20) NOT NULL DEFAULT 'yahoo',
+    recent_transactions_limit SMALLINT NOT NULL DEFAULT 5,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT user_preferences_default_quote_provider_check
-      CHECK (default_quote_provider IN ('yahoo','msn'))
+      CHECK (default_quote_provider IN ('yahoo','msn')),
+    CONSTRAINT user_preferences_recent_transactions_limit_check
+      CHECK (recent_transactions_limit BETWEEN 1 AND 20)
 );
 
 -- Auto Backup Settings (per-user configuration for automatic backups to a folder)

--- a/frontend/src/components/auth/ProtectedRoute.test.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.test.tsx
@@ -158,6 +158,7 @@ describe('ProtectedRoute', () => {
         favouriteReportIds: [],
         preferredExchanges: [],
     defaultQuoteProvider: 'yahoo' as const,
+    recentTransactionsLimit: 5,
         createdAt: '2026-01-01T00:00:00Z',
         updatedAt: '2026-01-01T00:00:00Z',
       },

--- a/frontend/src/components/settings/NotificationsSection.test.tsx
+++ b/frontend/src/components/settings/NotificationsSection.test.tsx
@@ -40,6 +40,7 @@ const mockPreferences: UserPreferences = {
   favouriteReportIds: [],
   preferredExchanges: [],
     defaultQuoteProvider: 'yahoo' as const,
+    recentTransactionsLimit: 5,
   createdAt: '2024-01-01T00:00:00Z',
   updatedAt: '2024-01-01T00:00:00Z',
 };

--- a/frontend/src/components/settings/PreferencesSection.test.tsx
+++ b/frontend/src/components/settings/PreferencesSection.test.tsx
@@ -62,6 +62,7 @@ const mockPreferences: UserPreferences = {
   favouriteReportIds: [],
   preferredExchanges: [],
     defaultQuoteProvider: 'yahoo' as const,
+    recentTransactionsLimit: 5,
   createdAt: '2024-01-01T00:00:00Z',
   updatedAt: '2024-01-01T00:00:00Z',
 };
@@ -117,6 +118,23 @@ describe('PreferencesSection', () => {
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to save preferences');
+    });
+  });
+
+  it('sends updated recent-transactions limit when changed and saved', async () => {
+    (userSettingsApi.updatePreferences as ReturnType<typeof vi.fn>).mockResolvedValue(mockPreferences);
+
+    render(<PreferencesSection preferences={mockPreferences} onPreferencesUpdated={mockOnPreferencesUpdated} />);
+
+    fireEvent.change(screen.getByLabelText('Recent transactions in quick-fill'), {
+      target: { value: '10' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Preferences' }));
+
+    await waitFor(() => {
+      expect(userSettingsApi.updatePreferences).toHaveBeenCalledWith(
+        expect.objectContaining({ recentTransactionsLimit: 10 }),
+      );
     });
   });
 

--- a/frontend/src/components/settings/PreferencesSection.tsx
+++ b/frontend/src/components/settings/PreferencesSection.tsx
@@ -67,6 +67,14 @@ const QUOTE_PROVIDER_OPTIONS = [
   { value: 'msn', label: 'MSN Money' },
 ];
 
+const RECENT_TRANSACTIONS_LIMIT_OPTIONS = [
+  { value: '3', label: '3' },
+  { value: '5', label: '5' },
+  { value: '10', label: '10' },
+  { value: '15', label: '15' },
+  { value: '20', label: '20' },
+];
+
 interface PreferencesSectionProps {
   preferences: UserPreferences;
   onPreferencesUpdated: (prefs: UserPreferences) => void;
@@ -89,6 +97,9 @@ export function PreferencesSection({ preferences, onPreferencesUpdated }: Prefer
   );
   const [defaultQuoteProvider, setDefaultQuoteProvider] = useState<'yahoo' | 'msn'>(
     preferences.defaultQuoteProvider ?? 'yahoo',
+  );
+  const [recentTransactionsLimit, setRecentTransactionsLimit] = useState(
+    preferences.recentTransactionsLimit ?? 5,
   );
   const [isUpdatingPreferences, setIsUpdatingPreferences] = useState(false);
 
@@ -127,6 +138,7 @@ export function PreferencesSection({ preferences, onPreferencesUpdated }: Prefer
         timeFormat,
         preferredExchanges: preferredExchanges.filter(Boolean),
         defaultQuoteProvider,
+        recentTransactionsLimit,
       };
 
       const updated = await userSettingsApi.updatePreferences(data);
@@ -272,6 +284,18 @@ export function PreferencesSection({ preferences, onPreferencesUpdated }: Prefer
             onChange={(e) => setTimeFormat(e.target.value as '24h' | '12h')}
           />
         )}
+
+        <div>
+          <Select
+            label="Recent transactions in quick-fill"
+            options={RECENT_TRANSACTIONS_LIMIT_OPTIONS}
+            value={String(recentTransactionsLimit)}
+            onChange={(e) => setRecentTransactionsLimit(Number(e.target.value))}
+          />
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            Number of entries shown in the history button popover next to the Payee field on transaction forms.
+          </p>
+        </div>
       </div>
 
       <div className="mt-6 flex justify-end">

--- a/frontend/src/components/settings/SecuritySection.test.tsx
+++ b/frontend/src/components/settings/SecuritySection.test.tsx
@@ -84,6 +84,7 @@ const mockPreferences: UserPreferences = {
   favouriteReportIds: [],
   preferredExchanges: [],
     defaultQuoteProvider: 'yahoo' as const,
+    recentTransactionsLimit: 5,
   createdAt: '2024-01-01T00:00:00Z',
   updatedAt: '2024-01-01T00:00:00Z',
 };

--- a/frontend/src/components/transactions/NormalTransactionFields.tsx
+++ b/frontend/src/components/transactions/NormalTransactionFields.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ReactNode } from 'react';
+import { ReactNode, useRef, useState } from 'react';
 import { UseFormRegister, UseFormSetValue, FieldErrors } from 'react-hook-form';
 import { Input } from '@/components/ui/Input';
 import { DateInput } from '@/components/ui/DateInput';
@@ -12,6 +12,7 @@ import { Account } from '@/types/account';
 import { Payee } from '@/types/payee';
 import { getCurrencySymbol } from '@/lib/format';
 import { buildAccountDropdownOptions } from '@/lib/account-utils';
+import { RecentTransactionsPopover } from './RecentTransactionsPopover';
 
 interface NormalTransactionFieldsProps {
   register: UseFormRegister<any>;
@@ -20,6 +21,7 @@ interface NormalTransactionFieldsProps {
   watchedAccountId: string;
   watchedAmount: number;
   watchedCurrencyCode: string;
+  watchedPayeeName?: string;
   accounts: Account[];
   selectedPayeeId: string;
   selectedCategoryId: string;
@@ -32,6 +34,9 @@ interface NormalTransactionFieldsProps {
   handleCategoryCreate: (name: string) => void;
   handleAmountChange: (value: number | undefined) => void;
   handleModeChange: (mode: 'normal' | 'split' | 'transfer') => void;
+  /** Quick-fill the form from a previous transaction. When undefined, the
+   *  history button is hidden (e.g. when editing). */
+  onQuickFill?: (transaction: Transaction) => void;
   transaction?: Transaction;
   createdAtSlot?: ReactNode;
 }
@@ -43,6 +48,7 @@ export function NormalTransactionFields({
   watchedAccountId,
   watchedAmount,
   watchedCurrencyCode,
+  watchedPayeeName,
   accounts,
   selectedPayeeId,
   selectedCategoryId,
@@ -55,9 +61,13 @@ export function NormalTransactionFields({
   handleCategoryCreate,
   handleAmountChange,
   handleModeChange,
+  onQuickFill,
   transaction,
   createdAtSlot,
 }: NormalTransactionFieldsProps) {
+  const historyButtonRef = useRef<HTMLButtonElement>(null);
+  const [showRecentPopover, setShowRecentPopover] = useState(false);
+
   return (
     <div className="space-y-4">
       {/* Row 1: Account, Date, and optionally Create Date */}
@@ -88,22 +98,68 @@ export function NormalTransactionFields({
 
       {/* Row 2: Payee and Category */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <Combobox
-          label="Payee"
-          placeholder="Select or type payee name..."
-          options={payees.map(payee => ({
-            value: payee.id,
-            label: payee.name,
-            subtitle: payee.defaultCategory?.name,
-            keywords: payeeAliasMap[payee.id],
-          }))}
-          value={selectedPayeeId}
-          initialDisplayValue={transaction?.payeeName || ''}
-          onChange={handlePayeeChange}
-          onCreateNew={handlePayeeCreate}
-          allowCustomValue={true}
-          error={errors.payeeName?.message as string | undefined}
-        />
+        <div className="flex items-end space-x-2">
+          <div className="flex-1 min-w-0">
+            <Combobox
+              label="Payee"
+              placeholder="Select or type payee name..."
+              options={payees.map(payee => ({
+                value: payee.id,
+                label: payee.name,
+                subtitle: payee.defaultCategory?.name,
+                keywords: payeeAliasMap[payee.id],
+              }))}
+              value={selectedPayeeId}
+              initialDisplayValue={transaction?.payeeName || ''}
+              onChange={handlePayeeChange}
+              onCreateNew={handlePayeeCreate}
+              allowCustomValue={true}
+              error={errors.payeeName?.message as string | undefined}
+            />
+          </div>
+          {onQuickFill && (
+            <button
+              ref={historyButtonRef}
+              type="button"
+              onClick={() => setShowRecentPopover((v) => !v)}
+              aria-label={
+                selectedPayeeId || watchedPayeeName
+                  ? 'Show recent transactions for this payee'
+                  : 'Show recent transactions'
+              }
+              aria-haspopup="dialog"
+              aria-expanded={showRecentPopover}
+              title="Quick fill from a recent transaction"
+              className="flex-shrink-0 px-2.5 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="h-5 w-5"
+                aria-hidden="true"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-13a.75.75 0 00-1.5 0v5c0 .2.08.39.22.53l3 3a.75.75 0 101.06-1.06L10.75 9.69V5z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          )}
+          {showRecentPopover && onQuickFill && (
+            <RecentTransactionsPopover
+              anchorRef={historyButtonRef}
+              payeeId={selectedPayeeId || undefined}
+              payeeName={selectedPayeeId ? undefined : watchedPayeeName || undefined}
+              onSelect={(t) => {
+                onQuickFill(t);
+                setShowRecentPopover(false);
+              }}
+              onClose={() => setShowRecentPopover(false)}
+            />
+          )}
+        </div>
         <div>
           <div className="flex items-end sm:space-x-2">
             <div className="flex-1">

--- a/frontend/src/components/transactions/NormalTransactionFields.tsx
+++ b/frontend/src/components/transactions/NormalTransactionFields.tsx
@@ -98,7 +98,7 @@ export function NormalTransactionFields({
 
       {/* Row 2: Payee and Category */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div className="flex items-end space-x-2">
+        <div className="flex items-stretch space-x-2">
           <div className="flex-1 min-w-0">
             <Combobox
               label="Payee"
@@ -118,6 +118,9 @@ export function NormalTransactionFields({
             />
           </div>
           {onQuickFill && (
+            // mt-6 (1.5rem) = label line-height (text-sm = 1.25rem) + mb-1 (0.25rem),
+            // pushing the button past the Combobox label so it visually aligns
+            // with the input box; flex-stretch fills the input's height.
             <button
               ref={historyButtonRef}
               type="button"
@@ -130,7 +133,7 @@ export function NormalTransactionFields({
               aria-haspopup="dialog"
               aria-expanded={showRecentPopover}
               title="Quick fill from a recent transaction"
-              className="flex-shrink-0 px-2.5 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+              className="flex-shrink-0 mt-6 flex items-center justify-center px-2.5 border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -161,7 +164,7 @@ export function NormalTransactionFields({
           )}
         </div>
         <div>
-          <div className="flex items-end sm:space-x-2">
+          <div className="flex items-stretch sm:space-x-2">
             <div className="flex-1">
               <Combobox
                 label="Category"
@@ -175,10 +178,11 @@ export function NormalTransactionFields({
                 error={errors.categoryId?.message as string | undefined}
               />
             </div>
+            {/* mt-6 + flex-stretch matches the Combobox input height (see Payee row). */}
             <button
               type="button"
               onClick={() => handleModeChange('split')}
-              className="hidden sm:block px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 whitespace-nowrap"
+              className="hidden sm:flex items-center justify-center flex-shrink-0 mt-6 px-3 text-sm border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 whitespace-nowrap"
             >
               Split Transaction
             </button>

--- a/frontend/src/components/transactions/RecentTransactionsPopover.test.tsx
+++ b/frontend/src/components/transactions/RecentTransactionsPopover.test.tsx
@@ -23,6 +23,12 @@ vi.mock('@/lib/logger', () => ({
   createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
 }));
 
+const mockPreferencesState = { recentTransactionsLimit: 5 as number | undefined };
+vi.mock('@/store/preferencesStore', () => ({
+  usePreferencesStore: (selector: (s: any) => any) =>
+    selector({ preferences: { recentTransactionsLimit: mockPreferencesState.recentTransactionsLimit } }),
+}));
+
 function txn(overrides: Partial<Transaction> = {}): Transaction {
   return {
     id: 'tx-1',
@@ -68,6 +74,31 @@ function Harness(props: { payeeId?: string; payeeName?: string; onSelect: (t: Tr
 describe('RecentTransactionsPopover', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPreferencesState.recentTransactionsLimit = 5;
+  });
+
+  it('uses the limit from preferences when fetching', async () => {
+    mockPreferencesState.recentTransactionsLimit = 12;
+    mockGetRecent.mockResolvedValue([]);
+    render(<Harness onSelect={vi.fn()} onClose={vi.fn()} />);
+    await waitFor(() => expect(mockGetRecent).toHaveBeenCalled());
+    expect(mockGetRecent).toHaveBeenCalledWith({
+      limit: 12,
+      payeeId: undefined,
+      payeeName: undefined,
+    });
+  });
+
+  it('falls back to a limit of 5 when no preference is set', async () => {
+    mockPreferencesState.recentTransactionsLimit = undefined;
+    mockGetRecent.mockResolvedValue([]);
+    render(<Harness onSelect={vi.fn()} onClose={vi.fn()} />);
+    await waitFor(() => expect(mockGetRecent).toHaveBeenCalled());
+    expect(mockGetRecent).toHaveBeenCalledWith({
+      limit: 5,
+      payeeId: undefined,
+      payeeName: undefined,
+    });
   });
 
   it('fetches global recents (no payee) when no filter is provided', async () => {

--- a/frontend/src/components/transactions/RecentTransactionsPopover.test.tsx
+++ b/frontend/src/components/transactions/RecentTransactionsPopover.test.tsx
@@ -133,6 +133,26 @@ describe('RecentTransactionsPopover', () => {
     });
   });
 
+  it('renders a Split row label with split categories', async () => {
+    const splitTxn: Transaction = txn({
+      id: 'split-1',
+      isSplit: true,
+      category: null,
+      categoryId: null,
+      splits: [
+        { id: 'sp-1', transactionId: 'split-1', categoryId: 'c1', category: { id: 'c1', name: 'Groceries' } as any, transferAccountId: null, transferAccount: null, linkedTransactionId: null, amount: -30, memo: null, createdAt: '2026-01-15T00:00:00Z' },
+        { id: 'sp-2', transactionId: 'split-1', categoryId: 'c2', category: { id: 'c2', name: 'Household' } as any, transferAccountId: null, transferAccount: null, linkedTransactionId: null, amount: -20, memo: null, createdAt: '2026-01-15T00:00:00Z' },
+      ],
+    });
+    mockGetRecent.mockResolvedValue([splitTxn]);
+
+    render(<Harness onSelect={vi.fn()} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Split: Groceries, Household/)).toBeInTheDocument();
+    });
+  });
+
   it('closes when Escape is pressed', async () => {
     mockGetRecent.mockResolvedValue([]);
     const onClose = vi.fn();

--- a/frontend/src/components/transactions/RecentTransactionsPopover.test.tsx
+++ b/frontend/src/components/transactions/RecentTransactionsPopover.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useRef } from 'react';
+import { render, screen, waitFor, fireEvent } from '@/test/render';
+import { RecentTransactionsPopover } from './RecentTransactionsPopover';
+import { Transaction, TransactionStatus } from '@/types/transaction';
+
+const mockGetRecent = vi.fn();
+vi.mock('@/lib/transactions', () => ({
+  transactionsApi: {
+    getRecent: (...args: any[]) => mockGetRecent(...args),
+  },
+}));
+
+vi.mock('@/lib/format', () => ({
+  formatCurrency: (amount: number, code: string) => `${code} ${amount.toFixed(2)}`,
+}));
+
+vi.mock('@/hooks/useDateFormat', () => ({
+  useDateFormat: () => ({ formatDate: (d: string) => d, dateFormat: 'browser' }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}));
+
+function txn(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: 'tx-1',
+    userId: 'user-1',
+    accountId: 'acc-1',
+    account: null,
+    transactionDate: '2026-01-15',
+    payeeId: 'payee-1',
+    payeeName: 'Grocery Store',
+    payee: null,
+    categoryId: 'cat-1',
+    category: { id: 'cat-1', name: 'Groceries' } as any,
+    amount: -42.5,
+    currencyCode: 'CAD',
+    exchangeRate: 1,
+    description: 'Weekly shop',
+    referenceNumber: null,
+    status: TransactionStatus.UNRECONCILED,
+    isCleared: false,
+    isReconciled: false,
+    isVoid: false,
+    reconciledDate: null,
+    isSplit: false,
+    parentTransactionId: null,
+    isTransfer: false,
+    linkedTransactionId: null,
+    createdAt: '2026-01-15T00:00:00Z',
+    updatedAt: '2026-01-15T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function Harness(props: { payeeId?: string; payeeName?: string; onSelect: (t: Transaction) => void; onClose: () => void }) {
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  return (
+    <>
+      <button ref={anchorRef}>anchor</button>
+      <RecentTransactionsPopover anchorRef={anchorRef} {...props} />
+    </>
+  );
+}
+
+describe('RecentTransactionsPopover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches global recents (no payee) when no filter is provided', async () => {
+    mockGetRecent.mockResolvedValue([txn()]);
+    render(<Harness onSelect={vi.fn()} onClose={vi.fn()} />);
+    await waitFor(() => expect(mockGetRecent).toHaveBeenCalled());
+    expect(mockGetRecent).toHaveBeenCalledWith({
+      limit: 5,
+      payeeId: undefined,
+      payeeName: undefined,
+    });
+  });
+
+  it('passes payeeId when provided and ignores payeeName', async () => {
+    mockGetRecent.mockResolvedValue([]);
+    render(<Harness payeeId="p1" payeeName="ignored" onSelect={vi.fn()} onClose={vi.fn()} />);
+    await waitFor(() => expect(mockGetRecent).toHaveBeenCalled());
+    expect(mockGetRecent).toHaveBeenCalledWith({
+      limit: 5,
+      payeeId: 'p1',
+      payeeName: undefined,
+    });
+  });
+
+  it('passes payeeName when payeeId is missing (free-text payee)', async () => {
+    mockGetRecent.mockResolvedValue([]);
+    render(<Harness payeeName="Free-text" onSelect={vi.fn()} onClose={vi.fn()} />);
+    await waitFor(() => expect(mockGetRecent).toHaveBeenCalled());
+    expect(mockGetRecent).toHaveBeenCalledWith({
+      limit: 5,
+      payeeId: undefined,
+      payeeName: 'Free-text',
+    });
+  });
+
+  it('renders rows for fetched transactions and calls onSelect when one is clicked', async () => {
+    const t = txn();
+    mockGetRecent.mockResolvedValue([t]);
+    const onSelect = vi.fn();
+    render(<Harness onSelect={onSelect} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Grocery Store')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Grocery Store'));
+    expect(onSelect).toHaveBeenCalledWith(t);
+  });
+
+  it('shows an empty state when no recents are returned', async () => {
+    mockGetRecent.mockResolvedValue([]);
+    render(<Harness onSelect={vi.fn()} onClose={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/No recent transactions/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error state when the fetch fails', async () => {
+    mockGetRecent.mockRejectedValue(new Error('boom'));
+    render(<Harness onSelect={vi.fn()} onClose={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/Could not load/)).toBeInTheDocument();
+    });
+  });
+
+  it('closes when Escape is pressed', async () => {
+    mockGetRecent.mockResolvedValue([]);
+    const onClose = vi.fn();
+    render(<Harness onSelect={vi.fn()} onClose={onClose} />);
+    await waitFor(() => expect(mockGetRecent).toHaveBeenCalled());
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/transactions/RecentTransactionsPopover.tsx
+++ b/frontend/src/components/transactions/RecentTransactionsPopover.tsx
@@ -24,6 +24,18 @@ interface RecentTransactionsPopoverProps {
 
 const POPOVER_WIDTH = 360;
 
+function formatSplitCategoryLabel(t: Transaction): string {
+  const categories = (t.splits ?? [])
+    .map((s) => s.category?.name)
+    .filter((name): name is string => !!name);
+  if (categories.length === 0) {
+    return `Split (${(t.splits ?? []).length} items)`;
+  }
+  const unique = Array.from(new Set(categories));
+  if (unique.length <= 2) return `Split: ${unique.join(', ')}`;
+  return `Split: ${unique.slice(0, 2).join(', ')} +${unique.length - 2}`;
+}
+
 export function RecentTransactionsPopover({
   anchorRef,
   payeeId,
@@ -128,7 +140,9 @@ export function RecentTransactionsPopover({
           <ul>
             {transactions.map((t) => {
               const payeeLabel = t.payeeName || t.payee?.name || '(no payee)';
-              const categoryLabel = t.category?.name || '(uncategorized)';
+              const categoryLabel = t.isSplit
+                ? formatSplitCategoryLabel(t)
+                : t.category?.name || '(uncategorized)';
               return (
                 <li key={t.id}>
                   <button

--- a/frontend/src/components/transactions/RecentTransactionsPopover.tsx
+++ b/frontend/src/components/transactions/RecentTransactionsPopover.tsx
@@ -6,6 +6,7 @@ import { transactionsApi } from '@/lib/transactions';
 import { Transaction } from '@/types/transaction';
 import { formatCurrency } from '@/lib/format';
 import { useDateFormat } from '@/hooks/useDateFormat';
+import { usePreferencesStore } from '@/store/preferencesStore';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('RecentTransactionsPopover');
@@ -45,6 +46,7 @@ export function RecentTransactionsPopover({
 }: RecentTransactionsPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const { formatDate } = useDateFormat();
+  const limit = usePreferencesStore((s) => s.preferences?.recentTransactionsLimit ?? 5);
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
   // The popover is mounted-on-open by the parent, so the fetch always starts
   // fresh - default to loading=true and clear once the request resolves.
@@ -70,7 +72,7 @@ export function RecentTransactionsPopover({
     let cancelled = false;
     transactionsApi
       .getRecent({
-        limit: 5,
+        limit,
         payeeId: payeeId || undefined,
         payeeName: payeeId ? undefined : payeeName || undefined,
       })
@@ -88,7 +90,7 @@ export function RecentTransactionsPopover({
     return () => {
       cancelled = true;
     };
-  }, [payeeId, payeeName]);
+  }, [payeeId, payeeName, limit]);
 
   // Outside-click and escape
   useEffect(() => {

--- a/frontend/src/components/transactions/RecentTransactionsPopover.tsx
+++ b/frontend/src/components/transactions/RecentTransactionsPopover.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useEffect, useRef, useState, RefObject } from 'react';
+import { createPortal } from 'react-dom';
+import { transactionsApi } from '@/lib/transactions';
+import { Transaction } from '@/types/transaction';
+import { formatCurrency } from '@/lib/format';
+import { useDateFormat } from '@/hooks/useDateFormat';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('RecentTransactionsPopover');
+
+interface RecentTransactionsPopoverProps {
+  /** Element the popover positions itself relative to (the trigger button). */
+  anchorRef: RefObject<HTMLElement | null>;
+  /** When set, scopes results to this payee; otherwise returns global deduped recents. */
+  payeeId?: string;
+  /** Free-text payee name fallback when no payeeId. Ignored if payeeId is set. */
+  payeeName?: string;
+  /** Called with the chosen transaction when the user picks a row. Closes the popover. */
+  onSelect: (transaction: Transaction) => void;
+  onClose: () => void;
+}
+
+const POPOVER_WIDTH = 360;
+
+export function RecentTransactionsPopover({
+  anchorRef,
+  payeeId,
+  payeeName,
+  onSelect,
+  onClose,
+}: RecentTransactionsPopoverProps) {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const { formatDate } = useDateFormat();
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+  // The popover is mounted-on-open by the parent, so the fetch always starts
+  // fresh - default to loading=true and clear once the request resolves.
+  const [isLoading, setIsLoading] = useState(true);
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  // Position next to the anchor button
+  useEffect(() => {
+    const anchor = anchorRef.current;
+    if (!anchor) return;
+    const rect = anchor.getBoundingClientRect();
+    let left = rect.left;
+    if (left + POPOVER_WIDTH > window.innerWidth - 8) {
+      left = window.innerWidth - POPOVER_WIDTH - 8;
+    }
+    if (left < 8) left = 8;
+    setPosition({ top: rect.bottom + 4, left });
+  }, [anchorRef]);
+
+  // Fetch on mount (the popover is unmounted/remounted by the parent on open/close)
+  useEffect(() => {
+    let cancelled = false;
+    transactionsApi
+      .getRecent({
+        limit: 5,
+        payeeId: payeeId || undefined,
+        payeeName: payeeId ? undefined : payeeName || undefined,
+      })
+      .then((rows) => {
+        if (cancelled) return;
+        setTransactions(rows);
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        logger.warn('Failed to load recent transactions', err);
+        setError('Could not load recent transactions');
+        setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [payeeId, payeeName]);
+
+  // Outside-click and escape
+  useEffect(() => {
+    const handleMouse = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (popoverRef.current?.contains(target)) return;
+      if (anchorRef.current?.contains(target)) return;
+      onClose();
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('mousedown', handleMouse);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleMouse);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [anchorRef, onClose]);
+
+  if (!position) return null;
+
+  const heading = payeeId || payeeName ? `Recent for ${payeeName || 'this payee'}` : 'Recent transactions';
+
+  const content = (
+    <div
+      ref={popoverRef}
+      role="dialog"
+      aria-label={heading}
+      style={{ top: position.top, left: position.left, width: POPOVER_WIDTH }}
+      className="fixed z-50 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg"
+    >
+      <div className="px-3 py-2 border-b border-gray-200 dark:border-gray-700 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {heading}
+      </div>
+      <div className="max-h-80 overflow-y-auto">
+        {isLoading && (
+          <div className="px-3 py-4 text-sm text-gray-500 dark:text-gray-400">Loading...</div>
+        )}
+        {!isLoading && error && (
+          <div className="px-3 py-4 text-sm text-red-600 dark:text-red-400">{error}</div>
+        )}
+        {!isLoading && !error && transactions.length === 0 && (
+          <div className="px-3 py-4 text-sm text-gray-500 dark:text-gray-400">
+            No recent transactions{payeeId || payeeName ? ' for this payee' : ''}.
+          </div>
+        )}
+        {!isLoading && !error && transactions.length > 0 && (
+          <ul>
+            {transactions.map((t) => {
+              const payeeLabel = t.payeeName || t.payee?.name || '(no payee)';
+              const categoryLabel = t.category?.name || '(uncategorized)';
+              return (
+                <li key={t.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(t)}
+                    className="w-full text-left px-3 py-2 hover:bg-gray-50 dark:hover:bg-gray-700 focus:bg-gray-50 dark:focus:bg-gray-700 focus:outline-none border-b last:border-b-0 border-gray-100 dark:border-gray-700"
+                  >
+                    <div className="flex items-baseline justify-between gap-2">
+                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                        {payeeLabel}
+                      </span>
+                      <span className="text-sm font-mono text-gray-700 dark:text-gray-200 whitespace-nowrap">
+                        {formatCurrency(Number(t.amount), t.currencyCode)}
+                      </span>
+                    </div>
+                    <div className="flex items-baseline justify-between gap-2 text-xs text-gray-500 dark:text-gray-400">
+                      <span className="truncate">{categoryLabel}</span>
+                      <span className="whitespace-nowrap">{formatDate(t.transactionDate)}</span>
+                    </div>
+                    {t.description && (
+                      <div className="mt-0.5 text-xs text-gray-500 dark:text-gray-400 truncate">
+                        {t.description}
+                      </div>
+                    )}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+
+  return createPortal(content, document.body);
+}

--- a/frontend/src/components/transactions/SplitTransactionFields.tsx
+++ b/frontend/src/components/transactions/SplitTransactionFields.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ReactNode } from 'react';
+import { ReactNode, useRef, useState } from 'react';
 import { UseFormRegister, UseFormSetValue, FieldErrors } from 'react-hook-form';
 import { Input } from '@/components/ui/Input';
 import { DateInput } from '@/components/ui/DateInput';
@@ -12,6 +12,7 @@ import { Account } from '@/types/account';
 import { Payee } from '@/types/payee';
 import { getCurrencySymbol } from '@/lib/format';
 import { buildAccountDropdownOptions } from '@/lib/account-utils';
+import { RecentTransactionsPopover } from './RecentTransactionsPopover';
 
 interface SplitTransactionFieldsProps {
   register: UseFormRegister<any>;
@@ -20,12 +21,15 @@ interface SplitTransactionFieldsProps {
   watchedAccountId: string;
   watchedAmount: number;
   watchedCurrencyCode: string;
+  watchedPayeeName?: string;
   accounts: Account[];
   selectedPayeeId: string;
   payees: Payee[];
   handlePayeeChange: (payeeId: string, payeeName: string) => void;
   handlePayeeCreate: (name: string) => void;
   handleAmountChange: (value: number | undefined) => void;
+  /** Quick-fill from a previous transaction (split or normal). Hidden when undefined. */
+  onQuickFill?: (transaction: Transaction) => void;
   transaction?: Transaction;
   createdAtSlot?: ReactNode;
 }
@@ -37,15 +41,20 @@ export function SplitTransactionFields({
   watchedAccountId,
   watchedAmount,
   watchedCurrencyCode,
+  watchedPayeeName,
   accounts,
   selectedPayeeId,
   payees,
   handlePayeeChange,
   handlePayeeCreate,
   handleAmountChange,
+  onQuickFill,
   transaction,
   createdAtSlot,
 }: SplitTransactionFieldsProps) {
+  const historyButtonRef = useRef<HTMLButtonElement>(null);
+  const [showRecentPopover, setShowRecentPopover] = useState(false);
+
   return (
     <div className="space-y-4">
       {/* Row 1: Account, Date, and optionally Create Date */}
@@ -76,21 +85,67 @@ export function SplitTransactionFields({
 
       {/* Row 2: Payee and Total Amount */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <Combobox
-          label="Payee"
-          placeholder="Select or type payee name..."
-          options={payees.map(payee => ({
-            value: payee.id,
-            label: payee.name,
-            subtitle: payee.defaultCategory?.name,
-          }))}
-          value={selectedPayeeId}
-          initialDisplayValue={transaction?.payeeName || ''}
-          onChange={handlePayeeChange}
-          onCreateNew={handlePayeeCreate}
-          allowCustomValue={true}
-          error={errors.payeeName?.message as string | undefined}
-        />
+        <div className="flex items-stretch space-x-2">
+          <div className="flex-1 min-w-0">
+            <Combobox
+              label="Payee"
+              placeholder="Select or type payee name..."
+              options={payees.map(payee => ({
+                value: payee.id,
+                label: payee.name,
+                subtitle: payee.defaultCategory?.name,
+              }))}
+              value={selectedPayeeId}
+              initialDisplayValue={transaction?.payeeName || ''}
+              onChange={handlePayeeChange}
+              onCreateNew={handlePayeeCreate}
+              allowCustomValue={true}
+              error={errors.payeeName?.message as string | undefined}
+            />
+          </div>
+          {onQuickFill && (
+            <button
+              ref={historyButtonRef}
+              type="button"
+              onClick={() => setShowRecentPopover((v) => !v)}
+              aria-label={
+                selectedPayeeId || watchedPayeeName
+                  ? 'Show recent transactions for this payee'
+                  : 'Show recent transactions'
+              }
+              aria-haspopup="dialog"
+              aria-expanded={showRecentPopover}
+              title="Quick fill from a recent transaction"
+              className="flex-shrink-0 mt-6 flex items-center justify-center px-2.5 border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="h-5 w-5"
+                aria-hidden="true"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-13a.75.75 0 00-1.5 0v5c0 .2.08.39.22.53l3 3a.75.75 0 101.06-1.06L10.75 9.69V5z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          )}
+          {showRecentPopover && onQuickFill && (
+            <RecentTransactionsPopover
+              anchorRef={historyButtonRef}
+              payeeId={selectedPayeeId || undefined}
+              payeeName={selectedPayeeId ? undefined : watchedPayeeName || undefined}
+              onSelect={(t) => {
+                onQuickFill(t);
+                setShowRecentPopover(false);
+              }}
+              onClose={() => setShowRecentPopover(false)}
+            />
+          )}
+        </div>
         <CurrencyInput
           label="Total Amount"
           prefix={getCurrencySymbol(watchedCurrencyCode)}

--- a/frontend/src/components/transactions/TransactionForm.test.tsx
+++ b/frontend/src/components/transactions/TransactionForm.test.tsx
@@ -2511,55 +2511,18 @@ describe('TransactionForm', () => {
     });
   });
 
-  describe('quick-fill from recent transactions', () => {
-    const recentTransaction = {
-      ...createExistingTransaction({
-        id: 'recent-1',
-        payeeId: 'payee-1',
-        payeeName: 'Grocery Store',
-        categoryId: 'cat-1',
-        amount: -42.5,
-        currencyCode: 'CAD',
-        description: 'Weekly shop',
-      }),
-      tags: [{ id: 'tag-1', name: 'Food', color: null, icon: null }],
-    };
-
-    it('fetches recent transactions on mount when creating a fresh transaction', async () => {
-      mockGetRecent.mockResolvedValue([recentTransaction]);
-
+  describe('quick-fill from recent transactions (history button)', () => {
+    it('renders the history button when creating a fresh transaction in normal mode', async () => {
       render(<TransactionForm onSuccess={mockOnSuccess} onCancel={mockOnCancel} />);
 
       await waitFor(() => {
-        expect(mockGetRecent).toHaveBeenCalledWith(5);
+        expect(
+          screen.getByLabelText('Show recent transactions'),
+        ).toBeInTheDocument();
       });
     });
 
-    it('renders the quick-fill combobox when recents are present', async () => {
-      mockGetRecent.mockResolvedValue([recentTransaction]);
-
-      render(<TransactionForm onSuccess={mockOnSuccess} onCancel={mockOnCancel} />);
-
-      await waitFor(() => {
-        expect(screen.getByTestId('combobox-Quick fill from recent')).toBeInTheDocument();
-      });
-    });
-
-    it('hides the quick-fill combobox when there are no recents', async () => {
-      mockGetRecent.mockResolvedValue([]);
-
-      render(<TransactionForm onSuccess={mockOnSuccess} onCancel={mockOnCancel} />);
-
-      await waitFor(() => {
-        expect(mockGetRecent).toHaveBeenCalled();
-      });
-      expect(
-        screen.queryByTestId('combobox-Quick fill from recent'),
-      ).not.toBeInTheDocument();
-    });
-
-    it('does not fetch or render quick-fill when editing an existing transaction', async () => {
-      mockGetRecent.mockResolvedValue([recentTransaction]);
+    it('does not render the history button when editing an existing transaction', async () => {
       const existing = createExistingTransaction();
 
       render(
@@ -2573,14 +2536,15 @@ describe('TransactionForm', () => {
       await waitFor(() => {
         expect(mockAccountsGetAll).toHaveBeenCalled();
       });
-      expect(mockGetRecent).not.toHaveBeenCalled();
       expect(
-        screen.queryByTestId('combobox-Quick fill from recent'),
+        screen.queryByLabelText('Show recent transactions'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText('Show recent transactions for this payee'),
       ).not.toBeInTheDocument();
     });
 
-    it('does not fetch or render quick-fill when duplicating a transaction', async () => {
-      mockGetRecent.mockResolvedValue([recentTransaction]);
+    it('does not render the history button when duplicating a transaction', async () => {
       const source = createExistingTransaction();
 
       render(
@@ -2594,41 +2558,39 @@ describe('TransactionForm', () => {
       await waitFor(() => {
         expect(mockAccountsGetAll).toHaveBeenCalled();
       });
-      expect(mockGetRecent).not.toHaveBeenCalled();
       expect(
-        screen.queryByTestId('combobox-Quick fill from recent'),
+        screen.queryByLabelText('Show recent transactions'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText('Show recent transactions for this payee'),
       ).not.toBeInTheDocument();
     });
 
-    it('hides the quick-fill combobox when switching out of normal mode', async () => {
-      mockGetRecent.mockResolvedValue([recentTransaction]);
-
+    it('does not render the history button when switching out of normal mode', async () => {
       render(<TransactionForm onSuccess={mockOnSuccess} onCancel={mockOnCancel} />);
 
       await waitFor(() => {
-        expect(screen.getByTestId('combobox-Quick fill from recent')).toBeInTheDocument();
+        expect(
+          screen.getByLabelText('Show recent transactions'),
+        ).toBeInTheDocument();
       });
 
       fireEvent.click(screen.getByText('Split'));
 
       await waitFor(() => {
         expect(
-          screen.queryByTestId('combobox-Quick fill from recent'),
+          screen.queryByLabelText('Show recent transactions'),
         ).not.toBeInTheDocument();
       });
     });
 
-    it('still renders the form when the recents fetch fails', async () => {
-      mockGetRecent.mockRejectedValue(new Error('boom'));
-
+    it('does not fetch recent transactions on mount (lazy fetch only when popover opens)', async () => {
       render(<TransactionForm onSuccess={mockOnSuccess} onCancel={mockOnCancel} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Account')).toBeInTheDocument();
+        expect(mockAccountsGetAll).toHaveBeenCalled();
       });
-      expect(
-        screen.queryByTestId('combobox-Quick fill from recent'),
-      ).not.toBeInTheDocument();
+      expect(mockGetRecent).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/components/transactions/TransactionForm.test.tsx
+++ b/frontend/src/components/transactions/TransactionForm.test.tsx
@@ -178,6 +178,7 @@ const mockCreate = vi.fn().mockResolvedValue({});
 const mockUpdate = vi.fn().mockResolvedValue({});
 const mockCreateTransfer = vi.fn().mockResolvedValue({});
 const mockUpdateTransfer = vi.fn().mockResolvedValue({});
+const mockGetRecent = vi.fn().mockResolvedValue([]);
 
 vi.mock('@/lib/transactions', () => ({
   transactionsApi: {
@@ -185,6 +186,7 @@ vi.mock('@/lib/transactions', () => ({
     update: (...args: any[]) => mockUpdate(...args),
     createTransfer: (...args: any[]) => mockCreateTransfer(...args),
     updateTransfer: (...args: any[]) => mockUpdateTransfer(...args),
+    getRecent: (...args: any[]) => mockGetRecent(...args),
   },
 }));
 
@@ -415,6 +417,7 @@ describe('TransactionForm', () => {
     mockAccountsGetAll.mockResolvedValue(mockAccounts);
     mockPayeesGetAll.mockResolvedValue(mockPayees);
     mockCategoriesGetAll.mockResolvedValue(mockCategories);
+    mockGetRecent.mockResolvedValue([]);
   });
 
   // =========================================================================
@@ -2505,6 +2508,127 @@ describe('TransactionForm', () => {
         expect(screen.getByText('Split')).toBeInTheDocument();
         expect(screen.getByText('Transfer')).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('quick-fill from recent transactions', () => {
+    const recentTransaction = {
+      ...createExistingTransaction({
+        id: 'recent-1',
+        payeeId: 'payee-1',
+        payeeName: 'Grocery Store',
+        categoryId: 'cat-1',
+        amount: -42.5,
+        currencyCode: 'CAD',
+        description: 'Weekly shop',
+      }),
+      tags: [{ id: 'tag-1', name: 'Food', color: null, icon: null }],
+    };
+
+    it('fetches recent transactions on mount when creating a fresh transaction', async () => {
+      mockGetRecent.mockResolvedValue([recentTransaction]);
+
+      render(<TransactionForm onSuccess={mockOnSuccess} onCancel={mockOnCancel} />);
+
+      await waitFor(() => {
+        expect(mockGetRecent).toHaveBeenCalledWith(5);
+      });
+    });
+
+    it('renders the quick-fill combobox when recents are present', async () => {
+      mockGetRecent.mockResolvedValue([recentTransaction]);
+
+      render(<TransactionForm onSuccess={mockOnSuccess} onCancel={mockOnCancel} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('combobox-Quick fill from recent')).toBeInTheDocument();
+      });
+    });
+
+    it('hides the quick-fill combobox when there are no recents', async () => {
+      mockGetRecent.mockResolvedValue([]);
+
+      render(<TransactionForm onSuccess={mockOnSuccess} onCancel={mockOnCancel} />);
+
+      await waitFor(() => {
+        expect(mockGetRecent).toHaveBeenCalled();
+      });
+      expect(
+        screen.queryByTestId('combobox-Quick fill from recent'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not fetch or render quick-fill when editing an existing transaction', async () => {
+      mockGetRecent.mockResolvedValue([recentTransaction]);
+      const existing = createExistingTransaction();
+
+      render(
+        <TransactionForm
+          transaction={existing}
+          onSuccess={mockOnSuccess}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockAccountsGetAll).toHaveBeenCalled();
+      });
+      expect(mockGetRecent).not.toHaveBeenCalled();
+      expect(
+        screen.queryByTestId('combobox-Quick fill from recent'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not fetch or render quick-fill when duplicating a transaction', async () => {
+      mockGetRecent.mockResolvedValue([recentTransaction]);
+      const source = createExistingTransaction();
+
+      render(
+        <TransactionForm
+          duplicateFrom={source}
+          onSuccess={mockOnSuccess}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockAccountsGetAll).toHaveBeenCalled();
+      });
+      expect(mockGetRecent).not.toHaveBeenCalled();
+      expect(
+        screen.queryByTestId('combobox-Quick fill from recent'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('hides the quick-fill combobox when switching out of normal mode', async () => {
+      mockGetRecent.mockResolvedValue([recentTransaction]);
+
+      render(<TransactionForm onSuccess={mockOnSuccess} onCancel={mockOnCancel} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('combobox-Quick fill from recent')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Split'));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId('combobox-Quick fill from recent'),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('still renders the form when the recents fetch fails', async () => {
+      mockGetRecent.mockRejectedValue(new Error('boom'));
+
+      render(<TransactionForm onSuccess={mockOnSuccess} onCancel={mockOnCancel} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Account')).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByTestId('combobox-Quick fill from recent'),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/transactions/TransactionForm.test.tsx
+++ b/frontend/src/components/transactions/TransactionForm.test.tsx
@@ -2566,7 +2566,7 @@ describe('TransactionForm', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('does not render the history button when switching out of normal mode', async () => {
+    it('keeps the history button visible after switching to split mode', async () => {
       render(<TransactionForm onSuccess={mockOnSuccess} onCancel={mockOnCancel} />);
 
       await waitFor(() => {
@@ -2576,6 +2576,24 @@ describe('TransactionForm', () => {
       });
 
       fireEvent.click(screen.getByText('Split'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByLabelText('Show recent transactions'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('hides the history button in transfer mode', async () => {
+      render(<TransactionForm onSuccess={mockOnSuccess} onCancel={mockOnCancel} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByLabelText('Show recent transactions'),
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Transfer'));
 
       await waitFor(() => {
         expect(

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -350,7 +350,9 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
 
   // Quick-fill the form from a previously entered transaction (chosen from
   // the history popover next to the Payee field). Resets date to today and
-  // status to UNRECONCILED, otherwise mirrors duplicateFrom behaviour.
+  // status to UNRECONCILED, otherwise mirrors duplicateFrom behaviour. When
+  // the source is a split, the form switches into split mode and the splits
+  // state is restored so the user gets back the same split breakdown.
   const handleQuickFill = (source: Transaction) => {
     const amount = Math.round(Number(source.amount) * 100) / 100;
     setValue('accountId', source.accountId, { shouldDirty: true, shouldValidate: true });
@@ -367,6 +369,16 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
     setSelectedPayeeId(source.payeeId || '');
     setSelectedCategoryId(source.categoryId || '');
     setSelectedTagIds(source.tags?.map((t) => t.id) || []);
+
+    if (source.isSplit && source.splits && source.splits.length > 0) {
+      setSplits(toSplitRows(source.splits));
+      setIsSplitMode(true);
+      setMode('split');
+    } else {
+      setSplits([]);
+      setIsSplitMode(false);
+      setMode('normal');
+    }
   };
 
   // Handle payee selection

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -7,8 +7,6 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import toast from 'react-hot-toast';
 import { Select } from '@/components/ui/Select';
-import { Combobox } from '@/components/ui/Combobox';
-import { formatCurrency } from '@/lib/format';
 import { SplitEditor, SplitRow, createEmptySplits, toSplitRows, toCreateSplitData } from './SplitEditor';
 import { NormalTransactionFields } from './NormalTransactionFields';
 import { SplitTransactionFields } from './SplitTransactionFields';
@@ -80,7 +78,6 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
   const [payees, setPayees] = useState<Payee[]>([]); // Full list of active payees
   const [payeeAliasMap, setPayeeAliasMap] = useState<Record<string, string[]>>({}); // payeeId -> alias strings
   const [tags, setTags] = useState<Tag[]>([]);
-  const [recentTransactions, setRecentTransactions] = useState<Transaction[]>([]);
   // initSource: the transaction to pre-fill from (either editing or duplicating)
   const initSource = transaction || duplicateFrom;
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>(
@@ -219,6 +216,7 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
   const watchedAccountId = watch('accountId');
   const watchedAmount = watch('amount');
   const watchedCurrencyCode = watch('currencyCode');
+  const watchedPayeeName = watch('payeeName');
 
   // Auto-set currencyCode from the selected account
   useEffect(() => {
@@ -306,20 +304,6 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
     }
   }, [defaultAccountId, transaction, setValue]);
 
-  // Fetch recent transactions for the quick-fill dropdown when creating fresh
-  // (skip when editing an existing transaction or duplicating, since those
-  // already pre-fill the form via initSource).
-  useEffect(() => {
-    if (transaction || duplicateFrom) return;
-    transactionsApi
-      .getRecent(5)
-      .then((rows) => setRecentTransactions(rows))
-      .catch((error) => {
-        // Non-critical: form still works without quick-fill
-        logger.warn('Failed to load recent transactions for quick-fill', error);
-      });
-  }, [transaction, duplicateFrom]);
-
   // Load accounts, categories, active payees on mount
   // When editing, also fetch the transaction's payee if it's inactive so it appears in the dropdown
   useEffect(() => {
@@ -364,14 +348,10 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
       });
   }, [transaction?.payeeId]);
 
-  // Quick-fill the form from a previously entered transaction. Mirrors the
-  // duplicateFrom behaviour but applied inline: copy payee/category/amount/
-  // currency/description/tags, reset date to today and status to UNRECONCILED.
-  const handleQuickFill = (transactionId: string) => {
-    if (!transactionId) return;
-    const source = recentTransactions.find((t) => t.id === transactionId);
-    if (!source) return;
-
+  // Quick-fill the form from a previously entered transaction (chosen from
+  // the history popover next to the Payee field). Resets date to today and
+  // status to UNRECONCILED, otherwise mirrors duplicateFrom behaviour.
+  const handleQuickFill = (source: Transaction) => {
     const amount = Math.round(Number(source.amount) * 100) / 100;
     setValue('accountId', source.accountId, { shouldDirty: true, shouldValidate: true });
     setValue('transactionDate', getLocalDateString(), { shouldDirty: true, shouldValidate: true });
@@ -388,19 +368,6 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
     setSelectedCategoryId(source.categoryId || '');
     setSelectedTagIds(source.tags?.map((t) => t.id) || []);
   };
-
-  const recentOptions = useMemo(
-    () =>
-      recentTransactions.map((t) => {
-        const payeeLabel = t.payeeName || t.payee?.name || '(no payee)';
-        const categoryLabel = t.category?.name || '(uncategorized)';
-        return {
-          value: t.id,
-          label: `${payeeLabel} - ${categoryLabel} - ${formatCurrency(Number(t.amount), t.currencyCode)}`,
-        };
-      }),
-    [recentTransactions],
-  );
 
   // Handle payee selection
   const handlePayeeChange = (payeeId: string, payeeName: string) => {
@@ -844,19 +811,6 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-      {/* Quick-fill from recent transactions: only when creating fresh in
-          normal mode and we actually have recents to suggest. */}
-      {!transaction && !duplicateFrom && mode === 'normal' && recentOptions.length > 0 && (
-        <Combobox
-          label="Quick fill from recent"
-          placeholder="Select a recent transaction..."
-          options={recentOptions}
-          onChange={handleQuickFill}
-          usePortal
-          alwaysShowSubtitle
-        />
-      )}
-
       {/* Mode selector - show for new/duplicate transactions, or non-transfer edits */}
       {(!transaction || !transaction.isTransfer) && (
         <div className="flex space-x-2 pb-2 border-b dark:border-gray-700">
@@ -916,6 +870,7 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
           watchedAccountId={watchedAccountId}
           watchedAmount={watchedAmount}
           watchedCurrencyCode={watchedCurrencyCode}
+          watchedPayeeName={watchedPayeeName}
           accounts={accounts}
           selectedPayeeId={selectedPayeeId}
           selectedCategoryId={selectedCategoryId}
@@ -928,6 +883,7 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
           handleCategoryCreate={handleCategoryCreate}
           handleAmountChange={handleAmountChange}
           handleModeChange={handleModeChange}
+          onQuickFill={!transaction && !duplicateFrom ? handleQuickFill : undefined}
           transaction={transaction}
           createdAtSlot={createdAtSlot}
         />

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -7,6 +7,8 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import toast from 'react-hot-toast';
 import { Select } from '@/components/ui/Select';
+import { Combobox } from '@/components/ui/Combobox';
+import { formatCurrency } from '@/lib/format';
 import { SplitEditor, SplitRow, createEmptySplits, toSplitRows, toCreateSplitData } from './SplitEditor';
 import { NormalTransactionFields } from './NormalTransactionFields';
 import { SplitTransactionFields } from './SplitTransactionFields';
@@ -78,6 +80,7 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
   const [payees, setPayees] = useState<Payee[]>([]); // Full list of active payees
   const [payeeAliasMap, setPayeeAliasMap] = useState<Record<string, string[]>>({}); // payeeId -> alias strings
   const [tags, setTags] = useState<Tag[]>([]);
+  const [recentTransactions, setRecentTransactions] = useState<Transaction[]>([]);
   // initSource: the transaction to pre-fill from (either editing or duplicating)
   const initSource = transaction || duplicateFrom;
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>(
@@ -303,6 +306,20 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
     }
   }, [defaultAccountId, transaction, setValue]);
 
+  // Fetch recent transactions for the quick-fill dropdown when creating fresh
+  // (skip when editing an existing transaction or duplicating, since those
+  // already pre-fill the form via initSource).
+  useEffect(() => {
+    if (transaction || duplicateFrom) return;
+    transactionsApi
+      .getRecent(5)
+      .then((rows) => setRecentTransactions(rows))
+      .catch((error) => {
+        // Non-critical: form still works without quick-fill
+        logger.warn('Failed to load recent transactions for quick-fill', error);
+      });
+  }, [transaction, duplicateFrom]);
+
   // Load accounts, categories, active payees on mount
   // When editing, also fetch the transaction's payee if it's inactive so it appears in the dropdown
   useEffect(() => {
@@ -346,6 +363,44 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
         logger.error(error);
       });
   }, [transaction?.payeeId]);
+
+  // Quick-fill the form from a previously entered transaction. Mirrors the
+  // duplicateFrom behaviour but applied inline: copy payee/category/amount/
+  // currency/description/tags, reset date to today and status to UNRECONCILED.
+  const handleQuickFill = (transactionId: string) => {
+    if (!transactionId) return;
+    const source = recentTransactions.find((t) => t.id === transactionId);
+    if (!source) return;
+
+    const amount = Math.round(Number(source.amount) * 100) / 100;
+    setValue('accountId', source.accountId, { shouldDirty: true, shouldValidate: true });
+    setValue('transactionDate', getLocalDateString(), { shouldDirty: true, shouldValidate: true });
+    setValue('payeeId', source.payeeId || undefined, { shouldDirty: true });
+    setValue('payeeName', source.payeeName || '', { shouldDirty: true });
+    setValue('categoryId', source.categoryId || '', { shouldDirty: true });
+    setValue('amount', amount, { shouldDirty: true, shouldValidate: true });
+    setValue('currencyCode', source.currencyCode, { shouldDirty: true });
+    setValue('description', source.description || '', { shouldDirty: true });
+    setValue('referenceNumber', '', { shouldDirty: true });
+    setValue('status', TransactionStatus.UNRECONCILED, { shouldDirty: true });
+
+    setSelectedPayeeId(source.payeeId || '');
+    setSelectedCategoryId(source.categoryId || '');
+    setSelectedTagIds(source.tags?.map((t) => t.id) || []);
+  };
+
+  const recentOptions = useMemo(
+    () =>
+      recentTransactions.map((t) => {
+        const payeeLabel = t.payeeName || t.payee?.name || '(no payee)';
+        const categoryLabel = t.category?.name || '(uncategorized)';
+        return {
+          value: t.id,
+          label: `${payeeLabel} - ${categoryLabel} - ${formatCurrency(Number(t.amount), t.currencyCode)}`,
+        };
+      }),
+    [recentTransactions],
+  );
 
   // Handle payee selection
   const handlePayeeChange = (payeeId: string, payeeName: string) => {
@@ -789,6 +844,19 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      {/* Quick-fill from recent transactions: only when creating fresh in
+          normal mode and we actually have recents to suggest. */}
+      {!transaction && !duplicateFrom && mode === 'normal' && recentOptions.length > 0 && (
+        <Combobox
+          label="Quick fill from recent"
+          placeholder="Select a recent transaction..."
+          options={recentOptions}
+          onChange={handleQuickFill}
+          usePortal
+          alwaysShowSubtitle
+        />
+      )}
+
       {/* Mode selector - show for new/duplicate transactions, or non-transfer edits */}
       {(!transaction || !transaction.isTransfer) && (
         <div className="flex space-x-2 pb-2 border-b dark:border-gray-700">

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -909,12 +909,14 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
           watchedAccountId={watchedAccountId}
           watchedAmount={watchedAmount}
           watchedCurrencyCode={watchedCurrencyCode}
+          watchedPayeeName={watchedPayeeName}
           accounts={accounts}
           selectedPayeeId={selectedPayeeId}
           payees={payees}
           handlePayeeChange={handlePayeeChange}
           handlePayeeCreate={handlePayeeCreate}
           handleAmountChange={handleSplitTotalChange}
+          onQuickFill={!transaction && !duplicateFrom ? handleQuickFill : undefined}
           transaction={transaction}
           createdAtSlot={createdAtSlot}
         />

--- a/frontend/src/lib/transactions.ts
+++ b/frontend/src/lib/transactions.ts
@@ -103,11 +103,20 @@ export const transactionsApi = {
     return response.data;
   },
 
-  // Get the most recent distinct transactions, used by the new-transaction
-  // form's quick-fill dropdown. Server-side dedup by payee+category.
-  getRecent: async (limit = 5): Promise<Transaction[]> => {
+  // Quick-fill recents. Without a payee filter the backend dedups by
+  // payee+category to surface variety; with payeeId or payeeName it returns
+  // the raw last-N entries for that payee.
+  getRecent: async (params?: {
+    limit?: number;
+    payeeId?: string;
+    payeeName?: string;
+  }): Promise<Transaction[]> => {
     const response = await apiClient.get<Transaction[]>('/transactions/recent', {
-      params: { limit },
+      params: {
+        limit: params?.limit ?? 5,
+        payeeId: params?.payeeId,
+        payeeName: params?.payeeName,
+      },
     });
     return response.data;
   },

--- a/frontend/src/lib/transactions.ts
+++ b/frontend/src/lib/transactions.ts
@@ -103,6 +103,15 @@ export const transactionsApi = {
     return response.data;
   },
 
+  // Get the most recent distinct transactions, used by the new-transaction
+  // form's quick-fill dropdown. Server-side dedup by payee+category.
+  getRecent: async (limit = 5): Promise<Transaction[]> => {
+    const response = await apiClient.get<Transaction[]>('/transactions/recent', {
+      params: { limit },
+    });
+    return response.data;
+  },
+
   // Get single transaction by ID
   getById: async (id: string): Promise<Transaction> => {
     const response = await apiClient.get<Transaction>(`/transactions/${id}`);

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -94,6 +94,7 @@ export interface UserPreferences {
   timeFormat: '24h' | '12h';
   preferredExchanges: string[];
   defaultQuoteProvider: 'yahoo' | 'msn';
+  recentTransactionsLimit: number;
   createdAt: string;
   updatedAt: string;
 }
@@ -151,6 +152,7 @@ export interface UpdatePreferencesData {
   timeFormat?: '24h' | '12h';
   preferredExchanges?: string[];
   defaultQuoteProvider?: 'yahoo' | 'msn';
+  recentTransactionsLimit?: number;
 }
 
 export interface ChangePasswordData {


### PR DESCRIPTION
## Summary
This PR adds a "recent transactions" quick-fill feature to the transaction form, allowing users to rapidly populate transaction fields by selecting from their recent transaction history. The feature includes both a backend API endpoint and a frontend popover UI component.

## Key Changes

### Backend
- **New endpoint**: `GET /transactions/recent` to fetch recent transactions for quick-fill
  - Supports optional payee filtering (by `payeeId` or `payeeName`)
  - Implements smart deduplication: when unfiltered, returns distinct transactions by payee+category to show variety; when payee-filtered, returns raw chronological entries
  - Configurable limit (1-20, default 5) with 6x window for dedup to ensure sufficient distinct results
  - Excludes transfers but includes split transactions
  - Loads full transaction relations (payee, category, account, tags, splits)

- **New DTO**: `GetRecentTransactionsDto` with validation for limit, payeeId, and payeeName parameters

- **Service method**: `TransactionsService.getRecent()` implements the deduplication logic and database query

### Frontend
- **New component**: `RecentTransactionsPopover` 
  - Positioned popover that displays recent transactions in a scrollable list
  - Supports both global recents and payee-scoped filtering
  - Lazy-loads data only when popover opens (no fetch on form mount)
  - Handles loading, error, and empty states
  - Closes on Escape key or outside click
  - Displays split transactions with formatted category labels

- **Form integration**: Added history button next to payee field in both `NormalTransactionFields` and `SplitTransactionFields`
  - Button only appears when creating new transactions (hidden when editing or duplicating)
  - Shows global recents by default, or payee-specific recents when a payee is selected
  - Clicking a transaction calls `onQuickFill` to populate the form

- **Quick-fill logic**: `TransactionForm.handleQuickFill()` 
  - Resets transaction date to today and status to UNRECONCILED
  - Copies payee, category, amount, and description from selected transaction
  - For split transactions, switches form to split mode and restores split breakdown
  - Marks form as dirty to enable save button

## Implementation Details
- The deduplication strategy uses a `payeeId|categoryId` key to collapse duplicate payee+category combinations while preserving the most recent entry
- Free-text payees (where `payeeId` is null) are deduplicated by `payeeName` instead
- The 6x window multiplier for unfiltered requests ensures the dedup process can still yield the requested number of distinct results
- Split parent transactions have `categoryId=null` (categories live on individual splits), so they naturally deduplicate to one entry per payee
- The popover uses React portals to render at the document root, avoiding z-index stacking issues

https://claude.ai/code/session_01LhQzy5arDeegTrPqV583Np