### PR TITLE
Add intraday chart fallback chain and cash balance inclusion

### DIFF
--- a/backend/src/securities/dto/intraday-value.dto.ts
+++ b/backend/src/securities/dto/intraday-value.dto.ts
@@ -36,7 +36,7 @@ export interface IntradayValuePoint {
 
 export interface IntradayValueResponse {
   points: IntradayValuePoint[];
-  interval: "1m" | "5m" | "15m";
+  interval: "1m" | "2m" | "5m" | "15m" | "30m" | "60m" | "90m";
   currency: string;
   /** Range that was actually returned (echoes the request). */
   range: IntradayRangeKey;

--- a/backend/src/securities/dto/intraday-value.dto.ts
+++ b/backend/src/securities/dto/intraday-value.dto.ts
@@ -48,11 +48,18 @@ export interface IntradayValueResponse {
    */
   skippedSymbols: string[];
   /**
-   * True when at least one holding's quote provider has no intraday support
-   * AND the requested range has a sensible daily-resolution fallback (1W/1M).
-   * The frontend should call the existing daily-snapshot endpoint instead of
-   * rendering this (partial) intraday series. 1D has no daily fallback so
-   * this stays false even when securities are skipped.
+   * Symbols whose intraday fetch failed at the provider level (network error,
+   * empty/invalid response, etc.) even though the provider does support
+   * intraday in principle. Distinguished from skippedSymbols so the frontend
+   * can show a distinct error message.
+   */
+  failedSymbols: string[];
+  /**
+   * True when the frontend must not render this intraday series and should
+   * instead use the daily-snapshot endpoint. Set when:
+   *   - any holding's quote provider has no intraday support (skippedSymbols),
+   *   - or any holding's intraday fetch failed (failedSymbols).
+   * In either case the points array is empty.
    */
   fallbackToDaily: boolean;
 }

--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -2837,9 +2837,11 @@ describe("PortfolioService", () => {
       expect(result.points[0].value).toBeCloseTo(3400, 4);
     });
 
-    it("silently falls back from 1m to 5m on 1D when the 1m endpoint is spotty", async () => {
-      // Yahoo's 1m endpoint is noticeably less reliable than 5m for some
-      // securities. When 1m returns no bars, retry at 5m before giving up.
+    it("walks the 1D fallback chain (1m -> 2m -> 5m...) until one interval works", async () => {
+      // Yahoo's narrow intervals are the most rate-limited and most likely
+      // to return empty responses. When a holding fails at the primary
+      // interval, retry at progressively coarser intervals before giving
+      // up on intraday entirely.
       accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
       holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
 
@@ -2850,7 +2852,7 @@ describe("PortfolioService", () => {
           _exchange: string | null,
           opts: { interval: string },
         ) => {
-          if (opts.interval === "1m") return null;
+          // 1m and 2m fail; 5m succeeds.
           if (opts.interval === "5m") return [{ timestamp: ts, close: 100 }];
           return null;
         },
@@ -2864,12 +2866,44 @@ describe("PortfolioService", () => {
       expect(result.fallbackToDaily).toBe(false);
       expect(result.failedSymbols).toEqual([]);
       expect(result.points).toHaveLength(1);
-      // The 5m bar still gets aggregated normally: 10 * 100 * 1.4 = 1400.
       expect(result.points[0].value).toBeCloseTo(1400, 4);
-      // Verify both intervals were tried in order.
+      // Intervals are tried in order until one yields data.
       const calls = yahooFinanceService.fetchIntradaySeries.mock.calls;
       expect(calls[0][2].interval).toBe("1m");
-      expect(calls[1][2].interval).toBe("5m");
+      expect(calls[1][2].interval).toBe("2m");
+      expect(calls[2][2].interval).toBe("5m");
+      // Stops once a non-empty response comes back.
+      expect(calls.length).toBe(3);
+    });
+
+    it("walks the 1W chain starting at 5m (not 1m, not 2m)", async () => {
+      accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+      holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
+
+      yahooFinanceService.fetchIntradaySeries.mockResolvedValue([
+        { timestamp: new Date("2026-05-06T13:30:00.000Z"), close: 100 },
+      ]);
+      exchangeRateService.getLatestRate.mockResolvedValue(1.4);
+
+      await service.getIntradayValueSeries(userId, { range: "1w" });
+
+      const calls = yahooFinanceService.fetchIntradaySeries.mock.calls;
+      expect(calls[0][2].interval).toBe("5m");
+    });
+
+    it("walks the 1M chain starting at 15m (not 1m, not 5m)", async () => {
+      accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+      holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
+
+      yahooFinanceService.fetchIntradaySeries.mockResolvedValue([
+        { timestamp: new Date("2026-05-06T13:30:00.000Z"), close: 100 },
+      ]);
+      exchangeRateService.getLatestRate.mockResolvedValue(1.4);
+
+      await service.getIntradayValueSeries(userId, { range: "1m" });
+
+      const calls = yahooFinanceService.fetchIntradaySeries.mock.calls;
+      expect(calls[0][2].interval).toBe("15m");
     });
 
     it("uses each failed holding's latest known close as a constant offset", async () => {
@@ -2936,15 +2970,12 @@ describe("PortfolioService", () => {
       accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
       holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
 
-      // Fail both interval candidates (1m + 5m) on the first call so the
-      // request triggers the all-failed fallbackToDaily path. Then succeed
-      // on the next call to prove the cache wasn't holding the failure.
-      yahooFinanceService.fetchIntradaySeries
-        .mockRejectedValueOnce(new Error("yahoo 500"))
-        .mockRejectedValueOnce(new Error("yahoo 500"))
-        .mockResolvedValueOnce([
-          { timestamp: new Date("2026-05-06T13:30:00.000Z"), close: 100 },
-        ]);
+      // Fail every interval in the 1D fallback chain on the first call so
+      // we trigger the all-failed fallbackToDaily path. Then succeed on the
+      // next call to prove the cache wasn't holding the failure.
+      yahooFinanceService.fetchIntradaySeries.mockRejectedValue(
+        new Error("yahoo 500"),
+      );
       exchangeRateService.getLatestRate.mockResolvedValue(1.4);
 
       const first = await service.getIntradayValueSeries(userId, {
@@ -2952,14 +2983,22 @@ describe("PortfolioService", () => {
       });
       expect(first.fallbackToDaily).toBe(true);
       expect(first.failedSymbols).toEqual(["AAPL"]);
+      const callsAfterFirst =
+        yahooFinanceService.fetchIntradaySeries.mock.calls.length;
+      expect(callsAfterFirst).toBeGreaterThan(0);
+
+      yahooFinanceService.fetchIntradaySeries.mockReset();
+      yahooFinanceService.fetchIntradaySeries.mockResolvedValue([
+        { timestamp: new Date("2026-05-06T13:30:00.000Z"), close: 100 },
+      ]);
 
       const second = await service.getIntradayValueSeries(userId, {
         range: "1d",
       });
       expect(second.fallbackToDaily).toBe(false);
       expect(second.points).toHaveLength(1);
-      // 2 (failed primary + fallback on first call) + 1 (success on second).
-      expect(yahooFinanceService.fetchIntradaySeries).toHaveBeenCalledTimes(3);
+      // The retry actually hit Yahoo again (cache wasn't serving the failure).
+      expect(yahooFinanceService.fetchIntradaySeries).toHaveBeenCalled();
     });
 
     it("does not surface failedSymbols on partial failures (fallback price covers it)", async () => {

--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -2824,6 +2824,34 @@ describe("PortfolioService", () => {
       expect(result.points).toEqual([]);
     });
 
+    it("does not cache the failure payload so a retry actually retries", async () => {
+      // Caching the failure for the usual 60s would leave the
+      // "Couldn't load intraday prices" banner stuck on screen even after
+      // the user clicks Refresh and the upstream blip resolves.
+      accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+      holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
+
+      yahooFinanceService.fetchIntradaySeries
+        .mockRejectedValueOnce(new Error("yahoo 500"))
+        .mockResolvedValueOnce([
+          { timestamp: new Date("2026-05-06T13:30:00.000Z"), close: 100 },
+        ]);
+      exchangeRateService.getLatestRate.mockResolvedValue(1.4);
+
+      const first = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+      expect(first.fallbackToDaily).toBe(true);
+      expect(first.failedSymbols).toEqual(["AAPL"]);
+
+      const second = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+      expect(second.fallbackToDaily).toBe(false);
+      expect(second.points).toHaveLength(1);
+      expect(yahooFinanceService.fetchIntradaySeries).toHaveBeenCalledTimes(2);
+    });
+
     it("returns fallbackToDaily=true with failedSymbols when a fetch returns no bars", async () => {
       accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
       holdingsRepository.find.mockResolvedValue([

--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -2631,10 +2631,10 @@ describe("PortfolioService", () => {
       expect(result.points).toHaveLength(2);
       expect(result.interval).toBe("1m");
       expect(result.currency).toBe("CAD");
-      // ts1: 10 * 100 * 1.4 + 50 * 80 = 1400 + 4000 = 5400
-      expect(result.points[0].value).toBeCloseTo(5400, 4);
-      // ts2: 10 * 110 * 1.4 + 50 * 81 = 1540 + 4050 = 5590
-      expect(result.points[1].value).toBeCloseTo(5590, 4);
+      // ts1: 10 * 100 * 1.4 + 50 * 80 + 5000 cash = 1400 + 4000 + 5000 = 10400
+      expect(result.points[0].value).toBeCloseTo(10400, 4);
+      // ts2: 10 * 110 * 1.4 + 50 * 81 + 5000 cash = 1540 + 4050 + 5000 = 10590
+      expect(result.points[1].value).toBeCloseTo(10590, 4);
     });
 
     it("caches results for 60 seconds keyed by user/range/accounts/currency", async () => {
@@ -2787,9 +2787,54 @@ describe("PortfolioService", () => {
         range: "1d",
       });
 
-      // ts2 should still include AAPL at its last known price (100).
+      // ts2 should still include AAPL at its last known price (100). No
+      // cash account is in scope here so cash contributes 0.
       expect(result.points).toHaveLength(2);
       expect(result.points[1].value).toBeCloseTo(10 * 100 * 1.4 + 50 * 90, 4);
+    });
+
+    it("adds the cash balance of the investment cash account to every point", async () => {
+      // Repro for the bug where the 1D/1W/1M intraday chart undershot the
+      // daily-snapshot chart because the cash sleeve wasn't included.
+      accountsRepository.find.mockResolvedValue([
+        mockBrokerageAccount,
+        mockCashAccount, // currentBalance: 5000 CAD
+      ]);
+      holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
+
+      const ts = new Date("2026-05-06T13:30:00.000Z");
+      yahooFinanceService.fetchIntradaySeries.mockResolvedValue([
+        { timestamp: ts, close: 100 },
+      ]);
+      exchangeRateService.getLatestRate.mockResolvedValue(1.4);
+
+      const result = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+
+      // 10 * 100 * 1.4 (USD->CAD) + 5000 cash = 1400 + 5000 = 6400.
+      expect(result.points).toHaveLength(1);
+      expect(result.points[0].value).toBeCloseTo(6400, 4);
+    });
+
+    it("includes standalone-account cash balances in every point", async () => {
+      accountsRepository.find.mockResolvedValue([mockStandaloneAccount]);
+      holdingsRepository.find.mockResolvedValue([
+        { ...mockHoldingAAPL, accountId: "acct-standalone-1" } as any,
+      ]);
+
+      const ts = new Date("2026-05-06T13:30:00.000Z");
+      yahooFinanceService.fetchIntradaySeries.mockResolvedValue([
+        { timestamp: ts, close: 100 },
+      ]);
+      exchangeRateService.getLatestRate.mockResolvedValue(1.4);
+
+      const result = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+
+      // 10 * 100 * 1.4 + 2000 standalone cash = 1400 + 2000 = 3400.
+      expect(result.points[0].value).toBeCloseTo(3400, 4);
     });
 
     it("returns fallbackToDaily=true with failedSymbols when any intraday fetch fails", async () => {

--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -2837,6 +2837,41 @@ describe("PortfolioService", () => {
       expect(result.points[0].value).toBeCloseTo(3400, 4);
     });
 
+    it("silently falls back from 1m to 5m on 1D when the 1m endpoint is spotty", async () => {
+      // Yahoo's 1m endpoint is noticeably less reliable than 5m for some
+      // securities. When 1m returns no bars, retry at 5m before giving up.
+      accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+      holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
+
+      const ts = new Date("2026-05-06T13:30:00.000Z");
+      yahooFinanceService.fetchIntradaySeries.mockImplementation(
+        async (
+          _symbol: string,
+          _exchange: string | null,
+          opts: { interval: string },
+        ) => {
+          if (opts.interval === "1m") return null;
+          if (opts.interval === "5m") return [{ timestamp: ts, close: 100 }];
+          return null;
+        },
+      );
+      exchangeRateService.getLatestRate.mockResolvedValue(1.4);
+
+      const result = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+
+      expect(result.fallbackToDaily).toBe(false);
+      expect(result.failedSymbols).toEqual([]);
+      expect(result.points).toHaveLength(1);
+      // The 5m bar still gets aggregated normally: 10 * 100 * 1.4 = 1400.
+      expect(result.points[0].value).toBeCloseTo(1400, 4);
+      // Verify both intervals were tried in order.
+      const calls = yahooFinanceService.fetchIntradaySeries.mock.calls;
+      expect(calls[0][2].interval).toBe("1m");
+      expect(calls[1][2].interval).toBe("5m");
+    });
+
     it("uses each failed holding's latest known close as a constant offset", async () => {
       // When some intraday fetches fail (Yahoo errored, was rate-limited
       // past retry, or simply has no minute-resolution data for the
@@ -2901,7 +2936,11 @@ describe("PortfolioService", () => {
       accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
       holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
 
+      // Fail both interval candidates (1m + 5m) on the first call so the
+      // request triggers the all-failed fallbackToDaily path. Then succeed
+      // on the next call to prove the cache wasn't holding the failure.
       yahooFinanceService.fetchIntradaySeries
+        .mockRejectedValueOnce(new Error("yahoo 500"))
         .mockRejectedValueOnce(new Error("yahoo 500"))
         .mockResolvedValueOnce([
           { timestamp: new Date("2026-05-06T13:30:00.000Z"), close: 100 },
@@ -2919,7 +2958,8 @@ describe("PortfolioService", () => {
       });
       expect(second.fallbackToDaily).toBe(false);
       expect(second.points).toHaveLength(1);
-      expect(yahooFinanceService.fetchIntradaySeries).toHaveBeenCalledTimes(2);
+      // 2 (failed primary + fallback on first call) + 1 (success on second).
+      expect(yahooFinanceService.fetchIntradaySeries).toHaveBeenCalledTimes(3);
     });
 
     it("does not surface failedSymbols on partial failures (fallback price covers it)", async () => {

--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -2791,5 +2791,64 @@ describe("PortfolioService", () => {
       expect(result.points).toHaveLength(2);
       expect(result.points[1].value).toBeCloseTo(10 * 100 * 1.4 + 50 * 90, 4);
     });
+
+    it("returns fallbackToDaily=true with failedSymbols when any intraday fetch fails", async () => {
+      // Repro: when one holding's intraday fetch threw and another's
+      // succeeded, the aggregate quietly omitted the failing holding's
+      // contribution -- producing a 1D total much lower than the 1W total
+      // that uses daily snapshots. Now we bail out and let the frontend
+      // fall back to daily for the whole series.
+      accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+      holdingsRepository.find.mockResolvedValue([
+        mockHoldingAAPL,
+        mockHoldingVFV,
+      ]);
+
+      yahooFinanceService.fetchIntradaySeries.mockImplementation(
+        async (symbol: string) => {
+          if (symbol === "AAPL") {
+            return [
+              { timestamp: new Date("2026-05-06T13:30:00.000Z"), close: 100 },
+            ];
+          }
+          throw new Error("yahoo 500");
+        },
+      );
+
+      const result = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+
+      expect(result.fallbackToDaily).toBe(true);
+      expect(result.failedSymbols).toEqual(["VFV.TO"]);
+      expect(result.points).toEqual([]);
+    });
+
+    it("returns fallbackToDaily=true with failedSymbols when a fetch returns no bars", async () => {
+      accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+      holdingsRepository.find.mockResolvedValue([
+        mockHoldingAAPL,
+        mockHoldingVFV,
+      ]);
+
+      yahooFinanceService.fetchIntradaySeries.mockImplementation(
+        async (symbol: string) => {
+          if (symbol === "AAPL") {
+            return [
+              { timestamp: new Date("2026-05-06T13:30:00.000Z"), close: 100 },
+            ];
+          }
+          return null;
+        },
+      );
+
+      const result = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+
+      expect(result.fallbackToDaily).toBe(true);
+      expect(result.failedSymbols).toEqual(["VFV.TO"]);
+      expect(result.points).toEqual([]);
+    });
   });
 });

--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -2837,27 +2837,52 @@ describe("PortfolioService", () => {
       expect(result.points[0].value).toBeCloseTo(3400, 4);
     });
 
-    it("returns fallbackToDaily=true with failedSymbols when any intraday fetch fails", async () => {
-      // Repro: when one holding's intraday fetch threw and another's
-      // succeeded, the aggregate quietly omitted the failing holding's
-      // contribution -- producing a 1D total much lower than the 1W total
-      // that uses daily snapshots. Now we bail out and let the frontend
-      // fall back to daily for the whole series.
+    it("uses each failed holding's latest known close as a constant offset", async () => {
+      // When some intraday fetches fail (Yahoo errored, was rate-limited
+      // past retry, or simply has no minute-resolution data for the
+      // security -- common for mutual funds), keep showing intraday for
+      // the holdings that succeeded and value the failed ones at their
+      // latest daily close. Treats them like cash: a flat additive offset.
       accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
       holdingsRepository.find.mockResolvedValue([
         mockHoldingAAPL,
         mockHoldingVFV,
       ]);
 
+      const ts = new Date("2026-05-06T13:30:00.000Z");
       yahooFinanceService.fetchIntradaySeries.mockImplementation(
         async (symbol: string) => {
-          if (symbol === "AAPL") {
-            return [
-              { timestamp: new Date("2026-05-06T13:30:00.000Z"), close: 100 },
-            ];
-          }
+          if (symbol === "AAPL") return [{ timestamp: ts, close: 100 }];
           throw new Error("yahoo 500");
         },
+      );
+      // VFV's latest daily close = 80 CAD per share, 50 shares = 4000 CAD.
+      securityPriceRepository.query.mockResolvedValue([
+        { security_id: "sec-2", close_price: "80", price_date: "2026-05-05" },
+      ]);
+      exchangeRateService.getLatestRate.mockResolvedValue(1.4);
+
+      const result = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+
+      // Don't fall back -- the failure is partial and we have a fallback price.
+      expect(result.fallbackToDaily).toBe(false);
+      expect(result.failedSymbols).toEqual([]);
+      expect(result.points).toHaveLength(1);
+      // 10 * 100 * 1.4 (AAPL intraday) + 50 * 80 (VFV stale) = 5400.
+      expect(result.points[0].value).toBeCloseTo(5400, 4);
+    });
+
+    it("falls back only when EVERY intraday fetch fails", async () => {
+      accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+      holdingsRepository.find.mockResolvedValue([
+        mockHoldingAAPL,
+        mockHoldingVFV,
+      ]);
+
+      yahooFinanceService.fetchIntradaySeries.mockRejectedValue(
+        new Error("yahoo 500"),
       );
 
       const result = await service.getIntradayValueSeries(userId, {
@@ -2865,7 +2890,7 @@ describe("PortfolioService", () => {
       });
 
       expect(result.fallbackToDaily).toBe(true);
-      expect(result.failedSymbols).toEqual(["VFV.TO"]);
+      expect(result.failedSymbols.sort()).toEqual(["AAPL", "VFV.TO"]);
       expect(result.points).toEqual([]);
     });
 
@@ -2897,7 +2922,11 @@ describe("PortfolioService", () => {
       expect(yahooFinanceService.fetchIntradaySeries).toHaveBeenCalledTimes(2);
     });
 
-    it("returns fallbackToDaily=true with failedSymbols when a fetch returns no bars", async () => {
+    it("does not surface failedSymbols on partial failures (fallback price covers it)", async () => {
+      // Mutual funds and illiquid securities legitimately return no
+      // intraday bars from Yahoo. Treat that the same as a fetch failure:
+      // value the holding at its latest close instead of pinning the
+      // "Couldn't load intraday prices" banner.
       accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
       holdingsRepository.find.mockResolvedValue([
         mockHoldingAAPL,
@@ -2914,14 +2943,18 @@ describe("PortfolioService", () => {
           return null;
         },
       );
+      securityPriceRepository.query.mockResolvedValue([
+        { security_id: "sec-2", close_price: "80", price_date: "2026-05-05" },
+      ]);
+      exchangeRateService.getLatestRate.mockResolvedValue(1.4);
 
       const result = await service.getIntradayValueSeries(userId, {
         range: "1d",
       });
 
-      expect(result.fallbackToDaily).toBe(true);
-      expect(result.failedSymbols).toEqual(["VFV.TO"]);
-      expect(result.points).toEqual([]);
+      expect(result.fallbackToDaily).toBe(false);
+      expect(result.failedSymbols).toEqual([]);
+      expect(result.points).toHaveLength(1);
     });
   });
 });

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -745,7 +745,7 @@ export class PortfolioService {
     const yahooParams = RANGE_TO_YAHOO[range];
 
     const accounts = await this.resolveAccounts(userId, accountIds);
-    const { holdingsAccountIds } =
+    const { cashAccounts, standaloneAccounts, holdingsAccountIds } =
       this.calculationService.categoriseAccounts(accounts);
 
     let activeHoldings: Array<{
@@ -910,6 +910,24 @@ export class PortfolioService {
       );
     }
 
+    // Cash held in the user's investment cash and standalone accounts is
+    // part of the portfolio value just like holdings -- the daily-snapshot
+    // endpoint already includes it (see net-worth.service.getDailyInvestments)
+    // and we mirror that here so the 1D/1W/1M intraday chart agrees with
+    // longer-range views. Cash doesn't move intraday from price changes, so
+    // it's a constant additive offset across every grid point.
+    const cashAccountList = [...cashAccounts, ...standaloneAccounts];
+    const cashIds = cashAccountList.map((a) => a.id);
+    const effectiveBalances =
+      await this.calculationService.computeEffectiveBalances(cashIds);
+    const totalCashValue = await this.calculationService.computeTotalCashValue(
+      cashAccountList,
+      effectiveBalances,
+      displayCurrency,
+      rateCache,
+    );
+    const cashCents = Math.round(totalCashValue * 10000);
+
     // Build per-security ordered timestamp/close arrays and a cursor-based
     // forward-fill so each grid point uses the latest known close.
     const sources = intradayHoldings
@@ -931,7 +949,7 @@ export class PortfolioService {
     const points: IntradayValuePoint[] = [];
 
     for (const ts of timestamps) {
-      let totalCents = 0; // integer arithmetic to avoid float drift
+      let totalCents = cashCents; // integer arithmetic to avoid float drift
       for (let i = 0; i < sources.length; i++) {
         const src = sources[i];
         // Advance cursor to the latest sample at-or-before ts.

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -871,9 +871,12 @@ export class PortfolioService {
     // aggregate -- the failed holdings would silently contribute 0 and the
     // total would be materially lower than the actual portfolio value (the
     // 1D-vs-1W discrepancy users have reported). Bail out and let the
-    // frontend use the daily-snapshot endpoint instead.
+    // frontend use the daily-snapshot endpoint instead. We deliberately do
+    // NOT cache this failure payload: caching it for 60s would leave the
+    // "Couldn't load intraday prices" banner stuck on screen even after the
+    // user clicks Refresh and the underlying provider issue resolves.
     if (failedSymbols.length > 0) {
-      const payload: IntradayValueResponse = {
+      return {
         points: [],
         interval: yahooParams.interval,
         currency: displayCurrency,
@@ -883,11 +886,6 @@ export class PortfolioService {
         failedSymbols,
         fallbackToDaily: true,
       };
-      this.intradayCache.set(cacheKey, {
-        expiresAt: now + INTRADAY_CACHE_TTL_MS,
-        payload,
-      });
-      return payload;
     }
 
     // Build the unified time grid from the union of all timestamps.

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -158,18 +158,36 @@ const RANGE_TO_YAHOO: Record<
 };
 
 // Per-range fallback chain attempted (per holding, in order) when the
-// primary interval fails. Yahoo's 1m endpoint for 1D is noticeably less
-// reliable than 5m -- when a holding fails at 1m, the same security at
-// 5m typically works fine. Coarser bars are still a much better chart
-// than no chart at all, and we use them silently rather than surfacing
-// a banner.
+// primary interval fails. Yahoo's narrowest intervals are the most
+// rate-limited and most likely to return empty responses for less-liquid
+// securities; each step up the ladder is more reliable. We try
+// progressively coarser bars at the same range until one works, then
+// only after the whole ladder fails do we fall back to the security's
+// latest daily close. The user sees no banner -- the chart silently
+// degrades to slightly coarser resolution instead.
 const RANGE_FALLBACKS: Record<
   IntradayRangeKey,
   Array<{ interval: IntradayInterval; range: IntradayRange }>
 > = {
-  "1d": [{ interval: "5m", range: "1d" }],
-  "1w": [],
-  "1m": [],
+  "1d": [
+    { interval: "2m", range: "1d" },
+    { interval: "5m", range: "1d" },
+    { interval: "15m", range: "1d" },
+    { interval: "30m", range: "1d" },
+    { interval: "60m", range: "1d" },
+    { interval: "90m", range: "1d" },
+  ],
+  "1w": [
+    { interval: "15m", range: "5d" },
+    { interval: "30m", range: "5d" },
+    { interval: "60m", range: "5d" },
+    { interval: "90m", range: "5d" },
+  ],
+  "1m": [
+    { interval: "30m", range: "1mo" },
+    { interval: "60m", range: "1mo" },
+    { interval: "90m", range: "1mo" },
+  ],
 };
 
 const INTRADAY_CACHE_TTL_MS = 60_000;

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -830,6 +830,7 @@ export class PortfolioService {
         range,
         fetchedAt,
         skippedSymbols,
+        failedSymbols: [],
         fallbackToDaily,
       };
       this.intradayCache.set(cacheKey, {
@@ -841,6 +842,7 @@ export class PortfolioService {
 
     const intradayHoldings = activeHoldings.filter((h) => h.hasIntraday);
     const seriesBySecurity = new Map<string, IntradayPoint[]>();
+    const failedSymbols: string[] = [];
     await Promise.all(
       intradayHoldings.map(async (h) => {
         try {
@@ -851,6 +853,8 @@ export class PortfolioService {
           );
           if (points && points.length > 0) {
             seriesBySecurity.set(h.securityId, points);
+          } else {
+            failedSymbols.push(h.symbol);
           }
         } catch (error) {
           this.logger.warn(
@@ -858,11 +862,17 @@ export class PortfolioService {
               error instanceof Error ? error.message : String(error)
             }`,
           );
+          failedSymbols.push(h.symbol);
         }
       }),
     );
 
-    if (seriesBySecurity.size === 0) {
+    // If any holding's intraday fetch failed we cannot render an accurate
+    // aggregate -- the failed holdings would silently contribute 0 and the
+    // total would be materially lower than the actual portfolio value (the
+    // 1D-vs-1W discrepancy users have reported). Bail out and let the
+    // frontend use the daily-snapshot endpoint instead.
+    if (failedSymbols.length > 0) {
       const payload: IntradayValueResponse = {
         points: [],
         interval: yahooParams.interval,
@@ -870,7 +880,8 @@ export class PortfolioService {
         range,
         fetchedAt,
         skippedSymbols,
-        fallbackToDaily: false,
+        failedSymbols,
+        fallbackToDaily: true,
       };
       this.intradayCache.set(cacheKey, {
         expiresAt: now + INTRADAY_CACHE_TTL_MS,
@@ -939,8 +950,7 @@ export class PortfolioService {
         // unstarted series contributes 0 and the aggregate jumps up the
         // moment each one's first bar arrives — which is exactly the
         // "significant jump" the chart used to show on multi-account views.
-        const close =
-          cursors[i] < 0 ? src.closes[0] : src.closes[cursors[i]];
+        const close = cursors[i] < 0 ? src.closes[0] : src.closes[cursors[i]];
         const valueInDisplay = src.quantity * close * src.fxRate;
         totalCents += Math.round(valueInDisplay * 10000);
       }
@@ -957,6 +967,7 @@ export class PortfolioService {
       range,
       fetchedAt,
       skippedSymbols,
+      failedSymbols: [],
       fallbackToDaily: false,
     };
     this.intradayCache.set(cacheKey, {

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -867,15 +867,15 @@ export class PortfolioService {
       }),
     );
 
-    // If any holding's intraday fetch failed we cannot render an accurate
-    // aggregate -- the failed holdings would silently contribute 0 and the
-    // total would be materially lower than the actual portfolio value (the
-    // 1D-vs-1W discrepancy users have reported). Bail out and let the
-    // frontend use the daily-snapshot endpoint instead. We deliberately do
-    // NOT cache this failure payload: caching it for 60s would leave the
-    // "Couldn't load intraday prices" banner stuck on screen even after the
-    // user clicks Refresh and the underlying provider issue resolves.
-    if (failedSymbols.length > 0) {
+    // If literally every holding failed we have nothing to chart -- assume
+    // a real upstream outage and fall back to daily for the whole series.
+    // We deliberately do NOT cache this failure payload: caching it would
+    // leave the "Couldn't load intraday prices" banner pinned on screen
+    // even after the user clicks Refresh and the issue resolves.
+    if (
+      failedSymbols.length > 0 &&
+      failedSymbols.length === intradayHoldings.length
+    ) {
       return {
         points: [],
         interval: yahooParams.interval,
@@ -928,6 +928,35 @@ export class PortfolioService {
     );
     const cashCents = Math.round(totalCashValue * 10000);
 
+    // For holdings whose intraday fetch failed (Yahoo errored, was
+    // rate-limited past the retry budget, or simply has no minute-resolution
+    // data for this security -- common for mutual funds and illiquid names),
+    // fall back to the security's latest known daily close. Treat that
+    // value as a constant additive offset, the same way cash is handled.
+    // Without this, a single mutual fund in the user's portfolio would
+    // either undercount the chart (if we ignored it) or pin the
+    // "Couldn't load intraday prices" banner permanently (if we treated
+    // it as a hard failure).
+    const failedHoldings = intradayHoldings.filter(
+      (h) => !seriesBySecurity.has(h.securityId),
+    );
+    let staleHoldingsCents = 0;
+    if (failedHoldings.length > 0) {
+      const latestPrices = await this.getLatestPrices(
+        failedHoldings.map((h) => h.securityId),
+      );
+      for (const h of failedHoldings) {
+        const lastClose = latestPrices.get(h.securityId);
+        if (lastClose == null) continue;
+        const fxRate =
+          rateCache.get(`${h.currencyCode}->${displayCurrency}`) ?? 1;
+        staleHoldingsCents += Math.round(
+          h.quantity * lastClose * fxRate * 10000,
+        );
+      }
+    }
+    const constantCents = cashCents + staleHoldingsCents;
+
     // Build per-security ordered timestamp/close arrays and a cursor-based
     // forward-fill so each grid point uses the latest known close.
     const sources = intradayHoldings
@@ -949,7 +978,7 @@ export class PortfolioService {
     const points: IntradayValuePoint[] = [];
 
     for (const ts of timestamps) {
-      let totalCents = cashCents; // integer arithmetic to avoid float drift
+      let totalCents = constantCents; // integer arithmetic to avoid float drift
       for (let i = 0; i < sources.length; i++) {
         const src = sources[i];
         // Advance cursor to the latest sample at-or-before ts.

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -157,6 +157,21 @@ const RANGE_TO_YAHOO: Record<
   "1m": { interval: "15m", range: "1mo" },
 };
 
+// Per-range fallback chain attempted (per holding, in order) when the
+// primary interval fails. Yahoo's 1m endpoint for 1D is noticeably less
+// reliable than 5m -- when a holding fails at 1m, the same security at
+// 5m typically works fine. Coarser bars are still a much better chart
+// than no chart at all, and we use them silently rather than surfacing
+// a banner.
+const RANGE_FALLBACKS: Record<
+  IntradayRangeKey,
+  Array<{ interval: IntradayInterval; range: IntradayRange }>
+> = {
+  "1d": [{ interval: "5m", range: "1d" }],
+  "1w": [],
+  "1m": [],
+};
+
 const INTRADAY_CACHE_TTL_MS = 60_000;
 
 @Injectable()
@@ -843,25 +858,33 @@ export class PortfolioService {
     const intradayHoldings = activeHoldings.filter((h) => h.hasIntraday);
     const seriesBySecurity = new Map<string, IntradayPoint[]>();
     const failedSymbols: string[] = [];
+    const intervalCandidates = [yahooParams, ...RANGE_FALLBACKS[range]];
     await Promise.all(
       intradayHoldings.map(async (h) => {
-        try {
-          const points = await this.yahooFinanceService.fetchIntradaySeries(
-            h.symbol,
-            h.exchange,
-            yahooParams,
-          );
-          if (points && points.length > 0) {
-            seriesBySecurity.set(h.securityId, points);
-          } else {
-            failedSymbols.push(h.symbol);
+        // Try the primary interval first, then any range-specific
+        // fallbacks (e.g. 1m -> 5m for 1D). The first non-empty series
+        // wins; silently degrade to coarser bars rather than treating it
+        // as a failure when the primary interval is spotty.
+        let points: IntradayPoint[] | null = null;
+        for (const params of intervalCandidates) {
+          try {
+            points = await this.yahooFinanceService.fetchIntradaySeries(
+              h.symbol,
+              h.exchange,
+              params,
+            );
+            if (points && points.length > 0) break;
+          } catch (error) {
+            this.logger.warn(
+              `Failed to fetch intraday series for ${h.symbol} at ${params.interval}: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
           }
-        } catch (error) {
-          this.logger.warn(
-            `Failed to fetch intraday series for ${h.symbol}: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-          );
+        }
+        if (points && points.length > 0) {
+          seriesBySecurity.set(h.securityId, points);
+        } else {
           failedSymbols.push(h.symbol);
         }
       }),

--- a/backend/src/securities/providers/quote-provider.interface.ts
+++ b/backend/src/securities/providers/quote-provider.interface.ts
@@ -18,7 +18,14 @@ export interface QuoteResult {
   msnResolvedInstrumentId?: string;
 }
 
-export type IntradayInterval = "1m" | "5m" | "15m";
+export type IntradayInterval =
+  | "1m"
+  | "2m"
+  | "5m"
+  | "15m"
+  | "30m"
+  | "60m"
+  | "90m";
 export type IntradayRange = "1d" | "5d" | "1mo";
 
 export interface IntradayPoint {

--- a/backend/src/securities/yahoo-finance.service.spec.ts
+++ b/backend/src/securities/yahoo-finance.service.spec.ts
@@ -1491,4 +1491,151 @@ describe("YahooFinanceService", () => {
       expect(result).toBeNull();
     });
   });
+
+  describe("rate-limit handling (throttledFetch)", () => {
+    // Make backoff effectively zero so the retry path runs synchronously
+    // for tests; the real values are unit-tested elsewhere.
+    beforeEach(() => {
+      (YahooFinanceService as any).RETRY_INITIAL_DELAY_MS = 0;
+      (YahooFinanceService as any).INTER_REQUEST_GAP_MS = 0;
+    });
+
+    const okIntradayResponse = () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      text: () => Promise.resolve(""),
+      json: () =>
+        Promise.resolve({
+          chart: {
+            result: [
+              {
+                meta: { currency: "USD" },
+                timestamp: [1],
+                indicators: { quote: [{ close: [100] }] },
+              },
+            ],
+          },
+        }),
+    });
+
+    const throttledResponse = (status: number) => ({
+      ok: false,
+      status,
+      headers: new Headers(),
+      text: () => Promise.resolve(""),
+      json: () => Promise.resolve({}),
+    });
+
+    it("retries on a 429 response and succeeds on the next attempt", async () => {
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValueOnce(throttledResponse(429))
+        .mockResolvedValueOnce(okIntradayResponse());
+      global.fetch = fetchMock as any;
+
+      const result = await service.fetchIntradaySeries("AAPL.TO", null, {
+        interval: "1m",
+        range: "1d",
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result).toHaveLength(1);
+      expect(result![0].close).toBe(100);
+    });
+
+    it("retries on a 503 response and succeeds on the next attempt", async () => {
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValueOnce(throttledResponse(503))
+        .mockResolvedValueOnce(okIntradayResponse());
+      global.fetch = fetchMock as any;
+
+      const result = await service.fetchIntradaySeries("AAPL.TO", null, {
+        interval: "1m",
+        range: "1d",
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result).toHaveLength(1);
+    });
+
+    it("gives up after the configured retry budget and returns null", async () => {
+      // Intraday allows maxRetries=1 (so 2 total attempts) per service config.
+      const fetchMock = jest.fn().mockResolvedValue(throttledResponse(429));
+      global.fetch = fetchMock as any;
+
+      const result = await service.fetchIntradaySeries("AAPL.TO", null, {
+        interval: "1m",
+        range: "1d",
+      });
+
+      expect(result).toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("does NOT retry non-throttled errors (e.g. 500)", async () => {
+      const fetchMock = jest.fn().mockResolvedValue(throttledResponse(500));
+      global.fetch = fetchMock as any;
+
+      const result = await service.fetchIntradaySeries("AAPL.TO", null, {
+        interval: "1m",
+        range: "1d",
+      });
+
+      expect(result).toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("caps concurrent in-flight requests", async () => {
+      // Drive 10 parallel intraday requests through a fetch that hangs until
+      // we count how many have started simultaneously.
+      let inFlight = 0;
+      let peak = 0;
+      const fetchMock = jest.fn().mockImplementation(async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await new Promise((r) => setTimeout(r, 10));
+        inFlight--;
+        return okIntradayResponse();
+      });
+      global.fetch = fetchMock as any;
+
+      await Promise.all(
+        Array.from({ length: 10 }, (_, i) =>
+          service.fetchIntradaySeries(`SYM${i}.TO`, null, {
+            interval: "1m",
+            range: "1d",
+          }),
+        ),
+      );
+
+      expect(peak).toBeLessThanOrEqual(
+        (YahooFinanceService as any).MAX_CONCURRENT_REQUESTS,
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(10);
+    });
+
+    it("honors the Retry-After header when the server provides one", async () => {
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          headers: new Headers({ "retry-after": "0" }),
+          text: () => Promise.resolve(""),
+          json: () => Promise.resolve({}),
+        })
+        .mockResolvedValueOnce(okIntradayResponse());
+      global.fetch = fetchMock as any;
+
+      const result = await service.fetchIntradaySeries("AAPL.TO", null, {
+        interval: "1m",
+        range: "1d",
+      });
+
+      expect(result).toHaveLength(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/backend/src/securities/yahoo-finance.service.ts
+++ b/backend/src/securities/yahoo-finance.service.ts
@@ -57,11 +57,111 @@ export class YahooFinanceService implements QuoteProvider {
   private static readonly USER_AGENT =
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 
+  // Yahoo's public chart API doesn't publish a rate limit but returns 429
+  // (and occasionally 503) when we burst-fetch dozens of symbols during a
+  // catalog-wide price refresh. Cap concurrency and retry transparently on
+  // throttled responses so the caller doesn't have to think about it.
+  private static readonly MAX_CONCURRENT_REQUESTS = 5;
+  private static readonly INTER_REQUEST_GAP_MS = 100;
+  private static readonly MAX_RETRIES = 2;
+  private static readonly RETRY_INITIAL_DELAY_MS = 500;
+  private static readonly RETRY_MAX_DELAY_MS = 30_000;
+  private static readonly THROTTLED_STATUSES: ReadonlySet<number> = new Set([
+    429, 503,
+  ]);
+
+  // Simple async semaphore: at most MAX_CONCURRENT_REQUESTS fetches in flight
+  // at once. Anyone who calls acquireSlot() while the gate is full waits in
+  // a FIFO queue until releaseSlot() admits them.
+  private activeRequests = 0;
+  private readonly waitQueue: Array<() => void> = [];
+
   /** Cached crumb+cookie for v10 API authentication */
   private crumb: string | null = null;
   private cookie: string | null = null;
   private crumbExpiresAt = 0;
   private crumbPromise: Promise<boolean> | null = null;
+
+  private async acquireSlot(): Promise<void> {
+    if (this.activeRequests < YahooFinanceService.MAX_CONCURRENT_REQUESTS) {
+      this.activeRequests++;
+      return;
+    }
+    await new Promise<void>((resolve) => this.waitQueue.push(resolve));
+    this.activeRequests++;
+  }
+
+  private releaseSlot(): void {
+    this.activeRequests--;
+    const next = this.waitQueue.shift();
+    if (next) next();
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Fetch wrapper that:
+   *   - caps concurrency at MAX_CONCURRENT_REQUESTS,
+   *   - leaves a small inter-request gap so we don't burst the next slot,
+   *   - retries 429/503 with exponential backoff (honoring Retry-After).
+   *
+   * Non-throttled HTTP errors (4xx other than 429, 5xx other than 503) are
+   * returned to the caller untouched -- the helper only handles the
+   * "upstream is asking us to slow down" case. Network errors propagate.
+   */
+  private async throttledFetch(
+    url: string,
+    init: RequestInit = {},
+    opts: { maxRetries?: number; timeoutMs?: number } = {},
+  ): Promise<Response> {
+    const maxRetries = opts.maxRetries ?? YahooFinanceService.MAX_RETRIES;
+    const timeoutMs = opts.timeoutMs ?? YahooFinanceService.FETCH_TIMEOUT_MS;
+    await this.acquireSlot();
+    try {
+      let lastResponse: Response | null = null;
+      for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        const response = await fetch(url, {
+          ...init,
+          signal: AbortSignal.timeout(timeoutMs),
+        });
+        lastResponse = response;
+        if (!YahooFinanceService.THROTTLED_STATUSES.has(response.status)) {
+          return response;
+        }
+        // Drain the body so the connection can be reused.
+        await response.text().catch(() => undefined);
+        if (attempt === maxRetries) return response;
+
+        // Honor Retry-After (delta-seconds) when the server provides one,
+        // otherwise back off exponentially with a touch of jitter so a herd
+        // of concurrent retries doesn't synchronize.
+        const retryAfter = response.headers.get("retry-after");
+        const retryAfterMs = retryAfter ? Number(retryAfter) * 1000 : 0;
+        const backoff =
+          YahooFinanceService.RETRY_INITIAL_DELAY_MS * 2 ** attempt;
+        const jitter = Math.floor(Math.random() * 250);
+        const delayMs = Math.min(
+          Math.max(retryAfterMs, backoff + jitter),
+          YahooFinanceService.RETRY_MAX_DELAY_MS,
+        );
+        this.logger.warn(
+          `Yahoo Finance returned ${response.status}; retrying in ${delayMs}ms (attempt ${attempt + 1}/${maxRetries})`,
+        );
+        await this.sleep(delayMs);
+      }
+      return lastResponse!;
+    } finally {
+      // Stagger slot release so the next request can't immediately follow
+      // the previous one back-to-back -- spreads load and helps avoid the
+      // 429 in the first place.
+      setTimeout(
+        () => this.releaseSlot(),
+        YahooFinanceService.INTER_REQUEST_GAP_MS,
+      );
+    }
+  }
 
   private async ensureCrumb(forceRefresh = false): Promise<boolean> {
     if (
@@ -170,12 +270,11 @@ export class YahooFinanceService implements QuoteProvider {
 
       let response: Response;
       try {
-        response = await fetch(fullUrl, {
+        response = await this.throttledFetch(fullUrl, {
           headers: {
             "User-Agent": YahooFinanceService.USER_AGENT,
             Cookie: this.cookie!,
           },
-          signal: AbortSignal.timeout(YahooFinanceService.FETCH_TIMEOUT_MS),
         });
       } catch (err) {
         this.logger.error(`Yahoo Finance v10 fetch error: ${err}`);
@@ -217,12 +316,11 @@ export class YahooFinanceService implements QuoteProvider {
     try {
       const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(yahooSymbol)}?interval=1d&range=1d`;
 
-      const response = await fetch(url, {
+      const response = await this.throttledFetch(url, {
         headers: {
           "User-Agent":
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
         },
-        signal: AbortSignal.timeout(YahooFinanceService.FETCH_TIMEOUT_MS),
       });
 
       if (!response.ok) {
@@ -301,13 +399,16 @@ export class YahooFinanceService implements QuoteProvider {
     try {
       const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(yahooSymbol)}?interval=1d&range=${encodeURIComponent(range)}`;
 
-      const response = await fetch(url, {
-        headers: {
-          "User-Agent":
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+      const response = await this.throttledFetch(
+        url,
+        {
+          headers: {
+            "User-Agent":
+              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+          },
         },
-        signal: AbortSignal.timeout(60000),
-      });
+        { timeoutMs: 60_000 },
+      );
 
       if (!response.ok) {
         this.logger.warn(
@@ -397,10 +498,17 @@ export class YahooFinanceService implements QuoteProvider {
     try {
       const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(yahooSymbol)}?interval=${encodeURIComponent(interval)}&range=${encodeURIComponent(range)}`;
 
-      const response = await fetch(url, {
-        headers: { "User-Agent": YahooFinanceService.USER_AGENT },
-        signal: AbortSignal.timeout(YahooFinanceService.FETCH_TIMEOUT_MS),
-      });
+      // Intraday is called inline by the chart endpoint which has its own
+      // tight client timeout, so cap retries lower than the default to avoid
+      // exceeding it. If we're being throttled we'll get fallbackToDaily
+      // upstream anyway.
+      const response = await this.throttledFetch(
+        url,
+        {
+          headers: { "User-Agent": YahooFinanceService.USER_AGENT },
+        },
+        { maxRetries: 1 },
+      );
 
       if (!response.ok) {
         this.logger.warn(
@@ -460,12 +568,11 @@ export class YahooFinanceService implements QuoteProvider {
     try {
       const url = `https://query1.finance.yahoo.com/v1/finance/search?q=${encodeURIComponent(query)}&quotesCount=50&newsCount=0`;
 
-      const response = await fetch(url, {
+      const response = await this.throttledFetch(url, {
         headers: {
           "User-Agent":
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
         },
-        signal: AbortSignal.timeout(YahooFinanceService.FETCH_TIMEOUT_MS),
       });
 
       if (!response.ok) {
@@ -771,11 +878,10 @@ export class YahooFinanceService implements QuoteProvider {
     try {
       const url = `https://query1.finance.yahoo.com/v1/finance/search?q=${encodeURIComponent(yahooSymbol)}&quotesCount=5&newsCount=0`;
 
-      const response = await fetch(url, {
+      const response = await this.throttledFetch(url, {
         headers: {
           "User-Agent": YahooFinanceService.USER_AGENT,
         },
-        signal: AbortSignal.timeout(YahooFinanceService.FETCH_TIMEOUT_MS),
       });
 
       if (!response.ok) {

--- a/backend/src/securities/yahoo-finance.service.ts
+++ b/backend/src/securities/yahoo-finance.service.ts
@@ -135,15 +135,15 @@ export class YahooFinanceService implements QuoteProvider {
         if (attempt === maxRetries) return response;
 
         // Honor Retry-After (delta-seconds) when the server provides one,
-        // otherwise back off exponentially with a touch of jitter so a herd
-        // of concurrent retries doesn't synchronize.
+        // otherwise back off exponentially. The MAX_CONCURRENT_REQUESTS gate
+        // and INTER_REQUEST_GAP_MS already keep retries naturally
+        // staggered, so we don't add explicit jitter on top.
         const retryAfter = response.headers.get("retry-after");
         const retryAfterMs = retryAfter ? Number(retryAfter) * 1000 : 0;
         const backoff =
           YahooFinanceService.RETRY_INITIAL_DELAY_MS * 2 ** attempt;
-        const jitter = Math.floor(Math.random() * 250);
         const delayMs = Math.min(
-          Math.max(retryAfterMs, backoff + jitter),
+          Math.max(retryAfterMs, backoff),
           YahooFinanceService.RETRY_MAX_DELAY_MS,
         );
         this.logger.warn(

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -18,7 +18,6 @@ vi.mock('recharts', () => ({
   YAxis: () => null,
   CartesianGrid: () => null,
   Tooltip: () => null,
-  Customized: () => null,
 }));
 
 vi.mock('@/hooks/useNumberFormat', () => ({

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -18,6 +18,7 @@ vi.mock('recharts', () => ({
   YAxis: () => null,
   CartesianGrid: () => null,
   Tooltip: () => null,
+  Customized: () => null,
 }));
 
 vi.mock('@/hooks/useNumberFormat', () => ({

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -291,6 +291,42 @@ describe('InvestmentValueChart', () => {
     });
   });
 
+  it('falls back to daily data and surfaces an error banner when intraday request fails', async () => {
+    dateRangeState.dateRange = '1w';
+    dateRangeState.resolvedRange = { start: '2023-12-25', end: '2024-01-01' };
+    vi.mocked(investmentsApi.getIntradayValue).mockRejectedValue(
+      new Error('Network error'),
+    );
+    vi.mocked(netWorthApi.getInvestmentsDaily).mockResolvedValue([
+      { date: '2023-12-25', value: 8000 },
+      { date: '2024-01-01', value: 9000 },
+    ]);
+    render(<InvestmentValueChart />);
+    const banner = await screen.findByTestId('intraday-error-banner');
+    expect(banner.textContent).toMatch(/intraday/i);
+    await waitFor(() => {
+      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled();
+    });
+    expect(screen.getByText('$9000')).toBeInTheDocument();
+  });
+
+  it('shows the error banner and falls back to daily on 1d when intraday request fails', async () => {
+    dateRangeState.dateRange = '1d';
+    dateRangeState.resolvedRange = { start: '2024-01-01', end: '2024-01-02' };
+    vi.mocked(investmentsApi.getIntradayValue).mockRejectedValue(
+      new Error('500 Internal Server Error'),
+    );
+    vi.mocked(netWorthApi.getInvestmentsDaily).mockResolvedValue([
+      { date: '2024-01-01', value: 7777 },
+    ]);
+    render(<InvestmentValueChart />);
+    const banner = await screen.findByTestId('intraday-error-banner');
+    expect(banner).toBeInTheDocument();
+    await waitFor(() => {
+      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled();
+    });
+  });
+
   it('shows a warning icon next to the title when 1w falls back to daily', async () => {
     dateRangeState.dateRange = '1w';
     dateRangeState.resolvedRange = { start: '2023-12-25', end: '2024-01-01' };

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -117,8 +117,9 @@ describe('InvestmentValueChart', () => {
 
   it('renders summary cards after data loads', async () => {
     render(<InvestmentValueChart />);
-    const currentValue = await screen.findByText('Current Value');
-    expect(currentValue).toBeInTheDocument();
+    const highest = await screen.findByText('Highest Value');
+    expect(highest).toBeInTheDocument();
+    expect(screen.getByText('Lowest Value')).toBeInTheDocument();
     expect(screen.getByText('Change')).toBeInTheDocument();
     expect(screen.getByText('Change %')).toBeInTheDocument();
   });
@@ -132,8 +133,9 @@ describe('InvestmentValueChart', () => {
   it('displays computed summary values', async () => {
     render(<InvestmentValueChart />);
     await screen.findByText('Portfolio Value Over Time');
-    // current: $15000, initial: $10000, change: $5000, percent: +50.0%
+    // highest=15000, lowest=10000, change=+5000, percent=+50.0%
     expect(screen.getByText('$15000')).toBeInTheDocument();
+    expect(screen.getByText('$10000')).toBeInTheDocument();
     expect(screen.getByText('+$5000')).toBeInTheDocument();
     expect(screen.getByText('+50.0%')).toBeInTheDocument();
   });
@@ -295,32 +297,7 @@ describe('InvestmentValueChart', () => {
     });
   });
 
-  it('falls back to daily and shows an error when some intraday fetches failed (failedSymbols)', async () => {
-    dateRangeState.dateRange = '1d';
-    dateRangeState.resolvedRange = { start: '2024-01-01', end: '2024-01-02' };
-    vi.mocked(investmentsApi.getIntradayValue).mockResolvedValue({
-      points: [],
-      interval: '1m',
-      currency: 'CAD',
-      range: '1d',
-      fetchedAt: '2024-01-02T15:00:00.000Z',
-      skippedSymbols: [],
-      failedSymbols: ['AAPL', 'VFV.TO'],
-      fallbackToDaily: true,
-    });
-    vi.mocked(netWorthApi.getInvestmentsDaily).mockResolvedValue([
-      { date: '2024-01-01', value: 12345 },
-    ]);
-    render(<InvestmentValueChart />);
-    const banner = await screen.findByTestId('intraday-error-banner');
-    expect(banner.textContent).toMatch(/AAPL/);
-    expect(banner.textContent).toMatch(/VFV\.TO/);
-    await waitFor(() => {
-      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled();
-    });
-  });
-
-  it('falls back to daily data and surfaces an error banner when intraday request fails', async () => {
+  it('silently falls back to daily on 1w when the intraday request rejects', async () => {
     dateRangeState.dateRange = '1w';
     dateRangeState.resolvedRange = { start: '2023-12-25', end: '2024-01-01' };
     vi.mocked(investmentsApi.getIntradayValue).mockRejectedValue(
@@ -331,15 +308,15 @@ describe('InvestmentValueChart', () => {
       { date: '2024-01-01', value: 9000 },
     ]);
     render(<InvestmentValueChart />);
-    const banner = await screen.findByTestId('intraday-error-banner');
-    expect(banner.textContent).toMatch(/intraday/i);
+    await screen.findByText('Portfolio Value Over Time');
     await waitFor(() => {
       expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled();
     });
+    expect(screen.queryByTestId('intraday-error-banner')).toBeNull();
     expect(screen.getByText('$9000')).toBeInTheDocument();
   });
 
-  it('shows the error banner and falls back to daily on 1d when intraday request fails', async () => {
+  it('silently falls back to daily on 1d when the intraday request rejects', async () => {
     dateRangeState.dateRange = '1d';
     dateRangeState.resolvedRange = { start: '2024-01-01', end: '2024-01-02' };
     vi.mocked(investmentsApi.getIntradayValue).mockRejectedValue(
@@ -349,11 +326,11 @@ describe('InvestmentValueChart', () => {
       { date: '2024-01-01', value: 7777 },
     ]);
     render(<InvestmentValueChart />);
-    const banner = await screen.findByTestId('intraday-error-banner');
-    expect(banner).toBeInTheDocument();
+    await screen.findByText('Portfolio Value Over Time');
     await waitFor(() => {
       expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled();
     });
+    expect(screen.queryByTestId('intraday-error-banner')).toBeNull();
   });
 
   it('shows a warning icon next to the title when 1w falls back to daily', async () => {

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -63,6 +63,7 @@ vi.mock('@/lib/investments', () => ({
       range: '1d',
       fetchedAt: new Date().toISOString(),
       skippedSymbols: [],
+      failedSymbols: [],
       fallbackToDaily: false,
     }),
   },
@@ -217,6 +218,7 @@ describe('InvestmentValueChart', () => {
       range: '1d',
       fetchedAt: '2024-01-02T15:00:00.000Z',
       skippedSymbols: [],
+      failedSymbols: [],
       fallbackToDaily: false,
     });
     render(<InvestmentValueChart />);
@@ -236,6 +238,7 @@ describe('InvestmentValueChart', () => {
       range: '1d',
       fetchedAt: '2024-01-02T15:00:00.000Z',
       skippedSymbols: ['VFV.TO'],
+      failedSymbols: [],
       fallbackToDaily: true,
     });
     render(<InvestmentValueChart />);
@@ -254,6 +257,7 @@ describe('InvestmentValueChart', () => {
       range: '1w',
       fetchedAt: '2024-01-02T15:00:00.000Z',
       skippedSymbols: ['VFV.TO'],
+      failedSymbols: [],
       fallbackToDaily: true,
     });
     render(<InvestmentValueChart />);
@@ -288,6 +292,31 @@ describe('InvestmentValueChart', () => {
     resolveDaily([{ date: '2023-12-01', value: 12000 }]);
     await waitFor(() => {
       expect(screen.queryByTestId('chart-loading-indicator')).toBeNull();
+    });
+  });
+
+  it('falls back to daily and shows an error when some intraday fetches failed (failedSymbols)', async () => {
+    dateRangeState.dateRange = '1d';
+    dateRangeState.resolvedRange = { start: '2024-01-01', end: '2024-01-02' };
+    vi.mocked(investmentsApi.getIntradayValue).mockResolvedValue({
+      points: [],
+      interval: '1m',
+      currency: 'CAD',
+      range: '1d',
+      fetchedAt: '2024-01-02T15:00:00.000Z',
+      skippedSymbols: [],
+      failedSymbols: ['AAPL', 'VFV.TO'],
+      fallbackToDaily: true,
+    });
+    vi.mocked(netWorthApi.getInvestmentsDaily).mockResolvedValue([
+      { date: '2024-01-01', value: 12345 },
+    ]);
+    render(<InvestmentValueChart />);
+    const banner = await screen.findByTestId('intraday-error-banner');
+    expect(banner.textContent).toMatch(/AAPL/);
+    expect(banner.textContent).toMatch(/VFV\.TO/);
+    await waitFor(() => {
+      expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled();
     });
   });
 
@@ -337,6 +366,7 @@ describe('InvestmentValueChart', () => {
       range: '1w',
       fetchedAt: '2024-01-02T15:00:00.000Z',
       skippedSymbols: ['VFV.TO'],
+      failedSymbols: [],
       fallbackToDaily: true,
     });
     render(<InvestmentValueChart />);
@@ -356,6 +386,7 @@ describe('InvestmentValueChart', () => {
       range: '1w',
       fetchedAt: '2024-01-02T15:00:00.000Z',
       skippedSymbols: [],
+      failedSymbols: [],
       fallbackToDaily: false,
     });
     render(<InvestmentValueChart />);
@@ -372,6 +403,7 @@ describe('InvestmentValueChart', () => {
       range: '1d',
       fetchedAt: '2024-01-02T15:00:00.000Z',
       skippedSymbols: [],
+      failedSymbols: [],
       fallbackToDaily: false,
     });
     render(<InvestmentValueChart />);

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -9,7 +9,6 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
-  Customized,
 } from 'recharts';
 import { format } from 'date-fns';
 import { netWorthApi } from '@/lib/net-worth';
@@ -516,39 +515,27 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
                 fill="url(#colorInvestments)"
                 name="Portfolio Value"
                 isAnimationActive={false}
+                dot={(props: { cx?: number; cy?: number; index?: number }) => {
+                  const { cx, cy, index } = props;
+                  if (cx == null || cy == null || index == null) {
+                    return <circle cx={0} cy={0} r={0} fill="none" />;
+                  }
+                  const isHighest = showFlags && index === highestIndex;
+                  const isLowest = showFlags && index === lowestIndex;
+                  if (!isHighest && !isLowest) {
+                    return <circle key={`dot-${index}`} cx={cx} cy={cy} r={0} fill="none" />;
+                  }
+                  const value = isHighest ? summary.highest : summary.lowest;
+                  return renderChartFlagDot({
+                    cx,
+                    cy,
+                    index,
+                    color: isHighest ? '#10b981' : '#ef4444',
+                    label: Math.abs(value) >= 1000 ? fmtAxis(value) : fmtVal(value),
+                    above: isHighest,
+                  });
+                }}
               />
-              {/* Highest/lowest flag callouts. Rendered as a Customized layer
-                  rather than via Area's `dot` prop so the bubbles paint on
-                  top of axis labels and the area fill, not underneath. */}
-              {showFlags && (
-                <Customized
-                  component={(props: { formattedGraphicalItems?: Array<{ props?: { points?: Array<{ x: number; y: number }> } }> }) => {
-                    const points = props.formattedGraphicalItems?.[0]?.props?.points;
-                    if (!points || points.length === 0) return null;
-                    const flags: Array<{ index: number; color: string; value: number; above: boolean }> = [];
-                    if (highestIndex >= 0 && points[highestIndex]) {
-                      flags.push({ index: highestIndex, color: '#10b981', value: summary.highest, above: true });
-                    }
-                    if (lowestIndex >= 0 && points[lowestIndex]) {
-                      flags.push({ index: lowestIndex, color: '#ef4444', value: summary.lowest, above: false });
-                    }
-                    return (
-                      <g>
-                        {flags.map((f) =>
-                          renderChartFlagDot({
-                            cx: points[f.index].x,
-                            cy: points[f.index].y,
-                            index: f.index,
-                            color: f.color,
-                            label: Math.abs(f.value) >= 1000 ? fmtAxis(f.value) : fmtVal(f.value),
-                            above: f.above,
-                          }),
-                        )}
-                      </g>
-                    );
-                  }}
-                />
-              )}
             </AreaChart>
           </ResponsiveContainer>
         </div>

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -532,7 +532,10 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
                     index,
                     color: isHighest ? '#10b981' : '#ef4444',
                     label: Math.abs(value) >= 1000 ? fmtAxis(value) : fmtVal(value),
-                    above: isHighest,
+                    // Both flags point upward -- the lowest point sits near
+                    // the bottom of the plot area where the x-axis labels
+                    // live, so a downward bubble would always overlap them.
+                    above: true,
                   });
                 }}
               />

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -50,7 +50,7 @@ interface InvestmentValueChartProps {
 }
 
 export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix }: InvestmentValueChartProps) {
-  const { formatCurrencyCompact, formatCurrencyAxis } = useNumberFormat();
+  const { formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
   const [chartPoints, setChartPoints] = useState<Array<{ name: string; Value: number }>>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -99,6 +99,14 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
     if (foreignCurrency) return formatCurrencyAxis(value, foreignCurrency);
     return formatCurrencyAxis(value);
   }, [foreignCurrency, formatCurrencyAxis]);
+
+  // Flag bubble label: 2-decimal compact notation. Reads more precisely
+  // than the 1-decimal axis ticks so the highlighted high/low value can
+  // be picked out without squinting at the connector position.
+  const fmtFlag = useCallback((value: number) => {
+    if (foreignCurrency) return formatCurrencyFlag(value, foreignCurrency);
+    return formatCurrencyFlag(value);
+  }, [foreignCurrency, formatCurrencyFlag]);
 
   // Sequence number for the latest in-flight load. Lets us cancel stale
   // results that resolve out-of-order if the user clicks ranges quickly.
@@ -540,7 +548,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
                     cy,
                     index,
                     color: isHighest ? '#10b981' : '#ef4444',
-                    label: Math.abs(value) >= 1000 ? fmtAxis(value) : fmtVal(value),
+                    label: fmtFlag(value),
                     side: isLeftHalf ? 'right' : 'left',
                   });
                 }}

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -526,20 +526,22 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
                     return <circle key={`dot-${index}`} cx={cx} cy={cy} r={0} fill="none" />;
                   }
                   const value = isHighest ? summary.highest : summary.lowest;
+                  // Place the bubble to the side of its dot (with a horizontal
+                  // connector) instead of above/below. This puts the bubble
+                  // in the chart's middle vertical band -- well clear of the
+                  // x-axis labels at the bottom and the top edge of the plot,
+                  // regardless of whether the dot itself is at the top or
+                  // bottom of the data range. Side is auto-picked based on
+                  // the dot's position within the series so the bubble
+                  // doesn't get pushed off the chart's left or right edge.
+                  const isLeftHalf = index < chartPoints.length / 2;
                   return renderChartFlagDot({
                     cx,
                     cy,
                     index,
                     color: isHighest ? '#10b981' : '#ef4444',
                     label: Math.abs(value) >= 1000 ? fmtAxis(value) : fmtVal(value),
-                    // Both flags point upward -- the lowest point sits near
-                    // the bottom of the plot area where the x-axis labels
-                    // live, so a downward bubble would always overlap them.
-                    above: true,
-                    // Tighter gap for the highest flag: it sits near the top
-                    // of the plot area where a full-size connector would push
-                    // the bubble out of the chart and get it clipped.
-                    gap: isHighest ? 10 : undefined,
+                    side: isLeftHalf ? 'right' : 'left',
                   });
                 }}
               />

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -9,6 +9,7 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
+  Customized,
 } from 'recharts';
 import { format } from 'date-fns';
 import { netWorthApi } from '@/lib/net-worth';
@@ -515,27 +516,39 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
                 fill="url(#colorInvestments)"
                 name="Portfolio Value"
                 isAnimationActive={false}
-                dot={(props: { cx?: number; cy?: number; index?: number; key?: string }) => {
-                  const { cx, cy, index } = props;
-                  if (cx == null || cy == null || index == null) {
-                    return <circle cx={0} cy={0} r={0} fill="none" />;
-                  }
-                  const isHighest = showFlags && index === highestIndex;
-                  const isLowest = showFlags && index === lowestIndex;
-                  if (!isHighest && !isLowest) {
-                    return <circle key={`dot-${index}`} cx={cx} cy={cy} r={0} fill="none" />;
-                  }
-                  const value = isHighest ? summary.highest : summary.lowest;
-                  return renderChartFlagDot({
-                    cx,
-                    cy,
-                    index,
-                    color: isHighest ? '#10b981' : '#ef4444',
-                    label: Math.abs(value) >= 1000 ? fmtAxis(value) : fmtVal(value),
-                    above: isHighest,
-                  });
-                }}
               />
+              {/* Highest/lowest flag callouts. Rendered as a Customized layer
+                  rather than via Area's `dot` prop so the bubbles paint on
+                  top of axis labels and the area fill, not underneath. */}
+              {showFlags && (
+                <Customized
+                  component={(props: { formattedGraphicalItems?: Array<{ props?: { points?: Array<{ x: number; y: number }> } }> }) => {
+                    const points = props.formattedGraphicalItems?.[0]?.props?.points;
+                    if (!points || points.length === 0) return null;
+                    const flags: Array<{ index: number; color: string; value: number; above: boolean }> = [];
+                    if (highestIndex >= 0 && points[highestIndex]) {
+                      flags.push({ index: highestIndex, color: '#10b981', value: summary.highest, above: true });
+                    }
+                    if (lowestIndex >= 0 && points[lowestIndex]) {
+                      flags.push({ index: lowestIndex, color: '#ef4444', value: summary.lowest, above: false });
+                    }
+                    return (
+                      <g>
+                        {flags.map((f) =>
+                          renderChartFlagDot({
+                            cx: points[f.index].x,
+                            cy: points[f.index].y,
+                            index: f.index,
+                            color: f.color,
+                            label: Math.abs(f.value) >= 1000 ? fmtAxis(f.value) : fmtVal(f.value),
+                            above: f.above,
+                          }),
+                        )}
+                      </g>
+                    );
+                  }}
+                />
+              )}
             </AreaChart>
           </ResponsiveContainer>
         </div>

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -206,7 +206,21 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
             currency: response.currency,
             fallbackToDaily: response.fallbackToDaily,
             skippedSymbols: response.skippedSymbols,
+            failedSymbols: response.failedSymbols ?? [],
           });
+
+          // Provider-level fetch failures: rendering the partial intraday
+          // series would understate the portfolio value (the failed holdings
+          // would silently contribute 0). Fall back to daily snapshots and
+          // surface the error -- same path as a request-level failure.
+          if (response.failedSymbols && response.failedSymbols.length > 0) {
+            const list = response.failedSymbols.join(', ');
+            setIntradayError(
+              `Couldn't load intraday prices for ${list}. Showing daily snapshots instead.`,
+            );
+            await loadDailyOrMonthly(seq);
+            return;
+          }
 
           if (response.fallbackToDaily) {
             // Some holdings (typically MSN-tracked) lack intraday support.

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -62,6 +62,10 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
   const [intradayFallbackNotice, setIntradayFallbackNotice] = useState<{
     skipped: string[];
   } | null>(null);
+  // Set when the intraday request itself fails (network/server error). We fall
+  // back to the daily endpoint and surface a banner so the user knows why the
+  // chart resolution is coarser than the button label suggests.
+  const [intradayError, setIntradayError] = useState<string | null>(null);
   const [persistedRange, setPersistedRange] = useLocalStorage<string>(
     RANGE_STORAGE_KEY,
     '1y',
@@ -151,6 +155,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
       setIsLoading(true);
       setIntradayUnavailable(null);
       setIntradayFallbackNotice(null);
+      setIntradayError(null);
       try {
         if (isIntraday) {
           const cacheKey = buildIntradayCacheKey(
@@ -182,8 +187,13 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
           } catch (error) {
             logger.error('Failed to load intraday data:', error);
             if (loadSeqRef.current !== seq) return;
-            setChartPoints([]);
-            setIsLoading(false);
+            // Intraday fetch failed -- fall back to the daily-snapshot endpoint
+            // so the user still sees a chart, and surface the error so they
+            // understand why the resolution is coarser than requested.
+            setIntradayError(
+              "Couldn't load intraday data. Showing daily snapshots instead.",
+            );
+            await loadDailyOrMonthly(seq);
             return;
           }
 
@@ -409,6 +419,18 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
           </div>
         </div>
       </div>
+
+      {/* Intraday error banner: shown when the intraday request failed and we
+          fell back to the daily-snapshot endpoint. */}
+      {intradayError && (
+        <div
+          role="alert"
+          data-testid="intraday-error-banner"
+          className="mb-4 rounded-md border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/40 px-3 py-2 text-sm text-red-700 dark:text-red-300"
+        >
+          {intradayError}
+        </div>
+      )}
 
       {/* Chart */}
       {intradayUnavailable ? (

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -27,6 +27,8 @@ import {
   writeIntradayCache,
   clearAllIntradayCache,
   computeTightYAxisDomain,
+  renderChartFlagDot,
+  ChartFlagShadowFilter,
 } from './portfolio-chart-utils';
 
 const logger = createLogger('InvestmentChart');
@@ -298,6 +300,25 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
     [chartPoints],
   );
 
+  // Index of the first point at the highest / lowest value, for the
+  // bubble callouts. Suppress when the series is flat (highest === lowest)
+  // -- two stacked bubbles at the same point would just be visual noise.
+  const highestIndex = useMemo(
+    () =>
+      chartPoints.length === 0
+        ? -1
+        : chartPoints.findIndex((p) => p.Value === summary.highest),
+    [chartPoints, summary.highest],
+  );
+  const lowestIndex = useMemo(
+    () =>
+      chartPoints.length === 0
+        ? -1
+        : chartPoints.findIndex((p) => p.Value === summary.lowest),
+    [chartPoints, summary.lowest],
+  );
+  const showFlags = summary.highest !== summary.lowest;
+
   const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: Array<{ value: number; payload: { name: string } }> }) => {
     if (active && payload && payload.length) {
       const data = payload[0]?.payload;
@@ -449,13 +470,14 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
           }`}
         >
           <ResponsiveContainer width="100%" height="100%" minWidth={0}>
-            <AreaChart data={chartPoints} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+            <AreaChart data={chartPoints} margin={{ top: 30, right: 30, left: 0, bottom: 30 }}>
               <defs>
                 <linearGradient id="colorInvestments" x1="0" y1="0" x2="0" y2="1">
                   <stop offset="5%" stopColor="#10b981" stopOpacity={0.3} />
                   <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
                 </linearGradient>
               </defs>
+              <ChartFlagShadowFilter />
               <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
               <XAxis
                 dataKey="name"
@@ -492,6 +514,27 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
                 fillOpacity={1}
                 fill="url(#colorInvestments)"
                 name="Portfolio Value"
+                isAnimationActive={false}
+                dot={(props: { cx?: number; cy?: number; index?: number; key?: string }) => {
+                  const { cx, cy, index } = props;
+                  if (cx == null || cy == null || index == null) {
+                    return <circle cx={0} cy={0} r={0} fill="none" />;
+                  }
+                  const isHighest = showFlags && index === highestIndex;
+                  const isLowest = showFlags && index === lowestIndex;
+                  if (!isHighest && !isLowest) {
+                    return <circle key={`dot-${index}`} cx={cx} cy={cy} r={0} fill="none" />;
+                  }
+                  const value = isHighest ? summary.highest : summary.lowest;
+                  return renderChartFlagDot({
+                    cx,
+                    cy,
+                    index,
+                    color: isHighest ? '#10b981' : '#ef4444',
+                    label: Math.abs(value) >= 1000 ? fmtAxis(value) : fmtVal(value),
+                    above: isHighest,
+                  });
+                }}
               />
             </AreaChart>
           </ResponsiveContainer>

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -536,6 +536,10 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
                     // the bottom of the plot area where the x-axis labels
                     // live, so a downward bubble would always overlap them.
                     above: true,
+                    // Tighter gap for the highest flag: it sits near the top
+                    // of the plot area where a full-size connector would push
+                    // the bubble out of the chart and get it clipped.
+                    gap: isHighest ? 10 : undefined,
                   });
                 }}
               />

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -62,10 +62,6 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
   const [intradayFallbackNotice, setIntradayFallbackNotice] = useState<{
     skipped: string[];
   } | null>(null);
-  // Set when the intraday request itself fails (network/server error). We fall
-  // back to the daily endpoint and surface a banner so the user knows why the
-  // chart resolution is coarser than the button label suggests.
-  const [intradayError, setIntradayError] = useState<string | null>(null);
   const [persistedRange, setPersistedRange] = useLocalStorage<string>(
     RANGE_STORAGE_KEY,
     '1y',
@@ -155,7 +151,6 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
       setIsLoading(true);
       setIntradayUnavailable(null);
       setIntradayFallbackNotice(null);
-      setIntradayError(null);
       try {
         if (isIntraday) {
           const cacheKey = buildIntradayCacheKey(
@@ -187,12 +182,8 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
           } catch (error) {
             logger.error('Failed to load intraday data:', error);
             if (loadSeqRef.current !== seq) return;
-            // Intraday fetch failed -- fall back to the daily-snapshot endpoint
-            // so the user still sees a chart, and surface the error so they
-            // understand why the resolution is coarser than requested.
-            setIntradayError(
-              "Couldn't load intraday data. Showing daily snapshots instead.",
-            );
+            // Intraday fetch failed -- silently fall back to the
+            // daily-snapshot endpoint so the user still sees a chart.
             await loadDailyOrMonthly(seq);
             return;
           }
@@ -208,19 +199,6 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
             skippedSymbols: response.skippedSymbols,
             failedSymbols: response.failedSymbols ?? [],
           });
-
-          // Provider-level fetch failures: rendering the partial intraday
-          // series would understate the portfolio value (the failed holdings
-          // would silently contribute 0). Fall back to daily snapshots and
-          // surface the error -- same path as a request-level failure.
-          if (response.failedSymbols && response.failedSymbols.length > 0) {
-            const list = response.failedSymbols.join(', ');
-            setIntradayError(
-              `Couldn't load intraday prices for ${list}. Showing daily snapshots instead.`,
-            );
-            await loadDailyOrMonthly(seq);
-            return;
-          }
 
           if (response.fallbackToDaily) {
             // Some holdings (typically MSN-tracked) lack intraday support.
@@ -291,12 +269,17 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
   }, [isIntraday, loadData]);
 
   const summary = useMemo(() => {
-    if (chartPoints.length === 0) return { current: 0, change: 0, changePercent: 0 };
+    if (chartPoints.length === 0) {
+      return { highest: 0, lowest: 0, change: 0, changePercent: 0 };
+    }
+    const values = chartPoints.map((p) => p.Value);
+    const highest = Math.max(...values);
+    const lowest = Math.min(...values);
     const current = chartPoints[chartPoints.length - 1]?.Value || 0;
     const initial = chartPoints[0]?.Value || 0;
     const change = current - initial;
     const changePercent = initial !== 0 ? (change / Math.abs(initial)) * 100 : 0;
-    return { current, change, changePercent };
+    return { highest, lowest, change, changePercent };
   }, [chartPoints]);
 
   const xAxisTicks = useMemo(() => {
@@ -409,11 +392,17 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
       </div>
 
       {/* Summary cards */}
-      <div className="grid grid-cols-3 gap-4 mb-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-4">
         <div>
-          <div className="text-xs text-gray-500 dark:text-gray-400">Current Value</div>
+          <div className="text-xs text-gray-500 dark:text-gray-400">Highest Value</div>
           <div className="text-lg font-bold text-gray-900 dark:text-gray-100">
-            {fmtVal(summary.current)}
+            {fmtVal(summary.highest)}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs text-gray-500 dark:text-gray-400">Lowest Value</div>
+          <div className="text-lg font-bold text-gray-900 dark:text-gray-100">
+            {fmtVal(summary.lowest)}
           </div>
         </div>
         <div>
@@ -433,18 +422,6 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
           </div>
         </div>
       </div>
-
-      {/* Intraday error banner: shown when the intraday request failed and we
-          fell back to the daily-snapshot endpoint. */}
-      {intradayError && (
-        <div
-          role="alert"
-          data-testid="intraday-error-banner"
-          className="mb-4 rounded-md border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/40 px-3 py-2 text-sm text-red-700 dark:text-red-300"
-        >
-          {intradayError}
-        </div>
-      )}
 
       {/* Chart */}
       {intradayUnavailable ? (

--- a/frontend/src/components/investments/portfolio-chart-utils.ts
+++ b/frontend/src/components/investments/portfolio-chart-utils.ts
@@ -21,7 +21,7 @@ export const INTRADAY_CACHE_PREFIX = 'monize-intraday|';
 export interface IntradayCachePayload {
   fetchedAt: number;
   points: Array<{ timestamp: string; value: number }>;
-  interval: '1m' | '5m' | '15m';
+  interval: '1m' | '2m' | '5m' | '15m' | '30m' | '60m' | '90m';
   currency: string;
   fallbackToDaily: boolean;
   skippedSymbols: string[];

--- a/frontend/src/components/investments/portfolio-chart-utils.ts
+++ b/frontend/src/components/investments/portfolio-chart-utils.ts
@@ -25,6 +25,7 @@ export interface IntradayCachePayload {
   currency: string;
   fallbackToDaily: boolean;
   skippedSymbols: string[];
+  failedSymbols: string[];
 }
 
 export function buildIntradayCacheKey(

--- a/frontend/src/components/investments/portfolio-chart-utils.tsx
+++ b/frontend/src/components/investments/portfolio-chart-utils.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ReactElement } from 'react';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('PortfolioValueChart');
@@ -136,4 +137,98 @@ export function computeTightYAxisDomain(
     return [Math.max(0, niceMin), niceMax];
   }
   return [niceMin, Math.min(0, niceMax)];
+}
+
+/**
+ * Bubble-style "flag" callout pinned to a chart datapoint. Mirrors the
+ * Cash Flow Forecast min-balance bubble: a colored dot with a dashed
+ * connector up/down to a rounded label showing the value. Used to mark
+ * the highest and lowest points on portfolio-value charts.
+ *
+ * Uses an SVG <filter> with id "chartFlagShadow"; callers must include
+ * <ChartFlagShadowFilter /> (or the equivalent <defs>) inside the chart's
+ * SVG once per render. Recharts dot renderers must return an SVGElement,
+ * so this is a plain function rather than a React component.
+ */
+export interface FlagDotOptions {
+  cx: number;
+  cy: number;
+  index: number;
+  /** Color of dot/bubble (e.g. '#10b981' for highest, '#ef4444' for lowest). */
+  color: string;
+  /** Pre-formatted label text (caller chooses compact vs full). */
+  label: string;
+  /** True = bubble above the dot, false = below. */
+  above: boolean;
+}
+
+export function renderChartFlagDot({
+  cx,
+  cy,
+  index,
+  color,
+  label,
+  above,
+}: FlagDotOptions): ReactElement {
+  const labelWidth = label.length * 7 + 14;
+  const labelHeight = 22;
+  const arrowSize = 5;
+  const gap = 24;
+  const bubbleEdgeY = above ? cy - gap : cy + gap;
+  const bubbleTop = above
+    ? bubbleEdgeY - arrowSize - labelHeight
+    : bubbleEdgeY + arrowSize;
+  const arrowTipY = bubbleEdgeY;
+  const arrowBaseY = above
+    ? bubbleEdgeY - arrowSize
+    : bubbleEdgeY + arrowSize;
+  return (
+    <g key={`flag-${index}-${above ? 'hi' : 'lo'}`}>
+      <circle cx={cx} cy={cy} r={5} fill={color} stroke="#fff" strokeWidth={2} />
+      <line
+        x1={cx}
+        y1={above ? cy - 5 : cy + 5}
+        x2={cx}
+        y2={arrowTipY}
+        stroke={color}
+        strokeWidth={1.5}
+        strokeDasharray="3 2"
+      />
+      <rect
+        x={cx - labelWidth / 2}
+        y={bubbleTop}
+        width={labelWidth}
+        height={labelHeight}
+        rx={5}
+        fill={color}
+        filter="url(#chartFlagShadow)"
+      />
+      <polygon
+        points={`${cx - arrowSize},${arrowBaseY} ${cx + arrowSize},${arrowBaseY} ${cx},${arrowTipY}`}
+        fill={color}
+      />
+      <text
+        x={cx}
+        y={bubbleTop + labelHeight / 2}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill="#fff"
+        fontSize={11}
+        fontWeight={600}
+      >
+        {label}
+      </text>
+    </g>
+  );
+}
+
+/** SVG <defs> block providing the drop-shadow filter the flag dots reference. */
+export function ChartFlagShadowFilter(): ReactElement {
+  return (
+    <defs>
+      <filter id="chartFlagShadow" x="-20%" y="-20%" width="140%" height="140%">
+        <feDropShadow dx="0" dy="1" stdDeviation="2" floodOpacity="0.3" />
+      </filter>
+    </defs>
+  );
 }

--- a/frontend/src/components/investments/portfolio-chart-utils.tsx
+++ b/frontend/src/components/investments/portfolio-chart-utils.tsx
@@ -160,6 +160,13 @@ export interface FlagDotOptions {
   label: string;
   /** True = bubble above the dot, false = below. */
   above: boolean;
+  /**
+   * Distance in pixels from the dot center to the bubble's near edge.
+   * Default: 24. Use a smaller value for callouts near the chart's top
+   * edge, where the full-size connector would push the bubble out of
+   * the plot area and get it clipped.
+   */
+  gap?: number;
 }
 
 export function renderChartFlagDot({
@@ -169,11 +176,11 @@ export function renderChartFlagDot({
   color,
   label,
   above,
+  gap = 24,
 }: FlagDotOptions): ReactElement {
   const labelWidth = label.length * 7 + 14;
   const labelHeight = 22;
   const arrowSize = 5;
-  const gap = 24;
   const bubbleEdgeY = above ? cy - gap : cy + gap;
   const bubbleTop = above
     ? bubbleEdgeY - arrowSize - labelHeight

--- a/frontend/src/components/investments/portfolio-chart-utils.tsx
+++ b/frontend/src/components/investments/portfolio-chart-utils.tsx
@@ -182,9 +182,27 @@ export function renderChartFlagDot({
   const arrowBaseY = above
     ? bubbleEdgeY - arrowSize
     : bubbleEdgeY + arrowSize;
+  // Explicit fillOpacity / strokeOpacity / opacity on every shape:
+  // recharts' <Area fillOpacity={...}> propagates a fillOpacity attribute
+  // down to dot children via SVG inheritance, which would render the
+  // bubble at the area's translucent fill instead of solid color.
   return (
-    <g key={`flag-${index}-${above ? 'hi' : 'lo'}`}>
-      <circle cx={cx} cy={cy} r={5} fill={color} stroke="#fff" strokeWidth={2} />
+    <g
+      key={`flag-${index}-${above ? 'hi' : 'lo'}`}
+      fillOpacity={1}
+      strokeOpacity={1}
+      opacity={1}
+    >
+      <circle
+        cx={cx}
+        cy={cy}
+        r={5}
+        fill={color}
+        fillOpacity={1}
+        stroke="#fff"
+        strokeWidth={2}
+        strokeOpacity={1}
+      />
       <line
         x1={cx}
         y1={above ? cy - 5 : cy + 5}
@@ -193,6 +211,7 @@ export function renderChartFlagDot({
         stroke={color}
         strokeWidth={1.5}
         strokeDasharray="3 2"
+        strokeOpacity={1}
       />
       <rect
         x={cx - labelWidth / 2}
@@ -201,11 +220,13 @@ export function renderChartFlagDot({
         height={labelHeight}
         rx={5}
         fill={color}
+        fillOpacity={1}
         filter="url(#chartFlagShadow)"
       />
       <polygon
         points={`${cx - arrowSize},${arrowBaseY} ${cx + arrowSize},${arrowBaseY} ${cx},${arrowTipY}`}
         fill={color}
+        fillOpacity={1}
       />
       <text
         x={cx}
@@ -213,6 +234,7 @@ export function renderChartFlagDot({
         textAnchor="middle"
         dominantBaseline="central"
         fill="#fff"
+        fillOpacity={1}
         fontSize={11}
         fontWeight={600}
       >

--- a/frontend/src/components/investments/portfolio-chart-utils.tsx
+++ b/frontend/src/components/investments/portfolio-chart-utils.tsx
@@ -158,13 +158,15 @@ export interface FlagDotOptions {
   color: string;
   /** Pre-formatted label text (caller chooses compact vs full). */
   label: string;
-  /** True = bubble above the dot, false = below. */
-  above: boolean;
+  /**
+   * Which side of the dot the bubble sits on. 'left' / 'right' produce a
+   * horizontal connector; 'above' / 'below' produce a vertical one.
+   */
+  side: 'above' | 'below' | 'left' | 'right';
   /**
    * Distance in pixels from the dot center to the bubble's near edge.
-   * Default: 24. Use a smaller value for callouts near the chart's top
-   * edge, where the full-size connector would push the bubble out of
-   * the plot area and get it clipped.
+   * Default: 24. Use a smaller value when the bubble is near a chart
+   * edge that would clip it.
    */
   gap?: number;
 }
@@ -175,27 +177,66 @@ export function renderChartFlagDot({
   index,
   color,
   label,
-  above,
+  side,
   gap = 24,
 }: FlagDotOptions): ReactElement {
   const labelWidth = label.length * 7 + 14;
   const labelHeight = 22;
   const arrowSize = 5;
-  const bubbleEdgeY = above ? cy - gap : cy + gap;
-  const bubbleTop = above
-    ? bubbleEdgeY - arrowSize - labelHeight
-    : bubbleEdgeY + arrowSize;
-  const arrowTipY = bubbleEdgeY;
-  const arrowBaseY = above
-    ? bubbleEdgeY - arrowSize
-    : bubbleEdgeY + arrowSize;
+
+  // Bubble centroid + arrow tip geometry. Vertical sides ('above'/'below')
+  // anchor the arrow on the top/bottom edge of the bubble; horizontal sides
+  // anchor it on the left/right edge.
+  let bubbleX: number;
+  let bubbleY: number;
+  let arrowTipX: number;
+  let arrowTipY: number;
+  let connectorX1: number;
+  let connectorY1: number;
+  let arrowPoints: string;
+
+  if (side === 'above') {
+    bubbleX = cx - labelWidth / 2;
+    bubbleY = cy - gap - arrowSize - labelHeight;
+    arrowTipX = cx;
+    arrowTipY = cy - gap;
+    connectorX1 = cx;
+    connectorY1 = cy - 5;
+    arrowPoints = `${cx - arrowSize},${arrowTipY - arrowSize} ${cx + arrowSize},${arrowTipY - arrowSize} ${cx},${arrowTipY}`;
+  } else if (side === 'below') {
+    bubbleX = cx - labelWidth / 2;
+    bubbleY = cy + gap + arrowSize;
+    arrowTipX = cx;
+    arrowTipY = cy + gap;
+    connectorX1 = cx;
+    connectorY1 = cy + 5;
+    arrowPoints = `${cx - arrowSize},${arrowTipY + arrowSize} ${cx + arrowSize},${arrowTipY + arrowSize} ${cx},${arrowTipY}`;
+  } else if (side === 'right') {
+    bubbleX = cx + gap + arrowSize;
+    bubbleY = cy - labelHeight / 2;
+    arrowTipX = cx + gap;
+    arrowTipY = cy;
+    connectorX1 = cx + 5;
+    connectorY1 = cy;
+    arrowPoints = `${arrowTipX + arrowSize},${cy - arrowSize} ${arrowTipX + arrowSize},${cy + arrowSize} ${arrowTipX},${cy}`;
+  } else {
+    // 'left'
+    bubbleX = cx - gap - arrowSize - labelWidth;
+    bubbleY = cy - labelHeight / 2;
+    arrowTipX = cx - gap;
+    arrowTipY = cy;
+    connectorX1 = cx - 5;
+    connectorY1 = cy;
+    arrowPoints = `${arrowTipX - arrowSize},${cy - arrowSize} ${arrowTipX - arrowSize},${cy + arrowSize} ${arrowTipX},${cy}`;
+  }
+
   // Explicit fillOpacity / strokeOpacity / opacity on every shape:
   // recharts' <Area fillOpacity={...}> propagates a fillOpacity attribute
   // down to dot children via SVG inheritance, which would render the
   // bubble at the area's translucent fill instead of solid color.
   return (
     <g
-      key={`flag-${index}-${above ? 'hi' : 'lo'}`}
+      key={`flag-${index}-${side}`}
       fillOpacity={1}
       strokeOpacity={1}
       opacity={1}
@@ -211,9 +252,9 @@ export function renderChartFlagDot({
         strokeOpacity={1}
       />
       <line
-        x1={cx}
-        y1={above ? cy - 5 : cy + 5}
-        x2={cx}
+        x1={connectorX1}
+        y1={connectorY1}
+        x2={arrowTipX}
         y2={arrowTipY}
         stroke={color}
         strokeWidth={1.5}
@@ -221,8 +262,8 @@ export function renderChartFlagDot({
         strokeOpacity={1}
       />
       <rect
-        x={cx - labelWidth / 2}
-        y={bubbleTop}
+        x={bubbleX}
+        y={bubbleY}
         width={labelWidth}
         height={labelHeight}
         rx={5}
@@ -230,14 +271,10 @@ export function renderChartFlagDot({
         fillOpacity={1}
         filter="url(#chartFlagShadow)"
       />
-      <polygon
-        points={`${cx - arrowSize},${arrowBaseY} ${cx + arrowSize},${arrowBaseY} ${cx},${arrowTipY}`}
-        fill={color}
-        fillOpacity={1}
-      />
+      <polygon points={arrowPoints} fill={color} fillOpacity={1} />
       <text
-        x={cx}
-        y={bubbleTop + labelHeight / 2}
+        x={bubbleX + labelWidth / 2}
+        y={bubbleY + labelHeight / 2}
         textAnchor="middle"
         dominantBaseline="central"
         fill="#fff"

--- a/frontend/src/components/reports/PortfolioValueReport.test.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.test.tsx
@@ -156,11 +156,11 @@ describe('PortfolioValueReport', () => {
     ]);
     render(<PortfolioValueReport />);
     await waitFor(() => {
-      expect(screen.getByText('Current Value')).toBeInTheDocument();
+      expect(screen.getByText('Highest Value')).toBeInTheDocument();
     });
+    expect(screen.getByText('Lowest Value')).toBeInTheDocument();
     expect(screen.getByText('Period Change')).toBeInTheDocument();
     expect(screen.getByText('Period Return')).toBeInTheDocument();
-    expect(screen.getByText('Period High / Low')).toBeInTheDocument();
   });
 
   it('renders the area chart', async () => {

--- a/frontend/src/components/reports/PortfolioValueReport.test.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.test.tsx
@@ -66,7 +66,6 @@ vi.mock('recharts', () => ({
     }
     return null;
   },
-  Customized: () => null,
 }));
 
 const mockGetInvestmentsMonthly = vi.fn();

--- a/frontend/src/components/reports/PortfolioValueReport.test.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.test.tsx
@@ -66,6 +66,7 @@ vi.mock('recharts', () => ({
     }
     return null;
   },
+  Customized: () => null,
 }));
 
 const mockGetInvestmentsMonthly = vi.fn();

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -56,7 +56,7 @@ function CustomTooltip({ active, payload, fmtFull }: {
 }
 
 export function PortfolioValueReport() {
-  const { formatCurrencyCompact, formatCurrencyAxis, formatCurrency: formatCurrencyFull } = useNumberFormat();
+  const { formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag, formatCurrency: formatCurrencyFull } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
   const chartRef = useRef<HTMLDivElement>(null);
   const [chartPoints, setChartPoints] = useState<Array<{ name: string; Value: number }>>([]);
@@ -113,6 +113,13 @@ export function PortfolioValueReport() {
     if (foreignCurrency) return formatCurrencyAxis(value, foreignCurrency);
     return formatCurrencyAxis(value);
   }, [foreignCurrency, formatCurrencyAxis]);
+
+  // Flag bubble label: 2-decimal compact notation, more precise than the
+  // 1-decimal axis tick formatter.
+  const fmtFlag = useCallback((value: number) => {
+    if (foreignCurrency) return formatCurrencyFlag(value, foreignCurrency);
+    return formatCurrencyFlag(value);
+  }, [foreignCurrency, formatCurrencyFlag]);
 
   // Sequence number for the latest in-flight load. Lets us drop stale
   // results so quick range/account switches can't write out-of-order data.
@@ -575,7 +582,7 @@ export function PortfolioValueReport() {
                       cy,
                       index,
                       color: isHighest ? '#10b981' : '#ef4444',
-                      label: Math.abs(value) >= 1000 ? fmtAxis(value) : fmtVal(value),
+                      label: fmtFlag(value),
                       side: isLeftHalf ? 'right' : 'left',
                     });
                   }}

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -9,7 +9,6 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
-  Customized,
 } from 'recharts';
 import { format } from 'date-fns';
 import { netWorthApi } from '@/lib/net-worth';
@@ -553,39 +552,27 @@ export function PortfolioValueReport() {
                   fill="url(#colorPortfolioValue)"
                   name="Portfolio Value"
                   isAnimationActive={false}
+                  dot={(props: { cx?: number; cy?: number; index?: number }) => {
+                    const { cx, cy, index } = props;
+                    if (cx == null || cy == null || index == null) {
+                      return <circle cx={0} cy={0} r={0} fill="none" />;
+                    }
+                    const isHighest = showFlags && index === highestIndex;
+                    const isLowest = showFlags && index === lowestIndex;
+                    if (!isHighest && !isLowest) {
+                      return <circle key={`dot-${index}`} cx={cx} cy={cy} r={0} fill="none" />;
+                    }
+                    const value = isHighest ? summary.highest : summary.lowest;
+                    return renderChartFlagDot({
+                      cx,
+                      cy,
+                      index,
+                      color: isHighest ? '#10b981' : '#ef4444',
+                      label: Math.abs(value) >= 1000 ? fmtAxis(value) : fmtVal(value),
+                      above: isHighest,
+                    });
+                  }}
                 />
-                {/* Highest/lowest flag callouts. Rendered as a Customized
-                    layer so the bubbles paint on top of axis labels and
-                    the area fill, not underneath. */}
-                {showFlags && (
-                  <Customized
-                    component={(props: { formattedGraphicalItems?: Array<{ props?: { points?: Array<{ x: number; y: number }> } }> }) => {
-                      const points = props.formattedGraphicalItems?.[0]?.props?.points;
-                      if (!points || points.length === 0) return null;
-                      const flags: Array<{ index: number; color: string; value: number; above: boolean }> = [];
-                      if (highestIndex >= 0 && points[highestIndex]) {
-                        flags.push({ index: highestIndex, color: '#10b981', value: summary.highest, above: true });
-                      }
-                      if (lowestIndex >= 0 && points[lowestIndex]) {
-                        flags.push({ index: lowestIndex, color: '#ef4444', value: summary.lowest, above: false });
-                      }
-                      return (
-                        <g>
-                          {flags.map((f) =>
-                            renderChartFlagDot({
-                              cx: points[f.index].x,
-                              cy: points[f.index].y,
-                              index: f.index,
-                              color: f.color,
-                              label: Math.abs(f.value) >= 1000 ? fmtAxis(f.value) : fmtVal(f.value),
-                              above: f.above,
-                            }),
-                          )}
-                        </g>
-                      );
-                    }}
-                  />
-                )}
               </AreaChart>
             </ResponsiveContainer>
           </div>

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -569,7 +569,10 @@ export function PortfolioValueReport() {
                       index,
                       color: isHighest ? '#10b981' : '#ef4444',
                       label: Math.abs(value) >= 1000 ? fmtAxis(value) : fmtVal(value),
-                      above: isHighest,
+                      // Both flags point upward -- the lowest point sits near
+                      // the bottom of the plot area where the x-axis labels
+                      // live, so a downward bubble would always overlap them.
+                      above: true,
                     });
                   }}
                 />

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -206,7 +206,9 @@ export function PortfolioValueReport() {
           } catch (error) {
             logger.error('Failed to load intraday data:', error);
             if (loadSeqRef.current !== seq) return;
-            setChartPoints([]);
+            // Silently fall back to the daily-snapshot endpoint so the
+            // user still sees a chart instead of an empty card.
+            await loadDailyOrMonthly();
             return;
           }
 
@@ -219,6 +221,7 @@ export function PortfolioValueReport() {
             currency: response.currency,
             fallbackToDaily: response.fallbackToDaily,
             skippedSymbols: response.skippedSymbols,
+            failedSymbols: response.failedSymbols ?? [],
           });
 
           if (response.fallbackToDaily) {
@@ -275,15 +278,17 @@ export function PortfolioValueReport() {
   ]);
 
   const summary = useMemo(() => {
-    if (chartPoints.length === 0) return { current: 0, initial: 0, change: 0, changePercent: 0, high: 0, low: 0 };
+    if (chartPoints.length === 0) {
+      return { change: 0, changePercent: 0, highest: 0, lowest: 0 };
+    }
+    const values = chartPoints.map((d) => d.Value);
+    const highest = Math.max(...values);
+    const lowest = Math.min(...values);
     const current = chartPoints[chartPoints.length - 1]?.Value || 0;
     const initial = chartPoints[0]?.Value || 0;
     const change = current - initial;
     const changePercent = initial !== 0 ? (change / Math.abs(initial)) * 100 : 0;
-    const values = chartPoints.map((d) => d.Value);
-    const high = Math.max(...values);
-    const low = Math.min(...values);
-    return { current, initial, change, changePercent, high, low };
+    return { change, changePercent, highest, lowest };
   }, [chartPoints]);
 
   const xAxisTicks = useMemo(() => {
@@ -319,7 +324,8 @@ export function PortfolioValueReport() {
       title: 'Portfolio Value',
       subtitle: accountLabel,
       summaryCards: [
-        { label: 'Current Value', value: fmtVal(summary.current), color: '#111827' },
+        { label: 'Highest Value', value: fmtVal(summary.highest), color: '#111827' },
+        { label: 'Lowest Value', value: fmtVal(summary.lowest), color: '#111827' },
         { label: 'Period Change', value: `${summary.change >= 0 ? '+' : ''}${fmtVal(summary.change)}`, color: summary.change >= 0 ? '#16a34a' : '#dc2626' },
         { label: 'Period Return', value: `${summary.changePercent >= 0 ? '+' : ''}${summary.changePercent.toFixed(1)}%`, color: summary.changePercent >= 0 ? '#16a34a' : '#dc2626' },
       ],
@@ -352,9 +358,15 @@ export function PortfolioValueReport() {
       {/* Summary Cards */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
-          <div className="text-sm text-gray-500 dark:text-gray-400">Current Value</div>
+          <div className="text-sm text-gray-500 dark:text-gray-400">Highest Value</div>
           <div className="text-xl font-bold text-gray-900 dark:text-gray-100">
-            {fmtVal(summary.current)}
+            {fmtVal(summary.highest)}
+          </div>
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
+          <div className="text-sm text-gray-500 dark:text-gray-400">Lowest Value</div>
+          <div className="text-xl font-bold text-gray-900 dark:text-gray-100">
+            {fmtVal(summary.lowest)}
           </div>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
@@ -367,14 +379,6 @@ export function PortfolioValueReport() {
           <div className="text-sm text-gray-500 dark:text-gray-400">Period Return</div>
           <div className={`text-xl font-bold ${summary.changePercent >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
             {summary.changePercent >= 0 ? '+' : ''}{summary.changePercent.toFixed(1)}%
-          </div>
-        </div>
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
-          <div className="text-sm text-gray-500 dark:text-gray-400">Period High / Low</div>
-          <div className="text-sm font-bold text-gray-900 dark:text-gray-100">
-            <span className="text-green-600 dark:text-green-400">{fmtVal(summary.high)}</span>
-            {' / '}
-            <span className="text-red-600 dark:text-red-400">{fmtVal(summary.low)}</span>
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -573,6 +573,10 @@ export function PortfolioValueReport() {
                       // the bottom of the plot area where the x-axis labels
                       // live, so a downward bubble would always overlap them.
                       above: true,
+                      // Tighter gap for the highest flag: it sits near the top
+                      // of the plot area where a full-size connector would push
+                      // the bubble out of the chart and get it clipped.
+                      gap: isHighest ? 10 : undefined,
                     });
                   }}
                 />

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -9,6 +9,7 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
+  Customized,
 } from 'recharts';
 import { format } from 'date-fns';
 import { netWorthApi } from '@/lib/net-worth';
@@ -552,27 +553,39 @@ export function PortfolioValueReport() {
                   fill="url(#colorPortfolioValue)"
                   name="Portfolio Value"
                   isAnimationActive={false}
-                  dot={(props: { cx?: number; cy?: number; index?: number }) => {
-                    const { cx, cy, index } = props;
-                    if (cx == null || cy == null || index == null) {
-                      return <circle cx={0} cy={0} r={0} fill="none" />;
-                    }
-                    const isHighest = showFlags && index === highestIndex;
-                    const isLowest = showFlags && index === lowestIndex;
-                    if (!isHighest && !isLowest) {
-                      return <circle key={`dot-${index}`} cx={cx} cy={cy} r={0} fill="none" />;
-                    }
-                    const value = isHighest ? summary.highest : summary.lowest;
-                    return renderChartFlagDot({
-                      cx,
-                      cy,
-                      index,
-                      color: isHighest ? '#10b981' : '#ef4444',
-                      label: Math.abs(value) >= 1000 ? fmtAxis(value) : fmtVal(value),
-                      above: isHighest,
-                    });
-                  }}
                 />
+                {/* Highest/lowest flag callouts. Rendered as a Customized
+                    layer so the bubbles paint on top of axis labels and
+                    the area fill, not underneath. */}
+                {showFlags && (
+                  <Customized
+                    component={(props: { formattedGraphicalItems?: Array<{ props?: { points?: Array<{ x: number; y: number }> } }> }) => {
+                      const points = props.formattedGraphicalItems?.[0]?.props?.points;
+                      if (!points || points.length === 0) return null;
+                      const flags: Array<{ index: number; color: string; value: number; above: boolean }> = [];
+                      if (highestIndex >= 0 && points[highestIndex]) {
+                        flags.push({ index: highestIndex, color: '#10b981', value: summary.highest, above: true });
+                      }
+                      if (lowestIndex >= 0 && points[lowestIndex]) {
+                        flags.push({ index: lowestIndex, color: '#ef4444', value: summary.lowest, above: false });
+                      }
+                      return (
+                        <g>
+                          {flags.map((f) =>
+                            renderChartFlagDot({
+                              cx: points[f.index].x,
+                              cy: points[f.index].y,
+                              index: f.index,
+                              color: f.color,
+                              label: Math.abs(f.value) >= 1000 ? fmtAxis(f.value) : fmtVal(f.value),
+                              above: f.above,
+                            }),
+                          )}
+                        </g>
+                      );
+                    }}
+                  />
+                )}
               </AreaChart>
             </ResponsiveContainer>
           </div>

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -29,6 +29,8 @@ import {
   readIntradayCache,
   writeIntradayCache,
   computeTightYAxisDomain,
+  renderChartFlagDot,
+  ChartFlagShadowFilter,
 } from '@/components/investments/portfolio-chart-utils';
 
 const logger = createLogger('PortfolioValueReport');
@@ -307,6 +309,24 @@ export function PortfolioValueReport() {
     [chartPoints],
   );
 
+  // Index of the first point at the highest / lowest value, for the
+  // bubble callouts. Suppress when the series is flat.
+  const highestIndex = useMemo(
+    () =>
+      chartPoints.length === 0
+        ? -1
+        : chartPoints.findIndex((p) => p.Value === summary.highest),
+    [chartPoints, summary.highest],
+  );
+  const lowestIndex = useMemo(
+    () =>
+      chartPoints.length === 0
+        ? -1
+        : chartPoints.findIndex((p) => p.Value === summary.lowest),
+    [chartPoints, summary.lowest],
+  );
+  const showFlags = summary.highest !== summary.lowest;
+
   const handleExportPdf = async () => {
     const { exportToPdf } = await import('@/lib/pdf-export');
     const accountLabel = selectedAccount
@@ -487,13 +507,14 @@ export function PortfolioValueReport() {
             }`}
           >
             <ResponsiveContainer width="100%" height="100%" minWidth={0}>
-              <AreaChart data={chartPoints} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+              <AreaChart data={chartPoints} margin={{ top: 30, right: 30, left: 0, bottom: 30 }}>
                 <defs>
                   <linearGradient id="colorPortfolioValue" x1="0" y1="0" x2="0" y2="1">
                     <stop offset="5%" stopColor="#10b981" stopOpacity={0.3} />
                     <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
                   </linearGradient>
                 </defs>
+                <ChartFlagShadowFilter />
                 <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
                 <XAxis
                   dataKey="name"
@@ -530,6 +551,27 @@ export function PortfolioValueReport() {
                   fillOpacity={1}
                   fill="url(#colorPortfolioValue)"
                   name="Portfolio Value"
+                  isAnimationActive={false}
+                  dot={(props: { cx?: number; cy?: number; index?: number }) => {
+                    const { cx, cy, index } = props;
+                    if (cx == null || cy == null || index == null) {
+                      return <circle cx={0} cy={0} r={0} fill="none" />;
+                    }
+                    const isHighest = showFlags && index === highestIndex;
+                    const isLowest = showFlags && index === lowestIndex;
+                    if (!isHighest && !isLowest) {
+                      return <circle key={`dot-${index}`} cx={cx} cy={cy} r={0} fill="none" />;
+                    }
+                    const value = isHighest ? summary.highest : summary.lowest;
+                    return renderChartFlagDot({
+                      cx,
+                      cy,
+                      index,
+                      color: isHighest ? '#10b981' : '#ef4444',
+                      label: Math.abs(value) >= 1000 ? fmtAxis(value) : fmtVal(value),
+                      above: isHighest,
+                    });
+                  }}
                 />
               </AreaChart>
             </ResponsiveContainer>

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -563,20 +563,20 @@ export function PortfolioValueReport() {
                       return <circle key={`dot-${index}`} cx={cx} cy={cy} r={0} fill="none" />;
                     }
                     const value = isHighest ? summary.highest : summary.lowest;
+                    // Place the bubble to the side of its dot (with a horizontal
+                    // connector) instead of above/below. This puts the bubble
+                    // in the chart's middle vertical band -- well clear of the
+                    // x-axis labels at the bottom and the top edge of the plot.
+                    // Side is auto-picked based on the dot's position so the
+                    // bubble stays inside the chart's left/right edges.
+                    const isLeftHalf = index < chartPoints.length / 2;
                     return renderChartFlagDot({
                       cx,
                       cy,
                       index,
                       color: isHighest ? '#10b981' : '#ef4444',
                       label: Math.abs(value) >= 1000 ? fmtAxis(value) : fmtVal(value),
-                      // Both flags point upward -- the lowest point sits near
-                      // the bottom of the plot area where the x-axis labels
-                      // live, so a downward bubble would always overlap them.
-                      above: true,
-                      // Tighter gap for the highest flag: it sits near the top
-                      // of the plot area where a full-size connector would push
-                      // the bubble out of the chart and get it clipped.
-                      gap: isHighest ? 10 : undefined,
+                      side: isLeftHalf ? 'right' : 'left',
                     });
                   }}
                 />

--- a/frontend/src/hooks/useDateRange.test.ts
+++ b/frontend/src/hooks/useDateRange.test.ts
@@ -18,6 +18,23 @@ describe('useDateRange', () => {
     expect(result.current.isValid).toBe(true);
   });
 
+  it('resolves 1d range as a one-week window with day-level end (intraday-fallback friendly)', () => {
+    // '1d' is an intraday-only preset; resolvedRange is consumed by the
+    // chart only when intraday fails and we fall back to daily snapshots.
+    // A single day's snapshot is one point, so the hook widens to a week.
+    const { result } = renderHook(() => useDateRange({ defaultRange: '1d' }));
+    expect(result.current.resolvedRange.start).toBe('2025-01-08');
+    expect(result.current.resolvedRange.end).toBe('2025-01-15');
+  });
+
+  it('resolves 1d range with month alignment still uses day-level dates', () => {
+    const { result } = renderHook(() =>
+      useDateRange({ defaultRange: '1d', alignment: 'month' }),
+    );
+    expect(result.current.resolvedRange.start).toBe('2025-01-08');
+    expect(result.current.resolvedRange.end).toBe('2025-01-15');
+  });
+
   it('resolves 1w range', () => {
     const { result } = renderHook(() => useDateRange({ defaultRange: '1w' }));
     expect(result.current.resolvedRange.start).toBe('2025-01-08');

--- a/frontend/src/hooks/useDateRange.test.ts
+++ b/frontend/src/hooks/useDateRange.test.ts
@@ -109,15 +109,12 @@ describe('useDateRange', () => {
     expect(result.current.resolvedRange.end).toBe('2025-01-15');
   });
 
-  it('resolves 2y range with month alignment: start snaps to month start, end stays at today', () => {
+  it('resolves 2y range as a rolling 730 days regardless of alignment', () => {
     const { result } = renderHook(() =>
       useDateRange({ defaultRange: '2y', alignment: 'month' })
     );
-    // Month alignment snaps the START to a month boundary so monthly
-    // aggregation lines up cleanly. The END is always today, even on
-    // long-range presets, because data only exists up to today and we
-    // don't want a flat-line tail through the rest of the month.
-    expect(result.current.resolvedRange.start).toBe('2023-02-01');
+    // 2025-01-15 minus 730 days = 2023-01-16 (2024 is a leap year).
+    expect(result.current.resolvedRange.start).toBe('2023-01-16');
     expect(result.current.resolvedRange.end).toBe('2025-01-15');
   });
 

--- a/frontend/src/hooks/useDateRange.test.ts
+++ b/frontend/src/hooks/useDateRange.test.ts
@@ -109,13 +109,16 @@ describe('useDateRange', () => {
     expect(result.current.resolvedRange.end).toBe('2025-01-15');
   });
 
-  it('resolves 2y range with month alignment snaps to month boundaries', () => {
+  it('resolves 2y range with month alignment: start snaps to month start, end stays at today', () => {
     const { result } = renderHook(() =>
       useDateRange({ defaultRange: '2y', alignment: 'month' })
     );
-    // Long ranges still use month alignment
+    // Month alignment snaps the START to a month boundary so monthly
+    // aggregation lines up cleanly. The END is always today, even on
+    // long-range presets, because data only exists up to today and we
+    // don't want a flat-line tail through the rest of the month.
     expect(result.current.resolvedRange.start).toBe('2023-02-01');
-    expect(result.current.resolvedRange.end).toBe('2025-01-31');
+    expect(result.current.resolvedRange.end).toBe('2025-01-15');
   });
 
   it('resolves all range with empty start', () => {

--- a/frontend/src/hooks/useDateRange.ts
+++ b/frontend/src/hooks/useDateRange.ts
@@ -43,7 +43,7 @@ export function useDateRange(options: UseDateRangeOptions): UseDateRangeReturn {
       const isMonth = alignment === 'month';
       // Short-range presets always use today as end date (day-level precision).
       // Long-range presets with month alignment snap to end of month.
-      const useDayLevel = ['1w', '1m', '3m', 'ytd', '1y'].includes(range);
+      const useDayLevel = ['1d', '1w', '1m', '3m', 'ytd', '1y'].includes(range);
       const end = isMonth && !useDayLevel
         ? format(endOfMonth(now), 'yyyy-MM-dd')
         : format(now, 'yyyy-MM-dd');
@@ -51,6 +51,13 @@ export function useDateRange(options: UseDateRangeOptions): UseDateRangeReturn {
       let start: string;
 
       switch (range) {
+        case '1d':
+          // '1d' is an intraday-only preset; resolvedRange is consumed only
+          // when the chart falls back to the daily-snapshot endpoint. A
+          // single day's snapshot is just one point, so widen to a week so
+          // the fallback chart is still readable.
+          start = format(subWeeks(now, 1), 'yyyy-MM-dd');
+          break;
         case '1w':
           start = format(subWeeks(now, 1), 'yyyy-MM-dd');
           break;

--- a/frontend/src/hooks/useDateRange.ts
+++ b/frontend/src/hooks/useDateRange.ts
@@ -76,9 +76,11 @@ export function useDateRange(options: UseDateRangeOptions): UseDateRangeReturn {
           start = format(subYears(now, 1), 'yyyy-MM-dd');
           break;
         case '2y':
-          start = isMonth
-            ? format(startOfMonth(subMonths(now, 23)), 'yyyy-MM-dd')
-            : format(subYears(now, 2), 'yyyy-MM-dd');
+          // Rolling 2 years = last 730 days. Same shape regardless of
+          // alignment: month alignment on the start was producing partial
+          // history at the leading edge (e.g. mid-month -> chart only
+          // showed 23.5 months back).
+          start = format(subDays(now, 730), 'yyyy-MM-dd');
           break;
         case '5y':
           start = isMonth

--- a/frontend/src/hooks/useDateRange.ts
+++ b/frontend/src/hooks/useDateRange.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo } from 'react';
-import { format, subMonths, subDays, subYears, subWeeks, startOfMonth, endOfMonth } from 'date-fns';
+import { format, subMonths, subDays, subYears, subWeeks, startOfMonth } from 'date-fns';
 
 interface UseDateRangeOptions {
   /** Which preset is selected by default. */
@@ -41,12 +41,12 @@ export function useDateRange(options: UseDateRangeOptions): UseDateRangeReturn {
 
       const now = new Date();
       const isMonth = alignment === 'month';
-      // Short-range presets always use today as end date (day-level precision).
-      // Long-range presets with month alignment snap to end of month.
-      const useDayLevel = ['1d', '1w', '1m', '3m', 'ytd', '1y'].includes(range);
-      const end = isMonth && !useDayLevel
-        ? format(endOfMonth(now), 'yyyy-MM-dd')
-        : format(now, 'yyyy-MM-dd');
+      // End date is always today: data only exists up to today, so snapping
+      // the end to end-of-month (the previous behaviour for long-range
+      // month-aligned presets like 2y/5y) just produced a flat-line tail
+      // from today through the rest of the month. Month alignment now
+      // affects the start date only.
+      const end = format(now, 'yyyy-MM-dd');
 
       let start: string;
 

--- a/frontend/src/hooks/useInvestmentData.test.ts
+++ b/frontend/src/hooks/useInvestmentData.test.ts
@@ -174,6 +174,32 @@ describe('useInvestmentData – handleDeleteTransaction', () => {
     expect(result.current.portfolioSummary).toEqual(freshSummary);
   });
 
+  it('keeps isLoading=false on subsequent reloads so sections do not redraw from blank', async () => {
+    // Initial load completes -> isLoading=false. Subsequent reloads (e.g.
+    // from a price refresh) should NOT flip isLoading back to true; the
+    // sections should keep showing existing data while the fetch is in
+    // flight. Without this, every refresh causes the summary card,
+    // allocation chart, holdings list, and transaction list to revert to
+    // their skeleton state -- the bug the user reported as "every section
+    // except the chart redraws from blank when refreshing prices".
+    mockGetPortfolioSummary.mockResolvedValue(mockSummary);
+    mockGetTransactions.mockResolvedValue({ data: [], pagination: null });
+
+    const { result } = renderHook(() => useInvestmentData());
+    await act(async () => { await new Promise(res => setTimeout(res, 0)); });
+
+    expect(result.current.isLoading).toBe(false);
+    const initialCalls = mockGetPortfolioSummary.mock.calls.length;
+
+    // Trigger a subsequent reload (the same path price-refresh uses).
+    await act(async () => {
+      await result.current.loadAllPortfolioData([], 1, {});
+    });
+
+    expect(mockGetPortfolioSummary.mock.calls.length).toBeGreaterThan(initialCalls);
+    expect(result.current.isLoading).toBe(false);
+  });
+
   it('does not call setIsLoading on successful delete (no full reload)', async () => {
     mockDeleteTransaction.mockResolvedValue(undefined);
 

--- a/frontend/src/hooks/useInvestmentData.ts
+++ b/frontend/src/hooks/useInvestmentData.ts
@@ -109,12 +109,22 @@ export function useInvestmentData() {
     }
   }, []);
 
+  // Track whether the initial load has completed so subsequent reloads
+  // (price refresh, account selection change, pagination, filter change)
+  // can run "in the background" while sections keep showing their existing
+  // data. Without this, every refresh flips isLoading=true and every
+  // skeleton-gated section re-mounts from blank -- which is the
+  // "everything redraws when prices refresh" bug. The Portfolio Value chart
+  // is unaffected because it already has its own keep-data-while-loading
+  // pattern; this generalises that behaviour to the rest of the page.
+  const hasLoadedRef = useRef(false);
+
   const loadAllPortfolioData = useCallback(async (
     accountIds: string[],
     page: number = 1,
     filters: TransactionFilters = {},
   ) => {
-    setIsLoading(true);
+    if (!hasLoadedRef.current) setIsLoading(true);
     try {
       const ids = accountIds.length > 0 ? accountIds : undefined;
       const [summaryData, txResponse] = await Promise.all([
@@ -138,7 +148,8 @@ export function useInvestmentData() {
       setTransactions([]);
       setPagination(null);
     } finally {
-      setIsLoading(false);
+      if (!hasLoadedRef.current) setIsLoading(false);
+      hasLoadedRef.current = true;
     }
   }, []);
 

--- a/frontend/src/hooks/useNumberFormat.ts
+++ b/frontend/src/hooks/useNumberFormat.ts
@@ -127,5 +127,26 @@ export function useNumberFormat() {
     [numberFormat, defaultCurrency]
   );
 
-  return { formatCurrency, formatCurrencyCompact, formatCurrencyAxis, formatCurrencyLabel, formatNumber, formatPercent, defaultCurrency, numberFormat };
+  /** Compact currency for chart flag/callout bubbles: same K/M/B/T notation
+   *  as the axis ticks but with exactly 2 decimal places (e.g., "$1.50K",
+   *  "$2.34M") so the highlighted high/low values read more precisely than
+   *  the surrounding axis labels. */
+  const formatCurrencyFlag = useCallback(
+    (value: number, currencyCode?: string): string => {
+      const currency = currencyCode || defaultCurrency;
+      const locale = getEffectiveLocale(numberFormat);
+      return new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency,
+        currencyDisplay: 'narrowSymbol',
+        notation: 'compact',
+        compactDisplay: 'short',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }).format(value);
+    },
+    [numberFormat, defaultCurrency]
+  );
+
+  return { formatCurrency, formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag, formatCurrencyLabel, formatNumber, formatPercent, defaultCurrency, numberFormat };
 }

--- a/frontend/src/lib/investments.test.ts
+++ b/frontend/src/lib/investments.test.ts
@@ -143,16 +143,25 @@ describe('investmentsApi', () => {
   it('refreshPrices posts to /securities/prices/refresh', async () => {
     vi.mocked(apiClient.post).mockResolvedValue({ data: { updated: 5 } });
     const result = await investmentsApi.refreshPrices();
-    expect(apiClient.post).toHaveBeenCalledWith('/securities/prices/refresh');
+    // Per-request 120s timeout overrides the global 10s default; the
+    // refresh-all endpoint hits Yahoo for every active security and
+    // routinely takes longer than 10s on portfolios with many holdings.
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/securities/prices/refresh',
+      undefined,
+      { timeout: 120_000 },
+    );
     expect(result.updated).toBe(5);
   });
 
   it('refreshSelectedPrices posts with securityIds', async () => {
     vi.mocked(apiClient.post).mockResolvedValue({ data: { updated: 2 } });
     await investmentsApi.refreshSelectedPrices(['s-1', 's-2']);
-    expect(apiClient.post).toHaveBeenCalledWith('/securities/prices/refresh/selected', {
-      securityIds: ['s-1', 's-2'],
-    });
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/securities/prices/refresh/selected',
+      { securityIds: ['s-1', 's-2'] },
+      { timeout: 120_000 },
+    );
   });
 
   it('getPriceStatus fetches /securities/prices/status', async () => {

--- a/frontend/src/lib/investments.ts
+++ b/frontend/src/lib/investments.ts
@@ -62,7 +62,7 @@ export const investmentsApi = {
     displayCurrency?: string;
   }): Promise<{
     points: Array<{ timestamp: string; value: number }>;
-    interval: '1m' | '5m' | '15m';
+    interval: '1m' | '2m' | '5m' | '15m' | '30m' | '60m' | '90m';
     currency: string;
     range: '1d' | '1w' | '1m';
     fetchedAt: string;

--- a/frontend/src/lib/investments.ts
+++ b/frontend/src/lib/investments.ts
@@ -333,7 +333,12 @@ export const investmentsApi = {
     }>;
     lastUpdated: string;
   }> => {
-    const response = await apiClient.post('/securities/prices/refresh');
+    // The default 10s axios timeout is too short for this endpoint -- it
+    // hits Yahoo Finance once per active security and can easily exceed
+    // 10s for larger catalogs. Give it 2 minutes.
+    const response = await apiClient.post('/securities/prices/refresh', undefined, {
+      timeout: 120_000,
+    });
     invalidateCache('investments:');
     return response.data;
   },
@@ -352,7 +357,11 @@ export const investmentsApi = {
     }>;
     lastUpdated: string;
   }> => {
-    const response = await apiClient.post('/securities/prices/refresh/selected', { securityIds });
+    const response = await apiClient.post(
+      '/securities/prices/refresh/selected',
+      { securityIds },
+      { timeout: 120_000 },
+    );
     invalidateCache('investments:');
     return response.data;
   },

--- a/frontend/src/lib/investments.ts
+++ b/frontend/src/lib/investments.ts
@@ -67,6 +67,7 @@ export const investmentsApi = {
     range: '1d' | '1w' | '1m';
     fetchedAt: string;
     skippedSymbols: string[];
+    failedSymbols: string[];
     fallbackToDaily: boolean;
   }> => {
     const response = await apiClient.get('/portfolio/intraday-value', { params });


### PR DESCRIPTION
## Summary
This PR improves the intraday portfolio value chart by implementing a graceful degradation strategy when narrow time intervals fail, and ensures cash balances are properly included in all portfolio valuations.

## Key Changes

### Backend (Portfolio Service & Yahoo Finance)
- **Intraday fallback chain**: When a holding's intraday fetch fails at the primary interval (1m for 1D, 5m for 1W, 15m for 1M), the service now retries at progressively coarser intervals (2m, 5m, 15m, 30m, 60m, 90m) before falling back to daily snapshots. This handles rate-limiting and data availability issues gracefully.
- **Cash balance inclusion**: Portfolio value calculations now include:
  - Investment account cash balances (from the linked cash account)
  - Standalone account cash balances (for accounts with no linked cash account)
  - This fixes a bug where intraday charts undershot daily-snapshot charts by omitting the cash sleeve
- **Rate-limit handling**: Added `throttledFetch()` wrapper in YahooFinanceService that:
  - Caps concurrent requests at 5 to avoid overwhelming the API
  - Retries on 429/503 responses with exponential backoff
  - Honors `Retry-After` headers
  - Leaves inter-request gaps to reduce burst load
- **Partial failure handling**: When some holdings fail intraday fetch but others succeed, uses the failed holdings' latest daily close as a constant offset rather than falling back entirely

### Frontend (Chart Components & Utilities)
- **Chart flag bubbles**: Added `renderChartFlagDot()` and `ChartFlagShadowFilter()` to display high/low value callouts with colored dots, dashed connectors, and rounded label bubbles
- **Flag formatting**: New `formatCurrencyFlag()` formatter provides 2-decimal compact notation (e.g., "$1.50K") for flag labels, more precise than 1-decimal axis ticks
- **Summary metrics**: Changed from "Current Value" to "Highest Value" and "Lowest Value" to highlight the range of portfolio performance
- **Graceful intraday fallback**: When intraday fetch fails, silently falls back to daily-snapshot endpoint instead of showing empty chart
- **Loading state fix**: Subsequent data reloads no longer flip `isLoading=true`, preventing skeleton states from redrawing existing sections during background refreshes
- **Date range resolution**: 1D intraday-only preset now resolves to a 1-week window for fallback daily snapshots (single day = one point)

### Testing
- Added comprehensive test coverage for:
  - Cash balance inclusion in portfolio calculations
  - Fallback chain retry logic per range (1D/1W/1M)
  - Rate-limit retry behavior with Retry-After header support
  - Concurrent request limiting
  - Partial failure handling with stale price fallbacks
  - Summary metric calculations with high/low values

## Notable Implementation Details
- The fallback chain is range-specific: 1D starts at 1m, 1W at 5m, 1M at 15m (avoiding the most rate-limited intervals for longer ranges)
- Failed intraday responses are NOT cached to avoid pinning error banners on screen after user refresh
- Concurrent request semaphore uses a FIFO queue to prevent thundering herd on retry
- Chart flag positioning automatically adjusts (above/below/left/right) to avoid clipping near chart edges

https://claude.ai/code/session_01MbWVQUJNUF1sYuqFWuVLFx