### PR TITLE
fix(investments): update embedded split row in place instead of spawning a new top-level cash transaction

### DIFF
--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -10,6 +10,7 @@ import {
   Transaction,
   TransactionStatus,
 } from "../transactions/entities/transaction.entity";
+import { TransactionSplit } from "../transactions/entities/transaction-split.entity";
 import { AccountSubType } from "../accounts/entities/account.entity";
 import { AccountsService } from "../accounts/accounts.service";
 import { TransactionsService } from "../transactions/transactions.service";
@@ -4480,6 +4481,212 @@ describe("InvestmentTransactionsService", () => {
       );
       // Cash side suppressed
       expect(accountsService.updateBalance).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("update embedded in split", () => {
+    const splitId = "split-1";
+    const parentTxId = "parent-tx-1";
+    const incomeSplitId = "split-income-1";
+
+    const buildEmbeddedBuy = (overrides: Partial<InvestmentTransaction> = {}) =>
+      ({
+        ...mockBuyTransaction,
+        id: transactionId,
+        transactionId: null,
+        transactionSplitId: splitId,
+        quantity: 10,
+        price: 100,
+        commission: 0,
+        totalAmount: 1000,
+        exchangeRate: 1,
+        ...overrides,
+      }) as InvestmentTransaction;
+
+    const wireSplitFetches = (opts: {
+      embedded: InvestmentTransaction;
+      parentAmount: number;
+      siblingIncomeAmount: number;
+      parentDate?: string;
+    }) => {
+      const split: any = {
+        id: splitId,
+        transactionId: parentTxId,
+        amount: Number(opts.embedded.totalAmount) * -1,
+      };
+      const incomeSplit: any = {
+        id: incomeSplitId,
+        transactionId: parentTxId,
+        amount: opts.siblingIncomeAmount,
+      };
+      const parentTx: any = {
+        id: parentTxId,
+        userId,
+        accountId: cashAccountId,
+        transactionDate: opts.parentDate ?? "2026-01-15",
+        amount: opts.parentAmount,
+      };
+
+      mockQueryRunner.manager.findOne = jest
+        .fn()
+        .mockImplementation((Entity: any, query: any) => {
+          if (Entity === TransactionSplit) return Promise.resolve(split);
+          if (Entity === Transaction) {
+            if (query?.where?.id === parentTxId)
+              return Promise.resolve(parentTx);
+            return transactionRepository.findOne(query);
+          }
+          return investmentTransactionsRepository.findOne(query);
+        });
+      mockQueryRunner.manager.find = jest
+        .fn()
+        .mockImplementation((Entity: any) => {
+          if (Entity === TransactionSplit)
+            return Promise.resolve([split, incomeSplit]);
+          return Promise.resolve([]);
+        });
+
+      return { split, incomeSplit, parentTx };
+    };
+
+    beforeEach(() => {
+      accountsService.findOne.mockImplementation((uid: string, aid: string) => {
+        if (aid === accountId) return Promise.resolve(mockInvestmentAccount);
+        if (aid === cashAccountId) return Promise.resolve(mockCashAccount);
+        return Promise.reject(new NotFoundException("Account not found"));
+      });
+    });
+
+    it("does not create a new cash transaction when price changes", async () => {
+      const embedded = buildEmbeddedBuy();
+      const firstFindQB = createMockQueryBuilder(embedded);
+      const secondFindQB = createMockQueryBuilder({
+        ...embedded,
+        price: 150,
+        totalAmount: 1500,
+      });
+      investmentTransactionsRepository.createQueryBuilder
+        .mockReturnValueOnce(firstFindQB)
+        .mockReturnValueOnce(secondFindQB);
+
+      wireSplitFetches({
+        embedded,
+        parentAmount: 0, // $1000 income + -$1000 investment
+        siblingIncomeAmount: 1000,
+      });
+
+      await service.update(userId, transactionId, { price: 150 });
+
+      // No standalone cash transaction is created on the cash account
+      const cashSaves = transactionRepository.save.mock.calls.filter(
+        ([data]: any[]) =>
+          data && data.accountId === cashAccountId && "amount" in data,
+      );
+      expect(cashSaves.length).toBe(0);
+    });
+
+    it("updates the parent split's amount and parent transaction amount", async () => {
+      const embedded = buildEmbeddedBuy();
+      const firstFindQB = createMockQueryBuilder(embedded);
+      const secondFindQB = createMockQueryBuilder({
+        ...embedded,
+        price: 150,
+        totalAmount: 1500,
+      });
+      investmentTransactionsRepository.createQueryBuilder
+        .mockReturnValueOnce(firstFindQB)
+        .mockReturnValueOnce(secondFindQB);
+
+      wireSplitFetches({
+        embedded,
+        parentAmount: 0,
+        siblingIncomeAmount: 1000,
+      });
+
+      await service.update(userId, transactionId, { price: 150 });
+
+      // Investment split amount = -(10 * 150) = -1500
+      expect(mockQueryRunner.manager.update).toHaveBeenCalledWith(
+        TransactionSplit,
+        splitId,
+        { amount: -1500 },
+      );
+      // Parent total = income (1000) + investment (-1500) = -500
+      expect(mockQueryRunner.manager.update).toHaveBeenCalledWith(
+        Transaction,
+        parentTxId,
+        { amount: -500 },
+      );
+    });
+
+    it("applies the delta to the cash account balance", async () => {
+      const embedded = buildEmbeddedBuy();
+      const firstFindQB = createMockQueryBuilder(embedded);
+      const secondFindQB = createMockQueryBuilder({
+        ...embedded,
+        price: 150,
+        totalAmount: 1500,
+      });
+      investmentTransactionsRepository.createQueryBuilder
+        .mockReturnValueOnce(firstFindQB)
+        .mockReturnValueOnce(secondFindQB);
+
+      wireSplitFetches({
+        embedded,
+        parentAmount: 0,
+        siblingIncomeAmount: 1000,
+      });
+
+      await service.update(userId, transactionId, { price: 150 });
+
+      // Old parent amount = 0, new = -500, delta = -500
+      expect(accountsService.updateBalance).toHaveBeenCalledWith(
+        cashAccountId,
+        -500,
+        mockQueryRunner,
+      );
+    });
+
+    it("rejects changing the brokerage account", async () => {
+      const embedded = buildEmbeddedBuy();
+      const firstFindQB = createMockQueryBuilder(embedded);
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValueOnce(
+        firstFindQB,
+      );
+
+      await expect(
+        service.update(userId, transactionId, {
+          accountId: "different-account",
+        }),
+      ).rejects.toThrow(/Cannot change the account/);
+    });
+
+    it("rejects changing the transaction date", async () => {
+      const embedded = buildEmbeddedBuy();
+      const firstFindQB = createMockQueryBuilder(embedded);
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValueOnce(
+        firstFindQB,
+      );
+
+      await expect(
+        service.update(userId, transactionId, {
+          transactionDate: "2027-01-01",
+        }),
+      ).rejects.toThrow(/Cannot change the date/);
+    });
+
+    it("rejects switching to an action not allowed in splits", async () => {
+      const embedded = buildEmbeddedBuy();
+      const firstFindQB = createMockQueryBuilder(embedded);
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValueOnce(
+        firstFindQB,
+      );
+
+      await expect(
+        service.update(userId, transactionId, {
+          action: InvestmentAction.ADD_SHARES,
+        }),
+      ).rejects.toThrow(/not allowed inside a split/);
     });
   });
 

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -32,6 +32,7 @@ import {
   Transaction,
   TransactionStatus,
 } from "../transactions/entities/transaction.entity";
+import { TransactionSplit } from "../transactions/entities/transaction-split.entity";
 import { Account, AccountSubType } from "../accounts/entities/account.entity";
 import { isTransactionInFuture } from "../common/date-utils";
 import { ActionHistoryService } from "../action-history/action-history.service";
@@ -907,6 +908,83 @@ export class InvestmentTransactionsService {
     await queryRunner.manager.remove(investmentTransaction);
   }
 
+  /**
+   * Sync a split transaction's parent after one of its embedded investment
+   * rows changes. Recomputes the split's cash-side amount from the saved
+   * investment row, re-sums all sibling splits to derive the parent
+   * transaction's new amount, and applies the delta to the cash account so
+   * its balance stays consistent.
+   */
+  private async updateEmbeddedSplitParent(
+    queryRunner: QueryRunner,
+    userId: string,
+    saved: InvestmentTransaction,
+    splitId: string,
+  ): Promise<void> {
+    const cashImpactInSecurity = computeInvestmentCashImpact(
+      saved.action,
+      Number(saved.quantity ?? 0),
+      Number(saved.price ?? 0),
+      Number(saved.commission ?? 0),
+    );
+    const newSplitAmount = roundToDecimals(
+      cashImpactInSecurity * Number(saved.exchangeRate),
+      4,
+    );
+
+    const split = await queryRunner.manager.findOne(TransactionSplit, {
+      where: { id: splitId },
+    });
+    if (!split) {
+      throw new NotFoundException(
+        `Transaction split ${splitId} not found for embedded investment update`,
+      );
+    }
+
+    await queryRunner.manager.update(TransactionSplit, splitId, {
+      amount: newSplitAmount,
+    });
+
+    const parentTransaction = await queryRunner.manager.findOne(Transaction, {
+      where: { id: split.transactionId, userId },
+    });
+    if (!parentTransaction) {
+      throw new NotFoundException(
+        `Parent transaction ${split.transactionId} not found for embedded investment update`,
+      );
+    }
+
+    const siblingSplits = await queryRunner.manager.find(TransactionSplit, {
+      where: { transactionId: split.transactionId },
+    });
+    const newParentTotalCents = siblingSplits.reduce((sum, s) => {
+      const amt = s.id === splitId ? newSplitAmount : Number(s.amount);
+      return sum + Math.round(amt * 10000);
+    }, 0);
+    const newParentAmount = newParentTotalCents / 10000;
+    const oldParentAmount = Number(parentTransaction.amount);
+    const delta = roundToDecimals(newParentAmount - oldParentAmount, 4);
+
+    await queryRunner.manager.update(Transaction, parentTransaction.id, {
+      amount: newParentAmount,
+    });
+
+    if (delta !== 0) {
+      if (isTransactionInFuture(parentTransaction.transactionDate)) {
+        await this.accountsService.recalculateCurrentBalance(
+          parentTransaction.accountId,
+          queryRunner,
+        );
+      } else {
+        await this.accountsService.updateBalance(
+          parentTransaction.accountId,
+          delta,
+          queryRunner,
+        );
+      }
+    }
+  }
+
   async findAll(
     userId: string,
     accountIds?: string[],
@@ -1075,14 +1153,11 @@ export class InvestmentTransactionsService {
       accountIds = [...resolvedIds];
     }
 
-    return this.portfolioCalculationService.calculateCapitalGainsByDay(
-      userId,
-      {
-        accountIds,
-        startDate: opts.startDate,
-        endDate: opts.endDate,
-      },
-    );
+    return this.portfolioCalculationService.calculateCapitalGainsByDay(userId, {
+      accountIds,
+      startDate: opts.startDate,
+      endDate: opts.endDate,
+    });
   }
 
   /**
@@ -1284,6 +1359,46 @@ export class InvestmentTransactionsService {
     const oldSecurityId = transaction.securityId;
     const oldTransactionDate = transaction.transactionDate;
     const oldAction = transaction.action;
+    const isEmbedded = transaction.transactionSplitId != null;
+
+    if (isEmbedded) {
+      // Embedded rows are pinned to their parent split: account, funding, and
+      // date come from the parent transaction. Letting the API mutate them
+      // here would silently desync the parent's cash side from the investment
+      // row. Anything else (action, security, qty, price, commission, fx,
+      // description) is fine -- those changes flow back into the parent
+      // split's amount below.
+      if (
+        updateDto.accountId !== undefined &&
+        updateDto.accountId !== transaction.accountId
+      ) {
+        throw new BadRequestException(
+          "Cannot change the account of an investment split; remove the split and add it on the new account instead",
+        );
+      }
+      if (
+        updateDto.fundingAccountId !== undefined &&
+        (updateDto.fundingAccountId || null) !== transaction.fundingAccountId
+      ) {
+        throw new BadRequestException(
+          "Investment splits do not use a separate funding account",
+        );
+      }
+      if (
+        updateDto.transactionDate !== undefined &&
+        updateDto.transactionDate !== transaction.transactionDate
+      ) {
+        throw new BadRequestException(
+          "Cannot change the date of an investment split; edit the parent split transaction date instead",
+        );
+      }
+      const effectiveAction = updateDto.action ?? transaction.action;
+      if (!isInvestmentActionAllowedInSplit(effectiveAction)) {
+        throw new BadRequestException(
+          `Investment action ${effectiveAction} is not allowed inside a split transaction`,
+        );
+      }
+    }
 
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
@@ -1402,12 +1517,26 @@ export class InvestmentTransactionsService {
       // current (possibly zero) balance. Correctness is enforced by the
       // history check below, which replays the affected accounts'
       // transactions in chronological order.
+      //
+      // For embedded splits, the parent transaction owns the cash side --
+      // skip the standalone cash-transaction path and instead reflect the
+      // new cash impact into the parent split + parent transaction amount.
       await this.processTransactionEffectsInTransaction(
         queryRunner,
         userId,
         saved,
         true,
+        !isEmbedded,
       );
+
+      if (isEmbedded) {
+        await this.updateEmbeddedSplitParent(
+          queryRunner,
+          userId,
+          saved,
+          transaction.transactionSplitId!,
+        );
+      }
 
       // Scope validation to the accounts AND securities this edit could
       // have affected (old + new if either changed). Validating every
@@ -1808,7 +1937,9 @@ export class InvestmentTransactionsService {
       });
     }
 
-    query.orderBy("it.transactionDate", "DESC").addOrderBy("it.createdAt", "DESC");
+    query
+      .orderBy("it.transactionDate", "DESC")
+      .addOrderBy("it.createdAt", "DESC");
 
     const rows = await query.getMany();
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1920,9 +1920,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
-      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1936,9 +1936,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
-      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -1952,9 +1952,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
-      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -1968,9 +1968,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
-      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
       ],
@@ -1984,9 +1984,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
-      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
       ],
@@ -2000,9 +2000,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
-      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
       ],
@@ -2016,9 +2016,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
-      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
       ],
@@ -2032,9 +2032,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
-      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -2048,9 +2048,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
-      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -8914,12 +8914,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
-      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.3",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -8933,14 +8933,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.3",
-        "@next/swc-darwin-x64": "16.2.3",
-        "@next/swc-linux-arm64-gnu": "16.2.3",
-        "@next/swc-linux-arm64-musl": "16.2.3",
-        "@next/swc-linux-x64-gnu": "16.2.3",
-        "@next/swc-linux-x64-musl": "16.2.3",
-        "@next/swc-win32-arm64-msvc": "16.2.3",
-        "@next/swc-win32-x64-msvc": "16.2.3",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {


### PR DESCRIPTION
Editing an investment leg of a split transaction was reverse-applying
the row and then re-applying it via the standalone cash path, which
created a fresh cash transaction in the linked cash account and left
the parent split's amount stale. The split then could not be saved
because its amount no longer matched the sum of its children.

Detect embedded rows (transactionSplitId set), suppress the standalone
cash side on re-apply, and propagate the new cash impact back into the
parent split's amount, the parent transaction's amount, and the cash
account balance delta. Pin account, funding account, and date so they
cannot drift from the parent.