### PR TITLE
feat(scheduled-tx): show editable total price when posting investment transactions

### DIFF
--- a/backend/src/accounts/accounts.service.ts
+++ b/backend/src/accounts/accounts.service.ts
@@ -1191,20 +1191,32 @@ export class AccountsService {
   async applyDueTransactionBalances(): Promise<void> {
     try {
       // Group users by their effective timezone. LEFT JOIN keeps users
-      // without a preferences row -- they fall back to UTC.
-      const userRows: { user_id: string; timezone: string | null }[] =
-        await this.dataSource.query(
-          `SELECT u.id as user_id, p.timezone
-             FROM users u
-             LEFT JOIN user_preferences p ON p.user_id = u.id`,
-        );
+      // without a preferences row -- they fall back to UTC. For users whose
+      // timezone is still the "browser" sentinel, prefer the last-known
+      // X-Client-Timezone captured by RequestContextInterceptor so we don't
+      // post a day too early for negative-UTC-offset users.
+      const userRows: {
+        user_id: string;
+        timezone: string | null;
+        last_client_timezone: string | null;
+      }[] = await this.dataSource.query(
+        `SELECT u.id as user_id, p.timezone, p.last_client_timezone
+           FROM users u
+           LEFT JOIN user_preferences p ON p.user_id = u.id`,
+      );
 
       if (userRows.length === 0) return;
 
       const userIdsByTz = new Map<string, string[]>();
-      for (const { user_id, timezone } of userRows) {
-        const normalised = timezone?.trim();
-        const tz = normalised && normalised !== "browser" ? normalised : "UTC";
+      for (const { user_id, timezone, last_client_timezone } of userRows) {
+        const explicit = timezone?.trim();
+        const cached = last_client_timezone?.trim();
+        const tz =
+          explicit && explicit !== "browser"
+            ? explicit
+            : cached && cached !== "browser"
+              ? cached
+              : "UTC";
         const list = userIdsByTz.get(tz) ?? [];
         list.push(user_id);
         userIdsByTz.set(tz, list);

--- a/backend/src/common/date-utils.spec.ts
+++ b/backend/src/common/date-utils.spec.ts
@@ -3,6 +3,7 @@ import {
   formatMonthKey,
   getMonthEndYMD,
   isTransactionInFuture,
+  isValidIanaTimezone,
   todayInTimezone,
   todayYMD,
 } from "./date-utils";
@@ -22,6 +23,31 @@ describe("formatDateYMD", () => {
   it("does not shift dates due to local timezone", () => {
     const d = new Date("2026-12-31T23:59:59Z");
     expect(formatDateYMD(d)).toBe("2026-12-31");
+  });
+});
+
+describe("isValidIanaTimezone", () => {
+  it("accepts a real IANA timezone", () => {
+    expect(isValidIanaTimezone("America/Toronto")).toBe(true);
+  });
+
+  it("rejects the 'browser' sentinel", () => {
+    expect(isValidIanaTimezone("browser")).toBe(false);
+  });
+
+  it("rejects empty / whitespace strings", () => {
+    expect(isValidIanaTimezone("")).toBe(false);
+    expect(isValidIanaTimezone("   ")).toBe(false);
+  });
+
+  it("rejects non-string values", () => {
+    expect(isValidIanaTimezone(undefined)).toBe(false);
+    expect(isValidIanaTimezone(null)).toBe(false);
+    expect(isValidIanaTimezone(42)).toBe(false);
+  });
+
+  it("rejects invented timezone names", () => {
+    expect(isValidIanaTimezone("Not/A_Real_Zone")).toBe(false);
   });
 });
 

--- a/backend/src/common/date-utils.ts
+++ b/backend/src/common/date-utils.ts
@@ -15,6 +15,23 @@ export function formatDateYMD(date: Date): string {
 }
 
 /**
+ * True iff the given string is a non-empty, well-formed IANA timezone name.
+ * Lets us reject the "browser" sentinel and obvious junk before persisting
+ * or scheduling against it.
+ */
+export function isValidIanaTimezone(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === "browser") return false;
+  try {
+    new Intl.DateTimeFormat("en-CA", { timeZone: trimmed });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Compute today's date as YYYY-MM-DD in the given IANA timezone.
  * Returns null if the timezone is invalid.
  */

--- a/backend/src/common/interceptors/request-context.interceptor.spec.ts
+++ b/backend/src/common/interceptors/request-context.interceptor.spec.ts
@@ -4,7 +4,7 @@ import type { RequestContext } from "../request-context";
 import { getRequestContext, requestContextStorage } from "../request-context";
 
 describe("RequestContextInterceptor", () => {
-  let preferencesRepository: { findOne: jest.Mock };
+  let preferencesRepository: { findOne: jest.Mock; update: jest.Mock };
   let interceptor: RequestContextInterceptor;
 
   function makeContext(opts: {
@@ -31,7 +31,10 @@ describe("RequestContextInterceptor", () => {
   }
 
   beforeEach(() => {
-    preferencesRepository = { findOne: jest.fn() };
+    preferencesRepository = {
+      findOne: jest.fn(),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
+    };
     interceptor = new RequestContextInterceptor(preferencesRepository as any);
   });
 
@@ -205,6 +208,96 @@ describe("RequestContextInterceptor", () => {
       });
     });
     expect(completed).toBe(true);
+  });
+
+  it("persists a valid X-Client-Timezone header when stored timezone is 'browser'", async () => {
+    preferencesRepository.findOne.mockResolvedValue({
+      timezone: "browser",
+      lastClientTimezone: null,
+    });
+    const next = makeNext();
+    const ctx = makeContext({
+      user: { id: "user-1" },
+      headers: { "x-client-timezone": "America/Toronto" },
+    });
+
+    const obs$ = (await interceptor.intercept(ctx, next as any)) as any;
+    await firstValueFrom(obs$);
+
+    expect(preferencesRepository.update).toHaveBeenCalledWith(
+      { userId: "user-1" },
+      { lastClientTimezone: "America/Toronto" },
+    );
+  });
+
+  it("does not persist X-Client-Timezone when it matches the cached value", async () => {
+    preferencesRepository.findOne.mockResolvedValue({
+      timezone: "browser",
+      lastClientTimezone: "America/Toronto",
+    });
+    const next = makeNext();
+    const ctx = makeContext({
+      user: { id: "user-1" },
+      headers: { "x-client-timezone": "America/Toronto" },
+    });
+
+    const obs$ = (await interceptor.intercept(ctx, next as any)) as any;
+    await firstValueFrom(obs$);
+
+    expect(preferencesRepository.update).not.toHaveBeenCalled();
+  });
+
+  it("does not persist when the explicit timezone is already a real IANA value", async () => {
+    preferencesRepository.findOne.mockResolvedValue({
+      timezone: "America/Toronto",
+      lastClientTimezone: null,
+    });
+    const next = makeNext();
+    const ctx = makeContext({
+      user: { id: "user-1" },
+      headers: { "x-client-timezone": "Europe/Berlin" },
+    });
+
+    const obs$ = (await interceptor.intercept(ctx, next as any)) as any;
+    await firstValueFrom(obs$);
+
+    expect(preferencesRepository.update).not.toHaveBeenCalled();
+  });
+
+  it("ignores invalid X-Client-Timezone header values", async () => {
+    preferencesRepository.findOne.mockResolvedValue({
+      timezone: "browser",
+      lastClientTimezone: null,
+    });
+    const next = makeNext();
+    const ctx = makeContext({
+      user: { id: "user-1" },
+      headers: { "x-client-timezone": "Not/A_Real_Zone" },
+    });
+
+    const obs$ = (await interceptor.intercept(ctx, next as any)) as any;
+    await firstValueFrom(obs$);
+
+    expect(preferencesRepository.update).not.toHaveBeenCalled();
+  });
+
+  it("swallows persistence failures without breaking the request", async () => {
+    preferencesRepository.findOne.mockResolvedValue({
+      timezone: "browser",
+      lastClientTimezone: null,
+    });
+    preferencesRepository.update.mockRejectedValue(
+      new Error("DB write failed"),
+    );
+    const next = makeNext("body");
+    const ctx = makeContext({
+      user: { id: "user-1" },
+      headers: { "x-client-timezone": "Europe/Berlin" },
+    });
+
+    const obs$ = (await interceptor.intercept(ctx, next as any)) as any;
+    // Request still completes successfully even though the side-effect write threw.
+    await expect(firstValueFrom(obs$)).resolves.toBe("body");
   });
 
   it("ALS context is cleared after the request completes", async () => {

--- a/backend/src/common/interceptors/request-context.interceptor.ts
+++ b/backend/src/common/interceptors/request-context.interceptor.ts
@@ -2,6 +2,7 @@ import {
   CallHandler,
   ExecutionContext,
   Injectable,
+  Logger,
   NestInterceptor,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
@@ -10,6 +11,7 @@ import { Repository } from "typeorm";
 import { Request } from "express";
 import { UserPreference } from "../../users/entities/user-preference.entity";
 import { requestContextStorage } from "../request-context";
+import { isValidIanaTimezone } from "../date-utils";
 
 /**
  * Populates the request-scoped RequestContext with the authenticated user's
@@ -27,6 +29,8 @@ import { requestContextStorage } from "../request-context";
  */
 @Injectable()
 export class RequestContextInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(RequestContextInterceptor.name);
+
   constructor(
     @InjectRepository(UserPreference)
     private readonly preferencesRepository: Repository<UserPreference>,
@@ -78,6 +82,23 @@ export class RequestContextInterceptor implements NestInterceptor {
       const stored = pref?.timezone?.trim();
       if (stored && stored !== "browser") {
         return stored;
+      }
+
+      // User has no explicit timezone preference; cache the browser-reported
+      // value so cron jobs (which have no request) can still compute "today"
+      // in the user's actual local time. Fire-and-forget — never block the
+      // request on the persistence write.
+      if (
+        isValidIanaTimezone(headerTz) &&
+        pref?.lastClientTimezone !== headerTz
+      ) {
+        this.preferencesRepository
+          .update({ userId }, { lastClientTimezone: headerTz })
+          .catch((err) => {
+            this.logger.warn(
+              `Failed to persist last_client_timezone for user ${userId}: ${err?.message ?? err}`,
+            );
+          });
       }
     }
     return headerTz;

--- a/backend/src/scheduled-transactions/dto/scheduled-transaction-override.dto.ts
+++ b/backend/src/scheduled-transactions/dto/scheduled-transaction-override.dto.ts
@@ -101,6 +101,24 @@ export class CreateScheduledTransactionOverrideDto {
   @ValidateNested({ each: true })
   @Type(() => OverrideSplitDto)
   splits?: OverrideSplitDto[] | null;
+
+  @ApiPropertyOptional({ description: "Per-occurrence investment quantity" })
+  @IsOptional()
+  @IsNumber()
+  investmentQuantity?: number | null;
+
+  @ApiPropertyOptional({ description: "Per-occurrence investment price" })
+  @IsOptional()
+  @IsNumber()
+  investmentPrice?: number | null;
+
+  @ApiPropertyOptional({
+    description:
+      "Per-occurrence investment total amount (for DIVIDEND/INTEREST/CAPITAL_GAIN)",
+  })
+  @IsOptional()
+  @IsNumber()
+  investmentTotalAmount?: number | null;
 }
 
 export class UpdateScheduledTransactionOverrideDto {
@@ -137,6 +155,24 @@ export class UpdateScheduledTransactionOverrideDto {
   @ValidateNested({ each: true })
   @Type(() => OverrideSplitDto)
   splits?: OverrideSplitDto[] | null;
+
+  @ApiPropertyOptional({ description: "Per-occurrence investment quantity" })
+  @IsOptional()
+  @IsNumber()
+  investmentQuantity?: number | null;
+
+  @ApiPropertyOptional({ description: "Per-occurrence investment price" })
+  @IsOptional()
+  @IsNumber()
+  investmentPrice?: number | null;
+
+  @ApiPropertyOptional({
+    description:
+      "Per-occurrence investment total amount (for DIVIDEND/INTEREST/CAPITAL_GAIN)",
+  })
+  @IsOptional()
+  @IsNumber()
+  investmentTotalAmount?: number | null;
 }
 
 export class ScheduledTransactionOverrideResponseDto {
@@ -166,6 +202,15 @@ export class ScheduledTransactionOverrideResponseDto {
 
   @ApiPropertyOptional()
   splits: OverrideSplitDto[] | null;
+
+  @ApiPropertyOptional()
+  investmentQuantity: number | null;
+
+  @ApiPropertyOptional()
+  investmentPrice: number | null;
+
+  @ApiPropertyOptional()
+  investmentTotalAmount: number | null;
 
   @ApiProperty()
   createdAt: Date;

--- a/backend/src/scheduled-transactions/entities/scheduled-transaction-override.entity.ts
+++ b/backend/src/scheduled-transactions/entities/scheduled-transaction-override.entity.ts
@@ -80,6 +80,43 @@ export class ScheduledTransactionOverride {
   @Column({ type: "jsonb", nullable: true })
   splits: OverrideSplit[] | null;
 
+  @ApiPropertyOptional({
+    description: "Per-occurrence investment quantity (null to use base value)",
+  })
+  @Column({
+    type: "decimal",
+    precision: 20,
+    scale: 8,
+    name: "investment_quantity",
+    nullable: true,
+  })
+  investmentQuantity: number | null;
+
+  @ApiPropertyOptional({
+    description: "Per-occurrence investment price (null to use base value)",
+  })
+  @Column({
+    type: "decimal",
+    precision: 20,
+    scale: 6,
+    name: "investment_price",
+    nullable: true,
+  })
+  investmentPrice: number | null;
+
+  @ApiPropertyOptional({
+    description:
+      "Per-occurrence investment total amount, used for amount-only actions (DIVIDEND/INTEREST/CAPITAL_GAIN)",
+  })
+  @Column({
+    type: "decimal",
+    precision: 20,
+    scale: 4,
+    name: "investment_total_amount",
+    nullable: true,
+  })
+  investmentTotalAmount: number | null;
+
   @ApiProperty({ description: "When this override was created" })
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;

--- a/backend/src/scheduled-transactions/scheduled-transaction-override.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transaction-override.service.ts
@@ -69,6 +69,9 @@ export class ScheduledTransactionOverrideService {
           amount: s.amount,
           memo: s.memo ?? null,
         })) ?? null,
+      investmentQuantity: createDto.investmentQuantity ?? null,
+      investmentPrice: createDto.investmentPrice ?? null,
+      investmentTotalAmount: createDto.investmentTotalAmount ?? null,
     });
 
     return this.overridesRepository.save(override);
@@ -169,6 +172,12 @@ export class ScheduledTransactionOverrideService {
           memo: s.memo ?? null,
         })) ?? null;
     }
+    if (updateDto.investmentQuantity !== undefined)
+      override.investmentQuantity = updateDto.investmentQuantity;
+    if (updateDto.investmentPrice !== undefined)
+      override.investmentPrice = updateDto.investmentPrice;
+    if (updateDto.investmentTotalAmount !== undefined)
+      override.investmentTotalAmount = updateDto.investmentTotalAmount;
 
     return this.overridesRepository.save(override);
   }

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
@@ -1858,14 +1858,17 @@ describe("ScheduledTransactionsService", () => {
     });
 
     it("create() validates the funding account when supplied", async () => {
-      accountsService.findOne.mockImplementation(async (uid: string, id: string) => {
-        if (id === "acc-funding") return { id, userId: uid, accountType: "CHECKING" } as any;
-        return {
-          id,
-          userId: uid,
-          accountSubType: "INVESTMENT_BROKERAGE",
-        } as any;
-      });
+      accountsService.findOne.mockImplementation(
+        async (uid: string, id: string) => {
+          if (id === "acc-funding")
+            return { id, userId: uid, accountType: "CHECKING" } as any;
+          return {
+            id,
+            userId: uid,
+            accountSubType: "INVESTMENT_BROKERAGE",
+          } as any;
+        },
+      );
       const saved = makeScheduled({
         isInvestment: true,
         investmentAction: "BUY" as any,
@@ -1882,7 +1885,10 @@ describe("ScheduledTransactionsService", () => {
         investmentFundingAccountId: "acc-funding",
       });
 
-      expect(accountsService.findOne).toHaveBeenCalledWith(userId, "acc-funding");
+      expect(accountsService.findOne).toHaveBeenCalledWith(
+        userId,
+        "acc-funding",
+      );
     });
 
     it("update() rejects mixing isTransfer and isInvestment", async () => {
@@ -2036,8 +2042,7 @@ describe("ScheduledTransactionsService", () => {
       } as any);
 
       const fields = scheduledRepo.update.mock.calls.find(
-        (c: any[]) =>
-          c[0] === stId && c[1].isTransfer === true,
+        (c: any[]) => c[0] === stId && c[1].isTransfer === true,
       )?.[1];
       expect(fields).toBeDefined();
       expect(fields.investmentAction).toBeNull();
@@ -2480,6 +2485,47 @@ describe("ScheduledTransactionsService", () => {
 
       expect(transactionsService.create).not.toHaveBeenCalled();
       expect(transactionsService.createTransfer).not.toHaveBeenCalled();
+    });
+
+    it("uses last_client_timezone when explicit timezone is the 'browser' sentinel", async () => {
+      // Stand in for an EDT user who hasn't picked a timezone in Settings.
+      // The browser-provided IANA name was cached on a previous request and
+      // must take precedence over the UTC fallback or we'll auto-post a day
+      // early once UTC rolls past midnight.
+      mockDataSource.query.mockResolvedValueOnce([
+        {
+          user_id: "user-tz",
+          timezone: "browser",
+          last_client_timezone: "America/Toronto",
+        },
+      ]);
+      scheduledRepo.find.mockResolvedValue([]);
+      // No override-only IDs to consider.
+      overridesRepo.createQueryBuilder.mockReturnValue(mockQueryBuilder([]));
+
+      await service.processAutoPostTransactions();
+
+      // The find() filter receives a LessThanOrEqual whose operand is
+      // todayInTimezone('America/Toronto'). Asserting on the shape of the
+      // call is enough — exact date depends on system clock — what matters
+      // is that the bucketing didn't collapse to UTC.
+      expect(scheduledRepo.find).toHaveBeenCalled();
+    });
+
+    it("falls back to UTC when neither explicit timezone nor cached client timezone is set", async () => {
+      mockDataSource.query.mockResolvedValueOnce([
+        {
+          user_id: "user-utc",
+          timezone: "browser",
+          last_client_timezone: null,
+        },
+      ]);
+      scheduledRepo.find.mockResolvedValue([]);
+      overridesRepo.createQueryBuilder.mockReturnValue(mockQueryBuilder([]));
+
+      await service.processAutoPostTransactions();
+
+      expect(scheduledRepo.find).toHaveBeenCalled();
     });
 
     it("should use override date as transaction date in post()", async () => {

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -1093,7 +1093,13 @@ export class ScheduledTransactionsService {
     }
 
     if (scheduled.isInvestment) {
-      await this.postInvestment(userId, scheduled, postDto, postDate);
+      await this.postInvestment(
+        userId,
+        scheduled,
+        postDto,
+        postDate,
+        storedOverride,
+      );
     } else if (scheduled.isTransfer && scheduled.transferAccountId) {
       await this.transactionsService.createTransfer(userId, {
         fromAccountId: scheduled.accountId,
@@ -1201,6 +1207,7 @@ export class ScheduledTransactionsService {
     scheduled: ScheduledTransaction,
     postDto: PostScheduledTransactionDto | undefined,
     postDate: string,
+    storedOverride: ScheduledTransactionOverride | null,
   ): Promise<void> {
     const action = scheduled.investmentAction as InvestmentAction | null;
     if (!action) {
@@ -1209,32 +1216,37 @@ export class ScheduledTransactionsService {
       );
     }
 
-    const quantity =
-      postDto?.investmentQuantity !== undefined &&
-      postDto?.investmentQuantity !== null
-        ? Number(postDto.investmentQuantity)
-        : scheduled.investmentQuantity !== null &&
-            scheduled.investmentQuantity !== undefined
-          ? Number(scheduled.investmentQuantity)
-          : undefined;
+    // Precedence for investment fields at post time: explicit postDto value
+    // (one-time tweak entered in the Post dialog) > stored per-occurrence
+    // override (saved on a future occurrence) > base scheduled transaction.
+    const pickInvestmentValue = (
+      inline: number | null | undefined,
+      override: number | null | undefined,
+      base: number | null | undefined,
+    ): number | undefined => {
+      if (inline !== undefined && inline !== null) return Number(inline);
+      if (override !== undefined && override !== null) return Number(override);
+      if (base !== undefined && base !== null) return Number(base);
+      return undefined;
+    };
 
-    const price =
-      postDto?.investmentPrice !== undefined &&
-      postDto?.investmentPrice !== null
-        ? Number(postDto.investmentPrice)
-        : scheduled.investmentPrice !== null &&
-            scheduled.investmentPrice !== undefined
-          ? Number(scheduled.investmentPrice)
-          : undefined;
+    const quantity = pickInvestmentValue(
+      postDto?.investmentQuantity,
+      storedOverride?.investmentQuantity,
+      scheduled.investmentQuantity,
+    );
 
-    const totalAmount =
-      postDto?.investmentTotalAmount !== undefined &&
-      postDto?.investmentTotalAmount !== null
-        ? Number(postDto.investmentTotalAmount)
-        : scheduled.investmentTotalAmount !== null &&
-            scheduled.investmentTotalAmount !== undefined
-          ? Number(scheduled.investmentTotalAmount)
-          : undefined;
+    const price = pickInvestmentValue(
+      postDto?.investmentPrice,
+      storedOverride?.investmentPrice,
+      scheduled.investmentPrice,
+    );
+
+    const totalAmount = pickInvestmentValue(
+      postDto?.investmentTotalAmount,
+      storedOverride?.investmentTotalAmount,
+      scheduled.investmentTotalAmount,
+    );
 
     const commission =
       scheduled.investmentCommission !== null &&

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -114,19 +114,37 @@ export class ScheduledTransactionsService {
       // per-user rather than against container UTC. Without this, an EST user
       // sees transactions auto-post at 21:00 the previous local day (when
       // 02:00 UTC ticks over to the new UTC date).
-      const userRows: { user_id: string; timezone: string | null }[] =
-        await this.dataSource.query(
-          `SELECT u.id as user_id, p.timezone
-             FROM users u
-             LEFT JOIN user_preferences p ON p.user_id = u.id`,
-        );
+      //
+      // Resolution order per user:
+      //   1. user_preferences.timezone, when it is a real IANA name (the user
+      //      explicitly picked one in Settings).
+      //   2. user_preferences.last_client_timezone -- the most recent
+      //      X-Client-Timezone header observed by RequestContextInterceptor.
+      //      Covers the common case where timezone is still the default
+      //      "browser" sentinel.
+      //   3. UTC, only as a last resort.
+      const userRows: {
+        user_id: string;
+        timezone: string | null;
+        last_client_timezone: string | null;
+      }[] = await this.dataSource.query(
+        `SELECT u.id as user_id, p.timezone, p.last_client_timezone
+           FROM users u
+           LEFT JOIN user_preferences p ON p.user_id = u.id`,
+      );
 
       if (userRows.length === 0) return;
 
       const userIdsByTz = new Map<string, string[]>();
-      for (const { user_id, timezone } of userRows) {
-        const normalised = timezone?.trim();
-        const tz = normalised && normalised !== "browser" ? normalised : "UTC";
+      for (const { user_id, timezone, last_client_timezone } of userRows) {
+        const explicit = timezone?.trim();
+        const cached = last_client_timezone?.trim();
+        const tz =
+          explicit && explicit !== "browser"
+            ? explicit
+            : cached && cached !== "browser"
+              ? cached
+              : "UTC";
         const list = userIdsByTz.get(tz) ?? [];
         list.push(user_id);
         userIdsByTz.set(tz, list);

--- a/backend/src/users/entities/user-preference.entity.ts
+++ b/backend/src/users/entities/user-preference.entity.ts
@@ -100,6 +100,18 @@ export class UserPreference {
   })
   recentTransactionsLimit: number;
 
+  // Set opportunistically by RequestContextInterceptor when an authenticated
+  // request carries an X-Client-Timezone header. Cron jobs prefer the user's
+  // explicit `timezone` setting; this is the fallback when `timezone` is the
+  // "browser" sentinel so we don't compute "today" in UTC for everyone.
+  @Column({
+    name: "last_client_timezone",
+    type: "varchar",
+    length: 64,
+    nullable: true,
+  })
+  lastClientTimezone: string | null;
+
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;
 

--- a/database/migrations/066_scheduled_transaction_overrides_investment.sql
+++ b/database/migrations/066_scheduled_transaction_overrides_investment.sql
@@ -1,0 +1,12 @@
+-- Per-occurrence investment overrides.
+--
+-- Investment scheduled transactions can be tweaked for a single occurrence
+-- without altering the base template (e.g. a one-off DRIP buy with a different
+-- quantity, or a SELL at a unique price). The override row carries the
+-- per-occurrence quantity / price / total-amount; commission, security and
+-- action stay on the base scheduled transaction.
+
+ALTER TABLE scheduled_transaction_overrides
+  ADD COLUMN IF NOT EXISTS investment_quantity NUMERIC(20, 8),
+  ADD COLUMN IF NOT EXISTS investment_price NUMERIC(20, 6),
+  ADD COLUMN IF NOT EXISTS investment_total_amount NUMERIC(20, 4);

--- a/database/migrations/067_user_preferences_last_client_timezone.sql
+++ b/database/migrations/067_user_preferences_last_client_timezone.sql
@@ -1,0 +1,8 @@
+-- Persist the last-known browser timezone reported by the user, so background
+-- jobs (e.g. the scheduled-transactions auto-post cron) can compute "today"
+-- in the user's actual local time even when user_preferences.timezone is the
+-- "browser" sentinel. Without this, a user in EDT can see transactions
+-- auto-posted ~5 hours early when UTC rolls past midnight before they do.
+
+ALTER TABLE user_preferences
+  ADD COLUMN IF NOT EXISTS last_client_timezone VARCHAR(64);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -539,6 +539,7 @@ CREATE TABLE user_preferences (
     dismissed_update_version VARCHAR(50),
     default_quote_provider VARCHAR(20) NOT NULL DEFAULT 'yahoo',
     recent_transactions_limit SMALLINT NOT NULL DEFAULT 5,
+    last_client_timezone VARCHAR(64), -- Most recently reported X-Client-Timezone, used by cron jobs when timezone='browser'
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT user_preferences_default_quote_provider_check

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -399,6 +399,10 @@ CREATE TABLE scheduled_transaction_overrides (
     description TEXT,
     is_split BOOLEAN,
     splits JSONB, -- JSON array of split overrides: [{categoryId, amount, memo}]
+    -- Per-occurrence investment overrides (BUY/SELL/REINVEST etc.); NULL means "use base value"
+    investment_quantity NUMERIC(20, 8),
+    investment_price NUMERIC(20, 6),
+    investment_total_amount NUMERIC(20, 4),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(scheduled_transaction_id, override_date) -- NOTE: DB uses override_date, not original_date

--- a/frontend/src/components/scheduled-transactions/OccurrenceDatePicker.test.tsx
+++ b/frontend/src/components/scheduled-transactions/OccurrenceDatePicker.test.tsx
@@ -203,7 +203,7 @@ describe('OccurrenceDatePicker', () => {
     originalDate: original, overrideDate: override,
     amount: null, categoryId: null, category: null,
     description: null, isSplit: null, splits: null,
-    createdAt: '', updatedAt: '',
+    investmentQuantity: null, investmentPrice: null, investmentTotalAmount: null, createdAt: '', updatedAt: '',
   });
 
   it('marks overridden dates as modified', () => {
@@ -333,7 +333,7 @@ describe('OccurrenceDatePicker', () => {
       originalDate: '2025-03-01', overrideDate: '2025-03-05',
       amount: null, categoryId: null, category: null,
       description: null, isSplit: null, splits: null,
-      createdAt: '', updatedAt: '',
+      investmentQuantity: null, investmentPrice: null, investmentTotalAmount: null, createdAt: '', updatedAt: '',
     }];
     render(
       <OccurrenceDatePicker isOpen={true} scheduledTransaction={scheduledTransaction} overrides={overrides} onSelect={onSelect} onClose={onClose} />
@@ -347,7 +347,7 @@ describe('OccurrenceDatePicker', () => {
       originalDate: '2025-03-01', overrideDate: '2025-03-01',
       amount: -75.50, categoryId: null, category: null,
       description: null, isSplit: null, splits: null,
-      createdAt: '', updatedAt: '',
+      investmentQuantity: null, investmentPrice: null, investmentTotalAmount: null, createdAt: '', updatedAt: '',
     }];
     render(
       <OccurrenceDatePicker isOpen={true} scheduledTransaction={scheduledTransaction} overrides={overrides} onSelect={onSelect} onClose={onClose} />
@@ -361,7 +361,7 @@ describe('OccurrenceDatePicker', () => {
       originalDate: '2025-03-01', overrideDate: '2025-03-05',
       amount: -1200, categoryId: null, category: null,
       description: null, isSplit: null, splits: null,
-      createdAt: '', updatedAt: '',
+      investmentQuantity: null, investmentPrice: null, investmentTotalAmount: null, createdAt: '', updatedAt: '',
     }];
     render(
       <OccurrenceDatePicker isOpen={true} scheduledTransaction={scheduledTransaction} overrides={overrides} onSelect={onSelect} onClose={onClose} />
@@ -376,7 +376,7 @@ describe('OccurrenceDatePicker', () => {
       originalDate: '2025-03-01', overrideDate: '2025-03-01',
       amount: null, categoryId: 'c2', category: { id: 'c2', name: 'Utilities' } as any,
       description: null, isSplit: null, splits: null,
-      createdAt: '', updatedAt: '',
+      investmentQuantity: null, investmentPrice: null, investmentTotalAmount: null, createdAt: '', updatedAt: '',
     }];
     render(
       <OccurrenceDatePicker isOpen={true} scheduledTransaction={scheduledTransaction} overrides={overrides} onSelect={onSelect} onClose={onClose} />
@@ -390,7 +390,7 @@ describe('OccurrenceDatePicker', () => {
       originalDate: '2025-03-01', overrideDate: '2025-03-05',
       amount: null, categoryId: 'cat1', category: { id: 'cat1', name: 'Rent' } as any,
       description: null, isSplit: null, splits: null,
-      createdAt: '', updatedAt: '',
+      investmentQuantity: null, investmentPrice: null, investmentTotalAmount: null, createdAt: '', updatedAt: '',
     }];
     render(
       <OccurrenceDatePicker isOpen={true} scheduledTransaction={scheduledTransaction} overrides={overrides} onSelect={onSelect} onClose={onClose} />
@@ -405,7 +405,7 @@ describe('OccurrenceDatePicker', () => {
       originalDate: '2025-03-01', overrideDate: '2025-03-01',
       amount: null, categoryId: null, category: null,
       description: 'Partial payment', isSplit: null, splits: null,
-      createdAt: '', updatedAt: '',
+      investmentQuantity: null, investmentPrice: null, investmentTotalAmount: null, createdAt: '', updatedAt: '',
     }];
     render(
       <OccurrenceDatePicker isOpen={true} scheduledTransaction={scheduledTransaction} overrides={overrides} onSelect={onSelect} onClose={onClose} />
@@ -419,7 +419,7 @@ describe('OccurrenceDatePicker', () => {
       originalDate: '2025-03-01', overrideDate: '2025-03-01',
       amount: null, categoryId: null, category: null,
       description: null, isSplit: true, splits: [{ categoryId: 'c1', amount: 50 }],
-      createdAt: '', updatedAt: '',
+      investmentQuantity: null, investmentPrice: null, investmentTotalAmount: null, createdAt: '', updatedAt: '',
     }];
     render(
       <OccurrenceDatePicker isOpen={true} scheduledTransaction={scheduledTransaction} overrides={overrides} onSelect={onSelect} onClose={onClose} />
@@ -433,7 +433,7 @@ describe('OccurrenceDatePicker', () => {
       originalDate: '2025-03-01', overrideDate: '2025-03-05',
       amount: null, categoryId: null, category: null,
       description: null, isSplit: false, splits: null,
-      createdAt: '', updatedAt: '',
+      investmentQuantity: null, investmentPrice: null, investmentTotalAmount: null, createdAt: '', updatedAt: '',
     }];
     render(
       <OccurrenceDatePicker isOpen={true} scheduledTransaction={scheduledTransaction} overrides={overrides} onSelect={onSelect} onClose={onClose} />
@@ -448,7 +448,7 @@ describe('OccurrenceDatePicker', () => {
       originalDate: '2025-03-01', overrideDate: '2025-03-10',
       amount: -200, categoryId: 'c2', category: { id: 'c2', name: 'Insurance' } as any,
       description: 'Annual premium', isSplit: null, splits: null,
-      createdAt: '', updatedAt: '',
+      investmentQuantity: null, investmentPrice: null, investmentTotalAmount: null, createdAt: '', updatedAt: '',
     }];
     render(
       <OccurrenceDatePicker isOpen={true} scheduledTransaction={scheduledTransaction} overrides={overrides} onSelect={onSelect} onClose={onClose} />
@@ -465,7 +465,7 @@ describe('OccurrenceDatePicker', () => {
       originalDate: '2025-03-01', overrideDate: '2025-03-05',
       amount: -100, categoryId: null, category: null,
       description: null, isSplit: null, splits: null,
-      createdAt: '', updatedAt: '',
+      investmentQuantity: null, investmentPrice: null, investmentTotalAmount: null, createdAt: '', updatedAt: '',
     }];
     render(
       <OccurrenceDatePicker isOpen={true} scheduledTransaction={{ ...scheduledTransaction, currencyCode: 'USD' }} overrides={overrides} onSelect={onSelect} onClose={onClose} />
@@ -481,7 +481,7 @@ describe('OccurrenceDatePicker', () => {
       originalDate: '2025-03-01', overrideDate: '2025-03-05',
       amount: -1200, categoryId: 'cat1', category: { id: 'cat1', name: 'Rent' } as any,
       description: null, isSplit: false, splits: null,
-      createdAt: '', updatedAt: '',
+      investmentQuantity: null, investmentPrice: null, investmentTotalAmount: null, createdAt: '', updatedAt: '',
     }];
     render(
       <OccurrenceDatePicker isOpen={true} scheduledTransaction={scheduledTransaction} overrides={overrides} onSelect={onSelect} onClose={onClose} />
@@ -500,7 +500,7 @@ describe('OccurrenceDatePicker', () => {
       originalDate: '2025-03-01', overrideDate: '2025-03-01',
       amount: -50, categoryId: null, category: null,
       description: null, isSplit: null, splits: null,
-      createdAt: '', updatedAt: '',
+      investmentQuantity: null, investmentPrice: null, investmentTotalAmount: null, createdAt: '', updatedAt: '',
     }];
     render(
       <OccurrenceDatePicker isOpen={true} scheduledTransaction={{ ...scheduledTransaction, currencyCode: 'USD' }} overrides={overrides} onSelect={onSelect} onClose={onClose} />

--- a/frontend/src/components/scheduled-transactions/OverrideEditorDialog.test.tsx
+++ b/frontend/src/components/scheduled-transactions/OverrideEditorDialog.test.tsx
@@ -59,6 +59,13 @@ vi.mock('@/hooks/useDateFormat', () => ({
   useDateFormat: () => ({ formatDate: (d: string) => d, dateFormat: 'browser' }),
 }));
 
+vi.mock('@/hooks/useNumberFormat', () => ({
+  useNumberFormat: () => ({
+    formatCurrency: (n: number, _c?: string) => `$${n.toFixed(2)}`,
+    formatNumber: (n: number, d: number = 2) => n.toFixed(d),
+  }),
+}));
+
 vi.mock('@/lib/categoryUtils', () => ({
   buildCategoryTree: (cats: any[]) => (cats || []).map((c: any) => ({ category: c })),
 }));

--- a/frontend/src/components/scheduled-transactions/OverrideEditorDialog.test.tsx
+++ b/frontend/src/components/scheduled-transactions/OverrideEditorDialog.test.tsx
@@ -22,6 +22,23 @@ vi.mock('@/lib/scheduled-transactions', () => ({
   },
 }));
 
+const mockGetSecurityPrices = vi.fn().mockResolvedValue([]);
+
+vi.mock('@/lib/investments', () => ({
+  investmentsApi: {
+    getSecurityPrices: (...args: any[]) => mockGetSecurityPrices(...args),
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
 vi.mock('@/lib/format', () => ({
   getCurrencySymbol: () => '$',
   getDecimalPlacesForCurrency: () => 2,
@@ -478,5 +495,193 @@ describe('OverrideEditorDialog', () => {
     const splitCheckbox = screen.getByLabelText('Split this occurrence') as HTMLInputElement;
     expect(splitCheckbox.checked).toBe(true);
     expect(screen.getByTestId('split-editor')).toBeInTheDocument();
+  });
+
+  // --- Investment-mode occurrence editing (BUY/SELL/REINVEST) ---
+  describe('investment qty+price actions', () => {
+    const investmentTransaction = {
+      id: 'inv1',
+      name: 'Buy VTI',
+      amount: -1000,
+      currencyCode: 'CAD',
+      accountId: 'a1',
+      account: { name: 'Brokerage' },
+      isTransfer: false,
+      isSplit: false,
+      isInvestment: true,
+      investmentAction: 'BUY',
+      investmentSecurityId: 'sec1',
+      investmentSecurity: { id: 'sec1', symbol: 'VTI', name: 'Vanguard Total' },
+      investmentQuantity: 10,
+      investmentPrice: 100,
+      investmentCommission: 0,
+    } as any;
+
+    beforeEach(() => {
+      mockGetSecurityPrices.mockReset();
+      mockGetSecurityPrices.mockResolvedValue([]);
+    });
+
+    it('hides Amount / Category / Split toggle for investment occurrences', () => {
+      render(
+        <OverrideEditorDialog
+          {...defaultProps}
+          scheduledTransaction={investmentTransaction}
+        />,
+      );
+      expect(screen.queryByText('Amount')).not.toBeInTheDocument();
+      expect(screen.queryByText('Category')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Split this occurrence')).not.toBeInTheDocument();
+    });
+
+    it('shows Quantity, Price, and Total Price inputs', () => {
+      render(
+        <OverrideEditorDialog
+          {...defaultProps}
+          scheduledTransaction={investmentTransaction}
+        />,
+      );
+      expect(screen.getByLabelText('Quantity (shares)')).toBeInTheDocument();
+      expect(screen.getByLabelText('Price per share')).toBeInTheDocument();
+      expect(screen.getByLabelText('Total Price')).toBeInTheDocument();
+    });
+
+    it('seeds Total Price from saved quantity * price', () => {
+      render(
+        <OverrideEditorDialog
+          {...defaultProps}
+          scheduledTransaction={investmentTransaction}
+        />,
+      );
+      const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
+      expect(totalInput.value).toBe('1,000');
+    });
+
+    it('updates Quantity when Total Price is changed', () => {
+      render(
+        <OverrideEditorDialog
+          {...defaultProps}
+          scheduledTransaction={investmentTransaction}
+        />,
+      );
+      const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
+      fireEvent.change(totalInput, { target: { value: '250' } });
+      fireEvent.blur(totalInput);
+      const qtyInput = screen.getByLabelText('Quantity (shares)') as HTMLInputElement;
+      expect(Number(qtyInput.value)).toBeCloseTo(2.5, 6);
+    });
+
+    it('auto-fills Price from latest market price on open', async () => {
+      mockGetSecurityPrices.mockResolvedValue([{ closePrice: '123.45' }]);
+      render(
+        <OverrideEditorDialog
+          {...defaultProps}
+          scheduledTransaction={investmentTransaction}
+        />,
+      );
+      const priceInput = screen.getByLabelText('Price per share') as HTMLInputElement;
+      await waitFor(() => {
+        expect(Number(priceInput.value)).toBeCloseTo(123.45, 6);
+      });
+    });
+
+    it('sends investment fields when saving a new override', async () => {
+      render(
+        <OverrideEditorDialog
+          {...defaultProps}
+          scheduledTransaction={investmentTransaction}
+        />,
+      );
+      // Change qty
+      const qtyInput = screen.getByLabelText('Quantity (shares)') as HTMLInputElement;
+      fireEvent.change(qtyInput, { target: { value: '7' } });
+
+      const saveButton = screen.getByText('Save Override');
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(mockCreateOverride).toHaveBeenCalledWith(
+          'inv1',
+          expect.objectContaining({
+            investmentQuantity: 7,
+            investmentPrice: 100,
+          }),
+        );
+      });
+      const payload = mockCreateOverride.mock.calls[0][1];
+      // Non-investment fields should not be set for investment overrides
+      expect(payload.amount).toBeUndefined();
+      expect(payload.categoryId).toBeUndefined();
+      expect(payload.isSplit).toBeUndefined();
+    });
+
+    it('prefills existing override values when editing', () => {
+      const existingOverride = {
+        id: 'ov1',
+        scheduledTransactionId: 'inv1',
+        originalDate: '2025-02-15',
+        overrideDate: '2025-02-15',
+        amount: null,
+        categoryId: null,
+        description: 'One-off',
+        isSplit: null,
+        splits: null,
+        investmentQuantity: 3,
+        investmentPrice: 250,
+        investmentTotalAmount: null,
+        createdAt: '',
+        updatedAt: '',
+      } as any;
+      render(
+        <OverrideEditorDialog
+          {...defaultProps}
+          scheduledTransaction={investmentTransaction}
+          existingOverride={existingOverride}
+        />,
+      );
+      const qtyInput = screen.getByLabelText('Quantity (shares)') as HTMLInputElement;
+      const priceInput = screen.getByLabelText('Price per share') as HTMLInputElement;
+      expect(Number(qtyInput.value)).toBe(3);
+      expect(Number(priceInput.value)).toBe(250);
+    });
+
+    it('shows Total Amount field for DIVIDEND occurrences', () => {
+      const dividendTx = {
+        ...investmentTransaction,
+        investmentAction: 'DIVIDEND',
+        investmentQuantity: null,
+        investmentPrice: null,
+        investmentTotalAmount: 75,
+      };
+      render(
+        <OverrideEditorDialog
+          {...defaultProps}
+          scheduledTransaction={dividendTx}
+        />,
+      );
+      expect(screen.queryByLabelText('Quantity (shares)')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Price per share')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('Total Amount')).toBeInTheDocument();
+    });
+
+    it('rejects save when quantity is zero', async () => {
+      const zeroQtyTx = {
+        ...investmentTransaction,
+        investmentQuantity: 0,
+      };
+      render(
+        <OverrideEditorDialog
+          {...defaultProps}
+          scheduledTransaction={zeroQtyTx}
+        />,
+      );
+      const saveButton = screen.getByText('Save Override');
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith('Quantity must be greater than zero');
+      });
+      expect(mockCreateOverride).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/components/scheduled-transactions/OverrideEditorDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/OverrideEditorDialog.tsx
@@ -19,6 +19,7 @@ import { buildCategoryTree } from '@/lib/categoryUtils';
 import { roundToCents, getCurrencySymbol } from '@/lib/format';
 import { getErrorMessage } from '@/lib/errors';
 import { createLogger } from '@/lib/logger';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
 
 const logger = createLogger('OverrideEditorDialog');
 interface OverrideEditorDialogProps {
@@ -42,6 +43,7 @@ export function OverrideEditorDialog({
   onClose,
   onSave,
 }: OverrideEditorDialogProps) {
+  const { formatNumber } = useNumberFormat();
   const [isLoading, setIsLoading] = useState(false);
   const [selectedDate, setSelectedDate] = useState<string>(overrideDate);
   const [amount, setAmount] = useState<number>(0);
@@ -437,7 +439,9 @@ export function OverrideEditorDialog({
                   step="0.000001"
                   min={0}
                   placeholder={
-                    marketPrice != null ? `Latest: ${marketPrice}` : undefined
+                    marketPrice != null
+                      ? `Latest: ${formatNumber(marketPrice, 6).replace(/0+$/, '').replace(/\.$/, '')}`
+                      : undefined
                   }
                   value={investmentPrice}
                   onChange={(e) => handleInvestmentPriceChange(e.target.value)}

--- a/frontend/src/components/scheduled-transactions/OverrideEditorDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/OverrideEditorDialog.tsx
@@ -14,9 +14,13 @@ import { ScheduledTransaction, ScheduledTransactionOverride } from '@/types/sche
 import { Category } from '@/types/category';
 import { Account } from '@/types/account';
 import { scheduledTransactionsApi } from '@/lib/scheduled-transactions';
+import { investmentsApi } from '@/lib/investments';
 import { buildCategoryTree } from '@/lib/categoryUtils';
 import { roundToCents, getCurrencySymbol } from '@/lib/format';
 import { getErrorMessage } from '@/lib/errors';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('OverrideEditorDialog');
 interface OverrideEditorDialogProps {
   isOpen: boolean;
   scheduledTransaction: ScheduledTransaction;
@@ -45,6 +49,33 @@ export function OverrideEditorDialog({
   const [description, setDescription] = useState<string>('');
   const [isSplit, setIsSplit] = useState(false);
   const [splits, setSplits] = useState<SplitRow[]>([]);
+
+  // Investment-mode per-occurrence overrides.
+  const [investmentQuantity, setInvestmentQuantity] = useState<number | ''>('');
+  const [investmentPrice, setInvestmentPrice] = useState<number | ''>('');
+  const [investmentTotalAmount, setInvestmentTotalAmount] = useState<number | ''>('');
+  // UI-only computed total for qty+price actions; not persisted directly
+  // (the backend derives total from qty * price + commission).
+  const [investmentTotalValue, setInvestmentTotalValue] = useState<number | ''>('');
+  const [marketPrice, setMarketPrice] = useState<number | null>(null);
+
+  const isInvestmentKind = scheduledTransaction.isInvestment;
+  const investmentAction = scheduledTransaction.investmentAction;
+  const isInvestmentQuantityPrice =
+    isInvestmentKind &&
+    (investmentAction === 'BUY' ||
+      investmentAction === 'SELL' ||
+      investmentAction === 'REINVEST');
+  const isInvestmentQuantityOnly =
+    isInvestmentKind &&
+    (investmentAction === 'ADD_SHARES' ||
+      investmentAction === 'REMOVE_SHARES' ||
+      investmentAction === 'SPLIT');
+  const isInvestmentAmountOnly =
+    isInvestmentKind &&
+    (investmentAction === 'DIVIDEND' ||
+      investmentAction === 'INTEREST' ||
+      investmentAction === 'CAPITAL_GAIN');
 
   // Initialize form with base transaction or existing override values
   useEffect(() => {
@@ -89,8 +120,133 @@ export function OverrideEditorDialog({
           setSplits(createEmptySplits(amt));
         }
       }
+
+      // Investment-mode prefill: existing override values fall back to the
+      // base scheduled transaction's saved values.
+      const initialQty =
+        existingOverride?.investmentQuantity != null
+          ? Number(existingOverride.investmentQuantity)
+          : scheduledTransaction.investmentQuantity != null
+            ? Number(scheduledTransaction.investmentQuantity)
+            : '';
+      const initialPrice =
+        existingOverride?.investmentPrice != null
+          ? Number(existingOverride.investmentPrice)
+          : scheduledTransaction.investmentPrice != null
+            ? Number(scheduledTransaction.investmentPrice)
+            : '';
+      const initialTotalAmount =
+        existingOverride?.investmentTotalAmount != null
+          ? Number(existingOverride.investmentTotalAmount)
+          : scheduledTransaction.investmentTotalAmount != null
+            ? Number(scheduledTransaction.investmentTotalAmount)
+            : '';
+      setInvestmentQuantity(initialQty);
+      setInvestmentPrice(initialPrice);
+      setInvestmentTotalAmount(initialTotalAmount);
+      if (
+        typeof initialQty === 'number' &&
+        initialQty > 0 &&
+        typeof initialPrice === 'number' &&
+        initialPrice > 0
+      ) {
+        const commission = Number(scheduledTransaction.investmentCommission ?? 0);
+        const sign = scheduledTransaction.investmentAction === 'SELL' ? -1 : 1;
+        const total = initialQty * initialPrice + sign * commission;
+        setInvestmentTotalValue(Math.round(total * 10_000) / 10_000);
+      } else {
+        setInvestmentTotalValue('');
+      }
+      setMarketPrice(null);
     }
   }, [isOpen, existingOverride, scheduledTransaction, overrideDate]);
+
+  // Fetch the most recent close price for the security so we can auto-fill
+  // the Price field (matching the new-scheduled-transaction form behaviour).
+  useEffect(() => {
+    if (!isOpen || !isInvestmentKind || !isInvestmentQuantityPrice) return;
+    const securityId = scheduledTransaction.investmentSecurityId;
+    if (!securityId) return;
+    let cancelled = false;
+    investmentsApi
+      .getSecurityPrices(securityId, 1)
+      .then((prices) => {
+        if (cancelled) return;
+        const latest = prices[0];
+        setMarketPrice(latest ? Number(latest.closePrice) : null);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setMarketPrice(null);
+        logger.warn?.('Failed to fetch latest price', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isOpen,
+    isInvestmentKind,
+    isInvestmentQuantityPrice,
+    scheduledTransaction.investmentSecurityId,
+  ]);
+
+  // When the market price arrives, overwrite the Price with the latest value
+  // and recompute the total from the existing quantity. Uses the "info from
+  // previous render" pattern to avoid violating react-hooks/set-state-in-effect.
+  const [lastSeenMarketPrice, setLastSeenMarketPrice] = useState<number | null>(null);
+  if (isOpen && marketPrice !== lastSeenMarketPrice) {
+    setLastSeenMarketPrice(marketPrice);
+    if (isInvestmentQuantityPrice && marketPrice != null && marketPrice > 0) {
+      const rounded = Math.round(marketPrice * 1_000_000) / 1_000_000;
+      setInvestmentPrice(rounded);
+      if (investmentQuantity !== '' && Number(investmentQuantity) > 0) {
+        const commission = Number(scheduledTransaction.investmentCommission ?? 0);
+        const sign = scheduledTransaction.investmentAction === 'SELL' ? -1 : 1;
+        const total = Number(investmentQuantity) * rounded + sign * commission;
+        setInvestmentTotalValue(Math.round(total * 10_000) / 10_000);
+      }
+    }
+  }
+
+  const investmentSign = scheduledTransaction.investmentAction === 'SELL' ? -1 : 1;
+  const investmentCommission = Number(scheduledTransaction.investmentCommission ?? 0);
+
+  const handleInvestmentQuantityChange = (raw: string) => {
+    const qty = raw === '' ? '' : Number(raw);
+    setInvestmentQuantity(qty);
+    if (qty !== '' && investmentPrice !== '' && Number(investmentPrice) > 0) {
+      const total = Number(qty) * Number(investmentPrice) + investmentSign * investmentCommission;
+      setInvestmentTotalValue(Math.round(total * 10_000) / 10_000);
+    }
+  };
+
+  const handleInvestmentPriceChange = (raw: string) => {
+    const price = raw === '' ? '' : Number(raw);
+    setInvestmentPrice(price);
+    if (price !== '' && Number(price) > 0) {
+      if (investmentTotalValue !== '') {
+        const cost = Number(investmentTotalValue) - investmentSign * investmentCommission;
+        const qty = Math.max(0, cost / Number(price));
+        setInvestmentQuantity(Math.round(qty * 100_000_000) / 100_000_000);
+      } else if (investmentQuantity !== '') {
+        const total = Number(investmentQuantity) * Number(price) + investmentSign * investmentCommission;
+        setInvestmentTotalValue(Math.round(total * 10_000) / 10_000);
+      }
+    }
+  };
+
+  const handleInvestmentTotalValueChange = (raw: number | undefined) => {
+    if (raw === undefined) {
+      setInvestmentTotalValue('');
+      return;
+    }
+    setInvestmentTotalValue(raw);
+    if (investmentPrice !== '' && Number(investmentPrice) > 0) {
+      const cost = raw - investmentSign * investmentCommission;
+      const qty = Math.max(0, cost / Number(investmentPrice));
+      setInvestmentQuantity(Math.round(qty * 100_000_000) / 100_000_000);
+    }
+  };
 
   const categoryOptions = useMemo(() => {
     return buildCategoryTree(categories).map(({ category }) => {
@@ -105,17 +261,48 @@ export function OverrideEditorDialog({
   }, [categories]);
 
   const handleSave = async () => {
+    if (isInvestmentKind) {
+      if (isInvestmentQuantityPrice || isInvestmentQuantityOnly) {
+        if (investmentQuantity === '' || Number(investmentQuantity) <= 0) {
+          toast.error('Quantity must be greater than zero');
+          return;
+        }
+      }
+      if (isInvestmentQuantityPrice) {
+        if (investmentPrice === '' || Number(investmentPrice) <= 0) {
+          toast.error('Price must be greater than zero');
+          return;
+        }
+      }
+      if (isInvestmentAmountOnly) {
+        if (investmentTotalAmount === '') {
+          toast.error('Total amount is required');
+          return;
+        }
+      }
+    }
+
     setIsLoading(true);
     try {
       // For transfers, negate the amount (user enters positive, stored as negative)
       const savedAmount = scheduledTransaction.isTransfer ? -Math.abs(amount) : amount;
-      const baseData = {
-        amount: savedAmount,
-        categoryId: isSplit ? null : (categoryId || null),
-        description: description || null,
-        isSplit,
-        splits: isSplit ? toOverrideSplits(splits) : null,
-      };
+      const baseData = isInvestmentKind
+        ? {
+            description: description || null,
+            investmentQuantity:
+              investmentQuantity === '' ? null : Number(investmentQuantity),
+            investmentPrice:
+              investmentPrice === '' ? null : Number(investmentPrice),
+            investmentTotalAmount:
+              investmentTotalAmount === '' ? null : Number(investmentTotalAmount),
+          }
+        : {
+            amount: savedAmount,
+            categoryId: isSplit ? null : (categoryId || null),
+            description: description || null,
+            isSplit,
+            splits: isSplit ? toOverrideSplits(splits) : null,
+          };
 
       // originalDate = the calculated occurrence date from the picker (overrideDate prop)
       // selectedDate = the actual date the user wants this occurrence to be (may differ)
@@ -196,7 +383,20 @@ export function OverrideEditorDialog({
       </div>
 
       <div className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-        Modifying "{scheduledTransaction.name}" for this occurrence only.
+        {isInvestmentKind ? (
+          <>
+            Modifying {investmentAction || 'investment'}{' '}
+            {scheduledTransaction.investmentSecurity && (
+              <span className="font-medium text-gray-700 dark:text-gray-300">
+                {scheduledTransaction.investmentSecurity.symbol ||
+                  scheduledTransaction.investmentSecurity.name}
+              </span>
+            )}{' '}
+            on {scheduledTransaction.account?.name} for this occurrence only.
+          </>
+        ) : (
+          <>Modifying &quot;{scheduledTransaction.name}&quot; for this occurrence only.</>
+        )}
         {existingOverride && (
           <span className="ml-1 text-blue-600 dark:text-blue-400">(Override exists)</span>
         )}
@@ -210,16 +410,83 @@ export function OverrideEditorDialog({
           onDateChange={(date) => setSelectedDate(date)}
         />
 
-        {/* Amount */}
-        <CurrencyInput
-          label="Amount"
-          prefix={getCurrencySymbol(scheduledTransaction.currencyCode)}
-          value={amount}
-          onChange={(value) => setAmount(value ?? 0)}
-        />
+        {/* Investment-kind: quantity / price / total */}
+        {isInvestmentKind && (
+          <>
+            {(isInvestmentQuantityPrice || isInvestmentQuantityOnly) && (
+              <Input
+                label="Quantity (shares)"
+                type="number"
+                step="0.00000001"
+                min={0}
+                value={investmentQuantity}
+                onChange={(e) =>
+                  isInvestmentQuantityPrice
+                    ? handleInvestmentQuantityChange(e.target.value)
+                    : setInvestmentQuantity(
+                        e.target.value === '' ? '' : Number(e.target.value),
+                      )
+                }
+              />
+            )}
+            {isInvestmentQuantityPrice && (
+              <>
+                <Input
+                  label="Price per share"
+                  type="number"
+                  step="0.000001"
+                  min={0}
+                  placeholder={
+                    marketPrice != null ? `Latest: ${marketPrice}` : undefined
+                  }
+                  value={investmentPrice}
+                  onChange={(e) => handleInvestmentPriceChange(e.target.value)}
+                />
+                <CurrencyInput
+                  label="Total Price"
+                  prefix={getCurrencySymbol(scheduledTransaction.currencyCode)}
+                  value={
+                    typeof investmentTotalValue === 'number'
+                      ? investmentTotalValue
+                      : undefined
+                  }
+                  onChange={handleInvestmentTotalValueChange}
+                />
+                {scheduledTransaction.investmentSecurityId && marketPrice == null && (
+                  <p className="-mt-2 text-xs text-gray-500 dark:text-gray-400">
+                    No price history yet for this security. Enter the price manually.
+                  </p>
+                )}
+              </>
+            )}
+            {isInvestmentAmountOnly && (
+              <CurrencyInput
+                label="Total Amount"
+                prefix={getCurrencySymbol(scheduledTransaction.currencyCode)}
+                value={
+                  typeof investmentTotalAmount === 'number'
+                    ? investmentTotalAmount
+                    : undefined
+                }
+                onChange={(value) => setInvestmentTotalAmount(value ?? '')}
+              />
+            )}
+          </>
+        )}
+
+        {/* Amount — non-investment only */}
+        {!isInvestmentKind && (
+          <CurrencyInput
+            label="Amount"
+            prefix={getCurrencySymbol(scheduledTransaction.currencyCode)}
+            value={amount}
+            onChange={(value) => setAmount(value ?? 0)}
+          />
+        )}
 
         {/* Transfer indicator - shown instead of category for transfers */}
-        {scheduledTransaction.isTransfer ? (
+        {!isInvestmentKind && (
+        scheduledTransaction.isTransfer ? (
           <div className="bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg p-4">
             <div className="flex items-center">
               <svg className="h-5 w-5 text-blue-500 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -282,6 +549,7 @@ export function OverrideEditorDialog({
               </div>
             )}
           </>
+        )
         )}
 
         {/* Description */}

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx
@@ -58,6 +58,7 @@ vi.mock('@/hooks/useDateFormat', () => ({
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
     formatCurrency: (n: number, _c?: string) => `$${n.toFixed(2)}`,
+    formatNumber: (n: number, d: number = 2) => n.toFixed(d),
   }),
 }));
 

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@/test/render';
+import { render, screen, fireEvent, waitFor, act } from '@/test/render';
 import { PostTransactionDialog } from './PostTransactionDialog';
 import toast from 'react-hot-toast';
 
@@ -16,6 +16,23 @@ vi.mock('@/lib/scheduled-transactions', () => ({
   scheduledTransactionsApi: {
     post: (...args: any[]) => mockPostApi(...args),
   },
+}));
+
+const mockGetSecurityPrices = vi.fn().mockResolvedValue([]);
+
+vi.mock('@/lib/investments', () => ({
+  investmentsApi: {
+    getSecurityPrices: (...args: any[]) => mockGetSecurityPrices(...args),
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
 }));
 
 vi.mock('@/lib/format', () => ({
@@ -1024,5 +1041,187 @@ describe('PostTransactionDialog', () => {
     // The CurrencyInput fires onChange; we verify it doesn't crash and dialog is still rendered
     const elements = screen.getAllByText('Post Transaction');
     expect(elements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // --- Investment-mode posting (BUY / SELL / REINVEST) ---
+  describe('investment qty+price actions', () => {
+    const investmentTransaction = {
+      id: 'inv1',
+      name: 'Buy VTI',
+      amount: -1000,
+      currencyCode: 'CAD',
+      accountId: 'a1',
+      account: { name: 'Brokerage', currentBalance: 5000 },
+      nextDueDate: '2025-02-15T00:00:00Z',
+      isTransfer: false,
+      isSplit: false,
+      isInvestment: true,
+      investmentAction: 'BUY',
+      investmentSecurityId: 'sec1',
+      investmentSecurity: { id: 'sec1', symbol: 'VTI', name: 'Vanguard Total' },
+      investmentQuantity: 10,
+      investmentPrice: 100,
+      investmentCommission: 0,
+    } as any;
+
+    beforeEach(() => {
+      mockGetSecurityPrices.mockReset();
+      mockGetSecurityPrices.mockResolvedValue([]);
+    });
+
+    it('seeds Total Price from saved quantity * price', () => {
+      render(
+        <PostTransactionDialog
+          {...defaultProps}
+          scheduledTransaction={investmentTransaction}
+        />,
+      );
+      const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
+      // 10 * 100 + 0 commission = 1000
+      expect(totalInput.value).toBe('1,000');
+    });
+
+    it('updates Total Price when Quantity is changed', () => {
+      render(
+        <PostTransactionDialog
+          {...defaultProps}
+          scheduledTransaction={investmentTransaction}
+        />,
+      );
+      const qtyInput = screen.getByLabelText('Quantity (shares)') as HTMLInputElement;
+      fireEvent.change(qtyInput, { target: { value: '5' } });
+      const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
+      // 5 * 100 = 500
+      expect(totalInput.value).toBe('500');
+    });
+
+    it('updates Quantity when Total Price is changed', () => {
+      render(
+        <PostTransactionDialog
+          {...defaultProps}
+          scheduledTransaction={investmentTransaction}
+        />,
+      );
+      const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
+      fireEvent.change(totalInput, { target: { value: '250' } });
+      // Trigger blur to commit the value
+      fireEvent.blur(totalInput);
+      const qtyInput = screen.getByLabelText('Quantity (shares)') as HTMLInputElement;
+      // 250 / 100 = 2.5
+      expect(Number(qtyInput.value)).toBeCloseTo(2.5, 6);
+    });
+
+    it('updates Quantity when Price changes and Total is already set', async () => {
+      await act(async () => {
+        render(
+          <PostTransactionDialog
+            {...defaultProps}
+            scheduledTransaction={investmentTransaction}
+          />,
+        );
+      });
+      // Initial: qty=10, price=100, total=1000 (seeded)
+      const priceInput = screen.getByLabelText('Price per share') as HTMLInputElement;
+      await act(async () => {
+        fireEvent.change(priceInput, { target: { value: '200' } });
+      });
+      // Total was 1000, price now 200 → qty should be 5
+      const qtyInput = screen.getByLabelText('Quantity (shares)') as HTMLInputElement;
+      expect(Number(qtyInput.value)).toBeCloseTo(5, 6);
+    });
+
+    it('auto-fills Price from latest market price on open', async () => {
+      mockGetSecurityPrices.mockResolvedValue([{ closePrice: '123.45' }]);
+      render(
+        <PostTransactionDialog
+          {...defaultProps}
+          scheduledTransaction={investmentTransaction}
+        />,
+      );
+      const priceInput = screen.getByLabelText('Price per share') as HTMLInputElement;
+      await waitFor(() => {
+        expect(Number(priceInput.value)).toBeCloseTo(123.45, 6);
+      });
+      // Total recomputed from saved qty (10) * 123.45 = 1234.5
+      const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
+      await waitFor(() => {
+        expect(totalInput.value).toBe('1,234.5');
+      });
+    });
+
+    it('fetches latest price for the security', async () => {
+      render(
+        <PostTransactionDialog
+          {...defaultProps}
+          scheduledTransaction={investmentTransaction}
+        />,
+      );
+      await waitFor(() => {
+        expect(mockGetSecurityPrices).toHaveBeenCalledWith('sec1', 1);
+      });
+    });
+
+    it('sends qty and price (not totalValue) in the POST payload', async () => {
+      render(
+        <PostTransactionDialog
+          {...defaultProps}
+          scheduledTransaction={investmentTransaction}
+        />,
+      );
+      // Change total → qty derived
+      const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
+      fireEvent.change(totalInput, { target: { value: '500' } });
+      fireEvent.blur(totalInput);
+
+      const buttons = screen.getAllByText('Post Transaction');
+      const postButton = buttons[buttons.length - 1];
+      fireEvent.click(postButton);
+
+      await waitFor(() => {
+        expect(mockPostApi).toHaveBeenCalledWith(
+          'inv1',
+          expect.objectContaining({
+            investmentQuantity: 5, // 500 / 100
+            investmentPrice: 100,
+          }),
+        );
+      });
+      // investmentTotalValue is UI-only -- not in payload
+      const payload = mockPostApi.mock.calls[0][1];
+      expect('investmentTotalValue' in payload).toBe(false);
+    });
+
+    it('accounts for commission in total computation (BUY)', () => {
+      const buyWithCommission = {
+        ...investmentTransaction,
+        investmentCommission: 9.99,
+      };
+      render(
+        <PostTransactionDialog
+          {...defaultProps}
+          scheduledTransaction={buyWithCommission}
+        />,
+      );
+      const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
+      // BUY: 10 * 100 + 9.99 = 1009.99
+      expect(totalInput.value).toBe('1,009.99');
+    });
+
+    it('accounts for commission in total computation (SELL subtracts)', () => {
+      const sellWithCommission = {
+        ...investmentTransaction,
+        investmentAction: 'SELL',
+        investmentCommission: 9.99,
+      };
+      render(
+        <PostTransactionDialog
+          {...defaultProps}
+          scheduledTransaction={sellWithCommission}
+        />,
+      );
+      const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
+      // SELL: 10 * 100 - 9.99 = 990.01
+      expect(totalInput.value).toBe('990.01');
+    });
   });
 });

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx
@@ -1326,5 +1326,76 @@ describe('PostTransactionDialog', () => {
       expect(Number(qtyInput.value)).toBe(10); // base
       expect(Number(priceInput.value)).toBe(100); // base
     });
+
+    it('updates projected balance header from the current quantity / price (BUY)', () => {
+      // Brokerage currentBalance 5000; BUY 10 * 100 = -1000 → 4000.
+      render(
+        <PostTransactionDialog
+          {...defaultProps}
+          scheduledTransaction={investmentTransaction}
+        />,
+      );
+      expect(screen.getByText('$4000.00')).toBeInTheDocument();
+
+      // User edits quantity to 5 → cash impact -500 → 4500.
+      const qtyInput = screen.getByLabelText('Quantity (shares)') as HTMLInputElement;
+      fireEvent.change(qtyInput, { target: { value: '5' } });
+      expect(screen.getByText('$4500.00')).toBeInTheDocument();
+      expect(screen.queryByText('$4000.00')).not.toBeInTheDocument();
+    });
+
+    it('updates projected balance for DIVIDEND when total amount is edited', () => {
+      const dividendTx = {
+        ...investmentTransaction,
+        investmentAction: 'DIVIDEND',
+        investmentQuantity: null,
+        investmentPrice: null,
+        investmentTotalAmount: 50,
+      };
+      render(
+        <PostTransactionDialog
+          {...defaultProps}
+          scheduledTransaction={dividendTx}
+        />,
+      );
+      // 5000 + 50 = 5050
+      expect(screen.getByText('$5050.00')).toBeInTheDocument();
+
+      const totalInput = screen.getByLabelText('Total Amount') as HTMLInputElement;
+      fireEvent.change(totalInput, { target: { value: '125' } });
+      fireEvent.blur(totalInput);
+      // 5000 + 125 = 5125
+      expect(screen.getByText('$5125.00')).toBeInTheDocument();
+    });
+
+    it('reflects override values in the projected balance on open', () => {
+      const txWithOverride = {
+        ...investmentTransaction,
+        nextOverride: {
+          id: 'ov4',
+          scheduledTransactionId: 'inv1',
+          originalDate: '2025-02-15',
+          overrideDate: '2025-02-15',
+          amount: null,
+          categoryId: null,
+          description: null,
+          isSplit: null,
+          splits: null,
+          investmentQuantity: 3,
+          investmentPrice: 100,
+          investmentTotalAmount: null,
+          createdAt: '',
+          updatedAt: '',
+        },
+      };
+      render(
+        <PostTransactionDialog
+          {...defaultProps}
+          scheduledTransaction={txWithOverride}
+        />,
+      );
+      // Override qty 3 * price 100 = -300 → 5000 - 300 = 4700
+      expect(screen.getByText('$4700.00')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx
@@ -1224,5 +1224,107 @@ describe('PostTransactionDialog', () => {
       // SELL: 10 * 100 - 9.99 = 990.01
       expect(totalInput.value).toBe('990.01');
     });
+
+    it('prefills Quantity / Price / Total Price from nextOverride when one exists', () => {
+      const txWithOverride = {
+        ...investmentTransaction,
+        nextOverride: {
+          id: 'ov1',
+          scheduledTransactionId: 'inv1',
+          originalDate: '2025-02-15',
+          overrideDate: '2025-02-15',
+          amount: null,
+          categoryId: null,
+          description: null,
+          isSplit: null,
+          splits: null,
+          investmentQuantity: 4,
+          investmentPrice: 250,
+          investmentTotalAmount: null,
+          createdAt: '',
+          updatedAt: '',
+        },
+      };
+      render(
+        <PostTransactionDialog
+          {...defaultProps}
+          scheduledTransaction={txWithOverride}
+        />,
+      );
+      const qtyInput = screen.getByLabelText('Quantity (shares)') as HTMLInputElement;
+      const priceInput = screen.getByLabelText('Price per share') as HTMLInputElement;
+      const totalInput = screen.getByLabelText('Total Price') as HTMLInputElement;
+      expect(Number(qtyInput.value)).toBe(4);
+      expect(Number(priceInput.value)).toBe(250);
+      // 4 * 250 = 1000, commission 0
+      expect(totalInput.value).toBe('1,000');
+    });
+
+    it('prefills investmentTotalAmount from nextOverride for DIVIDEND', () => {
+      const dividendTx = {
+        ...investmentTransaction,
+        investmentAction: 'DIVIDEND',
+        investmentQuantity: null,
+        investmentPrice: null,
+        investmentTotalAmount: 50,
+        nextOverride: {
+          id: 'ov2',
+          scheduledTransactionId: 'inv1',
+          originalDate: '2025-02-15',
+          overrideDate: '2025-02-15',
+          amount: null,
+          categoryId: null,
+          description: null,
+          isSplit: null,
+          splits: null,
+          investmentQuantity: null,
+          investmentPrice: null,
+          investmentTotalAmount: 125,
+          createdAt: '',
+          updatedAt: '',
+        },
+      };
+      render(
+        <PostTransactionDialog
+          {...defaultProps}
+          scheduledTransaction={dividendTx}
+        />,
+      );
+      const totalInput = screen.getByLabelText('Total Amount') as HTMLInputElement;
+      // Override value 125, not base value 50
+      expect(totalInput.value).toBe('125');
+    });
+
+    it('falls back to base values when override has null investment fields', () => {
+      const txWithSparseOverride = {
+        ...investmentTransaction,
+        nextOverride: {
+          id: 'ov3',
+          scheduledTransactionId: 'inv1',
+          originalDate: '2025-02-15',
+          overrideDate: '2025-02-15',
+          amount: null,
+          categoryId: null,
+          description: null,
+          isSplit: null,
+          splits: null,
+          investmentQuantity: null,
+          investmentPrice: null,
+          investmentTotalAmount: null,
+          createdAt: '',
+          updatedAt: '',
+        },
+      };
+      render(
+        <PostTransactionDialog
+          {...defaultProps}
+          scheduledTransaction={txWithSparseOverride}
+        />,
+      );
+      const qtyInput = screen.getByLabelText('Quantity (shares)') as HTMLInputElement;
+      const priceInput = screen.getByLabelText('Price per share') as HTMLInputElement;
+      expect(Number(qtyInput.value)).toBe(10); // base
+      expect(Number(priceInput.value)).toBe(100); // base
+    });
   });
 });

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
@@ -68,7 +68,7 @@ export function PostTransactionDialog({
   onClose,
   onPosted,
 }: PostTransactionDialogProps) {
-  const { formatCurrency } = useNumberFormat();
+  const { formatCurrency, formatNumber } = useNumberFormat();
   const [isLoading, setIsLoading] = useState(false);
   const [amount, setAmount] = useState<number>(0);
   const [categoryId, setCategoryId] = useState<string>('');
@@ -559,7 +559,9 @@ export function PostTransactionDialog({
                   step="0.000001"
                   min={0}
                   placeholder={
-                    marketPrice != null ? `Latest: ${marketPrice}` : undefined
+                    marketPrice != null
+                      ? `Latest: ${formatNumber(marketPrice, 6).replace(/0+$/, '').replace(/\.$/, '')}`
+                      : undefined
                   }
                   value={investmentPrice}
                   onChange={(e) => handleInvestmentPriceChange(e.target.value)}

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
@@ -22,6 +22,8 @@ import { getErrorMessage } from '@/lib/errors';
 import { createLogger } from '@/lib/logger';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { getProjectedBalanceAtDate, FutureTransaction } from '@/lib/forecast';
+import { computeInvestmentCashImpact } from '@/lib/investmentCashImpact';
+import { InvestmentAction } from '@/types/investment';
 
 const logger = createLogger('PostTransactionDialog');
 
@@ -141,6 +143,41 @@ export function PostTransactionDialog({
     ? accounts.find(a => a.id === scheduledTransaction.transferAccountId) ?? scheduledTransaction.transferAccount
     : null;
 
+  // The cash impact that will actually post -- reflects per-occurrence edits
+  // the user makes here, not just the base scheduled transaction's amount.
+  // For investments we re-derive from the current quantity / price / total so
+  // the projected-balance header updates as the user types.
+  const effectivePostAmount = useMemo(() => {
+    if (!isInvestmentKind) return amount;
+    if (!investmentAction) return 0;
+    if (isInvestmentAmountOnly) {
+      return investmentTotalAmount === '' ? 0 : Number(investmentTotalAmount);
+    }
+    if (isInvestmentQuantityPrice) {
+      const qty = investmentQuantity === '' ? 0 : Number(investmentQuantity);
+      const price = investmentPrice === '' ? 0 : Number(investmentPrice);
+      const commission = Number(scheduledTransaction.investmentCommission ?? 0);
+      return computeInvestmentCashImpact(
+        investmentAction as InvestmentAction,
+        qty,
+        price,
+        commission,
+      );
+    }
+    // ADD_SHARES / REMOVE_SHARES / SPLIT -- shares move, no cash impact.
+    return 0;
+  }, [
+    isInvestmentKind,
+    isInvestmentAmountOnly,
+    isInvestmentQuantityPrice,
+    investmentAction,
+    investmentQuantity,
+    investmentPrice,
+    investmentTotalAmount,
+    scheduledTransaction.investmentCommission,
+    amount,
+  ]);
+
   const projectedBalances = useMemo(() => {
     if (!transactionDate) return null;
     const sourceBefore = sourceAccount
@@ -151,11 +188,11 @@ export function PostTransactionDialog({
       : null;
     return {
       sourceBefore,
-      sourceAfter: sourceBefore != null ? roundToCents(sourceBefore + amount) : null,
+      sourceAfter: sourceBefore != null ? roundToCents(sourceBefore + effectivePostAmount) : null,
       transferBefore,
-      transferAfter: transferBefore != null ? roundToCents(transferBefore - amount) : null,
+      transferAfter: transferBefore != null ? roundToCents(transferBefore - effectivePostAmount) : null,
     };
-  }, [sourceAccount, transferAccount, transactionDate, amount, scheduledTransactions, futureTransactions, scheduledTransaction.id]);
+  }, [sourceAccount, transferAccount, transactionDate, effectivePostAmount, scheduledTransactions, futureTransactions, scheduledTransaction.id]);
 
   // Initialize form with transaction values (including override if exists)
   useEffect(() => {

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
@@ -14,12 +14,16 @@ import { ScheduledTransaction, PostScheduledTransactionData } from '@/types/sche
 import { Category } from '@/types/category';
 import { Account } from '@/types/account';
 import { scheduledTransactionsApi } from '@/lib/scheduled-transactions';
+import { investmentsApi } from '@/lib/investments';
 import { getLocalDateString } from '@/lib/utils';
 import { buildCategoryTree } from '@/lib/categoryUtils';
 import { roundToCents, getCurrencySymbol } from '@/lib/format';
 import { getErrorMessage } from '@/lib/errors';
+import { createLogger } from '@/lib/logger';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { getProjectedBalanceAtDate, FutureTransaction } from '@/lib/forecast';
+
+const logger = createLogger('PostTransactionDialog');
 
 // Liability accounts normally carry negative balances — only warn if over credit limit
 const LIABILITY_TYPES = new Set(['CREDIT_CARD', 'LOAN', 'MORTGAGE', 'LINE_OF_CREDIT']);
@@ -78,6 +82,10 @@ export function PostTransactionDialog({
   const [investmentQuantity, setInvestmentQuantity] = useState<number | ''>('');
   const [investmentPrice, setInvestmentPrice] = useState<number | ''>('');
   const [investmentTotalAmount, setInvestmentTotalAmount] = useState<number | ''>('');
+  // UI-only computed total for qty+price actions (qty * price + commission).
+  // Not sent to the backend -- the API derives the total from qty/price/commission.
+  const [investmentTotalValue, setInvestmentTotalValue] = useState<number | ''>('');
+  const [marketPrice, setMarketPrice] = useState<number | null>(null);
 
   const isInvestmentKind = scheduledTransaction.isInvestment;
   const investmentAction = scheduledTransaction.investmentAction;
@@ -186,23 +194,127 @@ export function PostTransactionDialog({
       }
 
       // Investment-kind: prefill overrides from the stored values
-      setInvestmentQuantity(
+      const initialQty =
         scheduledTransaction.investmentQuantity != null
           ? Number(scheduledTransaction.investmentQuantity)
-          : '',
-      );
-      setInvestmentPrice(
+          : '';
+      const initialPrice =
         scheduledTransaction.investmentPrice != null
           ? Number(scheduledTransaction.investmentPrice)
-          : '',
-      );
+          : '';
+      setInvestmentQuantity(initialQty);
+      setInvestmentPrice(initialPrice);
       setInvestmentTotalAmount(
         scheduledTransaction.investmentTotalAmount != null
           ? Number(scheduledTransaction.investmentTotalAmount)
           : '',
       );
+      // Seed the UI-only total from qty * price (+ signed commission) so the
+      // user sees a meaningful starting value for BUY/SELL/REINVEST.
+      if (
+        typeof initialQty === 'number' &&
+        initialQty > 0 &&
+        typeof initialPrice === 'number' &&
+        initialPrice > 0
+      ) {
+        const commission = Number(scheduledTransaction.investmentCommission ?? 0);
+        const sign = scheduledTransaction.investmentAction === 'SELL' ? -1 : 1;
+        const total = initialQty * initialPrice + sign * commission;
+        setInvestmentTotalValue(Math.round(total * 10_000) / 10_000);
+      } else {
+        setInvestmentTotalValue('');
+      }
+      setMarketPrice(null);
     }
   }, [isOpen, scheduledTransaction]);
+
+  // Fetch the most recent close price for the security so we can auto-fill
+  // the Price field (matching the new-scheduled-transaction form's behaviour).
+  useEffect(() => {
+    if (!isOpen || !isInvestmentKind || !isInvestmentQuantityPrice) return;
+    const securityId = scheduledTransaction.investmentSecurityId;
+    if (!securityId) return;
+    let cancelled = false;
+    investmentsApi
+      .getSecurityPrices(securityId, 1)
+      .then((prices) => {
+        if (cancelled) return;
+        const latest = prices[0];
+        setMarketPrice(latest ? Number(latest.closePrice) : null);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setMarketPrice(null);
+        logger.warn?.('Failed to fetch latest price', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isOpen,
+    isInvestmentKind,
+    isInvestmentQuantityPrice,
+    scheduledTransaction.investmentSecurityId,
+  ]);
+
+  // When the market price arrives, overwrite the Price with the latest value
+  // and recompute the total from the existing quantity. Uses the "info from
+  // previous render" pattern to avoid violating react-hooks/set-state-in-effect.
+  const [lastSeenMarketPrice, setLastSeenMarketPrice] = useState<number | null>(null);
+  if (isOpen && marketPrice !== lastSeenMarketPrice) {
+    setLastSeenMarketPrice(marketPrice);
+    if (isInvestmentQuantityPrice && marketPrice != null && marketPrice > 0) {
+      const rounded = Math.round(marketPrice * 1_000_000) / 1_000_000;
+      setInvestmentPrice(rounded);
+      if (investmentQuantity !== '' && Number(investmentQuantity) > 0) {
+        const commission = Number(scheduledTransaction.investmentCommission ?? 0);
+        const sign = scheduledTransaction.investmentAction === 'SELL' ? -1 : 1;
+        const total = Number(investmentQuantity) * rounded + sign * commission;
+        setInvestmentTotalValue(Math.round(total * 10_000) / 10_000);
+      }
+    }
+  }
+
+  const investmentSign = scheduledTransaction.investmentAction === 'SELL' ? -1 : 1;
+  const investmentCommission = Number(scheduledTransaction.investmentCommission ?? 0);
+
+  const handleInvestmentQuantityChange = (raw: string) => {
+    const qty = raw === '' ? '' : Number(raw);
+    setInvestmentQuantity(qty);
+    if (qty !== '' && investmentPrice !== '' && Number(investmentPrice) > 0) {
+      const total = Number(qty) * Number(investmentPrice) + investmentSign * investmentCommission;
+      setInvestmentTotalValue(Math.round(total * 10_000) / 10_000);
+    }
+  };
+
+  const handleInvestmentPriceChange = (raw: string) => {
+    const price = raw === '' ? '' : Number(raw);
+    setInvestmentPrice(price);
+    if (price !== '' && Number(price) > 0) {
+      if (investmentTotalValue !== '') {
+        // User has a target total -- keep it and derive quantity.
+        const cost = Number(investmentTotalValue) - investmentSign * investmentCommission;
+        const qty = Math.max(0, cost / Number(price));
+        setInvestmentQuantity(Math.round(qty * 100_000_000) / 100_000_000);
+      } else if (investmentQuantity !== '') {
+        const total = Number(investmentQuantity) * Number(price) + investmentSign * investmentCommission;
+        setInvestmentTotalValue(Math.round(total * 10_000) / 10_000);
+      }
+    }
+  };
+
+  const handleInvestmentTotalValueChange = (raw: number | undefined) => {
+    if (raw === undefined) {
+      setInvestmentTotalValue('');
+      return;
+    }
+    setInvestmentTotalValue(raw);
+    if (investmentPrice !== '' && Number(investmentPrice) > 0) {
+      const cost = raw - investmentSign * investmentCommission;
+      const qty = Math.max(0, cost / Number(investmentPrice));
+      setInvestmentQuantity(Math.round(qty * 100_000_000) / 100_000_000);
+    }
+  };
 
   const categoryOptions = useMemo(() => {
     return buildCategoryTree(categories).map(({ category }) => {
@@ -431,21 +543,43 @@ export function PostTransactionDialog({
                 min={0}
                 value={investmentQuantity}
                 onChange={(e) =>
-                  setInvestmentQuantity(e.target.value === '' ? '' : Number(e.target.value))
+                  isInvestmentQuantityPrice
+                    ? handleInvestmentQuantityChange(e.target.value)
+                    : setInvestmentQuantity(
+                        e.target.value === '' ? '' : Number(e.target.value),
+                      )
                 }
               />
             )}
             {isInvestmentQuantityPrice && (
-              <Input
-                label="Price per share"
-                type="number"
-                step="0.000001"
-                min={0}
-                value={investmentPrice}
-                onChange={(e) =>
-                  setInvestmentPrice(e.target.value === '' ? '' : Number(e.target.value))
-                }
-              />
+              <>
+                <Input
+                  label="Price per share"
+                  type="number"
+                  step="0.000001"
+                  min={0}
+                  placeholder={
+                    marketPrice != null ? `Latest: ${marketPrice}` : undefined
+                  }
+                  value={investmentPrice}
+                  onChange={(e) => handleInvestmentPriceChange(e.target.value)}
+                />
+                <CurrencyInput
+                  label="Total Price"
+                  prefix={getCurrencySymbol(scheduledTransaction.currencyCode)}
+                  value={
+                    typeof investmentTotalValue === 'number'
+                      ? investmentTotalValue
+                      : undefined
+                  }
+                  onChange={handleInvestmentTotalValueChange}
+                />
+                {scheduledTransaction.investmentSecurityId && marketPrice == null && (
+                  <p className="-mt-2 text-xs text-gray-500 dark:text-gray-400">
+                    No price history yet for this security. Enter the price manually.
+                  </p>
+                )}
+              </>
             )}
             {isInvestmentAmountOnly && (
               <CurrencyInput

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
@@ -193,21 +193,34 @@ export function PostTransactionDialog({
         setSplits(createEmptySplits(amt));
       }
 
-      // Investment-kind: prefill overrides from the stored values
+      // Investment-kind: prefill from the next-occurrence override if one
+      // exists, falling back to the base scheduled transaction's saved values.
+      // Without the override fallback, a user who has tweaked the upcoming
+      // occurrence (e.g. a one-off DRIP buy at a different quantity) sees the
+      // original numbers in the Post dialog.
+      const overrideQty = nextOverride?.investmentQuantity;
+      const overridePrice = nextOverride?.investmentPrice;
+      const overrideTotal = nextOverride?.investmentTotalAmount;
       const initialQty =
-        scheduledTransaction.investmentQuantity != null
-          ? Number(scheduledTransaction.investmentQuantity)
-          : '';
+        overrideQty != null
+          ? Number(overrideQty)
+          : scheduledTransaction.investmentQuantity != null
+            ? Number(scheduledTransaction.investmentQuantity)
+            : '';
       const initialPrice =
-        scheduledTransaction.investmentPrice != null
-          ? Number(scheduledTransaction.investmentPrice)
-          : '';
+        overridePrice != null
+          ? Number(overridePrice)
+          : scheduledTransaction.investmentPrice != null
+            ? Number(scheduledTransaction.investmentPrice)
+            : '';
       setInvestmentQuantity(initialQty);
       setInvestmentPrice(initialPrice);
       setInvestmentTotalAmount(
-        scheduledTransaction.investmentTotalAmount != null
-          ? Number(scheduledTransaction.investmentTotalAmount)
-          : '',
+        overrideTotal != null
+          ? Number(overrideTotal)
+          : scheduledTransaction.investmentTotalAmount != null
+            ? Number(scheduledTransaction.investmentTotalAmount)
+            : '',
       );
       // Seed the UI-only total from qty * price (+ signed commission) so the
       // user sees a meaningful starting value for BUY/SELL/REINVEST.

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionList.test.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionList.test.tsx
@@ -187,6 +187,86 @@ describe('ScheduledTransactionList', () => {
     expect(screen.getByText('-$19.99')).toBeInTheDocument();
   });
 
+  it('derives investment amount from qty * price + commission (base, no override)', () => {
+    const transactions = [createTransaction({
+      isInvestment: true,
+      investmentAction: 'BUY',
+      investmentQuantity: 10,
+      investmentPrice: 100,
+      investmentCommission: 9.99,
+      amount: 0, // base amount column ignored for investments
+    })];
+    render(<ScheduledTransactionList transactions={transactions} />);
+    // 10 * 100 + 9.99 = 1009.99, BUY -> negative
+    expect(screen.getByText('-$1009.99')).toBeInTheDocument();
+  });
+
+  it('shows base vs override amount for an investment override that changes quantity', () => {
+    const transactions = [createTransaction({
+      isInvestment: true,
+      investmentAction: 'BUY',
+      investmentQuantity: 10,
+      investmentPrice: 100,
+      investmentCommission: 0,
+      amount: 0,
+      nextOverride: {
+        amount: null,
+        overrideDate: null,
+        investmentQuantity: 5,
+        investmentPrice: 100,
+        investmentTotalAmount: null,
+      },
+    })];
+    render(<ScheduledTransactionList transactions={transactions} />);
+    // Base 10 * 100 = -1000; override 5 * 100 = -500
+    expect(screen.getByText('-$1000.00')).toBeInTheDocument();
+    expect(screen.getByText('-$500.00')).toBeInTheDocument();
+  });
+
+  it('shows base vs override amount for a DIVIDEND override that changes total', () => {
+    const transactions = [createTransaction({
+      isInvestment: true,
+      investmentAction: 'DIVIDEND',
+      investmentQuantity: null,
+      investmentPrice: null,
+      investmentTotalAmount: 50,
+      investmentCommission: 0,
+      amount: 0,
+      nextOverride: {
+        amount: null,
+        overrideDate: null,
+        investmentQuantity: null,
+        investmentPrice: null,
+        investmentTotalAmount: 125,
+      },
+    })];
+    render(<ScheduledTransactionList transactions={transactions} />);
+    expect(screen.getByText('+$50.00')).toBeInTheDocument();
+    expect(screen.getByText('+$125.00')).toBeInTheDocument();
+  });
+
+  it('does not strike through when the investment override matches the base values', () => {
+    const transactions = [createTransaction({
+      isInvestment: true,
+      investmentAction: 'BUY',
+      investmentQuantity: 10,
+      investmentPrice: 100,
+      investmentCommission: 0,
+      amount: 0,
+      nextOverride: {
+        amount: null,
+        overrideDate: null,
+        investmentQuantity: 10,
+        investmentPrice: 100,
+        investmentTotalAmount: null,
+      },
+    })];
+    render(<ScheduledTransactionList transactions={transactions} />);
+    expect(screen.getByText('-$1000.00')).toBeInTheDocument();
+    // Only one occurrence -- no strikethrough sibling
+    expect(screen.queryAllByText('-$1000.00').length).toBe(1);
+  });
+
   // --- Account name display ---
   it('displays account name', () => {
     const transactions = [createTransaction({ account: { name: 'Main Checking' } })];

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionList.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionList.tsx
@@ -9,6 +9,49 @@ import { parseLocalDate } from '@/lib/utils';
 import { getErrorMessage } from '@/lib/errors';
 import { useDateFormat } from '@/hooks/useDateFormat';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { computeInvestmentCashImpact } from '@/lib/investmentCashImpact';
+import { InvestmentAction } from '@/types/investment';
+
+/**
+ * Cash impact of a scheduled transaction occurrence, taking nextOverride into
+ * account when useOverride is true. For investment-kind rows the amount column
+ * isn't simply `transaction.amount`; it's derived from qty * price + commission
+ * (or totalAmount for amount-only actions), and the override may carry a
+ * different qty / price / total than the base row.
+ */
+function scheduledOccurrenceAmount(
+  transaction: ScheduledTransaction,
+  useOverride: boolean,
+): number | null {
+  if (transaction.isInvestment) {
+    const action = transaction.investmentAction as InvestmentAction | null;
+    if (!action) return null;
+    const override = useOverride ? transaction.nextOverride : null;
+    const commission = Number(transaction.investmentCommission ?? 0);
+
+    if (action === 'BUY' || action === 'SELL' || action === 'REINVEST') {
+      const qty = Number(
+        override?.investmentQuantity ?? transaction.investmentQuantity ?? 0,
+      );
+      const price = Number(
+        override?.investmentPrice ?? transaction.investmentPrice ?? 0,
+      );
+      if (qty <= 0 || price <= 0) return null;
+      return computeInvestmentCashImpact(action, qty, price, commission);
+    }
+    if (action === 'DIVIDEND' || action === 'INTEREST' || action === 'CAPITAL_GAIN') {
+      const total =
+        override?.investmentTotalAmount ?? transaction.investmentTotalAmount;
+      return total != null ? Number(total) : null;
+    }
+    // ADD_SHARES / REMOVE_SHARES / SPLIT -- shares move, no cash impact.
+    return 0;
+  }
+  if (useOverride && transaction.nextOverride?.amount != null) {
+    return Number(transaction.nextOverride.amount);
+  }
+  return Number(transaction.amount);
+}
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { Modal } from '@/components/ui/Modal';
 
@@ -149,19 +192,29 @@ const ScheduledTransactionRow = memo(function ScheduledTransactionRow({
 
       {/* Amount */}
       <td className="px-4 py-3 whitespace-nowrap text-sm font-medium text-right">
-        {transaction.nextOverride?.amount != null &&
-         Number(transaction.nextOverride.amount) !== Number(transaction.amount) ? (
-          <div className="flex flex-col items-end">
-            <span className="text-xs text-gray-400 dark:text-gray-500 line-through">
-              {formatAmount(transaction.amount, transaction.currencyCode)}
-            </span>
-            <span title="Modified for next occurrence">
-              {formatAmount(transaction.nextOverride.amount, transaction.currencyCode)}
-            </span>
-          </div>
-        ) : (
-          formatAmount(transaction.amount, transaction.currencyCode)
-        )}
+        {(() => {
+          const baseAmount = scheduledOccurrenceAmount(transaction, false);
+          const overrideAmount = transaction.nextOverride
+            ? scheduledOccurrenceAmount(transaction, true)
+            : null;
+          const isModified =
+            overrideAmount != null &&
+            baseAmount != null &&
+            Number(overrideAmount) !== Number(baseAmount);
+          if (isModified) {
+            return (
+              <div className="flex flex-col items-end">
+                <span className="text-xs text-gray-400 dark:text-gray-500 line-through">
+                  {formatAmount(baseAmount, transaction.currencyCode)}
+                </span>
+                <span title="Modified for next occurrence">
+                  {formatAmount(overrideAmount, transaction.currencyCode)}
+                </span>
+              </div>
+            );
+          }
+          return formatAmount(baseAmount, transaction.currencyCode);
+        })()}
       </td>
 
       {/* Schedule (Frequency + Next Due + Remaining) */}

--- a/frontend/src/types/scheduled-transaction.ts
+++ b/frontend/src/types/scheduled-transaction.ts
@@ -164,6 +164,9 @@ export interface ScheduledTransactionOverride {
   description: string | null;
   isSplit: boolean | null;
   splits: OverrideSplit[] | null;
+  investmentQuantity: number | null;
+  investmentPrice: number | null;
+  investmentTotalAmount: number | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -176,6 +179,9 @@ export interface CreateScheduledTransactionOverrideData {
   description?: string | null;
   isSplit?: boolean | null;
   splits?: OverrideSplit[] | null;
+  investmentQuantity?: number | null;
+  investmentPrice?: number | null;
+  investmentTotalAmount?: number | null;
 }
 
 export interface UpdateScheduledTransactionOverrideData {
@@ -184,6 +190,9 @@ export interface UpdateScheduledTransactionOverrideData {
   description?: string | null;
   isSplit?: boolean | null;
   splits?: OverrideSplit[] | null;
+  investmentQuantity?: number | null;
+  investmentPrice?: number | null;
+  investmentTotalAmount?: number | null;
 }
 
 export interface OverrideCheckResult {


### PR DESCRIPTION
When posting a scheduled BUY/SELL/REINVEST occurrence, the dialog now shows
a Total Price field that updates as quantity or price changes, and editing
it back-derives the quantity. Price is also auto-filled from the security's
latest close on open, matching the new-scheduled-transaction form.