### PR TITLE
Remove random condition for demo Costco split transactions

### DIFF
--- a/backend/src/database/demo-seed-data/transactions.ts
+++ b/backend/src/database/demo-seed-data/transactions.ts
@@ -337,11 +337,12 @@ export function generateTransactions(referenceDate: Date): DemoTransaction[] {
       const amount = isCostco
         ? randomBetween(rand, 180, 320)
         : randomBetween(rand, 75, 220);
-      const splitRand = rand();
+      // Reserved rand draw kept to preserve the seeded random sequence.
+      rand();
       const accountRand = rand();
 
       if (groceryDate <= referenceDate && groceryDate >= startDate) {
-        if (isCostco && splitRand > 0.5) {
+        if (isCostco) {
           // Split transaction for Costco
           const groceryAmt = Math.round(amount * 0.7 * 100) / 100;
           const homeGoodsAmt = Math.round((amount - groceryAmt) * 100) / 100;


### PR DESCRIPTION
## Summary
Simplified the logic for generating split transactions at Costco by removing a conditional check that was based on a random value. All Costco transactions will now be split consistently.

## Key Changes
- Removed the `splitRand > 0.5` condition that previously made Costco splits probabilistic
- Preserved the random number draw by calling `rand()` without assignment to maintain the seeded random sequence integrity
- All Costco transactions now always generate split transactions (grocery + home goods)

## Implementation Details
The random draw is still executed but not used in the conditional logic. This preserves the deterministic seeded random sequence for demo data generation, ensuring that other random values in the sequence remain consistent and reproducible.

https://claude.ai/code/session_01TEUe3ZrCjMpLuFh6rsZiDw