### PR TITLE
Suppress logger output and fix console warnings in tests

### DIFF
--- a/frontend/src/app/global-error.test.tsx
+++ b/frontend/src/app/global-error.test.tsx
@@ -1,9 +1,25 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import GlobalError from './global-error';
 
 describe('GlobalError', () => {
   const mockReset = vi.fn();
+
+  // GlobalError legitimately renders <html><body> (Next.js requirement).
+  // Testing-library mounts it into a <div>, which trips an unavoidable
+  // DOM nesting warning. Silence it.
+  const originalConsoleError = console.error;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+      const msg = String(args[0] ?? '');
+      if (msg.includes('cannot be a child of')) return;
+      originalConsoleError(...args);
+    });
+  });
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
 
   it('renders error heading', () => {
     render(<GlobalError error={new Error('test error')} reset={mockReset} />);

--- a/frontend/src/components/budgets/BudgetWizardReview.tsx
+++ b/frontend/src/components/budgets/BudgetWizardReview.tsx
@@ -246,9 +246,9 @@ export function BudgetWizardReview({
             ))}
             {expenseCategories
               .sort((a, b) => b.amount - a.amount)
-              .map((cat) => (
+              .map((cat, idx) => (
                 <tr
-                  key={cat.categoryId}
+                  key={cat.categoryId ?? `__expense-${idx}`}
                   className="border-b border-gray-100 dark:border-gray-700 last:border-0"
                 >
                   <td className="py-2 px-2 sm:px-4 text-sm text-gray-900 dark:text-gray-100">

--- a/frontend/src/components/reports/BudgetVsActualReport.tsx
+++ b/frontend/src/components/reports/BudgetVsActualReport.tsx
@@ -191,8 +191,8 @@ export function BudgetVsActualReport() {
                         return (
                           <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
                             <p className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">{label}</p>
-                            {payload.map((entry) => (
-                              <p key={entry.dataKey as string} className="text-sm" style={{ color: entry.color }}>
+                            {payload.map((entry, idx) => (
+                              <p key={(entry.dataKey as string) ?? entry.name ?? idx} className="text-sm" style={{ color: entry.color }}>
                                 {entry.name}: {formatCurrency(entry.value as number)}
                               </p>
                             ))}

--- a/frontend/src/components/reports/DebtPayoffTimelineReport.test.tsx
+++ b/frontend/src/components/reports/DebtPayoffTimelineReport.test.tsx
@@ -472,7 +472,7 @@ describe('DebtPayoffTimelineReport', () => {
     await waitFor(() => {
       expect(screen.getByText('Payment Breakdown')).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByText('Payment Breakdown'));
+    await act(async () => { fireEvent.click(screen.getByText('Payment Breakdown')); });
     expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
     expect(screen.queryByTestId('area-chart')).not.toBeInTheDocument();
   });
@@ -496,7 +496,7 @@ describe('DebtPayoffTimelineReport', () => {
     await waitFor(() => {
       expect(screen.getByText('Principal vs Interest')).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByText('Principal vs Interest'));
+    await act(async () => { fireEvent.click(screen.getByText('Principal vs Interest')); });
     expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
     expect(screen.queryByTestId('area-chart')).not.toBeInTheDocument();
   });

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -6,17 +6,37 @@ afterEach(() => {
   cleanup();
 });
 
-// Suppress known-harmless jsdom warnings for SVG elements used by Recharts
+// Suppress known-harmless jsdom warnings for SVG elements used by Recharts.
+// Also suppress tagged output from the project's `createLogger` (e.g.
+// "[useMonteCarloScenarios] Save failed: ..."). Tests intentionally exercise
+// logger.error/warn paths and assert behavioral effects (toasts, state) rather
+// than console output, so the tagged log lines are pure noise.
+const LOGGER_TAG_RE = /^\[[A-Za-z][\w-]*\]$/;
 const originalConsoleError = console.error;
 console.error = (...args: unknown[]) => {
   const msg = typeof args[0] === 'string' ? args[0] : '';
   if (
     msg.includes('is unrecognized in this browser') ||
-    msg.includes('is using incorrect casing')
+    msg.includes('is using incorrect casing') ||
+    LOGGER_TAG_RE.test(msg)
   ) {
     return;
   }
   originalConsoleError(...args);
+};
+
+const originalConsoleWarn = console.warn;
+console.warn = (...args: unknown[]) => {
+  const msg = typeof args[0] === 'string' ? args[0] : '';
+  if (LOGGER_TAG_RE.test(msg)) return;
+  originalConsoleWarn(...args);
+};
+
+const originalConsoleInfo = console.info;
+console.info = (...args: unknown[]) => {
+  const msg = typeof args[0] === 'string' ? args[0] : '';
+  if (LOGGER_TAG_RE.test(msg)) return;
+  originalConsoleInfo(...args);
 };
 
 // Mock next/navigation


### PR DESCRIPTION
## Summary
This PR improves test output cleanliness by suppressing expected console warnings and logger output that don't represent actual issues, and fixes React key warnings in list renderings.

## Key Changes

- **Test setup improvements** (`frontend/src/test/setup.ts`):
  - Extended console error suppression to filter out tagged logger output (e.g., `[useMonteCarloScenarios]`) using regex pattern matching
  - Added console.warn and console.info suppressors to filter the same logger tags
  - Added explanatory comments about why logger output is suppressed in tests

- **GlobalError component test** (`frontend/src/app/global-error.test.tsx`):
  - Added per-test console.error mocking to suppress unavoidable DOM nesting warnings
  - GlobalError legitimately renders `<html><body>` (Next.js requirement) which causes warnings when mounted in testing-library's `<div>` container
  - Implemented with beforeEach/afterEach hooks to isolate the mock to this test suite

- **BudgetWizardReview component** (`frontend/src/components/budgets/BudgetWizardReview.tsx`):
  - Fixed React key warning by using index as fallback when `categoryId` is undefined
  - Changed from `key={cat.categoryId}` to `key={cat.categoryId ?? \`__expense-${idx}\`}`

- **BudgetVsActualReport component** (`frontend/src/components/reports/BudgetVsActualReport.tsx`):
  - Fixed React key warning in tooltip payload rendering
  - Changed from `key={entry.dataKey as string}` to `key={(entry.dataKey as string) ?? entry.name ?? idx}` with proper fallback chain

## Implementation Details

The logger tag regex pattern `^\[[A-Za-z][\w-]*\]$` matches the project's createLogger output format, allowing tests to exercise error/warn paths without console noise while still catching unexpected warnings.

https://claude.ai/code/session_01BsibuQDexCYTsQR9ShLKqx