### PR TITLE
Fix CSV export to preserve numeric values without escaping

### DIFF
--- a/frontend/src/lib/csv-export.test.ts
+++ b/frontend/src/lib/csv-export.test.ts
@@ -97,4 +97,22 @@ describe('exportToCsv', () => {
       expect(text).toContain('true,42');
     });
   });
+
+  it('writes negative numbers as plain numeric values without tab or quotes', () => {
+    exportToCsv('out', ['A', 'B'], [[-100, -1.5]]);
+    const blobArg = (createObjectURL.mock.calls[0][0] as Blob);
+    return blobArg.text().then((text) => {
+      expect(text).toContain('-100,-1.5');
+      expect(text).not.toContain('"\t-100"');
+      expect(text).not.toContain('"-100"');
+    });
+  });
+
+  it('still applies formula-injection guard to string values starting with -', () => {
+    exportToCsv('out', ['F'], [['-1+cmd|run']]);
+    const blobArg = (createObjectURL.mock.calls[0][0] as Blob);
+    return blobArg.text().then((text) => {
+      expect(text).toContain('\t-1+cmd|run');
+    });
+  });
 });

--- a/frontend/src/lib/csv-export.ts
+++ b/frontend/src/lib/csv-export.ts
@@ -4,7 +4,10 @@
 
 function escapeCsvValue(value: string | number | boolean | null | undefined): string {
   if (value === null || value === undefined) return '';
-  let str = String(value);
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  let str = value;
   // Prevent CSV formula injection: prefix dangerous leading characters with a tab
   if (str.length > 0 && /^[=+\-@\t\r]/.test(str)) {
     str = `\t${str}`;


### PR DESCRIPTION
## Summary
Updated the CSV export function to properly handle numeric and boolean values by returning them as plain strings without applying formula-injection guards, while still protecting string values that happen to start with dangerous characters.

## Key Changes
- Modified `escapeCsvValue()` to detect numeric and boolean types and return them directly as strings without further processing
- String values that start with formula-injection characters (=, +, -, @, tab, carriage return) are still prefixed with a tab character to prevent injection attacks
- Added test coverage for negative numbers to ensure they export as plain numeric values without quotes or tabs
- Added test coverage to verify that string values starting with `-` (like `-1+cmd|run`) still receive the formula-injection guard

## Implementation Details
The fix distinguishes between actual numeric/boolean values and string representations:
- Numbers and booleans bypass the formula-injection check entirely, preserving their numeric format in the CSV
- Strings are still subject to the injection guard, even if they look like numbers (e.g., a string value of `"-1+cmd|run"` will be escaped)
- This prevents both data corruption (numeric values being quoted) and security issues (formula injection via strings)

https://claude.ai/code/session_01PgrEVCbRxZzfLJ3PztN55E