### PR TITLE
Fix: clearing a transfer's payee now reverts to the default name

### DIFF
--- a/backend/src/transactions/dto/update-transfer.dto.ts
+++ b/backend/src/transactions/dto/update-transfer.dto.ts
@@ -64,17 +64,20 @@ export class UpdateTransferDto {
   @Max(999999999999)
   toAmount?: number;
 
-  @ApiPropertyOptional({ description: "Payee ID" })
+  @ApiPropertyOptional({ description: "Payee ID (null to clear)" })
   @IsOptional()
   @IsUUID()
-  payeeId?: string;
+  payeeId?: string | null;
 
-  @ApiPropertyOptional({ description: "Payee name" })
+  @ApiPropertyOptional({
+    description:
+      "Payee name (null to clear and revert to default 'Transfer to/from <Account>')",
+  })
   @IsOptional()
   @IsString()
   @MaxLength(100)
   @SanitizeHtml()
-  payeeName?: string;
+  payeeName?: string | null;
 
   @ApiPropertyOptional({ description: "Transfer description/notes" })
   @IsOptional()

--- a/backend/src/transactions/transaction-transfer.service.spec.ts
+++ b/backend/src/transactions/transaction-transfer.service.spec.ts
@@ -853,6 +853,81 @@ describe("TransactionTransferService", () => {
       );
     });
 
+    it("regenerates default payeeName for both transactions when payeeName is explicitly cleared with null", async () => {
+      mockFindOne
+        .mockResolvedValueOnce(fromTransaction)
+        .mockResolvedValueOnce(toTransaction)
+        .mockResolvedValueOnce(fromTransaction)
+        .mockResolvedValueOnce(toTransaction);
+
+      await service.updateTransfer(
+        "user-1",
+        "from-tx",
+        { payeeId: null, payeeName: null },
+        mockFindOne,
+      );
+
+      // Default payee names regenerated from account names
+      expect(transactionsRepository.update).toHaveBeenCalledWith(
+        "from-tx",
+        expect.objectContaining({
+          payeeId: null,
+          payeeName: "Transfer to Savings",
+        }),
+      );
+      expect(transactionsRepository.update).toHaveBeenCalledWith(
+        "to-tx",
+        expect.objectContaining({
+          payeeId: null,
+          payeeName: "Transfer from Checking",
+        }),
+      );
+    });
+
+    it("regenerates default payeeName when payeeName is cleared with empty string", async () => {
+      mockFindOne
+        .mockResolvedValueOnce(fromTransaction)
+        .mockResolvedValueOnce(toTransaction)
+        .mockResolvedValueOnce(fromTransaction)
+        .mockResolvedValueOnce(toTransaction);
+
+      await service.updateTransfer(
+        "user-1",
+        "from-tx",
+        { payeeName: "" },
+        mockFindOne,
+      );
+
+      expect(transactionsRepository.update).toHaveBeenCalledWith(
+        "from-tx",
+        expect.objectContaining({ payeeName: "Transfer to Savings" }),
+      );
+      expect(transactionsRepository.update).toHaveBeenCalledWith(
+        "to-tx",
+        expect.objectContaining({ payeeName: "Transfer from Checking" }),
+      );
+    });
+
+    it("does not modify description when only clearing the payee", async () => {
+      mockFindOne
+        .mockResolvedValueOnce(fromTransaction)
+        .mockResolvedValueOnce(toTransaction)
+        .mockResolvedValueOnce(fromTransaction)
+        .mockResolvedValueOnce(toTransaction);
+
+      await service.updateTransfer(
+        "user-1",
+        "from-tx",
+        { payeeId: null, payeeName: null },
+        mockFindOne,
+      );
+
+      const fromCall = transactionsRepository.update.mock.calls.find(
+        (c: any[]) => c[0] === "from-tx",
+      );
+      expect(fromCall[1]).not.toHaveProperty("description");
+    });
+
     it("does not update payeeName when custom payeeName is set", async () => {
       accountsService.findOne.mockImplementation(
         (_userId: string, accountId: string) => {

--- a/backend/src/transactions/transaction-transfer.service.ts
+++ b/backend/src/transactions/transaction-transfer.service.ts
@@ -10,6 +10,7 @@ import { Repository, DataSource, QueryRunner } from "typeorm";
 import { Transaction, TransactionStatus } from "./entities/transaction.entity";
 import { TransactionSplit } from "./entities/transaction-split.entity";
 import { CreateTransferDto } from "./dto/create-transfer.dto";
+import { UpdateTransferDto } from "./dto/update-transfer.dto";
 import { AccountsService } from "../accounts/accounts.service";
 import { NetWorthService } from "../net-worth/net-worth.service";
 import { isTransactionInFuture } from "../common/date-utils";
@@ -399,7 +400,7 @@ export class TransactionTransferService {
   async updateTransfer(
     userId: string,
     transactionId: string,
-    updateDto: Partial<CreateTransferDto>,
+    updateDto: Partial<UpdateTransferDto>,
     findOne: (userId: string, id: string) => Promise<Transaction>,
   ): Promise<TransferResult> {
     const transaction = await findOne(userId, transactionId);
@@ -591,7 +592,7 @@ export class TransactionTransferService {
   }
 
   private buildFromUpdateData(
-    updateDto: Partial<CreateTransferDto>,
+    updateDto: Partial<UpdateTransferDto>,
     newAmount: number,
     oldFromAccountId: string,
     oldToAccountId: string,
@@ -619,13 +620,17 @@ export class TransactionTransferService {
       data.accountId = updateDto.fromAccountId;
     }
 
-    if (
-      updateDto.toAccountId &&
-      updateDto.toAccountId !== oldToAccountId &&
-      updateDto.payeeName === undefined
-    ) {
+    const payeeNameCleared =
+      updateDto.payeeName !== undefined && !updateDto.payeeName;
+    const toAccountChanged =
+      !!updateDto.toAccountId && updateDto.toAccountId !== oldToAccountId;
+    const shouldRegenerateDefault =
+      payeeNameCleared ||
+      (toAccountChanged && updateDto.payeeName === undefined);
+
+    if (shouldRegenerateDefault) {
       data.payeeName = `Transfer to ${newToAccount.name}`;
-      if (updateDto.description === undefined) {
+      if (updateDto.description === undefined && toAccountChanged) {
         data.description = `Transfer to ${newToAccount.name}`;
       }
     }
@@ -634,7 +639,7 @@ export class TransactionTransferService {
   }
 
   private buildToUpdateData(
-    updateDto: Partial<CreateTransferDto>,
+    updateDto: Partial<UpdateTransferDto>,
     newToAmount: number,
     newExchangeRate: number,
     oldFromAccountId: string,
@@ -665,13 +670,17 @@ export class TransactionTransferService {
       data.accountId = updateDto.toAccountId;
     }
 
-    if (
-      updateDto.fromAccountId &&
-      updateDto.fromAccountId !== oldFromAccountId &&
-      updateDto.payeeName === undefined
-    ) {
+    const payeeNameCleared =
+      updateDto.payeeName !== undefined && !updateDto.payeeName;
+    const fromAccountChanged =
+      !!updateDto.fromAccountId && updateDto.fromAccountId !== oldFromAccountId;
+    const shouldRegenerateDefault =
+      payeeNameCleared ||
+      (fromAccountChanged && updateDto.payeeName === undefined);
+
+    if (shouldRegenerateDefault) {
       data.payeeName = `Transfer from ${newFromAccount.name}`;
-      if (updateDto.description === undefined) {
+      if (updateDto.description === undefined && fromAccountChanged) {
         data.description = `Transfer from ${newFromAccount.name}`;
       }
     }

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -306,7 +306,10 @@ export class TransactionsService {
       .leftJoinAndSelect("splits.transferAccount", "splitTransferAccount")
       .leftJoinAndSelect("splits.tags", "splitTags")
       .leftJoinAndSelect("splits.investmentTransaction", "splitInvestmentTx")
-      .leftJoinAndSelect("splitInvestmentTx.security", "splitInvestmentSecurity")
+      .leftJoinAndSelect(
+        "splitInvestmentTx.security",
+        "splitInvestmentSecurity",
+      )
       .leftJoinAndSelect("transaction.linkedTransaction", "linkedTransaction")
       .leftJoinAndSelect("linkedTransaction.account", "linkedAccount")
       .leftJoinAndSelect("linkedTransaction.splits", "linkedSplits")
@@ -1484,11 +1487,7 @@ export class TransactionsService {
 
     try {
       if (transaction.isSplit) {
-        await this.splitService.deleteSplitSideEffects(
-          id,
-          userId,
-          queryRunner,
-        );
+        await this.splitService.deleteSplitSideEffects(id, userId, queryRunner);
       }
 
       const parentSplit = await queryRunner.manager.findOne(TransactionSplit, {

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -15,6 +15,7 @@ import { CreateTransactionDto } from "./dto/create-transaction.dto";
 import { UpdateTransactionDto } from "./dto/update-transaction.dto";
 import { CreateTransactionSplitDto } from "./dto/create-transaction-split.dto";
 import { CreateTransferDto } from "./dto/create-transfer.dto";
+import { UpdateTransferDto } from "./dto/update-transfer.dto";
 import { TagsService } from "../tags/tags.service";
 import { AccountsService } from "../accounts/accounts.service";
 import { PayeesService } from "../payees/payees.service";
@@ -1828,7 +1829,7 @@ export class TransactionsService {
   async updateTransfer(
     userId: string,
     transactionId: string,
-    updateDto: Partial<CreateTransferDto>,
+    updateDto: Partial<UpdateTransferDto>,
   ): Promise<TransferResult> {
     const result = await this.transferService.updateTransfer(
       userId,

--- a/frontend/src/components/reports/DividendYieldGrowthReport.test.tsx
+++ b/frontend/src/components/reports/DividendYieldGrowthReport.test.tsx
@@ -687,7 +687,11 @@ describe('DividendYieldGrowthReport', () => {
   });
 
   it('detects annual dividend frequency', async () => {
-    // 2 payments ~365 days apart within trailing 12 months (current date is 2026-05-06)
+    // 2 payments ~365 days apart within trailing 12 months. Pin Date so the
+    // trailing-12-months cutoff stays consistent regardless of when the test
+    // runs (other timers stay real so waitFor still works).
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-05-06T12:00:00'));
     mockGetTransactions.mockImplementation(async ({ action }: { action: string }) => {
       if (action === 'DIVIDEND') {
         return {
@@ -702,11 +706,15 @@ describe('DividendYieldGrowthReport', () => {
     });
     mockGetInvestmentAccounts.mockResolvedValue([]);
     mockGetPortfolioSummary.mockResolvedValue({ holdings: mockHoldings });
-    render(<DividendYieldGrowthReport />);
-    await waitFor(() => {
-      expect(screen.getByText('Per-Security Dividend Yield (Trailing 12 Months)')).toBeInTheDocument();
-    });
-    expect(screen.getByText('Annual')).toBeInTheDocument();
+    try {
+      render(<DividendYieldGrowthReport />);
+      await waitFor(() => {
+        expect(screen.getByText('Per-Security Dividend Yield (Trailing 12 Months)')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Annual')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('detects semi-annual dividend frequency', async () => {

--- a/frontend/src/components/transactions/TransactionForm.test.tsx
+++ b/frontend/src/components/transactions/TransactionForm.test.tsx
@@ -2077,6 +2077,47 @@ describe('TransactionForm', () => {
         expect(toast.success).toHaveBeenCalledWith('Transfer updated');
       });
     });
+
+    it('sends null payeeId/payeeName when the user clears a previously assigned payee on a transfer', async () => {
+      const transferTx = createTransferTransaction();
+      transferTx.payeeId = 'payee-1';
+      transferTx.payeeName = 'Grocery Store';
+
+      render(
+        <TransactionForm
+          transaction={transferTx}
+          onSuccess={mockOnSuccess}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('combobox-input-Payee (Optional)')).toBeInTheDocument();
+      });
+
+      // Clear the payee field — the mocked Combobox forwards the empty string
+      // via onChange('', '') because allowCustomValue=true. We change to a
+      // non-empty value first so React registers a different value on the
+      // second change to ''.
+      fireEvent.change(screen.getByTestId('combobox-input-Payee (Optional)'), {
+        target: { value: 'x' },
+      });
+      fireEvent.change(screen.getByTestId('combobox-input-Payee (Optional)'), {
+        target: { value: '' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /Update Transfer/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateTransfer).toHaveBeenCalledWith(
+          transferTx.id,
+          expect.objectContaining({
+            payeeId: null,
+            payeeName: null,
+          })
+        );
+      });
+    });
   });
 
   // =========================================================================

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -752,8 +752,8 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
           description: data.description ?? null,
           referenceNumber: data.referenceNumber ?? null,
           status: data.status,
-          payeeId: transferPayeeId || undefined,
-          payeeName: transferPayeeName || undefined,
+          payeeId: transferPayeeId || null,
+          payeeName: transferPayeeName || null,
           tagIds: selectedTagIds.length > 0 ? selectedTagIds : [],
         };
 


### PR DESCRIPTION
When a user cleared the payee field on an existing transfer, the change
silently failed: the frontend coerced the empty fields to `undefined`,
so the backend skipped the payee update entirely.

The frontend now sends `null` when the payee is cleared, and the
backend treats an explicit `null`/empty `payeeName` as a request to
regenerate the default `Transfer to/from <Account>` description on
both linked transactions.

https://claude.ai/code/session_01XLuXCnnkNonDQj1UtGVEpD