### PR TITLE
Extract SplitKind enum to separate file

### DIFF
--- a/backend/src/scheduled-transactions/dto/create-scheduled-transaction-split.dto.ts
+++ b/backend/src/scheduled-transactions/dto/create-scheduled-transaction-split.dto.ts
@@ -15,7 +15,7 @@ import { Type } from "class-transformer";
 import { ApiPropertyOptional } from "@nestjs/swagger";
 import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
 import { InvestmentSplitDto } from "../../transactions/dto/create-transaction-split.dto";
-import { SplitKind } from "../../transactions/entities/transaction-split.entity";
+import { SplitKind } from "../../transactions/entities/split-kind.enum";
 
 export class CreateScheduledTransactionSplitDto {
   @ApiPropertyOptional({ enum: SplitKind })

--- a/backend/src/scheduled-transactions/dto/post-scheduled-transaction.dto.ts
+++ b/backend/src/scheduled-transactions/dto/post-scheduled-transaction.dto.ts
@@ -14,7 +14,7 @@ import {
 import { Type } from "class-transformer";
 import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
 import { InvestmentSplitDto } from "../../transactions/dto/create-transaction-split.dto";
-import { SplitKind } from "../../transactions/entities/transaction-split.entity";
+import { SplitKind } from "../../transactions/entities/split-kind.enum";
 
 class InlineSplitDto {
   @ApiPropertyOptional({ enum: SplitKind })

--- a/backend/src/scheduled-transactions/dto/scheduled-transaction-override.dto.ts
+++ b/backend/src/scheduled-transactions/dto/scheduled-transaction-override.dto.ts
@@ -14,7 +14,7 @@ import {
 import { Type } from "class-transformer";
 import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
 import { InvestmentSplitDto } from "../../transactions/dto/create-transaction-split.dto";
-import { SplitKind } from "../../transactions/entities/transaction-split.entity";
+import { SplitKind } from "../../transactions/entities/split-kind.enum";
 
 export class OverrideSplitDto {
   @ApiPropertyOptional({ enum: SplitKind })

--- a/backend/src/scheduled-transactions/entities/scheduled-transaction-split.entity.ts
+++ b/backend/src/scheduled-transactions/entities/scheduled-transaction-split.entity.ts
@@ -14,7 +14,7 @@ import { Account } from "../../accounts/entities/account.entity";
 import { Tag } from "../../tags/entities/tag.entity";
 import { Security } from "../../securities/entities/security.entity";
 import { InvestmentAction } from "../../securities/entities/investment-transaction.entity";
-import { SplitKind } from "../../transactions/entities/transaction-split.entity";
+import { SplitKind } from "../../transactions/entities/split-kind.enum";
 
 @Entity("scheduled_transaction_splits")
 export class ScheduledTransactionSplit {

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -14,7 +14,7 @@ import {
   FrequencyType,
 } from "./entities/scheduled-transaction.entity";
 import { ScheduledTransactionSplit } from "./entities/scheduled-transaction-split.entity";
-import { SplitKind } from "../transactions/entities/transaction-split.entity";
+import { SplitKind } from "../transactions/entities/split-kind.enum";
 import { ScheduledTransactionOverride } from "./entities/scheduled-transaction-override.entity";
 import { CreateScheduledTransactionDto } from "./dto/create-scheduled-transaction.dto";
 import { UpdateScheduledTransactionDto } from "./dto/update-scheduled-transaction.dto";

--- a/backend/src/transactions/dto/create-transaction-split.dto.ts
+++ b/backend/src/transactions/dto/create-transaction-split.dto.ts
@@ -14,7 +14,7 @@ import { Type } from "class-transformer";
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
 import { InvestmentAction } from "../../securities/entities/investment-transaction.entity";
-import { SplitKind } from "../entities/transaction-split.entity";
+import { SplitKind } from "../entities/split-kind.enum";
 
 export class InvestmentSplitDto {
   @ApiProperty({ enum: InvestmentAction, description: "Investment action" })

--- a/backend/src/transactions/entities/split-kind.enum.ts
+++ b/backend/src/transactions/entities/split-kind.enum.ts
@@ -1,0 +1,5 @@
+export enum SplitKind {
+  CATEGORY = "category",
+  TRANSFER = "transfer",
+  INVESTMENT = "investment",
+}

--- a/backend/src/transactions/entities/transaction-split.entity.ts
+++ b/backend/src/transactions/entities/transaction-split.entity.ts
@@ -15,12 +15,7 @@ import { Category } from "../../categories/entities/category.entity";
 import { Tag } from "../../tags/entities/tag.entity";
 import { Account } from "../../accounts/entities/account.entity";
 import { InvestmentTransaction } from "../../securities/entities/investment-transaction.entity";
-
-export enum SplitKind {
-  CATEGORY = "category",
-  TRANSFER = "transfer",
-  INVESTMENT = "investment",
-}
+import { SplitKind } from "./split-kind.enum";
 
 @Entity("transaction_splits")
 export class TransactionSplit {

--- a/backend/src/transactions/transaction-split.service.ts
+++ b/backend/src/transactions/transaction-split.service.ts
@@ -8,10 +8,8 @@ import {
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository, DataSource, QueryRunner, In } from "typeorm";
 import { Transaction } from "./entities/transaction.entity";
-import {
-  TransactionSplit,
-  SplitKind,
-} from "./entities/transaction-split.entity";
+import { TransactionSplit } from "./entities/transaction-split.entity";
+import { SplitKind } from "./entities/split-kind.enum";
 import { Category } from "../categories/entities/category.entity";
 import { CreateTransactionSplitDto } from "./dto/create-transaction-split.dto";
 import { AccountsService } from "../accounts/accounts.service";

--- a/frontend/src/components/reports/BillPaymentHistoryReport.test.tsx
+++ b/frontend/src/components/reports/BillPaymentHistoryReport.test.tsx
@@ -31,11 +31,12 @@ vi.mock('@/hooks/useNumberFormat', () => ({
   }),
 }));
 
+const STABLE_RANGE = { start: '2024-01-01', end: '2025-01-01' };
 vi.mock('@/hooks/useDateRange', () => ({
   useDateRange: () => ({
     dateRange: '1y',
     setDateRange: vi.fn(),
-    resolvedRange: { start: '2024-01-01', end: '2025-01-01' },
+    resolvedRange: STABLE_RANGE,
     isValid: true,
   }),
 }));

--- a/frontend/src/components/reports/BillPaymentHistoryReport.test.tsx
+++ b/frontend/src/components/reports/BillPaymentHistoryReport.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@/test/render';
+import { render, screen, waitFor, fireEvent, act } from '@/test/render';
 import { BillPaymentHistoryReport } from './BillPaymentHistoryReport';
 
 const mockPush = vi.fn();
@@ -270,21 +270,30 @@ describe('BillPaymentHistoryReport', () => {
         },
       ],
     });
-    const { container } = render(<BillPaymentHistoryReport />);
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<BillPaymentHistoryReport />));
+    });
     // The view is "overview" by default; switch to "By Bill" view to render the table.
     await waitFor(() => expect(screen.getByText('By Bill')).toBeInTheDocument());
-    fireEvent.click(screen.getByText('By Bill'));
+    await act(async () => {
+      fireEvent.click(screen.getByText('By Bill'));
+    });
     await waitFor(() => expect(container.querySelector('table')).toBeInTheDocument());
     const __headerCount = container.querySelectorAll('table thead th').length;
     for (let __i = 0; __i < __headerCount; __i += 1) {
       const __ths = container.querySelectorAll('table thead th');
       if (!__ths[__i]) break;
-      fireEvent.click(__ths[__i]);
+      await act(async () => {
+        fireEvent.click(__ths[__i]);
+      });
     }
     for (let __i = 0; __i < __headerCount; __i += 1) {
       const __ths = container.querySelectorAll('table thead th');
       if (!__ths[__i]) break;
-      fireEvent.click(__ths[__i]);
+      await act(async () => {
+        fireEvent.click(__ths[__i]);
+      });
     }
   });
 });

--- a/frontend/src/components/reports/GeographicAllocationReport.test.tsx
+++ b/frontend/src/components/reports/GeographicAllocationReport.test.tsx
@@ -341,35 +341,38 @@ describe('GeographicAllocationReport', () => {
     mockGetPortfolioSummary.mockResolvedValue({ holdings: mockHoldings });
     mockGetInvestmentAccounts.mockResolvedValue([]);
     mockGetSecurities.mockResolvedValue(mockSecurities);
-    const { container } = render(<GeographicAllocationReport />);
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<GeographicAllocationReport />));
+    });
     await waitFor(() => expect(container.querySelector('table')).toBeInTheDocument());
     // Region view (default).
-    let __headerCount = container.querySelectorAll('table thead th').length;
+    const __headerCount = container.querySelectorAll('table thead th').length;
     for (let __i = 0; __i < __headerCount; __i += 1) {
       const __ths = container.querySelectorAll('table thead th');
       if (!__ths[__i]) break;
-      fireEvent.click(__ths[__i]);
+      await act(async () => { fireEvent.click(__ths[__i]); });
     }
     for (let __i = 0; __i < __headerCount; __i += 1) {
       const __ths = container.querySelectorAll('table thead th');
       if (!__ths[__i]) break;
-      fireEvent.click(__ths[__i]);
+      await act(async () => { fireEvent.click(__ths[__i]); });
     }
     // Switch to Exchange view by clicking the toggle button (text: Exchange).
     const exchangeBtns = screen.queryAllByRole('button', { name: 'Exchange' });
     if (exchangeBtns.length > 0) {
-      fireEvent.click(exchangeBtns[0]);
+      await act(async () => { fireEvent.click(exchangeBtns[0]); });
       await waitFor(() => expect(container.querySelector('table')).toBeInTheDocument());
       const __exHeaderCount = container.querySelectorAll('table thead th').length;
       for (let __i = 0; __i < __exHeaderCount; __i += 1) {
         const __ths = container.querySelectorAll('table thead th');
         if (!__ths[__i]) break;
-        fireEvent.click(__ths[__i]);
+        await act(async () => { fireEvent.click(__ths[__i]); });
       }
       for (let __i = 0; __i < __exHeaderCount; __i += 1) {
         const __ths = container.querySelectorAll('table thead th');
         if (!__ths[__i]) break;
-        fireEvent.click(__ths[__i]);
+        await act(async () => { fireEvent.click(__ths[__i]); });
       }
     }
   });

--- a/frontend/src/components/reports/InvestmentPerformanceReport.test.tsx
+++ b/frontend/src/components/reports/InvestmentPerformanceReport.test.tsx
@@ -277,7 +277,10 @@ describe('InvestmentPerformanceReport', () => {
       totalGainLossPercent: 61.1,
     });
     mockGetInvestmentAccounts.mockResolvedValue([]);
-    const { container } = render(<InvestmentPerformanceReport />);
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<InvestmentPerformanceReport />));
+    });
     await waitFor(() => expect(container.querySelector('table')).toBeInTheDocument());
     const headerCount = container.querySelectorAll('table thead th').length;
     expect(headerCount).toBeGreaterThan(0);

--- a/frontend/src/components/reports/InvestmentTransactionHistoryReport.test.tsx
+++ b/frontend/src/components/reports/InvestmentTransactionHistoryReport.test.tsx
@@ -289,7 +289,10 @@ describe('InvestmentTransactionHistoryReport', () => {
     mockGetInvestmentAccounts.mockResolvedValue([
       { id: 'acc-1', name: 'Brokerage', accountSubType: 'INVESTMENT_CASH', currencyCode: 'CAD' },
     ]);
-    const { container } = render(<InvestmentTransactionHistoryReport />);
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<InvestmentTransactionHistoryReport />));
+    });
     await waitFor(() => expect(container.querySelector('table')).toBeInTheDocument());
     const headerCount = container.querySelectorAll('table thead th').length;
     expect(headerCount).toBeGreaterThan(0);

--- a/frontend/src/components/reports/LoanAmortizationReport.test.tsx
+++ b/frontend/src/components/reports/LoanAmortizationReport.test.tsx
@@ -698,19 +698,22 @@ describe('LoanAmortizationReport', () => {
       ],
       pagination: { hasMore: false },
     });
-    const { container } = render(<LoanAmortizationReport />);
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<LoanAmortizationReport />));
+    });
     await waitFor(() => expect(container.querySelector('table')).toBeInTheDocument());
     const headerCount = container.querySelectorAll('table thead th').length;
     expect(headerCount).toBeGreaterThan(0);
     for (let __i = 0; __i < headerCount; __i += 1) {
       const __ths = container.querySelectorAll('table thead th');
       if (!__ths[__i]) break;
-      fireEvent.click(__ths[__i]);
+      await act(async () => { fireEvent.click(__ths[__i]); });
     }
     for (let __i = 0; __i < headerCount; __i += 1) {
       const __ths = container.querySelectorAll('table thead th');
       if (!__ths[__i]) break;
-      fireEvent.click(__ths[__i]);
+      await act(async () => { fireEvent.click(__ths[__i]); });
     }
   });
 });

--- a/frontend/src/components/reports/MonthlyComparisonReport.test.tsx
+++ b/frontend/src/components/reports/MonthlyComparisonReport.test.tsx
@@ -461,7 +461,10 @@ describe('MonthlyComparisonReport', () => {
 
   it('exercises every sortable column on comparison and top movers tables', async () => {
     mockGetMonthlyComparison.mockResolvedValue(mockResponse);
-    const { container } = render(<MonthlyComparisonReport />);
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<MonthlyComparisonReport />));
+    });
     await waitFor(() => expect(container.querySelectorAll('table').length).toBeGreaterThan(0));
     const tableCount = container.querySelectorAll('table').length;
     for (let t = 0; t < tableCount; t += 1) {
@@ -470,12 +473,12 @@ describe('MonthlyComparisonReport', () => {
       for (let i = 0; i < headerCount; i += 1) {
         const ths = container.querySelectorAll('table')[t].querySelectorAll('thead th');
         if (!ths[i]) break;
-        fireEvent.click(ths[i]);
+        await act(async () => { fireEvent.click(ths[i]); });
       }
       for (let i = 0; i < headerCount; i += 1) {
         const ths = container.querySelectorAll('table')[t].querySelectorAll('thead th');
         if (!ths[i]) break;
-        fireEvent.click(ths[i]);
+        await act(async () => { fireEvent.click(ths[i]); });
       }
     }
   });

--- a/frontend/src/components/reports/RecurringExpensesReport.test.tsx
+++ b/frontend/src/components/reports/RecurringExpensesReport.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@/test/render";
+import { render, screen, waitFor, fireEvent, act } from "@/test/render";
 import { RecurringExpensesReport } from "./RecurringExpensesReport";
 
 const mockPush = vi.fn();
@@ -335,19 +335,22 @@ describe("RecurringExpensesReport", () => {
       ],
       summary: { uniquePayees: 2, totalRecurring: 150, monthlyEstimate: 25 },
     });
-    const { container } = render(<RecurringExpensesReport />);
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<RecurringExpensesReport />));
+    });
     await waitFor(() => expect(container.querySelector("table")).toBeInTheDocument());
     const headerCount = container.querySelectorAll("table thead th").length;
     expect(headerCount).toBeGreaterThan(0);
     for (let __i = 0; __i < headerCount; __i += 1) {
       const __ths = container.querySelectorAll("table thead th");
       if (!__ths[__i]) break;
-      fireEvent.click(__ths[__i]);
+      await act(async () => { fireEvent.click(__ths[__i]); });
     }
     for (let __i = 0; __i < headerCount; __i += 1) {
       const __ths = container.querySelectorAll("table thead th");
       if (!__ths[__i]) break;
-      fireEvent.click(__ths[__i]);
+      await act(async () => { fireEvent.click(__ths[__i]); });
     }
   });
 });

--- a/frontend/src/components/reports/SectorWeightingsReport.test.tsx
+++ b/frontend/src/components/reports/SectorWeightingsReport.test.tsx
@@ -300,19 +300,22 @@ describe('SectorWeightingsReport', () => {
     });
     mockGetInvestmentAccounts.mockResolvedValue([]);
     mockGetSecurities.mockResolvedValue([]);
-    const { container } = render(<SectorWeightingsReport />);
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<SectorWeightingsReport />));
+    });
     await waitFor(() => expect(container.querySelector('table')).toBeInTheDocument());
     const headerCount = container.querySelectorAll('table thead th').length;
     expect(headerCount).toBeGreaterThan(0);
     for (let __i = 0; __i < headerCount; __i += 1) {
       const __ths = container.querySelectorAll('table thead th');
       if (!__ths[__i]) break;
-      fireEvent.click(__ths[__i]);
+      await act(async () => { fireEvent.click(__ths[__i]); });
     }
     for (let __i = 0; __i < headerCount; __i += 1) {
       const __ths = container.querySelectorAll('table thead th');
       if (!__ths[__i]) break;
-      fireEvent.click(__ths[__i]);
+      await act(async () => { fireEvent.click(__ths[__i]); });
     }
   });
 });

--- a/frontend/src/components/reports/SecurityTypeAllocationReport.test.tsx
+++ b/frontend/src/components/reports/SecurityTypeAllocationReport.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@/test/render';
+import { render, screen, waitFor, fireEvent, act } from '@/test/render';
 import { SecurityTypeAllocationReport } from './SecurityTypeAllocationReport';
 
 vi.mock('@/hooks/useNumberFormat', () => ({
@@ -218,18 +218,21 @@ describe('SecurityTypeAllocationReport', () => {
         { securityId: 's3', symbol: 'CCC', name: 'Charlie', currencyCode: 'CAD', securityType: 'BOND', marketValue: 2000, quantity: 20, accountId: 'a1' },
       ],
     });
-    const { container } = render(<SecurityTypeAllocationReport />);
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<SecurityTypeAllocationReport />));
+    });
     await waitFor(() => expect(container.querySelector('table')).toBeInTheDocument());
     const __headerCount = container.querySelectorAll('table thead th').length;
     for (let __i = 0; __i < __headerCount; __i += 1) {
       const __ths = container.querySelectorAll('table thead th');
       if (!__ths[__i]) break;
-      fireEvent.click(__ths[__i]);
+      await act(async () => { fireEvent.click(__ths[__i]); });
     }
     for (let __i = 0; __i < __headerCount; __i += 1) {
       const __ths = container.querySelectorAll('table thead th');
       if (!__ths[__i]) break;
-      fireEvent.click(__ths[__i]);
+      await act(async () => { fireEvent.click(__ths[__i]); });
     }
   });
 });


### PR DESCRIPTION
## Summary
Refactored the `SplitKind` enum from being defined inline in the `TransactionSplit` entity to a dedicated enum file for better code organization and reusability.

## Key Changes
- Created new file `backend/src/transactions/entities/split-kind.enum.ts` containing the `SplitKind` enum definition
- Removed `SplitKind` enum definition from `transaction-split.entity.ts`
- Updated all imports across the codebase to reference the new enum location:
  - `transaction-split.service.ts`
  - `create-transaction-split.dto.ts`
  - `create-scheduled-transaction-split.dto.ts`
  - `post-scheduled-transaction.dto.ts`
  - `scheduled-transaction-override.dto.ts`
  - `scheduled-transaction-split.entity.ts`
  - `scheduled-transactions.service.ts`

## Benefits
- Improves code organization by separating enum definitions from entity files
- Reduces circular dependency risks
- Makes the enum more discoverable and easier to import from other modules
- Follows single responsibility principle for file organization

https://claude.ai/code/session_01NRHjg8UxLUu1eLCAuHBGwb