### PR TITLE
Add reference number column to transaction list

### DIFF
--- a/frontend/src/components/transactions/TransactionList.tsx
+++ b/frontend/src/components/transactions/TransactionList.tsx
@@ -451,6 +451,7 @@ export function TransactionList({
               <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>Payee</th>
               <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden min-[900px]:table-cell`}>Category</th>
               <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden 2xl:table-cell`}>Description</th>
+              <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden 2xl:table-cell`}>Ref #</th>
               <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden xl:table-cell`}>Tags</th>
               <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>Amount</th>
               {showRunningBalance && (
@@ -463,7 +464,7 @@ export function TransactionList({
           <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
             {transactions.map((transaction, index) => {
               const isFuture = index < futureBoundaryIndex;
-              const colCount = 9
+              const colCount = 10
                 + (selectionMode ? 1 : 0)
                 + (showRunningBalance ? 1 : 0);
               return (

--- a/frontend/src/components/transactions/TransactionRow.tsx
+++ b/frontend/src/components/transactions/TransactionRow.tsx
@@ -380,6 +380,14 @@ export const TransactionRow = memo(function TransactionRow({
           {transaction.description || '-'}
         </div>
       </td>
+      <td className={`${cellPadding} text-sm text-gray-500 dark:text-gray-400 hidden 2xl:table-cell`}>
+        <div
+          className={`truncate max-w-[160px] ${isVoid ? 'line-through' : ''}`}
+          title={transaction.referenceNumber || undefined}
+        >
+          {transaction.referenceNumber || '-'}
+        </div>
+      </td>
       <td className={`${cellPadding} text-sm hidden xl:table-cell`}>
         {transaction.tags && transaction.tags.length > 0 ? (
           <div className="flex flex-wrap gap-1">


### PR DESCRIPTION
## Summary
Added a new "Reference Number" column to the transaction list table to display transaction reference numbers alongside other transaction details.

## Key Changes
- Added a new table header "Ref #" in the transaction list that displays on 2xl screens and larger
- Added a corresponding table cell in TransactionRow that displays the transaction's reference number
- The reference number cell includes:
  - Truncation with a max-width of 160px for long reference numbers
  - A tooltip showing the full reference number on hover
  - Strike-through styling applied to void transactions (consistent with other columns)
  - Fallback to '-' when no reference number is present
- Updated the column count calculation from 9 to 10 to account for the new column in responsive layout calculations

## Implementation Details
- The new column is hidden on smaller screens and only visible at the 2xl breakpoint, maintaining the responsive design pattern used for other optional columns (Description, Tags)
- Styling is consistent with existing columns using the same padding, text color, and dark mode support
- The reference number display respects the void transaction state by applying line-through styling

https://claude.ai/code/session_01HKW7JFMd1t63Hhn8gNWhb5