### PR TITLE
Add fallback for regularMarketOpen from indicators data

### DIFF
--- a/backend/src/securities/security-price.service.spec.ts
+++ b/backend/src/securities/security-price.service.spec.ts
@@ -1614,7 +1614,8 @@ describe("SecurityPriceService", () => {
     it("preserves existing openPrice when quote has no open", async () => {
       securitiesRepository.find.mockResolvedValue([mockSecurity]);
 
-      // The service code always sets regularMarketOpen to undefined for chart API
+      // The mock omits both meta.regularMarketOpen and indicators, so the
+      // Yahoo service returns regularMarketOpen=undefined.
       const yahooData = makeYahooChartResponse({
         regularMarketPrice: 200.0,
       });

--- a/backend/src/securities/yahoo-finance.service.spec.ts
+++ b/backend/src/securities/yahoo-finance.service.spec.ts
@@ -62,6 +62,110 @@ describe("YahooFinanceService", () => {
       expect(result!.regularMarketTime).toBe(1700000000);
     });
 
+    it("falls back to indicators.quote[0].open when meta omits regularMarketOpen", async () => {
+      mockFetchResponse({
+        chart: {
+          result: [
+            {
+              meta: {
+                symbol: "AAPL",
+                regularMarketPrice: 185.5,
+                regularMarketDayHigh: 187.0,
+                regularMarketDayLow: 183.0,
+                regularMarketVolume: 55000000,
+                regularMarketTime: 1700000000,
+              },
+              timestamp: [1700000000],
+              indicators: {
+                quote: [
+                  {
+                    open: [184.25],
+                    high: [187.0],
+                    low: [183.0],
+                    close: [185.5],
+                    volume: [55000000],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      });
+
+      const result = await service.fetchQuote("AAPL");
+
+      expect(result).not.toBeNull();
+      expect(result!.regularMarketOpen).toBe(184.25);
+    });
+
+    it("prefers meta.regularMarketOpen over indicators when both present", async () => {
+      mockFetchResponse({
+        chart: {
+          result: [
+            {
+              meta: {
+                symbol: "AAPL",
+                regularMarketPrice: 185.5,
+                regularMarketOpen: 184.0,
+              },
+              indicators: {
+                quote: [{ open: [999.99] }],
+              },
+            },
+          ],
+        },
+      });
+
+      const result = await service.fetchQuote("AAPL");
+
+      expect(result!.regularMarketOpen).toBe(184.0);
+    });
+
+    it("skips leading null entries in indicators.open when finding the day's open", async () => {
+      mockFetchResponse({
+        chart: {
+          result: [
+            {
+              meta: {
+                symbol: "AAPL",
+                regularMarketPrice: 185.5,
+              },
+              indicators: {
+                quote: [{ open: [null, null, 184.25, 184.5] }],
+              },
+            },
+          ],
+        },
+      });
+
+      const result = await service.fetchQuote("AAPL");
+
+      expect(result!.regularMarketOpen).toBe(184.25);
+    });
+
+    it("converts indicators-sourced open from GBX to GBP for LSE stocks", async () => {
+      mockFetchResponse({
+        chart: {
+          result: [
+            {
+              meta: {
+                symbol: "VOD.L",
+                currency: "GBp",
+                regularMarketPrice: 7250,
+              },
+              indicators: {
+                quote: [{ open: [7200] }],
+              },
+            },
+          ],
+        },
+      });
+
+      const result = await service.fetchQuote("VOD.L");
+
+      expect(result!.regularMarketOpen).toBe(72);
+    });
+
     it("should call fetch with correct URL and User-Agent header", async () => {
       mockFetchResponse({ chart: { result: [{ meta: { symbol: "AAPL" } }] } });
 

--- a/backend/src/securities/yahoo-finance.service.ts
+++ b/backend/src/securities/yahoo-finance.service.ts
@@ -333,15 +333,26 @@ export class YahooFinanceService implements QuoteProvider {
       const data = await response.json();
 
       if (data.chart?.result?.[0]?.meta) {
-        const meta = data.chart.result[0].meta;
+        const result = data.chart.result[0];
+        const meta = result.meta;
         const gbx = isGbxCurrency(meta.currency);
         const convert = (v: number | undefined) =>
           v !== undefined && gbx ? convertGbxToGbp(v) : v;
 
+        // The chart-endpoint meta omits regularMarketOpen, so fall back to
+        // the first non-null open in the indicators series (today's open
+        // for range=1d&interval=1d).
+        const openSeries = result.indicators?.quote?.[0]?.open as
+          | (number | null | undefined)[]
+          | undefined;
+        const openFromSeries = openSeries?.find(
+          (v): v is number => v != null && !Number.isNaN(v),
+        );
+
         return {
           symbol: meta.symbol,
           regularMarketPrice: convert(meta.regularMarketPrice),
-          regularMarketOpen: convert(meta.regularMarketOpen),
+          regularMarketOpen: convert(meta.regularMarketOpen ?? openFromSeries),
           regularMarketDayHigh: convert(meta.regularMarketDayHigh),
           regularMarketDayLow: convert(meta.regularMarketDayLow),
           regularMarketVolume: meta.regularMarketVolume,


### PR DESCRIPTION
## Summary
Enhanced the Yahoo Finance service to handle cases where the chart API's meta object omits `regularMarketOpen` by falling back to the indicators quote data series.

## Key Changes
- **Fallback logic**: When `meta.regularMarketOpen` is unavailable, the service now extracts the first non-null open value from `indicators.quote[0].open` array
- **Preference order**: Maintains preference for `meta.regularMarketOpen` when available, only using indicators data as a fallback
- **Null handling**: Skips leading null/undefined entries in the open series to find the actual day's opening price
- **Currency conversion**: Applies GBX to GBP conversion to fallback values for LSE stocks (GBp currency)
- **Test coverage**: Added four comprehensive test cases covering:
  - Fallback behavior when meta omits regularMarketOpen
  - Preference for meta value when both sources are present
  - Handling of null entries in the indicators series
  - Currency conversion for indicators-sourced values

## Implementation Details
The implementation uses a type-safe approach with a `find()` method to locate the first valid (non-null, non-NaN) number in the open series, ensuring robust handling of various data states from the Yahoo Finance API.

https://claude.ai/code/session_019vnk4UjCJaAHHrmNy1XdSu