### PR TITLE
Fix net worth chart drop when accounts have no current-month transactions

### DIFF
--- a/backend/src/net-worth/net-worth.service.spec.ts
+++ b/backend/src/net-worth/net-worth.service.spec.ts
@@ -113,7 +113,7 @@ describe("NetWorthService", () => {
   beforeEach(async () => {
     mabRepository = {
       count: jest.fn().mockResolvedValue(0),
-      find: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
       save: jest.fn(),
     };
 
@@ -788,12 +788,48 @@ describe("NetWorthService", () => {
       });
     });
 
-    it("does not recalculate when mab data already exists", async () => {
+    it("does not recalculate when all accounts have a current-month snapshot", async () => {
       mabRepository.count.mockResolvedValue(10);
+      accountRepository.find.mockResolvedValue([{ id: "account-1" }]);
+      mabRepository.find.mockResolvedValue([{ accountId: "account-1" }]);
 
       await service.ensurePopulated("user-1");
 
-      expect(accountRepository.find).not.toHaveBeenCalled();
+      expect(accountRepository.findOne).not.toHaveBeenCalled();
+      expect(dataSource.createQueryRunner).not.toHaveBeenCalled();
+    });
+
+    it("refreshes only accounts missing a current-month snapshot", async () => {
+      mabRepository.count.mockResolvedValue(10);
+      accountRepository.find.mockResolvedValue([
+        { id: "account-1" },
+        { id: "account-2" },
+        { id: "account-3" },
+      ]);
+      // account-1 has a current-month row; the other two are stale.
+      mabRepository.find.mockResolvedValue([{ accountId: "account-1" }]);
+      // recalculateAccount loads each account; pretend they were deleted
+      // so the recalc returns early and we just verify the lookups happened.
+      accountRepository.findOne.mockResolvedValue(null);
+
+      await service.ensurePopulated("user-1");
+
+      expect(accountRepository.findOne).toHaveBeenCalledTimes(2);
+      expect(accountRepository.findOne).toHaveBeenCalledWith({
+        where: { id: "account-2", userId: "user-1" },
+      });
+      expect(accountRepository.findOne).toHaveBeenCalledWith({
+        where: { id: "account-3", userId: "user-1" },
+      });
+    });
+
+    it("does not query for stale accounts when mab is empty (delegates to full recalc)", async () => {
+      mabRepository.count.mockResolvedValue(0);
+      accountRepository.find.mockResolvedValue([]);
+
+      await service.ensurePopulated("user-1");
+
+      expect(mabRepository.find).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/net-worth/net-worth.service.spec.ts
+++ b/backend/src/net-worth/net-worth.service.spec.ts
@@ -299,6 +299,22 @@ describe("NetWorthService", () => {
         expect(insertCalls[2][1][3]).toBe(250500);
       });
 
+      it("uses dateAcquired as start date for ASSET with no transactions", async () => {
+        const assetAccount = {
+          ...mockAssetAccount,
+          dateAcquired: new Date("2023-06-15"),
+        };
+        accountRepository.findOne.mockResolvedValue(assetAccount);
+        dataSource.query
+          .mockResolvedValueOnce([{ earliest: null }])
+          .mockResolvedValueOnce([]);
+
+        await service.recalculateAccount("user-1", "asset-1");
+
+        const costQuery = dataSource.query.mock.calls[1];
+        expect(costQuery[1][2]).toBe("2023-06-15");
+      });
+
       it("uses dateAcquired as start date for ASSET when it is earlier than first tx", async () => {
         const assetAccount = {
           ...mockAssetAccount,
@@ -773,6 +789,146 @@ describe("NetWorthService", () => {
     });
   });
 
+  describe("triggerDebouncedRecalc", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("schedules a recalc after the debounce window", () => {
+      const spy = jest
+        .spyOn(service, "recalculateAccount")
+        .mockResolvedValue(undefined);
+
+      service.triggerDebouncedRecalc("acc-1", "user-1");
+
+      expect(spy).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(2000);
+      expect(spy).toHaveBeenCalledWith("user-1", "acc-1");
+      spy.mockRestore();
+    });
+
+    it("debounces repeated triggers and only fires once", () => {
+      const spy = jest
+        .spyOn(service, "recalculateAccount")
+        .mockResolvedValue(undefined);
+
+      service.triggerDebouncedRecalc("acc-1", "user-1");
+      jest.advanceTimersByTime(1000);
+      service.triggerDebouncedRecalc("acc-1", "user-1");
+      jest.advanceTimersByTime(1000);
+      // Still within debounce window relative to the second call
+      expect(spy).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(1000);
+      expect(spy).toHaveBeenCalledTimes(1);
+      spy.mockRestore();
+    });
+
+    it("logs a warning when the scheduled recalc rejects", async () => {
+      const spy = jest
+        .spyOn(service, "recalculateAccount")
+        .mockRejectedValue(new Error("boom"));
+      const warnSpy = jest
+        .spyOn((service as any).logger, "warn")
+        .mockImplementation(() => undefined);
+
+      service.triggerDebouncedRecalc("acc-1", "user-1");
+      jest.advanceTimersByTime(2000);
+      // Allow the rejected promise's catch handler to run.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("acc-1"));
+      spy.mockRestore();
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("getLlmHistory", () => {
+    it("delegates to getMonthlyNetWorth with the provided range", async () => {
+      const spy = jest
+        .spyOn(service, "getMonthlyNetWorth")
+        .mockResolvedValue([]);
+
+      await service.getLlmHistory("user-1", "2024-01-01", "2024-12-31");
+
+      expect(spy).toHaveBeenCalledWith(
+        "user-1",
+        "2024-01-01",
+        "2024-12-31",
+      );
+      spy.mockRestore();
+    });
+
+    it("falls back to a 12-month default range when none is provided", async () => {
+      const spy = jest
+        .spyOn(service, "getMonthlyNetWorth")
+        .mockResolvedValue([]);
+
+      await service.getLlmHistory("user-1");
+
+      const [, start, end] = spy.mock.calls[0];
+      // Default range is roughly the last year through today.
+      expect(start).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(end).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(start! < end!).toBe(true);
+      spy.mockRestore();
+    });
+  });
+
+  describe("recalculateAllInvestmentSnapshots", () => {
+    it("recalculates each brokerage / standalone investment account", async () => {
+      const qb: any = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest
+          .fn()
+          .mockResolvedValue([{ ...mockBrokerageAccount, userId: "user-1" }]),
+      };
+      accountRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      dataSource.query
+        .mockResolvedValueOnce([{ earliest: null }])
+        .mockResolvedValueOnce([{ inv_earliest: null }])
+        .mockResolvedValueOnce([{ month: "2024-01-01", balance: 0 }]);
+      invTxRepository.find.mockResolvedValue([]);
+
+      await service.recalculateAllInvestmentSnapshots();
+
+      expect(qb.getMany).toHaveBeenCalled();
+      expect(dataSource.createQueryRunner).toHaveBeenCalledTimes(1);
+    });
+
+    it("continues when one account fails", async () => {
+      const qb: any = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([
+          { ...mockBrokerageAccount, id: "b-1", userId: "user-1" },
+          { ...mockBrokerageAccount, id: "b-2", userId: "user-1" },
+        ]),
+      };
+      accountRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      dataSource.query
+        // First account: earliest call rejects
+        .mockRejectedValueOnce(new Error("db down"))
+        // Second account: succeeds
+        .mockResolvedValueOnce([{ earliest: null }])
+        .mockResolvedValueOnce([{ inv_earliest: null }])
+        .mockResolvedValueOnce([{ month: "2024-01-01", balance: 0 }]);
+      invTxRepository.find.mockResolvedValue([]);
+
+      await expect(
+        service.recalculateAllInvestmentSnapshots(),
+      ).resolves.toBeUndefined();
+      expect(dataSource.createQueryRunner).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("ensurePopulated", () => {
     it("recalculates all accounts when mab count is zero", async () => {
       mabRepository.count.mockResolvedValue(0);
@@ -830,6 +986,39 @@ describe("NetWorthService", () => {
       await service.ensurePopulated("user-1");
 
       expect(mabRepository.find).not.toHaveBeenCalled();
+    });
+
+    it("returns early without querying MAB when the user has no accounts", async () => {
+      mabRepository.count.mockResolvedValue(10);
+      accountRepository.find.mockResolvedValue([]);
+
+      await service.ensurePopulated("user-1");
+
+      expect(mabRepository.find).not.toHaveBeenCalled();
+      expect(accountRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it("logs a warning and continues when a stale-account refresh fails", async () => {
+      mabRepository.count.mockResolvedValue(10);
+      accountRepository.find.mockResolvedValue([
+        { id: "account-1" },
+        { id: "account-2" },
+      ]);
+      mabRepository.find.mockResolvedValue([]);
+      // First lookup throws, second returns null so its recalc no-ops.
+      accountRepository.findOne
+        .mockRejectedValueOnce(new Error("db down"))
+        .mockResolvedValueOnce(null);
+      const warnSpy = jest
+        .spyOn((service as any).logger, "warn")
+        .mockImplementation(() => undefined);
+
+      await expect(service.ensurePopulated("user-1")).resolves.toBeUndefined();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("account-1"),
+      );
+      warnSpy.mockRestore();
     });
   });
 
@@ -1289,6 +1478,27 @@ describe("NetWorthService", () => {
       expect(result[0].assets).toBe(55000);
       expect(result[0].netWorth).toBe(55000);
     });
+
+    it("includes both market value and cash balance for standalone INVESTMENT accounts", async () => {
+      mabRepository.count.mockResolvedValue(5);
+      prefRepository.findOne.mockResolvedValue({ defaultCurrency: "USD" });
+
+      dataSource.query.mockResolvedValueOnce([
+        {
+          month: "2024-01-01",
+          balance: 2500,
+          market_value: 30000,
+          account_id: "standalone-1",
+          account_type: AccountType.INVESTMENT,
+          account_sub_type: null,
+          currency_code: "USD",
+        },
+      ]);
+
+      const result = await service.getMonthlyNetWorth("user-1");
+
+      expect(result[0].assets).toBe(32500);
+    });
   });
 
   describe("getMonthlyInvestments", () => {
@@ -1541,6 +1751,43 @@ describe("NetWorthService", () => {
       expect(mabRepository.count).toHaveBeenCalledWith({
         where: { userId: "user-1" },
       });
+    });
+
+    it("returns empty array when accountIds resolve to no accounts", async () => {
+      mabRepository.count.mockResolvedValue(5);
+      prefRepository.findOne.mockResolvedValue({ defaultCurrency: "USD" });
+      // Linked account resolution returns empty
+      dataSource.query.mockResolvedValueOnce([]);
+
+      const result = await service.getMonthlyInvestments(
+        "user-1",
+        undefined,
+        undefined,
+        ["unknown-id"],
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it("includes both market value and cash balance for standalone INVESTMENT accounts", async () => {
+      mabRepository.count.mockResolvedValue(5);
+      prefRepository.findOne.mockResolvedValue({ defaultCurrency: "USD" });
+
+      dataSource.query.mockResolvedValueOnce([
+        {
+          month: "2024-01-01",
+          balance: 1500,
+          market_value: 20000,
+          account_id: "standalone-1",
+          account_type: AccountType.INVESTMENT,
+          account_sub_type: null,
+          currency_code: "USD",
+        },
+      ]);
+
+      const result = await service.getMonthlyInvestments("user-1");
+
+      expect(result[0].value).toBe(21500);
     });
   });
 

--- a/backend/src/net-worth/net-worth.service.ts
+++ b/backend/src/net-worth/net-worth.service.ts
@@ -110,7 +110,54 @@ export class NetWorthService {
     const count = await this.mabRepo.count({ where: { userId } });
     if (count === 0) {
       await this.recalculateAllAccounts(userId);
+      return;
     }
+
+    await this.refreshStaleAccountsForCurrentMonth(userId);
+  }
+
+  /**
+   * Per-account recalc is debounced and only runs when an account's
+   * transactions change. When the calendar rolls into a new month, accounts
+   * that haven't been touched still have snapshots ending in the previous
+   * month, so they don't contribute to the new month's aggregate -- causing
+   * the chart to drop to whatever subset of accounts had a transaction post
+   * since the month rolled over. Detect those stale accounts and refresh them.
+   */
+  private async refreshStaleAccountsForCurrentMonth(
+    userId: string,
+  ): Promise<void> {
+    const now = new Date();
+    const currentMonthStr = `${now.getFullYear()}-${String(
+      now.getMonth() + 1,
+    ).padStart(2, "0")}-01`;
+
+    const accounts = await this.accountRepo.find({
+      where: { userId },
+      select: ["id"],
+    });
+    if (accounts.length === 0) return;
+
+    const populated = await this.mabRepo.find({
+      where: { userId, month: currentMonthStr as any },
+      select: ["accountId"],
+    });
+    const populatedIds = new Set(populated.map((p) => p.accountId));
+
+    const staleIds = accounts
+      .map((a) => a.id)
+      .filter((id) => !populatedIds.has(id));
+    if (staleIds.length === 0) return;
+
+    await Promise.all(
+      staleIds.map((id) =>
+        this.recalculateAccount(userId, id).catch((err) =>
+          this.logger.warn(
+            `Failed to refresh stale net worth for account ${id}: ${err.message}`,
+          ),
+        ),
+      ),
+    );
   }
 
   /**

--- a/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
@@ -126,6 +126,8 @@ describe('BalanceHistoryChart', () => {
           { date: '2026-03-19', balance: 800 },
           { date: '2026-04-15', balance: 650 },
           { date: '2026-05-01', balance: 500 },
+          { date: '2026-06-01', balance: 400 },
+          { date: '2026-07-01', balance: 300 },
         ]}
         isLoading={false}
       />


### PR DESCRIPTION
## Summary
When the calendar rolls into a new month, accounts that haven't had any transactions posted since the month changed still have snapshots ending in the previous month. This causes them to be excluded from the current month's net worth aggregate, making the chart incorrectly drop to only show accounts with recent activity.

This PR adds logic to detect and refresh "stale" accounts—those missing a snapshot for the current month—ensuring all accounts contribute to the net worth calculation regardless of transaction recency.

## Key Changes
- Added `refreshStaleAccountsForCurrentMonth()` method that:
  - Identifies all user accounts
  - Checks which accounts have a snapshot for the current month
  - Recalculates snapshots for accounts missing current-month data
  - Gracefully handles failures with warning logs
- Modified `ensurePopulated()` to call the new refresh method after initial population checks
- Updated test suite to reflect the new behavior:
  - Renamed test to clarify it checks for current-month snapshots
  - Added test verifying only stale accounts are refreshed
  - Added test confirming full recalc path skips stale account checks
  - Fixed mock setup to return empty array by default

## Implementation Details
- Uses a Set-based lookup for O(1) stale account detection
- Runs stale account recalculations in parallel with error handling
- Only executes when mab data already exists (skips on initial population)
- Month string format: `YYYY-MM-01` for consistent snapshot querying

https://claude.ai/code/session_01Uf3UX22rMczCPgpByYrxsR