### PR TITLE
fix: show action and symbol for investment splits in transaction list

### DIFF
--- a/frontend/src/components/transactions/TransactionRow.test.tsx
+++ b/frontend/src/components/transactions/TransactionRow.test.tsx
@@ -753,4 +753,71 @@ describe('TransactionRow', () => {
     );
     expect(screen.getByText(/Source/)).toBeInTheDocument();
   });
+
+  it('renders investment split with action label and security symbol', () => {
+    renderRow(
+      { density: 'normal' },
+      {
+        isSplit: true,
+        splits: [
+          {
+            id: 's1',
+            amount: 2500,
+            kind: 'category',
+            category: { id: 'cat-salary', name: 'Salary' },
+            transferAccount: null,
+            investmentTransaction: null,
+          } as any,
+          {
+            id: 's2',
+            amount: -1000,
+            kind: 'investment',
+            category: null,
+            transferAccount: null,
+            investmentTransaction: {
+              id: 'inv1',
+              action: 'BUY',
+              securityId: 'sec1',
+              security: { id: 'sec1', symbol: 'AAPL', name: 'Apple Inc.' },
+              quantity: 5,
+              price: 200,
+              commission: 0,
+              exchangeRate: 1,
+            },
+          } as any,
+        ],
+      },
+    );
+    expect(screen.getByText(/Salary:/)).toBeInTheDocument();
+    expect(screen.getByText(/Buy: AAPL:/)).toBeInTheDocument();
+  });
+
+  it('falls back to raw action when investment split lacks a security', () => {
+    renderRow(
+      { density: 'normal' },
+      {
+        isSplit: true,
+        splits: [
+          {
+            id: 's1',
+            amount: -50,
+            kind: 'investment',
+            category: null,
+            transferAccount: null,
+            investmentTransaction: {
+              id: 'inv1',
+              action: 'DIVIDEND',
+              securityId: null,
+              security: null,
+              quantity: null,
+              price: null,
+              commission: 0,
+              exchangeRate: 1,
+            },
+          } as any,
+        ],
+      },
+    );
+    expect(screen.getByText(/Dividend:/)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/transactions/TransactionRow.tsx
+++ b/frontend/src/components/transactions/TransactionRow.tsx
@@ -3,10 +3,32 @@
 import { memo, useState, useRef, useEffect, useCallback, type JSX } from 'react';
 import { createPortal } from 'react-dom';
 import { getIconComponent } from '@/components/ui/IconPicker';
-import { Transaction, TransactionStatus } from '@/types/transaction';
+import { Transaction, TransactionSplit, TransactionStatus } from '@/types/transaction';
 import { CategoryBudgetStatus } from '@/types/budget';
 import { DensityLevel } from '@/hooks/useTableDensity';
 import { formatAmountWithCommas, formatCurrency, getDecimalPlacesForCurrency } from '@/lib/format';
+
+const INVESTMENT_ACTION_LABELS: Record<string, string> = {
+  BUY: 'Buy',
+  SELL: 'Sell',
+  DIVIDEND: 'Dividend',
+  INTEREST: 'Interest',
+  CAPITAL_GAIN: 'Capital Gain',
+  SPLIT: 'Split',
+  TRANSFER_IN: 'Transfer In',
+  TRANSFER_OUT: 'Transfer Out',
+  REINVEST: 'Reinvest',
+  ADD_SHARES: 'Add Shares',
+  REMOVE_SHARES: 'Remove Shares',
+};
+
+function describeInvestmentSplit(split: TransactionSplit): string {
+  const inv = split.investmentTransaction;
+  if (!inv) return 'Uncategorized';
+  const action = INVESTMENT_ACTION_LABELS[inv.action] || inv.action;
+  const symbol = inv.security?.symbol;
+  return symbol ? `${action}: ${symbol}` : action;
+}
 
 function CopyDropdown({ density, onDuplicate, onScheduleRecurring }: {
   density: DensityLevel;
@@ -295,6 +317,10 @@ export const TransactionRow = memo(function TransactionRow({
                         {Number(split.amount) < 0
                           ? `\u2192 ${split.transferAccount.name}`
                           : `${split.transferAccount.name} \u2192`}: {formatAmountWithCommas(Math.abs(Number(split.amount)), getDecimalPlacesForCurrency(transaction.currencyCode))}
+                      </span>
+                    ) : split.investmentTransaction ? (
+                      <span className="text-emerald-600 dark:text-emerald-400">
+                        {describeInvestmentSplit(split)}: {formatAmountWithCommas(Math.abs(Number(split.amount)), getDecimalPlacesForCurrency(transaction.currencyCode))}
                       </span>
                     ) : (
                       <>{split.category?.name || 'Uncategorized'}: {formatAmountWithCommas(Math.abs(Number(split.amount)), getDecimalPlacesForCurrency(transaction.currencyCode))}</>

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -2,7 +2,7 @@ import { Payee } from './payee';
 import { Category } from './category';
 import { Account } from './account';
 import { Tag } from './tag';
-import { InvestmentAction } from './investment';
+import { InvestmentAction, Security } from './investment';
 
 export enum TransactionStatus {
   UNRECONCILED = 'UNRECONCILED',
@@ -40,6 +40,7 @@ export interface TransactionSplit {
     id: string;
     action: InvestmentAction;
     securityId: string | null;
+    security: Security | null;
     quantity: number | null;
     price: number | null;
     commission: number;


### PR DESCRIPTION
Investment portions of a split transaction were rendered as
"Uncategorized" in the transactions/investments cash view because the
split row only inspected `split.category`. The backend already loads
`splits.investmentTransaction.security`, so the data was available but
ignored on the client. Render investment splits as "Buy: AAPL" (or the
appropriate action label) and add the `security` field to the
TransactionSplit type so it's typed correctly.