### PR TITLE
Add transaction reconciliation status filtering

### DIFF
--- a/backend/src/transactions/transactions.controller.spec.ts
+++ b/backend/src/transactions/transactions.controller.spec.ts
@@ -149,6 +149,7 @@ describe("TransactionsController", () => {
         undefined,
         undefined,
         undefined,
+        undefined,
       );
     });
 
@@ -178,6 +179,7 @@ describe("TransactionsController", () => {
         undefined,
         undefined,
         undefined,
+        undefined,
       );
     });
 
@@ -196,6 +198,7 @@ describe("TransactionsController", () => {
         undefined,
         undefined,
         false,
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -231,6 +234,7 @@ describe("TransactionsController", () => {
         2,
         25,
         false,
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -272,6 +276,7 @@ describe("TransactionsController", () => {
         undefined,
         undefined,
         undefined,
+        undefined,
       );
     });
 
@@ -307,6 +312,7 @@ describe("TransactionsController", () => {
         false,
         "grocery",
         uuid3,
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -448,6 +454,74 @@ describe("TransactionsController", () => {
       expect(() => controller.findAll(mockReq, "not-a-uuid")).toThrow(
         BadRequestException,
       );
+    });
+
+    it("parses statuses from comma-separated string", async () => {
+      mockService.findAll.mockResolvedValue({ data: [], total: 0 });
+
+      await controller.findAll(
+        mockReq,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "UNRECONCILED,CLEARED",
+      );
+
+      expect(mockService.findAll).toHaveBeenCalledWith(
+        "user-1",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        false,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        ["UNRECONCILED", "CLEARED"],
+      );
+    });
+
+    it("rejects an unknown reconciliation status", () => {
+      expect(() =>
+        controller.findAll(
+          mockReq,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          "BOGUS",
+        ),
+      ).toThrow(BadRequestException);
     });
 
     it("rejects invalid targetTransactionId", () => {
@@ -912,6 +986,7 @@ describe("TransactionsController", () => {
         undefined,
         -100.5,
         500.25,
+        undefined,
         undefined,
       );
     });

--- a/backend/src/transactions/transactions.controller.ts
+++ b/backend/src/transactions/transactions.controller.ts
@@ -24,6 +24,7 @@ import {
 } from "@nestjs/swagger";
 import { AuthGuard } from "@nestjs/passport";
 import { TransactionsService } from "./transactions.service";
+import { TransactionStatus } from "./entities/transaction.entity";
 import { CreateTransactionDto } from "./dto/create-transaction.dto";
 import { UpdateTransactionDto } from "./dto/update-transaction.dto";
 import { CreateTransactionSplitDto } from "./dto/create-transaction-split.dto";
@@ -44,6 +45,26 @@ import {
   UUID_REGEX,
   DATE_REGEX,
 } from "../common/query-param-utils";
+
+const ALL_TRANSACTION_STATUSES = new Set<string>(
+  Object.values(TransactionStatus),
+);
+
+function parseTransactionStatuses(
+  value?: string,
+): TransactionStatus[] | undefined {
+  if (!value) return undefined;
+  const statuses = value
+    .split(",")
+    .map((s) => s.trim().toUpperCase())
+    .filter((s) => s);
+  for (const status of statuses) {
+    if (!ALL_TRANSACTION_STATUSES.has(status)) {
+      throw new BadRequestException(`Invalid transaction status: ${status}`);
+    }
+  }
+  return statuses.length > 0 ? (statuses as TransactionStatus[]) : undefined;
+}
 
 @ApiTags("Transactions")
 @Controller("transactions")
@@ -144,6 +165,12 @@ export class TransactionsController {
     description: "Filter by tag IDs (comma-separated)",
   })
   @ApiQuery({
+    name: "statuses",
+    required: false,
+    description:
+      "Filter by reconciliation statuses (comma-separated: UNRECONCILED, CLEARED, RECONCILED, VOID)",
+  })
+  @ApiQuery({
     name: "targetTransactionId",
     required: false,
     description:
@@ -173,6 +200,7 @@ export class TransactionsController {
     @Query("amountFrom") amountFrom?: string,
     @Query("amountTo") amountTo?: string,
     @Query("tagIds") tagIdsParam?: string,
+    @Query("statuses") statusesParam?: string,
   ) {
     // Validate pagination parameters
     if (page !== undefined) {
@@ -230,6 +258,7 @@ export class TransactionsController {
       parsedAmountFrom,
       parsedAmountTo,
       parseUuids(tagIdsParam),
+      parseTransactionStatuses(statusesParam),
     );
   }
 

--- a/backend/src/transactions/transactions.service.spec.ts
+++ b/backend/src/transactions/transactions.service.spec.ts
@@ -1658,6 +1658,67 @@ describe("TransactionsService", () => {
       );
     });
 
+    it("filters by reconciliation statuses when provided", async () => {
+      const mockQb = createMockQueryBuilder();
+      mockQb.getManyAndCount.mockResolvedValue([[], 0]);
+      transactionsRepository.createQueryBuilder.mockReturnValue(mockQb);
+      investmentTxRepository.find.mockResolvedValue([]);
+
+      await service.findAll(
+        "user-1",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        1,
+        50,
+        false,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [TransactionStatus.UNRECONCILED, TransactionStatus.CLEARED],
+      );
+
+      expect(mockQb.andWhere).toHaveBeenCalledWith(
+        "transaction.status IN (:...statuses)",
+        { statuses: [TransactionStatus.UNRECONCILED, TransactionStatus.CLEARED] },
+      );
+    });
+
+    it("does not apply status filter when statuses is empty", async () => {
+      const mockQb = createMockQueryBuilder();
+      mockQb.getManyAndCount.mockResolvedValue([[], 0]);
+      transactionsRepository.createQueryBuilder.mockReturnValue(mockQb);
+      investmentTxRepository.find.mockResolvedValue([]);
+
+      await service.findAll(
+        "user-1",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        1,
+        50,
+        false,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [],
+      );
+
+      const statusCalls = mockQb.andWhere.mock.calls.filter(
+        (call: any[]) =>
+          typeof call[0] === "string" && call[0].includes("transaction.status"),
+      );
+      expect(statusCalls.length).toBe(0);
+    });
+
     it("includes investment brokerage accounts when requested", async () => {
       const mockQb = createMockQueryBuilder();
       mockQb.getManyAndCount.mockResolvedValue([[], 0]);

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -291,6 +291,7 @@ export class TransactionsService {
     amountFrom?: number,
     amountTo?: number,
     tagIds?: string[],
+    statuses?: TransactionStatus[],
   ): Promise<PaginatedTransactions> {
     let safePage = Math.max(1, page);
     const safeLimit = Math.min(200, Math.max(1, limit));
@@ -390,6 +391,12 @@ export class TransactionsService {
           });
         }),
       );
+    }
+
+    if (statuses && statuses.length > 0) {
+      queryBuilder.andWhere("transaction.status IN (:...statuses)", {
+        statuses,
+      });
     }
 
     if (targetTransactionId) {

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -188,6 +188,7 @@ function TransactionsContent() {
           targetTransactionId: targetTransactionId || undefined,
           amountFrom: parsedAmountFrom,
           amountTo: parsedAmountTo,
+          statuses: filters.filterStatuses.length > 0 ? filters.filterStatuses : undefined,
         }),
         chartPromise,
       ]);
@@ -225,7 +226,7 @@ function TransactionsContent() {
     } finally {
       setIsLoading(false);
     }
-  }, [filters.filterAccountIds, filters.filterAccountStatus, filters.filteredAccounts, filters.filterCategoryIds, filters.filterPayeeIds, filters.filterTagIds, filters.filterStartDate, filters.filterEndDate, filters.filterSearch, filters.filterAmountFrom, filters.filterAmountTo]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [filters.filterAccountIds, filters.filterAccountStatus, filters.filteredAccounts, filters.filterCategoryIds, filters.filterPayeeIds, filters.filterTagIds, filters.filterStartDate, filters.filterEndDate, filters.filterSearch, filters.filterAmountFrom, filters.filterAmountTo, filters.filterStatuses]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const loadData = useCallback(async (page: number = filters.currentPage) => {
     await loadTransactions(page);
@@ -278,6 +279,7 @@ function TransactionsContent() {
         search: filters.filterSearch,
         amountFrom: filters.filterAmountFrom,
         amountTo: filters.filterAmountTo,
+        statuses: filters.filterStatuses,
       }, wasFilterChange);
     }
 
@@ -289,7 +291,7 @@ function TransactionsContent() {
     } else {
       loadTransactions(page);
     }
-  }, [filters.currentPage, filters.filterAccountIds, filters.filterCategoryIds, filters.filterPayeeIds, filters.filterTagIds, filters.filterStartDate, filters.filterEndDate, filters.filterSearch, filters.filterAmountFrom, filters.filterAmountTo, filters.updateUrl, loadTransactions, filters.filtersInitialized, undoRedoTick]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [filters.currentPage, filters.filterAccountIds, filters.filterCategoryIds, filters.filterPayeeIds, filters.filterTagIds, filters.filterStartDate, filters.filterEndDate, filters.filterSearch, filters.filterAmountFrom, filters.filterAmountTo, filters.filterStatuses, filters.updateUrl, loadTransactions, filters.filtersInitialized, undoRedoTick]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Patch popstate handler to skip when modals open
   useEffect(() => {
@@ -598,6 +600,7 @@ function TransactionsContent() {
         search: filters.filterSearch || undefined,
         amountFrom: parsedAmountFrom,
         amountTo: parsedAmountTo,
+        statuses: filters.filterStatuses.length > 0 ? filters.filterStatuses : undefined,
       };
 
       // Fetch all pages of filtered transactions
@@ -665,7 +668,7 @@ function TransactionsContent() {
     } finally {
       setIsExporting(false);
     }
-  }, [filters.filterAccountIds, filters.filteredAccounts, filters.filterCategoryIds, filters.filterPayeeIds, filters.filterTagIds, filters.filterStartDate, filters.filterEndDate, filters.filterSearch, filters.filterAmountFrom, filters.filterAmountTo]);
+  }, [filters.filterAccountIds, filters.filteredAccounts, filters.filterCategoryIds, filters.filterPayeeIds, filters.filterTagIds, filters.filterStartDate, filters.filterEndDate, filters.filterSearch, filters.filterAmountFrom, filters.filterAmountTo, filters.filterStatuses]);
 
   return (
     <PageLayout>
@@ -771,6 +774,7 @@ function TransactionsContent() {
           filterAmountFrom={filters.filterAmountFrom}
           filterAmountTo={filters.filterAmountTo}
           filterTagIds={filters.filterTagIds}
+          filterStatuses={filters.filterStatuses}
           weekStartsOn={weekStartsOn}
           handleArrayFilterChange={filters.handleArrayFilterChange}
           handleFilterChange={filters.handleFilterChange}
@@ -786,6 +790,7 @@ function TransactionsContent() {
           setFilterAmountFrom={filters.setFilterAmountFrom}
           setFilterAmountTo={filters.setFilterAmountTo}
           setFilterTagIds={filters.setFilterTagIds}
+          setFilterStatuses={filters.setFilterStatuses}
           filtersExpanded={filters.filtersExpanded}
           setFiltersExpanded={filters.setFiltersExpanded}
           activeFilterCount={filters.activeFilterCount}

--- a/frontend/src/components/transactions/TransactionFilterPanel.test.tsx
+++ b/frontend/src/components/transactions/TransactionFilterPanel.test.tsx
@@ -1639,7 +1639,7 @@ describe('TransactionFilterPanel', () => {
   });
 
   describe('Reconciliation status filter', () => {
-    it('renders the Reconciliation MultiSelect when expanded', () => {
+    it('renders the Status MultiSelect when expanded', () => {
       render(
         <TransactionFilterPanel
           {...defaultProps}
@@ -1647,7 +1647,7 @@ describe('TransactionFilterPanel', () => {
         />,
       );
 
-      expect(screen.getByText('Reconciliation')).toBeInTheDocument();
+      expect(screen.getByText('Status')).toBeInTheDocument();
       expect(screen.getByText('All statuses')).toBeInTheDocument();
     });
 

--- a/frontend/src/components/transactions/TransactionFilterPanel.test.tsx
+++ b/frontend/src/components/transactions/TransactionFilterPanel.test.tsx
@@ -101,6 +101,8 @@ describe('TransactionFilterPanel', () => {
     setFilterTagIds: vi.fn(),
     selectedTags: [],
     tagFilterOptions: [],
+    filterStatuses: [] as never[],
+    setFilterStatuses: vi.fn(),
     onClearFilters: vi.fn(),
   };
 
@@ -1633,6 +1635,54 @@ describe('TransactionFilterPanel', () => {
       );
 
       expect(screen.queryByLabelText('Remove amount filter')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Reconciliation status filter', () => {
+    it('renders the Reconciliation MultiSelect when expanded', () => {
+      render(
+        <TransactionFilterPanel
+          {...defaultProps}
+          filtersExpanded={true}
+        />,
+      );
+
+      expect(screen.getByText('Reconciliation')).toBeInTheDocument();
+      expect(screen.getByText('All statuses')).toBeInTheDocument();
+    });
+
+    it('shows a chip per selected status when collapsed', () => {
+      render(
+        <TransactionFilterPanel
+          {...defaultProps}
+          filtersExpanded={false}
+          activeFilterCount={2}
+          filterStatuses={['UNRECONCILED', 'VOID'] as any}
+        />,
+      );
+
+      expect(screen.getByText('Unreconciled')).toBeInTheDocument();
+      expect(screen.getByText('Void')).toBeInTheDocument();
+      expect(screen.getByLabelText('Remove Unreconciled filter')).toBeInTheDocument();
+      expect(screen.getByLabelText('Remove Void filter')).toBeInTheDocument();
+    });
+
+    it('removes a status from filterStatuses when its chip remove button is clicked', () => {
+      render(
+        <TransactionFilterPanel
+          {...defaultProps}
+          filtersExpanded={false}
+          activeFilterCount={2}
+          filterStatuses={['UNRECONCILED', 'CLEARED'] as any}
+        />,
+      );
+
+      fireEvent.click(screen.getByLabelText('Remove Cleared filter'));
+
+      expect(defaultProps.handleArrayFilterChange).toHaveBeenCalledWith(
+        defaultProps.setFilterStatuses,
+        ['UNRECONCILED'],
+      );
     });
   });
 });

--- a/frontend/src/components/transactions/TransactionFilterPanel.tsx
+++ b/frontend/src/components/transactions/TransactionFilterPanel.tsx
@@ -468,7 +468,7 @@ export function TransactionFilterPanel({
               {/* Second row: Time period, dates, amount range, reconciliation status, and search.
                   Uses an explicit fr template so Reconciliation can be a fraction
                   of the width of the other inputs. */}
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[1fr_2fr_2fr_2fr_2fr_1fr_2fr] gap-4 mt-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[2fr_2fr_2fr_1fr_1fr_2fr_3fr] gap-4 mt-4">
                 <Select
                   label="Time Period"
                   options={TIME_PERIOD_OPTIONS}

--- a/frontend/src/components/transactions/TransactionFilterPanel.tsx
+++ b/frontend/src/components/transactions/TransactionFilterPanel.tsx
@@ -537,7 +537,7 @@ export function TransactionFilterPanel({
                 />
 
                 <MultiSelect
-                  label="Reconciliation"
+                  label="Status"
                   options={STATUS_FILTER_OPTIONS}
                   value={filterStatuses}
                   onChange={(values) => handleArrayFilterChange(setFilterStatuses, values as TransactionStatus[])}

--- a/frontend/src/components/transactions/TransactionFilterPanel.tsx
+++ b/frontend/src/components/transactions/TransactionFilterPanel.tsx
@@ -466,107 +466,92 @@ export function TransactionFilterPanel({
               </div>
 
               {/* Second row: Time period, dates, amount range, reconciliation status, and search.
-                  Uses a 12-column grid so the Reconciliation dropdown can take width
-                  from the four narrow date/amount inputs while Time Period and Search
-                  keep their original size. */}
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-12 gap-4 mt-4">
-                <div className="lg:col-span-2">
-                  <Select
-                    label="Time Period"
-                    options={TIME_PERIOD_OPTIONS}
-                    value={filterTimePeriod}
-                    onChange={(e) => {
-                      const period = e.target.value;
-                      setFilterTimePeriod(period);
-                      if (period && period !== 'custom') {
-                        const { startDate, endDate } = resolveTimePeriod(period as TimePeriod, weekStartsOn);
-                        handleFilterChange(setFilterStartDate, startDate);
-                        handleFilterChange(setFilterEndDate, endDate);
-                      }
-                    }}
-                  />
-                </div>
+                  Uses an explicit fr template so Reconciliation can be a fraction
+                  of the width of the other inputs. */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[1fr_2fr_2fr_2fr_2fr_1fr_2fr] gap-4 mt-4">
+                <Select
+                  label="Time Period"
+                  options={TIME_PERIOD_OPTIONS}
+                  value={filterTimePeriod}
+                  onChange={(e) => {
+                    const period = e.target.value;
+                    setFilterTimePeriod(period);
+                    if (period && period !== 'custom') {
+                      const { startDate, endDate } = resolveTimePeriod(period as TimePeriod, weekStartsOn);
+                      handleFilterChange(setFilterStartDate, startDate);
+                      handleFilterChange(setFilterEndDate, endDate);
+                    }
+                  }}
+                />
 
-                <div className="lg:col-span-1">
-                  <DateInput
-                    label="Start Date"
-                    value={filterStartDate}
-                    onDateChange={(date) => {
-                      handleFilterChange(setFilterStartDate, date);
-                      if (filterTimePeriod && filterTimePeriod !== 'custom') {
-                        setFilterTimePeriod('custom');
-                      }
-                    }}
-                    onChange={(e) => {
-                      handleFilterChange(setFilterStartDate, e.target.value);
-                      if (filterTimePeriod && filterTimePeriod !== 'custom') {
-                        setFilterTimePeriod('custom');
-                      }
-                    }}
-                  />
-                </div>
+                <DateInput
+                  label="Start Date"
+                  value={filterStartDate}
+                  onDateChange={(date) => {
+                    handleFilterChange(setFilterStartDate, date);
+                    if (filterTimePeriod && filterTimePeriod !== 'custom') {
+                      setFilterTimePeriod('custom');
+                    }
+                  }}
+                  onChange={(e) => {
+                    handleFilterChange(setFilterStartDate, e.target.value);
+                    if (filterTimePeriod && filterTimePeriod !== 'custom') {
+                      setFilterTimePeriod('custom');
+                    }
+                  }}
+                />
 
-                <div className="lg:col-span-1">
-                  <DateInput
-                    label="End Date"
-                    value={filterEndDate}
-                    onDateChange={(date) => {
-                      handleFilterChange(setFilterEndDate, date);
-                      if (filterTimePeriod && filterTimePeriod !== 'custom') {
-                        setFilterTimePeriod('custom');
-                      }
-                    }}
-                    onChange={(e) => {
-                      handleFilterChange(setFilterEndDate, e.target.value);
-                      if (filterTimePeriod && filterTimePeriod !== 'custom') {
-                        setFilterTimePeriod('custom');
-                      }
-                    }}
-                  />
-                </div>
+                <DateInput
+                  label="End Date"
+                  value={filterEndDate}
+                  onDateChange={(date) => {
+                    handleFilterChange(setFilterEndDate, date);
+                    if (filterTimePeriod && filterTimePeriod !== 'custom') {
+                      setFilterTimePeriod('custom');
+                    }
+                  }}
+                  onChange={(e) => {
+                    handleFilterChange(setFilterEndDate, e.target.value);
+                    if (filterTimePeriod && filterTimePeriod !== 'custom') {
+                      setFilterTimePeriod('custom');
+                    }
+                  }}
+                />
 
-                <div className="lg:col-span-1">
-                  <Input
-                    label="Amount From"
-                    type="number"
-                    step="0.01"
-                    value={filterAmountFrom}
-                    onChange={(e) => handleFilterChange(setFilterAmountFrom, e.target.value)}
-                    placeholder="Min"
-                  />
-                </div>
+                <Input
+                  label="Amount From"
+                  type="number"
+                  step="0.01"
+                  value={filterAmountFrom}
+                  onChange={(e) => handleFilterChange(setFilterAmountFrom, e.target.value)}
+                  placeholder="Min"
+                />
 
-                <div className="lg:col-span-1">
-                  <Input
-                    label="Amount To"
-                    type="number"
-                    step="0.01"
-                    value={filterAmountTo}
-                    onChange={(e) => handleFilterChange(setFilterAmountTo, e.target.value)}
-                    placeholder="Max"
-                  />
-                </div>
+                <Input
+                  label="Amount To"
+                  type="number"
+                  step="0.01"
+                  value={filterAmountTo}
+                  onChange={(e) => handleFilterChange(setFilterAmountTo, e.target.value)}
+                  placeholder="Max"
+                />
 
-                <div className="lg:col-span-4">
-                  <MultiSelect
-                    label="Reconciliation"
-                    options={STATUS_FILTER_OPTIONS}
-                    value={filterStatuses}
-                    onChange={(values) => handleArrayFilterChange(setFilterStatuses, values as TransactionStatus[])}
-                    placeholder="All statuses"
-                    showSearch={false}
-                  />
-                </div>
+                <MultiSelect
+                  label="Reconciliation"
+                  options={STATUS_FILTER_OPTIONS}
+                  value={filterStatuses}
+                  onChange={(values) => handleArrayFilterChange(setFilterStatuses, values as TransactionStatus[])}
+                  placeholder="All statuses"
+                  showSearch={false}
+                />
 
-                <div className="lg:col-span-2">
-                  <Input
-                    label="Search"
-                    type="text"
-                    value={searchInput}
-                    onChange={(e) => handleSearchChange(e.target.value)}
-                    placeholder="Search payee, category, amount, tag, description, reference #..."
-                  />
-                </div>
+                <Input
+                  label="Search"
+                  type="text"
+                  value={searchInput}
+                  onChange={(e) => handleSearchChange(e.target.value)}
+                  placeholder="Search payee, category, amount, tag, description, reference #..."
+                />
               </div>
 
               {/* Bulk Update button - mobile only (full width at bottom) */}

--- a/frontend/src/components/transactions/TransactionFilterPanel.tsx
+++ b/frontend/src/components/transactions/TransactionFilterPanel.tsx
@@ -9,7 +9,22 @@ import { Account } from '@/types/account';
 import { Category } from '@/types/category';
 import { Payee } from '@/types/payee';
 import { Tag } from '@/types/tag';
+import { TransactionStatus } from '@/types/transaction';
 import { TimePeriod, TIME_PERIOD_OPTIONS, resolveTimePeriod } from '@/lib/time-periods';
+
+const STATUS_LABELS: Record<TransactionStatus, string> = {
+  [TransactionStatus.UNRECONCILED]: 'Unreconciled',
+  [TransactionStatus.CLEARED]: 'Cleared',
+  [TransactionStatus.RECONCILED]: 'Reconciled',
+  [TransactionStatus.VOID]: 'Void',
+};
+
+const STATUS_FILTER_OPTIONS: MultiSelectOption[] = [
+  { value: TransactionStatus.UNRECONCILED, label: STATUS_LABELS[TransactionStatus.UNRECONCILED] },
+  { value: TransactionStatus.CLEARED, label: STATUS_LABELS[TransactionStatus.CLEARED] },
+  { value: TransactionStatus.RECONCILED, label: STATUS_LABELS[TransactionStatus.RECONCILED] },
+  { value: TransactionStatus.VOID, label: STATUS_LABELS[TransactionStatus.VOID] },
+];
 
 interface TransactionFilterPanelProps {
   filterAccountIds: string[];
@@ -24,6 +39,7 @@ interface TransactionFilterPanelProps {
   filterAmountFrom: string;
   filterAmountTo: string;
   filterTagIds: string[];
+  filterStatuses: TransactionStatus[];
   weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   handleArrayFilterChange: <T>(setter: (value: T) => void, value: T) => void;
   handleFilterChange: (setter: (value: string) => void, value: string) => void;
@@ -39,6 +55,7 @@ interface TransactionFilterPanelProps {
   setFilterAmountFrom: (value: string) => void;
   setFilterAmountTo: (value: string) => void;
   setFilterTagIds: (value: string[]) => void;
+  setFilterStatuses: (value: TransactionStatus[]) => void;
   filtersExpanded: boolean;
   setFiltersExpanded: (value: boolean) => void;
   activeFilterCount: number;
@@ -70,6 +87,7 @@ export function TransactionFilterPanel({
   filterAmountFrom,
   filterAmountTo,
   filterTagIds,
+  filterStatuses,
   weekStartsOn,
   handleArrayFilterChange,
   handleFilterChange,
@@ -85,6 +103,7 @@ export function TransactionFilterPanel({
   setFilterAmountFrom,
   setFilterAmountTo,
   setFilterTagIds,
+  setFilterStatuses,
   filtersExpanded,
   setFiltersExpanded,
   activeFilterCount,
@@ -320,6 +339,24 @@ export function TransactionFilterPanel({
                   </button>
                 </span>
               )}
+              {/* Reconciliation status chips - Indigo */}
+              {filterStatuses.map(status => (
+                <span
+                  key={`status-${status}`}
+                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-indigo-100 dark:bg-indigo-900 text-indigo-800 dark:text-indigo-200 whitespace-nowrap"
+                >
+                  {STATUS_LABELS[status]}
+                  <button
+                    onClick={() => handleArrayFilterChange(setFilterStatuses, filterStatuses.filter(s => s !== status))}
+                    className="ml-0.5 -mr-1 p-0.5 rounded-full inline-flex items-center justify-center hover:bg-indigo-200 dark:hover:bg-indigo-800"
+                    aria-label={`Remove ${STATUS_LABELS[status]} filter`}
+                  >
+                    <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </span>
+              ))}
               {/* Search chip - Gray */}
               {filterSearch && (
                 <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200 whitespace-nowrap">
@@ -428,82 +465,108 @@ export function TransactionFilterPanel({
                 />
               </div>
 
-              {/* Second row: Time period, dates, amount range, and search */}
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4 mt-4">
-                <Select
-                  label="Time Period"
-                  options={TIME_PERIOD_OPTIONS}
-                  value={filterTimePeriod}
-                  onChange={(e) => {
-                    const period = e.target.value;
-                    setFilterTimePeriod(period);
-                    if (period && period !== 'custom') {
-                      const { startDate, endDate } = resolveTimePeriod(period as TimePeriod, weekStartsOn);
-                      handleFilterChange(setFilterStartDate, startDate);
-                      handleFilterChange(setFilterEndDate, endDate);
-                    }
-                  }}
-                />
+              {/* Second row: Time period, dates, amount range, reconciliation status, and search.
+                  Uses a 12-column grid so the Reconciliation dropdown can take width
+                  from the four narrow date/amount inputs while Time Period and Search
+                  keep their original size. */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-12 gap-4 mt-4">
+                <div className="lg:col-span-2">
+                  <Select
+                    label="Time Period"
+                    options={TIME_PERIOD_OPTIONS}
+                    value={filterTimePeriod}
+                    onChange={(e) => {
+                      const period = e.target.value;
+                      setFilterTimePeriod(period);
+                      if (period && period !== 'custom') {
+                        const { startDate, endDate } = resolveTimePeriod(period as TimePeriod, weekStartsOn);
+                        handleFilterChange(setFilterStartDate, startDate);
+                        handleFilterChange(setFilterEndDate, endDate);
+                      }
+                    }}
+                  />
+                </div>
 
-                <DateInput
-                  label="Start Date"
-                  value={filterStartDate}
-                  onDateChange={(date) => {
-                    handleFilterChange(setFilterStartDate, date);
-                    if (filterTimePeriod && filterTimePeriod !== 'custom') {
-                      setFilterTimePeriod('custom');
-                    }
-                  }}
-                  onChange={(e) => {
-                    handleFilterChange(setFilterStartDate, e.target.value);
-                    if (filterTimePeriod && filterTimePeriod !== 'custom') {
-                      setFilterTimePeriod('custom');
-                    }
-                  }}
-                />
+                <div className="lg:col-span-1">
+                  <DateInput
+                    label="Start Date"
+                    value={filterStartDate}
+                    onDateChange={(date) => {
+                      handleFilterChange(setFilterStartDate, date);
+                      if (filterTimePeriod && filterTimePeriod !== 'custom') {
+                        setFilterTimePeriod('custom');
+                      }
+                    }}
+                    onChange={(e) => {
+                      handleFilterChange(setFilterStartDate, e.target.value);
+                      if (filterTimePeriod && filterTimePeriod !== 'custom') {
+                        setFilterTimePeriod('custom');
+                      }
+                    }}
+                  />
+                </div>
 
-                <DateInput
-                  label="End Date"
-                  value={filterEndDate}
-                  onDateChange={(date) => {
-                    handleFilterChange(setFilterEndDate, date);
-                    if (filterTimePeriod && filterTimePeriod !== 'custom') {
-                      setFilterTimePeriod('custom');
-                    }
-                  }}
-                  onChange={(e) => {
-                    handleFilterChange(setFilterEndDate, e.target.value);
-                    if (filterTimePeriod && filterTimePeriod !== 'custom') {
-                      setFilterTimePeriod('custom');
-                    }
-                  }}
-                />
+                <div className="lg:col-span-1">
+                  <DateInput
+                    label="End Date"
+                    value={filterEndDate}
+                    onDateChange={(date) => {
+                      handleFilterChange(setFilterEndDate, date);
+                      if (filterTimePeriod && filterTimePeriod !== 'custom') {
+                        setFilterTimePeriod('custom');
+                      }
+                    }}
+                    onChange={(e) => {
+                      handleFilterChange(setFilterEndDate, e.target.value);
+                      if (filterTimePeriod && filterTimePeriod !== 'custom') {
+                        setFilterTimePeriod('custom');
+                      }
+                    }}
+                  />
+                </div>
 
-                <Input
-                  label="Amount From"
-                  type="number"
-                  step="0.01"
-                  value={filterAmountFrom}
-                  onChange={(e) => handleFilterChange(setFilterAmountFrom, e.target.value)}
-                  placeholder="Min"
-                />
+                <div className="lg:col-span-1">
+                  <Input
+                    label="Amount From"
+                    type="number"
+                    step="0.01"
+                    value={filterAmountFrom}
+                    onChange={(e) => handleFilterChange(setFilterAmountFrom, e.target.value)}
+                    placeholder="Min"
+                  />
+                </div>
 
-                <Input
-                  label="Amount To"
-                  type="number"
-                  step="0.01"
-                  value={filterAmountTo}
-                  onChange={(e) => handleFilterChange(setFilterAmountTo, e.target.value)}
-                  placeholder="Max"
-                />
+                <div className="lg:col-span-1">
+                  <Input
+                    label="Amount To"
+                    type="number"
+                    step="0.01"
+                    value={filterAmountTo}
+                    onChange={(e) => handleFilterChange(setFilterAmountTo, e.target.value)}
+                    placeholder="Max"
+                  />
+                </div>
 
-                <Input
-                  label="Search"
-                  type="text"
-                  value={searchInput}
-                  onChange={(e) => handleSearchChange(e.target.value)}
-                  placeholder="Search payee, category, amount, tag, description, reference #..."
-                />
+                <div className="lg:col-span-4">
+                  <MultiSelect
+                    label="Reconciliation"
+                    options={STATUS_FILTER_OPTIONS}
+                    value={filterStatuses}
+                    onChange={(values) => handleArrayFilterChange(setFilterStatuses, values as TransactionStatus[])}
+                    placeholder="All statuses"
+                    showSearch={false}
+                  />
+                </div>
+
+                <div className="lg:col-span-2">
+                  <Input
+                    label="Search"
+                    type="text"
+                    value={searchInput}
+                    onChange={(e) => handleSearchChange(e.target.value)}
+                    placeholder="Search payee, category, amount, tag, description, reference #..."
+                  />
+                </div>
               </div>
 
               {/* Bulk Update button - mobile only (full width at bottom) */}

--- a/frontend/src/hooks/useTransactionFilters.test.ts
+++ b/frontend/src/hooks/useTransactionFilters.test.ts
@@ -140,6 +140,18 @@ describe('useTransactionFilters - URL/localStorage initialization', () => {
     expect(result.current.filterTagIds).toEqual(['t1', 't2']);
   });
 
+  it('reads valid statuses from URL params and drops unknown values', () => {
+    mockSearchParams = new URLSearchParams('statuses=UNRECONCILED,CLEARED,BOGUS');
+    const { result } = renderHook(() => useTransactionFilters(defaultOptions));
+    expect(result.current.filterStatuses).toEqual(['UNRECONCILED', 'CLEARED']);
+  });
+
+  it('reads statuses from localStorage when no URL params present', () => {
+    localStorage.setItem('transactions.filter.statuses', JSON.stringify(['VOID']));
+    const { result } = renderHook(() => useTransactionFilters(defaultOptions));
+    expect(result.current.filterStatuses).toEqual(['VOID']);
+  });
+
   it('initializes currentPage from URL', () => {
     mockSearchParams = new URLSearchParams('page=3');
     const { result } = renderHook(() => useTransactionFilters(defaultOptions));
@@ -312,6 +324,7 @@ describe('useTransactionFilters - URL update', () => {
         search: 'foo',
         amountFrom: '1',
         amountTo: '5',
+        statuses: [],
       });
     });
     expect(mockReplace).toHaveBeenCalled();
@@ -327,6 +340,7 @@ describe('useTransactionFilters - URL update', () => {
       result.current.updateUrl(1, {
         accountIds: [], categoryIds: [], payeeIds: [], tagIds: [],
         startDate: '', endDate: '', search: '', amountFrom: '', amountTo: '',
+        statuses: [],
       }, true);
     });
     expect(mockPush).toHaveBeenCalledWith('/transactions', { scroll: false });
@@ -532,6 +546,46 @@ describe('useTransactionFilters - filter persistence', () => {
     });
     expect(localStorage.getItem('transactions.filter.accountStatus')).toBe('"active"');
   });
+
+  it('persists filterStatuses to localStorage', () => {
+    const { result } = renderHook(() => useTransactionFilters(defaultOptions));
+    act(() => {
+      result.current.setFilterStatuses(['UNRECONCILED' as any, 'CLEARED' as any]);
+    });
+    expect(localStorage.getItem('transactions.filter.statuses')).toBe(
+      JSON.stringify(['UNRECONCILED', 'CLEARED']),
+    );
+  });
+
+  it('includes statuses in updateUrl output and counts them in activeFilterCount', () => {
+    const { result } = renderHook(() => useTransactionFilters(defaultOptions));
+    act(() => {
+      result.current.setFilterStatuses(['RECONCILED' as any, 'VOID' as any]);
+    });
+    expect(result.current.activeFilterCount).toBe(2);
+
+    act(() => {
+      result.current.updateUrl(1, {
+        accountIds: [], categoryIds: [], payeeIds: [], tagIds: [],
+        startDate: '', endDate: '', search: '', amountFrom: '', amountTo: '',
+        statuses: result.current.filterStatuses,
+      });
+    });
+    expect(mockReplace).toHaveBeenCalled();
+    expect(mockReplace.mock.calls[0][0]).toContain('statuses=RECONCILED%2CVOID');
+  });
+
+  it('clearFilters resets filterStatuses', () => {
+    const { result } = renderHook(() => useTransactionFilters(defaultOptions));
+    act(() => {
+      result.current.setFilterStatuses(['CLEARED' as any]);
+    });
+    expect(result.current.filterStatuses).toEqual(['CLEARED']);
+    act(() => {
+      result.current.clearFilters();
+    });
+    expect(result.current.filterStatuses).toEqual([]);
+  });
 });
 
 describe('useTransactionFilters - header search event', () => {
@@ -571,6 +625,7 @@ describe('useTransactionFilters - header search event', () => {
     expect(result.current.filterTimePeriod).toBe('');
     expect(result.current.filterAmountFrom).toBe('');
     expect(result.current.filterAmountTo).toBe('');
+    expect(result.current.filterStatuses).toEqual([]);
     expect(result.current.filterAccountStatus).toBe('');
     expect(result.current.filterSearch).toBe('walmart');
     expect(result.current.searchInput).toBe('walmart');

--- a/frontend/src/hooks/useTransactionFilters.ts
+++ b/frontend/src/hooks/useTransactionFilters.ts
@@ -9,6 +9,7 @@ import { Account } from '@/types/account';
 import { Category } from '@/types/category';
 import { Payee } from '@/types/payee';
 import { Tag } from '@/types/tag';
+import { TransactionStatus } from '@/types/transaction';
 
 // LocalStorage keys for filter persistence
 const STORAGE_KEYS = {
@@ -23,7 +24,14 @@ const STORAGE_KEYS = {
   amountFrom: 'transactions.filter.amountFrom',
   amountTo: 'transactions.filter.amountTo',
   tagIds: 'transactions.filter.tagIds',
+  statuses: 'transactions.filter.statuses',
 };
+
+const VALID_TRANSACTION_STATUSES = new Set<string>(Object.values(TransactionStatus));
+
+function sanitizeStatuses(values: string[]): TransactionStatus[] {
+  return values.filter((v): v is TransactionStatus => VALID_TRANSACTION_STATUSES.has(v));
+}
 
 /**
  * Window event dispatched by the global header search to ask the
@@ -119,6 +127,7 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
   const [filterAmountFrom, setFilterAmountFrom] = useState<string>('');
   const [filterAmountTo, setFilterAmountTo] = useState<string>('');
   const [filterTagIds, setFilterTagIds] = useState<string[]>([]);
+  const [filterStatuses, setFilterStatuses] = useState<TransactionStatus[]>([]);
   const searchDebounceRef = useRef<NodeJS.Timeout | null>(null);
   const [filtersInitialized, setFiltersInitialized] = useState(false);
   const [filtersExpanded, setFiltersExpanded] = useState(true);
@@ -144,6 +153,7 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
     search: string;
     amountFrom: string;
     amountTo: string;
+    statuses: TransactionStatus[];
   }, push: boolean = false) => {
     const params = new URLSearchParams();
     if (page > 1) params.set('page', page.toString());
@@ -156,6 +166,7 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
     if (filters.search) params.set('search', filters.search);
     if (filters.amountFrom) params.set('amountFrom', filters.amountFrom);
     if (filters.amountTo) params.set('amountTo', filters.amountTo);
+    if (filters.statuses.length) params.set('statuses', filters.statuses.join(','));
 
     const queryString = params.toString();
     const newUrl = queryString ? `/transactions?${queryString}` : '/transactions';
@@ -287,13 +298,14 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
     count += filterCategoryIds.length;
     count += filterPayeeIds.length;
     count += filterTagIds.length;
+    count += filterStatuses.length;
     if (filterStartDate) count++;
     if (filterEndDate) count++;
     if (filterSearch) count++;
     if (filterAmountFrom) count++;
     if (filterAmountTo) count++;
     return count;
-  }, [filterAccountIds, filterCategoryIds, filterPayeeIds, filterTagIds, filterStartDate, filterEndDate, filterSearch, filterAmountFrom, filterAmountTo]);
+  }, [filterAccountIds, filterCategoryIds, filterPayeeIds, filterTagIds, filterStatuses, filterStartDate, filterEndDate, filterSearch, filterAmountFrom, filterAmountTo]);
 
   // Auto-collapse filters when there are active filters, expand when none
   useEffect(() => {
@@ -317,7 +329,8 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
       searchParams.has('search') ||
       searchParams.has('amountFrom') ||
       searchParams.has('amountTo') ||
-      searchParams.has('tagIds');
+      searchParams.has('tagIds') ||
+      searchParams.has('statuses');
 
     const getAccountIds = () => {
       const ids = searchParams.get('accountIds');
@@ -353,6 +366,7 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
     setSearchInput(initialSearch);
     setFilterAmountFrom(getFilterValue(STORAGE_KEYS.amountFrom, searchParams.get('amountFrom'), hasAnyUrlParams));
     setFilterAmountTo(getFilterValue(STORAGE_KEYS.amountTo, searchParams.get('amountTo'), hasAnyUrlParams));
+    setFilterStatuses(sanitizeStatuses(getFilterValues(STORAGE_KEYS.statuses, searchParams.get('statuses'), hasAnyUrlParams)));
     if (hasAnyUrlParams) {
       setFilterTimePeriod((initialStartDate || initialEndDate) ? 'custom' : '');
     } else {
@@ -379,7 +393,8 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
     localStorage.setItem(STORAGE_KEYS.timePeriod, filterTimePeriod);
     localStorage.setItem(STORAGE_KEYS.amountFrom, filterAmountFrom);
     localStorage.setItem(STORAGE_KEYS.amountTo, filterAmountTo);
-  }, [filterAccountIds, filterCategoryIds, filterPayeeIds, filterTagIds, filterStartDate, filterEndDate, filterSearch, filterTimePeriod, filterAmountFrom, filterAmountTo, filtersInitialized]);
+    localStorage.setItem(STORAGE_KEYS.statuses, JSON.stringify(filterStatuses));
+  }, [filterAccountIds, filterCategoryIds, filterPayeeIds, filterTagIds, filterStartDate, filterEndDate, filterSearch, filterTimePeriod, filterAmountFrom, filterAmountTo, filterStatuses, filtersInitialized]);
 
   // Helper to update array filter and mark as filter change
   const handleArrayFilterChange = useCallback(<T,>(setter: (value: T) => void, value: T) => {
@@ -436,6 +451,7 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
       setFilterTimePeriod('');
       setFilterAmountFrom('');
       setFilterAmountTo('');
+      setFilterStatuses([]);
       setSearchInput(term);
       setFilterSearch(term);
       setCurrentPage(1);
@@ -462,6 +478,7 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
       setSearchInput(search);
       setFilterAmountFrom(params.get('amountFrom') || '');
       setFilterAmountTo(params.get('amountTo') || '');
+      setFilterStatuses(sanitizeStatuses(params.get('statuses')?.split(',').filter(Boolean) || []));
       const hasDateParams = params.has('startDate') || params.has('endDate');
       setFilterTimePeriod(hasDateParams ? 'custom' : '');
       const pageParam = params.get('page');
@@ -526,6 +543,7 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
     setFilterTimePeriod('');
     setFilterAmountFrom('');
     setFilterAmountTo('');
+    setFilterStatuses([]);
     localStorage.removeItem(STORAGE_KEYS.accountIds);
     localStorage.removeItem(STORAGE_KEYS.categoryIds);
     localStorage.removeItem(STORAGE_KEYS.payeeIds);
@@ -536,6 +554,7 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
     localStorage.removeItem(STORAGE_KEYS.timePeriod);
     localStorage.removeItem(STORAGE_KEYS.amountFrom);
     localStorage.removeItem(STORAGE_KEYS.amountTo);
+    localStorage.removeItem(STORAGE_KEYS.statuses);
     router.replace('/transactions', { scroll: false });
   }, [router]);
 
@@ -560,6 +579,7 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
     filterAmountFrom, setFilterAmountFrom,
     filterAmountTo, setFilterAmountTo,
     filterTagIds, setFilterTagIds,
+    filterStatuses, setFilterStatuses,
     filtersInitialized,
     filtersExpanded, setFiltersExpanded,
     activeFilterCount,

--- a/frontend/src/lib/transactions.ts
+++ b/frontend/src/lib/transactions.ts
@@ -83,6 +83,7 @@ export const transactionsApi = {
     amountFrom?: number;
     amountTo?: number;
     tagIds?: string[];
+    statuses?: TransactionStatus[];
   }): Promise<PaginatedTransactions> => {
     const apiParams = {
       ...buildFilterParams(params),
@@ -94,6 +95,7 @@ export const transactionsApi = {
       targetTransactionId: params?.targetTransactionId,
       amountFrom: params?.amountFrom,
       amountTo: params?.amountTo,
+      statuses: params?.statuses && params.statuses.length > 0 ? params.statuses.join(',') : undefined,
     };
 
     const response = await apiClient.get<PaginatedTransactions>('/transactions', {


### PR DESCRIPTION
## Summary
This PR adds the ability to filter transactions by their reconciliation status (UNRECONCILED, CLEARED, RECONCILED, VOID) across both the backend API and frontend UI.

## Key Changes

**Backend:**
- Added `statuses` query parameter to the `findAll` endpoint with validation for valid transaction status values
- Implemented `parseTransactionStatuses()` helper to parse comma-separated status strings and validate against allowed values
- Updated `TransactionsService.findAll()` to accept optional `statuses` parameter and apply SQL WHERE clause filtering when provided
- Added comprehensive test coverage for status filtering in both controller and service specs

**Frontend:**
- Added `filterStatuses` state management to `useTransactionFilters` hook with localStorage persistence
- Implemented status filter initialization from URL parameters with validation (unknown statuses are dropped)
- Created `STATUS_FILTER_OPTIONS` with user-friendly labels for the four transaction statuses
- Added `MultiSelect` component for status filtering in the `TransactionFilterPanel`
- Status filters are displayed as indigo-colored chips when collapsed, matching the existing filter chip UI pattern
- Updated the filter grid layout to accommodate the new status filter input
- Integrated status filtering into the transactions page data loading flow
- Added comprehensive test coverage for status filter UI and state management

## Implementation Details

- Status validation occurs on both frontend (sanitization) and backend (rejection of invalid values)
- Empty status arrays are treated as "no filter applied" to avoid unnecessary query conditions
- Status filter state is persisted to localStorage and restored on page reload
- The status filter is included in the active filter count and URL parameter generation
- All existing tests were updated to account for the new parameter in function signatures

https://claude.ai/code/session_01TcrzabfFHV3BVGjnChPQrX