### PR TITLE
Make monte_carlo_scenarios trigger creation idempotent

### DIFF
--- a/database/migrations/056_monte_carlo_scenarios.sql
+++ b/database/migrations/056_monte_carlo_scenarios.sql
@@ -49,6 +49,11 @@ CREATE TABLE IF NOT EXISTS monte_carlo_scenarios (
 CREATE INDEX IF NOT EXISTS idx_monte_carlo_scenarios_user
   ON monte_carlo_scenarios(user_id);
 
-CREATE TRIGGER update_monte_carlo_scenarios_updated_at
-  BEFORE UPDATE ON monte_carlo_scenarios
-  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'update_monte_carlo_scenarios_updated_at') THEN
+        CREATE TRIGGER update_monte_carlo_scenarios_updated_at
+            BEFORE UPDATE ON monte_carlo_scenarios
+            FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
Modified the trigger creation for the `monte_carlo_scenarios` table to be idempotent, preventing errors when the migration is run multiple times.

## Key Changes
- Wrapped the `CREATE TRIGGER` statement in a `DO` block with an existence check
- Added conditional logic to only create the trigger if it doesn't already exist
- Uses `pg_trigger` system catalog to check for trigger existence before creation

## Implementation Details
The change prevents "trigger already exists" errors that would occur if this migration were executed multiple times. This is a best practice for database migrations, especially in environments where migrations might be re-run or applied across multiple database instances. The idempotent approach ensures the migration can be safely applied without manual intervention or error handling.

https://claude.ai/code/session_01V3wgj6Zmz2jgam3Ux4njGq