### PR TITLE
Add discussion template for announcements

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/announcements.md
+++ b/.github/DISCUSSION_TEMPLATE/announcements.md
@@ -1,0 +1,30 @@
+---
+title: Welcome to Monize Discussions!
+labels: []
+---
+
+## Welcome to Monize Discussions!
+
+This is the place to connect with other community members, share ideas, and get help with Monize — a personal finance management application.
+
+### New to Monize?
+
+The **[Monize Wiki](https://github.com/kenlasko/monize/wiki)** is the best place to start. It contains installation guides, configuration details, and feature documentation.
+
+### Reporting Bugs or Requesting Features?
+
+Please use the **[Issues section](https://github.com/kenlasko/monize/issues)** for:
+- Bug reports
+- Feature requests
+- Technical problems
+
+Discussions is for general questions, ideas, and community conversation — not for tracking bugs or feature requests. Posts that belong in Issues will be redirected there.
+
+### How to Participate
+
+- Ask questions you're wondering about
+- Share ideas and feedback
+- Engage with other community members
+- Be welcoming and open-minded
+
+To get started, comment below with an introduction and tell us what you do with Monize!


### PR DESCRIPTION
## Summary
This PR adds a discussion template to guide community members in the Monize project's Discussions section.

## Changes
- Added `.github/DISCUSSION_TEMPLATE/announcements.md` to provide a welcome message and guidelines for the Discussions feature
  - Includes a welcome header introducing Monize Discussions as a community space
  - Directs new users to the Monize Wiki for documentation
  - Clarifies that Issues should be used for bug reports and feature requests, while Discussions is for general questions and community conversation
  - Provides guidelines for participation and encourages community engagement

## Details
This template will be displayed when community members start a new discussion, helping set expectations for how the Discussions section should be used and directing users to appropriate resources (Wiki for documentation, Issues for bug/feature tracking).

https://claude.ai/code/session_013NJNxr7jHF9RgCm9Q6kNVg