### PR TITLE
Extract linked account counting logic into reusable utility

### DIFF
--- a/frontend/src/app/accounts/page.tsx
+++ b/frontend/src/app/accounts/page.tsx
@@ -12,6 +12,7 @@ import { Modal } from '@/components/ui/Modal';
 import { UnsavedChangesDialog } from '@/components/ui/UnsavedChangesDialog';
 import { accountsApi } from '@/lib/accounts';
 import { investmentsApi } from '@/lib/investments';
+import { countLogicalAccounts } from '@/lib/account-utils';
 import { Account } from '@/types/account';
 import { PortfolioSummary } from '@/types/investment';
 import { PageLayout } from '@/components/layout/PageLayout';
@@ -147,19 +148,7 @@ function AccountsContent() {
       }
     });
 
-    // Count a linked brokerage/cash pair as a single logical account.
-    const activeIds = new Set(activeAccounts.map((a) => a.id));
-    const counted = new Set<string>();
-    let accountCount = 0;
-    for (const a of activeAccounts) {
-      if (counted.has(a.id)) continue;
-      counted.add(a.id);
-      if (a.linkedAccountId && activeIds.has(a.linkedAccountId)) {
-        counted.add(a.linkedAccountId);
-      }
-      accountCount += 1;
-    }
-
+    const accountCount = countLogicalAccounts(activeAccounts);
     const totalBalance = totalAssets - totalLiabilities;
     return { totalBalance, totalAssets, totalLiabilities, accountCount };
   };

--- a/frontend/src/components/accounts/AccountList.test.tsx
+++ b/frontend/src/components/accounts/AccountList.test.tsx
@@ -863,6 +863,33 @@ describe('AccountList', () => {
     expect(screen.getByText(/Paired with Inv Cash/)).toBeInTheDocument();
   });
 
+  it('counts a linked investment brokerage/cash pair as a single account in the header', () => {
+    const accounts = [
+      createAccount({ id: 'a1', name: 'Chequing', accountType: 'CHEQUING' }),
+      createAccount({
+        id: 'cash-1',
+        name: 'Inv Cash',
+        accountType: 'INVESTMENT',
+        accountSubType: 'INVESTMENT_CASH',
+        linkedAccountId: 'broker-1',
+      }),
+      createAccount({
+        id: 'broker-1',
+        name: 'Inv Brokerage',
+        accountType: 'INVESTMENT',
+        accountSubType: 'INVESTMENT_BROKERAGE',
+        linkedAccountId: 'cash-1',
+      }),
+    ];
+
+    render(
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
+    );
+
+    // 1 chequing + 1 logical investment account (the linked pair) = 2
+    expect(screen.getByText('2 of 2 accounts')).toBeInTheDocument();
+  });
+
   it('shows Brokerage and Inv. Cash type labels for investment subtypes', () => {
     const accounts = [
       createAccount({

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -42,6 +42,27 @@ const ACCOUNT_TYPE_ORDER: AccountType[] = [
   'OTHER',
 ];
 
+// Count accounts treating a linked investment brokerage/cash pair as one
+// logical account (matches the per-group header count).
+function countLogicalAccounts(accounts: Account[]): number {
+  const ids = new Set(accounts.map((a) => a.id));
+  const counted = new Set<string>();
+  let count = 0;
+  for (const account of accounts) {
+    if (counted.has(account.id)) continue;
+    counted.add(account.id);
+    if (
+      account.accountType === 'INVESTMENT' &&
+      account.linkedAccountId &&
+      ids.has(account.linkedAccountId)
+    ) {
+      counted.add(account.linkedAccountId);
+    }
+    count += 1;
+  }
+  return count;
+}
+
 // Helper to get stored value
 function getStoredValue<T>(key: string, defaultValue: T): T {
   if (typeof window === 'undefined') return defaultValue;
@@ -369,26 +390,10 @@ export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, 
     let rowIndex = 0;
     for (const { type, accounts: groupAccounts } of groupedAccounts) {
       const isCollapsed = collapsedGroups.has(type);
-      // For investments, a linked brokerage/cash pair represents one logical
-      // account, so collapse pairs into a single count.
-      let count = groupAccounts.length;
-      if (type === 'INVESTMENT') {
-        const idsInGroup = new Set(groupAccounts.map((a) => a.id));
-        const counted = new Set<string>();
-        count = 0;
-        for (const account of groupAccounts) {
-          if (counted.has(account.id)) continue;
-          counted.add(account.id);
-          if (account.linkedAccountId && idsInGroup.has(account.linkedAccountId)) {
-            counted.add(account.linkedAccountId);
-          }
-          count += 1;
-        }
-      }
       items.push({
         kind: 'header',
         type,
-        count,
+        count: countLogicalAccounts(groupAccounts),
         total: groupTotals.get(type) ?? 0,
         isCollapsed,
       });
@@ -584,7 +589,7 @@ export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, 
             </div>
           </div>
           <span className="text-sm text-gray-500 dark:text-gray-400">
-            {filteredAndSortedAccounts.length} of {accounts.length} accounts
+            {countLogicalAccounts(filteredAndSortedAccounts)} of {countLogicalAccounts(accounts)} accounts
           </span>
         </div>
       </div>

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -12,7 +12,7 @@ import { getErrorMessage } from '@/lib/errors';
 import { AccountRow } from './AccountRow';
 import { useTableDensity, nextDensity, type DensityLevel } from '@/hooks/useTableDensity';
 import { SortIcon } from '@/components/ui/SortIcon';
-import { formatAccountType } from '@/lib/account-utils';
+import { formatAccountType, countLogicalAccounts } from '@/lib/account-utils';
 
 type SortField = 'name' | 'type' | 'balance' | 'status';
 type SortDirection = 'asc' | 'desc';
@@ -41,27 +41,6 @@ const ACCOUNT_TYPE_ORDER: AccountType[] = [
   'MORTGAGE',
   'OTHER',
 ];
-
-// Count accounts treating a linked investment brokerage/cash pair as one
-// logical account (matches the per-group header count).
-function countLogicalAccounts(accounts: Account[]): number {
-  const ids = new Set(accounts.map((a) => a.id));
-  const counted = new Set<string>();
-  let count = 0;
-  for (const account of accounts) {
-    if (counted.has(account.id)) continue;
-    counted.add(account.id);
-    if (
-      account.accountType === 'INVESTMENT' &&
-      account.linkedAccountId &&
-      ids.has(account.linkedAccountId)
-    ) {
-      counted.add(account.linkedAccountId);
-    }
-    count += 1;
-  }
-  return count;
-}
 
 // Helper to get stored value
 function getStoredValue<T>(key: string, defaultValue: T): T {

--- a/frontend/src/lib/account-utils.ts
+++ b/frontend/src/lib/account-utils.ts
@@ -71,6 +71,26 @@ export const isInvestmentBrokerageAccount = (account: Account): boolean => {
 };
 
 /**
+ * Count accounts treating a linked brokerage/cash investment pair as one
+ * logical account. Both halves of the pair must appear in the input list
+ * for the dedup to apply.
+ */
+export function countLogicalAccounts(accounts: Account[]): number {
+  const ids = new Set(accounts.map((a) => a.id));
+  const counted = new Set<string>();
+  let count = 0;
+  for (const account of accounts) {
+    if (counted.has(account.id)) continue;
+    counted.add(account.id);
+    if (account.linkedAccountId && ids.has(account.linkedAccountId)) {
+      counted.add(account.linkedAccountId);
+    }
+    count += 1;
+  }
+  return count;
+}
+
+/**
  * Build a human-readable label describing which accounts are currently in
  * a filter, for use in section headers.
  *


### PR DESCRIPTION
## Summary
Refactored the logic for counting linked investment brokerage/cash account pairs as single logical accounts into a reusable utility function to eliminate code duplication.

## Key Changes
- Created `countLogicalAccounts()` utility function in `account-utils.ts` that treats linked brokerage/cash investment pairs as a single logical account
- Replaced duplicate counting logic in `AccountList.tsx` (group header count calculation) with call to new utility
- Replaced duplicate counting logic in `page.tsx` (accounts page summary) with call to new utility
- Updated account header display to use the utility for both filtered and total account counts
- Added test case verifying that linked investment pairs are counted as a single account in the header

## Implementation Details
The `countLogicalAccounts()` function:
- Takes an array of accounts as input
- Builds a set of account IDs present in the input
- Iterates through accounts, skipping any already counted
- When an account has a `linkedAccountId` that exists in the input set, marks both as counted (treating them as one logical account)
- Returns the total count of logical accounts

This ensures consistent behavior across the application when displaying account counts to users.

https://claude.ai/code/session_013aWDJqXWZxxnrDciWcMonu