### PR TITLE
Add daily view to Dividend Income Report

### DIFF
--- a/backend/src/securities/investment-transactions.controller.spec.ts
+++ b/backend/src/securities/investment-transactions.controller.spec.ts
@@ -32,6 +32,7 @@ describe("InvestmentTransactionsController", () => {
       getSummary: jest.fn(),
       getRealizedGains: jest.fn(),
       getCapitalGainsByMonth: jest.fn(),
+      getCapitalGainsByDay: jest.fn(),
       findOne: jest.fn(),
       update: jest.fn(),
       remove: jest.fn(),
@@ -225,7 +226,7 @@ describe("InvestmentTransactionsController", () => {
     });
   });
 
-  describe("getCapitalGainsByMonth", () => {
+  describe("getCapitalGains", () => {
     it("passes startDate, endDate, and account filters through to the service", async () => {
       const rows = [
         {
@@ -237,7 +238,7 @@ describe("InvestmentTransactionsController", () => {
       ];
       service.getCapitalGainsByMonth.mockResolvedValue(rows);
 
-      const result = await controller.getCapitalGainsByMonth(
+      const result = await controller.getCapitalGains(
         req,
         "2024-01-01",
         "2024-12-31",
@@ -252,33 +253,73 @@ describe("InvestmentTransactionsController", () => {
       expect(result).toEqual(rows);
     });
 
+    it("dispatches to getCapitalGainsByDay when granularity=day", async () => {
+      const rows = [
+        {
+          month: "2024-06-15",
+          totalCapitalGain: 50,
+          realizedGain: 0,
+          unrealizedGain: 50,
+        },
+      ];
+      service.getCapitalGainsByDay.mockResolvedValue(rows);
+
+      const result = await controller.getCapitalGains(
+        req,
+        "2024-06-01",
+        "2024-06-30",
+        undefined,
+        "day",
+      );
+
+      expect(service.getCapitalGainsByDay).toHaveBeenCalledWith("user-1", {
+        accountIds: undefined,
+        startDate: "2024-06-01",
+        endDate: "2024-06-30",
+      });
+      expect(service.getCapitalGainsByMonth).not.toHaveBeenCalled();
+      expect(result).toEqual(rows);
+    });
+
+    it("rejects an unknown granularity value", () => {
+      expect(() =>
+        controller.getCapitalGains(
+          req,
+          "2024-01-01",
+          "2024-12-31",
+          undefined,
+          "week",
+        ),
+      ).toThrow(BadRequestException);
+    });
+
     it("requires startDate", () => {
       expect(() =>
-        controller.getCapitalGainsByMonth(req, "", "2024-12-31"),
+        controller.getCapitalGains(req, "", "2024-12-31"),
       ).toThrow(BadRequestException);
     });
 
     it("requires endDate", () => {
       expect(() =>
-        controller.getCapitalGainsByMonth(req, "2024-01-01", ""),
+        controller.getCapitalGains(req, "2024-01-01", ""),
       ).toThrow(BadRequestException);
     });
 
     it("rejects malformed dates", () => {
       expect(() =>
-        controller.getCapitalGainsByMonth(req, "2024/01/01", "2024-12-31"),
+        controller.getCapitalGains(req, "2024/01/01", "2024-12-31"),
       ).toThrow(BadRequestException);
     });
 
     it("rejects when startDate is after endDate", () => {
       expect(() =>
-        controller.getCapitalGainsByMonth(req, "2024-12-31", "2024-01-01"),
+        controller.getCapitalGains(req, "2024-12-31", "2024-01-01"),
       ).toThrow(BadRequestException);
     });
 
     it("rejects invalid account UUIDs", () => {
       expect(() =>
-        controller.getCapitalGainsByMonth(
+        controller.getCapitalGains(
           req,
           "2024-01-01",
           "2024-12-31",

--- a/backend/src/securities/investment-transactions.controller.ts
+++ b/backend/src/securities/investment-transactions.controller.ts
@@ -222,22 +222,24 @@ export class InvestmentTransactionsController {
   @Get("capital-gains")
   @ApiOperation({
     summary:
-      "Per-month capital gains (realized + unrealized) by security across the window",
+      "Per-period capital gains (realized + unrealized) by security across the window",
     description:
-      "Returns per (account, security, month) capital gain entries combining realized SELL gains and the unrealized mark-to-market change on the position. Requires startDate and endDate.",
+      "Returns per (account, security, period) capital gain entries combining realized SELL gains and the unrealized mark-to-market change on the position. Requires startDate and endDate. Use granularity=day for daily breakdown (default: month).",
   })
   @ApiQuery({ name: "accountIds", required: false })
   @ApiQuery({ name: "startDate", required: true })
   @ApiQuery({ name: "endDate", required: true })
+  @ApiQuery({ name: "granularity", required: false, enum: ["month", "day"] })
   @ApiResponse({
     status: 200,
-    description: "List of monthly capital gain entries",
+    description: "List of capital gain entries per period",
   })
-  getCapitalGainsByMonth(
+  getCapitalGains(
     @Request() req,
     @Query("startDate") startDate: string,
     @Query("endDate") endDate: string,
     @Query("accountIds") accountIds?: string,
+    @Query("granularity") granularity?: string,
   ) {
     const uuidRegex =
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -256,6 +258,11 @@ export class InvestmentTransactionsController {
     if (startDate > endDate) {
       throw new BadRequestException("startDate must be on or before endDate");
     }
+    if (granularity && granularity !== "month" && granularity !== "day") {
+      throw new BadRequestException(
+        "granularity must be 'month' or 'day' if provided",
+      );
+    }
 
     const ids = accountIds ? accountIds.split(",").filter(Boolean) : undefined;
     if (ids) {
@@ -264,6 +271,13 @@ export class InvestmentTransactionsController {
           throw new BadRequestException(`Invalid account UUID: ${id}`);
         }
       }
+    }
+
+    if (granularity === "day") {
+      return this.investmentTransactionsService.getCapitalGainsByDay(
+        req.user.id,
+        { accountIds: ids, startDate, endDate },
+      );
     }
 
     return this.investmentTransactionsService.getCapitalGainsByMonth(

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -886,6 +886,38 @@ export class InvestmentTransactionsService {
   }
 
   /**
+   * Per-day capital gain breakdown (realized + unrealized) per security in
+   * the requested window. Same account resolution as getCapitalGainsByMonth.
+   */
+  async getCapitalGainsByDay(
+    userId: string,
+    opts: {
+      accountIds?: string[];
+      startDate: string;
+      endDate: string;
+    },
+  ): Promise<CapitalGainEntry[]> {
+    let accountIds = opts.accountIds;
+    if (accountIds && accountIds.length > 0) {
+      const resolvedIds = new Set<string>(accountIds);
+      const accounts = await this.accountsService.findByIds(userId, accountIds);
+      for (const acct of accounts) {
+        if (acct.linkedAccountId) resolvedIds.add(acct.linkedAccountId);
+      }
+      accountIds = [...resolvedIds];
+    }
+
+    return this.portfolioCalculationService.calculateCapitalGainsByDay(
+      userId,
+      {
+        accountIds,
+        startDate: opts.startDate,
+        endDate: opts.endDate,
+      },
+    );
+  }
+
+  /**
    * LLM-friendly capital-gains roll-up sharing logic with the report endpoint
    * and the MCP server. Replays the user's investment history via
    * PortfolioCalculationService.calculateCapitalGainsByMonth, optionally

--- a/backend/src/securities/portfolio-calculation.service.spec.ts
+++ b/backend/src/securities/portfolio-calculation.service.spec.ts
@@ -494,3 +494,231 @@ describe("PortfolioCalculationService.calculateCapitalGainsByMonth", () => {
     expect(result).toEqual([]);
   });
 });
+
+describe("PortfolioCalculationService.calculateCapitalGainsByDay", () => {
+  let service: PortfolioCalculationService;
+  let txRepo: { find: jest.Mock };
+  let priceRepo: { query: jest.Mock };
+  let exchangeRateService: { getLatestRate: jest.Mock };
+
+  const userId = "user-1";
+  const accountId = "acct-1";
+  const securityId = "sec-1";
+
+  const makeTx = (overrides: Partial<InvestmentTransaction>) =>
+    ({
+      id: overrides.id ?? "tx",
+      userId,
+      accountId,
+      securityId,
+      action: InvestmentAction.BUY,
+      transactionDate: "2024-01-01",
+      quantity: 0,
+      price: 0,
+      commission: 0,
+      totalAmount: 0,
+      exchangeRate: 1,
+      description: null,
+      createdAt: new Date("2024-01-01"),
+      updatedAt: new Date("2024-01-01"),
+      account: {
+        id: accountId,
+        name: "TFSA",
+        currencyCode: "CAD",
+      } as Partial<Account>,
+      security: {
+        id: securityId,
+        symbol: "ABC",
+        name: "ABC Corp",
+        currencyCode: "CAD",
+      },
+      ...overrides,
+    }) as unknown as InvestmentTransaction;
+
+  const priceRows = (
+    rows: Array<{ date: string; price: number; securityId?: string }>,
+  ) =>
+    rows.map((r) => ({
+      security_id: r.securityId ?? securityId,
+      price_date: r.date,
+      close_price: String(r.price),
+    }));
+
+  beforeEach(async () => {
+    txRepo = { find: jest.fn() };
+    priceRepo = { query: jest.fn().mockResolvedValue([]) };
+    exchangeRateService = { getLatestRate: jest.fn().mockResolvedValue(null) };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PortfolioCalculationService,
+        { provide: getRepositoryToken(Holding), useValue: {} },
+        { provide: getRepositoryToken(SecurityPrice), useValue: priceRepo },
+        {
+          provide: getRepositoryToken(InvestmentTransaction),
+          useValue: txRepo,
+        },
+        { provide: getRepositoryToken(Account), useValue: {} },
+        { provide: ExchangeRateService, useValue: exchangeRateService },
+      ],
+    }).compile();
+    service = module.get(PortfolioCalculationService);
+  });
+
+  it("returns an empty array when there are no transactions", async () => {
+    txRepo.find.mockResolvedValue([]);
+    const result = await service.calculateCapitalGainsByDay(userId, {
+      startDate: "2024-01-01",
+      endDate: "2024-01-03",
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("uses YYYY-MM-DD keys in the month field", async () => {
+    txRepo.find.mockResolvedValue([
+      makeTx({
+        id: "buy",
+        action: InvestmentAction.BUY,
+        transactionDate: "2024-01-01",
+        quantity: 10,
+        price: 100,
+        totalAmount: 1000,
+      }),
+    ]);
+    priceRepo.query.mockResolvedValue(
+      priceRows([
+        { date: "2023-12-31", price: 100 },
+        { date: "2024-01-01", price: 105 },
+      ]),
+    );
+
+    const result = await service.calculateCapitalGainsByDay(userId, {
+      startDate: "2024-01-01",
+      endDate: "2024-01-01",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].month).toBe("2024-01-01");
+  });
+
+  it("captures unrealized mark-to-market change for a held position across two days", async () => {
+    // Buy 100 shares on Dec 31; price goes $50 -> $55 on Jan 1, $55 -> $60 on Jan 2.
+    txRepo.find.mockResolvedValue([
+      makeTx({
+        id: "buy",
+        action: InvestmentAction.BUY,
+        transactionDate: "2023-12-31",
+        quantity: 100,
+        price: 50,
+        totalAmount: 5000,
+      }),
+    ]);
+    priceRepo.query.mockResolvedValue(
+      priceRows([
+        { date: "2023-12-30", price: 50 },
+        { date: "2023-12-31", price: 50 },
+        { date: "2024-01-01", price: 55 },
+        { date: "2024-01-02", price: 60 },
+      ]),
+    );
+
+    const result = await service.calculateCapitalGainsByDay(userId, {
+      startDate: "2024-01-01",
+      endDate: "2024-01-02",
+    });
+
+    expect(result).toHaveLength(2);
+    const jan1 = result.find((r) => r.month === "2024-01-01")!;
+    const jan2 = result.find((r) => r.month === "2024-01-02")!;
+    // Jan 1: startValue = 50*100=5000, endValue = 55*100=5500, gain = +500
+    expect(jan1.totalCapitalGain).toBe(500);
+    expect(jan1.unrealizedGain).toBe(500);
+    expect(jan1.realizedGain).toBe(0);
+    // Jan 2: startValue = 55*100=5500, endValue = 60*100=6000, gain = +500
+    expect(jan2.totalCapitalGain).toBe(500);
+    expect(jan2.unrealizedGain).toBe(500);
+  });
+
+  it("decomposes a SELL day into realized + unrealized capital gains", async () => {
+    // Hold 100 shares at avg cost $50. On Jan 5, price is $60 and sell 40 shares.
+    txRepo.find.mockResolvedValue([
+      makeTx({
+        id: "buy",
+        action: InvestmentAction.BUY,
+        transactionDate: "2024-01-01",
+        quantity: 100,
+        price: 50,
+        totalAmount: 5000,
+      }),
+      makeTx({
+        id: "sell",
+        action: InvestmentAction.SELL,
+        transactionDate: "2024-01-05",
+        quantity: 40,
+        price: 60,
+        totalAmount: 2400,
+      }),
+    ]);
+    priceRepo.query.mockResolvedValue(
+      priceRows([
+        { date: "2024-01-04", price: 50 },
+        { date: "2024-01-05", price: 60 },
+      ]),
+    );
+
+    const result = await service.calculateCapitalGainsByDay(userId, {
+      startDate: "2024-01-05",
+      endDate: "2024-01-05",
+    });
+
+    expect(result).toHaveLength(1);
+    const day = result[0];
+    // realized = 40 * (60 - 50) = 400
+    expect(day.realizedGain).toBe(400);
+    // total = (endValue - startValue) + sells - buys
+    //       = (60*60 - 50*100) + 2400 - 0 = 3600 - 5000 + 2400 = 1000
+    expect(day.totalCapitalGain).toBe(1000);
+    // unrealized = 1000 - 400 = 600
+    expect(day.unrealizedGain).toBe(600);
+  });
+
+  it("drops days with no holding and no activity", async () => {
+    // Buy on Jan 3, sell on Jan 3 (same day). Jan 1, 2, 4 have no holding or activity.
+    txRepo.find.mockResolvedValue([
+      makeTx({
+        id: "buy",
+        action: InvestmentAction.BUY,
+        transactionDate: "2024-01-03",
+        quantity: 10,
+        price: 100,
+        totalAmount: 1000,
+      }),
+      makeTx({
+        id: "sell",
+        action: InvestmentAction.SELL,
+        transactionDate: "2024-01-03",
+        quantity: 10,
+        price: 100,
+        totalAmount: 1000,
+      }),
+    ]);
+    priceRepo.query.mockResolvedValue(
+      priceRows([{ date: "2024-01-03", price: 100 }]),
+    );
+
+    const result = await service.calculateCapitalGainsByDay(userId, {
+      startDate: "2024-01-01",
+      endDate: "2024-01-05",
+    });
+
+    expect(result.map((r) => r.month)).toEqual(["2024-01-03"]);
+  });
+
+  it("returns empty when startDate is after endDate", async () => {
+    txRepo.find.mockResolvedValue([]);
+    const result = await service.calculateCapitalGainsByDay(userId, {
+      startDate: "2024-12-01",
+      endDate: "2024-01-01",
+    });
+    expect(result).toEqual([]);
+  });
+});

--- a/backend/src/securities/portfolio-calculation.service.ts
+++ b/backend/src/securities/portfolio-calculation.service.ts
@@ -96,12 +96,11 @@ function addDaysIso(iso: string, days: number): string {
   return `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(2, "0")}-${String(dt.getUTCDate()).padStart(2, "0")}`;
 }
 
-interface MonthBucket {
-  month: string; // YYYY-MM
-  monthStart: string; // YYYY-MM-DD (first day of month, clamped to startDate)
-  monthEnd: string; // YYYY-MM-DD (last day of month, clamped to endDate)
-  priceLookupStart: string; // day before monthStart, used to value the
-  // position at the start of the month
+interface PeriodBucket {
+  key: string; // YYYY-MM for months, YYYY-MM-DD for days
+  periodStart: string; // YYYY-MM-DD first day of period
+  periodEnd: string; // YYYY-MM-DD last day of period
+  priceLookupStart: string; // day before periodStart, used to value the position at period start
 }
 
 /**
@@ -109,29 +108,49 @@ interface MonthBucket {
  * carries the YYYY-MM key, the (clamped) start/end day-of-month, and the
  * day-before-start date used to look up the starting price for the month.
  */
-function enumerateMonths(startDate: string, endDate: string): MonthBucket[] {
+function enumerateMonths(startDate: string, endDate: string): PeriodBucket[] {
   const [sy, sm] = startDate.split("-").map(Number);
   const [ey, em] = endDate.split("-").map(Number);
-  const buckets: MonthBucket[] = [];
+  const buckets: PeriodBucket[] = [];
   let y = sy;
   let m = sm;
   while (y < ey || (y === ey && m <= em)) {
     const firstOfMonth = `${y}-${String(m).padStart(2, "0")}-01`;
     const lastDayNum = new Date(Date.UTC(y, m, 0)).getUTCDate();
     const lastOfMonth = `${y}-${String(m).padStart(2, "0")}-${String(lastDayNum).padStart(2, "0")}`;
-    const monthStart = firstOfMonth < startDate ? startDate : firstOfMonth;
-    const monthEnd = lastOfMonth > endDate ? endDate : lastOfMonth;
+    const periodStart = firstOfMonth < startDate ? startDate : firstOfMonth;
+    const periodEnd = lastOfMonth > endDate ? endDate : lastOfMonth;
     buckets.push({
-      month: `${y}-${String(m).padStart(2, "0")}`,
-      monthStart,
-      monthEnd,
-      priceLookupStart: addDaysIso(monthStart, -1),
+      key: `${y}-${String(m).padStart(2, "0")}`,
+      periodStart,
+      periodEnd,
+      priceLookupStart: addDaysIso(periodStart, -1),
     });
     m++;
     if (m > 12) {
       m = 1;
       y++;
     }
+  }
+  return buckets;
+}
+
+/**
+ * Enumerate calendar days covered by [startDate, endDate]. Each entry
+ * carries the YYYY-MM-DD key and the day-before date for the start-of-day
+ * price lookup.
+ */
+function enumerateDays(startDate: string, endDate: string): PeriodBucket[] {
+  const buckets: PeriodBucket[] = [];
+  let current = startDate;
+  while (current <= endDate) {
+    buckets.push({
+      key: current,
+      periodStart: current,
+      periodEnd: current,
+      priceLookupStart: addDaysIso(current, -1),
+    });
+    current = addDaysIso(current, 1);
   }
   return buckets;
 }
@@ -625,8 +644,53 @@ export class PortfolioCalculationService {
       defaultCurrency?: string;
     },
   ): Promise<CapitalGainEntry[]> {
-    const { accountIds, startDate, endDate } = opts;
+    const { startDate, endDate } = opts;
     if (!startDate || !endDate || startDate > endDate) return [];
+    const periods = enumerateMonths(startDate, endDate);
+    if (periods.length === 0) return [];
+    return this.calculateCapitalGainsForPeriods(userId, opts, periods);
+  }
+
+  /**
+   * Compute realized + unrealized capital gains per (account, security, day)
+   * across the requested window. Identical to calculateCapitalGainsByMonth but
+   * snapshotted at daily rather than monthly boundaries. The `month` field on
+   * each returned CapitalGainEntry holds a YYYY-MM-DD key for the day.
+   */
+  async calculateCapitalGainsByDay(
+    userId: string,
+    opts: {
+      accountIds?: string[];
+      startDate: string;
+      endDate: string;
+      defaultCurrency?: string;
+    },
+  ): Promise<CapitalGainEntry[]> {
+    const { startDate, endDate } = opts;
+    if (!startDate || !endDate || startDate > endDate) return [];
+    const periods = enumerateDays(startDate, endDate);
+    if (periods.length === 0) return [];
+    return this.calculateCapitalGainsForPeriods(userId, opts, periods);
+  }
+
+  /**
+   * Core capital-gains replay loop shared by calculateCapitalGainsByMonth and
+   * calculateCapitalGainsByDay. Replays transaction history and snapshots the
+   * position at the boundary of each PeriodBucket. The `month` field on each
+   * returned entry is set to the bucket's `key` (YYYY-MM for months, YYYY-MM-DD
+   * for days).
+   */
+  private async calculateCapitalGainsForPeriods(
+    userId: string,
+    opts: {
+      accountIds?: string[];
+      startDate: string;
+      endDate: string;
+      defaultCurrency?: string;
+    },
+    periods: PeriodBucket[],
+  ): Promise<CapitalGainEntry[]> {
+    const { accountIds, endDate } = opts;
 
     const where: FindOptionsWhere<InvestmentTransaction> = { userId };
     if (accountIds && accountIds.length > 0) {
@@ -649,10 +713,6 @@ export class PortfolioCalculationService {
     ];
     const allPrices = await this.getAllPricesForSecurities(securityIds);
 
-    // Build the ordered list of month buckets to snapshot
-    const months = enumerateMonths(startDate, endDate);
-    if (months.length === 0) return [];
-
     // Group transactions by (account, security)
     type GroupKey = string;
     const groups = new Map<
@@ -670,8 +730,8 @@ export class PortfolioCalculationService {
     >();
     for (const tx of transactions) {
       if (!tx.securityId) continue;
-      const key = `${tx.accountId}:${tx.securityId}`;
-      let group = groups.get(key);
+      const groupKey = `${tx.accountId}:${tx.securityId}`;
+      let group = groups.get(groupKey);
       if (!group) {
         group = {
           accountId: tx.accountId,
@@ -683,7 +743,7 @@ export class PortfolioCalculationService {
           securityCurrencyCode: tx.security?.currencyCode ?? null,
           txs: [],
         };
-        groups.set(key, group);
+        groups.set(groupKey, group);
       }
       group.txs.push(tx);
     }
@@ -718,16 +778,16 @@ export class PortfolioCalculationService {
         group.accountCurrencyCode,
       );
 
-      // Replay any transactions strictly before startDate to seed state.
+      // Replay any transactions strictly before the first period to seed state.
       while (
         txIdx < txs.length &&
-        txs[txIdx].transactionDate < months[0].monthStart
+        txs[txIdx].transactionDate < periods[0].periodStart
       ) {
         applyTxToState(txs[txIdx], state);
         txIdx++;
       }
 
-      for (const { month, monthEnd, priceLookupStart } of months) {
+      for (const { key: periodKey, periodEnd, priceLookupStart } of periods) {
         const startQuantity = state.quantity;
         const startPrice =
           this.lookupPrice(group.securityId, priceLookupStart, allPrices) ?? 0;
@@ -737,7 +797,7 @@ export class PortfolioCalculationService {
         let sells = 0;
         let realizedGain = 0;
 
-        while (txIdx < txs.length && txs[txIdx].transactionDate <= monthEnd) {
+        while (txIdx < txs.length && txs[txIdx].transactionDate <= periodEnd) {
           const tx = txs[txIdx];
           const quantity = Number(tx.quantity) || 0;
           const price = Number(tx.price) || 0;
@@ -789,7 +849,7 @@ export class PortfolioCalculationService {
 
         const endQuantity = state.quantity;
         const endPrice =
-          this.lookupPrice(group.securityId, monthEnd, allPrices) ?? 0;
+          this.lookupPrice(group.securityId, periodEnd, allPrices) ?? 0;
         const endValue = endQuantity * endPrice * securityToAccountFx;
 
         const totalCapitalGain = endValue - startValue + sells - buys;
@@ -807,7 +867,7 @@ export class PortfolioCalculationService {
         const round = (n: number) => (Math.abs(n) < 0.005 ? 0 : roundMoney(n));
 
         results.push({
-          month,
+          month: periodKey,
           accountId: group.accountId,
           accountName: group.accountName,
           accountCurrencyCode: group.accountCurrencyCode,

--- a/frontend/src/components/reports/DividendIncomeReport.test.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.test.tsx
@@ -970,6 +970,126 @@ describe('DividendIncomeReport', () => {
       expect(screen.getByText('$1050.00')).toBeInTheDocument();
     });
 
+    it('shows a Hide inactive days toggle only in daily view', async () => {
+      mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
+      mockGetInvestmentAccounts.mockResolvedValue([]);
+      mockGetCapitalGains.mockResolvedValue([]);
+
+      render(<DividendIncomeReport />);
+
+      // Toggle should not be visible in monthly view (default).
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Monthly' })).toBeInTheDocument();
+      });
+      expect(screen.queryByRole('switch', { name: /hide inactive days/i })).not.toBeInTheDocument();
+
+      // Switch to daily view — toggle should appear.
+      fireEvent.click(screen.getByRole('button', { name: 'Daily' }));
+      expect(await screen.findByRole('switch', { name: /hide inactive days/i })).toBeInTheDocument();
+
+      // Switch back to monthly — toggle disappears again.
+      fireEvent.click(screen.getByRole('button', { name: 'Monthly' }));
+      await waitFor(() => {
+        expect(screen.queryByRole('switch', { name: /hide inactive days/i })).not.toBeInTheDocument();
+      });
+    });
+
+    it('hides days with all-zero activity when Hide inactive days is toggled on', async () => {
+      mockGetTransactions.mockResolvedValue({
+        data: [
+          {
+            id: 'tx-1',
+            transactionDate: '2024-06-17',
+            action: 'DIVIDEND',
+            totalAmount: 50,
+            accountId: 'acc-1',
+            securityId: 'sec-a',
+            security: { symbol: 'AAA', name: 'Alpha' },
+          },
+        ],
+        pagination: { hasMore: false },
+      });
+      mockGetInvestmentAccounts.mockResolvedValue([
+        { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+      ]);
+      // Day capital gains: Jun 15 has portfolio data, Jun 16 is an empty day
+      // (would be a weekend), Jun 17 has a dividend transaction.
+      mockGetCapitalGains.mockImplementation((params: { granularity?: string }) => {
+        if (params.granularity === 'day') {
+          return Promise.resolve([
+            {
+              month: '2024-06-15',
+              accountId: 'acc-1',
+              accountName: 'TFSA',
+              accountCurrencyCode: 'CAD',
+              securityId: 'sec-1',
+              symbol: 'ABC',
+              securityName: 'ABC Corp',
+              securityCurrencyCode: 'CAD',
+              startQuantity: 10,
+              endQuantity: 10,
+              startValue: 1000,
+              endValue: 1020,
+              buys: 0,
+              sells: 0,
+              realizedGain: 0,
+              unrealizedGain: 20,
+              totalCapitalGain: 20,
+            },
+            // Jun 16: zero everything — simulates a weekend / holiday
+            {
+              month: '2024-06-16',
+              accountId: 'acc-1',
+              accountName: 'TFSA',
+              accountCurrencyCode: 'CAD',
+              securityId: 'sec-1',
+              symbol: 'ABC',
+              securityName: 'ABC Corp',
+              securityCurrencyCode: 'CAD',
+              startQuantity: 0,
+              endQuantity: 0,
+              startValue: 0,
+              endValue: 0,
+              buys: 0,
+              sells: 0,
+              realizedGain: 0,
+              unrealizedGain: 0,
+              totalCapitalGain: 0,
+            },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      render(<DividendIncomeReport />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Daily' })).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Daily' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Table' }));
+
+      // All three days appear initially (toggle is off).
+      expect(await screen.findByText('Jun 15, 2024')).toBeInTheDocument();
+      expect(screen.getByText('Jun 16, 2024')).toBeInTheDocument();
+      expect(screen.getByText('Jun 17, 2024')).toBeInTheDocument();
+
+      // Enable the toggle — Jun 16 (all zeros) should disappear.
+      const toggle = screen.getByRole('switch', { name: /hide inactive days/i });
+      fireEvent.click(toggle);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Jun 16, 2024')).not.toBeInTheDocument();
+      });
+      // Active days remain visible.
+      expect(screen.getByText('Jun 15, 2024')).toBeInTheDocument();
+      expect(screen.getByText('Jun 17, 2024')).toBeInTheDocument();
+
+      // Disable the toggle — Jun 16 comes back.
+      fireEvent.click(toggle);
+      expect(await screen.findByText('Jun 16, 2024')).toBeInTheDocument();
+    });
+
     it('shows chart container (not table data) to PDF exporter in daily chart view', async () => {
       mockGetTransactions.mockResolvedValue({
         data: [

--- a/frontend/src/components/reports/DividendIncomeReport.test.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.test.tsx
@@ -646,6 +646,296 @@ describe('DividendIncomeReport', () => {
     expect(rows).toEqual([['AAA', 'Alpha', 100, 0, 0, 100, 'CAD']]);
   });
 
+  describe('Daily view', () => {
+    it('renders a Daily button alongside Monthly and By Security', async () => {
+      mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
+      mockGetInvestmentAccounts.mockResolvedValue([]);
+      mockGetCapitalGains.mockResolvedValue([]);
+      render(<DividendIncomeReport />);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Daily' })).toBeInTheDocument();
+      });
+      expect(screen.getByRole('button', { name: 'Monthly' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'By Security' })).toBeInTheDocument();
+    });
+
+    it('switches to a daily chart when Daily is clicked', async () => {
+      mockGetTransactions.mockResolvedValue({
+        data: [
+          {
+            id: 'tx-1',
+            transactionDate: '2024-06-15',
+            action: 'DIVIDEND',
+            totalAmount: 50,
+            accountId: 'acc-1',
+            securityId: 'sec-a',
+            security: { symbol: 'AAA', name: 'Alpha' },
+          },
+        ],
+        pagination: { hasMore: false },
+      });
+      mockGetInvestmentAccounts.mockResolvedValue([
+        { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+      ]);
+      mockGetCapitalGains.mockResolvedValue([]);
+
+      render(<DividendIncomeReport />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Daily' }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Daily Gains, Dividends & Interest')).toBeInTheDocument();
+    });
+
+    it('shows the daily table with a Date column when Table is clicked in Daily view', async () => {
+      mockGetTransactions.mockResolvedValue({
+        data: [
+          {
+            id: 'tx-1',
+            transactionDate: '2024-06-15',
+            action: 'DIVIDEND',
+            totalAmount: 75,
+            accountId: 'acc-1',
+            securityId: 'sec-a',
+            security: { symbol: 'AAA', name: 'Alpha' },
+          },
+          {
+            id: 'tx-2',
+            transactionDate: '2024-06-15',
+            action: 'INTEREST',
+            totalAmount: 10,
+            accountId: 'acc-1',
+            securityId: null,
+            security: null,
+          },
+          {
+            id: 'tx-3',
+            transactionDate: '2024-07-01',
+            action: 'DIVIDEND',
+            totalAmount: 25,
+            accountId: 'acc-1',
+            securityId: 'sec-a',
+            security: { symbol: 'AAA', name: 'Alpha' },
+          },
+        ],
+        pagination: { hasMore: false },
+      });
+      mockGetInvestmentAccounts.mockResolvedValue([
+        { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+      ]);
+      mockGetCapitalGains.mockResolvedValue([]);
+
+      render(<DividendIncomeReport />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Daily' })).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Daily' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Table' }));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('bar-chart')).not.toBeInTheDocument();
+      });
+      expect(screen.getByText('Date')).toBeInTheDocument();
+      // Two distinct days have data.
+      expect(screen.getByText('Jun 15, 2024')).toBeInTheDocument();
+      expect(screen.getByText('Jul 1, 2024')).toBeInTheDocument();
+      // Transactions on the same day should be aggregated ($75 + $10).
+      expect(screen.getByText('$85.00')).toBeInTheDocument();
+    });
+
+    it('does not include monthly capital gains entries in the daily table', async () => {
+      mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
+      mockGetInvestmentAccounts.mockResolvedValue([
+        { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+      ]);
+      // Capital gains exist but have no corresponding daily transactions.
+      mockGetCapitalGains.mockResolvedValue([
+        {
+          month: '2024-06',
+          accountId: 'acc-1',
+          accountName: 'TFSA',
+          accountCurrencyCode: 'CAD',
+          securityId: 'sec-1',
+          symbol: 'ABC',
+          securityName: 'ABC Corp',
+          securityCurrencyCode: 'CAD',
+          startQuantity: 10,
+          endQuantity: 0,
+          startValue: 800,
+          endValue: 0,
+          buys: 0,
+          sells: 800,
+          realizedGain: 300,
+          unrealizedGain: 0,
+          totalCapitalGain: 300,
+        },
+      ]);
+
+      render(<DividendIncomeReport />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Daily' })).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Daily' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Table' }));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('bar-chart')).not.toBeInTheDocument();
+      });
+      // The daily table shows the empty-data message, not a row for June.
+      expect(screen.getByText(/No daily transaction data/)).toBeInTheDocument();
+    });
+
+    it('writes a daily CSV with one row per day', async () => {
+      mockGetTransactions.mockResolvedValue({
+        data: [
+          {
+            id: 'tx-1',
+            transactionDate: '2024-06-15',
+            action: 'DIVIDEND',
+            totalAmount: 50,
+            accountId: 'acc-1',
+            securityId: 'sec-a',
+            security: { symbol: 'AAA', name: 'Alpha' },
+          },
+          {
+            id: 'tx-2',
+            transactionDate: '2024-07-10',
+            action: 'INTEREST',
+            totalAmount: 20,
+            accountId: 'acc-1',
+            securityId: null,
+            security: null,
+          },
+        ],
+        pagination: { hasMore: false },
+      });
+      mockGetInvestmentAccounts.mockResolvedValue([
+        { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+      ]);
+      mockGetCapitalGains.mockResolvedValue([]);
+
+      render(<DividendIncomeReport />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Daily' })).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Daily' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Table' }));
+
+      fireEvent.click(await screen.findByRole('button', { name: /^export$/i }));
+      fireEvent.click(screen.getByRole('button', { name: 'CSV' }));
+
+      expect(mockExportToCsv).toHaveBeenCalledTimes(1);
+      const [filename, headers, rows] = mockExportToCsv.mock.calls[0];
+      expect(filename).toMatch(/gains-dividends-interest-daily-all-accounts/);
+      expect(headers).toEqual(['Date', 'Dividends', 'Interest', 'Capital Gains', 'Total', 'Currency']);
+
+      const juneRow = rows.find((r: any[]) => r[0] === '2024-06-15');
+      expect(juneRow).toBeDefined();
+      expect(juneRow[1]).toBe(50);  // Dividends
+      expect(juneRow[2]).toBe(0);   // Interest
+      expect(juneRow[3]).toBe(0);   // Capital Gains
+      expect(juneRow[4]).toBe(50);  // Total
+      expect(juneRow[5]).toBe('CAD');
+
+      const julyRow = rows.find((r: any[]) => r[0] === '2024-07-10');
+      expect(julyRow).toBeDefined();
+      expect(julyRow[1]).toBe(0);   // Dividends
+      expect(julyRow[2]).toBe(20);  // Interest
+      expect(julyRow[3]).toBe(0);   // Capital Gains
+      expect(julyRow[4]).toBe(20);  // Total
+    });
+
+    it('hands daily table data to the PDF exporter', async () => {
+      mockGetTransactions.mockResolvedValue({
+        data: [
+          {
+            id: 'tx-1',
+            transactionDate: '2024-06-15',
+            action: 'DIVIDEND',
+            totalAmount: 50,
+            accountId: 'acc-1',
+            securityId: 'sec-a',
+            security: { symbol: 'AAA', name: 'Alpha' },
+          },
+        ],
+        pagination: { hasMore: false },
+      });
+      mockGetInvestmentAccounts.mockResolvedValue([
+        { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+      ]);
+      mockGetCapitalGains.mockResolvedValue([]);
+
+      render(<DividendIncomeReport />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Daily' })).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Daily' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Table' }));
+
+      fireEvent.click(await screen.findByRole('button', { name: /^export$/i }));
+      fireEvent.click(screen.getByRole('button', { name: 'PDF' }));
+
+      await waitFor(() => {
+        expect(mockExportToPdf).toHaveBeenCalledTimes(1);
+      });
+      const args = mockExportToPdf.mock.calls[0][0];
+      expect(args.chartContainer).toBeUndefined();
+      expect(args.tableData).toBeDefined();
+      expect(args.tableData.headers).toEqual(['Date', 'Dividends', 'Interest', 'Capital Gains', 'Total']);
+      expect(args.tableData.rows.length).toBeGreaterThan(0);
+      expect(args.tableData.totalRow?.[0]).toBe('Total');
+    });
+
+    it('shows chart container (not table data) to PDF exporter in daily chart view', async () => {
+      mockGetTransactions.mockResolvedValue({
+        data: [
+          {
+            id: 'tx-1',
+            transactionDate: '2024-06-15',
+            action: 'DIVIDEND',
+            totalAmount: 50,
+            accountId: 'acc-1',
+            securityId: 'sec-a',
+            security: { symbol: 'AAA', name: 'Alpha' },
+          },
+        ],
+        pagination: { hasMore: false },
+      });
+      mockGetInvestmentAccounts.mockResolvedValue([
+        { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+      ]);
+      mockGetCapitalGains.mockResolvedValue([]);
+
+      render(<DividendIncomeReport />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Daily' })).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Daily' }));
+
+      // Daily chart view: ExportDropdown collapses to PDF-only button.
+      const exportPdfBtn = await screen.findByRole('button', { name: /export pdf/i });
+      fireEvent.click(exportPdfBtn);
+
+      await waitFor(() => {
+        expect(mockExportToPdf).toHaveBeenCalledTimes(1);
+      });
+      const args = mockExportToPdf.mock.calls[0][0];
+      expect(args.chartContainer).not.toBeNull();
+      expect(args.tableData).toBeUndefined();
+    });
+  });
+
   it('renders series toggle pills and hides a series when one is clicked', async () => {
     mockGetTransactions.mockResolvedValue({
       data: [

--- a/frontend/src/components/reports/DividendIncomeReport.test.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.test.tsx
@@ -1012,8 +1012,9 @@ describe('DividendIncomeReport', () => {
       mockGetInvestmentAccounts.mockResolvedValue([
         { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
       ]);
-      // Day capital gains: Jun 15 has portfolio data, Jun 16 is an empty day
-      // (would be a weekend), Jun 17 has a dividend transaction.
+      // Day capital gains: Jun 15 has a price movement, Jun 16 is a weekend
+      // where the portfolio still holds value but no market activity occurred
+      // (start == end, zero gain), Jun 17 has a dividend transaction.
       mockGetCapitalGains.mockImplementation((params: { granularity?: string }) => {
         if (params.granularity === 'day') {
           return Promise.resolve([
@@ -1036,7 +1037,8 @@ describe('DividendIncomeReport', () => {
               unrealizedGain: 20,
               totalCapitalGain: 20,
             },
-            // Jun 16: zero everything — simulates a weekend / holiday
+            // Jun 16: weekend — portfolio still holds 10 shares at the Friday
+            // close, but no market activity so start == end and gain is zero.
             {
               month: '2024-06-16',
               accountId: 'acc-1',
@@ -1046,10 +1048,10 @@ describe('DividendIncomeReport', () => {
               symbol: 'ABC',
               securityName: 'ABC Corp',
               securityCurrencyCode: 'CAD',
-              startQuantity: 0,
-              endQuantity: 0,
-              startValue: 0,
-              endValue: 0,
+              startQuantity: 10,
+              endQuantity: 10,
+              startValue: 1020,
+              endValue: 1020,
               buys: 0,
               sells: 0,
               realizedGain: 0,

--- a/frontend/src/components/reports/DividendIncomeReport.test.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.test.tsx
@@ -755,28 +755,32 @@ describe('DividendIncomeReport', () => {
       mockGetInvestmentAccounts.mockResolvedValue([
         { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
       ]);
-      // Capital gains exist but have no corresponding daily transactions.
-      mockGetCapitalGains.mockResolvedValue([
-        {
-          month: '2024-06',
-          accountId: 'acc-1',
-          accountName: 'TFSA',
-          accountCurrencyCode: 'CAD',
-          securityId: 'sec-1',
-          symbol: 'ABC',
-          securityName: 'ABC Corp',
-          securityCurrencyCode: 'CAD',
-          startQuantity: 10,
-          endQuantity: 0,
-          startValue: 800,
-          endValue: 0,
-          buys: 0,
-          sells: 800,
-          realizedGain: 300,
-          unrealizedGain: 0,
-          totalCapitalGain: 300,
-        },
-      ]);
+      // Monthly capital gains (YYYY-MM key) go to the monthly/security views.
+      // The daily lazy-load uses granularity=day and returns nothing here.
+      mockGetCapitalGains.mockImplementation((params: { granularity?: string }) => {
+        if (params.granularity === 'day') return Promise.resolve([]);
+        return Promise.resolve([
+          {
+            month: '2024-06',
+            accountId: 'acc-1',
+            accountName: 'TFSA',
+            accountCurrencyCode: 'CAD',
+            securityId: 'sec-1',
+            symbol: 'ABC',
+            securityName: 'ABC Corp',
+            securityCurrencyCode: 'CAD',
+            startQuantity: 10,
+            endQuantity: 0,
+            startValue: 800,
+            endValue: 0,
+            buys: 0,
+            sells: 800,
+            realizedGain: 300,
+            unrealizedGain: 0,
+            totalCapitalGain: 300,
+          },
+        ]);
+      });
 
       render(<DividendIncomeReport />);
 
@@ -789,7 +793,7 @@ describe('DividendIncomeReport', () => {
       await waitFor(() => {
         expect(screen.queryByTestId('bar-chart')).not.toBeInTheDocument();
       });
-      // The daily table shows the empty-data message, not a row for June.
+      // Monthly CG entries are not folded into the daily table.
       expect(screen.getByText(/No daily transaction data/)).toBeInTheDocument();
     });
 
@@ -836,22 +840,33 @@ describe('DividendIncomeReport', () => {
       expect(mockExportToCsv).toHaveBeenCalledTimes(1);
       const [filename, headers, rows] = mockExportToCsv.mock.calls[0];
       expect(filename).toMatch(/gains-dividends-interest-daily-all-accounts/);
-      expect(headers).toEqual(['Date', 'Dividends', 'Interest', 'Capital Gains', 'Total', 'Currency']);
+      expect(headers).toEqual([
+        'Date',
+        'Start Value',
+        'End Value',
+        'Dividends',
+        'Interest',
+        'Capital Gains',
+        'Total',
+        'Currency',
+      ]);
 
       const juneRow = rows.find((r: any[]) => r[0] === '2024-06-15');
       expect(juneRow).toBeDefined();
-      expect(juneRow[1]).toBe(50);  // Dividends
-      expect(juneRow[2]).toBe(0);   // Interest
-      expect(juneRow[3]).toBe(0);   // Capital Gains
-      expect(juneRow[4]).toBe(50);  // Total
-      expect(juneRow[5]).toBe('CAD');
+      expect(juneRow[1]).toBe(0);   // Start Value
+      expect(juneRow[2]).toBe(0);   // End Value
+      expect(juneRow[3]).toBe(50);  // Dividends
+      expect(juneRow[4]).toBe(0);   // Interest
+      expect(juneRow[5]).toBe(0);   // Capital Gains
+      expect(juneRow[6]).toBe(50);  // Total
+      expect(juneRow[7]).toBe('CAD');
 
       const julyRow = rows.find((r: any[]) => r[0] === '2024-07-10');
       expect(julyRow).toBeDefined();
-      expect(julyRow[1]).toBe(0);   // Dividends
-      expect(julyRow[2]).toBe(20);  // Interest
-      expect(julyRow[3]).toBe(0);   // Capital Gains
-      expect(julyRow[4]).toBe(20);  // Total
+      expect(julyRow[3]).toBe(0);   // Dividends
+      expect(julyRow[4]).toBe(20);  // Interest
+      expect(julyRow[5]).toBe(0);   // Capital Gains
+      expect(julyRow[6]).toBe(20);  // Total
     });
 
     it('hands daily table data to the PDF exporter', async () => {
@@ -891,9 +906,68 @@ describe('DividendIncomeReport', () => {
       const args = mockExportToPdf.mock.calls[0][0];
       expect(args.chartContainer).toBeUndefined();
       expect(args.tableData).toBeDefined();
-      expect(args.tableData.headers).toEqual(['Date', 'Dividends', 'Interest', 'Capital Gains', 'Total']);
+      expect(args.tableData.headers).toEqual([
+        'Date',
+        'Start Value',
+        'End Value',
+        'Dividends',
+        'Interest',
+        'Capital Gains',
+        'Total',
+      ]);
       expect(args.tableData.rows.length).toBeGreaterThan(0);
       expect(args.tableData.totalRow?.[0]).toBe('Total');
+      // Start/End Value in the footer are intentionally blank (same as monthly table).
+      expect(args.tableData.totalRow?.[1]).toBe('');
+      expect(args.tableData.totalRow?.[2]).toBe('');
+    });
+
+    it('renders Start Value and End Value columns in the daily table from lazy-loaded capital gains', async () => {
+      mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
+      mockGetInvestmentAccounts.mockResolvedValue([
+        { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+      ]);
+      mockGetCapitalGains.mockImplementation((params: { granularity?: string }) => {
+        if (params.granularity === 'day') {
+          return Promise.resolve([
+            {
+              month: '2024-06-15',
+              accountId: 'acc-1',
+              accountName: 'TFSA',
+              accountCurrencyCode: 'CAD',
+              securityId: 'sec-1',
+              symbol: 'ABC',
+              securityName: 'ABC Corp',
+              securityCurrencyCode: 'CAD',
+              startQuantity: 10,
+              endQuantity: 10,
+              startValue: 1000,
+              endValue: 1050,
+              buys: 0,
+              sells: 0,
+              realizedGain: 0,
+              unrealizedGain: 50,
+              totalCapitalGain: 50,
+            },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      render(<DividendIncomeReport />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Daily' })).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Daily' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Table' }));
+
+      // Start/End Value headers appear in the daily table.
+      expect(await screen.findByText('Start Value')).toBeInTheDocument();
+      expect(screen.getByText('End Value')).toBeInTheDocument();
+      // The Jun 15 row carries the start ($1000) and end ($1050) values.
+      expect(await screen.findByText('$1000.00')).toBeInTheDocument();
+      expect(screen.getByText('$1050.00')).toBeInTheDocument();
     });
 
     it('shows chart container (not table data) to PDF exporter in daily chart view', async () => {

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -81,6 +81,7 @@ export function DividendIncomeReport() {
   const [isLoading, setIsLoading] = useState(true);
   const [viewType, setViewType] = useState<'monthly' | 'daily' | 'bySecurity'>('monthly');
   const [monthlyDisplay, setMonthlyDisplay] = useState<'chart' | 'table'>('chart');
+  const [hideInactiveDays, setHideInactiveDays] = useState(false);
   const [visibleSeries, setVisibleSeries] = useState<Record<SeriesKey, boolean>>({
     dividends: true,
     interest: true,
@@ -418,6 +419,24 @@ export function DividendIncomeReport() {
     return Array.from(dayMap.values()).sort((a, b) => a.date.localeCompare(b.date));
   }, [filteredTransactions, filteredDailyCapitalGains, getTxAmount, convertCapitalGain, convertFromAccountCurrency]);
 
+  // When hideInactiveDays is enabled, drop rows with no portfolio value and no
+  // income (dividends, interest, or capital gains). These are typically weekends
+  // and holidays where the market was closed and no transactions occurred.
+  const displayedDailyData = useMemo(
+    () =>
+      hideInactiveDays
+        ? dailyData.filter(
+            (row) =>
+              row.startValue !== 0 ||
+              row.endValue !== 0 ||
+              row.dividends !== 0 ||
+              row.interest !== 0 ||
+              row.capitalGains !== 0,
+          )
+        : dailyData,
+    [dailyData, hideInactiveDays],
+  );
+
   const securityData = useMemo((): SecurityIncome[] => {
     const securityMap = new Map<string, SecurityIncome>();
 
@@ -531,7 +550,7 @@ export function DividendIncomeReport() {
       if (visibleSeries.interest) headers.push('Interest');
       if (visibleSeries.capitalGains) headers.push('Capital Gains');
       headers.push('Total', 'Currency');
-      const rows = dailyData.map((row) => {
+      const rows = displayedDailyData.map((row) => {
         const out: (string | number)[] = [row.date, round4(row.startValue), round4(row.endValue)];
         let total = 0;
         if (visibleSeries.dividends) {
@@ -626,7 +645,7 @@ export function DividendIncomeReport() {
       if (visibleSeries.interest) headers.push('Interest');
       if (visibleSeries.capitalGains) headers.push('Capital Gains');
       headers.push('Total');
-      const rows = dailyData.map((row) => {
+      const rows = displayedDailyData.map((row) => {
         const out: (string | number)[] = [row.label, fmtValue(row.startValue), fmtValue(row.endValue)];
         let rowTotal = 0;
         if (visibleSeries.dividends) {
@@ -644,7 +663,7 @@ export function DividendIncomeReport() {
         out.push(fmtValue(rowTotal));
         return out;
       });
-      const dailyTotals = dailyData.reduce(
+      const dailyTotals = displayedDailyData.reduce(
         (acc, row) => ({
           dividends: acc.dividends + row.dividends,
           interest: acc.interest + row.interest,
@@ -778,7 +797,7 @@ export function DividendIncomeReport() {
   // instead of being hidden inside a stack.
   const hasNegativeCapitalGains = monthlyData.some((m) => m.capitalGains < 0);
   const stackId = hasNegativeCapitalGains ? undefined : 'a';
-  const dailyHasNegativeCapitalGains = dailyData.some((d) => d.capitalGains < 0);
+  const dailyHasNegativeCapitalGains = displayedDailyData.some((d) => d.capitalGains < 0);
   const dailyStackId = dailyHasNegativeCapitalGains ? undefined : 'a';
 
   return (
@@ -949,6 +968,28 @@ export function DividendIncomeReport() {
                 );
               })}
             </div>
+            {viewType === 'daily' && (
+              <button
+                type="button"
+                role="switch"
+                aria-checked={hideInactiveDays}
+                onClick={() => setHideInactiveDays((v) => !v)}
+                className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 ml-2"
+              >
+                <span
+                  className={`relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ${
+                    hideInactiveDays ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-600'
+                  }`}
+                >
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform duration-200 ${
+                      hideInactiveDays ? 'translate-x-4' : 'translate-x-0'
+                    }`}
+                  />
+                </span>
+                Hide inactive days
+              </button>
+            )}
           </div>
         )}
       </div>
@@ -1114,14 +1155,14 @@ export function DividendIncomeReport() {
           <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
             Daily Gains, Dividends & Interest
           </h3>
-          {dailyData.length === 0 ? (
+          {displayedDailyData.length === 0 ? (
             <p className="text-gray-500 dark:text-gray-400 text-center py-8">
               No daily transaction data for this period.
             </p>
           ) : (
             <div className="h-80">
               <ResponsiveContainer width="100%" height="100%" minWidth={0}>
-                <BarChart data={dailyData}>
+                <BarChart data={displayedDailyData}>
                   <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
                   <XAxis dataKey="label" tick={{ fontSize: 11 }} />
                   <YAxis tickFormatter={formatCurrencyAxis} />
@@ -1151,7 +1192,7 @@ export function DividendIncomeReport() {
                       fill={SERIES_COLORS.capitalGains.positive}
                       name="Capital Gains"
                     >
-                      {dailyData.map((entry) => (
+                      {displayedDailyData.map((entry) => (
                         <Cell
                           key={entry.date}
                           fill={
@@ -1176,7 +1217,7 @@ export function DividendIncomeReport() {
               Daily Gains, Dividends & Interest
             </h3>
           </div>
-          {dailyData.length === 0 ? (
+          {displayedDailyData.length === 0 ? (
             <p className="text-gray-500 dark:text-gray-400 text-center py-8">
               No daily transaction data for this period.
             </p>
@@ -1215,7 +1256,7 @@ export function DividendIncomeReport() {
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-                  {dailyData.map((row) => {
+                  {displayedDailyData.map((row) => {
                     const rowTotal =
                       (visibleSeries.dividends ? row.dividends : 0) +
                       (visibleSeries.interest ? row.interest : 0) +

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -402,7 +402,10 @@ export function DividendIncomeReport() {
     });
 
     filteredDailyCapitalGains.forEach((entry) => {
-      // entry.month holds YYYY-MM-DD for daily entries
+      // Daily entries use YYYY-MM-DD in the month field. Skip anything that
+      // doesn't match (e.g. an older backend echoing monthly entries) so
+      // parseLocalDate / format() don't blow up on a partial date.
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(entry.month)) return;
       const txDate = parseLocalDate(entry.month);
       const bucket = getOrCreateBucket(entry.month, txDate);
       const gain = convertCapitalGain(entry);

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -419,16 +419,16 @@ export function DividendIncomeReport() {
     return Array.from(dayMap.values()).sort((a, b) => a.date.localeCompare(b.date));
   }, [filteredTransactions, filteredDailyCapitalGains, getTxAmount, convertCapitalGain, convertFromAccountCurrency]);
 
-  // When hideInactiveDays is enabled, drop rows with no portfolio value and no
-  // income (dividends, interest, or capital gains). These are typically weekends
-  // and holidays where the market was closed and no transactions occurred.
+  // When hideInactiveDays is enabled, drop rows with no income and no price
+  // movement. On weekends/holidays the market is closed, so capital gains are
+  // zero (start and end values are identical) and there are no dividend or
+  // interest transactions. Start/End value alone is not a useful signal — the
+  // portfolio still has a value sitting on those non-trading days.
   const displayedDailyData = useMemo(
     () =>
       hideInactiveDays
         ? dailyData.filter(
             (row) =>
-              row.startValue !== 0 ||
-              row.endValue !== 0 ||
               row.dividends !== 0 ||
               row.interest !== 0 ||
               row.capitalGains !== 0,
@@ -974,7 +974,7 @@ export function DividendIncomeReport() {
                 role="switch"
                 aria-checked={hideInactiveDays}
                 onClick={() => setHideInactiveDays((v) => !v)}
-                className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 ml-2"
+                className="ml-auto flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400"
               >
                 <span
                   className={`relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ${

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -50,6 +50,15 @@ interface SecurityIncome {
   total: number;
 }
 
+interface DailyIncome {
+  date: string;
+  label: string;
+  dividends: number;
+  interest: number;
+  capitalGains: number;
+  total: number;
+}
+
 const SERIES_COLORS: Record<SeriesKey, { positive: string; negative: string; label: string }> = {
   dividends: { positive: '#22c55e', negative: '#22c55e', label: 'Dividends' },
   interest: { positive: '#3b82f6', negative: '#3b82f6', label: 'Interest' },
@@ -67,7 +76,7 @@ export function DividendIncomeReport() {
   const [selectedSecurityId, setSelectedSecurityId] = useState<string>('');
   const { dateRange, setDateRange, resolvedRange, isValid } = useDateRange({ defaultRange: '1y', alignment: 'month' });
   const [isLoading, setIsLoading] = useState(true);
-  const [viewType, setViewType] = useState<'monthly' | 'bySecurity'>('monthly');
+  const [viewType, setViewType] = useState<'monthly' | 'daily' | 'bySecurity'>('monthly');
   const [monthlyDisplay, setMonthlyDisplay] = useState<'chart' | 'table'>('chart');
   const [visibleSeries, setVisibleSeries] = useState<Record<SeriesKey, boolean>>({
     dividends: true,
@@ -321,6 +330,49 @@ export function DividendIncomeReport() {
     return Array.from(monthMap.values()).sort((a, b) => a.month.localeCompare(b.month));
   }, [filteredTransactions, filteredCapitalGains, dateRange, resolvedRange, getTxAmount, convertCapitalGain, convertFromAccountCurrency]);
 
+  // Daily view: groups transaction-level income (DIVIDEND, INTEREST, CAPITAL_GAIN)
+  // by calendar day. Monthly capital-gain entries are not available at daily
+  // granularity and are intentionally excluded here.
+  const dailyData = useMemo((): DailyIncome[] => {
+    const dayMap = new Map<string, DailyIncome>();
+
+    const getOrCreateBucket = (txDate: Date): DailyIncome => {
+      const key = format(txDate, 'yyyy-MM-dd');
+      let bucket = dayMap.get(key);
+      if (!bucket) {
+        bucket = {
+          date: key,
+          label: format(txDate, 'MMM d, yyyy'),
+          dividends: 0,
+          interest: 0,
+          capitalGains: 0,
+          total: 0,
+        };
+        dayMap.set(key, bucket);
+      }
+      return bucket;
+    };
+
+    filteredTransactions.forEach((tx) => {
+      const bucket = getOrCreateBucket(parseLocalDate(tx.transactionDate));
+      const contribution = getTxAmount(tx);
+      switch (tx.action) {
+        case 'DIVIDEND':
+          bucket.dividends += contribution;
+          break;
+        case 'INTEREST':
+          bucket.interest += contribution;
+          break;
+        case 'CAPITAL_GAIN':
+          bucket.capitalGains += contribution;
+          break;
+      }
+      bucket.total += contribution;
+    });
+
+    return Array.from(dayMap.values()).sort((a, b) => a.date.localeCompare(b.date));
+  }, [filteredTransactions, getTxAmount]);
+
   const securityData = useMemo((): SecurityIncome[] => {
     const securityMap = new Map<string, SecurityIncome>();
 
@@ -392,7 +444,8 @@ export function DividendIncomeReport() {
   // filter them; the currency code goes into a dedicated column.
   const isTableView =
     viewType === 'bySecurity' ||
-    (viewType === 'monthly' && monthlyDisplay === 'table');
+    (viewType === 'monthly' && monthlyDisplay === 'table') ||
+    (viewType === 'daily' && monthlyDisplay === 'table');
 
   const round4 = (n: number) => Math.round(n * 10000) / 10000;
 
@@ -424,6 +477,34 @@ export function DividendIncomeReport() {
         currencyCode,
       ]);
       exportToCsv(`${filenameBase}-by-security-${scope}`, headers, rows);
+      return;
+    }
+
+    if (viewType === 'daily') {
+      const headers: string[] = ['Date'];
+      if (visibleSeries.dividends) headers.push('Dividends');
+      if (visibleSeries.interest) headers.push('Interest');
+      if (visibleSeries.capitalGains) headers.push('Capital Gains');
+      headers.push('Total', 'Currency');
+      const rows = dailyData.map((row) => {
+        const out: (string | number)[] = [row.date];
+        let total = 0;
+        if (visibleSeries.dividends) {
+          out.push(round4(row.dividends));
+          total += row.dividends;
+        }
+        if (visibleSeries.interest) {
+          out.push(round4(row.interest));
+          total += row.interest;
+        }
+        if (visibleSeries.capitalGains) {
+          out.push(round4(row.capitalGains));
+          total += row.capitalGains;
+        }
+        out.push(round4(total), currencyCode);
+        return out;
+      });
+      exportToCsv(`${filenameBase}-daily-${scope}`, headers, rows);
       return;
     }
 
@@ -494,6 +575,54 @@ export function DividendIncomeReport() {
           fmtValue(totals.total),
         ],
       };
+    } else if (viewType === 'daily' && monthlyDisplay === 'table') {
+      const headers: string[] = ['Date'];
+      if (visibleSeries.dividends) headers.push('Dividends');
+      if (visibleSeries.interest) headers.push('Interest');
+      if (visibleSeries.capitalGains) headers.push('Capital Gains');
+      headers.push('Total');
+      const rows = dailyData.map((row) => {
+        const out: (string | number)[] = [row.label];
+        let rowTotal = 0;
+        if (visibleSeries.dividends) {
+          out.push(fmtValue(row.dividends));
+          rowTotal += row.dividends;
+        }
+        if (visibleSeries.interest) {
+          out.push(fmtValue(row.interest));
+          rowTotal += row.interest;
+        }
+        if (visibleSeries.capitalGains) {
+          out.push(fmtValue(row.capitalGains));
+          rowTotal += row.capitalGains;
+        }
+        out.push(fmtValue(rowTotal));
+        return out;
+      });
+      const dailyTotals = dailyData.reduce(
+        (acc, row) => ({
+          dividends: acc.dividends + row.dividends,
+          interest: acc.interest + row.interest,
+          capitalGains: acc.capitalGains + row.capitalGains,
+        }),
+        { dividends: 0, interest: 0, capitalGains: 0 },
+      );
+      const totalRow: (string | number)[] = ['Total'];
+      let grandTotal = 0;
+      if (visibleSeries.dividends) {
+        totalRow.push(fmtValue(dailyTotals.dividends));
+        grandTotal += dailyTotals.dividends;
+      }
+      if (visibleSeries.interest) {
+        totalRow.push(fmtValue(dailyTotals.interest));
+        grandTotal += dailyTotals.interest;
+      }
+      if (visibleSeries.capitalGains) {
+        totalRow.push(fmtValue(dailyTotals.capitalGains));
+        grandTotal += dailyTotals.capitalGains;
+      }
+      totalRow.push(fmtValue(grandTotal));
+      tableData = { headers, rows, totalRow };
     } else if (viewType === 'monthly' && monthlyDisplay === 'table') {
       const headers: string[] = ['Month', 'Start Value', 'End Value'];
       if (visibleSeries.dividends) headers.push('Dividends');
@@ -604,6 +733,8 @@ export function DividendIncomeReport() {
   // instead of being hidden inside a stack.
   const hasNegativeCapitalGains = monthlyData.some((m) => m.capitalGains < 0);
   const stackId = hasNegativeCapitalGains ? undefined : 'a';
+  const dailyHasNegativeCapitalGains = dailyData.some((d) => d.capitalGains < 0);
+  const dailyStackId = dailyHasNegativeCapitalGains ? undefined : 'a';
 
   return (
     <div className="space-y-6">
@@ -691,6 +822,16 @@ export function DividendIncomeReport() {
               Monthly
             </button>
             <button
+              onClick={() => setViewType('daily')}
+              className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                viewType === 'daily'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+              }`}
+            >
+              Daily
+            </button>
+            <button
               onClick={() => setViewType('bySecurity')}
               className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
                 viewType === 'bySecurity'
@@ -706,8 +847,8 @@ export function DividendIncomeReport() {
             />
           </div>
         </div>
-        {/* Monthly view sub-controls: chart/table switch + series toggles */}
-        {viewType === 'monthly' && (
+        {/* Monthly/Daily view sub-controls: chart/table switch + series toggles */}
+        {(viewType === 'monthly' || viewType === 'daily') && (
           <div className="flex flex-wrap gap-4 mt-3 items-center">
             <div
               className="inline-flex rounded-md border border-gray-200 dark:border-gray-600 overflow-hidden text-sm"
@@ -921,6 +1062,155 @@ export function DividendIncomeReport() {
               </tbody>
             </table>
           </div>
+        </div>
+      ) : viewType === 'daily' && monthlyDisplay === 'chart' ? (
+        /* Daily Chart */
+        <div ref={chartRef} className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 px-2 py-4 sm:p-6">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+            Daily Gains, Dividends & Interest
+          </h3>
+          {dailyData.length === 0 ? (
+            <p className="text-gray-500 dark:text-gray-400 text-center py-8">
+              No daily transaction data for this period.
+            </p>
+          ) : (
+            <div className="h-80">
+              <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+                <BarChart data={dailyData}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                  <XAxis dataKey="label" tick={{ fontSize: 11 }} />
+                  <YAxis tickFormatter={formatCurrencyAxis} />
+                  <Tooltip content={<CustomTooltip />} />
+                  <Legend />
+                  <ReferenceLine y={0} stroke="#9ca3af" />
+                  {visibleSeries.dividends && (
+                    <Bar
+                      dataKey="dividends"
+                      stackId={dailyStackId}
+                      fill={SERIES_COLORS.dividends.positive}
+                      name="Dividends"
+                    />
+                  )}
+                  {visibleSeries.interest && (
+                    <Bar
+                      dataKey="interest"
+                      stackId={dailyStackId}
+                      fill={SERIES_COLORS.interest.positive}
+                      name="Interest"
+                    />
+                  )}
+                  {visibleSeries.capitalGains && (
+                    <Bar
+                      dataKey="capitalGains"
+                      stackId={dailyStackId}
+                      fill={SERIES_COLORS.capitalGains.positive}
+                      name="Capital Gains"
+                    >
+                      {dailyData.map((entry) => (
+                        <Cell
+                          key={entry.date}
+                          fill={
+                            entry.capitalGains < 0
+                              ? SERIES_COLORS.capitalGains.negative
+                              : SERIES_COLORS.capitalGains.positive
+                          }
+                        />
+                      ))}
+                    </Bar>
+                  )}
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </div>
+      ) : viewType === 'daily' ? (
+        /* Daily Table */
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 overflow-hidden">
+          <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              Daily Gains, Dividends & Interest
+            </h3>
+          </div>
+          {dailyData.length === 0 ? (
+            <p className="text-gray-500 dark:text-gray-400 text-center py-8">
+              No daily transaction data for this period.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead className="bg-gray-50 dark:bg-gray-900/50">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                      Date
+                    </th>
+                    {visibleSeries.dividends && (
+                      <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                        Dividends
+                      </th>
+                    )}
+                    {visibleSeries.interest && (
+                      <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                        Interest
+                      </th>
+                    )}
+                    {visibleSeries.capitalGains && (
+                      <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                        Capital Gains
+                      </th>
+                    )}
+                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                      Total
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                  {dailyData.map((row) => {
+                    const rowTotal =
+                      (visibleSeries.dividends ? row.dividends : 0) +
+                      (visibleSeries.interest ? row.interest : 0) +
+                      (visibleSeries.capitalGains ? row.capitalGains : 0);
+                    return (
+                      <tr key={row.date} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                        <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">
+                          {row.label}
+                        </td>
+                        {visibleSeries.dividends && (
+                          <td className="px-4 py-3 text-right text-sm text-green-600 dark:text-green-400">
+                            {row.dividends !== 0 ? fmtValue(row.dividends) : '-'}
+                          </td>
+                        )}
+                        {visibleSeries.interest && (
+                          <td className="px-4 py-3 text-right text-sm text-blue-600 dark:text-blue-400">
+                            {row.interest !== 0 ? fmtValue(row.interest) : '-'}
+                          </td>
+                        )}
+                        {visibleSeries.capitalGains && (
+                          <td
+                            className={`px-4 py-3 text-right text-sm ${
+                              row.capitalGains < 0
+                                ? 'text-red-600 dark:text-red-400'
+                                : 'text-purple-600 dark:text-purple-400'
+                            }`}
+                          >
+                            {row.capitalGains !== 0 ? fmtValue(row.capitalGains) : '-'}
+                          </td>
+                        )}
+                        <td
+                          className={`px-4 py-3 text-right text-sm font-medium ${
+                            rowTotal < 0
+                              ? 'text-red-600 dark:text-red-400'
+                              : 'text-gray-900 dark:text-gray-100'
+                          }`}
+                        >
+                          {rowTotal !== 0 ? fmtValue(rowTotal) : '-'}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       ) : (
         /* By Security Table */

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -53,6 +53,8 @@ interface SecurityIncome {
 interface DailyIncome {
   date: string;
   label: string;
+  startValue: number;
+  endValue: number;
   dividends: number;
   interest: number;
   capitalGains: number;
@@ -71,6 +73,7 @@ export function DividendIncomeReport() {
   const chartRef = useRef<HTMLDivElement>(null);
   const [transactions, setTransactions] = useState<InvestmentTransaction[]>([]);
   const [capitalGains, setCapitalGains] = useState<CapitalGainEntry[]>([]);
+  const [dailyCapitalGains, setDailyCapitalGains] = useState<CapitalGainEntry[]>([]);
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [selectedAccountId, setSelectedAccountId] = useState<string>('');
   const [selectedSecurityId, setSelectedSecurityId] = useState<string>('');
@@ -107,7 +110,7 @@ export function DividendIncomeReport() {
         });
       }
     }
-    for (const entry of capitalGains) {
+    for (const entry of [...capitalGains, ...dailyCapitalGains]) {
       if (!map.has(entry.securityId)) {
         map.set(entry.securityId, {
           id: entry.securityId,
@@ -117,7 +120,7 @@ export function DividendIncomeReport() {
       }
     }
     return Array.from(map.values()).sort((a, b) => a.symbol.localeCompare(b.symbol));
-  }, [transactions, capitalGains]);
+  }, [transactions, capitalGains, dailyCapitalGains]);
 
   // Clear the security filter when the account changes or when the selected
   // security drops out of the available set (e.g. switching to an account
@@ -140,6 +143,11 @@ export function DividendIncomeReport() {
     if (!selectedSecurityId) return capitalGains;
     return capitalGains.filter((e) => e.securityId === selectedSecurityId);
   }, [capitalGains, selectedSecurityId]);
+
+  const filteredDailyCapitalGains = useMemo(() => {
+    if (!selectedSecurityId) return dailyCapitalGains;
+    return dailyCapitalGains.filter((e) => e.securityId === selectedSecurityId);
+  }, [dailyCapitalGains, selectedSecurityId]);
 
   // When a single account is selected, show in native currency; otherwise convert to default
   const selectedAccount = accounts.find((a) => a.id === selectedAccountId);
@@ -243,6 +251,27 @@ export function DividendIncomeReport() {
     loadData();
   }, [selectedAccountId, resolvedRange, isValid]);
 
+  // Lazy-load daily capital gains only when the user switches to the daily view.
+  useEffect(() => {
+    if (viewType !== 'daily' || !isValid) return;
+    const load = async () => {
+      try {
+        const { start, end } = resolvedRange;
+        const cgStart = start || '1970-01-01';
+        const data = await investmentsApi.getCapitalGains({
+          accountIds: selectedAccountId || undefined,
+          startDate: cgStart,
+          endDate: end,
+          granularity: 'day',
+        });
+        setDailyCapitalGains(data);
+      } catch (error) {
+        logger.error('Failed to load daily capital gains:', error);
+      }
+    };
+    load();
+  }, [viewType, selectedAccountId, resolvedRange, isValid]);
+
   const monthlyData = useMemo((): MonthlyIncome[] => {
     const { start, end } = resolvedRange;
     if (!start && dateRange !== 'all') return [];
@@ -330,31 +359,33 @@ export function DividendIncomeReport() {
     return Array.from(monthMap.values()).sort((a, b) => a.month.localeCompare(b.month));
   }, [filteredTransactions, filteredCapitalGains, dateRange, resolvedRange, getTxAmount, convertCapitalGain, convertFromAccountCurrency]);
 
-  // Daily view: groups transaction-level income (DIVIDEND, INTEREST, CAPITAL_GAIN)
-  // by calendar day. Monthly capital-gain entries are not available at daily
-  // granularity and are intentionally excluded here.
+  // Daily view: mirrors monthlyData but at daily granularity, combining
+  // transaction-level income (DIVIDEND, INTEREST, CAPITAL_GAIN) with the
+  // daily capital gains from the backend (realized + unrealized per day).
   const dailyData = useMemo((): DailyIncome[] => {
     const dayMap = new Map<string, DailyIncome>();
 
-    const getOrCreateBucket = (txDate: Date): DailyIncome => {
-      const key = format(txDate, 'yyyy-MM-dd');
-      let bucket = dayMap.get(key);
+    const getOrCreateBucket = (dateKey: string, txDate: Date): DailyIncome => {
+      let bucket = dayMap.get(dateKey);
       if (!bucket) {
         bucket = {
-          date: key,
+          date: dateKey,
           label: format(txDate, 'MMM d, yyyy'),
+          startValue: 0,
+          endValue: 0,
           dividends: 0,
           interest: 0,
           capitalGains: 0,
           total: 0,
         };
-        dayMap.set(key, bucket);
+        dayMap.set(dateKey, bucket);
       }
       return bucket;
     };
 
     filteredTransactions.forEach((tx) => {
-      const bucket = getOrCreateBucket(parseLocalDate(tx.transactionDate));
+      const txDate = parseLocalDate(tx.transactionDate);
+      const bucket = getOrCreateBucket(tx.transactionDate, txDate);
       const contribution = getTxAmount(tx);
       switch (tx.action) {
         case 'DIVIDEND':
@@ -370,8 +401,19 @@ export function DividendIncomeReport() {
       bucket.total += contribution;
     });
 
+    filteredDailyCapitalGains.forEach((entry) => {
+      // entry.month holds YYYY-MM-DD for daily entries
+      const txDate = parseLocalDate(entry.month);
+      const bucket = getOrCreateBucket(entry.month, txDate);
+      const gain = convertCapitalGain(entry);
+      bucket.capitalGains += gain;
+      bucket.total += gain;
+      bucket.startValue += convertFromAccountCurrency(entry.startValue, entry.accountCurrencyCode);
+      bucket.endValue += convertFromAccountCurrency(entry.endValue, entry.accountCurrencyCode);
+    });
+
     return Array.from(dayMap.values()).sort((a, b) => a.date.localeCompare(b.date));
-  }, [filteredTransactions, getTxAmount]);
+  }, [filteredTransactions, filteredDailyCapitalGains, getTxAmount, convertCapitalGain, convertFromAccountCurrency]);
 
   const securityData = useMemo((): SecurityIncome[] => {
     const securityMap = new Map<string, SecurityIncome>();
@@ -481,13 +523,13 @@ export function DividendIncomeReport() {
     }
 
     if (viewType === 'daily') {
-      const headers: string[] = ['Date'];
+      const headers: string[] = ['Date', 'Start Value', 'End Value'];
       if (visibleSeries.dividends) headers.push('Dividends');
       if (visibleSeries.interest) headers.push('Interest');
       if (visibleSeries.capitalGains) headers.push('Capital Gains');
       headers.push('Total', 'Currency');
       const rows = dailyData.map((row) => {
-        const out: (string | number)[] = [row.date];
+        const out: (string | number)[] = [row.date, round4(row.startValue), round4(row.endValue)];
         let total = 0;
         if (visibleSeries.dividends) {
           out.push(round4(row.dividends));
@@ -576,13 +618,13 @@ export function DividendIncomeReport() {
         ],
       };
     } else if (viewType === 'daily' && monthlyDisplay === 'table') {
-      const headers: string[] = ['Date'];
+      const headers: string[] = ['Date', 'Start Value', 'End Value'];
       if (visibleSeries.dividends) headers.push('Dividends');
       if (visibleSeries.interest) headers.push('Interest');
       if (visibleSeries.capitalGains) headers.push('Capital Gains');
       headers.push('Total');
       const rows = dailyData.map((row) => {
-        const out: (string | number)[] = [row.label];
+        const out: (string | number)[] = [row.label, fmtValue(row.startValue), fmtValue(row.endValue)];
         let rowTotal = 0;
         if (visibleSeries.dividends) {
           out.push(fmtValue(row.dividends));
@@ -607,7 +649,7 @@ export function DividendIncomeReport() {
         }),
         { dividends: 0, interest: 0, capitalGains: 0 },
       );
-      const totalRow: (string | number)[] = ['Total'];
+      const totalRow: (string | number)[] = ['Total', '', ''];
       let grandTotal = 0;
       if (visibleSeries.dividends) {
         totalRow.push(fmtValue(dailyTotals.dividends));
@@ -908,7 +950,7 @@ export function DividendIncomeReport() {
         )}
       </div>
 
-      {filteredTransactions.length === 0 && filteredCapitalGains.length === 0 ? (
+      {filteredTransactions.length === 0 && filteredCapitalGains.length === 0 && filteredDailyCapitalGains.length === 0 ? (
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
           <p className="text-gray-500 dark:text-gray-400 text-center py-8">
             No dividends, interest, or capital gain activity found for this period.
@@ -1143,6 +1185,12 @@ export function DividendIncomeReport() {
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
                       Date
                     </th>
+                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                      Start Value
+                    </th>
+                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                      End Value
+                    </th>
                     {visibleSeries.dividends && (
                       <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
                         Dividends
@@ -1173,6 +1221,12 @@ export function DividendIncomeReport() {
                       <tr key={row.date} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
                         <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">
                           {row.label}
+                        </td>
+                        <td className="px-4 py-3 text-right text-sm text-gray-700 dark:text-gray-300">
+                          {row.startValue !== 0 ? fmtValue(row.startValue) : '-'}
+                        </td>
+                        <td className="px-4 py-3 text-right text-sm text-gray-700 dark:text-gray-300">
+                          {row.endValue !== 0 ? fmtValue(row.endValue) : '-'}
                         </td>
                         {visibleSeries.dividends && (
                           <td className="px-4 py-3 text-right text-sm text-green-600 dark:text-green-400">

--- a/frontend/src/lib/investments.ts
+++ b/frontend/src/lib/investments.ts
@@ -155,11 +155,12 @@ export const investmentsApi = {
     return response.data;
   },
 
-  // Per-month capital gain breakdown (realized + unrealized) by security.
+  // Per-period capital gain breakdown (realized + unrealized) by security.
   getCapitalGains: async (params: {
     accountIds?: string;
     startDate: string;
     endDate: string;
+    granularity?: 'month' | 'day';
   }): Promise<CapitalGainEntry[]> => {
     const response = await apiClient.get<CapitalGainEntry[]>(
       '/investment-transactions/capital-gains',


### PR DESCRIPTION
## Summary
This PR adds a new "Daily" view to the Dividend Income Report component, allowing users to see gains, dividends, and interest aggregated by day instead of by month. The daily view includes lazy-loaded daily capital gains data and a toggle to hide inactive trading days.

## Key Changes

### Frontend (DividendIncomeReport)
- Added "Daily" button alongside existing "Monthly" and "By Security" view options
- Implemented `DailyIncome` interface to structure daily aggregated data
- Added `dailyCapitalGains` state and lazy-loading effect that fetches daily capital gains only when the daily view is active
- Created `dailyData` computed data that combines transaction-level income (dividends, interest, capital gains) with daily capital gains snapshots
- Implemented "Hide inactive days" toggle that filters out days with zero activity (no dividends, interest, or capital gains)
- Extended CSV export to support daily format with Date, Start Value, End Value, and income columns
- Extended PDF export to handle daily table data with proper headers and totals
- Updated table rendering logic to support daily view with date-based rows

### Backend (Portfolio Calculation Service)
- Added `calculateCapitalGainsByDay()` method that mirrors monthly calculation but at daily granularity
- Refactored `enumerateMonths()` into generic `PeriodBucket` interface to support both monthly and daily period enumeration
- Added `enumerateDays()` helper to generate daily period buckets across a date range
- Daily capital gains entries use YYYY-MM-DD format in the `month` field (instead of YYYY-MM for monthly)
- Filters out days with no holdings and no transaction activity

### Backend (Investment Transactions Service & Controller)
- Added `getCapitalGainsByDay()` service method with same account resolution logic as monthly variant
- Updated `getCapitalGains()` controller endpoint to accept optional `granularity` query parameter
- When `granularity=day`, dispatches to daily calculation; defaults to monthly for backward compatibility

## Notable Implementation Details
- Daily capital gains are lazy-loaded only when the user switches to the daily view to avoid unnecessary API calls
- The "Hide inactive days" toggle is only visible in daily view and filters rows where all income and capital gain values are zero
- Start/End Value columns in the daily table come from lazy-loaded daily capital gains data, not transaction-level data
- Daily CSV/PDF exports respect the series visibility toggles (dividends, interest, capital gains) just like monthly exports
- The implementation maintains backward compatibility—existing monthly view and API behavior are unchanged

https://claude.ai/code/session_01D1Jq66kCei8KkC5WnBPY1E