### PR TITLE
Handle funding account changes in investment transactions

### DIFF
--- a/backend/src/securities/entities/investment-transaction.entity.ts
+++ b/backend/src/securities/entities/investment-transaction.entity.ts
@@ -15,6 +15,12 @@ import { TransactionSplit } from "../../transactions/entities/transaction-split.
 import { Security } from "./security.entity";
 import { User } from "../../users/entities/user.entity";
 
+const numericTransformer = {
+  to: (value: number | null): number | null => value,
+  from: (value: string | null): number | null =>
+    value === null ? null : Number(value),
+};
+
 export enum InvestmentAction {
   BUY = "BUY",
   SELL = "SELL",
@@ -93,22 +99,46 @@ export class InvestmentTransaction {
   transactionDate: string;
 
   @ApiProperty({ example: 100, description: "Number of shares" })
-  @Column({ type: "decimal", precision: 20, scale: 8, nullable: true })
+  @Column({
+    type: "decimal",
+    precision: 20,
+    scale: 8,
+    nullable: true,
+    transformer: numericTransformer,
+  })
   quantity: number | null;
 
   @ApiProperty({ example: 150.25, description: "Price per share" })
-  @Column({ type: "decimal", precision: 20, scale: 6, nullable: true })
+  @Column({
+    type: "decimal",
+    precision: 20,
+    scale: 6,
+    nullable: true,
+    transformer: numericTransformer,
+  })
   price: number | null;
 
   @ApiProperty({ example: 9.99, description: "Commission or fee" })
-  @Column({ type: "decimal", precision: 20, scale: 4, default: 0 })
+  @Column({
+    type: "decimal",
+    precision: 20,
+    scale: 4,
+    default: 0,
+    transformer: numericTransformer,
+  })
   commission: number;
 
   @ApiProperty({
     example: 15035.99,
     description: "Total amount of transaction in the security's currency",
   })
-  @Column({ type: "decimal", precision: 20, scale: 4, name: "total_amount" })
+  @Column({
+    type: "decimal",
+    precision: 20,
+    scale: 4,
+    name: "total_amount",
+    transformer: numericTransformer,
+  })
   totalAmount: number;
 
   @ApiProperty({

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -2041,6 +2041,94 @@ describe("InvestmentTransactionsService", () => {
       );
     });
 
+    it("debits the new funding account and refunds the old one when fundingAccountId changes", async () => {
+      const newFundingAccountId = "funding-account-2";
+      const newCashTxId = "cash-tx-new-funding";
+      const mockNewFundingAccount = {
+        id: newFundingAccountId,
+        userId,
+        accountType: "CHEQUING",
+        accountSubType: null,
+        linkedAccountId: null,
+        currencyCode: "USD",
+        name: "Other Checking",
+      };
+      accountsService.findOne.mockImplementation((uid: string, aid: string) => {
+        if (aid === accountId) return Promise.resolve(mockInvestmentAccount);
+        if (aid === cashAccountId) return Promise.resolve(mockCashAccount);
+        if (aid === fundingAccountId)
+          return Promise.resolve(mockFundingAccount);
+        if (aid === newFundingAccountId)
+          return Promise.resolve(mockNewFundingAccount);
+        return Promise.reject(new NotFoundException("Account not found"));
+      });
+
+      // Existing BUY that was funded from the original fundingAccountId, with
+      // the eager-loaded fundingAccount relation pointing at the OLD account
+      // (this is what `findOne`'s leftJoinAndSelect produces in real usage).
+      const existingTx = {
+        ...mockBuyTransaction,
+        fundingAccountId,
+        fundingAccount: mockFundingAccount as any,
+      };
+      const firstFindQB = createMockQueryBuilder(existingTx);
+      const secondFindQB = createMockQueryBuilder({
+        ...existingTx,
+        fundingAccountId: newFundingAccountId,
+        fundingAccount: mockNewFundingAccount as any,
+      });
+      investmentTransactionsRepository.createQueryBuilder
+        .mockReturnValueOnce(firstFindQB)
+        .mockReturnValueOnce(secondFindQB);
+
+      // Linked cash transaction currently sits in the OLD funding account
+      transactionRepository.findOne.mockResolvedValue({
+        id: cashTransactionId,
+        userId,
+        accountId: fundingAccountId,
+        transactionDate: existingTx.transactionDate,
+        amount: -1509.99,
+      });
+
+      transactionRepository.create.mockImplementationOnce((data: any) => ({
+        ...data,
+        id: newCashTxId,
+      }));
+
+      await service.update(userId, transactionId, {
+        fundingAccountId: newFundingAccountId,
+      });
+
+      // OLD funding account should be refunded by reversing the original cash tx
+      expect(accountsService.updateBalance).toHaveBeenCalledWith(
+        fundingAccountId,
+        1509.99,
+        expect.anything(),
+      );
+
+      // NEW funding account should be debited via a freshly created cash tx
+      expect(accountsService.updateBalance).toHaveBeenCalledWith(
+        newFundingAccountId,
+        -1509.99,
+        expect.anything(),
+      );
+
+      // The new linked cash transaction must be persisted on the NEW account
+      expect(transactionRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId: newFundingAccountId,
+          amount: -1509.99,
+        }),
+      );
+
+      // And the investment row must be saved with the NEW fundingAccountId
+      expect(investmentTransactionsRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fundingAccountId: newFundingAccountId,
+        }),
+      );
+    });
+
     it("records action history on update", async () => {
       investmentTransactionsRepository.findOne.mockResolvedValue({
         ...mockBuyTransaction,

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -1415,8 +1415,14 @@ export class InvestmentTransactionsService {
       );
 
       // Update entity properties directly
-      if (updateDto.accountId !== undefined)
+      if (updateDto.accountId !== undefined) {
         transaction.accountId = updateDto.accountId;
+        // findOne's leftJoinAndSelect populated `account`; if we mutate only
+        // the FK column, TypeORM's save() will re-derive the column from the
+        // still-stale relation and silently revert the change. Point the
+        // relation stub at the new id to keep them in sync.
+        transaction.account = { id: updateDto.accountId } as any;
+      }
       if (updateDto.action !== undefined) {
         // M18: Re-validate security requirement when action changes
         const securityRequiredActions = [
@@ -1443,10 +1449,20 @@ export class InvestmentTransactionsService {
       }
       if (updateDto.transactionDate !== undefined)
         transaction.transactionDate = updateDto.transactionDate;
-      if (updateDto.securityId !== undefined)
+      if (updateDto.securityId !== undefined) {
         transaction.securityId = updateDto.securityId;
-      if (updateDto.fundingAccountId !== undefined)
+        transaction.security = updateDto.securityId
+          ? ({ id: updateDto.securityId } as any)
+          : (null as any);
+      }
+      if (updateDto.fundingAccountId !== undefined) {
         transaction.fundingAccountId = updateDto.fundingAccountId || null;
+        // Same reason as accountId above: keep the eager-loaded relation in
+        // sync with the new FK so save() doesn't write back the old one.
+        transaction.fundingAccount = transaction.fundingAccountId
+          ? ({ id: transaction.fundingAccountId } as any)
+          : null;
+      }
       if (updateDto.quantity !== undefined)
         transaction.quantity = updateDto.quantity;
       if (updateDto.price !== undefined) transaction.price = updateDto.price;

--- a/backend/test/integration/investment-transactions.integration.spec.ts
+++ b/backend/test/integration/investment-transactions.integration.spec.ts
@@ -1,0 +1,184 @@
+import { TestingModule } from "@nestjs/testing";
+import { DataSource } from "typeorm";
+import { InvestmentTransactionsService } from "@/securities/investment-transactions.service";
+import { SecuritiesModule } from "@/securities/securities.module";
+import { SecuritiesService } from "@/securities/securities.service";
+import {
+  Account,
+  AccountSubType,
+  AccountType,
+} from "@/accounts/entities/account.entity";
+import { Transaction } from "@/transactions/entities/transaction.entity";
+import {
+  InvestmentTransaction,
+  InvestmentAction,
+} from "@/securities/entities/investment-transaction.entity";
+import {
+  createIntegrationModule,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import { createTestAccount } from "../helpers/test-factories";
+
+describe("InvestmentTransactionsService funding account changes (integration)", () => {
+  let module: TestingModule;
+  let service: InvestmentTransactionsService;
+  let dataSource: DataSource;
+  let userId: string;
+  let brokerageAccountId: string;
+  let linkedCashAccountId: string;
+  let fundingAccountA: string;
+  let fundingAccountB: string;
+  let securityId: string;
+
+  beforeAll(async () => {
+    module = await createIntegrationModule([SecuritiesModule]);
+    service = module.get(InvestmentTransactionsService);
+    dataSource = module.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await cleanTables(dataSource, [
+      "action_history",
+      "holdings",
+      "securities",
+      "transaction_splits",
+      "transactions",
+      "accounts",
+      "categories",
+      "payees",
+      "scheduled_transaction_splits",
+      "scheduled_transaction_overrides",
+      "scheduled_transactions",
+      "investment_transactions",
+      "monthly_account_balances",
+      "users",
+    ]);
+    await dataSource.query(
+      `INSERT INTO currencies (code, name, symbol, decimal_places) VALUES ('USD', 'US Dollar', '$', 2) ON CONFLICT DO NOTHING`,
+    );
+
+    const user = await createTestUserDirect(dataSource);
+    userId = user.id;
+
+    const cash = await createTestAccount(dataSource, userId, {
+      name: "Brokerage Cash",
+      openingBalance: 0,
+      currentBalance: 0,
+    });
+    await dataSource.manager.update(Account, cash.id, {
+      accountType: AccountType.INVESTMENT,
+      accountSubType: AccountSubType.INVESTMENT_CASH,
+    });
+    linkedCashAccountId = cash.id;
+
+    const brokerage = await createTestAccount(dataSource, userId, {
+      name: "Brokerage",
+      openingBalance: 0,
+      currentBalance: 0,
+    });
+    await dataSource.manager.update(Account, brokerage.id, {
+      accountType: AccountType.INVESTMENT,
+      accountSubType: AccountSubType.INVESTMENT_BROKERAGE,
+      linkedAccountId: linkedCashAccountId,
+    });
+    brokerageAccountId = brokerage.id;
+
+    const accountA = await createTestAccount(dataSource, userId, {
+      name: "Funding A",
+      openingBalance: 10000,
+      currentBalance: 10000,
+    });
+    fundingAccountA = accountA.id;
+
+    const accountB = await createTestAccount(dataSource, userId, {
+      name: "Funding B",
+      openingBalance: 10000,
+      currentBalance: 10000,
+    });
+    fundingAccountB = accountB.id;
+
+    const securitiesService = module.get(SecuritiesService);
+    const security = await securitiesService.create(userId, {
+      symbol: "AAPL",
+      name: "Apple Inc.",
+      securityType: "STOCK" as any,
+      currencyCode: "USD",
+    } as any);
+    securityId = security.id;
+  });
+
+  it("moves the debit from old funding account to new funding account when fundingAccountId is changed", async () => {
+    const buy = await service.create(userId, {
+      accountId: brokerageAccountId,
+      action: InvestmentAction.BUY,
+      transactionDate: "2026-01-15",
+      securityId,
+      fundingAccountId: fundingAccountA,
+      quantity: 10,
+      price: 100,
+      commission: 0,
+    });
+
+    // After buy: A should be debited by 1000, B unchanged, linked cash unchanged
+    let a = await dataSource.manager.findOneOrFail(Account, {
+      where: { id: fundingAccountA },
+    });
+    let b = await dataSource.manager.findOneOrFail(Account, {
+      where: { id: fundingAccountB },
+    });
+    let cash = await dataSource.manager.findOneOrFail(Account, {
+      where: { id: linkedCashAccountId },
+    });
+    expect(Number(a.currentBalance)).toBe(9000);
+    expect(Number(b.currentBalance)).toBe(10000);
+    expect(Number(cash.currentBalance)).toBe(0);
+
+    const txInA = await dataSource.manager.find(Transaction, {
+      where: { accountId: fundingAccountA, userId },
+    });
+    expect(txInA).toHaveLength(1);
+    expect(Number(txInA[0].amount)).toBe(-1000);
+
+    // Now switch funding account to B
+    await service.update(userId, buy.id, {
+      fundingAccountId: fundingAccountB,
+    });
+
+    a = await dataSource.manager.findOneOrFail(Account, {
+      where: { id: fundingAccountA },
+    });
+    b = await dataSource.manager.findOneOrFail(Account, {
+      where: { id: fundingAccountB },
+    });
+    cash = await dataSource.manager.findOneOrFail(Account, {
+      where: { id: linkedCashAccountId },
+    });
+
+    expect(Number(a.currentBalance)).toBe(10000); // refunded
+    expect(Number(b.currentBalance)).toBe(9000); // debited
+    expect(Number(cash.currentBalance)).toBe(0); // untouched
+
+    // And the cash transactions follow: none in A, one in B
+    const txInAAfter = await dataSource.manager.find(Transaction, {
+      where: { accountId: fundingAccountA, userId },
+    });
+    const txInBAfter = await dataSource.manager.find(Transaction, {
+      where: { accountId: fundingAccountB, userId },
+    });
+    expect(txInAAfter).toHaveLength(0);
+    expect(txInBAfter).toHaveLength(1);
+    expect(Number(txInBAfter[0].amount)).toBe(-1000);
+
+    // The investment transaction itself should now point to fundingAccountB
+    const reloaded = await dataSource.manager.findOneOrFail(
+      InvestmentTransaction,
+      { where: { id: buy.id } },
+    );
+    expect(reloaded.fundingAccountId).toBe(fundingAccountB);
+  });
+});


### PR DESCRIPTION
## Summary
Adds support for changing the funding account on an existing investment transaction, with proper account balance reconciliation. When a BUY/SELL transaction's `fundingAccountId` is updated, the old funding account is refunded and the new one is debited accordingly.

## Key Changes

- **Investment transaction update logic**: When `fundingAccountId` changes, the service now:
  - Refunds the old funding account by reversing the original cash transaction amount
  - Creates a new cash transaction on the new funding account with the same amount
  - Updates the investment transaction entity to point to the new funding account
  - Keeps eager-loaded relation stubs in sync with foreign key changes to prevent TypeORM from silently reverting updates

- **Decimal field transformers**: Added `numericTransformer` to `InvestmentTransaction` entity columns (`quantity`, `price`, `commission`, `totalAmount`) to ensure decimal values are properly converted from database strings to JavaScript numbers, preventing type mismatches in calculations

- **Relation synchronization fix**: When updating `accountId`, `securityId`, or `fundingAccountId`, the corresponding eager-loaded relation properties are now updated alongside the foreign key columns. This prevents TypeORM's `save()` from re-deriving stale FK values from the old relation references

- **Integration test**: Added comprehensive test covering the full funding account change workflow, verifying:
  - Original funding account is refunded to its opening balance
  - New funding account is debited with the transaction amount
  - Linked cash account remains unaffected
  - Transaction records are correctly created/removed from the respective accounts
  - Investment transaction entity reflects the new funding account

## Implementation Details

The funding account change is handled within the existing `update()` method's transaction context, ensuring atomicity across account balance updates and transaction record creation. The solution mirrors the existing pattern used for other account-related changes in the service.

https://claude.ai/code/session_01NPVSSjE71FnQZciGGJzUsW