### PR TITLE
Exclude asset value change category from financial reports

### DIFF
--- a/backend/src/built-in-reports/built-in-reports.service.spec.ts
+++ b/backend/src/built-in-reports/built-in-reports.service.spec.ts
@@ -491,7 +491,7 @@ describe("BuiltInReportsService", () => {
       expect(result.totalIncome).toBe(5000);
     });
 
-    it("handles uncategorized income", async () => {
+    it("skips uncategorized income (SQL is_income filter excludes them)", async () => {
       transactionsRepository.query.mockResolvedValue([
         { category_id: null, currency_code: "USD", total: "200.00" },
       ]);
@@ -503,9 +503,8 @@ describe("BuiltInReportsService", () => {
         "2025-12-31",
       );
 
-      expect(result.data).toHaveLength(1);
-      expect(result.data[0].categoryId).toBeNull();
-      expect(result.data[0].categoryName).toBe("Uncategorized");
+      expect(result.data).toEqual([]);
+      expect(result.totalIncome).toBe(0);
     });
 
     it("converts income amounts from foreign currencies", async () => {

--- a/backend/src/built-in-reports/income-reports.service.spec.ts
+++ b/backend/src/built-in-reports/income-reports.service.spec.ts
@@ -128,7 +128,7 @@ describe("IncomeReportsService", () => {
       expect(result.totalIncome).toBe(0);
     });
 
-    it("aggregates income by parent category with rollup", async () => {
+    it("keeps subcategories separate with 'Parent: Child' name format", async () => {
       transactionsRepository.query.mockResolvedValue([
         { category_id: "cat-child", currency_code: "USD", total: "1000.00" },
         { category_id: "cat-parent", currency_code: "USD", total: "4000.00" },
@@ -144,14 +144,19 @@ describe("IncomeReportsService", () => {
         "2025-12-31",
       );
 
-      expect(result.data).toHaveLength(1);
-      expect(result.data[0].categoryId).toBe("cat-parent");
-      expect(result.data[0].categoryName).toBe("Employment");
-      expect(result.data[0].total).toBe(5000);
+      expect(result.data).toHaveLength(2);
+      const child = result.data.find((d) => d.categoryId === "cat-child");
+      const parent = result.data.find((d) => d.categoryId === "cat-parent");
+      expect(child).toBeDefined();
+      expect(child!.categoryName).toBe("Employment: Bonuses");
+      expect(child!.total).toBe(1000);
+      expect(parent).toBeDefined();
+      expect(parent!.categoryName).toBe("Employment");
+      expect(parent!.total).toBe(4000);
       expect(result.totalIncome).toBe(5000);
     });
 
-    it("handles uncategorized income", async () => {
+    it("skips uncategorized rows in JS (SQL already filters them out)", async () => {
       transactionsRepository.query.mockResolvedValue([
         { category_id: null, currency_code: "USD", total: "200.00" },
       ]);
@@ -163,12 +168,11 @@ describe("IncomeReportsService", () => {
         "2025-12-31",
       );
 
-      expect(result.data).toHaveLength(1);
-      expect(result.data[0].categoryId).toBeNull();
-      expect(result.data[0].categoryName).toBe("Uncategorized");
+      expect(result.data).toEqual([]);
+      expect(result.totalIncome).toBe(0);
     });
 
-    it("treats unknown category_id as uncategorized", async () => {
+    it("skips rows whose category_id is unknown", async () => {
       transactionsRepository.query.mockResolvedValue([
         {
           category_id: "nonexistent-id",
@@ -184,8 +188,8 @@ describe("IncomeReportsService", () => {
         "2025-12-31",
       );
 
-      expect(result.data[0].categoryId).toBeNull();
-      expect(result.data[0].categoryName).toBe("Uncategorized");
+      expect(result.data).toEqual([]);
+      expect(result.totalIncome).toBe(0);
     });
 
     it("converts income amounts from foreign currencies", async () => {
@@ -257,7 +261,7 @@ describe("IncomeReportsService", () => {
       expect(queryCall[0]).not.toContain("$3");
     });
 
-    it("returns color from parent category", async () => {
+    it("uses the subcategory's own color (does not roll up to parent)", async () => {
       transactionsRepository.query.mockResolvedValue([
         { category_id: "cat-child", currency_code: "USD", total: "500.00" },
       ]);
@@ -272,15 +276,16 @@ describe("IncomeReportsService", () => {
         "2025-12-31",
       );
 
-      expect(result.data[0].color).toBe("#FF5733");
+      expect(result.data[0].categoryId).toBe("cat-child");
+      expect(result.data[0].color).toBe("#33FF57");
     });
 
-    it("merges multiple uncategorized rows", async () => {
+    it("merges multi-currency rows for the same subcategory", async () => {
       transactionsRepository.query.mockResolvedValue([
-        { category_id: null, currency_code: "USD", total: "100.00" },
-        { category_id: null, currency_code: "EUR", total: "200.00" },
+        { category_id: "cat-income", currency_code: "USD", total: "100.00" },
+        { category_id: "cat-income", currency_code: "EUR", total: "200.00" },
       ]);
-      categoriesRepository.find.mockResolvedValue([]);
+      categoriesRepository.find.mockResolvedValue([mockIncomeCategory]);
 
       const result = await service.getIncomeBySource(
         mockUserId,
@@ -289,8 +294,20 @@ describe("IncomeReportsService", () => {
       );
 
       expect(result.data).toHaveLength(1);
+      expect(result.data[0].categoryId).toBe("cat-income");
       // 100 USD + 200 EUR * 1.1 = 320
       expect(result.data[0].total).toBe(320);
+    });
+
+    it("filters by is_income = true in the SQL query (income categories only)", async () => {
+      transactionsRepository.query.mockResolvedValue([]);
+      categoriesRepository.find.mockResolvedValue([]);
+
+      await service.getIncomeBySource(mockUserId, "2025-01-01", "2025-12-31");
+
+      const sql = transactionsRepository.query.mock.calls[0][0];
+      expect(sql).toContain("INNER JOIN categories c");
+      expect(sql).toContain("c.is_income = true");
     });
 
     it("rounds totals to 2 decimal places", async () => {

--- a/backend/src/built-in-reports/income-reports.service.spec.ts
+++ b/backend/src/built-in-reports/income-reports.service.spec.ts
@@ -307,6 +307,20 @@ describe("IncomeReportsService", () => {
 
       expect(result.data[0].total).toBe(33.33);
     });
+
+    it("filters out the asset value change category in the SQL query", async () => {
+      transactionsRepository.query.mockResolvedValue([]);
+      categoriesRepository.find.mockResolvedValue([]);
+
+      await service.getIncomeBySource(mockUserId, "2025-01-01", "2025-12-31");
+
+      const sql = transactionsRepository.query.mock.calls[0][0];
+      expect(sql).toContain("NOT EXISTS");
+      expect(sql).toContain("asset_category_id");
+      expect(sql).toMatch(
+        /ax\.asset_category_id\s*=\s*COALESCE\(ts\.category_id,\s*t\.category_id\)/,
+      );
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -488,6 +502,19 @@ describe("IncomeReportsService", () => {
       const sql = transactionsRepository.query.mock.calls[0][0];
       expect(sql).toContain("LEFT JOIN categories c");
       expect(sql).toContain("c.is_income");
+    });
+
+    it("filters out the asset value change category in the SQL query", async () => {
+      transactionsRepository.query.mockResolvedValue([]);
+
+      await service.getIncomeVsExpenses(mockUserId, "2025-01-01", "2025-12-31");
+
+      const sql = transactionsRepository.query.mock.calls[0][0];
+      expect(sql).toContain("NOT EXISTS");
+      expect(sql).toContain("asset_category_id");
+      expect(sql).toMatch(
+        /ax\.asset_category_id\s*=\s*COALESCE\(ts\.category_id,\s*t\.category_id\)/,
+      );
     });
 
     it("handles month with zero income correctly", async () => {

--- a/backend/src/built-in-reports/income-reports.service.ts
+++ b/backend/src/built-in-reports/income-reports.service.ts
@@ -50,6 +50,12 @@ export class IncomeReportsService {
         AND t.parent_transaction_id IS NULL
         AND a.account_type != 'INVESTMENT'
         AND (ts.transfer_account_id IS NULL OR ts.id IS NULL)
+        AND NOT EXISTS (
+          SELECT 1 FROM accounts ax
+          WHERE ax.user_id = t.user_id
+            AND ax.asset_category_id IS NOT NULL
+            AND ax.asset_category_id = COALESCE(ts.category_id, t.category_id)
+        )
     `;
 
     const params: (string | undefined)[] = [userId, endDate];
@@ -172,6 +178,12 @@ export class IncomeReportsService {
         AND t.parent_transaction_id IS NULL
         AND a.account_type != 'INVESTMENT'
         AND (ts.transfer_account_id IS NULL OR ts.id IS NULL)
+        AND NOT EXISTS (
+          SELECT 1 FROM accounts ax
+          WHERE ax.user_id = t.user_id
+            AND ax.asset_category_id IS NOT NULL
+            AND ax.asset_category_id = COALESCE(ts.category_id, t.category_id)
+        )
     `;
 
     const params: (string | undefined)[] = [userId, endDate];

--- a/backend/src/built-in-reports/income-reports.service.ts
+++ b/backend/src/built-in-reports/income-reports.service.ts
@@ -42,8 +42,10 @@ export class IncomeReportsService {
       FROM transactions t
       LEFT JOIN transaction_splits ts ON ts.transaction_id = t.id
       LEFT JOIN accounts a ON a.id = t.account_id
+      INNER JOIN categories c ON c.id = COALESCE(ts.category_id, t.category_id)
       WHERE t.user_id = $1
         AND t.transaction_date <= $2
+        AND c.is_income = true
         AND COALESCE(ts.amount, t.amount) > 0
         AND t.is_transfer = false
         AND (t.status IS NULL OR t.status != 'VOID')
@@ -75,9 +77,9 @@ export class IncomeReportsService {
     });
     const categoryMap = new Map(categories.map((c) => [c.id, c]));
 
-    const parentTotals = new Map<
+    const categoryTotals = new Map<
       string,
-      { total: number; category: Category | null }
+      { total: number; category: Category }
     >();
 
     for (const row of rawResults) {
@@ -88,47 +90,34 @@ export class IncomeReportsService {
         rateMap,
       );
       const categoryId = row.category_id;
-
-      if (!categoryId) {
-        const existing = parentTotals.get("uncategorized");
-        if (existing) {
-          existing.total += total;
-        } else {
-          parentTotals.set("uncategorized", { total, category: null });
-        }
-        continue;
-      }
+      if (!categoryId) continue;
 
       const category = categoryMap.get(categoryId);
-      if (!category) {
-        const existing = parentTotals.get("uncategorized");
-        if (existing) {
-          existing.total += total;
-        } else {
-          parentTotals.set("uncategorized", { total, category: null });
-        }
-        continue;
-      }
+      if (!category) continue;
 
       const parentCategory = category.parentId
         ? categoryMap.get(category.parentId)
         : null;
-      const displayCategory = parentCategory || category;
-      const displayId = displayCategory.id;
+      const displayName = parentCategory
+        ? `${parentCategory.name}: ${category.name}`
+        : category.name;
 
-      const existing = parentTotals.get(displayId);
+      const existing = categoryTotals.get(category.id);
       if (existing) {
         existing.total += total;
       } else {
-        parentTotals.set(displayId, { total, category: displayCategory });
+        categoryTotals.set(category.id, {
+          total,
+          category: { ...category, name: displayName } as Category,
+        });
       }
     }
 
-    const data: IncomeSourceItem[] = Array.from(parentTotals.entries())
+    const data: IncomeSourceItem[] = Array.from(categoryTotals.entries())
       .map(([id, { total, category }]) => ({
-        categoryId: id === "uncategorized" ? null : id,
-        categoryName: category?.name || "Uncategorized",
-        color: category?.color || null,
+        categoryId: id,
+        categoryName: category.name,
+        color: category.color || null,
         total: Math.round(total * 100) / 100,
       }))
       .sort((a, b) => b.total - a.total)

--- a/backend/src/built-in-reports/spending-reports.service.spec.ts
+++ b/backend/src/built-in-reports/spending-reports.service.spec.ts
@@ -323,6 +323,24 @@ describe("SpendingReportsService", () => {
       expect(result.data[0].total).toBe(100);
     });
 
+    it("filters out the asset value change category in the SQL query", async () => {
+      transactionsRepository.query.mockResolvedValue([]);
+      categoriesRepository.find.mockResolvedValue([]);
+
+      await service.getSpendingByCategory(
+        mockUserId,
+        "2025-01-01",
+        "2025-12-31",
+      );
+
+      const sql = transactionsRepository.query.mock.calls[0][0];
+      expect(sql).toContain("NOT EXISTS");
+      expect(sql).toContain("asset_category_id");
+      expect(sql).toMatch(
+        /ax\.asset_category_id\s*=\s*COALESCE\(ts\.category_id,\s*t\.category_id\)/,
+      );
+    });
+
     describe("rollupToParent = false", () => {
       it("keeps subcategories separate with 'Parent: Child' name format", async () => {
         transactionsRepository.query.mockResolvedValue([
@@ -589,6 +607,17 @@ describe("SpendingReportsService", () => {
 
       expect(result.totalSpending).toBe(300);
     });
+
+    it("filters out the asset value change category in the SQL query", async () => {
+      transactionsRepository.query.mockResolvedValue([]);
+
+      await service.getSpendingByPayee(mockUserId, "2025-01-01", "2025-12-31");
+
+      const sql = transactionsRepository.query.mock.calls[0][0];
+      expect(sql).toContain("NOT EXISTS");
+      expect(sql).toContain("asset_category_id");
+      expect(sql).toMatch(/ax\.asset_category_id\s*=\s*t\.category_id/);
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -785,6 +814,24 @@ describe("SpendingReportsService", () => {
       );
       expect(febParent).toBeDefined();
       expect(febParent!.total).toBe(0);
+    });
+
+    it("filters out the asset value change category in the SQL query", async () => {
+      transactionsRepository.query.mockResolvedValue([]);
+      categoriesRepository.find.mockResolvedValue([]);
+
+      await service.getMonthlySpendingTrend(
+        mockUserId,
+        "2025-01-01",
+        "2025-12-31",
+      );
+
+      const sql = transactionsRepository.query.mock.calls[0][0];
+      expect(sql).toContain("NOT EXISTS");
+      expect(sql).toContain("asset_category_id");
+      expect(sql).toMatch(
+        /ax\.asset_category_id\s*=\s*COALESCE\(ts\.category_id,\s*t\.category_id\)/,
+      );
     });
   });
 });

--- a/backend/src/built-in-reports/spending-reports.service.ts
+++ b/backend/src/built-in-reports/spending-reports.service.ts
@@ -58,6 +58,12 @@ export class SpendingReportsService {
         AND t.parent_transaction_id IS NULL
         AND a.account_type != 'INVESTMENT'
         AND (ts.transfer_account_id IS NULL OR ts.id IS NULL)
+        AND NOT EXISTS (
+          SELECT 1 FROM accounts ax
+          WHERE ax.user_id = t.user_id
+            AND ax.asset_category_id IS NOT NULL
+            AND ax.asset_category_id = COALESCE(ts.category_id, t.category_id)
+        )
     `;
 
     const params: (string | undefined)[] = [userId, endDate];
@@ -188,6 +194,12 @@ export class SpendingReportsService {
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
         AND a.account_type != 'INVESTMENT'
+        AND NOT EXISTS (
+          SELECT 1 FROM accounts ax
+          WHERE ax.user_id = t.user_id
+            AND ax.asset_category_id IS NOT NULL
+            AND ax.asset_category_id = t.category_id
+        )
       `;
 
     const params: (string | undefined)[] = [userId, endDate];
@@ -280,6 +292,12 @@ export class SpendingReportsService {
         AND t.parent_transaction_id IS NULL
         AND a.account_type != 'INVESTMENT'
         AND (ts.transfer_account_id IS NULL OR ts.id IS NULL)
+        AND NOT EXISTS (
+          SELECT 1 FROM accounts ax
+          WHERE ax.user_id = t.user_id
+            AND ax.asset_category_id IS NOT NULL
+            AND ax.asset_category_id = COALESCE(ts.category_id, t.category_id)
+        )
     `;
 
     const params: (string | undefined)[] = [userId, endDate];


### PR DESCRIPTION
## Summary
This PR updates the financial reporting services to exclude transactions categorized as "asset value change" from income, spending, and trend reports. It also refactors the income report logic to keep subcategories separate instead of rolling them up to parent categories.

## Key Changes

### Income Reports Service
- **SQL Query Updates**: Added `INNER JOIN` to filter by `c.is_income = true` and a `NOT EXISTS` subquery to exclude asset value change categories
- **Subcategory Handling**: Changed from rolling up subcategories to parent categories to keeping them separate with "Parent: Child" name format
- **Uncategorized Handling**: Removed support for uncategorized/unknown categories—rows with null or unknown `category_id` are now skipped entirely
- **Color Handling**: Subcategories now use their own color instead of inheriting from parent categories

### Spending Reports Service
- **SQL Query Updates**: Added `NOT EXISTS` subquery to exclude asset value change categories in:
  - `getSpendingByCategory()`
  - `getSpendingByPayee()`
  - `getMonthlySpendingTrend()`

### Test Updates
- Updated test descriptions and assertions to reflect new behavior
- Added new test cases to verify asset value change category filtering in SQL queries
- Updated assertions for subcategory name formatting and color handling
- Changed expectations for uncategorized/unknown category handling (now filtered out)

## Implementation Details
- The asset value change category exclusion uses a `NOT EXISTS` subquery that checks if a category is linked to any account's `asset_category_id`
- The subquery pattern varies slightly depending on whether transaction splits are involved: `COALESCE(ts.category_id, t.category_id)` vs `t.category_id`
- Income report data is now keyed by the actual category ID rather than parent ID, with display names constructed to show hierarchy

https://claude.ai/code/session_01Mf55SsBTpUsoGCR5cAJm5i