### PR TITLE
Add intraday portfolio value charts for 1D/1W/1M ranges

### DIFF
--- a/backend/src/securities/dto/intraday-value.dto.ts
+++ b/backend/src/securities/dto/intraday-value.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsIn, IsOptional, IsString, MaxLength } from "class-validator";
+
+export const INTRADAY_RANGES = ["1d", "1w", "1m"] as const;
+export type IntradayRangeKey = (typeof INTRADAY_RANGES)[number];
+
+export class IntradayValueQueryDto {
+  @ApiProperty({ enum: INTRADAY_RANGES })
+  @IsIn(INTRADAY_RANGES as unknown as string[])
+  range: IntradayRangeKey;
+
+  @ApiProperty({
+    required: false,
+    description: "Comma-separated account IDs to filter by",
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  accountIds?: string;
+
+  @ApiProperty({
+    required: false,
+    description:
+      "ISO currency code to convert all values to. Defaults to the user's preferred currency.",
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(8)
+  displayCurrency?: string;
+}
+
+export interface IntradayValuePoint {
+  timestamp: string;
+  value: number;
+}
+
+export interface IntradayValueResponse {
+  points: IntradayValuePoint[];
+  interval: "1m" | "5m" | "15m";
+  currency: string;
+  /** Range that was actually returned (echoes the request). */
+  range: IntradayRangeKey;
+  /** ISO timestamp of when this series was computed (server clock). */
+  fetchedAt: string;
+  /**
+   * Symbols of holdings whose quote provider does not expose intraday data
+   * (e.g. MSN Money). They were skipped from the aggregated series.
+   */
+  skippedSymbols: string[];
+  /**
+   * True when at least one holding's quote provider has no intraday support
+   * AND the requested range has a sensible daily-resolution fallback (1W/1M).
+   * The frontend should call the existing daily-snapshot endpoint instead of
+   * rendering this (partial) intraday series. 1D has no daily fallback so
+   * this stays false even when securities are skipped.
+   */
+  fallbackToDaily: boolean;
+}

--- a/backend/src/securities/portfolio.controller.spec.ts
+++ b/backend/src/securities/portfolio.controller.spec.ts
@@ -19,6 +19,7 @@ describe("PortfolioController", () => {
       getAssetAllocation: jest.fn(),
       getTopMovers: jest.fn(),
       getInvestmentAccounts: jest.fn(),
+      getIntradayValueSeries: jest.fn(),
     };
 
     sectorWeightingService = {
@@ -158,6 +159,59 @@ describe("PortfolioController", () => {
         "user-1",
       );
       expect(result).toEqual(accounts);
+    });
+  });
+
+  describe("getIntradayValue", () => {
+    it("delegates to service with parsed account IDs", async () => {
+      portfolioService.getIntradayValueSeries.mockResolvedValue({
+        points: [],
+        interval: "1m",
+        currency: "CAD",
+        range: "1d",
+        fetchedAt: "2026-05-06T12:00:00.000Z",
+      });
+
+      await controller.getIntradayValue(req, {
+        range: "1d",
+        accountIds: `${UUID1},${UUID2}`,
+        displayCurrency: "USD",
+      });
+
+      expect(portfolioService.getIntradayValueSeries).toHaveBeenCalledWith(
+        "user-1",
+        {
+          range: "1d",
+          accountIds: [UUID1, UUID2],
+          displayCurrency: "USD",
+        },
+      );
+    });
+
+    it("passes undefined accountIds when not provided", async () => {
+      portfolioService.getIntradayValueSeries.mockResolvedValue({
+        points: [],
+        interval: "1m",
+        currency: "CAD",
+        range: "1d",
+        fetchedAt: "2026-05-06T12:00:00.000Z",
+      });
+
+      await controller.getIntradayValue(req, { range: "1w" });
+
+      expect(portfolioService.getIntradayValueSeries).toHaveBeenCalledWith(
+        "user-1",
+        { range: "1w", accountIds: undefined, displayCurrency: undefined },
+      );
+    });
+
+    it("rejects invalid UUIDs in accountIds", () => {
+      expect(() =>
+        controller.getIntradayValue(req, {
+          range: "1d",
+          accountIds: "not-a-uuid",
+        }),
+      ).toThrow(BadRequestException);
     });
   });
 

--- a/backend/src/securities/portfolio.controller.ts
+++ b/backend/src/securities/portfolio.controller.ts
@@ -16,6 +16,7 @@ import {
 import { AuthGuard } from "@nestjs/passport";
 import { PortfolioService } from "./portfolio.service";
 import { SectorWeightingService } from "./sector-weighting.service";
+import { IntradayValueQueryDto } from "./dto/intraday-value.dto";
 
 @ApiTags("Portfolio")
 @Controller("portfolio")
@@ -108,6 +109,25 @@ export class PortfolioController {
   @ApiResponse({ status: 401, description: "Unauthorized" })
   getInvestmentAccounts(@Request() req) {
     return this.portfolioService.getInvestmentAccounts(req.user.id);
+  }
+
+  @Get("intraday-value")
+  @ApiOperation({
+    summary:
+      "Get intraday portfolio value series for the 1D / 1W / 1M chart ranges",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "Intraday portfolio value retrieved successfully",
+  })
+  @ApiResponse({ status: 401, description: "Unauthorized" })
+  getIntradayValue(@Request() req, @Query() query: IntradayValueQueryDto) {
+    const ids = this.parseUuidList(query.accountIds, "account");
+    return this.portfolioService.getIntradayValueSeries(req.user.id, {
+      range: query.range,
+      accountIds: ids,
+      displayCurrency: query.displayCurrency,
+    });
   }
 
   @Get("sector-weightings")

--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -15,6 +15,8 @@ import {
 } from "../accounts/entities/account.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { ExchangeRateService } from "../currencies/exchange-rate.service";
+import { YahooFinanceService } from "./yahoo-finance.service";
+import { QuoteProviderRegistry } from "./providers/quote-provider.registry";
 
 describe("PortfolioService", () => {
   let service: PortfolioService;
@@ -24,6 +26,8 @@ describe("PortfolioService", () => {
   let accountsRepository: Record<string, jest.Mock>;
   let prefRepository: Record<string, jest.Mock>;
   let exchangeRateService: Record<string, jest.Mock>;
+  let yahooFinanceService: Record<string, jest.Mock>;
+  let quoteProviderRegistry: { resolveForSecurity: jest.Mock };
 
   const userId = "user-1";
 
@@ -155,6 +159,21 @@ describe("PortfolioService", () => {
       getLatestRate: jest.fn(),
     };
 
+    yahooFinanceService = {
+      fetchIntradaySeries: jest.fn(),
+    };
+
+    // Default: every security resolves to a Yahoo-like provider that exposes
+    // fetchIntradaySeries. Tests for MSN override this per-security.
+    quoteProviderRegistry = {
+      resolveForSecurity: jest.fn().mockReturnValue([
+        {
+          name: "yahoo",
+          fetchIntradaySeries: yahooFinanceService.fetchIntradaySeries,
+        },
+      ]),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         PortfolioService,
@@ -182,6 +201,14 @@ describe("PortfolioService", () => {
         {
           provide: ExchangeRateService,
           useValue: exchangeRateService,
+        },
+        {
+          provide: YahooFinanceService,
+          useValue: yahooFinanceService,
+        },
+        {
+          provide: QuoteProviderRegistry,
+          useValue: quoteProviderRegistry,
         },
       ],
     }).compile();
@@ -2536,6 +2563,186 @@ describe("PortfolioService", () => {
 
       const result = await service.getAccountMarketValues(userId);
       expect(result.get("acct-brokerage-1")).toBe(2000);
+    });
+  });
+
+  describe("getIntradayValueSeries", () => {
+    beforeEach(() => {
+      prefRepository.findOne.mockResolvedValue(mockPref);
+    });
+
+    it("returns empty series when user has no holdings", async () => {
+      accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+      holdingsRepository.find.mockResolvedValue([]);
+
+      const result = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+
+      expect(result.points).toEqual([]);
+      expect(result.interval).toBe("1m");
+      expect(result.currency).toBe("CAD");
+      expect(yahooFinanceService.fetchIntradaySeries).not.toHaveBeenCalled();
+    });
+
+    it("aggregates intraday bars across multiple holdings on the same time grid", async () => {
+      accountsRepository.find.mockResolvedValue([
+        mockBrokerageAccount,
+        mockCashAccount,
+      ]);
+      holdingsRepository.find.mockResolvedValue([
+        mockHoldingAAPL,
+        mockHoldingVFV,
+      ]);
+
+      const ts1 = new Date("2026-05-06T13:30:00.000Z");
+      const ts2 = new Date("2026-05-06T13:31:00.000Z");
+
+      yahooFinanceService.fetchIntradaySeries.mockImplementation(
+        async (symbol: string) => {
+          if (symbol === "AAPL") {
+            return [
+              { timestamp: ts1, close: 100 },
+              { timestamp: ts2, close: 110 },
+            ];
+          }
+          if (symbol === "VFV.TO") {
+            return [
+              { timestamp: ts1, close: 80 },
+              { timestamp: ts2, close: 81 },
+            ];
+          }
+          return null;
+        },
+      );
+
+      // USD->CAD = 1.4 for AAPL conversion; VFV.TO already CAD.
+      exchangeRateService.getLatestRate.mockImplementation(
+        async (from: string, to: string) => {
+          if (from === "USD" && to === "CAD") return 1.4;
+          return null;
+        },
+      );
+
+      const result = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+
+      expect(result.points).toHaveLength(2);
+      expect(result.interval).toBe("1m");
+      expect(result.currency).toBe("CAD");
+      // ts1: 10 * 100 * 1.4 + 50 * 80 = 1400 + 4000 = 5400
+      expect(result.points[0].value).toBeCloseTo(5400, 4);
+      // ts2: 10 * 110 * 1.4 + 50 * 81 = 1540 + 4050 = 5590
+      expect(result.points[1].value).toBeCloseTo(5590, 4);
+    });
+
+    it("caches results for 60 seconds keyed by user/range/accounts/currency", async () => {
+      accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+      holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
+      yahooFinanceService.fetchIntradaySeries.mockResolvedValue([
+        { timestamp: new Date("2026-05-06T13:30:00.000Z"), close: 100 },
+      ]);
+      exchangeRateService.getLatestRate.mockResolvedValue(1.4);
+
+      await service.getIntradayValueSeries(userId, { range: "1d" });
+      await service.getIntradayValueSeries(userId, { range: "1d" });
+
+      expect(yahooFinanceService.fetchIntradaySeries).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back on 1D too when holdings mix Yahoo and MSN providers", async () => {
+      accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+      holdingsRepository.find.mockResolvedValue([
+        mockHoldingAAPL,
+        mockHoldingVFV,
+      ]);
+
+      // VFV resolves to MSN (no fetchIntradaySeries); AAPL stays on Yahoo.
+      quoteProviderRegistry.resolveForSecurity.mockImplementation(
+        (sec: { id: string }) => {
+          if (sec.id === "sec-2") return [{ name: "msn" }];
+          return [
+            {
+              name: "yahoo",
+              fetchIntradaySeries: yahooFinanceService.fetchIntradaySeries,
+            },
+          ];
+        },
+      );
+
+      const result = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+
+      // Mixed providers: do not render a partial intraday chart at all.
+      // For 1D the frontend will show a note instead.
+      expect(result.skippedSymbols).toEqual(["VFV.TO"]);
+      expect(result.fallbackToDaily).toBe(true);
+      expect(result.points).toEqual([]);
+      expect(yahooFinanceService.fetchIntradaySeries).not.toHaveBeenCalled();
+    });
+
+    it("returns fallbackToDaily=true on 1W when any holding is MSN-tracked", async () => {
+      accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+      holdingsRepository.find.mockResolvedValue([
+        mockHoldingAAPL,
+        mockHoldingVFV,
+      ]);
+
+      quoteProviderRegistry.resolveForSecurity.mockImplementation(
+        (sec: { id: string }) => {
+          if (sec.id === "sec-2") return [{ name: "msn" }];
+          return [
+            {
+              name: "yahoo",
+              fetchIntradaySeries: yahooFinanceService.fetchIntradaySeries,
+            },
+          ];
+        },
+      );
+
+      const result = await service.getIntradayValueSeries(userId, {
+        range: "1w",
+      });
+
+      expect(result.fallbackToDaily).toBe(true);
+      expect(result.points).toEqual([]);
+      expect(result.skippedSymbols).toContain("VFV.TO");
+      // No Yahoo fetches happen when we're going to fall back anyway.
+      expect(yahooFinanceService.fetchIntradaySeries).not.toHaveBeenCalled();
+    });
+
+    it("forward-fills when one security misses a timestamp the other has", async () => {
+      accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+      holdingsRepository.find.mockResolvedValue([
+        mockHoldingAAPL,
+        mockHoldingVFV,
+      ]);
+
+      const ts1 = new Date("2026-05-06T13:30:00.000Z");
+      const ts2 = new Date("2026-05-06T13:31:00.000Z");
+
+      yahooFinanceService.fetchIntradaySeries.mockImplementation(
+        async (symbol: string) => {
+          if (symbol === "AAPL") {
+            return [{ timestamp: ts1, close: 100 }];
+          }
+          return [
+            { timestamp: ts1, close: 80 },
+            { timestamp: ts2, close: 90 },
+          ];
+        },
+      );
+      exchangeRateService.getLatestRate.mockResolvedValue(1.4);
+
+      const result = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+
+      // ts2 should still include AAPL at its last known price (100).
+      expect(result.points).toHaveLength(2);
+      expect(result.points[1].value).toBeCloseTo(10 * 100 * 1.4 + 50 * 90, 4);
     });
   });
 });

--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -2713,6 +2713,53 @@ describe("PortfolioService", () => {
       expect(yahooFinanceService.fetchIntradaySeries).not.toHaveBeenCalled();
     });
 
+    it("back-fills securities whose first bar is later than the grid start", async () => {
+      // Repro for the multi-account intraday jump: when one holding's first
+      // bar arrives later than another's, the aggregate used to undercount
+      // before that bar and jump up the moment it arrived.
+      accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+      holdingsRepository.find.mockResolvedValue([
+        mockHoldingAAPL,
+        mockHoldingVFV,
+      ]);
+
+      const ts0 = new Date("2026-05-06T13:30:00.000Z");
+      const ts1 = new Date("2026-05-06T13:31:00.000Z");
+      const ts2 = new Date("2026-05-06T13:32:00.000Z");
+
+      yahooFinanceService.fetchIntradaySeries.mockImplementation(
+        async (symbol: string) => {
+          if (symbol === "AAPL") {
+            return [
+              { timestamp: ts0, close: 100 },
+              { timestamp: ts1, close: 100 },
+              { timestamp: ts2, close: 100 },
+            ];
+          }
+          // VFV's first available bar is at ts1, not ts0.
+          return [
+            { timestamp: ts1, close: 80 },
+            { timestamp: ts2, close: 80 },
+          ];
+        },
+      );
+      exchangeRateService.getLatestRate.mockResolvedValue(1.4);
+
+      const result = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+
+      expect(result.points).toHaveLength(3);
+      // Without the back-fill, ts0 would only contain AAPL (1400) and ts1
+      // would jump to 1400 + 4000 = 5400. With the back-fill, ts0 already
+      // includes VFV at its earliest known close (80), so all three points
+      // share the same value and there is no jump.
+      const ts0Value = result.points[0].value;
+      const ts1Value = result.points[1].value;
+      expect(ts0Value).toBeCloseTo(10 * 100 * 1.4 + 50 * 80, 4);
+      expect(ts1Value).toBeCloseTo(ts0Value, 4);
+    });
+
     it("forward-fills when one security misses a timestamp the other has", async () => {
       accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
       holdingsRepository.find.mockResolvedValue([

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository, In } from "typeorm";
 import { Holding } from "./entities/holding.entity";
@@ -6,6 +6,18 @@ import { SecurityPrice } from "./entities/security-price.entity";
 import { Account, AccountType } from "../accounts/entities/account.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { PortfolioCalculationService } from "./portfolio-calculation.service";
+import { YahooFinanceService } from "./yahoo-finance.service";
+import { QuoteProviderRegistry } from "./providers/quote-provider.registry";
+import {
+  IntradayInterval,
+  IntradayPoint,
+  IntradayRange,
+} from "./providers/quote-provider.interface";
+import {
+  IntradayRangeKey,
+  IntradayValuePoint,
+  IntradayValueResponse,
+} from "./dto/intraday-value.dto";
 
 export interface TopMover {
   securityId: string;
@@ -131,8 +143,27 @@ export interface LlmPortfolioSummary {
   allocation: LlmPortfolioAllocation[];
 }
 
+interface IntradayCacheEntry {
+  expiresAt: number;
+  payload: IntradayValueResponse;
+}
+
+const RANGE_TO_YAHOO: Record<
+  IntradayRangeKey,
+  { interval: IntradayInterval; range: IntradayRange }
+> = {
+  "1d": { interval: "1m", range: "1d" },
+  "1w": { interval: "5m", range: "5d" },
+  "1m": { interval: "15m", range: "1mo" },
+};
+
+const INTRADAY_CACHE_TTL_MS = 60_000;
+
 @Injectable()
 export class PortfolioService {
+  private readonly logger = new Logger(PortfolioService.name);
+  private readonly intradayCache = new Map<string, IntradayCacheEntry>();
+
   constructor(
     @InjectRepository(Holding)
     private holdingsRepository: Repository<Holding>,
@@ -143,6 +174,8 @@ export class PortfolioService {
     @InjectRepository(UserPreference)
     private prefRepository: Repository<UserPreference>,
     private calculationService: PortfolioCalculationService,
+    private yahooFinanceService: YahooFinanceService,
+    private quoteProviderRegistry: QuoteProviderRegistry,
   ) {}
 
   /**
@@ -672,6 +705,268 @@ export class PortfolioService {
       allocation: summary.allocation,
       totalValue: summary.totalPortfolioValue,
     };
+  }
+
+  /**
+   * Compute the intraday portfolio value series for the user's current
+   * holdings. Pulls live minute/hour bars from Yahoo Finance for each
+   * security, aligns them on a unified time grid, and converts each bar to
+   * the user's display currency.
+   *
+   * Results are cached in-memory for 60 seconds keyed by
+   * `userId|range|accountIds|currency` to absorb double clicks and the
+   * frontend's optimistic refresh.
+   */
+  async getIntradayValueSeries(
+    userId: string,
+    query: {
+      range: IntradayRangeKey;
+      accountIds?: string[];
+      displayCurrency?: string;
+    },
+  ): Promise<IntradayValueResponse> {
+    const { range, accountIds } = query;
+    const pref = await this.prefRepository.findOne({ where: { userId } });
+    const displayCurrency =
+      query.displayCurrency || pref?.defaultCurrency || "CAD";
+
+    const cacheKey = this.buildIntradayCacheKey(
+      userId,
+      range,
+      accountIds,
+      displayCurrency,
+    );
+    const now = Date.now();
+    const cached = this.intradayCache.get(cacheKey);
+    if (cached && cached.expiresAt > now) {
+      return cached.payload;
+    }
+
+    const yahooParams = RANGE_TO_YAHOO[range];
+
+    const accounts = await this.resolveAccounts(userId, accountIds);
+    const { holdingsAccountIds } =
+      this.calculationService.categoriseAccounts(accounts);
+
+    let activeHoldings: Array<{
+      securityId: string;
+      symbol: string;
+      exchange: string | null;
+      currencyCode: string;
+      quantity: number;
+      hasIntraday: boolean;
+    }> = [];
+
+    if (holdingsAccountIds.length > 0) {
+      const holdings = await this.holdingsRepository.find({
+        where: { accountId: In(holdingsAccountIds) },
+        relations: ["security"],
+      });
+
+      const userDefaultProvider = pref?.defaultQuoteProvider ?? null;
+
+      const aggregated = new Map<
+        string,
+        {
+          securityId: string;
+          symbol: string;
+          exchange: string | null;
+          currencyCode: string;
+          quantity: number;
+          hasIntraday: boolean;
+        }
+      >();
+      for (const h of holdings) {
+        const qty = Number(h.quantity);
+        if (!h.security || h.security.isActive === false) continue;
+        if (Math.abs(qty) < 0.0001) continue;
+        const existing = aggregated.get(h.securityId);
+        if (existing) {
+          existing.quantity += qty;
+        } else {
+          // Resolve the security's primary quote provider; only providers
+          // that implement fetchIntradaySeries can contribute to this chart.
+          // MSN Money does not expose intraday quotes — see the note in the
+          // user preferences UI under "Default Stock Quote Provider".
+          const [primaryProvider] =
+            this.quoteProviderRegistry.resolveForSecurity(
+              h.security,
+              userDefaultProvider,
+            );
+          const hasIntraday =
+            typeof primaryProvider.fetchIntradaySeries === "function";
+          aggregated.set(h.securityId, {
+            securityId: h.securityId,
+            symbol: h.security.symbol,
+            exchange: h.security.exchange,
+            currencyCode: h.security.currencyCode,
+            quantity: qty,
+            hasIntraday,
+          });
+        }
+      }
+      activeHoldings = [...aggregated.values()];
+    }
+
+    const fetchedAt = new Date().toISOString();
+    const skippedSymbols = activeHoldings
+      .filter((h) => !h.hasIntraday)
+      .map((h) => h.symbol);
+
+    // When any holding's provider lacks intraday support (MSN Money), do not
+    // render a partial intraday chart — it would hide a material chunk of the
+    // portfolio's value. The frontend uses this flag to:
+    //   - 1W / 1M: silently fall back to the existing daily-snapshot endpoint.
+    //   - 1D    : show a note explaining intraday is unavailable for this mix
+    //             of holdings (no sensible daily-resolution fallback for a
+    //             single day's series).
+    const fallbackToDaily = skippedSymbols.length > 0;
+
+    if (activeHoldings.length === 0 || fallbackToDaily) {
+      const payload: IntradayValueResponse = {
+        points: [],
+        interval: yahooParams.interval,
+        currency: displayCurrency,
+        range,
+        fetchedAt,
+        skippedSymbols,
+        fallbackToDaily,
+      };
+      this.intradayCache.set(cacheKey, {
+        expiresAt: now + INTRADAY_CACHE_TTL_MS,
+        payload,
+      });
+      return payload;
+    }
+
+    const intradayHoldings = activeHoldings.filter((h) => h.hasIntraday);
+    const seriesBySecurity = new Map<string, IntradayPoint[]>();
+    await Promise.all(
+      intradayHoldings.map(async (h) => {
+        try {
+          const points = await this.yahooFinanceService.fetchIntradaySeries(
+            h.symbol,
+            h.exchange,
+            yahooParams,
+          );
+          if (points && points.length > 0) {
+            seriesBySecurity.set(h.securityId, points);
+          }
+        } catch (error) {
+          this.logger.warn(
+            `Failed to fetch intraday series for ${h.symbol}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }),
+    );
+
+    if (seriesBySecurity.size === 0) {
+      const payload: IntradayValueResponse = {
+        points: [],
+        interval: yahooParams.interval,
+        currency: displayCurrency,
+        range,
+        fetchedAt,
+        skippedSymbols,
+        fallbackToDaily: false,
+      };
+      this.intradayCache.set(cacheKey, {
+        expiresAt: now + INTRADAY_CACHE_TTL_MS,
+        payload,
+      });
+      return payload;
+    }
+
+    // Build the unified time grid from the union of all timestamps.
+    const timestampSet = new Set<number>();
+    for (const series of seriesBySecurity.values()) {
+      for (const p of series) timestampSet.add(p.timestamp.getTime());
+    }
+    const timestamps = [...timestampSet].sort((a, b) => a - b);
+
+    // Pre-compute FX rates from each security currency to the display
+    // currency. Intraday FX moves are tiny relative to chart resolution and
+    // we already pay this latency once for the price fetches; reusing the
+    // latest spot rate is the same simplification used elsewhere.
+    const rateCache = new Map<string, number>();
+    const currencies = new Set(intradayHoldings.map((h) => h.currencyCode));
+    for (const c of currencies) {
+      await this.calculationService.convertToDefault(
+        1,
+        c,
+        displayCurrency,
+        rateCache,
+      );
+    }
+
+    // Build per-security ordered timestamp/close arrays and a cursor-based
+    // forward-fill so each grid point uses the latest known close.
+    const sources = intradayHoldings
+      .map((h) => {
+        const points = seriesBySecurity.get(h.securityId);
+        if (!points || points.length === 0) return null;
+        return {
+          quantity: h.quantity,
+          fxRate:
+            rateCache.get(`${h.currencyCode}->${displayCurrency}`) ??
+            (h.currencyCode === displayCurrency ? 1 : 1),
+          times: points.map((p) => p.timestamp.getTime()),
+          closes: points.map((p) => p.close),
+        };
+      })
+      .filter((s): s is NonNullable<typeof s> => s !== null);
+
+    const cursors = sources.map(() => -1);
+    const points: IntradayValuePoint[] = [];
+
+    for (const ts of timestamps) {
+      let totalCents = 0; // integer arithmetic to avoid float drift
+      for (let i = 0; i < sources.length; i++) {
+        const src = sources[i];
+        // Advance cursor to the latest sample at-or-before ts.
+        while (
+          cursors[i] + 1 < src.times.length &&
+          src.times[cursors[i] + 1] <= ts
+        ) {
+          cursors[i]++;
+        }
+        if (cursors[i] < 0) continue;
+        const close = src.closes[cursors[i]];
+        const valueInDisplay = src.quantity * close * src.fxRate;
+        totalCents += Math.round(valueInDisplay * 10000);
+      }
+      points.push({
+        timestamp: new Date(ts).toISOString(),
+        value: totalCents / 10000,
+      });
+    }
+
+    const payload: IntradayValueResponse = {
+      points,
+      interval: yahooParams.interval,
+      currency: displayCurrency,
+      range,
+      fetchedAt,
+      skippedSymbols,
+      fallbackToDaily: false,
+    };
+    this.intradayCache.set(cacheKey, {
+      expiresAt: now + INTRADAY_CACHE_TTL_MS,
+      payload,
+    });
+    return payload;
+  }
+
+  private buildIntradayCacheKey(
+    userId: string,
+    range: IntradayRangeKey,
+    accountIds: string[] | undefined,
+    displayCurrency: string,
+  ): string {
+    const acctPart = (accountIds ?? []).slice().sort().join(",");
+    return `${userId}|${range}|${acctPart}|${displayCurrency}`;
   }
 
   // ---------------------------------------------------------------------------

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -932,8 +932,15 @@ export class PortfolioService {
         ) {
           cursors[i]++;
         }
-        if (cursors[i] < 0) continue;
-        const close = src.closes[cursors[i]];
+        // Backfill: when this security's first bar is later than the current
+        // grid timestamp (e.g. one holding is on an exchange with thinner
+        // intraday coverage, or just has a slightly later first-bar than its
+        // peers), value it at its earliest known close. Without this, every
+        // unstarted series contributes 0 and the aggregate jumps up the
+        // moment each one's first bar arrives — which is exactly the
+        // "significant jump" the chart used to show on multi-account views.
+        const close =
+          cursors[i] < 0 ? src.closes[0] : src.closes[cursors[i]];
         const valueInDisplay = src.quantity * close * src.fxRate;
         totalCents += Math.round(valueInDisplay * 10000);
       }

--- a/backend/src/securities/providers/quote-provider.interface.ts
+++ b/backend/src/securities/providers/quote-provider.interface.ts
@@ -18,6 +18,16 @@ export interface QuoteResult {
   msnResolvedInstrumentId?: string;
 }
 
+export type IntradayInterval = "1m" | "5m" | "15m";
+export type IntradayRange = "1d" | "5d" | "1mo";
+
+export interface IntradayPoint {
+  /** Timestamp of the bar (UTC). */
+  timestamp: Date;
+  /** Close price at the bar (in the security's currency, GBX-converted to GBP). */
+  close: number;
+}
+
 export interface HistoricalPrice {
   date: Date;
   open: number | null;
@@ -76,6 +86,18 @@ export interface QuoteProvider {
     range?: string,
     opts?: QuoteProviderOptions,
   ): Promise<HistoricalPrice[] | null>;
+
+  /**
+   * Optional: fetch intraday price bars for a symbol. Used by the
+   * "Portfolio Value Over Time" intraday view (1D / 1W / 1M ranges).
+   * Providers that don't support intraday data may omit this method.
+   */
+  fetchIntradaySeries?(
+    symbol: string,
+    exchange: string | null,
+    opts: { interval: IntradayInterval; range: IntradayRange },
+    providerOpts?: QuoteProviderOptions,
+  ): Promise<IntradayPoint[] | null>;
 
   lookupSecurity(
     query: string,

--- a/backend/src/securities/securities.service.spec.ts
+++ b/backend/src/securities/securities.service.spec.ts
@@ -288,6 +288,20 @@ describe("SecuritiesService", () => {
       expect(saved.msnInstrumentId).toBe("a1u3p2");
     });
 
+    it("clears quoteProvider when explicitly set to null (Use Default)", async () => {
+      securitiesRepository.findOne.mockResolvedValue({
+        ...mockSecurity,
+        quoteProvider: "msn",
+      });
+
+      await service.update("user-1", "sec-1", {
+        quoteProvider: null as unknown as undefined,
+      });
+
+      const saved = securitiesRepository.save.mock.calls[0][0];
+      expect(saved.quoteProvider).toBeNull();
+    });
+
     it("records action history on update", async () => {
       securitiesRepository.findOne.mockResolvedValue({ ...mockSecurity });
 

--- a/backend/src/securities/yahoo-finance.service.spec.ts
+++ b/backend/src/securities/yahoo-finance.service.spec.ts
@@ -1409,4 +1409,86 @@ describe("YahooFinanceService", () => {
       expect(result).toEqual([]);
     });
   });
+
+  describe("fetchIntradaySeries", () => {
+    it("parses timestamps and closes for the requested interval", async () => {
+      mockFetchResponse({
+        chart: {
+          result: [
+            {
+              meta: { currency: "USD" },
+              timestamp: [1714989000, 1714989060, 1714989120],
+              indicators: { quote: [{ close: [100, 101, 102] }] },
+            },
+          ],
+        },
+      });
+
+      const result = await service.fetchIntradaySeries("AAPL", null, {
+        interval: "1m",
+        range: "1d",
+      });
+
+      expect(result).toHaveLength(3);
+      expect(result![0].close).toBe(100);
+      expect(result![2].timestamp.getTime()).toBe(1714989120 * 1000);
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("interval=1m&range=1d"),
+        expect.any(Object),
+      );
+    });
+
+    it("forward-fills null closes so multi-security alignment works", async () => {
+      mockFetchResponse({
+        chart: {
+          result: [
+            {
+              meta: { currency: "USD" },
+              timestamp: [1, 2, 3, 4],
+              indicators: { quote: [{ close: [100, null, null, 105] }] },
+            },
+          ],
+        },
+      });
+
+      const result = await service.fetchIntradaySeries("AAPL", null, {
+        interval: "1m",
+        range: "1d",
+      });
+
+      expect(result!.map((p) => p.close)).toEqual([100, 100, 100, 105]);
+    });
+
+    it("converts GBX prices to GBP", async () => {
+      mockFetchResponse({
+        chart: {
+          result: [
+            {
+              meta: { currency: "GBX" },
+              timestamp: [1],
+              indicators: { quote: [{ close: [200] }] },
+            },
+          ],
+        },
+      });
+
+      const result = await service.fetchIntradaySeries("BARC.L", "LSE", {
+        interval: "1m",
+        range: "1d",
+      });
+
+      expect(result![0].close).toBe(2);
+    });
+
+    it("returns null when the API responds with an error status", async () => {
+      mockFetchResponse({}, false, 500);
+
+      const result = await service.fetchIntradaySeries("AAPL", null, {
+        interval: "1m",
+        range: "1d",
+      });
+
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/backend/src/securities/yahoo-finance.service.ts
+++ b/backend/src/securities/yahoo-finance.service.ts
@@ -8,6 +8,9 @@ import {
   QuoteResult,
   SecurityLookupResult,
   HistoricalPrice,
+  IntradayInterval,
+  IntradayPoint,
+  IntradayRange,
   StockSectorInfo,
   EtfSectorWeighting,
 } from "./providers/quote-provider.interface";
@@ -363,6 +366,79 @@ export class YahooFinanceService implements QuoteProvider {
     } catch (error) {
       this.logger.error(
         `Failed to fetch historical prices for ${yahooSymbol}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+      return null;
+    }
+  }
+
+  async fetchIntradaySeries(
+    symbol: string,
+    exchange: string | null,
+    opts: { interval: IntradayInterval; range: IntradayRange },
+  ): Promise<IntradayPoint[] | null> {
+    const primary = this.getYahooSymbol(symbol, exchange);
+    const points = await this.fetchIntradayRaw(primary, opts);
+    if (points) return points;
+
+    if (primary === symbol) {
+      for (const altSymbol of this.getAlternateSymbols(symbol)) {
+        const alt = await this.fetchIntradayRaw(altSymbol, opts);
+        if (alt) return alt;
+      }
+    }
+    return null;
+  }
+
+  private async fetchIntradayRaw(
+    yahooSymbol: string,
+    { interval, range }: { interval: IntradayInterval; range: IntradayRange },
+  ): Promise<IntradayPoint[] | null> {
+    try {
+      const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(yahooSymbol)}?interval=${interval}&range=${range}`;
+
+      const response = await fetch(url, {
+        headers: { "User-Agent": YahooFinanceService.USER_AGENT },
+        signal: AbortSignal.timeout(YahooFinanceService.FETCH_TIMEOUT_MS),
+      });
+
+      if (!response.ok) {
+        this.logger.warn(
+          `Yahoo Finance intraday returned ${response.status} for ${yahooSymbol} (${interval}/${range})`,
+        );
+        return null;
+      }
+
+      const data = await response.json();
+      const result = data.chart?.result?.[0];
+      if (!result?.timestamp || !result.indicators?.quote?.[0]) {
+        return null;
+      }
+
+      const gbx = isGbxCurrency(result.meta?.currency);
+      const timestamps: number[] = result.timestamp;
+      const closes: (number | null | undefined)[] =
+        result.indicators.quote[0].close ?? [];
+
+      const points: IntradayPoint[] = [];
+      // Forward-fill nulls so multi-security alignment doesn't drop bars.
+      let lastClose: number | null = null;
+      for (let i = 0; i < timestamps.length; i++) {
+        const raw = closes[i];
+        if (raw != null && !isNaN(raw)) {
+          lastClose = gbx ? convertGbxToGbp(raw) : raw;
+        }
+        if (lastClose === null) continue;
+        points.push({
+          timestamp: new Date(timestamps[i] * 1000),
+          close: lastClose,
+        });
+      }
+
+      return points;
+    } catch (error) {
+      this.logger.error(
+        `Failed to fetch intraday series for ${yahooSymbol}`,
         error instanceof Error ? error.stack : undefined,
       );
       return null;

--- a/backend/src/securities/yahoo-finance.service.ts
+++ b/backend/src/securities/yahoo-finance.service.ts
@@ -395,7 +395,7 @@ export class YahooFinanceService implements QuoteProvider {
     { interval, range }: { interval: IntradayInterval; range: IntradayRange },
   ): Promise<IntradayPoint[] | null> {
     try {
-      const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(yahooSymbol)}?interval=${interval}&range=${range}`;
+      const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(yahooSymbol)}?interval=${encodeURIComponent(interval)}&range=${encodeURIComponent(range)}`;
 
       const response = await fetch(url, {
         headers: { "User-Agent": YahooFinanceService.USER_AGENT },

--- a/frontend/src/app/investments/page.test.tsx
+++ b/frontend/src/app/investments/page.test.tsx
@@ -332,6 +332,7 @@ vi.mock('@/components/investments/InvestmentValueChart', () => ({
       {accountIds?.length > 0 ? `Filtered: ${accountIds.join(',')}` : 'All accounts'}
     </div>
   ),
+  INVESTMENT_CHART_REFRESH_EVENT: 'monize:investment-chart-refresh',
 }));
 
 const mockCashAccounts = [

--- a/frontend/src/app/investments/page.tsx
+++ b/frontend/src/app/investments/page.tsx
@@ -17,7 +17,10 @@ import { AssetAllocationChart } from '@/components/investments/AssetAllocationCh
 import { InvestmentTransactionList } from '@/components/investments/InvestmentTransactionList';
 import { DensityLevel, nextDensity } from '@/hooks/useTableDensity';
 import { InvestmentTransactionForm } from '@/components/investments/InvestmentTransactionForm';
-import { InvestmentValueChart } from '@/components/investments/InvestmentValueChart';
+import {
+  InvestmentValueChart,
+  INVESTMENT_CHART_REFRESH_EVENT,
+} from '@/components/investments/InvestmentValueChart';
 import { TransactionList } from '@/components/transactions/TransactionList';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useInvestmentData } from '@/hooks/useInvestmentData';
@@ -72,6 +75,16 @@ function InvestmentsContent() {
     setInvestmentFormNeedsConversion(false);
     handleFormSuccess();
   }, [handleFormSuccess]);
+
+  // The Refresh button has two effects: (a) refresh security prices in the DB
+  // (existing flow that drives daily snapshots and Portfolio Summary), and
+  // (b) tell the InvestmentValueChart to drop its sessionStorage entry and
+  // re-fetch when it's currently rendering an intraday range. The chart
+  // itself decides whether the event applies based on its active range.
+  const handleRefreshClick = useCallback(async () => {
+    window.dispatchEvent(new Event(INVESTMENT_CHART_REFRESH_EVENT));
+    await data.handleRefreshPrices();
+  }, [data]);
 
   const handleTransactionViewChange = (view: TransactionViewType) => {
     setTransactionView(view);
@@ -159,7 +172,7 @@ function InvestmentsContent() {
                   </div>
                   <Button
                     variant="outline"
-                    onClick={data.handleRefreshPrices}
+                    onClick={handleRefreshClick}
                     disabled={data.isRefreshingPrices}
                     className="whitespace-nowrap h-full"
                     title={data.lastPriceUpdate ? `Last updated: ${formatRelativeTime(data.lastPriceUpdate)}` : 'Never updated'}

--- a/frontend/src/app/investments/page.tsx
+++ b/frontend/src/app/investments/page.tsx
@@ -77,13 +77,27 @@ function InvestmentsContent() {
   }, [handleFormSuccess]);
 
   // The Refresh button has two effects: (a) refresh security prices in the DB
-  // (existing flow that drives daily snapshots and Portfolio Summary), and
+  // (existing flow that drives daily snapshots and Portfolio Summary) and
   // (b) tell the InvestmentValueChart to drop its sessionStorage entry and
   // re-fetch when it's currently rendering an intraday range. The chart
   // itself decides whether the event applies based on its active range.
+  //
+  // Scope the price refresh to the holdings currently visible on screen:
+  // when an account filter is active we only refresh the IDs that show up
+  // in portfolioSummary.holdings instead of every active security in the
+  // user's catalog. With no filter we leave scope undefined so the hook
+  // refreshes all eligible securities.
   const handleRefreshClick = useCallback(async () => {
     window.dispatchEvent(new Event(INVESTMENT_CHART_REFRESH_EVENT));
-    await data.handleRefreshPrices();
+    const scope =
+      data.selectedAccountIds.length > 0
+        ? [
+            ...new Set(
+              (data.portfolioSummary?.holdings ?? []).map((h) => h.securityId),
+            ),
+          ]
+        : undefined;
+    await data.handleRefreshPrices(scope);
   }, [data]);
 
   const handleTransactionViewChange = (view: TransactionViewType) => {

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -263,6 +263,34 @@ describe('InvestmentValueChart', () => {
     });
   });
 
+  it('shows a background-load indicator when refetching with data already on screen', async () => {
+    let resolveDaily: (value: any) => void = () => {};
+    vi.mocked(netWorthApi.getInvestmentsDaily).mockImplementationOnce(() =>
+      Promise.resolve([
+        { date: '2023-06-01', value: 10000 },
+        { date: '2024-01-01', value: 15000 },
+      ]),
+    );
+    const { rerender } = render(<InvestmentValueChart />);
+    await screen.findByText('Portfolio Value Over Time');
+
+    // Trigger a second load that hangs so we can observe the indicator.
+    vi.mocked(netWorthApi.getInvestmentsDaily).mockImplementationOnce(
+      () => new Promise((resolve) => { resolveDaily = resolve; }),
+    );
+    dateRangeState.dateRange = '3m';
+    dateRangeState.resolvedRange = { start: '2023-10-01', end: '2024-01-01' };
+    rerender(<InvestmentValueChart />);
+
+    const indicator = await screen.findByTestId('chart-loading-indicator');
+    expect(indicator).toBeInTheDocument();
+
+    resolveDaily([{ date: '2023-12-01', value: 12000 }]);
+    await waitFor(() => {
+      expect(screen.queryByTestId('chart-loading-indicator')).toBeNull();
+    });
+  });
+
   it('shows a warning icon next to the title when 1w falls back to daily', async () => {
     dateRangeState.dateRange = '1w';
     dateRangeState.resolvedRange = { start: '2023-12-25', end: '2024-01-01' };

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from 'react';
 import { render, screen, waitFor } from '@/test/render';
-import { InvestmentValueChart } from './InvestmentValueChart';
+import {
+  InvestmentValueChart,
+  INVESTMENT_CHART_REFRESH_EVENT,
+} from './InvestmentValueChart';
 import { netWorthApi } from '@/lib/net-worth';
+import { investmentsApi } from '@/lib/investments';
 
 const dateRangeState = { dateRange: '1y', resolvedRange: { start: '2023-01-01', end: '2024-01-01' } };
 
@@ -47,6 +52,24 @@ vi.mock('@/lib/net-worth', () => ({
     ]),
     getInvestmentsMonthly: vi.fn().mockResolvedValue([]),
   },
+}));
+
+vi.mock('@/lib/investments', () => ({
+  investmentsApi: {
+    getIntradayValue: vi.fn().mockResolvedValue({
+      points: [],
+      interval: '1m',
+      currency: 'CAD',
+      range: '1d',
+      fetchedAt: new Date().toISOString(),
+      skippedSymbols: [],
+      fallbackToDaily: false,
+    }),
+  },
+}));
+
+vi.mock('@/hooks/useLocalStorage', () => ({
+  useLocalStorage: (_key: string, initial: any) => [initial, vi.fn()],
 }));
 
 vi.mock('@/lib/utils', () => ({
@@ -152,7 +175,7 @@ describe('InvestmentValueChart', () => {
     render(<InvestmentValueChart />);
     await screen.findByText('Portfolio Value Over Time');
     const lastCall = mockDateRangeSelectorProps.mock.calls[mockDateRangeSelectorProps.mock.calls.length - 1][0];
-    expect(lastCall.ranges).toEqual(['1w', '1m', '3m', 'ytd', '1y', '2y', '5y', 'all']);
+    expect(lastCall.ranges).toEqual(['1d', '1w', '1m', '3m', 'ytd', '1y', '2y', '5y', 'all']);
   });
 
   it('shows negative change values correctly', async () => {
@@ -180,6 +203,88 @@ describe('InvestmentValueChart', () => {
     await screen.findByText('Portfolio Value Over Time');
     expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled();
     expect(netWorthApi.getInvestmentsMonthly).not.toHaveBeenCalled();
+  });
+
+  it('uses intraday API for 1d range', async () => {
+    dateRangeState.dateRange = '1d';
+    vi.mocked(investmentsApi.getIntradayValue).mockResolvedValue({
+      points: [
+        { timestamp: '2024-01-02T14:30:00.000Z', value: 9500 },
+        { timestamp: '2024-01-02T14:31:00.000Z', value: 9600 },
+      ],
+      interval: '1m',
+      currency: 'CAD',
+      range: '1d',
+      fetchedAt: '2024-01-02T15:00:00.000Z',
+      skippedSymbols: [],
+      fallbackToDaily: false,
+    });
+    render(<InvestmentValueChart />);
+    await screen.findByText('Portfolio Value Over Time');
+    expect(investmentsApi.getIntradayValue).toHaveBeenCalledWith(
+      expect.objectContaining({ range: '1d' }),
+    );
+    expect(netWorthApi.getInvestmentsDaily).not.toHaveBeenCalled();
+  });
+
+  it('shows the unavailable note on 1d when providers are mixed', async () => {
+    dateRangeState.dateRange = '1d';
+    vi.mocked(investmentsApi.getIntradayValue).mockResolvedValue({
+      points: [],
+      interval: '1m',
+      currency: 'CAD',
+      range: '1d',
+      fetchedAt: '2024-01-02T15:00:00.000Z',
+      skippedSymbols: ['VFV.TO'],
+      fallbackToDaily: true,
+    });
+    render(<InvestmentValueChart />);
+    expect(
+      await screen.findByText(/Intraday view unavailable/i),
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to the daily endpoint on 1w when fallbackToDaily=true', async () => {
+    dateRangeState.dateRange = '1w';
+    dateRangeState.resolvedRange = { start: '2023-12-25', end: '2024-01-01' };
+    vi.mocked(investmentsApi.getIntradayValue).mockResolvedValue({
+      points: [],
+      interval: '5m',
+      currency: 'CAD',
+      range: '1w',
+      fetchedAt: '2024-01-02T15:00:00.000Z',
+      skippedSymbols: ['VFV.TO'],
+      fallbackToDaily: true,
+    });
+    render(<InvestmentValueChart />);
+    await screen.findByText('Portfolio Value Over Time');
+    await waitFor(() => {
+      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled();
+    });
+  });
+
+  it('clears intraday cache and re-fetches when refresh event fires on 1d', async () => {
+    dateRangeState.dateRange = '1d';
+    vi.mocked(investmentsApi.getIntradayValue).mockResolvedValue({
+      points: [{ timestamp: '2024-01-02T14:30:00.000Z', value: 9500 }],
+      interval: '1m',
+      currency: 'CAD',
+      range: '1d',
+      fetchedAt: '2024-01-02T15:00:00.000Z',
+      skippedSymbols: [],
+      fallbackToDaily: false,
+    });
+    render(<InvestmentValueChart />);
+    await screen.findByText('Portfolio Value Over Time');
+    const initialCalls = vi.mocked(investmentsApi.getIntradayValue).mock.calls.length;
+    await act(async () => {
+      window.dispatchEvent(new Event(INVESTMENT_CHART_REFRESH_EVENT));
+    });
+    await waitFor(() => {
+      expect(
+        vi.mocked(investmentsApi.getIntradayValue).mock.calls.length,
+      ).toBeGreaterThan(initialCalls);
+    });
   });
 
   it('uses monthly API for 5y range (not in DAILY_RANGES)', async () => {

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -263,6 +263,42 @@ describe('InvestmentValueChart', () => {
     });
   });
 
+  it('shows a warning icon next to the title when 1w falls back to daily', async () => {
+    dateRangeState.dateRange = '1w';
+    dateRangeState.resolvedRange = { start: '2023-12-25', end: '2024-01-01' };
+    vi.mocked(investmentsApi.getIntradayValue).mockResolvedValue({
+      points: [],
+      interval: '5m',
+      currency: 'CAD',
+      range: '1w',
+      fetchedAt: '2024-01-02T15:00:00.000Z',
+      skippedSymbols: ['VFV.TO'],
+      fallbackToDaily: true,
+    });
+    render(<InvestmentValueChart />);
+    const warning = await screen.findByTestId('intraday-fallback-warning');
+    expect(warning).toBeInTheDocument();
+    expect(warning.getAttribute('title')).toContain('VFV.TO');
+    expect(warning.getAttribute('title')).toContain('MSN Money');
+  });
+
+  it('does not show the warning icon when intraday data is fully available', async () => {
+    dateRangeState.dateRange = '1w';
+    dateRangeState.resolvedRange = { start: '2023-12-25', end: '2024-01-01' };
+    vi.mocked(investmentsApi.getIntradayValue).mockResolvedValue({
+      points: [{ timestamp: '2024-01-02T14:30:00.000Z', value: 9500 }],
+      interval: '5m',
+      currency: 'CAD',
+      range: '1w',
+      fetchedAt: '2024-01-02T15:00:00.000Z',
+      skippedSymbols: [],
+      fallbackToDaily: false,
+    });
+    render(<InvestmentValueChart />);
+    await screen.findByText('Portfolio Value Over Time');
+    expect(screen.queryByTestId('intraday-fallback-warning')).toBeNull();
+  });
+
   it('clears intraday cache and re-fetches when refresh event fires on 1d', async () => {
     dateRangeState.dateRange = '1d';
     vi.mocked(investmentsApi.getIntradayValue).mockResolvedValue({

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -394,6 +394,35 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
       <div className="flex flex-wrap items-center justify-between gap-4 mb-4">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-1.5">
           Portfolio Value Over Time{titleSuffix ? ` (${titleSuffix})` : ''}
+          {/* Background-load indicator: chart stays on screen during a refetch
+              so Recharts can animate into the new data, but a portfolio with
+              many securities can still take a few seconds (the backend pulls
+              prices for every holding). Surface a small spinner + label so
+              the user knows we're working. */}
+          {isLoading && chartPoints.length > 0 && (
+            <span
+              className="inline-flex items-center gap-1.5 ml-2 text-xs font-normal text-gray-500 dark:text-gray-400"
+              role="status"
+              aria-live="polite"
+              data-testid="chart-loading-indicator"
+            >
+              <svg
+                className="animate-spin h-3.5 w-3.5"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+              Updating…
+            </span>
+          )}
           {intradayFallbackNotice && (
             <span
               role="img"
@@ -467,7 +496,11 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
           No investment data for this period.
         </p>
       ) : (
-        <div className="h-80">
+        <div
+          className={`h-80 transition-opacity duration-200 ${
+            isLoading ? 'opacity-60' : 'opacity-100'
+          }`}
+        >
           <ResponsiveContainer width="100%" height="100%" minWidth={0}>
             <AreaChart data={chartPoints} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
               <defs>

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import {
   AreaChart,
   Area,
@@ -12,16 +12,86 @@ import {
 } from 'recharts';
 import { format } from 'date-fns';
 import { netWorthApi } from '@/lib/net-worth';
+import { investmentsApi } from '@/lib/investments';
 import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useDateRange } from '@/hooks/useDateRange';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('InvestmentChart');
 
+// Ranges that pull intraday bars from the live quote provider. 1W/1M move
+// from daily-snapshot data to intraday bars when every holding's provider
+// supports it; otherwise the backend signals fallbackToDaily=true and we
+// switch back to the existing daily endpoint.
+const INTRADAY_RANGES = new Set(['1d', '1w', '1m']);
 const DAILY_RANGES = new Set(['1w', '1m', '3m', 'ytd', '1y', '2y']);
+
+/**
+ * Frontend caches intraday responses in sessionStorage (per-tab). The
+ * page-level Refresh button broadcasts this event so the chart can clear its
+ * matching entry and re-fetch when the user is viewing an intraday range.
+ */
+export const INVESTMENT_CHART_REFRESH_EVENT = 'monize:investment-chart-refresh';
+
+const RANGE_STORAGE_KEY = 'monize-investments-chart-range';
+const INTRADAY_CACHE_PREFIX = 'monize-intraday|';
+
+interface IntradayCachePayload {
+  fetchedAt: number;
+  points: Array<{ timestamp: string; value: number }>;
+  interval: '1m' | '5m' | '15m';
+  currency: string;
+  fallbackToDaily: boolean;
+  skippedSymbols: string[];
+}
+
+function buildIntradayCacheKey(
+  range: string,
+  accountIds: string[] | undefined,
+  currency: string,
+): string {
+  const accts = (accountIds ?? []).slice().sort().join(',');
+  return `${INTRADAY_CACHE_PREFIX}${range}|${accts}|${currency}`;
+}
+
+function readIntradayCache(key: string): IntradayCachePayload | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(key);
+    if (!raw) return null;
+    return JSON.parse(raw) as IntradayCachePayload;
+  } catch {
+    return null;
+  }
+}
+
+function writeIntradayCache(key: string, payload: IntradayCachePayload): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(key, JSON.stringify(payload));
+  } catch (error) {
+    logger.warn('Failed to write intraday cache:', error);
+  }
+}
+
+function clearAllIntradayCache(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const ss = window.sessionStorage;
+    const keys: string[] = [];
+    for (let i = 0; i < ss.length; i++) {
+      const k = ss.key(i);
+      if (k && k.startsWith(INTRADAY_CACHE_PREFIX)) keys.push(k);
+    }
+    keys.forEach((k) => ss.removeItem(k));
+  } catch (error) {
+    logger.warn('Failed to clear intraday cache:', error);
+  }
+}
 
 interface InvestmentValueChartProps {
   accountIds?: string[];
@@ -34,14 +104,34 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
   const { defaultCurrency } = useExchangeRates();
   const [chartPoints, setChartPoints] = useState<Array<{ name: string; Value: number }>>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const { dateRange, setDateRange, resolvedRange, isValid } = useDateRange({ defaultRange: '1y', alignment: 'month' });
+  const [intradayUnavailable, setIntradayUnavailable] = useState<{
+    skipped: string[];
+  } | null>(null);
+  const [persistedRange, setPersistedRange] = useLocalStorage<string>(
+    RANGE_STORAGE_KEY,
+    '1y',
+  );
+  const { dateRange, setDateRange, resolvedRange, isValid } = useDateRange({
+    defaultRange: persistedRange,
+    alignment: 'month',
+  });
+  // Mirror the active range into localStorage when the user changes it.
+  const handleRangeChange = useCallback(
+    (next: string) => {
+      setDateRange(next);
+      setPersistedRange(next);
+    },
+    [setDateRange, setPersistedRange],
+  );
 
-  const useDaily = DAILY_RANGES.has(dateRange);
+  const isIntraday = INTRADAY_RANGES.has(dateRange);
+  const useDaily = !isIntraday && DAILY_RANGES.has(dateRange);
 
   // Determine the effective currency for display
   const foreignCurrency = displayCurrency && displayCurrency !== defaultCurrency
     ? displayCurrency
     : null;
+  const effectiveCurrency = foreignCurrency || defaultCurrency || 'USD';
 
   const fmtVal = useCallback((value: number) => {
     if (foreignCurrency) return `${formatCurrencyCompact(value, foreignCurrency)} ${foreignCurrency}`;
@@ -53,9 +143,22 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
     return formatCurrencyAxis(value);
   }, [foreignCurrency, formatCurrencyAxis]);
 
-  const loadData = useCallback(async () => {
-    setIsLoading(true);
-    try {
+  // Latest in-flight load token; lets us cancel stale results that resolve
+  // out-of-order if the user clicks ranges quickly.
+  const loadTokenRef = useRef(0);
+
+  const formatIntradayLabel = useCallback(
+    (iso: string, range: string) => {
+      const d = new Date(iso);
+      return range === '1d'
+        ? format(d, 'HH:mm')
+        : format(d, 'MMM d HH:mm');
+    },
+    [],
+  );
+
+  const loadDailyOrMonthly = useCallback(
+    async (token: number) => {
       const { start, end } = resolvedRange;
       const params = {
         startDate: start,
@@ -63,32 +166,145 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
         accountIds: accountIds?.length ? accountIds.join(',') : undefined,
         displayCurrency: foreignCurrency || undefined,
       };
-
-      if (useDaily) {
+      if (useDaily || isIntraday) {
+        // 1W/1M intraday fallback also uses the daily endpoint.
         const data = await netWorthApi.getInvestmentsDaily(params);
-        setChartPoints(data.map((d) => ({
-          name: format(parseLocalDate(d.date), 'MMM d, yyyy'),
-          Value: d.value,
-        })));
+        if (loadTokenRef.current !== token) return;
+        setChartPoints(
+          data.map((d) => ({
+            name: format(parseLocalDate(d.date), 'MMM d, yyyy'),
+            Value: d.value,
+          })),
+        );
       } else {
         const data = await netWorthApi.getInvestmentsMonthly(params);
-        setChartPoints(data.map((d) => ({
-          name: format(parseLocalDate(d.month), 'MMM yyyy'),
-          Value: d.value,
-        })));
+        if (loadTokenRef.current !== token) return;
+        setChartPoints(
+          data.map((d) => ({
+            name: format(parseLocalDate(d.month), 'MMM yyyy'),
+            Value: d.value,
+          })),
+        );
       }
-    } catch (error) {
-      logger.error('Failed to load investment data:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [resolvedRange, accountIds, foreignCurrency, useDaily]);
+    },
+    [resolvedRange, accountIds, foreignCurrency, useDaily, isIntraday],
+  );
+
+  const loadData = useCallback(
+    async (opts: { skipCache?: boolean } = {}) => {
+      const token = ++loadTokenRef.current;
+      setIsLoading(true);
+      setIntradayUnavailable(null);
+      try {
+        if (isIntraday) {
+          const cacheKey = buildIntradayCacheKey(
+            dateRange,
+            accountIds,
+            effectiveCurrency,
+          );
+          const cached = !opts.skipCache ? readIntradayCache(cacheKey) : null;
+
+          // Hydrate from cache immediately so the chart appears even before
+          // the network round-trip resolves.
+          if (cached && !cached.fallbackToDaily) {
+            setChartPoints(
+              cached.points.map((p) => ({
+                name: formatIntradayLabel(p.timestamp, dateRange),
+                Value: p.value,
+              })),
+            );
+            setIsLoading(false);
+          }
+
+          let response;
+          try {
+            response = await investmentsApi.getIntradayValue({
+              range: dateRange as '1d' | '1w' | '1m',
+              accountIds: accountIds?.length ? accountIds.join(',') : undefined,
+              displayCurrency: foreignCurrency || undefined,
+            });
+          } catch (error) {
+            logger.error('Failed to load intraday data:', error);
+            if (loadTokenRef.current !== token) return;
+            setChartPoints([]);
+            setIsLoading(false);
+            return;
+          }
+
+          if (loadTokenRef.current !== token) return;
+
+          writeIntradayCache(cacheKey, {
+            fetchedAt: Date.now(),
+            points: response.points,
+            interval: response.interval,
+            currency: response.currency,
+            fallbackToDaily: response.fallbackToDaily,
+            skippedSymbols: response.skippedSymbols,
+          });
+
+          if (response.fallbackToDaily) {
+            // Some holdings (typically MSN-tracked) lack intraday support.
+            if (dateRange === '1d') {
+              // No sensible daily-resolution fallback for a single day.
+              setChartPoints([]);
+              setIntradayUnavailable({ skipped: response.skippedSymbols });
+              setIsLoading(false);
+              return;
+            }
+            // 1W / 1M: silently fall back to the daily-snapshot endpoint.
+            setIntradayUnavailable(null);
+            await loadDailyOrMonthly(token);
+            return;
+          }
+
+          setChartPoints(
+            response.points.map((p) => ({
+              name: formatIntradayLabel(p.timestamp, dateRange),
+              Value: p.value,
+            })),
+          );
+        } else {
+          await loadDailyOrMonthly(token);
+        }
+      } catch (error) {
+        logger.error('Failed to load investment data:', error);
+      } finally {
+        if (loadTokenRef.current === token) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [
+      isIntraday,
+      dateRange,
+      accountIds,
+      effectiveCurrency,
+      foreignCurrency,
+      formatIntradayLabel,
+      loadDailyOrMonthly,
+    ],
+  );
 
   useEffect(() => {
     if (isValid) {
-      loadData();
+      void loadData();
     }
   }, [isValid, loadData]);
+
+  // Listen for the page-level Refresh button. When the user is on an intraday
+  // range, drop the sessionStorage entry and re-fetch only this chart's data.
+  useEffect(() => {
+    const handler = () => {
+      if (isIntraday) {
+        clearAllIntradayCache();
+        void loadData({ skipCache: true });
+      }
+    };
+    window.addEventListener(INVESTMENT_CHART_REFRESH_EVENT, handler);
+    return () => {
+      window.removeEventListener(INVESTMENT_CHART_REFRESH_EVENT, handler);
+    };
+  }, [isIntraday, loadData]);
 
   const summary = useMemo(() => {
     if (chartPoints.length === 0) return { current: 0, change: 0, changePercent: 0 };
@@ -101,15 +317,14 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
 
   const xAxisTicks = useMemo(() => {
     if (chartPoints.length <= 36) return undefined;
-    if (useDaily) {
-      // For daily data with many points, show ~6-8 evenly spaced ticks
+    if (isIntraday || useDaily) {
       const step = Math.ceil(chartPoints.length / 7);
-      return chartPoints.filter((_, i) => i % step === 0).map(d => d.name);
+      return chartPoints.filter((_, i) => i % step === 0).map((d) => d.name);
     }
     return chartPoints
-      .filter(d => d.name.startsWith('Jan '))
-      .map(d => d.name);
-  }, [chartPoints, useDaily]);
+      .filter((d) => d.name.startsWith('Jan '))
+      .map((d) => d.name);
+  }, [chartPoints, isIntraday, useDaily]);
 
   const yAxisDomain = useMemo(() => {
     if (chartPoints.length === 0) return [0, 'auto'] as [number, 'auto'];
@@ -164,9 +379,9 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
           Portfolio Value Over Time{titleSuffix ? ` (${titleSuffix})` : ''}
         </h3>
         <DateRangeSelector
-          ranges={['1w', '1m', '3m', 'ytd', '1y', '2y', '5y', 'all']}
+          ranges={['1d', '1w', '1m', '3m', 'ytd', '1y', '2y', '5y', 'all']}
           value={dateRange}
-          onChange={setDateRange}
+          onChange={handleRangeChange}
           activeColour="bg-emerald-600"
           size="sm"
         />
@@ -199,7 +414,21 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
       </div>
 
       {/* Chart */}
-      {chartPoints.length === 0 ? (
+      {intradayUnavailable ? (
+        <div className="text-center py-12 px-4">
+          <p className="text-sm text-gray-700 dark:text-gray-200 font-medium mb-1">
+            Intraday view unavailable for this account mix
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            One or more holdings use a quote provider (MSN Money) that does not
+            expose intraday data
+            {intradayUnavailable.skipped.length > 0
+              ? `: ${intradayUnavailable.skipped.join(', ')}`
+              : ''}
+            . Switch to a longer range to see daily snapshots.
+          </p>
+        </div>
+      ) : chartPoints.length === 0 ? (
         <p className="text-gray-500 dark:text-gray-400 text-center py-8">
           No investment data for this period.
         </p>
@@ -219,8 +448,10 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
                 tick={{ fontSize: 12 }}
                 {...(xAxisTicks ? { ticks: xAxisTicks } : {})}
                 tickFormatter={(value: string) => {
+                  if (isIntraday) {
+                    return value;
+                  }
                   if (useDaily) {
-                    // For daily data, show abbreviated date
                     const parts = value.split(', ');
                     return parts[0] || value;
                   }

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -20,95 +20,26 @@ import { useDateRange } from '@/hooks/useDateRange';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { createLogger } from '@/lib/logger';
+import {
+  INTRADAY_RANGES,
+  buildIntradayCacheKey,
+  readIntradayCache,
+  writeIntradayCache,
+  clearAllIntradayCache,
+  computeTightYAxisDomain,
+} from './portfolio-chart-utils';
 
 const logger = createLogger('InvestmentChart');
 
-// Ranges that pull intraday bars from the live quote provider. 1W/1M move
-// from daily-snapshot data to intraday bars when every holding's provider
-// supports it; otherwise the backend signals fallbackToDaily=true and we
-// switch back to the existing daily endpoint.
-const INTRADAY_RANGES = new Set(['1d', '1w', '1m']);
 const DAILY_RANGES = new Set(['1w', '1m', '3m', 'ytd', '1y', '2y']);
 
 /**
- * Frontend caches intraday responses in sessionStorage (per-tab). The
- * page-level Refresh button broadcasts this event so the chart can clear its
- * matching entry and re-fetch when the user is viewing an intraday range.
+ * The page-level Refresh button broadcasts this event so the chart can clear
+ * its sessionStorage cache and re-fetch when viewing an intraday range.
  */
 export const INVESTMENT_CHART_REFRESH_EVENT = 'monize:investment-chart-refresh';
 
 const RANGE_STORAGE_KEY = 'monize-investments-chart-range';
-const INTRADAY_CACHE_PREFIX = 'monize-intraday|';
-
-interface IntradayCachePayload {
-  fetchedAt: number;
-  points: Array<{ timestamp: string; value: number }>;
-  interval: '1m' | '5m' | '15m';
-  currency: string;
-  fallbackToDaily: boolean;
-  skippedSymbols: string[];
-}
-
-function buildIntradayCacheKey(
-  range: string,
-  accountIds: string[] | undefined,
-  currency: string,
-): string {
-  const accts = (accountIds ?? []).slice().sort().join(',');
-  return `${INTRADAY_CACHE_PREFIX}${range}|${accts}|${currency}`;
-}
-
-function readIntradayCache(key: string): IntradayCachePayload | null {
-  if (typeof window === 'undefined') return null;
-  try {
-    const raw = window.sessionStorage.getItem(key);
-    if (!raw) return null;
-    return JSON.parse(raw) as IntradayCachePayload;
-  } catch {
-    return null;
-  }
-}
-
-function writeIntradayCache(key: string, payload: IntradayCachePayload): void {
-  if (typeof window === 'undefined') return;
-  try {
-    window.sessionStorage.setItem(key, JSON.stringify(payload));
-  } catch (error) {
-    logger.warn('Failed to write intraday cache:', error);
-  }
-}
-
-function clearAllIntradayCache(): void {
-  if (typeof window === 'undefined') return;
-  try {
-    const ss = window.sessionStorage;
-    const keys: string[] = [];
-    for (let i = 0; i < ss.length; i++) {
-      const k = ss.key(i);
-      if (k && k.startsWith(INTRADAY_CACHE_PREFIX)) keys.push(k);
-    }
-    keys.forEach((k) => ss.removeItem(k));
-  } catch (error) {
-    logger.warn('Failed to clear intraday cache:', error);
-  }
-}
-
-/**
- * Round `raw` up to a "nice" axis step (1, 2, 5 × 10^n). Used to pick a
- * y-axis tick interval so labels look clean at any scale.
- */
-function niceAxisStep(raw: number): number {
-  if (raw <= 0) return 1;
-  const exp = Math.floor(Math.log10(raw));
-  const magnitude = Math.pow(10, exp);
-  const f = raw / magnitude;
-  let nf: number;
-  if (f < 1.5) nf = 1;
-  else if (f < 3) nf = 2;
-  else if (f < 7) nf = 5;
-  else nf = 10;
-  return nf * magnitude;
-}
 
 interface InvestmentValueChartProps {
   accountIds?: string[];
@@ -355,48 +286,10 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
       .map((d) => d.name);
   }, [chartPoints, isIntraday, useDaily]);
 
-  const yAxisDomain = useMemo(() => {
-    if (chartPoints.length === 0) return [0, 'auto'] as [number, number | 'auto'];
-
-    const values = chartPoints.map((d) => d.Value);
-    const minValue = Math.min(...values);
-    const maxValue = Math.max(...values);
-    const range = maxValue - minValue;
-
-    // Flat line: pad ±1% (or ±1 unit, whichever is larger) so the line
-    // doesn't sit on the axis edge.
-    if (range === 0) {
-      const pad = Math.max(Math.abs(minValue) * 0.01, 1);
-      return [minValue - pad, maxValue + pad] as [number, number];
-    }
-
-    // If the values cross zero, anchor the lower bound at 0 — otherwise
-    // gain/loss directionality reads wrong.
-    const crossesZero = minValue < 0 && maxValue > 0;
-    if (crossesZero) {
-      const niceMaxStep = niceAxisStep((maxValue - 0) / 5);
-      const niceMax = Math.ceil(maxValue / niceMaxStep) * niceMaxStep;
-      const niceMinStep = niceAxisStep((0 - minValue) / 5);
-      const niceMin = Math.floor(minValue / niceMinStep) * niceMinStep;
-      return [niceMin, niceMax] as [number, number];
-    }
-
-    // Tight zoom around the data so percent-level moves are visible. 5%
-    // padding above and below, snapped to a "nice" round step.
-    const padding = range * 0.05;
-    const rawMin = minValue - padding;
-    const rawMax = maxValue + padding;
-    const step = niceAxisStep(range / 5);
-    const niceMin = Math.floor(rawMin / step) * step;
-    const niceMax = Math.ceil(rawMax / step) * step;
-
-    // Don't dive below zero just because of padding when the data is all
-    // positive (or all negative).
-    if (minValue >= 0) {
-      return [Math.max(0, niceMin), niceMax] as [number, number];
-    }
-    return [niceMin, Math.min(0, niceMax)] as [number, number];
-  }, [chartPoints]);
+  const yAxisDomain = useMemo(
+    () => computeTightYAxisDomain(chartPoints.map((d) => d.Value)),
+    [chartPoints],
+  );
 
   const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: Array<{ value: number; payload: { name: string } }> }) => {
     if (active && payload && payload.length) {

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -93,6 +93,23 @@ function clearAllIntradayCache(): void {
   }
 }
 
+/**
+ * Round `raw` up to a "nice" axis step (1, 2, 5 × 10^n). Used to pick a
+ * y-axis tick interval so labels look clean at any scale.
+ */
+function niceAxisStep(raw: number): number {
+  if (raw <= 0) return 1;
+  const exp = Math.floor(Math.log10(raw));
+  const magnitude = Math.pow(10, exp);
+  const f = raw / magnitude;
+  let nf: number;
+  if (f < 1.5) nf = 1;
+  else if (f < 3) nf = 2;
+  else if (f < 7) nf = 5;
+  else nf = 10;
+  return nf * magnitude;
+}
+
 interface InvestmentValueChartProps {
   accountIds?: string[];
   displayCurrency?: string | null;
@@ -339,22 +356,46 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
   }, [chartPoints, isIntraday, useDaily]);
 
   const yAxisDomain = useMemo(() => {
-    if (chartPoints.length === 0) return [0, 'auto'] as [number, 'auto'];
+    if (chartPoints.length === 0) return [0, 'auto'] as [number, number | 'auto'];
 
-    const values = chartPoints.map(d => d.Value);
+    const values = chartPoints.map((d) => d.Value);
     const minValue = Math.min(...values);
     const maxValue = Math.max(...values);
     const range = maxValue - minValue;
 
-    if (minValue > 0 && minValue > range * 0.2) {
-      const padding = range * 0.1;
-      const rawMin = minValue - padding;
-      const magnitude = Math.pow(10, Math.floor(Math.log10(Math.abs(rawMin))));
-      const niceMin = Math.floor(rawMin / magnitude) * magnitude;
-      return [niceMin, 'auto'] as [number, 'auto'];
+    // Flat line: pad ±1% (or ±1 unit, whichever is larger) so the line
+    // doesn't sit on the axis edge.
+    if (range === 0) {
+      const pad = Math.max(Math.abs(minValue) * 0.01, 1);
+      return [minValue - pad, maxValue + pad] as [number, number];
     }
 
-    return [Math.min(0, minValue), 'auto'] as [number, 'auto'];
+    // If the values cross zero, anchor the lower bound at 0 — otherwise
+    // gain/loss directionality reads wrong.
+    const crossesZero = minValue < 0 && maxValue > 0;
+    if (crossesZero) {
+      const niceMaxStep = niceAxisStep((maxValue - 0) / 5);
+      const niceMax = Math.ceil(maxValue / niceMaxStep) * niceMaxStep;
+      const niceMinStep = niceAxisStep((0 - minValue) / 5);
+      const niceMin = Math.floor(minValue / niceMinStep) * niceMinStep;
+      return [niceMin, niceMax] as [number, number];
+    }
+
+    // Tight zoom around the data so percent-level moves are visible. 5%
+    // padding above and below, snapped to a "nice" round step.
+    const padding = range * 0.05;
+    const rawMin = minValue - padding;
+    const rawMax = maxValue + padding;
+    const step = niceAxisStep(range / 5);
+    const niceMin = Math.floor(rawMin / step) * step;
+    const niceMax = Math.ceil(rawMax / step) * step;
+
+    // Don't dive below zero just because of padding when the data is all
+    // positive (or all negative).
+    if (minValue >= 0) {
+      return [Math.max(0, niceMin), niceMax] as [number, number];
+    }
+    return [niceMin, Math.min(0, niceMax)] as [number, number];
   }, [chartPoints]);
 
   const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: Array<{ value: number; payload: { name: string } }> }) => {

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -98,9 +98,9 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
     return formatCurrencyAxis(value);
   }, [foreignCurrency, formatCurrencyAxis]);
 
-  // Latest in-flight load token; lets us cancel stale results that resolve
-  // out-of-order if the user clicks ranges quickly.
-  const loadTokenRef = useRef(0);
+  // Sequence number for the latest in-flight load. Lets us cancel stale
+  // results that resolve out-of-order if the user clicks ranges quickly.
+  const loadSeqRef = useRef(0);
 
   const formatIntradayLabel = useCallback(
     (iso: string, range: string) => {
@@ -113,7 +113,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
   );
 
   const loadDailyOrMonthly = useCallback(
-    async (token: number) => {
+    async (seq: number) => {
       const { start, end } = resolvedRange;
       const params = {
         startDate: start,
@@ -124,7 +124,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
       if (useDaily || isIntraday) {
         // 1W/1M intraday fallback also uses the daily endpoint.
         const data = await netWorthApi.getInvestmentsDaily(params);
-        if (loadTokenRef.current !== token) return;
+        if (loadSeqRef.current !== seq) return;
         setChartPoints(
           data.map((d) => ({
             name: format(parseLocalDate(d.date), 'MMM d, yyyy'),
@@ -133,7 +133,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
         );
       } else {
         const data = await netWorthApi.getInvestmentsMonthly(params);
-        if (loadTokenRef.current !== token) return;
+        if (loadSeqRef.current !== seq) return;
         setChartPoints(
           data.map((d) => ({
             name: format(parseLocalDate(d.month), 'MMM yyyy'),
@@ -147,7 +147,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
 
   const loadData = useCallback(
     async (opts: { skipCache?: boolean } = {}) => {
-      const token = ++loadTokenRef.current;
+      const seq = ++loadSeqRef.current;
       setIsLoading(true);
       setIntradayUnavailable(null);
       setIntradayFallbackNotice(null);
@@ -181,13 +181,13 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
             });
           } catch (error) {
             logger.error('Failed to load intraday data:', error);
-            if (loadTokenRef.current !== token) return;
+            if (loadSeqRef.current !== seq) return;
             setChartPoints([]);
             setIsLoading(false);
             return;
           }
 
-          if (loadTokenRef.current !== token) return;
+          if (loadSeqRef.current !== seq) return;
 
           writeIntradayCache(cacheKey, {
             fetchedAt: Date.now(),
@@ -213,7 +213,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
             // resolution.
             setIntradayUnavailable(null);
             setIntradayFallbackNotice({ skipped: response.skippedSymbols });
-            await loadDailyOrMonthly(token);
+            await loadDailyOrMonthly(seq);
             return;
           }
 
@@ -224,12 +224,12 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
             })),
           );
         } else {
-          await loadDailyOrMonthly(token);
+          await loadDailyOrMonthly(seq);
         }
       } catch (error) {
         logger.error('Failed to load investment data:', error);
       } finally {
-        if (loadTokenRef.current === token) {
+        if (loadSeqRef.current === seq) {
           setIsLoading(false);
         }
       }

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -360,7 +360,12 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
     return null;
   };
 
-  if (isLoading) {
+  // Only show the full-card skeleton on the very first load. Subsequent
+  // range / filter changes keep the previous chart on screen so Recharts can
+  // animate smoothly into the new data instead of unmounting and re-drawing
+  // the whole card. The intraday path already does this via the sessionStorage
+  // cache; this extends the same behaviour to daily/monthly ranges.
+  if (isLoading && chartPoints.length === 0 && !intradayUnavailable) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
         <div className="animate-pulse space-y-4">

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -107,6 +107,13 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
   const [intradayUnavailable, setIntradayUnavailable] = useState<{
     skipped: string[];
   } | null>(null);
+  // Set when 1W/1M silently fall back to daily snapshots because one or more
+  // holdings use a quote provider (MSN Money) without intraday support. We
+  // surface a small warning icon next to the title so the user understands
+  // why the chart resolution is coarser than the button label suggests.
+  const [intradayFallbackNotice, setIntradayFallbackNotice] = useState<{
+    skipped: string[];
+  } | null>(null);
   const [persistedRange, setPersistedRange] = useLocalStorage<string>(
     RANGE_STORAGE_KEY,
     '1y',
@@ -195,6 +202,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
       const token = ++loadTokenRef.current;
       setIsLoading(true);
       setIntradayUnavailable(null);
+      setIntradayFallbackNotice(null);
       try {
         if (isIntraday) {
           const cacheKey = buildIntradayCacheKey(
@@ -251,8 +259,12 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
               setIsLoading(false);
               return;
             }
-            // 1W / 1M: silently fall back to the daily-snapshot endpoint.
+            // 1W / 1M: silently fall back to the daily-snapshot endpoint and
+            // flag the title with a small warning icon so the user knows the
+            // chart is at daily resolution rather than the requested intraday
+            // resolution.
             setIntradayUnavailable(null);
+            setIntradayFallbackNotice({ skipped: response.skippedSymbols });
             await loadDailyOrMonthly(token);
             return;
           }
@@ -380,8 +392,25 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
       {/* Header with title and date range buttons */}
       <div className="flex flex-wrap items-center justify-between gap-4 mb-4">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-1.5">
           Portfolio Value Over Time{titleSuffix ? ` (${titleSuffix})` : ''}
+          {intradayFallbackNotice && (
+            <span
+              role="img"
+              aria-label="Detailed intraday pricing unavailable"
+              title={`Detailed intraday pricing isn't available because ${intradayFallbackNotice.skipped.length > 0 ? intradayFallbackNotice.skipped.join(', ') : 'one or more holdings'} use MSN Money, which doesn't expose intraday quotes. Showing daily snapshots instead.`}
+              className="inline-flex text-amber-500 dark:text-amber-400 cursor-help"
+              data-testid="intraday-fallback-warning"
+            >
+              <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path
+                  fillRule="evenodd"
+                  d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.515 2.625H3.72c-1.345 0-2.188-1.458-1.515-2.625L8.485 2.495zM10 6a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 6zm0 9a1 1 0 100-2 1 1 0 000 2z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </span>
+          )}
         </h3>
         <DateRangeSelector
           ranges={['1d', '1w', '1m', '3m', 'ytd', '1y', '2y', '5y', 'all']}

--- a/frontend/src/components/investments/portfolio-chart-utils.ts
+++ b/frontend/src/components/investments/portfolio-chart-utils.ts
@@ -1,0 +1,138 @@
+'use client';
+
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('PortfolioValueChart');
+
+/**
+ * Ranges that pull intraday bars from the live quote provider. 1W/1M move
+ * from daily-snapshot data to intraday bars when every holding's provider
+ * supports it; otherwise the backend signals fallbackToDaily=true and we
+ * switch back to the daily endpoint.
+ */
+export const INTRADAY_RANGES = new Set(['1d', '1w', '1m']);
+
+/**
+ * sessionStorage prefix for cached intraday responses. Per-tab, so the data
+ * persists during a navigation but not across browser sessions.
+ */
+export const INTRADAY_CACHE_PREFIX = 'monize-intraday|';
+
+export interface IntradayCachePayload {
+  fetchedAt: number;
+  points: Array<{ timestamp: string; value: number }>;
+  interval: '1m' | '5m' | '15m';
+  currency: string;
+  fallbackToDaily: boolean;
+  skippedSymbols: string[];
+}
+
+export function buildIntradayCacheKey(
+  range: string,
+  accountIds: string[] | undefined,
+  currency: string,
+): string {
+  const accts = (accountIds ?? []).slice().sort().join(',');
+  return `${INTRADAY_CACHE_PREFIX}${range}|${accts}|${currency}`;
+}
+
+export function readIntradayCache(key: string): IntradayCachePayload | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(key);
+    if (!raw) return null;
+    return JSON.parse(raw) as IntradayCachePayload;
+  } catch {
+    return null;
+  }
+}
+
+export function writeIntradayCache(
+  key: string,
+  payload: IntradayCachePayload,
+): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(key, JSON.stringify(payload));
+  } catch (error) {
+    logger.warn('Failed to write intraday cache:', error);
+  }
+}
+
+export function clearAllIntradayCache(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const ss = window.sessionStorage;
+    const keys: string[] = [];
+    for (let i = 0; i < ss.length; i++) {
+      const k = ss.key(i);
+      if (k && k.startsWith(INTRADAY_CACHE_PREFIX)) keys.push(k);
+    }
+    keys.forEach((k) => ss.removeItem(k));
+  } catch (error) {
+    logger.warn('Failed to clear intraday cache:', error);
+  }
+}
+
+/**
+ * Round `raw` up to a "nice" axis step (1, 2, 5 × 10^n). Used to pick a
+ * y-axis tick interval so labels look clean at any scale.
+ */
+export function niceAxisStep(raw: number): number {
+  if (raw <= 0) return 1;
+  const exp = Math.floor(Math.log10(raw));
+  const magnitude = Math.pow(10, exp);
+  const f = raw / magnitude;
+  let nf: number;
+  if (f < 1.5) nf = 1;
+  else if (f < 3) nf = 2;
+  else if (f < 7) nf = 5;
+  else nf = 10;
+  return nf * magnitude;
+}
+
+/**
+ * Tight-zoom y-axis bounds. Returns explicit [min, max] (not 'auto') so
+ * Recharts doesn't pad the data into the top/bottom slivers of the plot
+ * and small price moves stay visible.
+ *
+ *   - Flat line: ±1% padding (or ±1, whichever is larger).
+ *   - Crosses zero: anchor at 0 with nice steps on both sides.
+ *   - All-positive / all-negative: 5% padding, snapped to a nice step,
+ *     clamped so we don't dive past zero just from padding.
+ */
+export function computeTightYAxisDomain(
+  values: number[],
+): [number, number] | [number, 'auto'] {
+  if (values.length === 0) return [0, 'auto'];
+
+  const minValue = Math.min(...values);
+  const maxValue = Math.max(...values);
+  const range = maxValue - minValue;
+
+  if (range === 0) {
+    const pad = Math.max(Math.abs(minValue) * 0.01, 1);
+    return [minValue - pad, maxValue + pad];
+  }
+
+  const crossesZero = minValue < 0 && maxValue > 0;
+  if (crossesZero) {
+    const niceMaxStep = niceAxisStep((maxValue - 0) / 5);
+    const niceMax = Math.ceil(maxValue / niceMaxStep) * niceMaxStep;
+    const niceMinStep = niceAxisStep((0 - minValue) / 5);
+    const niceMin = Math.floor(minValue / niceMinStep) * niceMinStep;
+    return [niceMin, niceMax];
+  }
+
+  const padding = range * 0.05;
+  const rawMin = minValue - padding;
+  const rawMax = maxValue + padding;
+  const step = niceAxisStep(range / 5);
+  const niceMin = Math.floor(rawMin / step) * step;
+  const niceMax = Math.ceil(rawMax / step) * step;
+
+  if (minValue >= 0) {
+    return [Math.max(0, niceMin), niceMax];
+  }
+  return [niceMin, Math.min(0, niceMax)];
+}

--- a/frontend/src/components/reports/PortfolioValueReport.test.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.test.tsx
@@ -235,7 +235,7 @@ describe('PortfolioValueReport', () => {
       expect(mockDateRangeSelectorProps).toHaveBeenCalled();
     });
     const lastCall = mockDateRangeSelectorProps.mock.calls[mockDateRangeSelectorProps.mock.calls.length - 1][0];
-    expect(lastCall.ranges).toEqual(['1w', '1m', '3m', 'ytd', '1y', '2y', '5y', 'all']);
+    expect(lastCall.ranges).toEqual(['1d', '1w', '1m', '3m', 'ytd', '1y', '2y', '5y', 'all']);
   });
 
   it('handles loadData error gracefully', async () => {

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -112,9 +112,9 @@ export function PortfolioValueReport() {
     return formatCurrencyAxis(value);
   }, [foreignCurrency, formatCurrencyAxis]);
 
-  // Cancel-stale token so quick range/account switches can't write
-  // out-of-order results into state.
-  const loadTokenRef = useRef(0);
+  // Sequence number for the latest in-flight load. Lets us drop stale
+  // results so quick range/account switches can't write out-of-order data.
+  const loadSeqRef = useRef(0);
 
   const formatIntradayLabel = useCallback(
     (iso: string, range: string) => {
@@ -126,7 +126,7 @@ export function PortfolioValueReport() {
 
   useEffect(() => {
     if (!isValid) return;
-    const token = ++loadTokenRef.current;
+    const seq = ++loadSeqRef.current;
 
     const accountIds = selectedAccountId ? [selectedAccountId] : undefined;
     const accountIdsCsv = accountIds?.join(',');
@@ -141,7 +141,7 @@ export function PortfolioValueReport() {
       };
       if (useDaily || isIntraday) {
         const data = await netWorthApi.getInvestmentsDaily(params);
-        if (loadTokenRef.current !== token) return;
+        if (loadSeqRef.current !== seq) return;
         setChartPoints(
           data.map((d) => ({
             name: format(parseLocalDate(d.date), 'MMM d, yyyy'),
@@ -150,7 +150,7 @@ export function PortfolioValueReport() {
         );
       } else {
         const data = await netWorthApi.getInvestmentsMonthly(params);
-        if (loadTokenRef.current !== token) return;
+        if (loadSeqRef.current !== seq) return;
         setChartPoints(
           data.map((d) => ({
             name: format(parseLocalDate(d.month), 'MMM yyyy'),
@@ -205,12 +205,12 @@ export function PortfolioValueReport() {
             });
           } catch (error) {
             logger.error('Failed to load intraday data:', error);
-            if (loadTokenRef.current !== token) return;
+            if (loadSeqRef.current !== seq) return;
             setChartPoints([]);
             return;
           }
 
-          if (loadTokenRef.current !== token) return;
+          if (loadSeqRef.current !== seq) return;
 
           writeIntradayCache(cacheKey, {
             fetchedAt: Date.now(),
@@ -246,7 +246,7 @@ export function PortfolioValueReport() {
         }
 
         const summaryAndAccountsResult = await summaryAndAccounts;
-        if (loadTokenRef.current !== token) return;
+        if (loadSeqRef.current !== seq) return;
         if (summaryAndAccountsResult) {
           const [portfolioResult, accountsResult] = summaryAndAccountsResult;
           setPortfolio(portfolioResult);
@@ -255,7 +255,7 @@ export function PortfolioValueReport() {
       } catch (error) {
         logger.error('Failed to load portfolio data:', error);
       } finally {
-        if (loadTokenRef.current === token) {
+        if (loadSeqRef.current === seq) {
           setIsLoading(false);
         }
       }

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -19,13 +19,22 @@ import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useDateRange } from '@/hooks/useDateRange';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { createLogger } from '@/lib/logger';
+import {
+  INTRADAY_RANGES,
+  buildIntradayCacheKey,
+  readIntradayCache,
+  writeIntradayCache,
+  computeTightYAxisDomain,
+} from '@/components/investments/portfolio-chart-utils';
 
 const logger = createLogger('PortfolioValueReport');
 
 const DAILY_RANGES = new Set(['1w', '1m', '3m', 'ytd', '1y']);
+const RANGE_STORAGE_KEY = 'monize-reports-portfolio-value-range';
 
 function CustomTooltip({ active, payload, fmtFull }: {
   active?: boolean;
@@ -53,14 +62,40 @@ export function PortfolioValueReport() {
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [selectedAccountId, setSelectedAccountId] = useState<string>('');
   const [isLoading, setIsLoading] = useState(true);
-  const { dateRange, setDateRange, resolvedRange, isValid } = useDateRange({ defaultRange: '2y', alignment: 'month' });
+  const [intradayUnavailable, setIntradayUnavailable] = useState<{
+    skipped: string[];
+  } | null>(null);
+  // Set when 1W/1M silently fall back to daily snapshots because one or more
+  // holdings use a quote provider (MSN Money) without intraday support. We
+  // surface a small warning icon next to the title so the user understands
+  // why the chart resolution is coarser than the button label suggests.
+  const [intradayFallbackNotice, setIntradayFallbackNotice] = useState<{
+    skipped: string[];
+  } | null>(null);
+  const [persistedRange, setPersistedRange] = useLocalStorage<string>(
+    RANGE_STORAGE_KEY,
+    '2y',
+  );
+  const { dateRange, setDateRange, resolvedRange, isValid } = useDateRange({
+    defaultRange: persistedRange,
+    alignment: 'month',
+  });
+  const handleRangeChange = useCallback(
+    (next: string) => {
+      setDateRange(next);
+      setPersistedRange(next);
+    },
+    [setDateRange, setPersistedRange],
+  );
 
-  const useDaily = DAILY_RANGES.has(dateRange);
+  const isIntraday = INTRADAY_RANGES.has(dateRange);
+  const useDaily = !isIntraday && DAILY_RANGES.has(dateRange);
 
   const selectedAccount = accounts.find((a) => a.id === selectedAccountId);
   const foreignCurrency = selectedAccount?.currencyCode && selectedAccount.currencyCode !== defaultCurrency
     ? selectedAccount.currencyCode
     : null;
+  const effectiveCurrency = foreignCurrency || defaultCurrency || 'USD';
 
   const fmtVal = useCallback((value: number) => {
     if (foreignCurrency) return `${formatCurrencyCompact(value, foreignCurrency)} ${foreignCurrency}`;
@@ -77,53 +112,167 @@ export function PortfolioValueReport() {
     return formatCurrencyAxis(value);
   }, [foreignCurrency, formatCurrencyAxis]);
 
+  // Cancel-stale token so quick range/account switches can't write
+  // out-of-order results into state.
+  const loadTokenRef = useRef(0);
+
+  const formatIntradayLabel = useCallback(
+    (iso: string, range: string) => {
+      const d = new Date(iso);
+      return range === '1d' ? format(d, 'HH:mm') : format(d, 'MMM d HH:mm');
+    },
+    [],
+  );
+
   useEffect(() => {
     if (!isValid) return;
-    const loadData = async () => {
-      setIsLoading(true);
-      try {
-        const { start, end } = resolvedRange;
-        const accountIds = selectedAccountId ? [selectedAccountId] : undefined;
+    const token = ++loadTokenRef.current;
 
-        const params = {
-          startDate: start,
-          endDate: end,
-          accountIds: accountIds?.join(','),
-          displayCurrency: foreignCurrency || undefined,
-        };
+    const accountIds = selectedAccountId ? [selectedAccountId] : undefined;
+    const accountIdsCsv = accountIds?.join(',');
 
-        const [investmentResult, portfolioResult, accountsResult] = await Promise.all([
-          useDaily
-            ? netWorthApi.getInvestmentsDaily(params)
-            : netWorthApi.getInvestmentsMonthly(params),
-          investmentsApi.getPortfolioSummary(accountIds),
-          investmentsApi.getInvestmentAccounts(),
-        ]);
-
-        if (useDaily) {
-          const dailyData = investmentResult as Array<{ date: string; value: number }>;
-          setChartPoints(dailyData.map((d) => ({
+    const loadDailyOrMonthly = async () => {
+      const { start, end } = resolvedRange;
+      const params = {
+        startDate: start,
+        endDate: end,
+        accountIds: accountIdsCsv,
+        displayCurrency: foreignCurrency || undefined,
+      };
+      if (useDaily || isIntraday) {
+        const data = await netWorthApi.getInvestmentsDaily(params);
+        if (loadTokenRef.current !== token) return;
+        setChartPoints(
+          data.map((d) => ({
             name: format(parseLocalDate(d.date), 'MMM d, yyyy'),
             Value: d.value,
-          })));
-        } else {
-          const monthlyData = investmentResult as Array<{ month: string; value: number }>;
-          setChartPoints(monthlyData.map((d) => ({
+          })),
+        );
+      } else {
+        const data = await netWorthApi.getInvestmentsMonthly(params);
+        if (loadTokenRef.current !== token) return;
+        setChartPoints(
+          data.map((d) => ({
             name: format(parseLocalDate(d.month), 'MMM yyyy'),
             Value: d.value,
-          })));
+          })),
+        );
+      }
+    };
+
+    const loadData = async () => {
+      setIsLoading(true);
+      setIntradayUnavailable(null);
+      setIntradayFallbackNotice(null);
+
+      try {
+        // Portfolio summary + accounts list always load in parallel — they
+        // drive the breakdown table and the account picker regardless of
+        // which chart endpoint we hit. Swallow rejections here so a chart
+        // fetch failure below doesn't leave this dangling as an unhandled
+        // promise rejection (the outer catch logs the chart error).
+        const summaryAndAccounts = Promise.all([
+          investmentsApi.getPortfolioSummary(accountIds),
+          investmentsApi.getInvestmentAccounts(),
+        ]).catch((error) => {
+          logger.error('Failed to load portfolio summary/accounts:', error);
+          return null;
+        });
+
+        if (isIntraday) {
+          const cacheKey = buildIntradayCacheKey(
+            dateRange,
+            accountIds,
+            effectiveCurrency,
+          );
+          const cached = readIntradayCache(cacheKey);
+          if (cached && !cached.fallbackToDaily) {
+            setChartPoints(
+              cached.points.map((p) => ({
+                name: formatIntradayLabel(p.timestamp, dateRange),
+                Value: p.value,
+              })),
+            );
+            setIsLoading(false);
+          }
+
+          let response;
+          try {
+            response = await investmentsApi.getIntradayValue({
+              range: dateRange as '1d' | '1w' | '1m',
+              accountIds: accountIdsCsv,
+              displayCurrency: foreignCurrency || undefined,
+            });
+          } catch (error) {
+            logger.error('Failed to load intraday data:', error);
+            if (loadTokenRef.current !== token) return;
+            setChartPoints([]);
+            return;
+          }
+
+          if (loadTokenRef.current !== token) return;
+
+          writeIntradayCache(cacheKey, {
+            fetchedAt: Date.now(),
+            points: response.points,
+            interval: response.interval,
+            currency: response.currency,
+            fallbackToDaily: response.fallbackToDaily,
+            skippedSymbols: response.skippedSymbols,
+          });
+
+          if (response.fallbackToDaily) {
+            if (dateRange === '1d') {
+              // No sensible daily fallback for a single-day chart.
+              setChartPoints([]);
+              setIntradayUnavailable({ skipped: response.skippedSymbols });
+            } else {
+              // 1W / 1M silently fall back to the daily endpoint, with a
+              // small warning icon next to the title so the user knows
+              // intraday detail isn't available for this account mix.
+              setIntradayFallbackNotice({ skipped: response.skippedSymbols });
+              await loadDailyOrMonthly();
+            }
+          } else {
+            setChartPoints(
+              response.points.map((p) => ({
+                name: formatIntradayLabel(p.timestamp, dateRange),
+                Value: p.value,
+              })),
+            );
+          }
+        } else {
+          await loadDailyOrMonthly();
         }
 
-        setPortfolio(portfolioResult);
-        setAccounts(accountsResult);
+        const summaryAndAccountsResult = await summaryAndAccounts;
+        if (loadTokenRef.current !== token) return;
+        if (summaryAndAccountsResult) {
+          const [portfolioResult, accountsResult] = summaryAndAccountsResult;
+          setPortfolio(portfolioResult);
+          setAccounts(accountsResult);
+        }
       } catch (error) {
         logger.error('Failed to load portfolio data:', error);
       } finally {
-        setIsLoading(false);
+        if (loadTokenRef.current === token) {
+          setIsLoading(false);
+        }
       }
     };
+
     loadData();
-  }, [selectedAccountId, resolvedRange, isValid, foreignCurrency, useDaily]);
+  }, [
+    selectedAccountId,
+    resolvedRange,
+    isValid,
+    foreignCurrency,
+    effectiveCurrency,
+    useDaily,
+    isIntraday,
+    dateRange,
+    formatIntradayLabel,
+  ]);
 
   const summary = useMemo(() => {
     if (chartPoints.length === 0) return { current: 0, initial: 0, change: 0, changePercent: 0, high: 0, low: 0 };
@@ -139,33 +288,19 @@ export function PortfolioValueReport() {
 
   const xAxisTicks = useMemo(() => {
     if (chartPoints.length <= 36) return undefined;
-    if (useDaily) {
+    if (isIntraday || useDaily) {
       const step = Math.ceil(chartPoints.length / 7);
-      return chartPoints.filter((_, i) => i % step === 0).map(d => d.name);
+      return chartPoints.filter((_, i) => i % step === 0).map((d) => d.name);
     }
     return chartPoints
       .filter((d) => d.name.startsWith('Jan '))
       .map((d) => d.name);
-  }, [chartPoints, useDaily]);
+  }, [chartPoints, isIntraday, useDaily]);
 
-  const yAxisDomain = useMemo(() => {
-    if (chartPoints.length === 0) return [0, 'auto'] as [number, 'auto'];
-
-    const values = chartPoints.map((d) => d.Value);
-    const minValue = Math.min(...values);
-    const maxValue = Math.max(...values);
-    const range = maxValue - minValue;
-
-    if (minValue > 0 && minValue > range * 0.2) {
-      const padding = range * 0.1;
-      const rawMin = minValue - padding;
-      const magnitude = Math.pow(10, Math.floor(Math.log10(Math.abs(rawMin))));
-      const niceMin = Math.floor(rawMin / magnitude) * magnitude;
-      return [niceMin, 'auto'] as [number, 'auto'];
-    }
-
-    return [Math.min(0, minValue), 'auto'] as [number, 'auto'];
-  }, [chartPoints]);
+  const yAxisDomain = useMemo(
+    () => computeTightYAxisDomain(chartPoints.map((d) => d.Value)),
+    [chartPoints],
+  );
 
   const handleExportPdf = async () => {
     const { exportToPdf } = await import('@/lib/pdf-export');
@@ -198,7 +333,10 @@ export function PortfolioValueReport() {
     });
   };
 
-  if (isLoading) {
+  // Only show the full-card skeleton on the very first paint. Subsequent
+  // range/account changes keep the existing chart on screen so Recharts can
+  // animate into the new data instead of unmounting and re-drawing.
+  if (isLoading && chartPoints.length === 0 && !intradayUnavailable) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
         <div className="animate-pulse space-y-4">
@@ -261,9 +399,9 @@ export function PortfolioValueReport() {
                 ))}
             </select>
             <DateRangeSelector
-              ranges={['1w', '1m', '3m', 'ytd', '1y', '2y', '5y', 'all']}
+              ranges={['1d', '1w', '1m', '3m', 'ytd', '1y', '2y', '5y', 'all']}
               value={dateRange}
-              onChange={setDateRange}
+              onChange={handleRangeChange}
               activeColour="bg-emerald-600"
             />
           </div>
@@ -273,15 +411,77 @@ export function PortfolioValueReport() {
 
       {/* Chart */}
       <div ref={chartRef} className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 px-2 py-4 sm:p-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4 flex items-center gap-1.5">
           Portfolio Value Over Time
+          {/* Background-load indicator: chart stays on screen during a
+              refetch so Recharts can animate into the new data, but a
+              portfolio with many securities can take a few seconds. */}
+          {isLoading && chartPoints.length > 0 && (
+            <span
+              className="inline-flex items-center gap-1.5 ml-2 text-xs font-normal text-gray-500 dark:text-gray-400"
+              role="status"
+              aria-live="polite"
+              data-testid="report-chart-loading-indicator"
+            >
+              <svg
+                className="animate-spin h-3.5 w-3.5"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+              Updating…
+            </span>
+          )}
+          {intradayFallbackNotice && (
+            <span
+              role="img"
+              aria-label="Detailed intraday pricing unavailable"
+              title={`Detailed intraday pricing isn't available because ${intradayFallbackNotice.skipped.length > 0 ? intradayFallbackNotice.skipped.join(', ') : 'one or more holdings'} use MSN Money, which doesn't expose intraday quotes. Showing daily snapshots instead.`}
+              className="inline-flex text-amber-500 dark:text-amber-400 cursor-help"
+              data-testid="report-intraday-fallback-warning"
+            >
+              <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path
+                  fillRule="evenodd"
+                  d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.515 2.625H3.72c-1.345 0-2.188-1.458-1.515-2.625L8.485 2.495zM10 6a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 6zm0 9a1 1 0 100-2 1 1 0 000 2z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </span>
+          )}
         </h3>
-        {chartPoints.length === 0 ? (
+        {intradayUnavailable ? (
+          <div className="text-center py-12 px-4">
+            <p className="text-sm text-gray-700 dark:text-gray-200 font-medium mb-1">
+              Intraday view unavailable for this account mix
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              One or more holdings use a quote provider (MSN Money) that does
+              not expose intraday data
+              {intradayUnavailable.skipped.length > 0
+                ? `: ${intradayUnavailable.skipped.join(', ')}`
+                : ''}
+              . Switch to a longer range to see daily snapshots.
+            </p>
+          </div>
+        ) : chartPoints.length === 0 ? (
           <p className="text-gray-500 dark:text-gray-400 text-center py-8">
             No investment data for this period.
           </p>
         ) : (
-          <div className="h-80">
+          <div
+            className={`h-80 transition-opacity duration-200 ${
+              isLoading ? 'opacity-60' : 'opacity-100'
+            }`}
+          >
             <ResponsiveContainer width="100%" height="100%" minWidth={0}>
               <AreaChart data={chartPoints} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
                 <defs>
@@ -296,6 +496,9 @@ export function PortfolioValueReport() {
                   tick={{ fontSize: 12 }}
                   {...(xAxisTicks ? { ticks: xAxisTicks } : {})}
                   tickFormatter={(value: string) => {
+                    if (isIntraday) {
+                      return value;
+                    }
                     if (useDaily) {
                       const parts = value.split(', ');
                       return parts[0] || value;

--- a/frontend/src/components/securities/SecurityForm.tsx
+++ b/frontend/src/components/securities/SecurityForm.tsx
@@ -222,7 +222,10 @@ export function SecurityForm({ security, onSubmit, onCancel, onDirtyChange, subm
       securityType: data.securityType || undefined,
       exchange: data.exchange?.trim() || undefined,
       currencyCode: data.currencyCode,
-      quoteProvider: data.quoteProvider === '' ? undefined : data.quoteProvider,
+      // Send null (not undefined) when the user picks "Use Default" so the
+      // backend clears any existing override. Undefined would be stripped by
+      // axios and treated as "no change", leaving the previous override in place.
+      quoteProvider: data.quoteProvider === '' ? null : data.quoteProvider,
       msnInstrumentId: data.msnInstrumentId?.trim() || undefined,
     };
     await onSubmit(cleanedData);

--- a/frontend/src/components/settings/PreferencesSection.tsx
+++ b/frontend/src/components/settings/PreferencesSection.tsx
@@ -218,6 +218,9 @@ export function PreferencesSection({ preferences, onPreferencesUpdated }: Prefer
           <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
             Used when a security has no provider override. If the chosen provider fails, Monize automatically tries the other.
           </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            Note: MSN Money does not provide intraday quote data, so the 1D / 1W / 1M ranges on the Portfolio Value Over Time chart are unavailable for MSN-tracked holdings.
+          </p>
           {defaultQuoteProvider === 'msn' && msnReady === false && (
             <p
               role="alert"

--- a/frontend/src/hooks/usePriceRefresh.test.ts
+++ b/frontend/src/hooks/usePriceRefresh.test.ts
@@ -97,6 +97,34 @@ describe('usePriceRefresh', () => {
     expect(toast.success).toHaveBeenCalled();
   });
 
+  it('limits refresh to scopeSecurityIds when provided', async () => {
+    vi.mocked(investmentsApi.getSecurities).mockResolvedValue([
+      sec('s-1'),
+      sec('s-2'),
+      sec('s-3'),
+    ] as any);
+    vi.mocked(investmentsApi.refreshSelectedPrices).mockResolvedValue({
+      updated: 2, failed: 0, totalSecurities: 2, skipped: 0, results: [], lastUpdated: '',
+    });
+
+    const { result } = renderHook(() => usePriceRefresh());
+    await act(async () => {
+      await result.current.triggerManualRefresh(['s-1', 's-3']);
+    });
+    expect(investmentsApi.refreshSelectedPrices).toHaveBeenCalledWith(['s-1', 's-3']);
+  });
+
+  it('shows the no-securities toast when scope filters out everything', async () => {
+    vi.mocked(investmentsApi.getSecurities).mockResolvedValue([sec('s-1')] as any);
+
+    const { result } = renderHook(() => usePriceRefresh());
+    await act(async () => {
+      await result.current.triggerManualRefresh(['s-99']);
+    });
+    expect(investmentsApi.refreshSelectedPrices).not.toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith('No securities to update');
+  });
+
   it('includes securities even when no holdings exist (newly-added securities)', async () => {
     // Regression: ATL8021 was being excluded because it wasn't in the
     // portfolio summary's holdings list. Now we send every active security.

--- a/frontend/src/hooks/usePriceRefresh.ts
+++ b/frontend/src/hooks/usePriceRefresh.ts
@@ -50,70 +50,88 @@ interface UsePriceRefreshOptions {
 
 interface UsePriceRefreshReturn {
   isRefreshing: boolean;
-  triggerManualRefresh: () => Promise<void>;
+  /**
+   * Manually refresh quote prices.
+   *
+   * @param scopeSecurityIds When provided, only securities whose ID is in
+   *   this list are refreshed (intersected with the usual eligibility
+   *   filter). The page passes the IDs of the holdings currently shown so
+   *   the Refresh button only re-fetches what the user is looking at,
+   *   instead of every active security in their catalog.
+   */
+  triggerManualRefresh: (scopeSecurityIds?: string[]) => Promise<void>;
   triggerAutoRefresh: () => void;
 }
 
 export function usePriceRefresh({ onRefreshComplete }: UsePriceRefreshOptions = {}): UsePriceRefreshReturn {
   const [isRefreshing, setIsRefreshing] = useState(false);
 
-  const doRefresh = useCallback(async (silent: boolean) => {
-    if (refreshInProgress) return;
-    refreshInProgress = true;
-    setIsRefreshing(true);
-    try {
-      // Refresh prices for every active security in the user's catalog, not
-      // just the ones they currently hold. Newly-added or temporarily-zero
-      // positions (e.g. fully-sold mutual funds) still need their price
-      // history kept current.
-      //
-      // Eligibility rule mirrors the backend's isRefreshEligible(): a
-      // security is eligible when skipPriceUpdates is false OR the user has
-      // explicitly opted in by setting a quoteProvider override or an MSN
-      // Instrument ID. The latter rescues QIF-imported securities (which are
-      // flagged skipPriceUpdates=true by default) once the user has pointed
-      // them at a provider.
-      const securities = await investmentsApi.getSecurities(false);
-      const securityIds = securities
-        .filter(
-          (s) =>
-            s.isActive &&
-            (!s.skipPriceUpdates || !!s.quoteProvider || !!s.msnInstrumentId),
-        )
-        .map((s) => s.id);
-      if (securityIds.length === 0) {
-        if (!silent) toast.success('No securities to update');
-        return;
-      }
-      const result = await investmentsApi.refreshSelectedPrices(securityIds);
-      lastRefreshTimestamp = Date.now();
-      if (!silent) {
-        if (result.failed > 0) {
-          const failedSymbols = result.results
-            .filter((r) => !r.success)
-            .map((r) => r.symbol);
-          const symbolList = failedSymbols.join(', ');
-          toast.error(
-            `Prices updated: ${result.updated} succeeded, ${result.failed} failed${symbolList ? ` (${symbolList})` : ''}`,
-            { duration: 8000 },
-          );
-        } else {
-          toast.success(`${result.updated} security price${result.updated !== 1 ? 's' : ''} updated`);
+  const doRefresh = useCallback(
+    async (silent: boolean, scopeSecurityIds?: string[]) => {
+      if (refreshInProgress) return;
+      refreshInProgress = true;
+      setIsRefreshing(true);
+      try {
+        // Refresh prices for every active security in the user's catalog
+        // unless the caller has narrowed the scope (e.g. the Investments
+        // page passes the IDs of the holdings currently visible).
+        //
+        // Eligibility rule mirrors the backend's isRefreshEligible(): a
+        // security is eligible when skipPriceUpdates is false OR the user has
+        // explicitly opted in by setting a quoteProvider override or an MSN
+        // Instrument ID. The latter rescues QIF-imported securities (which are
+        // flagged skipPriceUpdates=true by default) once the user has pointed
+        // them at a provider.
+        const securities = await investmentsApi.getSecurities(false);
+        const scopeSet = scopeSecurityIds
+          ? new Set(scopeSecurityIds)
+          : null;
+        const securityIds = securities
+          .filter(
+            (s) =>
+              s.isActive &&
+              (!s.skipPriceUpdates || !!s.quoteProvider || !!s.msnInstrumentId) &&
+              (scopeSet === null || scopeSet.has(s.id)),
+          )
+          .map((s) => s.id);
+        if (securityIds.length === 0) {
+          if (!silent) toast.success('No securities to update');
+          return;
         }
+        const result = await investmentsApi.refreshSelectedPrices(securityIds);
+        lastRefreshTimestamp = Date.now();
+        if (!silent) {
+          if (result.failed > 0) {
+            const failedSymbols = result.results
+              .filter((r) => !r.success)
+              .map((r) => r.symbol);
+            const symbolList = failedSymbols.join(', ');
+            toast.error(
+              `Prices updated: ${result.updated} succeeded, ${result.failed} failed${symbolList ? ` (${symbolList})` : ''}`,
+              { duration: 8000 },
+            );
+          } else {
+            toast.success(`${result.updated} security price${result.updated !== 1 ? 's' : ''} updated`);
+          }
+        }
+        await onRefreshComplete?.(result.lastUpdated);
+      } catch (error) {
+        logger.error('Failed to refresh prices:', error);
+        if (!silent) toast.error(getErrorMessage(error, 'Failed to refresh prices'));
+      } finally {
+        refreshInProgress = false;
+        setIsRefreshing(false);
       }
-      await onRefreshComplete?.(result.lastUpdated);
-    } catch (error) {
-      logger.error('Failed to refresh prices:', error);
-      if (!silent) toast.error(getErrorMessage(error, 'Failed to refresh prices'));
-    } finally {
-      refreshInProgress = false;
-      setIsRefreshing(false);
-    }
-  }, [onRefreshComplete]);
+    },
+    [onRefreshComplete],
+  );
 
-  const triggerManualRefresh = useCallback(async () => {
-    await doRefresh(false);
-  }, [doRefresh]);
+  const triggerManualRefresh = useCallback(
+    async (scopeSecurityIds?: string[]) => {
+      await doRefresh(false, scopeSecurityIds);
+    },
+    [doRefresh],
+  );
 
   const triggerAutoRefresh = useCallback(() => {
     if (!isMarketHours()) {

--- a/frontend/src/lib/investments.ts
+++ b/frontend/src/lib/investments.ts
@@ -53,6 +53,26 @@ export const investmentsApi = {
     return response.data;
   },
 
+  // Intraday portfolio value series (1D / 1W / 1M ranges).
+  // Bypasses apiCache; the chart caches in sessionStorage instead so a manual
+  // Refresh can selectively invalidate just the intraday entries.
+  getIntradayValue: async (params: {
+    range: '1d' | '1w' | '1m';
+    accountIds?: string;
+    displayCurrency?: string;
+  }): Promise<{
+    points: Array<{ timestamp: string; value: number }>;
+    interval: '1m' | '5m' | '15m';
+    currency: string;
+    range: '1d' | '1w' | '1m';
+    fetchedAt: string;
+    skippedSymbols: string[];
+    fallbackToDaily: boolean;
+  }> => {
+    const response = await apiClient.get('/portfolio/intraday-value', { params });
+    return response.data;
+  },
+
   // Get top movers (daily price changes)
   getTopMovers: async (): Promise<TopMover[]> => {
     const cacheKey = 'investments:topMovers';

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -202,7 +202,7 @@ export interface CreateSecurityData {
   securityType?: string;
   exchange?: string;
   currencyCode: string;
-  quoteProvider?: QuoteProviderName;
+  quoteProvider?: QuoteProviderName | null;
   msnInstrumentId?: string;
 }
 


### PR DESCRIPTION
## Summary
This PR adds intraday (minute/hour-level) portfolio value charting for short-term ranges (1 day, 1 week, 1 month) while gracefully falling back to daily snapshots when holdings use quote providers without intraday support (e.g., MSN Money).

## Key Changes

### Backend
- **New intraday endpoint** (`GET /portfolio/intraday-value`): Fetches live minute/hour bars from Yahoo Finance for each security, aligns them on a unified time grid, and converts to the user's display currency
- **Intraday caching**: 60-second in-memory cache keyed by `userId|range|accountIds|currency` to absorb double-clicks and frontend refresh requests
- **Fallback detection**: When any holding's provider lacks intraday support, the endpoint signals `fallbackToDaily=true` so the frontend can switch to daily snapshots
- **Quote provider integration**: Uses `QuoteProviderRegistry` to determine which holdings support intraday data; aggregates quantities across multiple holdings of the same security
- **New DTO**: `IntradayValueQueryDto` and `IntradayValueResponse` for type-safe request/response handling

### Frontend
- **Intraday chart support**: `InvestmentValueChart` and `PortfolioValueReport` now support `1d`, `1w`, and `1m` ranges with intraday bars
- **SessionStorage caching**: Intraday responses cached per-tab in `sessionStorage` with utilities in `portfolio-chart-utils.ts` for cache management
- **Range persistence**: User's selected range is persisted to `localStorage` so it survives page reloads
- **Fallback handling**: When `fallbackToDaily=true`, the chart silently switches to the daily endpoint for `1w`/`1m`; for `1d`, shows an unavailable notice with affected symbols
- **Y-axis optimization**: `computeTightYAxisDomain()` provides tight zoom bounds so small intraday moves remain visible
- **Refresh integration**: Page-level Refresh button broadcasts `INVESTMENT_CHART_REFRESH_EVENT` to clear intraday cache and re-fetch
- **Scoped refresh**: `usePriceRefresh` now accepts optional `scopeSecurityIds` to limit refreshes to currently-visible holdings

### UI/UX
- Added `1d` to the range selector (now: `1d`, `1w`, `1m`, `3m`, `ytd`, `1y`, `2y`, `5y`, `all`)
- Warning icon next to chart title when `1w`/`1m` fall back to daily due to mixed providers
- Unavailable notice on `1d` when intraday data cannot be fetched for the current holdings mix

## Implementation Details
- **Load token pattern**: Both charts use `loadTokenRef` to cancel stale results if the user clicks ranges quickly
- **Parallel loading**: Portfolio summary and accounts list load in parallel with chart data; swallowed rejections prevent unhandled promise rejections
- **Currency handling**: Intraday bars are converted to display currency using the same exchange rate service as daily snapshots
- **GBX handling**: Yahoo Finance service converts GBX (pence) prices to GBP automatically
- **Forward-fill**: Null closes in intraday bars are forward-filled so multi-security alignment works correctly

https://claude.ai/code/session_01KhzDnPmVSys9ZEADVEAiE9