### PR TITLE
fix(dashboard): reduce CLS by reserving card heights and stabilizing charts

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -13,9 +13,18 @@ import { TopMovers } from '@/components/dashboard/TopMovers';
 import { InsightsWidget } from '@/components/dashboard/InsightsWidget';
 import { BudgetStatusWidget } from '@/components/dashboard/BudgetStatusWidget';
 
-const ExpensesPieChart = dynamic(() => import('@/components/dashboard/ExpensesPieChart').then(m => m.ExpensesPieChart), { ssr: false });
-const IncomeExpensesBarChart = dynamic(() => import('@/components/dashboard/IncomeExpensesBarChart').then(m => m.IncomeExpensesBarChart), { ssr: false });
-const NetWorthChart = dynamic(() => import('@/components/dashboard/NetWorthChart').then(m => m.NetWorthChart), { ssr: false });
+const ExpensesPieChart = dynamic(() => import('@/components/dashboard/ExpensesPieChart').then(m => m.ExpensesPieChart), {
+  ssr: false,
+  loading: () => <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6 lg:min-h-[540px]" />,
+});
+const IncomeExpensesBarChart = dynamic(() => import('@/components/dashboard/IncomeExpensesBarChart').then(m => m.IncomeExpensesBarChart), {
+  ssr: false,
+  loading: () => <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[540px]" />,
+});
+const NetWorthChart = dynamic(() => import('@/components/dashboard/NetWorthChart').then(m => m.NetWorthChart), {
+  ssr: false,
+  loading: () => <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[500px]" />,
+});
 import { accountsApi } from '@/lib/accounts';
 import { transactionsApi } from '@/lib/transactions';
 import { categoriesApi } from '@/lib/categories';

--- a/frontend/src/components/dashboard/BudgetStatusWidget.tsx
+++ b/frontend/src/components/dashboard/BudgetStatusWidget.tsx
@@ -43,7 +43,7 @@ export function BudgetStatusWidget({ isLoading: parentLoading }: BudgetStatusWid
 
   if (isLoading || parentLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[390px]">
         <button
           onClick={() => router.push('/budgets')}
           className="text-lg font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors mb-4"
@@ -61,7 +61,7 @@ export function BudgetStatusWidget({ isLoading: parentLoading }: BudgetStatusWid
 
   if (hasError || !summary) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[390px]">
         <button
           onClick={() => router.push('/budgets')}
           className="text-lg font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors mb-4"
@@ -82,7 +82,7 @@ export function BudgetStatusWidget({ isLoading: parentLoading }: BudgetStatusWid
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[390px]">
       <div className="flex items-center justify-between mb-3">
         <button
           onClick={() => router.push(`/budgets/${summary.budgetId}`)}

--- a/frontend/src/components/dashboard/ExpensesPieChart.tsx
+++ b/frontend/src/components/dashboard/ExpensesPieChart.tsx
@@ -155,7 +155,7 @@ export function ExpensesPieChart({
 
   if (isLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6 lg:min-h-[540px]">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
           Expenses by Category
         </h3>
@@ -168,7 +168,7 @@ export function ExpensesPieChart({
 
   if (chartData.length === 0) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6 lg:min-h-[540px]">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
           Expenses by Category
         </h3>
@@ -180,7 +180,7 @@ export function ExpensesPieChart({
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6 flex flex-col h-full">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6 lg:min-h-[540px] flex flex-col h-full">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
           Expenses by Category

--- a/frontend/src/components/dashboard/FavouriteAccounts.tsx
+++ b/frontend/src/components/dashboard/FavouriteAccounts.tsx
@@ -83,7 +83,7 @@ export function FavouriteAccounts({ accounts, brokerageMarketValues, isLoading, 
 
   if (isLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[640px]">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
           Favourite Accounts
         </h3>
@@ -98,7 +98,7 @@ export function FavouriteAccounts({ accounts, brokerageMarketValues, isLoading, 
 
   if (favouriteAccounts.length === 0) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[640px]">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
           Favourite Accounts
         </h3>
@@ -110,7 +110,7 @@ export function FavouriteAccounts({ accounts, brokerageMarketValues, isLoading, 
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[640px]">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
           Favourite Accounts

--- a/frontend/src/components/dashboard/IncomeExpensesBarChart.tsx
+++ b/frontend/src/components/dashboard/IncomeExpensesBarChart.tsx
@@ -176,7 +176,7 @@ export function IncomeExpensesBarChart({
 
   if (isLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[540px]">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
           Income vs Expenses
         </h3>
@@ -188,14 +188,14 @@ export function IncomeExpensesBarChart({
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 flex flex-col h-full">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[540px] flex flex-col h-full">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
           Income vs Expenses
         </h3>
         <span className="text-sm text-gray-500 dark:text-gray-400">Last 5 weeks</span>
       </div>
-      <div className="h-64 flex-grow">
+      <div className="h-64">
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           <BarChart
             data={chartData}

--- a/frontend/src/components/dashboard/InsightsWidget.tsx
+++ b/frontend/src/components/dashboard/InsightsWidget.tsx
@@ -41,7 +41,7 @@ export function InsightsWidget({ isLoading: parentLoading }: InsightsWidgetProps
 
   if (isLoading || parentLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[390px]">
         <button
           onClick={() => router.push('/insights')}
           className="text-lg font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors mb-4"
@@ -59,7 +59,7 @@ export function InsightsWidget({ isLoading: parentLoading }: InsightsWidgetProps
 
   if (insights.length === 0) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[390px]">
         <button
           onClick={() => router.push('/insights')}
           className="text-lg font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors mb-4"
@@ -80,7 +80,7 @@ export function InsightsWidget({ isLoading: parentLoading }: InsightsWidgetProps
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[390px]">
       <div className="flex items-center justify-between mb-4">
         <button
           onClick={() => router.push('/insights')}

--- a/frontend/src/components/dashboard/NetWorthChart.tsx
+++ b/frontend/src/components/dashboard/NetWorthChart.tsx
@@ -81,7 +81,7 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
 
   if (isLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[500px]">
         <button
           onClick={() => router.push('/reports/net-worth')}
           className="text-lg font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors mb-4"
@@ -98,7 +98,7 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
 
   if (chartData.length === 0) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[500px]">
         <button
           onClick={() => router.push('/reports/net-worth')}
           className="text-lg font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors mb-4"
@@ -115,7 +115,7 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
   const isPositive = summary!.change >= 0;
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 flex flex-col h-full">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[500px] flex flex-col h-full">
       <div className="flex items-center justify-between mb-1">
         <button
           onClick={() => router.push('/reports/net-worth')}
@@ -137,7 +137,7 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
           {isPositive ? '+' : ''}{formatCurrency(summary!.change)} ({isPositive ? '+' : ''}{summary!.changePercent.toFixed(1)}%)
         </div>
       </div>
-      <div className="h-40 flex-grow">
+      <div className="h-80">
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           <AreaChart data={chartData} margin={{ top: 5, right: 20, left: 20, bottom: 0 }}>
             <defs>

--- a/frontend/src/components/dashboard/TopMovers.tsx
+++ b/frontend/src/components/dashboard/TopMovers.tsx
@@ -46,7 +46,7 @@ export function TopMovers({ movers, isLoading, hasInvestmentAccounts, onRefresh,
 
   if (isLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[500px]">
         <div className="flex items-center justify-between mb-4">
           <button
             onClick={() => router.push('/investments')}
@@ -70,7 +70,7 @@ export function TopMovers({ movers, isLoading, hasInvestmentAccounts, onRefresh,
 
   if (movers.length === 0) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[500px]">
         <div className="flex items-center justify-between mb-4">
           <button
             onClick={() => router.push('/investments')}
@@ -93,7 +93,7 @@ export function TopMovers({ movers, isLoading, hasInvestmentAccounts, onRefresh,
   const topMovers = movers.slice(0, 5);
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[500px]">
       <div className="flex items-center justify-between mb-4">
         <button
           onClick={() => router.push('/investments')}

--- a/frontend/src/components/dashboard/UpcomingBills.tsx
+++ b/frontend/src/components/dashboard/UpcomingBills.tsx
@@ -158,7 +158,7 @@ export function UpcomingBills({ scheduledTransactions, accounts, isLoading, maxI
 
   if (isLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[640px]">
         <button
           onClick={() => router.push('/bills')}
           className="text-lg font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors mb-4"
@@ -176,7 +176,7 @@ export function UpcomingBills({ scheduledTransactions, accounts, isLoading, maxI
 
   if (upcomingItems.length === 0) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[640px]">
         <button
           onClick={() => router.push('/bills')}
           className="text-lg font-semibold text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors mb-4"
@@ -202,7 +202,7 @@ export function UpcomingBills({ scheduledTransactions, accounts, isLoading, maxI
   const hiddenCount = upcomingItems.length - visibleItems.length;
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[640px]">
       <div className="flex items-center justify-between mb-4">
         <button
           onClick={() => router.push('/bills')}


### PR DESCRIPTION
## Summary

- Add `lg:min-h-[...]` to all 8 dashboard card wrapper divs across every return path (loading, empty, data) so cards reserve their final height upfront instead of expanding from 0 when API responses arrive (CLS 0.31 -> target < 0.1)
- Add `loading` fallbacks to the 3 `dynamic()` chart imports so space is reserved while JS chunks download
- Remove `flex-grow` from NetWorthChart and IncomeExpensesBarChart chart wrappers to give Recharts stable dimensions on first measure, eliminating `width(-1)/height(-1)` console warnings

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run lint && npm run type-check` pass
- [ ] `npm run test` passes
- [ ] Run Chrome DevTools performance trace on `/dashboard` and confirm CLS < 0.1
- [ ] No Recharts `width(-1)/height(-1)` warnings in console
- [ ] Dashboard cards render correctly on both desktop (`lg:` breakpoint) and mobile (single column)
- [ ] Charts (Net Worth, Income vs Expenses, Expenses by Category) display at correct sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)