### PR TITLE
Fix opening balance handling for credit cards and loans

### DIFF
--- a/frontend/src/app/accounts/page.test.tsx
+++ b/frontend/src/app/accounts/page.test.tsx
@@ -480,6 +480,39 @@ describe('AccountsPage', () => {
       expect(callArg.openingBalance).toBe(-500);
     });
 
+    it('preserves positive opening balance for CREDIT_CARD when creating (no auto-negation)', async () => {
+      mockCreate.mockResolvedValue({ id: 'new-acc' });
+      render(<AccountsPage />);
+      await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
+      await act(async () => {
+        await capturedOnSubmit!({ accountType: 'CREDIT_CARD', openingBalance: 250 });
+      });
+      const callArg = mockCreate.mock.calls[0][0];
+      expect(callArg.openingBalance).toBe(250);
+    });
+
+    it('preserves positive opening balance for LINE_OF_CREDIT when creating', async () => {
+      mockCreate.mockResolvedValue({ id: 'new-acc' });
+      render(<AccountsPage />);
+      await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
+      await act(async () => {
+        await capturedOnSubmit!({ accountType: 'LINE_OF_CREDIT', openingBalance: 750 });
+      });
+      const callArg = mockCreate.mock.calls[0][0];
+      expect(callArg.openingBalance).toBe(750);
+    });
+
+    it('preserves negative opening balance for CHEQUING (overdrawn account)', async () => {
+      mockCreate.mockResolvedValue({ id: 'new-acc' });
+      render(<AccountsPage />);
+      await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
+      await act(async () => {
+        await capturedOnSubmit!({ accountType: 'CHEQUING', openingBalance: -150 });
+      });
+      const callArg = mockCreate.mock.calls[0][0];
+      expect(callArg.openingBalance).toBe(-150);
+    });
+
     it('does NOT negate opening balance for LOAN/MORTGAGE (backend handles it)', async () => {
       mockCreate.mockResolvedValue({ id: 'new-acc' });
       render(<AccountsPage />);
@@ -586,6 +619,42 @@ describe('AccountsPage', () => {
       });
       const callArg = mockUpdate.mock.calls[0][1];
       expect(callArg.openingBalance).toBe(-50000);
+    });
+
+    it('negates positive opening balance for MORTGAGE on update', async () => {
+      formModalState.editingItem = { id: 'mort-1', accountType: 'MORTGAGE' };
+      mockUpdate.mockResolvedValue({});
+      render(<AccountsPage />);
+      await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
+      await act(async () => {
+        await capturedOnSubmit!({ accountType: 'MORTGAGE', openingBalance: 250000 });
+      });
+      const callArg = mockUpdate.mock.calls[0][1];
+      expect(callArg.openingBalance).toBe(-250000);
+    });
+
+    it('passes opening balance as-is for LINE_OF_CREDIT on update', async () => {
+      formModalState.editingItem = { id: 'loc-1', accountType: 'LINE_OF_CREDIT' };
+      mockUpdate.mockResolvedValue({});
+      render(<AccountsPage />);
+      await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
+      await act(async () => {
+        await capturedOnSubmit!({ accountType: 'LINE_OF_CREDIT', openingBalance: -3000 });
+      });
+      const callArg = mockUpdate.mock.calls[0][1];
+      expect(callArg.openingBalance).toBe(-3000);
+    });
+
+    it('preserves positive opening balance for CREDIT_CARD on update', async () => {
+      formModalState.editingItem = { id: 'cc-2', accountType: 'CREDIT_CARD' };
+      mockUpdate.mockResolvedValue({});
+      render(<AccountsPage />);
+      await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
+      await act(async () => {
+        await capturedOnSubmit!({ accountType: 'CREDIT_CARD', openingBalance: 100 });
+      });
+      const callArg = mockUpdate.mock.calls[0][1];
+      expect(callArg.openingBalance).toBe(100);
     });
 
     it('preserves creditLimit value when provided', async () => {

--- a/frontend/src/app/accounts/page.test.tsx
+++ b/frontend/src/app/accounts/page.test.tsx
@@ -458,23 +458,23 @@ describe('AccountsPage', () => {
       expect(callArg).not.toHaveProperty('interestRate');
     });
 
-    it('negates opening balance for CREDIT_CARD when creating', async () => {
+    it('passes opening balance as-is for CREDIT_CARD when creating', async () => {
       mockCreate.mockResolvedValue({ id: 'new-acc' });
       render(<AccountsPage />);
       await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
       await act(async () => {
-        await capturedOnSubmit!({ accountType: 'CREDIT_CARD', openingBalance: 1000 });
+        await capturedOnSubmit!({ accountType: 'CREDIT_CARD', openingBalance: -1000 });
       });
       const callArg = mockCreate.mock.calls[0][0];
       expect(callArg.openingBalance).toBe(-1000);
     });
 
-    it('negates opening balance for LINE_OF_CREDIT when creating', async () => {
+    it('passes opening balance as-is for LINE_OF_CREDIT when creating', async () => {
       mockCreate.mockResolvedValue({ id: 'new-acc' });
       render(<AccountsPage />);
       await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
       await act(async () => {
-        await capturedOnSubmit!({ accountType: 'LINE_OF_CREDIT', openingBalance: 500 });
+        await capturedOnSubmit!({ accountType: 'LINE_OF_CREDIT', openingBalance: -500 });
       });
       const callArg = mockCreate.mock.calls[0][0];
       expect(callArg.openingBalance).toBe(-500);
@@ -491,7 +491,7 @@ describe('AccountsPage', () => {
       expect(callArg.openingBalance).toBe(10000);
     });
 
-    it('does NOT negate zero opening balance', async () => {
+    it('passes zero opening balance as-is for CREDIT_CARD', async () => {
       mockCreate.mockResolvedValue({ id: 'new-acc' });
       render(<AccountsPage />);
       await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
@@ -564,13 +564,13 @@ describe('AccountsPage', () => {
       expect(toast.default.success).toHaveBeenCalledWith('Account updated successfully');
     });
 
-    it('negates positive opening balance for liability types on update', async () => {
+    it('passes opening balance as-is for CREDIT_CARD on update', async () => {
       formModalState.editingItem = { ...mockAccounts[2], id: 'cc-1' };
       mockUpdate.mockResolvedValue({});
       render(<AccountsPage />);
       await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
       await act(async () => {
-        await capturedOnSubmit!({ accountType: 'CREDIT_CARD', openingBalance: 2000 });
+        await capturedOnSubmit!({ accountType: 'CREDIT_CARD', openingBalance: -2000 });
       });
       const callArg = mockUpdate.mock.calls[0][1];
       expect(callArg.openingBalance).toBe(-2000);

--- a/frontend/src/app/accounts/page.tsx
+++ b/frontend/src/app/accounts/page.tsx
@@ -88,19 +88,17 @@ function AccountsContent() {
         interestRate: data.interestRate || data.interestRate === 0 ? data.interestRate : undefined,
       };
 
-      // Liability accounts store openingBalance as negative.
-      // The form displays the absolute value, so negate it before saving.
-      // For new accounts, the backend handles negation for LOAN/MORTGAGE types
-      // (via loan-mortgage-account.service), so only negate on update, or for
-      // create of CREDIT_CARD/LINE_OF_CREDIT which go through the generic path.
-      const liabilityTypes = ['LOAN', 'MORTGAGE', 'LINE_OF_CREDIT', 'CREDIT_CARD'];
+      // LOAN/MORTGAGE store openingBalance as negative. The form shows the
+      // absolute amount ("Loan Amount" / "Mortgage Amount"), so negate it when
+      // saving an update. Backend handles negation on create for these types.
+      // All other account types (including CREDIT_CARD, LINE_OF_CREDIT) let the
+      // user type the sign directly, so no auto-negation is applied.
       const effectiveType = cleanedData.accountType || editingItem?.accountType;
-      const backendNegatesOnCreate = ['LOAN', 'MORTGAGE'];
       if (
         cleanedData.openingBalance != null &&
         cleanedData.openingBalance > 0 &&
-        liabilityTypes.includes(effectiveType) &&
-        (editingItem || !backendNegatesOnCreate.includes(effectiveType))
+        (effectiveType === 'LOAN' || effectiveType === 'MORTGAGE') &&
+        editingItem
       ) {
         cleanedData.openingBalance = -cleanedData.openingBalance;
       }

--- a/frontend/src/components/accounts/AccountForm.test.tsx
+++ b/frontend/src/components/accounts/AccountForm.test.tsx
@@ -1061,6 +1061,32 @@ describe('AccountForm', () => {
     expect(input.value).toBe('-500.00');
   });
 
+  it('shows positive opening balance unchanged for CREDIT_CARD when editing', async () => {
+    const ccAccount = createExistingAccount({
+      accountType: 'CREDIT_CARD',
+      openingBalance: 75,
+    });
+    render(<AccountForm account={ccAccount} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Update Account/i })).toBeInTheDocument();
+    });
+    const input = screen.getByLabelText('Opening Balance') as HTMLInputElement;
+    expect(input.value).toBe('75.00');
+  });
+
+  it('shows actual (negative) opening balance for SAVINGS when editing (overdrawn)', async () => {
+    const account = createExistingAccount({
+      accountType: 'SAVINGS',
+      openingBalance: -42,
+    });
+    render(<AccountForm account={account} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Update Account/i })).toBeInTheDocument();
+    });
+    const input = screen.getByLabelText('Opening Balance') as HTMLInputElement;
+    expect(input.value).toBe('-42.00');
+  });
+
   it('shows absolute opening balance for LOAN when editing', async () => {
     const loanAccount = createExistingAccount({
       accountType: 'LOAN',
@@ -1074,6 +1100,20 @@ describe('AccountForm', () => {
     const input = screen.getByLabelText('Loan Amount') as HTMLInputElement;
     expect(input.value).toBe('10000.00');
   });
+
+  it('shows absolute opening balance for MORTGAGE when editing', async () => {
+    const mortgageAccount = createExistingAccount({
+      accountType: 'MORTGAGE',
+      openingBalance: -250000,
+    });
+    render(<AccountForm account={mortgageAccount} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Update Account/i })).toBeInTheDocument();
+    });
+    const input = screen.getByLabelText('Mortgage Amount') as HTMLInputElement;
+    expect(input.value).toBe('250000.00');
+  });
+
 
   it('populates account with openingBalance of 0 correctly', async () => {
     const account = createExistingAccount({ openingBalance: 0 });

--- a/frontend/src/components/accounts/AccountForm.test.tsx
+++ b/frontend/src/components/accounts/AccountForm.test.tsx
@@ -1047,6 +1047,34 @@ describe('AccountForm', () => {
     });
   });
 
+  it('shows actual (negative) opening balance for CREDIT_CARD when editing', async () => {
+    const ccAccount = createExistingAccount({
+      accountType: 'CREDIT_CARD',
+      openingBalance: -500,
+    });
+    render(<AccountForm account={ccAccount} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Update Account/i })).toBeInTheDocument();
+    });
+    // Opening balance should be -500 (not abs value 500) for credit card
+    const input = screen.getByLabelText('Opening Balance') as HTMLInputElement;
+    expect(input.value).toBe('-500.00');
+  });
+
+  it('shows absolute opening balance for LOAN when editing', async () => {
+    const loanAccount = createExistingAccount({
+      accountType: 'LOAN',
+      openingBalance: -10000,
+    });
+    render(<AccountForm account={loanAccount} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Update Account/i })).toBeInTheDocument();
+    });
+    // Loan amount should show as positive (abs value)
+    const input = screen.getByLabelText('Loan Amount') as HTMLInputElement;
+    expect(input.value).toBe('10000.00');
+  });
+
   it('populates account with openingBalance of 0 correctly', async () => {
     const account = createExistingAccount({ openingBalance: 0 });
     render(<AccountForm account={account} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);

--- a/frontend/src/components/accounts/AccountForm.tsx
+++ b/frontend/src/components/accounts/AccountForm.tsx
@@ -148,7 +148,9 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
           accountType: account.accountType,
           currencyCode: account.currencyCode,
           openingBalance: account.openingBalance !== undefined
-            ? Math.round(Math.abs(Number(account.openingBalance)) * 100) / 100
+            ? (account.accountType === 'LOAN' || account.accountType === 'MORTGAGE'
+              ? Math.round(Math.abs(Number(account.openingBalance)) * 100) / 100
+              : Math.round(Number(account.openingBalance) * 100) / 100)
             : undefined,
           creditLimit: account.creditLimit
             ? Math.round(Number(account.creditLimit) * 100) / 100
@@ -464,7 +466,7 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
           value={watchedOpeningBalance}
           onChange={(value) => setValue('openingBalance', value, { shouldValidate: true })}
           error={errors.openingBalance?.message}
-          allowNegative={false}
+          allowNegative={!isLoanAccount && !isMortgageAccount}
         />
       </div>
 


### PR DESCRIPTION
## Summary
This PR corrects the handling of opening balances for different account types, particularly distinguishing between LOAN/MORTGAGE accounts (which store negative values internally) and CREDIT_CARD/LINE_OF_CREDIT accounts (which allow users to enter the sign directly).

## Key Changes

- **AccountForm.tsx**: Modified opening balance initialization to only apply absolute value conversion for LOAN and MORTGAGE accounts. Other account types (including CREDIT_CARD and LINE_OF_CREDIT) now display the actual stored value without conversion.

- **AccountForm.tsx**: Updated the `allowNegative` prop for the opening balance input field to permit negative values for non-loan/mortgage accounts, allowing users to enter negative balances directly for credit cards and lines of credit.

- **page.tsx**: Simplified the opening balance negation logic to only apply negation when updating LOAN or MORTGAGE accounts. Removed automatic negation for CREDIT_CARD and LINE_OF_CREDIT on creation, as these account types now expect users to enter the sign directly.

- **Test updates**: Updated test cases to reflect the new behavior:
  - CREDIT_CARD and LINE_OF_CREDIT now pass opening balances as-is (with user-entered signs)
  - LOAN and MORTGAGE continue to use absolute values in the form, with negation applied on update
  - Added new tests verifying that CREDIT_CARD displays negative opening balances correctly when editing

## Implementation Details

The key distinction is:
- **LOAN/MORTGAGE**: Form shows absolute value ("Loan Amount"/"Mortgage Amount"), backend stores as negative. Negation applied on update only.
- **CREDIT_CARD/LINE_OF_CREDIT**: Form shows actual value with sign, user controls the sign directly. No automatic negation applied.

https://claude.ai/code/session_01D76DNsYLwzy2uZeUXcSLTR