### PR TITLE
Use cost basis for first-month investment snapshots

### DIFF
--- a/backend/src/net-worth/net-worth.service.spec.ts
+++ b/backend/src/net-worth/net-worth.service.spec.ts
@@ -1516,24 +1516,30 @@ describe("NetWorthService", () => {
         defaultCurrency: "USD",
       });
 
-      dataSource.query.mockResolvedValueOnce([
-        {
-          month: "2024-01-01",
-          balance: 5000,
-          market_value: 8000,
-          account_id: "inv-1",
-          account_sub_type: "INVESTMENT_BROKERAGE",
-          currency_code: "USD",
-        },
-        {
-          month: "2024-01-01",
-          balance: 2000,
-          market_value: null,
-          account_id: "inv-cash",
-          account_sub_type: "INVESTMENT_CASH",
-          currency_code: "USD",
-        },
-      ]);
+      dataSource.query
+        .mockResolvedValueOnce([
+          {
+            month: "2024-01-01",
+            balance: 5000,
+            market_value: 8000,
+            account_id: "inv-1",
+            account_sub_type: "INVESTMENT_BROKERAGE",
+            currency_code: "USD",
+          },
+          {
+            month: "2024-01-01",
+            balance: 2000,
+            market_value: null,
+            account_id: "inv-cash",
+            account_sub_type: "INVESTMENT_CASH",
+            currency_code: "USD",
+          },
+        ])
+        // firstMonthRows lookup: account's first ever month is earlier than
+        // the snapshot, so no cost-basis adjustment kicks in.
+        .mockResolvedValueOnce([
+          { account_id: "inv-1", first_month: "2023-01-01" },
+        ]);
 
       const result = await service.getMonthlyInvestments("user-1");
 
@@ -1564,6 +1570,10 @@ describe("NetWorthService", () => {
             account_sub_type: "INVESTMENT_BROKERAGE",
             currency_code: "USD",
           },
+        ])
+        // firstMonthRows lookup: snapshot is not the account's first month
+        .mockResolvedValueOnce([
+          { account_id: "inv-1", first_month: "2023-01-01" },
         ]);
 
       const result = await service.getMonthlyInvestments(
@@ -1607,6 +1617,10 @@ describe("NetWorthService", () => {
             account_sub_type: "INVESTMENT_BROKERAGE",
             currency_code: "CAD",
           },
+        ])
+        // firstMonthRows lookup: snapshot is not the account's first month
+        .mockResolvedValueOnce([
+          { account_id: "cad-inv", first_month: "2023-01-01" },
         ])
         // exchange rates
         .mockResolvedValueOnce([
@@ -1724,6 +1738,10 @@ describe("NetWorthService", () => {
             account_sub_type: "INVESTMENT_CASH",
             currency_code: "USD",
           },
+        ])
+        // firstMonthRows lookup: snapshot is not the account's first month
+        .mockResolvedValueOnce([
+          { account_id: "inv-1", first_month: "2023-01-01" },
         ]);
 
       await service.getMonthlyInvestments("user-1", undefined, undefined, [
@@ -1769,21 +1787,220 @@ describe("NetWorthService", () => {
       mabRepository.count.mockResolvedValue(5);
       prefRepository.findOne.mockResolvedValue({ defaultCurrency: "USD" });
 
-      dataSource.query.mockResolvedValueOnce([
-        {
-          month: "2024-01-01",
-          balance: 1500,
-          market_value: 20000,
-          account_id: "standalone-1",
-          account_type: AccountType.INVESTMENT,
-          account_sub_type: null,
-          currency_code: "USD",
-        },
-      ]);
+      dataSource.query
+        .mockResolvedValueOnce([
+          {
+            month: "2024-01-01",
+            balance: 1500,
+            market_value: 20000,
+            account_id: "standalone-1",
+            account_type: AccountType.INVESTMENT,
+            account_sub_type: null,
+            currency_code: "USD",
+          },
+        ])
+        // firstMonthRows lookup: snapshot is not the account's first month
+        .mockResolvedValueOnce([
+          { account_id: "standalone-1", first_month: "2023-01-01" },
+        ]);
 
       const result = await service.getMonthlyInvestments("user-1");
 
       expect(result[0].value).toBe(21500);
+    });
+
+    it("uses cost basis for first active month brokerage snapshot", async () => {
+      mabRepository.count.mockResolvedValue(5);
+      prefRepository.findOne.mockResolvedValue({ defaultCurrency: "USD" });
+
+      dataSource.query
+        // snapshots
+        .mockResolvedValueOnce([
+          {
+            month: "2024-03-01",
+            balance: 0,
+            market_value: 11000,
+            account_id: "brokerage-new",
+            account_type: AccountType.INVESTMENT,
+            account_sub_type: "INVESTMENT_BROKERAGE",
+            currency_code: "USD",
+          },
+          {
+            month: "2024-04-01",
+            balance: 0,
+            market_value: 12000,
+            account_id: "brokerage-new",
+            account_type: AccountType.INVESTMENT,
+            account_sub_type: "INVESTMENT_BROKERAGE",
+            currency_code: "USD",
+          },
+        ])
+        // firstMonthRows: 2024-03-01 IS this account's first active month
+        .mockResolvedValueOnce([
+          { account_id: "brokerage-new", first_month: "2024-03-01" },
+        ])
+        // txRows: a buy and a sell in March
+        .mockResolvedValueOnce([
+          {
+            account_id: "brokerage-new",
+            action: "BUY",
+            quantity: 100,
+            price: 100,
+            transaction_date: "2024-03-05",
+            security_currency: "USD",
+          },
+          {
+            account_id: "brokerage-new",
+            action: "SELL",
+            quantity: 10,
+            price: 105,
+            transaction_date: "2024-03-20",
+            security_currency: "USD",
+          },
+        ]);
+
+      const result = await service.getMonthlyInvestments(
+        "user-1",
+        "2024-03-01",
+        "2024-04-30",
+      );
+
+      expect(result).toHaveLength(2);
+      // Cost basis for first month: 100*100 (BUY) - 10*105 (SELL) = 10000 - 1050 = 8950
+      // (replaces market_value of 11000)
+      expect(result[0]).toEqual({ month: "2024-03-01", value: 8950 });
+      // Second month uses market_value as before
+      expect(result[1]).toEqual({ month: "2024-04-01", value: 12000 });
+    });
+
+    it("does not adjust when snapshot month is after the account's first active month", async () => {
+      mabRepository.count.mockResolvedValue(5);
+      prefRepository.findOne.mockResolvedValue({ defaultCurrency: "USD" });
+
+      dataSource.query
+        .mockResolvedValueOnce([
+          {
+            month: "2024-03-01",
+            balance: 0,
+            market_value: 11000,
+            account_id: "brokerage-existing",
+            account_type: AccountType.INVESTMENT,
+            account_sub_type: "INVESTMENT_BROKERAGE",
+            currency_code: "USD",
+          },
+        ])
+        // firstMonthRows: account opened earlier than the requested period
+        .mockResolvedValueOnce([
+          { account_id: "brokerage-existing", first_month: "2020-01-01" },
+        ]);
+
+      const result = await service.getMonthlyInvestments(
+        "user-1",
+        "2024-03-01",
+        "2024-03-31",
+      );
+
+      expect(result).toHaveLength(1);
+      // No adjustment: market_value used as-is
+      expect(result[0].value).toBe(11000);
+    });
+
+    it("includes cash balance alongside cost basis for standalone accounts in first active month", async () => {
+      mabRepository.count.mockResolvedValue(5);
+      prefRepository.findOne.mockResolvedValue({ defaultCurrency: "USD" });
+
+      dataSource.query
+        .mockResolvedValueOnce([
+          {
+            month: "2024-03-01",
+            balance: 1500,
+            market_value: 20000,
+            account_id: "standalone-new",
+            account_type: AccountType.INVESTMENT,
+            account_sub_type: null,
+            currency_code: "USD",
+          },
+        ])
+        .mockResolvedValueOnce([
+          { account_id: "standalone-new", first_month: "2024-03-01" },
+        ])
+        .mockResolvedValueOnce([
+          {
+            account_id: "standalone-new",
+            action: "BUY",
+            quantity: 50,
+            price: 200,
+            transaction_date: "2024-03-10",
+            security_currency: "USD",
+          },
+        ]);
+
+      const result = await service.getMonthlyInvestments(
+        "user-1",
+        "2024-03-01",
+        "2024-03-31",
+      );
+
+      // Cost basis 50*200 = 10000, plus standalone cash balance 1500 = 11500
+      expect(result[0].value).toBe(11500);
+    });
+
+    it("converts first-month cost basis through security currency", async () => {
+      mabRepository.count.mockResolvedValue(5);
+      prefRepository.findOne.mockResolvedValue({ defaultCurrency: "USD" });
+
+      dataSource.query
+        .mockResolvedValueOnce([
+          {
+            month: "2024-03-01",
+            balance: 0,
+            market_value: 9000,
+            account_id: "brokerage-cad",
+            account_type: AccountType.INVESTMENT,
+            account_sub_type: "INVESTMENT_BROKERAGE",
+            currency_code: "CAD",
+          },
+        ])
+        .mockResolvedValueOnce([
+          { account_id: "brokerage-cad", first_month: "2024-03-01" },
+        ])
+        .mockResolvedValueOnce([
+          {
+            account_id: "brokerage-cad",
+            action: "BUY",
+            quantity: 40,
+            price: 250,
+            transaction_date: "2024-03-15",
+            security_currency: "CAD",
+          },
+        ])
+        // exchange rates for cost-basis conversion (CAD -> USD)
+        .mockResolvedValueOnce([
+          {
+            from_currency: "CAD",
+            to_currency: "USD",
+            rate: 0.75,
+            rate_date: "2024-03-20",
+          },
+        ])
+        // exchange rates for main snapshot conversion
+        .mockResolvedValueOnce([
+          {
+            from_currency: "CAD",
+            to_currency: "USD",
+            rate: 0.75,
+            rate_date: "2024-03-20",
+          },
+        ]);
+
+      const result = await service.getMonthlyInvestments(
+        "user-1",
+        "2024-03-01",
+        "2024-03-31",
+      );
+
+      // 40 * 250 = 10000 CAD * 0.75 = 7500 USD
+      expect(result[0].value).toBe(7500);
     });
   });
 

--- a/backend/src/net-worth/net-worth.service.ts
+++ b/backend/src/net-worth/net-worth.service.ts
@@ -381,6 +381,21 @@ export class NetWorthService {
 
     if (snapshots.length === 0) return [];
 
+    // For the first active month of an account, the stored market_value is the
+    // month-end snapshot which silently absorbs any gains/losses on positions
+    // that were established earlier the same month -- skewing the chart's
+    // change column. Replace that first-month market_value with a cost-basis
+    // computed from the in-month brokerage transactions so the starting point
+    // reflects the actual net invested.
+    const firstMonthCostBasisInDefault =
+      await this.computeFirstActiveMonthCostBasis(
+        userId,
+        snapshots,
+        defaultCurrency,
+        start,
+        end,
+      );
+
     const currencies = new Set<string>();
     for (const s of snapshots) {
       if (s.currency_code !== defaultCurrency) {
@@ -404,32 +419,51 @@ export class NetWorthService {
         monthMap.set(monthKey, 0);
       }
 
-      let rawValue: number;
-      if (
-        s.account_sub_type === "INVESTMENT_BROKERAGE" &&
-        s.market_value != null
-      ) {
-        rawValue = Number(s.market_value);
-      } else if (
-        s.account_type === "INVESTMENT" &&
-        s.account_sub_type === null &&
-        s.market_value != null
-      ) {
-        rawValue = Number(s.market_value) + Number(s.balance);
+      const monthEnd = this.monthEndDate(monthKey);
+      const adjKey = `${s.account_id}:${monthKey}`;
+      const costBasisInDefault = firstMonthCostBasisInDefault.get(adjKey);
+
+      let convertedValue: number;
+      if (costBasisInDefault !== undefined) {
+        convertedValue = costBasisInDefault;
+        // Standalone investment accounts hold cash inside the same account, so
+        // include the month-end cash balance alongside the cost basis.
+        if (s.account_type === "INVESTMENT" && s.account_sub_type === null) {
+          convertedValue += this.convertCurrency(
+            Number(s.balance),
+            s.currency_code,
+            defaultCurrency,
+            monthEnd,
+            rateIndex,
+          );
+        }
       } else {
-        rawValue = Number(s.balance);
+        let rawValue: number;
+        if (
+          s.account_sub_type === "INVESTMENT_BROKERAGE" &&
+          s.market_value != null
+        ) {
+          rawValue = Number(s.market_value);
+        } else if (
+          s.account_type === "INVESTMENT" &&
+          s.account_sub_type === null &&
+          s.market_value != null
+        ) {
+          rawValue = Number(s.market_value) + Number(s.balance);
+        } else {
+          rawValue = Number(s.balance);
+        }
+
+        convertedValue = this.convertCurrency(
+          rawValue,
+          s.currency_code,
+          defaultCurrency,
+          monthEnd,
+          rateIndex,
+        );
       }
 
-      const monthEnd = this.monthEndDate(monthKey);
-      const converted = this.convertCurrency(
-        rawValue,
-        s.currency_code,
-        defaultCurrency,
-        monthEnd,
-        rateIndex,
-      );
-
-      monthMap.set(monthKey, monthMap.get(monthKey)! + converted);
+      monthMap.set(monthKey, monthMap.get(monthKey)! + convertedValue);
     }
 
     return Array.from(monthMap.entries())
@@ -438,6 +472,118 @@ export class NetWorthService {
         month,
         value: Math.round(value),
       }));
+  }
+
+  /**
+   * For each brokerage / standalone-investment account in `snapshots` whose
+   * snapshot row coincides with that account's first-ever active month,
+   * compute the net cost basis of all in-month investment transactions
+   * converted to `defaultCurrency`. Returns a map keyed by
+   * `${accountId}:${monthKey}` -> value in `defaultCurrency`.
+   */
+  private async computeFirstActiveMonthCostBasis(
+    userId: string,
+    snapshots: any[],
+    defaultCurrency: string,
+    start: string,
+    end: string,
+  ): Promise<Map<string, number>> {
+    const result = new Map<string, number>();
+
+    const eligibleSnapshots = snapshots.filter((s) => {
+      const isBrokerage = s.account_sub_type === "INVESTMENT_BROKERAGE";
+      const isStandalone =
+        s.account_type === "INVESTMENT" && s.account_sub_type === null;
+      return isBrokerage || isStandalone;
+    });
+    if (eligibleSnapshots.length === 0) return result;
+
+    const accountIds = [...new Set(eligibleSnapshots.map((s) => s.account_id))];
+
+    const firstMonthRows: any[] = await this.dataSource.query(
+      `SELECT account_id, MIN(month)::DATE as first_month
+       FROM monthly_account_balances
+       WHERE account_id = ANY($1::UUID[]) AND user_id = $2
+       GROUP BY account_id`,
+      [accountIds, userId],
+    );
+    const firstActiveMonth = new Map<string, string>();
+    for (const r of firstMonthRows) {
+      firstActiveMonth.set(r.account_id, this.toDateString(r.first_month));
+    }
+
+    const targetMonthByAccount = new Map<string, string>();
+    for (const s of eligibleSnapshots) {
+      const monthKey = this.toDateString(s.month);
+      if (firstActiveMonth.get(s.account_id) === monthKey) {
+        targetMonthByAccount.set(s.account_id, monthKey);
+      }
+    }
+    if (targetMonthByAccount.size === 0) return result;
+
+    const targetAccountIds = [...targetMonthByAccount.keys()];
+    const txRows: any[] = await this.dataSource.query(
+      `SELECT it.account_id, it.action, it.quantity, it.price, it.transaction_date,
+              s.currency_code AS security_currency
+       FROM investment_transactions it
+       LEFT JOIN securities s ON s.id = it.security_id
+       WHERE it.account_id = ANY($1::UUID[])
+         AND it.price IS NOT NULL AND it.price > 0
+         AND it.action IN ('BUY', 'SELL', 'REINVEST', 'TRANSFER_IN', 'TRANSFER_OUT')`,
+      [targetAccountIds],
+    );
+
+    const adjCurrencies = new Set<string>();
+    for (const r of txRows) {
+      if (r.security_currency && r.security_currency !== defaultCurrency) {
+        adjCurrencies.add(r.security_currency);
+      }
+    }
+    const rateIndex =
+      adjCurrencies.size > 0
+        ? await this.buildRateIndex(adjCurrencies, defaultCurrency, start, end)
+        : new Map();
+
+    for (const r of txRows) {
+      const targetMonth = targetMonthByAccount.get(r.account_id);
+      if (!targetMonth) continue;
+      const txDate = this.toDateString(r.transaction_date);
+      if (txDate.substring(0, 7) !== targetMonth.substring(0, 7)) continue;
+
+      const qty = Number(r.quantity) || 0;
+      const price = Number(r.price) || 0;
+      if (qty === 0 || price <= 0) continue;
+
+      let signed: number;
+      switch (r.action) {
+        case "BUY":
+        case "REINVEST":
+        case "TRANSFER_IN":
+          signed = qty * price;
+          break;
+        case "SELL":
+        case "TRANSFER_OUT":
+          signed = -qty * price;
+          break;
+        default:
+          continue;
+      }
+
+      const secCurrency = r.security_currency || defaultCurrency;
+      const monthEnd = this.monthEndDate(targetMonth);
+      const inDefault = this.convertCurrency(
+        signed,
+        secCurrency,
+        defaultCurrency,
+        monthEnd,
+        rateIndex,
+      );
+
+      const key = `${r.account_id}:${targetMonth}`;
+      result.set(key, (result.get(key) || 0) + inDefault);
+    }
+
+    return result;
   }
 
   async getDailyInvestments(

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -3,6 +3,8 @@ import { render, screen, waitFor } from '@/test/render';
 import { InvestmentValueChart } from './InvestmentValueChart';
 import { netWorthApi } from '@/lib/net-worth';
 
+const dateRangeState = { dateRange: '1y', resolvedRange: { start: '2023-01-01', end: '2024-01-01' } };
+
 vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
   AreaChart: ({ children }: any) => <div data-testid="area-chart">{children}</div>,
@@ -30,9 +32,9 @@ vi.mock('@/hooks/useExchangeRates', () => ({
 
 vi.mock('@/hooks/useDateRange', () => ({
   useDateRange: () => ({
-    dateRange: '1y',
+    dateRange: dateRangeState.dateRange,
     setDateRange: vi.fn(),
-    resolvedRange: { start: '2023-01-01', end: '2024-01-01' },
+    resolvedRange: dateRangeState.resolvedRange,
     isValid: true,
   }),
 }));
@@ -67,6 +69,8 @@ vi.mock('@/components/ui/DateRangeSelector', () => ({
 describe('InvestmentValueChart', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    dateRangeState.dateRange = '1y';
+    dateRangeState.resolvedRange = { start: '2023-01-01', end: '2024-01-01' };
     // 1y is a daily range, so mock getInvestmentsDaily
     vi.mocked(netWorthApi.getInvestmentsDaily).mockResolvedValue([
       { date: '2023-06-01', value: 10000 },
@@ -167,5 +171,27 @@ describe('InvestmentValueChart', () => {
     await screen.findByText('Portfolio Value Over Time');
     expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled();
     expect(netWorthApi.getInvestmentsMonthly).not.toHaveBeenCalled();
+  });
+
+  it('uses daily API for 2y range (DAILY_RANGES)', async () => {
+    dateRangeState.dateRange = '2y';
+    dateRangeState.resolvedRange = { start: '2022-01-01', end: '2024-01-01' };
+    render(<InvestmentValueChart />);
+    await screen.findByText('Portfolio Value Over Time');
+    expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled();
+    expect(netWorthApi.getInvestmentsMonthly).not.toHaveBeenCalled();
+  });
+
+  it('uses monthly API for 5y range (not in DAILY_RANGES)', async () => {
+    dateRangeState.dateRange = '5y';
+    dateRangeState.resolvedRange = { start: '2019-01-01', end: '2024-01-01' };
+    vi.mocked(netWorthApi.getInvestmentsMonthly).mockResolvedValue([
+      { month: '2019-01-01', value: 1000 },
+      { month: '2024-01-01', value: 2000 },
+    ]);
+    render(<InvestmentValueChart />);
+    await screen.findByText('Portfolio Value Over Time');
+    expect(netWorthApi.getInvestmentsMonthly).toHaveBeenCalled();
+    expect(netWorthApi.getInvestmentsDaily).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -21,7 +21,7 @@ import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('InvestmentChart');
 
-const DAILY_RANGES = new Set(['1w', '1m', '3m', 'ytd', '1y']);
+const DAILY_RANGES = new Set(['1w', '1m', '3m', 'ytd', '1y', '2y']);
 
 interface InvestmentValueChartProps {
   accountIds?: string[];


### PR DESCRIPTION
## Summary
This PR improves the accuracy of investment portfolio charts by replacing month-end market values with cost-basis calculations for the first active month of brokerage and standalone investment accounts. This prevents gains/losses from intra-month transactions from distorting the starting point of the portfolio value trend.

## Key Changes

### Backend (net-worth.service.ts)
- Added `computeFirstActiveMonthCostBasis()` method that:
  - Identifies brokerage and standalone investment accounts whose snapshot month matches their first-ever active month
  - Queries investment transactions (BUY, SELL, REINVEST, TRANSFER_IN, TRANSFER_OUT) for those accounts in that month
  - Calculates net cost basis from transaction prices and quantities
  - Converts costs through security currency to the default currency using appropriate exchange rates
  
- Modified `getMonthlyInvestments()` to:
  - Call the new cost-basis computation before processing snapshots
  - Use cost basis instead of market_value for first-month snapshots
  - For standalone accounts, add the month-end cash balance to the cost basis (since cash is held in the same account)
  - Fall back to original market_value logic for all other months

### Frontend (InvestmentValueChart.tsx)
- Extended `DAILY_RANGES` to include '2y' range, ensuring 2-year views use daily granularity for better detail

### Tests
- Added comprehensive test coverage for the new cost-basis logic:
  - First-month cost basis calculation with buy/sell transactions
  - No adjustment when snapshot is after account's first month
  - Cost basis inclusion with cash balance for standalone accounts
  - Currency conversion through security currency for cost basis
  - Updated existing tests to mock the new `firstMonthRows` query
- Added frontend tests for daily vs. monthly API selection based on date range

## Implementation Details
- Cost basis is computed only for accounts where the snapshot month equals the account's first active month
- Transaction filtering includes only those with valid prices (price > 0) to avoid data quality issues
- Exchange rate lookups are optimized by only querying currencies that differ from the default currency
- The solution maintains backward compatibility by only affecting first-month snapshots of eligible account types

https://claude.ai/code/session_017UwWADTJAhmb6vGs4hJqKx