### PR TITLE
Clean up unused test spy variables and parameters

### DIFF
--- a/frontend/src/app/securities/page.test.tsx
+++ b/frontend/src/app/securities/page.test.tsx
@@ -11,7 +11,7 @@ vi.mock('next/image', () => ({
 
 // Mock next/dynamic to return a stub that exposes the loaded component name
 vi.mock('next/dynamic', () => ({
-  default: (loader: any) => {
+  default: (_loader: any) => {
     // Return a generic component depending on what was loaded
     const Stub = (props: any) => {
       // Detect via props which dynamic component this is (PriceHistory takes 'security' prop and 'onClose')

--- a/frontend/src/lib/accounts.test.ts
+++ b/frontend/src/lib/accounts.test.ts
@@ -159,7 +159,6 @@ describe('accountsApi', () => {
     let createObjectURL: any;
     let revokeObjectURL: any;
     let appendChildSpy: any;
-    let removeChildSpy: any;
     let clickSpy: any;
 
     beforeEach(() => {
@@ -183,9 +182,7 @@ describe('accountsApi', () => {
           }
           return node;
         });
-      removeChildSpy = vi
-        .spyOn(document.body, 'removeChild')
-        .mockImplementation((node: any) => node);
+      vi.spyOn(document.body, 'removeChild').mockImplementation((node: any) => node);
     });
 
     it('downloads CSV with default filename when no Content-Disposition', async () => {

--- a/frontend/src/lib/csv-export.test.ts
+++ b/frontend/src/lib/csv-export.test.ts
@@ -4,10 +4,7 @@ import { exportToCsv } from './csv-export';
 describe('exportToCsv', () => {
   let createObjectURL: any;
   let revokeObjectURL: any;
-  let appendChild: any;
-  let removeChild: any;
   let clickSpy: any;
-  let createElementSpy: any;
   let lastLink: HTMLAnchorElement | null;
 
   beforeEach(() => {
@@ -17,7 +14,8 @@ describe('exportToCsv', () => {
     Object.defineProperty(URL, 'createObjectURL', { value: createObjectURL, writable: true });
     Object.defineProperty(URL, 'revokeObjectURL', { value: revokeObjectURL, writable: true });
 
-    appendChild = vi.spyOn(document.body, 'appendChild').mockImplementation((node: any) => {
+    clickSpy = vi.fn();
+    vi.spyOn(document.body, 'appendChild').mockImplementation((node: any) => {
       lastLink = node;
       // Override click on the anchor element to capture downloads without
       // triggering a real navigation in jsdom.
@@ -26,9 +24,7 @@ describe('exportToCsv', () => {
       }
       return node;
     });
-    removeChild = vi.spyOn(document.body, 'removeChild').mockImplementation((node: any) => node);
-    clickSpy = vi.fn();
-    createElementSpy = vi.fn();
+    vi.spyOn(document.body, 'removeChild').mockImplementation((node: any) => node);
   });
 
   it('creates a csv blob with given headers and rows and triggers download', () => {


### PR DESCRIPTION
## Summary
This PR removes unused test spy variables and parameters across multiple test files to improve code clarity and reduce maintenance burden.

## Key Changes
- **csv-export.test.ts**: Removed unused spy variable assignments (`appendChild`, `removeChild`, `createElementSpy`) that were created but never referenced in assertions
- **accounts.test.ts**: Removed unused `removeChildSpy` variable that was assigned but never used
- **securities/page.test.tsx**: Renamed unused `loader` parameter to `_loader` to explicitly mark it as intentionally unused

## Implementation Details
These changes follow the principle of keeping test code clean by removing variables that don't contribute to test assertions. The spy functions are still being created and mocked (which is necessary for the code under test to function), but we no longer store references to them when they're not needed for verification. The underscore prefix convention in the securities test makes it clear to future maintainers that the parameter is intentionally unused.

https://claude.ai/code/session_015YYtxjGoPJ4dudHurtaWiW