### PR TITLE
Add transactionId to realized gains test data

### DIFF
--- a/frontend/src/components/reports/RealizedGainsReport.test.tsx
+++ b/frontend/src/components/reports/RealizedGainsReport.test.tsx
@@ -470,9 +470,9 @@ describe('RealizedGainsReport', () => {
 
   it('exercises sort headers on security and sells tables', async () => {
     mockGetRealizedGains.mockResolvedValue([
-      gainEntry({ symbol: 'BBB', securityName: 'Bravo', transactionDate: '2024-02-15', quantity: 5, price: 100, proceeds: 500, costBasis: 400, realizedGain: 100, accountCurrencyCode: 'CAD' }),
-      gainEntry({ symbol: 'AAA', securityName: 'Alpha', transactionDate: '2024-01-15', quantity: 10, price: 50, proceeds: 500, costBasis: 600, realizedGain: -100, accountCurrencyCode: 'CAD' }),
-      gainEntry({ symbol: 'CCC', securityName: 'Charlie', transactionDate: '2024-03-15', quantity: 2, price: 200, proceeds: 400, costBasis: 300, realizedGain: 100, accountCurrencyCode: 'CAD' }),
+      gainEntry({ transactionId: 'sell-bbb', symbol: 'BBB', securityName: 'Bravo', transactionDate: '2024-02-15', quantity: 5, price: 100, proceeds: 500, costBasis: 400, realizedGain: 100, accountCurrencyCode: 'CAD' }),
+      gainEntry({ transactionId: 'sell-aaa', symbol: 'AAA', securityName: 'Alpha', transactionDate: '2024-01-15', quantity: 10, price: 50, proceeds: 500, costBasis: 600, realizedGain: -100, accountCurrencyCode: 'CAD' }),
+      gainEntry({ transactionId: 'sell-ccc', symbol: 'CCC', securityName: 'Charlie', transactionDate: '2024-03-15', quantity: 2, price: 200, proceeds: 400, costBasis: 300, realizedGain: 100, accountCurrencyCode: 'CAD' }),
     ]);
     const { container } = render(<RealizedGainsReport />);
     await waitFor(() => expect(screen.getByTitle('Table')).toBeInTheDocument());


### PR DESCRIPTION
## Summary
Updated the test data in the RealizedGainsReport test suite to include `transactionId` fields for gain entries, ensuring test data matches the expected data structure.

## Key Changes
- Added `transactionId` parameter to all three `gainEntry()` calls in the 'exercises sort headers on security and sells tables' test
- Each entry now includes a unique transaction ID ('sell-bbb', 'sell-aaa', 'sell-ccc') corresponding to its security symbol

## Details
This change ensures that the test data structure aligns with the actual data model used by the RealizedGainsReport component, which likely requires a `transactionId` field for proper identification and handling of gain entries.

https://claude.ai/code/session_012ELZdvZgVwYJytisnUqqee