### PR TITLE
Return null for CAGR when holding period is less than one year

### DIFF
--- a/backend/src/securities/portfolio-calculation.service.ts
+++ b/backend/src/securities/portfolio-calculation.service.ts
@@ -1309,7 +1309,11 @@ export class PortfolioCalculationService {
     const now = new Date();
     const years =
       (now.getTime() - earliest.getTime()) / (365.25 * 24 * 60 * 60 * 1000);
-    if (years < 1 / 365.25) return null; // Less than 1 day of history
+    // CAGR annualizes the total return, so for periods shorter than a year
+    // it extrapolates a few days of price movement into a multi-decade
+    // growth rate. The math is correct but the number is meaningless and
+    // can run into the thousands of percent (or worse) for fresh accounts.
+    if (years < 1) return null;
 
     return (
       (Math.pow(totalPortfolioValue / totalNetInvested, 1 / years) - 1) * 100

--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -2469,6 +2469,44 @@ describe("PortfolioService", () => {
       const expectedCagr = (Math.pow(10000 / 9000, 1 / 2) - 1) * 100;
       expect(result.cagr).toBeCloseTo(expectedCagr, 1);
     });
+
+    it("returns null when the holding period is less than one year", async () => {
+      accountsRepository.find.mockResolvedValue([
+        mockBrokerageAccount,
+        mockCashAccount,
+      ]);
+      holdingsRepository.find.mockResolvedValue([mockHoldingVFV]);
+      securityPriceRepository.query.mockResolvedValue([
+        { security_id: "sec-2", close_price: "100", price_date: "2026-02-07" },
+      ]);
+
+      // Earliest transaction was a few days ago — annualizing a short
+      // period explodes into nonsensical CAGR values, so the service
+      // should report null instead.
+      const fewDaysAgo = new Date();
+      fewDaysAgo.setDate(fewDaysAgo.getDate() - 3);
+      const earliestDate = fewDaysAgo.toISOString().split("T")[0];
+
+      let queryCallCount = 0;
+      accountsRepository.query.mockImplementation(() => {
+        queryCallCount++;
+        if (queryCallCount === 1) {
+          return [
+            {
+              account_id: "acct-brokerage-1",
+              buys: "1000",
+              sells: "0",
+              income: "0",
+            },
+          ];
+        }
+        return [{ earliest: earliestDate }];
+      });
+
+      const result = await service.getPortfolioSummary(userId);
+
+      expect(result.cagr).toBeNull();
+    });
   });
 
   describe("getAccountMarketValues", () => {


### PR DESCRIPTION
## Summary
Updated CAGR calculation to return `null` for holding periods shorter than one year, preventing meaningless annualized returns that can reach thousands of percent for fresh accounts.

## Changes
- **portfolio-calculation.service.ts**: Changed the CAGR null-check threshold from 1 day to 1 year
  - Previously returned `null` only for periods < 1 day
  - Now returns `null` for periods < 1 year, with clarifying comment explaining why annualization is unreliable for short periods
  
- **portfolio.service.spec.ts**: Added test case validating the new behavior
  - Tests that CAGR returns `null` when earliest transaction is only a few days old
  - Verifies the service correctly identifies short holding periods and avoids extrapolating meaningless growth rates

## Implementation Details
The CAGR formula annualizes returns by raising the total return to the power of `1/years`. For periods much shorter than a year, this extrapolation produces nonsensical values (e.g., a 1% gain over 3 days annualizes to ~120% annually). By returning `null` for sub-year periods, we avoid displaying misleading metrics to users with fresh accounts.

https://claude.ai/code/session_01GoSC4DKqup1i7q5RkYW7GP