### PR TITLE
Refactor performance summary export and add to PDF reports

### DIFF
--- a/frontend/src/components/reports/MonteCarloReport.test.tsx
+++ b/frontend/src/components/reports/MonteCarloReport.test.tsx
@@ -525,7 +525,14 @@ describe('MonteCarloReport', () => {
       });
       expect(exportToPdf).toHaveBeenCalled();
       const args = (exportToPdf as ReturnType<typeof vi.fn>).mock.calls[0][0];
-      expect(args.tableData.headers).toContain('Events');
+      // Both tables are passed as additional sections, with the
+      // Performance Summary preceding the year-by-year percentile table.
+      expect(args.additionalTables).toHaveLength(2);
+      expect(args.additionalTables[0].title).toBe('Performance Summary');
+      expect(args.additionalTables[1].title).toBe(
+        'Portfolio Value Percentiles by Year',
+      );
+      expect(args.additionalTables[1].headers).toContain('Events');
       expect(args.summaryCards.length).toBe(4);
     });
   });
@@ -1272,7 +1279,11 @@ describe('MonteCarloReport', () => {
         fireEvent.click(pdfOption);
       });
       const args = (exportToPdf as ReturnType<typeof vi.fn>).mock.calls[0][0];
-      const events = args.tableData.rows
+      const yearlyTable = args.additionalTables.find(
+        (t: { title?: string }) =>
+          t.title === 'Portfolio Value Percentiles by Year',
+      );
+      const events = yearlyTable.rows
         .map((r: string[]) => r[r.length - 1])
         .join('\n');
       expect(events).toMatch(/Starts: Pension/);

--- a/frontend/src/components/reports/MonteCarloReport.tsx
+++ b/frontend/src/components/reports/MonteCarloReport.tsx
@@ -596,6 +596,7 @@ export function MonteCarloReport() {
     };
     const escape = (v: string) => `"${v.replace(/"/g, '""')}"`;
     const lines = [
+      escape('Portfolio Value Percentiles by Year'),
       header.map(escape).join(','),
       ...tableRows.map((row) =>
         [
@@ -609,6 +610,24 @@ export function MonteCarloReport() {
         ].join(','),
       ),
     ];
+    if (result.performanceSummary) {
+      const summaryRows = buildPerformanceSummaryRows(result.performanceSummary);
+      lines.push('');
+      lines.push(escape('Performance Summary'));
+      lines.push(PERFORMANCE_SUMMARY_HEADERS.map(escape).join(','));
+      for (const row of summaryRows) {
+        lines.push(
+          [
+            escape(row.label),
+            escape(formatSummaryValue(row.band.p10, row.format, formatCurrency)),
+            escape(formatSummaryValue(row.band.p25, row.format, formatCurrency)),
+            escape(formatSummaryValue(row.band.p50, row.format, formatCurrency)),
+            escape(formatSummaryValue(row.band.p75, row.format, formatCurrency)),
+            escape(formatSummaryValue(row.band.p90, row.format, formatCurrency)),
+          ].join(','),
+        );
+      }
+    }
     const blob = new Blob(['﻿' + lines.join('\n')], {
       type: 'text/csv;charset=utf-8;',
     });
@@ -620,7 +639,7 @@ export function MonteCarloReport() {
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
-  }, [result, tableRows, form.name]);
+  }, [result, tableRows, form.name, formatCurrency]);
 
   const handleExportPdf = useCallback(async () => {
     if (!result) return;
@@ -670,30 +689,51 @@ export function MonteCarloReport() {
       // the table — the chart container stays mounted offscreen so the
       // ResponsiveContainer has real dimensions for html2canvas to capture.
       chartContainer: chartRef.current,
-      tableData: {
-        headers: ['Year', '10%', '25%', 'Median', '75%', '90%', 'Events'],
-        rows: tableRows.map((r) => [
-          r.year,
-          formatCurrency(r.p10),
-          formatCurrency(r.p25),
-          formatCurrency(r.p50),
-          formatCurrency(r.p75),
-          formatCurrency(r.p90),
-          r.events
-            .map((e) => {
-              const prefix =
-                e.flowType === 'ONE_TIME'
-                  ? ''
-                  : e.role === 'start'
-                    ? 'Starts: '
-                    : 'Ends: ';
-              return `${prefix}${e.name} (${e.income ? '+' : ''}${formatCurrency(
-                e.amount,
-              )}${e.flowType === 'RECURRING' ? '/yr' : ''})`;
-            })
-            .join('; '),
-        ]),
-      },
+      additionalTables: [
+        ...(result.performanceSummary
+          ? [
+              {
+                title: 'Performance Summary',
+                headers: PERFORMANCE_SUMMARY_HEADERS,
+                rows: buildPerformanceSummaryRows(result.performanceSummary).map(
+                  (row) => [
+                    row.label,
+                    formatSummaryValue(row.band.p10, row.format, formatCurrency),
+                    formatSummaryValue(row.band.p25, row.format, formatCurrency),
+                    formatSummaryValue(row.band.p50, row.format, formatCurrency),
+                    formatSummaryValue(row.band.p75, row.format, formatCurrency),
+                    formatSummaryValue(row.band.p90, row.format, formatCurrency),
+                  ],
+                ),
+              },
+            ]
+          : []),
+        {
+          title: 'Portfolio Value Percentiles by Year',
+          headers: ['Year', '10%', '25%', 'Median', '75%', '90%', 'Events'],
+          rows: tableRows.map((r) => [
+            r.year,
+            formatCurrency(r.p10),
+            formatCurrency(r.p25),
+            formatCurrency(r.p50),
+            formatCurrency(r.p75),
+            formatCurrency(r.p90),
+            r.events
+              .map((e) => {
+                const prefix =
+                  e.flowType === 'ONE_TIME'
+                    ? ''
+                    : e.role === 'start'
+                      ? 'Starts: '
+                      : 'Ends: ';
+                return `${prefix}${e.name} (${e.income ? '+' : ''}${formatCurrency(
+                  e.amount,
+                )}${e.flowType === 'RECURRING' ? '/yr' : ''})`;
+              })
+              .join('; '),
+          ]),
+        },
+      ],
       filename: `monte-carlo-${(form.name || 'scenario').toLowerCase().replace(/\s+/g, '-')}`,
     });
   }, [
@@ -1678,14 +1718,8 @@ type SummaryRow = {
   format: 'currency' | 'percent' | 'ratio';
 };
 
-function PerformanceSummaryTable({
-  summary,
-  formatCurrency,
-}: {
-  summary: PerformanceSummary;
-  formatCurrency: (v: number) => string;
-}) {
-  const rows: SummaryRow[] = [
+function buildPerformanceSummaryRows(summary: PerformanceSummary): SummaryRow[] {
+  return [
     {
       label: 'Time Weighted Rate of Return (nominal)',
       description:
@@ -1757,13 +1791,38 @@ function PerformanceSummaryTable({
       format: 'percent',
     },
   ];
+}
 
-  const formatValue = (v: number, kind: SummaryRow['format']): string => {
-    if (!Number.isFinite(v)) return '—';
-    if (kind === 'currency') return formatCurrency(v);
-    if (kind === 'percent') return `${(v * 100).toFixed(2)}%`;
-    return v.toFixed(2);
-  };
+function formatSummaryValue(
+  v: number,
+  kind: SummaryRow['format'],
+  formatCurrency: (v: number) => string,
+): string {
+  if (!Number.isFinite(v)) return '—';
+  if (kind === 'currency') return formatCurrency(v);
+  if (kind === 'percent') return `${(v * 100).toFixed(2)}%`;
+  return v.toFixed(2);
+}
+
+const PERFORMANCE_SUMMARY_HEADERS = [
+  'Summary Statistics',
+  '10th Percentile',
+  '25th Percentile',
+  '50th Percentile',
+  '75th Percentile',
+  '90th Percentile',
+];
+
+function PerformanceSummaryTable({
+  summary,
+  formatCurrency,
+}: {
+  summary: PerformanceSummary;
+  formatCurrency: (v: number) => string;
+}) {
+  const rows = buildPerformanceSummaryRows(summary);
+  const formatValue = (v: number, kind: SummaryRow['format']): string =>
+    formatSummaryValue(v, kind, formatCurrency);
 
   return (
     <div className="overflow-x-auto">


### PR DESCRIPTION
## Summary
This PR refactors the performance summary functionality to enable exporting it in both CSV and PDF formats, while improving code reusability and maintainability.

## Key Changes
- **Extracted reusable functions**: Created `buildPerformanceSummaryRows()` and `formatSummaryValue()` to eliminate code duplication between the UI table and export functions
- **Enhanced CSV export**: Added performance summary section to CSV exports with proper formatting and headers
- **Improved PDF export**: Restructured PDF export to use `additionalTables` array, allowing multiple tables to be included with the performance summary appearing before the yearly percentile table
- **Added constants**: Introduced `PERFORMANCE_SUMMARY_HEADERS` constant for consistent header formatting across all export formats
- **Updated dependencies**: Added `formatCurrency` to the CSV export callback dependencies to ensure proper formatting

## Implementation Details
- The `PerformanceSummaryTable` component now uses the extracted `buildPerformanceSummaryRows()` function, reducing duplication
- Performance summary is conditionally included in both CSV and PDF exports only when `result.performanceSummary` is available
- The PDF export now passes tables via `additionalTables` array instead of `tableData`, providing better structure for multiple tables
- Tests were updated to reflect the new `additionalTables` structure and verify correct table ordering

https://claude.ai/code/session_01By2UvBZYnyGLD7fM1JtPWy