### PR TITLE
Add positive balance override for liability accounts

### DIFF
--- a/frontend/src/app/reconcile/page.test.tsx
+++ b/frontend/src/app/reconcile/page.test.tsx
@@ -414,6 +414,134 @@ describe('ReconcilePage', () => {
     });
   });
 
+  describe('Liability Account Auto-Negation', () => {
+    it('auto-negates a positive statement balance for a credit card account', async () => {
+      render(<ReconcilePage />);
+      await waitFor(() => expect(screen.getByText(/Visa/)).toBeInTheDocument());
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-2' } });
+      fireEvent.change(screen.getByLabelText('Statement Ending Balance'), { target: { value: '500' } });
+      const input = screen.getByLabelText('Statement Ending Balance') as HTMLInputElement;
+      expect(Number(input.value)).toBe(-500);
+    });
+
+    it('leaves a negative statement balance unchanged for a liability account', async () => {
+      render(<ReconcilePage />);
+      await waitFor(() => expect(screen.getByText(/Visa/)).toBeInTheDocument());
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-2' } });
+      fireEvent.change(screen.getByLabelText('Statement Ending Balance'), { target: { value: '-500' } });
+      const input = screen.getByLabelText('Statement Ending Balance') as HTMLInputElement;
+      expect(Number(input.value)).toBe(-500);
+    });
+
+    it('does not auto-negate for a non-liability account', async () => {
+      render(<ReconcilePage />);
+      await waitFor(() => expect(screen.getByText(/Checking/)).toBeInTheDocument());
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-1' } });
+      fireEvent.change(screen.getByLabelText('Statement Ending Balance'), { target: { value: '1500' } });
+      const input = screen.getByLabelText('Statement Ending Balance') as HTMLInputElement;
+      expect(Number(input.value)).toBe(1500);
+    });
+
+    it('passes undefined through without negating for liability account', async () => {
+      render(<ReconcilePage />);
+      await waitFor(() => expect(screen.getByText(/Visa/)).toBeInTheDocument());
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-2' } });
+      fireEvent.change(screen.getByLabelText('Statement Ending Balance'), { target: { value: '' } });
+      const input = screen.getByLabelText('Statement Ending Balance') as HTMLInputElement;
+      expect(input.value).toBe('');
+    });
+
+    it('shows the override checkbox for liability accounts', async () => {
+      render(<ReconcilePage />);
+      await waitFor(() => expect(screen.getByText(/Visa/)).toBeInTheDocument());
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-2' } });
+      expect(screen.getByLabelText(/Allow positive balance/i)).toBeInTheDocument();
+    });
+
+    it('does not show the override checkbox for non-liability accounts', async () => {
+      render(<ReconcilePage />);
+      await waitFor(() => expect(screen.getByText(/Checking/)).toBeInTheDocument());
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-1' } });
+      expect(screen.queryByLabelText(/Allow positive balance/i)).not.toBeInTheDocument();
+    });
+
+    it('allows a positive balance when the override checkbox is checked', async () => {
+      render(<ReconcilePage />);
+      await waitFor(() => expect(screen.getByText(/Visa/)).toBeInTheDocument());
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-2' } });
+      fireEvent.click(screen.getByLabelText(/Allow positive balance/i));
+      fireEvent.change(screen.getByLabelText('Statement Ending Balance'), { target: { value: '500' } });
+      const input = screen.getByLabelText('Statement Ending Balance') as HTMLInputElement;
+      expect(Number(input.value)).toBe(500);
+    });
+
+    it('re-negates a positive balance when the override is unchecked', async () => {
+      render(<ReconcilePage />);
+      await waitFor(() => expect(screen.getByText(/Visa/)).toBeInTheDocument());
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-2' } });
+      // Enable override and set a positive balance
+      fireEvent.click(screen.getByLabelText(/Allow positive balance/i));
+      fireEvent.change(screen.getByLabelText('Statement Ending Balance'), { target: { value: '500' } });
+      // Disable override — should negate the current positive balance
+      fireEvent.click(screen.getByLabelText(/Allow positive balance/i));
+      const input = screen.getByLabelText('Statement Ending Balance') as HTMLInputElement;
+      expect(Number(input.value)).toBe(-500);
+    });
+
+    it('does not re-negate when unchecking override if balance is already negative', async () => {
+      render(<ReconcilePage />);
+      await waitFor(() => expect(screen.getByText(/Visa/)).toBeInTheDocument());
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-2' } });
+      // Enable override and set a negative balance
+      fireEvent.click(screen.getByLabelText(/Allow positive balance/i));
+      fireEvent.change(screen.getByLabelText('Statement Ending Balance'), { target: { value: '-500' } });
+      // Disable override — negative stays negative
+      fireEvent.click(screen.getByLabelText(/Allow positive balance/i));
+      const input = screen.getByLabelText('Statement Ending Balance') as HTMLInputElement;
+      expect(Number(input.value)).toBe(-500);
+    });
+
+    it('resets the override checkbox when switching to a different account', async () => {
+      render(<ReconcilePage />);
+      await waitFor(() => expect(screen.getByText(/Visa/)).toBeInTheDocument());
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-2' } });
+      // Enable override
+      const checkbox = screen.getByLabelText(/Allow positive balance/i) as HTMLInputElement;
+      fireEvent.click(checkbox);
+      expect(checkbox.checked).toBe(true);
+      // Switch to a non-liability account and back
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-1' } });
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-2' } });
+      const freshCheckbox = screen.getByLabelText(/Allow positive balance/i) as HTMLInputElement;
+      expect(freshCheckbox.checked).toBe(false);
+    });
+
+    it('uses a negative placeholder for liability accounts without override', async () => {
+      render(<ReconcilePage />);
+      await waitFor(() => expect(screen.getByText(/Visa/)).toBeInTheDocument());
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-2' } });
+      const input = screen.getByLabelText('Statement Ending Balance') as HTMLInputElement;
+      expect(input.placeholder).toBe('-0.00');
+    });
+
+    it('uses a standard placeholder when override is checked', async () => {
+      render(<ReconcilePage />);
+      await waitFor(() => expect(screen.getByText(/Visa/)).toBeInTheDocument());
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-2' } });
+      fireEvent.click(screen.getByLabelText(/Allow positive balance/i));
+      const input = screen.getByLabelText('Statement Ending Balance') as HTMLInputElement;
+      expect(input.placeholder).toBe('0.00');
+    });
+
+    it('uses a standard placeholder for non-liability accounts', async () => {
+      render(<ReconcilePage />);
+      await waitFor(() => expect(screen.getByText(/Checking/)).toBeInTheDocument());
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-1' } });
+      const input = screen.getByLabelText('Statement Ending Balance') as HTMLInputElement;
+      expect(input.placeholder).toBe('0.00');
+    });
+  });
+
   describe('Error Handling', () => {
     it('shows error toast when accounts fail to load', async () => {
       const toast = await import('react-hot-toast');

--- a/frontend/src/app/reconcile/page.tsx
+++ b/frontend/src/app/reconcile/page.tsx
@@ -49,6 +49,7 @@ function ReconcileContent() {
   const [selectedTransactionIds, setSelectedTransactionIds] = useState<Set<string>>(new Set());
   const [isLoading, setIsLoading] = useState(false);
   const [isReconciling, setIsReconciling] = useState(false);
+  const [allowPositiveBalance, setAllowPositiveBalance] = useState(false);
 
   // Load accounts
   useEffect(() => {
@@ -73,6 +74,19 @@ function ReconcileContent() {
   );
 
   const isLiability = selectedAccount ? LIABILITY_TYPES.has(selectedAccount.accountType) : false;
+
+  // Reset override when switching accounts
+  useEffect(() => {
+    setAllowPositiveBalance(false);
+  }, [selectedAccountId]);
+
+  const handleStatementBalanceChange = (value: number | undefined) => {
+    if (isLiability && !allowPositiveBalance && value !== undefined && value > 0) {
+      setStatementBalance(-value);
+    } else {
+      setStatementBalance(value);
+    }
+  };
 
   const handleStartReconciliation = async () => {
     if (!selectedAccountId || !statementDate || statementBalance === undefined) {
@@ -219,14 +233,30 @@ function ReconcileContent() {
           <CurrencyInput
             label="Statement Ending Balance"
             prefix={getCurrencySymbol(selectedAccount?.currencyCode || defaultCurrency)}
-            placeholder={isLiability ? '-0.00' : '0.00'}
+            placeholder={isLiability && !allowPositiveBalance ? '-0.00' : '0.00'}
             value={statementBalance}
-            onChange={setStatementBalance}
+            onChange={handleStatementBalanceChange}
           />
           {isLiability && (
-            <p className="text-xs text-gray-500 dark:text-gray-400 -mt-2">
-              Liability accounts typically have a negative balance
-            </p>
+            <div className="-mt-2 space-y-1">
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                Liability accounts typically have a negative balance
+              </p>
+              <label className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={allowPositiveBalance}
+                  onChange={(e) => {
+                    setAllowPositiveBalance(e.target.checked);
+                    if (!e.target.checked && statementBalance !== undefined && statementBalance > 0) {
+                      setStatementBalance(-statementBalance);
+                    }
+                  }}
+                  className="h-3 w-3 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600"
+                />
+                Allow positive balance (e.g. credit)
+              </label>
+            </div>
           )}
         </div>
 


### PR DESCRIPTION
## Summary
Added functionality to allow users to input positive balances for liability accounts during reconciliation, with automatic conversion to negative values by default.

## Key Changes
- Added `allowPositiveBalance` state to track whether positive balances are permitted for liability accounts
- Implemented `handleStatementBalanceChange` handler that automatically negates positive values for liability accounts (unless the override is enabled)
- Added a reset effect to clear the override flag when switching between accounts
- Updated the statement balance input UI to include:
  - Dynamic placeholder text that reflects the current balance type expectation
  - A checkbox control labeled "Allow positive balance (e.g. credit)" for liability accounts
  - Automatic balance negation when unchecking the override if a positive balance exists

## Implementation Details
- The override state is account-specific and resets when the user switches accounts
- When a liability account is selected and the override is disabled, any positive input is automatically converted to negative
- When the override checkbox is unchecked, existing positive balances are automatically negated to maintain consistency
- The UI only shows the override option for liability account types

https://claude.ai/code/session_013SrzTnSNwUKvV7nYSWEEGn