### PR TITLE
Refactor chart flag rendering to use dot renderer instead of ReferenceDot

### DIFF
--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -9,7 +9,6 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
-  ReferenceDot,
 } from 'recharts';
 import { format } from 'date-fns';
 import { netWorthApi } from '@/lib/net-worth';
@@ -524,50 +523,29 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
                 fill="url(#colorInvestments)"
                 name="Portfolio Value"
                 isAnimationActive={false}
-                dot={false}
                 activeDot={{ r: 4, fill: '#10b981' }}
+                dot={(props: { cx?: number; cy?: number; index?: number }) => {
+                  const { cx, cy, index } = props;
+                  if (cx == null || cy == null || index == null) {
+                    return <circle cx={0} cy={0} r={0} fill="none" />;
+                  }
+                  const isHighest = showFlags && index === highestIndex;
+                  const isLowest = showFlags && index === lowestIndex;
+                  if (!isHighest && !isLowest) {
+                    return <circle key={`dot-${index}`} cx={cx} cy={cy} r={0} fill="none" />;
+                  }
+                  const value = isHighest ? summary.highest : summary.lowest;
+                  const isLeftHalf = index < chartPoints.length / 2;
+                  return renderChartFlagDot({
+                    cx,
+                    cy,
+                    index,
+                    color: isHighest ? '#10b981' : '#ef4444',
+                    label: fmtFlag(value),
+                    side: isLeftHalf ? 'right' : 'left',
+                  });
+                }}
               />
-              {/* Highest / lowest flag callouts. Using ReferenceDot instead of
-                  a per-point dot renderer keeps the SVG to two extra elements
-                  rather than one zero-radius <circle> for every datapoint --
-                  on long ranges (e.g. 366 daily points) that single change
-                  drops hundreds of nodes from the chart layer. */}
-              {showFlags && highestIndex >= 0 && (
-                <ReferenceDot
-                  x={chartPoints[highestIndex].name}
-                  y={summary.highest}
-                  shape={(props: { cx?: number; cy?: number }) => {
-                    const { cx, cy } = props;
-                    if (cx == null || cy == null) return <g />;
-                    return renderChartFlagDot({
-                      cx,
-                      cy,
-                      index: highestIndex,
-                      color: '#10b981',
-                      label: fmtFlag(summary.highest),
-                      side: highestIndex < chartPoints.length / 2 ? 'right' : 'left',
-                    });
-                  }}
-                />
-              )}
-              {showFlags && lowestIndex >= 0 && (
-                <ReferenceDot
-                  x={chartPoints[lowestIndex].name}
-                  y={summary.lowest}
-                  shape={(props: { cx?: number; cy?: number }) => {
-                    const { cx, cy } = props;
-                    if (cx == null || cy == null) return <g />;
-                    return renderChartFlagDot({
-                      cx,
-                      cy,
-                      index: lowestIndex,
-                      color: '#ef4444',
-                      label: fmtFlag(summary.lowest),
-                      side: lowestIndex < chartPoints.length / 2 ? 'right' : 'left',
-                    });
-                  }}
-                />
-              )}
             </AreaChart>
           </ResponsiveContainer>
         </div>


### PR DESCRIPTION
## Summary
Refactored the investment value chart's highest/lowest value flag rendering to use the Area chart's `dot` prop instead of separate `ReferenceDot` components. This consolidates the flag rendering logic into a single dot renderer function.

## Key Changes
- Removed the `ReferenceDot` import from recharts
- Replaced two separate `ReferenceDot` components (for highest and lowest values) with a unified `dot` renderer function on the `AreaChart`
- The new dot renderer conditionally renders flag callouts only for the highest and lowest data points when `showFlags` is enabled
- Invisible zero-radius circles are rendered for all other data points to maintain consistent dot handling

## Implementation Details
- The dot renderer receives chart point properties (`cx`, `cy`, `index`) and determines whether the current point is the highest or lowest value
- Flag positioning logic (left/right side) is preserved based on whether the point is in the first or second half of the chart
- The refactoring maintains the same visual behavior while simplifying the component structure by eliminating the need for conditional ReferenceDot rendering

https://claude.ai/code/session_014U1y8F8CEHiLHephJYAXHr