### PR TITLE
Add secondary sort by creation date for investment transactions

### DIFF
--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -170,6 +170,7 @@ describe("InvestmentTransactionsService", () => {
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
     skip: jest.fn().mockReturnThis(),
     take: jest.fn().mockReturnThis(),
     getOne: jest.fn().mockResolvedValue(result),
@@ -1587,7 +1588,7 @@ describe("InvestmentTransactionsService", () => {
       expect(result.data).toEqual([]);
     });
 
-    it("orders transactions by date descending", async () => {
+    it("orders transactions by date descending, breaking ties by creation order", async () => {
       const mockQB = createMockQueryBuilder([], 0);
       investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
         mockQB,
@@ -1596,6 +1597,7 @@ describe("InvestmentTransactionsService", () => {
       await service.findAll(userId);
 
       expect(mockQB.orderBy).toHaveBeenCalledWith("it.transactionDate", "DESC");
+      expect(mockQB.addOrderBy).toHaveBeenCalledWith("it.createdAt", "DESC");
     });
   });
 

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -802,6 +802,7 @@ export class InvestmentTransactionsService {
 
     const data = await query
       .orderBy("it.transactionDate", "DESC")
+      .addOrderBy("it.createdAt", "DESC")
       .skip((pageNum - 1) * pageSize)
       .take(pageSize)
       .getMany();
@@ -1626,7 +1627,7 @@ export class InvestmentTransactionsService {
       });
     }
 
-    query.orderBy("it.transactionDate", "DESC");
+    query.orderBy("it.transactionDate", "DESC").addOrderBy("it.createdAt", "DESC");
 
     const rows = await query.getMany();
 


### PR DESCRIPTION
## Summary
This PR adds a secondary sort order to investment transaction queries to ensure consistent and deterministic ordering when multiple transactions share the same date.

## Key Changes
- Added `addOrderBy("it.createdAt", "DESC")` to the `findAll()` method query to sort by creation timestamp as a tiebreaker
- Added `addOrderBy("it.createdAt", "DESC")` to another query in the service (appears to be for export/reporting functionality) for consistency
- Updated test expectations to verify both the primary sort (transaction date) and secondary sort (creation date) are applied
- Updated test description to clarify the sorting behavior: "orders transactions by date descending, breaking ties by creation order"

## Implementation Details
- Both query builders now use a two-level sort: primary by `transactionDate DESC`, secondary by `createdAt DESC`
- This ensures that when transactions have the same date, they are ordered by creation time (newest first)
- The test mock was updated to include the `addOrderBy` method to properly verify the chained query builder calls

https://claude.ai/code/session_01VnVHWPHRwdqsNZSJ8EHt4s