### PR TITLE
Fix multi-year chart data display by using unique month identifiers

### DIFF
--- a/frontend/src/components/reports/CashFlowReport.test.tsx
+++ b/frontend/src/components/reports/CashFlowReport.test.tsx
@@ -40,7 +40,7 @@ vi.mock("recharts", () => ({
   BarChart: ({ children, onClick }: any) => (
     <div
       data-testid="bar-chart"
-      onClick={() => onClick?.({ activeLabel: "Jul" })}
+      onClick={() => onClick?.({ activeLabel: "2024-07" })}
     >
       {children}
     </div>

--- a/frontend/src/components/reports/CashFlowReport.tsx
+++ b/frontend/src/components/reports/CashFlowReport.tsx
@@ -80,12 +80,15 @@ export function CashFlowReport() {
           builtInReportsApi.getSpendingByCategory(params),
         ]);
 
-      // Map monthly data
+      // Map monthly data. `name` must be unique across the dataset (used as
+      // the XAxis category key); a non-unique value like "May" causes
+      // Recharts to resolve the tooltip's payload to the first matching row,
+      // showing data from the wrong year on multi-year ranges.
       const data: ChartDataItem[] = cashFlowResponse.data.map(
         (item: MonthlyIncomeExpenseItem) => {
           const monthDate = parseISO(item.month + "-01");
           return {
-            name: format(monthDate, "MMM"),
+            name: item.month,
             fullName: format(monthDate, "MMM yyyy"),
             Income: Math.round(item.income),
             Expenses: Math.round(item.expenses),
@@ -199,11 +202,30 @@ export function CashFlowReport() {
   };
 
   if (isLoading) {
+    // Render the controls block too so focus inside DateInput survives
+    // reloads triggered by typing in the custom date range.
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+      <div className="space-y-6">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
+          <div className="flex flex-wrap gap-4 items-center justify-between">
+            <DateRangeSelector
+              ranges={["3m", "6m", "1y"]}
+              value={dateRange}
+              onChange={setDateRange}
+              showCustom
+              customStartDate={startDate}
+              onCustomStartDateChange={setStartDate}
+              customEndDate={endDate}
+              onCustomEndDateChange={setEndDate}
+            />
+            <ExportDropdown onExportPdf={handleExportPdf} />
+          </div>
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
+          <div className="animate-pulse space-y-4">
+            <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
+            <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+          </div>
         </div>
       </div>
     );
@@ -289,7 +311,13 @@ export function CashFlowReport() {
               style={{ cursor: "pointer" }}
             >
               <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-              <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+              <XAxis
+                dataKey="name"
+                tick={{ fontSize: 12 }}
+                tickFormatter={(value: string) =>
+                  format(parseISO(value + "-01"), "MMM")
+                }
+              />
               <YAxis
                 tickFormatter={formatCurrencyAxis}
                 tick={{ fontSize: 12 }}

--- a/frontend/src/components/reports/IncomeVsExpensesReport.test.tsx
+++ b/frontend/src/components/reports/IncomeVsExpensesReport.test.tsx
@@ -40,7 +40,7 @@ vi.mock("recharts", () => ({
   BarChart: ({ children, onClick }: any) => (
     <div
       data-testid="bar-chart"
-      onClick={() => onClick?.({ activeLabel: "Jan" })}
+      onClick={() => onClick?.({ activeLabel: "2024-01" })}
     >
       {children}
     </div>

--- a/frontend/src/components/reports/IncomeVsExpensesReport.tsx
+++ b/frontend/src/components/reports/IncomeVsExpensesReport.tsx
@@ -68,7 +68,10 @@ export function IncomeVsExpensesReport() {
         endDate: end,
       });
 
-      // Map response to chart data
+      // Map response to chart data. `name` must be unique across the dataset
+      // (used as the XAxis category key); a non-unique value like "May" causes
+      // Recharts to resolve the tooltip's payload to the first matching row,
+      // showing data from the wrong year on multi-year ranges.
       const data: ChartDataItem[] = response.data.map(
         (item: MonthlyIncomeExpenseItem) => {
           const monthDate = parseISO(item.month + "-01");
@@ -76,7 +79,7 @@ export function IncomeVsExpensesReport() {
           const savingsRate =
             item.income > 0 ? Math.round((savings / item.income) * 100) : 0;
           return {
-            name: format(monthDate, "MMM"),
+            name: item.month,
             fullName: format(monthDate, "MMM yyyy"),
             Income: Math.round(item.income),
             Expenses: Math.round(item.expenses),
@@ -185,20 +188,9 @@ export function IncomeVsExpensesReport() {
     return null;
   };
 
-  if (isLoading) {
-    return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-96 bg-gray-200 dark:bg-gray-700 rounded" />
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-6">
-      {/* Controls */}
+      {/* Controls -- always rendered so focus inside DateInput survives reloads */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-4 items-center justify-between">
           <DateRangeSelector
@@ -217,7 +209,12 @@ export function IncomeVsExpensesReport() {
 
       {/* Chart */}
       <div ref={chartRef} className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 px-2 py-4 sm:p-6">
-        {chartData.length === 0 ? (
+        {isLoading ? (
+          <div className="animate-pulse space-y-4">
+            <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
+            <div className="h-96 bg-gray-200 dark:bg-gray-700 rounded" />
+          </div>
+        ) : chartData.length === 0 ? (
           <p className="text-gray-500 dark:text-gray-400 text-center py-8">
             No data for this period.
           </p>
@@ -232,7 +229,13 @@ export function IncomeVsExpensesReport() {
                   style={{ cursor: "pointer" }}
                 >
                   <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-                  <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+                  <XAxis
+                    dataKey="name"
+                    tick={{ fontSize: 12 }}
+                    tickFormatter={(value: string) =>
+                      format(parseISO(value + "-01"), "MMM")
+                    }
+                  />
                   <YAxis
                     tickFormatter={formatCurrencyAxis}
                     tick={{ fontSize: 12 }}

--- a/frontend/src/components/reports/MonthlySpendingTrendReport.test.tsx
+++ b/frontend/src/components/reports/MonthlySpendingTrendReport.test.tsx
@@ -40,7 +40,7 @@ vi.mock("recharts", () => ({
   LineChart: ({ children, onClick }: any) => (
     <div
       data-testid="line-chart"
-      onClick={() => onClick?.({ activeLabel: "Jan" })}
+      onClick={() => onClick?.({ activeLabel: "2024-01" })}
     >
       {children}
     </div>

--- a/frontend/src/components/reports/MonthlySpendingTrendReport.tsx
+++ b/frontend/src/components/reports/MonthlySpendingTrendReport.tsx
@@ -60,12 +60,15 @@ export function MonthlySpendingTrendReport() {
         endDate: end,
       });
 
-      // Map response to chart data
+      // Map response to chart data. `name` must be unique across the dataset
+      // (used as the XAxis category key); a non-unique value like "May" causes
+      // Recharts to resolve the tooltip's payload to the first matching row,
+      // showing data from the wrong year on multi-year ranges.
       const data: ChartDataItem[] = response.data.map(
         (item: MonthlyIncomeExpenseItem) => {
           const monthDate = parseISO(item.month + "-01");
           return {
-            name: format(monthDate, "MMM"),
+            name: item.month,
             fullName: format(monthDate, "MMM yyyy"),
             Expenses: Math.round(item.expenses),
             Income: Math.round(item.income),
@@ -159,20 +162,9 @@ export function MonthlySpendingTrendReport() {
     return null;
   };
 
-  if (isLoading) {
-    return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-96 bg-gray-200 dark:bg-gray-700 rounded" />
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-6">
-      {/* Controls */}
+      {/* Controls -- always rendered so focus inside DateInput survives reloads */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-4 items-center justify-between">
           <DateRangeSelector
@@ -191,7 +183,12 @@ export function MonthlySpendingTrendReport() {
 
       {/* Chart */}
       <div ref={chartRef} className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 px-2 py-4 sm:p-6">
-        {chartData.length === 0 ? (
+        {isLoading ? (
+          <div className="animate-pulse space-y-4">
+            <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
+            <div className="h-96 bg-gray-200 dark:bg-gray-700 rounded" />
+          </div>
+        ) : chartData.length === 0 ? (
           <p className="text-gray-500 dark:text-gray-400 text-center py-8">
             No data for this period.
           </p>
@@ -206,7 +203,13 @@ export function MonthlySpendingTrendReport() {
                   style={{ cursor: "pointer" }}
                 >
                   <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-                  <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+                  <XAxis
+                    dataKey="name"
+                    tick={{ fontSize: 12 }}
+                    tickFormatter={(value: string) =>
+                      format(parseISO(value + "-01"), "MMM")
+                    }
+                  />
                   <YAxis
                     tickFormatter={formatCurrencyAxis}
                     tick={{ fontSize: 12 }}


### PR DESCRIPTION
## Summary
Fixed a bug in report charts where multi-year date ranges would display incorrect data in tooltips due to non-unique month names (e.g., "May" appearing in multiple years). The charts now use unique month identifiers (YYYY-MM format) as the XAxis key while maintaining the abbreviated month display format.

## Key Changes

- **Chart data mapping**: Changed the `name` field from abbreviated month format (`"MMM"`) to full month identifier (`item.month` in YYYY-MM format) across three report components:
  - CashFlowReport
  - IncomeVsExpensesReport
  - MonthlySpendingTrendReport

- **XAxis display formatting**: Added `tickFormatter` to XAxis components to display the full month identifier as an abbreviated month name (`"MMM"`) for end users, while maintaining unique keys internally for Recharts

- **Loading state improvements**: Refactored loading states to always render the controls section (DateRangeSelector and ExportDropdown) so that focus within DateInput fields is preserved during data reloads triggered by user input

- **Test updates**: Updated mock chart click handlers to use the new YYYY-MM format for `activeLabel` values

## Implementation Details

The root cause was that Recharts uses the `dataKey` value to match tooltip payloads. When multiple data points shared the same name (e.g., "May" from different years), Recharts would resolve to the first matching row, showing stale data. By using the full month identifier as the unique key and applying a formatter only for display, tooltips now correctly resolve to the intended data point while maintaining a clean UI.

The loading state refactor ensures better UX by preventing focus loss in date input fields when the report data refreshes.

https://claude.ai/code/session_01RSKixeTzDytcvbJu9hv326