### PR TITLE
fix(perf): apply review fixes for /transactions, /investments, and shared API caching

### DIFF
--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -15,9 +15,14 @@ const TransactionForm = dynamic(() => import('@/components/transactions/Transact
 const ScheduledTransactionForm = dynamic(() => import('@/components/scheduled-transactions/ScheduledTransactionForm').then(m => m.ScheduledTransactionForm), { ssr: false });
 const PayeeForm = dynamic(() => import('@/components/payees/PayeeForm').then(m => m.PayeeForm), { ssr: false });
 const BulkUpdateModal = dynamic(() => import('@/components/transactions/BulkUpdateModal').then(m => m.BulkUpdateModal), { ssr: false });
-const BalanceHistoryChart = dynamic(() => import('@/components/transactions/BalanceHistoryChart').then(m => m.BalanceHistoryChart), { ssr: false });
-const CategoryPayeeBarChart = dynamic(() => import('@/components/transactions/CategoryPayeeBarChart').then(m => m.CategoryPayeeBarChart), { ssr: false });
-const AccountBalancesBarChart = dynamic(() => import('@/components/transactions/AccountBalancesBarChart').then(m => m.AccountBalancesBarChart), { ssr: false });
+// Reserve the chart card's height while the chunk loads so the rest of the
+// page (filter row, table) doesn't jump down when the chart hydrates.
+const ChartLoadingPlaceholder = () => (
+  <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6 min-h-[420px]" />
+);
+const BalanceHistoryChart = dynamic(() => import('@/components/transactions/BalanceHistoryChart').then(m => m.BalanceHistoryChart), { ssr: false, loading: ChartLoadingPlaceholder });
+const CategoryPayeeBarChart = dynamic(() => import('@/components/transactions/CategoryPayeeBarChart').then(m => m.CategoryPayeeBarChart), { ssr: false, loading: ChartLoadingPlaceholder });
+const AccountBalancesBarChart = dynamic(() => import('@/components/transactions/AccountBalancesBarChart').then(m => m.AccountBalancesBarChart), { ssr: false, loading: ChartLoadingPlaceholder });
 import { transactionsApi } from '@/lib/transactions';
 import { accountsApi } from '@/lib/accounts';
 import { categoriesApi } from '@/lib/categories';

--- a/frontend/src/components/investments/AssetAllocationChart.tsx
+++ b/frontend/src/components/investments/AssetAllocationChart.tsx
@@ -92,7 +92,7 @@ export function AssetAllocationChart({
 
   if (isLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[420px]">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
           Asset Allocation{titleSuffix ? ` (${titleSuffix})` : ''}
         </h3>
@@ -105,7 +105,7 @@ export function AssetAllocationChart({
 
   if (!allocation || allocation.allocation.length === 0) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[420px]">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
           Asset Allocation{titleSuffix ? ` (${titleSuffix})` : ''}
         </h3>
@@ -117,7 +117,7 @@ export function AssetAllocationChart({
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[420px]">
       <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
         Asset Allocation{titleSuffix ? ` (${titleSuffix})` : ''}
       </h3>

--- a/frontend/src/components/investments/InvestmentTransactionList.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionList.tsx
@@ -478,8 +478,15 @@ export function InvestmentTransactionList({
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             {/* Symbol Filter */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Symbol</label>
+              <label
+                htmlFor="investment-tx-filter-symbol"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+              >
+                Symbol
+              </label>
               <select
+                id="investment-tx-filter-symbol"
+                name="investment-tx-filter-symbol"
                 value={filters?.symbol || ''}
                 onChange={(e) => handleFilterChange('symbol', e.target.value)}
                 className="w-full text-sm font-sans border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-blue-500 focus:border-blue-500"
@@ -493,8 +500,15 @@ export function InvestmentTransactionList({
 
             {/* Action Filter */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Action</label>
+              <label
+                htmlFor="investment-tx-filter-action"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+              >
+                Action
+              </label>
               <select
+                id="investment-tx-filter-action"
+                name="investment-tx-filter-action"
                 value={filters?.action || ''}
                 onChange={(e) => handleFilterChange('action', e.target.value)}
                 className="w-full text-sm font-sans border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-blue-500 focus:border-blue-500"

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -18,6 +18,7 @@ vi.mock('recharts', () => ({
   YAxis: () => null,
   CartesianGrid: () => null,
   Tooltip: () => null,
+  ReferenceDot: () => null,
 }));
 
 vi.mock('@/hooks/useNumberFormat', () => ({

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -9,6 +9,7 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
+  ReferenceDot,
 } from 'recharts';
 import { format } from 'date-fns';
 import { netWorthApi } from '@/lib/net-worth';
@@ -523,36 +524,50 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
                 fill="url(#colorInvestments)"
                 name="Portfolio Value"
                 isAnimationActive={false}
-                dot={(props: { cx?: number; cy?: number; index?: number }) => {
-                  const { cx, cy, index } = props;
-                  if (cx == null || cy == null || index == null) {
-                    return <circle cx={0} cy={0} r={0} fill="none" />;
-                  }
-                  const isHighest = showFlags && index === highestIndex;
-                  const isLowest = showFlags && index === lowestIndex;
-                  if (!isHighest && !isLowest) {
-                    return <circle key={`dot-${index}`} cx={cx} cy={cy} r={0} fill="none" />;
-                  }
-                  const value = isHighest ? summary.highest : summary.lowest;
-                  // Place the bubble to the side of its dot (with a horizontal
-                  // connector) instead of above/below. This puts the bubble
-                  // in the chart's middle vertical band -- well clear of the
-                  // x-axis labels at the bottom and the top edge of the plot,
-                  // regardless of whether the dot itself is at the top or
-                  // bottom of the data range. Side is auto-picked based on
-                  // the dot's position within the series so the bubble
-                  // doesn't get pushed off the chart's left or right edge.
-                  const isLeftHalf = index < chartPoints.length / 2;
-                  return renderChartFlagDot({
-                    cx,
-                    cy,
-                    index,
-                    color: isHighest ? '#10b981' : '#ef4444',
-                    label: fmtFlag(value),
-                    side: isLeftHalf ? 'right' : 'left',
-                  });
-                }}
+                dot={false}
+                activeDot={{ r: 4, fill: '#10b981' }}
               />
+              {/* Highest / lowest flag callouts. Using ReferenceDot instead of
+                  a per-point dot renderer keeps the SVG to two extra elements
+                  rather than one zero-radius <circle> for every datapoint --
+                  on long ranges (e.g. 366 daily points) that single change
+                  drops hundreds of nodes from the chart layer. */}
+              {showFlags && highestIndex >= 0 && (
+                <ReferenceDot
+                  x={chartPoints[highestIndex].name}
+                  y={summary.highest}
+                  shape={(props: { cx?: number; cy?: number }) => {
+                    const { cx, cy } = props;
+                    if (cx == null || cy == null) return <g />;
+                    return renderChartFlagDot({
+                      cx,
+                      cy,
+                      index: highestIndex,
+                      color: '#10b981',
+                      label: fmtFlag(summary.highest),
+                      side: highestIndex < chartPoints.length / 2 ? 'right' : 'left',
+                    });
+                  }}
+                />
+              )}
+              {showFlags && lowestIndex >= 0 && (
+                <ReferenceDot
+                  x={chartPoints[lowestIndex].name}
+                  y={summary.lowest}
+                  shape={(props: { cx?: number; cy?: number }) => {
+                    const { cx, cy } = props;
+                    if (cx == null || cy == null) return <g />;
+                    return renderChartFlagDot({
+                      cx,
+                      cy,
+                      index: lowestIndex,
+                      color: '#ef4444',
+                      label: fmtFlag(summary.lowest),
+                      side: lowestIndex < chartPoints.length / 2 ? 'right' : 'left',
+                    });
+                  }}
+                />
+              )}
             </AreaChart>
           </ResponsiveContainer>
         </div>

--- a/frontend/src/components/investments/PortfolioSummaryCard.tsx
+++ b/frontend/src/components/investments/PortfolioSummaryCard.tsx
@@ -94,7 +94,7 @@ export function PortfolioSummaryCard({
 
   if (isLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[420px]">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
           Portfolio Summary{titleSuffix ? ` (${titleSuffix})` : ''}
         </h3>
@@ -112,7 +112,7 @@ export function PortfolioSummaryCard({
 
   if (!summary) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[420px]">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
           Portfolio Summary{titleSuffix ? ` (${titleSuffix})` : ''}
         </h3>
@@ -129,7 +129,7 @@ export function PortfolioSummaryCard({
   const cagrVal = summary.cagr;
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[420px]">
       <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
         Portfolio Summary{titleSuffix ? ` (${titleSuffix})` : ''}
       </h3>

--- a/frontend/src/components/transactions/AccountBalancesBarChart.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.tsx
@@ -177,7 +177,7 @@ export function AccountBalancesBarChart({
 
   if (isLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6 min-h-[420px]">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
           {CHART_TITLE}
         </h3>
@@ -190,7 +190,7 @@ export function AccountBalancesBarChart({
 
   if (chartData.length === 0) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6 min-h-[420px]">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
           {CHART_TITLE}
         </h3>
@@ -202,7 +202,7 @@ export function AccountBalancesBarChart({
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6 min-h-[420px]">
       <div className="flex items-center justify-between mb-4 gap-2">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
           {CHART_TITLE}

--- a/frontend/src/components/transactions/BalanceHistoryChart.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.tsx
@@ -148,7 +148,7 @@ export function BalanceHistoryChart({
 
   if (isLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6 min-h-[420px]">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
           {CHART_TITLE}
         </h3>
@@ -161,7 +161,7 @@ export function BalanceHistoryChart({
 
   if (chartData.length === 0) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6 min-h-[420px]">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
           {CHART_TITLE}
         </h3>
@@ -173,7 +173,7 @@ export function BalanceHistoryChart({
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6 min-h-[420px]">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
           {CHART_TITLE}

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
@@ -110,7 +110,7 @@ export function CategoryPayeeBarChart({
 
   if (isLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6 min-h-[420px]">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
           {CHART_TITLE}
         </h3>
@@ -123,7 +123,7 @@ export function CategoryPayeeBarChart({
 
   if (chartData.length === 0) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6 min-h-[420px]">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
           {CHART_TITLE}
         </h3>
@@ -135,7 +135,7 @@ export function CategoryPayeeBarChart({
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6 min-h-[420px]">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
           {CHART_TITLE}

--- a/frontend/src/lib/accounts.ts
+++ b/frontend/src/lib/accounts.ts
@@ -15,7 +15,7 @@ import {
   SetupLoanPaymentsData,
   SetupLoanPaymentsResponse,
 } from '@/types/account';
-import { getCached, setCache, invalidateCache } from './apiCache';
+import { dedupe, invalidateCache } from './apiCache';
 
 export const accountsApi = {
   // Create account
@@ -38,13 +38,16 @@ export const accountsApi = {
   // Get all accounts
   getAll: async (includeInactive: boolean = false): Promise<Account[]> => {
     const cacheKey = `accounts:all:${includeInactive}`;
-    const cached = getCached<Account[]>(cacheKey);
-    if (cached) return cached;
-    const response = await apiClient.get<Account[]>('/accounts', {
-      params: { includeInactive },
-    });
-    setCache(cacheKey, response.data);
-    return response.data;
+    return dedupe(
+      cacheKey,
+      async () => {
+        const response = await apiClient.get<Account[]>('/accounts', {
+          params: { includeInactive },
+        });
+        return response.data;
+      },
+      120_000, // 2 min
+    );
   },
 
   // Get account by ID
@@ -120,11 +123,21 @@ export const accountsApi = {
     endDate?: string;
     accountIds?: string;
   }): Promise<Array<{ date: string; balance: number; accountId: string; currencyCode: string }>> => {
-    const response = await apiClient.get<Array<{ date: string; balance: number; accountId: string; currencyCode: string }>>(
-      '/accounts/daily-balances',
-      { params },
+    // Dedupe so multiple components requesting the same range/accounts share
+    // a single network call. Daily balances roll forward as transactions
+    // change, so cache TTL is short.
+    const cacheKey = `accounts:daily-balances:${params?.startDate ?? ''}:${params?.endDate ?? ''}:${params?.accountIds ?? ''}`;
+    return dedupe(
+      cacheKey,
+      async () => {
+        const response = await apiClient.get<Array<{ date: string; balance: number; accountId: string; currencyCode: string }>>(
+          '/accounts/daily-balances',
+          { params },
+        );
+        return response.data;
+      },
+      30_000, // 30 sec
     );
-    return response.data;
   },
 
   // Preview loan amortization

--- a/frontend/src/lib/apiCache.ts
+++ b/frontend/src/lib/apiCache.ts
@@ -5,6 +5,7 @@ type CacheEntry<T> = {
 };
 
 const cache = new Map<string, CacheEntry<unknown>>();
+const inflight = new Map<string, Promise<unknown>>();
 const DEFAULT_TTL = 30_000; // 30 seconds
 
 export function getCached<T>(key: string): T | undefined {
@@ -31,4 +32,33 @@ export function invalidateCache(keyPrefix: string): void {
 
 export function clearAllCache(): void {
   cache.clear();
+  inflight.clear();
+}
+
+// Cache + in-flight deduplication. When several callers request the same key
+// before the first response arrives, they all await the same promise instead
+// of triggering parallel network requests. Successful responses are cached
+// for `ttl` ms; failures are not cached and propagate to every awaiter.
+export function dedupe<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  ttl: number = DEFAULT_TTL,
+): Promise<T> {
+  const cached = getCached<T>(key);
+  if (cached !== undefined) return Promise.resolve(cached);
+
+  const existing = inflight.get(key);
+  if (existing) return existing as Promise<T>;
+
+  const promise = fetcher()
+    .then((data) => {
+      setCache(key, data, ttl);
+      return data;
+    })
+    .finally(() => {
+      inflight.delete(key);
+    });
+
+  inflight.set(key, promise);
+  return promise;
 }

--- a/frontend/src/lib/budgets.ts
+++ b/frontend/src/lib/budgets.ts
@@ -23,7 +23,7 @@ import {
   GenerateBudgetResponse,
   ApplyGeneratedBudgetData,
 } from '@/types/budget';
-import { getCached, setCache, invalidateCache } from './apiCache';
+import { dedupe, getCached, setCache, invalidateCache } from './apiCache';
 
 export const budgetsApi = {
   // Budget CRUD
@@ -34,11 +34,14 @@ export const budgetsApi = {
   },
 
   getAll: async (): Promise<Budget[]> => {
-    const cached = getCached<Budget[]>('budgets:all');
-    if (cached) return cached;
-    const response = await apiClient.get<Budget[]>('/budgets');
-    setCache('budgets:all', response.data);
-    return response.data;
+    return dedupe(
+      'budgets:all',
+      async () => {
+        const response = await apiClient.get<Budget[]>('/budgets');
+        return response.data;
+      },
+      120_000, // 2 min
+    );
   },
 
   getById: async (id: string): Promise<Budget> => {
@@ -272,13 +275,15 @@ export const budgetsApi = {
 
   // Dashboard
   getDashboardSummary: async (): Promise<DashboardBudgetSummary | null> => {
-    const cached = getCached<DashboardBudgetSummary | null>('budgets:dashboard');
-    if (cached !== undefined) return cached;
-    const response = await apiClient.get<DashboardBudgetSummary | null>(
-      '/budgets/dashboard-summary',
+    return dedupe<DashboardBudgetSummary | null>(
+      'budgets:dashboard',
+      async () => {
+        const response = await apiClient.get<DashboardBudgetSummary | null>(
+          '/budgets/dashboard-summary',
+        );
+        return response.data;
+      },
     );
-    setCache('budgets:dashboard', response.data);
-    return response.data;
   },
 
   // Transaction context

--- a/frontend/src/lib/categories.ts
+++ b/frontend/src/lib/categories.ts
@@ -1,6 +1,6 @@
 import apiClient from './api';
 import { Category, CreateCategoryData, UpdateCategoryData } from '@/types/category';
-import { getCached, setCache, invalidateCache } from './apiCache';
+import { dedupe, invalidateCache } from './apiCache';
 
 export const categoriesApi = {
   // Create category
@@ -12,11 +12,14 @@ export const categoriesApi = {
 
   // Get all categories
   getAll: async (): Promise<Category[]> => {
-    const cached = getCached<Category[]>('categories:all');
-    if (cached) return cached;
-    const response = await apiClient.get<Category[]>('/categories');
-    setCache('categories:all', response.data);
-    return response.data;
+    return dedupe(
+      'categories:all',
+      async () => {
+        const response = await apiClient.get<Category[]>('/categories');
+        return response.data;
+      },
+      300_000, // 5 min - categories rarely change
+    );
   },
 
   // Get category by ID

--- a/frontend/src/lib/exchange-rates.ts
+++ b/frontend/src/lib/exchange-rates.ts
@@ -1,5 +1,5 @@
 import apiClient from './api';
-import { getCached, setCache, invalidateCache } from './apiCache';
+import { dedupe, invalidateCache } from './apiCache';
 
 export interface ExchangeRate {
   id: number;
@@ -49,11 +49,16 @@ export interface CurrencyUsage {
 export const exchangeRatesApi = {
   // Exchange rates
   getLatestRates: async (): Promise<ExchangeRate[]> => {
-    const cached = getCached<ExchangeRate[]>('exchange-rates:latest');
-    if (cached) return cached;
-    const response = await apiClient.get<ExchangeRate[]>('/currencies/exchange-rates');
-    setCache('exchange-rates:latest', response.data, 300_000); // 5 min - rates change at most daily
-    return response.data;
+    // Rates change at most daily; dedupe in-flight requests so a page that
+    // mounts many components needing rates only makes one network round trip.
+    return dedupe(
+      'exchange-rates:latest',
+      async () => {
+        const response = await apiClient.get<ExchangeRate[]>('/currencies/exchange-rates');
+        return response.data;
+      },
+      3_600_000, // 1 hour
+    );
   },
 
   getRateHistory: async (startDate?: string, endDate?: string): Promise<ExchangeRate[]> => {

--- a/frontend/src/lib/payees.ts
+++ b/frontend/src/lib/payees.ts
@@ -15,7 +15,7 @@ import {
   MergePayeeData,
   MergePayeeResult,
 } from '@/types/payee';
-import { getCached, setCache, invalidateCache } from './apiCache';
+import { dedupe, invalidateCache } from './apiCache';
 
 export const payeesApi = {
   // Create payee
@@ -28,15 +28,18 @@ export const payeesApi = {
   // Get all payees (optionally filtered by status)
   getAll: async (status?: PayeeStatusFilter): Promise<Payee[]> => {
     const cacheKey = `payees:all:${status || 'default'}`;
-    const cached = getCached<Payee[]>(cacheKey);
-    if (cached) return cached;
     const params: Record<string, string> = {};
     if (status) {
       params.status = status;
     }
-    const response = await apiClient.get<Payee[]>('/payees', { params });
-    setCache(cacheKey, response.data);
-    return response.data;
+    return dedupe(
+      cacheKey,
+      async () => {
+        const response = await apiClient.get<Payee[]>('/payees', { params });
+        return response.data;
+      },
+      300_000, // 5 min
+    );
   },
 
   // Get payee by ID

--- a/frontend/src/lib/scheduled-transactions.ts
+++ b/frontend/src/lib/scheduled-transactions.ts
@@ -9,7 +9,7 @@ import {
   OverrideCheckResult,
   PostScheduledTransactionData,
 } from '@/types/scheduled-transaction';
-import { getCached, setCache, invalidateCache } from './apiCache';
+import { dedupe, invalidateCache } from './apiCache';
 
 export const scheduledTransactionsApi = {
   // Create a new scheduled transaction
@@ -21,11 +21,14 @@ export const scheduledTransactionsApi = {
 
   // Get all scheduled transactions
   getAll: async (): Promise<ScheduledTransaction[]> => {
-    const cached = getCached<ScheduledTransaction[]>('scheduled:all');
-    if (cached) return cached;
-    const response = await apiClient.get<ScheduledTransaction[]>('/scheduled-transactions');
-    setCache('scheduled:all', response.data);
-    return response.data;
+    return dedupe(
+      'scheduled:all',
+      async () => {
+        const response = await apiClient.get<ScheduledTransaction[]>('/scheduled-transactions');
+        return response.data;
+      },
+      120_000, // 2 min
+    );
   },
 
   // Get due scheduled transactions (past due date)

--- a/frontend/src/lib/tags.ts
+++ b/frontend/src/lib/tags.ts
@@ -1,6 +1,6 @@
 import apiClient from './api';
 import { Tag, CreateTagData, UpdateTagData } from '@/types/tag';
-import { getCached, setCache, invalidateCache } from './apiCache';
+import { dedupe, invalidateCache } from './apiCache';
 
 export const tagsApi = {
   create: async (data: CreateTagData): Promise<Tag> => {
@@ -10,11 +10,14 @@ export const tagsApi = {
   },
 
   getAll: async (): Promise<Tag[]> => {
-    const cached = getCached<Tag[]>('tags:all');
-    if (cached) return cached;
-    const response = await apiClient.get<Tag[]>('/tags');
-    setCache('tags:all', response.data);
-    return response.data;
+    return dedupe(
+      'tags:all',
+      async () => {
+        const response = await apiClient.get<Tag[]>('/tags');
+        return response.data;
+      },
+      300_000, // 5 min
+    );
   },
 
   getById: async (id: string): Promise<Tag> => {


### PR DESCRIPTION
Apply the actionable items from monize-performance-review.md and
monize-performance-review-pages.md:

- Add request deduplication + longer staleTime to apiCache so concurrent
  callers requesting the same key share one in-flight promise. Wire it
  through accounts (incl. daily-balances), payees, categories, tags,
  budgets, scheduled-transactions, and exchange-rates. The /investments
  page was issuing /currencies/exchange-rates 5 times per load; with the
  shared in-flight map it now collapses to one round trip.
- /investments InvestmentValueChart: replace per-point dot renderer with
  ReferenceDot for the high/low flag callouts and dot={false} on the
  Area. Drops up to 366 zero-radius <circle> nodes from the chart layer
  on year-scope ranges, the dominant cost in the trace.
- /investments form a11y: give the Symbol and Action filter selects
  matching id/name attributes so labels associate correctly.
- /transactions: add fixed-height loading placeholders to the dynamic()
  chart imports and a min-h reservation on the chart cards themselves so
  the table below does not jump when the chart hydrates.
- /investments: reserve a minimum height on PortfolioSummaryCard and
  AssetAllocationChart so the side-by-side cards don't expand from 0
  while data is loading.