### PR TITLE
Add month-to-date (mtd) date range option to investment charts

### DIFF
--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -175,11 +175,60 @@ describe('InvestmentValueChart', () => {
     );
   });
 
-  it('passes date filter ranges including 1w, 1m, 3m, ytd to DateRangeSelector', async () => {
+  it('passes date filter ranges including mtd between 1w and 1m to DateRangeSelector', async () => {
     render(<InvestmentValueChart />);
     await screen.findByText('Portfolio Value Over Time');
     const lastCall = mockDateRangeSelectorProps.mock.calls[mockDateRangeSelectorProps.mock.calls.length - 1][0];
-    expect(lastCall.ranges).toEqual(['1d', '1w', '1m', '3m', 'ytd', '1y', '2y', '5y', 'all']);
+    expect(lastCall.ranges).toEqual(['1d', '1w', 'mtd', '1m', '3m', 'ytd', '1y', '2y', '5y', 'all']);
+  });
+
+  it('uses intraday API for mtd range and passes 1m to backend', async () => {
+    dateRangeState.dateRange = 'mtd';
+    dateRangeState.resolvedRange = { start: '2024-01-01', end: '2024-01-15' };
+    vi.mocked(investmentsApi.getIntradayValue).mockResolvedValue({
+      points: [
+        { timestamp: '2024-01-01T14:30:00.000Z', value: 9500 },
+        { timestamp: '2024-01-10T14:30:00.000Z', value: 9700 },
+      ],
+      interval: '15m',
+      currency: 'CAD',
+      range: '1m',
+      fetchedAt: '2024-01-15T15:00:00.000Z',
+      skippedSymbols: [],
+      failedSymbols: [],
+      fallbackToDaily: false,
+    });
+    render(<InvestmentValueChart />);
+    await screen.findByText('Portfolio Value Over Time');
+    expect(investmentsApi.getIntradayValue).toHaveBeenCalledWith(
+      expect.objectContaining({ range: '1m' }),
+    );
+    expect(netWorthApi.getInvestmentsDaily).not.toHaveBeenCalled();
+  });
+
+  it('filters mtd intraday points to current month only', async () => {
+    dateRangeState.dateRange = 'mtd';
+    dateRangeState.resolvedRange = { start: '2024-01-01', end: '2024-01-15' };
+    vi.mocked(investmentsApi.getIntradayValue).mockResolvedValue({
+      points: [
+        { timestamp: '2023-12-28T14:30:00.000Z', value: 8000 },
+        { timestamp: '2024-01-01T14:30:00.000Z', value: 9000 },
+        { timestamp: '2024-01-10T14:30:00.000Z', value: 10000 },
+      ],
+      interval: '15m',
+      currency: 'CAD',
+      range: '1m',
+      fetchedAt: '2024-01-15T15:00:00.000Z',
+      skippedSymbols: [],
+      failedSymbols: [],
+      fallbackToDaily: false,
+    });
+    render(<InvestmentValueChart />);
+    await screen.findByText('Portfolio Value Over Time');
+    // highest should be 10000 (Jan 10), not 9000 or 8000 from December
+    expect(screen.getByText('$10000')).toBeInTheDocument();
+    // December point (8000) filtered out, so lowest is 9000
+    expect(screen.getByText('$9000')).toBeInTheDocument();
   });
 
   it('shows negative change values correctly', async () => {

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -173,8 +173,11 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
           // Hydrate from cache immediately so the chart appears even before
           // the network round-trip resolves.
           if (cached && !cached.fallbackToDaily) {
+            const cachedPoints = dateRange === 'mtd'
+              ? cached.points.filter((p) => p.timestamp >= resolvedRange.start)
+              : cached.points;
             setChartPoints(
-              cached.points.map((p) => ({
+              cachedPoints.map((p) => ({
                 name: formatIntradayLabel(p.timestamp, dateRange),
                 Value: p.value,
               })),
@@ -229,8 +232,11 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
             return;
           }
 
+          const responsePoints = dateRange === 'mtd'
+            ? response.points.filter((p) => p.timestamp >= resolvedRange.start)
+            : response.points;
           setChartPoints(
-            response.points.map((p) => ({
+            responsePoints.map((p) => ({
               name: formatIntradayLabel(p.timestamp, dateRange),
               Value: p.value,
             })),
@@ -249,6 +255,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
     [
       isIntraday,
       dateRange,
+      resolvedRange,
       accountIds,
       effectiveCurrency,
       foreignCurrency,

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -33,7 +33,7 @@ import {
 
 const logger = createLogger('InvestmentChart');
 
-const DAILY_RANGES = new Set(['1w', '1m', '3m', 'ytd', '1y', '2y']);
+const DAILY_RANGES = new Set(['1w', 'mtd', '1m', '3m', 'ytd', '1y', '2y']);
 
 /**
  * The page-level Refresh button broadcasts this event so the chart can clear
@@ -412,7 +412,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
           )}
         </h3>
         <DateRangeSelector
-          ranges={['1d', '1w', '1m', '3m', 'ytd', '1y', '2y', '5y', 'all']}
+          ranges={['1d', '1w', 'mtd', '1m', '3m', 'ytd', '1y', '2y', '5y', 'all']}
           value={dateRange}
           onChange={handleRangeChange}
           activeColour="bg-emerald-600"

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -185,7 +185,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
           let response;
           try {
             response = await investmentsApi.getIntradayValue({
-              range: dateRange as '1d' | '1w' | '1m',
+              range: (dateRange === 'mtd' ? '1m' : dateRange) as '1d' | '1w' | '1m',
               accountIds: accountIds?.length ? accountIds.join(',') : undefined,
               displayCurrency: foreignCurrency || undefined,
             });

--- a/frontend/src/components/investments/portfolio-chart-utils.tsx
+++ b/frontend/src/components/investments/portfolio-chart-utils.tsx
@@ -11,7 +11,7 @@ const logger = createLogger('PortfolioValueChart');
  * supports it; otherwise the backend signals fallbackToDaily=true and we
  * switch back to the daily endpoint.
  */
-export const INTRADAY_RANGES = new Set(['1d', '1w', '1m']);
+export const INTRADAY_RANGES = new Set(['1d', '1w', 'mtd', '1m']);
 
 /**
  * sessionStorage prefix for cached intraday responses. Per-tab, so the data

--- a/frontend/src/hooks/useDateRange.test.ts
+++ b/frontend/src/hooks/useDateRange.test.ts
@@ -50,6 +50,20 @@ describe('useDateRange', () => {
     expect(result.current.resolvedRange.end).toBe('2025-01-15');
   });
 
+  it('resolves mtd range to start of current month', () => {
+    const { result } = renderHook(() => useDateRange({ defaultRange: 'mtd' }));
+    expect(result.current.resolvedRange.start).toBe('2025-01-01');
+    expect(result.current.resolvedRange.end).toBe('2025-01-15');
+  });
+
+  it('resolves mtd range with month alignment uses same start-of-month date', () => {
+    const { result } = renderHook(() =>
+      useDateRange({ defaultRange: 'mtd', alignment: 'month' }),
+    );
+    expect(result.current.resolvedRange.start).toBe('2025-01-01');
+    expect(result.current.resolvedRange.end).toBe('2025-01-15');
+  });
+
   it('resolves 1m range as 30 days ago', () => {
     const { result } = renderHook(() => useDateRange({ defaultRange: '1m' }));
     expect(result.current.resolvedRange.start).toBe('2024-12-16');

--- a/frontend/src/hooks/useDateRange.ts
+++ b/frontend/src/hooks/useDateRange.ts
@@ -61,6 +61,9 @@ export function useDateRange(options: UseDateRangeOptions): UseDateRangeReturn {
         case '1w':
           start = format(subWeeks(now, 1), 'yyyy-MM-dd');
           break;
+        case 'mtd':
+          start = format(startOfMonth(now), 'yyyy-MM-dd');
+          break;
         case '1m':
           start = format(subDays(now, 30), 'yyyy-MM-dd');
           break;


### PR DESCRIPTION
## Summary
This PR adds support for a "month-to-date" (mtd) date range option to the investment value chart, allowing users to view their investment performance from the start of the current month to today.

## Key Changes
- Added 'mtd' to the `DAILY_RANGES` and `INTRADAY_RANGES` sets to enable intraday data fetching for the mtd range
- Updated `DateRangeSelector` to include 'mtd' in the available range options
- Implemented mtd range resolution in `useDateRange` hook to calculate the start of the current month
- Added filtering logic in `InvestmentValueChart` to filter cached and API response points to only include data from the start of the month onwards (since the API returns 1-month data)
- Updated the API call to map 'mtd' to '1m' range when fetching data, then filter the results client-side
- Added `resolvedRange` to the dependency array of the data-fetching effect to ensure proper reactivity
- Added test cases to verify mtd range resolution behavior

## Implementation Details
- The mtd range leverages the existing 1-month intraday data endpoint but filters results to only include points from the start of the current month
- This approach avoids needing a new backend endpoint while providing the desired functionality
- The filtering is applied consistently to both cached data and fresh API responses

https://claude.ai/code/session_01SkgQvxdzoytpba2WoQsH4s