### PR TITLE
Value foreign-currency holdings at per-bar FX rates

### DIFF
--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -161,6 +161,10 @@ describe("PortfolioService", () => {
 
     yahooFinanceService = {
       fetchIntradaySeries: jest.fn(),
+      // Default: no intraday FX series available. Tests that exercise the
+      // FX-per-timestamp path mock this explicitly. When this returns null
+      // the chart falls back to the latest spot from ExchangeRateService.
+      fetchIntradayFxSeries: jest.fn().mockResolvedValue(null),
     };
 
     // Default: every security resolves to a Yahoo-like provider that exposes
@@ -3037,6 +3041,116 @@ describe("PortfolioService", () => {
       expect(second.points).toHaveLength(1);
       // The retry actually hit Yahoo again (cache wasn't serving the failure).
       expect(yahooFinanceService.fetchIntradaySeries).toHaveBeenCalled();
+    });
+
+    it("values foreign-currency holdings at the FX rate prevailing at each bar", async () => {
+      // Each bar of a foreign-currency holding should be converted using
+      // the FX rate at that bar, not a single latest spot applied flat.
+      accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+      holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
+
+      const ts1 = new Date("2026-05-06T13:30:00.000Z");
+      const ts2 = new Date("2026-05-06T13:31:00.000Z");
+
+      yahooFinanceService.fetchIntradaySeries.mockResolvedValue([
+        { timestamp: ts1, close: 100 },
+        { timestamp: ts2, close: 100 },
+      ]);
+      yahooFinanceService.fetchIntradayFxSeries.mockImplementation(
+        async (from: string, to: string) => {
+          if (from === "USD" && to === "CAD") {
+            return [
+              { timestamp: ts1, close: 1.4 },
+              { timestamp: ts2, close: 1.5 },
+            ];
+          }
+          return null;
+        },
+      );
+      exchangeRateService.getLatestRate.mockResolvedValue(1.4);
+
+      const result = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+
+      // ts1: 10 * 100 * 1.4 = 1400; ts2 keeps the same price but FX moved.
+      expect(result.points[0].value).toBeCloseTo(1400, 4);
+      expect(result.points[1].value).toBeCloseTo(10 * 100 * 1.5, 4);
+    });
+
+    it("applies per-bar FX to cash held in a foreign currency", async () => {
+      // Cash amounts don't move intraday, but their value in the display
+      // currency does when FX moves. Confirms the chart no longer treats
+      // foreign-currency cash as a flat additive offset.
+      const usdCashAccount: Partial<Account> = {
+        ...mockCashAccount,
+        currencyCode: "USD",
+        currentBalance: 1000 as any,
+      };
+      accountsRepository.find.mockResolvedValue([
+        mockBrokerageAccount,
+        usdCashAccount,
+      ]);
+      holdingsRepository.find.mockResolvedValue([mockHoldingVFV]); // CAD-native, no FX
+
+      const ts1 = new Date("2026-05-06T13:30:00.000Z");
+      const ts2 = new Date("2026-05-06T13:31:00.000Z");
+
+      yahooFinanceService.fetchIntradaySeries.mockResolvedValue([
+        { timestamp: ts1, close: 80 },
+        { timestamp: ts2, close: 80 },
+      ]);
+      yahooFinanceService.fetchIntradayFxSeries.mockImplementation(
+        async (from: string, to: string) => {
+          if (from === "USD" && to === "CAD") {
+            return [
+              { timestamp: ts1, close: 1.4 },
+              { timestamp: ts2, close: 1.5 },
+            ];
+          }
+          return null;
+        },
+      );
+      exchangeRateService.getLatestRate.mockResolvedValue(1.4);
+
+      const result = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+
+      // VFV is CAD-native: 50 * 80 = 4000 at both bars.
+      // USD cash 1000 valued at 1.4 then 1.5 -> 1400 then 1500.
+      expect(result.points[0].value).toBeCloseTo(4000 + 1400, 4);
+      expect(result.points[1].value).toBeCloseTo(4000 + 1500, 4);
+    });
+
+    it("falls back to the latest spot when the intraday FX fetch fails", async () => {
+      // When Yahoo can't serve an FX series (rate limit, unsupported pair),
+      // we still need a sensible value per bar. Fall back to the latest spot
+      // rate from ExchangeRateService so the chart degrades gracefully rather
+      // than dropping the foreign-currency contribution.
+      accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+      holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
+
+      const ts = new Date("2026-05-06T13:30:00.000Z");
+      yahooFinanceService.fetchIntradaySeries.mockResolvedValue([
+        { timestamp: ts, close: 100 },
+      ]);
+      yahooFinanceService.fetchIntradayFxSeries.mockRejectedValue(
+        new Error("yahoo FX 429"),
+      );
+      exchangeRateService.getLatestRate.mockImplementation(
+        async (from: string, to: string) => {
+          if (from === "USD" && to === "CAD") return 1.4;
+          return null;
+        },
+      );
+
+      const result = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+
+      expect(result.points).toHaveLength(1);
+      expect(result.points[0].value).toBeCloseTo(10 * 100 * 1.4, 4);
     });
 
     it("does not surface failedSymbols on partial failures (fallback price covers it)", async () => {

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -936,44 +936,35 @@ export class PortfolioService {
     }
     const timestamps = [...timestampSet].sort((a, b) => a - b);
 
-    // Pre-compute FX rates from each security currency to the display
-    // currency. Intraday FX moves are tiny relative to chart resolution and
-    // we already pay this latency once for the price fetches; reusing the
-    // latest spot rate is the same simplification used elsewhere.
-    const rateCache = new Map<string, number>();
-    const currencies = new Set(intradayHoldings.map((h) => h.currencyCode));
-    for (const c of currencies) {
-      await this.calculationService.convertToDefault(
-        1,
-        c,
-        displayCurrency,
-        rateCache,
-      );
-    }
-
     // Cash held in the user's investment cash and standalone accounts is
     // part of the portfolio value just like holdings -- the daily-snapshot
     // endpoint already includes it (see net-worth.service.getDailyInvestments)
     // and we mirror that here so the 1D/1W/1M intraday chart agrees with
-    // longer-range views. Cash doesn't move intraday from price changes, so
-    // it's a constant additive offset across every grid point.
+    // longer-range views.
     const cashAccountList = [...cashAccounts, ...standaloneAccounts];
     const cashIds = cashAccountList.map((a) => a.id);
     const effectiveBalances =
       await this.calculationService.computeEffectiveBalances(cashIds);
-    const totalCashValue = await this.calculationService.computeTotalCashValue(
-      cashAccountList,
-      effectiveBalances,
-      displayCurrency,
-      rateCache,
-    );
-    const cashCents = Math.round(totalCashValue * 10000);
+
+    // Group cash by native currency so FX can be applied at each timestamp.
+    // Cash amounts don't move intraday, but their display-currency value does
+    // when FX moves -- so foreign-currency cash can't be a flat additive
+    // offset across the chart.
+    const cashByCurrency = new Map<string, number>();
+    for (const account of cashAccountList) {
+      const balance =
+        effectiveBalances.get(account.id) ?? Number(account.currentBalance);
+      cashByCurrency.set(
+        account.currencyCode,
+        (cashByCurrency.get(account.currencyCode) ?? 0) + balance,
+      );
+    }
 
     // For holdings whose intraday fetch failed (Yahoo errored, was
     // rate-limited past the retry budget, or simply has no minute-resolution
     // data for this security -- common for mutual funds and illiquid names),
-    // fall back to the security's latest known daily close. Treat that
-    // value as a constant additive offset, the same way cash is handled.
+    // fall back to the security's latest known daily close. Group by native
+    // currency so per-timestamp FX still applies to these "stale" amounts.
     // Without this, a single mutual fund in the user's portfolio would
     // either undercount the chart (if we ignored it) or pin the
     // "Couldn't load intraday prices" banner permanently (if we treated
@@ -981,7 +972,7 @@ export class PortfolioService {
     const failedHoldings = intradayHoldings.filter(
       (h) => !seriesBySecurity.has(h.securityId),
     );
-    let staleHoldingsCents = 0;
+    const staleByCurrency = new Map<string, number>();
     if (failedHoldings.length > 0) {
       const latestPrices = await this.getLatestPrices(
         failedHoldings.map((h) => h.securityId),
@@ -989,14 +980,77 @@ export class PortfolioService {
       for (const h of failedHoldings) {
         const lastClose = latestPrices.get(h.securityId);
         if (lastClose == null) continue;
-        const fxRate =
-          rateCache.get(`${h.currencyCode}->${displayCurrency}`) ?? 1;
-        staleHoldingsCents += Math.round(
-          h.quantity * lastClose * fxRate * 10000,
+        staleByCurrency.set(
+          h.currencyCode,
+          (staleByCurrency.get(h.currencyCode) ?? 0) + h.quantity * lastClose,
         );
       }
     }
-    const constantCents = cashCents + staleHoldingsCents;
+
+    // Fetch intraday FX series for every non-display currency in the
+    // portfolio (holding currencies + cash currencies). Each bar of the
+    // chart is then valued at the FX rate that prevailed at that moment,
+    // not the latest spot. Latest-spot is kept as a per-currency fallback
+    // for when the FX series fetch fails (rate limited, unsupported pair).
+    const rateCache = new Map<string, number>();
+    const fxCurrencies = new Set<string>([
+      ...intradayHoldings.map((h) => h.currencyCode),
+      ...cashByCurrency.keys(),
+    ]);
+    fxCurrencies.delete(displayCurrency);
+
+    type FxCursor = {
+      times: number[];
+      rates: number[];
+      cursor: number;
+      latest: number;
+    };
+    const fxByCurrency = new Map<string, FxCursor>();
+    await Promise.all(
+      [...fxCurrencies].map(async (currency) => {
+        const latest = await this.calculationService.convertToDefault(
+          1,
+          currency,
+          displayCurrency,
+          rateCache,
+        );
+        let series: IntradayPoint[] | null = null;
+        try {
+          series = await this.yahooFinanceService.fetchIntradayFxSeries(
+            currency,
+            displayCurrency,
+            yahooParams,
+          );
+        } catch (error) {
+          this.logger.warn(
+            `Failed to fetch intraday FX ${currency}->${displayCurrency}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+        fxByCurrency.set(currency, {
+          times: series?.map((p) => p.timestamp.getTime()) ?? [],
+          rates: series?.map((p) => p.close) ?? [],
+          cursor: -1,
+          latest,
+        });
+      }),
+    );
+
+    // Walk each FX cursor monotonically as the grid advances; if no
+    // intraday FX series is available (failed fetch or same-currency),
+    // use the latest spot. Backfill the earliest known rate when the
+    // first FX bar arrives after the current grid timestamp.
+    const fxAt = (currency: string, ts: number): number => {
+      if (currency === displayCurrency) return 1;
+      const fx = fxByCurrency.get(currency);
+      if (!fx) return rateCache.get(`${currency}->${displayCurrency}`) ?? 1;
+      if (fx.times.length === 0) return fx.latest;
+      while (fx.cursor + 1 < fx.times.length && fx.times[fx.cursor + 1] <= ts) {
+        fx.cursor++;
+      }
+      return fx.cursor < 0 ? fx.rates[0] : fx.rates[fx.cursor];
+    };
 
     // Build per-security ordered timestamp/close arrays and a cursor-based
     // forward-fill so each grid point uses the latest known close.
@@ -1006,9 +1060,7 @@ export class PortfolioService {
         if (!points || points.length === 0) return null;
         return {
           quantity: h.quantity,
-          fxRate:
-            rateCache.get(`${h.currencyCode}->${displayCurrency}`) ??
-            (h.currencyCode === displayCurrency ? 1 : 1),
+          currencyCode: h.currencyCode,
           times: points.map((p) => p.timestamp.getTime()),
           closes: points.map((p) => p.close),
         };
@@ -1019,7 +1071,16 @@ export class PortfolioService {
     const points: IntradayValuePoint[] = [];
 
     for (const ts of timestamps) {
-      let totalCents = constantCents; // integer arithmetic to avoid float drift
+      let totalCents = 0; // integer arithmetic to avoid float drift
+      // Cash contributions, valued at the FX rate prevailing at this bar.
+      for (const [ccy, amount] of cashByCurrency) {
+        totalCents += Math.round(amount * fxAt(ccy, ts) * 10000);
+      }
+      // Stale-holding contributions (last daily close * quantity), same
+      // per-timestamp FX treatment as live holdings.
+      for (const [ccy, amount] of staleByCurrency) {
+        totalCents += Math.round(amount * fxAt(ccy, ts) * 10000);
+      }
       for (let i = 0; i < sources.length; i++) {
         const src = sources[i];
         // Advance cursor to the latest sample at-or-before ts.
@@ -1037,7 +1098,8 @@ export class PortfolioService {
         // moment each one's first bar arrives — which is exactly the
         // "significant jump" the chart used to show on multi-account views.
         const close = cursors[i] < 0 ? src.closes[0] : src.closes[cursors[i]];
-        const valueInDisplay = src.quantity * close * src.fxRate;
+        const valueInDisplay =
+          src.quantity * close * fxAt(src.currencyCode, ts);
         totalCents += Math.round(valueInDisplay * 10000);
       }
       points.push({

--- a/backend/src/securities/yahoo-finance.service.ts
+++ b/backend/src/securities/yahoo-finance.service.ts
@@ -502,6 +502,21 @@ export class YahooFinanceService implements QuoteProvider {
     return null;
   }
 
+  // Intraday FX series. Yahoo exposes currency pairs under the
+  // "{FROM}{TO}=X" symbol convention (e.g. USDCAD=X for USD->CAD) on the
+  // same chart endpoint as equities, so we reuse fetchIntradayRaw. Used
+  // by the Portfolio Value Over Time chart so foreign-currency holdings
+  // and cash are valued at each bar's FX rate, not the latest spot.
+  async fetchIntradayFxSeries(
+    fromCurrency: string,
+    toCurrency: string,
+    opts: { interval: IntradayInterval; range: IntradayRange },
+  ): Promise<IntradayPoint[] | null> {
+    if (fromCurrency === toCurrency) return null;
+    const pairSymbol = `${fromCurrency.toUpperCase()}${toCurrency.toUpperCase()}=X`;
+    return this.fetchIntradayRaw(pairSymbol, opts);
+  }
+
   private async fetchIntradayRaw(
     yahooSymbol: string,
     { interval, range }: { interval: IntradayInterval; range: IntradayRange },


### PR DESCRIPTION
## Summary
The intraday portfolio value chart now values foreign-currency holdings and cash at the FX rate prevailing at each bar, rather than applying a single latest spot rate across the entire chart. This fixes a significant accuracy issue where FX movements intraday were ignored.

## Key Changes
- **FX series fetching**: Added `fetchIntradayFxSeries()` to `YahooFinanceService` to retrieve intraday FX data for currency pairs (e.g., USDCAD=X) using Yahoo's existing chart endpoint
- **Per-timestamp FX application**: Replaced flat `fxRate` field on holdings with a `currencyCode` field; FX is now looked up dynamically at each chart bar via a new `fxAt()` function that:
  - Walks FX cursors monotonically through intraday series
  - Falls back to latest spot rate when FX series fetch fails (rate limit, unsupported pair)
  - Handles same-currency case (returns 1.0)
- **Cash and stale holdings**: Refactored to group by native currency instead of pre-computing a single total; each bar now applies the appropriate FX rate to foreign-currency cash and fallback holdings
- **Graceful degradation**: When intraday FX data is unavailable, the chart uses the latest spot rate from `ExchangeRateService` rather than dropping the contribution entirely

## Implementation Details
- FX cursors are initialized and advanced once per grid point, avoiding repeated binary searches
- Backfill logic ensures the earliest known FX rate is used when the first bar arrives after the current timestamp
- All FX fetches happen in parallel via `Promise.all()` to minimize latency
- Integer arithmetic (cents) is preserved throughout to avoid floating-point drift
- Three new test cases cover: per-bar FX on holdings, per-bar FX on foreign-currency cash, and fallback to spot when FX fetch fails

https://claude.ai/code/session_015iMsGKSmYD3em61UbaPw6S