### PR TITLE
Support scheduled investment transactions in cash flow forecasts

### DIFF
--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
@@ -181,10 +181,10 @@ export function PostTransactionDialog({
   const projectedBalances = useMemo(() => {
     if (!transactionDate) return null;
     const sourceBefore = sourceAccount
-      ? getProjectedBalanceAtDate(sourceAccount, transactionDate, scheduledTransactions, futureTransactions, scheduledTransaction.id)
+      ? getProjectedBalanceAtDate(sourceAccount, transactionDate, scheduledTransactions, futureTransactions, scheduledTransaction.id, accounts)
       : null;
     const transferBefore = transferAccount
-      ? getProjectedBalanceAtDate(transferAccount, transactionDate, scheduledTransactions, futureTransactions, scheduledTransaction.id)
+      ? getProjectedBalanceAtDate(transferAccount, transactionDate, scheduledTransactions, futureTransactions, scheduledTransaction.id, accounts)
       : null;
     return {
       sourceBefore,

--- a/frontend/src/lib/forecast.test.ts
+++ b/frontend/src/lib/forecast.test.ts
@@ -696,6 +696,103 @@ describe('buildForecast', () => {
   });
 
   // --- Multiple accounts and transactions ---
+  describe('scheduled investment transactions', () => {
+    it('applies a scheduled BUY to the investment cash funding account', () => {
+      const cashAccount = makeAccount({ id: 'cash-1', currentBalance: 10000 });
+      const transactions = [makeScheduled({
+        id: 'inv-1',
+        name: 'Buy AAPL',
+        accountId: 'brokerage-1',
+        amount: -2500, // signed cash impact (BUY)
+        frequency: 'ONCE',
+        nextDueDate: '2025-01-20',
+        isInvestment: true,
+        investmentFundingAccountId: 'cash-1',
+        investmentExchangeRate: 1,
+      } as any)];
+      const result = buildForecast([cashAccount], transactions, 'month', 'cash-1');
+      const jan20 = result.find(dp => dp.date === '2025-01-20');
+      expect(jan20?.transactions.length).toBe(1);
+      expect(jan20?.transactions[0].amount).toBe(-2500);
+      expect(jan20?.balance).toBe(7500);
+    });
+
+    it('applies a scheduled SELL as a positive cash inflow on the funding account', () => {
+      const cashAccount = makeAccount({ id: 'cash-1', currentBalance: 10000 });
+      const transactions = [makeScheduled({
+        id: 'inv-1',
+        name: 'Sell AAPL',
+        accountId: 'brokerage-1',
+        amount: 1500, // signed cash impact (SELL)
+        frequency: 'ONCE',
+        nextDueDate: '2025-01-20',
+        isInvestment: true,
+        investmentFundingAccountId: 'cash-1',
+        investmentExchangeRate: 1,
+      } as any)];
+      const result = buildForecast([cashAccount], transactions, 'month', 'cash-1');
+      const jan20 = result.find(dp => dp.date === '2025-01-20');
+      expect(jan20?.balance).toBe(11500);
+    });
+
+    it('converts the cash impact via investmentExchangeRate', () => {
+      const cashAccount = makeAccount({ id: 'cash-1', currentBalance: 10000 });
+      const transactions = [makeScheduled({
+        id: 'inv-1',
+        name: 'Buy ABC.TO',
+        accountId: 'brokerage-1',
+        amount: -1000, // security currency
+        frequency: 'ONCE',
+        nextDueDate: '2025-01-20',
+        isInvestment: true,
+        investmentFundingAccountId: 'cash-1',
+        investmentExchangeRate: 1.35,
+      } as any)];
+      const result = buildForecast([cashAccount], transactions, 'month', 'cash-1');
+      const jan20 = result.find(dp => dp.date === '2025-01-20');
+      // -1000 * 1.35 = -1350
+      expect(jan20?.balance).toBe(8650);
+    });
+
+    it('does not affect a non-funding account when selected', () => {
+      const otherCash = makeAccount({ id: 'cash-other', currentBalance: 4000 });
+      const transactions = [makeScheduled({
+        id: 'inv-1',
+        accountId: 'brokerage-1',
+        amount: -2500,
+        frequency: 'ONCE',
+        nextDueDate: '2025-01-20',
+        isInvestment: true,
+        investmentFundingAccountId: 'cash-1',
+        investmentExchangeRate: 1,
+      } as any)];
+      const result = buildForecast([otherCash], transactions, 'month', 'cash-other');
+      const allBalances = result.map(dp => dp.balance);
+      expect(allBalances.every(b => b === 4000)).toBe(true);
+    });
+
+    it('expands recurring scheduled investments on the funding account', () => {
+      const cashAccount = makeAccount({ id: 'cash-1', currentBalance: 10000 });
+      const transactions = [makeScheduled({
+        id: 'inv-1',
+        accountId: 'brokerage-1',
+        amount: -500,
+        frequency: 'MONTHLY',
+        nextDueDate: '2025-01-20',
+        isInvestment: true,
+        investmentFundingAccountId: 'cash-1',
+        investmentExchangeRate: 1,
+      } as any)];
+      const result = buildForecast([cashAccount], transactions, '90days', 'cash-1');
+      const jan20 = result.find(dp => dp.date === '2025-01-20');
+      const feb20 = result.find(dp => dp.date === '2025-02-20');
+      const mar20 = result.find(dp => dp.date === '2025-03-20');
+      expect(jan20?.balance).toBe(9500);
+      expect(feb20?.balance).toBe(9000);
+      expect(mar20?.balance).toBe(8500);
+    });
+  });
+
   describe('multiple accounts and transactions', () => {
     it('sums balances from multiple accounts', () => {
       const accounts = [
@@ -1237,5 +1334,21 @@ describe('getProjectedBalanceAtDate', () => {
     // Jan 15, Jan 22, Jan 29 = 3 occurrences
     const result = getProjectedBalanceAtDate(account, '2025-01-29', scheduled, []);
     expect(result).toBe(4400); // 5000 - 3*200
+  });
+
+  it('applies scheduled investment BUYs to the funding cash account', () => {
+    const cashAccount = makeAccount({ id: 'cash-1', currentBalance: 10000 });
+    const scheduled = [makeScheduled({
+      id: 'inv-1',
+      accountId: 'brokerage-1',
+      amount: -1500,
+      frequency: 'ONCE',
+      nextDueDate: '2025-01-20',
+      isInvestment: true,
+      investmentFundingAccountId: 'cash-1',
+      investmentExchangeRate: 1,
+    } as any)];
+    const result = getProjectedBalanceAtDate(cashAccount, '2025-01-25', scheduled, []);
+    expect(result).toBe(8500);
   });
 });

--- a/frontend/src/lib/forecast.test.ts
+++ b/frontend/src/lib/forecast.test.ts
@@ -771,6 +771,30 @@ describe('buildForecast', () => {
       expect(allBalances.every(b => b === 4000)).toBe(true);
     });
 
+    it('falls back to the brokerage linked cash account when fundingAccountId is null', () => {
+      const cashAccount = makeAccount({ id: 'cash-1', currentBalance: 10000 });
+      const brokerage = makeAccount({
+        id: 'brokerage-1',
+        currentBalance: 0,
+        linkedAccountId: 'cash-1',
+        accountSubType: 'INVESTMENT_BROKERAGE',
+      } as any);
+      const transactions = [makeScheduled({
+        id: 'inv-1',
+        name: 'Buy AAPL',
+        accountId: 'brokerage-1',
+        amount: -2500,
+        frequency: 'ONCE',
+        nextDueDate: '2025-01-20',
+        isInvestment: true,
+        investmentFundingAccountId: null,
+        investmentExchangeRate: 1,
+      } as any)];
+      const result = buildForecast([cashAccount, brokerage], transactions, 'month', 'cash-1');
+      const jan20 = result.find(dp => dp.date === '2025-01-20');
+      expect(jan20?.balance).toBe(7500);
+    });
+
     it('expands recurring scheduled investments on the funding account', () => {
       const cashAccount = makeAccount({ id: 'cash-1', currentBalance: 10000 });
       const transactions = [makeScheduled({

--- a/frontend/src/lib/forecast.ts
+++ b/frontend/src/lib/forecast.ts
@@ -223,6 +223,42 @@ function isTransfer(transaction: ScheduledTransaction): boolean {
 }
 
 /**
+ * Scheduled investment transactions store `accountId` as the brokerage account
+ * but the cash side flows through `investmentFundingAccountId` (typically an
+ * INVESTMENT_CASH account). Reshape them so the forecast treats the cash
+ * account as the affected account, with the amount converted into that
+ * account's currency via the recorded exchange rate.
+ */
+function normalizeInvestmentForForecast(transaction: ScheduledTransaction): ScheduledTransaction {
+  if (!transaction.isInvestment || !transaction.investmentFundingAccountId) {
+    return transaction;
+  }
+  const rate = transaction.investmentExchangeRate != null
+    ? Number(transaction.investmentExchangeRate)
+    : 1;
+  if (!Number.isFinite(rate) || rate === 1) {
+    // No conversion needed; just re-target the account.
+    if (transaction.accountId === transaction.investmentFundingAccountId) {
+      return transaction;
+    }
+    return { ...transaction, accountId: transaction.investmentFundingAccountId };
+  }
+  const convertOverride = <T extends { amount: number | null }>(o: T): T => ({
+    ...o,
+    amount: o.amount != null ? Number(o.amount) * rate : o.amount,
+  });
+  return {
+    ...transaction,
+    accountId: transaction.investmentFundingAccountId,
+    amount: Number(transaction.amount) * rate,
+    futureOverrides: transaction.futureOverrides?.map(convertOverride),
+    nextOverride: transaction.nextOverride
+      ? convertOverride(transaction.nextOverride)
+      : transaction.nextOverride,
+  };
+}
+
+/**
  * Build forecast data points for the cash flow chart.
  *
  * futureTransactions: already-posted transactions with a date after today.
@@ -238,6 +274,10 @@ export function buildForecast(
   futureTransactions: FutureTransaction[] = [],
   convertAmount?: (amount: number, currencyCode: string) => number,
 ): ForecastDataPoint[] {
+  // Remap scheduled investment transactions onto their funding cash account so
+  // BUY/SELL/etc. show up in the cash flow forecast for INVESTMENT_CASH accounts.
+  transactions = transactions.map(normalizeInvestmentForForecast);
+
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const todayKey = formatDateKey(today);
@@ -381,6 +421,8 @@ export function getProjectedBalanceAtDate(
   futureTransactions: FutureTransaction[] = [],
   excludeScheduledId?: string
 ): number {
+  scheduledTransactions = scheduledTransactions.map(normalizeInvestmentForForecast);
+
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const todayKey = formatDateKey(today);

--- a/frontend/src/lib/forecast.ts
+++ b/frontend/src/lib/forecast.ts
@@ -225,23 +225,37 @@ function isTransfer(transaction: ScheduledTransaction): boolean {
 /**
  * Scheduled investment transactions store `accountId` as the brokerage account
  * but the cash side flows through `investmentFundingAccountId` (typically an
- * INVESTMENT_CASH account). Reshape them so the forecast treats the cash
- * account as the affected account, with the amount converted into that
- * account's currency via the recorded exchange rate.
+ * INVESTMENT_CASH account). When the funding account is left blank, the cash
+ * side falls back to the brokerage's linked cash account. Reshape the
+ * scheduled transaction so the forecast treats the cash account as the
+ * affected account, with the amount converted into that account's currency
+ * via the recorded exchange rate.
  */
-function normalizeInvestmentForForecast(transaction: ScheduledTransaction): ScheduledTransaction {
-  if (!transaction.isInvestment || !transaction.investmentFundingAccountId) {
+function normalizeInvestmentForForecast(
+  transaction: ScheduledTransaction,
+  accountsById: Map<string, Account>,
+): ScheduledTransaction {
+  if (!transaction.isInvestment) {
+    return transaction;
+  }
+  let cashAccountId = transaction.investmentFundingAccountId;
+  if (!cashAccountId) {
+    const brokerage = accountsById.get(transaction.accountId);
+    if (brokerage?.linkedAccountId) {
+      cashAccountId = brokerage.linkedAccountId;
+    }
+  }
+  if (!cashAccountId) {
     return transaction;
   }
   const rate = transaction.investmentExchangeRate != null
     ? Number(transaction.investmentExchangeRate)
     : 1;
   if (!Number.isFinite(rate) || rate === 1) {
-    // No conversion needed; just re-target the account.
-    if (transaction.accountId === transaction.investmentFundingAccountId) {
+    if (transaction.accountId === cashAccountId) {
       return transaction;
     }
-    return { ...transaction, accountId: transaction.investmentFundingAccountId };
+    return { ...transaction, accountId: cashAccountId };
   }
   const convertOverride = <T extends { amount: number | null }>(o: T): T => ({
     ...o,
@@ -249,7 +263,7 @@ function normalizeInvestmentForForecast(transaction: ScheduledTransaction): Sche
   });
   return {
     ...transaction,
-    accountId: transaction.investmentFundingAccountId,
+    accountId: cashAccountId,
     amount: Number(transaction.amount) * rate,
     futureOverrides: transaction.futureOverrides?.map(convertOverride),
     nextOverride: transaction.nextOverride
@@ -276,7 +290,8 @@ export function buildForecast(
 ): ForecastDataPoint[] {
   // Remap scheduled investment transactions onto their funding cash account so
   // BUY/SELL/etc. show up in the cash flow forecast for INVESTMENT_CASH accounts.
-  transactions = transactions.map(normalizeInvestmentForForecast);
+  const accountsById = new Map(accounts.map(a => [a.id, a]));
+  transactions = transactions.map(t => normalizeInvestmentForForecast(t, accountsById));
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -419,9 +434,17 @@ export function getProjectedBalanceAtDate(
   targetDate: string,
   scheduledTransactions: ScheduledTransaction[],
   futureTransactions: FutureTransaction[] = [],
-  excludeScheduledId?: string
+  excludeScheduledId?: string,
+  allAccounts?: Account[],
 ): number {
-  scheduledTransactions = scheduledTransactions.map(normalizeInvestmentForForecast);
+  const accountsById = new Map<string, Account>();
+  accountsById.set(account.id, account);
+  if (allAccounts) {
+    for (const a of allAccounts) accountsById.set(a.id, a);
+  }
+  scheduledTransactions = scheduledTransactions.map(t =>
+    normalizeInvestmentForForecast(t, accountsById),
+  );
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## Summary
This PR adds support for scheduled investment transactions (BUY/SELL orders) in cash flow forecasts. Investment transactions are now properly reflected in the funding cash account's balance projections, with currency conversion applied via exchange rates.

## Key Changes
- **New `normalizeInvestmentForForecast()` function**: Reshapes scheduled investment transactions to target their funding cash account instead of the brokerage account. Handles:
  - Explicit `investmentFundingAccountId` when specified
  - Fallback to the brokerage's `linkedAccountId` when funding account is null
  - Currency conversion via `investmentExchangeRate` for multi-currency investments
  
- **Updated `buildForecast()`**: Normalizes all scheduled investment transactions before processing, ensuring BUY/SELL orders appear in cash flow forecasts for INVESTMENT_CASH accounts

- **Updated `getProjectedBalanceAtDate()`**: Added optional `allAccounts` parameter to support investment transaction normalization when calculating projected balances at specific dates

- **Updated `PostTransactionDialog`**: Passes `accounts` array to `getProjectedBalanceAtDate()` calls to enable proper investment transaction handling in balance projections

## Implementation Details
- Investment transactions are identified by the `isInvestment` flag
- The cash impact amount is multiplied by `investmentExchangeRate` to convert from security currency to funding account currency
- Both `futureOverrides` and `nextOverride` amounts are converted when present
- Non-investment transactions and transactions without a valid funding account are passed through unchanged
- Comprehensive test coverage includes: basic BUY/SELL, currency conversion, account filtering, linked account fallback, and recurring investment expansion

https://claude.ai/code/session_0138QbArQbsMcAB9gYvJknN6