### PR TITLE
Add investment split support to transaction splits

### DIFF
--- a/backend/src/scheduled-transactions/dto/create-scheduled-transaction-split.dto.ts
+++ b/backend/src/scheduled-transactions/dto/create-scheduled-transaction-split.dto.ts
@@ -4,32 +4,52 @@ import {
   IsOptional,
   IsString,
   IsArray,
+  IsEnum,
+  ValidateNested,
   ValidateIf,
   MaxLength,
   Min,
   Max,
 } from "class-validator";
+import { Type } from "class-transformer";
 import { ApiPropertyOptional } from "@nestjs/swagger";
 import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
+import { InvestmentSplitDto } from "../../transactions/dto/create-transaction-split.dto";
+import { SplitKind } from "../../transactions/entities/transaction-split.entity";
 
 export class CreateScheduledTransactionSplitDto {
+  @ApiPropertyOptional({ enum: SplitKind })
+  @IsOptional()
+  @IsEnum(SplitKind)
+  splitKind?: SplitKind;
+
   @ApiPropertyOptional({
     description:
-      "Category ID for expense/income splits (mutually exclusive with transferAccountId)",
+      "Category ID for expense/income splits (mutually exclusive with transferAccountId / investment)",
   })
   @IsOptional()
   @IsUUID()
-  @ValidateIf((o) => !o.transferAccountId)
+  @ValidateIf((o) => !o.transferAccountId && !o.investment)
   categoryId?: string;
 
   @ApiPropertyOptional({
     description:
-      "Target account ID for transfer splits (mutually exclusive with categoryId)",
+      "Target account ID for transfer splits (mutually exclusive with categoryId / investment)",
   })
   @IsOptional()
   @IsUUID()
-  @ValidateIf((o) => !o.categoryId)
+  @ValidateIf((o) => !o.categoryId && !o.investment)
   transferAccountId?: string;
+
+  @ApiPropertyOptional({
+    description:
+      "Embedded investment payload (mutually exclusive with categoryId / transferAccountId). When set, the split is persisted with kind='investment' and posted as an embedded BUY/SELL/etc.",
+    type: InvestmentSplitDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => InvestmentSplitDto)
+  investment?: InvestmentSplitDto;
 
   @IsNumber({ maxDecimalPlaces: 4 })
   @Min(-999999999999)

--- a/backend/src/scheduled-transactions/dto/post-scheduled-transaction.dto.ts
+++ b/backend/src/scheduled-transactions/dto/post-scheduled-transaction.dto.ts
@@ -6,14 +6,22 @@ import {
   IsString,
   IsBoolean,
   IsArray,
+  IsEnum,
   ValidateNested,
   IsDateString,
   MaxLength,
 } from "class-validator";
 import { Type } from "class-transformer";
 import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
+import { InvestmentSplitDto } from "../../transactions/dto/create-transaction-split.dto";
+import { SplitKind } from "../../transactions/entities/transaction-split.entity";
 
 class InlineSplitDto {
+  @ApiPropertyOptional({ enum: SplitKind })
+  @IsOptional()
+  @IsEnum(SplitKind)
+  splitKind?: SplitKind;
+
   @ApiPropertyOptional({ description: "Category ID for this split" })
   @IsOptional()
   @IsUUID()
@@ -23,6 +31,15 @@ class InlineSplitDto {
   @IsOptional()
   @IsUUID()
   transferAccountId?: string | null;
+
+  @ApiPropertyOptional({
+    description: "Embedded investment payload",
+    type: InvestmentSplitDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => InvestmentSplitDto)
+  investment?: InvestmentSplitDto;
 
   @ApiPropertyOptional({ description: "Amount for this split" })
   @IsNumber()

--- a/backend/src/scheduled-transactions/dto/scheduled-transaction-override.dto.ts
+++ b/backend/src/scheduled-transactions/dto/scheduled-transaction-override.dto.ts
@@ -6,14 +6,22 @@ import {
   IsUUID,
   IsBoolean,
   IsArray,
+  IsEnum,
   ValidateNested,
   IsDateString,
   MaxLength,
 } from "class-validator";
 import { Type } from "class-transformer";
 import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
+import { InvestmentSplitDto } from "../../transactions/dto/create-transaction-split.dto";
+import { SplitKind } from "../../transactions/entities/transaction-split.entity";
 
 export class OverrideSplitDto {
+  @ApiPropertyOptional({ enum: SplitKind })
+  @IsOptional()
+  @IsEnum(SplitKind)
+  splitKind?: SplitKind;
+
   @ApiPropertyOptional({ description: "Category ID for this split" })
   @IsOptional()
   @IsUUID()
@@ -23,6 +31,15 @@ export class OverrideSplitDto {
   @IsOptional()
   @IsUUID()
   transferAccountId?: string | null;
+
+  @ApiPropertyOptional({
+    description: "Embedded investment payload",
+    type: InvestmentSplitDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => InvestmentSplitDto)
+  investment?: InvestmentSplitDto;
 
   @ApiProperty({ description: "Amount for this split" })
   @IsNumber()

--- a/backend/src/scheduled-transactions/entities/scheduled-transaction-override.entity.ts
+++ b/backend/src/scheduled-transactions/entities/scheduled-transaction-override.entity.ts
@@ -90,11 +90,24 @@ export class ScheduledTransactionOverride {
 }
 
 /**
- * Structure for split overrides stored in the JSON column
+ * Structure for split overrides stored in the JSON column.
+ *
+ * Optional `splitKind` and `investment` fields lets a per-occurrence
+ * override carry an investment action (BUY/SELL/etc) when the parent
+ * scheduled transaction lives on an INVESTMENT_CASH account.
  */
 export interface OverrideSplit {
+  splitKind?: "category" | "transfer" | "investment";
   categoryId: string | null;
   transferAccountId?: string | null;
+  investment?: {
+    action: string;
+    securityId?: string;
+    quantity?: number;
+    price?: number;
+    commission?: number;
+    exchangeRate?: number;
+  };
   amount: number;
   memo?: string | null;
 }

--- a/backend/src/scheduled-transactions/entities/scheduled-transaction-split.entity.ts
+++ b/backend/src/scheduled-transactions/entities/scheduled-transaction-split.entity.ts
@@ -12,6 +12,9 @@ import { ScheduledTransaction } from "./scheduled-transaction.entity";
 import { Category } from "../../categories/entities/category.entity";
 import { Account } from "../../accounts/entities/account.entity";
 import { Tag } from "../../tags/entities/tag.entity";
+import { Security } from "../../securities/entities/security.entity";
+import { InvestmentAction } from "../../securities/entities/investment-transaction.entity";
+import { SplitKind } from "../../transactions/entities/transaction-split.entity";
 
 @Entity("scheduled_transaction_splits")
 export class ScheduledTransactionSplit {
@@ -26,6 +29,9 @@ export class ScheduledTransactionSplit {
   })
   @JoinColumn({ name: "scheduled_transaction_id" })
   scheduledTransaction: ScheduledTransaction;
+
+  @Column({ type: "varchar", length: 20, default: SplitKind.CATEGORY })
+  kind: SplitKind;
 
   @Column({ type: "uuid", name: "category_id", nullable: true })
   categoryId: string | null;
@@ -46,6 +52,59 @@ export class ScheduledTransactionSplit {
 
   @Column({ type: "text", nullable: true })
   memo: string | null;
+
+  // Investment-split fields (populated when kind === SplitKind.INVESTMENT)
+
+  @Column({
+    type: "varchar",
+    length: 50,
+    name: "investment_action",
+    nullable: true,
+  })
+  investmentAction: InvestmentAction | null;
+
+  @Column({ type: "uuid", name: "investment_security_id", nullable: true })
+  investmentSecurityId: string | null;
+
+  @ManyToOne(() => Security, { nullable: true })
+  @JoinColumn({ name: "investment_security_id" })
+  investmentSecurity: Security | null;
+
+  @Column({
+    type: "decimal",
+    precision: 20,
+    scale: 8,
+    name: "investment_quantity",
+    nullable: true,
+  })
+  investmentQuantity: number | null;
+
+  @Column({
+    type: "decimal",
+    precision: 20,
+    scale: 6,
+    name: "investment_price",
+    nullable: true,
+  })
+  investmentPrice: number | null;
+
+  @Column({
+    type: "decimal",
+    precision: 20,
+    scale: 4,
+    name: "investment_commission",
+    nullable: true,
+  })
+  investmentCommission: number | null;
+
+  @Column({
+    type: "decimal",
+    precision: 20,
+    scale: 10,
+    name: "investment_exchange_rate",
+    nullable: true,
+  })
+  investmentExchangeRate: number | null;
 
   @ManyToMany(() => Tag)
   @JoinTable({

--- a/backend/src/scheduled-transactions/scheduled-transaction-override.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transaction-override.service.spec.ts
@@ -257,8 +257,22 @@ describe("ScheduledTransactionOverrideService", () => {
       expect(overridesRepository.create).toHaveBeenCalledWith(
         expect.objectContaining({
           splits: [
-            { categoryId: null, amount: -60, memo: null },
-            { categoryId: null, amount: -40, memo: null },
+            {
+              splitKind: undefined,
+              categoryId: null,
+              transferAccountId: null,
+              investment: undefined,
+              amount: -60,
+              memo: null,
+            },
+            {
+              splitKind: undefined,
+              categoryId: null,
+              transferAccountId: null,
+              investment: undefined,
+              amount: -40,
+              memo: null,
+            },
           ],
         }),
       );

--- a/backend/src/scheduled-transactions/scheduled-transaction-override.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transaction-override.service.ts
@@ -62,7 +62,10 @@ export class ScheduledTransactionOverrideService {
       isSplit: createDto.isSplit ?? null,
       splits:
         createDto.splits?.map((s) => ({
+          splitKind: s.splitKind,
           categoryId: s.categoryId ?? null,
+          transferAccountId: s.transferAccountId ?? null,
+          investment: s.investment,
           amount: s.amount,
           memo: s.memo ?? null,
         })) ?? null,
@@ -158,7 +161,10 @@ export class ScheduledTransactionOverrideService {
     if (updateDto.splits !== undefined) {
       override.splits =
         updateDto.splits?.map((s) => ({
+          splitKind: s.splitKind,
           categoryId: s.categoryId ?? null,
+          transferAccountId: s.transferAccountId ?? null,
+          investment: s.investment,
           amount: s.amount,
           memo: s.memo ?? null,
         })) ?? null;

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
@@ -2069,4 +2069,320 @@ describe("ScheduledTransactionsService", () => {
       expect(splitsRepo.save).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe("scheduled investment splits", () => {
+    const buyInvestment = {
+      action: "BUY" as const,
+      securityId: "sec-1",
+      quantity: 75,
+      price: 10,
+      commission: 0,
+    };
+
+    it("persists kind='investment' and the investment fields on save", async () => {
+      const dto = {
+        accountId: "acc-1",
+        name: "Equity Grant",
+        amount: 0,
+        currencyCode: "USD",
+        frequency: "MONTHLY" as const,
+        nextDueDate: "2026-05-09",
+        startDate: "2026-05-09",
+        splits: [
+          { amount: 1000, categoryId: "cat-income" },
+          { amount: -250, categoryId: "cat-tax" },
+          { amount: -750, investment: buyInvestment },
+        ],
+      };
+      accountsService.findOne.mockResolvedValue({
+        id: "acc-1",
+        accountType: "INVESTMENT",
+        accountSubType: "INVESTMENT_CASH",
+        currencyCode: "USD",
+      });
+      scheduledRepo.create.mockImplementation((d) => ({ id: stId, ...d }));
+      scheduledRepo.save.mockImplementation(async (d) => d);
+      splitsRepo.create.mockImplementation((d) => d);
+      splitsRepo.save.mockImplementation(async (d) => ({ id: "split-x", ...d }));
+
+      // findOne returns the saved scheduled transaction
+      scheduledRepo.findOne.mockResolvedValue(makeScheduled({ amount: 0 }));
+
+      await service.create(userId, dto as any);
+
+      // Verify the investment-kind split was created with all fields populated
+      const investmentCall = splitsRepo.create.mock.calls.find(
+        ([arg]) => arg.kind === "investment",
+      );
+      expect(investmentCall).toBeDefined();
+      expect(investmentCall![0]).toMatchObject({
+        kind: "investment",
+        categoryId: null,
+        transferAccountId: null,
+        amount: -750,
+        investmentAction: "BUY",
+        investmentSecurityId: "sec-1",
+        investmentQuantity: 75,
+        investmentPrice: 10,
+        investmentCommission: 0,
+      });
+    });
+
+    it("rejects single category split when no transfer/investment passthrough", async () => {
+      const dto = {
+        accountId: "acc-1",
+        name: "Bad",
+        amount: -100,
+        currencyCode: "USD",
+        frequency: "MONTHLY" as const,
+        nextDueDate: "2026-05-09",
+        startDate: "2026-05-09",
+        splits: [{ amount: -100, categoryId: "cat-1" }],
+      };
+      accountsService.findOne.mockResolvedValue({
+        id: "acc-1",
+        accountType: "CHEQUING",
+        accountSubType: null,
+        currencyCode: "USD",
+      });
+
+      await expect(service.create(userId, dto as any)).rejects.toThrow(
+        /at least 2 splits/,
+      );
+    });
+
+    it("accepts a single investment split as a passthrough", async () => {
+      const dto = {
+        accountId: "acc-1",
+        name: "Pure equity grant",
+        amount: -750,
+        currencyCode: "USD",
+        frequency: "MONTHLY" as const,
+        nextDueDate: "2026-05-09",
+        startDate: "2026-05-09",
+        splits: [{ amount: -750, investment: buyInvestment }],
+      };
+      accountsService.findOne.mockResolvedValue({
+        id: "acc-1",
+        accountType: "INVESTMENT",
+        accountSubType: "INVESTMENT_CASH",
+        currencyCode: "USD",
+      });
+      scheduledRepo.create.mockImplementation((d) => ({ id: stId, ...d }));
+      scheduledRepo.save.mockImplementation(async (d) => d);
+      splitsRepo.create.mockImplementation((d) => d);
+      splitsRepo.save.mockImplementation(async (d) => ({ id: "split-x", ...d }));
+      scheduledRepo.findOne.mockResolvedValue(makeScheduled({ amount: -750 }));
+
+      await expect(service.create(userId, dto as any)).resolves.toBeDefined();
+    });
+
+    it("post() forwards investment payload from scheduled splits to TransactionsService.create", async () => {
+      const investmentSplit: any = {
+        id: "ss-3",
+        kind: "investment",
+        amount: -750,
+        memo: null,
+        categoryId: null,
+        transferAccountId: null,
+        investmentAction: "BUY",
+        investmentSecurityId: "sec-1",
+        investmentQuantity: 75,
+        investmentPrice: 10,
+        investmentCommission: 0,
+        investmentExchangeRate: 1,
+        tags: [],
+      };
+      const incomeSplit: any = {
+        id: "ss-1",
+        kind: "category",
+        amount: 1000,
+        memo: null,
+        categoryId: "cat-income",
+        transferAccountId: null,
+        tags: [],
+      };
+      const taxSplit: any = {
+        id: "ss-2",
+        kind: "category",
+        amount: -250,
+        memo: null,
+        categoryId: "cat-tax",
+        transferAccountId: null,
+        tags: [],
+      };
+      const scheduled = makeScheduled({
+        amount: 0,
+        isSplit: true,
+        splits: [incomeSplit, taxSplit, investmentSplit],
+        frequency: "ONCE",
+      });
+      scheduledRepo.findOne.mockResolvedValue(scheduled);
+      overridesRepo.createQueryBuilder = jest
+        .fn()
+        .mockReturnValue({
+          where: jest.fn().mockReturnThis(),
+          andWhere: jest.fn().mockReturnThis(),
+          getOne: jest.fn().mockResolvedValue(null),
+        });
+      mockQueryRunner.manager.delete = jest
+        .fn()
+        .mockResolvedValue({ affected: 1 });
+      transactionsService.create.mockResolvedValue({ id: "tx-new" });
+
+      await service.post(userId, stId);
+
+      expect(transactionsService.create).toHaveBeenCalledTimes(1);
+      const callArg = transactionsService.create.mock.calls[0][1];
+      const investmentPayload = callArg.splits.find(
+        (s: any) => s.splitKind === "investment",
+      );
+      expect(investmentPayload).toBeDefined();
+      expect(investmentPayload.investment).toMatchObject({
+        action: "BUY",
+        securityId: "sec-1",
+        quantity: 75,
+        price: 10,
+        commission: 0,
+        exchangeRate: 1,
+      });
+      expect(investmentPayload.amount).toBe(-750);
+
+      // Cash splits passed through with splitKind='category'
+      const incomePayload = callArg.splits.find(
+        (s: any) => s.amount === 1000,
+      );
+      expect(incomePayload.splitKind).toBe("category");
+      expect(incomePayload.investment).toBeUndefined();
+    });
+
+    it("post() forwards investment payload from inline postDto.splits", async () => {
+      const scheduled = makeScheduled({
+        amount: 0,
+        isSplit: true,
+        splits: [],
+        frequency: "ONCE",
+      });
+      scheduledRepo.findOne.mockResolvedValue(scheduled);
+      overridesRepo.createQueryBuilder = jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+      });
+      mockQueryRunner.manager.delete = jest
+        .fn()
+        .mockResolvedValue({ affected: 1 });
+      transactionsService.create.mockResolvedValue({ id: "tx-new" });
+
+      await service.post(userId, stId, {
+        amount: 0,
+        isSplit: true,
+        splits: [
+          { categoryId: "cat-income", amount: 1000 } as any,
+          { categoryId: "cat-tax", amount: -250 } as any,
+          {
+            splitKind: "investment",
+            amount: -750,
+            investment: buyInvestment,
+          } as any,
+        ],
+      });
+
+      const callArg = transactionsService.create.mock.calls[0][1];
+      expect(callArg.splits).toHaveLength(3);
+      const inv = callArg.splits.find(
+        (s: any) => s.splitKind === "investment",
+      );
+      expect(inv).toBeDefined();
+      expect(inv.investment).toMatchObject(buyInvestment);
+    });
+
+    it("post() forwards investment payload from stored override splits", async () => {
+      const scheduled = makeScheduled({
+        amount: 0,
+        isSplit: true,
+        splits: [],
+        frequency: "ONCE",
+      });
+      scheduledRepo.findOne.mockResolvedValue(scheduled);
+
+      const storedOverride: any = {
+        amount: 0,
+        isSplit: true,
+        splits: [
+          { categoryId: "cat-income", amount: 1000 },
+          { categoryId: "cat-tax", amount: -250 },
+          {
+            splitKind: "investment",
+            amount: -750,
+            investment: buyInvestment,
+          },
+        ],
+      };
+      overridesRepo.createQueryBuilder = jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(storedOverride),
+      });
+      mockQueryRunner.manager.delete = jest
+        .fn()
+        .mockResolvedValue({ affected: 1 });
+      transactionsService.create.mockResolvedValue({ id: "tx-new" });
+
+      await service.post(userId, stId);
+
+      const callArg = transactionsService.create.mock.calls[0][1];
+      const inv = callArg.splits.find(
+        (s: any) => s.splitKind === "investment",
+      );
+      expect(inv).toBeDefined();
+      expect(inv.investment).toMatchObject(buyInvestment);
+    });
+
+    it("post() preserves null investment fields when scheduled split is non-investment", async () => {
+      const incomeSplit: any = {
+        id: "ss-1",
+        kind: "category",
+        amount: -50,
+        memo: null,
+        categoryId: "cat-1",
+        transferAccountId: null,
+        tags: [],
+        // No investment* fields
+      };
+      const expenseSplit: any = {
+        id: "ss-2",
+        kind: "category",
+        amount: -50,
+        memo: null,
+        categoryId: "cat-2",
+        transferAccountId: null,
+        tags: [],
+      };
+      const scheduled = makeScheduled({
+        amount: -100,
+        isSplit: true,
+        splits: [incomeSplit, expenseSplit],
+        frequency: "ONCE",
+      });
+      scheduledRepo.findOne.mockResolvedValue(scheduled);
+      overridesRepo.createQueryBuilder = jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+      });
+      mockQueryRunner.manager.delete = jest
+        .fn()
+        .mockResolvedValue({ affected: 1 });
+      transactionsService.create.mockResolvedValue({ id: "tx-new" });
+
+      await service.post(userId, stId);
+
+      const callArg = transactionsService.create.mock.calls[0][1];
+      callArg.splits.forEach((s: any) => {
+        expect(s.investment).toBeUndefined();
+        expect(s.splitKind).toBe("category");
+      });
+    });
+  });
 });

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -14,6 +14,7 @@ import {
   FrequencyType,
 } from "./entities/scheduled-transaction.entity";
 import { ScheduledTransactionSplit } from "./entities/scheduled-transaction-split.entity";
+import { SplitKind } from "../transactions/entities/transaction-split.entity";
 import { ScheduledTransactionOverride } from "./entities/scheduled-transaction-override.entity";
 import { CreateScheduledTransactionDto } from "./dto/create-scheduled-transaction.dto";
 import { UpdateScheduledTransactionDto } from "./dto/update-scheduled-transaction.dto";
@@ -76,6 +77,7 @@ export class ScheduledTransactionsService {
           "splits.category",
           "splits.transferAccount",
           "splits.tags",
+          "splits.investmentSecurity",
         ],
         order: { nextDueDate: "ASC" },
       });
@@ -240,9 +242,11 @@ export class ScheduledTransactionsService {
     splits: CreateScheduledTransactionSplitDto[],
     transactionAmount: number,
   ): void {
-    const isTransfer = splits.length === 1 && splits[0].transferAccountId;
+    const isPassthrough =
+      splits.length === 1 &&
+      (splits[0].transferAccountId || splits[0].investment);
 
-    if (splits.length < 2 && !isTransfer) {
+    if (splits.length < 2 && !isPassthrough) {
       throw new BadRequestException(
         "Split transactions must have at least 2 splits",
       );
@@ -269,12 +273,51 @@ export class ScheduledTransactionsService {
     const savedSplits: ScheduledTransactionSplit[] = [];
 
     for (const split of splits) {
+      const inferredKind: SplitKind = split.splitKind
+        ? split.splitKind
+        : split.investment
+          ? SplitKind.INVESTMENT
+          : split.transferAccountId
+            ? SplitKind.TRANSFER
+            : SplitKind.CATEGORY;
+
       const entity = this.splitsRepository.create({
         scheduledTransactionId,
-        categoryId: split.categoryId || null,
-        transferAccountId: split.transferAccountId || null,
+        kind: inferredKind,
+        categoryId:
+          inferredKind === SplitKind.CATEGORY
+            ? split.categoryId || null
+            : null,
+        transferAccountId:
+          inferredKind === SplitKind.TRANSFER
+            ? split.transferAccountId || null
+            : null,
         amount: split.amount,
         memo: split.memo || null,
+        investmentAction:
+          inferredKind === SplitKind.INVESTMENT && split.investment
+            ? split.investment.action
+            : null,
+        investmentSecurityId:
+          inferredKind === SplitKind.INVESTMENT && split.investment
+            ? split.investment.securityId || null
+            : null,
+        investmentQuantity:
+          inferredKind === SplitKind.INVESTMENT && split.investment
+            ? (split.investment.quantity ?? null)
+            : null,
+        investmentPrice:
+          inferredKind === SplitKind.INVESTMENT && split.investment
+            ? (split.investment.price ?? null)
+            : null,
+        investmentCommission:
+          inferredKind === SplitKind.INVESTMENT && split.investment
+            ? (split.investment.commission ?? null)
+            : null,
+        investmentExchangeRate:
+          inferredKind === SplitKind.INVESTMENT && split.investment
+            ? (split.investment.exchangeRate ?? null)
+            : null,
       });
 
       const saved = await this.splitsRepository.save(entity);
@@ -310,6 +353,7 @@ export class ScheduledTransactionsService {
       .leftJoinAndSelect("splits.category", "splitCategory")
       .leftJoinAndSelect("splits.transferAccount", "splitTransferAccount")
       .leftJoinAndSelect("splits.tags", "splitTags")
+      .leftJoinAndSelect("splits.investmentSecurity", "splitInvestmentSecurity")
       .where("st.userId = :userId", { userId })
       .orderBy("st.nextDueDate", "ASC")
       .getMany();
@@ -398,6 +442,7 @@ export class ScheduledTransactionsService {
         "splits.category",
         "splits.transferAccount",
         "splits.tags",
+        "splits.investmentSecurity",
       ],
     });
 
@@ -472,6 +517,7 @@ export class ScheduledTransactionsService {
           "splits.category",
           "splits.transferAccount",
           "splits.tags",
+          "splits.investmentSecurity",
         ],
       });
 
@@ -495,6 +541,7 @@ export class ScheduledTransactionsService {
       .leftJoinAndSelect("splits.category", "splitCategory")
       .leftJoinAndSelect("splits.transferAccount", "splitTransferAccount")
       .leftJoinAndSelect("splits.tags", "splitTags")
+      .leftJoinAndSelect("splits.investmentSecurity", "splitInvestmentSecurity")
       .where("st.userId = :userId", { userId })
       .andWhere("st.isActive = :isActive", { isActive: true })
       .andWhere("st.nextDueDate <= :futureDate", { futureDate })
@@ -738,22 +785,54 @@ export class ScheduledTransactionsService {
     if (useSplits) {
       if (hasInlineSplits && postDto?.splits) {
         transactionPayload.splits = postDto.splits.map((split) => ({
+          splitKind: split.splitKind,
           categoryId: split.categoryId || undefined,
           transferAccountId: split.transferAccountId || undefined,
+          investment: split.investment,
           amount: Number(split.amount),
           memo: split.memo || undefined,
         }));
       } else if (storedOverride?.splits && storedOverride.splits.length > 0) {
         transactionPayload.splits = storedOverride.splits.map((split: any) => ({
+          splitKind: split.splitKind,
           categoryId: split.categoryId || undefined,
           transferAccountId: split.transferAccountId || undefined,
+          investment: split.investment,
           amount: Number(split.amount),
           memo: split.memo || undefined,
         }));
       } else if (scheduled.splits && scheduled.splits.length > 0) {
         transactionPayload.splits = scheduled.splits.map((split) => ({
+          splitKind: split.kind,
           categoryId: split.categoryId || undefined,
           transferAccountId: split.transferAccountId || undefined,
+          investment:
+            split.kind === SplitKind.INVESTMENT && split.investmentAction
+              ? {
+                  action: split.investmentAction,
+                  securityId: split.investmentSecurityId || undefined,
+                  quantity:
+                    split.investmentQuantity !== null &&
+                    split.investmentQuantity !== undefined
+                      ? Number(split.investmentQuantity)
+                      : undefined,
+                  price:
+                    split.investmentPrice !== null &&
+                    split.investmentPrice !== undefined
+                      ? Number(split.investmentPrice)
+                      : undefined,
+                  commission:
+                    split.investmentCommission !== null &&
+                    split.investmentCommission !== undefined
+                      ? Number(split.investmentCommission)
+                      : undefined,
+                  exchangeRate:
+                    split.investmentExchangeRate !== null &&
+                    split.investmentExchangeRate !== undefined
+                      ? Number(split.investmentExchangeRate)
+                      : undefined,
+                }
+              : undefined,
           amount: Number(split.amount),
           memo: split.memo || undefined,
           tagIds:

--- a/backend/src/securities/cash-impact.util.spec.ts
+++ b/backend/src/securities/cash-impact.util.spec.ts
@@ -1,0 +1,78 @@
+import {
+  computeInvestmentCashImpact,
+  isInvestmentActionAllowedInSplit,
+} from "./cash-impact.util";
+import { InvestmentAction } from "./entities/investment-transaction.entity";
+
+describe("computeInvestmentCashImpact", () => {
+  it("returns negative for BUY (cash leaves)", () => {
+    expect(computeInvestmentCashImpact(InvestmentAction.BUY, 75, 10, 0)).toBe(
+      -750,
+    );
+  });
+
+  it("includes commission in BUY total", () => {
+    expect(
+      computeInvestmentCashImpact(InvestmentAction.BUY, 100, 50, 9.99),
+    ).toBe(-5009.99);
+  });
+
+  it("returns positive for SELL (cash arrives) net of commission", () => {
+    expect(
+      computeInvestmentCashImpact(InvestmentAction.SELL, 100, 50, 9.99),
+    ).toBe(4990.01);
+  });
+
+  it.each([
+    InvestmentAction.DIVIDEND,
+    InvestmentAction.INTEREST,
+    InvestmentAction.CAPITAL_GAIN,
+  ])("treats %s with default qty=1 and uses price as the cash amount", (action) => {
+    expect(computeInvestmentCashImpact(action, 0, 25.5, 0)).toBe(25.5);
+    expect(computeInvestmentCashImpact(action, 1, 25.5, 0)).toBe(25.5);
+  });
+
+  it("returns 0 for REINVEST (net-zero cash, holdings still update)", () => {
+    expect(
+      computeInvestmentCashImpact(InvestmentAction.REINVEST, 5, 10, 0),
+    ).toBe(0);
+  });
+
+  it("returns 0 for share-only actions", () => {
+    expect(
+      computeInvestmentCashImpact(InvestmentAction.ADD_SHARES, 10, 0, 0),
+    ).toBe(0);
+    expect(
+      computeInvestmentCashImpact(InvestmentAction.REMOVE_SHARES, 10, 0, 0),
+    ).toBe(0);
+    expect(
+      computeInvestmentCashImpact(InvestmentAction.TRANSFER_IN, 10, 5, 0),
+    ).toBe(0);
+    expect(computeInvestmentCashImpact(InvestmentAction.SPLIT, 2, 0, 0)).toBe(
+      0,
+    );
+  });
+});
+
+describe("isInvestmentActionAllowedInSplit", () => {
+  it("allows cash-impacting actions", () => {
+    [
+      InvestmentAction.BUY,
+      InvestmentAction.SELL,
+      InvestmentAction.DIVIDEND,
+      InvestmentAction.INTEREST,
+      InvestmentAction.CAPITAL_GAIN,
+      InvestmentAction.REINVEST,
+    ].forEach((a) => expect(isInvestmentActionAllowedInSplit(a)).toBe(true));
+  });
+
+  it("disallows share-only actions", () => {
+    [
+      InvestmentAction.ADD_SHARES,
+      InvestmentAction.REMOVE_SHARES,
+      InvestmentAction.TRANSFER_IN,
+      InvestmentAction.TRANSFER_OUT,
+      InvestmentAction.SPLIT,
+    ].forEach((a) => expect(isInvestmentActionAllowedInSplit(a)).toBe(false));
+  });
+});

--- a/backend/src/securities/cash-impact.util.ts
+++ b/backend/src/securities/cash-impact.util.ts
@@ -1,0 +1,52 @@
+import { InvestmentAction } from "./entities/investment-transaction.entity";
+
+export const EMBEDDED_INVESTMENT_SPLIT_ACTIONS: ReadonlySet<InvestmentAction> =
+  new Set([
+    InvestmentAction.BUY,
+    InvestmentAction.SELL,
+    InvestmentAction.DIVIDEND,
+    InvestmentAction.INTEREST,
+    InvestmentAction.CAPITAL_GAIN,
+    InvestmentAction.REINVEST,
+  ]);
+
+export function isInvestmentActionAllowedInSplit(
+  action: InvestmentAction,
+): boolean {
+  return EMBEDDED_INVESTMENT_SPLIT_ACTIONS.has(action);
+}
+
+/**
+ * Signed cash impact of an investment action in the security's currency,
+ * before any FX conversion. Used by transaction-split validation to ensure the
+ * embedded investment split's amount matches the implied cash side.
+ *
+ * Negative = cash leaves the brokerage cash account (BUY).
+ * Positive = cash arrives in the brokerage cash account (SELL, DIVIDEND, etc).
+ * Zero     = no cash side (REINVEST and the share-only actions).
+ */
+export function computeInvestmentCashImpact(
+  action: InvestmentAction,
+  quantity: number,
+  price: number,
+  commission: number,
+): number {
+  const q = Number(quantity) || 0;
+  const p = Number(price) || 0;
+  const c = Number(commission) || 0;
+
+  switch (action) {
+    case InvestmentAction.BUY:
+      return -(q * p + c);
+    case InvestmentAction.SELL:
+      return q * p - c;
+    case InvestmentAction.DIVIDEND:
+    case InvestmentAction.INTEREST:
+    case InvestmentAction.CAPITAL_GAIN:
+      return (q || 1) * p;
+    case InvestmentAction.REINVEST:
+      return 0;
+    default:
+      return 0;
+  }
+}

--- a/backend/src/securities/entities/investment-transaction.entity.ts
+++ b/backend/src/securities/entities/investment-transaction.entity.ts
@@ -3,6 +3,7 @@ import {
   PrimaryGeneratedColumn,
   Column,
   ManyToOne,
+  OneToOne,
   JoinColumn,
   CreateDateColumn,
   UpdateDateColumn,
@@ -10,6 +11,7 @@ import {
 import { ApiProperty } from "@nestjs/swagger";
 import { Account } from "../../accounts/entities/account.entity";
 import { Transaction } from "../../transactions/entities/transaction.entity";
+import { TransactionSplit } from "../../transactions/entities/transaction-split.entity";
 import { Security } from "./security.entity";
 import { User } from "../../users/entities/user.entity";
 
@@ -48,6 +50,14 @@ export class InvestmentTransaction {
   @ApiProperty({ required: false })
   @Column({ type: "uuid", name: "transaction_id", nullable: true })
   transactionId: string | null;
+
+  @ApiProperty({
+    required: false,
+    description:
+      "When set, this investment transaction is embedded inside a split transaction; the split's amount is the cash impact and no separate linked cash transaction is created.",
+  })
+  @Column({ type: "uuid", name: "transaction_split_id", nullable: true })
+  transactionSplitId: string | null;
 
   @ApiProperty({ required: false })
   @Column({ type: "uuid", name: "security_id", nullable: true })
@@ -132,6 +142,10 @@ export class InvestmentTransaction {
   @ManyToOne(() => Transaction, { nullable: true })
   @JoinColumn({ name: "transaction_id" })
   transaction: Transaction;
+
+  @OneToOne(() => TransactionSplit, { nullable: true, onDelete: "CASCADE" })
+  @JoinColumn({ name: "transaction_split_id" })
+  transactionSplit: TransactionSplit | null;
 
   @ManyToOne(() => Security, { nullable: true })
   @JoinColumn({ name: "security_id" })

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -114,6 +114,8 @@ describe("InvestmentTransactionsService", () => {
     transaction: null as any,
     security: mockSecurity as any,
     fundingAccount: null,
+    transactionSplitId: null,
+    transactionSplit: null,
     createdAt: new Date(),
     updatedAt: new Date(),
   };
@@ -137,6 +139,8 @@ describe("InvestmentTransactionsService", () => {
     transaction: null as any,
     security: mockSecurity as any,
     fundingAccount: null,
+    transactionSplitId: null,
+    transactionSplit: null,
     createdAt: new Date(),
     updatedAt: new Date(),
   };
@@ -160,6 +164,8 @@ describe("InvestmentTransactionsService", () => {
     transaction: null as any,
     security: mockSecurity as any,
     fundingAccount: null,
+    transactionSplitId: null,
+    transactionSplit: null,
     createdAt: new Date(),
     updatedAt: new Date(),
   };
@@ -4261,6 +4267,145 @@ describe("InvestmentTransactionsService", () => {
       expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
       expect(mockQueryRunner.commitTransaction).not.toHaveBeenCalled();
       expect(mockQueryRunner.release).toHaveBeenCalled();
+    });
+  });
+
+  describe("createEmbeddedForSplit", () => {
+    it("creates an embedded BUY without spawning a linked cash transaction", async () => {
+      accountsService.findOne.mockResolvedValue(mockInvestmentAccount);
+      securitiesService.findOne.mockResolvedValue(mockSecurity);
+      // resolveCashExchangeRate path: same currency -> rate 1
+      exchangeRateService.getLatestRate.mockResolvedValue(1);
+
+      const created = await service.createEmbeddedForSplit(
+        mockQueryRunner as any,
+        userId,
+        "2026-05-09",
+        "split-1",
+        accountId,
+        cashAccountId,
+        {
+          action: InvestmentAction.BUY,
+          securityId,
+          quantity: 75,
+          price: 10,
+          commission: 0,
+        },
+      );
+
+      // No linked cash transaction created
+      const transactionSaves = mockQueryRunner.manager.save.mock.calls.filter(
+        ([entity]: any[]) =>
+          entity && entity.constructor && entity.constructor.name === "Object",
+      );
+      expect(transactionSaves.length).toBeGreaterThan(0); // saved the InvestmentTransaction
+      expect(holdingsService.updateHolding).toHaveBeenCalledWith(
+        userId,
+        accountId,
+        securityId,
+        75,
+        10,
+        mockQueryRunner,
+        false,
+      );
+      // The embedded path should never invoke the cash-side balance update
+      // for a cash account (only holdings updates).
+      expect(accountsService.updateBalance).not.toHaveBeenCalled();
+
+      // The created entity carries the split linkage and a null transactionId
+      expect(mockQueryRunner.manager.create).toHaveBeenCalledWith(
+        InvestmentTransaction,
+        expect.objectContaining({
+          transactionSplitId: "split-1",
+          transactionId: null,
+          accountId,
+          securityId,
+          action: InvestmentAction.BUY,
+          quantity: 75,
+          price: 10,
+        }),
+      );
+      expect(created).toBeDefined();
+    });
+
+    it("rejects disallowed actions in an embedded split", async () => {
+      await expect(
+        service.createEmbeddedForSplit(
+          mockQueryRunner as any,
+          userId,
+          "2026-05-09",
+          "split-1",
+          accountId,
+          cashAccountId,
+          {
+            action: InvestmentAction.ADD_SHARES,
+            securityId,
+            quantity: 5,
+          },
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it("rejects non-brokerage target accounts", async () => {
+      accountsService.findOne.mockResolvedValueOnce({
+        ...mockInvestmentAccount,
+        accountSubType: AccountSubType.INVESTMENT_CASH,
+      });
+
+      await expect(
+        service.createEmbeddedForSplit(
+          mockQueryRunner as any,
+          userId,
+          "2026-05-09",
+          "split-1",
+          accountId,
+          cashAccountId,
+          {
+            action: InvestmentAction.BUY,
+            securityId,
+            quantity: 1,
+            price: 1,
+          },
+        ),
+      ).rejects.toThrow(/INVESTMENT_BROKERAGE/);
+    });
+  });
+
+  describe("reverseAndRemoveEmbedded", () => {
+    it("reverses holdings and removes the row", async () => {
+      const embedded: any = {
+        id: "emb-1",
+        userId,
+        accountId,
+        securityId,
+        action: InvestmentAction.BUY,
+        quantity: 5,
+        price: 10,
+        commission: 0,
+        totalAmount: 50,
+        exchangeRate: 1,
+        transactionDate: "2026-05-09",
+        transactionId: null,
+        transactionSplitId: "split-1",
+      };
+
+      await service.reverseAndRemoveEmbedded(
+        mockQueryRunner as any,
+        userId,
+        embedded,
+      );
+
+      // Reverse-of-BUY decrements holdings by qty
+      expect(holdingsService.updateHolding).toHaveBeenCalledWith(
+        userId,
+        accountId,
+        securityId,
+        -5,
+        10,
+        mockQueryRunner,
+        true,
+      );
+      expect(mockQueryRunner.manager.remove).toHaveBeenCalledWith(embedded);
     });
   });
 });

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -4391,6 +4391,25 @@ describe("InvestmentTransactionsService", () => {
       ).rejects.toThrow(/Security ID is required/);
     });
 
+    it.each([InvestmentAction.DIVIDEND, InvestmentAction.CAPITAL_GAIN])(
+      "rejects %s without a securityId",
+      async (action) => {
+        accountsService.findOne.mockResolvedValue(mockInvestmentAccount);
+
+        await expect(
+          service.createEmbeddedForSplit(
+            mockQueryRunner as any,
+            userId,
+            "2026-05-09",
+            "split-1",
+            accountId,
+            cashAccountId,
+            { action, price: 50 },
+          ),
+        ).rejects.toThrow(/Security ID is required/);
+      },
+    );
+
     it("creates a DIVIDEND embedded split (no quantity required)", async () => {
       accountsService.findOne.mockResolvedValue(mockInvestmentAccount);
       securitiesService.findOne.mockResolvedValue(mockSecurity);

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -4369,6 +4369,94 @@ describe("InvestmentTransactionsService", () => {
         ),
       ).rejects.toThrow(/INVESTMENT_BROKERAGE/);
     });
+
+    it("rejects BUY without a securityId", async () => {
+      accountsService.findOne.mockResolvedValue(mockInvestmentAccount);
+
+      await expect(
+        service.createEmbeddedForSplit(
+          mockQueryRunner as any,
+          userId,
+          "2026-05-09",
+          "split-1",
+          accountId,
+          cashAccountId,
+          {
+            action: InvestmentAction.BUY,
+            // no securityId
+            quantity: 5,
+            price: 10,
+          },
+        ),
+      ).rejects.toThrow(/Security ID is required/);
+    });
+
+    it("creates a DIVIDEND embedded split (no quantity required)", async () => {
+      accountsService.findOne.mockResolvedValue(mockInvestmentAccount);
+      securitiesService.findOne.mockResolvedValue(mockSecurity);
+      exchangeRateService.getLatestRate.mockResolvedValue(1);
+
+      const created = await service.createEmbeddedForSplit(
+        mockQueryRunner as any,
+        userId,
+        "2026-05-09",
+        "split-1",
+        accountId,
+        cashAccountId,
+        {
+          action: InvestmentAction.DIVIDEND,
+          securityId,
+          price: 50, // dividend amount
+        },
+      );
+
+      // No holdings update for DIVIDEND, no cash transaction either
+      expect(holdingsService.updateHolding).not.toHaveBeenCalled();
+      expect(accountsService.updateBalance).not.toHaveBeenCalled();
+      expect(created).toBeDefined();
+      expect(mockQueryRunner.manager.create).toHaveBeenCalledWith(
+        InvestmentTransaction,
+        expect.objectContaining({
+          action: InvestmentAction.DIVIDEND,
+          transactionId: null,
+          transactionSplitId: "split-1",
+        }),
+      );
+    });
+
+    it("creates a SELL embedded split that updates holdings without cash side", async () => {
+      accountsService.findOne.mockResolvedValue(mockInvestmentAccount);
+      securitiesService.findOne.mockResolvedValue(mockSecurity);
+      exchangeRateService.getLatestRate.mockResolvedValue(1);
+
+      await service.createEmbeddedForSplit(
+        mockQueryRunner as any,
+        userId,
+        "2026-05-09",
+        "split-1",
+        accountId,
+        cashAccountId,
+        {
+          action: InvestmentAction.SELL,
+          securityId,
+          quantity: 10,
+          price: 50,
+          commission: 0,
+        },
+      );
+
+      expect(holdingsService.updateHolding).toHaveBeenCalledWith(
+        userId,
+        accountId,
+        securityId,
+        -10,
+        50,
+        mockQueryRunner,
+        false,
+      );
+      // Cash side suppressed
+      expect(accountsService.updateBalance).not.toHaveBeenCalled();
+    });
   });
 
   describe("reverseAndRemoveEmbedded", () => {

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -805,6 +805,8 @@ export class InvestmentTransactionsService {
       InvestmentAction.BUY,
       InvestmentAction.SELL,
       InvestmentAction.REINVEST,
+      InvestmentAction.DIVIDEND,
+      InvestmentAction.CAPITAL_GAIN,
     ];
     if (securityRequiredActions.includes(dto.action) && !dto.securityId) {
       throw new BadRequestException(

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -35,6 +35,10 @@ import {
 import { Account, AccountSubType } from "../accounts/entities/account.entity";
 import { isTransactionInFuture } from "../common/date-utils";
 import { ActionHistoryService } from "../action-history/action-history.service";
+import {
+  computeInvestmentCashImpact,
+  isInvestmentActionAllowedInSplit,
+} from "./cash-impact.util";
 
 export type LlmInvestmentTxGroupBy = "account" | "date" | "security" | "action";
 
@@ -573,6 +577,7 @@ export class InvestmentTransactionsService {
     userId: string,
     transaction: InvestmentTransaction,
     allowNegative: boolean = false,
+    createCashSide: boolean = true,
   ): Promise<void> {
     if (isTransactionInFuture(transaction.transactionDate)) {
       return;
@@ -588,14 +593,19 @@ export class InvestmentTransactionsService {
       fundingAccountId,
     } = transaction;
 
-    let cashAccount: Account;
-    if (fundingAccountId) {
-      cashAccount = await this.accountsService.findOne(
-        userId,
-        fundingAccountId,
-      );
-    } else {
-      cashAccount = await this.findCashAccount(userId, accountId);
+    // Cash account is only needed when we're creating the linked cash transaction.
+    // Embedded-in-split investment transactions skip cash creation because the
+    // parent split's amount IS the cash side.
+    let cashAccount: Account | null = null;
+    if (createCashSide) {
+      if (fundingAccountId) {
+        cashAccount = await this.accountsService.findOne(
+          userId,
+          fundingAccountId,
+        );
+      } else {
+        cashAccount = await this.findCashAccount(userId, accountId);
+      }
     }
     let cashTransactionId: string | null = null;
 
@@ -610,13 +620,15 @@ export class InvestmentTransactionsService {
           queryRunner,
           allowNegative,
         );
-        cashTransactionId = await this.createCashTransactionInTransaction(
-          queryRunner,
-          userId,
-          cashAccount,
-          transaction,
-          -Number(totalAmount),
-        );
+        if (createCashSide && cashAccount) {
+          cashTransactionId = await this.createCashTransactionInTransaction(
+            queryRunner,
+            userId,
+            cashAccount,
+            transaction,
+            -Number(totalAmount),
+          );
+        }
         break;
 
       case InvestmentAction.SELL:
@@ -629,25 +641,29 @@ export class InvestmentTransactionsService {
           queryRunner,
           allowNegative,
         );
-        cashTransactionId = await this.createCashTransactionInTransaction(
-          queryRunner,
-          userId,
-          cashAccount,
-          transaction,
-          Number(totalAmount),
-        );
+        if (createCashSide && cashAccount) {
+          cashTransactionId = await this.createCashTransactionInTransaction(
+            queryRunner,
+            userId,
+            cashAccount,
+            transaction,
+            Number(totalAmount),
+          );
+        }
         break;
 
       case InvestmentAction.DIVIDEND:
       case InvestmentAction.INTEREST:
       case InvestmentAction.CAPITAL_GAIN:
-        cashTransactionId = await this.createCashTransactionInTransaction(
-          queryRunner,
-          userId,
-          cashAccount,
-          transaction,
-          Number(totalAmount),
-        );
+        if (createCashSide && cashAccount) {
+          cashTransactionId = await this.createCashTransactionInTransaction(
+            queryRunner,
+            userId,
+            cashAccount,
+            transaction,
+            Number(totalAmount),
+          );
+        }
         break;
 
       case InvestmentAction.REINVEST:
@@ -738,6 +754,134 @@ export class InvestmentTransactionsService {
         transactionId: cashTransactionId,
       });
     }
+  }
+
+  /**
+   * Create an InvestmentTransaction that is embedded inside a parent split
+   * transaction. The parent split's amount represents the cash side, so this
+   * path skips the auto-generated linked cash Transaction (transactionId stays
+   * null) and only updates Holdings.
+   *
+   * Reuses the same cash-impact computation, exchange-rate resolution, and
+   * holdings logic as `create()` so embedded rows behave identically to
+   * free-standing ones in portfolio reports.
+   */
+  async createEmbeddedForSplit(
+    queryRunner: QueryRunner,
+    userId: string,
+    parentTransactionDate: string,
+    parentSplitId: string,
+    brokerageAccountId: string,
+    cashAccountId: string,
+    dto: {
+      action: InvestmentAction;
+      securityId?: string | null;
+      quantity?: number | null;
+      price?: number | null;
+      commission?: number | null;
+      exchangeRate?: number | null;
+      description?: string | null;
+    },
+  ): Promise<InvestmentTransaction> {
+    if (!isInvestmentActionAllowedInSplit(dto.action)) {
+      throw new BadRequestException(
+        `Investment action ${dto.action} is not allowed inside a split transaction`,
+      );
+    }
+
+    const brokerageAccount = await this.accountsService.findOne(
+      userId,
+      brokerageAccountId,
+    );
+    if (
+      brokerageAccount.accountSubType !== AccountSubType.INVESTMENT_BROKERAGE
+    ) {
+      throw new BadRequestException(
+        "Embedded investment splits require an INVESTMENT_BROKERAGE account",
+      );
+    }
+
+    const securityRequiredActions = [
+      InvestmentAction.BUY,
+      InvestmentAction.SELL,
+      InvestmentAction.REINVEST,
+    ];
+    if (securityRequiredActions.includes(dto.action) && !dto.securityId) {
+      throw new BadRequestException(
+        `Security ID is required for ${dto.action} transactions`,
+      );
+    }
+
+    if (dto.securityId) {
+      await this.securitiesService.findOne(userId, dto.securityId);
+    }
+
+    const totalAmount = Math.abs(
+      computeInvestmentCashImpact(
+        dto.action,
+        Number(dto.quantity ?? 0),
+        Number(dto.price ?? 0),
+        Number(dto.commission ?? 0),
+      ),
+    );
+
+    const exchangeRate = await this.resolveCashExchangeRate(
+      userId,
+      brokerageAccountId,
+      cashAccountId,
+      dto.securityId ?? null,
+      dto.exchangeRate ?? undefined,
+    );
+
+    const investmentTransaction = queryRunner.manager.create(
+      InvestmentTransaction,
+      {
+        userId,
+        accountId: brokerageAccountId,
+        securityId: dto.securityId ?? null,
+        fundingAccountId: null,
+        transactionId: null,
+        transactionSplitId: parentSplitId,
+        action: dto.action,
+        transactionDate: parentTransactionDate,
+        quantity: dto.quantity ?? 0,
+        price: dto.price ?? 0,
+        commission: dto.commission ?? 0,
+        totalAmount,
+        exchangeRate,
+        description: dto.description ?? null,
+      },
+    );
+
+    const saved = await queryRunner.manager.save(investmentTransaction);
+
+    await this.processTransactionEffectsInTransaction(
+      queryRunner,
+      userId,
+      saved,
+      false,
+      false,
+    );
+
+    return saved;
+  }
+
+  /**
+   * Reverse the holdings effects of an embedded investment transaction and
+   * delete the row. The parent split's deletion would cascade-delete this row
+   * via the FK, but we need the holdings reversal to happen first.
+   */
+  async reverseAndRemoveEmbedded(
+    queryRunner: QueryRunner,
+    userId: string,
+    investmentTransaction: InvestmentTransaction,
+  ): Promise<void> {
+    await this.reverseTransactionEffectsInTransaction(
+      queryRunner,
+      userId,
+      investmentTransaction,
+    );
+    await queryRunner.manager.remove(investmentTransaction);
   }
 
   async findAll(

--- a/backend/src/transactions/dto/create-transaction-split.dto.ts
+++ b/backend/src/transactions/dto/create-transaction-split.dto.ts
@@ -4,17 +4,76 @@ import {
   IsOptional,
   IsUUID,
   IsArray,
+  IsEnum,
+  ValidateNested,
   MaxLength,
   Min,
   Max,
 } from "class-validator";
+import { Type } from "class-transformer";
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
+import { InvestmentAction } from "../../securities/entities/investment-transaction.entity";
+import { SplitKind } from "../entities/transaction-split.entity";
+
+export class InvestmentSplitDto {
+  @ApiProperty({ enum: InvestmentAction, description: "Investment action" })
+  @IsEnum(InvestmentAction)
+  action: InvestmentAction;
+
+  @ApiPropertyOptional({ description: "Security ID for the action" })
+  @IsOptional()
+  @IsUUID()
+  securityId?: string;
+
+  @ApiPropertyOptional({ description: "Number of shares" })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 8 })
+  @Min(0)
+  quantity?: number;
+
+  @ApiPropertyOptional({ description: "Price per share" })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 6 })
+  @Min(0)
+  price?: number;
+
+  @ApiPropertyOptional({ description: "Commission or fee", default: 0 })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 4 })
+  @Min(0)
+  commission?: number;
+
+  @ApiPropertyOptional({
+    description:
+      "Exchange rate from security currency into the parent transaction's cash account currency. Defaults to 1 / market rate when omitted.",
+  })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 10 })
+  @Min(0)
+  exchangeRate?: number;
+
+  @ApiPropertyOptional({ description: "Description of the action" })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  @SanitizeHtml()
+  description?: string;
+}
 
 export class CreateTransactionSplitDto {
   @ApiPropertyOptional({
+    enum: SplitKind,
     description:
-      "Category ID for this split (mutually exclusive with transferAccountId)",
+      "Discriminator. If omitted, inferred from which of categoryId/transferAccountId/investment is set.",
+  })
+  @IsOptional()
+  @IsEnum(SplitKind)
+  splitKind?: SplitKind;
+
+  @ApiPropertyOptional({
+    description:
+      "Category ID for this split (mutually exclusive with transferAccountId/investment)",
   })
   @IsOptional()
   @IsUUID()
@@ -22,11 +81,21 @@ export class CreateTransactionSplitDto {
 
   @ApiPropertyOptional({
     description:
-      "Target account ID for transfer split (mutually exclusive with categoryId)",
+      "Target account ID for transfer split (mutually exclusive with categoryId/investment)",
   })
   @IsOptional()
   @IsUUID()
   transferAccountId?: string;
+
+  @ApiPropertyOptional({
+    description:
+      "Embedded investment action (mutually exclusive with categoryId/transferAccountId). The split's amount must equal the cash impact of this action.",
+    type: InvestmentSplitDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => InvestmentSplitDto)
+  investment?: InvestmentSplitDto;
 
   @ApiProperty({
     description:

--- a/backend/src/transactions/entities/transaction-split.entity.ts
+++ b/backend/src/transactions/entities/transaction-split.entity.ts
@@ -4,6 +4,7 @@ import {
   PrimaryGeneratedColumn,
   CreateDateColumn,
   ManyToOne,
+  OneToOne,
   ManyToMany,
   JoinColumn,
   JoinTable,
@@ -13,6 +14,13 @@ import { Transaction } from "./transaction.entity";
 import { Category } from "../../categories/entities/category.entity";
 import { Tag } from "../../tags/entities/tag.entity";
 import { Account } from "../../accounts/entities/account.entity";
+import { InvestmentTransaction } from "../../securities/entities/investment-transaction.entity";
+
+export enum SplitKind {
+  CATEGORY = "category",
+  TRANSFER = "transfer",
+  INVESTMENT = "investment",
+}
 
 @Entity("transaction_splits")
 export class TransactionSplit {
@@ -27,6 +35,14 @@ export class TransactionSplit {
   @ManyToOne(() => Transaction)
   @JoinColumn({ name: "transaction_id" })
   transaction: Transaction;
+
+  @ApiProperty({
+    enum: SplitKind,
+    description:
+      "Discriminator for the split type. 'category' assigns the split to a category, 'transfer' moves cash to another account, 'investment' embeds an investment action (BUY/SELL/etc) whose cash impact is this split's amount.",
+  })
+  @Column({ type: "varchar", length: 20, default: SplitKind.CATEGORY })
+  kind: SplitKind;
 
   @ApiProperty({ example: "category-uuid", required: false })
   @Column({ type: "uuid", name: "category_id", nullable: true })
@@ -75,6 +91,13 @@ export class TransactionSplit {
     inverseJoinColumn: { name: "tag_id", referencedColumnName: "id" },
   })
   tags: Tag[];
+
+  @OneToOne(
+    () => InvestmentTransaction,
+    (investmentTransaction) => investmentTransaction.transactionSplit,
+    { nullable: true },
+  )
+  investmentTransaction: InvestmentTransaction | null;
 
   @ApiProperty()
   @CreateDateColumn({ name: "created_at" })

--- a/backend/src/transactions/transaction-split.service.spec.ts
+++ b/backend/src/transactions/transaction-split.service.spec.ts
@@ -161,6 +161,24 @@ describe("TransactionSplitService", () => {
       createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
     };
 
+    const investmentTransactionsService = {
+      createEmbeddedForSplit: jest.fn().mockResolvedValue({}),
+      reverseAndRemoveEmbedded: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const netWorthService = {
+      triggerDebouncedRecalc: jest.fn(),
+    };
+
+    const {
+      InvestmentTransactionsService,
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+    } = require("../securities/investment-transactions.service");
+    const {
+      NetWorthService,
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+    } = require("../net-worth/net-worth.service");
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TransactionSplitService,
@@ -177,6 +195,11 @@ describe("TransactionSplitService", () => {
           useValue: categoriesRepository,
         },
         { provide: AccountsService, useValue: accountsService },
+        {
+          provide: InvestmentTransactionsService,
+          useValue: investmentTransactionsService,
+        },
+        { provide: NetWorthService, useValue: netWorthService },
         { provide: DataSource, useValue: mockDataSource },
       ],
     }).compile();
@@ -266,6 +289,7 @@ describe("TransactionSplitService", () => {
         TransactionSplit,
         {
           transactionId: "tx-1",
+          kind: "category",
           categoryId: "cat-1",
           transferAccountId: null,
           amount: -60,
@@ -419,6 +443,7 @@ describe("TransactionSplitService", () => {
         TransactionSplit,
         {
           transactionId: "tx-1",
+          kind: "category",
           categoryId: null,
           transferAccountId: null,
           amount: -60,
@@ -540,7 +565,7 @@ describe("TransactionSplitService", () => {
 
       expect(splitsRepository.find).toHaveBeenCalledWith({
         where: { transactionId: "tx-1" },
-        relations: ["category", "transferAccount"],
+        relations: ["category", "transferAccount", "investmentTransaction"],
         order: { createdAt: "ASC" },
       });
       expect(result).toEqual([mockSplit, mockSplit2]);
@@ -668,6 +693,7 @@ describe("TransactionSplitService", () => {
 
       expect(splitsRepository.create).toHaveBeenCalledWith({
         transactionId: "tx-1",
+        kind: "category",
         categoryId: "cat-3",
         transferAccountId: null,
         amount: -10,
@@ -1273,6 +1299,164 @@ describe("TransactionSplitService", () => {
       expect(externalQr.commitTransaction).not.toHaveBeenCalled();
       expect(externalQr.rollbackTransaction).not.toHaveBeenCalled();
       expect(externalQr.release).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("investment splits", () => {
+    it("validates that the cash impact matches the split amount for BUY", () => {
+      // 75 shares @ $10 = $750 cash out (negative)
+      const splits = [
+        { amount: 1000, categoryId: "cat-1" },
+        { amount: -250, categoryId: "cat-2" },
+        {
+          amount: -750,
+          investment: {
+            action: "BUY" as any,
+            securityId: "sec-1",
+            quantity: 75,
+            price: 10,
+            commission: 0,
+          },
+        },
+      ];
+      expect(() => service.validateSplits(splits, 0)).not.toThrow();
+    });
+
+    it("rejects when investment split amount does not match computed cash impact", () => {
+      const splits = [
+        { amount: 1000, categoryId: "cat-1" },
+        { amount: -250, categoryId: "cat-2" },
+        {
+          amount: -700, // Wrong: should be -750
+          investment: {
+            action: "BUY" as any,
+            securityId: "sec-1",
+            quantity: 75,
+            price: 10,
+            commission: 0,
+          },
+        },
+      ];
+      expect(() => service.validateSplits(splits, 50)).toThrow(
+        BadRequestException,
+      );
+      expect(() => service.validateSplits(splits, 50)).toThrow(
+        /does not match the cash impact/,
+      );
+    });
+
+    it("rejects investment splits that combine with categoryId", () => {
+      const splits = [
+        { amount: -50, categoryId: "cat-1" },
+        {
+          amount: -50,
+          categoryId: "cat-2",
+          investment: {
+            action: "BUY" as any,
+            securityId: "sec-1",
+            quantity: 5,
+            price: 10,
+          },
+        },
+      ];
+      expect(() => service.validateSplits(splits, -100)).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it("rejects disallowed actions inside a split", () => {
+      const splits = [
+        { amount: -100, categoryId: "cat-1" },
+        {
+          amount: 0,
+          investment: {
+            action: "ADD_SHARES" as any,
+            securityId: "sec-1",
+            quantity: 5,
+          },
+        },
+      ];
+      expect(() => service.validateSplits(splits, -100)).toThrow(
+        BadRequestException,
+      );
+      expect(() => service.validateSplits(splits, -100)).toThrow(
+        /not allowed inside a split transaction/,
+      );
+    });
+
+    it("requires the parent account to be INVESTMENT_CASH", async () => {
+      accountsService.findOne.mockResolvedValueOnce({
+        id: "account-1",
+        accountSubType: "CHECKING",
+        linkedAccountId: null,
+      });
+
+      const splits = [
+        { amount: 1000, categoryId: "cat-1" },
+        { amount: -250, categoryId: "cat-2" },
+        {
+          amount: -750,
+          investment: {
+            action: "BUY" as any,
+            securityId: "sec-1",
+            quantity: 75,
+            price: 10,
+          },
+        },
+      ];
+
+      await expect(
+        service.createSplits(
+          "tx-1",
+          splits,
+          "user-1",
+          "account-1",
+          new Date("2026-05-09"),
+        ),
+      ).rejects.toThrow(/INVESTMENT_CASH/);
+    });
+
+    it("creates investment split via embedded path on INVESTMENT_CASH parent", async () => {
+      accountsService.findOne.mockResolvedValueOnce({
+        id: "account-1",
+        accountSubType: "INVESTMENT_CASH",
+        linkedAccountId: "brokerage-1",
+      });
+
+      const splits = [
+        { amount: 1000, categoryId: "cat-1" },
+        { amount: -250, categoryId: "cat-2" },
+        {
+          amount: -750,
+          investment: {
+            action: "BUY" as any,
+            securityId: "sec-1",
+            quantity: 75,
+            price: 10,
+            commission: 0,
+          },
+        },
+      ];
+
+      const result = await service.createSplits(
+        "tx-1",
+        splits,
+        "user-1",
+        "account-1",
+        new Date("2026-05-09"),
+      );
+
+      // Two regular splits + one investment split
+      expect(result).toHaveLength(3);
+      expect(mockQueryRunner.manager.create).toHaveBeenCalledWith(
+        TransactionSplit,
+        expect.objectContaining({
+          kind: "investment",
+          categoryId: null,
+          transferAccountId: null,
+          amount: -750,
+        }),
+      );
     });
   });
 });

--- a/backend/src/transactions/transaction-split.service.spec.ts
+++ b/backend/src/transactions/transaction-split.service.spec.ts
@@ -1458,5 +1458,309 @@ describe("TransactionSplitService", () => {
         }),
       );
     });
+
+    it("rejects investment split when payload is missing", () => {
+      const splits = [
+        { amount: -100, categoryId: "cat-1" },
+        {
+          amount: 0,
+          splitKind: "investment" as any,
+          // no `investment` payload provided
+        },
+      ];
+      expect(() => service.validateSplits(splits, -100)).toThrow(
+        BadRequestException,
+      );
+      expect(() => service.validateSplits(splits, -100)).toThrow(
+        /requires an investment payload/,
+      );
+    });
+
+    it("rejects investment split combined with transferAccountId", () => {
+      const splits = [
+        { amount: -50, categoryId: "cat-1" },
+        {
+          amount: -50,
+          transferAccountId: "account-2",
+          investment: {
+            action: "BUY" as any,
+            securityId: "sec-1",
+            quantity: 5,
+            price: 10,
+          },
+        },
+      ];
+      expect(() => service.validateSplits(splits, -100)).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it("validates with exchangeRate when security currency differs", () => {
+      // 75 shares @ $10 USD = $750 USD; with rate 1.35 -> $1012.50 in parent currency
+      const splits = [
+        { amount: 1350, categoryId: "cat-1" },
+        { amount: -337.5, categoryId: "cat-2" },
+        {
+          amount: -1012.5,
+          investment: {
+            action: "BUY" as any,
+            securityId: "sec-1",
+            quantity: 75,
+            price: 10,
+            commission: 0,
+            exchangeRate: 1.35,
+          },
+        },
+      ];
+      expect(() => service.validateSplits(splits, 0)).not.toThrow();
+    });
+
+    it("accepts a single investment split as a passthrough", () => {
+      const splits = [
+        {
+          amount: -750,
+          investment: {
+            action: "BUY" as any,
+            securityId: "sec-1",
+            quantity: 75,
+            price: 10,
+            commission: 0,
+          },
+        },
+      ];
+      expect(() => service.validateSplits(splits, -750)).not.toThrow();
+    });
+
+    it("rejects investment splits when userId or sourceAccountId is missing", async () => {
+      const splits = [
+        { amount: 1000, categoryId: "cat-1" },
+        { amount: -250, categoryId: "cat-2" },
+        {
+          amount: -750,
+          investment: {
+            action: "BUY" as any,
+            securityId: "sec-1",
+            quantity: 75,
+            price: 10,
+          },
+        },
+      ];
+
+      await expect(
+        service.createSplits("tx-1", splits, undefined, "account-1"),
+      ).rejects.toThrow(/known source account/);
+    });
+
+    it("rejects when INVESTMENT_CASH parent has no linkedAccountId", async () => {
+      accountsService.findOne.mockResolvedValueOnce({
+        id: "account-1",
+        accountSubType: "INVESTMENT_CASH",
+        linkedAccountId: null,
+      });
+
+      const splits = [
+        { amount: 1000, categoryId: "cat-1" },
+        { amount: -250, categoryId: "cat-2" },
+        {
+          amount: -750,
+          investment: {
+            action: "BUY" as any,
+            securityId: "sec-1",
+            quantity: 75,
+            price: 10,
+          },
+        },
+      ];
+
+      await expect(
+        service.createSplits(
+          "tx-1",
+          splits,
+          "user-1",
+          "account-1",
+          new Date("2026-05-09"),
+        ),
+      ).rejects.toThrow(/not linked to a brokerage account/);
+    });
+
+    it("rejects adding an investment split via addSplit", async () => {
+      const transaction = { ...mockTransaction, isSplit: true } as Transaction;
+      await expect(
+        service.addSplit(
+          transaction,
+          {
+            amount: -750,
+            investment: {
+              action: "BUY" as any,
+              securityId: "sec-1",
+              quantity: 75,
+              price: 10,
+            },
+          } as any,
+          "user-1",
+        ),
+      ).rejects.toThrow(/cannot be added incrementally/);
+    });
+
+    it("removeSplit reverses holdings via reverseAndRemoveEmbedded for an investment split", async () => {
+      const investmentTx = { id: "inv-1", action: "BUY" };
+      splitsRepository.findOne.mockResolvedValue({
+        id: "split-3",
+        transactionId: "tx-1",
+        kind: "investment",
+        investmentTransaction: investmentTx,
+      });
+      const remaining = [
+        { id: "split-1", kind: "category", categoryId: "cat-1" },
+        { id: "split-2", kind: "category", categoryId: "cat-2" },
+      ];
+      mockQueryRunner.manager.find = jest
+        .fn()
+        .mockResolvedValue(remaining);
+
+      const investmentService = (service as any).investmentTransactionsService;
+
+      await service.removeSplit(
+        { ...mockTransaction } as Transaction,
+        "split-3",
+        "user-1",
+      );
+
+      expect(investmentService.reverseAndRemoveEmbedded).toHaveBeenCalledWith(
+        mockQueryRunner,
+        "user-1",
+        investmentTx,
+      );
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+    });
+
+    it("removeSplit keeps isSplit=true when the last remaining split is investment", async () => {
+      splitsRepository.findOne.mockResolvedValue({
+        id: "split-1",
+        transactionId: "tx-1",
+        kind: "category",
+        categoryId: "cat-1",
+      });
+      // After removing the category split, an investment split remains alone
+      mockQueryRunner.manager.find = jest.fn().mockResolvedValue([
+        {
+          id: "split-2",
+          kind: "investment",
+          investmentTransaction: { id: "inv-1" },
+        },
+      ]);
+
+      await service.removeSplit(
+        { ...mockTransaction } as Transaction,
+        "split-1",
+        "user-1",
+      );
+
+      // The collapse path should be skipped: no Transaction update to isSplit=false
+      const updateCalls = (mockQueryRunner.manager.update as jest.Mock).mock
+        .calls;
+      const setIsSplitFalse = updateCalls.find(
+        ([entity, _id, data]: any[]) =>
+          entity === Transaction && data?.isSplit === false,
+      );
+      expect(setIsSplitFalse).toBeUndefined();
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+    });
+
+    it("deleteSplitSideEffects reverses each investment split", async () => {
+      const externalQr: any = {
+        ...mockQueryRunner,
+        manager: { ...mockQueryRunner.manager, getRepository: jest.fn() },
+      };
+      const splitsRepo = {
+        find: jest.fn().mockResolvedValue([
+          {
+            id: "split-1",
+            kind: "investment",
+            investmentTransaction: { id: "inv-a" },
+          },
+          {
+            id: "split-2",
+            kind: "investment",
+            investmentTransaction: { id: "inv-b" },
+          },
+          // Without an investmentTransaction relation - skipped
+          {
+            id: "split-3",
+            kind: "investment",
+            investmentTransaction: null,
+          },
+        ]),
+      };
+      const txRepo = { find: jest.fn().mockResolvedValue([]) };
+      externalQr.manager.getRepository = jest.fn().mockImplementation((e) => {
+        if (e === TransactionSplit) return splitsRepo;
+        if (e === Transaction) return txRepo;
+        return {};
+      });
+
+      const investmentService = (service as any).investmentTransactionsService;
+      investmentService.reverseAndRemoveEmbedded.mockClear();
+
+      await service.deleteSplitSideEffects("tx-1", "user-1", externalQr);
+
+      expect(investmentService.reverseAndRemoveEmbedded).toHaveBeenCalledTimes(
+        2,
+      );
+      expect(investmentService.reverseAndRemoveEmbedded).toHaveBeenCalledWith(
+        externalQr,
+        "user-1",
+        { id: "inv-a" },
+      );
+      expect(investmentService.reverseAndRemoveEmbedded).toHaveBeenCalledWith(
+        externalQr,
+        "user-1",
+        { id: "inv-b" },
+      );
+    });
+
+    it("supports multiple investment splits in one createSplits call", async () => {
+      accountsService.findOne.mockResolvedValueOnce({
+        id: "account-1",
+        accountSubType: "INVESTMENT_CASH",
+        linkedAccountId: "brokerage-1",
+      });
+
+      const splits = [
+        { amount: 5000, categoryId: "cat-1" },
+        {
+          amount: -3000,
+          investment: {
+            action: "BUY" as any,
+            securityId: "sec-1",
+            quantity: 30,
+            price: 100,
+            commission: 0,
+          },
+        },
+        {
+          amount: -2000,
+          investment: {
+            action: "BUY" as any,
+            securityId: "sec-2",
+            quantity: 20,
+            price: 100,
+            commission: 0,
+          },
+        },
+      ];
+
+      const result = await service.createSplits(
+        "tx-1",
+        splits,
+        "user-1",
+        "account-1",
+        new Date("2026-05-09"),
+      );
+      expect(result).toHaveLength(3);
+
+      const investmentService = (service as any).investmentTransactionsService;
+      expect(investmentService.createEmbeddedForSplit).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/backend/src/transactions/transaction-split.service.ts
+++ b/backend/src/transactions/transaction-split.service.ts
@@ -8,11 +8,28 @@ import {
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository, DataSource, QueryRunner, In } from "typeorm";
 import { Transaction } from "./entities/transaction.entity";
-import { TransactionSplit } from "./entities/transaction-split.entity";
+import {
+  TransactionSplit,
+  SplitKind,
+} from "./entities/transaction-split.entity";
 import { Category } from "../categories/entities/category.entity";
 import { CreateTransactionSplitDto } from "./dto/create-transaction-split.dto";
 import { AccountsService } from "../accounts/accounts.service";
+import { AccountSubType } from "../accounts/entities/account.entity";
 import { isTransactionInFuture } from "../common/date-utils";
+import { InvestmentTransactionsService } from "../securities/investment-transactions.service";
+import {
+  computeInvestmentCashImpact,
+  isInvestmentActionAllowedInSplit,
+} from "../securities/cash-impact.util";
+import { NetWorthService } from "../net-worth/net-worth.service";
+
+function inferSplitKind(split: CreateTransactionSplitDto): SplitKind {
+  if (split.splitKind) return split.splitKind;
+  if (split.investment) return SplitKind.INVESTMENT;
+  if (split.transferAccountId) return SplitKind.TRANSFER;
+  return SplitKind.CATEGORY;
+}
 
 @Injectable()
 export class TransactionSplitService {
@@ -25,6 +42,10 @@ export class TransactionSplitService {
     private categoriesRepository: Repository<Category>,
     @Inject(forwardRef(() => AccountsService))
     private accountsService: AccountsService,
+    @Inject(forwardRef(() => InvestmentTransactionsService))
+    private investmentTransactionsService: InvestmentTransactionsService,
+    @Inject(forwardRef(() => NetWorthService))
+    private netWorthService: NetWorthService,
     private dataSource: DataSource,
   ) {}
 
@@ -44,15 +65,16 @@ export class TransactionSplitService {
     splits: CreateTransactionSplitDto[],
     transactionAmount: number,
   ): void {
-    const isTransfer = splits.length === 1 && splits[0].transferAccountId;
+    const isSinglePassthrough =
+      splits.length === 1 &&
+      (splits[0].transferAccountId || splits[0].investment);
 
-    if (splits.length < 2 && !isTransfer) {
+    if (splits.length < 2 && !isSinglePassthrough) {
       throw new BadRequestException(
         "Split transactions must have at least 2 splits",
       );
     }
 
-    // Use integer arithmetic in ten-thousandths to avoid floating-point drift
     const splitsSumCents = splits.reduce(
       (sum, split) => sum + Math.round(Number(split.amount) * 10000),
       0,
@@ -63,6 +85,51 @@ export class TransactionSplitService {
       throw new BadRequestException(
         `Split amounts (${splitsSumCents / 10000}) must equal transaction amount (${expectedSumCents / 10000})`,
       );
+    }
+
+    for (const split of splits) {
+      const kind = inferSplitKind(split);
+      if (kind !== SplitKind.INVESTMENT) continue;
+
+      const inv = split.investment;
+      if (!inv) {
+        throw new BadRequestException(
+          "Investment split requires an investment payload",
+        );
+      }
+      if (!isInvestmentActionAllowedInSplit(inv.action)) {
+        throw new BadRequestException(
+          `Investment action ${inv.action} is not allowed inside a split transaction`,
+        );
+      }
+      if (split.categoryId || split.transferAccountId) {
+        throw new BadRequestException(
+          "Investment splits cannot also set categoryId or transferAccountId",
+        );
+      }
+
+      const cashImpactInSecurity = computeInvestmentCashImpact(
+        inv.action,
+        Number(inv.quantity ?? 0),
+        Number(inv.price ?? 0),
+        Number(inv.commission ?? 0),
+      );
+      const exchangeRate =
+        inv.exchangeRate !== undefined && inv.exchangeRate !== null
+          ? Number(inv.exchangeRate)
+          : 1;
+      const expectedAmount = cashImpactInSecurity * exchangeRate;
+
+      const expectedCents = Math.round(expectedAmount * 10000);
+      const actualCents = Math.round(Number(split.amount) * 10000);
+
+      if (expectedCents !== actualCents) {
+        throw new BadRequestException(
+          `Investment split amount (${split.amount}) does not match the cash impact ` +
+            `of ${inv.action} ${inv.quantity ?? 0} @ ${inv.price ?? 0} ` +
+            `(expected ${expectedAmount.toFixed(4)})`,
+        );
+      }
     }
   }
 
@@ -75,7 +142,6 @@ export class TransactionSplitService {
     parentPayeeName?: string | null,
     externalQueryRunner?: QueryRunner,
   ): Promise<TransactionSplit[]> {
-    // Use provided queryRunner or create our own transaction
     const ownTransaction = !externalQueryRunner;
     const queryRunner =
       externalQueryRunner ?? this.dataSource.createQueryRunner();
@@ -122,7 +188,6 @@ export class TransactionSplitService {
     transactionDate?: Date,
     parentPayeeName?: string | null,
   ): Promise<TransactionSplit[]> {
-    // L1: Batch-validate all category IDs in a single query
     if (userId) {
       const categoryIds = [
         ...new Set(
@@ -144,37 +209,83 @@ export class TransactionSplitService {
       }
     }
 
-    // Separate regular splits from transfer splits
-    const regularSplits = splits.filter(
-      (s) => !s.transferAccountId || !userId || !sourceAccountId,
+    const hasInvestment = splits.some(
+      (s) => inferSplitKind(s) === SplitKind.INVESTMENT,
     );
-    const transferSplits = splits.filter(
-      (s) => s.transferAccountId && userId && sourceAccountId,
-    );
+    let brokerageAccountId: string | null = null;
+    let parentDateStr = "";
+
+    if (hasInvestment) {
+      if (!userId || !sourceAccountId) {
+        throw new BadRequestException(
+          "Investment splits require a known source account",
+        );
+      }
+      const sourceAccount = await this.accountsService.findOne(
+        userId,
+        sourceAccountId,
+      );
+      if (sourceAccount.accountSubType !== AccountSubType.INVESTMENT_CASH) {
+        throw new BadRequestException(
+          "Investment splits require the parent transaction to be on an INVESTMENT_CASH account",
+        );
+      }
+      if (!sourceAccount.linkedAccountId) {
+        throw new BadRequestException(
+          "Source INVESTMENT_CASH account is not linked to a brokerage account",
+        );
+      }
+      brokerageAccountId = sourceAccount.linkedAccountId;
+      parentDateStr = transactionDate
+        ? transactionDate.toISOString().substring(0, 10)
+        : "";
+    }
 
     const savedSplits: TransactionSplit[] = [];
 
-    // Batch-save regular (non-transfer) splits
+    // Plain category splits (and transfers without userId/sourceAccountId
+    // context, e.g. import flows) are batch-saved together.
+    const regularSplits = splits.filter((s) => {
+      const k = inferSplitKind(s);
+      if (k === SplitKind.INVESTMENT) return false;
+      if (k === SplitKind.TRANSFER && userId && sourceAccountId) return false;
+      return true;
+    });
+    const transferSplits = splits.filter(
+      (s) =>
+        inferSplitKind(s) === SplitKind.TRANSFER &&
+        s.transferAccountId &&
+        userId &&
+        sourceAccountId,
+    );
+    const investmentSplits = splits.filter(
+      (s) => inferSplitKind(s) === SplitKind.INVESTMENT,
+    );
+
     if (regularSplits.length > 0) {
-      const regularEntities = regularSplits.map((split) =>
-        queryRunner.manager.create(TransactionSplit, {
+      const regularEntities = regularSplits.map((split) => {
+        const kind = split.transferAccountId
+          ? SplitKind.TRANSFER
+          : SplitKind.CATEGORY;
+        return queryRunner.manager.create(TransactionSplit, {
           transactionId,
+          kind,
           categoryId: split.categoryId || null,
           transferAccountId: split.transferAccountId || null,
           amount: split.amount,
           memo: split.memo || null,
-        }),
-      );
+        });
+      });
       const batchSaved = await queryRunner.manager.save(regularEntities);
       savedSplits.push(...batchSaved);
     }
 
-    // Process transfer splits individually (they need linked transactions)
     for (const split of transferSplits) {
       const splitEntity = queryRunner.manager.create(TransactionSplit, {
         transactionId,
-        categoryId: split.categoryId || null,
-        transferAccountId: split.transferAccountId || null,
+        kind: SplitKind.TRANSFER,
+        categoryId: null,
+        transferAccountId: split.transferAccountId,
         amount: split.amount,
         memo: split.memo || null,
       });
@@ -233,9 +344,102 @@ export class TransactionSplitService {
       savedSplits.push(savedSplit);
     }
 
+    for (const split of investmentSplits) {
+      const splitEntity = queryRunner.manager.create(TransactionSplit, {
+        transactionId,
+        kind: SplitKind.INVESTMENT,
+        categoryId: null,
+        transferAccountId: null,
+        amount: split.amount,
+        memo: split.memo || null,
+      });
+      const savedSplit = await queryRunner.manager.save(splitEntity);
+
+      await this.investmentTransactionsService.createEmbeddedForSplit(
+        queryRunner,
+        userId!,
+        parentDateStr,
+        savedSplit.id,
+        brokerageAccountId!,
+        sourceAccountId!,
+        split.investment!,
+      );
+
+      savedSplits.push(savedSplit);
+    }
+
+    if (hasInvestment && userId && brokerageAccountId) {
+      this.netWorthService.triggerDebouncedRecalc(brokerageAccountId, userId);
+    }
+
     return savedSplits;
   }
 
+  async deleteSplitSideEffects(
+    transactionId: string,
+    userId: string,
+    externalQueryRunner?: QueryRunner,
+  ): Promise<void> {
+    const repo = externalQueryRunner
+      ? externalQueryRunner.manager.getRepository(TransactionSplit)
+      : this.splitsRepository;
+    const txRepo = externalQueryRunner
+      ? externalQueryRunner.manager.getRepository(Transaction)
+      : this.transactionsRepository;
+
+    const splits = await repo.find({
+      where: { transactionId },
+      relations: ["linkedTransaction", "investmentTransaction"],
+    });
+
+    // Reverse investment splits' holdings effects before the split rows are deleted.
+    if (externalQueryRunner) {
+      for (const s of splits) {
+        if (s.kind === SplitKind.INVESTMENT && s.investmentTransaction) {
+          await this.investmentTransactionsService.reverseAndRemoveEmbedded(
+            externalQueryRunner,
+            userId,
+            s.investmentTransaction,
+          );
+        }
+      }
+    }
+
+    const linkedTxIds = splits
+      .filter((s) => s.linkedTransactionId && s.transferAccountId)
+      .map((s) => s.linkedTransactionId!);
+
+    if (linkedTxIds.length === 0) return;
+
+    const linkedTransactions = await txRepo.find({
+      where: { id: In(linkedTxIds) },
+    });
+
+    for (const linkedTx of linkedTransactions) {
+      const linkedIsFuture = isTransactionInFuture(linkedTx.transactionDate);
+      const linkedAccId = linkedTx.accountId;
+      if (!linkedIsFuture) {
+        await this.accountsService.updateBalance(
+          linkedAccId,
+          -Number(linkedTx.amount),
+          externalQueryRunner,
+        );
+      }
+      await txRepo.remove(linkedTx);
+      if (linkedIsFuture) {
+        await this.accountsService.recalculateCurrentBalance(
+          linkedAccId,
+          externalQueryRunner,
+        );
+      }
+    }
+  }
+
+  /**
+   * @deprecated use deleteSplitSideEffects
+   * Kept as a thin wrapper for callers that don't have a userId in scope and
+   * only need transfer-side cleanup.
+   */
   async deleteTransferSplitLinkedTransactions(
     transactionId: string,
     externalQueryRunner?: QueryRunner,
@@ -252,19 +456,16 @@ export class TransactionSplitService {
       relations: ["linkedTransaction"],
     });
 
-    // Collect linked transaction IDs for batch fetch
     const linkedTxIds = transferSplits
       .filter((s) => s.linkedTransactionId && s.transferAccountId)
       .map((s) => s.linkedTransactionId!);
 
     if (linkedTxIds.length === 0) return;
 
-    // Batch-fetch all linked transactions in one query
     const linkedTransactions = await txRepo.find({
       where: { id: In(linkedTxIds) },
     });
 
-    // Process balance reversals and removals
     for (const linkedTx of linkedTransactions) {
       const linkedIsFuture = isTransactionInFuture(linkedTx.transactionDate);
       const linkedAccId = linkedTx.accountId;
@@ -288,7 +489,7 @@ export class TransactionSplitService {
   async getSplits(transactionId: string): Promise<TransactionSplit[]> {
     return this.splitsRepository.find({
       where: { transactionId },
-      relations: ["category", "transferAccount"],
+      relations: ["category", "transferAccount", "investmentTransaction"],
       order: { createdAt: "ASC" },
     });
   }
@@ -305,8 +506,9 @@ export class TransactionSplitService {
     await queryRunner.startTransaction();
 
     try {
-      await this.deleteTransferSplitLinkedTransactions(
+      await this.deleteSplitSideEffects(
         transaction.id,
+        userId,
         queryRunner,
       );
 
@@ -344,6 +546,11 @@ export class TransactionSplitService {
     splitDto: CreateTransactionSplitDto,
     userId: string,
   ): Promise<TransactionSplit> {
+    if (splitDto.investment) {
+      throw new BadRequestException(
+        "Investment splits cannot be added incrementally; replace the full split set instead.",
+      );
+    }
     if (splitDto.categoryId) {
       await this.validateCategoryOwnership(userId, splitDto.categoryId);
     }
@@ -374,8 +581,12 @@ export class TransactionSplitService {
     let savedSplitId: string;
 
     try {
+      const splitKind = splitDto.transferAccountId
+        ? SplitKind.TRANSFER
+        : SplitKind.CATEGORY;
       const split = queryRunner.manager.create(TransactionSplit, {
         transactionId: transaction.id,
+        kind: splitKind,
         categoryId: splitDto.categoryId || null,
         transferAccountId: splitDto.transferAccountId || null,
         amount: splitDto.amount,
@@ -460,10 +671,11 @@ export class TransactionSplitService {
   async removeSplit(
     transaction: Transaction,
     splitId: string,
-    _userId: string,
+    userId: string,
   ): Promise<void> {
     const split = await this.splitsRepository.findOne({
       where: { id: splitId, transactionId: transaction.id },
+      relations: ["investmentTransaction"],
     });
 
     if (!split) {
@@ -475,7 +687,13 @@ export class TransactionSplitService {
     await queryRunner.startTransaction();
 
     try {
-      if (split.linkedTransactionId && split.transferAccountId) {
+      if (split.kind === SplitKind.INVESTMENT && split.investmentTransaction) {
+        await this.investmentTransactionsService.reverseAndRemoveEmbedded(
+          queryRunner,
+          userId,
+          split.investmentTransaction,
+        );
+      } else if (split.linkedTransactionId && split.transferAccountId) {
         const linkedTx = await queryRunner.manager.findOne(Transaction, {
           where: { id: split.linkedTransactionId },
         });
@@ -506,13 +724,20 @@ export class TransactionSplitService {
 
       const remainingSplits = await queryRunner.manager.find(TransactionSplit, {
         where: { transactionId: transaction.id },
-        relations: ["category", "transferAccount"],
+        relations: ["category", "transferAccount", "investmentTransaction"],
         order: { createdAt: "ASC" },
       });
 
       if (remainingSplits.length < 2) {
         if (remainingSplits.length === 1) {
           const lastSplit = remainingSplits[0];
+
+          // Don't auto-collapse if the last remaining split is investment-kind
+          // — that representation only makes sense as part of a split parent.
+          if (lastSplit.kind === SplitKind.INVESTMENT) {
+            await queryRunner.commitTransaction();
+            return;
+          }
 
           if (lastSplit.linkedTransactionId && lastSplit.transferAccountId) {
             const linkedTx = await queryRunner.manager.findOne(Transaction, {

--- a/backend/src/transactions/transactions.module.ts
+++ b/backend/src/transactions/transactions.module.ts
@@ -17,6 +17,7 @@ import { PayeesModule } from "../payees/payees.module";
 import { TagsModule } from "../tags/tags.module";
 import { NetWorthModule } from "../net-worth/net-worth.module";
 import { ActionHistoryModule } from "../action-history/action-history.module";
+import { SecuritiesModule } from "../securities/securities.module";
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { ActionHistoryModule } from "../action-history/action-history.module";
     ]),
     forwardRef(() => AccountsModule),
     forwardRef(() => NetWorthModule),
+    forwardRef(() => SecuritiesModule),
     PayeesModule,
     TagsModule,
     ActionHistoryModule,

--- a/backend/src/transactions/transactions.service.spec.ts
+++ b/backend/src/transactions/transactions.service.spec.ts
@@ -211,6 +211,15 @@ describe("TransactionsService", () => {
           provide: ActionHistoryService,
           useValue: { record: jest.fn().mockResolvedValue(null) },
         },
+        {
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          provide: require("../securities/investment-transactions.service")
+            .InvestmentTransactionsService,
+          useValue: {
+            createEmbeddedForSplit: jest.fn().mockResolvedValue({}),
+            reverseAndRemoveEmbedded: jest.fn().mockResolvedValue(undefined),
+          },
+        },
         TransactionSplitService,
         TransactionTransferService,
         TransactionReconciliationService,
@@ -3519,7 +3528,7 @@ describe("TransactionsService", () => {
       expect(result).toEqual(mockSplits);
       expect(splitsRepository.find).toHaveBeenCalledWith({
         where: { transactionId: "tx-1" },
-        relations: ["category", "transferAccount"],
+        relations: ["category", "transferAccount", "investmentTransaction"],
         order: { createdAt: "ASC" },
       });
     });

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -1261,8 +1261,9 @@ export class TransactionsService {
     try {
       if (splits !== undefined) {
         if (Array.isArray(splits) && splits.length > 0) {
-          await this.splitService.deleteTransferSplitLinkedTransactions(
+          await this.splitService.deleteSplitSideEffects(
             id,
+            userId,
             queryRunner,
           );
           await queryRunner.manager.delete(TransactionSplit, {
@@ -1297,8 +1298,9 @@ export class TransactionsService {
             }
           }
         } else if (Array.isArray(splits) && splits.length === 0) {
-          await this.splitService.deleteTransferSplitLinkedTransactions(
+          await this.splitService.deleteSplitSideEffects(
             id,
+            userId,
             queryRunner,
           );
           await queryRunner.manager.delete(TransactionSplit, {
@@ -1475,8 +1477,9 @@ export class TransactionsService {
 
     try {
       if (transaction.isSplit) {
-        await this.splitService.deleteTransferSplitLinkedTransactions(
+        await this.splitService.deleteSplitSideEffects(
           id,
+          userId,
           queryRunner,
         );
       }

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -250,6 +250,8 @@ export class TransactionsService {
         "splits.category",
         "splits.transferAccount",
         "splits.tags",
+        "splits.investmentTransaction",
+        "splits.investmentTransaction.security",
       ],
     });
 
@@ -302,6 +304,8 @@ export class TransactionsService {
       .leftJoinAndSelect("splits.category", "splitCategory")
       .leftJoinAndSelect("splits.transferAccount", "splitTransferAccount")
       .leftJoinAndSelect("splits.tags", "splitTags")
+      .leftJoinAndSelect("splits.investmentTransaction", "splitInvestmentTx")
+      .leftJoinAndSelect("splitInvestmentTx.security", "splitInvestmentSecurity")
       .leftJoinAndSelect("transaction.linkedTransaction", "linkedTransaction")
       .leftJoinAndSelect("linkedTransaction.account", "linkedAccount")
       .leftJoinAndSelect("linkedTransaction.splits", "linkedSplits")
@@ -1204,6 +1208,8 @@ export class TransactionsService {
         "splits.category",
         "splits.transferAccount",
         "splits.tags",
+        "splits.investmentTransaction",
+        "splits.investmentTransaction.security",
         "linkedTransaction",
         "linkedTransaction.account",
       ],

--- a/database/migrations/062_investment_splits.sql
+++ b/database/migrations/062_investment_splits.sql
@@ -1,0 +1,37 @@
+-- Allow a transaction split to embed an investment action (BUY/SELL/DIVIDEND/etc).
+-- Lets a single split transaction represent paycheck-with-equity-grant style entries:
+-- gross income (+), tax withholding (-), and BUY shares (-) all in one balanced post.
+
+-- 1) Discriminator column for split kind.
+ALTER TABLE transaction_splits
+  ADD COLUMN IF NOT EXISTS kind VARCHAR(20);
+
+UPDATE transaction_splits SET kind = 'transfer'
+  WHERE kind IS NULL AND transfer_account_id IS NOT NULL;
+UPDATE transaction_splits SET kind = 'category'
+  WHERE kind IS NULL;
+
+ALTER TABLE transaction_splits
+  ALTER COLUMN kind SET NOT NULL;
+
+ALTER TABLE transaction_splits
+  ALTER COLUMN kind SET DEFAULT 'category';
+
+-- 2) Back-link from investment_transactions to the owning split (when embedded).
+ALTER TABLE investment_transactions
+  ADD COLUMN IF NOT EXISTS transaction_split_id UUID
+    REFERENCES transaction_splits(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_investment_transactions_split_id
+  ON investment_transactions(transaction_split_id);
+
+-- 3) Mutual-exclusion check: exactly one of category / transfer / investment per split.
+ALTER TABLE transaction_splits
+  DROP CONSTRAINT IF EXISTS chk_split_kind_exclusive;
+
+ALTER TABLE transaction_splits
+  ADD CONSTRAINT chk_split_kind_exclusive CHECK (
+    (kind = 'category'   AND category_id IS NOT NULL AND transfer_account_id IS NULL) OR
+    (kind = 'transfer'   AND transfer_account_id IS NOT NULL AND category_id IS NULL) OR
+    (kind = 'investment' AND category_id IS NULL AND transfer_account_id IS NULL)
+  );

--- a/database/migrations/062_investment_splits.sql
+++ b/database/migrations/062_investment_splits.sql
@@ -6,8 +6,18 @@
 ALTER TABLE transaction_splits
   ADD COLUMN IF NOT EXISTS kind VARCHAR(20);
 
+-- Backfill: transfers first (transfer_account_id wins, matching existing service logic).
 UPDATE transaction_splits SET kind = 'transfer'
   WHERE kind IS NULL AND transfer_account_id IS NOT NULL;
+
+-- Legacy data hygiene: a transfer-marked row should not also carry a category_id
+-- (the category was meaningless for a transfer split). Clear it so the new
+-- mutual-exclusion constraint can hold.
+UPDATE transaction_splits SET category_id = NULL
+  WHERE kind = 'transfer' AND category_id IS NOT NULL;
+
+-- Everything else is a category split (including legacy uncategorized rows where
+-- category_id may be NULL — the DTO allows that, so the constraint must too).
 UPDATE transaction_splits SET kind = 'category'
   WHERE kind IS NULL;
 
@@ -25,13 +35,15 @@ ALTER TABLE investment_transactions
 CREATE INDEX IF NOT EXISTS idx_investment_transactions_split_id
   ON investment_transactions(transaction_split_id);
 
--- 3) Mutual-exclusion check: exactly one of category / transfer / investment per split.
+-- 3) Mutual-exclusion check between the three split kinds. Category kind allows
+-- a NULL category_id (uncategorized split); the only hard rule is that the
+-- columns associated with the *other* kinds must be NULL.
 ALTER TABLE transaction_splits
   DROP CONSTRAINT IF EXISTS chk_split_kind_exclusive;
 
 ALTER TABLE transaction_splits
   ADD CONSTRAINT chk_split_kind_exclusive CHECK (
-    (kind = 'category'   AND category_id IS NOT NULL AND transfer_account_id IS NULL) OR
+    (kind = 'category'   AND transfer_account_id IS NULL) OR
     (kind = 'transfer'   AND transfer_account_id IS NOT NULL AND category_id IS NULL) OR
     (kind = 'investment' AND category_id IS NULL AND transfer_account_id IS NULL)
   );

--- a/database/migrations/063_scheduled_investment_splits.sql
+++ b/database/migrations/063_scheduled_investment_splits.sql
@@ -1,0 +1,40 @@
+-- Allow scheduled-transaction splits to embed an investment action so a
+-- recurring paycheck-with-equity-grant template can be saved and posted
+-- with brokerage holdings updates each occurrence.
+
+ALTER TABLE scheduled_transaction_splits
+  ADD COLUMN IF NOT EXISTS kind VARCHAR(20);
+
+UPDATE scheduled_transaction_splits SET kind = 'transfer'
+  WHERE kind IS NULL AND transfer_account_id IS NOT NULL;
+UPDATE scheduled_transaction_splits SET category_id = NULL
+  WHERE kind = 'transfer' AND category_id IS NOT NULL;
+UPDATE scheduled_transaction_splits SET kind = 'category'
+  WHERE kind IS NULL;
+
+ALTER TABLE scheduled_transaction_splits
+  ALTER COLUMN kind SET NOT NULL;
+
+ALTER TABLE scheduled_transaction_splits
+  ALTER COLUMN kind SET DEFAULT 'category';
+
+ALTER TABLE scheduled_transaction_splits
+  ADD COLUMN IF NOT EXISTS investment_action VARCHAR(50),
+  ADD COLUMN IF NOT EXISTS investment_security_id UUID REFERENCES securities(id),
+  ADD COLUMN IF NOT EXISTS investment_quantity NUMERIC(20, 8),
+  ADD COLUMN IF NOT EXISTS investment_price NUMERIC(20, 6),
+  ADD COLUMN IF NOT EXISTS investment_commission NUMERIC(20, 4),
+  ADD COLUMN IF NOT EXISTS investment_exchange_rate NUMERIC(20, 10);
+
+CREATE INDEX IF NOT EXISTS idx_scheduled_transaction_splits_inv_security
+  ON scheduled_transaction_splits(investment_security_id);
+
+ALTER TABLE scheduled_transaction_splits
+  DROP CONSTRAINT IF EXISTS chk_scheduled_split_kind_exclusive;
+
+ALTER TABLE scheduled_transaction_splits
+  ADD CONSTRAINT chk_scheduled_split_kind_exclusive CHECK (
+    (kind = 'category'   AND transfer_account_id IS NULL AND investment_action IS NULL) OR
+    (kind = 'transfer'   AND transfer_account_id IS NOT NULL AND category_id IS NULL AND investment_action IS NULL) OR
+    (kind = 'investment' AND category_id IS NULL AND transfer_account_id IS NULL AND investment_action IS NOT NULL)
+  );

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -238,12 +238,18 @@ CREATE INDEX idx_transactions_user_cleared ON transactions(user_id, is_cleared);
 CREATE TABLE transaction_splits (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     transaction_id UUID NOT NULL REFERENCES transactions(id) ON DELETE CASCADE,
+    kind VARCHAR(20) NOT NULL DEFAULT 'category', -- 'category', 'transfer', or 'investment'
     category_id UUID REFERENCES categories(id),
     transfer_account_id UUID REFERENCES accounts(id) ON DELETE SET NULL, -- target account for transfer splits
     linked_transaction_id UUID REFERENCES transactions(id) ON DELETE SET NULL, -- linked transaction in target account
     amount NUMERIC(20, 4) NOT NULL,
     memo TEXT,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_split_kind_exclusive CHECK (
+        (kind = 'category'   AND category_id IS NOT NULL AND transfer_account_id IS NULL) OR
+        (kind = 'transfer'   AND transfer_account_id IS NOT NULL AND category_id IS NULL) OR
+        (kind = 'investment' AND category_id IS NULL AND transfer_account_id IS NULL)
+    )
 );
 
 CREATE INDEX idx_transaction_splits_transaction ON transaction_splits(transaction_id);
@@ -458,6 +464,7 @@ CREATE TABLE investment_transactions (
     user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
     transaction_id UUID REFERENCES transactions(id) ON DELETE SET NULL,
+    transaction_split_id UUID REFERENCES transaction_splits(id) ON DELETE CASCADE, -- when embedded inside a split transaction
     security_id UUID REFERENCES securities(id),
     funding_account_id UUID REFERENCES accounts(id) ON DELETE SET NULL,
     action investment_action NOT NULL,
@@ -477,6 +484,7 @@ CREATE INDEX idx_investment_transactions_account ON investment_transactions(acco
 CREATE INDEX idx_investment_transactions_security ON investment_transactions(security_id);
 CREATE INDEX idx_investment_transactions_date ON investment_transactions(transaction_date DESC);
 CREATE INDEX idx_investment_transactions_transaction ON investment_transactions(transaction_id);
+CREATE INDEX idx_investment_transactions_split_id ON investment_transactions(transaction_split_id);
 
 -- User Preferences
 CREATE TABLE user_preferences (

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -246,7 +246,7 @@ CREATE TABLE transaction_splits (
     memo TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT chk_split_kind_exclusive CHECK (
-        (kind = 'category'   AND category_id IS NOT NULL AND transfer_account_id IS NULL) OR
+        (kind = 'category'   AND transfer_account_id IS NULL) OR
         (kind = 'transfer'   AND transfer_account_id IS NOT NULL AND category_id IS NULL) OR
         (kind = 'investment' AND category_id IS NULL AND transfer_account_id IS NULL)
     )

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -330,16 +330,30 @@ CREATE INDEX idx_scheduled_transactions_transfer_account ON scheduled_transactio
 CREATE TABLE scheduled_transaction_splits (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     scheduled_transaction_id UUID NOT NULL REFERENCES scheduled_transactions(id) ON DELETE CASCADE,
+    kind VARCHAR(20) NOT NULL DEFAULT 'category', -- 'category', 'transfer', or 'investment'
     category_id UUID REFERENCES categories(id),
     transfer_account_id UUID REFERENCES accounts(id) ON DELETE SET NULL, -- target account for transfer splits
     amount NUMERIC(20, 4) NOT NULL,
     memo TEXT,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    -- Investment-split fields (populated when kind='investment'):
+    investment_action VARCHAR(50),
+    investment_security_id UUID REFERENCES securities(id),
+    investment_quantity NUMERIC(20, 8),
+    investment_price NUMERIC(20, 6),
+    investment_commission NUMERIC(20, 4),
+    investment_exchange_rate NUMERIC(20, 10),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_scheduled_split_kind_exclusive CHECK (
+        (kind = 'category'   AND transfer_account_id IS NULL AND investment_action IS NULL) OR
+        (kind = 'transfer'   AND transfer_account_id IS NOT NULL AND category_id IS NULL AND investment_action IS NULL) OR
+        (kind = 'investment' AND category_id IS NULL AND transfer_account_id IS NULL AND investment_action IS NOT NULL)
+    )
 );
 
 CREATE INDEX idx_scheduled_transaction_splits_scheduled ON scheduled_transaction_splits(scheduled_transaction_id);
 CREATE INDEX idx_scheduled_transaction_splits_category ON scheduled_transaction_splits(category_id);
 CREATE INDEX idx_scheduled_transaction_splits_transfer_account ON scheduled_transaction_splits(transfer_account_id);
+CREATE INDEX idx_scheduled_transaction_splits_inv_security ON scheduled_transaction_splits(investment_security_id);
 
 -- Scheduled Transaction Split Tags (many-to-many)
 CREATE TABLE scheduled_transaction_split_tags (

--- a/frontend/src/app/investments/page.tsx
+++ b/frontend/src/app/investments/page.tsx
@@ -341,9 +341,9 @@ function InvestmentsContent() {
                   </div>
                 </div>
                 <div className="flex items-center gap-2 w-full sm:w-auto">
-                  <button onClick={data.openCashCreate} className="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600">
+                  <button onClick={data.openCashCreate} className="inline-flex items-center justify-center px-3 py-1.5 text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 sm:min-w-[14rem]">
                     <span className="sm:hidden">+ New</span>
-                    <span className="hidden sm:inline">+ New Transaction</span>
+                    <span className="hidden sm:inline">+ New Cash Transaction</span>
                   </button>
                   <button
                     onClick={() => data.setShowCashFilters(!data.showCashFilters)}

--- a/frontend/src/components/investments/InvestmentTransactionList.test.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionList.test.tsx
@@ -52,19 +52,19 @@ describe('InvestmentTransactionList', () => {
   it('shows New Transaction button when callback provided', () => {
     const transactions = [makeTx()] as any[];
     render(<InvestmentTransactionList transactions={transactions} isLoading={false} onNewTransaction={vi.fn()} />);
-    expect(screen.getByText('+ New Transaction')).toBeInTheDocument();
+    expect(screen.getByText('+ New Brokerage Transaction')).toBeInTheDocument();
   });
 
   it('shows New Transaction button in empty state when callback provided', () => {
     render(<InvestmentTransactionList transactions={[]} isLoading={false} onNewTransaction={vi.fn()} />);
-    expect(screen.getByText('+ New Transaction')).toBeInTheDocument();
+    expect(screen.getByText('+ New Brokerage Transaction')).toBeInTheDocument();
   });
 
   it('calls onNewTransaction when button is clicked', () => {
     const onNewTransaction = vi.fn();
     const transactions = [makeTx()] as any[];
     render(<InvestmentTransactionList transactions={transactions} isLoading={false} onNewTransaction={onNewTransaction} />);
-    fireEvent.click(screen.getByText('+ New Transaction'));
+    fireEvent.click(screen.getByText('+ New Brokerage Transaction'));
     expect(onNewTransaction).toHaveBeenCalled();
   });
 

--- a/frontend/src/components/investments/InvestmentTransactionList.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionList.tsx
@@ -387,9 +387,9 @@ export function InvestmentTransactionList({
           {onNewTransaction && (
             <button
               onClick={onNewTransaction}
-              className="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+              className="inline-flex items-center justify-center px-3 py-1.5 text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 sm:min-w-[14rem]"
             >
-              + New Transaction
+              + New Brokerage Transaction
             </button>
           )}
         </div>
@@ -433,10 +433,10 @@ export function InvestmentTransactionList({
         {onNewTransaction && (
           <button
             onClick={onNewTransaction}
-            className="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+            className="inline-flex items-center justify-center px-3 py-1.5 text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 sm:min-w-[14rem]"
           >
             <span className="sm:hidden">+ New</span>
-            <span className="hidden sm:inline">+ New Transaction</span>
+            <span className="hidden sm:inline">+ New Brokerage Transaction</span>
           </button>
         )}
         {onFiltersChange && (

--- a/frontend/src/components/layout/PageHeader.test.tsx
+++ b/frontend/src/components/layout/PageHeader.test.tsx
@@ -37,13 +37,13 @@ describe('PageHeader', () => {
 
   it('renders help link when helpUrl is provided', () => {
     render(<PageHeader title="My Page" helpUrl="https://example.com/help" />);
-    const helpLink = screen.getByRole('link', { name: 'Help' });
+    const helpLink = screen.getByRole('link', { name: /Open the Monize wiki/i });
     expect(helpLink).toBeInTheDocument();
   });
 
   it('help link has correct href, target, and rel attributes', () => {
     render(<PageHeader title="My Page" helpUrl="https://example.com/help" />);
-    const helpLink = screen.getByRole('link', { name: 'Help' });
+    const helpLink = screen.getByRole('link', { name: /Open the Monize wiki/i });
     expect(helpLink).toHaveAttribute('href', 'https://example.com/help');
     expect(helpLink).toHaveAttribute('target', '_blank');
     expect(helpLink).toHaveAttribute('rel', 'noopener noreferrer');
@@ -51,7 +51,14 @@ describe('PageHeader', () => {
 
   it('does not render help link when helpUrl is omitted', () => {
     render(<PageHeader title="My Page" />);
-    expect(screen.queryByRole('link', { name: 'Help' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Open the Monize wiki/i })).not.toBeInTheDocument();
+  });
+
+  it('shows a tooltip describing the wiki destination', () => {
+    render(<PageHeader title="My Page" helpUrl="https://example.com/help" />);
+    expect(
+      screen.getByRole('tooltip', { name: /Open the Monize wiki/i }),
+    ).toBeInTheDocument();
   });
 
   it('renders help link alongside action buttons when both are provided', () => {
@@ -62,7 +69,7 @@ describe('PageHeader', () => {
         actions={<button>Add New</button>}
       />,
     );
-    expect(screen.getByRole('link', { name: 'Help' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open the Monize wiki/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Add New' })).toBeInTheDocument();
   });
 
@@ -70,7 +77,7 @@ describe('PageHeader', () => {
     const { container } = render(
       <PageHeader title="My Page" helpUrl="https://example.com/help" />,
     );
-    expect(screen.getByRole('link', { name: 'Help' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open the Monize wiki/i })).toBeInTheDocument();
     // No actions container should exist when only helpUrl is provided
     const actionsContainer = container.querySelector('.flex.flex-wrap');
     expect(actionsContainer).toBeNull();

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -25,15 +25,24 @@ export function PageHeader({ title, subtitle, actions, helpUrl }: PageHeaderProp
             {title}
           </h1>
           {helpUrl && (
-            <a
-              href={helpUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-gray-400 hover:text-blue-500 transition-colors"
-              aria-label="Help"
-            >
-              <QuestionMarkCircleIcon className="h-5 w-5" />
-            </a>
+            <span className="relative inline-flex items-center group/help">
+              <a
+                href={helpUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-gray-400 hover:text-blue-500 transition-colors"
+                aria-label="Open the Monize wiki for help with this section"
+                title="Open the Monize wiki for help with this section"
+              >
+                <QuestionMarkCircleIcon className="h-5 w-5" />
+              </a>
+              <span
+                role="tooltip"
+                className="pointer-events-none hidden md:group-hover/help:block absolute z-20 left-1/2 -translate-x-1/2 top-full mt-1 w-56 whitespace-normal rounded-md bg-gray-900 dark:bg-gray-700 px-2.5 py-2 text-xs font-normal leading-snug text-white shadow-lg"
+              >
+                Open the Monize wiki for help with this section
+              </span>
+            </span>
           )}
         </div>
         {subtitle && (

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -32,7 +32,6 @@ export function PageHeader({ title, subtitle, actions, helpUrl }: PageHeaderProp
                 rel="noopener noreferrer"
                 className="text-gray-400 hover:text-blue-500 transition-colors"
                 aria-label="Open the Monize wiki for help with this section"
-                title="Open the Monize wiki for help with this section"
               >
                 <QuestionMarkCircleIcon className="h-5 w-5" />
               </a>

--- a/frontend/src/components/scheduled-transactions/OverrideEditorDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/OverrideEditorDialog.tsx
@@ -9,6 +9,7 @@ import { CurrencyInput } from '@/components/ui/CurrencyInput';
 import { Combobox } from '@/components/ui/Combobox';
 import { Modal } from '@/components/ui/Modal';
 import { SplitEditor, SplitRow, createEmptySplits, toSplitRows } from '@/components/transactions/SplitEditor';
+import { toOverrideSplits } from './splitSerialization';
 import { ScheduledTransaction, ScheduledTransactionOverride } from '@/types/scheduled-transaction';
 import { Category } from '@/types/category';
 import { Account } from '@/types/account';
@@ -113,12 +114,7 @@ export function OverrideEditorDialog({
         categoryId: isSplit ? null : (categoryId || null),
         description: description || null,
         isSplit,
-        splits: isSplit ? splits.map(s => ({
-          categoryId: s.splitType === 'category' ? (s.categoryId ?? null) : null,
-          transferAccountId: s.splitType === 'transfer' ? (s.transferAccountId ?? null) : null,
-          amount: s.amount,
-          memo: s.memo ?? null,
-        })) : null,
+        splits: isSplit ? toOverrideSplits(splits) : null,
       };
 
       // originalDate = the calculated occurrence date from the picker (overrideDate prop)

--- a/frontend/src/components/scheduled-transactions/OverrideEditorDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/OverrideEditorDialog.tsx
@@ -263,6 +263,10 @@ export function OverrideEditorDialog({
                 categories={categories}
                 accounts={accounts}
                 sourceAccountId={scheduledTransaction.accountId}
+                parentAccountSubType={
+                  accounts.find((a) => a.id === scheduledTransaction.accountId)
+                    ?.accountSubType ?? null
+                }
                 transactionAmount={amount}
                 onTransactionAmountChange={handleAmountChange}
                 currencyCode={scheduledTransaction.currencyCode}

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
@@ -9,6 +9,7 @@ import { CurrencyInput } from '@/components/ui/CurrencyInput';
 import { Combobox } from '@/components/ui/Combobox';
 import { Modal } from '@/components/ui/Modal';
 import { SplitEditor, SplitRow, createEmptySplits, toSplitRows } from '@/components/transactions/SplitEditor';
+import { toOverrideSplits } from './splitSerialization';
 import { ScheduledTransaction, PostScheduledTransactionData } from '@/types/scheduled-transaction';
 import { Category } from '@/types/category';
 import { Account } from '@/types/account';
@@ -172,12 +173,7 @@ export function PostTransactionDialog({
         description: description || null,
         referenceNumber: referenceNumber || undefined,
         isSplit,
-        splits: isSplit ? splits.map(s => ({
-          categoryId: s.splitType === 'category' ? (s.categoryId ?? null) : null,
-          transferAccountId: s.splitType === 'transfer' ? (s.transferAccountId ?? null) : null,
-          amount: s.amount,
-          memo: s.memo ?? null,
-        })) : undefined,
+        splits: isSplit ? toOverrideSplits(splits) : undefined,
       };
 
       await scheduledTransactionsApi.post(scheduledTransaction.id, postData);

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
@@ -366,6 +366,10 @@ export function PostTransactionDialog({
                 categories={categories}
                 accounts={accounts}
                 sourceAccountId={scheduledTransaction.accountId}
+                parentAccountSubType={
+                  accounts.find((a) => a.id === scheduledTransaction.accountId)
+                    ?.accountSubType ?? null
+                }
                 transactionAmount={amount}
                 onTransactionAmountChange={handleAmountChange}
                 currencyCode={scheduledTransaction.currencyCode}

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx
@@ -905,6 +905,9 @@ export function ScheduledTransactionForm({
               tags={tags}
               accounts={accounts}
               sourceAccountId={watchedAccountId || ''}
+              parentAccountSubType={
+                accounts.find((a) => a.id === watchedAccountId)?.accountSubType ?? null
+              }
               transactionAmount={watchedAmount || 0}
               onTransactionAmountChange={handleTransactionAmountChange}
               currencyCode={watchedCurrencyCode || defaultCurrency}

--- a/frontend/src/components/scheduled-transactions/splitSerialization.test.ts
+++ b/frontend/src/components/scheduled-transactions/splitSerialization.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { toOverrideSplits } from './splitSerialization';
+import type { SplitRow } from '@/components/transactions/SplitEditor';
+
+describe('toOverrideSplits', () => {
+  it('preserves splitKind and the investment payload for investment-kind rows', () => {
+    const rows: SplitRow[] = [
+      {
+        id: '1',
+        splitType: 'category',
+        categoryId: 'cat-income',
+        amount: 1000,
+        memo: '',
+      },
+      {
+        id: '2',
+        splitType: 'category',
+        categoryId: 'cat-tax',
+        amount: -250,
+        memo: '',
+      },
+      {
+        id: '3',
+        splitType: 'investment',
+        amount: -750,
+        memo: '',
+        investment: {
+          action: 'BUY',
+          securityId: 'sec-1',
+          quantity: 75,
+          price: 10,
+          commission: 0,
+          exchangeRate: 1,
+        },
+      },
+    ];
+    const out = toOverrideSplits(rows);
+    expect(out).toHaveLength(3);
+    expect(out[2]).toMatchObject({
+      splitKind: 'investment',
+      categoryId: null,
+      transferAccountId: null,
+      amount: -750,
+      investment: {
+        action: 'BUY',
+        securityId: 'sec-1',
+        quantity: 75,
+        price: 10,
+      },
+    });
+  });
+
+  it('clears categoryId/transferAccountId for non-matching kinds', () => {
+    const rows: SplitRow[] = [
+      {
+        id: '1',
+        splitType: 'transfer',
+        transferAccountId: 'acc-2',
+        // categoryId stale leftover; should be cleared on output
+        categoryId: 'cat-stale',
+        amount: -50,
+        memo: '',
+      },
+      {
+        id: '2',
+        splitType: 'category',
+        categoryId: 'cat-1',
+        // transferAccountId stale; should be cleared on output
+        transferAccountId: 'acc-stale',
+        amount: -50,
+        memo: '',
+      },
+    ];
+    const out = toOverrideSplits(rows);
+    expect(out[0]).toMatchObject({
+      splitKind: 'transfer',
+      transferAccountId: 'acc-2',
+      categoryId: null,
+    });
+    expect(out[1]).toMatchObject({
+      splitKind: 'category',
+      categoryId: 'cat-1',
+      transferAccountId: null,
+    });
+  });
+
+  it('omits investment payload on non-investment rows', () => {
+    const rows: SplitRow[] = [
+      {
+        id: '1',
+        splitType: 'category',
+        categoryId: 'cat-1',
+        amount: -10,
+        memo: '',
+        // Stale investment payload - should be dropped on output
+        investment: {
+          action: 'BUY',
+          securityId: 'sec-x',
+          quantity: 1,
+          price: 1,
+        } as any,
+      },
+    ];
+    const out = toOverrideSplits(rows);
+    expect(out[0].investment).toBeUndefined();
+  });
+});

--- a/frontend/src/components/scheduled-transactions/splitSerialization.ts
+++ b/frontend/src/components/scheduled-transactions/splitSerialization.ts
@@ -1,0 +1,20 @@
+import { SplitRow } from '@/components/transactions/SplitEditor';
+import { OverrideSplit } from '@/types/scheduled-transaction';
+
+/**
+ * Serialize a SplitRow array into the OverrideSplit shape used by both the
+ * scheduled-transaction Post and Override APIs. Round-trips the splitKind and
+ * embedded investment payload so an investment-kind split survives editing in
+ * the post / override dialogs.
+ */
+export function toOverrideSplits(splits: SplitRow[]): OverrideSplit[] {
+  return splits.map((s) => ({
+    splitKind: s.splitType,
+    categoryId: s.splitType === 'category' ? (s.categoryId ?? null) : null,
+    transferAccountId:
+      s.splitType === 'transfer' ? (s.transferAccountId ?? null) : null,
+    investment: s.splitType === 'investment' ? s.investment : undefined,
+    amount: s.amount,
+    memo: s.memo ?? null,
+  }));
+}

--- a/frontend/src/components/transactions/InvestmentSplitFields.tsx
+++ b/frontend/src/components/transactions/InvestmentSplitFields.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Select } from '@/components/ui/Select';
+import { NumericInput } from '@/components/ui/NumericInput';
+import { CurrencyInput } from '@/components/ui/CurrencyInput';
+import { investmentsApi } from '@/lib/investments';
+import {
+  EMBEDDED_INVESTMENT_SPLIT_ACTIONS,
+  computeInvestmentCashImpact,
+} from '@/lib/investmentCashImpact';
+import { roundToCents, getCurrencySymbol } from '@/lib/format';
+import { InvestmentAction, Security } from '@/types/investment';
+import { InvestmentSplitDetails } from '@/types/transaction';
+
+interface InvestmentSplitFieldsProps {
+  value: InvestmentSplitDetails | undefined;
+  onChange: (next: InvestmentSplitDetails, computedAmount: number) => void;
+  disabled?: boolean;
+  currencyCode?: string;
+}
+
+const ACTION_LABELS: Record<InvestmentAction, string> = {
+  BUY: 'Buy',
+  SELL: 'Sell',
+  DIVIDEND: 'Dividend',
+  INTEREST: 'Interest',
+  CAPITAL_GAIN: 'Capital Gain',
+  REINVEST: 'Reinvest',
+  SPLIT: 'Split',
+  TRANSFER_IN: 'Transfer In',
+  TRANSFER_OUT: 'Transfer Out',
+  ADD_SHARES: 'Add Shares',
+  REMOVE_SHARES: 'Remove Shares',
+};
+
+const ACTIONS_NEEDING_SECURITY: ReadonlySet<InvestmentAction> = new Set([
+  'BUY',
+  'SELL',
+  'REINVEST',
+]);
+
+const ACTIONS_NEEDING_QUANTITY_PRICE: ReadonlySet<InvestmentAction> = new Set([
+  'BUY',
+  'SELL',
+  'REINVEST',
+]);
+
+export function InvestmentSplitFields({
+  value,
+  onChange,
+  disabled = false,
+  currencyCode = 'CAD',
+}: InvestmentSplitFieldsProps) {
+  const [securities, setSecurities] = useState<Security[]>([]);
+  const symbol = getCurrencySymbol(currencyCode);
+
+  useEffect(() => {
+    investmentsApi
+      .getSecurities()
+      .then(setSecurities)
+      .catch(() => {
+        /* fail silently - editor stays usable without the dropdown */
+      });
+  }, []);
+
+  const action: InvestmentAction = value?.action ?? 'BUY';
+  const quantity = value?.quantity ?? 0;
+  const price = value?.price ?? 0;
+  const commission = value?.commission ?? 0;
+  const exchangeRate = value?.exchangeRate ?? 1;
+
+  const updateField = <K extends keyof InvestmentSplitDetails>(
+    field: K,
+    fieldValue: InvestmentSplitDetails[K],
+  ) => {
+    const next: InvestmentSplitDetails = {
+      action,
+      securityId: value?.securityId,
+      quantity,
+      price,
+      commission,
+      exchangeRate,
+      description: value?.description,
+      ...(field === 'action' ? { action: fieldValue as InvestmentAction } : {}),
+      [field]: fieldValue,
+    };
+
+    const cashImpact = computeInvestmentCashImpact(
+      next.action,
+      Number(next.quantity ?? 0),
+      Number(next.price ?? 0),
+      Number(next.commission ?? 0),
+    );
+    const amount = roundToCents(cashImpact * Number(next.exchangeRate ?? 1));
+    onChange(next, amount);
+  };
+
+  const needsSecurity = ACTIONS_NEEDING_SECURITY.has(action);
+  const needsQtyPrice = ACTIONS_NEEDING_QUANTITY_PRICE.has(action);
+
+  return (
+    <div className="space-y-2 p-2 bg-gray-50 dark:bg-gray-800 rounded">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+        <Select
+          options={EMBEDDED_INVESTMENT_SPLIT_ACTIONS.map((a) => ({
+            value: a,
+            label: ACTION_LABELS[a],
+          }))}
+          value={action}
+          onChange={(e) => updateField('action', e.target.value as InvestmentAction)}
+          disabled={disabled}
+          aria-label="Investment action"
+        />
+        {needsSecurity && (
+          <Select
+            options={[
+              { value: '', label: 'Select security...' },
+              ...securities.map((s) => ({
+                value: s.id,
+                label: `${s.symbol} - ${s.name}`,
+              })),
+            ]}
+            value={value?.securityId ?? ''}
+            onChange={(e) => updateField('securityId', e.target.value || undefined)}
+            disabled={disabled}
+            aria-label="Security"
+          />
+        )}
+      </div>
+      {needsQtyPrice && (
+        <div className="grid grid-cols-3 gap-2">
+          <NumericInput
+            value={quantity || undefined}
+            onChange={(v) => updateField('quantity', Number(v ?? 0))}
+            decimalPlaces={8}
+            min={0}
+            disabled={disabled}
+            placeholder="Quantity"
+          />
+          <NumericInput
+            value={price || undefined}
+            onChange={(v) => updateField('price', Number(v ?? 0))}
+            decimalPlaces={6}
+            min={0}
+            disabled={disabled}
+            placeholder="Price"
+            prefix={symbol}
+          />
+          <CurrencyInput
+            value={commission || undefined}
+            onChange={(v) => updateField('commission', Number(v ?? 0))}
+            disabled={disabled}
+            placeholder="Commission"
+            prefix={symbol}
+            allowNegative={false}
+          />
+        </div>
+      )}
+      {!needsQtyPrice && (
+        <CurrencyInput
+          value={price || undefined}
+          onChange={(v) => updateField('price', Number(v ?? 0))}
+          disabled={disabled}
+          placeholder={`Amount (${currencyCode})`}
+          prefix={symbol}
+          allowNegative={false}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/transactions/InvestmentSplitFields.tsx
+++ b/frontend/src/components/transactions/InvestmentSplitFields.tsx
@@ -38,6 +38,8 @@ const ACTIONS_NEEDING_SECURITY: ReadonlySet<InvestmentAction> = new Set([
   'BUY',
   'SELL',
   'REINVEST',
+  'DIVIDEND',
+  'CAPITAL_GAIN',
 ]);
 
 const ACTIONS_NEEDING_QUANTITY_PRICE: ReadonlySet<InvestmentAction> = new Set([

--- a/frontend/src/components/transactions/SplitEditor.test.tsx
+++ b/frontend/src/components/transactions/SplitEditor.test.tsx
@@ -1826,3 +1826,46 @@ describe('toCreateSplitData', () => {
     expect(data[1].memo).toBe('Transfer');
   });
 });
+
+describe('SplitEditor — investment kind gating by parent account', () => {
+  const baseAccounts = [
+    { id: 'acc-cash', name: 'Chequing', isClosed: false, accountSubType: null, isFavourite: false, favouriteSortOrder: 0, currencyCode: 'CAD' },
+    { id: 'acc-savings', name: 'Savings', isClosed: false, accountSubType: null, isFavourite: false, favouriteSortOrder: 0, currencyCode: 'CAD' },
+  ] as any[];
+
+  const baseSplits = [
+    { id: 's1', splitType: 'category', categoryId: undefined, transferAccountId: undefined, amount: -50, memo: '' },
+    { id: 's2', splitType: 'category', categoryId: undefined, transferAccountId: undefined, amount: -50, memo: '' },
+  ] as any[];
+
+  it('shows the Investment option when parentAccountSubType is INVESTMENT_CASH', () => {
+    render(
+      <SplitEditor
+        splits={baseSplits}
+        onChange={vi.fn()}
+        categories={[]}
+        accounts={baseAccounts}
+        sourceAccountId="acc-cash"
+        parentAccountSubType="INVESTMENT_CASH"
+        transactionAmount={-100}
+      />,
+    );
+    // Both desktop and mobile renderings include the Investment option
+    expect(screen.getAllByRole('option', { name: 'Investment' }).length).toBeGreaterThan(0);
+  });
+
+  it('omits the Investment option for non-INVESTMENT_CASH parents', () => {
+    render(
+      <SplitEditor
+        splits={baseSplits}
+        onChange={vi.fn()}
+        categories={[]}
+        accounts={baseAccounts}
+        sourceAccountId="acc-cash"
+        parentAccountSubType={null}
+        transactionAmount={-100}
+      />,
+    );
+    expect(screen.queryByRole('option', { name: 'Investment' })).toBeNull();
+  });
+});

--- a/frontend/src/components/transactions/SplitEditor.test.tsx
+++ b/frontend/src/components/transactions/SplitEditor.test.tsx
@@ -1869,3 +1869,97 @@ describe('SplitEditor — investment kind gating by parent account', () => {
     expect(screen.queryByRole('option', { name: 'Investment' })).toBeNull();
   });
 });
+
+describe('toSplitRows — investment shapes', () => {
+  it('hydrates investment fields from a transaction-split investmentTransaction relation', () => {
+    const rows = toSplitRows([
+      {
+        id: 's1',
+        amount: -750,
+        kind: 'investment',
+        categoryId: null,
+        transferAccountId: null,
+        investmentTransaction: {
+          action: 'BUY',
+          securityId: 'sec-1',
+          quantity: 75,
+          price: 10,
+          commission: 0,
+          exchangeRate: 1,
+        },
+      },
+    ]);
+    expect(rows[0].splitType).toBe('investment');
+    expect(rows[0].investment).toMatchObject({
+      action: 'BUY',
+      securityId: 'sec-1',
+      quantity: 75,
+      price: 10,
+      commission: 0,
+      exchangeRate: 1,
+    });
+  });
+
+  it('hydrates investment fields from scheduled-transaction-split denormalized columns', () => {
+    const rows = toSplitRows([
+      {
+        id: 's1',
+        amount: -750,
+        kind: 'investment',
+        categoryId: null,
+        transferAccountId: null,
+        investmentAction: 'BUY',
+        investmentSecurityId: 'sec-1',
+        investmentQuantity: 75,
+        investmentPrice: 10,
+        investmentCommission: 0,
+        investmentExchangeRate: 1,
+      } as any,
+    ]);
+    expect(rows[0].splitType).toBe('investment');
+    expect(rows[0].investment).toMatchObject({
+      action: 'BUY',
+      securityId: 'sec-1',
+      quantity: 75,
+      price: 10,
+      commission: 0,
+      exchangeRate: 1,
+    });
+  });
+
+  it('hydrates investment fields from override JSON shape (splitKind + investment object)', () => {
+    const rows = toSplitRows([
+      {
+        amount: -750,
+        splitKind: 'investment',
+        categoryId: null,
+        investment: {
+          action: 'SELL',
+          securityId: 'sec-1',
+          quantity: 5,
+          price: 100,
+          commission: 1,
+          exchangeRate: 1,
+        },
+      } as any,
+    ]);
+    expect(rows[0].splitType).toBe('investment');
+    expect(rows[0].investment).toMatchObject({
+      action: 'SELL',
+      quantity: 5,
+      price: 100,
+      commission: 1,
+    });
+  });
+
+  it('still classifies plain category and transfer rows correctly', () => {
+    const rows = toSplitRows([
+      { id: 'c', amount: -10, categoryId: 'cat-1' },
+      { id: 't', amount: -20, transferAccountId: 'acc-2' },
+    ]);
+    expect(rows[0].splitType).toBe('category');
+    expect(rows[0].investment).toBeUndefined();
+    expect(rows[1].splitType).toBe('transfer');
+    expect(rows[1].investment).toBeUndefined();
+  });
+});

--- a/frontend/src/components/transactions/SplitEditor.tsx
+++ b/frontend/src/components/transactions/SplitEditor.tsx
@@ -10,12 +10,13 @@ import { MultiSelect } from '@/components/ui/MultiSelect';
 import { Category } from '@/types/category';
 import { Account } from '@/types/account';
 import { Tag } from '@/types/tag';
-import { CreateSplitData } from '@/types/transaction';
+import { CreateSplitData, InvestmentSplitDetails } from '@/types/transaction';
 import { buildCategoryTree } from '@/lib/categoryUtils';
 import { roundToCents, getCurrencySymbol, formatAmountWithCommas, getDecimalPlacesForCurrency } from '@/lib/format';
 import { buildAccountDropdownOptions } from '@/lib/account-utils';
+import { InvestmentSplitFields } from './InvestmentSplitFields';
 
-export type SplitType = 'category' | 'transfer';
+export type SplitType = 'category' | 'transfer' | 'investment';
 
 export interface SplitRow extends CreateSplitData {
   id: string; // Temporary ID for React keys
@@ -29,6 +30,8 @@ interface SplitEditorProps {
   tags?: Tag[];
   accounts?: Account[];
   sourceAccountId?: string;
+  /** When the parent account is INVESTMENT_CASH, the investment split kind is enabled. */
+  parentAccountSubType?: string | null;
   transactionAmount: number;
   disabled?: boolean;
   onTransactionAmountChange?: (amount: number) => void;
@@ -42,11 +45,13 @@ export function SplitEditor({
   tags = [],
   accounts = [],
   sourceAccountId = '',
+  parentAccountSubType,
   transactionAmount,
   disabled = false,
   onTransactionAmountChange,
   currencyCode = 'CAD',
 }: SplitEditorProps) {
+  const investmentSplitsEnabled = parentAccountSubType === 'INVESTMENT_CASH';
   const currencySymbol = getCurrencySymbol(currencyCode);
   const decimals = getDecimalPlacesForCurrency(currencyCode);
   const [localSplits, setLocalSplits] = useState<SplitRow[]>(splits);
@@ -101,13 +106,48 @@ export function SplitEditor({
   const handleSplitChange = (index: number, field: keyof SplitRow, value: any) => {
     const newSplits = [...localSplits];
 
-    // If changing split type, clear the other field
+    // If changing split type, clear the other-kind fields
     if (field === 'splitType') {
       if (value === 'category') {
-        newSplits[index] = { ...newSplits[index], splitType: 'category', transferAccountId: undefined };
+        newSplits[index] = {
+          ...newSplits[index],
+          splitType: 'category',
+          transferAccountId: undefined,
+          investment: undefined,
+        };
+      } else if (value === 'transfer') {
+        newSplits[index] = {
+          ...newSplits[index],
+          splitType: 'transfer',
+          categoryId: undefined,
+          investment: undefined,
+        };
       } else {
-        newSplits[index] = { ...newSplits[index], splitType: 'transfer', categoryId: undefined };
+        newSplits[index] = {
+          ...newSplits[index],
+          splitType: 'investment',
+          categoryId: undefined,
+          transferAccountId: undefined,
+          investment: newSplits[index].investment ?? { action: 'BUY' },
+        };
       }
+      setLocalSplits(newSplits);
+      onChange(newSplits);
+      return;
+    }
+
+    if (field === 'investment') {
+      // Caller updated the investment payload; set both `investment` and the
+      // computed cash impact passed as `_amount` via the value object.
+      const { investment, amount } = value as {
+        investment: InvestmentSplitDetails;
+        amount: number;
+      };
+      newSplits[index] = {
+        ...newSplits[index],
+        investment,
+        amount,
+      };
       setLocalSplits(newSplits);
       onChange(newSplits);
       return;
@@ -349,6 +389,9 @@ export function SplitEditor({
                     options={[
                       { value: 'category', label: 'Category' },
                       { value: 'transfer', label: 'Transfer' },
+                      ...(investmentSplitsEnabled
+                        ? [{ value: 'investment', label: 'Investment' }]
+                        : []),
                     ]}
                     value={split.splitType}
                     onChange={(e) => handleSplitChange(index, 'splitType', e.target.value)}
@@ -356,7 +399,16 @@ export function SplitEditor({
                     className="w-full"
                   />
                 )}
-                {split.splitType === 'category' || !supportsTransfers ? (
+                {split.splitType === 'investment' ? (
+                  <InvestmentSplitFields
+                    value={split.investment}
+                    onChange={(investment, amount) =>
+                      handleSplitChange(index, 'investment', { investment, amount })
+                    }
+                    disabled={disabled}
+                    currencyCode={currencyCode}
+                  />
+                ) : split.splitType === 'category' || !supportsTransfers ? (
                   <Combobox
                     placeholder="Select category..."
                     options={categoryOptions}
@@ -496,6 +548,9 @@ export function SplitEditor({
                       options={[
                         { value: 'category', label: 'Category' },
                         { value: 'transfer', label: 'Transfer' },
+                        ...(investmentSplitsEnabled
+                          ? [{ value: 'investment', label: 'Investment' }]
+                          : []),
                       ]}
                       value={split.splitType}
                       onChange={(e) => handleSplitChange(index, 'splitType', e.target.value)}
@@ -505,7 +560,16 @@ export function SplitEditor({
                   </td>
                 )}
                 <td className="px-1 py-2">
-                  {split.splitType === 'category' || !supportsTransfers ? (
+                  {split.splitType === 'investment' ? (
+                    <InvestmentSplitFields
+                      value={split.investment}
+                      onChange={(investment, amount) =>
+                        handleSplitChange(index, 'investment', { investment, amount })
+                      }
+                      disabled={disabled}
+                      currencyCode={currencyCode}
+                    />
+                  ) : split.splitType === 'category' || !supportsTransfers ? (
                     <Combobox
                       placeholder="Select category..."
                       options={categoryOptions}
@@ -685,23 +749,60 @@ export function createEmptySplits(transactionAmount: number): SplitRow[] {
 }
 
 // Convert API splits to SplitRow format
-export function toSplitRows(splits: { id?: string; categoryId?: string | null; transferAccountId?: string | null; amount: number; memo?: string | null; tags?: { id: string }[] }[]): SplitRow[] {
-  return splits.map((split, index) => ({
-    id: split.id || `temp-${Date.now()}-${index}`,
-    splitType: split.transferAccountId ? 'transfer' : 'category',
-    categoryId: split.categoryId || undefined,
-    transferAccountId: split.transferAccountId || undefined,
-    amount: Number(split.amount),
-    memo: split.memo || '',
-    tagIds: split.tags?.map(t => t.id) || [],
-  }));
+export function toSplitRows(splits: {
+  id?: string;
+  kind?: 'category' | 'transfer' | 'investment';
+  categoryId?: string | null;
+  transferAccountId?: string | null;
+  amount: number;
+  memo?: string | null;
+  tags?: { id: string }[];
+  investmentTransaction?: {
+    action: string;
+    securityId: string | null;
+    quantity: number | null;
+    price: number | null;
+    commission: number;
+    exchangeRate: number;
+  } | null;
+}[]): SplitRow[] {
+  return splits.map((split, index) => {
+    const kind: SplitType =
+      split.kind === 'investment' || split.investmentTransaction
+        ? 'investment'
+        : split.transferAccountId
+          ? 'transfer'
+          : 'category';
+    const investment = split.investmentTransaction
+      ? {
+          action: split.investmentTransaction.action as InvestmentSplitDetails['action'],
+          securityId: split.investmentTransaction.securityId ?? undefined,
+          quantity: Number(split.investmentTransaction.quantity ?? 0),
+          price: Number(split.investmentTransaction.price ?? 0),
+          commission: Number(split.investmentTransaction.commission ?? 0),
+          exchangeRate: Number(split.investmentTransaction.exchangeRate ?? 1),
+        }
+      : undefined;
+    return {
+      id: split.id || `temp-${Date.now()}-${index}`,
+      splitType: kind,
+      categoryId: split.categoryId || undefined,
+      transferAccountId: split.transferAccountId || undefined,
+      investment,
+      amount: Number(split.amount),
+      memo: split.memo || '',
+      tagIds: split.tags?.map(t => t.id) || [],
+    };
+  });
 }
 
 // Convert SplitRow to API format (removes temporary id and splitType)
 export function toCreateSplitData(splits: SplitRow[]): CreateSplitData[] {
   return splits.map((split) => ({
+    splitKind: split.splitType,
     categoryId: split.splitType === 'category' ? split.categoryId : undefined,
     transferAccountId: split.splitType === 'transfer' ? split.transferAccountId : undefined,
+    investment: split.splitType === 'investment' ? split.investment : undefined,
     amount: split.amount,
     memo: split.memo || undefined,
     tagIds: split.tagIds && split.tagIds.length > 0 ? split.tagIds : undefined,

--- a/frontend/src/components/transactions/SplitEditor.tsx
+++ b/frontend/src/components/transactions/SplitEditor.tsx
@@ -748,7 +748,9 @@ export function createEmptySplits(transactionAmount: number): SplitRow[] {
   ];
 }
 
-// Convert API splits to SplitRow format
+// Convert API splits to SplitRow format. Accepts both transaction splits (with
+// `investmentTransaction` relation) and scheduled-transaction splits (with the
+// investment payload denormalized as `investment*` columns on the row itself).
 export function toSplitRows(splits: {
   id?: string;
   kind?: 'category' | 'transfer' | 'investment';
@@ -765,24 +767,64 @@ export function toSplitRows(splits: {
     commission: number;
     exchangeRate: number;
   } | null;
+  // Scheduled-transaction-split shape
+  investmentAction?: string | null;
+  investmentSecurityId?: string | null;
+  investmentQuantity?: number | null;
+  investmentPrice?: number | null;
+  investmentCommission?: number | null;
+  investmentExchangeRate?: number | null;
+  // Override JSON shape
+  splitKind?: 'category' | 'transfer' | 'investment';
+  investment?: {
+    action: string;
+    securityId?: string;
+    quantity?: number;
+    price?: number;
+    commission?: number;
+    exchangeRate?: number;
+  };
 }[]): SplitRow[] {
   return splits.map((split, index) => {
     const kind: SplitType =
-      split.kind === 'investment' || split.investmentTransaction
+      split.kind === 'investment' ||
+      split.splitKind === 'investment' ||
+      split.investmentTransaction ||
+      split.investmentAction ||
+      split.investment
         ? 'investment'
         : split.transferAccountId
           ? 'transfer'
           : 'category';
-    const investment = split.investmentTransaction
-      ? {
-          action: split.investmentTransaction.action as InvestmentSplitDetails['action'],
-          securityId: split.investmentTransaction.securityId ?? undefined,
-          quantity: Number(split.investmentTransaction.quantity ?? 0),
-          price: Number(split.investmentTransaction.price ?? 0),
-          commission: Number(split.investmentTransaction.commission ?? 0),
-          exchangeRate: Number(split.investmentTransaction.exchangeRate ?? 1),
-        }
-      : undefined;
+    let investment: InvestmentSplitDetails | undefined;
+    if (split.investmentTransaction) {
+      investment = {
+        action: split.investmentTransaction.action as InvestmentSplitDetails['action'],
+        securityId: split.investmentTransaction.securityId ?? undefined,
+        quantity: Number(split.investmentTransaction.quantity ?? 0),
+        price: Number(split.investmentTransaction.price ?? 0),
+        commission: Number(split.investmentTransaction.commission ?? 0),
+        exchangeRate: Number(split.investmentTransaction.exchangeRate ?? 1),
+      };
+    } else if (split.investmentAction) {
+      investment = {
+        action: split.investmentAction as InvestmentSplitDetails['action'],
+        securityId: split.investmentSecurityId ?? undefined,
+        quantity: Number(split.investmentQuantity ?? 0),
+        price: Number(split.investmentPrice ?? 0),
+        commission: Number(split.investmentCommission ?? 0),
+        exchangeRate: Number(split.investmentExchangeRate ?? 1),
+      };
+    } else if (split.investment) {
+      investment = {
+        action: split.investment.action as InvestmentSplitDetails['action'],
+        securityId: split.investment.securityId,
+        quantity: split.investment.quantity,
+        price: split.investment.price,
+        commission: split.investment.commission,
+        exchangeRate: split.investment.exchangeRate,
+      };
+    }
     return {
       id: split.id || `temp-${Date.now()}-${index}`,
       splitType: kind,

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -1004,6 +1004,9 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
             tags={tags}
             accounts={accounts}
             sourceAccountId={watchedAccountId || ''}
+            parentAccountSubType={
+              accounts.find((a) => a.id === watchedAccountId)?.accountSubType ?? null
+            }
             transactionAmount={watchedAmount || 0}
             disabled={isLoading}
             onTransactionAmountChange={(amount) => setValue('amount', amount, { shouldDirty: true, shouldValidate: true })}

--- a/frontend/src/components/ui/DateInput.tsx
+++ b/frontend/src/components/ui/DateInput.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, forwardRef, InputHTMLAttributes, KeyboardEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 import { Input } from './Input';
 import { CalendarPopover } from './CalendarPopover';
 import { cn, getLocalDateString, formatDate, parseDateFromFormat, inputBaseClasses, inputErrorClasses } from '@/lib/utils';
@@ -57,16 +58,10 @@ function DateShortcutTooltip() {
       onMouseEnter={showTooltip}
       onMouseLeave={hideTooltip}
     >
-      <svg
+      <QuestionMarkCircleIcon
         className="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 cursor-help"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
         strokeWidth={2}
-      >
-        <circle cx="12" cy="12" r="10" />
-        <path d="M12 16v-4M12 8h.01" />
-      </svg>
+      />
       {position && createPortal(
         <div
           role="tooltip"

--- a/frontend/src/hooks/useInvestmentData.ts
+++ b/frontend/src/hooks/useInvestmentData.ts
@@ -426,6 +426,10 @@ export function useInvestmentData() {
     // The portfolio summary drives the Holdings by Account section's cash
     // balances, so refresh it when a cash transaction changes.
     loadPortfolioSummary(selectedAccountIds);
+    // A cash transaction can embed an investment-split action (BUY/SELL/etc),
+    // which writes to the linked brokerage account; refresh the brokerage
+    // transaction list so the new row appears without a manual reload.
+    loadTransactions(selectedAccountIds, currentPage, transactionFilters);
   };
 
   const refreshCashTransactions = useCallback(() => {

--- a/frontend/src/lib/investmentCashImpact.test.ts
+++ b/frontend/src/lib/investmentCashImpact.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeInvestmentCashImpact,
+  isInvestmentActionAllowedInSplit,
+  EMBEDDED_INVESTMENT_SPLIT_ACTIONS,
+} from './investmentCashImpact';
+
+describe('computeInvestmentCashImpact', () => {
+  it('returns -750 for BUY 75 @ $10', () => {
+    expect(computeInvestmentCashImpact('BUY', 75, 10, 0)).toBe(-750);
+  });
+
+  it('adds commission to BUY total', () => {
+    expect(computeInvestmentCashImpact('BUY', 100, 50, 9.99)).toBe(-5009.99);
+  });
+
+  it('subtracts commission from SELL', () => {
+    expect(computeInvestmentCashImpact('SELL', 100, 50, 9.99)).toBe(4990.01);
+  });
+
+  it('treats DIVIDEND with default qty=1', () => {
+    expect(computeInvestmentCashImpact('DIVIDEND', 0, 25.5, 0)).toBe(25.5);
+    expect(computeInvestmentCashImpact('DIVIDEND', 1, 25.5, 0)).toBe(25.5);
+  });
+
+  it('returns 0 for REINVEST', () => {
+    expect(computeInvestmentCashImpact('REINVEST', 5, 10, 0)).toBe(0);
+  });
+
+  it('returns 0 for share-only actions', () => {
+    expect(computeInvestmentCashImpact('ADD_SHARES', 10, 0, 0)).toBe(0);
+    expect(computeInvestmentCashImpact('REMOVE_SHARES', 10, 0, 0)).toBe(0);
+    expect(computeInvestmentCashImpact('TRANSFER_IN', 10, 5, 0)).toBe(0);
+    expect(computeInvestmentCashImpact('SPLIT', 2, 0, 0)).toBe(0);
+  });
+});
+
+describe('isInvestmentActionAllowedInSplit', () => {
+  it('allows the cash-impacting subset', () => {
+    EMBEDDED_INVESTMENT_SPLIT_ACTIONS.forEach((a) =>
+      expect(isInvestmentActionAllowedInSplit(a)).toBe(true),
+    );
+  });
+
+  it('rejects share-only actions', () => {
+    (['ADD_SHARES', 'REMOVE_SHARES', 'TRANSFER_IN', 'SPLIT'] as const).forEach(
+      (a) => expect(isInvestmentActionAllowedInSplit(a)).toBe(false),
+    );
+  });
+});

--- a/frontend/src/lib/investmentCashImpact.ts
+++ b/frontend/src/lib/investmentCashImpact.ts
@@ -1,0 +1,43 @@
+import { InvestmentAction } from '@/types/investment';
+
+export const EMBEDDED_INVESTMENT_SPLIT_ACTIONS: ReadonlyArray<InvestmentAction> = [
+  'BUY',
+  'SELL',
+  'DIVIDEND',
+  'INTEREST',
+  'CAPITAL_GAIN',
+  'REINVEST',
+];
+
+export function isInvestmentActionAllowedInSplit(action: InvestmentAction): boolean {
+  return EMBEDDED_INVESTMENT_SPLIT_ACTIONS.includes(action);
+}
+
+/**
+ * Mirrors backend `computeInvestmentCashImpact` so the split editor can
+ * derive the cash side of an investment split as the user types.
+ */
+export function computeInvestmentCashImpact(
+  action: InvestmentAction,
+  quantity: number,
+  price: number,
+  commission: number,
+): number {
+  const q = Number(quantity) || 0;
+  const p = Number(price) || 0;
+  const c = Number(commission) || 0;
+  switch (action) {
+    case 'BUY':
+      return -(q * p + c);
+    case 'SELL':
+      return q * p - c;
+    case 'DIVIDEND':
+    case 'INTEREST':
+    case 'CAPITAL_GAIN':
+      return (q || 1) * p;
+    case 'REINVEST':
+      return 0;
+    default:
+      return 0;
+  }
+}

--- a/frontend/src/types/scheduled-transaction.ts
+++ b/frontend/src/types/scheduled-transaction.ts
@@ -2,6 +2,8 @@ import { Account } from './account';
 import { Payee } from './payee';
 import { Category } from './category';
 import { Tag } from './tag';
+import { InvestmentAction, Security } from './investment';
+import { SplitKind, InvestmentSplitDetails } from './transaction';
 
 export type FrequencyType =
   | 'ONCE'
@@ -29,6 +31,7 @@ export const FREQUENCY_LABELS: Record<FrequencyType, string> = {
 export interface ScheduledTransactionSplit {
   id: string;
   scheduledTransactionId: string;
+  kind?: SplitKind;
   categoryId: string | null;
   category: Category | null;
   transferAccountId: string | null;
@@ -36,6 +39,14 @@ export interface ScheduledTransactionSplit {
   amount: number;
   memo: string | null;
   tags?: Tag[];
+  // Investment-split fields
+  investmentAction?: InvestmentAction | null;
+  investmentSecurityId?: string | null;
+  investmentSecurity?: Security | null;
+  investmentQuantity?: number | null;
+  investmentPrice?: number | null;
+  investmentCommission?: number | null;
+  investmentExchangeRate?: number | null;
   createdAt: string;
 }
 
@@ -77,8 +88,10 @@ export interface ScheduledTransaction {
 }
 
 export interface CreateScheduledTransactionSplitData {
+  splitKind?: SplitKind;
   categoryId?: string;
   transferAccountId?: string;
+  investment?: InvestmentSplitDetails;
   amount: number;
   memo?: string;
   tagIds?: string[];
@@ -112,8 +125,10 @@ export interface UpdateScheduledTransactionData extends Partial<CreateScheduledT
 // ==================== Override Types ====================
 
 export interface OverrideSplit {
+  splitKind?: SplitKind;
   categoryId: string | null;
   transferAccountId?: string | null;
+  investment?: InvestmentSplitDetails;
   amount: number;
   memo?: string | null;
 }

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -2,6 +2,7 @@ import { Payee } from './payee';
 import { Category } from './category';
 import { Account } from './account';
 import { Tag } from './tag';
+import { InvestmentAction } from './investment';
 
 export enum TransactionStatus {
   UNRECONCILED = 'UNRECONCILED',
@@ -10,9 +11,22 @@ export enum TransactionStatus {
   VOID = 'VOID',
 }
 
+export type SplitKind = 'category' | 'transfer' | 'investment';
+
+export interface InvestmentSplitDetails {
+  action: InvestmentAction;
+  securityId?: string;
+  quantity?: number;
+  price?: number;
+  commission?: number;
+  exchangeRate?: number;
+  description?: string;
+}
+
 export interface TransactionSplit {
   id: string;
   transactionId: string;
+  kind?: SplitKind;
   categoryId: string | null;
   category: Category | null;
   transferAccountId: string | null;
@@ -21,6 +35,16 @@ export interface TransactionSplit {
   amount: number;
   memo: string | null;
   tags?: Tag[];
+  /** Present when kind === 'investment' */
+  investmentTransaction?: {
+    id: string;
+    action: InvestmentAction;
+    securityId: string | null;
+    quantity: number | null;
+    price: number | null;
+    commission: number;
+    exchangeRate: number;
+  } | null;
   createdAt: string;
 }
 
@@ -60,8 +84,10 @@ export interface Transaction {
 }
 
 export interface CreateSplitData {
+  splitKind?: SplitKind;
   categoryId?: string;
   transferAccountId?: string;
+  investment?: InvestmentSplitDetails;
   amount: number;
   memo?: string;
   tagIds?: string[];


### PR DESCRIPTION
## Summary
This PR adds support for embedding investment transactions (BUY, SELL, DIVIDEND, etc.) directly within split transactions. This enables paycheck-with-equity-grant style entries where gross income, tax withholding, and share purchases are all recorded in a single balanced transaction.

## Key Changes

### Backend
- **New split kind**: Added `SplitKind` enum (CATEGORY, TRANSFER, INVESTMENT) to `TransactionSplit` entity with database migration
- **Investment split validation**: Implemented comprehensive validation in `TransactionSplitService.validateSplits()`:
  - Ensures investment split amount matches computed cash impact (quantity × price ± commission)
  - Supports exchange rate conversion for foreign-currency securities
  - Restricts to allowed actions (BUY, SELL, DIVIDEND, INTEREST, CAPITAL_GAIN, REINVEST)
  - Prevents mixing investment splits with categoryId or transferAccountId
  - Requires parent transaction to be on INVESTMENT_CASH account linked to a brokerage
- **Embedded investment creation**: Added `InvestmentTransactionsService.createEmbeddedForSplit()` to create investment transactions without auto-generating linked cash transactions (the parent split's amount IS the cash side)
- **Cash impact utility**: Created `cash-impact.util.ts` with `computeInvestmentCashImpact()` and `isInvestmentActionAllowedInSplit()` for consistent cash-side calculations
- **Holdings updates**: Investment splits update holdings via the embedded path, skipping the separate cash transaction creation
- **Reversal support**: `removeSplit()` calls `reverseAndRemoveEmbedded()` to properly reverse holdings when removing an investment split

### Frontend
- **Investment split editor**: New `InvestmentSplitFields.tsx` component for editing investment split details (action, security, quantity, price, commission, exchange rate)
- **Split type selector**: Extended `SplitEditor.tsx` to support 'investment' split type alongside 'category' and 'transfer'
- **Conditional rendering**: Investment split option only appears when parent account is INVESTMENT_CASH
- **Real-time calculation**: Split editor computes and displays the cash impact as user modifies investment parameters
- **Cash impact library**: Frontend mirror of backend `computeInvestmentCashImpact()` in `investmentCashImpact.ts` for client-side validation

### Data Model
- `TransactionSplit` now has optional `investmentTransaction` one-to-one relationship
- `InvestmentTransaction` now has optional `transactionSplitId` and `transactionSplit` relationship
- Split queries now include `investmentTransaction` relation for complete data loading
- Database schema updated with `kind` column and appropriate constraints

### Testing
- Comprehensive test coverage for investment split validation (cash impact matching, action restrictions, account type checks)
- Tests for embedded creation path vs. standard creation path
- Tests for split removal with investment reversal
- Frontend tests for investment split UI gating by parent account type

## Implementation Details
- Investment splits are validated to ensure the split amount exactly matches the computed cash impact, preventing data inconsistencies
- The embedded path skips cash transaction creation because the parent split transaction's amount already represents the cash side
- Exchange rates are applied when security currency differs from the parent account currency
- Only specific investment actions (BUY, SELL, DIVIDEND, INTEREST, CAPITAL_GAIN, REINVEST) are allowed in splits; share-only actions (ADD_SHARES, REMOVE_SHARES, etc.) are rejected
- Investment splits cannot be added incrementally via `addSplit()`; they must be created as part of the initial split set

https://claude.ai/code/session_01Kpc2o8TfJ3iesHzZk9wW6A