### PR TITLE
feat(monte-carlo): cache simulation results in localStorage

### DIFF
--- a/frontend/src/components/reports/MonteCarloReport.tsx
+++ b/frontend/src/components/reports/MonteCarloReport.tsx
@@ -23,6 +23,11 @@ import {
   CashFlow,
   CashFlowType,
 } from '@/lib/monte-carlo';
+import {
+  getCachedResult,
+  setCachedResult,
+  clearCachedResult,
+} from '@/lib/monte-carlo-cache';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { getCurrencySymbol } from '@/lib/format';
 import { showErrorToast } from '@/lib/errors';
@@ -107,8 +112,14 @@ export function MonteCarloReport() {
       /* ignore quota / privacy errors */
     }
   }, [activeId]);
-  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  // Persist simulation results to localStorage so the user doesn't have to
+  // re-run the simulation after a page refresh. Only cache for saved scenarios
+  // -- ad-hoc/draft results have no stable key.
   const [result, setResult] = useState<SimulationResult | null>(null);
+  useEffect(() => {
+    if (activeId && result) setCachedResult(activeId, result);
+  }, [activeId, result]);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [holdingStats, setHoldingStats] = useState<AccountHoldingStats[] | null>(null);
   const [holdingStatsLoading, setHoldingStatsLoading] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -170,6 +181,8 @@ export function MonteCarloReport() {
                 inflationAdjust: cf.inflationAdjust,
               })),
             });
+            const cached = getCachedResult(match.id);
+            if (cached) setResult(cached);
           } else {
             setActiveId(null);
           }
@@ -286,7 +299,7 @@ export function MonteCarloReport() {
         inflationAdjust: cf.inflationAdjust,
       })),
     });
-    setResult(null);
+    setResult(getCachedResult(s.id));
   };
 
   const newScenario = () => {
@@ -442,6 +455,7 @@ export function MonteCarloReport() {
     }
     try {
       await monteCarloApi.remove(activeId);
+      clearCachedResult(activeId);
       setScenarios((prev) => prev.filter((s) => s.id !== activeId));
       newScenario();
       toast.success('Scenario deleted.');

--- a/frontend/src/lib/monte-carlo-cache.ts
+++ b/frontend/src/lib/monte-carlo-cache.ts
@@ -1,0 +1,49 @@
+import { SimulationResult } from './monte-carlo';
+
+const STORAGE_KEY = 'monize:monte-carlo-results';
+
+type CacheMap = Record<string, SimulationResult>;
+
+function read(): CacheMap {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as CacheMap) : {};
+  } catch {
+    return {};
+  }
+}
+
+function write(map: CacheMap): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    /* quota / privacy errors */
+  }
+}
+
+export function getCachedResult(scenarioId: string): SimulationResult | null {
+  return read()[scenarioId] ?? null;
+}
+
+export function setCachedResult(
+  scenarioId: string,
+  result: SimulationResult,
+): void {
+  const all = read();
+  all[scenarioId] = result;
+  write(all);
+}
+
+export function clearCachedResult(scenarioId: string): void {
+  const all = read();
+  if (scenarioId in all) {
+    delete all[scenarioId];
+    write(all);
+  }
+}
+
+export const MONTE_CARLO_RESULTS_STORAGE_KEY = STORAGE_KEY;

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -62,6 +62,7 @@ export const useAuthStore = create<AuthState>()(
         try {
           if (typeof window !== 'undefined') {
             window.localStorage.removeItem('monize:ai-chat-messages');
+            window.localStorage.removeItem('monize:monte-carlo-results');
           }
         } catch {
           // localStorage unavailable — nothing to do


### PR DESCRIPTION
Persist Monte Carlo simulation results per saved scenario so users don't
have to re-run the simulation after a page refresh. Results are restored
on mount, when switching scenarios, and cleared on scenario delete and
logout (multi-user safety).

https://claude.ai/code/session_01Y2eHdsr2YPMMEjabGrEqJE