### PR TITLE
fix(ui): match Select placeholder color to MultiSelect

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -184,6 +184,14 @@ select {
   color: rgb(156 163 175) !important; /* gray-400 - matches placeholder */
 }
 
+/* Select placeholder color - applied when no option is selected. The selectors
+   are scoped tightly enough (class + element) to win against the global
+   `.dark select { text-gray-100 }` rule above. */
+select.select-placeholder,
+.dark select.select-placeholder {
+  color: rgb(156 163 175); /* gray-400 - matches MultiSelect placeholder */
+}
+
 /* Calendar picker indicator for dark mode */
 .dark [type='date']::-webkit-calendar-picker-indicator {
   filter: invert(0.7);

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -27,13 +27,19 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           className={cn(
             inputBaseClasses,
             'border px-3 py-2 font-sans focus:ring-1 focus:outline-none',
+            (props.value === '' || props.value === undefined) && 'text-gray-400 dark:text-gray-400',
             error && inputErrorClasses,
             className
           )}
           {...props}
         >
           {options.map((option) => (
-            <option key={option.value} value={option.value} disabled={option.disabled}>
+            <option
+              key={option.value}
+              value={option.value}
+              disabled={option.disabled}
+              className="text-gray-900 dark:text-gray-100"
+            >
               {option.label}
             </option>
           ))}

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -10,6 +10,7 @@ interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
   ({ label, error, options, className, id, ...props }, ref) => {
     const selectId = id || `select-${label?.toLowerCase().replace(/\s+/g, '-')}`;
+    const isPlaceholder = props.value === '' || props.value === undefined;
 
     return (
       <div className="w-full">
@@ -27,7 +28,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           className={cn(
             inputBaseClasses,
             'border px-3 py-2 font-sans focus:ring-1 focus:outline-none',
-            (props.value === '' || props.value === undefined) && 'text-gray-400 dark:text-gray-400',
+            isPlaceholder && 'select-placeholder',
             error && inputErrorClasses,
             className
           )}


### PR DESCRIPTION
The native <select>'s placeholder option (e.g. "Select period..." in
the Transactions filter) inherits the default text color, while
MultiSelect renders its placeholder in text-gray-400. Apply the same
gray to Select when value is empty so all filter placeholders look
consistent.

https://claude.ai/code/session_01XLBSkeT4hNTtQb91zFRJMD