### PR TITLE
Fix intraday chart range trimming for 1W and 1M requests

### DIFF
--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -3053,6 +3053,75 @@ describe("PortfolioService", () => {
       expect(calls[0][2].interval).toBe("15m");
     });
 
+    it("fetches a wider Yahoo range for 1W and trims to a 7-day cutoff", async () => {
+      // Yahoo's "5d" range only covers 5 trading days, which leaves a 1W
+      // request on a Wednesday reaching back only to the previous Thursday.
+      // We over-fetch (range="1mo") and trim here to a precise
+      // start-of-day(today - 7 days) cutoff so the chart always covers a
+      // full week.
+      jest.useFakeTimers().setSystemTime(new Date("2026-05-13T18:00:00.000Z"));
+      try {
+        accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+        holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
+
+        yahooFinanceService.fetchIntradaySeries.mockResolvedValue([
+          // Outside the 7-day window: must be filtered out.
+          { timestamp: new Date("2026-05-05T13:30:00.000Z"), close: 90 },
+          { timestamp: new Date("2026-05-05T23:59:59.000Z"), close: 91 },
+          // Right at the boundary: start of day(2026-05-06) is inclusive.
+          { timestamp: new Date("2026-05-06T00:00:00.000Z"), close: 95 },
+          { timestamp: new Date("2026-05-06T13:30:00.000Z"), close: 100 },
+          { timestamp: new Date("2026-05-13T15:00:00.000Z"), close: 110 },
+        ]);
+        exchangeRateService.getLatestRate.mockResolvedValue(1);
+
+        const result = await service.getIntradayValueSeries(userId, {
+          range: "1w",
+        });
+
+        const calls = yahooFinanceService.fetchIntradaySeries.mock.calls;
+        expect(calls[0][2]).toEqual({ interval: "5m", range: "1mo" });
+
+        const isoTimestamps = result.points.map((p) => p.timestamp);
+        expect(isoTimestamps).toEqual([
+          "2026-05-06T00:00:00.000Z",
+          "2026-05-06T13:30:00.000Z",
+          "2026-05-13T15:00:00.000Z",
+        ]);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("trims the 1M series to a 30-day cutoff", async () => {
+      jest.useFakeTimers().setSystemTime(new Date("2026-05-13T18:00:00.000Z"));
+      try {
+        accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+        holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
+
+        yahooFinanceService.fetchIntradaySeries.mockResolvedValue([
+          // Outside the 30-day window: must be filtered out.
+          { timestamp: new Date("2026-04-12T13:30:00.000Z"), close: 90 },
+          // Inside the 30-day window: start of day(2026-04-13) is inclusive.
+          { timestamp: new Date("2026-04-13T13:30:00.000Z"), close: 100 },
+          { timestamp: new Date("2026-05-13T15:00:00.000Z"), close: 110 },
+        ]);
+        exchangeRateService.getLatestRate.mockResolvedValue(1);
+
+        const result = await service.getIntradayValueSeries(userId, {
+          range: "1m",
+        });
+
+        const isoTimestamps = result.points.map((p) => p.timestamp);
+        expect(isoTimestamps).toEqual([
+          "2026-04-13T13:30:00.000Z",
+          "2026-05-13T15:00:00.000Z",
+        ]);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it("uses each failed holding's latest known close as a constant offset", async () => {
       // When some intraday fetches fail (Yahoo errored, was rate-limited
       // past retry, or simply has no minute-resolution data for the

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -153,8 +153,21 @@ const RANGE_TO_YAHOO: Record<
   { interval: IntradayInterval; range: IntradayRange }
 > = {
   "1d": { interval: "1m", range: "1d" },
-  "1w": { interval: "5m", range: "5d" },
+  // Yahoo's "5d" range only covers 5 trading days, so a 1W request that lands
+  // on a Wednesday would only reach back to the previous Thursday. Pull a
+  // full month and let the cutoff filter trim to exactly 7 calendar days.
+  "1w": { interval: "5m", range: "1mo" },
   "1m": { interval: "15m", range: "1mo" },
+};
+
+// Calendar-day lookback used to trim the intraday series to a precise
+// "beginning of (today - N days)" boundary. Yahoo's range parameter is
+// approximate (e.g. "5d" returns 5 trading days, "1mo" excludes the
+// boundary date), so we over-fetch and filter here.
+const RANGE_LOOKBACK_DAYS: Record<IntradayRangeKey, number | null> = {
+  "1d": null,
+  "1w": 7,
+  "1m": 30,
 };
 
 // Per-range fallback chain attempted (per holding, in order) when the
@@ -178,10 +191,10 @@ const RANGE_FALLBACKS: Record<
     { interval: "90m", range: "1d" },
   ],
   "1w": [
-    { interval: "15m", range: "5d" },
-    { interval: "30m", range: "5d" },
-    { interval: "60m", range: "5d" },
-    { interval: "90m", range: "5d" },
+    { interval: "15m", range: "1mo" },
+    { interval: "30m", range: "1mo" },
+    { interval: "60m", range: "1mo" },
+    { interval: "90m", range: "1mo" },
   ],
   "1m": [
     { interval: "30m", range: "1mo" },
@@ -934,7 +947,20 @@ export class PortfolioService {
     for (const series of seriesBySecurity.values()) {
       for (const p of series) timestampSet.add(p.timestamp.getTime());
     }
-    const timestamps = [...timestampSet].sort((a, b) => a - b);
+    let timestamps = [...timestampSet].sort((a, b) => a - b);
+
+    // Trim to a precise "start of (today - N days)" boundary. Yahoo's range
+    // parameter is approximate (e.g. "1mo" excludes the calendar-month
+    // boundary date), so we over-fetched above and now drop any bars that
+    // fall before the requested calendar window.
+    const lookbackDays = RANGE_LOOKBACK_DAYS[range];
+    if (lookbackDays != null) {
+      const cutoff = new Date();
+      cutoff.setUTCHours(0, 0, 0, 0);
+      cutoff.setUTCDate(cutoff.getUTCDate() - lookbackDays);
+      const cutoffMs = cutoff.getTime();
+      timestamps = timestamps.filter((ts) => ts >= cutoffMs);
+    }
 
     // Cash held in the user's investment cash and standalone accounts is
     // part of the portfolio value just like holdings -- the daily-snapshot
@@ -1114,7 +1140,8 @@ export class PortfolioService {
         } else {
           price = src.closes[cursors[i]];
         }
-        const valueInDisplay = src.quantity * price * fxAt(src.currencyCode, ts);
+        const valueInDisplay =
+          src.quantity * price * fxAt(src.currencyCode, ts);
         totalCents += Math.round(valueInDisplay * 10000);
       }
       points.push({

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -23,6 +23,7 @@ vi.mock('recharts', () => ({
 
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
+    formatCurrency: (n: number) => `$${n.toFixed(2)}`,
     formatCurrencyCompact: (n: number) => `$${n.toFixed(0)}`,
     formatCurrencyAxis: (n: number) => `$${n}`,
   }),
@@ -135,9 +136,9 @@ describe('InvestmentValueChart', () => {
     render(<InvestmentValueChart />);
     await screen.findByText('Portfolio Value Over Time');
     // highest=15000, lowest=10000, change=+5000, percent=+50.0%
-    expect(screen.getByText('$15000')).toBeInTheDocument();
-    expect(screen.getByText('$10000')).toBeInTheDocument();
-    expect(screen.getByText('+$5000')).toBeInTheDocument();
+    expect(screen.getByText('$15000.00')).toBeInTheDocument();
+    expect(screen.getByText('$10000.00')).toBeInTheDocument();
+    expect(screen.getByText('+$5000.00')).toBeInTheDocument();
     expect(screen.getByText('+50.0%')).toBeInTheDocument();
   });
 
@@ -226,9 +227,9 @@ describe('InvestmentValueChart', () => {
     render(<InvestmentValueChart />);
     await screen.findByText('Portfolio Value Over Time');
     // highest should be 10000 (Jan 10), not 9000 or 8000 from December
-    expect(screen.getByText('$10000')).toBeInTheDocument();
+    expect(screen.getByText('$10000.00')).toBeInTheDocument();
     // December point (8000) filtered out, so lowest is 9000
-    expect(screen.getByText('$9000')).toBeInTheDocument();
+    expect(screen.getByText('$9000.00')).toBeInTheDocument();
   });
 
   it('shows negative change values correctly', async () => {
@@ -238,7 +239,7 @@ describe('InvestmentValueChart', () => {
     ]);
     render(<InvestmentValueChart />);
     await screen.findByText('Portfolio Value Over Time');
-    expect(screen.getByText('$15000')).toBeInTheDocument();
+    expect(screen.getByText('$15000.00')).toBeInTheDocument();
     expect(screen.getByText('-25.0%')).toBeInTheDocument();
   });
 
@@ -363,7 +364,7 @@ describe('InvestmentValueChart', () => {
       expect(netWorthApi.getInvestmentsDaily).toHaveBeenCalled();
     });
     expect(screen.queryByTestId('intraday-error-banner')).toBeNull();
-    expect(screen.getByText('$9000')).toBeInTheDocument();
+    expect(screen.getByText('$9000.00')).toBeInTheDocument();
   });
 
   it('silently falls back to daily on 1d when the intraday request rejects', async () => {
@@ -490,8 +491,8 @@ describe('InvestmentValueChart', () => {
   it('formats values with foreign currency label when displayCurrency differs', async () => {
     render(<InvestmentValueChart displayCurrency="USD" />);
     await screen.findByText('Portfolio Value Over Time');
-    // fmtVal includes the currency code when foreignCurrency is set
-    expect(screen.getByText('$15000 USD')).toBeInTheDocument();
+    // fmtFull includes the currency code when foreignCurrency is set
+    expect(screen.getByText('$15000.00 USD')).toBeInTheDocument();
   });
 
   it('shows changePercent as 0 when initial value is zero', async () => {

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -50,7 +50,7 @@ interface InvestmentValueChartProps {
 }
 
 export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix }: InvestmentValueChartProps) {
-  const { formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag } = useNumberFormat();
+  const { formatCurrency, formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
   const [chartPoints, setChartPoints] = useState<Array<{ name: string; Value: number }>>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -94,6 +94,14 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
     if (foreignCurrency) return `${formatCurrencyCompact(value, foreignCurrency)} ${foreignCurrency}`;
     return formatCurrencyCompact(value);
   }, [foreignCurrency, formatCurrencyCompact]);
+
+  // Summary-card values (Highest / Lowest / Change) use the currency's
+  // standard fraction digits rather than the rounded compact form, so the
+  // user sees the full precision instead of a truncated dollar figure.
+  const fmtFull = useCallback((value: number) => {
+    if (foreignCurrency) return `${formatCurrency(value, foreignCurrency)} ${foreignCurrency}`;
+    return formatCurrency(value);
+  }, [foreignCurrency, formatCurrency]);
 
   const fmtAxis = useCallback((value: number) => {
     if (foreignCurrency) return formatCurrencyAxis(value, foreignCurrency);
@@ -432,13 +440,13 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
         <div>
           <div className="text-xs text-gray-500 dark:text-gray-400">Highest Value</div>
           <div className="text-lg font-bold text-gray-900 dark:text-gray-100">
-            {fmtVal(summary.highest)}
+            {fmtFull(summary.highest)}
           </div>
         </div>
         <div>
           <div className="text-xs text-gray-500 dark:text-gray-400">Lowest Value</div>
           <div className="text-lg font-bold text-gray-900 dark:text-gray-100">
-            {fmtVal(summary.lowest)}
+            {fmtFull(summary.lowest)}
           </div>
         </div>
         <div>
@@ -446,7 +454,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
           <div className={`text-lg font-bold ${
             summary.change >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
           }`}>
-            {summary.change >= 0 ? '+' : ''}{fmtVal(summary.change)}
+            {summary.change >= 0 ? '+' : ''}{fmtFull(summary.change)}
           </div>
         </div>
         <div>


### PR DESCRIPTION
## Summary
Fixes intraday portfolio value chart to properly trim data to precise calendar-day boundaries for 1-week and 1-month ranges. Yahoo Finance's range parameters are approximate (e.g., "5d" covers 5 trading days, "1mo" excludes the boundary date), so we now over-fetch and filter to ensure consistent, predictable chart windows.

## Key Changes

**Backend (PortfolioService)**
- Changed 1W range from Yahoo's "5d" to "1mo" to ensure full 7-day coverage (5d only covers 5 trading days, leaving gaps on certain weekdays)
- Added `RANGE_LOOKBACK_DAYS` constant to define precise calendar-day cutoffs (7 days for 1W, 30 days for 1M, null for 1D)
- Implemented timestamp filtering logic that trims results to "start of (today - N days)" boundary after fetching
- Updated all 1W fallback intervals to use "1mo" range instead of "5d"

**Frontend (InvestmentValueChart)**
- Added `formatCurrency` formatter for summary card values (Highest/Lowest/Change)
- Created `fmtFull` callback to display full currency precision instead of compact form for summary metrics
- Updated summary card rendering to use `fmtFull` instead of `fmtVal` for better readability

**Tests**
- Added comprehensive test for 1W range: verifies over-fetching from "1mo" and precise 7-day boundary trimming
- Added test for 1M range: verifies 30-day cutoff filtering
- Updated frontend test mocks to include `formatCurrency` and adjusted expected output format to include decimal places (e.g., "$15000.00" instead of "$15000")

## Implementation Details

The trimming logic calculates a cutoff date at UTC midnight of (today - N days) and filters out any timestamps before that boundary. This ensures:
- 1W requests always cover exactly 7 calendar days
- 1M requests always cover exactly 30 calendar days
- Boundary dates are inclusive (e.g., start of day 2026-05-06 is included in a 1W window)
- The approach is resilient to Yahoo's approximate range behavior

https://claude.ai/code/session_01FFgTx5E2DKwy3TWU6igVWb