### PR TITLE
fix(ui): respect user currency and date format preferences

### DIFF
--- a/backend/src/currencies/exchange-rate.service.ts
+++ b/backend/src/currencies/exchange-rate.service.ts
@@ -219,7 +219,11 @@ export class ExchangeRateService implements OnModuleInit {
     const startTime = Date.now();
     this.logger.log("Starting exchange rate refresh");
 
-    // Fetch all currencies used in accounts/securities
+    // Fetch all currencies in use: account currencies, security currencies for
+    // active holdings, and every user's preferred default currency. Including
+    // defaults ensures we fetch (CAD, GBP) even when the user has no GBP-
+    // denominated accounts -- otherwise their GBP totals would silently fall
+    // back to unconverted CAD values.
     const usedCurrencies: { code: string }[] = await this.dataSource.query(
       `SELECT DISTINCT code FROM (
          SELECT currency_code AS code FROM accounts WHERE is_closed = false
@@ -229,6 +233,9 @@ export class ExchangeRateService implements OnModuleInit {
          INNER JOIN holdings h ON h.security_id = s.id
          INNER JOIN accounts a ON a.id = h.account_id AND a.is_closed = false
          WHERE s.is_active = true AND h.quantity > 0
+         UNION
+         SELECT default_currency AS code FROM user_preferences
+         WHERE default_currency IS NOT NULL
        ) sub`,
     );
 

--- a/backend/src/transactions/transaction-transfer.service.ts
+++ b/backend/src/transactions/transaction-transfer.service.ts
@@ -14,6 +14,7 @@ import { AccountsService } from "../accounts/accounts.service";
 import { NetWorthService } from "../net-worth/net-worth.service";
 import { isTransactionInFuture } from "../common/date-utils";
 import { ActionHistoryService } from "../action-history/action-history.service";
+import { formatCurrency } from "../common/format-currency.util";
 
 export interface TransferResult {
   fromTransaction: Transaction;
@@ -187,7 +188,7 @@ export class TransactionTransferService {
         fromAccountId,
         toAccountId,
       },
-      description: `Created transfer $${amount.toFixed(2)} from ${fromAccount.name} to ${toAccount.name}`,
+      description: `Created transfer ${formatCurrency(amount, fromCurrencyCode)} from ${fromAccount.name} to ${toAccount.name}`,
     });
 
     return result;

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -35,6 +35,7 @@ import { BulkUpdateDto, BulkDeleteDto } from "./dto/bulk-update.dto";
 import { isTransactionInFuture } from "../common/date-utils";
 import { ActionHistoryService } from "../action-history/action-history.service";
 import { getAllCategoryIdsWithChildren } from "../common/category-tree.util";
+import { formatCurrency } from "../common/format-currency.util";
 
 export interface TransactionWithInvestmentLink extends Transaction {
   linkedInvestmentTransactionId?: string | null;
@@ -1461,7 +1462,7 @@ export class TransactionsService {
       action: "update",
       beforeData: beforeSnapshot,
       afterData: this.snapshotTransaction(finalTransaction),
-      description: `Updated transaction ${finalTransaction.payeeName || ""} $${Number(finalTransaction.amount).toFixed(2)}`,
+      description: `Updated transaction ${finalTransaction.payeeName || ""} ${formatCurrency(Number(finalTransaction.amount), finalTransaction.currencyCode)}`,
     });
     return finalTransaction;
   }
@@ -1911,7 +1912,7 @@ export class TransactionsService {
       action,
       beforeData: action === "create" ? undefined : beforeData,
       afterData: action === "delete" ? undefined : snapshot,
-      description: `${action === "create" ? "Created" : action === "update" ? "Updated" : "Deleted"} transaction ${tx.payeeName || ""} $${Number(tx.amount).toFixed(2)}`,
+      description: `${action === "create" ? "Created" : action === "update" ? "Updated" : "Deleted"} transaction ${tx.payeeName || ""} ${formatCurrency(Number(tx.amount), tx.currencyCode)}`,
     });
   }
 }

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -8,7 +8,6 @@ import { PersonalAccessToken } from "../auth/entities/personal-access-token.enti
 import { UsersService } from "./users.service";
 import { UsersController } from "./users.controller";
 import { PasswordBreachService } from "../auth/password-breach.service";
-import { CurrenciesModule } from "../currencies/currencies.module";
 
 @Module({
   imports: [
@@ -19,7 +18,6 @@ import { CurrenciesModule } from "../currencies/currencies.module";
       RefreshToken,
       PersonalAccessToken,
     ]),
-    CurrenciesModule,
   ],
   providers: [UsersService, PasswordBreachService],
   controllers: [UsersController],

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -8,6 +8,7 @@ import { PersonalAccessToken } from "../auth/entities/personal-access-token.enti
 import { UsersService } from "./users.service";
 import { UsersController } from "./users.controller";
 import { PasswordBreachService } from "../auth/password-breach.service";
+import { CurrenciesModule } from "../currencies/currencies.module";
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { PasswordBreachService } from "../auth/password-breach.service";
       RefreshToken,
       PersonalAccessToken,
     ]),
+    CurrenciesModule,
   ],
   providers: [UsersService, PasswordBreachService],
   controllers: [UsersController],

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -15,6 +15,7 @@ import { TrustedDevice } from "./entities/trusted-device.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
 import { PersonalAccessToken } from "../auth/entities/personal-access-token.entity";
 import { PasswordBreachService } from "../auth/password-breach.service";
+import { ExchangeRateService } from "../currencies/exchange-rate.service";
 
 describe("UsersService", () => {
   let service: UsersService;
@@ -24,6 +25,7 @@ describe("UsersService", () => {
   let patRepository: Record<string, jest.Mock>;
   let trustedDevicesRepository: Record<string, jest.Mock>;
   let passwordBreachService: { isBreached: jest.Mock };
+  let exchangeRateService: { refreshAllRates: jest.Mock };
   let mockQueryRunner: Record<string, jest.Mock>;
 
   const mockUser = {
@@ -89,6 +91,16 @@ describe("UsersService", () => {
       isBreached: jest.fn().mockResolvedValue(false),
     };
 
+    exchangeRateService = {
+      refreshAllRates: jest.fn().mockResolvedValue({
+        totalPairs: 0,
+        updated: 0,
+        failed: 0,
+        results: [],
+        lastUpdated: new Date(),
+      }),
+    };
+
     mockQueryRunner = {
       connect: jest.fn(),
       startTransaction: jest.fn(),
@@ -124,6 +136,7 @@ describe("UsersService", () => {
         },
         { provide: DataSource, useValue: mockDataSource },
         { provide: PasswordBreachService, useValue: passwordBreachService },
+        { provide: ExchangeRateService, useValue: exchangeRateService },
       ],
     }).compile();
 

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -15,6 +15,7 @@ import { TrustedDevice } from "./entities/trusted-device.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
 import { PersonalAccessToken } from "../auth/entities/personal-access-token.entity";
 import { PasswordBreachService } from "../auth/password-breach.service";
+import { ModuleRef } from "@nestjs/core";
 import { ExchangeRateService } from "../currencies/exchange-rate.service";
 
 describe("UsersService", () => {
@@ -26,6 +27,7 @@ describe("UsersService", () => {
   let trustedDevicesRepository: Record<string, jest.Mock>;
   let passwordBreachService: { isBreached: jest.Mock };
   let exchangeRateService: { refreshAllRates: jest.Mock };
+  let moduleRef: { get: jest.Mock };
   let mockQueryRunner: Record<string, jest.Mock>;
 
   const mockUser = {
@@ -101,6 +103,13 @@ describe("UsersService", () => {
       }),
     };
 
+    moduleRef = {
+      get: jest.fn((token) => {
+        if (token === ExchangeRateService) return exchangeRateService;
+        return undefined;
+      }),
+    };
+
     mockQueryRunner = {
       connect: jest.fn(),
       startTransaction: jest.fn(),
@@ -136,7 +145,7 @@ describe("UsersService", () => {
         },
         { provide: DataSource, useValue: mockDataSource },
         { provide: PasswordBreachService, useValue: passwordBreachService },
-        { provide: ExchangeRateService, useValue: exchangeRateService },
+        { provide: ModuleRef, useValue: moduleRef },
       ],
     }).compile();
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -20,6 +20,7 @@ import { UpdatePreferencesDto } from "./dto/update-preferences.dto";
 import { ChangePasswordDto } from "./dto/change-password.dto";
 import { DeleteDataDto } from "./dto/delete-data.dto";
 import { PasswordBreachService } from "../auth/password-breach.service";
+import { ExchangeRateService } from "../currencies/exchange-rate.service";
 
 @Injectable()
 export class UsersService {
@@ -38,6 +39,7 @@ export class UsersService {
     private trustedDevicesRepository: Repository<TrustedDevice>,
     private dataSource: DataSource,
     private passwordBreachService: PasswordBreachService,
+    private exchangeRateService: ExchangeRateService,
   ) {}
 
   async findById(id: string): Promise<User | null> {
@@ -145,6 +147,8 @@ export class UsersService {
       preferences = await this.getPreferences(userId);
     }
 
+    const previousDefaultCurrency = preferences.defaultCurrency;
+
     // Update only provided fields
     if (dto.defaultCurrency !== undefined) {
       preferences.defaultCurrency = dto.defaultCurrency;
@@ -198,7 +202,23 @@ export class UsersService {
       preferences.recentTransactionsLimit = dto.recentTransactionsLimit;
     }
 
-    return this.preferencesRepository.save(preferences);
+    const saved = await this.preferencesRepository.save(preferences);
+
+    // Fetch fresh exchange rates whenever the user picks a new default
+    // currency so multi-currency totals (Net Worth card, account group totals)
+    // can convert immediately instead of waiting for the next daily cron.
+    if (
+      dto.defaultCurrency !== undefined &&
+      dto.defaultCurrency !== previousDefaultCurrency
+    ) {
+      this.exchangeRateService.refreshAllRates().catch((err) => {
+        this.logger.warn(
+          `Background exchange rate refresh after default-currency change failed: ${err.message}`,
+        );
+      });
+    }
+
+    return saved;
   }
 
   async changePassword(userId: string, dto: ChangePasswordDto): Promise<void> {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -20,6 +20,7 @@ import { UpdatePreferencesDto } from "./dto/update-preferences.dto";
 import { ChangePasswordDto } from "./dto/change-password.dto";
 import { DeleteDataDto } from "./dto/delete-data.dto";
 import { PasswordBreachService } from "../auth/password-breach.service";
+import { ModuleRef } from "@nestjs/core";
 import { ExchangeRateService } from "../currencies/exchange-rate.service";
 
 @Injectable()
@@ -39,7 +40,7 @@ export class UsersService {
     private trustedDevicesRepository: Repository<TrustedDevice>,
     private dataSource: DataSource,
     private passwordBreachService: PasswordBreachService,
-    private exchangeRateService: ExchangeRateService,
+    private moduleRef: ModuleRef,
   ) {}
 
   async findById(id: string): Promise<User | null> {
@@ -207,15 +208,26 @@ export class UsersService {
     // Fetch fresh exchange rates whenever the user picks a new default
     // currency so multi-currency totals (Net Worth card, account group totals)
     // can convert immediately instead of waiting for the next daily cron.
+    // Resolved lazily via ModuleRef to avoid a UsersModule -> CurrenciesModule
+    // import that would create a circular dependency through Notifications.
     if (
       dto.defaultCurrency !== undefined &&
       dto.defaultCurrency !== previousDefaultCurrency
     ) {
-      this.exchangeRateService.refreshAllRates().catch((err) => {
+      try {
+        const exchangeRateService = this.moduleRef.get(ExchangeRateService, {
+          strict: false,
+        });
+        exchangeRateService.refreshAllRates().catch((err) => {
+          this.logger.warn(
+            `Background exchange rate refresh after default-currency change failed: ${err.message}`,
+          );
+        });
+      } catch (err) {
         this.logger.warn(
-          `Background exchange rate refresh after default-currency change failed: ${err.message}`,
+          `Could not resolve ExchangeRateService for background refresh: ${err.message}`,
         );
-      });
+      }
     }
 
     return saved;

--- a/frontend/src/components/accounts/LoanFields.tsx
+++ b/frontend/src/components/accounts/LoanFields.tsx
@@ -12,6 +12,7 @@ import { buildCategoryTree } from '@/lib/categoryUtils';
 import { accountsApi } from '@/lib/accounts';
 import { buildAccountDropdownOptions } from '@/lib/account-utils';
 import { createLogger } from '@/lib/logger';
+import { useDateFormat } from '@/hooks/useDateFormat';
 
 const logger = createLogger('LoanFields');
 
@@ -58,6 +59,7 @@ export function LoanFields({
   selectedInterestCategoryId,
   handleInterestCategoryChange,
 }: LoanFieldsProps) {
+  const { formatDate } = useDateFormat();
   const [amortizationPreview, setAmortizationPreview] = useState<AmortizationPreview | null>(null);
   const [isLoadingPreview, setIsLoadingPreview] = useState(false);
 
@@ -196,7 +198,7 @@ export function LoanFields({
               <span className="text-gray-500 dark:text-gray-400">Est. Payoff:</span>{' '}
               <span className="font-medium">
                 {amortizationPreview.totalPayments > 0
-                  ? new Date(amortizationPreview.endDate).toLocaleDateString()
+                  ? formatDate(new Date(amortizationPreview.endDate))
                   : 'N/A'}
               </span>
             </div>

--- a/frontend/src/components/accounts/MortgageFields.tsx
+++ b/frontend/src/components/accounts/MortgageFields.tsx
@@ -12,6 +12,7 @@ import { buildCategoryTree } from '@/lib/categoryUtils';
 import { accountsApi } from '@/lib/accounts';
 import { buildAccountDropdownOptions } from '@/lib/account-utils';
 import { createLogger } from '@/lib/logger';
+import { useDateFormat } from '@/hooks/useDateFormat';
 
 const logger = createLogger('MortgageFields');
 
@@ -65,6 +66,7 @@ export function MortgageFields({
   selectedInterestCategoryId,
   handleInterestCategoryChange,
 }: MortgageFieldsProps) {
+  const { formatDate } = useDateFormat();
   const [mortgagePreview, setMortgagePreview] = useState<MortgageAmortizationPreview | null>(null);
   const [isLoadingPreview, setIsLoadingPreview] = useState(false);
 
@@ -386,7 +388,7 @@ export function MortgageFields({
                   <span className="text-gray-500 dark:text-gray-400">Est. Payoff Date:</span>{' '}
                   <span className="font-medium">
                     {mortgagePreview.totalPayments > 0
-                      ? new Date(mortgagePreview.endDate).toLocaleDateString()
+                      ? formatDate(new Date(mortgagePreview.endDate))
                       : 'N/A'}
                   </span>
                 </div>

--- a/frontend/src/components/admin/UserManagementTable.tsx
+++ b/frontend/src/components/admin/UserManagementTable.tsx
@@ -4,6 +4,8 @@ import { useMemo } from 'react';
 import { AdminUser } from '@/types/auth';
 import { Button } from '@/components/ui/Button';
 import { useDateFormat } from '@/hooks/useDateFormat';
+import { usePreferencesStore } from '@/store/preferencesStore';
+import { formatTime } from '@/lib/utils';
 
 interface UserManagementTableProps {
   users: AdminUser[];
@@ -23,6 +25,13 @@ export function UserManagementTable({
   onDeleteUser,
 }: UserManagementTableProps) {
   const { formatDate } = useDateFormat();
+  const timeFormat = usePreferencesStore((s) => s.preferences?.timeFormat) || '24h';
+
+  const formatLastLogin = (iso: string): string => {
+    const d = new Date(iso);
+    const time24 = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+    return `${formatDate(d)} ${formatTime(time24, timeFormat)}`;
+  };
 
   const sortedUsers = useMemo(() => {
     return [...users].sort((a, b) =>
@@ -124,9 +133,7 @@ export function UserManagementTable({
 
                 {/* Last Login */}
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
-                  {user.lastLogin
-                    ? `${formatDate(new Date(user.lastLogin))} ${new Date(user.lastLogin).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}`
-                    : 'Never'}
+                  {user.lastLogin ? formatLastLogin(user.lastLogin) : 'Never'}
                 </td>
 
                 {/* Actions */}

--- a/frontend/src/components/ai/ResultChart.tsx
+++ b/frontend/src/components/ai/ResultChart.tsx
@@ -17,6 +17,7 @@ import {
   Area,
 } from 'recharts';
 import { captureSvgAsImage } from '@/lib/pdf-export-charts';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
 
 const COLORS = [
   '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6',
@@ -34,11 +35,6 @@ interface ResultChartProps {
   data: ChartData[];
 }
 
-function formatCurrency(value: number | undefined): string {
-  if (value === undefined) return '';
-  return `$${value.toLocaleString(undefined, { minimumFractionDigits: 2 })}`;
-}
-
 function ChartTooltip({
   active,
   payload,
@@ -48,6 +44,7 @@ function ChartTooltip({
   payload?: Array<{ name?: string; value?: number; payload?: { label?: string } }>;
   label?: string;
 }) {
+  const { formatCurrency } = useNumberFormat();
   if (!active || !payload || payload.length === 0) return null;
   const heading = label ?? payload[0]?.payload?.label ?? payload[0]?.name;
   return (
@@ -60,7 +57,7 @@ function ChartTooltip({
           key={`tooltip-${index}`}
           className="text-sm text-blue-600 dark:text-blue-400"
         >
-          {formatCurrency(entry.value)}
+          {entry.value !== undefined ? formatCurrency(entry.value) : ''}
         </p>
       ))}
     </div>

--- a/frontend/src/components/insights/InsightCard.tsx
+++ b/frontend/src/components/insights/InsightCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { AiInsight, INSIGHT_TYPE_LABELS } from '@/types/ai';
+import { useDateFormat } from '@/hooks/useDateFormat';
 
 interface InsightCardProps {
   insight: AiInsight;
@@ -39,6 +40,7 @@ const typeStyles: Record<string, string> = {
 };
 
 export function InsightCard({ insight, onDismiss, isDismissing }: InsightCardProps) {
+  const { formatDate } = useDateFormat();
   const style = severityStyles[insight.severity] || severityStyles.info;
   const typeStyle = typeStyles[insight.type] || typeStyles.anomaly;
 
@@ -70,7 +72,7 @@ export function InsightCard({ insight, onDismiss, isDismissing }: InsightCardPro
           </p>
           <div className="flex items-center justify-between">
             <span className="text-xs text-gray-500 dark:text-gray-400">
-              {new Date(insight.generatedAt).toLocaleDateString()}
+              {formatDate(new Date(insight.generatedAt))}
             </span>
             {!insight.isDismissed && (
               <button

--- a/frontend/src/components/insights/InsightsList.tsx
+++ b/frontend/src/components/insights/InsightsList.tsx
@@ -6,6 +6,9 @@ import { AiInsight, AiStatus, InsightType, InsightSeverity, INSIGHT_TYPE_LABELS,
 import { InsightCard } from './InsightCard';
 import { createLogger } from '@/lib/logger';
 import Link from 'next/link';
+import { useDateFormat } from '@/hooks/useDateFormat';
+import { usePreferencesStore } from '@/store/preferencesStore';
+import { formatTime } from '@/lib/utils';
 
 const logger = createLogger('InsightsList');
 
@@ -13,6 +16,8 @@ const POLL_INTERVAL = 5000;
 const MAX_POLL_ATTEMPTS = 150; // 150 * 5s = 12.5 minutes max for CPU inference
 
 export function InsightsList() {
+  const { formatDate } = useDateFormat();
+  const timeFormat = usePreferencesStore((s) => s.preferences?.timeFormat) || '24h';
   const [insights, setInsights] = useState<AiInsight[]>([]);
   const [total, setTotal] = useState(0);
   const [lastGeneratedAt, setLastGeneratedAt] = useState<string | null>(null);
@@ -186,11 +191,15 @@ export function InsightsList() {
               {warningCount} warning{warningCount !== 1 ? 's' : ''}
             </span>
           )}
-          {lastGeneratedAt && (
-            <span className="text-xs text-gray-500 dark:text-gray-400">
-              Last updated: {new Date(lastGeneratedAt).toLocaleString()}
-            </span>
-          )}
+          {lastGeneratedAt && (() => {
+            const d = new Date(lastGeneratedAt);
+            const time24 = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+            return (
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                Last updated: {formatDate(d)} {formatTime(time24, timeFormat)}
+              </span>
+            );
+          })()}
         </div>
         <button
           onClick={handleGenerate}

--- a/frontend/src/components/payees/DeactivateUnusedPayeesDialog.tsx
+++ b/frontend/src/components/payees/DeactivateUnusedPayeesDialog.tsx
@@ -8,6 +8,7 @@ import { DeactivationCandidate } from '@/types/payee';
 import toast from 'react-hot-toast';
 import { createLogger } from '@/lib/logger';
 import { getErrorMessage } from '@/lib/errors';
+import { useDateFormat } from '@/hooks/useDateFormat';
 
 const logger = createLogger('DeactivateUnusedPayees');
 
@@ -22,6 +23,7 @@ export function DeactivateUnusedPayeesDialog({
   onClose,
   onSuccess,
 }: DeactivateUnusedPayeesDialogProps) {
+  const { formatDate: formatUserDate } = useDateFormat();
   const [maxTransactions, setMaxTransactions] = useState(3);
   const [monthsUnused, setMonthsUnused] = useState(12);
   const [candidates, setCandidates] = useState<DeactivationCandidate[]>([]);
@@ -111,8 +113,7 @@ export function DeactivateUnusedPayeesDialog({
 
   const formatDate = (dateStr: string | null): string => {
     if (!dateStr) return 'Never used';
-    const date = new Date(dateStr + 'T00:00:00');
-    return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+    return formatUserDate(dateStr);
   };
 
   return (

--- a/frontend/src/components/settings/ApiAccessSection.tsx
+++ b/frontend/src/components/settings/ApiAccessSection.tsx
@@ -14,6 +14,7 @@ import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { authApi } from '@/lib/auth';
 import { PersonalAccessToken } from '@/types/auth';
 import { getErrorMessage } from '@/lib/errors';
+import { useDateFormat } from '@/hooks/useDateFormat';
 
 const MCP_PATH = '/api/v1/mcp';
 
@@ -37,7 +38,10 @@ const createTokenSchema = z.object({
 
 type CreateTokenFormData = z.infer<typeof createTokenSchema>;
 
-function formatRelativeDate(dateStr: string | null): string {
+function relativeOrFormatted(
+  dateStr: string | null,
+  formatDate: (date: Date | string) => string,
+): string {
   if (!dateStr) return 'Never';
   const date = new Date(dateStr);
   const now = new Date();
@@ -48,10 +52,11 @@ function formatRelativeDate(dateStr: string | null): string {
   if (diffDays === 1) return 'Yesterday';
   if (diffDays < 30) return `${diffDays} days ago`;
   if (diffDays < 365) return `${Math.floor(diffDays / 30)} months ago`;
-  return date.toLocaleDateString();
+  return formatDate(date);
 }
 
 export function ApiAccessSection() {
+  const { formatDate } = useDateFormat();
   const [tokens, setTokens] = useState<PersonalAccessToken[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [showCreateModal, setShowCreateModal] = useState(false);
@@ -275,13 +280,13 @@ export function ApiAccessSection() {
                   ))}
                 </div>
                 <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                  Created {new Date(token.createdAt).toLocaleDateString()}
+                  Created {formatDate(new Date(token.createdAt))}
                   {' \u00B7 '}
-                  Last used {formatRelativeDate(token.lastUsedAt)}
+                  Last used {relativeOrFormatted(token.lastUsedAt, formatDate)}
                   {token.expiresAt && (
                     <>
                       {' \u00B7 '}
-                      Expires {new Date(token.expiresAt).toLocaleDateString()}
+                      Expires {formatDate(new Date(token.expiresAt))}
                     </>
                   )}
                 </div>

--- a/frontend/src/components/settings/AutoBackupSection.tsx
+++ b/frontend/src/components/settings/AutoBackupSection.tsx
@@ -7,7 +7,7 @@ import { Input } from '@/components/ui/Input';
 import { Select } from '@/components/ui/Select';
 import { backupApi } from '@/lib/backupApi';
 import { getErrorMessage } from '@/lib/errors';
-import { resolveTimezone } from '@/lib/utils';
+import { resolveTimezone, isoToDatetimeLocal, formatDatetimeLocal } from '@/lib/utils';
 import { AutoBackupSettings, UpdateAutoBackupSettingsData } from '@/types/auth';
 import { usePreferencesStore } from '@/store/preferencesStore';
 
@@ -18,18 +18,22 @@ const FREQUENCY_OPTIONS = [
   { value: 'weekly', label: 'Weekly' },
 ];
 
-function formatDateTime(dateStr: string | null, timezone: string): string {
+function formatDateTime(
+  dateStr: string | null,
+  timezone: string,
+  dateFormat: string,
+  timeFormat: '24h' | '12h',
+): string {
   if (!dateStr) return 'Never';
-  // Backend stores timestamps as UTC but PostgreSQL 'timestamp' (without tz)
-  // omits the Z suffix, so append it to ensure correct UTC parsing
-  const normalized = /[Z+-]/.test(dateStr.slice(-6)) ? dateStr : dateStr + 'Z';
-  const date = new Date(normalized);
-  return date.toLocaleString(undefined, { timeZone: timezone });
+  const datetimeLocal = isoToDatetimeLocal(dateStr, timezone);
+  return formatDatetimeLocal(datetimeLocal, dateFormat, timeFormat);
 }
 
 export function AutoBackupSection() {
   const preferences = usePreferencesStore((s) => s.preferences);
   const userTimezone = resolveTimezone(preferences?.timezone);
+  const dateFormat = preferences?.dateFormat || 'browser';
+  const timeFormat = preferences?.timeFormat || '24h';
 
   const [settings, setSettings] = useState<AutoBackupSettings | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -461,7 +465,7 @@ export function AutoBackupSection() {
               <div className="flex justify-between">
                 <dt className="text-gray-600 dark:text-gray-400">Last backup</dt>
                 <dd className="font-medium text-gray-900 dark:text-white flex items-center gap-2">
-                  {formatDateTime(settings.lastBackupAt, userTimezone)}
+                  {formatDateTime(settings.lastBackupAt, userTimezone, dateFormat, timeFormat)}
                   {settings.lastBackupStatus === 'success' && (
                     <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300">
                       Success
@@ -487,7 +491,7 @@ export function AutoBackupSection() {
               <div className="flex justify-between">
                 <dt className="text-gray-600 dark:text-gray-400">Next backup</dt>
                 <dd className="font-medium text-gray-900 dark:text-white">
-                  {formatDateTime(settings.nextBackupAt, userTimezone)}
+                  {formatDateTime(settings.nextBackupAt, userTimezone, dateFormat, timeFormat)}
                 </dd>
               </div>
             )}

--- a/frontend/src/components/settings/SecuritySection.tsx
+++ b/frontend/src/components/settings/SecuritySection.tsx
@@ -18,6 +18,7 @@ import { usePreferencesStore } from '@/store/preferencesStore';
 import { User, UserPreferences, TrustedDevice } from '@/types/auth';
 import { getErrorMessage } from '@/lib/errors';
 import { passwordSchema, PASSWORD_REQUIREMENTS_TEXT } from '@/lib/zod-helpers';
+import { useDateFormat } from '@/hooks/useDateFormat';
 
 const changePasswordSchema = z.object({
   currentPassword: z.string().min(1, 'Current password is required').max(128, 'Password must be 128 characters or less'),
@@ -39,6 +40,7 @@ interface SecuritySectionProps {
 
 export function SecuritySection({ user, preferences, force2fa, onPreferencesUpdated }: SecuritySectionProps) {
   const updatePreferencesStore = usePreferencesStore((state) => state.updatePreferences);
+  const { formatDate } = useDateFormat();
 
   const {
     register,
@@ -434,11 +436,11 @@ export function SecuritySection({ user, preferences, force2fa, onPreferencesUpda
                     <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 space-y-0.5">
                       {device.ipAddress && <p>IP: {device.ipAddress}</p>}
                       <p>
-                        Added {new Date(device.createdAt).toLocaleDateString()}
+                        Added {formatDate(new Date(device.createdAt))}
                         {' \u00B7 '}
-                        Last used {new Date(device.lastUsedAt).toLocaleDateString()}
+                        Last used {formatDate(new Date(device.lastUsedAt))}
                         {' \u00B7 '}
-                        Expires {new Date(device.expiresAt).toLocaleDateString()}
+                        Expires {formatDate(new Date(device.expiresAt))}
                       </p>
                     </div>
                   </div>

--- a/frontend/src/components/settings/ai/UsageDashboard.tsx
+++ b/frontend/src/components/settings/ai/UsageDashboard.tsx
@@ -10,6 +10,7 @@ import type {
 import { AI_PROVIDER_LABELS } from '@/types/ai';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { usePreferencesStore } from '@/store/preferencesStore';
+import { useDateFormat } from '@/hooks/useDateFormat';
 
 interface UsageDashboardProps {
   usage: AiUsageSummary;
@@ -88,6 +89,7 @@ export function UsageDashboard({ usage, configs, onPeriodChange }: UsageDashboar
   const { convert } = useExchangeRates();
   const homeCurrency =
     usePreferencesStore((state) => state.preferences?.defaultCurrency) || 'USD';
+  const { formatDate } = useDateFormat();
 
   const handlePeriodChange = (days: number | undefined) => {
     setSelectedPeriod(days);
@@ -284,7 +286,7 @@ export function UsageDashboard({ usage, configs, onPeriodChange }: UsageDashboar
                 {usage.recentLogs.map((log) => (
                   <tr key={log.id} className="border-b border-gray-100 dark:border-gray-700/50">
                     <td className="py-2 text-gray-600 dark:text-gray-300">
-                      {new Date(log.createdAt).toLocaleDateString()}
+                      {formatDate(new Date(log.createdAt))}
                     </td>
                     <td className="py-2 text-gray-900 dark:text-white">{resolveLogName(log.provider, log.model, configs)}</td>
                     <td className="py-2 text-gray-600 dark:text-gray-300">{log.feature}</td>

--- a/frontend/src/hooks/useExchangeRates.ts
+++ b/frontend/src/hooks/useExchangeRates.ts
@@ -48,10 +48,17 @@ export function useExchangeRates() {
       const inverseRate = rateMap.get(`${target}->${fromCurrency}`);
       if (inverseRate && inverseRate !== 0) return amount / inverseRate;
 
-      // No rate available, return amount unconverted
+      // No rate available -- log so missing pairs are visible instead of
+      // silently rendering an unconverted figure under the wrong currency.
+      // Skip the warning while the rates request is still in flight.
+      if (!isLoading) {
+        logger.warn(
+          `No exchange rate for ${fromCurrency}->${target}; returning amount unconverted`,
+        );
+      }
       return amount;
     },
-    [rateMap, defaultCurrency],
+    [rateMap, defaultCurrency, isLoading],
   );
 
   const convertToDefault = useCallback(


### PR DESCRIPTION
Action history descriptions, backup timestamps, API token dates, and
several other places used hardcoded $ or browser-default formatting.
Switch them to the user's home currency and configured date/time format.