### PR TITLE
Delegate account access

### DIFF
--- a/backend/src/accounts/accounts.controller.spec.ts
+++ b/backend/src/accounts/accounts.controller.spec.ts
@@ -315,10 +315,10 @@ describe("AccountsController", () => {
   });
 
   describe("getDailyBalances()", () => {
-    it("delegates to accountsService.getDailyBalances with parsed accountIds", () => {
+    it("delegates to accountsService.getDailyBalances with parsed accountIds", async () => {
       mockAccountsService.getDailyBalances!.mockReturnValue("balances");
 
-      const result = controller.getDailyBalances(
+      const result = await controller.getDailyBalances(
         mockReq,
         "2025-01-01",
         "2025-12-31",
@@ -334,10 +334,10 @@ describe("AccountsController", () => {
       );
     });
 
-    it("passes undefined accountIds when not provided", () => {
+    it("passes undefined accountIds when not provided", async () => {
       mockAccountsService.getDailyBalances!.mockReturnValue("balances");
 
-      controller.getDailyBalances(
+      await controller.getDailyBalances(
         mockReq,
         "2025-01-01",
         "2025-12-31",

--- a/backend/src/accounts/accounts.controller.spec.ts
+++ b/backend/src/accounts/accounts.controller.spec.ts
@@ -5,11 +5,13 @@ import { AccountsService } from "./accounts.service";
 import { AccountExportService } from "./account-export.service";
 import { LoanPaymentDetectorService } from "./loan-payment-detector.service";
 import { LoanPaymentSetupService } from "./loan-payment-setup.service";
+import { DelegationService } from "../delegation/delegation.service";
 
 describe("AccountsController", () => {
   let controller: AccountsController;
   let mockAccountsService: Partial<Record<keyof AccountsService, jest.Mock>>;
   let mockExportService: Partial<Record<keyof AccountExportService, jest.Mock>>;
+  let mockDelegationService: Record<string, jest.Mock>;
   const mockReq = { user: { id: "user-1" } };
 
   beforeEach(async () => {
@@ -37,6 +39,11 @@ describe("AccountsController", () => {
       exportQif: jest.fn(),
     };
 
+    mockDelegationService = {
+      readableAccountIds: jest.fn().mockResolvedValue([]),
+      hasReadAccess: jest.fn().mockResolvedValue(true),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AccountsController],
       providers: [
@@ -55,6 +62,10 @@ describe("AccountsController", () => {
         {
           provide: LoanPaymentSetupService,
           useValue: { setupLoanPayments: jest.fn() },
+        },
+        {
+          provide: DelegationService,
+          useValue: mockDelegationService,
         },
       ],
     }).compile();
@@ -75,21 +86,36 @@ describe("AccountsController", () => {
   });
 
   describe("findAll()", () => {
-    it("delegates to accountsService.findAll with userId and includeInactive", () => {
-      mockAccountsService.findAll!.mockReturnValue("accounts");
+    it("delegates to accountsService.findAll with userId and includeInactive", async () => {
+      mockAccountsService.findAll!.mockResolvedValue("accounts");
 
-      const result = controller.findAll(mockReq, true);
+      const result = await controller.findAll(mockReq, true);
 
       expect(result).toBe("accounts");
       expect(mockAccountsService.findAll).toHaveBeenCalledWith("user-1", true);
     });
 
-    it("defaults includeInactive to false when undefined", () => {
-      mockAccountsService.findAll!.mockReturnValue("accounts");
+    it("defaults includeInactive to false when undefined", async () => {
+      mockAccountsService.findAll!.mockResolvedValue("accounts");
 
-      controller.findAll(mockReq, undefined);
+      await controller.findAll(mockReq, undefined);
 
       expect(mockAccountsService.findAll).toHaveBeenCalledWith("user-1", false);
+    });
+
+    it("filters to READ-granted accounts when acting as a delegate", async () => {
+      mockAccountsService.findAll!.mockResolvedValue([
+        { id: "a1" },
+        { id: "a2" },
+      ]);
+      mockDelegationService.readableAccountIds.mockResolvedValue(["a1"]);
+      const actingReq = {
+        user: { id: "owner-1", isActing: true, delegationId: "g1" },
+      };
+
+      const result = await controller.findAll(actingReq as never, false);
+
+      expect(result).toEqual([{ id: "a1" }]);
     });
   });
 

--- a/backend/src/accounts/accounts.controller.spec.ts
+++ b/backend/src/accounts/accounts.controller.spec.ts
@@ -42,6 +42,9 @@ describe("AccountsController", () => {
     mockDelegationService = {
       readableAccountIds: jest.fn().mockResolvedValue([]),
       hasReadAccess: jest.fn().mockResolvedValue(true),
+      getDelegateFavourites: jest.fn().mockResolvedValue(new Map()),
+      setDelegateFavourite: jest.fn().mockResolvedValue(undefined),
+      reorderDelegateFavourites: jest.fn().mockResolvedValue(undefined),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -105,17 +108,54 @@ describe("AccountsController", () => {
 
     it("filters to READ-granted accounts when acting as a delegate", async () => {
       mockAccountsService.findAll!.mockResolvedValue([
-        { id: "a1" },
-        { id: "a2" },
+        { id: "a1", isFavourite: false, favouriteSortOrder: 0 },
+        { id: "a2", isFavourite: false, favouriteSortOrder: 0 },
       ]);
       mockDelegationService.readableAccountIds.mockResolvedValue(["a1"]);
       const actingReq = {
-        user: { id: "owner-1", isActing: true, delegationId: "g1" },
+        user: {
+          id: "owner-1",
+          realUserId: "deleg-1",
+          isActing: true,
+          delegationId: "g1",
+        },
       };
 
       const result = await controller.findAll(actingReq as never, false);
 
-      expect(result).toEqual([{ id: "a1" }]);
+      expect(result).toEqual([
+        { id: "a1", isFavourite: false, favouriteSortOrder: 0 },
+      ]);
+    });
+
+    it("overlays the delegate's own favourites, not the owner's", async () => {
+      mockAccountsService.findAll!.mockResolvedValue([
+        { id: "a1", isFavourite: true, favouriteSortOrder: 5 },
+        { id: "a2", isFavourite: false, favouriteSortOrder: 0 },
+      ]);
+      mockDelegationService.readableAccountIds.mockResolvedValue(["a1", "a2"]);
+      // Owner has a1 favourite; delegate instead favourites only a2.
+      mockDelegationService.getDelegateFavourites.mockResolvedValue(
+        new Map([["a2", 3]]),
+      );
+      const actingReq = {
+        user: {
+          id: "owner-1",
+          realUserId: "deleg-1",
+          isActing: true,
+          delegationId: "g1",
+        },
+      };
+
+      const result = await controller.findAll(actingReq as never, false);
+
+      expect(result).toEqual([
+        { id: "a1", isFavourite: false, favouriteSortOrder: 0 },
+        { id: "a2", isFavourite: true, favouriteSortOrder: 3 },
+      ]);
+      expect(mockDelegationService.getDelegateFavourites).toHaveBeenCalledWith(
+        "deleg-1",
+      );
     });
   });
 
@@ -189,16 +229,43 @@ describe("AccountsController", () => {
   });
 
   describe("findOne()", () => {
-    it("delegates to accountsService.findOne with userId and id", () => {
-      mockAccountsService.findOne!.mockReturnValue("account");
+    it("delegates to accountsService.findOne with userId and id", async () => {
+      mockAccountsService.findOne!.mockResolvedValue("account");
 
-      const result = controller.findOne(mockReq, "account-1");
+      const result = await controller.findOne(mockReq, "account-1");
 
       expect(result).toBe("account");
       expect(mockAccountsService.findOne).toHaveBeenCalledWith(
         "user-1",
         "account-1",
       );
+    });
+
+    it("overlays the delegate's own favourite when acting", async () => {
+      mockAccountsService.findOne!.mockResolvedValue({
+        id: "a1",
+        isFavourite: true,
+        favouriteSortOrder: 9,
+      });
+      mockDelegationService.getDelegateFavourites.mockResolvedValue(
+        new Map([["a1", 2]]),
+      );
+      const actingReq = {
+        user: {
+          id: "owner-1",
+          realUserId: "deleg-1",
+          isActing: true,
+          delegationId: "g1",
+        },
+      };
+
+      const result = await controller.findOne(actingReq as never, "a1");
+
+      expect(result).toEqual({
+        id: "a1",
+        isFavourite: true,
+        favouriteSortOrder: 2,
+      });
     });
   });
 
@@ -595,6 +662,50 @@ describe("AccountsController", () => {
         "user-1",
         ["id-1", "id-2", "id-3"],
       );
+    });
+
+    it("reorders the delegate's own overlay when acting", () => {
+      const dto = { accountIds: ["a1", "a2"] };
+      const actingReq = {
+        user: { id: "owner-1", realUserId: "deleg-1", isActing: true },
+      };
+
+      controller.reorderFavourites(actingReq as never, dto);
+
+      expect(
+        mockDelegationService.reorderDelegateFavourites,
+      ).toHaveBeenCalledWith("deleg-1", ["a1", "a2"]);
+      expect(mockAccountsService.reorderFavourites).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("setDelegateFavourite()", () => {
+    it("stores the favourite on the delegate overlay when acting", async () => {
+      const actingReq = {
+        user: { id: "owner-1", realUserId: "deleg-1", isActing: true },
+      };
+
+      const result = await controller.setDelegateFavourite(
+        actingReq as never,
+        "a1",
+        { isFavourite: true },
+      );
+
+      expect(result).toEqual({ isFavourite: true });
+      expect(mockDelegationService.setDelegateFavourite).toHaveBeenCalledWith(
+        "deleg-1",
+        "a1",
+        true,
+      );
+    });
+
+    it("rejects non-delegate callers", async () => {
+      await expect(
+        controller.setDelegateFavourite(mockReq, "a1", {
+          isFavourite: true,
+        }),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockDelegationService.setDelegateFavourite).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/accounts/accounts.controller.ts
+++ b/backend/src/accounts/accounts.controller.ts
@@ -179,7 +179,8 @@ export class AccountsController {
     description: "Daily balance data retrieved successfully",
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  getDailyBalances(
+  @AllowDelegate()
+  async getDailyBalances(
     @Request() req,
     @Query("startDate") startDate?: string,
     @Query("endDate") endDate?: string,
@@ -193,7 +194,20 @@ export class AccountsController {
       throw new BadRequestException("startDate must be YYYY-MM-DD");
     if (ed && !dateRegex.test(ed))
       throw new BadRequestException("endDate must be YYYY-MM-DD");
-    const ids = aIds ? aIds.split(",").filter(Boolean) : undefined;
+    let ids = aIds ? aIds.split(",").filter(Boolean) : undefined;
+    if (req.user.isActing) {
+      // Restrict to the delegate's READ-granted accounts (never an
+      // unfiltered owner-wide query).
+      const readable = await this.delegationService.readableAccountIds(
+        req.user.delegationId,
+      );
+      const readableSet = new Set(readable);
+      ids =
+        ids && ids.length > 0
+          ? ids.filter((id) => readableSet.has(id))
+          : readable;
+      if (ids.length === 0) return [];
+    }
     return this.accountsService.getDailyBalances(req.user.id, sd, ed, ids);
   }
 

--- a/backend/src/accounts/accounts.controller.ts
+++ b/backend/src/accounts/accounts.controller.ts
@@ -25,6 +25,11 @@ import {
 import { Response } from "express";
 import { AuthGuard } from "@nestjs/passport";
 import { AccountsService } from "./accounts.service";
+import { DelegationService } from "../delegation/delegation.service";
+import {
+  AllowDelegate,
+  DelegatedAccountParam,
+} from "../delegation/decorators/delegate-access.decorator";
 import { AccountExportService } from "./account-export.service";
 import { LoanPaymentDetectorService } from "./loan-payment-detector.service";
 import { LoanPaymentSetupService } from "./loan-payment-setup.service";
@@ -98,6 +103,7 @@ export class AccountsController {
     private readonly accountExportService: AccountExportService,
     private readonly loanPaymentDetectorService: LoanPaymentDetectorService,
     private readonly loanPaymentSetupService: LoanPaymentSetupService,
+    private readonly delegationService: DelegationService,
   ) {}
 
   @Post()
@@ -125,12 +131,22 @@ export class AccountsController {
     description: "List of accounts retrieved successfully",
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  findAll(
+  @AllowDelegate()
+  async findAll(
     @Request() req,
     @Query("includeInactive", new ParseBoolPipe({ optional: true }))
     includeInactive?: boolean,
   ) {
-    return this.accountsService.findAll(req.user.id, includeInactive || false);
+    const accounts = await this.accountsService.findAll(
+      req.user.id,
+      includeInactive || false,
+    );
+    if (!req.user.isActing) return accounts;
+    // Delegate: restrict to READ-granted accounts only (Phase 1).
+    const readable = new Set(
+      await this.delegationService.readableAccountIds(req.user.delegationId),
+    );
+    return accounts.filter((a) => readable.has(a.id));
   }
 
   @Patch("reorder-favourites")
@@ -359,6 +375,8 @@ export class AccountsController {
     description: "Forbidden - account does not belong to user",
   })
   @ApiResponse({ status: 404, description: "Account not found" })
+  @AllowDelegate()
+  @DelegatedAccountParam("id")
   findOne(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
     return this.accountsService.findOne(req.user.id, id);
   }
@@ -379,6 +397,8 @@ export class AccountsController {
     description: "Forbidden - account does not belong to user",
   })
   @ApiResponse({ status: 404, description: "Account not found" })
+  @AllowDelegate()
+  @DelegatedAccountParam("id")
   getBalance(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
     return this.accountsService.getBalance(req.user.id, id);
   }

--- a/backend/src/accounts/accounts.controller.ts
+++ b/backend/src/accounts/accounts.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Put,
   Body,
   Patch,
   Param,
@@ -36,6 +37,7 @@ import { LoanPaymentSetupService } from "./loan-payment-setup.service";
 import { CreateAccountDto } from "./dto/create-account.dto";
 import { UpdateAccountDto } from "./dto/update-account.dto";
 import { ReorderFavouriteAccountsDto } from "./dto/reorder-favourite-accounts.dto";
+import { SetDelegateFavouriteDto } from "./dto/set-delegate-favourite.dto";
 import { LoanPreviewDto } from "./dto/loan-preview.dto";
 import {
   MortgagePreviewDto,
@@ -146,10 +148,29 @@ export class AccountsController {
     const readable = new Set(
       await this.delegationService.readableAccountIds(req.user.delegationId),
     );
-    return accounts.filter((a) => readable.has(a.id));
+    const visible = accounts.filter((a) => readable.has(a.id));
+    return this.applyDelegateFavourites(req.user.realUserId, visible);
+  }
+
+  /**
+   * Account favourites are owner-scoped on the accounts row. A delegate
+   * keeps their own, so when acting we replace isFavourite /
+   * favouriteSortOrder with the delegate's overlay (never the owner's).
+   */
+  private async applyDelegateFavourites<
+    T extends { id: string; isFavourite: boolean; favouriteSortOrder: number },
+  >(delegateUserId: string, accounts: T[]): Promise<T[]> {
+    const overlay =
+      await this.delegationService.getDelegateFavourites(delegateUserId);
+    return accounts.map((a) => ({
+      ...a,
+      isFavourite: overlay.has(a.id),
+      favouriteSortOrder: overlay.get(a.id) ?? 0,
+    }));
   }
 
   @Patch("reorder-favourites")
+  @AllowDelegate()
   @ApiOperation({
     summary: "Reorder favourite accounts",
     description:
@@ -161,7 +182,42 @@ export class AccountsController {
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   reorderFavourites(@Request() req, @Body() dto: ReorderFavouriteAccountsDto) {
+    // A delegate reorders their own favourites overlay, never the owner's.
+    if (req.user.isActing) {
+      return this.delegationService.reorderDelegateFavourites(
+        req.user.realUserId,
+        dto.accountIds,
+      );
+    }
     return this.accountsService.reorderFavourites(req.user.id, dto.accountIds);
+  }
+
+  @Put(":id/favourite")
+  @AllowDelegate()
+  @DelegatedAccountParam("id")
+  @ApiOperation({
+    summary: "Set the acting delegate's own favourite flag for an account",
+  })
+  @ApiResponse({ status: 200, description: "Favourite updated" })
+  @ApiResponse({ status: 400, description: "Bad request" })
+  async setDelegateFavourite(
+    @Request() req,
+    @Param("id", ParseUUIDPipe) id: string,
+    @Body() dto: SetDelegateFavouriteDto,
+  ): Promise<{ isFavourite: boolean }> {
+    // Owners manage favourites through the normal account update; this
+    // endpoint exists only for the delegate's independent overlay.
+    if (!req.user.isActing) {
+      throw new BadRequestException(
+        "Use the account update endpoint to change favourites",
+      );
+    }
+    await this.delegationService.setDelegateFavourite(
+      req.user.realUserId,
+      id,
+      dto.isFavourite,
+    );
+    return { isFavourite: dto.isFavourite };
   }
 
   @Get("daily-balances")
@@ -391,8 +447,13 @@ export class AccountsController {
   @ApiResponse({ status: 404, description: "Account not found" })
   @AllowDelegate()
   @DelegatedAccountParam("id")
-  findOne(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
-    return this.accountsService.findOne(req.user.id, id);
+  async findOne(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
+    const account = await this.accountsService.findOne(req.user.id, id);
+    if (!req.user.isActing) return account;
+    const [overlaid] = await this.applyDelegateFavourites(req.user.realUserId, [
+      account,
+    ]);
+    return overlaid;
   }
 
   @Get(":id/balance")

--- a/backend/src/accounts/accounts.module.ts
+++ b/backend/src/accounts/accounts.module.ts
@@ -19,6 +19,7 @@ import { NetWorthModule } from "../net-worth/net-worth.module";
 import { SecuritiesModule } from "../securities/securities.module";
 import { ActionHistoryModule } from "../action-history/action-history.module";
 import { NotificationsModule } from "../notifications/notifications.module";
+import { DelegationModule } from "../delegation/delegation.module";
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { NotificationsModule } from "../notifications/notifications.module";
     forwardRef(() => SecuritiesModule),
     ActionHistoryModule,
     NotificationsModule,
+    DelegationModule,
   ],
   providers: [
     AccountsService,

--- a/backend/src/accounts/dto/set-delegate-favourite.dto.ts
+++ b/backend/src/accounts/dto/set-delegate-favourite.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsBoolean } from "class-validator";
+
+export class SetDelegateFavouriteDto {
+  @ApiProperty({
+    example: true,
+    description: "Whether the acting delegate marks this account a favourite",
+  })
+  @IsBoolean()
+  isFavourite: boolean;
+}

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -7,6 +7,7 @@ import { PersonalAccessToken } from "../auth/entities/personal-access-token.enti
 import { AdminService } from "./admin.service";
 import { AdminController } from "./admin.controller";
 import { OAuthModule } from "../oauth/oauth.module";
+import { UsersModule } from "../users/users.module";
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { OAuthModule } from "../oauth/oauth.module";
       PersonalAccessToken,
     ]),
     OAuthModule,
+    UsersModule,
   ],
   providers: [AdminService],
   controllers: [AdminController],

--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -59,6 +59,7 @@ describe("AdminService", () => {
       save: jest.fn().mockImplementation((data) => data),
       remove: jest.fn(),
       count: jest.fn(),
+      createQueryBuilder: jest.fn(),
     };
 
     preferencesRepository = {
@@ -104,8 +105,19 @@ describe("AdminService", () => {
   });
 
   describe("findAllUsers", () => {
+    let qb: Record<string, jest.Mock>;
+
+    function mockQuery(rows: unknown[]) {
+      qb = {
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(rows),
+      };
+      usersRepository.createQueryBuilder.mockReturnValue(qb);
+    }
+
     it("returns users with sensitive fields stripped", async () => {
-      usersRepository.find.mockResolvedValue([mockAdmin, mockTargetUser]);
+      mockQuery([mockAdmin, mockTargetUser]);
 
       const result = await service.findAllUsers();
 
@@ -120,7 +132,7 @@ describe("AdminService", () => {
     });
 
     it("sets hasPassword false for OIDC users without password", async () => {
-      usersRepository.find.mockResolvedValue([
+      mockQuery([
         { ...mockTargetUser, passwordHash: null, authProvider: "oidc" },
       ]);
 
@@ -129,14 +141,15 @@ describe("AdminService", () => {
       expect(result[0].hasPassword).toBe(false);
     });
 
-    it("orders users by createdAt ASC", async () => {
-      usersRepository.find.mockResolvedValue([]);
+    it("excludes pure delegates and orders by createdAt ASC", async () => {
+      mockQuery([]);
 
       await service.findAllUsers();
 
-      expect(usersRepository.find).toHaveBeenCalledWith({
-        order: { createdAt: "ASC" },
-      });
+      const whereSql = qb.where.mock.calls[0][0] as string;
+      expect(whereSql).toContain("account_delegates");
+      expect(whereSql).toContain("delegate_user_id");
+      expect(qb.orderBy).toHaveBeenCalledWith("u.created_at", "ASC");
     });
   });
 

--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -11,6 +11,7 @@ import { UserPreference } from "../users/entities/user-preference.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
 import { PersonalAccessToken } from "../auth/entities/personal-access-token.entity";
 import { OAuthProviderService } from "../oauth/oauth-provider.service";
+import { UsersService } from "../users/users.service";
 
 describe("AdminService", () => {
   let service: AdminService;
@@ -19,6 +20,7 @@ describe("AdminService", () => {
   let refreshTokensRepository: Record<string, jest.Mock>;
   let patRepository: Record<string, jest.Mock>;
   let oauthProviderService: Record<string, jest.Mock>;
+  let usersService: Record<string, jest.Mock>;
 
   const mockAdmin = {
     id: "admin-1",
@@ -78,6 +80,11 @@ describe("AdminService", () => {
       revokeAllForUser: jest.fn().mockResolvedValue(0),
     };
 
+    usersService = {
+      isActingDelegate: jest.fn().mockResolvedValue(false),
+      purgeForDowngrade: jest.fn().mockResolvedValue(undefined),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AdminService,
@@ -97,6 +104,10 @@ describe("AdminService", () => {
         {
           provide: OAuthProviderService,
           useValue: oauthProviderService,
+        },
+        {
+          provide: UsersService,
+          useValue: usersService,
         },
       ],
     }).compile();
@@ -329,6 +340,36 @@ describe("AdminService", () => {
 
       await service.deleteUser("admin-1", "user-2");
 
+      expect(oauthProviderService.revokeAllForUser).toHaveBeenCalledWith(
+        "user-2",
+      );
+    });
+
+    it("revokes refresh tokens and PATs on delete", async () => {
+      usersRepository.findOne.mockResolvedValue({ ...mockTargetUser });
+
+      await service.deleteUser("admin-1", "user-2");
+
+      expect(refreshTokensRepository.update).toHaveBeenCalledWith(
+        { userId: "user-2", isRevoked: false },
+        { isRevoked: true },
+      );
+      expect(patRepository.update).toHaveBeenCalledWith(
+        { userId: "user-2", isRevoked: false },
+        { isRevoked: true },
+      );
+    });
+
+    it("demotes a delegate to a pure delegate instead of deleting", async () => {
+      usersRepository.findOne.mockResolvedValue({ ...mockTargetUser });
+      usersService.isActingDelegate.mockResolvedValue(true);
+
+      await service.deleteUser("admin-1", "user-2");
+
+      expect(usersService.purgeForDowngrade).toHaveBeenCalledWith("user-2");
+      expect(preferencesRepository.delete).not.toHaveBeenCalled();
+      expect(usersRepository.remove).not.toHaveBeenCalled();
+      // Sessions are still revoked so the demotion takes effect immediately.
       expect(oauthProviderService.revokeAllForUser).toHaveBeenCalledWith(
         "user-2",
       );

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -29,9 +29,21 @@ export class AdminService {
   ) {}
 
   async findAllUsers() {
-    const users = await this.usersRepository.find({
-      order: { createdAt: "ASC" },
-    });
+    // Pure delegates (users that exist only because an account owner granted
+    // them Shared Access) must not appear here -- they are managed solely from
+    // the owner's Shared Access page. A user is still listed if they own data,
+    // own a delegation, are an admin, or simply are not a delegate at all.
+    const users = await this.usersRepository
+      .createQueryBuilder("u")
+      .where(
+        `(NOT EXISTS (SELECT 1 FROM account_delegates ad WHERE ad.delegate_user_id = u.id)
+          OR EXISTS (SELECT 1 FROM accounts a WHERE a.user_id = u.id)
+          OR EXISTS (SELECT 1 FROM account_delegates o WHERE o.owner_user_id = u.id)
+          OR u.role = :adminRole)`,
+        { adminRole: "admin" },
+      )
+      .orderBy("u.created_at", "ASC")
+      .getMany();
     return users.map((user) => {
       const {
         passwordHash,

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -13,6 +13,7 @@ import { RefreshToken } from "../auth/entities/refresh-token.entity";
 import { PersonalAccessToken } from "../auth/entities/personal-access-token.entity";
 import { generateReadablePassword } from "./utils/password-generator";
 import { OAuthProviderService } from "../oauth/oauth-provider.service";
+import { UsersService } from "../users/users.service";
 
 @Injectable()
 export class AdminService {
@@ -26,6 +27,7 @@ export class AdminService {
     @InjectRepository(PersonalAccessToken)
     private patRepository: Repository<PersonalAccessToken>,
     private oauthProviderService: OAuthProviderService,
+    private usersService: UsersService,
   ) {}
 
   async findAllUsers() {
@@ -163,12 +165,29 @@ export class AdminService {
       }
     }
 
-    // Delete preferences first (FK constraint), then sweep OIDC artifacts
-    // to avoid leaving orphan oauth_payloads rows referencing the deleted
-    // subject. (The findAccount gate would reject them anyway, but the
-    // rows are cheap to delete and keep the table clean.)
-    await this.preferencesRepository.delete({ userId: targetUserId });
+    // Revoke sessions/PATs and sweep OIDC artifacts (forces re-login and
+    // avoids orphan oauth_payloads rows) -- needed whether the account is
+    // fully removed or demoted to a delegate.
+    await this.refreshTokensRepository.update(
+      { userId: targetUserId, isRevoked: false },
+      { isRevoked: true },
+    );
+    await this.patRepository.update(
+      { userId: targetUserId, isRevoked: false },
+      { isRevoked: true },
+    );
     await this.oauthProviderService.revokeAllForUser(targetUserId);
+
+    // A full account that is also a delegate of someone else is demoted to
+    // a pure delegate instead of being removed: their own data goes, but
+    // their login and the delegate access others granted them stay.
+    if (await this.usersService.isActingDelegate(targetUserId)) {
+      await this.usersService.purgeForDowngrade(targetUserId);
+      return;
+    }
+
+    // Delete preferences first (FK constraint), then the user.
+    await this.preferencesRepository.delete({ userId: targetUserId });
     await this.usersRepository.remove(targetUser);
   }
 

--- a/backend/src/ai/insights/ai-insights.controller.ts
+++ b/backend/src/ai/insights/ai-insights.controller.ts
@@ -24,17 +24,26 @@ import {
 import { AiInsightsService } from "./ai-insights.service";
 import { GetInsightsQueryDto } from "./dto/ai-insights.dto";
 import { InsightType } from "../entities/ai-insight.entity";
+import {
+  AllowDelegate,
+  DelegateRequiresSection,
+} from "../../delegation/decorators/delegate-access.decorator";
 
 @ApiTags("AI Insights")
 @Controller("ai/insights")
 @UseGuards(AuthGuard("jwt"))
 @ApiBearerAuth()
+// Read-only "ai" section: only the @AllowDelegate() GET is reachable by a
+// delegate, and only with the owner's "ai" grant. Generate/dismiss have no
+// @AllowDelegate() -> fail closed.
+@DelegateRequiresSection("ai")
 export class AiInsightsController {
   private readonly logger = new Logger(AiInsightsController.name);
 
   constructor(private readonly insightsService: AiInsightsService) {}
 
   @Get()
+  @AllowDelegate()
   @Throttle({ default: { ttl: 60000, limit: 60 } })
   @ApiOperation({ summary: "Get spending insights for the current user" })
   getInsights(

--- a/backend/src/ai/query/ai-query.controller.ts
+++ b/backend/src/ai/query/ai-query.controller.ts
@@ -13,17 +13,26 @@ import { ApiTags, ApiBearerAuth, ApiOperation } from "@nestjs/swagger";
 import { Response } from "express";
 import { AiQueryService } from "./ai-query.service";
 import { AiQueryDto } from "./dto/ai-query.dto";
+import {
+  AllowDelegate,
+  DelegateRequiresSection,
+} from "../../delegation/decorators/delegate-access.decorator";
 
 @ApiTags("AI")
 @Controller("ai")
 @UseGuards(AuthGuard("jwt"))
 @ApiBearerAuth()
+// The AI assistant is a read-only "ai" section for delegates: the query
+// endpoints only read the owner's data (effective-user scoping) using the
+// owner's configured provider. Reachable only with the "ai" grant.
+@DelegateRequiresSection("ai")
 export class AiQueryController {
   private readonly logger = new Logger(AiQueryController.name);
 
   constructor(private readonly queryService: AiQueryService) {}
 
   @Post("query")
+  @AllowDelegate()
   @ApiOperation({ summary: "Execute a natural language financial query" })
   @Throttle({ default: { ttl: 60000, limit: 10 } })
   async query(
@@ -38,6 +47,7 @@ export class AiQueryController {
   }
 
   @Post("query/stream")
+  @AllowDelegate()
   @ApiOperation({
     summary: "Execute a natural language financial query with SSE streaming",
   })

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -46,6 +46,7 @@ import { BackupModule } from "./backup/backup.module";
 import { ActionHistoryModule } from "./action-history/action-history.module";
 import { UpdatesModule } from "./updates/updates.module";
 import { MonteCarloModule } from "./monte-carlo/monte-carlo.module";
+import { DelegationModule } from "./delegation/delegation.module";
 
 @Module({
   imports: [
@@ -126,6 +127,7 @@ import { MonteCarloModule } from "./monte-carlo/monte-carlo.module";
     ActionHistoryModule,
     UpdatesModule,
     MonteCarloModule,
+    DelegationModule,
   ],
   providers: [
     { provide: APP_FILTER, useClass: GlobalExceptionFilter },

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -2118,6 +2118,70 @@ describe("AuthController", () => {
     });
   });
 
+  describe("getContexts", () => {
+    async function buildController(delegation: Record<string, jest.Mock>) {
+      const module: TestingModule = await Test.createTestingModule({
+        controllers: [AuthController],
+        providers: [
+          { provide: AuthService, useValue: authService },
+          { provide: OidcService, useValue: oidcService },
+          { provide: ConfigService, useValue: configService },
+          { provide: EmailService, useValue: emailService },
+          { provide: DemoModeService, useValue: demoModeService },
+          {
+            provide: TokenService,
+            useValue: { getRefreshExpiryMs: jest.fn() },
+          },
+          { provide: DelegationService, useValue: delegation },
+        ],
+      }).compile();
+      return module.get<AuthController>(AuthController);
+    }
+
+    it("returns capabilities and sections when acting", async () => {
+      const delegation = {
+        getAvailableContexts: jest.fn().mockResolvedValue([{ userId: "o1" }]),
+        getCapabilities: jest.fn().mockResolvedValue({ payees: {} }),
+        getSections: jest.fn().mockResolvedValue({ bills: true }),
+      };
+      const c = await buildController(delegation);
+      const res = await c.getContexts({
+        user: {
+          id: "o1",
+          realUserId: "d1",
+          isActing: true,
+          delegationId: "g1",
+        },
+      } as never);
+      expect(res).toEqual({
+        actingAsUserId: "o1",
+        contexts: [{ userId: "o1" }],
+        capabilities: { payees: {} },
+        sections: { bills: true },
+      });
+      expect(delegation.getSections).toHaveBeenCalledWith("g1");
+    });
+
+    it("returns null capabilities and sections when not acting", async () => {
+      const delegation = {
+        getAvailableContexts: jest.fn().mockResolvedValue([]),
+        getCapabilities: jest.fn(),
+        getSections: jest.fn(),
+      };
+      const c = await buildController(delegation);
+      const res = await c.getContexts({
+        user: { id: "d1", realUserId: "d1", isActing: false },
+      } as never);
+      expect(res).toEqual({
+        actingAsUserId: null,
+        contexts: [],
+        capabilities: null,
+        sections: null,
+      });
+      expect(delegation.getSections).not.toHaveBeenCalled();
+    });
+  });
+
   // Use the previously-imported helpers without regenerating the controller
   // — these branches don't depend on alternate config.
   void encryptTrustedDeviceCookieForTest;

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -390,7 +390,7 @@ describe("AuthController", () => {
       const loginResult = {
         accessToken: "access-token",
         refreshToken: "refresh-token",
-        user: { id: "user-1", email: "test@example.com" },
+        user: { id: "user-1", realUserId: "user-1", email: "test@example.com" },
       };
       authService.login.mockResolvedValue(loginResult);
       const res = mockRes();
@@ -419,7 +419,7 @@ describe("AuthController", () => {
       const loginResult = {
         accessToken: "access-token",
         refreshToken: "refresh-token",
-        user: { id: "user-1", email: "test@example.com" },
+        user: { id: "user-1", realUserId: "user-1", email: "test@example.com" },
         rememberMe: true,
       };
       authService.login.mockResolvedValue(loginResult);
@@ -856,7 +856,7 @@ describe("AuthController", () => {
   describe("csrfRefresh", () => {
     it("sets csrf_token cookie and returns success message", async () => {
       const res = mockRes();
-      const req = { user: { id: "user-1" } };
+      const req = { user: { id: "user-1", realUserId: "user-1" } };
 
       await controller.csrfRefresh(req as any, res as any);
 
@@ -880,7 +880,7 @@ describe("AuthController", () => {
       const verifyResult = {
         accessToken: "2fa-access",
         refreshToken: "2fa-refresh",
-        user: { id: "user-1", email: "test@example.com" },
+        user: { id: "user-1", realUserId: "user-1", email: "test@example.com" },
         trustedDeviceRef: null,
       };
       authService.verify2FA.mockResolvedValue(verifyResult);
@@ -922,7 +922,7 @@ describe("AuthController", () => {
       const verifyResult = {
         accessToken: "2fa-access",
         refreshToken: "2fa-refresh",
-        user: { id: "user-1", email: "test@example.com" },
+        user: { id: "user-1", realUserId: "user-1", email: "test@example.com" },
         trustedDeviceRef: "trusted-device-token-abc",
       };
       authService.verify2FA.mockResolvedValue(verifyResult);
@@ -970,7 +970,7 @@ describe("AuthController", () => {
       const verifyResult = {
         accessToken: "2fa-access",
         refreshToken: "2fa-refresh",
-        user: { id: "user-1", email: "test@example.com" },
+        user: { id: "user-1", realUserId: "user-1", email: "test@example.com" },
         trustedDeviceRef: null,
       };
       authService.verify2FA.mockResolvedValue(verifyResult);
@@ -999,7 +999,7 @@ describe("AuthController", () => {
       const verifyResult = {
         accessToken: "2fa-access",
         refreshToken: "2fa-refresh",
-        user: { id: "user-1" },
+        user: { id: "user-1", realUserId: "user-1" },
         trustedDeviceRef: null,
       };
       authService.verify2FA.mockResolvedValue(verifyResult);
@@ -1033,7 +1033,7 @@ describe("AuthController", () => {
         qrCodeDataUrl: "data:image/png;base64,abc123",
       };
       authService.setup2FA.mockResolvedValue(setupResult);
-      const reqWithUser = { user: { id: "user-1" } };
+      const reqWithUser = { user: { id: "user-1", realUserId: "user-1" } };
 
       const result = await controller.setup2FA(reqWithUser, {
         currentPassword: "correct-password",
@@ -1051,7 +1051,7 @@ describe("AuthController", () => {
     it("delegates to authService.confirmSetup2FA with user id and code", async () => {
       const confirmResult = { message: "2FA enabled successfully" };
       authService.confirmSetup2FA.mockResolvedValue(confirmResult);
-      const reqWithUser = { user: { id: "user-1" } };
+      const reqWithUser = { user: { id: "user-1", realUserId: "user-1" } };
       const dto = { code: "123456" };
 
       const result = await controller.confirmSetup2FA(reqWithUser, dto as any);
@@ -1068,13 +1068,65 @@ describe("AuthController", () => {
     it("delegates to authService.disable2FA with user id and code", async () => {
       const disableResult = { message: "2FA disabled successfully" };
       authService.disable2FA.mockResolvedValue(disableResult);
-      const reqWithUser = { user: { id: "user-1" } };
+      const reqWithUser = { user: { id: "user-1", realUserId: "user-1" } };
       const dto = { code: "654321" };
 
       const result = await controller.disable2FA(reqWithUser, dto as any);
 
       expect(authService.disable2FA).toHaveBeenCalledWith("user-1", "654321");
       expect(result).toEqual(disableResult);
+    });
+
+    it("targets the real (delegate) user id, never the owner, when acting", async () => {
+      authService.disable2FA.mockResolvedValue({ message: "ok" });
+      const actingReq = {
+        user: { id: "owner-1", realUserId: "delegate-1", isActing: true },
+      };
+
+      await controller.disable2FA(actingReq as any, { code: "123456" } as any);
+
+      expect(authService.disable2FA).toHaveBeenCalledWith(
+        "delegate-1",
+        "123456",
+      );
+    });
+  });
+
+  describe("get2FAStatus", () => {
+    it("returns the 2FA-enabled flag for the real (delegate) user id", async () => {
+      (authService as any).is2FAEnabled = jest.fn().mockResolvedValue(true);
+      const actingReq = {
+        user: { id: "owner-1", realUserId: "delegate-1", isActing: true },
+      };
+
+      const result = await controller.get2FAStatus(actingReq as any);
+
+      expect((authService as any).is2FAEnabled).toHaveBeenCalledWith(
+        "delegate-1",
+      );
+      expect(result).toEqual({ enabled: true });
+    });
+  });
+
+  describe("getSelfProfile", () => {
+    it("loads and sanitizes the real (delegate) user, never the owner", async () => {
+      const delegateUser = { id: "delegate-1", email: "d@x.com" } as any;
+      (authService as any).getUserById = jest
+        .fn()
+        .mockResolvedValue(delegateUser);
+      (authService as any).sanitizeUser = jest
+        .fn()
+        .mockReturnValue({ id: "delegate-1", email: "d@x.com" });
+      const actingReq = {
+        user: { id: "owner-1", realUserId: "delegate-1", isActing: true },
+      };
+
+      const result = await controller.getSelfProfile(actingReq as any);
+
+      expect((authService as any).getUserById).toHaveBeenCalledWith(
+        "delegate-1",
+      );
+      expect(result).toEqual({ id: "delegate-1", email: "d@x.com" });
     });
   });
 
@@ -1103,7 +1155,7 @@ describe("AuthController", () => {
       authService.findTrustedDeviceByToken.mockResolvedValue("device-1");
       const res = mockRes();
       const expressReq = {
-        user: { id: "user-1" },
+        user: { id: "user-1", realUserId: "user-1" },
         cookies: { trusted_device: "current-device-token" },
       } as any;
 
@@ -1124,7 +1176,7 @@ describe("AuthController", () => {
       authService.getTrustedDevices.mockResolvedValue(mockDevices);
       const res = mockRes();
       const expressReq = {
-        user: { id: "user-1" },
+        user: { id: "user-1", realUserId: "user-1" },
         cookies: {},
       } as any;
 
@@ -1141,7 +1193,7 @@ describe("AuthController", () => {
       authService.getTrustedDevices.mockResolvedValue([]);
       const res = mockRes();
       const expressReq = {
-        user: { id: "user-1" },
+        user: { id: "user-1", realUserId: "user-1" },
         cookies: {},
       } as any;
 
@@ -1157,7 +1209,7 @@ describe("AuthController", () => {
       authService.findTrustedDeviceByToken.mockResolvedValue("device-1");
       const res = mockRes();
       const expressReq = {
-        user: { id: "user-1" },
+        user: { id: "user-1", realUserId: "user-1" },
         cookies: { trusted_device: "current-device-token" },
       } as any;
 
@@ -1182,7 +1234,7 @@ describe("AuthController", () => {
       authService.findTrustedDeviceByToken.mockResolvedValue("device-2");
       const res = mockRes();
       const expressReq = {
-        user: { id: "user-1" },
+        user: { id: "user-1", realUserId: "user-1" },
         cookies: { trusted_device: "current-device-token" },
       } as any;
 
@@ -1202,7 +1254,7 @@ describe("AuthController", () => {
       authService.revokeTrustedDevice.mockResolvedValue(undefined);
       const res = mockRes();
       const expressReq = {
-        user: { id: "user-1" },
+        user: { id: "user-1", realUserId: "user-1" },
         cookies: {},
       } as any;
 
@@ -1220,7 +1272,7 @@ describe("AuthController", () => {
       authService.findTrustedDeviceByToken.mockResolvedValue(null);
       const res = mockRes();
       const expressReq = {
-        user: { id: "user-1" },
+        user: { id: "user-1", realUserId: "user-1" },
         cookies: { trusted_device: "stale-token" },
       } as any;
 
@@ -1235,7 +1287,7 @@ describe("AuthController", () => {
       authService.revokeAllTrustedDevices.mockResolvedValue(3);
       const res = mockRes();
       const expressReq = {
-        user: { id: "user-1" },
+        user: { id: "user-1", realUserId: "user-1" },
       } as any;
 
       await controller.revokeAllTrustedDevices(expressReq, res as any);
@@ -1254,7 +1306,7 @@ describe("AuthController", () => {
       authService.revokeAllTrustedDevices.mockResolvedValue(0);
       const res = mockRes();
       const expressReq = {
-        user: { id: "user-1" },
+        user: { id: "user-1", realUserId: "user-1" },
       } as any;
 
       await controller.revokeAllTrustedDevices(expressReq, res as any);
@@ -1332,7 +1384,7 @@ describe("AuthController", () => {
       const loginResult = {
         accessToken: "access-token",
         refreshToken: "refresh-token",
-        user: { id: "user-1", email: "test@example.com" },
+        user: { id: "user-1", realUserId: "user-1", email: "test@example.com" },
       };
       authService.login.mockResolvedValue(loginResult);
       const res = mockRes();
@@ -1359,7 +1411,7 @@ describe("AuthController", () => {
       const loginResult = {
         accessToken: "access-token",
         refreshToken: "refresh-token",
-        user: { id: "user-1", email: "test@example.com" },
+        user: { id: "user-1", realUserId: "user-1", email: "test@example.com" },
       };
       authService.login.mockResolvedValue(loginResult);
       const res = mockRes();
@@ -1382,7 +1434,7 @@ describe("AuthController", () => {
       const loginResult = {
         accessToken: "access-token",
         refreshToken: "refresh-token",
-        user: { id: "user-1", email: "test@example.com" },
+        user: { id: "user-1", realUserId: "user-1", email: "test@example.com" },
       };
       authService.login.mockResolvedValue(loginResult);
       const res = mockRes();

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -2144,6 +2144,7 @@ describe("AuthController", () => {
         getCapabilities: jest.fn().mockResolvedValue({ payees: {} }),
         getSections: jest.fn().mockResolvedValue({ bills: true }),
         hasTransactionalAccess: jest.fn().mockResolvedValue(true),
+        hasAnyAccountAccess: jest.fn().mockResolvedValue(true),
       };
       const c = await buildController(delegation);
       const res = await c.getContexts({
@@ -2158,10 +2159,11 @@ describe("AuthController", () => {
         actingAsUserId: "o1",
         contexts: [{ userId: "o1" }],
         capabilities: { payees: {} },
-        sections: { bills: true, transactions: true },
+        sections: { bills: true, transactions: true, accounts: true },
       });
       expect(delegation.getSections).toHaveBeenCalledWith("g1");
       expect(delegation.hasTransactionalAccess).toHaveBeenCalledWith("g1");
+      expect(delegation.hasAnyAccountAccess).toHaveBeenCalledWith("g1");
     });
 
     it("returns null capabilities and sections when not acting", async () => {

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -2143,6 +2143,7 @@ describe("AuthController", () => {
         getAvailableContexts: jest.fn().mockResolvedValue([{ userId: "o1" }]),
         getCapabilities: jest.fn().mockResolvedValue({ payees: {} }),
         getSections: jest.fn().mockResolvedValue({ bills: true }),
+        hasTransactionalAccess: jest.fn().mockResolvedValue(true),
       };
       const c = await buildController(delegation);
       const res = await c.getContexts({
@@ -2157,9 +2158,10 @@ describe("AuthController", () => {
         actingAsUserId: "o1",
         contexts: [{ userId: "o1" }],
         capabilities: { payees: {} },
-        sections: { bills: true },
+        sections: { bills: true, transactions: true },
       });
       expect(delegation.getSections).toHaveBeenCalledWith("g1");
+      expect(delegation.hasTransactionalAccess).toHaveBeenCalledWith("g1");
     });
 
     it("returns null capabilities and sections when not acting", async () => {

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -11,6 +11,7 @@ import { OidcService } from "./oidc/oidc.service";
 import { EmailService } from "../notifications/email.service";
 import { DemoModeService } from "../common/demo-mode.service";
 import { TokenService } from "./token.service";
+import { DelegationService } from "../delegation/delegation.service";
 import { encrypt, derivePurposeKey } from "./crypto.util";
 
 // Matches the JWT_SECRET used in the configService mock below; kept in one
@@ -149,6 +150,14 @@ describe("AuthController", () => {
               .mockReturnValue(7 * 24 * 60 * 60 * 1000),
           },
         },
+        {
+          provide: DelegationService,
+          useValue: {
+            getAvailableContexts: jest.fn().mockResolvedValue([]),
+            resolveSwitchTarget: jest.fn(),
+            validateActingContext: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -189,6 +198,14 @@ describe("AuthController", () => {
               getRefreshExpiryMs: jest
                 .fn()
                 .mockReturnValue(7 * 24 * 60 * 60 * 1000),
+            },
+          },
+          {
+            provide: DelegationService,
+            useValue: {
+              getAvailableContexts: jest.fn().mockResolvedValue([]),
+              resolveSwitchTarget: jest.fn(),
+              validateActingContext: jest.fn(),
             },
           },
         ],
@@ -235,6 +252,14 @@ describe("AuthController", () => {
               getRefreshExpiryMs: jest
                 .fn()
                 .mockReturnValue(7 * 24 * 60 * 60 * 1000),
+            },
+          },
+          {
+            provide: DelegationService,
+            useValue: {
+              getAvailableContexts: jest.fn().mockResolvedValue([]),
+              resolveSwitchTarget: jest.fn(),
+              validateActingContext: jest.fn(),
             },
           },
         ],
@@ -313,6 +338,14 @@ describe("AuthController", () => {
               getRefreshExpiryMs: jest
                 .fn()
                 .mockReturnValue(7 * 24 * 60 * 60 * 1000),
+            },
+          },
+          {
+            provide: DelegationService,
+            useValue: {
+              getAvailableContexts: jest.fn().mockResolvedValue([]),
+              resolveSwitchTarget: jest.fn(),
+              validateActingContext: jest.fn(),
             },
           },
         ],
@@ -545,6 +578,14 @@ describe("AuthController", () => {
               getRefreshExpiryMs: jest
                 .fn()
                 .mockReturnValue(7 * 24 * 60 * 60 * 1000),
+            },
+          },
+          {
+            provide: DelegationService,
+            useValue: {
+              getAvailableContexts: jest.fn().mockResolvedValue([]),
+              resolveSwitchTarget: jest.fn(),
+              validateActingContext: jest.fn(),
             },
           },
         ],
@@ -1392,6 +1433,14 @@ describe("AuthController", () => {
                 .mockReturnValue(7 * 24 * 60 * 60 * 1000),
             },
           },
+          {
+            provide: DelegationService,
+            useValue: {
+              getAvailableContexts: jest.fn().mockResolvedValue([]),
+              resolveSwitchTarget: jest.fn(),
+              validateActingContext: jest.fn(),
+            },
+          },
         ],
       }).compile();
 
@@ -1446,6 +1495,14 @@ describe("AuthController", () => {
               getRefreshExpiryMs: jest
                 .fn()
                 .mockReturnValue(7 * 24 * 60 * 60 * 1000),
+            },
+          },
+          {
+            provide: DelegationService,
+            useValue: {
+              getAvailableContexts: jest.fn().mockResolvedValue([]),
+              resolveSwitchTarget: jest.fn(),
+              validateActingContext: jest.fn(),
             },
           },
         ],
@@ -1527,6 +1584,14 @@ describe("AuthController", () => {
                 .mockReturnValue(7 * 24 * 60 * 60 * 1000),
             },
           },
+          {
+            provide: DelegationService,
+            useValue: {
+              getAvailableContexts: jest.fn().mockResolvedValue([]),
+              resolveSwitchTarget: jest.fn(),
+              validateActingContext: jest.fn(),
+            },
+          },
         ],
       }).compile();
       const c = force2faModule.get<AuthController>(AuthController);
@@ -1592,6 +1657,14 @@ describe("AuthController", () => {
               getRefreshExpiryMs: jest
                 .fn()
                 .mockReturnValue(7 * 24 * 60 * 60 * 1000),
+            },
+          },
+          {
+            provide: DelegationService,
+            useValue: {
+              getAvailableContexts: jest.fn().mockResolvedValue([]),
+              resolveSwitchTarget: jest.fn(),
+              validateActingContext: jest.fn(),
             },
           },
         ],
@@ -1663,6 +1736,14 @@ describe("AuthController", () => {
                   .mockReturnValue(7 * 24 * 60 * 60 * 1000),
               },
             },
+            {
+              provide: DelegationService,
+              useValue: {
+                getAvailableContexts: jest.fn().mockResolvedValue([]),
+                resolveSwitchTarget: jest.fn(),
+                validateActingContext: jest.fn(),
+              },
+            },
           ],
         }).compile();
         const c = m.get<AuthController>(AuthController);
@@ -1704,12 +1785,24 @@ describe("AuthController", () => {
                 .mockReturnValue(7 * 24 * 60 * 60 * 1000),
             },
           },
+          {
+            provide: DelegationService,
+            useValue: {
+              getAvailableContexts: jest.fn().mockResolvedValue([]),
+              resolveSwitchTarget: jest.fn(),
+              validateActingContext: jest.fn(),
+            },
+          },
         ],
       }).compile();
       const c = m.get<AuthController>(AuthController);
       const res = mockRes();
       const req = { cookies: { oidc_state: "s", oidc_nonce: "n" } };
-      await c.oidcCallback({ error: "access_denied" }, req as never, res as never);
+      await c.oidcCallback(
+        { error: "access_denied" },
+        req as never,
+        res as never,
+      );
       expect(res.redirect).toHaveBeenCalledWith(
         "http://localhost:3000/auth/callback?error=authentication_failed",
       );
@@ -1740,6 +1833,14 @@ describe("AuthController", () => {
               getRefreshExpiryMs: jest
                 .fn()
                 .mockReturnValue(7 * 24 * 60 * 60 * 1000),
+            },
+          },
+          {
+            provide: DelegationService,
+            useValue: {
+              getAvailableContexts: jest.fn().mockResolvedValue([]),
+              resolveSwitchTarget: jest.fn(),
+              validateActingContext: jest.fn(),
             },
           },
         ],
@@ -1794,6 +1895,14 @@ describe("AuthController", () => {
                 .mockReturnValue(7 * 24 * 60 * 60 * 1000),
             },
           },
+          {
+            provide: DelegationService,
+            useValue: {
+              getAvailableContexts: jest.fn().mockResolvedValue([]),
+              resolveSwitchTarget: jest.fn(),
+              validateActingContext: jest.fn(),
+            },
+          },
         ],
       }).compile();
       const c = m.get<AuthController>(AuthController);
@@ -1830,6 +1939,14 @@ describe("AuthController", () => {
               getRefreshExpiryMs: jest
                 .fn()
                 .mockReturnValue(7 * 24 * 60 * 60 * 1000),
+            },
+          },
+          {
+            provide: DelegationService,
+            useValue: {
+              getAvailableContexts: jest.fn().mockResolvedValue([]),
+              resolveSwitchTarget: jest.fn(),
+              validateActingContext: jest.fn(),
             },
           },
         ],

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -225,6 +225,7 @@ export class AuthController {
   }
 
   @Post("register")
+  @AllowDelegate()
   @SkipCsrf()
   @DemoRestricted()
   @Throttle({ default: { ttl: 900000, limit: 5 } }) // 5 attempts per 15 minutes
@@ -252,6 +253,7 @@ export class AuthController {
   }
 
   @Post("login")
+  @AllowDelegate()
   @SkipCsrf()
   @Throttle({ default: { ttl: 900000, limit: 5 } }) // 5 attempts per 15 minutes
   @ApiOperation({ summary: "Login with local credentials" })
@@ -293,6 +295,7 @@ export class AuthController {
   }
 
   @Get("oidc")
+  @AllowDelegate()
   @ApiOperation({ summary: "Initiate OIDC authentication" })
   @ApiResponse({ status: 302, description: "Redirects to OIDC provider" })
   @ApiResponse({ status: 400, description: "OIDC not configured" })
@@ -320,6 +323,7 @@ export class AuthController {
   }
 
   @Get("oidc/callback")
+  @AllowDelegate()
   @ApiOperation({ summary: "OIDC callback handler" })
   async oidcCallback(
     @Query() query: Record<string, string>,
@@ -418,6 +422,7 @@ export class AuthController {
   }
 
   @Get("oidc/status")
+  @AllowDelegate()
   @ApiOperation({ summary: "Check if OIDC is enabled" })
   @ApiResponse({ status: 200, description: "Returns OIDC enabled status" })
   async oidcStatus() {
@@ -425,6 +430,7 @@ export class AuthController {
   }
 
   @Get("methods")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get available authentication methods" })
   @ApiResponse({
     status: 200,
@@ -524,6 +530,7 @@ export class AuthController {
   }
 
   @Post("forgot-password")
+  @AllowDelegate()
   @SkipCsrf()
   @DemoRestricted()
   @Throttle({ default: { ttl: 900000, limit: 3 } })
@@ -574,6 +581,7 @@ export class AuthController {
   }
 
   @Post("reset-password")
+  @AllowDelegate()
   @SkipCsrf()
   @DemoRestricted()
   @Throttle({ default: { ttl: 900000, limit: 5 } })
@@ -584,6 +592,7 @@ export class AuthController {
   }
 
   @Post("2fa/verify")
+  @AllowDelegate()
   @SkipCsrf()
   @Throttle({ default: { ttl: 900000, limit: 5 } })
   @ApiOperation({ summary: "Verify TOTP code to complete 2FA login" })
@@ -730,6 +739,7 @@ export class AuthController {
   }
 
   @Post("refresh")
+  @AllowDelegate()
   @SkipCsrf()
   @Throttle({ default: { ttl: 60000, limit: 10 } }) // 10 refreshes per minute
   @ApiOperation({ summary: "Refresh access token using refresh token cookie" })
@@ -769,6 +779,7 @@ export class AuthController {
   }
 
   @Get("oidc/confirm-link")
+  @AllowDelegate()
   @SkipCsrf()
   @ApiOperation({ summary: "Confirm OIDC account linking via email token" })
   async confirmOidcLink(@Query("token") token: string, @Res() res: Response) {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -485,6 +485,10 @@ export class AuthController {
       contexts: await this.delegationService.getAvailableContexts(
         req.user.realUserId,
       ),
+      capabilities:
+        req.user.isActing && req.user.delegationId
+          ? await this.delegationService.getCapabilities(req.user.delegationId)
+          : null,
     };
   }
 

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -472,6 +472,21 @@ export class AuthController {
     return this.authService.sanitizeUser(req.user);
   }
 
+  @Get("me-self")
+  @UseGuards(AuthGuard("jwt"))
+  @AllowDelegate()
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      "Authenticated user's OWN profile (delegate id, never the owner). " +
+      "Used by Security settings while acting as a delegate.",
+  })
+  async getSelfProfile(@Request() req) {
+    const user = await this.authService.getUserById(req.user.realUserId);
+    if (!user) return null;
+    return this.authService.sanitizeUser(user);
+  }
+
   @Get("contexts")
   @UseGuards(AuthGuard("jwt"))
   @AllowDelegate()
@@ -667,48 +682,66 @@ export class AuthController {
 
   @Post("2fa/setup")
   @UseGuards(AuthGuard("jwt"))
+  @AllowDelegate()
   @DemoRestricted()
   @Throttle({ default: { ttl: 900000, limit: 5 } })
   @ApiBearerAuth()
   @ApiOperation({ summary: "Generate QR code and secret for 2FA setup" })
   async setup2FA(@Request() req, @Body() dto: Setup2faInitDto) {
-    return this.authService.setup2FA(req.user.id, dto.currentPassword);
+    return this.authService.setup2FA(req.user.realUserId, dto.currentPassword);
   }
 
   @Post("2fa/confirm-setup")
   @UseGuards(AuthGuard("jwt"))
+  @AllowDelegate()
   @DemoRestricted()
   @Throttle({ default: { ttl: 900000, limit: 5 } })
   @ApiBearerAuth()
   @ApiOperation({ summary: "Confirm 2FA setup with verification code" })
   async confirmSetup2FA(@Request() req, @Body() dto: Setup2faDto) {
-    return this.authService.confirmSetup2FA(req.user.id, dto.code);
+    return this.authService.confirmSetup2FA(req.user.realUserId, dto.code);
   }
 
   @Post("2fa/disable")
   @UseGuards(AuthGuard("jwt"))
+  @AllowDelegate()
   @DemoRestricted()
   @Throttle({ default: { ttl: 900000, limit: 5 } })
   @ApiBearerAuth()
   @ApiOperation({ summary: "Disable 2FA with verification code" })
   async disable2FA(@Request() req, @Body() dto: Setup2faDto) {
-    return this.authService.disable2FA(req.user.id, dto.code);
+    return this.authService.disable2FA(req.user.realUserId, dto.code);
+  }
+
+  @Get("2fa/status")
+  @UseGuards(AuthGuard("jwt"))
+  @AllowDelegate()
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: "Whether 2FA is enabled for the authenticated user (self).",
+  })
+  async get2FAStatus(@Request() req) {
+    const enabled = await this.authService.is2FAEnabled(req.user.realUserId);
+    return { enabled };
   }
 
   @Get("2fa/trusted-devices")
   @UseGuards(AuthGuard("jwt"))
+  @AllowDelegate()
   @ApiBearerAuth()
   @ApiOperation({ summary: "List trusted devices for the current user" })
   async getTrustedDevices(
     @Request() req: ExpressRequest & { user: any },
     @Res() res: Response,
   ) {
-    const devices = await this.authService.getTrustedDevices(req.user.id);
+    const devices = await this.authService.getTrustedDevices(
+      req.user.realUserId,
+    );
     const currentToken = req.cookies?.["trusted_device"];
     let currentDeviceId: string | null = null;
     if (currentToken) {
       currentDeviceId = await this.authService.findTrustedDeviceByToken(
-        req.user.id,
+        req.user.realUserId,
         currentToken,
       );
     }
@@ -726,6 +759,7 @@ export class AuthController {
 
   @Delete("2fa/trusted-devices/:id")
   @UseGuards(AuthGuard("jwt"))
+  @AllowDelegate()
   @ApiBearerAuth()
   @ApiOperation({ summary: "Revoke a specific trusted device" })
   async revokeTrustedDevice(
@@ -733,12 +767,12 @@ export class AuthController {
     @Param("id", ParseUUIDPipe) deviceId: string,
     @Res() res: Response,
   ) {
-    await this.authService.revokeTrustedDevice(req.user.id, deviceId);
+    await this.authService.revokeTrustedDevice(req.user.realUserId, deviceId);
     // If revoking the current device, clear the cookie
     const currentToken = req.cookies?.["trusted_device"];
     if (currentToken) {
       const currentDeviceId = await this.authService.findTrustedDeviceByToken(
-        req.user.id,
+        req.user.realUserId,
         currentToken,
       );
       if (!currentDeviceId || currentDeviceId === deviceId) {
@@ -750,13 +784,16 @@ export class AuthController {
 
   @Delete("2fa/trusted-devices")
   @UseGuards(AuthGuard("jwt"))
+  @AllowDelegate()
   @ApiBearerAuth()
   @ApiOperation({ summary: "Revoke all trusted devices" })
   async revokeAllTrustedDevices(
     @Request() req: ExpressRequest & { user: any },
     @Res() res: Response,
   ) {
-    const count = await this.authService.revokeAllTrustedDevices(req.user.id);
+    const count = await this.authService.revokeAllTrustedDevices(
+      req.user.realUserId,
+    );
     res.clearCookie("trusted_device");
     res.json({ message: `${count} device(s) revoked`, count });
   }
@@ -789,13 +826,14 @@ export class AuthController {
 
   @Post("2fa/backup-codes")
   @UseGuards(AuthGuard("jwt"))
+  @AllowDelegate()
   @DemoRestricted()
   @Throttle({ default: { ttl: 900000, limit: 5 } })
   @ApiBearerAuth()
   @ApiOperation({ summary: "Generate new 2FA backup codes" })
   async generateBackupCodes(@Request() req, @Body() dto: Setup2faDto) {
     const codes = await this.authService.generateBackupCodes(
-      req.user.id,
+      req.user.realUserId,
       dto.code,
     );
     return { codes };

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -501,6 +501,11 @@ export class AuthController {
               transactions: await this.delegationService.hasTransactionalAccess(
                 req.user.delegationId,
               ),
+              // Likewise derived: the Accounts nav appears as soon as the
+              // delegate can read any one of the owner's accounts.
+              accounts: await this.delegationService.hasAnyAccountAccess(
+                req.user.delegationId,
+              ),
             }
           : null,
     };

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -489,6 +489,10 @@ export class AuthController {
         req.user.isActing && req.user.delegationId
           ? await this.delegationService.getCapabilities(req.user.delegationId)
           : null,
+      sections:
+        req.user.isActing && req.user.delegationId
+          ? await this.delegationService.getSections(req.user.delegationId)
+          : null,
     };
   }
 

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -38,6 +38,9 @@ import { VerifyTotpDto } from "./dto/verify-totp.dto";
 import { Setup2faDto } from "./dto/setup-2fa.dto";
 import { Setup2faInitDto } from "./dto/setup-2fa-init.dto";
 import { passwordResetTemplate } from "../notifications/email-templates";
+import { SwitchContextDto } from "./dto/switch-context.dto";
+import { DelegationService } from "../delegation/delegation.service";
+import { AllowDelegate } from "../delegation/decorators/delegate-access.decorator";
 import { SkipCsrf } from "../common/decorators/skip-csrf.decorator";
 import { SkipPasswordCheck } from "./decorators/skip-password-check.decorator";
 import { DemoRestricted } from "../common/decorators/demo-restricted.decorator";
@@ -63,6 +66,7 @@ export class AuthController {
     private emailService: EmailService,
     private demoModeService: DemoModeService,
     private tokenService: TokenService,
+    private delegationService: DelegationService,
   ) {
     // Default to true if not explicitly set to 'false'
     const localAuthSetting = this.configService.get<string>(
@@ -441,6 +445,7 @@ export class AuthController {
 
   @Get("csrf-refresh")
   @UseGuards(AuthGuard("jwt"))
+  @AllowDelegate()
   @ApiBearerAuth()
   @ApiOperation({ summary: "Refresh CSRF token cookie" })
   async csrfRefresh(@Request() req, @Res() res: Response) {
@@ -454,10 +459,68 @@ export class AuthController {
 
   @Get("profile")
   @UseGuards(AuthGuard("jwt"))
+  @AllowDelegate()
   @ApiBearerAuth()
   @ApiOperation({ summary: "Get current user profile" })
   async getProfile(@Request() req) {
     return this.authService.sanitizeUser(req.user);
+  }
+
+  @Get("contexts")
+  @UseGuards(AuthGuard("jwt"))
+  @AllowDelegate()
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: "List delegate contexts and the current acting context",
+  })
+  async getContexts(@Request() req) {
+    return {
+      actingAsUserId: req.user.isActing ? req.user.id : null,
+      contexts: await this.delegationService.getAvailableContexts(
+        req.user.realUserId,
+      ),
+    };
+  }
+
+  @Post("switch-context")
+  @UseGuards(AuthGuard("jwt"))
+  @AllowDelegate()
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: "Switch the acting account without re-login (delegate)",
+  })
+  async switchContext(
+    @Request() req: ExpressRequest & { user: any },
+    @Body() dto: SwitchContextDto,
+    @Res() res: Response,
+  ) {
+    const realUserId = req.user.realUserId;
+    const target = await this.delegationService.resolveSwitchTarget(
+      realUserId,
+      dto.targetUserId,
+    );
+
+    const realUser = await this.authService.getUserById(realUserId);
+    if (!realUser || !realUser.isActive) {
+      throw new UnauthorizedException("User not found or inactive");
+    }
+
+    // SECURITY: revoke the current refresh family so a stale refresh token
+    // cannot silently restore the previous context.
+    const currentRefresh = req.cookies?.["refresh_token"];
+    if (currentRefresh) {
+      await this.authService.revokeRefreshToken(currentRefresh);
+    }
+
+    const context = target
+      ? { actingAsUserId: target.ownerUserId, delegationId: target.id }
+      : undefined;
+
+    const { accessToken, refreshToken } =
+      await this.tokenService.generateTokenPair(realUser, false, context);
+
+    this.setAuthCookies(res, accessToken, refreshToken, realUser.id);
+    res.json({ actingAsUserId: target ? target.ownerUserId : null });
   }
 
   @Post("forgot-password")
@@ -731,6 +794,7 @@ export class AuthController {
 
   @Post("logout")
   @SkipCsrf()
+  @AllowDelegate()
   @ApiOperation({ summary: "Logout current user" })
   async logout(@Request() req: ExpressRequest, @Res() res: Response) {
     // Revoke the refresh token family in the database

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -491,7 +491,17 @@ export class AuthController {
           : null,
       sections:
         req.user.isActing && req.user.delegationId
-          ? await this.delegationService.getSections(req.user.delegationId)
+          ? {
+              ...(await this.delegationService.getSections(
+                req.user.delegationId,
+              )),
+              // Not a stored section: derived from per-account grants so the
+              // delegate's Transactions nav appears when they can read any
+              // non-investment account.
+              transactions: await this.delegationService.hasTransactionalAccess(
+                req.user.delegationId,
+              ),
+            }
           : null,
     };
   }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -22,6 +22,7 @@ import { AuthEmailService } from "./auth-email.service";
 import { PatController } from "./pat.controller";
 import { UsersModule } from "../users/users.module";
 import { NotificationsModule } from "../notifications/notifications.module";
+import { DelegationModule } from "../delegation/delegation.module";
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { NotificationsModule } from "../notifications/notifications.module";
     PassportModule,
     UsersModule,
     NotificationsModule,
+    DelegationModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -51,7 +51,10 @@ describe("AuthService", () => {
   let refreshTokensRepository: Record<string, jest.Mock>;
   let jwtService: Partial<JwtService>;
   let configService: { get: jest.Mock };
-  let delegationService: { isDelegateUser: jest.Mock };
+  let delegationService: {
+    isDelegateUser: jest.Mock;
+    isFullAccount: jest.Mock;
+  };
   let dataSource: Record<string, jest.Mock>;
   let passwordBreachService: { isBreached: jest.Mock };
   let emailService: { sendMail: jest.Mock };
@@ -166,6 +169,7 @@ describe("AuthService", () => {
           provide: DelegationService,
           useValue: {
             isDelegateUser: jest.fn().mockResolvedValue(false),
+            isFullAccount: jest.fn().mockResolvedValue(false),
           },
         },
       ],
@@ -286,19 +290,88 @@ describe("AuthService", () => {
       expect(result.user).not.toHaveProperty("passwordHash");
     });
 
-    it("does not claim an existing delegate that already has a password", async () => {
-      usersRepository.findOne.mockResolvedValue({
-        id: "deleg-2",
-        email: "shared2@example.com",
+    it("claims a delegate with a temp password when the correct currentPassword is supplied", async () => {
+      const tempPwHash = await bcrypt.hash("Temp-Pw-9!aB", 4);
+      const tempDelegate = {
+        id: "deleg-3",
+        email: "shared3@example.com",
         authProvider: "local",
-        passwordHash: "existing-hash",
+        passwordHash: tempPwHash,
+        mustChangePassword: true,
+        failedLoginAttempts: 2,
+        lockedUntil: null,
+        resetToken: null,
+        resetTokenExpiry: null,
+      };
+      usersRepository.findOne.mockResolvedValue(tempDelegate);
+      delegationService.isDelegateUser.mockResolvedValue(true);
+      delegationService.isFullAccount.mockResolvedValue(false);
+      passwordBreachService.isBreached.mockResolvedValue(false);
+      usersRepository.save.mockImplementation(async (u: any) => u);
+
+      const result = await service.register({
+        email: "shared3@example.com",
+        password: "StrongPass123!",
+        currentPassword: "Temp-Pw-9!aB",
+      });
+
+      expect(delegationService.isDelegateUser).toHaveBeenCalledWith("deleg-3");
+      expect(delegationService.isFullAccount).toHaveBeenCalledWith("deleg-3");
+      // The temp password hash is replaced by the new one.
+      expect(tempDelegate.passwordHash).not.toBe(tempPwHash);
+      // Bootstrap markers are cleared so the new owner has a clean state.
+      expect(tempDelegate.mustChangePassword).toBe(false);
+      expect(tempDelegate.failedLoginAttempts).toBe(0);
+      expect(tempDelegate.lockedUntil).toBeNull();
+      expect(result.accessToken).toBeDefined();
+      expect(result.user).not.toHaveProperty("passwordHash");
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+    });
+
+    it("rejects a delegate claim when the currentPassword is wrong or missing", async () => {
+      const tempPwHash = await bcrypt.hash("Temp-Pw-9!aB", 4);
+      usersRepository.findOne.mockResolvedValue({
+        id: "deleg-4",
+        email: "shared4@example.com",
+        authProvider: "local",
+        passwordHash: tempPwHash,
       });
       delegationService.isDelegateUser.mockResolvedValue(true);
+      delegationService.isFullAccount.mockResolvedValue(false);
 
       await expect(
         service.register({
-          email: "shared2@example.com",
+          email: "shared4@example.com",
           password: "StrongPass123!",
+        }),
+      ).rejects.toThrow(/temporary password/i);
+
+      await expect(
+        service.register({
+          email: "shared4@example.com",
+          password: "StrongPass123!",
+          currentPassword: "WrongPassword!",
+        }),
+      ).rejects.toThrow(/temporary password/i);
+    });
+
+    it("never claims a row that already owns data (full account)", async () => {
+      usersRepository.findOne.mockResolvedValue({
+        id: "full-1",
+        email: "owner@example.com",
+        authProvider: "local",
+        passwordHash: "some-hash",
+      });
+      // A delegate row that has since become a full account: isDelegateUser
+      // may still be true, but isFullAccount must veto the claim path.
+      delegationService.isDelegateUser.mockResolvedValue(true);
+      delegationService.isFullAccount.mockResolvedValue(true);
+
+      await expect(
+        service.register({
+          email: "owner@example.com",
+          password: "StrongPass123!",
+          currentPassword: "anything",
         }),
       ).rejects.toThrow(ConflictException);
     });

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -17,6 +17,7 @@ import { AuthService } from "./auth.service";
 import { TokenService } from "./token.service";
 import { TwoFactorService } from "./two-factor.service";
 import { AuthEmailService } from "./auth-email.service";
+import { DelegationService } from "../delegation/delegation.service";
 import { User } from "../users/entities/user.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { TrustedDevice } from "../users/entities/trusted-device.entity";
@@ -50,6 +51,7 @@ describe("AuthService", () => {
   let refreshTokensRepository: Record<string, jest.Mock>;
   let jwtService: Partial<JwtService>;
   let configService: { get: jest.Mock };
+  let delegationService: { isDelegateUser: jest.Mock };
   let dataSource: Record<string, jest.Mock>;
   let passwordBreachService: { isBreached: jest.Mock };
   let emailService: { sendMail: jest.Mock };
@@ -160,11 +162,18 @@ describe("AuthService", () => {
         { provide: DataSource, useValue: dataSource },
         { provide: PasswordBreachService, useValue: passwordBreachService },
         { provide: EmailService, useValue: emailService },
+        {
+          provide: DelegationService,
+          useValue: {
+            isDelegateUser: jest.fn().mockResolvedValue(false),
+          },
+        },
       ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);
     configService = module.get(ConfigService);
+    delegationService = module.get(DelegationService);
 
     // Spy on logger for security event logging tests (C2+C3)
     jest.spyOn((service as any).logger, "warn").mockImplementation();
@@ -244,6 +253,51 @@ describe("AuthService", () => {
       await expect(
         service.register({
           email: "test@example.com",
+          password: "StrongPass123!",
+        }),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it("claims an invited (passwordless) delegate instead of duplicating", async () => {
+      const invitedDelegate = {
+        id: "deleg-1",
+        email: "shared@example.com",
+        authProvider: "local",
+        passwordHash: null,
+        resetToken: "tok",
+        resetTokenExpiry: new Date(),
+      };
+      usersRepository.findOne.mockResolvedValue(invitedDelegate);
+      delegationService.isDelegateUser.mockResolvedValue(true);
+      passwordBreachService.isBreached.mockResolvedValue(false);
+      usersRepository.save.mockImplementation(async (u: any) => u);
+
+      const result = await service.register({
+        email: "shared@example.com",
+        password: "StrongPass123!",
+        firstName: "Real",
+      });
+
+      expect(delegationService.isDelegateUser).toHaveBeenCalledWith("deleg-1");
+      expect(invitedDelegate.passwordHash).toBeTruthy();
+      expect(usersRepository.save).toHaveBeenCalledWith(invitedDelegate);
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+      expect(result.accessToken).toBeDefined();
+      expect(result.user).not.toHaveProperty("passwordHash");
+    });
+
+    it("does not claim an existing delegate that already has a password", async () => {
+      usersRepository.findOne.mockResolvedValue({
+        id: "deleg-2",
+        email: "shared2@example.com",
+        authProvider: "local",
+        passwordHash: "existing-hash",
+      });
+      delegationService.isDelegateUser.mockResolvedValue(true);
+
+      await expect(
+        service.register({
+          email: "shared2@example.com",
           password: "StrongPass123!",
         }),
       ).rejects.toThrow(ConflictException);

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -2990,6 +2990,30 @@ describe("AuthService", () => {
   // Atomic backup code consumption
   // ---------------------------------------------------------------
 
+  describe("is2FAEnabled", () => {
+    it("returns true when the user's preferences have 2FA enabled", async () => {
+      preferencesRepository.findOne.mockResolvedValue({
+        userId: "u1",
+        twoFactorEnabled: true,
+      });
+      await expect(service.is2FAEnabled("u1")).resolves.toBe(true);
+      expect(preferencesRepository.findOne).toHaveBeenCalledWith({
+        where: { userId: "u1" },
+      });
+    });
+
+    it("returns false when preferences are missing or 2FA is disabled", async () => {
+      preferencesRepository.findOne.mockResolvedValueOnce(null);
+      await expect(service.is2FAEnabled("u1")).resolves.toBe(false);
+
+      preferencesRepository.findOne.mockResolvedValueOnce({
+        userId: "u1",
+        twoFactorEnabled: false,
+      });
+      await expect(service.is2FAEnabled("u1")).resolves.toBe(false);
+    });
+  });
+
   describe("verify2FA - atomic backup code consumption", () => {
     it("uses QueryRunner transaction for backup code removal", async () => {
       const encryptedSecret = encrypt("TESTSECRET", TEST_TOTP_KEY);

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -29,6 +29,7 @@ import {
 import { TokenService } from "./token.service";
 import { TwoFactorService } from "./two-factor.service";
 import { AuthEmailService } from "./auth-email.service";
+import { DelegationService } from "../delegation/delegation.service";
 
 @Injectable()
 export class AuthService {
@@ -56,6 +57,7 @@ export class AuthService {
     private tokenService: TokenService,
     private twoFactorService: TwoFactorService,
     private authEmailService: AuthEmailService,
+    private delegationService: DelegationService,
   ) {
     this.jwtSecret = this.configService.get<string>("JWT_SECRET")!;
     this.csrfKey = derivePurposeKey(this.jwtSecret, "csrf-token");
@@ -78,7 +80,40 @@ export class AuthService {
     });
 
     if (existingUser) {
-      throw new ConflictException("Unable to complete registration");
+      // An invited delegate is a real `users` row that has no password yet.
+      // Registering with that same email must claim (upgrade) the existing
+      // row -- never create a duplicate, and never overwrite a row that
+      // already has credentials (that would be account takeover).
+      const claimable =
+        existingUser.authProvider === "local" &&
+        !existingUser.passwordHash &&
+        (await this.delegationService.isDelegateUser(existingUser.id));
+      if (!claimable) {
+        throw new ConflictException("Unable to complete registration");
+      }
+
+      const breached = await this.passwordBreachService.isBreached(password);
+      if (breached) {
+        throw new BadRequestException(
+          "This password has been found in a data breach. Please choose a different password.",
+        );
+      }
+
+      existingUser.passwordHash = await bcrypt.hash(password, 12);
+      if (firstName) existingUser.firstName = firstName;
+      if (lastName) existingUser.lastName = lastName;
+      existingUser.mustChangePassword = false;
+      existingUser.resetToken = null;
+      existingUser.resetTokenExpiry = null;
+      const upgraded = await this.usersRepository.save(existingUser);
+
+      const { accessToken, refreshToken } =
+        await this.tokenService.generateTokenPair(upgraded);
+      return {
+        user: this.sanitizeUser(upgraded),
+        accessToken,
+        refreshToken,
+      };
     }
 
     // Check for breached password

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -476,6 +476,18 @@ export class AuthService {
     return this.usersRepository.findOne({ where: { id } });
   }
 
+  /**
+   * Returns whether the given user has 2FA enabled. Lets the Security UI
+   * (including a delegate managing their own credentials) read the
+   * authenticated user's 2FA state without exposing the secret.
+   */
+  async is2FAEnabled(userId: string): Promise<boolean> {
+    const prefs = await this.preferencesRepository.findOne({
+      where: { userId },
+    });
+    return !!prefs?.twoFactorEnabled;
+  }
+
   async getUserStateById(
     id: string,
   ): Promise<Pick<

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -69,7 +69,8 @@ export class AuthService {
   }
 
   async register(registerDto: RegisterDto) {
-    const { email, password, firstName, lastName } = registerDto;
+    const { email, password, firstName, lastName, currentPassword } =
+      registerDto;
 
     // H7: Normalize email before lookups
     const normalizedEmail = email.toLowerCase().trim();
@@ -80,16 +81,42 @@ export class AuthService {
     });
 
     if (existingUser) {
-      // An invited delegate is a real `users` row that has no password yet.
-      // Registering with that same email must claim (upgrade) the existing
-      // row -- never create a duplicate, and never overwrite a row that
-      // already has credentials (that would be account takeover).
-      const claimable =
+      // Delegates live in the `users` table so they reuse the auth stack.
+      // Registering with the same email must CLAIM (upgrade) the existing
+      // delegate row -- never create a duplicate, and never overwrite a
+      // row that belongs to a full account (that would be takeover).
+      //
+      // A row is claimable when it's a "pure delegate":
+      //  - authProvider === 'local' (an OIDC user can't be claimed via a
+      //    password registration),
+      //  - it appears in account_delegates.delegate_user_id, and
+      //  - it owns no data (no accounts, no delegations as owner, not admin).
+      //
+      // If the delegate row already has a password (the owner provisioned
+      // it with a temp password and shared it out-of-band), the registrant
+      // must prove they hold that temp password via `currentPassword`.
+      // Without that proof anyone who knows the email could take over the
+      // delegate row.
+      const isPureDelegate =
         existingUser.authProvider === "local" &&
-        !existingUser.passwordHash &&
-        (await this.delegationService.isDelegateUser(existingUser.id));
-      if (!claimable) {
+        (await this.delegationService.isDelegateUser(existingUser.id)) &&
+        !(await this.delegationService.isFullAccount(existingUser.id));
+      if (!isPureDelegate) {
         throw new ConflictException("Unable to complete registration");
+      }
+
+      if (existingUser.passwordHash) {
+        const supplied = (currentPassword ?? "").trim();
+        const ok =
+          supplied.length > 0 &&
+          (await bcrypt.compare(supplied, existingUser.passwordHash));
+        if (!ok) {
+          throw new UnauthorizedException(
+            "An account with this email already exists as a shared user. " +
+              "Provide the temporary password your administrator gave you " +
+              "to claim it.",
+          );
+        }
       }
 
       const breached = await this.passwordBreachService.isBreached(password);
@@ -105,6 +132,8 @@ export class AuthService {
       existingUser.mustChangePassword = false;
       existingUser.resetToken = null;
       existingUser.resetTokenExpiry = null;
+      existingUser.failedLoginAttempts = 0;
+      existingUser.lockedUntil = null;
       const upgraded = await this.usersRepository.save(existingUser);
 
       const { accessToken, refreshToken } =

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -41,4 +41,17 @@ export class RegisterDto {
   @MaxLength(100)
   @SanitizeHtml()
   lastName?: string;
+
+  @ApiProperty({
+    required: false,
+    description:
+      "Temporary password issued by an account owner when the email " +
+      "already belongs to a delegate. Supplying it lets the registrant " +
+      "claim and upgrade the existing delegate row into a full account, " +
+      "preserving its id so all account_delegates links continue to work.",
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  currentPassword?: string;
 }

--- a/backend/src/auth/dto/switch-context.dto.ts
+++ b/backend/src/auth/dto/switch-context.dto.ts
@@ -1,0 +1,9 @@
+import { IsUUID } from "class-validator";
+
+export class SwitchContextDto {
+  /**
+   * The owner account to act as, or the delegate's own id to return to self.
+   */
+  @IsUUID()
+  targetUserId: string;
+}

--- a/backend/src/auth/entities/refresh-token.entity.ts
+++ b/backend/src/auth/entities/refresh-token.entity.ts
@@ -42,6 +42,16 @@ export class RefreshToken {
   @Column({ name: "remember_me", type: "boolean", default: false })
   rememberMe: boolean;
 
+  // Delegate "acting as owner" context. Carried across rotation so a 15-minute
+  // access-token expiry does not silently drop the context. NULL for normal
+  // (acting-as-self) sessions. `userId` above always stays the real
+  // authenticated (delegate) user.
+  @Column({ name: "acting_as_user_id", type: "uuid", nullable: true })
+  actingAsUserId: string | null;
+
+  @Column({ name: "delegation_id", type: "uuid", nullable: true })
+  delegationId: string | null;
+
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;
 

--- a/backend/src/auth/strategies/jwt.strategy.spec.ts
+++ b/backend/src/auth/strategies/jwt.strategy.spec.ts
@@ -3,11 +3,13 @@ import { UnauthorizedException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { JwtStrategy } from "./jwt.strategy";
 import { AuthService } from "../auth.service";
+import { DelegationService } from "../../delegation/delegation.service";
 
 describe("JwtStrategy", () => {
   let strategy: JwtStrategy;
   let authService: Record<string, jest.Mock>;
   let configService: Record<string, jest.Mock>;
+  let delegationService: Record<string, jest.Mock>;
 
   const mockUser = {
     id: "user-1",
@@ -19,6 +21,10 @@ describe("JwtStrategy", () => {
   beforeEach(async () => {
     authService = {
       getUserStateById: jest.fn(),
+    };
+
+    delegationService = {
+      validateActingContext: jest.fn(),
     };
 
     configService = {
@@ -34,6 +40,7 @@ describe("JwtStrategy", () => {
         JwtStrategy,
         { provide: AuthService, useValue: authService },
         { provide: ConfigService, useValue: configService },
+        { provide: DelegationService, useValue: delegationService },
       ],
     }).compile();
 
@@ -51,7 +58,11 @@ describe("JwtStrategy", () => {
       };
 
       expect(() => {
-        new JwtStrategy(noSecretConfig as any, authService as any);
+        new JwtStrategy(
+          noSecretConfig as any,
+          authService as any,
+          delegationService as any,
+        );
       }).toThrow(
         "JWT_SECRET environment variable must be at least 32 characters",
       );
@@ -63,7 +74,11 @@ describe("JwtStrategy", () => {
       };
 
       expect(() => {
-        new JwtStrategy(shortSecretConfig as any, authService as any);
+        new JwtStrategy(
+          shortSecretConfig as any,
+          authService as any,
+          delegationService as any,
+        );
       }).toThrow(
         "JWT_SECRET environment variable must be at least 32 characters",
       );
@@ -106,14 +121,85 @@ describe("JwtStrategy", () => {
       );
     });
 
-    it("returns user for valid payload", async () => {
+    it("returns enriched self user for a non-delegate payload", async () => {
       const payload = { sub: "user-1" };
       authService.getUserStateById.mockResolvedValue(mockUser);
 
       const result = await strategy.validate(payload);
 
       expect(authService.getUserStateById).toHaveBeenCalledWith("user-1");
-      expect(result).toEqual(mockUser);
+      expect(result).toEqual({
+        ...mockUser,
+        realUserId: "user-1",
+        isActing: false,
+        delegationId: null,
+      });
+      expect(delegationService.validateActingContext).not.toHaveBeenCalled();
+    });
+
+    it("maps the effective id to the owner when acting as a delegate", async () => {
+      const payload = {
+        sub: "delegate-1",
+        actingAsUserId: "owner-1",
+        delegationId: "deleg-1",
+      };
+      authService.getUserStateById.mockResolvedValue({
+        id: "delegate-1",
+        isActive: true,
+        mustChangePassword: false,
+        role: "user",
+      });
+      delegationService.validateActingContext.mockResolvedValue({});
+
+      const result = await strategy.validate(payload);
+
+      expect(delegationService.validateActingContext).toHaveBeenCalledWith({
+        delegateUserId: "delegate-1",
+        actingAsUserId: "owner-1",
+        delegationId: "deleg-1",
+      });
+      expect(result).toEqual({
+        id: "owner-1",
+        realUserId: "delegate-1",
+        isActing: true,
+        delegationId: "deleg-1",
+        isActive: true,
+        mustChangePassword: false,
+        role: "user",
+      });
+    });
+
+    it("fails closed when the delegation is no longer valid", async () => {
+      const payload = {
+        sub: "delegate-1",
+        actingAsUserId: "owner-1",
+        delegationId: "deleg-1",
+      };
+      authService.getUserStateById.mockResolvedValue(mockUser);
+      delegationService.validateActingContext.mockRejectedValue(
+        new UnauthorizedException("Delegated access is no longer valid"),
+      );
+
+      await expect(strategy.validate(payload)).rejects.toThrow(
+        "Delegated access is no longer valid",
+      );
+    });
+
+    it("rejects the inactive real user before resolving delegation", async () => {
+      const payload = {
+        sub: "delegate-1",
+        actingAsUserId: "owner-1",
+        delegationId: "deleg-1",
+      };
+      authService.getUserStateById.mockResolvedValue({
+        ...mockUser,
+        isActive: false,
+      });
+
+      await expect(strategy.validate(payload)).rejects.toThrow(
+        "User not found or inactive",
+      );
+      expect(delegationService.validateActingContext).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -4,6 +4,7 @@ import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { Request } from "express";
 import { AuthService } from "../auth.service";
+import { DelegationService } from "../../delegation/delegation.service";
 
 /**
  * Extract JWT from request - tries Authorization header first, then auth_token cookie
@@ -28,6 +29,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(
     private configService: ConfigService,
     private authService: AuthService,
+    private delegationService: DelegationService,
   ) {
     const jwtSecret = configService.get<string>("JWT_SECRET");
 
@@ -60,6 +62,37 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     if (!user || !user.isActive) {
       throw new UnauthorizedException("User not found or inactive");
     }
-    return user;
+
+    // Acting-as-self / normal user: unchanged shape plus passthrough fields.
+    if (!payload.actingAsUserId || !payload.delegationId) {
+      return {
+        ...user,
+        realUserId: user.id,
+        isActing: false,
+        delegationId: null,
+      };
+    }
+
+    // Delegate acting as an owner. Re-validate every request (fail closed):
+    // revoked/inactive delegation, inactive owner, or an unmet 2FA
+    // requirement all reject the token here.
+    await this.delegationService.validateActingContext({
+      delegateUserId: payload.sub,
+      actingAsUserId: payload.actingAsUserId,
+      delegationId: payload.delegationId,
+    });
+
+    // SECURITY: `id` becomes the OWNER's id so every existing
+    // `where: { userId }` query is correctly scoped to the owner's data.
+    // `realUserId` keeps the delegate's id for audit/auth decisions.
+    return {
+      id: payload.actingAsUserId,
+      realUserId: payload.sub,
+      isActing: true,
+      delegationId: payload.delegationId,
+      isActive: true,
+      mustChangePassword: user.mustChangePassword,
+      role: user.role,
+    };
   }
 }

--- a/backend/src/auth/token.service.spec.ts
+++ b/backend/src/auth/token.service.spec.ts
@@ -133,6 +133,8 @@ describe("TokenService", () => {
         expiresAt: expect.any(Date),
         replacedByHash: null,
         rememberMe: false,
+        actingAsUserId: null,
+        delegationId: null,
       });
       expect(refreshTokensRepository.save).toHaveBeenCalledWith(
         mockRefreshToken,
@@ -167,6 +169,28 @@ describe("TokenService", () => {
       expect(createCall.expiresAt).toEqual(expectedExpiry);
 
       jest.restoreAllMocks();
+    });
+
+    it("embeds delegate context in the payload and refresh row when acting", async () => {
+      await service.generateTokenPair(mockUser as any, false, {
+        actingAsUserId: "owner-9",
+        delegationId: "deleg-9",
+      });
+
+      expect(jwtService.sign).toHaveBeenCalledWith(
+        {
+          sub: "user-1",
+          email: "test@example.com",
+          authProvider: "local",
+          role: "user",
+          actingAsUserId: "owner-9",
+          delegationId: "deleg-9",
+        },
+        { expiresIn: "15m" },
+      );
+      const createCall = refreshTokensRepository.create.mock.calls[0][0];
+      expect(createCall.actingAsUserId).toBe("owner-9");
+      expect(createCall.delegationId).toBe("deleg-9");
     });
   });
 
@@ -216,6 +240,8 @@ describe("TokenService", () => {
         expiresAt: expect.any(Date),
         replacedByHash: null,
         rememberMe: false,
+        actingAsUserId: null,
+        delegationId: null,
       });
 
       expect(jwtService.sign).toHaveBeenCalledWith(
@@ -233,6 +259,32 @@ describe("TokenService", () => {
         refreshToken: "mock-random-token-hex",
         userId: "user-1",
       });
+    });
+
+    it("carries the delegate context forward through rotation", async () => {
+      const existingToken = {
+        ...mockRefreshToken,
+        isRevoked: false,
+        expiresAt: new Date(Date.now() + 1000 * 60 * 60),
+        actingAsUserId: "owner-9",
+        delegationId: "deleg-9",
+      };
+      mockManager.findOne
+        .mockResolvedValueOnce(existingToken)
+        .mockResolvedValueOnce(mockUser);
+
+      await service.refreshTokens("raw-refresh-token");
+
+      const createCall = mockManager.create.mock.calls[0][1];
+      expect(createCall.actingAsUserId).toBe("owner-9");
+      expect(createCall.delegationId).toBe("deleg-9");
+      expect(jwtService.sign).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actingAsUserId: "owner-9",
+          delegationId: "deleg-9",
+        }),
+        { expiresIn: "15m" },
+      );
     });
 
     it("should throw UnauthorizedException when token is not found", async () => {
@@ -491,10 +543,16 @@ describe("TokenService with zero REMEMBER_ME_DAYS", () => {
     const module = await Test.createTestingModule({
       providers: [
         TokenService,
-        { provide: getRepositoryToken(RefreshToken), useValue: refreshTokensRepository },
+        {
+          provide: getRepositoryToken(RefreshToken),
+          useValue: refreshTokensRepository,
+        },
         { provide: JwtService, useValue: { sign: jest.fn() } },
         { provide: DataSource, useValue: { createQueryRunner: jest.fn() } },
-        { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue("0") } },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue("0") },
+        },
       ],
     }).compile();
 

--- a/backend/src/auth/token.service.ts
+++ b/backend/src/auth/token.service.ts
@@ -10,6 +10,11 @@ import { User } from "../users/entities/user.entity";
 import { RefreshToken } from "./entities/refresh-token.entity";
 import { hashToken } from "./crypto.util";
 
+export interface DelegationTokenContext {
+  actingAsUserId: string;
+  delegationId: string;
+}
+
 @Injectable()
 export class TokenService {
   private readonly logger = new Logger(TokenService.name);
@@ -41,13 +46,22 @@ export class TokenService {
   async generateTokenPair(
     user: User,
     rememberMe?: boolean,
+    context?: DelegationTokenContext,
   ): Promise<{ accessToken: string; refreshToken: string }> {
-    const payload = {
+    // SECURITY: `sub` is ALWAYS the real authenticated user. When acting as a
+    // delegate the data-scoping id is carried separately in actingAsUserId so
+    // refresh rotation / family revocation / replay detection keep keying off
+    // the real user.
+    const payload: Record<string, unknown> = {
       sub: user.id,
       email: user.email,
       authProvider: user.authProvider,
       role: user.role,
     };
+    if (context?.actingAsUserId && context?.delegationId) {
+      payload.actingAsUserId = context.actingAsUserId;
+      payload.delegationId = context.delegationId;
+    }
     const accessToken = this.jwtService.sign(payload, {
       expiresIn: this.ACCESS_TOKEN_EXPIRY,
     });
@@ -65,6 +79,8 @@ export class TokenService {
       expiresAt: new Date(Date.now() + expiryMs),
       replacedByHash: null,
       rememberMe: !!rememberMe,
+      actingAsUserId: context?.actingAsUserId ?? null,
+      delegationId: context?.delegationId ?? null,
     });
     await this.refreshTokensRepository.save(refreshTokenEntity);
 
@@ -134,15 +150,23 @@ export class TokenService {
         expiresAt: new Date(Date.now() + rotatedExpiryMs),
         replacedByHash: null,
         rememberMe: existingToken.rememberMe,
+        // Carry the delegate "acting as owner" context forward through
+        // rotation so the context survives access-token expiry.
+        actingAsUserId: existingToken.actingAsUserId ?? null,
+        delegationId: existingToken.delegationId ?? null,
       });
       await manager.save(newRefreshTokenEntity);
 
-      const payload = {
+      const payload: Record<string, unknown> = {
         sub: user.id,
         email: user.email,
         authProvider: user.authProvider,
         role: user.role,
       };
+      if (existingToken.actingAsUserId && existingToken.delegationId) {
+        payload.actingAsUserId = existingToken.actingAsUserId;
+        payload.delegationId = existingToken.delegationId;
+      }
       const accessToken = this.jwtService.sign(payload, {
         expiresIn: this.ACCESS_TOKEN_EXPIRY,
       });

--- a/backend/src/budgets/budgets.controller.ts
+++ b/backend/src/budgets/budgets.controller.ts
@@ -35,11 +35,19 @@ import { GenerateBudgetDto } from "./dto/generate-budget.dto";
 import { ApplyGeneratedBudgetDto } from "./dto/apply-generated-budget.dto";
 import { BudgetReportQueryDto } from "./dto/budget-report-query.dto";
 import { CategoryBudgetStatusDto } from "./dto/category-budget-status.dto";
+import {
+  AllowDelegate,
+  DelegateRequiresSection,
+} from "../delegation/decorators/delegate-access.decorator";
 
 @ApiTags("Budgets")
 @Controller("budgets")
 @UseGuards(AuthGuard("jwt"))
 @ApiBearerAuth()
+// Read-only section: only @AllowDelegate() GETs are reachable by a
+// delegate, and only when the owner granted the "budgets" section. Writes
+// have no @AllowDelegate() so the global guard fails them closed.
+@DelegateRequiresSection("budgets")
 export class BudgetsController {
   constructor(
     private readonly budgetsService: BudgetsService,
@@ -58,6 +66,7 @@ export class BudgetsController {
   }
 
   @Get()
+  @AllowDelegate()
   @ApiOperation({ summary: "Get all budgets for the authenticated user" })
   @ApiResponse({ status: 200, description: "List of budgets retrieved" })
   @ApiResponse({ status: 401, description: "Unauthorized" })
@@ -66,6 +75,7 @@ export class BudgetsController {
   }
 
   @Get("dashboard-summary")
+  @AllowDelegate()
   @ApiOperation({
     summary: "Get budget summary for dashboard widget",
   })
@@ -129,6 +139,7 @@ export class BudgetsController {
   }
 
   @Get("alerts")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get budget alerts" })
   @ApiQuery({
     name: "unreadOnly",
@@ -175,6 +186,7 @@ export class BudgetsController {
   }
 
   @Get(":id")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get a specific budget with categories" })
   @ApiParam({ name: "id", description: "Budget UUID" })
   @ApiResponse({ status: 200, description: "Budget retrieved" })
@@ -279,6 +291,7 @@ export class BudgetsController {
   }
 
   @Get(":id/summary")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get current period budget summary" })
   @ApiParam({ name: "id", description: "Budget UUID" })
   @ApiResponse({ status: 200, description: "Budget summary retrieved" })
@@ -289,6 +302,7 @@ export class BudgetsController {
   }
 
   @Get(":id/velocity")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get spending velocity and projections" })
   @ApiParam({ name: "id", description: "Budget UUID" })
   @ApiResponse({ status: 200, description: "Velocity data retrieved" })
@@ -299,6 +313,7 @@ export class BudgetsController {
   }
 
   @Get(":id/periods")
+  @AllowDelegate()
   @ApiOperation({ summary: "List historical budget periods" })
   @ApiParam({ name: "id", description: "Budget UUID" })
   @ApiResponse({ status: 200, description: "Periods retrieved" })
@@ -309,6 +324,7 @@ export class BudgetsController {
   }
 
   @Get(":id/periods/:periodId")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get period detail with category breakdowns" })
   @ApiParam({ name: "id", description: "Budget UUID" })
   @ApiParam({ name: "periodId", description: "Budget period UUID" })
@@ -337,6 +353,7 @@ export class BudgetsController {
   // --- Budget Reports ---
 
   @Get(":id/reports/trend")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get budget vs actual trend over N months" })
   @ApiParam({ name: "id", description: "Budget UUID" })
   @ApiQuery({
@@ -361,6 +378,7 @@ export class BudgetsController {
   }
 
   @Get(":id/reports/category-trend")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get per-category trend over time" })
   @ApiParam({ name: "id", description: "Budget UUID" })
   @ApiQuery({
@@ -392,6 +410,7 @@ export class BudgetsController {
   }
 
   @Get(":id/reports/health-score")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get budget health score (0-100)" })
   @ApiParam({ name: "id", description: "Budget UUID" })
   @ApiResponse({ status: 200, description: "Health score calculated" })
@@ -402,6 +421,7 @@ export class BudgetsController {
   }
 
   @Get(":id/reports/seasonal")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get seasonal spending patterns" })
   @ApiParam({ name: "id", description: "Budget UUID" })
   @ApiResponse({ status: 200, description: "Seasonal patterns retrieved" })
@@ -412,6 +432,7 @@ export class BudgetsController {
   }
 
   @Get(":id/reports/flex-groups")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get flex group aggregation status" })
   @ApiParam({ name: "id", description: "Budget UUID" })
   @ApiResponse({ status: 200, description: "Flex group status retrieved" })
@@ -422,6 +443,7 @@ export class BudgetsController {
   }
 
   @Get(":id/reports/daily-spending")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get daily spending for current period (heatmap)" })
   @ApiParam({ name: "id", description: "Budget UUID" })
   @ApiResponse({ status: 200, description: "Daily spending data retrieved" })
@@ -432,6 +454,7 @@ export class BudgetsController {
   }
 
   @Get(":id/reports/savings-rate")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get savings rate over N months" })
   @ApiParam({ name: "id", description: "Budget UUID" })
   @ApiQuery({
@@ -456,6 +479,7 @@ export class BudgetsController {
   }
 
   @Get(":id/reports/health-score-history")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get health score history over N months" })
   @ApiParam({ name: "id", description: "Budget UUID" })
   @ApiQuery({

--- a/backend/src/categories/categories.controller.ts
+++ b/backend/src/categories/categories.controller.ts
@@ -71,6 +71,7 @@ export class CategoriesController {
   }
 
   @Get("tree")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get categories in tree structure (hierarchical)" })
   @ApiResponse({
     status: 200,
@@ -82,6 +83,7 @@ export class CategoriesController {
   }
 
   @Get("stats")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get category statistics" })
   @ApiResponse({
     status: 200,
@@ -108,6 +110,7 @@ export class CategoriesController {
   }
 
   @Get("income")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get all income categories" })
   @ApiResponse({
     status: 200,
@@ -119,6 +122,7 @@ export class CategoriesController {
   }
 
   @Get("expense")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get all expense categories" })
   @ApiResponse({
     status: 200,
@@ -130,6 +134,7 @@ export class CategoriesController {
   }
 
   @Get(":id")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get a specific category by ID" })
   @ApiParam({ name: "id", description: "Category UUID" })
   @ApiResponse({
@@ -191,6 +196,7 @@ export class CategoriesController {
   }
 
   @Get(":id/transaction-count")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get the count of transactions using a category" })
   @ApiParam({ name: "id", description: "Category UUID" })
   @ApiResponse({

--- a/backend/src/categories/categories.controller.ts
+++ b/backend/src/categories/categories.controller.ts
@@ -43,7 +43,7 @@ export class CategoriesController {
   @ApiResponse({ status: 400, description: "Bad request" })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   @AllowDelegate()
-  @DelegateRequiresCapability("categories")
+  @DelegateRequiresCapability("categories", "create")
   create(@Request() req, @Body() createCategoryDto: CreateCategoryDto) {
     return this.categoriesService.create(req.user.id, createCategoryDto);
   }
@@ -166,7 +166,7 @@ export class CategoriesController {
   })
   @ApiResponse({ status: 404, description: "Category not found" })
   @AllowDelegate()
-  @DelegateRequiresCapability("categories")
+  @DelegateRequiresCapability("categories", "edit")
   update(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,
@@ -190,7 +190,7 @@ export class CategoriesController {
   })
   @ApiResponse({ status: 404, description: "Category not found" })
   @AllowDelegate()
-  @DelegateRequiresCapability("categories")
+  @DelegateRequiresCapability("categories", "delete")
   remove(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
     return this.categoriesService.remove(req.user.id, id);
   }

--- a/backend/src/categories/categories.controller.ts
+++ b/backend/src/categories/categories.controller.ts
@@ -25,6 +25,7 @@ import { CategoriesService } from "./categories.service";
 import { CreateCategoryDto } from "./dto/create-category.dto";
 import { UpdateCategoryDto } from "./dto/update-category.dto";
 import { ReassignTransactionsDto } from "./dto/reassign-transactions.dto";
+import { AllowDelegate } from "../delegation/decorators/delegate-access.decorator";
 
 @ApiTags("Categories")
 @Controller("categories")
@@ -55,6 +56,7 @@ export class CategoriesController {
     description: "List of categories retrieved successfully",
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
+  @AllowDelegate()
   findAll(
     @Request() req,
     @Query("includeSystem", new ParseBoolPipe({ optional: true }))

--- a/backend/src/categories/categories.controller.ts
+++ b/backend/src/categories/categories.controller.ts
@@ -25,7 +25,10 @@ import { CategoriesService } from "./categories.service";
 import { CreateCategoryDto } from "./dto/create-category.dto";
 import { UpdateCategoryDto } from "./dto/update-category.dto";
 import { ReassignTransactionsDto } from "./dto/reassign-transactions.dto";
-import { AllowDelegate } from "../delegation/decorators/delegate-access.decorator";
+import {
+  AllowDelegate,
+  DelegateRequiresCapability,
+} from "../delegation/decorators/delegate-access.decorator";
 
 @ApiTags("Categories")
 @Controller("categories")
@@ -39,6 +42,8 @@ export class CategoriesController {
   @ApiResponse({ status: 201, description: "Category created successfully" })
   @ApiResponse({ status: 400, description: "Bad request" })
   @ApiResponse({ status: 401, description: "Unauthorized" })
+  @AllowDelegate()
+  @DelegateRequiresCapability("categories")
   create(@Request() req, @Body() createCategoryDto: CreateCategoryDto) {
     return this.categoriesService.create(req.user.id, createCategoryDto);
   }
@@ -155,6 +160,8 @@ export class CategoriesController {
     description: "Forbidden - category does not belong to user",
   })
   @ApiResponse({ status: 404, description: "Category not found" })
+  @AllowDelegate()
+  @DelegateRequiresCapability("categories")
   update(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,
@@ -177,6 +184,8 @@ export class CategoriesController {
     description: "Forbidden - category does not belong to user",
   })
   @ApiResponse({ status: 404, description: "Category not found" })
+  @AllowDelegate()
+  @DelegateRequiresCapability("categories")
   remove(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
     return this.categoriesService.remove(req.user.id, id);
   }

--- a/backend/src/currencies/currencies.controller.ts
+++ b/backend/src/currencies/currencies.controller.ts
@@ -24,6 +24,7 @@ import { Throttle } from "@nestjs/throttler";
 import { ParseCurrencyCodePipe } from "../common/pipes/parse-currency-code.pipe";
 import { RolesGuard } from "../auth/guards/roles.guard";
 import { Roles } from "../auth/decorators/roles.decorator";
+import { AllowDelegate } from "../delegation/decorators/delegate-access.decorator";
 import {
   ExchangeRateService,
   RateRefreshSummary,
@@ -52,6 +53,7 @@ export class CurrenciesController {
   // ── Currency list ───────────────────────────────────────────────
 
   @Get()
+  @AllowDelegate()
   @ApiOperation({ summary: "Get all currencies" })
   @ApiQuery({
     name: "includeInactive",
@@ -74,6 +76,7 @@ export class CurrenciesController {
   // ── Static-segment routes (must be BEFORE :code param route) ────
 
   @Get("lookup")
+  @AllowDelegate()
   @Throttle({ default: { ttl: 60000, limit: 10 } }) // L2: 10 lookups per minute
   @ApiOperation({ summary: "Lookup currency on Yahoo Finance" })
   @ApiQuery({ name: "q", required: true, type: String })
@@ -85,6 +88,7 @@ export class CurrenciesController {
   }
 
   @Get("usage")
+  @AllowDelegate()
   @ApiOperation({
     summary: "Get usage counts for all currencies",
   })
@@ -97,6 +101,7 @@ export class CurrenciesController {
   }
 
   @Get("exchange-rates")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get latest exchange rates" })
   @ApiResponse({
     status: 200,
@@ -108,6 +113,7 @@ export class CurrenciesController {
   }
 
   @Get("exchange-rates/history")
+  @AllowDelegate()
   @Throttle({ default: { ttl: 60000, limit: 10 } }) // L2: 10 requests per minute
   @ApiOperation({ summary: "Get exchange rates for a date range" })
   @ApiQuery({ name: "startDate", required: false, type: String })
@@ -125,6 +131,7 @@ export class CurrenciesController {
   }
 
   @Get("exchange-rates/status")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get exchange rate update status" })
   @ApiResponse({ status: 200, description: "Last update time" })
   async getRateStatus(): Promise<{ lastUpdated: Date | null }> {
@@ -157,6 +164,7 @@ export class CurrenciesController {
   // ── Param routes (:code) ────────────────────────────────────────
 
   @Get(":code")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get a single currency by code" })
   @ApiResponse({ status: 200, description: "Currency details" })
   findOne(@Param("code", ParseCurrencyCodePipe) code: string) {

--- a/backend/src/delegation/decorators/delegate-access.decorator.spec.ts
+++ b/backend/src/delegation/decorators/delegate-access.decorator.spec.ts
@@ -3,10 +3,14 @@ import {
   AllowDelegate,
   DelegatedAccountParam,
   DelegatedTransactionParam,
+  DelegatedTransferBody,
+  DelegatedTransferParam,
   DelegateRequires,
   ALLOW_DELEGATE_KEY,
   DELEGATED_ACCOUNT_PARAM_KEY,
   DELEGATED_TRANSACTION_PARAM_KEY,
+  DELEGATED_TRANSFER_BODY_KEY,
+  DELEGATED_TRANSFER_PARAM_KEY,
   DELEGATE_OPERATION_KEY,
 } from "./delegate-access.decorator";
 
@@ -58,6 +62,26 @@ describe("delegate-access decorators", () => {
     }
     expect(
       reflector.get(DELEGATED_TRANSACTION_PARAM_KEY, C.prototype.handler),
+    ).toBe("id");
+  });
+
+  it("DelegatedTransferBody sets [fromKey, toKey]", () => {
+    class C {
+      @DelegatedTransferBody()
+      handler() {}
+    }
+    expect(
+      reflector.get(DELEGATED_TRANSFER_BODY_KEY, C.prototype.handler),
+    ).toEqual(["fromAccountId", "toAccountId"]);
+  });
+
+  it("DelegatedTransferParam sets the transfer-id key", () => {
+    class C {
+      @DelegatedTransferParam()
+      handler() {}
+    }
+    expect(
+      reflector.get(DELEGATED_TRANSFER_PARAM_KEY, C.prototype.handler),
     ).toBe("id");
   });
 });

--- a/backend/src/delegation/decorators/delegate-access.decorator.spec.ts
+++ b/backend/src/delegation/decorators/delegate-access.decorator.spec.ts
@@ -2,9 +2,11 @@ import { Reflector } from "@nestjs/core";
 import {
   AllowDelegate,
   DelegatedAccountParam,
+  DelegatedTransactionParam,
   DelegateRequires,
   ALLOW_DELEGATE_KEY,
   DELEGATED_ACCOUNT_PARAM_KEY,
+  DELEGATED_TRANSACTION_PARAM_KEY,
   DELEGATE_OPERATION_KEY,
 } from "./delegate-access.decorator";
 
@@ -47,5 +49,15 @@ describe("delegate-access decorators", () => {
     expect(reflector.get(DELEGATE_OPERATION_KEY, C.prototype.handler)).toBe(
       "create",
     );
+  });
+
+  it("DelegatedTransactionParam sets the transaction-id key", () => {
+    class C {
+      @DelegatedTransactionParam()
+      handler() {}
+    }
+    expect(
+      reflector.get(DELEGATED_TRANSACTION_PARAM_KEY, C.prototype.handler),
+    ).toBe("id");
   });
 });

--- a/backend/src/delegation/decorators/delegate-access.decorator.spec.ts
+++ b/backend/src/delegation/decorators/delegate-access.decorator.spec.ts
@@ -87,13 +87,13 @@ describe("delegate-access decorators", () => {
     ).toBe("id");
   });
 
-  it("DelegateRequiresCapability sets the capability", () => {
+  it("DelegateRequiresCapability sets {resource, operation}", () => {
     class C {
-      @DelegateRequiresCapability("payees")
+      @DelegateRequiresCapability("payees", "edit")
       handler() {}
     }
-    expect(reflector.get(DELEGATE_CAPABILITY_KEY, C.prototype.handler)).toBe(
-      "payees",
+    expect(reflector.get(DELEGATE_CAPABILITY_KEY, C.prototype.handler)).toEqual(
+      { resource: "payees", operation: "edit" },
     );
   });
 });

--- a/backend/src/delegation/decorators/delegate-access.decorator.spec.ts
+++ b/backend/src/delegation/decorators/delegate-access.decorator.spec.ts
@@ -2,8 +2,10 @@ import { Reflector } from "@nestjs/core";
 import {
   AllowDelegate,
   DelegatedAccountParam,
+  DelegateRequires,
   ALLOW_DELEGATE_KEY,
   DELEGATED_ACCOUNT_PARAM_KEY,
+  DELEGATE_OPERATION_KEY,
 } from "./delegate-access.decorator";
 
 describe("delegate-access decorators", () => {
@@ -35,5 +37,15 @@ describe("delegate-access decorators", () => {
     expect(
       reflector.get(DELEGATED_ACCOUNT_PARAM_KEY, C.prototype.handler),
     ).toBe("accountId");
+  });
+
+  it("DelegateRequires sets the required operation", () => {
+    class C {
+      @DelegateRequires("create")
+      handler() {}
+    }
+    expect(reflector.get(DELEGATE_OPERATION_KEY, C.prototype.handler)).toBe(
+      "create",
+    );
   });
 });

--- a/backend/src/delegation/decorators/delegate-access.decorator.spec.ts
+++ b/backend/src/delegation/decorators/delegate-access.decorator.spec.ts
@@ -7,13 +7,17 @@ import {
   DelegatedTransferParam,
   DelegateRequires,
   DelegateRequiresCapability,
+  DelegatedScheduledParam,
+  DelegateRequiresSection,
   ALLOW_DELEGATE_KEY,
   DELEGATED_ACCOUNT_PARAM_KEY,
   DELEGATED_TRANSACTION_PARAM_KEY,
   DELEGATED_TRANSFER_BODY_KEY,
   DELEGATED_TRANSFER_PARAM_KEY,
+  DELEGATED_SCHEDULED_PARAM_KEY,
   DELEGATE_OPERATION_KEY,
   DELEGATE_CAPABILITY_KEY,
+  DELEGATE_SECTION_KEY,
 } from "./delegate-access.decorator";
 
 describe("delegate-access decorators", () => {
@@ -94,6 +98,31 @@ describe("delegate-access decorators", () => {
     }
     expect(reflector.get(DELEGATE_CAPABILITY_KEY, C.prototype.handler)).toEqual(
       { resource: "payees", operation: "edit" },
+    );
+  });
+
+  it("DelegatedScheduledParam defaults to 'id' and accepts a custom key", () => {
+    class C {
+      @DelegatedScheduledParam()
+      a() {}
+      @DelegatedScheduledParam("scheduledId")
+      b() {}
+    }
+    expect(reflector.get(DELEGATED_SCHEDULED_PARAM_KEY, C.prototype.a)).toBe(
+      "id",
+    );
+    expect(reflector.get(DELEGATED_SCHEDULED_PARAM_KEY, C.prototype.b)).toBe(
+      "scheduledId",
+    );
+  });
+
+  it("DelegateRequiresSection sets the section", () => {
+    class C {
+      @DelegateRequiresSection("bills")
+      handler() {}
+    }
+    expect(reflector.get(DELEGATE_SECTION_KEY, C.prototype.handler)).toBe(
+      "bills",
     );
   });
 });

--- a/backend/src/delegation/decorators/delegate-access.decorator.spec.ts
+++ b/backend/src/delegation/decorators/delegate-access.decorator.spec.ts
@@ -1,0 +1,39 @@
+import { Reflector } from "@nestjs/core";
+import {
+  AllowDelegate,
+  DelegatedAccountParam,
+  ALLOW_DELEGATE_KEY,
+  DELEGATED_ACCOUNT_PARAM_KEY,
+} from "./delegate-access.decorator";
+
+describe("delegate-access decorators", () => {
+  const reflector = new Reflector();
+
+  it("AllowDelegate sets the allow-delegate metadata", () => {
+    class C {
+      @AllowDelegate()
+      handler() {}
+    }
+    expect(reflector.get(ALLOW_DELEGATE_KEY, C.prototype.handler)).toBe(true);
+  });
+
+  it("DelegatedAccountParam defaults to 'id'", () => {
+    class C {
+      @DelegatedAccountParam()
+      handler() {}
+    }
+    expect(
+      reflector.get(DELEGATED_ACCOUNT_PARAM_KEY, C.prototype.handler),
+    ).toBe("id");
+  });
+
+  it("DelegatedAccountParam accepts a custom key", () => {
+    class C {
+      @DelegatedAccountParam("accountId")
+      handler() {}
+    }
+    expect(
+      reflector.get(DELEGATED_ACCOUNT_PARAM_KEY, C.prototype.handler),
+    ).toBe("accountId");
+  });
+});

--- a/backend/src/delegation/decorators/delegate-access.decorator.spec.ts
+++ b/backend/src/delegation/decorators/delegate-access.decorator.spec.ts
@@ -6,12 +6,14 @@ import {
   DelegatedTransferBody,
   DelegatedTransferParam,
   DelegateRequires,
+  DelegateRequiresCapability,
   ALLOW_DELEGATE_KEY,
   DELEGATED_ACCOUNT_PARAM_KEY,
   DELEGATED_TRANSACTION_PARAM_KEY,
   DELEGATED_TRANSFER_BODY_KEY,
   DELEGATED_TRANSFER_PARAM_KEY,
   DELEGATE_OPERATION_KEY,
+  DELEGATE_CAPABILITY_KEY,
 } from "./delegate-access.decorator";
 
 describe("delegate-access decorators", () => {
@@ -83,5 +85,15 @@ describe("delegate-access decorators", () => {
     expect(
       reflector.get(DELEGATED_TRANSFER_PARAM_KEY, C.prototype.handler),
     ).toBe("id");
+  });
+
+  it("DelegateRequiresCapability sets the capability", () => {
+    class C {
+      @DelegateRequiresCapability("payees")
+      handler() {}
+    }
+    expect(reflector.get(DELEGATE_CAPABILITY_KEY, C.prototype.handler)).toBe(
+      "payees",
+    );
   });
 });

--- a/backend/src/delegation/decorators/delegate-access.decorator.ts
+++ b/backend/src/delegation/decorators/delegate-access.decorator.ts
@@ -36,3 +36,21 @@ export const DelegateRequires = (operation: DelegateOperation) =>
 export const DELEGATED_TRANSACTION_PARAM_KEY = "delegatedTransactionParam";
 export const DelegatedTransactionParam = (key = "id") =>
   SetMetadata(DELEGATED_TRANSACTION_PARAM_KEY, key);
+
+/**
+ * A transfer-create route: both body account ids (from/to) must satisfy the
+ * required operation. Value is the [fromKey, toKey] body field names.
+ */
+export const DELEGATED_TRANSFER_BODY_KEY = "delegatedTransferBody";
+export const DelegatedTransferBody = (
+  fromKey = "fromAccountId",
+  toKey = "toAccountId",
+) => SetMetadata(DELEGATED_TRANSFER_BODY_KEY, [fromKey, toKey]);
+
+/**
+ * A transfer edit/delete-by-id route: BOTH legs' accounts (resolved from the
+ * transaction id) must satisfy the required operation.
+ */
+export const DELEGATED_TRANSFER_PARAM_KEY = "delegatedTransferParam";
+export const DelegatedTransferParam = (key = "id") =>
+  SetMetadata(DELEGATED_TRANSFER_PARAM_KEY, key);

--- a/backend/src/delegation/decorators/delegate-access.decorator.ts
+++ b/backend/src/delegation/decorators/delegate-access.decorator.ts
@@ -27,3 +27,12 @@ export type DelegateOperation = "read" | "create" | "edit" | "delete";
 export const DELEGATE_OPERATION_KEY = "delegateOperation";
 export const DelegateRequires = (operation: DelegateOperation) =>
   SetMetadata(DELEGATE_OPERATION_KEY, operation);
+
+/**
+ * Like @DelegatedAccountParam but the request key holds a TRANSACTION id; the
+ * guard resolves that transaction's account and checks the grant against it.
+ * Used for edit/delete-by-id where the account is not in the request.
+ */
+export const DELEGATED_TRANSACTION_PARAM_KEY = "delegatedTransactionParam";
+export const DelegatedTransactionParam = (key = "id") =>
+  SetMetadata(DELEGATED_TRANSACTION_PARAM_KEY, key);

--- a/backend/src/delegation/decorators/delegate-access.decorator.ts
+++ b/backend/src/delegation/decorators/delegate-access.decorator.ts
@@ -18,3 +18,12 @@ export const AllowDelegate = () => SetMetadata(ALLOW_DELEGATE_KEY, true);
 export const DELEGATED_ACCOUNT_PARAM_KEY = "delegatedAccountParam";
 export const DelegatedAccountParam = (key = "id") =>
   SetMetadata(DELEGATED_ACCOUNT_PARAM_KEY, key);
+
+/**
+ * The per-account operation a delegate route requires on the resolved
+ * account. Defaults to "read" when absent. Pair with @DelegatedAccountParam.
+ */
+export type DelegateOperation = "read" | "create" | "edit" | "delete";
+export const DELEGATE_OPERATION_KEY = "delegateOperation";
+export const DelegateRequires = (operation: DelegateOperation) =>
+  SetMetadata(DELEGATE_OPERATION_KEY, operation);

--- a/backend/src/delegation/decorators/delegate-access.decorator.ts
+++ b/backend/src/delegation/decorators/delegate-access.decorator.ts
@@ -60,7 +60,14 @@ export const DelegatedTransferParam = (key = "id") =>
  * categories, tags). A delegate may reach it only if the owner granted the
  * matching per-delegation manage capability.
  */
-export type DelegateCapability = "payees" | "categories" | "tags";
+export type DelegateResource = "payees" | "categories" | "tags";
+export type DelegateCapabilityOp = "create" | "edit" | "delete";
+export interface DelegateCapabilityReq {
+  resource: DelegateResource;
+  operation: DelegateCapabilityOp;
+}
 export const DELEGATE_CAPABILITY_KEY = "delegateCapability";
-export const DelegateRequiresCapability = (capability: DelegateCapability) =>
-  SetMetadata(DELEGATE_CAPABILITY_KEY, capability);
+export const DelegateRequiresCapability = (
+  resource: DelegateResource,
+  operation: DelegateCapabilityOp,
+) => SetMetadata(DELEGATE_CAPABILITY_KEY, { resource, operation });

--- a/backend/src/delegation/decorators/delegate-access.decorator.ts
+++ b/backend/src/delegation/decorators/delegate-access.decorator.ts
@@ -71,3 +71,20 @@ export const DelegateRequiresCapability = (
   resource: DelegateResource,
   operation: DelegateCapabilityOp,
 ) => SetMetadata(DELEGATE_CAPABILITY_KEY, { resource, operation });
+
+/**
+ * 3A: a route belonging to a whole app section a delegate can be granted
+ * READ on (Bills & Deposits, Investments, Budgets, Reports, AI). A delegate
+ * may reach it only if the owner granted that section. Pair with
+ * @AllowDelegate(); account-scoped data still also needs the per-account
+ * decorators.
+ */
+export type DelegateSection =
+  | "bills"
+  | "investments"
+  | "budgets"
+  | "reports"
+  | "ai";
+export const DELEGATE_SECTION_KEY = "delegateSection";
+export const DelegateRequiresSection = (section: DelegateSection) =>
+  SetMetadata(DELEGATE_SECTION_KEY, section);

--- a/backend/src/delegation/decorators/delegate-access.decorator.ts
+++ b/backend/src/delegation/decorators/delegate-access.decorator.ts
@@ -54,3 +54,13 @@ export const DelegatedTransferBody = (
 export const DELEGATED_TRANSFER_PARAM_KEY = "delegatedTransferParam";
 export const DelegatedTransferParam = (key = "id") =>
   SetMetadata(DELEGATED_TRANSFER_PARAM_KEY, key);
+
+/**
+ * 2C: a route that creates/edits/deletes shared reference data (payees,
+ * categories, tags). A delegate may reach it only if the owner granted the
+ * matching per-delegation manage capability.
+ */
+export type DelegateCapability = "payees" | "categories" | "tags";
+export const DELEGATE_CAPABILITY_KEY = "delegateCapability";
+export const DelegateRequiresCapability = (capability: DelegateCapability) =>
+  SetMetadata(DELEGATE_CAPABILITY_KEY, capability);

--- a/backend/src/delegation/decorators/delegate-access.decorator.ts
+++ b/backend/src/delegation/decorators/delegate-access.decorator.ts
@@ -56,6 +56,16 @@ export const DelegatedTransferParam = (key = "id") =>
   SetMetadata(DELEGATED_TRANSFER_PARAM_KEY, key);
 
 /**
+ * Like @DelegatedTransferParam but the request key holds a SCHEDULED
+ * transaction id; the guard resolves every account it touches (its own
+ * account plus the transfer counterpart) and requires the operation on each.
+ * Used for scheduled read/edit/delete/post/skip + override routes.
+ */
+export const DELEGATED_SCHEDULED_PARAM_KEY = "delegatedScheduledParam";
+export const DelegatedScheduledParam = (key = "id") =>
+  SetMetadata(DELEGATED_SCHEDULED_PARAM_KEY, key);
+
+/**
  * 2C: a route that creates/edits/deletes shared reference data (payees,
  * categories, tags). A delegate may reach it only if the owner granted the
  * matching per-delegation manage capability.

--- a/backend/src/delegation/decorators/delegate-access.decorator.ts
+++ b/backend/src/delegation/decorators/delegate-access.decorator.ts
@@ -1,0 +1,20 @@
+import { SetMetadata } from "@nestjs/common";
+
+/**
+ * Marks a route as reachable by a delegate who is acting as an owner.
+ *
+ * The default posture is fail-closed: while a request carries a delegate
+ * "acting-as" context, AccountDelegateGuard rejects any route NOT annotated
+ * with @AllowDelegate(). Normal (non-delegate) requests are unaffected.
+ */
+export const ALLOW_DELEGATE_KEY = "allowDelegate";
+export const AllowDelegate = () => SetMetadata(ALLOW_DELEGATE_KEY, true);
+
+/**
+ * Marks a route as account-scoped for delegates. The value is the request key
+ * holding the account id; the guard additionally requires an active READ grant
+ * for that account. Lookup order: route params, then body, then query.
+ */
+export const DELEGATED_ACCOUNT_PARAM_KEY = "delegatedAccountParam";
+export const DelegatedAccountParam = (key = "id") =>
+  SetMetadata(DELEGATED_ACCOUNT_PARAM_KEY, key);

--- a/backend/src/delegation/delegation.controller.spec.ts
+++ b/backend/src/delegation/delegation.controller.spec.ts
@@ -14,6 +14,7 @@ describe("DelegationController", () => {
       revokeDelegate: jest.fn().mockResolvedValue(undefined),
       setGrants: jest.fn().mockResolvedValue(undefined),
       setCapabilities: jest.fn().mockResolvedValue(undefined),
+      setSectionGrants: jest.fn().mockResolvedValue(undefined),
       resetDelegatePassword: jest
         .fn()
         .mockResolvedValue({ temporaryPassword: "x" }),
@@ -53,6 +54,12 @@ describe("DelegationController", () => {
     const dto = { canManagePayees: true };
     await controller.setCapabilities(req, "g1", dto as never);
     expect(service.setCapabilities).toHaveBeenCalledWith("owner-1", "g1", dto);
+  });
+
+  it("sets section grants", async () => {
+    const dto = { billsCanRead: true };
+    await controller.setSectionGrants(req, "g1", dto as never);
+    expect(service.setSectionGrants).toHaveBeenCalledWith("owner-1", "g1", dto);
   });
 
   it("resets a delegate password", async () => {

--- a/backend/src/delegation/delegation.controller.spec.ts
+++ b/backend/src/delegation/delegation.controller.spec.ts
@@ -11,6 +11,7 @@ describe("DelegationController", () => {
     service = {
       listDelegates: jest.fn().mockResolvedValue(["d"]),
       createDelegate: jest.fn().mockResolvedValue({ id: "g1" }),
+      delegateEmailExists: jest.fn().mockResolvedValue(true),
       revokeDelegate: jest.fn().mockResolvedValue(undefined),
       setGrants: jest.fn().mockResolvedValue(undefined),
       setCapabilities: jest.fn().mockResolvedValue(undefined),
@@ -31,6 +32,13 @@ describe("DelegationController", () => {
   it("lists delegates for the current owner", async () => {
     await expect(controller.listDelegates(req)).resolves.toEqual(["d"]);
     expect(service.listDelegates).toHaveBeenCalledWith("owner-1");
+  });
+
+  it("looks up whether an email already exists", async () => {
+    await expect(
+      controller.lookupDelegate({ email: "a@b.c" } as never),
+    ).resolves.toEqual({ exists: true });
+    expect(service.delegateEmailExists).toHaveBeenCalledWith("a@b.c");
   });
 
   it("creates a delegate", async () => {

--- a/backend/src/delegation/delegation.controller.spec.ts
+++ b/backend/src/delegation/delegation.controller.spec.ts
@@ -43,8 +43,9 @@ describe("DelegationController", () => {
   });
 
   it("sets grants", async () => {
-    await controller.setGrants(req, "g1", { accountIds: ["a1"] } as never);
-    expect(service.setGrants).toHaveBeenCalledWith("owner-1", "g1", ["a1"]);
+    const grants = [{ accountId: "a1", canRead: true, canCreate: true }];
+    await controller.setGrants(req, "g1", { grants } as never);
+    expect(service.setGrants).toHaveBeenCalledWith("owner-1", "g1", grants);
   });
 
   it("resets a delegate password", async () => {

--- a/backend/src/delegation/delegation.controller.spec.ts
+++ b/backend/src/delegation/delegation.controller.spec.ts
@@ -13,6 +13,7 @@ describe("DelegationController", () => {
       createDelegate: jest.fn().mockResolvedValue({ id: "g1" }),
       revokeDelegate: jest.fn().mockResolvedValue(undefined),
       setGrants: jest.fn().mockResolvedValue(undefined),
+      setCapabilities: jest.fn().mockResolvedValue(undefined),
       resetDelegatePassword: jest
         .fn()
         .mockResolvedValue({ temporaryPassword: "x" }),
@@ -46,6 +47,12 @@ describe("DelegationController", () => {
     const grants = [{ accountId: "a1", canRead: true, canCreate: true }];
     await controller.setGrants(req, "g1", { grants } as never);
     expect(service.setGrants).toHaveBeenCalledWith("owner-1", "g1", grants);
+  });
+
+  it("sets capabilities", async () => {
+    const dto = { canManagePayees: true };
+    await controller.setCapabilities(req, "g1", dto as never);
+    expect(service.setCapabilities).toHaveBeenCalledWith("owner-1", "g1", dto);
   });
 
   it("resets a delegate password", async () => {

--- a/backend/src/delegation/delegation.controller.spec.ts
+++ b/backend/src/delegation/delegation.controller.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { DelegationController } from "./delegation.controller";
+import { DelegationService } from "./delegation.service";
+
+describe("DelegationController", () => {
+  let controller: DelegationController;
+  let service: Record<string, jest.Mock>;
+  const req = { user: { id: "owner-1" } };
+
+  beforeEach(async () => {
+    service = {
+      listDelegates: jest.fn().mockResolvedValue(["d"]),
+      createDelegate: jest.fn().mockResolvedValue({ id: "g1" }),
+      revokeDelegate: jest.fn().mockResolvedValue(undefined),
+      setGrants: jest.fn().mockResolvedValue(undefined),
+      resetDelegatePassword: jest
+        .fn()
+        .mockResolvedValue({ temporaryPassword: "x" }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DelegationController],
+      providers: [{ provide: DelegationService, useValue: service }],
+    }).compile();
+
+    controller = module.get<DelegationController>(DelegationController);
+  });
+
+  it("lists delegates for the current owner", async () => {
+    await expect(controller.listDelegates(req)).resolves.toEqual(["d"]);
+    expect(service.listDelegates).toHaveBeenCalledWith("owner-1");
+  });
+
+  it("creates a delegate", async () => {
+    const dto = { email: "a@b.c" } as never;
+    await controller.createDelegate(req, dto);
+    expect(service.createDelegate).toHaveBeenCalledWith("owner-1", dto);
+  });
+
+  it("revokes a delegate", async () => {
+    await controller.revokeDelegate(req, "g1");
+    expect(service.revokeDelegate).toHaveBeenCalledWith("owner-1", "g1");
+  });
+
+  it("sets grants", async () => {
+    await controller.setGrants(req, "g1", { accountIds: ["a1"] } as never);
+    expect(service.setGrants).toHaveBeenCalledWith("owner-1", "g1", ["a1"]);
+  });
+
+  it("resets a delegate password", async () => {
+    await expect(controller.resetPassword(req, "g1")).resolves.toEqual({
+      temporaryPassword: "x",
+    });
+    expect(service.resetDelegatePassword).toHaveBeenCalledWith("owner-1", "g1");
+  });
+});

--- a/backend/src/delegation/delegation.controller.ts
+++ b/backend/src/delegation/delegation.controller.ts
@@ -19,6 +19,7 @@ import { DelegationService } from "./delegation.service";
 import { CreateDelegateDto } from "./dto/create-delegate.dto";
 import { SetGrantsDto } from "./dto/set-grants.dto";
 import { SetCapabilitiesDto } from "./dto/set-capabilities.dto";
+import { SetSectionsDto } from "./dto/set-sections.dto";
 
 /**
  * Owner-scoped delegate management ("Shared Access" settings). Every endpoint
@@ -80,6 +81,19 @@ export class DelegationController {
     @Body() dto: SetCapabilitiesDto,
   ) {
     return this.delegationService.setCapabilities(req.user.id, id, dto);
+  }
+
+  @Put("delegates/:id/sections")
+  @DemoRestricted()
+  @ApiOperation({
+    summary: "Set the delegate's section READ grants (bills/investments/...)",
+  })
+  setSectionGrants(
+    @Request() req,
+    @Param("id", ParseUUIDPipe) id: string,
+    @Body() dto: SetSectionsDto,
+  ) {
+    return this.delegationService.setSectionGrants(req.user.id, id, dto);
   }
 
   @Post("delegates/:id/reset-password")

--- a/backend/src/delegation/delegation.controller.ts
+++ b/backend/src/delegation/delegation.controller.ts
@@ -18,6 +18,7 @@ import { DemoRestricted } from "../common/decorators/demo-restricted.decorator";
 import { DelegationService } from "./delegation.service";
 import { CreateDelegateDto } from "./dto/create-delegate.dto";
 import { SetGrantsDto } from "./dto/set-grants.dto";
+import { SetCapabilitiesDto } from "./dto/set-capabilities.dto";
 
 /**
  * Owner-scoped delegate management ("Shared Access" settings). Every endpoint
@@ -66,6 +67,19 @@ export class DelegationController {
     @Body() dto: SetGrantsDto,
   ) {
     return this.delegationService.setGrants(req.user.id, id, dto.grants);
+  }
+
+  @Put("delegates/:id/capabilities")
+  @DemoRestricted()
+  @ApiOperation({
+    summary: "Set the delegate's manage capabilities (payees/categories/tags)",
+  })
+  setCapabilities(
+    @Request() req,
+    @Param("id", ParseUUIDPipe) id: string,
+    @Body() dto: SetCapabilitiesDto,
+  ) {
+    return this.delegationService.setCapabilities(req.user.id, id, dto);
   }
 
   @Post("delegates/:id/reset-password")

--- a/backend/src/delegation/delegation.controller.ts
+++ b/backend/src/delegation/delegation.controller.ts
@@ -6,6 +6,7 @@ import {
   Delete,
   Body,
   Param,
+  Query,
   Request,
   UseGuards,
   HttpCode,
@@ -20,6 +21,7 @@ import { CreateDelegateDto } from "./dto/create-delegate.dto";
 import { SetGrantsDto } from "./dto/set-grants.dto";
 import { SetCapabilitiesDto } from "./dto/set-capabilities.dto";
 import { SetSectionsDto } from "./dto/set-sections.dto";
+import { LookupDelegateDto } from "./dto/lookup-delegate.dto";
 
 /**
  * Owner-scoped delegate management ("Shared Access" settings). Every endpoint
@@ -40,6 +42,16 @@ export class DelegationController {
   @ApiOperation({ summary: "List delegates for the current account" })
   listDelegates(@Request() req) {
     return this.delegationService.listDelegates(req.user.id);
+  }
+
+  @Get("delegates/lookup")
+  @ApiOperation({
+    summary: "Whether an email already has a Monize login",
+  })
+  async lookupDelegate(@Query() dto: LookupDelegateDto) {
+    return {
+      exists: await this.delegationService.delegateEmailExists(dto.email),
+    };
   }
 
   @Post("delegates")

--- a/backend/src/delegation/delegation.controller.ts
+++ b/backend/src/delegation/delegation.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Request,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+  ParseUUIDPipe,
+} from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import { ApiTags, ApiOperation, ApiBearerAuth } from "@nestjs/swagger";
+import { DemoRestricted } from "../common/decorators/demo-restricted.decorator";
+import { DelegationService } from "./delegation.service";
+import { CreateDelegateDto } from "./dto/create-delegate.dto";
+import { SetGrantsDto } from "./dto/set-grants.dto";
+
+/**
+ * Owner-scoped delegate management ("Shared Access" settings). Every endpoint
+ * uses req.user.id as the OWNER. This is NOT the admin module and requires no
+ * admin role -- any normal user can manage delegates for their own account.
+ *
+ * Not annotated @AllowDelegate(): a delegate acting as an owner is blocked
+ * from managing that owner's delegates by AccountDelegateGuard (fail closed).
+ */
+@ApiTags("Delegation")
+@Controller("delegation")
+@UseGuards(AuthGuard("jwt"))
+@ApiBearerAuth()
+export class DelegationController {
+  constructor(private readonly delegationService: DelegationService) {}
+
+  @Get("delegates")
+  @ApiOperation({ summary: "List delegates for the current account" })
+  listDelegates(@Request() req) {
+    return this.delegationService.listDelegates(req.user.id);
+  }
+
+  @Post("delegates")
+  @DemoRestricted()
+  @ApiOperation({
+    summary: "Create or link a delegate for the current account",
+  })
+  createDelegate(@Request() req, @Body() dto: CreateDelegateDto) {
+    return this.delegationService.createDelegate(req.user.id, dto);
+  }
+
+  @Delete("delegates/:id")
+  @HttpCode(HttpStatus.OK)
+  @DemoRestricted()
+  @ApiOperation({ summary: "Revoke a delegate" })
+  revokeDelegate(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
+    return this.delegationService.revokeDelegate(req.user.id, id);
+  }
+
+  @Put("delegates/:id/grants")
+  @DemoRestricted()
+  @ApiOperation({ summary: "Set the delegate's READ-granted accounts" })
+  setGrants(
+    @Request() req,
+    @Param("id", ParseUUIDPipe) id: string,
+    @Body() dto: SetGrantsDto,
+  ) {
+    return this.delegationService.setGrants(req.user.id, id, dto.accountIds);
+  }
+
+  @Post("delegates/:id/reset-password")
+  @HttpCode(HttpStatus.OK)
+  @DemoRestricted()
+  @ApiOperation({ summary: "Reset a delegate's password (owner-driven)" })
+  resetPassword(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
+    return this.delegationService.resetDelegatePassword(req.user.id, id);
+  }
+}

--- a/backend/src/delegation/delegation.controller.ts
+++ b/backend/src/delegation/delegation.controller.ts
@@ -65,7 +65,7 @@ export class DelegationController {
     @Param("id", ParseUUIDPipe) id: string,
     @Body() dto: SetGrantsDto,
   ) {
-    return this.delegationService.setGrants(req.user.id, id, dto.accountIds);
+    return this.delegationService.setGrants(req.user.id, id, dto.grants);
   }
 
   @Post("delegates/:id/reset-password")

--- a/backend/src/delegation/delegation.module.ts
+++ b/backend/src/delegation/delegation.module.ts
@@ -14,6 +14,7 @@ import { Transaction } from "../transactions/entities/transaction.entity";
 import { DelegationService } from "./delegation.service";
 import { DelegationController } from "./delegation.controller";
 import { AccountDelegateGuard } from "./guards/account-delegate.guard";
+import { DelegateTransferMaskInterceptor } from "./interceptors/delegate-transfer-mask.interceptor";
 import { NotificationsModule } from "../notifications/notifications.module";
 
 /**
@@ -52,10 +53,15 @@ import { NotificationsModule } from "../notifications/notifications.module";
   providers: [
     DelegationService,
     AccountDelegateGuard,
+    DelegateTransferMaskInterceptor,
     // Providing APP_GUARD here registers it globally (Nest treats the
     // APP_GUARD token specially regardless of the declaring module).
     { provide: APP_GUARD, useExisting: AccountDelegateGuard },
   ],
-  exports: [DelegationService, AccountDelegateGuard],
+  exports: [
+    DelegationService,
+    AccountDelegateGuard,
+    DelegateTransferMaskInterceptor,
+  ],
 })
 export class DelegationModule {}

--- a/backend/src/delegation/delegation.module.ts
+++ b/backend/src/delegation/delegation.module.ts
@@ -10,6 +10,7 @@ import { User } from "../users/entities/user.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
 import { Account } from "../accounts/entities/account.entity";
+import { Transaction } from "../transactions/entities/transaction.entity";
 import { DelegationService } from "./delegation.service";
 import { DelegationController } from "./delegation.controller";
 import { AccountDelegateGuard } from "./guards/account-delegate.guard";
@@ -29,6 +30,7 @@ import { NotificationsModule } from "../notifications/notifications.module";
       UserPreference,
       RefreshToken,
       Account,
+      Transaction,
     ]),
     NotificationsModule,
     JwtModule.registerAsync({

--- a/backend/src/delegation/delegation.module.ts
+++ b/backend/src/delegation/delegation.module.ts
@@ -1,0 +1,59 @@
+import { Module } from "@nestjs/common";
+import { APP_GUARD } from "@nestjs/core";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { JwtModule } from "@nestjs/jwt";
+import { ConfigModule, ConfigService } from "@nestjs/config";
+
+import { AccountDelegate } from "./entities/account-delegate.entity";
+import { AccountDelegateGrant } from "./entities/account-delegate-grant.entity";
+import { User } from "../users/entities/user.entity";
+import { UserPreference } from "../users/entities/user-preference.entity";
+import { RefreshToken } from "../auth/entities/refresh-token.entity";
+import { Account } from "../accounts/entities/account.entity";
+import { DelegationService } from "./delegation.service";
+import { DelegationController } from "./delegation.controller";
+import { AccountDelegateGuard } from "./guards/account-delegate.guard";
+import { NotificationsModule } from "../notifications/notifications.module";
+
+/**
+ * Self-contained: registers its own JwtModule (same secret) so the global
+ * AccountDelegateGuard can verify tokens without importing AuthModule, which
+ * keeps AuthModule -> DelegationModule one-directional (no circular import).
+ */
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      AccountDelegate,
+      AccountDelegateGrant,
+      User,
+      UserPreference,
+      RefreshToken,
+      Account,
+    ]),
+    NotificationsModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get("JWT_SECRET"),
+        signOptions: {
+          expiresIn: configService.get("JWT_EXPIRATION", "15m"),
+          algorithm: "HS256" as const,
+        },
+        verifyOptions: {
+          algorithms: ["HS256" as const],
+        },
+      }),
+    }),
+  ],
+  controllers: [DelegationController],
+  providers: [
+    DelegationService,
+    AccountDelegateGuard,
+    // Providing APP_GUARD here registers it globally (Nest treats the
+    // APP_GUARD token specially regardless of the declaring module).
+    { provide: APP_GUARD, useExisting: AccountDelegateGuard },
+  ],
+  exports: [DelegationService, AccountDelegateGuard],
+})
+export class DelegationModule {}

--- a/backend/src/delegation/delegation.module.ts
+++ b/backend/src/delegation/delegation.module.ts
@@ -11,10 +11,12 @@ import { UserPreference } from "../users/entities/user-preference.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
 import { Account } from "../accounts/entities/account.entity";
 import { Transaction } from "../transactions/entities/transaction.entity";
+import { ScheduledTransaction } from "../scheduled-transactions/entities/scheduled-transaction.entity";
 import { DelegationService } from "./delegation.service";
 import { DelegationController } from "./delegation.controller";
 import { AccountDelegateGuard } from "./guards/account-delegate.guard";
 import { DelegateTransferMaskInterceptor } from "./interceptors/delegate-transfer-mask.interceptor";
+import { DelegateScheduledTransferMaskInterceptor } from "./interceptors/delegate-scheduled-transfer-mask.interceptor";
 import { NotificationsModule } from "../notifications/notifications.module";
 
 /**
@@ -32,6 +34,7 @@ import { NotificationsModule } from "../notifications/notifications.module";
       RefreshToken,
       Account,
       Transaction,
+      ScheduledTransaction,
     ]),
     NotificationsModule,
     JwtModule.registerAsync({
@@ -54,6 +57,7 @@ import { NotificationsModule } from "../notifications/notifications.module";
     DelegationService,
     AccountDelegateGuard,
     DelegateTransferMaskInterceptor,
+    DelegateScheduledTransferMaskInterceptor,
     // Providing APP_GUARD here registers it globally (Nest treats the
     // APP_GUARD token specially regardless of the declaring module).
     { provide: APP_GUARD, useExisting: AccountDelegateGuard },
@@ -62,6 +66,7 @@ import { NotificationsModule } from "../notifications/notifications.module";
     DelegationService,
     AccountDelegateGuard,
     DelegateTransferMaskInterceptor,
+    DelegateScheduledTransferMaskInterceptor,
   ],
 })
 export class DelegationModule {}

--- a/backend/src/delegation/delegation.module.ts
+++ b/backend/src/delegation/delegation.module.ts
@@ -6,6 +6,7 @@ import { ConfigModule, ConfigService } from "@nestjs/config";
 
 import { AccountDelegate } from "./entities/account-delegate.entity";
 import { AccountDelegateGrant } from "./entities/account-delegate-grant.entity";
+import { DelegateAccountFavourite } from "./entities/delegate-account-favourite.entity";
 import { User } from "../users/entities/user.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
@@ -29,6 +30,7 @@ import { NotificationsModule } from "../notifications/notifications.module";
     TypeOrmModule.forFeature([
       AccountDelegate,
       AccountDelegateGrant,
+      DelegateAccountFavourite,
       User,
       UserPreference,
       RefreshToken,

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -22,7 +22,7 @@ describe("DelegationService", () => {
 
   beforeEach(() => {
     delegatesRepo = { findOne: jest.fn(), find: jest.fn(), save: jest.fn() };
-    grantsRepo = { findOne: jest.fn(), find: jest.fn() };
+    grantsRepo = { findOne: jest.fn(), find: jest.fn(), count: jest.fn() };
     usersRepo = { findOne: jest.fn(), save: jest.fn() };
     prefsRepo = { findOne: jest.fn() };
     refreshRepo = { update: jest.fn() };
@@ -1150,6 +1150,21 @@ describe("DelegationService", () => {
       ]);
       accountsRepo.count.mockResolvedValue(1);
       await expect(service.hasTransactionalAccess("g1")).resolves.toBe(true);
+    });
+  });
+
+  describe("hasAnyAccountAccess", () => {
+    it("is false when the delegate has no readable account grant", async () => {
+      grantsRepo.count.mockResolvedValue(0);
+      await expect(service.hasAnyAccountAccess("g1")).resolves.toBe(false);
+      expect(grantsRepo.count).toHaveBeenCalledWith({
+        where: { delegationId: "g1", canRead: true },
+      });
+    });
+
+    it("is true when the delegate can read at least one account", async () => {
+      grantsRepo.count.mockResolvedValue(2);
+      await expect(service.hasAnyAccountAccess("g1")).resolves.toBe(true);
     });
   });
 

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -153,6 +153,33 @@ describe("DelegationService", () => {
     });
   });
 
+  describe("accountIdsForTransfer", () => {
+    it("returns both legs' accounts", async () => {
+      transactionsRepo.findOne
+        .mockResolvedValueOnce({ accountId: "a1", linkedTransactionId: "t2" })
+        .mockResolvedValueOnce({ accountId: "a2" });
+      await expect(service.accountIdsForTransfer("t1")).resolves.toEqual([
+        "a1",
+        "a2",
+      ]);
+    });
+
+    it("returns just the one account when there is no linked leg", async () => {
+      transactionsRepo.findOne.mockResolvedValueOnce({
+        accountId: "a1",
+        linkedTransactionId: null,
+      });
+      await expect(service.accountIdsForTransfer("t1")).resolves.toEqual([
+        "a1",
+      ]);
+    });
+
+    it("returns [] when the transaction does not exist", async () => {
+      transactionsRepo.findOne.mockResolvedValueOnce(null);
+      await expect(service.accountIdsForTransfer("t1")).resolves.toEqual([]);
+    });
+  });
+
   describe("hasReadAccess", () => {
     it("is true only when a can_read grant exists", async () => {
       grantsRepo.findOne.mockResolvedValue({ id: "x" });

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -3,6 +3,7 @@ import {
   ForbiddenException,
   NotFoundException,
 } from "@nestjs/common";
+import * as bcrypt from "bcryptjs";
 import { DelegationService, DELEGATE_2FA_REQUIRED } from "./delegation.service";
 
 describe("DelegationService", () => {
@@ -606,6 +607,7 @@ describe("DelegationService", () => {
     const makeManager = () => {
       const manager: any = {
         findOne: jest.fn(),
+        count: jest.fn().mockResolvedValue(0),
         create: jest.fn((_e: any, v: any) => v),
         save: jest.fn((v: any) => ({ id: "g-new", ...v })),
       };
@@ -715,20 +717,49 @@ describe("DelegationService", () => {
       ).rejects.toThrow(/yourself/);
     });
 
-    it("throws when the new delegate user fails to persist", async () => {
+    it("sets a password on an existing passwordless pure-delegate (re-link)", async () => {
       usersRepo.findOne.mockResolvedValue({ id: "o1", email: "own@x.y" });
-      const manager: any = {
-        findOne: jest.fn().mockResolvedValue(null),
-        create: jest.fn((_e: any, v: any) => v),
-        save: jest.fn().mockResolvedValue(undefined),
-      };
+      const existing = { id: "d1", passwordHash: null };
+      const manager = makeManager();
+      manager.findOne
+        .mockResolvedValueOnce(existing) // existing user
+        .mockResolvedValueOnce(null); // no delegation yet
+      // count(Account)=0, count(AccountDelegate owner)=0 -> pure delegate
       dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
-      await expect(
-        service.createDelegate("o1", {
-          email: "new@x.y",
-          password: "StrongPass1!xyz",
-        } as any),
-      ).rejects.toThrow(/Unable to create delegate/);
+
+      await service.createDelegate("o1", {
+        email: "shared@x.y",
+        password: "StrongPass1!xyz",
+      } as any);
+
+      expect(existing.passwordHash).toBeTruthy();
+      expect(
+        await bcrypt.compare("StrongPass1!xyz", existing.passwordHash as any),
+      ).toBe(true);
+    });
+
+    it("never touches credentials of an existing full user", async () => {
+      usersRepo.findOne.mockResolvedValue({ id: "o1", email: "own@x.y" });
+      const existing = {
+        id: "d1",
+        passwordHash: "ORIGINAL",
+        oidcSubject: null,
+        role: "user",
+      };
+      const manager = makeManager();
+      manager.findOne
+        .mockResolvedValueOnce(existing)
+        .mockResolvedValueOnce(null);
+      manager.count.mockResolvedValue(2); // owns accounts -> full user
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+
+      const res = await service.createDelegate("o1", {
+        email: "full@x.y",
+        password: "StrongPass1!xyz",
+      } as any);
+
+      expect(existing.passwordHash).toBe("ORIGINAL");
+      expect(res.temporaryPassword).toBeUndefined();
     });
 
     it("logs (does not throw) when the invite email fails to send", async () => {

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -361,16 +361,117 @@ describe("DelegationService", () => {
       );
     });
 
-    it("revokes the delegation and kills live sessions", async () => {
-      const delegation = { id: "g1", ownerUserId: "o1", status: "active" };
-      delegatesRepo.findOne.mockResolvedValue(delegation);
-      delegatesRepo.save.mockResolvedValue(delegation);
+    function managerFor(counts: {
+      otherDelegations: number;
+      ownsAccounts: number;
+      ownsDelegations: number;
+      role?: string;
+    }) {
+      const manager: any = {
+        delete: jest.fn(),
+        count: jest
+          .fn()
+          .mockResolvedValueOnce(counts.otherDelegations)
+          .mockResolvedValueOnce(counts.ownsAccounts)
+          .mockResolvedValueOnce(counts.ownsDelegations),
+        findOne: jest
+          .fn()
+          .mockResolvedValue({ id: "d1", role: counts.role ?? "user" }),
+      };
+      return manager;
+    }
+
+    it("fully deletes a pure delegate with no other ties", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        id: "g1",
+        ownerUserId: "o1",
+        delegateUserId: "d1",
+      });
+      const manager = managerFor({
+        otherDelegations: 0,
+        ownsAccounts: 0,
+        ownsDelegations: 0,
+      });
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+
       await service.revokeDelegate("o1", "g1");
-      expect(delegation.status).toBe("revoked");
-      expect(refreshRepo.update).toHaveBeenCalledWith(
-        { delegationId: "g1", isRevoked: false },
-        { isRevoked: true },
-      );
+
+      expect(manager.delete).toHaveBeenCalledWith(expect.anything(), {
+        id: "g1",
+      });
+      expect(manager.delete).toHaveBeenCalledWith(expect.anything(), {
+        id: "d1",
+      });
+    });
+
+    it("keeps the user when they delegate for someone else", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        id: "g1",
+        ownerUserId: "o1",
+        delegateUserId: "d1",
+      });
+      const manager = managerFor({
+        otherDelegations: 1,
+        ownsAccounts: 0,
+        ownsDelegations: 0,
+      });
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+
+      await service.revokeDelegate("o1", "g1");
+
+      expect(manager.delete).toHaveBeenCalledTimes(1); // delegation only
+      expect(manager.delete).toHaveBeenCalledWith(expect.anything(), {
+        id: "g1",
+      });
+    });
+
+    it("keeps the user when they own data of their own", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        id: "g1",
+        ownerUserId: "o1",
+        delegateUserId: "d1",
+      });
+      const manager = managerFor({
+        otherDelegations: 0,
+        ownsAccounts: 3,
+        ownsDelegations: 0,
+      });
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+
+      await service.revokeDelegate("o1", "g1");
+
+      expect(manager.delete).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps an admin delegate", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        id: "g1",
+        ownerUserId: "o1",
+        delegateUserId: "d1",
+      });
+      const manager = managerFor({
+        otherDelegations: 0,
+        ownsAccounts: 0,
+        ownsDelegations: 0,
+        role: "admin",
+      });
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+
+      await service.revokeDelegate("o1", "g1");
+
+      expect(manager.delete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("isDelegateUser", () => {
+    it("is true when the user has at least one delegation", async () => {
+      delegatesRepo.count = jest.fn().mockResolvedValue(2);
+      await expect(service.isDelegateUser("d1")).resolves.toBe(true);
+    });
+
+    it("is false when the user has no delegations", async () => {
+      delegatesRepo.count = jest.fn().mockResolvedValue(0);
+      await expect(service.isDelegateUser("d1")).resolves.toBe(false);
     });
   });
 

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -13,6 +13,7 @@ describe("DelegationService", () => {
   let prefsRepo: Record<string, jest.Mock>;
   let refreshRepo: Record<string, jest.Mock>;
   let accountsRepo: Record<string, jest.Mock>;
+  let transactionsRepo: Record<string, jest.Mock>;
   let emailService: Record<string, jest.Mock>;
   let configService: Record<string, jest.Mock>;
   let dataSource: Record<string, jest.Mock>;
@@ -24,6 +25,7 @@ describe("DelegationService", () => {
     prefsRepo = { findOne: jest.fn() };
     refreshRepo = { update: jest.fn() };
     accountsRepo = { find: jest.fn(), exists: jest.fn() };
+    transactionsRepo = { findOne: jest.fn() };
     emailService = { getStatus: jest.fn(), sendMail: jest.fn() };
     configService = { get: jest.fn() };
     dataSource = { transaction: jest.fn() };
@@ -35,6 +37,7 @@ describe("DelegationService", () => {
       prefsRepo as any,
       refreshRepo as any,
       accountsRepo as any,
+      transactionsRepo as any,
       emailService as any,
       configService as any,
       dataSource as any,
@@ -134,6 +137,18 @@ describe("DelegationService", () => {
       await expect(service.validateActingContext(args)).resolves.toBe(
         delegation,
       );
+    });
+  });
+
+  describe("accountIdForTransaction", () => {
+    it("returns the transaction's account id", async () => {
+      transactionsRepo.findOne.mockResolvedValue({ accountId: "a1" });
+      await expect(service.accountIdForTransaction("t1")).resolves.toBe("a1");
+    });
+
+    it("returns null when the transaction does not exist", async () => {
+      transactionsRepo.findOne.mockResolvedValue(null);
+      await expect(service.accountIdForTransaction("t1")).resolves.toBeNull();
     });
   });
 

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -434,9 +434,15 @@ describe("DelegationService", () => {
             lastName: null,
             passwordHash: "h",
           },
-          canManagePayees: true,
-          canManageCategories: false,
-          canManageTags: true,
+          payeesCanCreate: true,
+          payeesCanEdit: true,
+          payeesCanDelete: false,
+          categoriesCanCreate: false,
+          categoriesCanEdit: false,
+          categoriesCanDelete: false,
+          tagsCanCreate: true,
+          tagsCanEdit: false,
+          tagsCanDelete: false,
           grants: [
             {
               accountId: "a1",
@@ -470,7 +476,11 @@ describe("DelegationService", () => {
             canDelete: false,
           },
         ],
-        capabilities: { payees: true, categories: false, tags: true },
+        capabilities: {
+          payees: { create: true, edit: true, delete: false },
+          categories: { create: false, edit: false, delete: false },
+          tags: { create: true, edit: false, delete: false },
+        },
       });
     });
   });
@@ -478,43 +488,60 @@ describe("DelegationService", () => {
   describe("hasCapability", () => {
     it("is false when there is no active delegation", async () => {
       delegatesRepo.findOne.mockResolvedValue(null);
-      await expect(service.hasCapability("g1", "payees")).resolves.toBe(false);
+      await expect(
+        service.hasCapability("g1", "payees", "create"),
+      ).resolves.toBe(false);
     });
 
-    it("maps each capability to the matching flag", async () => {
+    it("maps resource+operation to the matching flag", async () => {
       delegatesRepo.findOne.mockResolvedValue({
-        canManagePayees: true,
-        canManageCategories: false,
-        canManageTags: true,
+        payeesCanCreate: true,
+        payeesCanEdit: false,
+        payeesCanDelete: false,
+        categoriesCanEdit: true,
+        tagsCanDelete: true,
       });
-      await expect(service.hasCapability("g1", "payees")).resolves.toBe(true);
-      await expect(service.hasCapability("g1", "categories")).resolves.toBe(
+      await expect(
+        service.hasCapability("g1", "payees", "create"),
+      ).resolves.toBe(true);
+      await expect(service.hasCapability("g1", "payees", "edit")).resolves.toBe(
         false,
       );
-      await expect(service.hasCapability("g1", "tags")).resolves.toBe(true);
+      await expect(
+        service.hasCapability("g1", "categories", "edit"),
+      ).resolves.toBe(true);
+      await expect(service.hasCapability("g1", "tags", "delete")).resolves.toBe(
+        true,
+      );
     });
   });
 
   describe("getCapabilities", () => {
-    it("returns all flags for an active delegation", async () => {
+    it("returns the nested capability set for an active delegation", async () => {
       delegatesRepo.findOne.mockResolvedValue({
-        canManagePayees: true,
-        canManageCategories: false,
-        canManageTags: true,
+        payeesCanCreate: true,
+        payeesCanEdit: false,
+        payeesCanDelete: true,
+        categoriesCanCreate: false,
+        categoriesCanEdit: true,
+        categoriesCanDelete: false,
+        tagsCanCreate: false,
+        tagsCanEdit: false,
+        tagsCanDelete: false,
       });
       await expect(service.getCapabilities("g1")).resolves.toEqual({
-        payees: true,
-        categories: false,
-        tags: true,
+        payees: { create: true, edit: false, delete: true },
+        categories: { create: false, edit: true, delete: false },
+        tags: { create: false, edit: false, delete: false },
       });
     });
 
     it("returns all-false when there is no active delegation", async () => {
       delegatesRepo.findOne.mockResolvedValue(null);
       await expect(service.getCapabilities("g1")).resolves.toEqual({
-        payees: false,
-        categories: false,
-        tags: false,
+        payees: { create: false, edit: false, delete: false },
+        categories: { create: false, edit: false, delete: false },
+        tags: { create: false, edit: false, delete: false },
       });
     });
   });
@@ -523,7 +550,7 @@ describe("DelegationService", () => {
     it("throws when the delegation is not owned by the caller", async () => {
       delegatesRepo.findOne.mockResolvedValue(null);
       await expect(
-        service.setCapabilities("o1", "g1", { canManagePayees: true }),
+        service.setCapabilities("o1", "g1", { payeesCanCreate: true }),
       ).rejects.toBeInstanceOf(NotFoundException);
     });
 
@@ -531,18 +558,23 @@ describe("DelegationService", () => {
       const delegation = {
         id: "g1",
         ownerUserId: "o1",
-        canManagePayees: false,
-        canManageCategories: true,
-        canManageTags: false,
+        payeesCanCreate: false,
+        payeesCanEdit: false,
+        categoriesCanEdit: true,
+        tagsCanDelete: false,
       };
       delegatesRepo.findOne.mockResolvedValue(delegation);
       delegatesRepo.save.mockResolvedValue(delegation);
 
-      await service.setCapabilities("o1", "g1", { canManagePayees: true });
+      await service.setCapabilities("o1", "g1", {
+        payeesCanCreate: true,
+        tagsCanDelete: true,
+      });
 
-      expect(delegation.canManagePayees).toBe(true);
-      expect(delegation.canManageCategories).toBe(true); // unchanged
-      expect(delegation.canManageTags).toBe(false); // unchanged
+      expect(delegation.payeesCanCreate).toBe(true);
+      expect(delegation.tagsCanDelete).toBe(true);
+      expect(delegation.payeesCanEdit).toBe(false); // unchanged
+      expect(delegation.categoriesCanEdit).toBe(true); // unchanged
       expect(delegatesRepo.save).toHaveBeenCalledWith(delegation);
     });
   });

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -481,6 +481,36 @@ describe("DelegationService", () => {
           categories: { create: false, edit: false, delete: false },
           tags: { create: true, edit: false, delete: false },
         },
+        sections: {
+          bills: false,
+          investments: false,
+          budgets: false,
+          reports: false,
+          ai: false,
+        },
+      });
+    });
+
+    it("includes granted sections in the summary", async () => {
+      delegatesRepo.find.mockResolvedValue([
+        {
+          id: "g1",
+          status: "active",
+          createdAt: new Date("2026-01-01"),
+          delegateUserId: "d1",
+          delegate: { email: "d@e.f", passwordHash: "h" },
+          billsCanRead: true,
+          reportsCanRead: true,
+          grants: [],
+        },
+      ]);
+      const res = await service.listDelegates("o1");
+      expect(res[0].sections).toEqual({
+        bills: true,
+        investments: false,
+        budgets: false,
+        reports: true,
+        ai: false,
       });
     });
   });
@@ -575,6 +605,88 @@ describe("DelegationService", () => {
       expect(delegation.tagsCanDelete).toBe(true);
       expect(delegation.payeesCanEdit).toBe(false); // unchanged
       expect(delegation.categoriesCanEdit).toBe(true); // unchanged
+      expect(delegatesRepo.save).toHaveBeenCalledWith(delegation);
+    });
+  });
+
+  describe("hasSection", () => {
+    it("is false when there is no active delegation", async () => {
+      delegatesRepo.findOne.mockResolvedValue(null);
+      await expect(service.hasSection("g1", "bills")).resolves.toBe(false);
+    });
+
+    it("maps the section to the matching flag", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        billsCanRead: true,
+        investmentsCanRead: false,
+        budgetsCanRead: true,
+      });
+      await expect(service.hasSection("g1", "bills")).resolves.toBe(true);
+      await expect(service.hasSection("g1", "investments")).resolves.toBe(
+        false,
+      );
+      await expect(service.hasSection("g1", "budgets")).resolves.toBe(true);
+      await expect(service.hasSection("g1", "ai")).resolves.toBe(false);
+    });
+  });
+
+  describe("getSections", () => {
+    it("returns the section set for an active delegation", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        billsCanRead: true,
+        investmentsCanRead: false,
+        budgetsCanRead: false,
+        reportsCanRead: true,
+        aiCanRead: true,
+      });
+      await expect(service.getSections("g1")).resolves.toEqual({
+        bills: true,
+        investments: false,
+        budgets: false,
+        reports: true,
+        ai: true,
+      });
+    });
+
+    it("returns all-false when there is no active delegation", async () => {
+      delegatesRepo.findOne.mockResolvedValue(null);
+      await expect(service.getSections("g1")).resolves.toEqual({
+        bills: false,
+        investments: false,
+        budgets: false,
+        reports: false,
+        ai: false,
+      });
+    });
+  });
+
+  describe("setSectionGrants", () => {
+    it("throws when the delegation is not owned by the caller", async () => {
+      delegatesRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.setSectionGrants("o1", "g1", { billsCanRead: true }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it("updates only the provided sections", async () => {
+      const delegation = {
+        id: "g1",
+        ownerUserId: "o1",
+        billsCanRead: false,
+        investmentsCanRead: true,
+        reportsCanRead: false,
+      };
+      delegatesRepo.findOne.mockResolvedValue(delegation);
+      delegatesRepo.save.mockResolvedValue(delegation);
+
+      await service.setSectionGrants("o1", "g1", {
+        billsCanRead: true,
+        reportsCanRead: true,
+      });
+
+      expect(delegation.billsCanRead).toBe(true);
+      expect(delegation.reportsCanRead).toBe(true);
+      expect(delegation.investmentsCanRead).toBe(true); // unchanged
       expect(delegatesRepo.save).toHaveBeenCalledWith(delegation);
     });
   });

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -1285,8 +1285,18 @@ describe("DelegationService", () => {
 
     it("reorderDelegateFavourites sets sortOrder by position", async () => {
       const manager = { update: jest.fn() };
-      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+      const queryRunner = {
+        connect: jest.fn(),
+        startTransaction: jest.fn(),
+        commitTransaction: jest.fn(),
+        rollbackTransaction: jest.fn(),
+        release: jest.fn(),
+        manager,
+      };
+      dataSource.createQueryRunner = jest.fn().mockReturnValue(queryRunner);
       await service.reorderDelegateFavourites("d1", ["a2", "a1"]);
+      expect(queryRunner.commitTransaction).toHaveBeenCalled();
+      expect(queryRunner.release).toHaveBeenCalled();
       expect(manager.update).toHaveBeenNthCalledWith(
         1,
         DelegateAccountFavourite,

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -495,6 +495,30 @@ describe("DelegationService", () => {
     });
   });
 
+  describe("getCapabilities", () => {
+    it("returns all flags for an active delegation", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        canManagePayees: true,
+        canManageCategories: false,
+        canManageTags: true,
+      });
+      await expect(service.getCapabilities("g1")).resolves.toEqual({
+        payees: true,
+        categories: false,
+        tags: true,
+      });
+    });
+
+    it("returns all-false when there is no active delegation", async () => {
+      delegatesRepo.findOne.mockResolvedValue(null);
+      await expect(service.getCapabilities("g1")).resolves.toEqual({
+        payees: false,
+        categories: false,
+        tags: false,
+      });
+    });
+  });
+
   describe("setCapabilities", () => {
     it("throws when the delegation is not owned by the caller", async () => {
       delegatesRepo.findOne.mockResolvedValue(null);

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -191,4 +191,403 @@ describe("DelegationService", () => {
       expect(manager.save).toHaveBeenCalled();
     });
   });
+
+  describe("delegateMustEnrollOwn2FA", () => {
+    it("is false when the owner does not require 2FA", async () => {
+      usersRepo.findOne.mockResolvedValue({ id: "o1", twoFactorSecret: null });
+      prefsRepo.findOne.mockResolvedValue({ twoFactorEnabled: false });
+      await expect(service.delegateMustEnrollOwn2FA("o1", "d1")).resolves.toBe(
+        false,
+      );
+    });
+
+    it("is false when the delegate already has their own 2FA", async () => {
+      usersRepo.findOne.mockImplementation(({ where }: any) =>
+        where.id === "o1"
+          ? { id: "o1", twoFactorSecret: "s" }
+          : { id: "d1", twoFactorSecret: "d" },
+      );
+      prefsRepo.findOne.mockImplementation(({ where }: any) =>
+        where.userId === "o1"
+          ? { twoFactorEnabled: true }
+          : { twoFactorEnabled: true },
+      );
+      await expect(service.delegateMustEnrollOwn2FA("o1", "d1")).resolves.toBe(
+        false,
+      );
+    });
+  });
+
+  describe("resolveSwitchTarget", () => {
+    it("throws DELEGATE_2FA_REQUIRED when the target owner requires 2FA", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        id: "g1",
+        delegateUserId: "d1",
+        ownerUserId: "o1",
+        status: "active",
+      });
+      usersRepo.findOne.mockImplementation(({ where }: any) =>
+        where.id === "o1"
+          ? { id: "o1", twoFactorSecret: "s" }
+          : { id: "d1", twoFactorSecret: null },
+      );
+      prefsRepo.findOne.mockImplementation(({ where }: any) =>
+        where.userId === "o1"
+          ? { twoFactorEnabled: true }
+          : { twoFactorEnabled: false },
+      );
+      await expect(service.resolveSwitchTarget("d1", "o1")).rejects.toThrow(
+        DELEGATE_2FA_REQUIRED,
+      );
+    });
+
+    it("returns the delegation when the switch is allowed", async () => {
+      const delegation = {
+        id: "g1",
+        delegateUserId: "d1",
+        ownerUserId: "o1",
+        status: "active",
+      };
+      delegatesRepo.findOne.mockResolvedValue(delegation);
+      usersRepo.findOne.mockResolvedValue({ id: "o1", twoFactorSecret: null });
+      prefsRepo.findOne.mockResolvedValue({ twoFactorEnabled: false });
+      await expect(service.resolveSwitchTarget("d1", "o1")).resolves.toBe(
+        delegation,
+      );
+    });
+  });
+
+  describe("getAvailableContexts", () => {
+    it("returns [] when the user does not exist", async () => {
+      usersRepo.findOne.mockResolvedValue(null);
+      await expect(service.getAvailableContexts("u1")).resolves.toEqual([]);
+    });
+
+    it("returns [] for a user with no delegations", async () => {
+      usersRepo.findOne.mockResolvedValue({ id: "u1" });
+      delegatesRepo.find.mockResolvedValue([]);
+      await expect(service.getAvailableContexts("u1")).resolves.toEqual([]);
+    });
+
+    it("includes a self context only when the user owns data", async () => {
+      usersRepo.findOne.mockImplementation(({ where }: any) =>
+        where.id === "u1"
+          ? { id: "u1", firstName: "Del", lastName: "Egate" }
+          : {
+              id: "o1",
+              firstName: "Own",
+              lastName: "Er",
+              twoFactorSecret: null,
+            },
+      );
+      delegatesRepo.find.mockResolvedValue([
+        {
+          ownerUserId: "o1",
+          owner: { id: "o1", firstName: "Own", lastName: "Er" },
+        },
+      ]);
+      accountsRepo.exists.mockResolvedValue(true);
+      prefsRepo.findOne.mockResolvedValue({ twoFactorEnabled: false });
+
+      const res = await service.getAvailableContexts("u1");
+      expect(res).toHaveLength(2);
+      expect(res[0]).toEqual(
+        expect.objectContaining({ userId: "u1", isSelf: true }),
+      );
+      expect(res[1]).toEqual(
+        expect.objectContaining({ userId: "o1", isSelf: false }),
+      );
+    });
+
+    it("omits the self context when the user owns no data", async () => {
+      usersRepo.findOne.mockImplementation(({ where }: any) =>
+        where.id === "u1" ? { id: "u1" } : { id: "o1", twoFactorSecret: null },
+      );
+      delegatesRepo.find.mockResolvedValue([
+        { ownerUserId: "o1", owner: null },
+      ]);
+      accountsRepo.exists.mockResolvedValue(false);
+      prefsRepo.findOne.mockResolvedValue({ twoFactorEnabled: false });
+
+      const res = await service.getAvailableContexts("u1");
+      expect(res).toHaveLength(1);
+      expect(res[0].isSelf).toBe(false);
+      expect(res[0].label).toBe("o1");
+    });
+  });
+
+  describe("listDelegates", () => {
+    it("maps delegations to a safe summary", async () => {
+      delegatesRepo.find.mockResolvedValue([
+        {
+          id: "g1",
+          status: "active",
+          createdAt: new Date("2026-01-01"),
+          delegateUserId: "d1",
+          delegate: {
+            email: "d@e.f",
+            firstName: "D",
+            lastName: null,
+            passwordHash: "h",
+          },
+          grants: [
+            { accountId: "a1", canRead: true },
+            { accountId: "a2", canRead: false },
+          ],
+        },
+      ]);
+      const res = await service.listDelegates("o1");
+      expect(res[0]).toEqual({
+        id: "g1",
+        status: "active",
+        createdAt: new Date("2026-01-01"),
+        delegate: {
+          id: "d1",
+          email: "d@e.f",
+          firstName: "D",
+          lastName: null,
+          hasPassword: true,
+        },
+        accountIds: ["a1"],
+      });
+    });
+  });
+
+  describe("revokeDelegate", () => {
+    it("throws when the delegation is not found", async () => {
+      delegatesRepo.findOne.mockResolvedValue(null);
+      await expect(service.revokeDelegate("o1", "g1")).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it("revokes the delegation and kills live sessions", async () => {
+      const delegation = { id: "g1", ownerUserId: "o1", status: "active" };
+      delegatesRepo.findOne.mockResolvedValue(delegation);
+      delegatesRepo.save.mockResolvedValue(delegation);
+      await service.revokeDelegate("o1", "g1");
+      expect(delegation.status).toBe("revoked");
+      expect(refreshRepo.update).toHaveBeenCalledWith(
+        { delegationId: "g1", isRevoked: false },
+        { isRevoked: true },
+      );
+    });
+  });
+
+  describe("resetDelegatePassword", () => {
+    it("throws when the delegation is not found", async () => {
+      delegatesRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.resetDelegatePassword("o1", "g1"),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it("rejects an SSO delegate", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        id: "g1",
+        delegateUserId: "d1",
+      });
+      usersRepo.findOne.mockResolvedValue({ id: "d1", oidcSubject: "sso" });
+      await expect(service.resetDelegatePassword("o1", "g1")).rejects.toThrow(
+        /SSO/,
+      );
+    });
+
+    it("sets a temporary password and revokes sessions", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        id: "g1",
+        delegateUserId: "d1",
+      });
+      const delegate = { id: "d1", oidcSubject: null };
+      usersRepo.findOne.mockResolvedValue(delegate);
+      usersRepo.save.mockResolvedValue(delegate);
+      const res = await service.resetDelegatePassword("o1", "g1");
+      expect(res.temporaryPassword).toBeTruthy();
+      expect((delegate as any).mustChangePassword).toBe(true);
+      expect(refreshRepo.update).toHaveBeenCalledWith(
+        { userId: "d1", isRevoked: false },
+        { isRevoked: true },
+      );
+    });
+  });
+
+  describe("createDelegate", () => {
+    const makeManager = () => {
+      const manager: any = {
+        findOne: jest.fn(),
+        create: jest.fn((_e: any, v: any) => v),
+        save: jest.fn((v: any) => ({ id: "g-new", ...v })),
+      };
+      return manager;
+    };
+
+    it("throws when the owner is not found", async () => {
+      usersRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.createDelegate("o1", { email: "a@b.c" } as any),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it("rejects delegating to your own email", async () => {
+      usersRepo.findOne.mockResolvedValue({ id: "o1", email: "me@x.y" });
+      await expect(
+        service.createDelegate("o1", { email: "ME@x.y" } as any),
+      ).rejects.toThrow(/yourself/);
+    });
+
+    it("auto-generates a temporary password for a brand-new delegate", async () => {
+      usersRepo.findOne.mockResolvedValue({ id: "o1", email: "own@x.y" });
+      const manager = makeManager();
+      manager.findOne.mockResolvedValue(null); // no existing user, no delegation
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+      const res = await service.createDelegate("o1", {
+        email: "new@x.y",
+      } as any);
+      expect(res.temporaryPassword).toBeTruthy();
+      expect(res.invited).toBe(false);
+    });
+
+    it("sends an invite when sendInvite is set and SMTP is configured", async () => {
+      usersRepo.findOne.mockResolvedValue({ id: "o1", email: "own@x.y" });
+      emailService.getStatus.mockReturnValue({ configured: true });
+      emailService.sendMail.mockResolvedValue(undefined);
+      configService.get.mockReturnValue("http://app");
+      const manager = makeManager();
+      manager.findOne.mockResolvedValue(null);
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+      const res = await service.createDelegate("o1", {
+        email: "new@x.y",
+        sendInvite: true,
+      } as any);
+      expect(res.invited).toBe(true);
+      expect(emailService.sendMail).toHaveBeenCalled();
+    });
+
+    it("rejects an invite when SMTP is not configured", async () => {
+      usersRepo.findOne.mockResolvedValue({ id: "o1", email: "own@x.y" });
+      emailService.getStatus.mockReturnValue({ configured: false });
+      const manager = makeManager();
+      manager.findOne.mockResolvedValue(null);
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+      await expect(
+        service.createDelegate("o1", {
+          email: "new@x.y",
+          sendInvite: true,
+        } as any),
+      ).rejects.toThrow(/SMTP/);
+    });
+
+    it("uses an owner-supplied password without forcing a change", async () => {
+      usersRepo.findOne.mockResolvedValue({ id: "o1", email: "own@x.y" });
+      const manager = makeManager();
+      manager.findOne.mockResolvedValue(null);
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+      const res = await service.createDelegate("o1", {
+        email: "new@x.y",
+        password: "StrongPass1!xyz",
+      } as any);
+      expect(res.temporaryPassword).toBeUndefined();
+      expect(res.invited).toBe(false);
+    });
+
+    it("reactivates a previously revoked delegation for an existing user", async () => {
+      usersRepo.findOne.mockResolvedValue({ id: "o1", email: "own@x.y" });
+      const manager = makeManager();
+      const existingDelegation = { id: "g1", status: "revoked" };
+      manager.findOne
+        .mockResolvedValueOnce({ id: "d1" }) // existing user
+        .mockResolvedValueOnce(existingDelegation); // existing delegation
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+      await service.createDelegate("o1", { email: "new@x.y" } as any);
+      expect(existingDelegation.status).toBe("active");
+    });
+
+    it("conflicts when the user is already an active delegate", async () => {
+      usersRepo.findOne.mockResolvedValue({ id: "o1", email: "own@x.y" });
+      const manager = makeManager();
+      manager.findOne
+        .mockResolvedValueOnce({ id: "d1" })
+        .mockResolvedValueOnce({ id: "g1", status: "active" });
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+      await expect(
+        service.createDelegate("o1", { email: "new@x.y" } as any),
+      ).rejects.toThrow(/already a delegate/);
+    });
+
+    it("rejects when the existing user is the owner themselves", async () => {
+      usersRepo.findOne.mockResolvedValue({ id: "o1", email: "own@x.y" });
+      const manager = makeManager();
+      manager.findOne.mockResolvedValueOnce({ id: "o1" });
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+      await expect(
+        service.createDelegate("o1", { email: "new@x.y" } as any),
+      ).rejects.toThrow(/yourself/);
+    });
+
+    it("throws when the new delegate user fails to persist", async () => {
+      usersRepo.findOne.mockResolvedValue({ id: "o1", email: "own@x.y" });
+      const manager: any = {
+        findOne: jest.fn().mockResolvedValue(null),
+        create: jest.fn((_e: any, v: any) => v),
+        save: jest.fn().mockResolvedValue(undefined),
+      };
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+      await expect(
+        service.createDelegate("o1", {
+          email: "new@x.y",
+          password: "StrongPass1!xyz",
+        } as any),
+      ).rejects.toThrow(/Unable to create delegate/);
+    });
+
+    it("logs (does not throw) when the invite email fails to send", async () => {
+      usersRepo.findOne.mockResolvedValue({ id: "o1", email: "own@x.y" });
+      emailService.getStatus.mockReturnValue({ configured: true });
+      emailService.sendMail.mockRejectedValue(new Error("smtp down"));
+      configService.get.mockReturnValue("http://app");
+      const manager: any = {
+        findOne: jest.fn().mockResolvedValue(null),
+        create: jest.fn((_e: any, v: any) => v),
+        save: jest.fn((v: any) => ({ id: "g-new", ...v })),
+      };
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+      const res = await service.createDelegate("o1", {
+        email: "new@x.y",
+        sendInvite: true,
+      } as any);
+      expect(res.invited).toBe(true);
+      await new Promise((r) => setImmediate(r));
+      expect(emailService.sendMail).toHaveBeenCalled();
+    });
+  });
+
+  describe("readableAccountIds", () => {
+    it("returns the account ids of READ grants", async () => {
+      grantsRepo.find.mockResolvedValue([
+        { accountId: "a1" },
+        { accountId: "a2" },
+      ]);
+      await expect(service.readableAccountIds("g1")).resolves.toEqual([
+        "a1",
+        "a2",
+      ]);
+      expect(grantsRepo.find).toHaveBeenCalledWith({
+        where: { delegationId: "g1", canRead: true },
+        select: ["accountId"],
+      });
+    });
+  });
+
+  describe("resetDelegatePassword (missing delegate user)", () => {
+    it("throws when the delegate user no longer exists", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        id: "g1",
+        delegateUserId: "d1",
+      });
+      usersRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.resetDelegatePassword("o1", "g1"),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
 });

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -23,7 +23,12 @@ describe("DelegationService", () => {
   let dataSource: Record<string, jest.Mock>;
 
   beforeEach(() => {
-    delegatesRepo = { findOne: jest.fn(), find: jest.fn(), save: jest.fn() };
+    delegatesRepo = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+      save: jest.fn(),
+      count: jest.fn().mockResolvedValue(0),
+    };
     grantsRepo = { findOne: jest.fn(), find: jest.fn(), count: jest.fn() };
     usersRepo = { findOne: jest.fn(), save: jest.fn() };
     prefsRepo = { findOne: jest.fn() };
@@ -509,6 +514,7 @@ describe("DelegationService", () => {
           firstName: "D",
           lastName: null,
           hasPassword: true,
+          canResetPassword: true,
         },
         grants: [
           {
@@ -899,6 +905,60 @@ describe("DelegationService", () => {
         { isRevoked: true },
       );
     });
+
+    it("refuses when the delegate is a full account (owns accounts)", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        id: "g1",
+        delegateUserId: "d1",
+      });
+      usersRepo.findOne.mockResolvedValue({ id: "d1", oidcSubject: null });
+      accountsRepo.count.mockResolvedValue(2); // owns their own accounts
+      await expect(service.resetDelegatePassword("o1", "g1")).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(usersRepo.save).not.toHaveBeenCalled();
+    });
+
+    it("refuses when the delegate is a delegate for another owner too", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        id: "g1",
+        delegateUserId: "d1",
+      });
+      usersRepo.findOne.mockResolvedValue({ id: "d1", oidcSubject: null });
+      accountsRepo.count.mockResolvedValue(0);
+      // isFullAccount's ownerUserId count = 0; delegateUserId count = 2.
+      delegatesRepo.count = jest
+        .fn()
+        .mockResolvedValueOnce(0) // ownsDelegations (isFullAccount)
+        .mockResolvedValueOnce(2); // delegations as delegate
+      await expect(service.resetDelegatePassword("o1", "g1")).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(usersRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("canOwnerResetDelegatePassword", () => {
+    it("is true for an owner-provisioned pure delegate", async () => {
+      accountsRepo.count.mockResolvedValue(0);
+      delegatesRepo.count = jest.fn().mockResolvedValue(0);
+      usersRepo.findOne.mockResolvedValue({ id: "d1", role: "user" });
+      await expect(service.canOwnerResetDelegatePassword("d1")).resolves.toBe(
+        true,
+      );
+    });
+
+    it("is false when the delegate is also a delegate elsewhere", async () => {
+      accountsRepo.count.mockResolvedValue(0);
+      delegatesRepo.count = jest
+        .fn()
+        .mockResolvedValueOnce(0) // ownsDelegations (isFullAccount)
+        .mockResolvedValueOnce(2); // delegations as delegate
+      usersRepo.findOne.mockResolvedValue({ id: "d1", role: "user" });
+      await expect(service.canOwnerResetDelegatePassword("d1")).resolves.toBe(
+        false,
+      );
+    });
   });
 
   describe("delegateEmailExists", () => {
@@ -1213,6 +1273,14 @@ describe("DelegationService", () => {
         accountId: "a1",
         sortOrder: 0,
       });
+    });
+
+    it("reorderDelegateFavourites rejects a non-array (CWE-834)", async () => {
+      await expect(
+        service.reorderDelegateFavourites("d1", {
+          length: 1e9,
+        } as unknown as string[]),
+      ).rejects.toThrow(/must be an array/);
     });
 
     it("reorderDelegateFavourites sets sortOrder by position", async () => {

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -891,6 +891,23 @@ describe("DelegationService", () => {
     });
   });
 
+  describe("delegateEmailExists", () => {
+    it("is true when a user with the (normalized) email exists", async () => {
+      usersRepo.findOne.mockResolvedValue({ id: "u1" });
+      await expect(service.delegateEmailExists("  Foo@Bar.Com ")).resolves.toBe(
+        true,
+      );
+      expect(usersRepo.findOne).toHaveBeenCalledWith({
+        where: { email: "foo@bar.com" },
+      });
+    });
+
+    it("is false when no user has that email", async () => {
+      usersRepo.findOne.mockResolvedValue(null);
+      await expect(service.delegateEmailExists("x@y.z")).resolves.toBe(false);
+    });
+  });
+
   describe("createDelegate", () => {
     const makeManager = () => {
       const manager: any = {

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -15,6 +15,7 @@ describe("DelegationService", () => {
   let refreshRepo: Record<string, jest.Mock>;
   let accountsRepo: Record<string, jest.Mock>;
   let transactionsRepo: Record<string, jest.Mock>;
+  let scheduledTxRepo: Record<string, jest.Mock>;
   let emailService: Record<string, jest.Mock>;
   let configService: Record<string, jest.Mock>;
   let dataSource: Record<string, jest.Mock>;
@@ -27,6 +28,7 @@ describe("DelegationService", () => {
     refreshRepo = { update: jest.fn() };
     accountsRepo = { find: jest.fn(), exists: jest.fn() };
     transactionsRepo = { findOne: jest.fn() };
+    scheduledTxRepo = { findOne: jest.fn() };
     emailService = { getStatus: jest.fn(), sendMail: jest.fn() };
     configService = { get: jest.fn() };
     dataSource = { transaction: jest.fn() };
@@ -39,6 +41,7 @@ describe("DelegationService", () => {
       refreshRepo as any,
       accountsRepo as any,
       transactionsRepo as any,
+      scheduledTxRepo as any,
       emailService as any,
       configService as any,
       dataSource as any,
@@ -177,6 +180,36 @@ describe("DelegationService", () => {
     it("returns [] when the transaction does not exist", async () => {
       transactionsRepo.findOne.mockResolvedValueOnce(null);
       await expect(service.accountIdsForTransfer("t1")).resolves.toEqual([]);
+    });
+  });
+
+  describe("accountIdsForScheduled", () => {
+    it("returns [] when the scheduled row does not exist", async () => {
+      scheduledTxRepo.findOne.mockResolvedValue(null);
+      await expect(service.accountIdsForScheduled("s1")).resolves.toEqual([]);
+    });
+
+    it("returns just the account for a non-transfer", async () => {
+      scheduledTxRepo.findOne.mockResolvedValue({
+        accountId: "a1",
+        isTransfer: false,
+        transferAccountId: null,
+      });
+      await expect(service.accountIdsForScheduled("s1")).resolves.toEqual([
+        "a1",
+      ]);
+    });
+
+    it("returns both accounts for a transfer", async () => {
+      scheduledTxRepo.findOne.mockResolvedValue({
+        accountId: "a1",
+        isTransfer: true,
+        transferAccountId: "a2",
+      });
+      await expect(service.accountIdsForScheduled("s1")).resolves.toEqual([
+        "a1",
+        "a2",
+      ]);
     });
   });
 

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -870,12 +870,20 @@ describe("DelegationService", () => {
         id: "g1",
         delegateUserId: "d1",
       });
-      const delegate = { id: "d1", oidcSubject: null };
+      const delegate = {
+        id: "d1",
+        oidcSubject: null,
+        failedLoginAttempts: 5,
+        lockedUntil: new Date(Date.now() + 60000),
+      };
       usersRepo.findOne.mockResolvedValue(delegate);
       usersRepo.save.mockResolvedValue(delegate);
       const res = await service.resetDelegatePassword("o1", "g1");
       expect(res.temporaryPassword).toBeTruthy();
       expect((delegate as any).mustChangePassword).toBe(true);
+      // Owner reset must clear any lockout so the delegate can sign in.
+      expect((delegate as any).failedLoginAttempts).toBe(0);
+      expect((delegate as any).lockedUntil).toBeNull();
       expect(refreshRepo.update).toHaveBeenCalledWith(
         { userId: "d1", isRevoked: false },
         { isRevoked: true },
@@ -918,6 +926,31 @@ describe("DelegationService", () => {
       } as any);
       expect(res.temporaryPassword).toBeTruthy();
       expect(res.invited).toBe(false);
+    });
+
+    it("clears lockout when the owner sets a password for a locked delegate", async () => {
+      usersRepo.findOne.mockResolvedValue({ id: "o1", email: "own@x.y" });
+      const lockedUser = {
+        id: "d1",
+        email: "new@x.y",
+        oidcSubject: null,
+        role: "user",
+        passwordHash: "old-hash",
+        failedLoginAttempts: 5,
+        lockedUntil: new Date(Date.now() + 60000),
+      };
+      const manager = makeManager();
+      manager.findOne
+        .mockResolvedValueOnce(lockedUser) // User by email
+        .mockResolvedValueOnce(null); // no existing delegation
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+      await service.createDelegate("o1", {
+        email: "new@x.y",
+        password: "StrongPass1!xyz",
+      } as any);
+      expect(lockedUser.failedLoginAttempts).toBe(0);
+      expect(lockedUser.lockedUntil).toBeNull();
+      expect(lockedUser.passwordHash).not.toBe("old-hash");
     });
 
     it("sends an invite when sendInvite is set and SMTP is configured", async () => {

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -5,6 +5,7 @@ import {
 } from "@nestjs/common";
 import * as bcrypt from "bcryptjs";
 import { DelegationService, DELEGATE_2FA_REQUIRED } from "./delegation.service";
+import { DelegateAccountFavourite } from "./entities/delegate-account-favourite.entity";
 
 describe("DelegationService", () => {
   let service: DelegationService;
@@ -16,6 +17,7 @@ describe("DelegationService", () => {
   let accountsRepo: Record<string, jest.Mock>;
   let transactionsRepo: Record<string, jest.Mock>;
   let scheduledTxRepo: Record<string, jest.Mock>;
+  let delegateFavouritesRepo: Record<string, jest.Mock>;
   let emailService: Record<string, jest.Mock>;
   let configService: Record<string, jest.Mock>;
   let dataSource: Record<string, jest.Mock>;
@@ -29,6 +31,13 @@ describe("DelegationService", () => {
     accountsRepo = { find: jest.fn(), exists: jest.fn(), count: jest.fn() };
     transactionsRepo = { findOne: jest.fn() };
     scheduledTxRepo = { findOne: jest.fn() };
+    delegateFavouritesRepo = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      delete: jest.fn(),
+      save: jest.fn(),
+      create: jest.fn((v) => v),
+    };
     emailService = { getStatus: jest.fn(), sendMail: jest.fn() };
     configService = { get: jest.fn() };
     dataSource = { transaction: jest.fn() };
@@ -42,6 +51,7 @@ describe("DelegationService", () => {
       accountsRepo as any,
       transactionsRepo as any,
       scheduledTxRepo as any,
+      delegateFavouritesRepo as any,
       emailService as any,
       configService as any,
       dataSource as any,
@@ -1165,6 +1175,62 @@ describe("DelegationService", () => {
     it("is true when the delegate can read at least one account", async () => {
       grantsRepo.count.mockResolvedValue(2);
       await expect(service.hasAnyAccountAccess("g1")).resolves.toBe(true);
+    });
+  });
+
+  describe("delegate favourites overlay", () => {
+    it("getDelegateFavourites maps accountId -> sortOrder", async () => {
+      delegateFavouritesRepo.find.mockResolvedValue([
+        { accountId: "a1", sortOrder: 0 },
+        { accountId: "a2", sortOrder: 3 },
+      ]);
+      const map = await service.getDelegateFavourites("d1");
+      expect(map.get("a1")).toBe(0);
+      expect(map.get("a2")).toBe(3);
+      expect(map.size).toBe(2);
+    });
+
+    it("setDelegateFavourite removes the row when unfavouriting", async () => {
+      await service.setDelegateFavourite("d1", "a1", false);
+      expect(delegateFavouritesRepo.delete).toHaveBeenCalledWith({
+        delegateUserId: "d1",
+        accountId: "a1",
+      });
+      expect(delegateFavouritesRepo.save).not.toHaveBeenCalled();
+    });
+
+    it("setDelegateFavourite is idempotent when already a favourite", async () => {
+      delegateFavouritesRepo.findOne.mockResolvedValue({ id: "f1" });
+      await service.setDelegateFavourite("d1", "a1", true);
+      expect(delegateFavouritesRepo.save).not.toHaveBeenCalled();
+    });
+
+    it("setDelegateFavourite inserts a new favourite", async () => {
+      delegateFavouritesRepo.findOne.mockResolvedValue(null);
+      await service.setDelegateFavourite("d1", "a1", true);
+      expect(delegateFavouritesRepo.save).toHaveBeenCalledWith({
+        delegateUserId: "d1",
+        accountId: "a1",
+        sortOrder: 0,
+      });
+    });
+
+    it("reorderDelegateFavourites sets sortOrder by position", async () => {
+      const manager = { update: jest.fn() };
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+      await service.reorderDelegateFavourites("d1", ["a2", "a1"]);
+      expect(manager.update).toHaveBeenNthCalledWith(
+        1,
+        DelegateAccountFavourite,
+        { delegateUserId: "d1", accountId: "a2" },
+        { sortOrder: 0 },
+      );
+      expect(manager.update).toHaveBeenNthCalledWith(
+        2,
+        DelegateAccountFavourite,
+        { delegateUserId: "d1", accountId: "a1" },
+        { sortOrder: 1 },
+      );
     });
   });
 

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -164,7 +164,10 @@ describe("DelegationService", () => {
       delegatesRepo.findOne.mockResolvedValue({ id: "g1", ownerUserId: "o1" });
       accountsRepo.find.mockResolvedValue([{ id: "a1" }]); // only 1 of 2 owned
       await expect(
-        service.setGrants("o1", "g1", ["a1", "a2"]),
+        service.setGrants("o1", "g1", [
+          { accountId: "a1", canRead: true },
+          { accountId: "a2", canRead: true },
+        ]),
       ).rejects.toBeInstanceOf(ForbiddenException);
     });
 
@@ -175,20 +178,78 @@ describe("DelegationService", () => {
       );
     });
 
-    it("replaces grants atomically for owned accounts", async () => {
+    it("rejects CREATE/EDIT/DELETE without READ", async () => {
+      delegatesRepo.findOne.mockResolvedValue({ id: "g1", ownerUserId: "o1" });
+      await expect(
+        service.setGrants("o1", "g1", [
+          { accountId: "a1", canRead: false, canCreate: true },
+        ]),
+      ).rejects.toThrow(/READ access is required/);
+    });
+
+    it("persists per-account CRUD flags for readable accounts", async () => {
       delegatesRepo.findOne.mockResolvedValue({ id: "g1", ownerUserId: "o1" });
       accountsRepo.find.mockResolvedValue([{ id: "a1" }]);
+      const saved: any[] = [];
       const manager = {
         delete: jest.fn(),
         create: jest.fn((_e, v) => v),
-        save: jest.fn(),
+        save: jest.fn((rows) => saved.push(...rows)),
       };
       dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
 
-      await service.setGrants("o1", "g1", ["a1"]);
+      await service.setGrants("o1", "g1", [
+        {
+          accountId: "a1",
+          canRead: true,
+          canCreate: true,
+          canEdit: false,
+          canDelete: true,
+        },
+        // canRead=false -> dropped entirely (no access)
+        { accountId: "a2", canRead: false },
+      ]);
 
       expect(manager.delete).toHaveBeenCalled();
-      expect(manager.save).toHaveBeenCalled();
+      expect(saved).toHaveLength(1);
+      expect(saved[0]).toEqual({
+        delegationId: "g1",
+        accountId: "a1",
+        canRead: true,
+        canCreate: true,
+        canEdit: false,
+        canDelete: true,
+      });
+    });
+  });
+
+  describe("hasAccountPermission", () => {
+    it("is false when there is no readable grant", async () => {
+      grantsRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.hasAccountPermission("g1", "a1", "read"),
+      ).resolves.toBe(false);
+    });
+
+    it("maps each operation to the matching flag", async () => {
+      grantsRepo.findOne.mockResolvedValue({
+        canRead: true,
+        canCreate: true,
+        canEdit: false,
+        canDelete: true,
+      });
+      await expect(
+        service.hasAccountPermission("g1", "a1", "read"),
+      ).resolves.toBe(true);
+      await expect(
+        service.hasAccountPermission("g1", "a1", "create"),
+      ).resolves.toBe(true);
+      await expect(
+        service.hasAccountPermission("g1", "a1", "edit"),
+      ).resolves.toBe(false);
+      await expect(
+        service.hasAccountPermission("g1", "a1", "delete"),
+      ).resolves.toBe(true);
     });
   });
 
@@ -331,7 +392,13 @@ describe("DelegationService", () => {
             passwordHash: "h",
           },
           grants: [
-            { accountId: "a1", canRead: true },
+            {
+              accountId: "a1",
+              canRead: true,
+              canCreate: true,
+              canEdit: false,
+              canDelete: false,
+            },
             { accountId: "a2", canRead: false },
           ],
         },
@@ -348,7 +415,15 @@ describe("DelegationService", () => {
           lastName: null,
           hasPassword: true,
         },
-        accountIds: ["a1"],
+        grants: [
+          {
+            accountId: "a1",
+            canRead: true,
+            canCreate: true,
+            canEdit: false,
+            canDelete: false,
+          },
+        ],
       });
     });
   });

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -26,7 +26,7 @@ describe("DelegationService", () => {
     usersRepo = { findOne: jest.fn(), save: jest.fn() };
     prefsRepo = { findOne: jest.fn() };
     refreshRepo = { update: jest.fn() };
-    accountsRepo = { find: jest.fn(), exists: jest.fn() };
+    accountsRepo = { find: jest.fn(), exists: jest.fn(), count: jest.fn() };
     transactionsRepo = { findOne: jest.fn() };
     scheduledTxRepo = { findOne: jest.fn() };
     emailService = { getStatus: jest.fn(), sendMail: jest.fn() };
@@ -1110,6 +1110,29 @@ describe("DelegationService", () => {
         where: { delegationId: "g1", canRead: true },
         select: ["accountId"],
       });
+    });
+  });
+
+  describe("hasTransactionalAccess", () => {
+    it("is false when there are no readable accounts", async () => {
+      grantsRepo.find.mockResolvedValue([]);
+      await expect(service.hasTransactionalAccess("g1")).resolves.toBe(false);
+      expect(accountsRepo.count).not.toHaveBeenCalled();
+    });
+
+    it("is false when every readable account is an investment account", async () => {
+      grantsRepo.find.mockResolvedValue([{ accountId: "a1" }]);
+      accountsRepo.count.mockResolvedValue(0);
+      await expect(service.hasTransactionalAccess("g1")).resolves.toBe(false);
+    });
+
+    it("is true when at least one readable account is non-investment", async () => {
+      grantsRepo.find.mockResolvedValue([
+        { accountId: "a1" },
+        { accountId: "a2" },
+      ]);
+      accountsRepo.count.mockResolvedValue(1);
+      await expect(service.hasTransactionalAccess("g1")).resolves.toBe(true);
     });
   });
 

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -434,6 +434,9 @@ describe("DelegationService", () => {
             lastName: null,
             passwordHash: "h",
           },
+          canManagePayees: true,
+          canManageCategories: false,
+          canManageTags: true,
           grants: [
             {
               accountId: "a1",
@@ -467,7 +470,56 @@ describe("DelegationService", () => {
             canDelete: false,
           },
         ],
+        capabilities: { payees: true, categories: false, tags: true },
       });
+    });
+  });
+
+  describe("hasCapability", () => {
+    it("is false when there is no active delegation", async () => {
+      delegatesRepo.findOne.mockResolvedValue(null);
+      await expect(service.hasCapability("g1", "payees")).resolves.toBe(false);
+    });
+
+    it("maps each capability to the matching flag", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        canManagePayees: true,
+        canManageCategories: false,
+        canManageTags: true,
+      });
+      await expect(service.hasCapability("g1", "payees")).resolves.toBe(true);
+      await expect(service.hasCapability("g1", "categories")).resolves.toBe(
+        false,
+      );
+      await expect(service.hasCapability("g1", "tags")).resolves.toBe(true);
+    });
+  });
+
+  describe("setCapabilities", () => {
+    it("throws when the delegation is not owned by the caller", async () => {
+      delegatesRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.setCapabilities("o1", "g1", { canManagePayees: true }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it("updates only the provided flags", async () => {
+      const delegation = {
+        id: "g1",
+        ownerUserId: "o1",
+        canManagePayees: false,
+        canManageCategories: true,
+        canManageTags: false,
+      };
+      delegatesRepo.findOne.mockResolvedValue(delegation);
+      delegatesRepo.save.mockResolvedValue(delegation);
+
+      await service.setCapabilities("o1", "g1", { canManagePayees: true });
+
+      expect(delegation.canManagePayees).toBe(true);
+      expect(delegation.canManageCategories).toBe(true); // unchanged
+      expect(delegation.canManageTags).toBe(false); // unchanged
+      expect(delegatesRepo.save).toHaveBeenCalledWith(delegation);
     });
   });
 

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -1,0 +1,194 @@
+import {
+  UnauthorizedException,
+  ForbiddenException,
+  NotFoundException,
+} from "@nestjs/common";
+import { DelegationService, DELEGATE_2FA_REQUIRED } from "./delegation.service";
+
+describe("DelegationService", () => {
+  let service: DelegationService;
+  let delegatesRepo: Record<string, jest.Mock>;
+  let grantsRepo: Record<string, jest.Mock>;
+  let usersRepo: Record<string, jest.Mock>;
+  let prefsRepo: Record<string, jest.Mock>;
+  let refreshRepo: Record<string, jest.Mock>;
+  let accountsRepo: Record<string, jest.Mock>;
+  let emailService: Record<string, jest.Mock>;
+  let configService: Record<string, jest.Mock>;
+  let dataSource: Record<string, jest.Mock>;
+
+  beforeEach(() => {
+    delegatesRepo = { findOne: jest.fn(), find: jest.fn(), save: jest.fn() };
+    grantsRepo = { findOne: jest.fn(), find: jest.fn() };
+    usersRepo = { findOne: jest.fn(), save: jest.fn() };
+    prefsRepo = { findOne: jest.fn() };
+    refreshRepo = { update: jest.fn() };
+    accountsRepo = { find: jest.fn(), exists: jest.fn() };
+    emailService = { getStatus: jest.fn(), sendMail: jest.fn() };
+    configService = { get: jest.fn() };
+    dataSource = { transaction: jest.fn() };
+
+    service = new DelegationService(
+      delegatesRepo as any,
+      grantsRepo as any,
+      usersRepo as any,
+      prefsRepo as any,
+      refreshRepo as any,
+      accountsRepo as any,
+      emailService as any,
+      configService as any,
+      dataSource as any,
+    );
+  });
+
+  describe("validateActingContext", () => {
+    const args = {
+      delegateUserId: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    };
+
+    it("rejects when the delegation is missing", async () => {
+      delegatesRepo.findOne.mockResolvedValue(null);
+      await expect(service.validateActingContext(args)).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+
+    it("rejects when the delegation is revoked", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        id: "g1",
+        status: "revoked",
+        delegateUserId: "d1",
+        ownerUserId: "o1",
+      });
+      await expect(service.validateActingContext(args)).rejects.toThrow(
+        "Delegated access is no longer valid",
+      );
+    });
+
+    it("rejects when the delegate id does not match the token", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        id: "g1",
+        status: "active",
+        delegateUserId: "someone-else",
+        ownerUserId: "o1",
+      });
+      await expect(service.validateActingContext(args)).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+
+    it("rejects when the owner is inactive", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        id: "g1",
+        status: "active",
+        delegateUserId: "d1",
+        ownerUserId: "o1",
+      });
+      usersRepo.findOne.mockResolvedValue({ id: "o1", isActive: false });
+      await expect(service.validateActingContext(args)).rejects.toThrow(
+        "Delegated access is no longer valid",
+      );
+    });
+
+    it("throws DELEGATE_2FA_REQUIRED when owner needs 2FA and delegate lacks it", async () => {
+      delegatesRepo.findOne.mockResolvedValue({
+        id: "g1",
+        status: "active",
+        delegateUserId: "d1",
+        ownerUserId: "o1",
+      });
+      // owner active (validateActingContext call) then owner+pref for 2FA
+      usersRepo.findOne.mockImplementation(({ where }: any) =>
+        where.id === "o1"
+          ? { id: "o1", isActive: true, twoFactorSecret: "secret" }
+          : { id: "d1", twoFactorSecret: null },
+      );
+      prefsRepo.findOne.mockImplementation(({ where }: any) =>
+        where.userId === "o1"
+          ? { userId: "o1", twoFactorEnabled: true }
+          : { userId: "d1", twoFactorEnabled: false },
+      );
+
+      await expect(service.validateActingContext(args)).rejects.toThrow(
+        DELEGATE_2FA_REQUIRED,
+      );
+    });
+
+    it("returns the delegation when everything checks out", async () => {
+      const delegation = {
+        id: "g1",
+        status: "active",
+        delegateUserId: "d1",
+        ownerUserId: "o1",
+      };
+      delegatesRepo.findOne.mockResolvedValue(delegation);
+      usersRepo.findOne.mockResolvedValue({
+        id: "o1",
+        isActive: true,
+        twoFactorSecret: null,
+      });
+      prefsRepo.findOne.mockResolvedValue({ twoFactorEnabled: false });
+
+      await expect(service.validateActingContext(args)).resolves.toBe(
+        delegation,
+      );
+    });
+  });
+
+  describe("hasReadAccess", () => {
+    it("is true only when a can_read grant exists", async () => {
+      grantsRepo.findOne.mockResolvedValue({ id: "x" });
+      await expect(service.hasReadAccess("g1", "a1")).resolves.toBe(true);
+      grantsRepo.findOne.mockResolvedValue(null);
+      await expect(service.hasReadAccess("g1", "a1")).resolves.toBe(false);
+    });
+  });
+
+  describe("resolveSwitchTarget", () => {
+    it("returns null for the delegate's own id (self)", async () => {
+      await expect(service.resolveSwitchTarget("d1", "d1")).resolves.toBeNull();
+    });
+
+    it("throws when there is no active delegation for the target", async () => {
+      delegatesRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.resolveSwitchTarget("d1", "o1"),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  describe("setGrants", () => {
+    it("rejects accounts that do not belong to the owner", async () => {
+      delegatesRepo.findOne.mockResolvedValue({ id: "g1", ownerUserId: "o1" });
+      accountsRepo.find.mockResolvedValue([{ id: "a1" }]); // only 1 of 2 owned
+      await expect(
+        service.setGrants("o1", "g1", ["a1", "a2"]),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it("throws when the delegation is not owned by the caller", async () => {
+      delegatesRepo.findOne.mockResolvedValue(null);
+      await expect(service.setGrants("o1", "g1", [])).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it("replaces grants atomically for owned accounts", async () => {
+      delegatesRepo.findOne.mockResolvedValue({ id: "g1", ownerUserId: "o1" });
+      accountsRepo.find.mockResolvedValue([{ id: "a1" }]);
+      const manager = {
+        delete: jest.fn(),
+        create: jest.fn((_e, v) => v),
+        save: jest.fn(),
+      };
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+
+      await service.setGrants("o1", "g1", ["a1"]);
+
+      expect(manager.delete).toHaveBeenCalled();
+      expect(manager.save).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -331,6 +331,20 @@ export class DelegationService {
     }
   }
 
+  /** All manage capabilities for an active delegation (all false if none). */
+  async getCapabilities(
+    delegationId: string,
+  ): Promise<{ payees: boolean; categories: boolean; tags: boolean }> {
+    const delegation = await this.delegatesRepository.findOne({
+      where: { id: delegationId, status: "active" },
+    });
+    return {
+      payees: !!delegation?.canManagePayees,
+      categories: !!delegation?.canManageCategories,
+      tags: !!delegation?.canManageTags,
+    };
+  }
+
   async setCapabilities(
     ownerUserId: string,
     delegationId: string,

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -325,16 +325,48 @@ export class DelegationService {
 
     return this.dataSource.transaction(async (manager) => {
       let delegateUser = await manager.findOne(User, { where: { email } });
+      const isNew = !delegateUser;
+
+      if (delegateUser && delegateUser.id === ownerUserId) {
+        throw new BadRequestException("You cannot delegate access to yourself");
+      }
+
+      // An existing user that is a full account in its own right (owns data,
+      // owns delegations, is an admin, or is SSO) must NEVER have its
+      // credentials touched here -- that would be account takeover. They log
+      // in with their own credentials; the owner only links the delegation.
+      // New users and pure-delegate identities are owner-managed, so the
+      // owner may set their password / send an invite.
+      let mayManageCredentials = true;
+      if (delegateUser) {
+        if (delegateUser.oidcSubject || delegateUser.role === "admin") {
+          mayManageCredentials = false;
+        } else {
+          const [ownsAccounts, ownsDelegations] = await Promise.all([
+            manager.count(Account, {
+              where: { userId: delegateUser.id },
+            }),
+            manager.count(AccountDelegate, {
+              where: { ownerUserId: delegateUser.id },
+            }),
+          ]);
+          if (ownsAccounts > 0 || ownsDelegations > 0) {
+            mayManageCredentials = false;
+          }
+        }
+      }
 
       if (!delegateUser) {
-        const newUser = manager.create(User, {
+        delegateUser = manager.create(User, {
           email,
           firstName: dto.firstName ?? null,
           lastName: dto.lastName ?? null,
           authProvider: "local",
           role: "user",
         });
+      }
 
+      if (mayManageCredentials) {
         if (dto.sendInvite) {
           if (!this.emailService.getStatus().configured) {
             throw new BadRequestException(
@@ -342,33 +374,34 @@ export class DelegationService {
             );
           }
           const rawToken = crypto.randomBytes(32).toString("hex");
-          newUser.resetToken = hashToken(rawToken);
-          newUser.resetTokenExpiry = new Date(Date.now() + 24 * 60 * 60 * 1000);
-          // The invitee sets their own password via the reset link, so they
-          // are NOT forced to change it again on first login.
+          delegateUser.resetToken = hashToken(rawToken);
+          delegateUser.resetTokenExpiry = new Date(
+            Date.now() + 24 * 60 * 60 * 1000,
+          );
+          // The invitee sets their own password via the reset link.
           inviteToken = rawToken;
         } else if (dto.password) {
-          newUser.passwordHash = await bcrypt.hash(
+          delegateUser.passwordHash = await bcrypt.hash(
             dto.password,
             this.BCRYPT_ROUNDS,
           );
-        } else {
+          delegateUser.mustChangePassword = false;
+          delegateUser.resetToken = null;
+          delegateUser.resetTokenExpiry = null;
+        } else if (isNew || !delegateUser.passwordHash) {
+          // Guarantee the delegate can actually sign in.
           temporaryPassword = generateReadablePassword();
-          newUser.passwordHash = await bcrypt.hash(
+          delegateUser.passwordHash = await bcrypt.hash(
             temporaryPassword,
             this.BCRYPT_ROUNDS,
           );
-          newUser.mustChangePassword = true;
+          delegateUser.mustChangePassword = true;
+          delegateUser.resetToken = null;
+          delegateUser.resetTokenExpiry = null;
         }
-
-        delegateUser = await manager.save(newUser);
-      } else if (delegateUser.id === ownerUserId) {
-        throw new BadRequestException("You cannot delegate access to yourself");
       }
 
-      if (!delegateUser) {
-        throw new BadRequestException("Unable to create delegate");
-      }
+      delegateUser = await manager.save(delegateUser);
 
       let delegation = await manager.findOne(AccountDelegate, {
         where: { ownerUserId, delegateUserId: delegateUser.id },

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -29,7 +29,21 @@ import { delegateInviteTemplate } from "../notifications/email-templates";
 import { ConfigService } from "@nestjs/config";
 import { CreateDelegateDto } from "./dto/create-delegate.dto";
 import { AccountGrantDto } from "./dto/set-grants.dto";
-import { DelegateCapability } from "./decorators/delegate-access.decorator";
+import {
+  DelegateResource,
+  DelegateCapabilityOp,
+} from "./decorators/delegate-access.decorator";
+
+export interface ResourceCapabilities {
+  create: boolean;
+  edit: boolean;
+  delete: boolean;
+}
+export interface DelegateCapabilitySet {
+  payees: ResourceCapabilities;
+  categories: ResourceCapabilities;
+  tags: ResourceCapabilities;
+}
 
 export type DelegateOperation = "read" | "create" | "edit" | "delete";
 
@@ -304,55 +318,75 @@ export class DelegationService {
           canEdit: g.canEdit,
           canDelete: g.canDelete,
         })),
-      capabilities: {
-        payees: d.canManagePayees,
-        categories: d.canManageCategories,
-        tags: d.canManageTags,
-      },
+      capabilities: this.toCapabilitySet(d),
     }));
   }
 
-  /** Whether the delegation may manage the given shared reference type. */
+  private toCapabilitySet(d?: AccountDelegate | null): DelegateCapabilitySet {
+    return {
+      payees: {
+        create: !!d?.payeesCanCreate,
+        edit: !!d?.payeesCanEdit,
+        delete: !!d?.payeesCanDelete,
+      },
+      categories: {
+        create: !!d?.categoriesCanCreate,
+        edit: !!d?.categoriesCanEdit,
+        delete: !!d?.categoriesCanDelete,
+      },
+      tags: {
+        create: !!d?.tagsCanCreate,
+        edit: !!d?.tagsCanEdit,
+        delete: !!d?.tagsCanDelete,
+      },
+    };
+  }
+
+  /** Whether the delegation may perform `operation` on `resource`. */
   async hasCapability(
     delegationId: string,
-    capability: DelegateCapability,
+    resource: DelegateResource,
+    operation: DelegateCapabilityOp,
   ): Promise<boolean> {
     const delegation = await this.delegatesRepository.findOne({
       where: { id: delegationId, status: "active" },
     });
     if (!delegation) return false;
-    switch (capability) {
-      case "payees":
-        return delegation.canManagePayees;
-      case "categories":
-        return delegation.canManageCategories;
-      case "tags":
-        return delegation.canManageTags;
-    }
+    const opKey =
+      operation === "create"
+        ? "Create"
+        : operation === "edit"
+          ? "Edit"
+          : "Delete";
+    const field = `${resource}Can${opKey}` as keyof AccountDelegate;
+    return !!delegation[field];
   }
 
-  /** All manage capabilities for an active delegation (all false if none). */
-  async getCapabilities(
-    delegationId: string,
-  ): Promise<{ payees: boolean; categories: boolean; tags: boolean }> {
+  /** All granular capabilities for an active delegation (all false if none). */
+  async getCapabilities(delegationId: string): Promise<DelegateCapabilitySet> {
     const delegation = await this.delegatesRepository.findOne({
       where: { id: delegationId, status: "active" },
     });
-    return {
-      payees: !!delegation?.canManagePayees,
-      categories: !!delegation?.canManageCategories,
-      tags: !!delegation?.canManageTags,
-    };
+    return this.toCapabilitySet(delegation);
   }
 
   async setCapabilities(
     ownerUserId: string,
     delegationId: string,
-    caps: {
-      canManagePayees?: boolean;
-      canManageCategories?: boolean;
-      canManageTags?: boolean;
-    },
+    caps: Partial<
+      Record<
+        | "payeesCanCreate"
+        | "payeesCanEdit"
+        | "payeesCanDelete"
+        | "categoriesCanCreate"
+        | "categoriesCanEdit"
+        | "categoriesCanDelete"
+        | "tagsCanCreate"
+        | "tagsCanEdit"
+        | "tagsCanDelete",
+        boolean
+      >
+    >,
   ): Promise<void> {
     const delegation = await this.delegatesRepository.findOne({
       where: { id: delegationId, ownerUserId },
@@ -360,14 +394,10 @@ export class DelegationService {
     if (!delegation) {
       throw new NotFoundException("Delegate not found");
     }
-    if (caps.canManagePayees !== undefined) {
-      delegation.canManagePayees = caps.canManagePayees;
-    }
-    if (caps.canManageCategories !== undefined) {
-      delegation.canManageCategories = caps.canManageCategories;
-    }
-    if (caps.canManageTags !== undefined) {
-      delegation.canManageTags = caps.canManageTags;
+    for (const [key, value] of Object.entries(caps)) {
+      if (value !== undefined) {
+        (delegation as unknown as Record<string, boolean>)[key] = value;
+      }
     }
     await this.delegatesRepository.save(delegation);
   }

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -328,19 +328,29 @@ export class DelegationService {
     // Defensive: reject anything that isn't a proper array. An attacker
     // could submit {length: 1e100} and force an unbounded loop (CWE-834).
     // The DTO layer already validates this via @IsArray, but re-check here
-    // so the bound is visible to static analysis.
+    // so the bound is visible to static analysis. Keep the guard and the
+    // loop in the same scope (no closure) so the barrier is tracked.
     if (!Array.isArray(accountIds)) {
       throw new BadRequestException("accountIds must be an array");
     }
-    await this.dataSource.transaction(async (manager) => {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    try {
       for (let i = 0; i < accountIds.length; i++) {
-        await manager.update(
+        await queryRunner.manager.update(
           DelegateAccountFavourite,
           { delegateUserId, accountId: accountIds[i] },
           { sortOrder: i },
         );
       }
-    });
+      await queryRunner.commitTransaction();
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
   }
 
   // --- Login / switch context ---

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -262,6 +262,18 @@ export class DelegationService {
     return count > 0;
   }
 
+  /**
+   * Whether the delegate can READ at least one account at all. Drives the
+   * delegate Accounts nav/route visibility (any granted account, including
+   * investment accounts, makes the Accounts section reachable).
+   */
+  async hasAnyAccountAccess(delegationId: string): Promise<boolean> {
+    const count = await this.grantsRepository.count({
+      where: { delegationId, canRead: true },
+    });
+    return count > 0;
+  }
+
   // --- Login / switch context ---
 
   /**

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -32,6 +32,7 @@ import { AccountGrantDto } from "./dto/set-grants.dto";
 import {
   DelegateResource,
   DelegateCapabilityOp,
+  DelegateSection,
 } from "./decorators/delegate-access.decorator";
 
 export interface ResourceCapabilities {
@@ -44,6 +45,22 @@ export interface DelegateCapabilitySet {
   categories: ResourceCapabilities;
   tags: ResourceCapabilities;
 }
+
+export interface DelegateSectionSet {
+  bills: boolean;
+  investments: boolean;
+  budgets: boolean;
+  reports: boolean;
+  ai: boolean;
+}
+
+const SECTION_FIELD: Record<DelegateSection, keyof AccountDelegate> = {
+  bills: "billsCanRead",
+  investments: "investmentsCanRead",
+  budgets: "budgetsCanRead",
+  reports: "reportsCanRead",
+  ai: "aiCanRead",
+};
 
 export type DelegateOperation = "read" | "create" | "edit" | "delete";
 
@@ -319,7 +336,18 @@ export class DelegationService {
           canDelete: g.canDelete,
         })),
       capabilities: this.toCapabilitySet(d),
+      sections: this.toSectionSet(d),
     }));
+  }
+
+  private toSectionSet(d?: AccountDelegate | null): DelegateSectionSet {
+    return {
+      bills: !!d?.billsCanRead,
+      investments: !!d?.investmentsCanRead,
+      budgets: !!d?.budgetsCanRead,
+      reports: !!d?.reportsCanRead,
+      ai: !!d?.aiCanRead,
+    };
   }
 
   private toCapabilitySet(d?: AccountDelegate | null): DelegateCapabilitySet {
@@ -368,6 +396,54 @@ export class DelegationService {
       where: { id: delegationId, status: "active" },
     });
     return this.toCapabilitySet(delegation);
+  }
+
+  /** Whether the active delegation was granted READ on `section`. */
+  async hasSection(
+    delegationId: string,
+    section: DelegateSection,
+  ): Promise<boolean> {
+    const delegation = await this.delegatesRepository.findOne({
+      where: { id: delegationId, status: "active" },
+    });
+    if (!delegation) return false;
+    return !!delegation[SECTION_FIELD[section]];
+  }
+
+  /** All section grants for an active delegation (all false if none). */
+  async getSections(delegationId: string): Promise<DelegateSectionSet> {
+    const delegation = await this.delegatesRepository.findOne({
+      where: { id: delegationId, status: "active" },
+    });
+    return this.toSectionSet(delegation);
+  }
+
+  async setSectionGrants(
+    ownerUserId: string,
+    delegationId: string,
+    sections: Partial<
+      Record<
+        | "billsCanRead"
+        | "investmentsCanRead"
+        | "budgetsCanRead"
+        | "reportsCanRead"
+        | "aiCanRead",
+        boolean
+      >
+    >,
+  ): Promise<void> {
+    const delegation = await this.delegatesRepository.findOne({
+      where: { id: delegationId, ownerUserId },
+    });
+    if (!delegation) {
+      throw new NotFoundException("Delegate not found");
+    }
+    for (const [key, value] of Object.entries(sections)) {
+      if (value !== undefined) {
+        (delegation as unknown as Record<string, boolean>)[key] = value;
+      }
+    }
+    await this.delegatesRepository.save(delegation);
   }
 
   async setCapabilities(

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -21,6 +21,7 @@ import { User } from "../users/entities/user.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
 import { Account } from "../accounts/entities/account.entity";
+import { Transaction } from "../transactions/entities/transaction.entity";
 import { hashToken } from "../auth/crypto.util";
 import { generateReadablePassword } from "../admin/utils/password-generator";
 import { EmailService } from "../notifications/email.service";
@@ -62,6 +63,8 @@ export class DelegationService {
     private refreshTokensRepository: Repository<RefreshToken>,
     @InjectRepository(Account)
     private accountsRepository: Repository<Account>,
+    @InjectRepository(Transaction)
+    private transactionsRepository: Repository<Transaction>,
     private emailService: EmailService,
     private configService: ConfigService,
     private dataSource: DataSource,
@@ -151,6 +154,15 @@ export class DelegationService {
       where: { delegationId, accountId, canRead: true },
     });
     return !!grant;
+  }
+
+  /** The account a transaction belongs to, or null if it does not exist. */
+  async accountIdForTransaction(transactionId: string): Promise<string | null> {
+    const tx = await this.transactionsRepository.findOne({
+      where: { id: transactionId },
+      select: ["accountId"],
+    });
+    return tx?.accountId ?? null;
   }
 
   async readableAccountIds(delegationId: string): Promise<string[]> {

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -165,6 +165,28 @@ export class DelegationService {
     return tx?.accountId ?? null;
   }
 
+  /**
+   * Both account ids involved in a transfer identified by either leg's
+   * transaction id (this leg + the linked leg). Empty if the transaction
+   * does not exist.
+   */
+  async accountIdsForTransfer(transactionId: string): Promise<string[]> {
+    const tx = await this.transactionsRepository.findOne({
+      where: { id: transactionId },
+      select: ["accountId", "linkedTransactionId"],
+    });
+    if (!tx) return [];
+    const ids = new Set<string>([tx.accountId]);
+    if (tx.linkedTransactionId) {
+      const linked = await this.transactionsRepository.findOne({
+        where: { id: tx.linkedTransactionId },
+        select: ["accountId"],
+      });
+      if (linked) ids.add(linked.accountId);
+    }
+    return [...ids];
+  }
+
   async readableAccountIds(delegationId: string): Promise<string[]> {
     const grants = await this.grantsRepository.find({
       where: { delegationId, canRead: true },

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -132,6 +132,14 @@ export class DelegationService {
     return !delegateHas2FA;
   }
 
+  /** True if the user is a delegate for at least one owner. */
+  async isDelegateUser(userId: string): Promise<boolean> {
+    const count = await this.delegatesRepository.count({
+      where: { delegateUserId: userId },
+    });
+    return count > 0;
+  }
+
   async hasReadAccess(
     delegationId: string,
     accountId: string,
@@ -381,15 +389,39 @@ export class DelegationService {
     if (!delegation) {
       throw new NotFoundException("Delegate not found");
     }
-    delegation.status = "revoked";
-    delegation.revokedAt = new Date();
-    await this.delegatesRepository.save(delegation);
+    const delegateUserId = delegation.delegateUserId;
 
-    // Kill any live delegate session that was acting via this delegation.
-    await this.refreshTokensRepository.update(
-      { delegationId, isRevoked: false },
-      { isRevoked: true },
-    );
+    await this.dataSource.transaction(async (manager) => {
+      // Hard-delete the delegation. FK cascades remove its grants and any
+      // refresh tokens scoped to it, so live delegate sessions acting via
+      // this delegation are immediately invalidated.
+      await manager.delete(AccountDelegate, { id: delegationId });
+
+      // Entirely remove the delegate's login unless it has another reason to
+      // exist: a delegation elsewhere, its own data, it owns a delegation, or
+      // it is an admin (i.e. it is a full user in its own right).
+      const [otherDelegations, ownsAccounts, ownsDelegations] =
+        await Promise.all([
+          manager.count(AccountDelegate, { where: { delegateUserId } }),
+          manager.count(Account, { where: { userId: delegateUserId } }),
+          manager.count(AccountDelegate, {
+            where: { ownerUserId: delegateUserId },
+          }),
+        ]);
+      const delegateUser = await manager.findOne(User, {
+        where: { id: delegateUserId },
+      });
+
+      if (
+        otherDelegations === 0 &&
+        ownsAccounts === 0 &&
+        ownsDelegations === 0 &&
+        delegateUser?.role !== "admin"
+      ) {
+        // FK ON DELETE CASCADE cleans preferences, tokens, trusted devices.
+        await manager.delete(User, { id: delegateUserId });
+      }
+    });
   }
 
   async setGrants(

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -603,6 +603,8 @@ export class DelegationService {
           delegateUser.mustChangePassword = false;
           delegateUser.resetToken = null;
           delegateUser.resetTokenExpiry = null;
+          delegateUser.failedLoginAttempts = 0;
+          delegateUser.lockedUntil = null;
         } else if (isNew || !delegateUser.passwordHash) {
           // Guarantee the delegate can actually sign in.
           temporaryPassword = generateReadablePassword();
@@ -613,6 +615,8 @@ export class DelegationService {
           delegateUser.mustChangePassword = true;
           delegateUser.resetToken = null;
           delegateUser.resetTokenExpiry = null;
+          delegateUser.failedLoginAttempts = 0;
+          delegateUser.lockedUntil = null;
         }
       }
 
@@ -804,6 +808,10 @@ export class DelegationService {
     delegate.mustChangePassword = true;
     delegate.resetToken = null;
     delegate.resetTokenExpiry = null;
+    // Owner-driven reset is an explicit recovery action: clear any lockout
+    // so a locked-out delegate can sign in with the new password.
+    delegate.failedLoginAttempts = 0;
+    delegate.lockedUntil = null;
     await this.usersRepository.save(delegate);
 
     await this.refreshTokensRepository.update(

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -8,7 +8,7 @@ import {
   Logger,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository, In, DataSource } from "typeorm";
+import { Repository, In, Not, DataSource } from "typeorm";
 import * as bcrypt from "bcryptjs";
 import * as crypto from "crypto";
 
@@ -20,7 +20,7 @@ import { AccountDelegateGrant } from "./entities/account-delegate-grant.entity";
 import { User } from "../users/entities/user.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
-import { Account } from "../accounts/entities/account.entity";
+import { Account, AccountType } from "../accounts/entities/account.entity";
 import { Transaction } from "../transactions/entities/transaction.entity";
 import { ScheduledTransaction } from "../scheduled-transactions/entities/scheduled-transaction.entity";
 import { hashToken } from "../auth/crypto.util";
@@ -246,6 +246,20 @@ export class DelegationService {
       select: ["accountId"],
     });
     return grants.map((g) => g.accountId);
+  }
+
+  /**
+   * Whether the delegate can READ at least one account whose activity shows
+   * in the Transactions section (i.e. any non-investment account they were
+   * granted). Drives the delegate Transactions nav/route visibility.
+   */
+  async hasTransactionalAccess(delegationId: string): Promise<boolean> {
+    const readable = await this.readableAccountIds(delegationId);
+    if (readable.length === 0) return false;
+    const count = await this.accountsRepository.count({
+      where: { id: In(readable), accountType: Not(AccountType.INVESTMENT) },
+    });
+    return count > 0;
   }
 
   // --- Login / switch context ---

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -27,6 +27,9 @@ import { EmailService } from "../notifications/email.service";
 import { delegateInviteTemplate } from "../notifications/email-templates";
 import { ConfigService } from "@nestjs/config";
 import { CreateDelegateDto } from "./dto/create-delegate.dto";
+import { AccountGrantDto } from "./dto/set-grants.dto";
+
+export type DelegateOperation = "read" | "create" | "edit" | "delete";
 
 /**
  * Distinct message so the frontend can route a delegate to 2FA enrollment
@@ -257,10 +260,41 @@ export class DelegationService {
         lastName: d.delegate?.lastName ?? null,
         hasPassword: !!d.delegate?.passwordHash,
       },
-      accountIds: (d.grants ?? [])
+      grants: (d.grants ?? [])
         .filter((g) => g.canRead)
-        .map((g) => g.accountId),
+        .map((g) => ({
+          accountId: g.accountId,
+          canRead: g.canRead,
+          canCreate: g.canCreate,
+          canEdit: g.canEdit,
+          canDelete: g.canDelete,
+        })),
     }));
+  }
+
+  /**
+   * Whether the delegation grants `operation` on `accountId`. READ is implied
+   * by any stored grant (rows are only written when canRead is true).
+   */
+  async hasAccountPermission(
+    delegationId: string,
+    accountId: string,
+    operation: DelegateOperation,
+  ): Promise<boolean> {
+    const grant = await this.grantsRepository.findOne({
+      where: { delegationId, accountId, canRead: true },
+    });
+    if (!grant) return false;
+    switch (operation) {
+      case "read":
+        return true;
+      case "create":
+        return grant.canCreate;
+      case "edit":
+        return grant.canEdit;
+      case "delete":
+        return grant.canDelete;
+    }
   }
 
   async createDelegate(ownerUserId: string, dto: CreateDelegateDto) {
@@ -427,7 +461,7 @@ export class DelegationService {
   async setGrants(
     ownerUserId: string,
     delegationId: string,
-    accountIds: string[],
+    grants: AccountGrantDto[],
   ): Promise<void> {
     const delegation = await this.delegatesRepository.findOne({
       where: { id: delegationId, ownerUserId },
@@ -435,6 +469,19 @@ export class DelegationService {
     if (!delegation) {
       throw new NotFoundException("Delegate not found");
     }
+
+    // READ is the minimum and a prerequisite for CREATE/EDIT/DELETE.
+    for (const g of grants) {
+      if (!g.canRead && (g.canCreate || g.canEdit || g.canDelete)) {
+        throw new BadRequestException(
+          "READ access is required for CREATE, EDIT or DELETE",
+        );
+      }
+    }
+
+    // Only grants that include READ represent actual access.
+    const readable = grants.filter((g) => g.canRead);
+    const accountIds = readable.map((g) => g.accountId);
 
     if (accountIds.length > 0) {
       const owned = await this.accountsRepository.find({
@@ -450,15 +497,18 @@ export class DelegationService {
 
     await this.dataSource.transaction(async (manager) => {
       await manager.delete(AccountDelegateGrant, { delegationId });
-      if (accountIds.length > 0) {
-        const grants = accountIds.map((accountId) =>
+      if (readable.length > 0) {
+        const rows = readable.map((g) =>
           manager.create(AccountDelegateGrant, {
             delegationId,
-            accountId,
+            accountId: g.accountId,
             canRead: true,
+            canCreate: !!g.canCreate,
+            canEdit: !!g.canEdit,
+            canDelete: !!g.canDelete,
           }),
         );
-        await manager.save(grants);
+        await manager.save(rows);
       }
     });
   }

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -17,6 +17,7 @@ import {
   DelegationStatus,
 } from "./entities/account-delegate.entity";
 import { AccountDelegateGrant } from "./entities/account-delegate-grant.entity";
+import { DelegateAccountFavourite } from "./entities/delegate-account-favourite.entity";
 import { User } from "../users/entities/user.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
@@ -100,6 +101,8 @@ export class DelegationService {
     private transactionsRepository: Repository<Transaction>,
     @InjectRepository(ScheduledTransaction)
     private scheduledTransactionsRepository: Repository<ScheduledTransaction>,
+    @InjectRepository(DelegateAccountFavourite)
+    private delegateFavouritesRepository: Repository<DelegateAccountFavourite>,
     private emailService: EmailService,
     private configService: ConfigService,
     private dataSource: DataSource,
@@ -272,6 +275,65 @@ export class DelegationService {
       where: { delegationId, canRead: true },
     });
     return count > 0;
+  }
+
+  // --- Delegate's own (non-shared) account favourites ---
+
+  /** Map of accountId -> sortOrder for the delegate's own favourites. */
+  async getDelegateFavourites(
+    delegateUserId: string,
+  ): Promise<Map<string, number>> {
+    const rows = await this.delegateFavouritesRepository.find({
+      where: { delegateUserId },
+      select: ["accountId", "sortOrder"],
+    });
+    return new Map(rows.map((r) => [r.accountId, r.sortOrder]));
+  }
+
+  /** Add or remove an account from the delegate's own favourites. */
+  async setDelegateFavourite(
+    delegateUserId: string,
+    accountId: string,
+    isFavourite: boolean,
+  ): Promise<void> {
+    if (!isFavourite) {
+      await this.delegateFavouritesRepository.delete({
+        delegateUserId,
+        accountId,
+      });
+      return;
+    }
+    const existing = await this.delegateFavouritesRepository.findOne({
+      where: { delegateUserId, accountId },
+    });
+    if (existing) return;
+    await this.delegateFavouritesRepository.save(
+      this.delegateFavouritesRepository.create({
+        delegateUserId,
+        accountId,
+        sortOrder: 0,
+      }),
+    );
+  }
+
+  /**
+   * Set the delegate's favourite display order. The position of each id in
+   * `accountIds` becomes its sort order; ids that are not favourites are
+   * ignored.
+   */
+  async reorderDelegateFavourites(
+    delegateUserId: string,
+    accountIds: string[],
+  ): Promise<void> {
+    await this.dataSource.transaction(async (manager) => {
+      for (let i = 0; i < accountIds.length; i++) {
+        await manager.update(
+          DelegateAccountFavourite,
+          { delegateUserId, accountId: accountIds[i] },
+          { sortOrder: i },
+        );
+      }
+    });
   }
 
   // --- Login / switch context ---

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -325,6 +325,13 @@ export class DelegationService {
     delegateUserId: string,
     accountIds: string[],
   ): Promise<void> {
+    // Defensive: reject anything that isn't a proper array. An attacker
+    // could submit {length: 1e100} and force an unbounded loop (CWE-834).
+    // The DTO layer already validates this via @IsArray, but re-check here
+    // so the bound is visible to static analysis.
+    if (!Array.isArray(accountIds)) {
+      throw new BadRequestException("accountIds must be an array");
+    }
     await this.dataSource.transaction(async (manager) => {
       for (let i = 0; i < accountIds.length; i++) {
         await manager.update(
@@ -415,6 +422,41 @@ export class DelegationService {
 
   // --- Owner-facing management ---
 
+  /**
+   * A delegate is a "full account" -- a real user in their own right --
+   * when they own data, are an owner of their own delegations, or are an
+   * admin. Owners must not be able to reset such a user's password (it is
+   * that person's own login, not an owner-provisioned credential).
+   */
+  async isFullAccount(userId: string): Promise<boolean> {
+    const [ownsAccounts, ownsDelegations, user] = await Promise.all([
+      this.accountsRepository.count({ where: { userId } }),
+      this.delegatesRepository.count({ where: { ownerUserId: userId } }),
+      this.usersRepository.findOne({
+        where: { id: userId },
+        select: ["id", "role"],
+      }),
+    ]);
+    return ownsAccounts > 0 || ownsDelegations > 0 || user?.role === "admin";
+  }
+
+  /**
+   * An owner may reset a delegate's password only when that password is an
+   * owner-provisioned credential used solely for this relationship: the
+   * delegate is not a full account in their own right AND is not also a
+   * delegate for any other owner. Otherwise the password belongs to the
+   * person, not the owner, so only they may change it.
+   */
+  async canOwnerResetDelegatePassword(
+    delegateUserId: string,
+  ): Promise<boolean> {
+    if (await this.isFullAccount(delegateUserId)) return false;
+    const delegationCount = await this.delegatesRepository.count({
+      where: { delegateUserId },
+    });
+    return delegationCount <= 1;
+  }
+
   async listDelegates(ownerUserId: string) {
     const delegations = await this.delegatesRepository.find({
       where: {
@@ -424,29 +466,36 @@ export class DelegationService {
       relations: ["delegate", "grants"],
       order: { createdAt: "DESC" },
     });
-    return delegations.map((d) => ({
-      id: d.id,
-      status: d.status,
-      createdAt: d.createdAt,
-      delegate: {
-        id: d.delegateUserId,
-        email: d.delegate?.email ?? null,
-        firstName: d.delegate?.firstName ?? null,
-        lastName: d.delegate?.lastName ?? null,
-        hasPassword: !!d.delegate?.passwordHash,
-      },
-      grants: (d.grants ?? [])
-        .filter((g) => g.canRead)
-        .map((g) => ({
-          accountId: g.accountId,
-          canRead: g.canRead,
-          canCreate: g.canCreate,
-          canEdit: g.canEdit,
-          canDelete: g.canDelete,
-        })),
-      capabilities: this.toCapabilitySet(d),
-      sections: this.toSectionSet(d),
-    }));
+    return Promise.all(
+      delegations.map(async (d) => ({
+        id: d.id,
+        status: d.status,
+        createdAt: d.createdAt,
+        delegate: {
+          id: d.delegateUserId,
+          email: d.delegate?.email ?? null,
+          firstName: d.delegate?.firstName ?? null,
+          lastName: d.delegate?.lastName ?? null,
+          hasPassword: !!d.delegate?.passwordHash,
+          // False when the password is the delegate's own (full account or
+          // a delegate elsewhere); the owner cannot reset it.
+          canResetPassword: await this.canOwnerResetDelegatePassword(
+            d.delegateUserId,
+          ),
+        },
+        grants: (d.grants ?? [])
+          .filter((g) => g.canRead)
+          .map((g) => ({
+            accountId: g.accountId,
+            canRead: g.canRead,
+            canCreate: g.canCreate,
+            canEdit: g.canEdit,
+            canDelete: g.canDelete,
+          })),
+        capabilities: this.toCapabilitySet(d),
+        sections: this.toSectionSet(d),
+      })),
+    );
   }
 
   private toSectionSet(d?: AccountDelegate | null): DelegateSectionSet {
@@ -899,6 +948,13 @@ export class DelegationService {
     if (delegate.oidcSubject) {
       throw new BadRequestException(
         "Cannot reset password for an SSO delegate account",
+      );
+    }
+    if (!(await this.canOwnerResetDelegatePassword(delegate.id))) {
+      throw new ForbiddenException(
+        "This delegate manages their own password (they have their own " +
+          "Monize account or delegated access elsewhere). Only they can " +
+          "change it.",
       );
     }
 

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -29,6 +29,7 @@ import { delegateInviteTemplate } from "../notifications/email-templates";
 import { ConfigService } from "@nestjs/config";
 import { CreateDelegateDto } from "./dto/create-delegate.dto";
 import { AccountGrantDto } from "./dto/set-grants.dto";
+import { DelegateCapability } from "./decorators/delegate-access.decorator";
 
 export type DelegateOperation = "read" | "create" | "edit" | "delete";
 
@@ -303,7 +304,58 @@ export class DelegationService {
           canEdit: g.canEdit,
           canDelete: g.canDelete,
         })),
+      capabilities: {
+        payees: d.canManagePayees,
+        categories: d.canManageCategories,
+        tags: d.canManageTags,
+      },
     }));
+  }
+
+  /** Whether the delegation may manage the given shared reference type. */
+  async hasCapability(
+    delegationId: string,
+    capability: DelegateCapability,
+  ): Promise<boolean> {
+    const delegation = await this.delegatesRepository.findOne({
+      where: { id: delegationId, status: "active" },
+    });
+    if (!delegation) return false;
+    switch (capability) {
+      case "payees":
+        return delegation.canManagePayees;
+      case "categories":
+        return delegation.canManageCategories;
+      case "tags":
+        return delegation.canManageTags;
+    }
+  }
+
+  async setCapabilities(
+    ownerUserId: string,
+    delegationId: string,
+    caps: {
+      canManagePayees?: boolean;
+      canManageCategories?: boolean;
+      canManageTags?: boolean;
+    },
+  ): Promise<void> {
+    const delegation = await this.delegatesRepository.findOne({
+      where: { id: delegationId, ownerUserId },
+    });
+    if (!delegation) {
+      throw new NotFoundException("Delegate not found");
+    }
+    if (caps.canManagePayees !== undefined) {
+      delegation.canManagePayees = caps.canManagePayees;
+    }
+    if (caps.canManageCategories !== undefined) {
+      delegation.canManageCategories = caps.canManageCategories;
+    }
+    if (caps.canManageTags !== undefined) {
+      delegation.canManageTags = caps.canManageTags;
+    }
+    await this.delegatesRepository.save(delegation);
   }
 
   /**

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -22,6 +22,7 @@ import { UserPreference } from "../users/entities/user-preference.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
 import { Account } from "../accounts/entities/account.entity";
 import { Transaction } from "../transactions/entities/transaction.entity";
+import { ScheduledTransaction } from "../scheduled-transactions/entities/scheduled-transaction.entity";
 import { hashToken } from "../auth/crypto.util";
 import { generateReadablePassword } from "../admin/utils/password-generator";
 import { EmailService } from "../notifications/email.service";
@@ -97,6 +98,8 @@ export class DelegationService {
     private accountsRepository: Repository<Account>,
     @InjectRepository(Transaction)
     private transactionsRepository: Repository<Transaction>,
+    @InjectRepository(ScheduledTransaction)
+    private scheduledTransactionsRepository: Repository<ScheduledTransaction>,
     private emailService: EmailService,
     private configService: ConfigService,
     private dataSource: DataSource,
@@ -215,6 +218,24 @@ export class DelegationService {
         select: ["accountId"],
       });
       if (linked) ids.add(linked.accountId);
+    }
+    return [...ids];
+  }
+
+  /**
+   * Every account a scheduled transaction touches: its own account plus the
+   * transfer counterpart when it is a transfer. Empty if the row does not
+   * exist (the owner-scoped service then returns 404).
+   */
+  async accountIdsForScheduled(scheduledId: string): Promise<string[]> {
+    const st = await this.scheduledTransactionsRepository.findOne({
+      where: { id: scheduledId },
+      select: ["accountId", "transferAccountId", "isTransfer"],
+    });
+    if (!st) return [];
+    const ids = new Set<string>([st.accountId]);
+    if (st.isTransfer && st.transferAccountId) {
+      ids.add(st.transferAccountId);
     }
     return [...ids];
   }

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -1,0 +1,474 @@
+import {
+  Injectable,
+  UnauthorizedException,
+  ForbiddenException,
+  BadRequestException,
+  NotFoundException,
+  ConflictException,
+  Logger,
+} from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository, In, DataSource } from "typeorm";
+import * as bcrypt from "bcryptjs";
+import * as crypto from "crypto";
+
+import {
+  AccountDelegate,
+  DelegationStatus,
+} from "./entities/account-delegate.entity";
+import { AccountDelegateGrant } from "./entities/account-delegate-grant.entity";
+import { User } from "../users/entities/user.entity";
+import { UserPreference } from "../users/entities/user-preference.entity";
+import { RefreshToken } from "../auth/entities/refresh-token.entity";
+import { Account } from "../accounts/entities/account.entity";
+import { hashToken } from "../auth/crypto.util";
+import { generateReadablePassword } from "../admin/utils/password-generator";
+import { EmailService } from "../notifications/email.service";
+import { delegateInviteTemplate } from "../notifications/email-templates";
+import { ConfigService } from "@nestjs/config";
+import { CreateDelegateDto } from "./dto/create-delegate.dto";
+
+/**
+ * Distinct message so the frontend can route a delegate to 2FA enrollment
+ * before letting them act as an owner who requires 2FA.
+ */
+export const DELEGATE_2FA_REQUIRED = "DELEGATE_2FA_REQUIRED";
+
+export interface AvailableContext {
+  userId: string;
+  label: string;
+  isSelf: boolean;
+  ownerHas2FA: boolean;
+}
+
+@Injectable()
+export class DelegationService {
+  private readonly logger = new Logger(DelegationService.name);
+  private readonly BCRYPT_ROUNDS = 12;
+
+  constructor(
+    @InjectRepository(AccountDelegate)
+    private delegatesRepository: Repository<AccountDelegate>,
+    @InjectRepository(AccountDelegateGrant)
+    private grantsRepository: Repository<AccountDelegateGrant>,
+    @InjectRepository(User)
+    private usersRepository: Repository<User>,
+    @InjectRepository(UserPreference)
+    private preferencesRepository: Repository<UserPreference>,
+    @InjectRepository(RefreshToken)
+    private refreshTokensRepository: Repository<RefreshToken>,
+    @InjectRepository(Account)
+    private accountsRepository: Repository<Account>,
+    private emailService: EmailService,
+    private configService: ConfigService,
+    private dataSource: DataSource,
+  ) {}
+
+  // --- Context resolution (used by JwtStrategy and the guard) ---
+
+  /**
+   * Validate that `delegateUserId` may currently act as `actingAsUserId` via
+   * `delegationId`. Throws (fail closed) on any mismatch, revoked/inactive
+   * delegation, inactive owner, or unmet 2FA requirement.
+   */
+  async validateActingContext(args: {
+    delegateUserId: string;
+    actingAsUserId: string;
+    delegationId: string;
+  }): Promise<AccountDelegate> {
+    const { delegateUserId, actingAsUserId, delegationId } = args;
+
+    const delegation = await this.delegatesRepository.findOne({
+      where: { id: delegationId },
+    });
+
+    if (
+      !delegation ||
+      delegation.status !== "active" ||
+      delegation.delegateUserId !== delegateUserId ||
+      delegation.ownerUserId !== actingAsUserId
+    ) {
+      throw new UnauthorizedException("Delegated access is no longer valid");
+    }
+
+    const owner = await this.usersRepository.findOne({
+      where: { id: actingAsUserId },
+    });
+    if (!owner || !owner.isActive) {
+      throw new UnauthorizedException("Delegated access is no longer valid");
+    }
+
+    if (await this.delegateMustEnrollOwn2FA(actingAsUserId, delegateUserId)) {
+      throw new UnauthorizedException(DELEGATE_2FA_REQUIRED);
+    }
+
+    return delegation;
+  }
+
+  /**
+   * True when the owner requires 2FA but the delegate has not enrolled their
+   * own 2FA. (TOTP secrets are per-user and never shared.)
+   */
+  async delegateMustEnrollOwn2FA(
+    ownerUserId: string,
+    delegateUserId: string,
+  ): Promise<boolean> {
+    const [owner, ownerPref] = await Promise.all([
+      this.usersRepository.findOne({ where: { id: ownerUserId } }),
+      this.preferencesRepository.findOne({ where: { userId: ownerUserId } }),
+    ]);
+    const ownerRequires2FA = !!(
+      ownerPref?.twoFactorEnabled && owner?.twoFactorSecret
+    );
+    if (!ownerRequires2FA) return false;
+
+    const [delegate, delegatePref] = await Promise.all([
+      this.usersRepository.findOne({ where: { id: delegateUserId } }),
+      this.preferencesRepository.findOne({ where: { userId: delegateUserId } }),
+    ]);
+    const delegateHas2FA = !!(
+      delegatePref?.twoFactorEnabled && delegate?.twoFactorSecret
+    );
+    return !delegateHas2FA;
+  }
+
+  async hasReadAccess(
+    delegationId: string,
+    accountId: string,
+  ): Promise<boolean> {
+    const grant = await this.grantsRepository.findOne({
+      where: { delegationId, accountId, canRead: true },
+    });
+    return !!grant;
+  }
+
+  async readableAccountIds(delegationId: string): Promise<string[]> {
+    const grants = await this.grantsRepository.find({
+      where: { delegationId, canRead: true },
+      select: ["accountId"],
+    });
+    return grants.map((g) => g.accountId);
+  }
+
+  // --- Login / switch context ---
+
+  /**
+   * Contexts the authenticated user can operate in. Returns an empty array
+   * for a normal user with no delegations (so login behaviour is unchanged).
+   */
+  async getAvailableContexts(userId: string): Promise<AvailableContext[]> {
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+    if (!user) return [];
+
+    const delegations = await this.delegatesRepository.find({
+      where: { delegateUserId: user.id, status: "active" },
+      relations: ["owner"],
+    });
+
+    if (delegations.length === 0) return [];
+
+    const ownsData = await this.accountsRepository.exists({
+      where: { userId: user.id },
+    });
+
+    const contexts: AvailableContext[] = [];
+    if (ownsData) {
+      contexts.push({
+        userId: user.id,
+        label: this.userLabel(user),
+        isSelf: true,
+        ownerHas2FA: false,
+      });
+    }
+
+    for (const d of delegations) {
+      contexts.push({
+        userId: d.ownerUserId,
+        label: d.owner ? this.userLabel(d.owner) : d.ownerUserId,
+        isSelf: false,
+        ownerHas2FA: await this.delegateMustEnrollOwn2FA(
+          d.ownerUserId,
+          user.id,
+        ),
+      });
+    }
+    return contexts;
+  }
+
+  /**
+   * Resolve a target context for /auth/switch-context. Returns null context
+   * for "self"; otherwise the validated active delegation.
+   */
+  async resolveSwitchTarget(
+    delegateUserId: string,
+    targetUserId: string,
+  ): Promise<AccountDelegate | null> {
+    if (targetUserId === delegateUserId) {
+      return null;
+    }
+    const delegation = await this.delegatesRepository.findOne({
+      where: {
+        delegateUserId,
+        ownerUserId: targetUserId,
+        status: "active",
+      },
+    });
+    if (!delegation) {
+      throw new ForbiddenException("No active delegation for that account");
+    }
+    if (await this.delegateMustEnrollOwn2FA(targetUserId, delegateUserId)) {
+      throw new ForbiddenException(DELEGATE_2FA_REQUIRED);
+    }
+    return delegation;
+  }
+
+  private userLabel(user: User): string {
+    const name = [user.firstName, user.lastName].filter(Boolean).join(" ");
+    return name || user.email || user.id;
+  }
+
+  // --- Owner-facing management ---
+
+  async listDelegates(ownerUserId: string) {
+    const delegations = await this.delegatesRepository.find({
+      where: {
+        ownerUserId,
+        status: In(["active", "pending"] as DelegationStatus[]),
+      },
+      relations: ["delegate", "grants"],
+      order: { createdAt: "DESC" },
+    });
+    return delegations.map((d) => ({
+      id: d.id,
+      status: d.status,
+      createdAt: d.createdAt,
+      delegate: {
+        id: d.delegateUserId,
+        email: d.delegate?.email ?? null,
+        firstName: d.delegate?.firstName ?? null,
+        lastName: d.delegate?.lastName ?? null,
+        hasPassword: !!d.delegate?.passwordHash,
+      },
+      accountIds: (d.grants ?? [])
+        .filter((g) => g.canRead)
+        .map((g) => g.accountId),
+    }));
+  }
+
+  async createDelegate(ownerUserId: string, dto: CreateDelegateDto) {
+    const email = dto.email.toLowerCase().trim();
+
+    const owner = await this.usersRepository.findOne({
+      where: { id: ownerUserId },
+    });
+    if (!owner) throw new NotFoundException("User not found");
+    if (owner.email && owner.email.toLowerCase().trim() === email) {
+      throw new BadRequestException("You cannot delegate access to yourself");
+    }
+
+    let temporaryPassword: string | undefined;
+    let inviteToken: string | undefined;
+
+    return this.dataSource.transaction(async (manager) => {
+      let delegateUser = await manager.findOne(User, { where: { email } });
+
+      if (!delegateUser) {
+        const newUser = manager.create(User, {
+          email,
+          firstName: dto.firstName ?? null,
+          lastName: dto.lastName ?? null,
+          authProvider: "local",
+          role: "user",
+        });
+
+        if (dto.sendInvite) {
+          if (!this.emailService.getStatus().configured) {
+            throw new BadRequestException(
+              "SMTP is not configured. Set a password for the delegate instead.",
+            );
+          }
+          const rawToken = crypto.randomBytes(32).toString("hex");
+          newUser.resetToken = hashToken(rawToken);
+          newUser.resetTokenExpiry = new Date(Date.now() + 24 * 60 * 60 * 1000);
+          // The invitee sets their own password via the reset link, so they
+          // are NOT forced to change it again on first login.
+          inviteToken = rawToken;
+        } else if (dto.password) {
+          newUser.passwordHash = await bcrypt.hash(
+            dto.password,
+            this.BCRYPT_ROUNDS,
+          );
+        } else {
+          temporaryPassword = generateReadablePassword();
+          newUser.passwordHash = await bcrypt.hash(
+            temporaryPassword,
+            this.BCRYPT_ROUNDS,
+          );
+          newUser.mustChangePassword = true;
+        }
+
+        delegateUser = await manager.save(newUser);
+      } else if (delegateUser.id === ownerUserId) {
+        throw new BadRequestException("You cannot delegate access to yourself");
+      }
+
+      if (!delegateUser) {
+        throw new BadRequestException("Unable to create delegate");
+      }
+
+      let delegation = await manager.findOne(AccountDelegate, {
+        where: { ownerUserId, delegateUserId: delegateUser.id },
+      });
+      if (delegation) {
+        if (delegation.status === "active") {
+          throw new ConflictException(
+            "That user is already a delegate for your account",
+          );
+        }
+        delegation.status = "active";
+        delegation.revokedAt = null;
+      } else {
+        delegation = manager.create(AccountDelegate, {
+          ownerUserId,
+          delegateUserId: delegateUser.id,
+          status: "active",
+        });
+      }
+      delegation = await manager.save(delegation);
+
+      if (inviteToken) {
+        const frontendUrl = this.configService.get<string>(
+          "PUBLIC_APP_URL",
+          "http://localhost:3000",
+        );
+        const inviteUrl = `${frontendUrl}/reset-password?token=${inviteToken}`;
+        this.emailService
+          .sendMail(
+            email,
+            "You have been invited to Monize",
+            delegateInviteTemplate(
+              dto.firstName || "",
+              this.userLabel(owner),
+              inviteUrl,
+            ),
+          )
+          .catch((err) =>
+            this.logger.warn(
+              `Failed to send delegate invite email: ${
+                err instanceof Error ? err.message : err
+              }`,
+            ),
+          );
+      }
+
+      return {
+        id: delegation.id,
+        delegateUserId: delegateUser.id,
+        email,
+        temporaryPassword,
+        invited: !!inviteToken,
+      };
+    });
+  }
+
+  async revokeDelegate(
+    ownerUserId: string,
+    delegationId: string,
+  ): Promise<void> {
+    const delegation = await this.delegatesRepository.findOne({
+      where: { id: delegationId, ownerUserId },
+    });
+    if (!delegation) {
+      throw new NotFoundException("Delegate not found");
+    }
+    delegation.status = "revoked";
+    delegation.revokedAt = new Date();
+    await this.delegatesRepository.save(delegation);
+
+    // Kill any live delegate session that was acting via this delegation.
+    await this.refreshTokensRepository.update(
+      { delegationId, isRevoked: false },
+      { isRevoked: true },
+    );
+  }
+
+  async setGrants(
+    ownerUserId: string,
+    delegationId: string,
+    accountIds: string[],
+  ): Promise<void> {
+    const delegation = await this.delegatesRepository.findOne({
+      where: { id: delegationId, ownerUserId },
+    });
+    if (!delegation) {
+      throw new NotFoundException("Delegate not found");
+    }
+
+    if (accountIds.length > 0) {
+      const owned = await this.accountsRepository.find({
+        where: { id: In(accountIds), userId: ownerUserId },
+        select: ["id"],
+      });
+      if (owned.length !== accountIds.length) {
+        throw new ForbiddenException(
+          "One or more accounts do not belong to you",
+        );
+      }
+    }
+
+    await this.dataSource.transaction(async (manager) => {
+      await manager.delete(AccountDelegateGrant, { delegationId });
+      if (accountIds.length > 0) {
+        const grants = accountIds.map((accountId) =>
+          manager.create(AccountDelegateGrant, {
+            delegationId,
+            accountId,
+            canRead: true,
+          }),
+        );
+        await manager.save(grants);
+      }
+    });
+  }
+
+  async resetDelegatePassword(
+    ownerUserId: string,
+    delegationId: string,
+  ): Promise<{ temporaryPassword: string }> {
+    const delegation = await this.delegatesRepository.findOne({
+      where: { id: delegationId, ownerUserId, status: "active" },
+    });
+    if (!delegation) {
+      throw new NotFoundException("Delegate not found");
+    }
+
+    const delegate = await this.usersRepository.findOne({
+      where: { id: delegation.delegateUserId },
+    });
+    if (!delegate) {
+      throw new NotFoundException("Delegate not found");
+    }
+    if (delegate.oidcSubject) {
+      throw new BadRequestException(
+        "Cannot reset password for an SSO delegate account",
+      );
+    }
+
+    const temporaryPassword = generateReadablePassword();
+    delegate.passwordHash = await bcrypt.hash(
+      temporaryPassword,
+      this.BCRYPT_ROUNDS,
+    );
+    delegate.mustChangePassword = true;
+    delegate.resetToken = null;
+    delegate.resetTokenExpiry = null;
+    await this.usersRepository.save(delegate);
+
+    await this.refreshTokensRepository.update(
+      { userId: delegate.id, isRevoked: false },
+      { isRevoked: true },
+    );
+
+    return { temporaryPassword };
+  }
+}

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -538,6 +538,20 @@ export class DelegationService {
     }
   }
 
+  /**
+   * Whether a Monize login already exists for this email (existing full
+   * account or a delegate of another owner). Used by the Add-delegate UI
+   * to skip the password / invite controls -- such a user keeps their own
+   * credentials and is only granted the additional shared access.
+   */
+  async delegateEmailExists(email: string): Promise<boolean> {
+    const normalized = email.toLowerCase().trim();
+    const user = await this.usersRepository.findOne({
+      where: { email: normalized },
+    });
+    return !!user;
+  }
+
   async createDelegate(ownerUserId: string, dto: CreateDelegateDto) {
     const email = dto.email.toLowerCase().trim();
 

--- a/backend/src/delegation/dto/create-delegate.dto.ts
+++ b/backend/src/delegation/dto/create-delegate.dto.ts
@@ -5,6 +5,7 @@ import {
   IsBoolean,
   MaxLength,
   MinLength,
+  Matches,
 } from "class-validator";
 
 export class CreateDelegateDto {
@@ -29,8 +30,12 @@ export class CreateDelegateDto {
    */
   @IsOptional()
   @IsString()
-  @MinLength(8)
-  @MaxLength(128)
+  @MinLength(12)
+  @MaxLength(100)
+  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z\d\s])/, {
+    message:
+      "Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character",
+  })
   password?: string;
 
   /**

--- a/backend/src/delegation/dto/create-delegate.dto.ts
+++ b/backend/src/delegation/dto/create-delegate.dto.ts
@@ -1,0 +1,43 @@
+import {
+  IsEmail,
+  IsOptional,
+  IsString,
+  IsBoolean,
+  MaxLength,
+  MinLength,
+} from "class-validator";
+
+export class CreateDelegateDto {
+  @IsEmail()
+  @MaxLength(255)
+  email: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  firstName?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  lastName?: string;
+
+  /**
+   * Owner-chosen password for a brand-new delegate user. Mutually exclusive
+   * with sendInvite. Ignored when the email already belongs to an existing
+   * user (that user keeps their own credentials).
+   */
+  @IsOptional()
+  @IsString()
+  @MinLength(8)
+  @MaxLength(128)
+  password?: string;
+
+  /**
+   * When true, create the delegate without a password and email them an
+   * invite link to set one (requires SMTP to be configured).
+   */
+  @IsOptional()
+  @IsBoolean()
+  sendInvite?: boolean;
+}

--- a/backend/src/delegation/dto/lookup-delegate.dto.ts
+++ b/backend/src/delegation/dto/lookup-delegate.dto.ts
@@ -1,0 +1,7 @@
+import { IsEmail, MaxLength } from "class-validator";
+
+export class LookupDelegateDto {
+  @IsEmail()
+  @MaxLength(255)
+  email: string;
+}

--- a/backend/src/delegation/dto/set-capabilities.dto.ts
+++ b/backend/src/delegation/dto/set-capabilities.dto.ts
@@ -1,19 +1,20 @@
 import { IsBoolean, IsOptional } from "class-validator";
 
 /**
- * 2C: owner toggles a delegate's per-delegation manage capabilities for
- * shared reference data. Omitted fields are left unchanged.
+ * 2C granular: owner toggles a delegate's per-resource create/edit/delete
+ * capabilities for shared reference data. READ is always allowed and is not
+ * represented here. Omitted fields are left unchanged.
  */
 export class SetCapabilitiesDto {
-  @IsOptional()
-  @IsBoolean()
-  canManagePayees?: boolean;
+  @IsOptional() @IsBoolean() payeesCanCreate?: boolean;
+  @IsOptional() @IsBoolean() payeesCanEdit?: boolean;
+  @IsOptional() @IsBoolean() payeesCanDelete?: boolean;
 
-  @IsOptional()
-  @IsBoolean()
-  canManageCategories?: boolean;
+  @IsOptional() @IsBoolean() categoriesCanCreate?: boolean;
+  @IsOptional() @IsBoolean() categoriesCanEdit?: boolean;
+  @IsOptional() @IsBoolean() categoriesCanDelete?: boolean;
 
-  @IsOptional()
-  @IsBoolean()
-  canManageTags?: boolean;
+  @IsOptional() @IsBoolean() tagsCanCreate?: boolean;
+  @IsOptional() @IsBoolean() tagsCanEdit?: boolean;
+  @IsOptional() @IsBoolean() tagsCanDelete?: boolean;
 }

--- a/backend/src/delegation/dto/set-capabilities.dto.ts
+++ b/backend/src/delegation/dto/set-capabilities.dto.ts
@@ -1,0 +1,19 @@
+import { IsBoolean, IsOptional } from "class-validator";
+
+/**
+ * 2C: owner toggles a delegate's per-delegation manage capabilities for
+ * shared reference data. Omitted fields are left unchanged.
+ */
+export class SetCapabilitiesDto {
+  @IsOptional()
+  @IsBoolean()
+  canManagePayees?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  canManageCategories?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  canManageTags?: boolean;
+}

--- a/backend/src/delegation/dto/set-grants.dto.ts
+++ b/backend/src/delegation/dto/set-grants.dto.ts
@@ -1,12 +1,46 @@
-import { ArrayUnique, IsArray, IsUUID } from "class-validator";
+import { Type } from "class-transformer";
+import {
+  ArrayUnique,
+  IsArray,
+  IsBoolean,
+  IsOptional,
+  IsUUID,
+  ValidateNested,
+} from "class-validator";
 
 /**
- * Phase 1: the owner grants the delegate READ on this exact set of accounts.
- * The set is authoritative -- accounts not listed have their grant removed.
+ * One account's permission set for a delegate. READ is the minimum: a grant
+ * with canRead=false means "no access" and is not stored. CREATE/EDIT/DELETE
+ * require READ (enforced server-side).
+ */
+export class AccountGrantDto {
+  @IsUUID("4")
+  accountId: string;
+
+  @IsBoolean()
+  canRead: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  canCreate?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  canEdit?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  canDelete?: boolean;
+}
+
+/**
+ * Phase 2: the authoritative set of per-account permissions for a delegate.
+ * Accounts not present (or present with canRead=false) have all access removed.
  */
 export class SetGrantsDto {
   @IsArray()
-  @ArrayUnique()
-  @IsUUID("4", { each: true })
-  accountIds: string[];
+  @ArrayUnique((g: AccountGrantDto) => g.accountId)
+  @ValidateNested({ each: true })
+  @Type(() => AccountGrantDto)
+  grants: AccountGrantDto[];
 }

--- a/backend/src/delegation/dto/set-grants.dto.ts
+++ b/backend/src/delegation/dto/set-grants.dto.ts
@@ -1,0 +1,12 @@
+import { ArrayUnique, IsArray, IsUUID } from "class-validator";
+
+/**
+ * Phase 1: the owner grants the delegate READ on this exact set of accounts.
+ * The set is authoritative -- accounts not listed have their grant removed.
+ */
+export class SetGrantsDto {
+  @IsArray()
+  @ArrayUnique()
+  @IsUUID("4", { each: true })
+  accountIds: string[];
+}

--- a/backend/src/delegation/dto/set-sections.dto.ts
+++ b/backend/src/delegation/dto/set-sections.dto.ts
@@ -1,0 +1,14 @@
+import { IsBoolean, IsOptional } from "class-validator";
+
+/**
+ * 3A: owner toggles a delegate's READ access to whole app sections
+ * (Bills & Deposits, Investments, Budgets, Reports, AI). Omitted fields are
+ * left unchanged.
+ */
+export class SetSectionsDto {
+  @IsOptional() @IsBoolean() billsCanRead?: boolean;
+  @IsOptional() @IsBoolean() investmentsCanRead?: boolean;
+  @IsOptional() @IsBoolean() budgetsCanRead?: boolean;
+  @IsOptional() @IsBoolean() reportsCanRead?: boolean;
+  @IsOptional() @IsBoolean() aiCanRead?: boolean;
+}

--- a/backend/src/delegation/entities/account-delegate-grant.entity.ts
+++ b/backend/src/delegation/entities/account-delegate-grant.entity.ts
@@ -1,0 +1,44 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from "typeorm";
+import { AccountDelegate } from "./account-delegate.entity";
+
+@Entity("account_delegate_grants")
+export class AccountDelegateGrant {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @Column({ name: "delegation_id", type: "uuid" })
+  delegationId: string;
+
+  @Column({ name: "account_id", type: "uuid" })
+  accountId: string;
+
+  @Column({ name: "can_read", type: "boolean", default: true })
+  canRead: boolean;
+
+  // can_create / can_edit / can_delete are part of the Phase 2 design and are
+  // not enforced yet. They exist so the grant model does not need to change.
+  @Column({ name: "can_create", type: "boolean", default: false })
+  canCreate: boolean;
+
+  @Column({ name: "can_edit", type: "boolean", default: false })
+  canEdit: boolean;
+
+  @Column({ name: "can_delete", type: "boolean", default: false })
+  canDelete: boolean;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt: Date;
+
+  @ManyToOne(() => AccountDelegate, (delegation) => delegation.grants, {
+    onDelete: "CASCADE",
+  })
+  @JoinColumn({ name: "delegation_id" })
+  delegation: AccountDelegate;
+}

--- a/backend/src/delegation/entities/account-delegate.entity.ts
+++ b/backend/src/delegation/entities/account-delegate.entity.ts
@@ -36,15 +36,34 @@ export class AccountDelegate {
   @Column({ name: "revoked_at", type: "timestamp", nullable: true })
   revokedAt: Date | null;
 
-  // 2C: per-delegation "manage" capabilities for shared reference data.
-  @Column({ name: "can_manage_payees", type: "boolean", default: false })
-  canManagePayees: boolean;
+  // 2C: per-delegation, per-resource, per-operation capabilities for shared
+  // reference data. READ is always allowed; these gate create/edit/delete.
+  @Column({ name: "payees_can_create", type: "boolean", default: false })
+  payeesCanCreate: boolean;
 
-  @Column({ name: "can_manage_categories", type: "boolean", default: false })
-  canManageCategories: boolean;
+  @Column({ name: "payees_can_edit", type: "boolean", default: false })
+  payeesCanEdit: boolean;
 
-  @Column({ name: "can_manage_tags", type: "boolean", default: false })
-  canManageTags: boolean;
+  @Column({ name: "payees_can_delete", type: "boolean", default: false })
+  payeesCanDelete: boolean;
+
+  @Column({ name: "categories_can_create", type: "boolean", default: false })
+  categoriesCanCreate: boolean;
+
+  @Column({ name: "categories_can_edit", type: "boolean", default: false })
+  categoriesCanEdit: boolean;
+
+  @Column({ name: "categories_can_delete", type: "boolean", default: false })
+  categoriesCanDelete: boolean;
+
+  @Column({ name: "tags_can_create", type: "boolean", default: false })
+  tagsCanCreate: boolean;
+
+  @Column({ name: "tags_can_edit", type: "boolean", default: false })
+  tagsCanEdit: boolean;
+
+  @Column({ name: "tags_can_delete", type: "boolean", default: false })
+  tagsCanDelete: boolean;
 
   @ManyToOne(() => User)
   @JoinColumn({ name: "owner_user_id" })

--- a/backend/src/delegation/entities/account-delegate.entity.ts
+++ b/backend/src/delegation/entities/account-delegate.entity.ts
@@ -65,6 +65,24 @@ export class AccountDelegate {
   @Column({ name: "tags_can_delete", type: "boolean", default: false })
   tagsCanDelete: boolean;
 
+  // 3A: per-delegation READ grants for whole app sections. Gate tab
+  // visibility + section read endpoints. Account-scoped data still also
+  // requires the per-account grants in account_delegate_grants.
+  @Column({ name: "bills_can_read", type: "boolean", default: false })
+  billsCanRead: boolean;
+
+  @Column({ name: "investments_can_read", type: "boolean", default: false })
+  investmentsCanRead: boolean;
+
+  @Column({ name: "budgets_can_read", type: "boolean", default: false })
+  budgetsCanRead: boolean;
+
+  @Column({ name: "reports_can_read", type: "boolean", default: false })
+  reportsCanRead: boolean;
+
+  @Column({ name: "ai_can_read", type: "boolean", default: false })
+  aiCanRead: boolean;
+
   @ManyToOne(() => User)
   @JoinColumn({ name: "owner_user_id" })
   owner: User;

--- a/backend/src/delegation/entities/account-delegate.entity.ts
+++ b/backend/src/delegation/entities/account-delegate.entity.ts
@@ -36,6 +36,16 @@ export class AccountDelegate {
   @Column({ name: "revoked_at", type: "timestamp", nullable: true })
   revokedAt: Date | null;
 
+  // 2C: per-delegation "manage" capabilities for shared reference data.
+  @Column({ name: "can_manage_payees", type: "boolean", default: false })
+  canManagePayees: boolean;
+
+  @Column({ name: "can_manage_categories", type: "boolean", default: false })
+  canManageCategories: boolean;
+
+  @Column({ name: "can_manage_tags", type: "boolean", default: false })
+  canManageTags: boolean;
+
   @ManyToOne(() => User)
   @JoinColumn({ name: "owner_user_id" })
   owner: User;

--- a/backend/src/delegation/entities/account-delegate.entity.ts
+++ b/backend/src/delegation/entities/account-delegate.entity.ts
@@ -1,0 +1,49 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+} from "typeorm";
+import { User } from "../../users/entities/user.entity";
+import { AccountDelegateGrant } from "./account-delegate-grant.entity";
+
+export type DelegationStatus = "pending" | "active" | "revoked";
+
+@Entity("account_delegates")
+export class AccountDelegate {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @Column({ name: "owner_user_id", type: "uuid" })
+  ownerUserId: string;
+
+  @Column({ name: "delegate_user_id", type: "uuid" })
+  delegateUserId: string;
+
+  @Column({ type: "varchar", length: 20, default: "active" })
+  status: DelegationStatus;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt: Date;
+
+  @Column({ name: "revoked_at", type: "timestamp", nullable: true })
+  revokedAt: Date | null;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: "owner_user_id" })
+  owner: User;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: "delegate_user_id" })
+  delegate: User;
+
+  @OneToMany(() => AccountDelegateGrant, (grant) => grant.delegation)
+  grants: AccountDelegateGrant[];
+}

--- a/backend/src/delegation/entities/delegate-account-favourite.entity.ts
+++ b/backend/src/delegation/entities/delegate-account-favourite.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  Unique,
+} from "typeorm";
+
+/**
+ * A delegate's own favourite marker for an account they have access to.
+ *
+ * Account favourites live on the accounts row (owner-scoped). When a
+ * delegate acts as an owner, that shared flag must NOT be reused -- the
+ * delegate keeps an independent set of favourites here, keyed by their own
+ * user id, so owner and delegate favourites never affect each other.
+ */
+@Entity("delegate_account_favourites")
+@Unique(["delegateUserId", "accountId"])
+export class DelegateAccountFavourite {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @Column({ name: "delegate_user_id", type: "uuid" })
+  delegateUserId: string;
+
+  @Column({ name: "account_id", type: "uuid" })
+  accountId: string;
+
+  @Column({ name: "sort_order", type: "integer", default: 0 })
+  sortOrder: number;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt: Date;
+}

--- a/backend/src/delegation/guards/account-delegate.guard.spec.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.spec.ts
@@ -3,6 +3,7 @@ import { AccountDelegateGuard } from "./account-delegate.guard";
 import {
   ALLOW_DELEGATE_KEY,
   DELEGATED_ACCOUNT_PARAM_KEY,
+  DELEGATED_TRANSACTION_PARAM_KEY,
   DELEGATE_OPERATION_KEY,
 } from "../decorators/delegate-access.decorator";
 
@@ -23,7 +24,10 @@ describe("AccountDelegateGuard", () => {
   beforeEach(() => {
     reflector = { getAllAndOverride: jest.fn() };
     jwtService = { verify: jest.fn() };
-    delegationService = { hasAccountPermission: jest.fn() };
+    delegationService = {
+      hasAccountPermission: jest.fn(),
+      accountIdForTransaction: jest.fn(),
+    };
     guard = new AccountDelegateGuard(
       reflector as any,
       jwtService as any,
@@ -124,6 +128,57 @@ describe("AccountDelegateGuard", () => {
       params: { id: "acc-1" },
     });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it("resolves a transaction's account and enforces the edit grant", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATED_TRANSACTION_PARAM_KEY) return "id";
+      if (key === DELEGATE_OPERATION_KEY) return "edit";
+      return undefined;
+    });
+    delegationService.accountIdForTransaction.mockResolvedValue("acc-9");
+    delegationService.hasAccountPermission.mockResolvedValue(false);
+    const ctx = makeContext({
+      headers: { authorization: "Bearer x" },
+      params: { id: "tx-1" },
+    });
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(delegationService.accountIdForTransaction).toHaveBeenCalledWith(
+      "tx-1",
+    );
+    expect(delegationService.hasAccountPermission).toHaveBeenCalledWith(
+      "g1",
+      "acc-9",
+      "edit",
+    );
+  });
+
+  it("lets an unknown transaction fall through to the service (404)", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATED_TRANSACTION_PARAM_KEY) return "id";
+      return undefined;
+    });
+    delegationService.accountIdForTransaction.mockResolvedValue(null);
+    const ctx = makeContext({
+      headers: { authorization: "Bearer x" },
+      params: { id: "tx-missing" },
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(delegationService.hasAccountPermission).not.toHaveBeenCalled();
   });
 
   it("ignores 2fa_pending tokens", async () => {

--- a/backend/src/delegation/guards/account-delegate.guard.spec.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.spec.ts
@@ -4,6 +4,8 @@ import {
   ALLOW_DELEGATE_KEY,
   DELEGATED_ACCOUNT_PARAM_KEY,
   DELEGATED_TRANSACTION_PARAM_KEY,
+  DELEGATED_TRANSFER_BODY_KEY,
+  DELEGATED_TRANSFER_PARAM_KEY,
   DELEGATE_OPERATION_KEY,
 } from "../decorators/delegate-access.decorator";
 
@@ -27,6 +29,7 @@ describe("AccountDelegateGuard", () => {
     delegationService = {
       hasAccountPermission: jest.fn(),
       accountIdForTransaction: jest.fn(),
+      accountIdsForTransfer: jest.fn(),
     };
     guard = new AccountDelegateGuard(
       reflector as any,
@@ -173,6 +176,103 @@ describe("AccountDelegateGuard", () => {
       return undefined;
     });
     delegationService.accountIdForTransaction.mockResolvedValue(null);
+    const ctx = makeContext({
+      headers: { authorization: "Bearer x" },
+      params: { id: "tx-missing" },
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(delegationService.hasAccountPermission).not.toHaveBeenCalled();
+  });
+
+  it("requires the operation on BOTH accounts of a transfer body", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATED_TRANSFER_BODY_KEY)
+        return ["fromAccountId", "toAccountId"];
+      if (key === DELEGATE_OPERATION_KEY) return "create";
+      return undefined;
+    });
+    // from-account allowed, to-account denied -> overall denied
+    delegationService.hasAccountPermission.mockImplementation(
+      async (_g: string, accId: string) => accId === "from-acc",
+    );
+    const ctx = makeContext({
+      headers: { authorization: "Bearer x" },
+      body: { fromAccountId: "from-acc", toAccountId: "to-acc" },
+    });
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(delegationService.hasAccountPermission).toHaveBeenCalledWith(
+      "g1",
+      "to-acc",
+      "create",
+    );
+  });
+
+  it("allows a transfer body when both accounts are permitted", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATED_TRANSFER_BODY_KEY)
+        return ["fromAccountId", "toAccountId"];
+      if (key === DELEGATE_OPERATION_KEY) return "create";
+      return undefined;
+    });
+    delegationService.hasAccountPermission.mockResolvedValue(true);
+    const ctx = makeContext({
+      headers: { authorization: "Bearer x" },
+      body: { fromAccountId: "a1", toAccountId: "a2" },
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it("requires the operation on both legs of a transfer-by-id", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATED_TRANSFER_PARAM_KEY) return "id";
+      if (key === DELEGATE_OPERATION_KEY) return "delete";
+      return undefined;
+    });
+    delegationService.accountIdsForTransfer.mockResolvedValue(["a1", "a2"]);
+    delegationService.hasAccountPermission.mockImplementation(
+      async (_g: string, accId: string) => accId === "a1",
+    );
+    const ctx = makeContext({
+      headers: { authorization: "Bearer x" },
+      params: { id: "tx-1" },
+    });
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it("lets an unknown transfer fall through (404)", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATED_TRANSFER_PARAM_KEY) return "id";
+      return undefined;
+    });
+    delegationService.accountIdsForTransfer.mockResolvedValue([]);
     const ctx = makeContext({
       headers: { authorization: "Bearer x" },
       params: { id: "tx-missing" },

--- a/backend/src/delegation/guards/account-delegate.guard.spec.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.spec.ts
@@ -8,6 +8,7 @@ import {
   DELEGATED_TRANSFER_PARAM_KEY,
   DELEGATE_OPERATION_KEY,
   DELEGATE_CAPABILITY_KEY,
+  DELEGATE_SECTION_KEY,
 } from "../decorators/delegate-access.decorator";
 
 describe("AccountDelegateGuard", () => {
@@ -32,6 +33,7 @@ describe("AccountDelegateGuard", () => {
       accountIdForTransaction: jest.fn(),
       accountIdsForTransfer: jest.fn(),
       hasCapability: jest.fn(),
+      hasSection: jest.fn(),
     };
     guard = new AccountDelegateGuard(
       reflector as any,
@@ -320,6 +322,41 @@ describe("AccountDelegateGuard", () => {
       return undefined;
     });
     delegationService.hasCapability.mockResolvedValue(true);
+    const ctx = makeContext({ headers: { authorization: "Bearer x" } });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it("blocks a delegate lacking the required section grant", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATE_SECTION_KEY) return "bills";
+      return undefined;
+    });
+    delegationService.hasSection.mockResolvedValue(false);
+    const ctx = makeContext({ headers: { authorization: "Bearer x" } });
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(delegationService.hasSection).toHaveBeenCalledWith("g1", "bills");
+  });
+
+  it("allows a delegate with the required section grant", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATE_SECTION_KEY) return "budgets";
+      return undefined;
+    });
+    delegationService.hasSection.mockResolvedValue(true);
     const ctx = makeContext({ headers: { authorization: "Bearer x" } });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
   });

--- a/backend/src/delegation/guards/account-delegate.guard.spec.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.spec.ts
@@ -291,7 +291,8 @@ describe("AccountDelegateGuard", () => {
     });
     reflector.getAllAndOverride.mockImplementation((key: string) => {
       if (key === ALLOW_DELEGATE_KEY) return true;
-      if (key === DELEGATE_CAPABILITY_KEY) return "payees";
+      if (key === DELEGATE_CAPABILITY_KEY)
+        return { resource: "payees", operation: "edit" };
       return undefined;
     });
     delegationService.hasCapability.mockResolvedValue(false);
@@ -302,6 +303,7 @@ describe("AccountDelegateGuard", () => {
     expect(delegationService.hasCapability).toHaveBeenCalledWith(
       "g1",
       "payees",
+      "edit",
     );
   });
 
@@ -313,7 +315,8 @@ describe("AccountDelegateGuard", () => {
     });
     reflector.getAllAndOverride.mockImplementation((key: string) => {
       if (key === ALLOW_DELEGATE_KEY) return true;
-      if (key === DELEGATE_CAPABILITY_KEY) return "tags";
+      if (key === DELEGATE_CAPABILITY_KEY)
+        return { resource: "tags", operation: "delete" };
       return undefined;
     });
     delegationService.hasCapability.mockResolvedValue(true);

--- a/backend/src/delegation/guards/account-delegate.guard.spec.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.spec.ts
@@ -3,6 +3,7 @@ import { AccountDelegateGuard } from "./account-delegate.guard";
 import {
   ALLOW_DELEGATE_KEY,
   DELEGATED_ACCOUNT_PARAM_KEY,
+  DELEGATE_OPERATION_KEY,
 } from "../decorators/delegate-access.decorator";
 
 describe("AccountDelegateGuard", () => {
@@ -22,7 +23,7 @@ describe("AccountDelegateGuard", () => {
   beforeEach(() => {
     reflector = { getAllAndOverride: jest.fn() };
     jwtService = { verify: jest.fn() };
-    delegationService = { hasReadAccess: jest.fn() };
+    delegationService = { hasAccountPermission: jest.fn() };
     guard = new AccountDelegateGuard(
       reflector as any,
       jwtService as any,
@@ -90,7 +91,7 @@ describe("AccountDelegateGuard", () => {
       if (key === DELEGATED_ACCOUNT_PARAM_KEY) return "id";
       return undefined;
     });
-    delegationService.hasReadAccess.mockResolvedValue(false);
+    delegationService.hasAccountPermission.mockResolvedValue(false);
     const ctx = makeContext({
       headers: { authorization: "Bearer x" },
       params: { id: "acc-1" },
@@ -98,7 +99,11 @@ describe("AccountDelegateGuard", () => {
     await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(
       ForbiddenException,
     );
-    expect(delegationService.hasReadAccess).toHaveBeenCalledWith("g1", "acc-1");
+    expect(delegationService.hasAccountPermission).toHaveBeenCalledWith(
+      "g1",
+      "acc-1",
+      "read",
+    );
   });
 
   it("allows a delegate with READ access to the account", async () => {
@@ -112,7 +117,7 @@ describe("AccountDelegateGuard", () => {
       if (key === DELEGATED_ACCOUNT_PARAM_KEY) return "id";
       return undefined;
     });
-    delegationService.hasReadAccess.mockResolvedValue(true);
+    delegationService.hasAccountPermission.mockResolvedValue(true);
     const ctx = makeContext({
       headers: {},
       cookies: { auth_token: "ck" },
@@ -155,15 +160,16 @@ describe("AccountDelegateGuard", () => {
       if (key === DELEGATED_ACCOUNT_PARAM_KEY) return "accountId";
       return undefined;
     });
-    delegationService.hasReadAccess.mockResolvedValue(true);
+    delegationService.hasAccountPermission.mockResolvedValue(true);
     const ctx = makeContext({
       headers: { authorization: "Bearer x" },
       body: { accountId: "acc-body" },
     });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
-    expect(delegationService.hasReadAccess).toHaveBeenCalledWith(
+    expect(delegationService.hasAccountPermission).toHaveBeenCalledWith(
       "g1",
       "acc-body",
+      "read",
     );
   });
 
@@ -178,15 +184,43 @@ describe("AccountDelegateGuard", () => {
       if (key === DELEGATED_ACCOUNT_PARAM_KEY) return "accountId";
       return undefined;
     });
-    delegationService.hasReadAccess.mockResolvedValue(true);
+    delegationService.hasAccountPermission.mockResolvedValue(true);
     const ctx = makeContext({
       headers: { authorization: "Bearer x" },
       query: { accountId: "acc-query" },
     });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
-    expect(delegationService.hasReadAccess).toHaveBeenCalledWith(
+    expect(delegationService.hasAccountPermission).toHaveBeenCalledWith(
       "g1",
       "acc-query",
+      "read",
+    );
+  });
+
+  it("enforces the required write operation (create)", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATED_ACCOUNT_PARAM_KEY) return "accountId";
+      if (key === DELEGATE_OPERATION_KEY) return "create";
+      return undefined;
+    });
+    delegationService.hasAccountPermission.mockResolvedValue(false);
+    const ctx = makeContext({
+      headers: { authorization: "Bearer x" },
+      body: { accountId: "acc-1" },
+    });
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(delegationService.hasAccountPermission).toHaveBeenCalledWith(
+      "g1",
+      "acc-1",
+      "create",
     );
   });
 
@@ -203,6 +237,6 @@ describe("AccountDelegateGuard", () => {
     });
     const ctx = makeContext({ headers: { authorization: "Bearer x" } });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
-    expect(delegationService.hasReadAccess).not.toHaveBeenCalled();
+    expect(delegationService.hasAccountPermission).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/delegation/guards/account-delegate.guard.spec.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.spec.ts
@@ -1,0 +1,129 @@
+import { ForbiddenException } from "@nestjs/common";
+import { AccountDelegateGuard } from "./account-delegate.guard";
+import {
+  ALLOW_DELEGATE_KEY,
+  DELEGATED_ACCOUNT_PARAM_KEY,
+} from "../decorators/delegate-access.decorator";
+
+describe("AccountDelegateGuard", () => {
+  let guard: AccountDelegateGuard;
+  let reflector: Record<string, jest.Mock>;
+  let jwtService: Record<string, jest.Mock>;
+  let delegationService: Record<string, jest.Mock>;
+
+  const makeContext = (req: any) =>
+    ({
+      getType: () => "http",
+      switchToHttp: () => ({ getRequest: () => req }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    }) as any;
+
+  beforeEach(() => {
+    reflector = { getAllAndOverride: jest.fn() };
+    jwtService = { verify: jest.fn() };
+    delegationService = { hasReadAccess: jest.fn() };
+    guard = new AccountDelegateGuard(
+      reflector as any,
+      jwtService as any,
+      delegationService as any,
+    );
+  });
+
+  it("allows requests with no token (normal AuthGuard handles auth)", async () => {
+    const ctx = makeContext({ headers: {} });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(jwtService.verify).not.toHaveBeenCalled();
+  });
+
+  it("allows when the token is invalid (AuthGuard will reject)", async () => {
+    jwtService.verify.mockImplementation(() => {
+      throw new Error("bad token");
+    });
+    const ctx = makeContext({
+      headers: { authorization: "Bearer x" },
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it("allows a normal (non-delegate) token unchanged", async () => {
+    jwtService.verify.mockReturnValue({ sub: "u1" });
+    const ctx = makeContext({ headers: { authorization: "Bearer x" } });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(reflector.getAllAndOverride).not.toHaveBeenCalled();
+  });
+
+  it("blocks a delegate on a route not annotated @AllowDelegate (fail closed)", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockReturnValue(undefined);
+    const ctx = makeContext({ headers: { authorization: "Bearer x" } });
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it("allows a delegate on an @AllowDelegate route with no account param", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) =>
+      key === ALLOW_DELEGATE_KEY ? true : undefined,
+    );
+    const ctx = makeContext({ headers: { authorization: "Bearer x" } });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it("blocks a delegate without READ access to the account", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATED_ACCOUNT_PARAM_KEY) return "id";
+      return undefined;
+    });
+    delegationService.hasReadAccess.mockResolvedValue(false);
+    const ctx = makeContext({
+      headers: { authorization: "Bearer x" },
+      params: { id: "acc-1" },
+    });
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(delegationService.hasReadAccess).toHaveBeenCalledWith("g1", "acc-1");
+  });
+
+  it("allows a delegate with READ access to the account", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATED_ACCOUNT_PARAM_KEY) return "id";
+      return undefined;
+    });
+    delegationService.hasReadAccess.mockResolvedValue(true);
+    const ctx = makeContext({
+      headers: {},
+      cookies: { auth_token: "ck" },
+      params: { id: "acc-1" },
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it("ignores 2fa_pending tokens", async () => {
+    jwtService.verify.mockReturnValue({ sub: "u1", type: "2fa_pending" });
+    const ctx = makeContext({ headers: { authorization: "Bearer x" } });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+});

--- a/backend/src/delegation/guards/account-delegate.guard.spec.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.spec.ts
@@ -126,4 +126,83 @@ describe("AccountDelegateGuard", () => {
     const ctx = makeContext({ headers: { authorization: "Bearer x" } });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
   });
+
+  it("allows non-http execution contexts", async () => {
+    const ctx = {
+      getType: () => "ws",
+      switchToHttp: () => ({ getRequest: () => ({}) }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as any;
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it("treats a token with actingAsUserId but no delegationId as non-delegate", async () => {
+    jwtService.verify.mockReturnValue({ sub: "d1", actingAsUserId: "o1" });
+    const ctx = makeContext({ headers: { authorization: "Bearer x" } });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(reflector.getAllAndOverride).not.toHaveBeenCalled();
+  });
+
+  it("resolves the account id from the request body", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATED_ACCOUNT_PARAM_KEY) return "accountId";
+      return undefined;
+    });
+    delegationService.hasReadAccess.mockResolvedValue(true);
+    const ctx = makeContext({
+      headers: { authorization: "Bearer x" },
+      body: { accountId: "acc-body" },
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(delegationService.hasReadAccess).toHaveBeenCalledWith(
+      "g1",
+      "acc-body",
+    );
+  });
+
+  it("resolves the account id from the query string", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATED_ACCOUNT_PARAM_KEY) return "accountId";
+      return undefined;
+    });
+    delegationService.hasReadAccess.mockResolvedValue(true);
+    const ctx = makeContext({
+      headers: { authorization: "Bearer x" },
+      query: { accountId: "acc-query" },
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(delegationService.hasReadAccess).toHaveBeenCalledWith(
+      "g1",
+      "acc-query",
+    );
+  });
+
+  it("skips the grant check when the account id is absent", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATED_ACCOUNT_PARAM_KEY) return "id";
+      return undefined;
+    });
+    const ctx = makeContext({ headers: { authorization: "Bearer x" } });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(delegationService.hasReadAccess).not.toHaveBeenCalled();
+  });
 });

--- a/backend/src/delegation/guards/account-delegate.guard.spec.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.spec.ts
@@ -6,6 +6,7 @@ import {
   DELEGATED_TRANSACTION_PARAM_KEY,
   DELEGATED_TRANSFER_BODY_KEY,
   DELEGATED_TRANSFER_PARAM_KEY,
+  DELEGATED_SCHEDULED_PARAM_KEY,
   DELEGATE_OPERATION_KEY,
   DELEGATE_CAPABILITY_KEY,
   DELEGATE_SECTION_KEY,
@@ -32,6 +33,7 @@ describe("AccountDelegateGuard", () => {
       hasAccountPermission: jest.fn(),
       accountIdForTransaction: jest.fn(),
       accountIdsForTransfer: jest.fn(),
+      accountIdsForScheduled: jest.fn(),
       hasCapability: jest.fn(),
       hasSection: jest.fn(),
     };
@@ -324,6 +326,80 @@ describe("AccountDelegateGuard", () => {
     delegationService.hasCapability.mockResolvedValue(true);
     const ctx = makeContext({ headers: { authorization: "Bearer x" } });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it("requires the operation on every account of a scheduled-by-id", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATED_SCHEDULED_PARAM_KEY) return "id";
+      if (key === DELEGATE_OPERATION_KEY) return "edit";
+      return undefined;
+    });
+    delegationService.accountIdsForScheduled.mockResolvedValue(["a1", "a2"]);
+    delegationService.hasAccountPermission.mockImplementation(
+      async (_g: string, accId: string) => accId === "a1",
+    );
+    const ctx = makeContext({
+      headers: { authorization: "Bearer x" },
+      params: { id: "s-1" },
+    });
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it("lets an unknown scheduled txn fall through (404)", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATED_SCHEDULED_PARAM_KEY) return "id";
+      return undefined;
+    });
+    delegationService.accountIdsForScheduled.mockResolvedValue([]);
+    const ctx = makeContext({
+      headers: { authorization: "Bearer x" },
+      params: { id: "s-missing" },
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(delegationService.hasAccountPermission).not.toHaveBeenCalled();
+  });
+
+  it("READ of a scheduled transfer only gates the primary account", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATED_SCHEDULED_PARAM_KEY) return "id";
+      // no DELEGATE_OPERATION_KEY -> defaults to "read"
+      return undefined;
+    });
+    delegationService.accountIdsForScheduled.mockResolvedValue(["a1", "a2"]);
+    delegationService.hasAccountPermission.mockImplementation(
+      async (_g: string, accId: string) => accId === "a1",
+    );
+    const ctx = makeContext({
+      headers: { authorization: "Bearer x" },
+      params: { id: "s-1" },
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(delegationService.hasAccountPermission).toHaveBeenCalledTimes(1);
+    expect(delegationService.hasAccountPermission).toHaveBeenCalledWith(
+      "g1",
+      "a1",
+      "read",
+    );
   });
 
   it("blocks a delegate lacking the required section grant", async () => {

--- a/backend/src/delegation/guards/account-delegate.guard.spec.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.spec.ts
@@ -7,6 +7,7 @@ import {
   DELEGATED_TRANSFER_BODY_KEY,
   DELEGATED_TRANSFER_PARAM_KEY,
   DELEGATE_OPERATION_KEY,
+  DELEGATE_CAPABILITY_KEY,
 } from "../decorators/delegate-access.decorator";
 
 describe("AccountDelegateGuard", () => {
@@ -30,6 +31,7 @@ describe("AccountDelegateGuard", () => {
       hasAccountPermission: jest.fn(),
       accountIdForTransaction: jest.fn(),
       accountIdsForTransfer: jest.fn(),
+      hasCapability: jest.fn(),
     };
     guard = new AccountDelegateGuard(
       reflector as any,
@@ -279,6 +281,44 @@ describe("AccountDelegateGuard", () => {
     });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
     expect(delegationService.hasAccountPermission).not.toHaveBeenCalled();
+  });
+
+  it("blocks a delegate lacking the required manage capability", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATE_CAPABILITY_KEY) return "payees";
+      return undefined;
+    });
+    delegationService.hasCapability.mockResolvedValue(false);
+    const ctx = makeContext({ headers: { authorization: "Bearer x" } });
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(delegationService.hasCapability).toHaveBeenCalledWith(
+      "g1",
+      "payees",
+    );
+  });
+
+  it("allows a delegate with the required manage capability", async () => {
+    jwtService.verify.mockReturnValue({
+      sub: "d1",
+      actingAsUserId: "o1",
+      delegationId: "g1",
+    });
+    reflector.getAllAndOverride.mockImplementation((key: string) => {
+      if (key === ALLOW_DELEGATE_KEY) return true;
+      if (key === DELEGATE_CAPABILITY_KEY) return "tags";
+      return undefined;
+    });
+    delegationService.hasCapability.mockResolvedValue(true);
+    const ctx = makeContext({ headers: { authorization: "Bearer x" } });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
   });
 
   it("ignores 2fa_pending tokens", async () => {

--- a/backend/src/delegation/guards/account-delegate.guard.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.ts
@@ -11,6 +11,8 @@ import {
   ALLOW_DELEGATE_KEY,
   DELEGATED_ACCOUNT_PARAM_KEY,
   DELEGATED_TRANSACTION_PARAM_KEY,
+  DELEGATED_TRANSFER_BODY_KEY,
+  DELEGATED_TRANSFER_PARAM_KEY,
   DELEGATE_OPERATION_KEY,
   DelegateOperation,
 } from "../decorators/delegate-access.decorator";
@@ -97,6 +99,45 @@ export class AccountDelegateGuard implements CanActivate {
           await this.delegationService.accountIdForTransaction(txId);
         // Unknown transaction: let the owner-scoped service return 404.
         if (accountId) {
+          await this.assertPermission(
+            payload.delegationId,
+            accountId,
+            operation,
+          );
+        }
+      }
+    }
+
+    const transferBodyKeys = this.reflector.getAllAndOverride<[string, string]>(
+      DELEGATED_TRANSFER_BODY_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (transferBodyKeys) {
+      // A transfer touches two accounts; the delegate needs the operation on
+      // BOTH ends (no moving money via an account they cannot access).
+      for (const key of transferBodyKeys) {
+        const accountId = this.resolveAccountId(req, key);
+        if (accountId) {
+          await this.assertPermission(
+            payload.delegationId,
+            accountId,
+            operation,
+          );
+        }
+      }
+    }
+
+    const transferParamKey = this.reflector.getAllAndOverride<string>(
+      DELEGATED_TRANSFER_PARAM_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (transferParamKey) {
+      const txId = this.resolveAccountId(req, transferParamKey);
+      if (txId) {
+        const accountIds =
+          await this.delegationService.accountIdsForTransfer(txId);
+        // Unknown transfer: let the owner-scoped service return 404.
+        for (const accountId of accountIds) {
           await this.assertPermission(
             payload.delegationId,
             accountId,

--- a/backend/src/delegation/guards/account-delegate.guard.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.ts
@@ -23,6 +23,20 @@ import {
 } from "../decorators/delegate-access.decorator";
 import { DelegationService } from "../delegation.service";
 
+const SECTION_LABELS: Record<DelegateSection, string> = {
+  bills: "Bills & Deposits",
+  investments: "Investments",
+  budgets: "Budgets",
+  reports: "Reports",
+  ai: "AI Assistant",
+};
+
+const RESOURCE_LABELS: Record<DelegateCapabilityReq["resource"], string> = {
+  payees: "payees",
+  categories: "categories",
+  tags: "tags",
+};
+
 /**
  * Fail-closed enforcement for delegate ("acting as owner") requests.
  *
@@ -72,7 +86,8 @@ export class AccountDelegateGuard implements CanActivate {
     );
     if (!allowed) {
       throw new ForbiddenException(
-        "Delegated access is not permitted for this resource",
+        "This action isn't available while you're acting on behalf of " +
+          "another user. Only the account owner can do this.",
       );
     }
 
@@ -189,7 +204,9 @@ export class AccountDelegateGuard implements CanActivate {
       );
       if (!ok) {
         throw new ForbiddenException(
-          `You are not permitted to ${capability.operation} ${capability.resource}`,
+          `The account owner has not granted you permission to ` +
+            `${capability.operation} ${RESOURCE_LABELS[capability.resource]}. ` +
+            `Ask them to enable this in your delegated-access settings.`,
         );
       }
     }
@@ -204,7 +221,10 @@ export class AccountDelegateGuard implements CanActivate {
         section,
       );
       if (!ok) {
-        throw new ForbiddenException("You do not have access to this section");
+        throw new ForbiddenException(
+          `The account owner has not shared the ${SECTION_LABELS[section]} ` +
+            `section with you.`,
+        );
       }
     }
 
@@ -222,7 +242,12 @@ export class AccountDelegateGuard implements CanActivate {
       operation,
     );
     if (!ok) {
-      throw new ForbiddenException("You do not have access to this account");
+      throw new ForbiddenException(
+        operation === "read"
+          ? "The account owner has not shared this account with you."
+          : `The account owner has not granted you permission to ` +
+              `${operation} transactions in this account.`,
+      );
     }
   }
 

--- a/backend/src/delegation/guards/account-delegate.guard.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.ts
@@ -10,6 +10,8 @@ import { Request } from "express";
 import {
   ALLOW_DELEGATE_KEY,
   DELEGATED_ACCOUNT_PARAM_KEY,
+  DELEGATE_OPERATION_KEY,
+  DelegateOperation,
 } from "../decorators/delegate-access.decorator";
 import { DelegationService } from "../delegation.service";
 
@@ -73,9 +75,15 @@ export class AccountDelegateGuard implements CanActivate {
     if (accountParamKey) {
       const accountId = this.resolveAccountId(req, accountParamKey);
       if (accountId) {
-        const ok = await this.delegationService.hasReadAccess(
+        const operation =
+          this.reflector.getAllAndOverride<DelegateOperation>(
+            DELEGATE_OPERATION_KEY,
+            [context.getHandler(), context.getClass()],
+          ) ?? "read";
+        const ok = await this.delegationService.hasAccountPermission(
           payload.delegationId,
           accountId,
+          operation,
         );
         if (!ok) {
           throw new ForbiddenException(

--- a/backend/src/delegation/guards/account-delegate.guard.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.ts
@@ -10,6 +10,7 @@ import { Request } from "express";
 import {
   ALLOW_DELEGATE_KEY,
   DELEGATED_ACCOUNT_PARAM_KEY,
+  DELEGATED_TRANSACTION_PARAM_KEY,
   DELEGATE_OPERATION_KEY,
   DelegateOperation,
 } from "../decorators/delegate-access.decorator";
@@ -68,6 +69,12 @@ export class AccountDelegateGuard implements CanActivate {
       );
     }
 
+    const operation =
+      this.reflector.getAllAndOverride<DelegateOperation>(
+        DELEGATE_OPERATION_KEY,
+        [context.getHandler(), context.getClass()],
+      ) ?? "read";
+
     const accountParamKey = this.reflector.getAllAndOverride<string>(
       DELEGATED_ACCOUNT_PARAM_KEY,
       [context.getHandler(), context.getClass()],
@@ -75,25 +82,46 @@ export class AccountDelegateGuard implements CanActivate {
     if (accountParamKey) {
       const accountId = this.resolveAccountId(req, accountParamKey);
       if (accountId) {
-        const operation =
-          this.reflector.getAllAndOverride<DelegateOperation>(
-            DELEGATE_OPERATION_KEY,
-            [context.getHandler(), context.getClass()],
-          ) ?? "read";
-        const ok = await this.delegationService.hasAccountPermission(
-          payload.delegationId,
-          accountId,
-          operation,
-        );
-        if (!ok) {
-          throw new ForbiddenException(
-            "You do not have access to this account",
+        await this.assertPermission(payload.delegationId, accountId, operation);
+      }
+    }
+
+    const txParamKey = this.reflector.getAllAndOverride<string>(
+      DELEGATED_TRANSACTION_PARAM_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (txParamKey) {
+      const txId = this.resolveAccountId(req, txParamKey);
+      if (txId) {
+        const accountId =
+          await this.delegationService.accountIdForTransaction(txId);
+        // Unknown transaction: let the owner-scoped service return 404.
+        if (accountId) {
+          await this.assertPermission(
+            payload.delegationId,
+            accountId,
+            operation,
           );
         }
       }
     }
 
     return true;
+  }
+
+  private async assertPermission(
+    delegationId: string,
+    accountId: string,
+    operation: DelegateOperation,
+  ): Promise<void> {
+    const ok = await this.delegationService.hasAccountPermission(
+      delegationId,
+      accountId,
+      operation,
+    );
+    if (!ok) {
+      throw new ForbiddenException("You do not have access to this account");
+    }
   }
 
   private extractToken(req: Request): string | null {

--- a/backend/src/delegation/guards/account-delegate.guard.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.ts
@@ -15,8 +15,10 @@ import {
   DELEGATED_TRANSFER_PARAM_KEY,
   DELEGATE_OPERATION_KEY,
   DELEGATE_CAPABILITY_KEY,
+  DELEGATE_SECTION_KEY,
   DelegateOperation,
   DelegateCapabilityReq,
+  DelegateSection,
 } from "../decorators/delegate-access.decorator";
 import { DelegationService } from "../delegation.service";
 
@@ -163,6 +165,20 @@ export class AccountDelegateGuard implements CanActivate {
         throw new ForbiddenException(
           `You are not permitted to ${capability.operation} ${capability.resource}`,
         );
+      }
+    }
+
+    const section = this.reflector.getAllAndOverride<DelegateSection>(
+      DELEGATE_SECTION_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (section) {
+      const ok = await this.delegationService.hasSection(
+        payload.delegationId,
+        section,
+      );
+      if (!ok) {
+        throw new ForbiddenException("You do not have access to this section");
       }
     }
 

--- a/backend/src/delegation/guards/account-delegate.guard.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.ts
@@ -16,7 +16,7 @@ import {
   DELEGATE_OPERATION_KEY,
   DELEGATE_CAPABILITY_KEY,
   DelegateOperation,
-  DelegateCapability,
+  DelegateCapabilityReq,
 } from "../decorators/delegate-access.decorator";
 import { DelegationService } from "../delegation.service";
 
@@ -149,18 +149,19 @@ export class AccountDelegateGuard implements CanActivate {
       }
     }
 
-    const capability = this.reflector.getAllAndOverride<DelegateCapability>(
+    const capability = this.reflector.getAllAndOverride<DelegateCapabilityReq>(
       DELEGATE_CAPABILITY_KEY,
       [context.getHandler(), context.getClass()],
     );
     if (capability) {
       const ok = await this.delegationService.hasCapability(
         payload.delegationId,
-        capability,
+        capability.resource,
+        capability.operation,
       );
       if (!ok) {
         throw new ForbiddenException(
-          `You are not permitted to manage ${capability}`,
+          `You are not permitted to ${capability.operation} ${capability.resource}`,
         );
       }
     }

--- a/backend/src/delegation/guards/account-delegate.guard.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.ts
@@ -1,0 +1,107 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { JwtService } from "@nestjs/jwt";
+import { Request } from "express";
+import {
+  ALLOW_DELEGATE_KEY,
+  DELEGATED_ACCOUNT_PARAM_KEY,
+} from "../decorators/delegate-access.decorator";
+import { DelegationService } from "../delegation.service";
+
+/**
+ * Fail-closed enforcement for delegate ("acting as owner") requests.
+ *
+ * Registered globally. Because NestJS runs global guards before route-level
+ * AuthGuard('jwt'), this guard does NOT rely on req.user being populated --
+ * it independently reads and verifies the access token. This keeps a single
+ * ordering-independent choke point.
+ *
+ * Behaviour:
+ *  - No token / invalid token / non-delegate token: returns true. The normal
+ *    AuthGuard('jwt') still authenticates/authorizes the request as before;
+ *    normal users and owners are completely unaffected.
+ *  - Delegate (acting) token: the route MUST be @AllowDelegate(); otherwise
+ *    403. If the route is @DelegatedAccountParam(), an active READ grant for
+ *    the referenced account is additionally required.
+ */
+@Injectable()
+export class AccountDelegateGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    private jwtService: JwtService,
+    private delegationService: DelegationService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    if (context.getType() !== "http") return true;
+
+    const req = context.switchToHttp().getRequest<Request>();
+    const token = this.extractToken(req);
+    if (!token) return true;
+
+    let payload: any;
+    try {
+      payload = this.jwtService.verify(token);
+    } catch {
+      return true; // AuthGuard('jwt') will reject it
+    }
+
+    if (payload?.type === "2fa_pending") return true;
+    if (!payload?.actingAsUserId || !payload?.delegationId) {
+      return true; // acting as self / normal user
+    }
+
+    const allowed = this.reflector.getAllAndOverride<boolean>(
+      ALLOW_DELEGATE_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (!allowed) {
+      throw new ForbiddenException(
+        "Delegated access is not permitted for this resource",
+      );
+    }
+
+    const accountParamKey = this.reflector.getAllAndOverride<string>(
+      DELEGATED_ACCOUNT_PARAM_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (accountParamKey) {
+      const accountId = this.resolveAccountId(req, accountParamKey);
+      if (accountId) {
+        const ok = await this.delegationService.hasReadAccess(
+          payload.delegationId,
+          accountId,
+        );
+        if (!ok) {
+          throw new ForbiddenException(
+            "You do not have access to this account",
+          );
+        }
+      }
+    }
+
+    return true;
+  }
+
+  private extractToken(req: Request): string | null {
+    const header = req.headers?.authorization;
+    if (header && header.startsWith("Bearer ")) {
+      return header.slice(7);
+    }
+    const cookieToken = (req as any).cookies?.["auth_token"];
+    return typeof cookieToken === "string" ? cookieToken : null;
+  }
+
+  private resolveAccountId(req: Request, key: string): string | undefined {
+    const params = req.params as Record<string, unknown> | undefined;
+    const body = req.body as Record<string, unknown> | undefined;
+    const query = req.query as Record<string, unknown> | undefined;
+    const candidate = params?.[key] ?? body?.[key] ?? (query?.[key] as unknown);
+    return typeof candidate === "string" ? candidate : undefined;
+  }
+}

--- a/backend/src/delegation/guards/account-delegate.guard.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.ts
@@ -93,8 +93,12 @@ export class AccountDelegateGuard implements CanActivate {
     if (header && header.startsWith("Bearer ")) {
       return header.slice(7);
     }
-    const cookieToken = (req as any).cookies?.["auth_token"];
-    return typeof cookieToken === "string" ? cookieToken : null;
+    const cookies = (req as Request & { cookies?: Record<string, string> })
+      .cookies;
+    if (cookies && cookies["auth_token"]) {
+      return cookies["auth_token"];
+    }
+    return null;
   }
 
   private resolveAccountId(req: Request, key: string): string | undefined {

--- a/backend/src/delegation/guards/account-delegate.guard.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.ts
@@ -14,7 +14,9 @@ import {
   DELEGATED_TRANSFER_BODY_KEY,
   DELEGATED_TRANSFER_PARAM_KEY,
   DELEGATE_OPERATION_KEY,
+  DELEGATE_CAPABILITY_KEY,
   DelegateOperation,
+  DelegateCapability,
 } from "../decorators/delegate-access.decorator";
 import { DelegationService } from "../delegation.service";
 
@@ -144,6 +146,22 @@ export class AccountDelegateGuard implements CanActivate {
             operation,
           );
         }
+      }
+    }
+
+    const capability = this.reflector.getAllAndOverride<DelegateCapability>(
+      DELEGATE_CAPABILITY_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (capability) {
+      const ok = await this.delegationService.hasCapability(
+        payload.delegationId,
+        capability,
+      );
+      if (!ok) {
+        throw new ForbiddenException(
+          `You are not permitted to manage ${capability}`,
+        );
       }
     }
 

--- a/backend/src/delegation/guards/account-delegate.guard.ts
+++ b/backend/src/delegation/guards/account-delegate.guard.ts
@@ -13,6 +13,7 @@ import {
   DELEGATED_TRANSACTION_PARAM_KEY,
   DELEGATED_TRANSFER_BODY_KEY,
   DELEGATED_TRANSFER_PARAM_KEY,
+  DELEGATED_SCHEDULED_PARAM_KEY,
   DELEGATE_OPERATION_KEY,
   DELEGATE_CAPABILITY_KEY,
   DELEGATE_SECTION_KEY,
@@ -142,6 +143,31 @@ export class AccountDelegateGuard implements CanActivate {
           await this.delegationService.accountIdsForTransfer(txId);
         // Unknown transfer: let the owner-scoped service return 404.
         for (const accountId of accountIds) {
+          await this.assertPermission(
+            payload.delegationId,
+            accountId,
+            operation,
+          );
+        }
+      }
+    }
+
+    const scheduledParamKey = this.reflector.getAllAndOverride<string>(
+      DELEGATED_SCHEDULED_PARAM_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (scheduledParamKey) {
+      const scheduledId = this.resolveAccountId(req, scheduledParamKey);
+      if (scheduledId) {
+        const accountIds =
+          await this.delegationService.accountIdsForScheduled(scheduledId);
+        // Unknown scheduled txn: let the owner-scoped service return 404.
+        // READ only needs the primary account (accountIds[0]); the transfer
+        // counterpart is masked by the interceptor, not blocked. WRITES must
+        // hold the op on BOTH legs (no moving money via a hidden account).
+        const gated =
+          operation === "read" ? accountIds.slice(0, 1) : accountIds;
+        for (const accountId of gated) {
           await this.assertPermission(
             payload.delegationId,
             accountId,

--- a/backend/src/delegation/interceptors/delegate-scheduled-transfer-mask.interceptor.spec.ts
+++ b/backend/src/delegation/interceptors/delegate-scheduled-transfer-mask.interceptor.spec.ts
@@ -91,6 +91,31 @@ describe("DelegateScheduledTransferMaskInterceptor", () => {
     expect(body[0].transferAccount).toEqual({ id: "a2", name: "Savings" });
   });
 
+  it("masks the source side when the delegate only holds the recipient", async () => {
+    delegationService.readableAccountIds.mockResolvedValue(["a2"]);
+    const body = [
+      {
+        id: "s1",
+        isTransfer: true,
+        accountId: "a1",
+        account: { id: "a1", name: "Chequing" },
+        accountName: "Chequing",
+        transferAccountId: "a2",
+        transferAccount: { id: "a2", name: "Savings" },
+      },
+    ];
+    await lastValueFrom(
+      interceptor.intercept(
+        ctxFor({ isActing: true, delegationId: "g1" }),
+        handlerOf(body),
+      ),
+    );
+    expect(body[0].account).toEqual({ id: "a1", name: "Hidden account" });
+    expect(body[0].accountName).toBe("Hidden account");
+    // The recipient side is readable, so it stays intact.
+    expect(body[0].transferAccount).toEqual({ id: "a2", name: "Savings" });
+  });
+
   it("masks a single (non-array) scheduled object", async () => {
     delegationService.readableAccountIds.mockResolvedValue([]);
     const body = {

--- a/backend/src/delegation/interceptors/delegate-scheduled-transfer-mask.interceptor.spec.ts
+++ b/backend/src/delegation/interceptors/delegate-scheduled-transfer-mask.interceptor.spec.ts
@@ -1,0 +1,113 @@
+import { of, lastValueFrom } from "rxjs";
+import { DelegateScheduledTransferMaskInterceptor } from "./delegate-scheduled-transfer-mask.interceptor";
+
+describe("DelegateScheduledTransferMaskInterceptor", () => {
+  let interceptor: DelegateScheduledTransferMaskInterceptor;
+  let delegationService: Record<string, jest.Mock>;
+
+  const ctxFor = (user: unknown) =>
+    ({
+      getType: () => "http",
+      switchToHttp: () => ({ getRequest: () => ({ user }) }),
+    }) as never;
+  const handlerOf = (body: unknown) => ({ handle: () => of(body) }) as never;
+
+  beforeEach(() => {
+    delegationService = { readableAccountIds: jest.fn() };
+    interceptor = new DelegateScheduledTransferMaskInterceptor(
+      delegationService as never,
+    );
+  });
+
+  it("passes through for a non-http context", async () => {
+    const out = await lastValueFrom(
+      interceptor.intercept({ getType: () => "ws" } as never, handlerOf("x")),
+    );
+    expect(out).toBe("x");
+  });
+
+  it("passes through for a non-delegate request", async () => {
+    const body = [{ id: "s1", isTransfer: true }];
+    const out = await lastValueFrom(
+      interceptor.intercept(ctxFor({ isActing: false }), handlerOf(body)),
+    );
+    expect(out).toBe(body);
+    expect(delegationService.readableAccountIds).not.toHaveBeenCalled();
+  });
+
+  it("masks a scheduled transfer counterpart the delegate cannot READ", async () => {
+    delegationService.readableAccountIds.mockResolvedValue(["a1"]);
+    const body = {
+      data: [
+        {
+          id: "s1",
+          isTransfer: true,
+          transferAccountId: "a2",
+          transferAccount: { id: "a2", name: "Savings" },
+          transferAccountName: "Savings",
+          splits: [
+            {
+              isTransfer: true,
+              transferAccountId: "a3",
+              transferAccount: { id: "a3", name: "Brokerage" },
+            },
+          ],
+        },
+      ],
+    };
+    await lastValueFrom(
+      interceptor.intercept(
+        ctxFor({ isActing: true, delegationId: "g1" }),
+        handlerOf(body),
+      ),
+    );
+    expect(body.data[0].transferAccount).toEqual({
+      id: "a2",
+      name: "Hidden account",
+    });
+    expect(body.data[0].transferAccountName).toBe("Hidden account");
+    expect(body.data[0].splits[0].transferAccount).toEqual({
+      id: "a3",
+      name: "Hidden account",
+    });
+  });
+
+  it("leaves a readable counterpart untouched", async () => {
+    delegationService.readableAccountIds.mockResolvedValue(["a1", "a2"]);
+    const body = [
+      {
+        id: "s1",
+        isTransfer: true,
+        transferAccountId: "a2",
+        transferAccount: { id: "a2", name: "Savings" },
+      },
+    ];
+    await lastValueFrom(
+      interceptor.intercept(
+        ctxFor({ isActing: true, delegationId: "g1" }),
+        handlerOf(body),
+      ),
+    );
+    expect(body[0].transferAccount).toEqual({ id: "a2", name: "Savings" });
+  });
+
+  it("masks a single (non-array) scheduled object", async () => {
+    delegationService.readableAccountIds.mockResolvedValue([]);
+    const body = {
+      id: "s1",
+      isTransfer: true,
+      transferAccountId: "a2",
+      transferAccount: { id: "a2", name: "Savings" },
+    };
+    await lastValueFrom(
+      interceptor.intercept(
+        ctxFor({ isActing: true, delegationId: "g1" }),
+        handlerOf(body),
+      ),
+    );
+    expect(body.transferAccount).toEqual({
+      id: "a2",
+      name: "Hidden account",
+    });
+  });
+});

--- a/backend/src/delegation/interceptors/delegate-scheduled-transfer-mask.interceptor.ts
+++ b/backend/src/delegation/interceptors/delegate-scheduled-transfer-mask.interceptor.ts
@@ -80,14 +80,30 @@ export class DelegateScheduledTransferMaskInterceptor implements NestInterceptor
   }
 
   private maskLeg(s: Record<string, any>, readable: Set<string>): void {
-    const otherId: string | undefined = s.transferAccountId;
-    if (!s.isTransfer && !otherId) return;
-    if (!otherId || readable.has(otherId)) return;
-    if (s.transferAccount && typeof s.transferAccount === "object") {
-      s.transferAccount = { id: otherId, name: HIDDEN };
+    const srcId: string | undefined = s.accountId;
+    const dstId: string | undefined = s.transferAccountId;
+    // Only transfers (or split transfer legs) have a counterpart to hide.
+    if (!s.isTransfer && !dstId) return;
+
+    // Hide the recipient side when the delegate cannot READ it.
+    if (dstId && !readable.has(dstId)) {
+      if (s.transferAccount && typeof s.transferAccount === "object") {
+        s.transferAccount = { id: dstId, name: HIDDEN };
+      }
+      if (typeof s.transferAccountName === "string") {
+        s.transferAccountName = HIDDEN;
+      }
     }
-    if (typeof s.transferAccountName === "string") {
-      s.transferAccountName = HIDDEN;
+
+    // Hide the source side when the delegate only has the recipient
+    // account (the row surfaced because they hold the transfer target).
+    if (srcId && !readable.has(srcId)) {
+      if (s.account && typeof s.account === "object") {
+        s.account = { id: srcId, name: HIDDEN };
+      }
+      if (typeof s.accountName === "string") {
+        s.accountName = HIDDEN;
+      }
     }
   }
 }

--- a/backend/src/delegation/interceptors/delegate-scheduled-transfer-mask.interceptor.ts
+++ b/backend/src/delegation/interceptors/delegate-scheduled-transfer-mask.interceptor.ts
@@ -1,0 +1,93 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from "@nestjs/common";
+import { Request } from "express";
+import { Observable, from, switchMap } from "rxjs";
+import { map } from "rxjs/operators";
+import { DelegationService } from "../delegation.service";
+
+const HIDDEN = "Hidden account";
+
+/**
+ * 3B: when a delegate (acting as owner) reads scheduled transactions, any
+ * scheduled transfer whose counterpart account they lack READ on must be
+ * masked so the other side shows "Hidden account" instead of the real
+ * account/name. Mirrors DelegateTransferMaskInterceptor but for the
+ * scheduled-transaction shape (transferAccount / transferAccountId).
+ *
+ * Runs after the route handler, so req.user is populated by JwtStrategy.
+ * Non-delegate requests pass straight through.
+ */
+@Injectable()
+export class DelegateScheduledTransferMaskInterceptor implements NestInterceptor {
+  constructor(private readonly delegationService: DelegationService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    if (context.getType() !== "http") return next.handle();
+    const req = context
+      .switchToHttp()
+      .getRequest<
+        Request & { user?: { isActing?: boolean; delegationId?: string } }
+      >();
+    const user = req.user;
+    if (!user?.isActing || !user.delegationId) {
+      return next.handle();
+    }
+    const delegationId = user.delegationId;
+
+    return next.handle().pipe(
+      switchMap((body) =>
+        from(this.delegationService.readableAccountIds(delegationId)).pipe(
+          map((readableIds) => {
+            const readable = new Set(readableIds);
+            this.maskPayload(body, readable);
+            return body;
+          }),
+        ),
+      ),
+    );
+  }
+
+  private maskPayload(body: unknown, readable: Set<string>): void {
+    if (Array.isArray(body)) {
+      body.forEach((s) => this.maskScheduled(s, readable));
+      return;
+    }
+    if (body && typeof body === "object") {
+      const obj = body as Record<string, unknown>;
+      if (Array.isArray(obj.data)) {
+        (obj.data as unknown[]).forEach((s) => this.maskScheduled(s, readable));
+        return;
+      }
+      this.maskScheduled(body, readable);
+    }
+  }
+
+  private maskScheduled(st: unknown, readable: Set<string>): void {
+    if (!st || typeof st !== "object") return;
+    const s = st as Record<string, any>;
+    this.maskLeg(s, readable);
+    if (Array.isArray(s.splits)) {
+      s.splits.forEach((sp: unknown) => {
+        if (sp && typeof sp === "object") {
+          this.maskLeg(sp as Record<string, any>, readable);
+        }
+      });
+    }
+  }
+
+  private maskLeg(s: Record<string, any>, readable: Set<string>): void {
+    const otherId: string | undefined = s.transferAccountId;
+    if (!s.isTransfer && !otherId) return;
+    if (!otherId || readable.has(otherId)) return;
+    if (s.transferAccount && typeof s.transferAccount === "object") {
+      s.transferAccount = { id: otherId, name: HIDDEN };
+    }
+    if (typeof s.transferAccountName === "string") {
+      s.transferAccountName = HIDDEN;
+    }
+  }
+}

--- a/backend/src/delegation/interceptors/delegate-transfer-mask.interceptor.spec.ts
+++ b/backend/src/delegation/interceptors/delegate-transfer-mask.interceptor.spec.ts
@@ -1,0 +1,100 @@
+import { of, lastValueFrom } from "rxjs";
+import { DelegateTransferMaskInterceptor } from "./delegate-transfer-mask.interceptor";
+
+describe("DelegateTransferMaskInterceptor", () => {
+  let interceptor: DelegateTransferMaskInterceptor;
+  let delegationService: Record<string, jest.Mock>;
+
+  const ctxFor = (user: any) =>
+    ({
+      getType: () => "http",
+      switchToHttp: () => ({ getRequest: () => ({ user }) }),
+    }) as any;
+  const handlerOf = (body: unknown) => ({ handle: () => of(body) }) as any;
+
+  beforeEach(() => {
+    delegationService = { readableAccountIds: jest.fn() };
+    interceptor = new DelegateTransferMaskInterceptor(delegationService as any);
+  });
+
+  it("passes through for a non-delegate request", async () => {
+    const body = [{ id: "t1", isTransfer: true }];
+    const out = await lastValueFrom(
+      interceptor.intercept(ctxFor({ isActing: false }), handlerOf(body)),
+    );
+    expect(out).toBe(body);
+    expect(delegationService.readableAccountIds).not.toHaveBeenCalled();
+  });
+
+  it("masks a transfer counterpart the delegate cannot READ", async () => {
+    delegationService.readableAccountIds.mockResolvedValue(["a1"]);
+    const body = {
+      data: [
+        {
+          id: "t1",
+          isTransfer: true,
+          payeeName: "Transfer to Savings",
+          linkedTransaction: {
+            accountId: "a2",
+            account: { id: "a2", name: "Savings" },
+          },
+        },
+      ],
+    };
+    const out: any = await lastValueFrom(
+      interceptor.intercept(
+        ctxFor({ isActing: true, delegationId: "g1" }),
+        handlerOf(body),
+      ),
+    );
+    expect(out.data[0].linkedTransaction.account).toEqual({
+      id: "a2",
+      name: "Hidden account",
+    });
+    expect(out.data[0].payeeName).toBe("Transfer to Hidden account");
+  });
+
+  it("does not mask when the counterpart is readable", async () => {
+    delegationService.readableAccountIds.mockResolvedValue(["a1", "a2"]);
+    const body = [
+      {
+        id: "t1",
+        isTransfer: true,
+        payeeName: "Transfer to Savings",
+        linkedTransaction: {
+          accountId: "a2",
+          account: { id: "a2", name: "Savings" },
+        },
+      },
+    ];
+    const out: any = await lastValueFrom(
+      interceptor.intercept(
+        ctxFor({ isActing: true, delegationId: "g1" }),
+        handlerOf(body),
+      ),
+    );
+    expect(out[0].linkedTransaction.account.name).toBe("Savings");
+    expect(out[0].payeeName).toBe("Transfer to Savings");
+  });
+
+  it("masks a single transaction object and ignores non-transfers", async () => {
+    delegationService.readableAccountIds.mockResolvedValue([]);
+    const body = {
+      id: "t1",
+      isTransfer: true,
+      payeeName: "Transfer from Chequing",
+      linkedTransaction: {
+        accountId: "a9",
+        account: { id: "a9", name: "Chequing" },
+      },
+    };
+    const out: any = await lastValueFrom(
+      interceptor.intercept(
+        ctxFor({ isActing: true, delegationId: "g1" }),
+        handlerOf(body),
+      ),
+    );
+    expect(out.linkedTransaction.account.name).toBe("Hidden account");
+    expect(out.payeeName).toBe("Transfer from Hidden account");
+  });
+});

--- a/backend/src/delegation/interceptors/delegate-transfer-mask.interceptor.ts
+++ b/backend/src/delegation/interceptors/delegate-transfer-mask.interceptor.ts
@@ -1,0 +1,90 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from "@nestjs/common";
+import { Request } from "express";
+import { Observable, from, switchMap } from "rxjs";
+import { map } from "rxjs/operators";
+import { DelegationService } from "../delegation.service";
+
+const HIDDEN = "Hidden account";
+
+/**
+ * 2B: when a delegate (acting as owner) reads transactions, any transfer
+ * whose counterpart account they lack READ on must be masked so the other
+ * side shows "Hidden account" instead of the real account/name.
+ *
+ * Runs after the route handler, so req.user is populated by JwtStrategy.
+ * Non-delegate requests pass straight through.
+ */
+@Injectable()
+export class DelegateTransferMaskInterceptor implements NestInterceptor {
+  constructor(private readonly delegationService: DelegationService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    if (context.getType() !== "http") return next.handle();
+    const req = context
+      .switchToHttp()
+      .getRequest<
+        Request & { user?: { isActing?: boolean; delegationId?: string } }
+      >();
+    const user = req.user;
+    if (!user?.isActing || !user.delegationId) {
+      return next.handle();
+    }
+    const delegationId = user.delegationId;
+
+    return next.handle().pipe(
+      switchMap((body) =>
+        from(this.delegationService.readableAccountIds(delegationId)).pipe(
+          map((readableIds) => {
+            const readable = new Set(readableIds);
+            this.maskPayload(body, readable);
+            return body;
+          }),
+        ),
+      ),
+    );
+  }
+
+  private maskPayload(body: unknown, readable: Set<string>): void {
+    if (Array.isArray(body)) {
+      body.forEach((t) => this.maskTransaction(t, readable));
+      return;
+    }
+    if (body && typeof body === "object") {
+      const obj = body as Record<string, unknown>;
+      if (Array.isArray(obj.data)) {
+        (obj.data as unknown[]).forEach((t) =>
+          this.maskTransaction(t, readable),
+        );
+        return;
+      }
+      this.maskTransaction(body, readable);
+    }
+  }
+
+  private maskTransaction(tx: unknown, readable: Set<string>): void {
+    if (!tx || typeof tx !== "object") return;
+    const t = tx as Record<string, any>;
+    const linked = t.linkedTransaction as Record<string, any> | undefined;
+    if (!t.isTransfer || !linked) return;
+    const otherAccountId: string | undefined = linked.accountId;
+    if (!otherAccountId || readable.has(otherAccountId)) return;
+
+    if (linked.account && typeof linked.account === "object") {
+      linked.account = { id: linked.accountId, name: HIDDEN };
+    }
+    if (typeof linked.accountName === "string") {
+      linked.accountName = HIDDEN;
+    }
+    // The visible row's auto payee name embeds the counterpart account name
+    // ("Transfer to/from <name>") -- rewrite the trailing name.
+    if (typeof t.payeeName === "string") {
+      const m = /^(Transfer (?:to|from) ).+/.exec(t.payeeName);
+      if (m) t.payeeName = `${m[1]}${HIDDEN}`;
+    }
+  }
+}

--- a/backend/src/import/import-regular-processor.service.spec.ts
+++ b/backend/src/import/import-regular-processor.service.spec.ts
@@ -3,6 +3,7 @@ import { ImportContext } from "./import-context";
 import { TransactionStatus } from "../transactions/entities/transaction.entity";
 import { AccountType } from "../accounts/entities/account.entity";
 import { Payee } from "../payees/entities/payee.entity";
+import { SplitKind } from "../transactions/entities/split-kind.enum";
 import { ImportResultDto } from "./dto/import.dto";
 
 describe("ImportRegularProcessorService", () => {
@@ -300,6 +301,57 @@ describe("ImportRegularProcessorService", () => {
       const createCalls = ctx.queryRunner.manager.create.mock.calls;
       // Main transaction + 2 splits = at least 3 create calls
       expect(createCalls.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("sets kind=category and clears transferAccountId for category splits", async () => {
+      const categoryMap = new Map<string, string | null>();
+      categoryMap.set("Food", "cat-food");
+      const ctx = makeContext({ categoryMap });
+
+      await service.processTransaction(ctx, {
+        date: "2025-01-15",
+        amount: -60,
+        splits: [{ amount: -60, category: "Food", memo: "Food" }],
+      });
+
+      const splitCreate = ctx.queryRunner.manager.create.mock.calls.find(
+        (c: unknown[]) =>
+          c[1] != null && typeof c[1] === "object" && "kind" in c[1],
+      );
+      expect(splitCreate?.[1]).toMatchObject({
+        kind: SplitKind.CATEGORY,
+        categoryId: "cat-food",
+        transferAccountId: null,
+      });
+    });
+
+    it("sets kind=transfer and clears categoryId for transfer splits", async () => {
+      const accountMap = new Map<string, string | null>();
+      accountMap.set("Checking", "acc-chk");
+      const ctx = makeContext({ accountMap });
+
+      await service.processTransaction(ctx, {
+        date: "2025-01-15",
+        amount: -50,
+        splits: [
+          {
+            amount: -50,
+            isTransfer: true,
+            transferAccount: "Checking",
+            memo: "xfer",
+          },
+        ],
+      });
+
+      const splitCreate = ctx.queryRunner.manager.create.mock.calls.find(
+        (c: unknown[]) =>
+          c[1] != null && typeof c[1] === "object" && "kind" in c[1],
+      );
+      expect(splitCreate?.[1]).toMatchObject({
+        kind: SplitKind.TRANSFER,
+        categoryId: null,
+        transferAccountId: "acc-chk",
+      });
     });
   });
 

--- a/backend/src/import/import-regular-processor.service.ts
+++ b/backend/src/import/import-regular-processor.service.ts
@@ -5,6 +5,7 @@ import {
   TransactionStatus,
 } from "../transactions/entities/transaction.entity";
 import { TransactionSplit } from "../transactions/entities/transaction-split.entity";
+import { SplitKind } from "../transactions/entities/split-kind.enum";
 import { Payee } from "../payees/entities/payee.entity";
 import { PayeeAlias } from "../payees/entities/payee-alias.entity";
 import { TransactionTag } from "../tags/entities/transaction-tag.entity";
@@ -473,7 +474,10 @@ export class ImportRegularProcessorService {
         TransactionSplit,
         {
           transactionId: savedTx.id,
-          categoryId: splitCategoryId,
+          kind: splitTransferAccountId
+            ? SplitKind.TRANSFER
+            : SplitKind.CATEGORY,
+          categoryId: splitTransferAccountId ? null : splitCategoryId,
           transferAccountId: splitTransferAccountId,
           amount: split.amount,
           memo: split.memo,

--- a/backend/src/net-worth/net-worth.controller.spec.ts
+++ b/backend/src/net-worth/net-worth.controller.spec.ts
@@ -1,11 +1,16 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { NetWorthController } from "./net-worth.controller";
 import { NetWorthService } from "./net-worth.service";
+import { DelegationService } from "../delegation/delegation.service";
 
 describe("NetWorthController", () => {
   let controller: NetWorthController;
   let mockNetWorthService: Partial<Record<keyof NetWorthService, jest.Mock>>;
+  let delegationService: Record<string, jest.Mock>;
   const mockReq = { user: { id: "user-1" } };
+  const UUID_A = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+  const UUID_B = "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e";
+  const NO_READABLE = "00000000-0000-0000-0000-000000000000";
 
   beforeEach(async () => {
     mockNetWorthService = {
@@ -13,6 +18,9 @@ describe("NetWorthController", () => {
       getMonthlyInvestments: jest.fn(),
       getDailyInvestments: jest.fn(),
       recalculateAllAccounts: jest.fn(),
+    };
+    delegationService = {
+      readableAccountIds: jest.fn().mockResolvedValue([]),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -22,6 +30,7 @@ describe("NetWorthController", () => {
           provide: NetWorthService,
           useValue: mockNetWorthService,
         },
+        { provide: DelegationService, useValue: delegationService },
       ],
     }).compile();
 
@@ -60,14 +69,14 @@ describe("NetWorthController", () => {
   });
 
   describe("getMonthlyInvestments()", () => {
-    it("delegates to netWorthService.getMonthlyInvestments with userId, dates, and parsed accountIds", () => {
+    it("delegates to netWorthService.getMonthlyInvestments with userId, dates, and parsed accountIds", async () => {
       mockNetWorthService.getMonthlyInvestments!.mockReturnValue("investments");
 
-      const result = controller.getMonthlyInvestments(
+      const result = await controller.getMonthlyInvestments(
         mockReq,
         "2024-01-01",
         "2024-12-31",
-        "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d,b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
+        `${UUID_A},${UUID_B}`,
         undefined,
       );
 
@@ -76,18 +85,15 @@ describe("NetWorthController", () => {
         "user-1",
         "2024-01-01",
         "2024-12-31",
-        [
-          "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
-          "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
-        ],
+        [UUID_A, UUID_B],
         undefined,
       );
     });
 
-    it("passes undefined accountIds when not provided", () => {
+    it("passes undefined accountIds when not provided", async () => {
       mockNetWorthService.getMonthlyInvestments!.mockReturnValue("investments");
 
-      controller.getMonthlyInvestments(
+      await controller.getMonthlyInvestments(
         mockReq,
         "2024-01-01",
         "2024-12-31",
@@ -103,17 +109,60 @@ describe("NetWorthController", () => {
         undefined,
       );
     });
+
+    it("scopes accountIds to readable accounts for an acting delegate", async () => {
+      mockNetWorthService.getMonthlyInvestments!.mockReturnValue("ok");
+      delegationService.readableAccountIds.mockResolvedValue([UUID_A]);
+      const actReq = {
+        user: { id: "owner-1", isActing: true, delegationId: "d-1" },
+      };
+
+      await controller.getMonthlyInvestments(
+        actReq,
+        undefined,
+        undefined,
+        `${UUID_A},${UUID_B}`,
+        undefined,
+      );
+
+      expect(delegationService.readableAccountIds).toHaveBeenCalledWith("d-1");
+      expect(mockNetWorthService.getMonthlyInvestments).toHaveBeenCalledWith(
+        "owner-1",
+        undefined,
+        undefined,
+        [UUID_A],
+        undefined,
+      );
+    });
+
+    it("returns an empty result for a delegate with no readable accounts", async () => {
+      mockNetWorthService.getMonthlyInvestments!.mockReturnValue("ok");
+      delegationService.readableAccountIds.mockResolvedValue([]);
+      const actReq = {
+        user: { id: "owner-1", isActing: true, delegationId: "d-1" },
+      };
+
+      await controller.getMonthlyInvestments(actReq);
+
+      expect(mockNetWorthService.getMonthlyInvestments).toHaveBeenCalledWith(
+        "owner-1",
+        undefined,
+        undefined,
+        [NO_READABLE],
+        undefined,
+      );
+    });
   });
 
   describe("getDailyInvestments()", () => {
-    it("delegates to netWorthService.getDailyInvestments with userId, dates, and parsed accountIds", () => {
+    it("delegates to netWorthService.getDailyInvestments with userId, dates, and parsed accountIds", async () => {
       mockNetWorthService.getDailyInvestments!.mockReturnValue("daily");
 
-      const result = controller.getDailyInvestments(
+      const result = await controller.getDailyInvestments(
         mockReq,
         "2025-02-01",
         "2025-03-04",
-        "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+        UUID_A,
         "USD",
       );
 
@@ -122,15 +171,15 @@ describe("NetWorthController", () => {
         "user-1",
         "2025-02-01",
         "2025-03-04",
-        ["a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"],
+        [UUID_A],
         "USD",
       );
     });
 
-    it("passes undefined accountIds when not provided", () => {
+    it("passes undefined accountIds when not provided", async () => {
       mockNetWorthService.getDailyInvestments!.mockReturnValue("daily");
 
-      controller.getDailyInvestments(
+      await controller.getDailyInvestments(
         mockReq,
         "2025-02-01",
         "2025-03-04",
@@ -147,8 +196,32 @@ describe("NetWorthController", () => {
       );
     });
 
-    it("throws BadRequestException for invalid startDate format", () => {
-      expect(() =>
+    it("scopes accountIds to readable accounts for an acting delegate", async () => {
+      mockNetWorthService.getDailyInvestments!.mockReturnValue("ok");
+      delegationService.readableAccountIds.mockResolvedValue([UUID_A]);
+      const actReq = {
+        user: { id: "owner-1", isActing: true, delegationId: "d-1" },
+      };
+
+      await controller.getDailyInvestments(
+        actReq,
+        undefined,
+        undefined,
+        `${UUID_A},${UUID_B}`,
+        undefined,
+      );
+
+      expect(mockNetWorthService.getDailyInvestments).toHaveBeenCalledWith(
+        "owner-1",
+        undefined,
+        undefined,
+        [UUID_A],
+        undefined,
+      );
+    });
+
+    it("throws BadRequestException for invalid startDate format", async () => {
+      await expect(
         controller.getDailyInvestments(
           mockReq,
           "invalid",
@@ -156,11 +229,11 @@ describe("NetWorthController", () => {
           undefined,
           undefined,
         ),
-      ).toThrow("startDate must be YYYY-MM-DD");
+      ).rejects.toThrow("startDate must be YYYY-MM-DD");
     });
 
-    it("throws BadRequestException for invalid accountIds", () => {
-      expect(() =>
+    it("throws BadRequestException for invalid accountIds", async () => {
+      await expect(
         controller.getDailyInvestments(
           mockReq,
           "2025-01-01",
@@ -168,7 +241,7 @@ describe("NetWorthController", () => {
           "not-a-uuid",
           undefined,
         ),
-      ).toThrow("accountIds must be comma-separated UUIDs");
+      ).rejects.toThrow("accountIds must be comma-separated UUIDs");
     });
   });
 
@@ -201,18 +274,16 @@ describe("NetWorthController", () => {
   });
 
   describe("getMonthlyInvestments edge cases", () => {
-    it("uppercases and slices currency to 3 chars", () => {
+    it("uppercases and slices currency to 3 chars", async () => {
       mockNetWorthService.getMonthlyInvestments!.mockReturnValue("ok");
-      controller.getMonthlyInvestments(
+      await controller.getMonthlyInvestments(
         mockReq,
         undefined,
         undefined,
         undefined,
         "usdextra",
       );
-      expect(
-        mockNetWorthService.getMonthlyInvestments,
-      ).toHaveBeenCalledWith(
+      expect(mockNetWorthService.getMonthlyInvestments).toHaveBeenCalledWith(
         "user-1",
         undefined,
         undefined,
@@ -221,34 +292,34 @@ describe("NetWorthController", () => {
       );
     });
 
-    it("throws on invalid endDate", () => {
-      expect(() =>
+    it("throws on invalid endDate", async () => {
+      await expect(
         controller.getMonthlyInvestments(mockReq, undefined, "bad-date"),
-      ).toThrow(/endDate/);
+      ).rejects.toThrow(/endDate/);
     });
 
-    it("throws on invalid startDate", () => {
-      expect(() =>
+    it("throws on invalid startDate", async () => {
+      await expect(
         controller.getMonthlyInvestments(mockReq, "x"),
-      ).toThrow(/startDate/);
+      ).rejects.toThrow(/startDate/);
     });
 
-    it("throws when accountIds contains a non-UUID", () => {
-      expect(() =>
+    it("throws when accountIds contains a non-UUID", async () => {
+      await expect(
         controller.getMonthlyInvestments(
           mockReq,
           undefined,
           undefined,
           "not-a-uuid",
         ),
-      ).toThrow(/UUID/);
+      ).rejects.toThrow(/UUID/);
     });
   });
 
   describe("getDailyInvestments edge cases", () => {
-    it("uppercases and slices currency to 3 chars", () => {
+    it("uppercases and slices currency to 3 chars", async () => {
       mockNetWorthService.getDailyInvestments!.mockReturnValue("ok");
-      controller.getDailyInvestments(
+      await controller.getDailyInvestments(
         mockReq,
         undefined,
         undefined,
@@ -264,10 +335,10 @@ describe("NetWorthController", () => {
       );
     });
 
-    it("throws on invalid endDate", () => {
-      expect(() =>
+    it("throws on invalid endDate", async () => {
+      await expect(
         controller.getDailyInvestments(mockReq, undefined, "bad-date"),
-      ).toThrow(/endDate/);
+      ).rejects.toThrow(/endDate/);
     });
   });
 });

--- a/backend/src/net-worth/net-worth.controller.ts
+++ b/backend/src/net-worth/net-worth.controller.ts
@@ -17,13 +17,47 @@ import {
 } from "@nestjs/swagger";
 import { assertStringParam } from "../common/query-param-utils";
 import { NetWorthService } from "./net-worth.service";
+import {
+  AllowDelegate,
+  DelegateRequiresSection,
+} from "../delegation/decorators/delegate-access.decorator";
+import { DelegationService } from "../delegation/delegation.service";
+
+// A UUID that cannot match any real account: forces a naturally-empty,
+// correctly-shaped result for an acting delegate with no readable accounts
+// (instead of passing undefined, which the service treats as "all").
+const NO_READABLE_ACCOUNT = "00000000-0000-0000-0000-000000000000";
 
 @ApiTags("Net Worth")
 @Controller("net-worth")
 @UseGuards(AuthGuard("jwt"))
 @ApiBearerAuth()
 export class NetWorthController {
-  constructor(private readonly netWorthService: NetWorthService) {}
+  constructor(
+    private readonly netWorthService: NetWorthService,
+    private readonly delegationService: DelegationService,
+  ) {}
+
+  /**
+   * For an acting delegate, restrict the account-id filter to the accounts
+   * they were granted READ on (intersecting any explicit request). Returns
+   * the original ids unchanged for non-delegate requests so owner behaviour
+   * (undefined = all accounts) is preserved.
+   */
+  private async scopeIds(
+    req: { user: { isActing?: boolean; delegationId?: string } },
+    ids?: string[],
+  ): Promise<string[] | undefined> {
+    if (!req.user.isActing || !req.user.delegationId) return ids;
+    const readable = new Set(
+      await this.delegationService.readableAccountIds(req.user.delegationId),
+    );
+    const eff =
+      ids && ids.length > 0
+        ? ids.filter((i) => readable.has(i))
+        : [...readable];
+    return eff.length > 0 ? eff : [NO_READABLE_ACCOUNT];
+  }
 
   @Get("monthly")
   @ApiOperation({ summary: "Get monthly net worth data" })
@@ -49,6 +83,8 @@ export class NetWorthController {
   }
 
   @Get("investments-monthly")
+  @AllowDelegate()
+  @DelegateRequiresSection("investments")
   @ApiOperation({ summary: "Get monthly investment portfolio value" })
   @ApiQuery({ name: "startDate", required: false, example: "2023-01-01" })
   @ApiQuery({ name: "endDate", required: false, example: "2024-12-31" })
@@ -66,7 +102,7 @@ export class NetWorthController {
   })
   @ApiResponse({ status: 200, description: "Monthly investment value data" })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  getMonthlyInvestments(
+  async getMonthlyInvestments(
     @Request() req,
     @Query("startDate") startDate?: string,
     @Query("endDate") endDate?: string,
@@ -98,12 +134,14 @@ export class NetWorthController {
       req.user.id,
       sd,
       ed,
-      ids,
+      await this.scopeIds(req, ids),
       safeCurrency,
     );
   }
 
   @Get("investments-daily")
+  @AllowDelegate()
+  @DelegateRequiresSection("investments")
   @ApiOperation({ summary: "Get daily investment portfolio value" })
   @ApiQuery({ name: "startDate", required: false, example: "2025-01-01" })
   @ApiQuery({ name: "endDate", required: false, example: "2025-03-04" })
@@ -121,7 +159,7 @@ export class NetWorthController {
   })
   @ApiResponse({ status: 200, description: "Daily investment value data" })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  getDailyInvestments(
+  async getDailyInvestments(
     @Request() req,
     @Query("startDate") startDate?: string,
     @Query("endDate") endDate?: string,
@@ -153,7 +191,7 @@ export class NetWorthController {
       req.user.id,
       sd,
       ed,
-      ids,
+      await this.scopeIds(req, ids),
       safeCurrency,
     );
   }

--- a/backend/src/net-worth/net-worth.module.ts
+++ b/backend/src/net-worth/net-worth.module.ts
@@ -9,6 +9,7 @@ import { ExchangeRate } from "../currencies/entities/exchange-rate.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { NetWorthService } from "./net-worth.service";
 import { NetWorthController } from "./net-worth.controller";
+import { DelegationModule } from "../delegation/delegation.module";
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { NetWorthController } from "./net-worth.controller";
       ExchangeRate,
       UserPreference,
     ]),
+    DelegationModule,
   ],
   providers: [NetWorthService],
   controllers: [NetWorthController],

--- a/backend/src/notifications/email-templates.ts
+++ b/backend/src/notifications/email-templates.ts
@@ -456,3 +456,25 @@ export function passwordResetTemplate(
     </div>
   `;
 }
+
+export function delegateInviteTemplate(
+  firstName: string,
+  ownerLabel: string,
+  inviteUrl: string,
+): string {
+  const safeName = escapeHtml(firstName || "there");
+  const safeOwner = escapeHtml(ownerLabel);
+  const safeUrl = escapeHtml(inviteUrl);
+  return `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+      <h2 style="color: #1f2937;">You have been invited to Monize</h2>
+      <p style="color: #374151;">Hi ${safeName},</p>
+      <p style="color: #374151;">${safeOwner} has invited you to access their Monize account as a delegate. Click the button below to set your password and get started:</p>
+      <p style="margin: 24px 0;">
+        <a href="${safeUrl}" style="display: inline-block; padding: 12px 24px; background: #2563eb; color: #ffffff; border-radius: 6px; text-decoration: none; font-weight: 500;">Set Your Password</a>
+      </p>
+      <p style="color: #374151;">This link will expire in 24 hours. If you were not expecting this invitation, you can safely ignore this email.</p>
+      <p style="color: #6b7280; font-size: 14px; margin-top: 24px;">-- Monize</p>
+    </div>
+  `;
+}

--- a/backend/src/payees/payees.controller.ts
+++ b/backend/src/payees/payees.controller.ts
@@ -53,7 +53,7 @@ export class PayeesController {
   })
   @ApiResponse({ status: 409, description: "Payee with name already exists" })
   @AllowDelegate()
-  @DelegateRequiresCapability("payees")
+  @DelegateRequiresCapability("payees", "create")
   create(
     @Request() req,
     @Body() createPayeeDto: CreatePayeeDto,
@@ -397,7 +397,7 @@ export class PayeesController {
   @ApiResponse({ status: 404, description: "Payee not found" })
   @ApiResponse({ status: 409, description: "Payee with name already exists" })
   @AllowDelegate()
-  @DelegateRequiresCapability("payees")
+  @DelegateRequiresCapability("payees", "edit")
   update(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,
@@ -411,7 +411,7 @@ export class PayeesController {
   @ApiResponse({ status: 200, description: "Payee deleted successfully" })
   @ApiResponse({ status: 404, description: "Payee not found" })
   @AllowDelegate()
-  @DelegateRequiresCapability("payees")
+  @DelegateRequiresCapability("payees", "delete")
   remove(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,

--- a/backend/src/payees/payees.controller.ts
+++ b/backend/src/payees/payees.controller.ts
@@ -79,6 +79,7 @@ export class PayeesController {
   }
 
   @Get("search")
+  @AllowDelegate()
   @ApiOperation({ summary: "Search payees by name" })
   @ApiQuery({ name: "q", required: true, description: "Search query" })
   @ApiQuery({
@@ -100,6 +101,7 @@ export class PayeesController {
   }
 
   @Get("autocomplete")
+  @AllowDelegate()
   @ApiOperation({ summary: "Autocomplete payees (for input suggestions)" })
   @ApiQuery({
     name: "q",
@@ -118,6 +120,7 @@ export class PayeesController {
   }
 
   @Get("most-used")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get most frequently used payees" })
   @ApiQuery({
     name: "limit",
@@ -135,6 +138,7 @@ export class PayeesController {
   }
 
   @Get("recently-used")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get recently used payees" })
   @ApiQuery({
     name: "limit",
@@ -156,6 +160,7 @@ export class PayeesController {
   }
 
   @Get("summary")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get payee statistics summary" })
   @ApiResponse({ status: 200, description: "Payee summary statistics" })
   getSummary(@Request() req) {
@@ -163,6 +168,7 @@ export class PayeesController {
   }
 
   @Get("aliases")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get all aliases for the user" })
   @ApiResponse({
     status: 200,
@@ -214,6 +220,7 @@ export class PayeesController {
   }
 
   @Get("category-suggestions/preview")
+  @AllowDelegate()
   @ApiOperation({
     summary:
       "Preview category auto-assignment suggestions based on transaction history",
@@ -271,6 +278,7 @@ export class PayeesController {
   }
 
   @Get("deactivation/preview")
+  @AllowDelegate()
   @ApiOperation({
     summary: "Preview which payees would be deactivated based on criteria",
   })
@@ -332,6 +340,7 @@ export class PayeesController {
   }
 
   @Get(":id/aliases")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get all aliases for a specific payee" })
   @ApiResponse({
     status: 200,
@@ -347,6 +356,7 @@ export class PayeesController {
   }
 
   @Get("inactive/match")
+  @AllowDelegate()
   @ApiOperation({
     summary: "Check if a payee name matches an inactive payee",
   })
@@ -366,6 +376,7 @@ export class PayeesController {
   }
 
   @Get(":id")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get a payee by ID" })
   @ApiResponse({ status: 200, description: "Payee details", type: Payee })
   @ApiResponse({ status: 404, description: "Payee not found" })

--- a/backend/src/payees/payees.controller.ts
+++ b/backend/src/payees/payees.controller.ts
@@ -32,6 +32,7 @@ import { ApplyCategorySuggestionsDto } from "./dto/apply-category-suggestions.dt
 import { DeactivatePayeesDto } from "./dto/deactivate-payees.dto";
 import { Payee } from "./entities/payee.entity";
 import { PayeeAlias } from "./entities/payee-alias.entity";
+import { AllowDelegate } from "../delegation/decorators/delegate-access.decorator";
 
 @ApiTags("Payees")
 @ApiBearerAuth()
@@ -64,6 +65,7 @@ export class PayeesController {
     description: "Filter by active status (default: all)",
   })
   @ApiResponse({ status: 200, description: "List of payees", type: [Payee] })
+  @AllowDelegate()
   findAll(
     @Request() req,
     @Query("status") status?: "active" | "inactive" | "all",

--- a/backend/src/payees/payees.controller.ts
+++ b/backend/src/payees/payees.controller.ts
@@ -32,7 +32,10 @@ import { ApplyCategorySuggestionsDto } from "./dto/apply-category-suggestions.dt
 import { DeactivatePayeesDto } from "./dto/deactivate-payees.dto";
 import { Payee } from "./entities/payee.entity";
 import { PayeeAlias } from "./entities/payee-alias.entity";
-import { AllowDelegate } from "../delegation/decorators/delegate-access.decorator";
+import {
+  AllowDelegate,
+  DelegateRequiresCapability,
+} from "../delegation/decorators/delegate-access.decorator";
 
 @ApiTags("Payees")
 @ApiBearerAuth()
@@ -49,6 +52,8 @@ export class PayeesController {
     type: Payee,
   })
   @ApiResponse({ status: 409, description: "Payee with name already exists" })
+  @AllowDelegate()
+  @DelegateRequiresCapability("payees")
   create(
     @Request() req,
     @Body() createPayeeDto: CreatePayeeDto,
@@ -380,6 +385,8 @@ export class PayeesController {
   })
   @ApiResponse({ status: 404, description: "Payee not found" })
   @ApiResponse({ status: 409, description: "Payee with name already exists" })
+  @AllowDelegate()
+  @DelegateRequiresCapability("payees")
   update(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,
@@ -392,6 +399,8 @@ export class PayeesController {
   @ApiOperation({ summary: "Delete a payee" })
   @ApiResponse({ status: 200, description: "Payee deleted successfully" })
   @ApiResponse({ status: 404, description: "Payee not found" })
+  @AllowDelegate()
+  @DelegateRequiresCapability("payees")
   remove(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,

--- a/backend/src/reports/reports.controller.ts
+++ b/backend/src/reports/reports.controller.ts
@@ -23,11 +23,19 @@ import { CreateCustomReportDto } from "./dto/create-custom-report.dto";
 import { UpdateCustomReportDto } from "./dto/update-custom-report.dto";
 import { ExecuteReportDto } from "./dto/execute-report.dto";
 import { CustomReport } from "./entities/custom-report.entity";
+import {
+  AllowDelegate,
+  DelegateRequiresSection,
+} from "../delegation/decorators/delegate-access.decorator";
 
 @ApiTags("Custom Reports")
 @Controller("reports/custom")
 @UseGuards(AuthGuard("jwt"))
 @ApiBearerAuth()
+// Read-only section for delegates: only the @AllowDelegate() GETs are
+// reachable, and only with the "reports" section grant. Writes (create/
+// update/delete/execute) have no @AllowDelegate() -> fail closed.
+@DelegateRequiresSection("reports")
 export class ReportsController {
   constructor(private readonly reportsService: ReportsService) {}
 
@@ -48,6 +56,7 @@ export class ReportsController {
   }
 
   @Get()
+  @AllowDelegate()
   @ApiOperation({ summary: "Get all custom reports for the current user" })
   @ApiResponse({
     status: 200,
@@ -60,6 +69,7 @@ export class ReportsController {
   }
 
   @Get(":id")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get a specific custom report by ID" })
   @ApiParam({ name: "id", description: "Report ID" })
   @ApiResponse({

--- a/backend/src/scheduled-transactions/entities/scheduled-transaction-split.entity.ts
+++ b/backend/src/scheduled-transactions/entities/scheduled-transaction-split.entity.ts
@@ -36,7 +36,7 @@ export class ScheduledTransactionSplit {
   @Column({ type: "uuid", name: "category_id", nullable: true })
   categoryId: string | null;
 
-  @ManyToOne(() => Category, { nullable: true })
+  @ManyToOne(() => Category, { nullable: true, onDelete: "SET NULL" })
   @JoinColumn({ name: "category_id" })
   category: Category | null;
 

--- a/backend/src/scheduled-transactions/entities/scheduled-transaction.entity.ts
+++ b/backend/src/scheduled-transactions/entities/scheduled-transaction.entity.ts
@@ -75,7 +75,7 @@ export class ScheduledTransaction {
   @Column({ type: "uuid", name: "category_id", nullable: true })
   categoryId: string | null;
 
-  @ManyToOne(() => Category, { nullable: true })
+  @ManyToOne(() => Category, { nullable: true, onDelete: "SET NULL" })
   @JoinColumn({ name: "category_id" })
   category: Category | null;
 

--- a/backend/src/scheduled-transactions/scheduled-transactions.controller.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.controller.spec.ts
@@ -91,6 +91,42 @@ describe("ScheduledTransactionsController", () => {
       expect(result).toEqual([{ id: "st-2", accountId: "a2" }]);
       expect(delegationMock.readableAccountIds).toHaveBeenCalledWith("g1");
     });
+
+    it("keeps a transfer where the delegate holds the recipient side", async () => {
+      const actingReq = {
+        user: { id: "owner-1", isActing: true, delegationId: "g1" },
+      };
+      mockService.findAll.mockResolvedValue([
+        // source unreadable, recipient readable -> visible (masked)
+        {
+          id: "st-1",
+          accountId: "a1",
+          isTransfer: true,
+          transferAccountId: "a2",
+        },
+        // neither side readable -> hidden
+        {
+          id: "st-2",
+          accountId: "a3",
+          isTransfer: true,
+          transferAccountId: "a4",
+        },
+        // non-transfer on an unreadable account -> hidden
+        { id: "st-3", accountId: "a1", isTransfer: false },
+      ]);
+      delegationMock.readableAccountIds.mockResolvedValue(["a2"]);
+
+      const result = await controller.findAll(actingReq);
+
+      expect(result).toEqual([
+        {
+          id: "st-1",
+          accountId: "a1",
+          isTransfer: true,
+          transferAccountId: "a2",
+        },
+      ]);
+    });
   });
 
   describe("findDue()", () => {

--- a/backend/src/scheduled-transactions/scheduled-transactions.controller.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.controller.spec.ts
@@ -1,10 +1,12 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { ScheduledTransactionsController } from "./scheduled-transactions.controller";
 import { ScheduledTransactionsService } from "./scheduled-transactions.service";
+import { DelegationService } from "../delegation/delegation.service";
 
 describe("ScheduledTransactionsController", () => {
   let controller: ScheduledTransactionsController;
   let mockService: Record<string, jest.Mock>;
+  let delegationMock: Record<string, jest.Mock>;
   const mockReq = { user: { id: "user-1" } };
 
   beforeEach(async () => {
@@ -34,6 +36,13 @@ describe("ScheduledTransactionsController", () => {
         {
           provide: ScheduledTransactionsService,
           useValue: mockService,
+        },
+        {
+          provide: DelegationService,
+          useValue: (delegationMock = {
+            readableAccountIds: jest.fn().mockResolvedValue([]),
+            accountIdsForScheduled: jest.fn().mockResolvedValue([]),
+          }),
         },
       ],
     }).compile();
@@ -65,6 +74,22 @@ describe("ScheduledTransactionsController", () => {
 
       expect(result).toEqual(expected);
       expect(mockService.findAll).toHaveBeenCalledWith("user-1");
+    });
+
+    it("filters to readable accounts for an acting delegate", async () => {
+      const actingReq = {
+        user: { id: "owner-1", isActing: true, delegationId: "g1" },
+      };
+      mockService.findAll.mockResolvedValue([
+        { id: "st-1", accountId: "a1" },
+        { id: "st-2", accountId: "a2" },
+      ]);
+      delegationMock.readableAccountIds.mockResolvedValue(["a2"]);
+
+      const result = await controller.findAll(actingReq);
+
+      expect(result).toEqual([{ id: "st-2", accountId: "a2" }]);
+      expect(delegationMock.readableAccountIds).toHaveBeenCalledWith("g1");
     });
   });
 

--- a/backend/src/scheduled-transactions/scheduled-transactions.controller.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.controller.ts
@@ -54,10 +54,19 @@ export class ScheduledTransactionsController {
   ) {}
 
   /**
-   * Restrict a result set to scheduled rows on accounts the delegate was
-   * granted READ on. Non-delegate requests pass through unchanged.
+   * Restrict a result set to scheduled rows the delegate may see: those on
+   * an account they were granted READ on, OR transfers where the granted
+   * account is the source or the recipient (the unreadable counterpart is
+   * masked by DelegateScheduledTransferMaskInterceptor). Non-delegate
+   * requests pass through unchanged.
    */
-  private async filterForDelegate<T extends { accountId: string }>(
+  private async filterForDelegate<
+    T extends {
+      accountId: string;
+      transferAccountId?: string | null;
+      isTransfer?: boolean;
+    },
+  >(
     req: { user: { isActing?: boolean; delegationId?: string } },
     rows: T[],
   ): Promise<T[]> {
@@ -65,7 +74,13 @@ export class ScheduledTransactionsController {
     const readable = new Set(
       await this.delegationService.readableAccountIds(req.user.delegationId),
     );
-    return rows.filter((r) => readable.has(r.accountId));
+    return rows.filter(
+      (r) =>
+        readable.has(r.accountId) ||
+        (!!r.isTransfer &&
+          !!r.transferAccountId &&
+          readable.has(r.transferAccountId)),
+    );
   }
 
   @Post()

--- a/backend/src/scheduled-transactions/scheduled-transactions.controller.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Delete,
   UseGuards,
+  UseInterceptors,
   Request,
   Query,
   ParseUUIDPipe,
@@ -31,15 +32,41 @@ import {
   CreateScheduledTransactionOverrideDto,
   UpdateScheduledTransactionOverrideDto,
 } from "./dto/scheduled-transaction-override.dto";
+import {
+  AllowDelegate,
+  DelegatedTransferBody,
+  DelegatedScheduledParam,
+  DelegateRequires,
+  DelegateRequiresSection,
+} from "../delegation/decorators/delegate-access.decorator";
+import { DelegateScheduledTransferMaskInterceptor } from "../delegation/interceptors/delegate-scheduled-transfer-mask.interceptor";
+import { DelegationService } from "../delegation/delegation.service";
 
 @ApiTags("Scheduled Transactions")
 @Controller("scheduled-transactions")
 @UseGuards(AuthGuard("jwt"))
+@UseInterceptors(DelegateScheduledTransferMaskInterceptor)
 @ApiBearerAuth()
 export class ScheduledTransactionsController {
   constructor(
     private readonly scheduledTransactionsService: ScheduledTransactionsService,
+    private readonly delegationService: DelegationService,
   ) {}
+
+  /**
+   * Restrict a result set to scheduled rows on accounts the delegate was
+   * granted READ on. Non-delegate requests pass through unchanged.
+   */
+  private async filterForDelegate<T extends { accountId: string }>(
+    req: { user: { isActing?: boolean; delegationId?: string } },
+    rows: T[],
+  ): Promise<T[]> {
+    if (!req.user.isActing || !req.user.delegationId) return rows;
+    const readable = new Set(
+      await this.delegationService.readableAccountIds(req.user.delegationId),
+    );
+    return rows.filter((r) => readable.has(r.accountId));
+  }
 
   @Post()
   @ApiOperation({ summary: "Create a new scheduled transaction" })
@@ -49,6 +76,10 @@ export class ScheduledTransactionsController {
   })
   @ApiResponse({ status: 400, description: "Bad request" })
   @ApiResponse({ status: 401, description: "Unauthorized" })
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  @DelegatedTransferBody("accountId", "transferAccountId")
+  @DelegateRequires("create")
   create(@Request() req, @Body() createDto: CreateScheduledTransactionDto) {
     return this.scheduledTransactionsService.create(req.user.id, createDto);
   }
@@ -62,8 +93,11 @@ export class ScheduledTransactionsController {
     description: "List of scheduled transactions retrieved successfully",
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  findAll(@Request() req) {
-    return this.scheduledTransactionsService.findAll(req.user.id);
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  async findAll(@Request() req) {
+    const rows = await this.scheduledTransactionsService.findAll(req.user.id);
+    return this.filterForDelegate(req, rows);
   }
 
   @Get("due")
@@ -73,8 +107,11 @@ export class ScheduledTransactionsController {
     description: "List of due scheduled transactions retrieved successfully",
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  findDue(@Request() req) {
-    return this.scheduledTransactionsService.findDue(req.user.id);
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  async findDue(@Request() req) {
+    const rows = await this.scheduledTransactionsService.findDue(req.user.id);
+    return this.filterForDelegate(req, rows);
   }
 
   @Get("upcoming")
@@ -90,11 +127,17 @@ export class ScheduledTransactionsController {
       "List of upcoming scheduled transactions retrieved successfully",
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  findUpcoming(
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  async findUpcoming(
     @Request() req,
     @Query("days", new DefaultValuePipe(30), ParseIntPipe) days: number,
   ) {
-    return this.scheduledTransactionsService.findUpcoming(req.user.id, days);
+    const rows = await this.scheduledTransactionsService.findUpcoming(
+      req.user.id,
+      days,
+    );
+    return this.filterForDelegate(req, rows);
   }
 
   @Get(":id")
@@ -110,6 +153,9 @@ export class ScheduledTransactionsController {
     description: "Forbidden - scheduled transaction does not belong to user",
   })
   @ApiResponse({ status: 404, description: "Scheduled transaction not found" })
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  @DelegatedScheduledParam("id")
   findOne(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
     return this.scheduledTransactionsService.findOne(req.user.id, id);
   }
@@ -128,6 +174,10 @@ export class ScheduledTransactionsController {
     description: "Forbidden - scheduled transaction does not belong to user",
   })
   @ApiResponse({ status: 404, description: "Scheduled transaction not found" })
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  @DelegatedScheduledParam("id")
+  @DelegateRequires("edit")
   update(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,
@@ -149,6 +199,10 @@ export class ScheduledTransactionsController {
     description: "Forbidden - scheduled transaction does not belong to user",
   })
   @ApiResponse({ status: 404, description: "Scheduled transaction not found" })
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  @DelegatedScheduledParam("id")
+  @DelegateRequires("delete")
   remove(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
     return this.scheduledTransactionsService.remove(req.user.id, id);
   }
@@ -161,6 +215,10 @@ export class ScheduledTransactionsController {
   @ApiResponse({ status: 200, description: "Transaction posted successfully" })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   @ApiResponse({ status: 404, description: "Scheduled transaction not found" })
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  @DelegatedScheduledParam("id")
+  @DelegateRequires("edit")
   post(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,
@@ -177,6 +235,10 @@ export class ScheduledTransactionsController {
   @ApiResponse({ status: 200, description: "Occurrence skipped successfully" })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   @ApiResponse({ status: 404, description: "Scheduled transaction not found" })
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  @DelegatedScheduledParam("id")
+  @DelegateRequires("edit")
   skip(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
     return this.scheduledTransactionsService.skip(req.user.id, id);
   }
@@ -192,6 +254,9 @@ export class ScheduledTransactionsController {
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   @ApiResponse({ status: 404, description: "Scheduled transaction not found" })
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  @DelegatedScheduledParam("id")
   findOverrides(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
     return this.scheduledTransactionsService.findOverrides(req.user.id, id);
   }
@@ -204,6 +269,9 @@ export class ScheduledTransactionsController {
   @ApiResponse({ status: 200, description: "Override check completed" })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   @ApiResponse({ status: 404, description: "Scheduled transaction not found" })
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  @DelegatedScheduledParam("id")
   hasOverrides(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
     return this.scheduledTransactionsService.hasOverrides(req.user.id, id);
   }
@@ -218,6 +286,9 @@ export class ScheduledTransactionsController {
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   @ApiResponse({ status: 404, description: "Scheduled transaction not found" })
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  @DelegatedScheduledParam("id")
   findOverrideByDate(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,
@@ -243,6 +314,10 @@ export class ScheduledTransactionsController {
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   @ApiResponse({ status: 404, description: "Scheduled transaction not found" })
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  @DelegatedScheduledParam("id")
+  @DelegateRequires("edit")
   createOverride(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,
@@ -262,6 +337,9 @@ export class ScheduledTransactionsController {
   @ApiResponse({ status: 200, description: "Override retrieved successfully" })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   @ApiResponse({ status: 404, description: "Override not found" })
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  @DelegatedScheduledParam("id")
   findOverride(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,
@@ -281,6 +359,10 @@ export class ScheduledTransactionsController {
   @ApiResponse({ status: 200, description: "Override updated successfully" })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   @ApiResponse({ status: 404, description: "Override not found" })
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  @DelegatedScheduledParam("id")
+  @DelegateRequires("edit")
   updateOverride(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,
@@ -302,6 +384,10 @@ export class ScheduledTransactionsController {
   @ApiResponse({ status: 200, description: "Override deleted successfully" })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   @ApiResponse({ status: 404, description: "Override not found" })
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  @DelegatedScheduledParam("id")
+  @DelegateRequires("delete")
   removeOverride(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,
@@ -323,6 +409,10 @@ export class ScheduledTransactionsController {
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   @ApiResponse({ status: 404, description: "Scheduled transaction not found" })
+  @AllowDelegate()
+  @DelegateRequiresSection("bills")
+  @DelegatedScheduledParam("id")
+  @DelegateRequires("delete")
   removeAllOverrides(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
     return this.scheduledTransactionsService.removeAllOverrides(
       req.user.id,

--- a/backend/src/scheduled-transactions/scheduled-transactions.module.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.module.ts
@@ -13,6 +13,7 @@ import { AccountsModule } from "../accounts/accounts.module";
 import { TransactionsModule } from "../transactions/transactions.module";
 import { SecuritiesModule } from "../securities/securities.module";
 import { ActionHistoryModule } from "../action-history/action-history.module";
+import { DelegationModule } from "../delegation/delegation.module";
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { ActionHistoryModule } from "../action-history/action-history.module";
     TransactionsModule,
     forwardRef(() => SecuritiesModule),
     ActionHistoryModule,
+    DelegationModule,
   ],
   providers: [
     ScheduledTransactionsService,

--- a/backend/src/securities/investment-transactions.controller.spec.ts
+++ b/backend/src/securities/investment-transactions.controller.spec.ts
@@ -2,10 +2,12 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { BadRequestException } from "@nestjs/common";
 import { InvestmentTransactionsController } from "./investment-transactions.controller";
 import { InvestmentTransactionsService } from "./investment-transactions.service";
+import { DelegationService } from "../delegation/delegation.service";
 
 describe("InvestmentTransactionsController", () => {
   let controller: InvestmentTransactionsController;
   let service: Record<string, jest.Mock>;
+  let delegationMock: Record<string, jest.Mock>;
 
   const req = { user: { id: "user-1" } };
   const UUID1 = "00000000-0000-0000-0000-000000000001";
@@ -43,6 +45,12 @@ describe("InvestmentTransactionsController", () => {
       controllers: [InvestmentTransactionsController],
       providers: [
         { provide: InvestmentTransactionsService, useValue: service },
+        {
+          provide: DelegationService,
+          useValue: (delegationMock = {
+            readableAccountIds: jest.fn().mockResolvedValue([]),
+          }),
+        },
       ],
     }).compile();
 
@@ -115,26 +123,26 @@ describe("InvestmentTransactionsController", () => {
       );
     });
 
-    it("rejects invalid UUIDs in accountIds", () => {
-      expect(() => controller.findAll(req, "not-a-uuid")).toThrow(
+    it("rejects invalid UUIDs in accountIds", async () => {
+      await expect(controller.findAll(req, "not-a-uuid")).rejects.toThrow(
         BadRequestException,
       );
     });
 
-    it("rejects invalid date format for startDate", () => {
-      expect(() => controller.findAll(req, undefined, "01-01-2025")).toThrow(
-        BadRequestException,
-      );
+    it("rejects invalid date format for startDate", async () => {
+      await expect(
+        controller.findAll(req, undefined, "01-01-2025"),
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects invalid page parameter", () => {
-      expect(() =>
+    it("rejects invalid page parameter", async () => {
+      await expect(
         controller.findAll(req, undefined, undefined, undefined, "abc"),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects limit exceeding 200", () => {
-      expect(() =>
+    it("rejects limit exceeding 200", async () => {
+      await expect(
         controller.findAll(
           req,
           undefined,
@@ -143,7 +151,7 @@ describe("InvestmentTransactionsController", () => {
           undefined,
           "500",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
     it("parses page and limit as integers", async () => {
@@ -169,6 +177,48 @@ describe("InvestmentTransactionsController", () => {
         25,
         "AAPL",
         "BUY",
+      );
+    });
+
+    it("scopes an acting delegate to readable accounts", async () => {
+      const actingReq = {
+        user: { id: "owner-1", isActing: true, delegationId: "g1" },
+      };
+      service.findAll.mockResolvedValue({ data: [], total: 0 });
+      delegationMock.readableAccountIds.mockResolvedValue([UUID2]);
+
+      await controller.findAll(actingReq, `${UUID1},${UUID2}`);
+
+      expect(service.findAll).toHaveBeenCalledWith(
+        "owner-1",
+        [UUID2],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it("returns a naturally-empty result when the delegate has no readable accounts", async () => {
+      const actingReq = {
+        user: { id: "owner-1", isActing: true, delegationId: "g1" },
+      };
+      service.findAll.mockResolvedValue({ data: [], total: 0 });
+      delegationMock.readableAccountIds.mockResolvedValue([]);
+
+      await controller.findAll(actingReq);
+
+      expect(service.findAll).toHaveBeenCalledWith(
+        "owner-1",
+        ["00000000-0000-0000-0000-000000000000"],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
       );
     });
   });
@@ -213,16 +263,16 @@ describe("InvestmentTransactionsController", () => {
       expect(result).toEqual(rows);
     });
 
-    it("rejects invalid UUIDs", () => {
-      expect(() => controller.getRealizedGains(req, "not-a-uuid")).toThrow(
-        BadRequestException,
-      );
+    it("rejects invalid UUIDs", async () => {
+      await expect(
+        controller.getRealizedGains(req, "not-a-uuid"),
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects malformed dates", () => {
-      expect(() =>
+    it("rejects malformed dates", async () => {
+      await expect(
         controller.getRealizedGains(req, undefined, "2024/01/01"),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
   });
 
@@ -281,8 +331,8 @@ describe("InvestmentTransactionsController", () => {
       expect(result).toEqual(rows);
     });
 
-    it("rejects an unknown granularity value", () => {
-      expect(() =>
+    it("rejects an unknown granularity value", async () => {
+      await expect(
         controller.getCapitalGains(
           req,
           "2024-01-01",
@@ -290,42 +340,42 @@ describe("InvestmentTransactionsController", () => {
           undefined,
           "week",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("requires startDate", () => {
-      expect(() =>
+    it("requires startDate", async () => {
+      await expect(
         controller.getCapitalGains(req, "", "2024-12-31"),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("requires endDate", () => {
-      expect(() =>
+    it("requires endDate", async () => {
+      await expect(
         controller.getCapitalGains(req, "2024-01-01", ""),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects malformed dates", () => {
-      expect(() =>
+    it("rejects malformed dates", async () => {
+      await expect(
         controller.getCapitalGains(req, "2024/01/01", "2024-12-31"),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects when startDate is after endDate", () => {
-      expect(() =>
+    it("rejects when startDate is after endDate", async () => {
+      await expect(
         controller.getCapitalGains(req, "2024-12-31", "2024-01-01"),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects invalid account UUIDs", () => {
-      expect(() =>
+    it("rejects invalid account UUIDs", async () => {
+      await expect(
         controller.getCapitalGains(
           req,
           "2024-01-01",
           "2024-12-31",
           "not-a-uuid",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/backend/src/securities/investment-transactions.controller.ts
+++ b/backend/src/securities/investment-transactions.controller.ts
@@ -27,6 +27,16 @@ import {
   InvestmentTransaction,
   InvestmentAction,
 } from "./entities/investment-transaction.entity";
+import {
+  AllowDelegate,
+  DelegateRequiresSection,
+} from "../delegation/decorators/delegate-access.decorator";
+import { DelegationService } from "../delegation/delegation.service";
+
+// A UUID that cannot match any real account: forces a naturally-empty,
+// correctly-shaped result for an acting delegate with no readable accounts
+// (instead of passing undefined, which the service treats as "all").
+const NO_READABLE_ACCOUNT = "00000000-0000-0000-0000-000000000000";
 
 @ApiTags("Investment Transactions")
 @ApiBearerAuth()
@@ -35,7 +45,29 @@ import {
 export class InvestmentTransactionsController {
   constructor(
     private readonly investmentTransactionsService: InvestmentTransactionsService,
+    private readonly delegationService: DelegationService,
   ) {}
+
+  /**
+   * For an acting delegate, restrict the account-id filter to the accounts
+   * they were granted READ on (intersecting any explicit request). Returns
+   * the original ids unchanged for non-delegate requests so owner behaviour
+   * (undefined = all accounts) is preserved.
+   */
+  private async scopeIds(
+    req: { user: { isActing?: boolean; delegationId?: string } },
+    ids?: string[],
+  ): Promise<string[] | undefined> {
+    if (!req.user.isActing || !req.user.delegationId) return ids;
+    const readable = new Set(
+      await this.delegationService.readableAccountIds(req.user.delegationId),
+    );
+    const eff =
+      ids && ids.length > 0
+        ? ids.filter((i) => readable.has(i))
+        : [...readable];
+    return eff.length > 0 ? eff : [NO_READABLE_ACCOUNT];
+  }
 
   @Post()
   @ApiOperation({
@@ -97,7 +129,9 @@ export class InvestmentTransactionsController {
     status: 200,
     description: "List of investment transactions with pagination",
   })
-  findAll(
+  @AllowDelegate()
+  @DelegateRequiresSection("investments")
+  async findAll(
     @Request() req,
     @Query("accountIds") accountIds?: string,
     @Query("startDate") startDate?: string,
@@ -155,7 +189,7 @@ export class InvestmentTransactionsController {
 
     return this.investmentTransactionsService.findAll(
       req.user.id,
-      ids,
+      await this.scopeIds(req, ids),
       startDate,
       endDate,
       page ? parseInt(page, 10) : undefined,
@@ -173,9 +207,14 @@ export class InvestmentTransactionsController {
     description: "Comma-separated account IDs to filter by",
   })
   @ApiResponse({ status: 200, description: "Investment transaction summary" })
-  getSummary(@Request() req, @Query("accountIds") accountIds?: string) {
+  @AllowDelegate()
+  @DelegateRequiresSection("investments")
+  async getSummary(@Request() req, @Query("accountIds") accountIds?: string) {
     const ids = accountIds ? accountIds.split(",").filter(Boolean) : undefined;
-    return this.investmentTransactionsService.getSummary(req.user.id, ids);
+    return this.investmentTransactionsService.getSummary(
+      req.user.id,
+      await this.scopeIds(req, ids),
+    );
   }
 
   @Get("realized-gains")
@@ -187,7 +226,9 @@ export class InvestmentTransactionsController {
   @ApiQuery({ name: "startDate", required: false })
   @ApiQuery({ name: "endDate", required: false })
   @ApiResponse({ status: 200, description: "List of SELLs with realized gain" })
-  getRealizedGains(
+  @AllowDelegate()
+  @DelegateRequiresSection("investments")
+  async getRealizedGains(
     @Request() req,
     @Query("accountIds") accountIds?: string,
     @Query("startDate") startDate?: string,
@@ -213,7 +254,7 @@ export class InvestmentTransactionsController {
     }
 
     return this.investmentTransactionsService.getRealizedGains(req.user.id, {
-      accountIds: ids,
+      accountIds: await this.scopeIds(req, ids),
       startDate,
       endDate,
     });
@@ -234,7 +275,9 @@ export class InvestmentTransactionsController {
     status: 200,
     description: "List of capital gain entries per period",
   })
-  getCapitalGains(
+  @AllowDelegate()
+  @DelegateRequiresSection("investments")
+  async getCapitalGains(
     @Request() req,
     @Query("startDate") startDate: string,
     @Query("endDate") endDate: string,
@@ -273,16 +316,18 @@ export class InvestmentTransactionsController {
       }
     }
 
+    const scoped = await this.scopeIds(req, ids);
+
     if (granularity === "day") {
       return this.investmentTransactionsService.getCapitalGainsByDay(
         req.user.id,
-        { accountIds: ids, startDate, endDate },
+        { accountIds: scoped, startDate, endDate },
       );
     }
 
     return this.investmentTransactionsService.getCapitalGainsByMonth(
       req.user.id,
-      { accountIds: ids, startDate, endDate },
+      { accountIds: scoped, startDate, endDate },
     );
   }
 

--- a/backend/src/securities/portfolio.controller.spec.ts
+++ b/backend/src/securities/portfolio.controller.spec.ts
@@ -3,15 +3,18 @@ import { BadRequestException } from "@nestjs/common";
 import { PortfolioController } from "./portfolio.controller";
 import { PortfolioService } from "./portfolio.service";
 import { SectorWeightingService } from "./sector-weighting.service";
+import { DelegationService } from "../delegation/delegation.service";
 
 describe("PortfolioController", () => {
   let controller: PortfolioController;
   let portfolioService: Record<string, jest.Mock>;
   let sectorWeightingService: Record<string, jest.Mock>;
+  let delegationService: Record<string, jest.Mock>;
 
   const req = { user: { id: "user-1" } };
   const UUID1 = "00000000-0000-0000-0000-000000000001";
   const UUID2 = "00000000-0000-0000-0000-000000000002";
+  const NO_READABLE = "00000000-0000-0000-0000-000000000000";
 
   beforeEach(async () => {
     portfolioService = {
@@ -32,6 +35,10 @@ describe("PortfolioController", () => {
       }),
     };
 
+    delegationService = {
+      readableAccountIds: jest.fn().mockResolvedValue([]),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [PortfolioController],
       providers: [
@@ -40,6 +47,7 @@ describe("PortfolioController", () => {
           provide: SectorWeightingService,
           useValue: sectorWeightingService,
         },
+        { provide: DelegationService, useValue: delegationService },
       ],
     }).compile();
 
@@ -91,9 +99,40 @@ describe("PortfolioController", () => {
       );
     });
 
-    it("rejects invalid UUIDs in accountIds", () => {
-      expect(() => controller.getSummary(req, "not-a-uuid")).toThrow(
+    it("rejects invalid UUIDs in accountIds", async () => {
+      await expect(controller.getSummary(req, "not-a-uuid")).rejects.toThrow(
         BadRequestException,
+      );
+    });
+
+    it("scopes accountIds to readable accounts for an acting delegate", async () => {
+      portfolioService.getPortfolioSummary.mockResolvedValue({});
+      delegationService.readableAccountIds.mockResolvedValue([UUID1]);
+      const actReq = {
+        user: { id: "owner-1", isActing: true, delegationId: "d-1" },
+      };
+
+      await controller.getSummary(actReq, `${UUID1},${UUID2}`);
+
+      expect(delegationService.readableAccountIds).toHaveBeenCalledWith("d-1");
+      expect(portfolioService.getPortfolioSummary).toHaveBeenCalledWith(
+        "owner-1",
+        [UUID1],
+      );
+    });
+
+    it("returns an empty-shaped result for a delegate with no readable accounts", async () => {
+      portfolioService.getPortfolioSummary.mockResolvedValue({});
+      delegationService.readableAccountIds.mockResolvedValue([]);
+      const actReq = {
+        user: { id: "owner-1", isActing: true, delegationId: "d-1" },
+      };
+
+      await controller.getSummary(actReq);
+
+      expect(portfolioService.getPortfolioSummary).toHaveBeenCalledWith(
+        "owner-1",
+        [NO_READABLE],
       );
     });
   });
@@ -126,8 +165,8 @@ describe("PortfolioController", () => {
       );
     });
 
-    it("rejects invalid UUIDs in accountIds", () => {
-      expect(() => controller.getAllocation(req, "not-a-uuid")).toThrow(
+    it("rejects invalid UUIDs in accountIds", async () => {
+      await expect(controller.getAllocation(req, "not-a-uuid")).rejects.toThrow(
         BadRequestException,
       );
     });
@@ -159,6 +198,22 @@ describe("PortfolioController", () => {
         "user-1",
       );
       expect(result).toEqual(accounts);
+    });
+
+    it("filters accounts to readable ones for an acting delegate", async () => {
+      const accounts = [
+        { id: UUID1, name: "Granted", type: "INVESTMENT" },
+        { id: UUID2, name: "Not granted", type: "INVESTMENT" },
+      ];
+      portfolioService.getInvestmentAccounts.mockResolvedValue(accounts);
+      delegationService.readableAccountIds.mockResolvedValue([UUID1]);
+      const actReq = {
+        user: { id: "owner-1", isActing: true, delegationId: "d-1" },
+      };
+
+      const result = await controller.getInvestmentAccounts(actReq);
+
+      expect(result).toEqual([accounts[0]]);
     });
   });
 
@@ -205,13 +260,13 @@ describe("PortfolioController", () => {
       );
     });
 
-    it("rejects invalid UUIDs in accountIds", () => {
-      expect(() =>
+    it("rejects invalid UUIDs in accountIds", async () => {
+      await expect(
         controller.getIntradayValue(req, {
           range: "1d",
           accountIds: "not-a-uuid",
         }),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
   });
 
@@ -236,16 +291,16 @@ describe("PortfolioController", () => {
       );
     });
 
-    it("rejects invalid UUID in accountIds", () => {
-      expect(() => controller.getSectorWeightings(req, "not-a-uuid")).toThrow(
-        BadRequestException,
-      );
+    it("rejects invalid UUID in accountIds", async () => {
+      await expect(
+        controller.getSectorWeightings(req, "not-a-uuid"),
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects invalid UUID in securityIds", () => {
-      expect(() =>
+    it("rejects invalid UUID in securityIds", async () => {
+      await expect(
         controller.getSectorWeightings(req, undefined, "not-a-uuid"),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/backend/src/securities/portfolio.controller.ts
+++ b/backend/src/securities/portfolio.controller.ts
@@ -17,6 +17,16 @@ import { AuthGuard } from "@nestjs/passport";
 import { PortfolioService } from "./portfolio.service";
 import { SectorWeightingService } from "./sector-weighting.service";
 import { IntradayValueQueryDto } from "./dto/intraday-value.dto";
+import {
+  AllowDelegate,
+  DelegateRequiresSection,
+} from "../delegation/decorators/delegate-access.decorator";
+import { DelegationService } from "../delegation/delegation.service";
+
+// A UUID that cannot match any real account: forces a naturally-empty,
+// correctly-shaped result for an acting delegate with no readable accounts
+// (instead of passing undefined, which the service treats as "all").
+const NO_READABLE_ACCOUNT = "00000000-0000-0000-0000-000000000000";
 
 @ApiTags("Portfolio")
 @Controller("portfolio")
@@ -29,7 +39,29 @@ export class PortfolioController {
   constructor(
     private readonly portfolioService: PortfolioService,
     private readonly sectorWeightingService: SectorWeightingService,
+    private readonly delegationService: DelegationService,
   ) {}
+
+  /**
+   * For an acting delegate, restrict the account-id filter to the accounts
+   * they were granted READ on (intersecting any explicit request). Returns
+   * the original ids unchanged for non-delegate requests so owner behaviour
+   * (undefined = all accounts) is preserved.
+   */
+  private async scopeIds(
+    req: { user: { isActing?: boolean; delegationId?: string } },
+    ids?: string[],
+  ): Promise<string[] | undefined> {
+    if (!req.user.isActing || !req.user.delegationId) return ids;
+    const readable = new Set(
+      await this.delegationService.readableAccountIds(req.user.delegationId),
+    );
+    const eff =
+      ids && ids.length > 0
+        ? ids.filter((i) => readable.has(i))
+        : [...readable];
+    return eff.length > 0 ? eff : [NO_READABLE_ACCOUNT];
+  }
 
   private parseUuidList(
     csv: string | undefined,
@@ -46,6 +78,8 @@ export class PortfolioController {
   }
 
   @Get("summary")
+  @AllowDelegate()
+  @DelegateRequiresSection("investments")
   @ApiOperation({
     summary: "Get portfolio summary with holdings and market values",
   })
@@ -60,12 +94,17 @@ export class PortfolioController {
     description: "Portfolio summary retrieved successfully",
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  getSummary(@Request() req, @Query("accountIds") accountIds?: string) {
+  async getSummary(@Request() req, @Query("accountIds") accountIds?: string) {
     const ids = this.parseUuidList(accountIds, "account");
-    return this.portfolioService.getPortfolioSummary(req.user.id, ids);
+    return this.portfolioService.getPortfolioSummary(
+      req.user.id,
+      await this.scopeIds(req, ids),
+    );
   }
 
   @Get("allocation")
+  @AllowDelegate()
+  @DelegateRequiresSection("investments")
   @ApiOperation({
     summary: "Get asset allocation breakdown",
   })
@@ -80,9 +119,15 @@ export class PortfolioController {
     description: "Asset allocation retrieved successfully",
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  getAllocation(@Request() req, @Query("accountIds") accountIds?: string) {
+  async getAllocation(
+    @Request() req,
+    @Query("accountIds") accountIds?: string,
+  ) {
     const ids = this.parseUuidList(accountIds, "account");
-    return this.portfolioService.getAssetAllocation(req.user.id, ids);
+    return this.portfolioService.getAssetAllocation(
+      req.user.id,
+      await this.scopeIds(req, ids),
+    );
   }
 
   @Get("top-movers")
@@ -99,6 +144,8 @@ export class PortfolioController {
   }
 
   @Get("accounts")
+  @AllowDelegate()
+  @DelegateRequiresSection("investments")
   @ApiOperation({
     summary: "Get all investment accounts for the user",
   })
@@ -107,11 +154,20 @@ export class PortfolioController {
     description: "Investment accounts retrieved successfully",
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  getInvestmentAccounts(@Request() req) {
-    return this.portfolioService.getInvestmentAccounts(req.user.id);
+  async getInvestmentAccounts(@Request() req) {
+    const accounts = await this.portfolioService.getInvestmentAccounts(
+      req.user.id,
+    );
+    if (!req.user.isActing || !req.user.delegationId) return accounts;
+    const readable = new Set(
+      await this.delegationService.readableAccountIds(req.user.delegationId),
+    );
+    return accounts.filter((a) => readable.has(a.id));
   }
 
   @Get("intraday-value")
+  @AllowDelegate()
+  @DelegateRequiresSection("investments")
   @ApiOperation({
     summary:
       "Get intraday portfolio value series for the 1D / 1W / 1M chart ranges",
@@ -121,16 +177,21 @@ export class PortfolioController {
     description: "Intraday portfolio value retrieved successfully",
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  getIntradayValue(@Request() req, @Query() query: IntradayValueQueryDto) {
+  async getIntradayValue(
+    @Request() req,
+    @Query() query: IntradayValueQueryDto,
+  ) {
     const ids = this.parseUuidList(query.accountIds, "account");
     return this.portfolioService.getIntradayValueSeries(req.user.id, {
       range: query.range,
-      accountIds: ids,
+      accountIds: await this.scopeIds(req, ids),
       displayCurrency: query.displayCurrency,
     });
   }
 
   @Get("sector-weightings")
+  @AllowDelegate()
+  @DelegateRequiresSection("investments")
   @ApiOperation({
     summary: "Get sector weightings breakdown for investment portfolio",
   })
@@ -149,7 +210,7 @@ export class PortfolioController {
     description: "Sector weightings retrieved successfully",
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  getSectorWeightings(
+  async getSectorWeightings(
     @Request() req,
     @Query("accountIds") accountIds?: string,
     @Query("securityIds") securityIds?: string,
@@ -158,7 +219,7 @@ export class PortfolioController {
     const sIds = this.parseUuidList(securityIds, "security");
     return this.sectorWeightingService.getSectorWeightings(
       req.user.id,
-      aIds,
+      await this.scopeIds(req, aIds),
       sIds,
     );
   }

--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -572,7 +572,33 @@ describe("PortfolioService", () => {
           where: {
             id: expect.anything(),
             userId,
+            accountType: AccountType.INVESTMENT,
           },
+        });
+      });
+
+      it("restricts requested and linked fetches to INVESTMENT accounts so non-investment readable accounts (delegate) never leak in", async () => {
+        accountsRepository.find
+          .mockResolvedValueOnce([mockBrokerageAccount])
+          .mockResolvedValueOnce([mockCashAccount])
+          .mockResolvedValueOnce([mockCashAccount]);
+        holdingsRepository.find.mockResolvedValue([]);
+        securityPriceRepository.query.mockResolvedValue([]);
+
+        await service.getPortfolioSummary(userId, [
+          "acct-brokerage-1",
+          "acct-chequing-1",
+        ]);
+
+        expect(accountsRepository.find).toHaveBeenNthCalledWith(1, {
+          where: expect.objectContaining({
+            accountType: AccountType.INVESTMENT,
+          }),
+        });
+        expect(accountsRepository.find).toHaveBeenNthCalledWith(2, {
+          where: expect.objectContaining({
+            accountType: AccountType.INVESTMENT,
+          }),
         });
       });
 

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -1192,9 +1192,18 @@ export class PortfolioService {
       return this.getInvestmentAccounts(userId);
     }
 
-    // Batch fetch all requested accounts in one query
+    // Batch fetch all requested accounts in one query. Restricted to
+    // INVESTMENT accounts so a caller passing non-investment ids (e.g. an
+    // acting delegate whose readable set spans chequing/savings granted for
+    // other tabs) never leaks them into portfolio/holdings computations.
+    // Investment-cash siblings are accountType INVESTMENT, so linked pairs
+    // still resolve.
     const requestedAccounts = await this.accountsRepository.find({
-      where: { id: In(accountIds), userId },
+      where: {
+        id: In(accountIds),
+        userId,
+        accountType: AccountType.INVESTMENT,
+      },
     });
     // Resolve linked pairs
     const resolvedIds = new Set<string>(requestedAccounts.map((a) => a.id));
@@ -1209,7 +1218,11 @@ export class PortfolioService {
     );
     if (linkedOnly.length > 0) {
       const linkedAccounts = await this.accountsRepository.find({
-        where: { id: In(linkedOnly), userId },
+        where: {
+          id: In(linkedOnly),
+          userId,
+          accountType: AccountType.INVESTMENT,
+        },
       });
       return [...requestedAccounts, ...linkedAccounts];
     }

--- a/backend/src/securities/securities.module.ts
+++ b/backend/src/securities/securities.module.ts
@@ -26,6 +26,7 @@ import { TransactionsModule } from "../transactions/transactions.module";
 import { CurrenciesModule } from "../currencies/currencies.module";
 import { NetWorthModule } from "../net-worth/net-worth.module";
 import { ActionHistoryModule } from "../action-history/action-history.module";
+import { DelegationModule } from "../delegation/delegation.module";
 
 @Module({
   imports: [
@@ -43,6 +44,7 @@ import { ActionHistoryModule } from "../action-history/action-history.module";
     forwardRef(() => CurrenciesModule),
     NetWorthModule,
     ActionHistoryModule,
+    DelegationModule,
   ],
   providers: [
     SecuritiesService,

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -41,6 +41,7 @@ export class TagsController {
   }
 
   @Get("transaction-counts")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get transaction counts for all tags" })
   @ApiResponse({
     status: 200,
@@ -51,6 +52,7 @@ export class TagsController {
   }
 
   @Get(":id")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get a tag by ID" })
   @ApiResponse({ status: 200, description: "Tag retrieved successfully" })
   @ApiResponse({ status: 404, description: "Tag not found" })
@@ -59,6 +61,7 @@ export class TagsController {
   }
 
   @Get(":id/transaction-count")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get number of transactions using this tag" })
   @ApiResponse({ status: 200, description: "Count retrieved successfully" })
   getTransactionCount(@Request() req, @Param("id", ParseUUIDPipe) id: string) {

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -73,7 +73,7 @@ export class TagsController {
   @ApiResponse({ status: 201, description: "Tag created successfully" })
   @ApiResponse({ status: 409, description: "Tag name already exists" })
   @AllowDelegate()
-  @DelegateRequiresCapability("tags")
+  @DelegateRequiresCapability("tags", "create")
   create(@Request() req, @Body() createTagDto: CreateTagDto) {
     return this.tagsService.create(req.user.id, createTagDto);
   }
@@ -83,7 +83,7 @@ export class TagsController {
   @ApiResponse({ status: 200, description: "Tag updated successfully" })
   @ApiResponse({ status: 404, description: "Tag not found" })
   @AllowDelegate()
-  @DelegateRequiresCapability("tags")
+  @DelegateRequiresCapability("tags", "edit")
   update(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,
@@ -97,7 +97,7 @@ export class TagsController {
   @ApiResponse({ status: 200, description: "Tag deleted successfully" })
   @ApiResponse({ status: 404, description: "Tag not found" })
   @AllowDelegate()
-  @DelegateRequiresCapability("tags")
+  @DelegateRequiresCapability("tags", "delete")
   remove(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
     return this.tagsService.remove(req.user.id, id);
   }

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -20,6 +20,7 @@ import { AuthGuard } from "@nestjs/passport";
 import { TagsService } from "./tags.service";
 import { CreateTagDto } from "./dto/create-tag.dto";
 import { UpdateTagDto } from "./dto/update-tag.dto";
+import { AllowDelegate } from "../delegation/decorators/delegate-access.decorator";
 
 @ApiTags("Tags")
 @Controller("tags")
@@ -31,6 +32,7 @@ export class TagsController {
   @Get()
   @ApiOperation({ summary: "Get all tags for the authenticated user" })
   @ApiResponse({ status: 200, description: "Tags retrieved successfully" })
+  @AllowDelegate()
   findAll(@Request() req) {
     return this.tagsService.findAll(req.user.id);
   }

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -20,7 +20,10 @@ import { AuthGuard } from "@nestjs/passport";
 import { TagsService } from "./tags.service";
 import { CreateTagDto } from "./dto/create-tag.dto";
 import { UpdateTagDto } from "./dto/update-tag.dto";
-import { AllowDelegate } from "../delegation/decorators/delegate-access.decorator";
+import {
+  AllowDelegate,
+  DelegateRequiresCapability,
+} from "../delegation/decorators/delegate-access.decorator";
 
 @ApiTags("Tags")
 @Controller("tags")
@@ -66,6 +69,8 @@ export class TagsController {
   @ApiOperation({ summary: "Create a new tag" })
   @ApiResponse({ status: 201, description: "Tag created successfully" })
   @ApiResponse({ status: 409, description: "Tag name already exists" })
+  @AllowDelegate()
+  @DelegateRequiresCapability("tags")
   create(@Request() req, @Body() createTagDto: CreateTagDto) {
     return this.tagsService.create(req.user.id, createTagDto);
   }
@@ -74,6 +79,8 @@ export class TagsController {
   @ApiOperation({ summary: "Update a tag" })
   @ApiResponse({ status: 200, description: "Tag updated successfully" })
   @ApiResponse({ status: 404, description: "Tag not found" })
+  @AllowDelegate()
+  @DelegateRequiresCapability("tags")
   update(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,
@@ -86,6 +93,8 @@ export class TagsController {
   @ApiOperation({ summary: "Delete a tag" })
   @ApiResponse({ status: 200, description: "Tag deleted successfully" })
   @ApiResponse({ status: 404, description: "Tag not found" })
+  @AllowDelegate()
+  @DelegateRequiresCapability("tags")
   remove(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
     return this.tagsService.remove(req.user.id, id);
   }

--- a/backend/src/transactions/entities/transaction-split.entity.ts
+++ b/backend/src/transactions/entities/transaction-split.entity.ts
@@ -43,7 +43,7 @@ export class TransactionSplit {
   @Column({ type: "uuid", name: "category_id", nullable: true })
   categoryId: string | null;
 
-  @ManyToOne(() => Category, { nullable: true })
+  @ManyToOne(() => Category, { nullable: true, onDelete: "SET NULL" })
   @JoinColumn({ name: "category_id" })
   category: Category | null;
 

--- a/backend/src/transactions/entities/transaction.entity.ts
+++ b/backend/src/transactions/entities/transaction.entity.ts
@@ -78,7 +78,7 @@ export class Transaction {
   @Column({ type: "uuid", name: "category_id", nullable: true })
   categoryId: string | null;
 
-  @ManyToOne(() => Category, { nullable: true })
+  @ManyToOne(() => Category, { nullable: true, onDelete: "SET NULL" })
   @JoinColumn({ name: "category_id" })
   category: Category | null;
 

--- a/backend/src/transactions/transaction-split.service.spec.ts
+++ b/backend/src/transactions/transaction-split.service.spec.ts
@@ -1614,9 +1614,7 @@ describe("TransactionSplitService", () => {
         { id: "split-1", kind: "category", categoryId: "cat-1" },
         { id: "split-2", kind: "category", categoryId: "cat-2" },
       ];
-      mockQueryRunner.manager.find = jest
-        .fn()
-        .mockResolvedValue(remaining);
+      mockQueryRunner.manager.find = jest.fn().mockResolvedValue(remaining);
 
       const investmentService = (service as any).investmentTransactionsService;
 

--- a/backend/src/transactions/transaction-split.service.ts
+++ b/backend/src/transactions/transaction-split.service.ts
@@ -504,11 +504,7 @@ export class TransactionSplitService {
     await queryRunner.startTransaction();
 
     try {
-      await this.deleteSplitSideEffects(
-        transaction.id,
-        userId,
-        queryRunner,
-      );
+      await this.deleteSplitSideEffects(transaction.id, userId, queryRunner);
 
       await queryRunner.manager.delete(TransactionSplit, {
         transactionId: transaction.id,

--- a/backend/src/transactions/transactions.controller.spec.ts
+++ b/backend/src/transactions/transactions.controller.spec.ts
@@ -2,6 +2,8 @@ import { BadRequestException } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { TransactionsController } from "./transactions.controller";
 import { TransactionsService } from "./transactions.service";
+import { DelegateTransferMaskInterceptor } from "../delegation/interceptors/delegate-transfer-mask.interceptor";
+import { DelegationService } from "../delegation/delegation.service";
 
 describe("TransactionsController", () => {
   let controller: TransactionsController;
@@ -45,6 +47,11 @@ describe("TransactionsController", () => {
         {
           provide: TransactionsService,
           useValue: mockService,
+        },
+        DelegateTransferMaskInterceptor,
+        {
+          provide: DelegationService,
+          useValue: { readableAccountIds: jest.fn().mockResolvedValue([]) },
         },
       ],
     }).compile();

--- a/backend/src/transactions/transactions.controller.spec.ts
+++ b/backend/src/transactions/transactions.controller.spec.ts
@@ -1137,8 +1137,8 @@ describe("TransactionsController", () => {
       );
     });
 
-    it("rejects non-numeric amountFrom in monthly totals", () => {
-      expect(() =>
+    it("rejects non-numeric amountFrom in monthly totals", async () => {
+      await expect(
         controller.getMonthlyTotals(
           mockReq,
           undefined,
@@ -1149,11 +1149,11 @@ describe("TransactionsController", () => {
           undefined,
           "abc",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects non-numeric amountTo in monthly totals", () => {
-      expect(() =>
+    it("rejects non-numeric amountTo in monthly totals", async () => {
+      await expect(
         controller.getMonthlyTotals(
           mockReq,
           undefined,
@@ -1165,7 +1165,7 @@ describe("TransactionsController", () => {
           undefined,
           "xyz",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/backend/src/transactions/transactions.controller.spec.ts
+++ b/backend/src/transactions/transactions.controller.spec.ts
@@ -328,8 +328,8 @@ describe("TransactionsController", () => {
 
     // ── Validation tests ────────────────────────────────────────
 
-    it("rejects negative page number", () => {
-      expect(() =>
+    it("rejects negative page number", async () => {
+      await expect(
         controller.findAll(
           mockReq,
           undefined,
@@ -342,11 +342,11 @@ describe("TransactionsController", () => {
           undefined,
           "-1",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects page=0", () => {
-      expect(() =>
+    it("rejects page=0", async () => {
+      await expect(
         controller.findAll(
           mockReq,
           undefined,
@@ -359,11 +359,11 @@ describe("TransactionsController", () => {
           undefined,
           "0",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects non-numeric page", () => {
-      expect(() =>
+    it("rejects non-numeric page", async () => {
+      await expect(
         controller.findAll(
           mockReq,
           undefined,
@@ -376,11 +376,11 @@ describe("TransactionsController", () => {
           undefined,
           "abc",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects limit=0", () => {
-      expect(() =>
+    it("rejects limit=0", async () => {
+      await expect(
         controller.findAll(
           mockReq,
           undefined,
@@ -394,11 +394,11 @@ describe("TransactionsController", () => {
           undefined,
           "0",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects negative limit", () => {
-      expect(() =>
+    it("rejects negative limit", async () => {
+      await expect(
         controller.findAll(
           mockReq,
           undefined,
@@ -412,11 +412,11 @@ describe("TransactionsController", () => {
           undefined,
           "-5",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects limit exceeding 200", () => {
-      expect(() =>
+    it("rejects limit exceeding 200", async () => {
+      await expect(
         controller.findAll(
           mockReq,
           undefined,
@@ -430,17 +430,17 @@ describe("TransactionsController", () => {
           undefined,
           "201",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects invalid startDate format", () => {
-      expect(() =>
+    it("rejects invalid startDate format", async () => {
+      await expect(
         controller.findAll(mockReq, undefined, undefined, "notadate"),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects invalid endDate format", () => {
-      expect(() =>
+    it("rejects invalid endDate format", async () => {
+      await expect(
         controller.findAll(
           mockReq,
           undefined,
@@ -448,17 +448,17 @@ describe("TransactionsController", () => {
           undefined,
           "2024/01/01",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects invalid UUID in accountIds", () => {
-      expect(() =>
+    it("rejects invalid UUID in accountIds", async () => {
+      await expect(
         controller.findAll(mockReq, undefined, "not-a-uuid"),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects invalid UUID in singular accountId", () => {
-      expect(() => controller.findAll(mockReq, "not-a-uuid")).toThrow(
+    it("rejects invalid UUID in singular accountId", async () => {
+      await expect(controller.findAll(mockReq, "not-a-uuid")).rejects.toThrow(
         BadRequestException,
       );
     });
@@ -506,8 +506,8 @@ describe("TransactionsController", () => {
       );
     });
 
-    it("rejects an unknown reconciliation status", () => {
-      expect(() =>
+    it("rejects an unknown reconciliation status", async () => {
+      await expect(
         controller.findAll(
           mockReq,
           undefined,
@@ -528,11 +528,11 @@ describe("TransactionsController", () => {
           undefined,
           "BOGUS",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects invalid targetTransactionId", () => {
-      expect(() =>
+    it("rejects invalid targetTransactionId", async () => {
+      await expect(
         controller.findAll(
           mockReq,
           undefined,
@@ -549,7 +549,7 @@ describe("TransactionsController", () => {
           undefined,
           "not-a-uuid",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
   });
 
@@ -1008,8 +1008,8 @@ describe("TransactionsController", () => {
       expect(call[12]).toBeUndefined(); // amountTo
     });
 
-    it("rejects non-numeric amountFrom", () => {
-      expect(() =>
+    it("rejects non-numeric amountFrom", async () => {
+      await expect(
         controller.findAll(
           mockReq,
           undefined,
@@ -1027,11 +1027,11 @@ describe("TransactionsController", () => {
           undefined,
           "not-a-number",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects non-numeric amountTo", () => {
-      expect(() =>
+    it("rejects non-numeric amountTo", async () => {
+      await expect(
         controller.findAll(
           mockReq,
           undefined,
@@ -1050,7 +1050,7 @@ describe("TransactionsController", () => {
           undefined,
           "not-a-number",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
     it("allows only amountFrom without amountTo", async () => {

--- a/backend/src/transactions/transactions.controller.ts
+++ b/backend/src/transactions/transactions.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Delete,
   UseGuards,
+  UseInterceptors,
   Request,
   Query,
   ParseUUIDPipe,
@@ -28,8 +29,11 @@ import {
   AllowDelegate,
   DelegatedAccountParam,
   DelegatedTransactionParam,
+  DelegatedTransferBody,
+  DelegatedTransferParam,
   DelegateRequires,
 } from "../delegation/decorators/delegate-access.decorator";
+import { DelegateTransferMaskInterceptor } from "../delegation/interceptors/delegate-transfer-mask.interceptor";
 import { TransactionStatus } from "./entities/transaction.entity";
 import { CreateTransactionDto } from "./dto/create-transaction.dto";
 import { UpdateTransactionDto } from "./dto/update-transaction.dto";
@@ -75,6 +79,7 @@ function parseTransactionStatuses(
 @ApiTags("Transactions")
 @Controller("transactions")
 @UseGuards(AuthGuard("jwt"))
+@UseInterceptors(DelegateTransferMaskInterceptor)
 @ApiBearerAuth()
 export class TransactionsController {
   constructor(private readonly transactionsService: TransactionsService) {}
@@ -579,6 +584,9 @@ export class TransactionsController {
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   @ApiResponse({ status: 404, description: "Account not found" })
+  @AllowDelegate()
+  @DelegatedTransferBody()
+  @DelegateRequires("create")
   createTransfer(@Request() req, @Body() createTransferDto: CreateTransferDto) {
     return this.transactionsService.createTransfer(
       req.user.id,
@@ -827,6 +835,9 @@ export class TransactionsController {
   @ApiResponse({ status: 400, description: "Transaction is not a transfer" })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   @ApiResponse({ status: 404, description: "Transaction not found" })
+  @AllowDelegate()
+  @DelegatedTransferParam("id")
+  @DelegateRequires("delete")
   removeTransfer(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
     return this.transactionsService.removeTransfer(req.user.id, id);
   }
@@ -843,6 +854,9 @@ export class TransactionsController {
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   @ApiResponse({ status: 404, description: "Transaction not found" })
+  @AllowDelegate()
+  @DelegatedTransferParam("id")
+  @DelegateRequires("edit")
   updateTransfer(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,

--- a/backend/src/transactions/transactions.controller.ts
+++ b/backend/src/transactions/transactions.controller.ts
@@ -465,7 +465,8 @@ export class TransactionsController {
     description: "Monthly totals retrieved successfully",
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  getMonthlyTotals(
+  @AllowDelegate()
+  async getMonthlyTotals(
     @Request() req,
     @Query("accountIds") accountIds?: string,
     @Query("startDate") startDate?: string,
@@ -492,9 +493,22 @@ export class TransactionsController {
       throw new BadRequestException("amountTo must be a number");
     }
 
+    let effectiveAccountIds = parseUuids(accountIds);
+    if (req.user.isActing) {
+      const readable = await this.delegationService.readableAccountIds(
+        req.user.delegationId,
+      );
+      const readableSet = new Set(readable);
+      effectiveAccountIds =
+        effectiveAccountIds && effectiveAccountIds.length > 0
+          ? effectiveAccountIds.filter((id) => readableSet.has(id))
+          : readable;
+      if (effectiveAccountIds.length === 0) return [];
+    }
+
     return this.transactionsService.getMonthlyTotals(
       req.user.id,
-      parseUuids(accountIds),
+      effectiveAccountIds,
       startDate,
       endDate,
       parseCategoryIds(categoryIds),

--- a/backend/src/transactions/transactions.controller.ts
+++ b/backend/src/transactions/transactions.controller.ts
@@ -27,6 +27,7 @@ import { TransactionsService } from "./transactions.service";
 import {
   AllowDelegate,
   DelegatedAccountParam,
+  DelegatedTransactionParam,
   DelegateRequires,
 } from "../delegation/decorators/delegate-access.decorator";
 import { TransactionStatus } from "./entities/transaction.entity";
@@ -642,6 +643,9 @@ export class TransactionsController {
     description: "Forbidden - transaction does not belong to user",
   })
   @ApiResponse({ status: 404, description: "Transaction not found" })
+  @AllowDelegate()
+  @DelegatedTransactionParam("id")
+  @DelegateRequires("edit")
   update(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,
@@ -664,6 +668,9 @@ export class TransactionsController {
     description: "Forbidden - transaction does not belong to user",
   })
   @ApiResponse({ status: 404, description: "Transaction not found" })
+  @AllowDelegate()
+  @DelegatedTransactionParam("id")
+  @DelegateRequires("delete")
   remove(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
     return this.transactionsService.remove(req.user.id, id);
   }

--- a/backend/src/transactions/transactions.controller.ts
+++ b/backend/src/transactions/transactions.controller.ts
@@ -34,6 +34,7 @@ import {
   DelegateRequires,
 } from "../delegation/decorators/delegate-access.decorator";
 import { DelegateTransferMaskInterceptor } from "../delegation/interceptors/delegate-transfer-mask.interceptor";
+import { DelegationService } from "../delegation/delegation.service";
 import { TransactionStatus } from "./entities/transaction.entity";
 import { CreateTransactionDto } from "./dto/create-transaction.dto";
 import { UpdateTransactionDto } from "./dto/update-transaction.dto";
@@ -82,7 +83,10 @@ function parseTransactionStatuses(
 @UseInterceptors(DelegateTransferMaskInterceptor)
 @ApiBearerAuth()
 export class TransactionsController {
-  constructor(private readonly transactionsService: TransactionsService) {}
+  constructor(
+    private readonly transactionsService: TransactionsService,
+    private readonly delegationService: DelegationService,
+  ) {}
 
   @Post()
   @ApiOperation({ summary: "Create a new transaction" })
@@ -195,7 +199,8 @@ export class TransactionsController {
     description: "List of transactions retrieved successfully",
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  findAll(
+  @AllowDelegate()
+  async findAll(
     @Request() req,
     @Query("accountId") accountId?: string,
     @Query("accountIds") accountIds?: string,
@@ -257,9 +262,39 @@ export class TransactionsController {
       throw new BadRequestException("amountTo must be a number");
     }
 
+    let effectiveAccountIds = parseIds(accountIds, accountId);
+    if (req.user.isActing) {
+      // A delegate only ever sees transactions for the accounts they were
+      // granted READ on. Intersect any requested ids with the readable set;
+      // an empty result means "no visible accounts" -> empty page (NOT an
+      // unfiltered query, which would leak the whole owner ledger).
+      const readable = await this.delegationService.readableAccountIds(
+        req.user.delegationId,
+      );
+      const readableSet = new Set(readable);
+      effectiveAccountIds =
+        effectiveAccountIds && effectiveAccountIds.length > 0
+          ? effectiveAccountIds.filter((id) => readableSet.has(id))
+          : readable;
+      if (effectiveAccountIds.length === 0) {
+        const safeLimit = limit ? parseInt(limit, 10) : 50;
+        const safePage = page ? parseInt(page, 10) : 1;
+        return {
+          data: [],
+          pagination: {
+            page: safePage,
+            limit: safeLimit,
+            total: 0,
+            totalPages: 0,
+            hasMore: false,
+          },
+        };
+      }
+    }
+
     return this.transactionsService.findAll(
       req.user.id,
-      parseIds(accountIds, accountId),
+      effectiveAccountIds,
       startDate,
       endDate,
       parseCategoryIds(categoryIds ?? categoryId),
@@ -633,6 +668,8 @@ export class TransactionsController {
     description: "Forbidden - transaction does not belong to user",
   })
   @ApiResponse({ status: 404, description: "Transaction not found" })
+  @AllowDelegate()
+  @DelegatedTransactionParam("id")
   findOne(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
     return this.transactionsService.findOne(req.user.id, id);
   }
@@ -822,6 +859,8 @@ export class TransactionsController {
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   @ApiResponse({ status: 404, description: "Transaction not found" })
+  @AllowDelegate()
+  @DelegatedTransactionParam("id")
   getLinkedTransaction(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
     return this.transactionsService.getLinkedTransaction(req.user.id, id);
   }

--- a/backend/src/transactions/transactions.controller.ts
+++ b/backend/src/transactions/transactions.controller.ts
@@ -24,6 +24,11 @@ import {
 } from "@nestjs/swagger";
 import { AuthGuard } from "@nestjs/passport";
 import { TransactionsService } from "./transactions.service";
+import {
+  AllowDelegate,
+  DelegatedAccountParam,
+  DelegateRequires,
+} from "../delegation/decorators/delegate-access.decorator";
 import { TransactionStatus } from "./entities/transaction.entity";
 import { CreateTransactionDto } from "./dto/create-transaction.dto";
 import { UpdateTransactionDto } from "./dto/update-transaction.dto";
@@ -78,6 +83,9 @@ export class TransactionsController {
   @ApiResponse({ status: 201, description: "Transaction created successfully" })
   @ApiResponse({ status: 400, description: "Bad request" })
   @ApiResponse({ status: 401, description: "Unauthorized" })
+  @AllowDelegate()
+  @DelegatedAccountParam("accountId")
+  @DelegateRequires("create")
   create(@Request() req, @Body() createTransactionDto: CreateTransactionDto) {
     return this.transactionsService.create(req.user.id, createTransactionDto);
   }

--- a/backend/src/transactions/transactions.module.ts
+++ b/backend/src/transactions/transactions.module.ts
@@ -18,6 +18,7 @@ import { TagsModule } from "../tags/tags.module";
 import { NetWorthModule } from "../net-worth/net-worth.module";
 import { ActionHistoryModule } from "../action-history/action-history.module";
 import { SecuritiesModule } from "../securities/securities.module";
+import { DelegationModule } from "../delegation/delegation.module";
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { SecuritiesModule } from "../securities/securities.module";
     PayeesModule,
     TagsModule,
     ActionHistoryModule,
+    DelegationModule,
   ],
   providers: [
     TransactionsService,

--- a/backend/src/transactions/transactions.service.spec.ts
+++ b/backend/src/transactions/transactions.service.spec.ts
@@ -1684,7 +1684,9 @@ describe("TransactionsService", () => {
 
       expect(mockQb.andWhere).toHaveBeenCalledWith(
         "transaction.status IN (:...statuses)",
-        { statuses: [TransactionStatus.UNRECONCILED, TransactionStatus.CLEARED] },
+        {
+          statuses: [TransactionStatus.UNRECONCILED, TransactionStatus.CLEARED],
+        },
       );
     });
 

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -5,7 +5,7 @@ import { UsersService } from "./users.service";
 describe("UsersController", () => {
   let controller: UsersController;
   let mockUsersService: Record<string, jest.Mock>;
-  const mockReq = { user: { id: "user-1" } };
+  const mockReq = { user: { id: "user-1", realUserId: "user-1" } };
 
   beforeEach(async () => {
     mockUsersService = {
@@ -141,6 +141,21 @@ describe("UsersController", () => {
       expect(result).toEqual({ message: "Password changed successfully" });
       expect(mockUsersService.changePassword).toHaveBeenCalledWith(
         "user-1",
+        dto,
+      );
+    });
+
+    it("targets the real (delegate) user id, never the owner, when acting", async () => {
+      const dto = { currentPassword: "old123", newPassword: "new456" };
+      mockUsersService.changePassword.mockResolvedValue(undefined);
+      const actingReq = {
+        user: { id: "owner-1", realUserId: "delegate-1", isActing: true },
+      };
+
+      await controller.changePassword(actingReq as any, dto as any);
+
+      expect(mockUsersService.changePassword).toHaveBeenCalledWith(
+        "delegate-1",
         dto,
       );
     });

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -74,6 +74,7 @@ export class UsersController {
 
   @Post("change-password")
   @SkipPasswordCheck()
+  @AllowDelegate()
   @DemoRestricted()
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "Change current user password" })
@@ -83,7 +84,10 @@ export class UsersController {
     description: "Invalid current password or validation error",
   })
   async changePassword(@Request() req, @Body() dto: ChangePasswordDto) {
-    await this.usersService.changePassword(req.user.id, dto);
+    // Security: a delegate acting as an owner manages their OWN password,
+    // not the owner's — use realUserId so the change always targets the
+    // authenticated identity regardless of acting context.
+    await this.usersService.changePassword(req.user.realUserId, dto);
     return { message: "Password changed successfully" };
   }
 

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -24,6 +24,7 @@ import { DeleteAccountDto } from "./dto/delete-account.dto";
 import { DeleteDataDto } from "./dto/delete-data.dto";
 import { SkipPasswordCheck } from "../auth/decorators/skip-password-check.decorator";
 import { DemoRestricted } from "../common/decorators/demo-restricted.decorator";
+import { AllowDelegate } from "../delegation/decorators/delegate-access.decorator";
 
 @ApiTags("Users")
 @Controller("users")
@@ -34,6 +35,7 @@ export class UsersController {
 
   @Get("me")
   @SkipPasswordCheck()
+  @AllowDelegate()
   @ApiOperation({ summary: "Get current user profile" })
   async getProfile(@Request() req) {
     const user = await this.usersService.findById(req.user.id);
@@ -57,6 +59,7 @@ export class UsersController {
   }
 
   @Get("preferences")
+  @AllowDelegate()
   @ApiOperation({ summary: "Get current user preferences" })
   getPreferences(@Request() req) {
     return this.usersService.getPreferences(req.user.id);

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -29,6 +29,7 @@ describe("UsersService", () => {
   let exchangeRateService: { refreshAllRates: jest.Mock };
   let moduleRef: { get: jest.Mock };
   let mockQueryRunner: Record<string, jest.Mock>;
+  let mockDataSource: Record<string, jest.Mock>;
 
   const mockUser = {
     id: "user-1",
@@ -119,8 +120,9 @@ describe("UsersService", () => {
       query: jest.fn().mockResolvedValue([null, 0]),
     };
 
-    const mockDataSource = {
+    mockDataSource = {
       createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+      query: jest.fn().mockResolvedValue([]),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -645,6 +647,32 @@ describe("UsersService", () => {
       await expect(
         service.deleteAccount("nonexistent", { password: "pass" }),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it("demotes a delegate to a pure delegate instead of deleting", async () => {
+      const hashedPassword = await bcrypt.hash("CorrectPass123!", 10);
+      usersRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        passwordHash: hashedPassword,
+      });
+      // isActingDelegate -> account_delegates lookup returns a row.
+      mockDataSource.query.mockResolvedValue([{ "?column?": 1 }]);
+
+      await service.deleteAccount("user-1", { password: "CorrectPass123!" });
+
+      // Sessions revoked, but the login and incoming delegations stay.
+      expect(refreshTokensRepository.update).toHaveBeenCalled();
+      expect(patRepository.update).toHaveBeenCalled();
+      expect(preferencesRepository.delete).not.toHaveBeenCalled();
+      expect(usersRepository.remove).not.toHaveBeenCalled();
+      // Owned data + owner-side delegations are purged in a transaction.
+      expect(mockQueryRunner.startTransaction).toHaveBeenCalled();
+      const queries = mockQueryRunner.query.mock.calls.map((c) => c[0]);
+      expect(
+        queries.some((q: string) =>
+          q.includes("DELETE FROM account_delegates WHERE owner_user_id"),
+        ),
+      ).toBe(true);
     });
 
     it("prevents the last admin from self-deleting", async () => {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -8,7 +8,7 @@ import {
   UnauthorizedException,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository, DataSource } from "typeorm";
+import { Repository, DataSource, QueryRunner } from "typeorm";
 import * as bcrypt from "bcryptjs";
 import { User } from "./entities/user.entity";
 import { UserPreference } from "./entities/user-preference.entity";
@@ -326,10 +326,7 @@ export class UsersService {
       }
     }
 
-    // Delete preferences first (due to FK constraint)
-    await this.preferencesRepository.delete({ userId });
-
-    // Revoke all refresh tokens and PATs before deletion
+    // Revoke all refresh tokens and PATs (forces re-login either way).
     await this.refreshTokensRepository.update(
       { userId, isRevoked: false },
       { isRevoked: true },
@@ -339,7 +336,17 @@ export class UsersService {
       { isRevoked: true },
     );
 
-    // Delete the user
+    // A full account that is also a delegate of someone else is demoted to
+    // a pure delegate instead of being removed: their own data goes, but
+    // their login and the delegate access others granted them stay, so
+    // they can keep acting as a delegate.
+    if (await this.isActingDelegate(userId)) {
+      await this.purgeForDowngrade(userId);
+      return;
+    }
+
+    // Delete preferences first (due to FK constraint), then the user.
+    await this.preferencesRepository.delete({ userId });
     await this.usersRepository.remove(user);
   }
 
@@ -376,236 +383,294 @@ export class UsersService {
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
     await queryRunner.startTransaction();
-
-    const deleted: Record<string, number> = {};
-
     try {
-      // Always deleted: financial transaction data, investments, summaries, budgets
-
-      // Investment data (FK-safe order)
-      let result = await queryRunner.query(
-        "DELETE FROM investment_transactions WHERE user_id = $1",
-        [userId],
-      );
-      deleted.investmentTransactions = result[1] ?? 0;
-
-      result = await queryRunner.query(
-        `DELETE FROM holdings WHERE account_id IN
-         (SELECT id FROM accounts WHERE user_id = $1)`,
-        [userId],
-      );
-      deleted.holdings = result[1] ?? 0;
-
-      result = await queryRunner.query(
-        `DELETE FROM security_prices WHERE security_id IN
-         (SELECT id FROM securities WHERE user_id = $1)`,
-        [userId],
-      );
-      deleted.securityPrices = result[1] ?? 0;
-
-      result = await queryRunner.query(
-        "DELETE FROM securities WHERE user_id = $1",
-        [userId],
-      );
-      deleted.securities = result[1] ?? 0;
-
-      // Budget data
-      result = await queryRunner.query(
-        `DELETE FROM budget_alerts WHERE user_id = $1`,
-        [userId],
-      );
-      deleted.budgetAlerts = result[1] ?? 0;
-
-      result = await queryRunner.query(
-        `DELETE FROM budget_period_categories WHERE budget_period_id IN
-         (SELECT bp.id FROM budget_periods bp
-          JOIN budgets b ON bp.budget_id = b.id
-          WHERE b.user_id = $1)`,
-        [userId],
-      );
-      deleted.budgetPeriodCategories = result[1] ?? 0;
-
-      result = await queryRunner.query(
-        `DELETE FROM budget_periods WHERE budget_id IN
-         (SELECT id FROM budgets WHERE user_id = $1)`,
-        [userId],
-      );
-      deleted.budgetPeriods = result[1] ?? 0;
-
-      result = await queryRunner.query(
-        `DELETE FROM budget_categories WHERE budget_id IN
-         (SELECT id FROM budgets WHERE user_id = $1)`,
-        [userId],
-      );
-      deleted.budgetCategories = result[1] ?? 0;
-
-      result = await queryRunner.query(
-        "DELETE FROM budgets WHERE user_id = $1",
-        [userId],
-      );
-      deleted.budgets = result[1] ?? 0;
-
-      // Transaction tags
-      result = await queryRunner.query(
-        `DELETE FROM transaction_split_tags WHERE transaction_split_id IN
-         (SELECT ts.id FROM transaction_splits ts
-          JOIN transactions t ON ts.transaction_id = t.id
-          WHERE t.user_id = $1)`,
-        [userId],
-      );
-
-      result = await queryRunner.query(
-        `DELETE FROM transaction_tags WHERE transaction_id IN
-         (SELECT id FROM transactions WHERE user_id = $1)`,
-        [userId],
-      );
-
-      // Transaction splits
-      result = await queryRunner.query(
-        `DELETE FROM transaction_splits WHERE transaction_id IN
-         (SELECT id FROM transactions WHERE user_id = $1)`,
-        [userId],
-      );
-      deleted.transactionSplits = result[1] ?? 0;
-
-      // Transactions
-      result = await queryRunner.query(
-        "DELETE FROM transactions WHERE user_id = $1",
-        [userId],
-      );
-      deleted.transactions = result[1] ?? 0;
-
-      // Tags (now that transaction_tags are gone)
-      result = await queryRunner.query("DELETE FROM tags WHERE user_id = $1", [
-        userId,
-      ]);
-      deleted.tags = result[1] ?? 0;
-
-      // Scheduled transactions
-      result = await queryRunner.query(
-        `DELETE FROM scheduled_transaction_overrides WHERE scheduled_transaction_id IN
-         (SELECT id FROM scheduled_transactions WHERE user_id = $1)`,
-        [userId],
-      );
-
-      result = await queryRunner.query(
-        `DELETE FROM scheduled_transaction_splits WHERE scheduled_transaction_id IN
-         (SELECT id FROM scheduled_transactions WHERE user_id = $1)`,
-        [userId],
-      );
-
-      result = await queryRunner.query(
-        "DELETE FROM scheduled_transactions WHERE user_id = $1",
-        [userId],
-      );
-      deleted.scheduledTransactions = result[1] ?? 0;
-
-      // Monthly account balances
-      result = await queryRunner.query(
-        "DELETE FROM monthly_account_balances WHERE user_id = $1",
-        [userId],
-      );
-      deleted.monthlyBalances = result[1] ?? 0;
-
-      // Custom reports
-      result = await queryRunner.query(
-        "DELETE FROM custom_reports WHERE user_id = $1",
-        [userId],
-      );
-      deleted.customReports = result[1] ?? 0;
-
-      // Import column mappings
-      result = await queryRunner.query(
-        "DELETE FROM import_column_mappings WHERE user_id = $1",
-        [userId],
-      );
-      deleted.importMappings = result[1] ?? 0;
-
-      // AI data
-      result = await queryRunner.query(
-        "DELETE FROM ai_insights WHERE user_id = $1",
-        [userId],
-      );
-      deleted.aiInsights = result[1] ?? 0;
-
-      result = await queryRunner.query(
-        "DELETE FROM ai_usage_logs WHERE user_id = $1",
-        [userId],
-      );
-
-      // Optional: delete payees (before accounts, since payee default_category_id
-      // references categories, and accounts may reference payee-related data)
-      if (dto.deletePayees) {
-        result = await queryRunner.query(
-          "DELETE FROM payee_aliases WHERE user_id = $1",
-          [userId],
-        );
-        result = await queryRunner.query(
-          "DELETE FROM payees WHERE user_id = $1",
-          [userId],
-        );
-        deleted.payees = result[1] ?? 0;
-      }
-
-      // Optional: delete accounts (must come after transactions)
-      if (dto.deleteAccounts) {
-        result = await queryRunner.query(
-          "DELETE FROM accounts WHERE user_id = $1",
-          [userId],
-        );
-        deleted.accounts = result[1] ?? 0;
-      } else {
-        // Reset account balances to opening balance when transactions are deleted
-        await queryRunner.query(
-          "UPDATE accounts SET current_balance = opening_balance WHERE user_id = $1",
-          [userId],
-        );
-      }
-
-      // Optional: delete categories (must come after transactions and budgets)
-      if (dto.deleteCategories) {
-        // Clear payee default_category_id references first
-        await queryRunner.query(
-          `UPDATE payees SET default_category_id = NULL WHERE user_id = $1`,
-          [userId],
-        );
-        // Clear account category references
-        await queryRunner.query(
-          `UPDATE accounts SET principal_category_id = NULL,
-           interest_category_id = NULL, asset_category_id = NULL
-           WHERE user_id = $1`,
-          [userId],
-        );
-        result = await queryRunner.query(
-          "DELETE FROM categories WHERE user_id = $1",
-          [userId],
-        );
-        deleted.categories = result[1] ?? 0;
-      }
-
-      // Optional: delete exchange rates
-      if (dto.deleteExchangeRates) {
-        result = await queryRunner.query(
-          "DELETE FROM user_currency_preferences WHERE user_id = $1",
-          [userId],
-        );
-        deleted.exchangeRates = result[1] ?? 0;
-      }
-
-      // Clear action history (undo/redo) -- references deleted entities
-      result = await queryRunner.query(
-        "DELETE FROM action_history WHERE user_id = $1",
-        [userId],
-      );
-      deleted.actionHistory = result[1] ?? 0;
-
+      const deleted = await this.runOwnedDataDeletes(userId, dto, queryRunner);
       await queryRunner.commitTransaction();
-
       this.logger.log(
         `User ${userId} deleted data: ${JSON.stringify(deleted)}`,
       );
-
       return { deleted };
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  /**
+   * Deletes all data owned by a user -- the same set the self-service
+   * "delete my data" flow removes. Runs inside the caller's transaction.
+   * `opts` mirror DeleteDataDto's optional toggles.
+   */
+  private async runOwnedDataDeletes(
+    userId: string,
+    opts: {
+      deletePayees?: boolean;
+      deleteAccounts?: boolean;
+      deleteCategories?: boolean;
+      deleteExchangeRates?: boolean;
+    },
+    queryRunner: QueryRunner,
+  ): Promise<Record<string, number>> {
+    const deleted: Record<string, number> = {};
+
+    // Always deleted: financial transaction data, investments, summaries, budgets
+
+    // Investment data (FK-safe order)
+    let result = await queryRunner.query(
+      "DELETE FROM investment_transactions WHERE user_id = $1",
+      [userId],
+    );
+    deleted.investmentTransactions = result[1] ?? 0;
+
+    result = await queryRunner.query(
+      `DELETE FROM holdings WHERE account_id IN
+         (SELECT id FROM accounts WHERE user_id = $1)`,
+      [userId],
+    );
+    deleted.holdings = result[1] ?? 0;
+
+    result = await queryRunner.query(
+      `DELETE FROM security_prices WHERE security_id IN
+         (SELECT id FROM securities WHERE user_id = $1)`,
+      [userId],
+    );
+    deleted.securityPrices = result[1] ?? 0;
+
+    result = await queryRunner.query(
+      "DELETE FROM securities WHERE user_id = $1",
+      [userId],
+    );
+    deleted.securities = result[1] ?? 0;
+
+    // Budget data
+    result = await queryRunner.query(
+      `DELETE FROM budget_alerts WHERE user_id = $1`,
+      [userId],
+    );
+    deleted.budgetAlerts = result[1] ?? 0;
+
+    result = await queryRunner.query(
+      `DELETE FROM budget_period_categories WHERE budget_period_id IN
+         (SELECT bp.id FROM budget_periods bp
+          JOIN budgets b ON bp.budget_id = b.id
+          WHERE b.user_id = $1)`,
+      [userId],
+    );
+    deleted.budgetPeriodCategories = result[1] ?? 0;
+
+    result = await queryRunner.query(
+      `DELETE FROM budget_periods WHERE budget_id IN
+         (SELECT id FROM budgets WHERE user_id = $1)`,
+      [userId],
+    );
+    deleted.budgetPeriods = result[1] ?? 0;
+
+    result = await queryRunner.query(
+      `DELETE FROM budget_categories WHERE budget_id IN
+         (SELECT id FROM budgets WHERE user_id = $1)`,
+      [userId],
+    );
+    deleted.budgetCategories = result[1] ?? 0;
+
+    result = await queryRunner.query("DELETE FROM budgets WHERE user_id = $1", [
+      userId,
+    ]);
+    deleted.budgets = result[1] ?? 0;
+
+    // Transaction tags
+    result = await queryRunner.query(
+      `DELETE FROM transaction_split_tags WHERE transaction_split_id IN
+         (SELECT ts.id FROM transaction_splits ts
+          JOIN transactions t ON ts.transaction_id = t.id
+          WHERE t.user_id = $1)`,
+      [userId],
+    );
+
+    result = await queryRunner.query(
+      `DELETE FROM transaction_tags WHERE transaction_id IN
+         (SELECT id FROM transactions WHERE user_id = $1)`,
+      [userId],
+    );
+
+    // Transaction splits
+    result = await queryRunner.query(
+      `DELETE FROM transaction_splits WHERE transaction_id IN
+         (SELECT id FROM transactions WHERE user_id = $1)`,
+      [userId],
+    );
+    deleted.transactionSplits = result[1] ?? 0;
+
+    // Transactions
+    result = await queryRunner.query(
+      "DELETE FROM transactions WHERE user_id = $1",
+      [userId],
+    );
+    deleted.transactions = result[1] ?? 0;
+
+    // Tags (now that transaction_tags are gone)
+    result = await queryRunner.query("DELETE FROM tags WHERE user_id = $1", [
+      userId,
+    ]);
+    deleted.tags = result[1] ?? 0;
+
+    // Scheduled transactions
+    result = await queryRunner.query(
+      `DELETE FROM scheduled_transaction_overrides WHERE scheduled_transaction_id IN
+         (SELECT id FROM scheduled_transactions WHERE user_id = $1)`,
+      [userId],
+    );
+
+    result = await queryRunner.query(
+      `DELETE FROM scheduled_transaction_splits WHERE scheduled_transaction_id IN
+         (SELECT id FROM scheduled_transactions WHERE user_id = $1)`,
+      [userId],
+    );
+
+    result = await queryRunner.query(
+      "DELETE FROM scheduled_transactions WHERE user_id = $1",
+      [userId],
+    );
+    deleted.scheduledTransactions = result[1] ?? 0;
+
+    // Monthly account balances
+    result = await queryRunner.query(
+      "DELETE FROM monthly_account_balances WHERE user_id = $1",
+      [userId],
+    );
+    deleted.monthlyBalances = result[1] ?? 0;
+
+    // Custom reports
+    result = await queryRunner.query(
+      "DELETE FROM custom_reports WHERE user_id = $1",
+      [userId],
+    );
+    deleted.customReports = result[1] ?? 0;
+
+    // Import column mappings
+    result = await queryRunner.query(
+      "DELETE FROM import_column_mappings WHERE user_id = $1",
+      [userId],
+    );
+    deleted.importMappings = result[1] ?? 0;
+
+    // AI data
+    result = await queryRunner.query(
+      "DELETE FROM ai_insights WHERE user_id = $1",
+      [userId],
+    );
+    deleted.aiInsights = result[1] ?? 0;
+
+    result = await queryRunner.query(
+      "DELETE FROM ai_usage_logs WHERE user_id = $1",
+      [userId],
+    );
+
+    // Optional: delete payees (before accounts, since payee default_category_id
+    // references categories, and accounts may reference payee-related data)
+    if (opts.deletePayees) {
+      result = await queryRunner.query(
+        "DELETE FROM payee_aliases WHERE user_id = $1",
+        [userId],
+      );
+      result = await queryRunner.query(
+        "DELETE FROM payees WHERE user_id = $1",
+        [userId],
+      );
+      deleted.payees = result[1] ?? 0;
+    }
+
+    // Optional: delete accounts (must come after transactions)
+    if (opts.deleteAccounts) {
+      result = await queryRunner.query(
+        "DELETE FROM accounts WHERE user_id = $1",
+        [userId],
+      );
+      deleted.accounts = result[1] ?? 0;
+    } else {
+      // Reset account balances to opening balance when transactions are deleted
+      await queryRunner.query(
+        "UPDATE accounts SET current_balance = opening_balance WHERE user_id = $1",
+        [userId],
+      );
+    }
+
+    // Optional: delete categories (must come after transactions and budgets)
+    if (opts.deleteCategories) {
+      // Clear payee default_category_id references first
+      await queryRunner.query(
+        `UPDATE payees SET default_category_id = NULL WHERE user_id = $1`,
+        [userId],
+      );
+      // Clear account category references
+      await queryRunner.query(
+        `UPDATE accounts SET principal_category_id = NULL,
+           interest_category_id = NULL, asset_category_id = NULL
+           WHERE user_id = $1`,
+        [userId],
+      );
+      result = await queryRunner.query(
+        "DELETE FROM categories WHERE user_id = $1",
+        [userId],
+      );
+      deleted.categories = result[1] ?? 0;
+    }
+
+    // Optional: delete exchange rates
+    if (opts.deleteExchangeRates) {
+      result = await queryRunner.query(
+        "DELETE FROM user_currency_preferences WHERE user_id = $1",
+        [userId],
+      );
+      deleted.exchangeRates = result[1] ?? 0;
+    }
+
+    // Clear action history (undo/redo) -- references deleted entities
+    result = await queryRunner.query(
+      "DELETE FROM action_history WHERE user_id = $1",
+      [userId],
+    );
+    deleted.actionHistory = result[1] ?? 0;
+
+    return deleted;
+  }
+
+  /** True if the user is a delegate of someone else (has incoming access). */
+  async isActingDelegate(userId: string): Promise<boolean> {
+    const rows = await this.dataSource.query(
+      "SELECT 1 FROM account_delegates WHERE delegate_user_id = $1 LIMIT 1",
+      [userId],
+    );
+    return rows.length > 0;
+  }
+
+  /**
+   * Wipes everything the user owns but keeps their login and the delegate
+   * access others granted them -- demoting a full account to a pure
+   * delegate. Delegations the user owned are removed (their accounts are
+   * gone); the rows where they are the delegate are left untouched.
+   */
+  async purgeForDowngrade(userId: string): Promise<void> {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    try {
+      await this.runOwnedDataDeletes(
+        userId,
+        {
+          deletePayees: true,
+          deleteAccounts: true,
+          deleteCategories: true,
+          deleteExchangeRates: true,
+        },
+        queryRunner,
+      );
+      await queryRunner.query(
+        "DELETE FROM account_delegates WHERE owner_user_id = $1",
+        [userId],
+      );
+      await queryRunner.commitTransaction();
     } catch (error) {
       await queryRunner.rollbackTransaction();
       throw error;

--- a/backend/test/integration/category-delete-set-null.integration.spec.ts
+++ b/backend/test/integration/category-delete-set-null.integration.spec.ts
@@ -1,7 +1,6 @@
 import { TestingModule } from "@nestjs/testing";
 import { DataSource } from "typeorm";
 import { TransactionsModule } from "@/transactions/transactions.module";
-import { User } from "@/users/entities/user.entity";
 import { Transaction } from "@/transactions/entities/transaction.entity";
 import { TransactionSplit } from "@/transactions/entities/transaction-split.entity";
 import { SplitKind } from "@/transactions/entities/split-kind.enum";
@@ -24,7 +23,13 @@ import {
 // because the category_id FKs on transactions / transaction_splits /
 // scheduled_transactions / scheduled_transaction_splits were ON DELETE
 // NO ACTION instead of SET NULL like every other category reference.
-describe("User deletion category-FK cascade (integration)", () => {
+//
+// Deleting a user cascades to delete that user's categories (schema.sql
+// declares categories.user_id ON DELETE CASCADE). The fix is that a
+// category deletion must null out the category_id on any referencing
+// transaction/split rather than block it. This asserts that contract
+// directly across all four affected tables.
+describe("Category delete -> SET NULL on referencing rows (integration)", () => {
   let module: TestingModule;
   let dataSource: DataSource;
 
@@ -55,7 +60,7 @@ describe("User deletion category-FK cascade (integration)", () => {
     );
   });
 
-  async function seedUserWithCategorizedSplits(): Promise<{ userId: string }> {
+  it("nulls category_id on transactions, splits and scheduled rows when the category is deleted", async () => {
     const user = await createTestUserDirect(dataSource);
     const account = await createTestAccount(dataSource, user.id, {
       openingBalance: 1000,
@@ -70,10 +75,11 @@ describe("User deletion category-FK cascade (integration)", () => {
         transactionDate: "2026-01-15",
         amount: -50,
         currencyCode: "USD",
+        categoryId: category.id,
         isSplit: true,
       }),
     );
-    await dataSource.manager.save(
+    const split = await dataSource.manager.save(
       dataSource.manager.create(TransactionSplit, {
         transactionId: txn.id,
         kind: SplitKind.CATEGORY,
@@ -95,7 +101,7 @@ describe("User deletion category-FK cascade (integration)", () => {
         startDate: "2026-01-01",
       }),
     );
-    await dataSource.manager.save(
+    const scheduledSplit = await dataSource.manager.save(
       dataSource.manager.create(ScheduledTransactionSplit, {
         scheduledTransactionId: scheduled.id,
         kind: SplitKind.CATEGORY,
@@ -104,64 +110,25 @@ describe("User deletion category-FK cascade (integration)", () => {
       }),
     );
 
-    return { userId: user.id };
-  }
-
-  it("deletes a user that has category-referencing splits without an FK violation", async () => {
-    const { userId } = await seedUserWithCategorizedSplits();
-    const user = await dataSource.manager.findOneByOrFail(User, {
-      id: userId,
-    });
-
+    // Previously ON DELETE NO ACTION -> this threw a FK violation.
     await expect(
-      dataSource.getRepository(User).remove(user),
+      dataSource.getRepository(Category).delete(category.id),
     ).resolves.toBeDefined();
 
-    // Cascades from users(id) removed everything user-owned.
-    await expect(
-      dataSource.manager.count(Category, { where: { userId } }),
-    ).resolves.toBe(0);
-    await expect(
-      dataSource.manager.count(Transaction, { where: { userId } }),
-    ).resolves.toBe(0);
-    await expect(dataSource.manager.count(TransactionSplit)).resolves.toBe(0);
-    await expect(
-      dataSource.manager.count(ScheduledTransactionSplit),
-    ).resolves.toBe(0);
-  });
-
-  it("nulls category_id on referencing rows when a category is deleted directly", async () => {
-    const user = await createTestUserDirect(dataSource);
-    const account = await createTestAccount(dataSource, user.id, {
-      openingBalance: 1000,
-      currentBalance: 1000,
-    });
-    const category = await createTestCategory(dataSource, user.id);
-    const txn = await dataSource.manager.save(
-      dataSource.manager.create(Transaction, {
-        userId: user.id,
-        accountId: account.id,
-        transactionDate: "2026-01-15",
-        amount: -50,
-        currencyCode: "USD",
-        isSplit: true,
+    const [reTxn, reSplit, reSched, reSchedSplit] = await Promise.all([
+      dataSource.manager.findOneByOrFail(Transaction, { id: txn.id }),
+      dataSource.manager.findOneByOrFail(TransactionSplit, { id: split.id }),
+      dataSource.manager.findOneByOrFail(ScheduledTransaction, {
+        id: scheduled.id,
       }),
-    );
-    const split = await dataSource.manager.save(
-      dataSource.manager.create(TransactionSplit, {
-        transactionId: txn.id,
-        kind: SplitKind.CATEGORY,
-        categoryId: category.id,
-        amount: -50,
+      dataSource.manager.findOneByOrFail(ScheduledTransactionSplit, {
+        id: scheduledSplit.id,
       }),
-    );
+    ]);
 
-    await dataSource.getRepository(Category).delete(category.id);
-
-    const reloaded = await dataSource.manager.findOneByOrFail(
-      TransactionSplit,
-      { id: split.id },
-    );
-    expect(reloaded.categoryId).toBeNull();
+    expect(reTxn.categoryId).toBeNull();
+    expect(reSplit.categoryId).toBeNull();
+    expect(reSched.categoryId).toBeNull();
+    expect(reSchedSplit.categoryId).toBeNull();
   });
 });

--- a/backend/test/integration/user-deletion.integration.spec.ts
+++ b/backend/test/integration/user-deletion.integration.spec.ts
@@ -1,0 +1,167 @@
+import { TestingModule } from "@nestjs/testing";
+import { DataSource } from "typeorm";
+import { TransactionsModule } from "@/transactions/transactions.module";
+import { User } from "@/users/entities/user.entity";
+import { Transaction } from "@/transactions/entities/transaction.entity";
+import { TransactionSplit } from "@/transactions/entities/transaction-split.entity";
+import { SplitKind } from "@/transactions/entities/split-kind.enum";
+import { Category } from "@/categories/entities/category.entity";
+import { ScheduledTransaction } from "@/scheduled-transactions/entities/scheduled-transaction.entity";
+import { ScheduledTransactionSplit } from "@/scheduled-transactions/entities/scheduled-transaction-split.entity";
+import {
+  createIntegrationModule,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import {
+  createTestAccount,
+  createTestCategory,
+} from "../helpers/test-factories";
+
+// Regression: deleting a user used to fail with
+//   update or delete on table "categories" violates foreign key constraint
+//   "transaction_splits_category_id_fkey"
+// because the category_id FKs on transactions / transaction_splits /
+// scheduled_transactions / scheduled_transaction_splits were ON DELETE
+// NO ACTION instead of SET NULL like every other category reference.
+describe("User deletion category-FK cascade (integration)", () => {
+  let module: TestingModule;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    module = await createIntegrationModule([TransactionsModule]);
+    dataSource = module.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await cleanTables(dataSource, [
+      "action_history",
+      "transaction_splits",
+      "transactions",
+      "scheduled_transaction_splits",
+      "scheduled_transaction_overrides",
+      "scheduled_transactions",
+      "accounts",
+      "categories",
+      "payees",
+      "users",
+    ]);
+    await dataSource.query(
+      `INSERT INTO currencies (code, name, symbol, decimal_places) VALUES ('USD', 'US Dollar', '$', 2) ON CONFLICT DO NOTHING`,
+    );
+  });
+
+  async function seedUserWithCategorizedSplits(): Promise<{ userId: string }> {
+    const user = await createTestUserDirect(dataSource);
+    const account = await createTestAccount(dataSource, user.id, {
+      openingBalance: 1000,
+      currentBalance: 1000,
+    });
+    const category = await createTestCategory(dataSource, user.id);
+
+    const txn = await dataSource.manager.save(
+      dataSource.manager.create(Transaction, {
+        userId: user.id,
+        accountId: account.id,
+        transactionDate: "2026-01-15",
+        amount: -50,
+        currencyCode: "USD",
+        isSplit: true,
+      }),
+    );
+    await dataSource.manager.save(
+      dataSource.manager.create(TransactionSplit, {
+        transactionId: txn.id,
+        kind: SplitKind.CATEGORY,
+        categoryId: category.id,
+        amount: -50,
+      }),
+    );
+
+    const scheduled = await dataSource.manager.save(
+      dataSource.manager.create(ScheduledTransaction, {
+        userId: user.id,
+        accountId: account.id,
+        name: "Recurring",
+        categoryId: category.id,
+        amount: -25,
+        currencyCode: "USD",
+        frequency: "MONTHLY",
+        nextDueDate: "2026-02-01",
+        startDate: "2026-01-01",
+      }),
+    );
+    await dataSource.manager.save(
+      dataSource.manager.create(ScheduledTransactionSplit, {
+        scheduledTransactionId: scheduled.id,
+        kind: SplitKind.CATEGORY,
+        categoryId: category.id,
+        amount: -25,
+      }),
+    );
+
+    return { userId: user.id };
+  }
+
+  it("deletes a user that has category-referencing splits without an FK violation", async () => {
+    const { userId } = await seedUserWithCategorizedSplits();
+    const user = await dataSource.manager.findOneByOrFail(User, {
+      id: userId,
+    });
+
+    await expect(
+      dataSource.getRepository(User).remove(user),
+    ).resolves.toBeDefined();
+
+    // Cascades from users(id) removed everything user-owned.
+    await expect(
+      dataSource.manager.count(Category, { where: { userId } }),
+    ).resolves.toBe(0);
+    await expect(
+      dataSource.manager.count(Transaction, { where: { userId } }),
+    ).resolves.toBe(0);
+    await expect(dataSource.manager.count(TransactionSplit)).resolves.toBe(0);
+    await expect(
+      dataSource.manager.count(ScheduledTransactionSplit),
+    ).resolves.toBe(0);
+  });
+
+  it("nulls category_id on referencing rows when a category is deleted directly", async () => {
+    const user = await createTestUserDirect(dataSource);
+    const account = await createTestAccount(dataSource, user.id, {
+      openingBalance: 1000,
+      currentBalance: 1000,
+    });
+    const category = await createTestCategory(dataSource, user.id);
+    const txn = await dataSource.manager.save(
+      dataSource.manager.create(Transaction, {
+        userId: user.id,
+        accountId: account.id,
+        transactionDate: "2026-01-15",
+        amount: -50,
+        currencyCode: "USD",
+        isSplit: true,
+      }),
+    );
+    const split = await dataSource.manager.save(
+      dataSource.manager.create(TransactionSplit, {
+        transactionId: txn.id,
+        kind: SplitKind.CATEGORY,
+        categoryId: category.id,
+        amount: -50,
+      }),
+    );
+
+    await dataSource.getRepository(Category).delete(category.id);
+
+    const reloaded = await dataSource.manager.findOneByOrFail(
+      TransactionSplit,
+      { id: split.id },
+    );
+    expect(reloaded.categoryId).toBeNull();
+  });
+});

--- a/database/migrations/068_account_delegates.sql
+++ b/database/migrations/068_account_delegates.sql
@@ -1,0 +1,43 @@
+-- Delegate account access (Phase 1)
+-- An account owner can grant another user ("delegate") scoped access to their
+-- financial data. Delegates are normal `users` rows; the relationship and the
+-- per-account permissions live here. Only can_read is enforced in Phase 1;
+-- can_create/edit/delete columns exist for Phase 2.
+
+CREATE TABLE IF NOT EXISTS account_delegates (
+    id               UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    owner_user_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    delegate_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status           VARCHAR(20) NOT NULL DEFAULT 'active', -- 'pending' | 'active' | 'revoked'
+    created_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    revoked_at       TIMESTAMP,
+    CONSTRAINT account_delegates_owner_delegate_unique UNIQUE (owner_user_id, delegate_user_id),
+    CONSTRAINT account_delegates_no_self CHECK (owner_user_id <> delegate_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_account_delegates_delegate
+    ON account_delegates(delegate_user_id) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS idx_account_delegates_owner
+    ON account_delegates(owner_user_id);
+
+CREATE TABLE IF NOT EXISTS account_delegate_grants (
+    id            UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    delegation_id UUID NOT NULL REFERENCES account_delegates(id) ON DELETE CASCADE,
+    account_id    UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    can_read   BOOLEAN NOT NULL DEFAULT true,
+    can_create BOOLEAN NOT NULL DEFAULT false,
+    can_edit   BOOLEAN NOT NULL DEFAULT false,
+    can_delete BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT account_delegate_grants_unique UNIQUE (delegation_id, account_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_adg_delegation
+    ON account_delegate_grants(delegation_id);
+
+-- Carry the delegate "acting as owner" context across refresh-token rotation
+-- so a 15-minute access-token expiry does not silently drop the context.
+ALTER TABLE refresh_tokens
+    ADD COLUMN IF NOT EXISTS acting_as_user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    ADD COLUMN IF NOT EXISTS delegation_id UUID REFERENCES account_delegates(id) ON DELETE CASCADE;

--- a/database/migrations/069_account_delegate_capabilities.sql
+++ b/database/migrations/069_account_delegate_capabilities.sql
@@ -1,0 +1,8 @@
+-- Delegate "manage" capabilities (Phase 2 / 2C). These are per-delegation
+-- (not per-account): the owner may let a delegate CREATE/EDIT/DELETE payees,
+-- categories and/or tags. Default false (fail closed).
+
+ALTER TABLE account_delegates
+    ADD COLUMN IF NOT EXISTS can_manage_payees     BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS can_manage_categories BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS can_manage_tags       BOOLEAN NOT NULL DEFAULT false;

--- a/database/migrations/070_account_delegate_granular_capabilities.sql
+++ b/database/migrations/070_account_delegate_granular_capabilities.sql
@@ -1,0 +1,40 @@
+-- Phase 2 / 2C granular: split each shared-resource "manage" capability into
+-- separate create / edit / delete flags (per delegation). Backfills the new
+-- columns from the old can_manage_* booleans, then drops the old columns.
+-- Idempotent: safe to run multiple times.
+
+ALTER TABLE account_delegates
+    ADD COLUMN IF NOT EXISTS payees_can_create     BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS payees_can_edit       BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS payees_can_delete     BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS categories_can_create BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS categories_can_edit   BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS categories_can_delete BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS tags_can_create       BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS tags_can_edit         BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS tags_can_delete       BOOLEAN NOT NULL DEFAULT false;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'account_delegates'
+          AND column_name = 'can_manage_payees'
+    ) THEN
+        UPDATE account_delegates SET
+            payees_can_create     = can_manage_payees,
+            payees_can_edit       = can_manage_payees,
+            payees_can_delete     = can_manage_payees,
+            categories_can_create = can_manage_categories,
+            categories_can_edit   = can_manage_categories,
+            categories_can_delete = can_manage_categories,
+            tags_can_create       = can_manage_tags,
+            tags_can_edit         = can_manage_tags,
+            tags_can_delete       = can_manage_tags;
+
+        ALTER TABLE account_delegates
+            DROP COLUMN can_manage_payees,
+            DROP COLUMN can_manage_categories,
+            DROP COLUMN can_manage_tags;
+    END IF;
+END $$;

--- a/database/migrations/071_account_delegate_sections.sql
+++ b/database/migrations/071_account_delegate_sections.sql
@@ -1,0 +1,11 @@
+-- Phase 3 / 3A: per-delegation READ grants for whole app sections. These gate
+-- tab visibility and the section read endpoints (Bills & Deposits,
+-- Investments, Budgets, Reports, AI). Account-scoped data still also requires
+-- the existing per-account grants. Idempotent: safe to run multiple times.
+
+ALTER TABLE account_delegates
+    ADD COLUMN IF NOT EXISTS bills_can_read       BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS investments_can_read BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS budgets_can_read     BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS reports_can_read     BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS ai_can_read          BOOLEAN NOT NULL DEFAULT false;

--- a/database/migrations/072_category_fk_set_null_on_delete.sql
+++ b/database/migrations/072_category_fk_set_null_on_delete.sql
@@ -1,0 +1,47 @@
+-- Fix: deleting a user fails with
+--   update or delete on table "categories" violates foreign key constraint
+--   "transaction_splits_category_id_fkey" on table "transaction_splits"
+--
+-- The category_id foreign keys on transactions, transaction_splits,
+-- scheduled_transactions and scheduled_transaction_splits were created
+-- with the implicit ON DELETE NO ACTION. Every other category reference
+-- in the schema (accounts principal/interest/asset categories, budget
+-- categories, etc.) uses ON DELETE SET NULL. When a user is deleted,
+-- Postgres cascade-deletes that user's categories; any split/transaction
+-- still referencing one of those categories then blocks the delete
+-- instead of having its category_id nulled out.
+--
+-- Single-category deletion is unaffected: CategoriesService.remove()
+-- already refuses to delete a category that has referencing transactions
+-- ("Reassign transactions first"), so SET NULL only ever applies on the
+-- user-deletion cascade path.
+--
+-- Nulling category_id keeps the kind-exclusive CHECK constraints
+-- satisfied: a 'category' kind split only requires transfer_account_id
+-- (and investment_action) to be NULL, not category_id.
+--
+-- Idempotent: safe to run multiple times.
+
+ALTER TABLE transactions
+    DROP CONSTRAINT IF EXISTS transactions_category_id_fkey;
+ALTER TABLE transactions
+    ADD CONSTRAINT transactions_category_id_fkey
+    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL;
+
+ALTER TABLE transaction_splits
+    DROP CONSTRAINT IF EXISTS transaction_splits_category_id_fkey;
+ALTER TABLE transaction_splits
+    ADD CONSTRAINT transaction_splits_category_id_fkey
+    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL;
+
+ALTER TABLE scheduled_transactions
+    DROP CONSTRAINT IF EXISTS scheduled_transactions_category_id_fkey;
+ALTER TABLE scheduled_transactions
+    ADD CONSTRAINT scheduled_transactions_category_id_fkey
+    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL;
+
+ALTER TABLE scheduled_transaction_splits
+    DROP CONSTRAINT IF EXISTS scheduled_transaction_splits_category_id_fkey;
+ALTER TABLE scheduled_transaction_splits
+    ADD CONSTRAINT scheduled_transaction_splits_category_id_fkey
+    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL;

--- a/database/migrations/073_delegate_account_favourites.sql
+++ b/database/migrations/073_delegate_account_favourites.sql
@@ -1,0 +1,18 @@
+-- A delegate's account favourites are independent of the owner's.
+--
+-- accounts.is_favourite / favourite_sort_order are owner-scoped. When a
+-- delegate acts as an owner those flags must not be reused, so a delegate
+-- keeps their own favourites here keyed by their own user id. The owner
+-- path is unchanged. Idempotent: safe to run multiple times.
+
+CREATE TABLE IF NOT EXISTS delegate_account_favourites (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    delegate_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (delegate_user_id, account_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_delegate_account_favourites_user
+    ON delegate_account_favourites(delegate_user_id);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -616,9 +616,15 @@ CREATE TABLE account_delegates (
     created_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     revoked_at       TIMESTAMP,
-    can_manage_payees     BOOLEAN NOT NULL DEFAULT false,
-    can_manage_categories BOOLEAN NOT NULL DEFAULT false,
-    can_manage_tags       BOOLEAN NOT NULL DEFAULT false,
+    payees_can_create     BOOLEAN NOT NULL DEFAULT false,
+    payees_can_edit       BOOLEAN NOT NULL DEFAULT false,
+    payees_can_delete     BOOLEAN NOT NULL DEFAULT false,
+    categories_can_create BOOLEAN NOT NULL DEFAULT false,
+    categories_can_edit   BOOLEAN NOT NULL DEFAULT false,
+    categories_can_delete BOOLEAN NOT NULL DEFAULT false,
+    tags_can_create       BOOLEAN NOT NULL DEFAULT false,
+    tags_can_edit         BOOLEAN NOT NULL DEFAULT false,
+    tags_can_delete       BOOLEAN NOT NULL DEFAULT false,
     CONSTRAINT account_delegates_owner_delegate_unique UNIQUE (owner_user_id, delegate_user_id),
     CONSTRAINT account_delegates_no_self CHECK (owner_user_id <> delegate_user_id)
 );

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -625,6 +625,11 @@ CREATE TABLE account_delegates (
     tags_can_create       BOOLEAN NOT NULL DEFAULT false,
     tags_can_edit         BOOLEAN NOT NULL DEFAULT false,
     tags_can_delete       BOOLEAN NOT NULL DEFAULT false,
+    bills_can_read        BOOLEAN NOT NULL DEFAULT false,
+    investments_can_read  BOOLEAN NOT NULL DEFAULT false,
+    budgets_can_read      BOOLEAN NOT NULL DEFAULT false,
+    reports_can_read      BOOLEAN NOT NULL DEFAULT false,
+    ai_can_read           BOOLEAN NOT NULL DEFAULT false,
     CONSTRAINT account_delegates_owner_delegate_unique UNIQUE (owner_user_id, delegate_user_id),
     CONSTRAINT account_delegates_no_self CHECK (owner_user_id <> delegate_user_id)
 );

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -205,7 +205,7 @@ CREATE TABLE transactions (
     transaction_date DATE NOT NULL,
     payee_id UUID REFERENCES payees(id),
     payee_name VARCHAR(255), -- can be different from payee.name
-    category_id UUID REFERENCES categories(id), -- category for non-split transactions
+    category_id UUID REFERENCES categories(id) ON DELETE SET NULL, -- category for non-split transactions
     amount NUMERIC(20, 4) NOT NULL, -- positive for income/deposits, negative for expenses
     currency_code VARCHAR(3) NOT NULL REFERENCES currencies(code),
     exchange_rate NUMERIC(20, 10) DEFAULT 1, -- rate at transaction time
@@ -239,7 +239,7 @@ CREATE TABLE transaction_splits (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     transaction_id UUID NOT NULL REFERENCES transactions(id) ON DELETE CASCADE,
     kind VARCHAR(20) NOT NULL DEFAULT 'category', -- 'category', 'transfer', or 'investment'
-    category_id UUID REFERENCES categories(id),
+    category_id UUID REFERENCES categories(id) ON DELETE SET NULL,
     transfer_account_id UUID REFERENCES accounts(id) ON DELETE CASCADE, -- target account for transfer splits
     linked_transaction_id UUID REFERENCES transactions(id) ON DELETE SET NULL, -- linked transaction in target account
     amount NUMERIC(20, 4) NOT NULL,
@@ -299,7 +299,7 @@ CREATE TABLE scheduled_transactions (
     name VARCHAR(255) NOT NULL, -- display name for the scheduled transaction
     payee_id UUID REFERENCES payees(id),
     payee_name VARCHAR(255),
-    category_id UUID REFERENCES categories(id),
+    category_id UUID REFERENCES categories(id) ON DELETE SET NULL,
     amount NUMERIC(20, 4) NOT NULL,
     currency_code VARCHAR(3) NOT NULL REFERENCES currencies(code),
     description TEXT,
@@ -344,7 +344,7 @@ CREATE TABLE scheduled_transaction_splits (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     scheduled_transaction_id UUID NOT NULL REFERENCES scheduled_transactions(id) ON DELETE CASCADE,
     kind VARCHAR(20) NOT NULL DEFAULT 'category', -- 'category', 'transfer', or 'investment'
-    category_id UUID REFERENCES categories(id),
+    category_id UUID REFERENCES categories(id) ON DELETE SET NULL,
     transfer_account_id UUID REFERENCES accounts(id) ON DELETE CASCADE, -- target account for transfer splits
     amount NUMERIC(20, 4) NOT NULL,
     memo TEXT,

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -594,6 +594,8 @@ CREATE TABLE refresh_tokens (
     remember_me BOOLEAN NOT NULL DEFAULT false,
     expires_at TIMESTAMP NOT NULL,
     replaced_by_hash VARCHAR(64),
+    acting_as_user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    delegation_id UUID,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
@@ -601,6 +603,39 @@ CREATE TABLE refresh_tokens (
 CREATE UNIQUE INDEX idx_refresh_tokens_token_hash ON refresh_tokens(token_hash);
 CREATE INDEX idx_refresh_tokens_family ON refresh_tokens(family_id);
 CREATE INDEX idx_refresh_tokens_expires ON refresh_tokens(expires_at);
+
+-- Delegate account access (Phase 1). A user (owner) can grant another user
+-- (delegate) scoped access to their data. Delegates are normal `users` rows;
+-- this defines the relationship and per-account permissions. Only can_read is
+-- enforced in Phase 1; the other grant columns exist for Phase 2.
+CREATE TABLE account_delegates (
+    id               UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    owner_user_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    delegate_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status           VARCHAR(20) NOT NULL DEFAULT 'active', -- 'pending' | 'active' | 'revoked'
+    created_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    revoked_at       TIMESTAMP,
+    CONSTRAINT account_delegates_owner_delegate_unique UNIQUE (owner_user_id, delegate_user_id),
+    CONSTRAINT account_delegates_no_self CHECK (owner_user_id <> delegate_user_id)
+);
+
+CREATE INDEX idx_account_delegates_delegate ON account_delegates(delegate_user_id) WHERE status = 'active';
+CREATE INDEX idx_account_delegates_owner ON account_delegates(owner_user_id);
+
+CREATE TABLE account_delegate_grants (
+    id            UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    delegation_id UUID NOT NULL REFERENCES account_delegates(id) ON DELETE CASCADE,
+    account_id    UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    can_read   BOOLEAN NOT NULL DEFAULT true,
+    can_create BOOLEAN NOT NULL DEFAULT false,
+    can_edit   BOOLEAN NOT NULL DEFAULT false,
+    can_delete BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT account_delegate_grants_unique UNIQUE (delegation_id, account_id)
+);
+
+CREATE INDEX idx_adg_delegation ON account_delegate_grants(delegation_id);
 
 -- Custom Reports (user-defined configurable reports)
 -- view_type: TABLE, LINE_CHART, BAR_CHART, PIE_CHART

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -616,6 +616,9 @@ CREATE TABLE account_delegates (
     created_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     revoked_at       TIMESTAMP,
+    can_manage_payees     BOOLEAN NOT NULL DEFAULT false,
+    can_manage_categories BOOLEAN NOT NULL DEFAULT false,
+    can_manage_tags       BOOLEAN NOT NULL DEFAULT false,
     CONSTRAINT account_delegates_owner_delegate_unique UNIQUE (owner_user_id, delegate_user_id),
     CONSTRAINT account_delegates_no_self CHECK (owner_user_id <> delegate_user_id)
 );

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -651,6 +651,20 @@ CREATE TABLE account_delegate_grants (
 
 CREATE INDEX idx_adg_delegation ON account_delegate_grants(delegation_id);
 
+-- A delegate's account favourites, independent of the owner's
+-- accounts.is_favourite (which stays owner-scoped).
+CREATE TABLE delegate_account_favourites (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    delegate_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (delegate_user_id, account_id)
+);
+
+CREATE INDEX idx_delegate_account_favourites_user
+    ON delegate_account_favourites(delegate_user_id);
+
 -- Custom Reports (user-defined configurable reports)
 -- view_type: TABLE, LINE_CHART, BAR_CHART, PIE_CHART
 -- timeframe_type: LAST_7_DAYS, LAST_30_DAYS, LAST_MONTH, LAST_3_MONTHS, LAST_6_MONTHS, LAST_12_MONTHS, LAST_YEAR, YEAR_TO_DATE, CUSTOM

--- a/frontend/src/app/ai/layout.tsx
+++ b/frontend/src/app/ai/layout.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { DelegateSectionGuard } from '@/components/auth/DelegateSectionGuard';
+
+export default function AiSectionLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <DelegateSectionGuard section="ai">{children}</DelegateSectionGuard>
+  );
+}

--- a/frontend/src/app/bills/layout.tsx
+++ b/frontend/src/app/bills/layout.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { DelegateSectionGuard } from '@/components/auth/DelegateSectionGuard';
+
+export default function BillsSectionLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <DelegateSectionGuard section="bills">{children}</DelegateSectionGuard>
+  );
+}

--- a/frontend/src/app/budgets/layout.tsx
+++ b/frontend/src/app/budgets/layout.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { DelegateSectionGuard } from '@/components/auth/DelegateSectionGuard';
+
+export default function BudgetsSectionLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <DelegateSectionGuard section="budgets">{children}</DelegateSectionGuard>
+  );
+}

--- a/frontend/src/app/budgets/page.test.tsx
+++ b/frontend/src/app/budgets/page.test.tsx
@@ -260,4 +260,13 @@ describe('BudgetsPage', () => {
     });
   });
 
+  it('does not toast on a 403 (the section guard owns that message)', async () => {
+    mockGetAll.mockRejectedValueOnce({ response: { status: 403 } });
+    render(<BudgetsPage />);
+    await waitFor(() => {
+      expect(mockGetAll).toHaveBeenCalled();
+    });
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
 });

--- a/frontend/src/app/budgets/page.tsx
+++ b/frontend/src/app/budgets/page.tsx
@@ -40,7 +40,16 @@ function BudgetsContent() {
       const data = await budgetsApi.getAll();
       setBudgets(data);
     } catch (error) {
-      toast.error(getErrorMessage(error, 'Failed to load budgets'));
+      // A 403 here means a delegate hit /budgets without the section
+      // grant; DelegateSectionGuard already shows the single, consistent
+      // "no access" message and redirects, so don't double-toast.
+      const status =
+        typeof error === 'object' && error && 'response' in error
+          ? (error as { response?: { status?: number } }).response?.status
+          : undefined;
+      if (status !== 403) {
+        toast.error(getErrorMessage(error, 'Failed to load budgets'));
+      }
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/app/dashboard/page.test.tsx
+++ b/frontend/src/app/dashboard/page.test.tsx
@@ -17,41 +17,36 @@ vi.mock('@/lib/logger', () => ({
   }),
 }));
 
-// Mock auth store
+// Mock auth store (mutable so tests can switch to a delegate context)
+const { authState } = vi.hoisted(() => {
+  const baseUser = {
+    id: 'test-user-id',
+    email: 'test@example.com',
+    firstName: 'Test',
+    lastName: 'User',
+    role: 'user',
+    hasPassword: true,
+  };
+  return {
+    authState: {
+      current: {
+        user: baseUser,
+        isAuthenticated: true,
+        isLoading: false,
+        _hasHydrated: true,
+        logout: () => {},
+        actingAsUserId: null as string | null,
+        delegateSections: null as Record<string, boolean> | null,
+      },
+    },
+  };
+});
+
 vi.mock('@/store/authStore', () => ({
   useAuthStore: Object.assign(
-    (selector?: any) => {
-      const state = {
-        user: {
-          id: 'test-user-id',
-          email: 'test@example.com',
-          firstName: 'Test',
-          lastName: 'User',
-          role: 'user',
-          hasPassword: true,
-        },
-        isAuthenticated: true,
-        isLoading: false,
-        _hasHydrated: true,
-        logout: vi.fn(),
-      };
-      return selector ? selector(state) : state;
-    },
-    {
-      getState: vi.fn(() => ({
-        user: {
-          id: 'test-user-id',
-          email: 'test@example.com',
-          firstName: 'Test',
-          lastName: 'User',
-          role: 'user',
-          hasPassword: true,
-        },
-        isAuthenticated: true,
-        isLoading: false,
-        _hasHydrated: true,
-      })),
-    },
+    (selector?: any) =>
+      selector ? selector(authState.current) : authState.current,
+    { getState: () => authState.current },
   ),
 }));
 
@@ -101,9 +96,12 @@ vi.mock('@/lib/categories', () => ({
   },
 }));
 
+const { mockGetScheduled } = vi.hoisted(() => ({
+  mockGetScheduled: vi.fn().mockResolvedValue([]),
+}));
 vi.mock('@/lib/scheduled-transactions', () => ({
   scheduledTransactionsApi: {
-    getAll: vi.fn().mockResolvedValue([]),
+    getAll: (...args: any[]) => mockGetScheduled(...args),
   },
 }));
 
@@ -177,6 +175,9 @@ describe('DashboardPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetAccounts.mockResolvedValue([]);
+    mockGetScheduled.mockResolvedValue([]);
+    authState.current.actingAsUserId = null;
+    authState.current.delegateSections = null;
   });
 
   it('renders the welcome message with user name', async () => {
@@ -298,5 +299,28 @@ describe('DashboardPage', () => {
     await waitFor(() => {
       expect(screen.getByTestId('favourite-accounts')).toHaveTextContent('loading');
     });
+  });
+
+  it('delegate without the Bills grant sees only Favourite Accounts', async () => {
+    authState.current.actingAsUserId = 'owner-1';
+    authState.current.delegateSections = { bills: false };
+    render(<DashboardPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('favourite-accounts')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('upcoming-bills')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('getting-started')).not.toBeInTheDocument();
+    expect(mockGetScheduled).not.toHaveBeenCalled();
+  });
+
+  it('delegate with the Bills grant also sees Upcoming Bills', async () => {
+    authState.current.actingAsUserId = 'owner-1';
+    authState.current.delegateSections = { bills: true };
+    render(<DashboardPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('upcoming-bills')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('favourite-accounts')).toBeInTheDocument();
+    expect(mockGetScheduled).toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -57,6 +57,8 @@ function DashboardContent() {
   const { user } = useAuthStore();
   const actingAsUserId = useAuthStore((s) => s.actingAsUserId);
   const isDelegateView = !!actingAsUserId;
+  const delegateSections = useAuthStore((s) => s.delegateSections);
+  const delegateBills = !!delegateSections?.bills;
   const weekStartsOn = (usePreferencesStore((s) => s.preferences?.weekStartsOn) ?? 1) as 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
   const [accounts, setAccounts] = useState<Account[]>([]);
@@ -105,6 +107,17 @@ function DashboardContent() {
       if (isDelegateView) {
         const delegateAccounts = await accountsApi.getAll();
         setAccounts(delegateAccounts);
+        // 3C: when the owner granted the Bills & Deposits section, the
+        // scheduled endpoint is delegate-reachable (server-filtered to the
+        // delegate's readable accounts) so the widget can render.
+        if (delegateBills) {
+          try {
+            const sched = await scheduledTransactionsApi.getAll();
+            setScheduledTransactions(sched);
+          } catch (error) {
+            logger.error('Failed to load delegate scheduled data:', error);
+          }
+        }
         setIsLoading(false);
         return;
       }
@@ -171,7 +184,7 @@ function DashboardContent() {
     } finally {
       setIsLoading(false);
     }
-  }, [weekStartsOn, isDelegateView]);
+  }, [weekStartsOn, isDelegateView, delegateBills]);
 
   useEffect(() => {
     loadDashboardData();
@@ -218,6 +231,17 @@ function DashboardContent() {
                 isLoading={isLoading}
                 onAccountsChanged={loadDashboardData}
               />
+              {delegateBills && (
+                <UpcomingBills
+                  scheduledTransactions={scheduledTransactions}
+                  accounts={accounts}
+                  isLoading={isLoading}
+                  maxItems={
+                    accounts.filter((a) => a.isFavourite && !a.isClosed)
+                      .length + 2
+                  }
+                />
+              )}
             </div>
           ) : (
             <>

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -59,6 +59,11 @@ function DashboardContent() {
   const isDelegateView = !!actingAsUserId;
   const delegateSections = useAuthStore((s) => s.delegateSections);
   const delegateBills = !!delegateSections?.bills;
+  // The acting-as context is rehydrated from localStorage; running the
+  // owner-only data load before that completes would spuriously 403 a
+  // delegate on the owner endpoints (and then re-run with the right
+  // path), so wait until the store has hydrated before firing.
+  const authHydrated = useAuthStore((s) => s._hasHydrated);
   const weekStartsOn = (usePreferencesStore((s) => s.preferences?.weekStartsOn) ?? 1) as 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
   const [accounts, setAccounts] = useState<Account[]>([]);
@@ -99,6 +104,7 @@ function DashboardContent() {
   });
 
   const loadDashboardData = useCallback(async () => {
+    if (!authHydrated) return;
     setIsLoading(true);
     try {
       // Phase 1: a delegate only sees the Favourite Accounts widget, and the
@@ -184,7 +190,7 @@ function DashboardContent() {
     } finally {
       setIsLoading(false);
     }
-  }, [weekStartsOn, isDelegateView, delegateBills]);
+  }, [authHydrated, weekStartsOn, isDelegateView, delegateBills]);
 
   useEffect(() => {
     loadDashboardData();

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -55,6 +55,8 @@ export default function DashboardPage() {
 
 function DashboardContent() {
   const { user } = useAuthStore();
+  const actingAsUserId = useAuthStore((s) => s.actingAsUserId);
+  const isDelegateView = !!actingAsUserId;
   const weekStartsOn = (usePreferencesStore((s) => s.preferences?.weekStartsOn) ?? 1) as 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
   const [accounts, setAccounts] = useState<Account[]>([]);
@@ -97,6 +99,16 @@ function DashboardContent() {
   const loadDashboardData = useCallback(async () => {
     setIsLoading(true);
     try {
+      // Phase 1: a delegate only sees the Favourite Accounts widget, and the
+      // other dashboard endpoints are not delegate-accessible. Load just the
+      // (server-filtered) accounts and stop.
+      if (isDelegateView) {
+        const delegateAccounts = await accountsApi.getAll();
+        setAccounts(delegateAccounts);
+        setIsLoading(false);
+        return;
+      }
+
       const now = new Date();
       const currentWeekStart = startOfWeek(now, { weekStartsOn });
       const fiveWeeksAgoStart = subWeeks(currentWeekStart, 4);
@@ -159,7 +171,7 @@ function DashboardContent() {
     } finally {
       setIsLoading(false);
     }
-  }, [weekStartsOn]);
+  }, [weekStartsOn, isDelegateView]);
 
   useEffect(() => {
     loadDashboardData();
@@ -198,37 +210,50 @@ function DashboardContent() {
             </p>
           </div>
 
-          <GettingStarted />
+          {isDelegateView ? (
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+              <FavouriteAccounts
+                accounts={accounts}
+                brokerageMarketValues={brokerageMarketValues}
+                isLoading={isLoading}
+                onAccountsChanged={loadDashboardData}
+              />
+            </div>
+          ) : (
+            <>
+              <GettingStarted />
 
-          {/* Reports Grid */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-            <FavouriteAccounts accounts={accounts} brokerageMarketValues={brokerageMarketValues} isLoading={isLoading} onAccountsChanged={loadDashboardData} />
-            <UpcomingBills
-              scheduledTransactions={scheduledTransactions}
-              accounts={accounts}
-              isLoading={isLoading}
-              maxItems={accounts.filter((a) => a.isFavourite && !a.isClosed).length + 2}
-            />
-          </div>
+              {/* Reports Grid */}
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+                <FavouriteAccounts accounts={accounts} brokerageMarketValues={brokerageMarketValues} isLoading={isLoading} onAccountsChanged={loadDashboardData} />
+                <UpcomingBills
+                  scheduledTransactions={scheduledTransactions}
+                  accounts={accounts}
+                  isLoading={isLoading}
+                  maxItems={accounts.filter((a) => a.isFavourite && !a.isClosed).length + 2}
+                />
+              </div>
 
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-            <NetWorthChart data={netWorthData} isLoading={isLoading} />
-            <TopMovers movers={topMovers} isLoading={isLoading} hasInvestmentAccounts={hasInvestments} onRefresh={triggerManualRefresh} isRefreshing={isRefreshing} />
-          </div>
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+                <NetWorthChart data={netWorthData} isLoading={isLoading} />
+                <TopMovers movers={topMovers} isLoading={isLoading} hasInvestmentAccounts={hasInvestments} onRefresh={triggerManualRefresh} isRefreshing={isRefreshing} />
+              </div>
 
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-            <ExpensesPieChart
-              transactions={transactions}
-              categories={categories}
-              isLoading={isLoading}
-            />
-            <IncomeExpensesBarChart transactions={transactions} isLoading={isLoading} />
-          </div>
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+                <ExpensesPieChart
+                  transactions={transactions}
+                  categories={categories}
+                  isLoading={isLoading}
+                />
+                <IncomeExpensesBarChart transactions={transactions} isLoading={isLoading} />
+              </div>
 
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <BudgetStatusWidget isLoading={isLoading} />
-            <InsightsWidget isLoading={isLoading} />
-          </div>
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <BudgetStatusWidget isLoading={isLoading} />
+                <InsightsWidget isLoading={isLoading} />
+              </div>
+            </>
+          )}
         </div>
       </main>
     </PageLayout>

--- a/frontend/src/app/insights/layout.tsx
+++ b/frontend/src/app/insights/layout.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { DelegateSectionGuard } from '@/components/auth/DelegateSectionGuard';
+
+export default function InsightsSectionLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <DelegateSectionGuard section="ai">{children}</DelegateSectionGuard>
+  );
+}

--- a/frontend/src/app/investments/layout.tsx
+++ b/frontend/src/app/investments/layout.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { DelegateSectionGuard } from '@/components/auth/DelegateSectionGuard';
+
+export default function InvestmentsSectionLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <DelegateSectionGuard section="investments">{children}</DelegateSectionGuard>
+  );
+}

--- a/frontend/src/app/register/page.test.tsx
+++ b/frontend/src/app/register/page.test.tsx
@@ -189,6 +189,81 @@ describe('RegisterPage', () => {
     });
   });
 
+  it('sends currentPassword when the registrant supplies a temporary password', async () => {
+    const mockUser = { id: 'd1', email: 'shared@example.com' };
+    (authApi.register as ReturnType<typeof vi.fn>).mockResolvedValue({ user: mockUser });
+
+    render(<RegisterPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^email/i)).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/^email/i), {
+        target: { value: 'shared@example.com' },
+      });
+      fireEvent.change(screen.getByLabelText(/^password$/i), {
+        target: { value: 'StrongPass1!' },
+      });
+      fireEvent.change(screen.getByLabelText(/confirm password/i), {
+        target: { value: 'StrongPass1!' },
+      });
+      fireEvent.change(screen.getByLabelText(/temporary password/i), {
+        target: { value: '  Temp-Pw-9!aB  ' },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    });
+
+    await waitFor(() =>
+      expect(authApi.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'shared@example.com',
+          password: 'StrongPass1!',
+          currentPassword: 'Temp-Pw-9!aB',
+        }),
+      ),
+    );
+  });
+
+  it('does not send currentPassword when the temp-password field is left blank', async () => {
+    const mockUser = { id: 'u2', email: 'new@example.com' };
+    (authApi.register as ReturnType<typeof vi.fn>).mockResolvedValue({ user: mockUser });
+
+    render(<RegisterPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^email/i)).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/^email/i), {
+        target: { value: 'new@example.com' },
+      });
+      fireEvent.change(screen.getByLabelText(/^password$/i), {
+        target: { value: 'StrongPass1!' },
+      });
+      fireEvent.change(screen.getByLabelText(/confirm password/i), {
+        target: { value: 'StrongPass1!' },
+      });
+      // Whitespace-only temp password must NOT be sent.
+      fireEvent.change(screen.getByLabelText(/temporary password/i), {
+        target: { value: '   ' },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    });
+
+    await waitFor(() => expect(authApi.register).toHaveBeenCalled());
+    const callArg = (authApi.register as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArg).not.toHaveProperty('currentPassword');
+  });
+
   it('shows error toast on registration failure', async () => {
     (authApi.register as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Registration failed'));
 

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -26,6 +26,9 @@ const registerSchema = z.object({
   confirmPassword: z.string(),
   firstName: z.string().max(100, 'First name must be less than 100 characters').optional(),
   lastName: z.string().max(100, 'Last name must be less than 100 characters').optional(),
+  // Optional: lets a registrant whose email already belongs to a delegate
+  // row claim and upgrade it into a full account.
+  currentPassword: z.string().max(200).optional(),
 }).refine((data) => data.password === data.confirmPassword, {
   message: "Passwords don't match",
   path: ['confirmPassword'],
@@ -70,7 +73,13 @@ export default function RegisterPage() {
   const onSubmit = async (data: RegisterFormData) => {
     setIsLoading(true);
     try {
-      const { confirmPassword, ...registerData } = data;
+      const { confirmPassword, currentPassword, ...rest } = data;
+      // Only include currentPassword when the registrant actually typed one
+      // (claim path); a blank value should send nothing.
+      const trimmed = currentPassword?.trim();
+      const registerData = trimmed
+        ? { ...rest, currentPassword: trimmed }
+        : rest;
       const response = await authApi.register(registerData);
       // Token is now in httpOnly cookie, not in response body
       login(response.user!, 'httpOnly');
@@ -78,11 +87,16 @@ export default function RegisterPage() {
       // Show 2FA setup after registration
       setShowTwoFactorSetup(true);
     } catch (error) {
-      // Show specific backend message only for 400 (e.g. breached password, validation).
-      // For everything else (409 duplicate email, 429 rate limit, 5xx), use generic message
-      // to prevent account enumeration and hide internal details.
+      // Show specific backend message only for 400 (e.g. breached password, validation)
+      // and for 401 on the delegate-claim path (so the user knows to supply the
+      // temporary password their administrator gave them). For everything else
+      // (409 duplicate email, 429 rate limit, 5xx), use the generic message to
+      // prevent account enumeration and hide internal details.
       const fallback = 'Unable to create account. Please try again.';
-      if (error instanceof AxiosError && error.response?.status === 400) {
+      if (
+        error instanceof AxiosError &&
+        (error.response?.status === 400 || error.response?.status === 401)
+      ) {
         toast.error(error.response.data?.message || fallback);
       } else {
         toast.error(fallback);
@@ -198,6 +212,21 @@ export default function RegisterPage() {
               error={errors.confirmPassword?.message}
               {...register('confirmPassword')}
             />
+
+            <div>
+              <Input
+                label="Temporary password (optional)"
+                type="password"
+                autoComplete="off"
+                error={errors.currentPassword?.message}
+                {...register('currentPassword')}
+              />
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                Only fill this in if another Monize account holder invited
+                you as a shared user. We will use it to link this email to
+                the existing invitation instead of creating a duplicate.
+              </p>
+            </div>
           </div>
 
           <div className="space-y-3">

--- a/frontend/src/app/reports/layout.tsx
+++ b/frontend/src/app/reports/layout.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { DelegateSectionGuard } from '@/components/auth/DelegateSectionGuard';
+
+export default function ReportsSectionLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <DelegateSectionGuard section="reports">{children}</DelegateSectionGuard>
+  );
+}

--- a/frontend/src/app/section-layouts.test.tsx
+++ b/frontend/src/app/section-layouts.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@/test/render';
+import BillsLayout from './bills/layout';
+import InvestmentsLayout from './investments/layout';
+import BudgetsLayout from './budgets/layout';
+import ReportsLayout from './reports/layout';
+import InsightsLayout from './insights/layout';
+import AiLayout from './ai/layout';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+}));
+
+// Non-delegate: the guard passes children straight through.
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: (selector: (s: unknown) => unknown) =>
+    selector({ actingAsUserId: null, delegateSections: null }),
+}));
+
+describe('section route layouts', () => {
+  it('render their children for a non-delegate', () => {
+    const layouts = [
+      ['bills', BillsLayout],
+      ['investments', InvestmentsLayout],
+      ['budgets', BudgetsLayout],
+      ['reports', ReportsLayout],
+      ['insights', InsightsLayout],
+      ['ai', AiLayout],
+    ] as const;
+    for (const [name, Layout] of layouts) {
+      const { unmount } = render(<Layout>{<p>{name}-child</p>}</Layout>);
+      expect(screen.getByText(`${name}-child`)).toBeInTheDocument();
+      unmount();
+    }
+  });
+});

--- a/frontend/src/app/settings/layout.test.tsx
+++ b/frontend/src/app/settings/layout.test.tsx
@@ -3,8 +3,10 @@ import { render, screen } from '@/test/render';
 import SettingsLayout from './layout';
 
 const replaceMock = vi.fn();
+let pathname = '/settings';
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace: replaceMock, push: vi.fn() }),
+  usePathname: () => pathname,
 }));
 
 let actingAsUserId: string | null = null;
@@ -16,6 +18,7 @@ describe('SettingsLayout', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     actingAsUserId = null;
+    pathname = '/settings';
   });
 
   it('renders children for a normal (non-delegate) user', () => {
@@ -28,14 +31,27 @@ describe('SettingsLayout', () => {
     expect(replaceMock).not.toHaveBeenCalled();
   });
 
-  it('redirects a delegate away from settings', () => {
+  it('renders children for a delegate at the root /settings (Security-only view)', () => {
     actingAsUserId = 'owner-1';
+    pathname = '/settings';
+    render(
+      <SettingsLayout>
+        <div data-testid="child">settings</div>
+      </SettingsLayout>,
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it('redirects a delegate away from a /settings sub-route back to /settings', () => {
+    actingAsUserId = 'owner-1';
+    pathname = '/settings/shared-access';
     render(
       <SettingsLayout>
         <div data-testid="child">settings</div>
       </SettingsLayout>,
     );
     expect(screen.queryByTestId('child')).not.toBeInTheDocument();
-    expect(replaceMock).toHaveBeenCalledWith('/dashboard');
+    expect(replaceMock).toHaveBeenCalledWith('/settings');
   });
 });

--- a/frontend/src/app/settings/layout.test.tsx
+++ b/frontend/src/app/settings/layout.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@/test/render';
+import SettingsLayout from './layout';
+
+const replaceMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: replaceMock, push: vi.fn() }),
+}));
+
+let actingAsUserId: string | null = null;
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: (selector: any) => selector({ actingAsUserId }),
+}));
+
+describe('SettingsLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    actingAsUserId = null;
+  });
+
+  it('renders children for a normal (non-delegate) user', () => {
+    render(
+      <SettingsLayout>
+        <div data-testid="child">settings</div>
+      </SettingsLayout>,
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it('redirects a delegate away from settings', () => {
+    actingAsUserId = 'owner-1';
+    render(
+      <SettingsLayout>
+        <div data-testid="child">settings</div>
+      </SettingsLayout>,
+    );
+    expect(screen.queryByTestId('child')).not.toBeInTheDocument();
+    expect(replaceMock).toHaveBeenCalledWith('/dashboard');
+  });
+});

--- a/frontend/src/app/settings/layout.tsx
+++ b/frontend/src/app/settings/layout.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useAuthStore } from '@/store/authStore';
 
 /**
- * Settings (and its subpages) are owner-only. A delegate acting as an owner
- * must not reach Settings -- they manage nothing here and read-through of the
- * owner's profile/security would be inappropriate. Redirect them away.
+ * Settings sub-pages are owner-only. The root /settings page is also
+ * reachable for a delegate, but renders a Security-only view so the
+ * delegate can manage their own credentials (password + 2FA). Any deeper
+ * settings sub-route (shared-access, ai, etc.) is owner-only and
+ * redirects a delegate back to /settings.
  */
 export default function SettingsLayout({
   children,
@@ -15,16 +17,18 @@ export default function SettingsLayout({
   children: React.ReactNode;
 }) {
   const router = useRouter();
+  const pathname = usePathname();
   const actingAsUserId = useAuthStore((s) => s.actingAsUserId);
   const isDelegateView = !!actingAsUserId;
+  const isSubRoute = pathname !== '/settings';
 
   useEffect(() => {
-    if (isDelegateView) {
-      router.replace('/dashboard');
+    if (isDelegateView && isSubRoute) {
+      router.replace('/settings');
     }
-  }, [isDelegateView, router]);
+  }, [isDelegateView, isSubRoute, router]);
 
-  if (isDelegateView) return null;
+  if (isDelegateView && isSubRoute) return null;
 
   return <>{children}</>;
 }

--- a/frontend/src/app/settings/layout.tsx
+++ b/frontend/src/app/settings/layout.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/store/authStore';
+
+/**
+ * Settings (and its subpages) are owner-only. A delegate acting as an owner
+ * must not reach Settings -- they manage nothing here and read-through of the
+ * owner's profile/security would be inappropriate. Redirect them away.
+ */
+export default function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+  const actingAsUserId = useAuthStore((s) => s.actingAsUserId);
+  const isDelegateView = !!actingAsUserId;
+
+  useEffect(() => {
+    if (isDelegateView) {
+      router.replace('/dashboard');
+    }
+  }, [isDelegateView, router]);
+
+  if (isDelegateView) return null;
+
+  return <>{children}</>;
+}

--- a/frontend/src/app/settings/page.delegate.test.tsx
+++ b/frontend/src/app/settings/page.delegate.test.tsx
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@/test/render';
+import SettingsPage from './page';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => '/settings',
+}));
+
+vi.mock('@/components/auth/ProtectedRoute', () => ({
+  ProtectedRoute: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/layout/PageLayout', () => ({
+  PageLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/layout/PageHeader', () => ({
+  PageHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
+}));
+
+vi.mock('@/components/ui/LoadingSpinner', () => ({
+  LoadingSpinner: () => <div data-testid="loading">loading</div>,
+}));
+
+// Render a minimal SecuritySection so the delegate branch is exercised
+// without dragging in its full dependency tree.
+vi.mock('@/components/settings/SecuritySection', () => ({
+  SecuritySection: ({
+    user,
+    preferences,
+    onPreferencesUpdated,
+  }: {
+    user: { email: string };
+    preferences: { twoFactorEnabled: boolean };
+    onPreferencesUpdated: (p: { twoFactorEnabled?: boolean }) => void;
+  }) => (
+    <div data-testid="security">
+      <div data-testid="user-email">{user.email}</div>
+      <div data-testid="tfa">{preferences.twoFactorEnabled ? 'on' : 'off'}</div>
+      <button
+        data-testid="toggle-tfa"
+        onClick={() => onPreferencesUpdated({ twoFactorEnabled: true })}
+      >
+        toggle
+      </button>
+    </div>
+  ),
+}));
+
+// Settings page imports many owner-only sections. Stub them so the
+// delegate render path doesn't reach into them; they should never render
+// for a delegate but mocking is defensive.
+vi.mock('@/components/settings/ProfileSection', () => ({
+  ProfileSection: () => <div data-testid="profile" />,
+}));
+vi.mock('@/components/settings/PreferencesSection', () => ({
+  PreferencesSection: () => <div data-testid="prefs" />,
+}));
+vi.mock('@/components/settings/NotificationsSection', () => ({
+  NotificationsSection: () => <div data-testid="notifs" />,
+}));
+vi.mock('@/components/settings/DangerZoneSection', () => ({
+  DangerZoneSection: () => <div data-testid="danger" />,
+}));
+vi.mock('@/components/settings/BackupRestoreSection', () => ({
+  BackupRestoreSection: () => <div data-testid="backup" />,
+}));
+vi.mock('@/components/settings/AutoBackupSection', () => ({
+  AutoBackupSection: () => <div data-testid="auto-backup" />,
+}));
+vi.mock('@/components/settings/ApiAccessSection', () => ({
+  ApiAccessSection: () => <div data-testid="api-access" />,
+}));
+vi.mock('@/components/settings/SettingsNav', () => ({
+  SettingsNav: () => <nav data-testid="nav" />,
+}));
+
+vi.mock('@/store/demoStore', () => ({
+  useDemoStore: (selector: any) => selector({ isDemoMode: false, setDemoMode: vi.fn() }),
+}));
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: (selector: any) =>
+    selector({ actingAsUserId: 'owner-1' }),
+}));
+
+const mocks = vi.hoisted(() => ({
+  getSelfProfile: vi.fn(),
+  get2FAStatus: vi.fn(),
+  getAuthMethods: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authApi: {
+    getSelfProfile: mocks.getSelfProfile,
+    get2FAStatus: mocks.get2FAStatus,
+    getAuthMethods: mocks.getAuthMethods,
+  },
+}));
+
+vi.mock('@/lib/user-settings', () => ({
+  userSettingsApi: {
+    getProfile: vi.fn(),
+    getPreferences: vi.fn(),
+    getSmtpStatus: vi.fn(),
+  },
+}));
+
+describe('SettingsPage - acting delegate (Security-only view)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSelfProfile.mockResolvedValue({
+      id: 'delegate-1',
+      email: 'delegate@example.com',
+      firstName: 'Del',
+      authProvider: 'local',
+      hasPassword: true,
+    });
+    mocks.get2FAStatus.mockResolvedValue({ enabled: false });
+    mocks.getAuthMethods.mockResolvedValue({
+      local: true,
+      oidc: false,
+      registration: true,
+      smtp: false,
+      force2fa: false,
+      demo: false,
+    });
+  });
+
+  it('renders only the Security section with the delegate own email', async () => {
+    await act(async () => {
+      render(<SettingsPage />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('security')).toBeInTheDocument();
+    });
+
+    expect(mocks.getSelfProfile).toHaveBeenCalled();
+    expect(mocks.get2FAStatus).toHaveBeenCalled();
+    // Delegate's own profile is used, not the owner's.
+    expect(screen.getByTestId('user-email')).toHaveTextContent(
+      'delegate@example.com',
+    );
+    // Other settings sections must not render for a delegate.
+    expect(screen.queryByTestId('profile')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('prefs')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('notifs')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('danger')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('backup')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('nav')).not.toBeInTheDocument();
+  });
+
+  it('uses the actor 2FA-status flag (not the owner preferences)', async () => {
+    mocks.get2FAStatus.mockResolvedValue({ enabled: true });
+    await act(async () => {
+      render(<SettingsPage />);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('tfa')).toHaveTextContent('on'),
+    );
+  });
+
+  it('keeps local 2FA state in sync via onPreferencesUpdated', async () => {
+    await act(async () => {
+      render(<SettingsPage />);
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('tfa')).toHaveTextContent('off'),
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('toggle-tfa'));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('tfa')).toHaveTextContent('on'),
+    );
+  });
+
+  it('shows an error fallback when the profile fetch fails', async () => {
+    mocks.getSelfProfile.mockRejectedValue(new Error('boom'));
+    await act(async () => {
+      render(<SettingsPage />);
+    });
+    await act(async () => {});
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Unable to load your security settings/i),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -20,6 +20,7 @@ import { authApi } from '@/lib/auth';
 import { User, UserPreferences } from '@/types/auth';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { useDemoStore } from '@/store/demoStore';
+import { useAuthStore } from '@/store/authStore';
 import { createLogger } from '@/lib/logger';
 import { getErrorMessage } from '@/lib/errors';
 import Link from 'next/link';
@@ -47,7 +48,106 @@ export default function SettingsPage() {
   );
 }
 
+/**
+ * Settings view for an acting delegate. Renders ONLY the Security section
+ * so the delegate can manage their own password and 2FA. The fetched
+ * profile is the delegate's own (via /auth/me-self), and the 2FA status
+ * comes from /auth/2fa/status -- backend security endpoints all operate
+ * on req.user.realUserId. Other settings sections are intentionally
+ * hidden: they would reflect or alter the owner's account.
+ */
+function DelegateSecurityView() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [user, setUser] = useState<User | null>(null);
+  const [twoFactorEnabled, setTwoFactorEnabled] = useState(false);
+  const [force2fa, setForce2fa] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([
+      authApi.getSelfProfile(),
+      authApi.get2FAStatus(),
+      authApi
+        .getAuthMethods()
+        .catch(() => ({ force2fa: false } as { force2fa: boolean })),
+    ])
+      .then(([self, status, methods]) => {
+        if (cancelled) return;
+        setUser(self as User);
+        setTwoFactorEnabled(!!status.enabled);
+        setForce2fa(!!methods.force2fa);
+      })
+      .catch((error) => {
+        toast.error(getErrorMessage(error, 'Failed to load security settings'));
+        logger.error(error);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (isLoading) {
+    return (
+      <PageLayout>
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-12 pt-6 pb-8">
+          <div className="flex justify-center items-center h-64">
+            <LoadingSpinner />
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (!user) {
+    return (
+      <PageLayout>
+        <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-12 pt-6 pb-8">
+          <PageHeader title="Settings" />
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            Unable to load your security settings.
+          </p>
+        </main>
+      </PageLayout>
+    );
+  }
+
+  // SecuritySection only reads `preferences.twoFactorEnabled` -- supply a
+  // minimal stub so it can render without fetching the owner's preferences
+  // (which would not be the delegate's own 2FA state anyway).
+  const preferencesStub = {
+    twoFactorEnabled,
+  } as unknown as UserPreferences;
+
+  return (
+    <PageLayout>
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-12 pt-6 pb-8">
+        <PageHeader title="Settings" />
+        <div id="security">
+          <SecuritySection
+            user={user}
+            preferences={preferencesStub}
+            force2fa={force2fa}
+            onPreferencesUpdated={(next) => {
+              if (typeof next.twoFactorEnabled === 'boolean') {
+                setTwoFactorEnabled(next.twoFactorEnabled);
+              }
+            }}
+          />
+        </div>
+      </main>
+    </PageLayout>
+  );
+}
+
 function SettingsContent() {
+  const isDelegateView = useAuthStore((s) => !!s.actingAsUserId);
+  return isDelegateView ? <DelegateSecurityView /> : <OwnerSettingsView />;
+}
+
+function OwnerSettingsView() {
   const [isLoading, setIsLoading] = useState(true);
   const [user, setUser] = useState<User | null>(null);
   const [preferences, setPreferences] = useState<UserPreferences | null>(null);

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -13,7 +13,6 @@ import { DangerZoneSection } from '@/components/settings/DangerZoneSection';
 import { BackupRestoreSection } from '@/components/settings/BackupRestoreSection';
 import { AutoBackupSection } from '@/components/settings/AutoBackupSection';
 import { ApiAccessSection } from '@/components/settings/ApiAccessSection';
-import { SharedAccessSection } from '@/components/settings/SharedAccessSection';
 import { SettingsNav, SettingsSection } from '@/components/settings/SettingsNav';
 import { useScrollSpy } from '@/hooks/useScrollSpy';
 import { userSettingsApi } from '@/lib/user-settings';
@@ -32,7 +31,7 @@ const ALL_SETTINGS_SECTIONS: readonly (SettingsSection & { demoVisible?: boolean
   { id: 'preferences', label: 'Preferences', demoVisible: true },
   { id: 'notifications', label: 'Notifications', demoVisible: true },
   { id: 'security', label: 'Security' },
-  { id: 'shared-access', label: 'Shared Access' },
+  { id: 'shared-access', label: 'Shared Access', href: '/settings/shared-access' },
   { id: 'api-access', label: 'API Access' },
   { id: 'ai-settings', label: 'AI Settings', href: '/settings/ai' },
   { id: 'backup-restore', label: 'Backup & Restore' },
@@ -199,7 +198,17 @@ function SettingsContent() {
 
             {!isDemoMode && (
               <div id="shared-access" className="scroll-mt-16 lg:scroll-mt-6">
-                <SharedAccessSection />
+                <Link
+                  href="/settings/shared-access"
+                  className="block bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg p-6 mb-6 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                >
+                  <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">
+                    Shared Access
+                  </h2>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    Grant another person scoped read access to specific accounts.
+                  </p>
+                </Link>
               </div>
             )}
 

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -13,6 +13,7 @@ import { DangerZoneSection } from '@/components/settings/DangerZoneSection';
 import { BackupRestoreSection } from '@/components/settings/BackupRestoreSection';
 import { AutoBackupSection } from '@/components/settings/AutoBackupSection';
 import { ApiAccessSection } from '@/components/settings/ApiAccessSection';
+import { SharedAccessSection } from '@/components/settings/SharedAccessSection';
 import { SettingsNav, SettingsSection } from '@/components/settings/SettingsNav';
 import { useScrollSpy } from '@/hooks/useScrollSpy';
 import { userSettingsApi } from '@/lib/user-settings';
@@ -31,6 +32,7 @@ const ALL_SETTINGS_SECTIONS: readonly (SettingsSection & { demoVisible?: boolean
   { id: 'preferences', label: 'Preferences', demoVisible: true },
   { id: 'notifications', label: 'Notifications', demoVisible: true },
   { id: 'security', label: 'Security' },
+  { id: 'shared-access', label: 'Shared Access' },
   { id: 'api-access', label: 'API Access' },
   { id: 'ai-settings', label: 'AI Settings', href: '/settings/ai' },
   { id: 'backup-restore', label: 'Backup & Restore' },
@@ -192,6 +194,12 @@ function SettingsContent() {
                   force2fa={force2fa}
                   onPreferencesUpdated={setPreferences}
                 />
+              </div>
+            )}
+
+            {!isDemoMode && (
+              <div id="shared-access" className="scroll-mt-16 lg:scroll-mt-6">
+                <SharedAccessSection />
               </div>
             )}
 

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -206,7 +206,7 @@ function SettingsContent() {
                     Shared Access
                   </h2>
                   <p className="text-sm text-gray-500 dark:text-gray-400">
-                    Grant another person scoped read access to specific accounts.
+                    Grant another person granular access to specific accounts.
                   </p>
                 </Link>
               </div>

--- a/frontend/src/app/settings/shared-access/page.test.tsx
+++ b/frontend/src/app/settings/shared-access/page.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@/test/render';
+import SharedAccessPage from './page';
+
+vi.mock('@/components/auth/ProtectedRoute', () => ({
+  ProtectedRoute: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('@/components/layout/PageLayout', () => ({
+  PageLayout: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('@/components/layout/PageHeader', () => ({
+  PageHeader: ({ title }: any) => <h1>{title}</h1>,
+}));
+vi.mock('@/components/settings/SharedAccessSection', () => ({
+  SharedAccessSection: () => <div data-testid="shared-access-section" />,
+}));
+
+const mockUseDemoMode = vi.fn();
+vi.mock('@/hooks/useDemoMode', () => ({
+  useDemoMode: () => mockUseDemoMode(),
+}));
+
+describe('SharedAccessPage', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the section when not in demo mode', () => {
+    mockUseDemoMode.mockReturnValue(false);
+    render(<SharedAccessPage />);
+    expect(screen.getByText('Shared Access')).toBeInTheDocument();
+    expect(screen.getByTestId('shared-access-section')).toBeInTheDocument();
+  });
+
+  it('shows a restricted message in demo mode', () => {
+    mockUseDemoMode.mockReturnValue(true);
+    render(<SharedAccessPage />);
+    expect(screen.getByText('Restricted in Demo Mode')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('shared-access-section'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/settings/shared-access/page.tsx
+++ b/frontend/src/app/settings/shared-access/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Link from 'next/link';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { PageHeader } from '@/components/layout/PageHeader';
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+import { SharedAccessSection } from '@/components/settings/SharedAccessSection';
+import { useDemoMode } from '@/hooks/useDemoMode';
+
+export default function SharedAccessPage() {
+  return (
+    <ProtectedRoute>
+      <SharedAccessContent />
+    </ProtectedRoute>
+  );
+}
+
+function SharedAccessContent() {
+  const isDemoMode = useDemoMode();
+
+  return (
+    <PageLayout>
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-12 pt-6 pb-8">
+        <div className="mb-4">
+          <Link
+            href="/settings"
+            className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            &larr; Back to Settings
+          </Link>
+        </div>
+
+        <PageHeader
+          title="Shared Access"
+          subtitle="Grant another person scoped read access to specific accounts"
+        />
+
+        {isDemoMode ? (
+          <div className="bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800 rounded-lg p-6 mb-6">
+            <h2 className="text-lg font-semibold text-amber-800 dark:text-amber-200 mb-2">
+              Restricted in Demo Mode
+            </h2>
+            <p className="text-sm text-amber-700 dark:text-amber-300">
+              Delegate management is disabled in demo mode.
+            </p>
+          </div>
+        ) : (
+          <SharedAccessSection />
+        )}
+      </main>
+    </PageLayout>
+  );
+}

--- a/frontend/src/app/settings/shared-access/page.tsx
+++ b/frontend/src/app/settings/shared-access/page.tsx
@@ -32,7 +32,7 @@ function SharedAccessContent() {
 
         <PageHeader
           title="Shared Access"
-          subtitle="Grant another person scoped read access to specific accounts"
+          subtitle="Grant another person granular access to specific accounts"
         />
 
         {isDemoMode ? (

--- a/frontend/src/components/accounts/AccountForm.test.tsx
+++ b/frontend/src/components/accounts/AccountForm.test.tsx
@@ -316,6 +316,26 @@ describe('AccountForm', () => {
     });
   });
 
+  it('hides the favourite toggle for a delegate (acting view)', async () => {
+    const { useAuthStore } = await import('@/store/authStore');
+    act(() => {
+      useAuthStore
+        .getState()
+        .setDelegation('owner-1', [], null, { accounts: true } as never);
+    });
+
+    render(<AccountForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Account Name')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Add to favourites')).not.toBeInTheDocument();
+
+    act(() => {
+      useAuthStore.getState().setDelegation(null, [], null, null);
+    });
+  });
+
   it('toggles favourite when star button is clicked', async () => {
     render(
       <AccountForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />

--- a/frontend/src/components/accounts/AccountForm.tsx
+++ b/frontend/src/components/accounts/AccountForm.tsx
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/Input';
 import { CurrencyInput } from '@/components/ui/CurrencyInput';
 import { Select } from '@/components/ui/Select';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
+import { useAuthStore } from '@/store/authStore';
 import toast from 'react-hot-toast';
 import { Account, PaymentFrequency } from '@/types/account';
 import { Category } from '@/types/category';
@@ -194,6 +195,10 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
 
   const watchedCurrency = useWatch({ control, name: 'currencyCode' });
   const watchedIsFavourite = useWatch({ control, name: 'isFavourite' });
+  // Account edits are owner-only. A delegate sets favourites from the
+  // account list (their own overlay), so the in-form toggle is hidden for
+  // them to avoid an owner-only save error.
+  const isDelegateView = useAuthStore((s) => !!s.actingAsUserId);
   const watchedAccountType = useWatch({ control, name: 'accountType' });
   const watchedOpeningBalance = useWatch({ control, name: 'openingBalance' });
   const watchedCreditLimit = useWatch({ control, name: 'creditLimit' });
@@ -651,6 +656,7 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
 
       {/* Favourite star toggle */}
       <div className="flex flex-wrap items-center justify-between gap-2">
+        {!isDelegateView && (
         <button
           type="button"
           onClick={toggleFavourite}
@@ -678,6 +684,7 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
             {watchedIsFavourite ? 'Favourite' : 'Add to favourites'}
           </span>
         </button>
+        )}
         {/* Hidden input for form registration */}
         <input type="hidden" {...register('isFavourite')} />
 

--- a/frontend/src/components/accounts/AccountList.test.tsx
+++ b/frontend/src/components/accounts/AccountList.test.tsx
@@ -852,7 +852,32 @@ describe('AccountList', () => {
       isFavourite: true,
     });
     expect(accountsApi.setDelegateFavourite).not.toHaveBeenCalled();
-    expect(mockOnRefresh).toHaveBeenCalled();
+    // Optimistic update only -- no full list reload.
+    expect(mockOnRefresh).not.toHaveBeenCalled();
+    expect(
+      screen.getByLabelText('Remove from favourites'),
+    ).toBeInTheDocument();
+  });
+
+  it('rolls back the star when the favourite update fails', async () => {
+    (accountsApi.update as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('nope'),
+    );
+    const account = createAccount({ isFavourite: false });
+
+    render(
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Add to favourites'));
+    });
+    await act(async () => {});
+
+    expect(
+      screen.getByLabelText('Add to favourites'),
+    ).toBeInTheDocument();
+    expect(mockOnRefresh).not.toHaveBeenCalled();
   });
 
   it('a delegate toggling the star writes the delegate overlay', async () => {

--- a/frontend/src/components/accounts/AccountList.test.tsx
+++ b/frontend/src/components/accounts/AccountList.test.tsx
@@ -10,6 +10,8 @@ vi.mock('@/lib/accounts', () => ({
     close: vi.fn().mockResolvedValue(undefined),
     reopen: vi.fn().mockResolvedValue(undefined),
     delete: vi.fn().mockResolvedValue(undefined),
+    update: vi.fn().mockResolvedValue(undefined),
+    setDelegateFavourite: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -823,15 +825,62 @@ describe('AccountList', () => {
     expect(allButton!.className).toContain('bg-blue-600');
   });
 
-  it('shows favourite star icon for favourite accounts', () => {
+  it('shows an interactive favourite star for favourite accounts', () => {
     const account = createAccount({ isFavourite: true });
 
     render(
       <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
     );
 
-    // The favourite star icon has aria-label "Favourite"
-    expect(screen.getByLabelText('Favourite')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Remove from favourites'),
+    ).toBeInTheDocument();
+  });
+
+  it('owner toggling the star updates the account favourite', async () => {
+    const account = createAccount({ isFavourite: false });
+
+    render(
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Add to favourites'));
+    });
+
+    expect(accountsApi.update).toHaveBeenCalledWith(account.id, {
+      isFavourite: true,
+    });
+    expect(accountsApi.setDelegateFavourite).not.toHaveBeenCalled();
+    expect(mockOnRefresh).toHaveBeenCalled();
+  });
+
+  it('a delegate toggling the star writes the delegate overlay', async () => {
+    const { useAuthStore } = await import('@/store/authStore');
+    act(() => {
+      useAuthStore
+        .getState()
+        .setDelegation('owner-1', [], null, { accounts: true } as never);
+    });
+    const account = createAccount({ isFavourite: false });
+
+    render(
+      <AccountList accounts={[account]} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Add to favourites'));
+    });
+
+    expect(accountsApi.setDelegateFavourite).toHaveBeenCalledWith(
+      account.id,
+      true,
+    );
+    expect(accountsApi.update).not.toHaveBeenCalled();
+
+    act(() => {
+      useAuthStore.getState().setDelegation(null, [], null, null);
+    });
   });
 
   it('shows linked account info for investment pairs', () => {

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -99,6 +99,9 @@ export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, 
   const [accountToDelete, setAccountToDelete] = useState<Account | null>(null);
   const [isClosing, setIsClosing] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  // Optimistic favourite state so toggling the star does not trigger a full
+  // page reload. Keyed by account id; absence means "use the prop value".
+  const [favOverrides, setFavOverrides] = useState<Record<string, boolean>>({});
   const deletableAccounts = useMemo(
     () => new Set(accounts.filter(a => a.canDelete).map(a => a.id)),
     [accounts],
@@ -238,7 +241,11 @@ export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, 
 
   // Filter and sort accounts
   const filteredAndSortedAccounts = useMemo(() => {
-    let result = [...accounts];
+    let result = accounts.map((a) =>
+      a.id in favOverrides
+        ? { ...a, isFavourite: favOverrides[a.id] }
+        : a,
+    );
 
     // Apply filters
     if (filterStatus) {
@@ -274,7 +281,7 @@ export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, 
     });
 
     return result;
-  }, [accounts, filterStatus, filterNetWorth, sortField, sortDirection]);
+  }, [accounts, favOverrides, filterStatus, filterNetWorth, sortField, sortDirection]);
 
   // Build a map of account IDs to names for showing linked account pairs
   const accountNameMap = useMemo(() => {
@@ -496,8 +503,10 @@ export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, 
 
   const handleToggleFavourite = useCallback(
     async (account: Account) => {
+      const next = !account.isFavourite;
+      // Optimistically flip the star in place -- no list reload/spinner.
+      setFavOverrides((prev) => ({ ...prev, [account.id]: next }));
       try {
-        const next = !account.isFavourite;
         // Owner favourites live on the account row; a delegate keeps an
         // independent overlay (the owner-scoped flag is never touched).
         if (isDelegateView) {
@@ -505,12 +514,13 @@ export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, 
         } else {
           await accountsApi.update(account.id, { isFavourite: next });
         }
-        onRefresh();
       } catch (error) {
+        // Roll back the optimistic change on failure.
+        setFavOverrides((prev) => ({ ...prev, [account.id]: !next }));
         toast.error(getErrorMessage(error, 'Failed to update favourite'));
       }
     },
-    [isDelegateView, onRefresh],
+    [isDelegateView],
   );
 
   const formatCurrency = useCallback((amount: number | string | null | undefined, currency: string) => {

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -497,16 +497,20 @@ export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, 
   const handleToggleFavourite = useCallback(
     async (account: Account) => {
       try {
-        await accountsApi.setDelegateFavourite(
-          account.id,
-          !account.isFavourite,
-        );
+        const next = !account.isFavourite;
+        // Owner favourites live on the account row; a delegate keeps an
+        // independent overlay (the owner-scoped flag is never touched).
+        if (isDelegateView) {
+          await accountsApi.setDelegateFavourite(account.id, next);
+        } else {
+          await accountsApi.update(account.id, { isFavourite: next });
+        }
         onRefresh();
       } catch (error) {
         toast.error(getErrorMessage(error, 'Failed to update favourite'));
       }
     },
-    [onRefresh],
+    [isDelegateView, onRefresh],
   );
 
   const formatCurrency = useCallback((amount: number | string | null | undefined, currency: string) => {
@@ -732,9 +736,7 @@ export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, 
                   onLongPressStartTouch={handleLongPressStart}
                   onLongPressEnd={handleLongPressEnd}
                   onTouchMove={handleTouchMove}
-                  onToggleFavourite={
-                    isDelegateView ? handleToggleFavourite : undefined
-                  }
+                  onToggleFavourite={handleToggleFavourite}
                 />
               ),
             )}

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -6,6 +6,7 @@ import { Account, AccountType } from '@/types/account';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { Modal } from '@/components/ui/Modal';
 import { accountsApi } from '@/lib/accounts';
+import { useAuthStore } from '@/store/authStore';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import toast from 'react-hot-toast';
 import { getErrorMessage } from '@/lib/errors';
@@ -90,6 +91,7 @@ interface AccountListProps {
 
 export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, convertToDefault, onEdit, onRefresh }: AccountListProps) {
   const router = useRouter();
+  const isDelegateView = useAuthStore((s) => !!s.actingAsUserId);
   const { formatCurrency: formatCurrencyBase } = useNumberFormat();
   const [closeDialogOpen, setCloseDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -492,6 +494,21 @@ export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, 
     }
   }, [onRefresh]);
 
+  const handleToggleFavourite = useCallback(
+    async (account: Account) => {
+      try {
+        await accountsApi.setDelegateFavourite(
+          account.id,
+          !account.isFavourite,
+        );
+        onRefresh();
+      } catch (error) {
+        toast.error(getErrorMessage(error, 'Failed to update favourite'));
+      }
+    },
+    [onRefresh],
+  );
+
   const formatCurrency = useCallback((amount: number | string | null | undefined, currency: string) => {
     const numericAmount = Number(amount) || 0;
     const formatted = formatCurrencyBase(numericAmount, currency);
@@ -715,6 +732,9 @@ export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, 
                   onLongPressStartTouch={handleLongPressStart}
                   onLongPressEnd={handleLongPressEnd}
                   onTouchMove={handleTouchMove}
+                  onToggleFavourite={
+                    isDelegateView ? handleToggleFavourite : undefined
+                  }
                 />
               ),
             )}

--- a/frontend/src/components/accounts/AccountRow.test.tsx
+++ b/frontend/src/components/accounts/AccountRow.test.tsx
@@ -199,6 +199,32 @@ describe('AccountRow', () => {
 
       expect(screen.queryByLabelText('Favourite')).not.toBeInTheDocument();
     });
+
+    it('renders an interactive favourite toggle when onToggleFavourite is given', () => {
+      const onToggleFavourite = vi.fn();
+      const account = createAccount({ isFavourite: false });
+      renderAccountRow(
+        createDefaultProps({ account, onToggleFavourite }),
+      );
+
+      const btn = screen.getByLabelText('Add to favourites');
+      fireEvent.click(btn);
+
+      expect(onToggleFavourite).toHaveBeenCalledWith(account);
+    });
+
+    it('shows the toggle as pressed for a delegate favourite', () => {
+      renderAccountRow(
+        createDefaultProps({
+          account: createAccount({ isFavourite: true }),
+          onToggleFavourite: vi.fn(),
+        }),
+      );
+
+      expect(
+        screen.getByLabelText('Remove from favourites'),
+      ).toHaveAttribute('aria-pressed', 'true');
+    });
   });
 
   describe('account types', () => {

--- a/frontend/src/components/accounts/AccountRow.tsx
+++ b/frontend/src/components/accounts/AccountRow.tsx
@@ -28,6 +28,9 @@ export interface AccountRowProps {
   onLongPressStartTouch: (account: Account, e: React.TouchEvent) => void;
   onLongPressEnd: () => void;
   onTouchMove: (e: React.TouchEvent) => void;
+  // Provided only in delegate (acting) view: makes the favourite star an
+  // interactive toggle for the delegate's own (non-shared) favourites.
+  onToggleFavourite?: (account: Account) => void;
 }
 
 export const AccountRow = memo(function AccountRow({
@@ -54,6 +57,7 @@ export const AccountRow = memo(function AccountRow({
   onLongPressStartTouch,
   onLongPressEnd,
   onTouchMove,
+  onToggleFavourite,
 }: AccountRowProps) {
   return (
     <tr
@@ -75,15 +79,46 @@ export const AccountRow = memo(function AccountRow({
             : account.name}
         >
           <div className="flex items-center text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300">
-            {account.isFavourite && (
-              <svg
-                className="w-4 h-4 mr-1 flex-shrink-0 text-yellow-500"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-                aria-label="Favourite"
+            {onToggleFavourite ? (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleFavourite(account);
+                }}
+                className={`mr-1 flex-shrink-0 ${account.isFavourite ? 'text-yellow-500' : 'text-gray-300 dark:text-gray-600 hover:text-yellow-500'}`}
+                aria-label={
+                  account.isFavourite
+                    ? 'Remove from favourites'
+                    : 'Add to favourites'
+                }
+                aria-pressed={account.isFavourite}
+                title={
+                  account.isFavourite
+                    ? 'Remove from favourites'
+                    : 'Add to favourites'
+                }
               >
-                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-              </svg>
+                <svg
+                  className="w-4 h-4"
+                  fill={account.isFavourite ? 'currentColor' : 'none'}
+                  stroke="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                </svg>
+              </button>
+            ) : (
+              account.isFavourite && (
+                <svg
+                  className="w-4 h-4 mr-1 flex-shrink-0 text-yellow-500"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                  aria-label="Favourite"
+                >
+                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                </svg>
+              )
             )}
             <span className="truncate">{account.name}</span>
             {density !== 'normal' && account.linkedAccountId && (account.accountSubType === 'INVESTMENT_CASH' || account.accountSubType === 'INVESTMENT_BROKERAGE') && (

--- a/frontend/src/components/auth/DelegateSectionGuard.test.tsx
+++ b/frontend/src/components/auth/DelegateSectionGuard.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@/test/render';
+import { DelegateSectionGuard } from './DelegateSectionGuard';
+
+const mockReplace = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+let state: {
+  actingAsUserId: string | null;
+  delegateSections: Record<string, boolean> | null;
+};
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: (selector: (s: typeof state) => unknown) => selector(state),
+}));
+
+describe('DelegateSectionGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state = { actingAsUserId: null, delegateSections: null };
+  });
+
+  it('renders children for a non-delegate', () => {
+    render(
+      <DelegateSectionGuard section="bills">
+        <p>content</p>
+      </DelegateSectionGuard>,
+    );
+    expect(screen.getByText('content')).toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing while acting before sections load', () => {
+    state = { actingAsUserId: 'o1', delegateSections: null };
+    render(
+      <DelegateSectionGuard section="bills">
+        <p>content</p>
+      </DelegateSectionGuard>,
+    );
+    expect(screen.queryByText('content')).not.toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('renders children when the section is granted', () => {
+    state = {
+      actingAsUserId: 'o1',
+      delegateSections: { bills: true },
+    };
+    render(
+      <DelegateSectionGuard section="bills">
+        <p>content</p>
+      </DelegateSectionGuard>,
+    );
+    expect(screen.getByText('content')).toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('redirects to dashboard when the section is not granted', async () => {
+    state = {
+      actingAsUserId: 'o1',
+      delegateSections: { bills: false },
+    };
+    render(
+      <DelegateSectionGuard section="bills">
+        <p>content</p>
+      </DelegateSectionGuard>,
+    );
+    expect(screen.queryByText('content')).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith('/dashboard'),
+    );
+  });
+});

--- a/frontend/src/components/auth/DelegateSectionGuard.test.tsx
+++ b/frontend/src/components/auth/DelegateSectionGuard.test.tsx
@@ -7,6 +7,11 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace: mockReplace }),
 }));
 
+const mockToastError = vi.fn();
+vi.mock('react-hot-toast', () => ({
+  default: { error: (...a: unknown[]) => mockToastError(...a) },
+}));
+
 let state: {
   actingAsUserId: string | null;
   delegateSections: Record<string, boolean> | null;
@@ -71,5 +76,21 @@ describe('DelegateSectionGuard', () => {
     await waitFor(() =>
       expect(mockReplace).toHaveBeenCalledWith('/dashboard'),
     );
+    expect(mockToastError).toHaveBeenCalledWith(
+      "You don't have access to that section.",
+    );
+  });
+
+  it('does not render content or skeleton flash when blocked', () => {
+    state = {
+      actingAsUserId: 'o1',
+      delegateSections: { reports: false },
+    };
+    render(
+      <DelegateSectionGuard section="reports">
+        <p>reports-screen</p>
+      </DelegateSectionGuard>,
+    );
+    expect(screen.queryByText('reports-screen')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/auth/DelegateSectionGuard.tsx
+++ b/frontend/src/components/auth/DelegateSectionGuard.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/store/authStore';
+import type { DelegateSectionGrants } from '@/lib/delegation';
+
+type Section = keyof DelegateSectionGrants;
+
+/**
+ * Client-side UX guard for section-scoped routes. The backend
+ * AccountDelegateGuard is the real enforcement; this just keeps a delegate
+ * out of a section they were not granted instead of showing an empty/403
+ * page. Non-delegates are unaffected.
+ *
+ * While acting but before /auth/contexts has resolved (delegateSections
+ * still null), render nothing rather than redirecting -- a premature
+ * redirect would eject a delegate who actually has the grant.
+ */
+export function DelegateSectionGuard({
+  section,
+  children,
+}: {
+  section: Section;
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+  const actingAsUserId = useAuthStore((s) => s.actingAsUserId);
+  const delegateSections = useAuthStore((s) => s.delegateSections);
+  const isDelegateView = !!actingAsUserId;
+  const blocked =
+    isDelegateView &&
+    delegateSections !== null &&
+    !delegateSections[section];
+
+  useEffect(() => {
+    if (blocked) {
+      router.replace('/dashboard');
+    }
+  }, [blocked, router]);
+
+  if (isDelegateView && delegateSections === null) return null;
+  if (blocked) return null;
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/auth/DelegateSectionGuard.tsx
+++ b/frontend/src/components/auth/DelegateSectionGuard.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
+import toast from 'react-hot-toast';
 import { useAuthStore } from '@/store/authStore';
 import type { DelegateSectionGrants } from '@/lib/delegation';
 
@@ -32,15 +33,21 @@ export function DelegateSectionGuard({
     isDelegateView &&
     delegateSections !== null &&
     !delegateSections[section];
+  const notified = useRef(false);
 
   useEffect(() => {
-    if (blocked) {
+    if (blocked && !notified.current) {
+      notified.current = true;
+      toast.error("You don't have access to that section.");
       router.replace('/dashboard');
     }
   }, [blocked, router]);
 
-  if (isDelegateView && delegateSections === null) return null;
-  if (blocked) return null;
+  // For an acting delegate, never render the section content (or its
+  // loading skeleton) until we know the grant: nothing while contexts load,
+  // and nothing when blocked. This keeps the redirect consistent and
+  // flash-free across every section route.
+  if (isDelegateView && (delegateSections === null || blocked)) return null;
 
   return <>{children}</>;
 }

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -59,7 +59,9 @@ export function AppHeader() {
   const visibleToolsLinks = isDelegateView
     ? toolsLinks.filter((l) => {
         const cap = toolsCapabilityByHref[l.href];
-        return cap ? !!delegateCapabilities?.[cap] : false;
+        if (!cap) return false;
+        const r = delegateCapabilities?.[cap];
+        return !!r && (r.create || r.edit || r.delete);
       })
     : toolsLinks;
   const [toolsOpen, setToolsOpen] = useState(false);

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -41,10 +41,27 @@ const aiLinks: { href: string; label: string }[] = [
 export function AppHeader() {
   const router = useRouter();
   const pathname = usePathname();
-  const { user, logout, actingAsUserId } = useAuthStore();
+  const { user, logout, actingAsUserId, delegateCapabilities } =
+    useAuthStore();
   // Phase 1: a delegate acting as an owner only sees the Dashboard.
   const isDelegateView = !!actingAsUserId;
   const visibleNavLinks = isDelegateView ? [] : navLinks;
+  // A delegate sees only the Tools sections they were granted manage
+  // capability for (payees/categories/tags). Everyone else sees all.
+  const toolsCapabilityByHref: Record<
+    string,
+    'payees' | 'categories' | 'tags'
+  > = {
+    '/categories': 'categories',
+    '/payees': 'payees',
+    '/tags': 'tags',
+  };
+  const visibleToolsLinks = isDelegateView
+    ? toolsLinks.filter((l) => {
+        const cap = toolsCapabilityByHref[l.href];
+        return cap ? !!delegateCapabilities?.[cap] : false;
+      })
+    : toolsLinks;
   const [toolsOpen, setToolsOpen] = useState(false);
   const [aiOpen, setAiOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -208,7 +225,11 @@ export function AppHeader() {
                         {link.label}
                       </button>
                     ))}
+                    </>
+                    )}
 
+                    {visibleToolsLinks.length > 0 && (
+                    <>
                     {/* Divider */}
                     <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
 
@@ -218,7 +239,7 @@ export function AppHeader() {
                     </div>
 
                     {/* Tools links */}
-                    {toolsLinks.map((link) => (
+                    {visibleToolsLinks.map((link) => (
                       <button
                         key={link.href}
                         onClick={() => router.push(link.href)}
@@ -236,9 +257,11 @@ export function AppHeader() {
                         )}
                       </button>
                     ))}
+                    </>
+                    )}
 
                     {/* Admin section - only for admins */}
-                    {user?.role === 'admin' && (
+                    {!isDelegateView && user?.role === 'admin' && (
                       <>
                         <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
                         <div className="px-4 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
@@ -255,8 +278,6 @@ export function AppHeader() {
                           User Management
                         </button>
                       </>
-                    )}
-                    </>
                     )}
 
                     {/* Divider */}
@@ -289,7 +310,7 @@ export function AppHeader() {
               <Image src="/icons/monize-logo.svg" alt="Monize" width={32} height={32} className="rounded" priority />
               <span className="hidden lg:inline">Monize</span>
             </button>
-            {!isDelegateView && (
+            {(!isDelegateView || visibleToolsLinks.length > 0) && (
             <nav className="hidden lg:ml-8 lg:flex lg:items-center lg:space-x-4">
               {visibleNavLinks.map((link) => (
                 <button
@@ -305,6 +326,8 @@ export function AppHeader() {
                 </button>
               ))}
 
+              {!isDelegateView && (
+              <>
               {/* AI Dropdown */}
               <div className="relative" ref={aiRef}>
                 <button
@@ -350,6 +373,11 @@ export function AppHeader() {
                 )}
               </div>
 
+              </>
+              )}
+
+              {visibleToolsLinks.length > 0 && (
+              <>
               {/* Tools Dropdown */}
               <div className="relative" ref={toolsRef}>
                 <button
@@ -374,7 +402,7 @@ export function AppHeader() {
                 {toolsOpen && (
                   <div className="absolute left-0 mt-1 w-48 bg-white dark:bg-gray-800 rounded-md shadow-lg dark:shadow-gray-700/50 border border-gray-200 dark:border-gray-700 z-50">
                     <div className="py-1">
-                      {toolsLinks.map((link) => (
+                      {visibleToolsLinks.map((link) => (
                         <button
                           key={link.href}
                           onClick={() => {
@@ -400,8 +428,11 @@ export function AppHeader() {
                 )}
               </div>
 
+              </>
+              )}
+
               {/* Admin link - only visible to admins */}
-              {user?.role === 'admin' && (
+              {!isDelegateView && user?.role === 'admin' && (
                 <button
                   onClick={() => router.push('/admin/users')}
                   className={`px-3 py-2 text-sm font-medium rounded-md transition-colors ${

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -309,23 +309,20 @@ export function AppHeader() {
                     )}
 
                     {/* Divider */}
-                    {!isDelegateView && (
-                      <>
-                        <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
+                    <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
 
-                        {/* Settings link */}
-                        <button
-                          onClick={() => router.push('/settings')}
-                          className={`block w-full text-left px-4 py-2 text-sm transition-colors ${
-                            pathname === '/settings'
-                              ? 'bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-200'
-                              : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                          }`}
-                        >
-                          Settings
-                        </button>
-                      </>
-                    )}
+                    {/* Settings link -- delegates land on a Security-only
+                        view that manages their OWN credentials. */}
+                    <button
+                      onClick={() => router.push('/settings')}
+                      className={`block w-full text-left px-4 py-2 text-sm transition-colors ${
+                        pathname === '/settings'
+                          ? 'bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-200'
+                          : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                      }`}
+                    >
+                      Settings
+                    </button>
                   </div>
                 </div>
               )}
@@ -529,7 +526,6 @@ export function AppHeader() {
             </div>
             <ActionHistoryPanel />
             <BudgetAlertBadge />
-            {!isDelegateView && (
             <button
               onClick={() => router.push('/settings')}
               className={`flex items-center gap-2 px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
@@ -560,7 +556,6 @@ export function AppHeader() {
               </svg>
               <span className="hidden sm:inline">{user?.firstName || user?.email}</span>
             </button>
-            )}
             <Button
               variant="outline"
               size="sm"

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -41,11 +41,34 @@ const aiLinks: { href: string; label: string }[] = [
 export function AppHeader() {
   const router = useRouter();
   const pathname = usePathname();
-  const { user, logout, actingAsUserId, delegateCapabilities } =
-    useAuthStore();
-  // Phase 1: a delegate acting as an owner only sees the Dashboard.
+  const {
+    user,
+    logout,
+    actingAsUserId,
+    delegateCapabilities,
+    delegateSections,
+  } = useAuthStore();
   const isDelegateView = !!actingAsUserId;
-  const visibleNavLinks = isDelegateView ? [] : navLinks;
+  // A delegate sees a top-nav section only if the owner granted it.
+  // Accounts & Transactions are scoped via per-account grants, not section
+  // grants, so they stay hidden from the section-gated nav (current
+  // behaviour); the dashboard remains the delegate's landing page.
+  const navSectionByHref: Record<
+    string,
+    'bills' | 'investments' | 'budgets' | 'reports'
+  > = {
+    '/bills': 'bills',
+    '/investments': 'investments',
+    '/budgets': 'budgets',
+    '/reports': 'reports',
+  };
+  const visibleNavLinks = isDelegateView
+    ? navLinks.filter((l) => {
+        const sec = navSectionByHref[l.href];
+        return !!sec && !!delegateSections?.[sec];
+      })
+    : navLinks;
+  const showAiMenu = !isDelegateView || !!delegateSections?.ai;
   // A delegate sees only the Tools sections they were granted manage
   // capability for (payees/categories/tags). Everyone else sees all.
   const toolsCapabilityByHref: Record<
@@ -203,7 +226,7 @@ export function AppHeader() {
                       </button>
                     ))}
 
-                    {!isDelegateView && (
+                    {showAiMenu && (
                     <>
                     {/* Divider */}
                     <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
@@ -312,7 +335,10 @@ export function AppHeader() {
               <Image src="/icons/monize-logo.svg" alt="Monize" width={32} height={32} className="rounded" priority />
               <span className="hidden lg:inline">Monize</span>
             </button>
-            {(!isDelegateView || visibleToolsLinks.length > 0) && (
+            {(!isDelegateView ||
+              visibleNavLinks.length > 0 ||
+              visibleToolsLinks.length > 0 ||
+              showAiMenu) && (
             <nav className="hidden lg:ml-8 lg:flex lg:items-center lg:space-x-4">
               {visibleNavLinks.map((link) => (
                 <button
@@ -328,7 +354,7 @@ export function AppHeader() {
                 </button>
               ))}
 
-              {!isDelegateView && (
+              {showAiMenu && (
               <>
               {/* AI Dropdown */}
               <div className="relative" ref={aiRef}>

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -56,8 +56,9 @@ export function AppHeader() {
   // the section nav; the dashboard remains the delegate's landing page.
   const navSectionByHref: Record<
     string,
-    'bills' | 'investments' | 'budgets' | 'reports' | 'transactions'
+    'bills' | 'investments' | 'budgets' | 'reports' | 'transactions' | 'accounts'
   > = {
+    '/accounts': 'accounts',
     '/transactions': 'transactions',
     '/bills': 'bills',
     '/investments': 'investments',

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -41,7 +41,10 @@ const aiLinks: { href: string; label: string }[] = [
 export function AppHeader() {
   const router = useRouter();
   const pathname = usePathname();
-  const { user, logout } = useAuthStore();
+  const { user, logout, actingAsUserId } = useAuthStore();
+  // Phase 1: a delegate acting as an owner only sees the Dashboard.
+  const isDelegateView = !!actingAsUserId;
+  const visibleNavLinks = isDelegateView ? [] : navLinks;
   const [toolsOpen, setToolsOpen] = useState(false);
   const [aiOpen, setAiOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -167,7 +170,7 @@ export function AppHeader() {
                     </button>
 
                     {/* Main nav links */}
-                    {navLinks.map((link) => (
+                    {visibleNavLinks.map((link) => (
                       <button
                         key={link.href}
                         onClick={() => router.push(link.href)}
@@ -181,6 +184,8 @@ export function AppHeader() {
                       </button>
                     ))}
 
+                    {!isDelegateView && (
+                    <>
                     {/* Divider */}
                     <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
 
@@ -251,6 +256,8 @@ export function AppHeader() {
                         </button>
                       </>
                     )}
+                    </>
+                    )}
 
                     {/* Divider */}
                     <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
@@ -278,8 +285,9 @@ export function AppHeader() {
               <Image src="/icons/monize-logo.svg" alt="Monize" width={32} height={32} className="rounded" priority />
               <span className="hidden lg:inline">Monize</span>
             </button>
+            {!isDelegateView && (
             <nav className="hidden lg:ml-8 lg:flex lg:items-center lg:space-x-4">
-              {navLinks.map((link) => (
+              {visibleNavLinks.map((link) => (
                 <button
                   key={link.href}
                   onClick={() => router.push(link.href)}
@@ -402,6 +410,7 @@ export function AppHeader() {
                 </button>
               )}
             </nav>
+            )}
           </div>
           <div className="flex items-center space-x-1 sm:space-x-4">
             <div className="relative" ref={searchRef}>

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -49,14 +49,16 @@ export function AppHeader() {
     delegateSections,
   } = useAuthStore();
   const isDelegateView = !!actingAsUserId;
-  // A delegate sees a top-nav section only if the owner granted it.
-  // Accounts & Transactions are scoped via per-account grants, not section
-  // grants, so they stay hidden from the section-gated nav (current
-  // behaviour); the dashboard remains the delegate's landing page.
+  // A delegate sees a top-nav entry only if it is reachable: granted
+  // sections (bills/investments/budgets/reports) plus Transactions when
+  // they can read any non-investment account (delegateSections.transactions,
+  // derived server-side). Accounts stays per-account scoped and hidden from
+  // the section nav; the dashboard remains the delegate's landing page.
   const navSectionByHref: Record<
     string,
-    'bills' | 'investments' | 'budgets' | 'reports'
+    'bills' | 'investments' | 'budgets' | 'reports' | 'transactions'
   > = {
+    '/transactions': 'transactions',
     '/bills': 'bills',
     '/investments': 'investments',
     '/budgets': 'budgets',

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -260,19 +260,23 @@ export function AppHeader() {
                     )}
 
                     {/* Divider */}
-                    <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
+                    {!isDelegateView && (
+                      <>
+                        <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
 
-                    {/* Settings link */}
-                    <button
-                      onClick={() => router.push('/settings')}
-                      className={`block w-full text-left px-4 py-2 text-sm transition-colors ${
-                        pathname === '/settings'
-                          ? 'bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-200'
-                          : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                      }`}
-                    >
-                      Settings
-                    </button>
+                        {/* Settings link */}
+                        <button
+                          onClick={() => router.push('/settings')}
+                          className={`block w-full text-left px-4 py-2 text-sm transition-colors ${
+                            pathname === '/settings'
+                              ? 'bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-200'
+                              : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                          }`}
+                        >
+                          Settings
+                        </button>
+                      </>
+                    )}
                   </div>
                 </div>
               )}
@@ -463,6 +467,7 @@ export function AppHeader() {
             </div>
             <ActionHistoryPanel />
             <BudgetAlertBadge />
+            {!isDelegateView && (
             <button
               onClick={() => router.push('/settings')}
               className={`flex items-center gap-2 px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
@@ -493,6 +498,7 @@ export function AppHeader() {
               </svg>
               <span className="hidden sm:inline">{user?.firstName || user?.email}</span>
             </button>
+            )}
             <Button
               variant="outline"
               size="sm"

--- a/frontend/src/components/layout/DelegationBanner.test.tsx
+++ b/frontend/src/components/layout/DelegationBanner.test.tsx
@@ -53,6 +53,7 @@ describe('DelegationBanner', () => {
 
   it('renders nothing when there are no contexts', async () => {
     vi.mocked(delegationApi.getContexts).mockResolvedValue({
+      capabilities: null,
       actingAsUserId: null,
       contexts: [],
     });
@@ -77,6 +78,7 @@ describe('DelegationBanner', () => {
       { userId: 'o1', label: 'Owner One', isSelf: false, ownerHas2FA: false },
     ];
     vi.mocked(delegationApi.getContexts).mockResolvedValue({
+      capabilities: null,
       actingAsUserId: null,
       contexts: state.availableContexts,
     });
@@ -103,6 +105,7 @@ describe('DelegationBanner', () => {
 
   it('auto-picks the only owner context for a pure delegate', async () => {
     vi.mocked(delegationApi.getContexts).mockResolvedValue({
+      capabilities: null,
       actingAsUserId: null,
       contexts: [
         { userId: 'o1', label: 'Owner', isSelf: false, ownerHas2FA: false },
@@ -127,6 +130,7 @@ describe('DelegationBanner', () => {
       { userId: 'o1', label: 'Owner', isSelf: false, ownerHas2FA: true },
     ];
     vi.mocked(delegationApi.getContexts).mockResolvedValue({
+      capabilities: null,
       actingAsUserId: null,
       contexts: state.availableContexts,
     });

--- a/frontend/src/components/layout/DelegationBanner.test.tsx
+++ b/frontend/src/components/layout/DelegationBanner.test.tsx
@@ -54,6 +54,7 @@ describe('DelegationBanner', () => {
   it('renders nothing when there are no contexts', async () => {
     vi.mocked(delegationApi.getContexts).mockResolvedValue({
       capabilities: null,
+      sections: null,
       actingAsUserId: null,
       contexts: [],
     });
@@ -79,6 +80,7 @@ describe('DelegationBanner', () => {
     ];
     vi.mocked(delegationApi.getContexts).mockResolvedValue({
       capabilities: null,
+      sections: null,
       actingAsUserId: null,
       contexts: state.availableContexts,
     });
@@ -106,6 +108,7 @@ describe('DelegationBanner', () => {
   it('auto-picks the only owner context for a pure delegate', async () => {
     vi.mocked(delegationApi.getContexts).mockResolvedValue({
       capabilities: null,
+      sections: null,
       actingAsUserId: null,
       contexts: [
         { userId: 'o1', label: 'Owner', isSelf: false, ownerHas2FA: false },
@@ -131,6 +134,7 @@ describe('DelegationBanner', () => {
     ];
     vi.mocked(delegationApi.getContexts).mockResolvedValue({
       capabilities: null,
+      sections: null,
       actingAsUserId: null,
       contexts: state.availableContexts,
     });

--- a/frontend/src/components/layout/DelegationBanner.test.tsx
+++ b/frontend/src/components/layout/DelegationBanner.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@/test/render';
+import { DelegationBanner } from './DelegationBanner';
+
+vi.mock('@/lib/delegation', () => ({
+  delegationApi: {
+    getContexts: vi.fn(),
+    switchContext: vi.fn(),
+  },
+}));
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { delegationApi } from '@/lib/delegation';
+
+const state: {
+  isAuthenticated: boolean;
+  actingAsUserId: string | null;
+  availableContexts: any[];
+  setDelegation: (a: string | null, c: any[]) => void;
+} = {
+  isAuthenticated: true,
+  actingAsUserId: null,
+  availableContexts: [],
+  setDelegation: vi.fn((a, c) => {
+    state.actingAsUserId = a;
+    state.availableContexts = c;
+  }),
+};
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: (selector: any) => selector(state),
+}));
+
+const assignMock = vi.fn();
+
+describe('DelegationBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.isAuthenticated = true;
+    state.actingAsUserId = null;
+    state.availableContexts = [];
+    state.setDelegation = vi.fn((a, c) => {
+      state.actingAsUserId = a;
+      state.availableContexts = c;
+    });
+    Object.defineProperty(window, 'location', {
+      value: { assign: assignMock },
+      writable: true,
+    });
+  });
+
+  it('renders nothing when there are no contexts', async () => {
+    vi.mocked(delegationApi.getContexts).mockResolvedValue({
+      actingAsUserId: null,
+      contexts: [],
+    });
+    await act(async () => {
+      render(<DelegationBanner />);
+    });
+    expect(screen.queryByText(/Viewing:/)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when unauthenticated and does not call the API', async () => {
+    state.isAuthenticated = false;
+    await act(async () => {
+      render(<DelegationBanner />);
+    });
+    expect(delegationApi.getContexts).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Viewing:/)).not.toBeInTheDocument();
+  });
+
+  it('shows the switcher and switches context on selection', async () => {
+    state.availableContexts = [
+      { userId: 'u1', label: 'Me', isSelf: true, ownerHas2FA: false },
+      { userId: 'o1', label: 'Owner One', isSelf: false, ownerHas2FA: false },
+    ];
+    vi.mocked(delegationApi.getContexts).mockResolvedValue({
+      actingAsUserId: null,
+      contexts: state.availableContexts,
+    });
+    vi.mocked(delegationApi.switchContext).mockResolvedValue({
+      actingAsUserId: 'o1',
+    });
+
+    await act(async () => {
+      render(<DelegationBanner />);
+    });
+    expect(await screen.findByText(/Viewing:/)).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Switch account'), {
+        target: { value: 'o1' },
+      });
+    });
+
+    await waitFor(() =>
+      expect(delegationApi.switchContext).toHaveBeenCalledWith('o1'),
+    );
+    expect(assignMock).toHaveBeenCalledWith('/dashboard');
+  });
+
+  it('auto-picks the only owner context for a pure delegate', async () => {
+    vi.mocked(delegationApi.getContexts).mockResolvedValue({
+      actingAsUserId: null,
+      contexts: [
+        { userId: 'o1', label: 'Owner', isSelf: false, ownerHas2FA: false },
+      ],
+    });
+    vi.mocked(delegationApi.switchContext).mockResolvedValue({
+      actingAsUserId: 'o1',
+    });
+
+    await act(async () => {
+      render(<DelegationBanner />);
+    });
+
+    await waitFor(() =>
+      expect(delegationApi.switchContext).toHaveBeenCalledWith('o1'),
+    );
+  });
+
+  it('surfaces a 2FA-required error without switching', async () => {
+    state.availableContexts = [
+      { userId: 'u1', label: 'Me', isSelf: true, ownerHas2FA: false },
+      { userId: 'o1', label: 'Owner', isSelf: false, ownerHas2FA: true },
+    ];
+    vi.mocked(delegationApi.getContexts).mockResolvedValue({
+      actingAsUserId: null,
+      contexts: state.availableContexts,
+    });
+    vi.mocked(delegationApi.switchContext).mockRejectedValue({
+      response: { data: { message: 'DELEGATE_2FA_REQUIRED' } },
+    });
+    const toast = (await import('react-hot-toast')).default;
+
+    await act(async () => {
+      render(<DelegationBanner />);
+    });
+    await screen.findByText(/Viewing:/);
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Switch account'), {
+        target: { value: 'o1' },
+      });
+    });
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/layout/DelegationBanner.test.tsx
+++ b/frontend/src/components/layout/DelegationBanner.test.tsx
@@ -64,6 +64,22 @@ describe('DelegationBanner', () => {
     expect(screen.queryByText(/Viewing:/)).not.toBeInTheDocument();
   });
 
+  it('renders nothing for a delegate with a single context', async () => {
+    state.availableContexts = [
+      { userId: 'o1', label: 'Owner', isSelf: false, ownerHas2FA: false },
+    ];
+    vi.mocked(delegationApi.getContexts).mockResolvedValue({
+      capabilities: null,
+      sections: null,
+      actingAsUserId: 'o1',
+      contexts: state.availableContexts,
+    });
+    await act(async () => {
+      render(<DelegationBanner />);
+    });
+    expect(screen.queryByText(/Viewing:/)).not.toBeInTheDocument();
+  });
+
   it('renders nothing when unauthenticated and does not call the API', async () => {
     state.isAuthenticated = false;
     await act(async () => {

--- a/frontend/src/components/layout/DelegationBanner.tsx
+++ b/frontend/src/components/layout/DelegationBanner.tsx
@@ -50,7 +50,7 @@ export function DelegationBanner() {
       .getContexts()
       .then((res) => {
         if (cancelled) return;
-        setDelegation(res.actingAsUserId, res.contexts);
+        setDelegation(res.actingAsUserId, res.contexts, res.capabilities);
         // Smart auto-pick: a pure delegate with exactly one owner context
         // and not yet acting is dropped straight into that account.
         if (

--- a/frontend/src/components/layout/DelegationBanner.tsx
+++ b/frontend/src/components/layout/DelegationBanner.tsx
@@ -93,9 +93,34 @@ export function DelegationBanner() {
       : 'Your account';
 
   return (
-    <div className="bg-amber-100 dark:bg-amber-900/40 border-b border-amber-300 dark:border-amber-700 px-4 sm:px-6 lg:px-12 py-2 flex items-center gap-3 text-sm">
-      <span className="font-medium text-amber-900 dark:text-amber-100 truncate min-w-0">
-        Viewing: {currentLabel}
+    <div
+      aria-busy={switching}
+      className="bg-amber-50 dark:bg-amber-900/30 border-b border-amber-200 dark:border-amber-800 shadow-sm px-4 sm:px-6 lg:px-12 py-2.5 flex items-center gap-3 text-sm"
+    >
+      <svg
+        aria-hidden="true"
+        className="w-4 h-4 flex-shrink-0 text-amber-600 dark:text-amber-300"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+        />
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+        />
+      </svg>
+      <span className="text-amber-700 dark:text-amber-300/90 truncate min-w-0 flex items-center gap-2">
+        Viewing:
+        <span className="inline-flex items-center max-w-[40vw] sm:max-w-xs truncate rounded-full bg-amber-200/70 dark:bg-amber-800/50 text-amber-900 dark:text-amber-100 font-medium px-2.5 py-0.5">
+          {currentLabel}
+        </span>
       </span>
       <label className="sr-only" htmlFor="delegation-context-select">
         Switch account
@@ -107,7 +132,7 @@ export function DelegationBanner() {
         onChange={(e) => {
           if (e.target.value) void switchTo(e.target.value);
         }}
-        className="flex-shrink-0 rounded border border-amber-400 dark:border-amber-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-2 py-1"
+        className="ml-auto flex-shrink-0 rounded-md border border-amber-300 dark:border-amber-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm px-2.5 py-1.5 shadow-sm focus:border-sky-500 focus:ring-1 focus:ring-sky-500 disabled:cursor-not-allowed disabled:opacity-60"
       >
         {availableContexts.map((c) => (
           <option key={c.userId} value={c.userId}>

--- a/frontend/src/components/layout/DelegationBanner.tsx
+++ b/frontend/src/components/layout/DelegationBanner.tsx
@@ -50,7 +50,12 @@ export function DelegationBanner() {
       .getContexts()
       .then((res) => {
         if (cancelled) return;
-        setDelegation(res.actingAsUserId, res.contexts, res.capabilities);
+        setDelegation(
+          res.actingAsUserId,
+          res.contexts,
+          res.capabilities,
+          res.sections,
+        );
         // Smart auto-pick: a pure delegate with exactly one owner context
         // and not yet acting is dropped straight into that account.
         if (

--- a/frontend/src/components/layout/DelegationBanner.tsx
+++ b/frontend/src/components/layout/DelegationBanner.tsx
@@ -77,7 +77,9 @@ export function DelegationBanner() {
     };
   }, [isAuthenticated, setDelegation, switchTo]);
 
-  if (!isAuthenticated || availableContexts.length === 0) return null;
+  // Nothing to switch between when there is at most one context (a pure
+  // delegate with a single owner, or a normal user) -- hide the banner.
+  if (!isAuthenticated || availableContexts.length < 2) return null;
 
   const current =
     availableContexts.find((c) =>
@@ -91,8 +93,8 @@ export function DelegationBanner() {
       : 'Your account';
 
   return (
-    <div className="bg-amber-100 dark:bg-amber-900/40 border-b border-amber-300 dark:border-amber-700 px-4 sm:px-6 lg:px-12 py-2 flex flex-wrap items-center gap-3 text-sm">
-      <span className="font-medium text-amber-900 dark:text-amber-100">
+    <div className="bg-amber-100 dark:bg-amber-900/40 border-b border-amber-300 dark:border-amber-700 px-4 sm:px-6 lg:px-12 py-2 flex items-center gap-3 text-sm">
+      <span className="font-medium text-amber-900 dark:text-amber-100 truncate min-w-0">
         Viewing: {currentLabel}
       </span>
       <label className="sr-only" htmlFor="delegation-context-select">
@@ -105,7 +107,7 @@ export function DelegationBanner() {
         onChange={(e) => {
           if (e.target.value) void switchTo(e.target.value);
         }}
-        className="rounded border border-amber-400 dark:border-amber-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-2 py-1"
+        className="flex-shrink-0 rounded border border-amber-400 dark:border-amber-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-2 py-1"
       >
         {availableContexts.map((c) => (
           <option key={c.userId} value={c.userId}>

--- a/frontend/src/components/layout/DelegationBanner.tsx
+++ b/frontend/src/components/layout/DelegationBanner.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useAuthStore } from '@/store/authStore';
+import { delegationApi } from '@/lib/delegation';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('DelegationBanner');
+
+/**
+ * Always-visible "Viewing: X" indicator + context switcher for delegates
+ * (Phase 1, req 1G/1H). Renders nothing for normal users with no delegations.
+ */
+export function DelegationBanner() {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const actingAsUserId = useAuthStore((s) => s.actingAsUserId);
+  const availableContexts = useAuthStore((s) => s.availableContexts);
+  const setDelegation = useAuthStore((s) => s.setDelegation);
+  const [switching, setSwitching] = useState(false);
+  const autoPicked = useRef(false);
+
+  const switchTo = useCallback(async (targetUserId: string) => {
+    setSwitching(true);
+    try {
+      await delegationApi.switchContext(targetUserId);
+      // Full reload so every view re-fetches under the new context.
+      window.location.assign('/dashboard');
+    } catch (err: unknown) {
+      setSwitching(false);
+      const status =
+        typeof err === 'object' && err && 'response' in err
+          ? (err as { response?: { status?: number; data?: { message?: string } } }).response
+          : undefined;
+      if (status?.data?.message === 'DELEGATE_2FA_REQUIRED') {
+        toast.error(
+          'That account requires two-factor authentication. Set up 2FA in Settings before switching.',
+        );
+      } else {
+        toast.error('Unable to switch account');
+      }
+      logger.error(err);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    let cancelled = false;
+    delegationApi
+      .getContexts()
+      .then((res) => {
+        if (cancelled) return;
+        setDelegation(res.actingAsUserId, res.contexts);
+        // Smart auto-pick: a pure delegate with exactly one owner context
+        // and not yet acting is dropped straight into that account.
+        if (
+          !autoPicked.current &&
+          res.actingAsUserId === null &&
+          res.contexts.length === 1 &&
+          !res.contexts[0].isSelf
+        ) {
+          autoPicked.current = true;
+          void switchTo(res.contexts[0].userId);
+        }
+      })
+      .catch((err) => {
+        // Non-delegate users get an empty list / harmless failure.
+        logger.error(err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, setDelegation, switchTo]);
+
+  if (!isAuthenticated || availableContexts.length === 0) return null;
+
+  const current =
+    availableContexts.find((c) =>
+      actingAsUserId === null ? c.isSelf : c.userId === actingAsUserId,
+    ) ?? null;
+  const currentLabel = current
+    ? current.label
+    : actingAsUserId
+      ? availableContexts.find((c) => c.userId === actingAsUserId)?.label ??
+        'Shared account'
+      : 'Your account';
+
+  return (
+    <div className="bg-amber-100 dark:bg-amber-900/40 border-b border-amber-300 dark:border-amber-700 px-4 sm:px-6 lg:px-12 py-2 flex flex-wrap items-center gap-3 text-sm">
+      <span className="font-medium text-amber-900 dark:text-amber-100">
+        Viewing: {currentLabel}
+      </span>
+      <label className="sr-only" htmlFor="delegation-context-select">
+        Switch account
+      </label>
+      <select
+        id="delegation-context-select"
+        disabled={switching}
+        value={actingAsUserId ?? current?.userId ?? ''}
+        onChange={(e) => {
+          if (e.target.value) void switchTo(e.target.value);
+        }}
+        className="rounded border border-amber-400 dark:border-amber-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-2 py-1"
+      >
+        {availableContexts.map((c) => (
+          <option key={c.userId} value={c.userId}>
+            {c.isSelf ? `${c.label} (you)` : c.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/SwipeShell.tsx
+++ b/frontend/src/components/layout/SwipeShell.tsx
@@ -3,6 +3,7 @@
 import { ReactNode } from 'react';
 import { usePathname } from 'next/navigation';
 import { AppHeader } from './AppHeader';
+import { DelegationBanner } from './DelegationBanner';
 import { BackendDownBanner } from './BackendDownBanner';
 import { DemoModeBanner } from './DemoModeBanner';
 import { HttpWarningBanner } from './HttpWarningBanner';
@@ -36,6 +37,7 @@ export function SwipeShell({ children, httpsHeadersActive = false }: SwipeShellP
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 overflow-x-clip">
       <AppHeader />
+      <DelegationBanner />
       <HttpWarningBanner httpsHeadersActive={httpsHeadersActive} />
       <BackendDownBanner httpsHeadersActive={httpsHeadersActive} />
       <DemoModeBanner />

--- a/frontend/src/components/settings/DangerZoneSection.tsx
+++ b/frontend/src/components/settings/DangerZoneSection.tsx
@@ -265,8 +265,13 @@ export function DangerZoneSection({ user }: DangerZoneSectionProps) {
       {/* Delete Account Section */}
       <div>
         <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-1">Delete Account</h3>
-        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">
           Permanently delete your account and all associated data. This cannot be undone.
+        </p>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+          If you have been granted delegate access to someone else&apos;s
+          accounts, that access and your login are kept: only your own data
+          is removed and your account becomes a delegate-only account.
         </p>
 
         {!showDeleteConfirm ? (

--- a/frontend/src/components/settings/DelegateAccessModal.test.tsx
+++ b/frontend/src/components/settings/DelegateAccessModal.test.tsx
@@ -28,6 +28,7 @@ const baseDelegate: DelegateSummary = {
     firstName: null,
     lastName: null,
     hasPassword: true,
+    canResetPassword: true,
   },
   grants: [],
   capabilities: {

--- a/frontend/src/components/settings/DelegateAccessModal.test.tsx
+++ b/frontend/src/components/settings/DelegateAccessModal.test.tsx
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@/test/render';
+import { DelegateAccessModal } from './DelegateAccessModal';
+import type { DelegateSummary } from '@/lib/delegation';
+import type { Account } from '@/types/account';
+
+vi.mock('@/lib/delegation', () => ({
+  delegationApi: {
+    setGrants: vi.fn(),
+    setCapabilities: vi.fn(),
+    setSectionGrants: vi.fn(),
+  },
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { delegationApi } from '@/lib/delegation';
+
+const baseDelegate: DelegateSummary = {
+  id: 'g1',
+  status: 'active',
+  createdAt: '2026-01-01',
+  delegate: {
+    id: 'd1',
+    email: 'd@e.f',
+    firstName: null,
+    lastName: null,
+    hasPassword: true,
+  },
+  grants: [],
+  capabilities: {
+    payees: { create: false, edit: false, delete: false },
+    categories: { create: false, edit: false, delete: false },
+    tags: { create: false, edit: false, delete: false },
+  },
+};
+
+const accounts = [
+  { id: 'a1', name: 'Chequing', accountType: 'CHEQUING' },
+] as unknown as Account[];
+
+function renderModal(delegate: DelegateSummary = baseDelegate) {
+  const submitRef = { current: null as (() => void) | null };
+  const setFormDirty = vi.fn();
+  const onSaved = vi.fn();
+  const onCancel = vi.fn();
+  render(
+    <DelegateAccessModal
+      delegate={delegate}
+      accounts={accounts}
+      onCancel={onCancel}
+      onSaved={onSaved}
+      setFormDirty={setFormDirty}
+      submitRef={submitRef}
+    />,
+  );
+  return { submitRef, setFormDirty, onSaved, onCancel };
+}
+
+describe('DelegateAccessModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(delegationApi.setGrants).mockResolvedValue();
+    vi.mocked(delegationApi.setCapabilities).mockResolvedValue();
+    vi.mocked(delegationApi.setSectionGrants).mockResolvedValue();
+  });
+
+  it('lists grantable accounts grouped by type', () => {
+    renderModal();
+    expect(screen.getAllByText('Chequing').length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole('switch', { name: /Read access to Chequing/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('Save is disabled until something changes', () => {
+    const { setFormDirty } = renderModal();
+    expect(screen.getByText('Save')).toBeDisabled();
+    expect(setFormDirty).toHaveBeenLastCalledWith(false);
+  });
+
+  it('batches a per-account READ grant on Save', async () => {
+    renderModal();
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('switch', { name: /Read access to Chequing/i }),
+      );
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+    });
+
+    await waitFor(() =>
+      expect(delegationApi.setGrants).toHaveBeenCalledWith('g1', [
+        {
+          accountId: 'a1',
+          canRead: true,
+          canCreate: false,
+          canEdit: false,
+          canDelete: false,
+        },
+      ]),
+    );
+    expect(delegationApi.setCapabilities).not.toHaveBeenCalled();
+    expect(delegationApi.setSectionGrants).not.toHaveBeenCalled();
+  });
+
+  it('enabling CREATE implies READ', async () => {
+    renderModal({
+      ...baseDelegate,
+      grants: [{ accountId: 'a1', canRead: true }],
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('switch', { name: /Create access to Chequing/i }),
+      );
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+    });
+
+    await waitFor(() =>
+      expect(delegationApi.setGrants).toHaveBeenCalledWith('g1', [
+        expect.objectContaining({
+          accountId: 'a1',
+          canRead: true,
+          canCreate: true,
+        }),
+      ]),
+    );
+  });
+
+  it('batches a granular capability change (Edit Payees)', async () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Shared data' }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('switch', { name: /^Edit Payees$/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+    });
+
+    await waitFor(() =>
+      expect(delegationApi.setCapabilities).toHaveBeenCalledWith('g1', {
+        payeesCanEdit: true,
+      }),
+    );
+    expect(delegationApi.setGrants).not.toHaveBeenCalled();
+  });
+
+  it('batches Delete Tags independently', async () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Shared data' }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('switch', { name: /^Delete Tags$/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+    });
+
+    await waitFor(() =>
+      expect(delegationApi.setCapabilities).toHaveBeenCalledWith('g1', {
+        tagsCanDelete: true,
+      }),
+    );
+  });
+
+  it('batches a section grant on Save', async () => {
+    const { onSaved } = renderModal();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Sections' }));
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('switch', { name: /Bills & Deposits section/i }),
+      );
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+    });
+
+    await waitFor(() =>
+      expect(delegationApi.setSectionGrants).toHaveBeenCalledWith('g1', {
+        billsCanRead: true,
+      }),
+    );
+    expect(onSaved).toHaveBeenCalled();
+  });
+
+  it('marks the form dirty when a toggle changes', async () => {
+    const { setFormDirty } = renderModal();
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('switch', { name: /Read access to Chequing/i }),
+      );
+    });
+    expect(setFormDirty).toHaveBeenLastCalledWith(true);
+  });
+});

--- a/frontend/src/components/settings/DelegateAccessModal.tsx
+++ b/frontend/src/components/settings/DelegateAccessModal.tsx
@@ -478,9 +478,9 @@ export function DelegateAccessModal({
             {CAP_RESOURCES.map((res) => (
               <div
                 key={res.key}
-                className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-700 dark:text-gray-300 border-b border-gray-100 dark:border-gray-700/50 pb-2"
+                className="flex items-center gap-x-3 text-sm text-gray-700 dark:text-gray-300 border-b border-gray-100 dark:border-gray-700/50 pb-2"
               >
-                <span className="w-40 truncate font-medium">
+                <span className="w-24 shrink-0 truncate font-medium">
                   {res.label}
                 </span>
                 {CAP_OPS.map((o) => (

--- a/frontend/src/components/settings/DelegateAccessModal.tsx
+++ b/frontend/src/components/settings/DelegateAccessModal.tsx
@@ -175,6 +175,9 @@ export function DelegateAccessModal({
       list.push(a);
       groups.set(a.accountType, list);
     }
+    for (const list of groups.values()) {
+      list.sort((a, b) => a.name.localeCompare(b.name));
+    }
     return Array.from(groups.entries()).sort((x, y) =>
       formatAccountType(x[0]).localeCompare(formatAccountType(y[0])),
     );

--- a/frontend/src/components/settings/DelegateAccessModal.tsx
+++ b/frontend/src/components/settings/DelegateAccessModal.tsx
@@ -348,7 +348,7 @@ export function DelegateAccessModal({
         ))}
       </div>
 
-      <div className="overflow-y-auto px-6 py-4 flex-1">
+      <div className="overflow-y-auto px-6 py-4 h-[60vh]">
         {tab === 'sections' && (
           <div className="space-y-3">
             <p className="text-xs text-gray-500 dark:text-gray-400">

--- a/frontend/src/components/settings/DelegateAccessModal.tsx
+++ b/frontend/src/components/settings/DelegateAccessModal.tsx
@@ -317,7 +317,7 @@ export function DelegateAccessModal({
 
   return (
     <div className="flex flex-col max-h-[90vh]">
-      <div className="border-b border-gray-200 dark:border-gray-700 px-6 py-4">
+      <div className="border-b border-gray-200 dark:border-gray-700 px-4 py-3">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
           Edit access
         </h2>
@@ -328,7 +328,7 @@ export function DelegateAccessModal({
 
       <div
         role="tablist"
-        className="flex gap-1 border-b border-gray-200 dark:border-gray-700 px-4"
+        className="flex gap-1 border-b border-gray-200 dark:border-gray-700 px-2"
       >
         {tabs.map((t) => (
           <button
@@ -348,7 +348,7 @@ export function DelegateAccessModal({
         ))}
       </div>
 
-      <div className="overflow-y-auto px-6 py-4 h-[60vh]">
+      <div className="overflow-y-auto px-4 py-3 h-[65vh]">
         {tab === 'sections' && (
           <div className="space-y-3">
             <p className="text-xs text-gray-500 dark:text-gray-400">
@@ -500,7 +500,7 @@ export function DelegateAccessModal({
         )}
       </div>
 
-      <div className="border-t border-gray-200 dark:border-gray-700 px-6 py-4 flex justify-end gap-3">
+      <div className="border-t border-gray-200 dark:border-gray-700 px-4 py-3 flex justify-end gap-3">
         <Button variant="outline" onClick={onCancel} disabled={saving}>
           Cancel
         </Button>

--- a/frontend/src/components/settings/DelegateAccessModal.tsx
+++ b/frontend/src/components/settings/DelegateAccessModal.tsx
@@ -1,0 +1,517 @@
+'use client';
+
+import { MutableRefObject, useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
+import {
+  delegationApi,
+  DelegateSummary,
+  AccountGrant,
+  DelegateCapabilities,
+  DelegateSectionFlags,
+} from '@/lib/delegation';
+import { Account, AccountType } from '@/types/account';
+import { formatAccountType } from '@/lib/account-utils';
+import { createLogger } from '@/lib/logger';
+import { getErrorMessage } from '@/lib/errors';
+import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
+import { Button } from '@/components/ui/Button';
+
+const logger = createLogger('DelegateAccessModal');
+
+type GrantOp = 'canRead' | 'canCreate' | 'canEdit' | 'canDelete';
+type CapOp = 'create' | 'edit' | 'delete';
+type CapResource = 'payees' | 'categories' | 'tags';
+type SectionKey = 'bills' | 'investments' | 'budgets' | 'reports' | 'ai';
+type Tab = 'sections' | 'accounts' | 'shared';
+
+interface DraftGrant {
+  canRead: boolean;
+  canCreate: boolean;
+  canEdit: boolean;
+  canDelete: boolean;
+}
+
+interface Draft {
+  grants: Record<string, DraftGrant>;
+  capabilities: Record<CapResource, Record<CapOp, boolean>>;
+  sections: Record<SectionKey, boolean>;
+}
+
+const GRANT_OPS: { key: GrantOp; label: string }[] = [
+  { key: 'canRead', label: 'Read' },
+  { key: 'canCreate', label: 'Create' },
+  { key: 'canEdit', label: 'Edit' },
+  { key: 'canDelete', label: 'Delete' },
+];
+
+const CAP_RESOURCES: { key: CapResource; label: string }[] = [
+  { key: 'payees', label: 'Payees' },
+  { key: 'categories', label: 'Categories' },
+  { key: 'tags', label: 'Tags' },
+];
+
+const CAP_OPS: { op: CapOp; label: string }[] = [
+  { op: 'create', label: 'Create' },
+  { op: 'edit', label: 'Edit' },
+  { op: 'delete', label: 'Delete' },
+];
+
+const SECTIONS: { key: SectionKey; label: string; description: string }[] = [
+  {
+    key: 'bills',
+    label: 'Bills & Deposits',
+    description: 'Scheduled transactions for granted accounts',
+  },
+  {
+    key: 'investments',
+    label: 'Investments',
+    description: 'Holdings and investment transactions for granted accounts',
+  },
+  { key: 'budgets', label: 'Budgets', description: 'Read-only budget figures' },
+  { key: 'reports', label: 'Reports', description: 'Read-only reports' },
+  {
+    key: 'ai',
+    label: 'AI Assistant',
+    description: "Uses the owner's configured AI provider",
+  },
+];
+
+const SECTION_FIELD: Record<SectionKey, keyof DelegateSectionFlags> = {
+  bills: 'billsCanRead',
+  investments: 'investmentsCanRead',
+  budgets: 'budgetsCanRead',
+  reports: 'reportsCanRead',
+  ai: 'aiCanRead',
+};
+
+function emptyGrant(): DraftGrant {
+  return { canRead: false, canCreate: false, canEdit: false, canDelete: false };
+}
+
+function buildInitialDraft(delegate: DelegateSummary): Draft {
+  const grants: Record<string, DraftGrant> = {};
+  for (const g of delegate.grants) {
+    grants[g.accountId] = {
+      canRead: !!g.canRead,
+      canCreate: !!g.canCreate,
+      canEdit: !!g.canEdit,
+      canDelete: !!g.canDelete,
+    };
+  }
+  const caps = delegate.capabilities;
+  return {
+    grants,
+    capabilities: {
+      payees: { ...caps.payees },
+      categories: { ...caps.categories },
+      tags: { ...caps.tags },
+    },
+    sections: {
+      bills: !!delegate.sections?.bills,
+      investments: !!delegate.sections?.investments,
+      budgets: !!delegate.sections?.budgets,
+      reports: !!delegate.sections?.reports,
+      ai: !!delegate.sections?.ai,
+    },
+  };
+}
+
+/** Apply READ-prerequisite rules to a single grant change. */
+function applyGrantRule(
+  current: DraftGrant,
+  op: GrantOp,
+  value: boolean,
+): DraftGrant {
+  const next: DraftGrant = { ...current, [op]: value };
+  if (op === 'canRead' && !value) {
+    next.canCreate = false;
+    next.canEdit = false;
+    next.canDelete = false;
+  }
+  if (op !== 'canRead' && value) {
+    next.canRead = true;
+  }
+  return next;
+}
+
+function grantsToArray(
+  accounts: Account[],
+  grants: Record<string, DraftGrant>,
+): AccountGrant[] {
+  return accounts
+    .map((a) => ({ accountId: a.id, ...(grants[a.id] ?? emptyGrant()) }))
+    .filter((g) => g.canRead);
+}
+
+interface DelegateAccessModalProps {
+  delegate: DelegateSummary;
+  accounts: Account[];
+  onCancel: () => void;
+  onSaved: () => void;
+  setFormDirty: (dirty: boolean) => void;
+  submitRef: MutableRefObject<(() => void) | null>;
+}
+
+export function DelegateAccessModal({
+  delegate,
+  accounts,
+  onCancel,
+  onSaved,
+  setFormDirty,
+  submitRef,
+}: DelegateAccessModalProps) {
+  const baseline = useMemo(
+    () => buildInitialDraft(delegate),
+    [delegate],
+  );
+  const [draft, setDraft] = useState<Draft>(baseline);
+  const [tab, setTab] = useState<Tab>('accounts');
+  const [saving, setSaving] = useState(false);
+
+  const groupedAccounts = useMemo(() => {
+    const groups = new Map<AccountType, Account[]>();
+    for (const a of accounts) {
+      const list = groups.get(a.accountType) ?? [];
+      list.push(a);
+      groups.set(a.accountType, list);
+    }
+    return Array.from(groups.entries()).sort((x, y) =>
+      formatAccountType(x[0]).localeCompare(formatAccountType(y[0])),
+    );
+  }, [accounts]);
+
+  const baselineGrantArray = useMemo(
+    () => grantsToArray(accounts, baseline.grants),
+    [accounts, baseline],
+  );
+
+  // Diffs against the baseline drive both the dirty flag and the batched save.
+  const grantChanged =
+    JSON.stringify(grantsToArray(accounts, draft.grants)) !==
+    JSON.stringify(baselineGrantArray);
+
+  const capabilityPatch: DelegateCapabilities = {};
+  for (const { key: resource } of CAP_RESOURCES) {
+    for (const { op } of CAP_OPS) {
+      if (
+        draft.capabilities[resource][op] !==
+        baseline.capabilities[resource][op]
+      ) {
+        const cap = op.charAt(0).toUpperCase() + op.slice(1);
+        const field =
+          `${resource}Can${cap}` as keyof DelegateCapabilities;
+        capabilityPatch[field] = draft.capabilities[resource][op];
+      }
+    }
+  }
+
+  const sectionPatch: DelegateSectionFlags = {};
+  for (const { key } of SECTIONS) {
+    if (draft.sections[key] !== baseline.sections[key]) {
+      sectionPatch[SECTION_FIELD[key]] = draft.sections[key];
+    }
+  }
+
+  const dirty =
+    grantChanged ||
+    Object.keys(capabilityPatch).length > 0 ||
+    Object.keys(sectionPatch).length > 0;
+  setFormDirty(dirty);
+
+  const setGrant = (accountId: string, op: GrantOp, value: boolean) => {
+    setDraft((prev) => ({
+      ...prev,
+      grants: {
+        ...prev.grants,
+        [accountId]: applyGrantRule(
+          prev.grants[accountId] ?? emptyGrant(),
+          op,
+          value,
+        ),
+      },
+    }));
+  };
+
+  const setColumnForAccounts = (
+    accountIds: string[],
+    op: GrantOp,
+    value: boolean,
+  ) => {
+    setDraft((prev) => {
+      const grants = { ...prev.grants };
+      for (const id of accountIds) {
+        grants[id] = applyGrantRule(grants[id] ?? emptyGrant(), op, value);
+      }
+      return { ...prev, grants };
+    });
+  };
+
+  const setCapability = (
+    resource: CapResource,
+    op: CapOp,
+    value: boolean,
+  ) => {
+    setDraft((prev) => ({
+      ...prev,
+      capabilities: {
+        ...prev.capabilities,
+        [resource]: { ...prev.capabilities[resource], [op]: value },
+      },
+    }));
+  };
+
+  const setSection = (key: SectionKey, value: boolean) => {
+    setDraft((prev) => ({
+      ...prev,
+      sections: { ...prev.sections, [key]: value },
+    }));
+  };
+
+  const handleSave = async () => {
+    if (!dirty) {
+      onSaved();
+      return;
+    }
+    setSaving(true);
+    try {
+      const calls: Promise<void>[] = [];
+      if (grantChanged) {
+        calls.push(
+          delegationApi.setGrants(
+            delegate.id,
+            grantsToArray(accounts, draft.grants),
+          ),
+        );
+      }
+      if (Object.keys(capabilityPatch).length > 0) {
+        calls.push(
+          delegationApi.setCapabilities(delegate.id, capabilityPatch),
+        );
+      }
+      if (Object.keys(sectionPatch).length > 0) {
+        calls.push(
+          delegationApi.setSectionGrants(delegate.id, sectionPatch),
+        );
+      }
+      await Promise.all(calls);
+      toast.success('Access updated');
+      setFormDirty(false);
+      onSaved();
+    } catch (err) {
+      toast.error(getErrorMessage(err, 'Failed to update access'));
+      logger.error(err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  submitRef.current = () => {
+    void handleSave();
+  };
+
+  const tabs: { key: Tab; label: string }[] = [
+    { key: 'accounts', label: 'Accounts' },
+    { key: 'sections', label: 'Sections' },
+    { key: 'shared', label: 'Shared data' },
+  ];
+
+  return (
+    <div className="flex flex-col max-h-[90vh]">
+      <div className="border-b border-gray-200 dark:border-gray-700 px-6 py-4">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          Edit access
+        </h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {delegate.delegate.email}
+        </p>
+      </div>
+
+      <div
+        role="tablist"
+        className="flex gap-1 border-b border-gray-200 dark:border-gray-700 px-4"
+      >
+        {tabs.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            role="tab"
+            aria-selected={tab === t.key}
+            onClick={() => setTab(t.key)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px ${
+              tab === t.key
+                ? 'border-blue-600 text-blue-600 dark:text-blue-400'
+                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="overflow-y-auto px-6 py-4 flex-1">
+        {tab === 'sections' && (
+          <div className="space-y-3">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Grant read-only access to whole app sections. Account-scoped
+              data still also needs per-account access.
+            </p>
+            {SECTIONS.map((s) => (
+              <div
+                key={s.key}
+                className="flex items-center justify-between gap-4 border-b border-gray-100 dark:border-gray-700/50 pb-2"
+              >
+                <div>
+                  <p className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                    {s.label}
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    {s.description}
+                  </p>
+                </div>
+                <ToggleSwitch
+                  checked={draft.sections[s.key]}
+                  onChange={(v) => setSection(s.key, v)}
+                  label={`${s.label} section`}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {tab === 'accounts' && (
+          <div className="space-y-3">
+            {accounts.length === 0 ? (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                No accounts to grant.
+              </p>
+            ) : (
+              groupedAccounts.map(([type, list]) => {
+                const typeLabel = formatAccountType(type);
+                const ids = list.map((a) => a.id);
+                return (
+                  <details
+                    key={type}
+                    open
+                    className="border border-gray-200 dark:border-gray-700 rounded-lg"
+                  >
+                    <summary className="cursor-pointer select-none px-3 py-2 text-sm font-medium text-gray-800 dark:text-gray-200">
+                      {typeLabel}{' '}
+                      <span className="text-xs text-gray-400">
+                        ({list.length})
+                      </span>
+                    </summary>
+                    <div className="px-3 pb-3">
+                      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 border-b border-gray-100 dark:border-gray-700/50 pb-2 mb-2">
+                        <span className="w-40 text-xs uppercase tracking-wide text-gray-400">
+                          Grant all
+                        </span>
+                        {GRANT_OPS.map((o) => (
+                          <label
+                            key={o.key}
+                            className="flex items-center gap-1.5"
+                          >
+                            <ToggleSwitch
+                              size="sm"
+                              checked={list.every(
+                                (a) =>
+                                  !!(draft.grants[a.id] ?? emptyGrant())[
+                                    o.key
+                                  ],
+                              )}
+                              onChange={(v) =>
+                                setColumnForAccounts(ids, o.key, v)
+                              }
+                              label={`${o.label} all ${typeLabel} accounts`}
+                            />
+                            <span className="text-xs">{o.label}</span>
+                          </label>
+                        ))}
+                      </div>
+                      <div className="space-y-2">
+                        {list.map((a) => {
+                          const g = draft.grants[a.id] ?? emptyGrant();
+                          return (
+                            <div
+                              key={a.id}
+                              className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-700 dark:text-gray-300"
+                            >
+                              <span className="w-40 truncate font-medium">
+                                {a.name}
+                              </span>
+                              {GRANT_OPS.map((o) => (
+                                <label
+                                  key={o.key}
+                                  className="flex items-center gap-1.5"
+                                >
+                                  <ToggleSwitch
+                                    size="sm"
+                                    checked={!!g[o.key]}
+                                    disabled={
+                                      o.key !== 'canRead' && !g.canRead
+                                    }
+                                    onChange={(v) =>
+                                      setGrant(a.id, o.key, v)
+                                    }
+                                    label={`${o.label} access to ${a.name}`}
+                                  />
+                                  <span className="text-xs">{o.label}</span>
+                                </label>
+                              ))}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  </details>
+                );
+              })
+            )}
+          </div>
+        )}
+
+        {tab === 'shared' && (
+          <div className="space-y-2">
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+              READ of payees, categories and tags is always allowed. These
+              control create/edit/delete.
+            </p>
+            {CAP_RESOURCES.map((res) => (
+              <div
+                key={res.key}
+                className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-700 dark:text-gray-300 border-b border-gray-100 dark:border-gray-700/50 pb-2"
+              >
+                <span className="w-40 truncate font-medium">
+                  {res.label}
+                </span>
+                {CAP_OPS.map((o) => (
+                  <label key={o.op} className="flex items-center gap-1.5">
+                    <ToggleSwitch
+                      size="sm"
+                      checked={draft.capabilities[res.key][o.op]}
+                      onChange={(v) => setCapability(res.key, o.op, v)}
+                      label={`${o.label} ${res.label}`}
+                    />
+                    <span className="text-xs">{o.label}</span>
+                  </label>
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="border-t border-gray-200 dark:border-gray-700 px-6 py-4 flex justify-end gap-3">
+        <Button variant="outline" onClick={onCancel} disabled={saving}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() => void handleSave()}
+          isLoading={saving}
+          disabled={!dirty}
+        >
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/SharedAccessSection.test.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.test.tsx
@@ -222,6 +222,12 @@ describe('SharedAccessSection', () => {
     expect(
       screen.queryByPlaceholderText('Set a password'),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText('First name (optional)'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText('Last name (optional)'),
+    ).not.toBeInTheDocument();
 
     await act(async () => {
       submitCreate();

--- a/frontend/src/components/settings/SharedAccessSection.test.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.test.tsx
@@ -43,7 +43,11 @@ const delegate = {
     canEdit?: boolean;
     canDelete?: boolean;
   }>,
-  capabilities: { payees: false, categories: false, tags: false },
+  capabilities: {
+    payees: { create: false, edit: false, delete: false },
+    categories: { create: false, edit: false, delete: false },
+    tags: { create: false, edit: false, delete: false },
+  },
 };
 
 async function renderSection() {
@@ -163,19 +167,35 @@ describe('SharedAccessSection', () => {
     ]);
   });
 
-  it('toggles a manage capability', async () => {
+  it('toggles a granular manage capability (Edit Payees)', async () => {
     vi.mocked(delegationApi.setCapabilities).mockResolvedValue();
     await renderSection();
     await screen.findByText('d@e.f');
 
     await act(async () => {
       fireEvent.click(
-        screen.getByRole('switch', { name: /Manage Payees/i }),
+        screen.getByRole('switch', { name: /^Edit Payees$/i }),
       );
     });
 
     expect(delegationApi.setCapabilities).toHaveBeenCalledWith('g1', {
-      canManagePayees: true,
+      payeesCanEdit: true,
+    });
+  });
+
+  it('toggles Delete Tags independently', async () => {
+    vi.mocked(delegationApi.setCapabilities).mockResolvedValue();
+    await renderSection();
+    await screen.findByText('d@e.f');
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('switch', { name: /^Delete Tags$/i }),
+      );
+    });
+
+    expect(delegationApi.setCapabilities).toHaveBeenCalledWith('g1', {
+      tagsCanDelete: true,
     });
   });
 });

--- a/frontend/src/components/settings/SharedAccessSection.test.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@/test/render';
+import { SharedAccessSection } from './SharedAccessSection';
+
+vi.mock('@/lib/delegation', () => ({
+  delegationApi: {
+    listDelegates: vi.fn(),
+    createDelegate: vi.fn(),
+    setGrants: vi.fn(),
+    revokeDelegate: vi.fn(),
+    resetPassword: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/accounts', () => ({
+  accountsApi: { getAll: vi.fn() },
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { delegationApi } from '@/lib/delegation';
+import { accountsApi } from '@/lib/accounts';
+import toast from 'react-hot-toast';
+
+const delegate = {
+  id: 'g1',
+  status: 'active',
+  createdAt: '2026-01-01',
+  delegate: {
+    id: 'd1',
+    email: 'd@e.f',
+    firstName: null,
+    lastName: null,
+    hasPassword: true,
+  },
+  accountIds: [] as string[],
+};
+
+async function renderSection() {
+  await act(async () => {
+    render(<SharedAccessSection />);
+  });
+}
+
+describe('SharedAccessSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(delegationApi.listDelegates).mockResolvedValue([{ ...delegate }]);
+    vi.mocked(accountsApi.getAll).mockResolvedValue([
+      { id: 'a1', name: 'Chequing' },
+    ] as never);
+  });
+
+  it('lists delegates and their grantable accounts', async () => {
+    await renderSection();
+    expect(await screen.findByText('d@e.f')).toBeInTheDocument();
+    expect(screen.getByText('Chequing')).toBeInTheDocument();
+  });
+
+  it('rejects a password that fails the complexity policy', async () => {
+    await renderSection();
+    await screen.findByText('d@e.f');
+
+    fireEvent.change(screen.getByPlaceholderText('Delegate email'), {
+      target: { value: 'new@x.y' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('Set a password (optional)'),
+      { target: { value: 'weak' } },
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByText('Add delegate'));
+    });
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(delegationApi.createDelegate).not.toHaveBeenCalled();
+  });
+
+  it('creates a delegate with a policy-compliant password', async () => {
+    vi.mocked(delegationApi.createDelegate).mockResolvedValue({
+      id: 'g2',
+      delegateUserId: 'd2',
+      email: 'new@x.y',
+      invited: false,
+    });
+    await renderSection();
+    await screen.findByText('d@e.f');
+
+    fireEvent.change(screen.getByPlaceholderText('Delegate email'), {
+      target: { value: 'new@x.y' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('Set a password (optional)'),
+      { target: { value: 'StrongPass1!xyz' } },
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByText('Add delegate'));
+    });
+
+    await waitFor(() =>
+      expect(delegationApi.createDelegate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'new@x.y',
+          password: 'StrongPass1!xyz',
+          sendInvite: false,
+        }),
+      ),
+    );
+  });
+
+  it('toggles a per-account READ grant', async () => {
+    vi.mocked(delegationApi.setGrants).mockResolvedValue();
+    await renderSection();
+    await screen.findByText('d@e.f');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('switch', { name: /Read access to Chequing/i }));
+    });
+
+    expect(delegationApi.setGrants).toHaveBeenCalledWith('g1', ['a1']);
+  });
+});

--- a/frontend/src/components/settings/SharedAccessSection.test.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.test.tsx
@@ -59,6 +59,17 @@ async function renderSection() {
   });
 }
 
+// The header trigger and the modal submit are both "Add delegate"; the
+// trigger renders first.
+function openCreateModal() {
+  const triggers = screen.getAllByRole('button', { name: 'Add delegate' });
+  fireEvent.click(triggers[0]);
+}
+function submitCreate() {
+  const buttons = screen.getAllByRole('button', { name: 'Add delegate' });
+  fireEvent.click(buttons[buttons.length - 1]);
+}
+
 describe('SharedAccessSection', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -94,9 +105,34 @@ describe('SharedAccessSection', () => {
     ).toBeInTheDocument();
   });
 
+  it('add-delegate is a modal with a last name field', async () => {
+    await renderSection();
+    await screen.findByText('d@e.f');
+
+    expect(
+      screen.queryByPlaceholderText('Delegate email'),
+    ).not.toBeInTheDocument();
+
+    await act(async () => {
+      openCreateModal();
+    });
+
+    expect(
+      await screen.findByPlaceholderText('Delegate email'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Last name (optional)'),
+    ).toBeInTheDocument();
+  });
+
   it('rejects a password that fails the complexity policy', async () => {
     await renderSection();
     await screen.findByText('d@e.f');
+
+    await act(async () => {
+      openCreateModal();
+    });
+    await screen.findByPlaceholderText('Delegate email');
 
     fireEvent.change(screen.getByPlaceholderText('Delegate email'), {
       target: { value: 'new@x.y' },
@@ -106,14 +142,14 @@ describe('SharedAccessSection', () => {
       { target: { value: 'weak' } },
     );
     await act(async () => {
-      fireEvent.click(screen.getByText('Add delegate'));
+      submitCreate();
     });
 
     expect(toast.error).toHaveBeenCalled();
     expect(delegationApi.createDelegate).not.toHaveBeenCalled();
   });
 
-  it('creates a delegate with a policy-compliant password', async () => {
+  it('creates a delegate with a policy-compliant password and last name', async () => {
     vi.mocked(delegationApi.createDelegate).mockResolvedValue({
       id: 'g2',
       delegateUserId: 'd2',
@@ -123,21 +159,30 @@ describe('SharedAccessSection', () => {
     await renderSection();
     await screen.findByText('d@e.f');
 
+    await act(async () => {
+      openCreateModal();
+    });
+    await screen.findByPlaceholderText('Delegate email');
+
     fireEvent.change(screen.getByPlaceholderText('Delegate email'), {
       target: { value: 'new@x.y' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Last name (optional)'), {
+      target: { value: 'Doe' },
     });
     fireEvent.change(
       screen.getByPlaceholderText('Set a password (optional)'),
       { target: { value: 'StrongPass1!xyz' } },
     );
     await act(async () => {
-      fireEvent.click(screen.getByText('Add delegate'));
+      submitCreate();
     });
 
     await waitFor(() =>
       expect(delegationApi.createDelegate).toHaveBeenCalledWith(
         expect.objectContaining({
           email: 'new@x.y',
+          lastName: 'Doe',
           password: 'StrongPass1!xyz',
           sendInvite: false,
         }),
@@ -145,18 +190,48 @@ describe('SharedAccessSection', () => {
     );
   });
 
-  it('revokes a delegate after confirmation', async () => {
+  it('revokes a delegate via the confirm dialog', async () => {
     vi.mocked(delegationApi.revokeDelegate).mockResolvedValue();
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
     await renderSection();
     await screen.findByText('d@e.f');
 
     await act(async () => {
-      fireEvent.click(screen.getByText('Remove'));
+      fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    });
+
+    // The confirm dialog adds a second "Remove" (the confirm action).
+    const removeButtons = await screen.findAllByRole('button', {
+      name: 'Remove',
+    });
+    expect(removeButtons.length).toBeGreaterThan(1);
+    await act(async () => {
+      fireEvent.click(removeButtons[removeButtons.length - 1]);
     });
 
     await waitFor(() =>
       expect(delegationApi.revokeDelegate).toHaveBeenCalledWith('g1'),
     );
+  });
+
+  it('shows the reset temporary password in a modal with a copy option', async () => {
+    vi.mocked(delegationApi.resetPassword).mockResolvedValue({
+      temporaryPassword: 'Tiger!River42',
+    });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    await renderSection();
+    await screen.findByText('d@e.f');
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Reset password'));
+    });
+
+    expect(await screen.findByText('Tiger!River42')).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    });
+    expect(writeText).toHaveBeenCalledWith('Tiger!River42');
+    expect(await screen.findByText('Copied')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/settings/SharedAccessSection.test.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.test.tsx
@@ -38,6 +38,7 @@ const delegate = {
     firstName: null,
     lastName: null,
     hasPassword: true,
+    canResetPassword: true,
   },
   grants: [{ accountId: 'a1', canRead: true }],
   capabilities: {
@@ -287,5 +288,18 @@ describe('SharedAccessSection', () => {
     });
     expect(writeText).toHaveBeenCalledWith('Tiger!River42');
     expect(await screen.findByText('Copied')).toBeInTheDocument();
+  });
+
+  it('disables Reset password when the delegate manages their own', async () => {
+    vi.mocked(delegationApi.listDelegates).mockResolvedValue([
+      { ...delegate, delegate: { ...delegate.delegate, canResetPassword: false } },
+    ]);
+
+    await renderSection();
+    await screen.findByText('d@e.f');
+
+    expect(
+      screen.getByRole('button', { name: 'Reset password' }),
+    ).toBeDisabled();
   });
 });

--- a/frontend/src/components/settings/SharedAccessSection.test.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.test.tsx
@@ -138,7 +138,7 @@ describe('SharedAccessSection', () => {
       target: { value: 'new@x.y' },
     });
     fireEvent.change(
-      screen.getByPlaceholderText('Set a password (optional)'),
+      screen.getByPlaceholderText('Set a password'),
       { target: { value: 'weak' } },
     );
     await act(async () => {
@@ -171,7 +171,7 @@ describe('SharedAccessSection', () => {
       target: { value: 'Doe' },
     });
     fireEvent.change(
-      screen.getByPlaceholderText('Set a password (optional)'),
+      screen.getByPlaceholderText('Set a password'),
       { target: { value: 'StrongPass1!xyz' } },
     );
     await act(async () => {

--- a/frontend/src/components/settings/SharedAccessSection.test.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.test.tsx
@@ -35,7 +35,13 @@ const delegate = {
     lastName: null,
     hasPassword: true,
   },
-  accountIds: [] as string[],
+  grants: [] as Array<{
+    accountId: string;
+    canRead: boolean;
+    canCreate?: boolean;
+    canEdit?: boolean;
+    canDelete?: boolean;
+  }>,
 };
 
 async function renderSection() {
@@ -110,15 +116,48 @@ describe('SharedAccessSection', () => {
     );
   });
 
-  it('toggles a per-account READ grant', async () => {
+  it('grants per-account READ', async () => {
     vi.mocked(delegationApi.setGrants).mockResolvedValue();
     await renderSection();
     await screen.findByText('d@e.f');
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('switch', { name: /Read access to Chequing/i }));
+      fireEvent.click(
+        screen.getByRole('switch', { name: /Read access to Chequing/i }),
+      );
     });
 
-    expect(delegationApi.setGrants).toHaveBeenCalledWith('g1', ['a1']);
+    expect(delegationApi.setGrants).toHaveBeenCalledWith('g1', [
+      {
+        accountId: 'a1',
+        canRead: true,
+        canCreate: false,
+        canEdit: false,
+        canDelete: false,
+      },
+    ]);
+  });
+
+  it('enabling CREATE implies READ', async () => {
+    vi.mocked(delegationApi.listDelegates).mockResolvedValue([
+      { ...delegate, grants: [{ accountId: 'a1', canRead: true }] },
+    ]);
+    vi.mocked(delegationApi.setGrants).mockResolvedValue();
+    await renderSection();
+    await screen.findByText('d@e.f');
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('switch', { name: /Create access to Chequing/i }),
+      );
+    });
+
+    expect(delegationApi.setGrants).toHaveBeenCalledWith('g1', [
+      expect.objectContaining({
+        accountId: 'a1',
+        canRead: true,
+        canCreate: true,
+      }),
+    ]);
   });
 });

--- a/frontend/src/components/settings/SharedAccessSection.test.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act, waitFor } from '@/test/render';
 import { SharedAccessSection } from './SharedAccessSection';
+import { __resetModalStateForTesting } from '@/components/ui/Modal';
 
 vi.mock('@/lib/delegation', () => ({
   delegationApi: {
@@ -8,6 +9,7 @@ vi.mock('@/lib/delegation', () => ({
     createDelegate: vi.fn(),
     setGrants: vi.fn(),
     setCapabilities: vi.fn(),
+    setSectionGrants: vi.fn(),
     revokeDelegate: vi.fn(),
     resetPassword: vi.fn(),
   },
@@ -36,17 +38,18 @@ const delegate = {
     lastName: null,
     hasPassword: true,
   },
-  grants: [] as Array<{
-    accountId: string;
-    canRead: boolean;
-    canCreate?: boolean;
-    canEdit?: boolean;
-    canDelete?: boolean;
-  }>,
+  grants: [{ accountId: 'a1', canRead: true }],
   capabilities: {
-    payees: { create: false, edit: false, delete: false },
+    payees: { create: false, edit: true, delete: false },
     categories: { create: false, edit: false, delete: false },
     tags: { create: false, edit: false, delete: false },
+  },
+  sections: {
+    bills: true,
+    investments: false,
+    budgets: false,
+    reports: false,
+    ai: false,
   },
 };
 
@@ -59,16 +62,36 @@ async function renderSection() {
 describe('SharedAccessSection', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(delegationApi.listDelegates).mockResolvedValue([{ ...delegate }]);
+    __resetModalStateForTesting();
+    vi.mocked(delegationApi.listDelegates).mockResolvedValue([
+      { ...delegate },
+    ]);
     vi.mocked(accountsApi.getAll).mockResolvedValue([
-      { id: 'a1', name: 'Chequing' },
+      { id: 'a1', name: 'Chequing', accountType: 'CHEQUING' },
     ] as never);
   });
 
-  it('lists delegates and their grantable accounts', async () => {
+  it('lists delegates with a summary of granted access', async () => {
     await renderSection();
     expect(await screen.findByText('d@e.f')).toBeInTheDocument();
-    expect(screen.getByText('Chequing')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Sections: 1.*Accounts: 1.*Shared data: 1/),
+    ).toBeInTheDocument();
+  });
+
+  it('opens the edit-access modal for a delegate', async () => {
+    await renderSection();
+    await screen.findByText('d@e.f');
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Edit access'));
+    });
+
+    expect(
+      await screen.findByRole('switch', {
+        name: /Read access to Chequing/i,
+      }),
+    ).toBeInTheDocument();
   });
 
   it('rejects a password that fails the complexity policy', async () => {
@@ -122,80 +145,18 @@ describe('SharedAccessSection', () => {
     );
   });
 
-  it('grants per-account READ', async () => {
-    vi.mocked(delegationApi.setGrants).mockResolvedValue();
+  it('revokes a delegate after confirmation', async () => {
+    vi.mocked(delegationApi.revokeDelegate).mockResolvedValue();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     await renderSection();
     await screen.findByText('d@e.f');
 
     await act(async () => {
-      fireEvent.click(
-        screen.getByRole('switch', { name: /Read access to Chequing/i }),
-      );
+      fireEvent.click(screen.getByText('Remove'));
     });
 
-    expect(delegationApi.setGrants).toHaveBeenCalledWith('g1', [
-      {
-        accountId: 'a1',
-        canRead: true,
-        canCreate: false,
-        canEdit: false,
-        canDelete: false,
-      },
-    ]);
-  });
-
-  it('enabling CREATE implies READ', async () => {
-    vi.mocked(delegationApi.listDelegates).mockResolvedValue([
-      { ...delegate, grants: [{ accountId: 'a1', canRead: true }] },
-    ]);
-    vi.mocked(delegationApi.setGrants).mockResolvedValue();
-    await renderSection();
-    await screen.findByText('d@e.f');
-
-    await act(async () => {
-      fireEvent.click(
-        screen.getByRole('switch', { name: /Create access to Chequing/i }),
-      );
-    });
-
-    expect(delegationApi.setGrants).toHaveBeenCalledWith('g1', [
-      expect.objectContaining({
-        accountId: 'a1',
-        canRead: true,
-        canCreate: true,
-      }),
-    ]);
-  });
-
-  it('toggles a granular manage capability (Edit Payees)', async () => {
-    vi.mocked(delegationApi.setCapabilities).mockResolvedValue();
-    await renderSection();
-    await screen.findByText('d@e.f');
-
-    await act(async () => {
-      fireEvent.click(
-        screen.getByRole('switch', { name: /^Edit Payees$/i }),
-      );
-    });
-
-    expect(delegationApi.setCapabilities).toHaveBeenCalledWith('g1', {
-      payeesCanEdit: true,
-    });
-  });
-
-  it('toggles Delete Tags independently', async () => {
-    vi.mocked(delegationApi.setCapabilities).mockResolvedValue();
-    await renderSection();
-    await screen.findByText('d@e.f');
-
-    await act(async () => {
-      fireEvent.click(
-        screen.getByRole('switch', { name: /^Delete Tags$/i }),
-      );
-    });
-
-    expect(delegationApi.setCapabilities).toHaveBeenCalledWith('g1', {
-      tagsCanDelete: true,
-    });
+    await waitFor(() =>
+      expect(delegationApi.revokeDelegate).toHaveBeenCalledWith('g1'),
+    );
   });
 });

--- a/frontend/src/components/settings/SharedAccessSection.test.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.test.tsx
@@ -6,6 +6,7 @@ import { __resetModalStateForTesting } from '@/components/ui/Modal';
 vi.mock('@/lib/delegation', () => ({
   delegationApi: {
     listDelegates: vi.fn(),
+    lookupEmail: vi.fn(),
     createDelegate: vi.fn(),
     setGrants: vi.fn(),
     setCapabilities: vi.fn(),
@@ -74,6 +75,9 @@ describe('SharedAccessSection', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     __resetModalStateForTesting();
+    vi.mocked(delegationApi.lookupEmail).mockResolvedValue({
+      exists: false,
+    });
     vi.mocked(delegationApi.listDelegates).mockResolvedValue([
       { ...delegate },
     ]);
@@ -184,6 +188,50 @@ describe('SharedAccessSection', () => {
           email: 'new@x.y',
           lastName: 'Doe',
           password: 'StrongPass1!xyz',
+          sendInvite: false,
+        }),
+      ),
+    );
+  });
+
+  it('links an existing user without password/invite', async () => {
+    vi.mocked(delegationApi.lookupEmail).mockResolvedValue({ exists: true });
+    vi.mocked(delegationApi.createDelegate).mockResolvedValue({
+      id: 'g3',
+      delegateUserId: 'd3',
+      email: 'exists@x.y',
+      invited: false,
+    });
+    await renderSection();
+    await screen.findByText('d@e.f');
+
+    await act(async () => {
+      openCreateModal();
+    });
+    await screen.findByPlaceholderText('Delegate email');
+
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText('Delegate email'), {
+        target: { value: 'exists@x.y' },
+      });
+    });
+
+    expect(
+      await screen.findByText(/already has a Monize login/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText('Set a password'),
+    ).not.toBeInTheDocument();
+
+    await act(async () => {
+      submitCreate();
+    });
+
+    await waitFor(() =>
+      expect(delegationApi.createDelegate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'exists@x.y',
+          password: undefined,
           sendInvite: false,
         }),
       ),

--- a/frontend/src/components/settings/SharedAccessSection.test.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.test.tsx
@@ -7,6 +7,7 @@ vi.mock('@/lib/delegation', () => ({
     listDelegates: vi.fn(),
     createDelegate: vi.fn(),
     setGrants: vi.fn(),
+    setCapabilities: vi.fn(),
     revokeDelegate: vi.fn(),
     resetPassword: vi.fn(),
   },
@@ -42,6 +43,7 @@ const delegate = {
     canEdit?: boolean;
     canDelete?: boolean;
   }>,
+  capabilities: { payees: false, categories: false, tags: false },
 };
 
 async function renderSection() {
@@ -159,5 +161,21 @@ describe('SharedAccessSection', () => {
         canCreate: true,
       }),
     ]);
+  });
+
+  it('toggles a manage capability', async () => {
+    vi.mocked(delegationApi.setCapabilities).mockResolvedValue();
+    await renderSection();
+    await screen.findByText('d@e.f');
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('switch', { name: /Manage Payees/i }),
+      );
+    });
+
+    expect(delegationApi.setCapabilities).toHaveBeenCalledWith('g1', {
+      canManagePayees: true,
+    });
   });
 });

--- a/frontend/src/components/settings/SharedAccessSection.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.tsx
@@ -311,32 +311,34 @@ export function SharedAccessSection() {
               />
             </div>
 
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  First name
-                </label>
-                <input
-                  type="text"
-                  placeholder="First name (optional)"
-                  value={firstName}
-                  onChange={(e) => setFirstName(e.target.value)}
-                  className={inputClass}
-                />
+            {!emailExists && (
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    First name
+                  </label>
+                  <input
+                    type="text"
+                    placeholder="First name (optional)"
+                    value={firstName}
+                    onChange={(e) => setFirstName(e.target.value)}
+                    className={inputClass}
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    Last name
+                  </label>
+                  <input
+                    type="text"
+                    placeholder="Last name (optional)"
+                    value={lastName}
+                    onChange={(e) => setLastName(e.target.value)}
+                    className={inputClass}
+                  />
+                </div>
               </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Last name
-                </label>
-                <input
-                  type="text"
-                  placeholder="Last name (optional)"
-                  value={lastName}
-                  onChange={(e) => setLastName(e.target.value)}
-                  className={inputClass}
-                />
-              </div>
-            </div>
+            )}
 
             {emailExists ? (
               <div className="rounded border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/30 px-3 py-2 text-sm text-blue-800 dark:text-blue-200">

--- a/frontend/src/components/settings/SharedAccessSection.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.tsx
@@ -9,7 +9,9 @@ import { createLogger } from '@/lib/logger';
 import { getErrorMessage } from '@/lib/errors';
 import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
 import { Button } from '@/components/ui/Button';
+import { PasswordInput } from '@/components/ui/PasswordInput';
 import { Modal } from '@/components/ui/Modal';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { UnsavedChangesDialog } from '@/components/ui/UnsavedChangesDialog';
 import { useFormModal } from '@/hooks/useFormModal';
 import { passwordSchema, PASSWORD_REQUIREMENTS_TEXT } from '@/lib/zod-helpers';
@@ -37,15 +39,29 @@ function sharedDataCount(d: DelegateSummary): number {
   );
 }
 
+const inputClass =
+  'w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm';
+
 export function SharedAccessSection() {
   const [delegates, setDelegates] = useState<DelegateSummary[]>([]);
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [loading, setLoading] = useState(true);
+
+  const [showCreate, setShowCreate] = useState(false);
   const [email, setEmail] = useState('');
   const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
   const [password, setPassword] = useState('');
   const [sendInvite, setSendInvite] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+
+  const [revokeTarget, setRevokeTarget] = useState<DelegateSummary | null>(
+    null,
+  );
+  const [revoking, setRevoking] = useState(false);
+
+  const [tempPassword, setTempPassword] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   const {
     showForm,
@@ -79,6 +95,19 @@ export function SharedAccessSection() {
     void load();
   }, [load]);
 
+  const resetCreateForm = () => {
+    setEmail('');
+    setFirstName('');
+    setLastName('');
+    setPassword('');
+    setSendInvite(false);
+  };
+
+  const openCreate = () => {
+    resetCreateForm();
+    setShowCreate(true);
+  };
+
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -95,6 +124,7 @@ export function SharedAccessSection() {
       const res = await delegationApi.createDelegate({
         email: email.trim(),
         firstName: firstName.trim() || undefined,
+        lastName: lastName.trim() || undefined,
         password: sendInvite ? undefined : password || undefined,
         sendInvite,
       });
@@ -108,10 +138,8 @@ export function SharedAccessSection() {
       } else {
         toast.success('Delegate created');
       }
-      setEmail('');
-      setFirstName('');
-      setPassword('');
-      setSendInvite(false);
+      setShowCreate(false);
+      resetCreateForm();
       await load();
     } catch (err) {
       toast.error(getErrorMessage(err, 'Failed to create delegate'));
@@ -121,102 +149,55 @@ export function SharedAccessSection() {
     }
   };
 
-  const handleRevoke = async (id: string) => {
-    if (
-      !window.confirm(
-        'Remove this delegate? They lose access to your account. If they ' +
-          'have no other shared access and no account of their own, their ' +
-          'login is deleted entirely.',
-      )
-    ) {
-      return;
-    }
+  const handleRevoke = async () => {
+    if (!revokeTarget) return;
+    setRevoking(true);
     try {
-      await delegationApi.revokeDelegate(id);
+      await delegationApi.revokeDelegate(revokeTarget.id);
       toast.success('Delegate removed');
+      setRevokeTarget(null);
       await load();
     } catch (err) {
       toast.error(getErrorMessage(err, 'Failed to revoke delegate'));
       logger.error(err);
+    } finally {
+      setRevoking(false);
     }
   };
 
   const handleResetPassword = async (id: string) => {
     try {
       const res = await delegationApi.resetPassword(id);
-      toast.success(`Temporary password: ${res.temporaryPassword}`, {
-        duration: 12000,
-      });
+      setCopied(false);
+      setTempPassword(res.temporaryPassword);
     } catch (err) {
       toast.error(getErrorMessage(err, 'Failed to reset password'));
       logger.error(err);
     }
   };
 
+  const copyTempPassword = async () => {
+    if (!tempPassword) return;
+    try {
+      await navigator.clipboard.writeText(tempPassword);
+      setCopied(true);
+    } catch (err) {
+      toast.error('Could not copy to clipboard');
+      logger.error(err);
+    }
+  };
+
   return (
     <div className="bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg p-6 mb-6">
-      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-        Delegates sign in with their own credentials and never see your
-        password. They only see the accounts and sections you grant them.
-      </p>
-
-      <form
-        onSubmit={handleCreate}
-        className="grid gap-3 sm:grid-cols-2 mb-6 border-b border-gray-200 dark:border-gray-700 pb-6"
-      >
-        <input
-          type="email"
-          required
-          placeholder="Delegate email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          className="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm"
-        />
-        <input
-          type="text"
-          placeholder="First name (optional)"
-          value={firstName}
-          onChange={(e) => setFirstName(e.target.value)}
-          className="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm"
-        />
-
-        <div className="sm:col-span-2 flex items-center gap-3">
-          <ToggleSwitch
-            checked={sendInvite}
-            onChange={setSendInvite}
-            label="Send an email invite instead of setting a password"
-          />
-          <span className="text-sm text-gray-700 dark:text-gray-300">
-            Send an email invite instead of setting a password
-          </span>
-        </div>
-
-        {!sendInvite && (
-          <div className="sm:col-span-2">
-            <input
-              type="password"
-              placeholder="Set a password (optional)"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm"
-            />
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              {PASSWORD_REQUIREMENTS_TEXT} Leave blank to auto-generate a
-              temporary password.
-            </p>
-          </div>
-        )}
-
-        <div className="sm:col-span-2">
-          <button
-            type="submit"
-            disabled={submitting}
-            className="rounded bg-blue-600 hover:bg-blue-700 disabled:opacity-60 text-white px-4 py-2 text-sm font-medium"
-          >
-            {submitting ? 'Adding...' : 'Add delegate'}
-          </button>
-        </div>
-      </form>
+      <div className="flex flex-wrap items-start justify-between gap-3 mb-4">
+        <p className="text-sm text-gray-500 dark:text-gray-400 max-w-2xl">
+          Delegates sign in with their own credentials and never see your
+          password. They only see the accounts and sections you grant them.
+        </p>
+        <Button size="sm" onClick={openCreate}>
+          Add delegate
+        </Button>
+      </div>
 
       {loading ? (
         <p className="text-sm text-gray-500">Loading...</p>
@@ -253,7 +234,7 @@ export function SharedAccessSection() {
                 <Button
                   variant="danger"
                   size="sm"
-                  onClick={() => handleRevoke(d.id)}
+                  onClick={() => setRevokeTarget(d)}
                 >
                   Remove
                 </Button>
@@ -262,6 +243,110 @@ export function SharedAccessSection() {
           ))}
         </ul>
       )}
+
+      <Modal
+        isOpen={showCreate}
+        onClose={() => setShowCreate(false)}
+        maxWidth="lg"
+        pushHistory
+      >
+        <form onSubmit={handleCreate} className="flex flex-col">
+          <div className="border-b border-gray-200 dark:border-gray-700 px-6 py-4">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+              Add delegate
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Grant another person scoped access to your accounts.
+            </p>
+          </div>
+
+          <div className="px-6 py-4 space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Email
+              </label>
+              <input
+                type="email"
+                required
+                placeholder="Delegate email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className={inputClass}
+              />
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  First name
+                </label>
+                <input
+                  type="text"
+                  placeholder="First name (optional)"
+                  value={firstName}
+                  onChange={(e) => setFirstName(e.target.value)}
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Last name
+                </label>
+                <input
+                  type="text"
+                  placeholder="Last name (optional)"
+                  value={lastName}
+                  onChange={(e) => setLastName(e.target.value)}
+                  className={inputClass}
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <ToggleSwitch
+                checked={sendInvite}
+                onChange={setSendInvite}
+                label="Send an email invite instead of setting a password"
+              />
+              <span className="text-sm text-gray-700 dark:text-gray-300">
+                Send an email invite instead of setting a password
+              </span>
+            </div>
+
+            {!sendInvite && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Password
+                </label>
+                <PasswordInput
+                  placeholder="Set a password (optional)"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className={inputClass}
+                />
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  {PASSWORD_REQUIREMENTS_TEXT} Leave blank to auto-generate a
+                  temporary password.
+                </p>
+              </div>
+            )}
+          </div>
+
+          <div className="border-t border-gray-200 dark:border-gray-700 px-6 py-4 flex justify-end gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setShowCreate(false)}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" isLoading={submitting}>
+              Add delegate
+            </Button>
+          </div>
+        </form>
+      </Modal>
 
       <Modal
         isOpen={showForm}
@@ -282,6 +367,51 @@ export function SharedAccessSection() {
             submitRef={formSubmitRef}
           />
         )}
+      </Modal>
+
+      <ConfirmDialog
+        isOpen={revokeTarget !== null}
+        title="Remove delegate"
+        message={
+          'Remove this delegate? They lose access to your account. If they ' +
+          'have no other shared access and no account of their own, their ' +
+          'login is deleted entirely.'
+        }
+        confirmLabel={revoking ? 'Removing...' : 'Remove'}
+        variant="danger"
+        pushHistory
+        onConfirm={handleRevoke}
+        onCancel={() => setRevokeTarget(null)}
+      />
+
+      <Modal
+        isOpen={tempPassword !== null}
+        onClose={() => setTempPassword(null)}
+        maxWidth="md"
+        pushHistory
+      >
+        <div className="p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Temporary password
+          </h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Share this with the delegate securely. They will be asked to
+            change it on first sign in. It will not be shown again.
+          </p>
+          <div className="mt-4 flex items-stretch gap-2">
+            <code className="flex-1 select-all rounded border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 px-3 py-2 text-sm font-mono break-all">
+              {tempPassword}
+            </code>
+            <Button type="button" variant="outline" onClick={copyTempPassword}>
+              {copied ? 'Copied' : 'Copy'}
+            </Button>
+          </div>
+          <div className="mt-6 flex justify-end">
+            <Button type="button" onClick={() => setTempPassword(null)}>
+              Done
+            </Button>
+          </div>
+        </div>
       </Modal>
 
       <UnsavedChangesDialog {...unsavedChangesDialog} />

--- a/frontend/src/components/settings/SharedAccessSection.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.tsx
@@ -138,22 +138,34 @@ export function SharedAccessSection() {
 
   const updateCapability = async (
     delegate: DelegateSummary,
-    key: 'payees' | 'categories' | 'tags',
+    resource: 'payees' | 'categories' | 'tags',
+    op: 'create' | 'edit' | 'delete',
     value: boolean,
   ) => {
-    const fieldMap = {
-      payees: 'canManagePayees',
-      categories: 'canManageCategories',
-      tags: 'canManageTags',
-    } as const;
+    const opPart =
+      op === 'create' ? 'Create' : op === 'edit' ? 'Edit' : 'Delete';
+    const field = `${resource}Can${opPart}` as
+      | 'payeesCanCreate'
+      | 'payeesCanEdit'
+      | 'payeesCanDelete'
+      | 'categoriesCanCreate'
+      | 'categoriesCanEdit'
+      | 'categoriesCanDelete'
+      | 'tagsCanCreate'
+      | 'tagsCanEdit'
+      | 'tagsCanDelete';
     try {
-      await delegationApi.setCapabilities(delegate.id, {
-        [fieldMap[key]]: value,
-      });
+      await delegationApi.setCapabilities(delegate.id, { [field]: value });
       setDelegates((prev) =>
         prev.map((d) =>
           d.id === delegate.id
-            ? { ...d, capabilities: { ...d.capabilities, [key]: value } }
+            ? {
+                ...d,
+                capabilities: {
+                  ...d.capabilities,
+                  [resource]: { ...d.capabilities[resource], [op]: value },
+                },
+              }
             : d,
         ),
       );
@@ -294,28 +306,46 @@ export function SharedAccessSection() {
                 </div>
               </div>
               <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
-                Can create/edit/delete:
+                Shared data (READ is always allowed):
               </p>
-              <div className="flex flex-wrap gap-x-4 gap-y-1 mb-4">
+              <div className="space-y-2 mb-4">
                 {(
                   [
                     { key: 'payees' as const, label: 'Payees' },
                     { key: 'categories' as const, label: 'Categories' },
                     { key: 'tags' as const, label: 'Tags' },
                   ]
-                ).map((cap) => (
-                  <label
-                    key={cap.key}
-                    className="flex items-center gap-1.5 text-sm text-gray-700 dark:text-gray-300"
+                ).map((res) => (
+                  <div
+                    key={res.key}
+                    className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-700 dark:text-gray-300 border-b border-gray-100 dark:border-gray-700/50 pb-2"
                   >
-                    <ToggleSwitch
-                      size="sm"
-                      checked={!!d.capabilities?.[cap.key]}
-                      onChange={(v) => updateCapability(d, cap.key, v)}
-                      label={`Manage ${cap.label}`}
-                    />
-                    <span className="text-xs">{cap.label}</span>
-                  </label>
+                    <span className="w-40 truncate font-medium">
+                      {res.label}
+                    </span>
+                    {(
+                      [
+                        { op: 'create' as const, label: 'Create' },
+                        { op: 'edit' as const, label: 'Edit' },
+                        { op: 'delete' as const, label: 'Delete' },
+                      ]
+                    ).map((o) => (
+                      <label
+                        key={o.op}
+                        className="flex items-center gap-1.5"
+                      >
+                        <ToggleSwitch
+                          size="sm"
+                          checked={!!d.capabilities?.[res.key]?.[o.op]}
+                          onChange={(v) =>
+                            updateCapability(d, res.key, o.op, v)
+                          }
+                          label={`${o.label} ${res.label}`}
+                        />
+                        <span className="text-xs">{o.label}</span>
+                      </label>
+                    ))}
+                  </div>
                 ))}
               </div>
               <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">

--- a/frontend/src/components/settings/SharedAccessSection.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.tsx
@@ -104,12 +104,18 @@ export function SharedAccessSection() {
   };
 
   const handleRevoke = async (id: string) => {
-    if (!window.confirm('Revoke this delegate? They will lose all access.')) {
+    if (
+      !window.confirm(
+        'Remove this delegate? They lose access to your account. If they ' +
+          'have no other shared access and no account of their own, their ' +
+          'login is deleted entirely.',
+      )
+    ) {
       return;
     }
     try {
       await delegationApi.revokeDelegate(id);
-      toast.success('Delegate revoked');
+      toast.success('Delegate removed');
       await load();
     } catch (err) {
       toast.error(getErrorMessage(err, 'Failed to revoke delegate'));
@@ -223,7 +229,7 @@ export function SharedAccessSection() {
                     onClick={() => handleRevoke(d.id)}
                     className="rounded border border-red-300 text-red-600 px-3 py-1 text-xs"
                   >
-                    Revoke
+                    Remove
                   </button>
                 </div>
               </div>

--- a/frontend/src/components/settings/SharedAccessSection.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.tsx
@@ -2,14 +2,13 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
-import {
-  delegationApi,
-  DelegateSummary,
-} from '@/lib/delegation';
+import { delegationApi, DelegateSummary } from '@/lib/delegation';
 import { accountsApi } from '@/lib/accounts';
 import { Account } from '@/types/account';
 import { createLogger } from '@/lib/logger';
 import { getErrorMessage } from '@/lib/errors';
+import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
+import { passwordSchema, PASSWORD_REQUIREMENTS_TEXT } from '@/lib/zod-helpers';
 
 const logger = createLogger('SharedAccess');
 
@@ -46,6 +45,15 @@ export function SharedAccessSection() {
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (!sendInvite && password) {
+      const parsed = passwordSchema.safeParse(password);
+      if (!parsed.success) {
+        toast.error(PASSWORD_REQUIREMENTS_TEXT);
+        return;
+      }
+    }
+
     setSubmitting(true);
     try {
       const res = await delegationApi.createDelegate({
@@ -77,10 +85,7 @@ export function SharedAccessSection() {
     }
   };
 
-  const toggleGrant = async (
-    delegate: DelegateSummary,
-    accountId: string,
-  ) => {
+  const toggleGrant = async (delegate: DelegateSummary, accountId: string) => {
     const has = delegate.accountIds.includes(accountId);
     const next = has
       ? delegate.accountIds.filter((id) => id !== accountId)
@@ -126,12 +131,9 @@ export function SharedAccessSection() {
 
   return (
     <div className="bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg p-6 mb-6">
-      <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">
-        Shared Access
-      </h2>
       <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-        Grant another person scoped read access to specific accounts. Delegates
-        sign in with their own credentials and never see your password.
+        Delegates sign in with their own credentials and never see your
+        password. They only see the accounts you grant them.
       </p>
 
       <form
@@ -153,24 +155,34 @@ export function SharedAccessSection() {
           onChange={(e) => setFirstName(e.target.value)}
           className="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm"
         />
-        {!sendInvite && (
-          <input
-            type="password"
-            placeholder="Set a password (optional)"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            minLength={8}
-            className="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm"
-          />
-        )}
-        <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-          <input
-            type="checkbox"
+
+        <div className="sm:col-span-2 flex items-center gap-3">
+          <ToggleSwitch
             checked={sendInvite}
-            onChange={(e) => setSendInvite(e.target.checked)}
+            onChange={setSendInvite}
+            label="Send an email invite instead of setting a password"
           />
-          Send email invite instead
-        </label>
+          <span className="text-sm text-gray-700 dark:text-gray-300">
+            Send an email invite instead of setting a password
+          </span>
+        </div>
+
+        {!sendInvite && (
+          <div className="sm:col-span-2">
+            <input
+              type="password"
+              placeholder="Set a password (optional)"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm"
+            />
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {PASSWORD_REQUIREMENTS_TEXT} Leave blank to auto-generate a
+              temporary password.
+            </p>
+          </div>
+        )}
+
         <div className="sm:col-span-2">
           <button
             type="submit"
@@ -218,19 +230,20 @@ export function SharedAccessSection() {
               <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Accounts this delegate can read:
               </p>
-              <div className="grid gap-1 sm:grid-cols-2">
+              <div className="grid gap-2 sm:grid-cols-2">
                 {accounts.map((a) => (
-                  <label
+                  <div
                     key={a.id}
                     className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300"
                   >
-                    <input
-                      type="checkbox"
+                    <ToggleSwitch
+                      size="sm"
                       checked={d.accountIds.includes(a.id)}
                       onChange={() => toggleGrant(d, a.id)}
+                      label={`Read access to ${a.name}`}
                     />
-                    {a.name}
-                  </label>
+                    <span>{a.name}</span>
+                  </div>
                 ))}
               </div>
             </li>

--- a/frontend/src/components/settings/SharedAccessSection.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.tsx
@@ -263,6 +263,12 @@ export function SharedAccessSection() {
                 <Button
                   variant="outline"
                   size="sm"
+                  disabled={!d.delegate.canResetPassword}
+                  title={
+                    !d.delegate.canResetPassword
+                      ? 'This person manages their own password (they have their own Monize account or delegated access elsewhere).'
+                      : undefined
+                  }
                   onClick={() => handleResetPassword(d.id)}
                 >
                   Reset password

--- a/frontend/src/components/settings/SharedAccessSection.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.tsx
@@ -136,6 +136,33 @@ export function SharedAccessSection() {
     }
   };
 
+  const updateCapability = async (
+    delegate: DelegateSummary,
+    key: 'payees' | 'categories' | 'tags',
+    value: boolean,
+  ) => {
+    const fieldMap = {
+      payees: 'canManagePayees',
+      categories: 'canManageCategories',
+      tags: 'canManageTags',
+    } as const;
+    try {
+      await delegationApi.setCapabilities(delegate.id, {
+        [fieldMap[key]]: value,
+      });
+      setDelegates((prev) =>
+        prev.map((d) =>
+          d.id === delegate.id
+            ? { ...d, capabilities: { ...d.capabilities, [key]: value } }
+            : d,
+        ),
+      );
+    } catch (err) {
+      toast.error(getErrorMessage(err, 'Failed to update access'));
+      logger.error(err);
+    }
+  };
+
   const handleRevoke = async (id: string) => {
     if (
       !window.confirm(
@@ -265,6 +292,31 @@ export function SharedAccessSection() {
                     Remove
                   </button>
                 </div>
+              </div>
+              <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Can create/edit/delete:
+              </p>
+              <div className="flex flex-wrap gap-x-4 gap-y-1 mb-4">
+                {(
+                  [
+                    { key: 'payees' as const, label: 'Payees' },
+                    { key: 'categories' as const, label: 'Categories' },
+                    { key: 'tags' as const, label: 'Tags' },
+                  ]
+                ).map((cap) => (
+                  <label
+                    key={cap.key}
+                    className="flex items-center gap-1.5 text-sm text-gray-700 dark:text-gray-300"
+                  >
+                    <ToggleSwitch
+                      size="sm"
+                      checked={!!d.capabilities?.[cap.key]}
+                      onChange={(v) => updateCapability(d, cap.key, v)}
+                      label={`Manage ${cap.label}`}
+                    />
+                    <span className="text-xs">{cap.label}</span>
+                  </label>
+                ))}
               </div>
               <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Per-account access (READ is required for the others):

--- a/frontend/src/components/settings/SharedAccessSection.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.tsx
@@ -54,6 +54,8 @@ export function SharedAccessSection() {
   const [password, setPassword] = useState('');
   const [sendInvite, setSendInvite] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  // null = unknown / not yet checked; true = email already has a login.
+  const [emailExists, setEmailExists] = useState<boolean | null>(null);
 
   const [revokeTarget, setRevokeTarget] = useState<DelegateSummary | null>(
     null,
@@ -101,7 +103,35 @@ export function SharedAccessSection() {
     setLastName('');
     setPassword('');
     setSendInvite(false);
+    setEmailExists(null);
   };
+
+  // Debounced check: if the email already has a Monize login (existing
+  // full account, or a delegate of another owner), the owner only links
+  // the additional access -- no password / invite is set here.
+  useEffect(() => {
+    if (!showCreate) return;
+    const value = email.trim();
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+      setEmailExists(null);
+      return;
+    }
+    let cancelled = false;
+    const t = setTimeout(() => {
+      delegationApi
+        .lookupEmail(value)
+        .then((r) => {
+          if (!cancelled) setEmailExists(r.exists);
+        })
+        .catch(() => {
+          if (!cancelled) setEmailExists(null);
+        });
+    }, 400);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [email, showCreate]);
 
   const openCreate = () => {
     resetCreateForm();
@@ -111,7 +141,8 @@ export function SharedAccessSection() {
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (!sendInvite) {
+    // Existing login: just link the access, never touch their credentials.
+    if (!emailExists && !sendInvite) {
       if (!password) {
         toast.error('Set a password or send an email invite.');
         return;
@@ -129,8 +160,9 @@ export function SharedAccessSection() {
         email: email.trim(),
         firstName: firstName.trim() || undefined,
         lastName: lastName.trim() || undefined,
-        password: sendInvite ? undefined : password || undefined,
-        sendInvite,
+        password:
+          emailExists || sendInvite ? undefined : password || undefined,
+        sendInvite: emailExists ? false : sendInvite,
       });
       if (res.temporaryPassword) {
         toast.success(
@@ -306,33 +338,43 @@ export function SharedAccessSection() {
               </div>
             </div>
 
-            <div className="flex items-center gap-3">
-              <ToggleSwitch
-                checked={sendInvite}
-                onChange={setSendInvite}
-                label="Send an email invite instead of setting a password"
-              />
-              <span className="text-sm text-gray-700 dark:text-gray-300">
-                Send an email invite instead of setting a password
-              </span>
-            </div>
-
-            {!sendInvite && (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Password
-                </label>
-                <PasswordInput
-                  required
-                  placeholder="Set a password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className={inputClass}
-                />
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  {PASSWORD_REQUIREMENTS_TEXT}
-                </p>
+            {emailExists ? (
+              <div className="rounded border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/30 px-3 py-2 text-sm text-blue-800 dark:text-blue-200">
+                This person already has a Monize login. They&apos;ll keep
+                their own credentials and simply be granted the additional
+                shared access &mdash; no password or invite needed.
               </div>
+            ) : (
+              <>
+                <div className="flex items-center gap-3">
+                  <ToggleSwitch
+                    checked={sendInvite}
+                    onChange={setSendInvite}
+                    label="Send an email invite instead of setting a password"
+                  />
+                  <span className="text-sm text-gray-700 dark:text-gray-300">
+                    Send an email invite instead of setting a password
+                  </span>
+                </div>
+
+                {!sendInvite && (
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      Password
+                    </label>
+                    <PasswordInput
+                      required
+                      placeholder="Set a password"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      className={inputClass}
+                    />
+                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      {PASSWORD_REQUIREMENTS_TEXT}
+                    </p>
+                  </div>
+                )}
+              </>
             )}
           </div>
 

--- a/frontend/src/components/settings/SharedAccessSection.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import {
+  delegationApi,
+  DelegateSummary,
+} from '@/lib/delegation';
+import { accountsApi } from '@/lib/accounts';
+import { Account } from '@/types/account';
+import { createLogger } from '@/lib/logger';
+import { getErrorMessage } from '@/lib/errors';
+
+const logger = createLogger('SharedAccess');
+
+export function SharedAccessSection() {
+  const [delegates, setDelegates] = useState<DelegateSummary[]>([]);
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [email, setEmail] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [password, setPassword] = useState('');
+  const [sendInvite, setSendInvite] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [d, a] = await Promise.all([
+        delegationApi.listDelegates(),
+        accountsApi.getAll(),
+      ]);
+      setDelegates(d);
+      setAccounts(a);
+    } catch (err) {
+      toast.error(getErrorMessage(err, 'Failed to load shared access'));
+      logger.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const res = await delegationApi.createDelegate({
+        email: email.trim(),
+        firstName: firstName.trim() || undefined,
+        password: sendInvite ? undefined : password || undefined,
+        sendInvite,
+      });
+      if (res.temporaryPassword) {
+        toast.success(
+          `Delegate created. Temporary password: ${res.temporaryPassword}`,
+          { duration: 12000 },
+        );
+      } else if (res.invited) {
+        toast.success('Invitation email sent');
+      } else {
+        toast.success('Delegate created');
+      }
+      setEmail('');
+      setFirstName('');
+      setPassword('');
+      setSendInvite(false);
+      await load();
+    } catch (err) {
+      toast.error(getErrorMessage(err, 'Failed to create delegate'));
+      logger.error(err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const toggleGrant = async (
+    delegate: DelegateSummary,
+    accountId: string,
+  ) => {
+    const has = delegate.accountIds.includes(accountId);
+    const next = has
+      ? delegate.accountIds.filter((id) => id !== accountId)
+      : [...delegate.accountIds, accountId];
+    try {
+      await delegationApi.setGrants(delegate.id, next);
+      setDelegates((prev) =>
+        prev.map((d) =>
+          d.id === delegate.id ? { ...d, accountIds: next } : d,
+        ),
+      );
+    } catch (err) {
+      toast.error(getErrorMessage(err, 'Failed to update access'));
+      logger.error(err);
+    }
+  };
+
+  const handleRevoke = async (id: string) => {
+    if (!window.confirm('Revoke this delegate? They will lose all access.')) {
+      return;
+    }
+    try {
+      await delegationApi.revokeDelegate(id);
+      toast.success('Delegate revoked');
+      await load();
+    } catch (err) {
+      toast.error(getErrorMessage(err, 'Failed to revoke delegate'));
+      logger.error(err);
+    }
+  };
+
+  const handleResetPassword = async (id: string) => {
+    try {
+      const res = await delegationApi.resetPassword(id);
+      toast.success(`Temporary password: ${res.temporaryPassword}`, {
+        duration: 12000,
+      });
+    } catch (err) {
+      toast.error(getErrorMessage(err, 'Failed to reset password'));
+      logger.error(err);
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg p-6 mb-6">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">
+        Shared Access
+      </h2>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        Grant another person scoped read access to specific accounts. Delegates
+        sign in with their own credentials and never see your password.
+      </p>
+
+      <form
+        onSubmit={handleCreate}
+        className="grid gap-3 sm:grid-cols-2 mb-6 border-b border-gray-200 dark:border-gray-700 pb-6"
+      >
+        <input
+          type="email"
+          required
+          placeholder="Delegate email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm"
+        />
+        <input
+          type="text"
+          placeholder="First name (optional)"
+          value={firstName}
+          onChange={(e) => setFirstName(e.target.value)}
+          className="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm"
+        />
+        {!sendInvite && (
+          <input
+            type="password"
+            placeholder="Set a password (optional)"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            minLength={8}
+            className="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm"
+          />
+        )}
+        <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+          <input
+            type="checkbox"
+            checked={sendInvite}
+            onChange={(e) => setSendInvite(e.target.checked)}
+          />
+          Send email invite instead
+        </label>
+        <div className="sm:col-span-2">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded bg-blue-600 hover:bg-blue-700 disabled:opacity-60 text-white px-4 py-2 text-sm font-medium"
+          >
+            {submitting ? 'Adding...' : 'Add delegate'}
+          </button>
+        </div>
+      </form>
+
+      {loading ? (
+        <p className="text-sm text-gray-500">Loading...</p>
+      ) : delegates.length === 0 ? (
+        <p className="text-sm text-gray-500">No delegates yet.</p>
+      ) : (
+        <ul className="space-y-6">
+          {delegates.map((d) => (
+            <li
+              key={d.id}
+              className="border border-gray-200 dark:border-gray-700 rounded-lg p-4"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
+                <div>
+                  <p className="font-medium text-gray-900 dark:text-white">
+                    {d.delegate.email}
+                  </p>
+                  <p className="text-xs text-gray-500">Status: {d.status}</p>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => handleResetPassword(d.id)}
+                    className="rounded border border-gray-300 dark:border-gray-600 px-3 py-1 text-xs"
+                  >
+                    Reset password
+                  </button>
+                  <button
+                    onClick={() => handleRevoke(d.id)}
+                    className="rounded border border-red-300 text-red-600 px-3 py-1 text-xs"
+                  >
+                    Revoke
+                  </button>
+                </div>
+              </div>
+              <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Accounts this delegate can read:
+              </p>
+              <div className="grid gap-1 sm:grid-cols-2">
+                {accounts.map((a) => (
+                  <label
+                    key={a.id}
+                    className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={d.accountIds.includes(a.id)}
+                      onChange={() => toggleGrant(d, a.id)}
+                    />
+                    {a.name}
+                  </label>
+                ))}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/settings/SharedAccessSection.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.tsx
@@ -2,19 +2,40 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
-import {
-  delegationApi,
-  DelegateSummary,
-  AccountGrant,
-} from '@/lib/delegation';
+import { delegationApi, DelegateSummary } from '@/lib/delegation';
 import { accountsApi } from '@/lib/accounts';
 import { Account } from '@/types/account';
 import { createLogger } from '@/lib/logger';
 import { getErrorMessage } from '@/lib/errors';
 import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
+import { Button } from '@/components/ui/Button';
+import { Modal } from '@/components/ui/Modal';
+import { UnsavedChangesDialog } from '@/components/ui/UnsavedChangesDialog';
+import { useFormModal } from '@/hooks/useFormModal';
 import { passwordSchema, PASSWORD_REQUIREMENTS_TEXT } from '@/lib/zod-helpers';
+import { DelegateAccessModal } from './DelegateAccessModal';
 
 const logger = createLogger('SharedAccess');
+
+function sectionCount(d: DelegateSummary): number {
+  const s = d.sections;
+  if (!s) return 0;
+  return [s.bills, s.investments, s.budgets, s.reports, s.ai].filter(Boolean)
+    .length;
+}
+
+function accountCount(d: DelegateSummary): number {
+  return d.grants.filter((g) => g.canRead).length;
+}
+
+function sharedDataCount(d: DelegateSummary): number {
+  const c = d.capabilities;
+  return [c.payees, c.categories, c.tags].reduce(
+    (n, r) =>
+      n + (r.create ? 1 : 0) + (r.edit ? 1 : 0) + (r.delete ? 1 : 0),
+    0,
+  );
+}
 
 export function SharedAccessSection() {
   const [delegates, setDelegates] = useState<DelegateSummary[]>([]);
@@ -25,6 +46,17 @@ export function SharedAccessSection() {
   const [password, setPassword] = useState('');
   const [sendInvite, setSendInvite] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+
+  const {
+    showForm,
+    editingItem,
+    openEdit,
+    close,
+    modalProps,
+    setFormDirty,
+    unsavedChangesDialog,
+    formSubmitRef,
+  } = useFormModal<DelegateSummary>();
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -89,92 +121,6 @@ export function SharedAccessSection() {
     }
   };
 
-  const grantFor = (
-    delegate: DelegateSummary,
-    accountId: string,
-  ): AccountGrant =>
-    delegate.grants.find((g) => g.accountId === accountId) ?? {
-      accountId,
-      canRead: false,
-      canCreate: false,
-      canEdit: false,
-      canDelete: false,
-    };
-
-  const updateGrant = async (
-    delegate: DelegateSummary,
-    accountId: string,
-    op: 'canRead' | 'canCreate' | 'canEdit' | 'canDelete',
-    value: boolean,
-  ) => {
-    const updated: AccountGrant = { ...grantFor(delegate, accountId), [op]: value };
-    if (op === 'canRead' && !value) {
-      updated.canCreate = false;
-      updated.canEdit = false;
-      updated.canDelete = false;
-    }
-    if (op !== 'canRead' && value) {
-      // CREATE/EDIT/DELETE require READ.
-      updated.canRead = true;
-    }
-    // Authoritative set: every still-readable account for this delegate.
-    const nextGrants = accounts
-      .map((a) =>
-        a.id === accountId ? updated : grantFor(delegate, a.id),
-      )
-      .filter((g) => g.canRead);
-    try {
-      await delegationApi.setGrants(delegate.id, nextGrants);
-      setDelegates((prev) =>
-        prev.map((d) =>
-          d.id === delegate.id ? { ...d, grants: nextGrants } : d,
-        ),
-      );
-    } catch (err) {
-      toast.error(getErrorMessage(err, 'Failed to update access'));
-      logger.error(err);
-    }
-  };
-
-  const updateCapability = async (
-    delegate: DelegateSummary,
-    resource: 'payees' | 'categories' | 'tags',
-    op: 'create' | 'edit' | 'delete',
-    value: boolean,
-  ) => {
-    const opPart =
-      op === 'create' ? 'Create' : op === 'edit' ? 'Edit' : 'Delete';
-    const field = `${resource}Can${opPart}` as
-      | 'payeesCanCreate'
-      | 'payeesCanEdit'
-      | 'payeesCanDelete'
-      | 'categoriesCanCreate'
-      | 'categoriesCanEdit'
-      | 'categoriesCanDelete'
-      | 'tagsCanCreate'
-      | 'tagsCanEdit'
-      | 'tagsCanDelete';
-    try {
-      await delegationApi.setCapabilities(delegate.id, { [field]: value });
-      setDelegates((prev) =>
-        prev.map((d) =>
-          d.id === delegate.id
-            ? {
-                ...d,
-                capabilities: {
-                  ...d.capabilities,
-                  [resource]: { ...d.capabilities[resource], [op]: value },
-                },
-              }
-            : d,
-        ),
-      );
-    } catch (err) {
-      toast.error(getErrorMessage(err, 'Failed to update access'));
-      logger.error(err);
-    }
-  };
-
   const handleRevoke = async (id: string) => {
     if (
       !window.confirm(
@@ -211,7 +157,7 @@ export function SharedAccessSection() {
     <div className="bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg p-6 mb-6">
       <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
         Delegates sign in with their own credentials and never see your
-        password. They only see the accounts you grant them.
+        password. They only see the accounts and sections you grant them.
       </p>
 
       <form
@@ -277,122 +223,68 @@ export function SharedAccessSection() {
       ) : delegates.length === 0 ? (
         <p className="text-sm text-gray-500">No delegates yet.</p>
       ) : (
-        <ul className="space-y-6">
+        <ul className="space-y-3">
           {delegates.map((d) => (
             <li
               key={d.id}
-              className="border border-gray-200 dark:border-gray-700 rounded-lg p-4"
+              className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 flex flex-wrap items-center justify-between gap-3"
             >
-              <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
-                <div>
-                  <p className="font-medium text-gray-900 dark:text-white">
-                    {d.delegate.email}
-                  </p>
-                  <p className="text-xs text-gray-500">Status: {d.status}</p>
-                </div>
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => handleResetPassword(d.id)}
-                    className="rounded border border-gray-300 dark:border-gray-600 px-3 py-1 text-xs"
-                  >
-                    Reset password
-                  </button>
-                  <button
-                    onClick={() => handleRevoke(d.id)}
-                    className="rounded border border-red-300 text-red-600 px-3 py-1 text-xs"
-                  >
-                    Remove
-                  </button>
-                </div>
+              <div className="min-w-0">
+                <p className="font-medium text-gray-900 dark:text-white truncate">
+                  {d.delegate.email}
+                </p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Status: {d.status} &middot; Sections: {sectionCount(d)}{' '}
+                  &middot; Accounts: {accountCount(d)} &middot; Shared data:{' '}
+                  {sharedDataCount(d)}
+                </p>
               </div>
-              <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
-                Shared data (READ is always allowed):
-              </p>
-              <div className="space-y-2 mb-4">
-                {(
-                  [
-                    { key: 'payees' as const, label: 'Payees' },
-                    { key: 'categories' as const, label: 'Categories' },
-                    { key: 'tags' as const, label: 'Tags' },
-                  ]
-                ).map((res) => (
-                  <div
-                    key={res.key}
-                    className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-700 dark:text-gray-300 border-b border-gray-100 dark:border-gray-700/50 pb-2"
-                  >
-                    <span className="w-40 truncate font-medium">
-                      {res.label}
-                    </span>
-                    {(
-                      [
-                        { op: 'create' as const, label: 'Create' },
-                        { op: 'edit' as const, label: 'Edit' },
-                        { op: 'delete' as const, label: 'Delete' },
-                      ]
-                    ).map((o) => (
-                      <label
-                        key={o.op}
-                        className="flex items-center gap-1.5"
-                      >
-                        <ToggleSwitch
-                          size="sm"
-                          checked={!!d.capabilities?.[res.key]?.[o.op]}
-                          onChange={(v) =>
-                            updateCapability(d, res.key, o.op, v)
-                          }
-                          label={`${o.label} ${res.label}`}
-                        />
-                        <span className="text-xs">{o.label}</span>
-                      </label>
-                    ))}
-                  </div>
-                ))}
-              </div>
-              <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
-                Per-account access (READ is required for the others):
-              </p>
-              <div className="space-y-2">
-                {accounts.map((a) => {
-                  const g = grantFor(d, a.id);
-                  const ops = [
-                    { key: 'canRead' as const, label: 'Read' },
-                    { key: 'canCreate' as const, label: 'Create' },
-                    { key: 'canEdit' as const, label: 'Edit' },
-                    { key: 'canDelete' as const, label: 'Delete' },
-                  ];
-                  return (
-                    <div
-                      key={a.id}
-                      className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-700 dark:text-gray-300 border-b border-gray-100 dark:border-gray-700/50 pb-2"
-                    >
-                      <span className="w-40 truncate font-medium">
-                        {a.name}
-                      </span>
-                      {ops.map((op) => (
-                        <label
-                          key={op.key}
-                          className="flex items-center gap-1.5"
-                        >
-                          <ToggleSwitch
-                            size="sm"
-                            checked={!!g[op.key]}
-                            disabled={op.key !== 'canRead' && !g.canRead}
-                            onChange={(v) =>
-                              updateGrant(d, a.id, op.key, v)
-                            }
-                            label={`${op.label} access to ${a.name}`}
-                          />
-                          <span className="text-xs">{op.label}</span>
-                        </label>
-                      ))}
-                    </div>
-                  );
-                })}
+              <div className="flex gap-2">
+                <Button size="sm" onClick={() => openEdit(d)}>
+                  Edit access
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleResetPassword(d.id)}
+                >
+                  Reset password
+                </Button>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  onClick={() => handleRevoke(d.id)}
+                >
+                  Remove
+                </Button>
               </div>
             </li>
           ))}
         </ul>
       )}
+
+      <Modal
+        isOpen={showForm}
+        onClose={close}
+        maxWidth="4xl"
+        {...modalProps}
+      >
+        {editingItem && (
+          <DelegateAccessModal
+            delegate={editingItem}
+            accounts={accounts}
+            onCancel={close}
+            onSaved={() => {
+              close();
+              void load();
+            }}
+            setFormDirty={setFormDirty}
+            submitRef={formSubmitRef}
+          />
+        )}
+      </Modal>
+
+      <UnsavedChangesDialog {...unsavedChangesDialog} />
     </div>
   );
 }

--- a/frontend/src/components/settings/SharedAccessSection.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.tsx
@@ -2,7 +2,11 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
-import { delegationApi, DelegateSummary } from '@/lib/delegation';
+import {
+  delegationApi,
+  DelegateSummary,
+  AccountGrant,
+} from '@/lib/delegation';
 import { accountsApi } from '@/lib/accounts';
 import { Account } from '@/types/account';
 import { createLogger } from '@/lib/logger';
@@ -85,16 +89,45 @@ export function SharedAccessSection() {
     }
   };
 
-  const toggleGrant = async (delegate: DelegateSummary, accountId: string) => {
-    const has = delegate.accountIds.includes(accountId);
-    const next = has
-      ? delegate.accountIds.filter((id) => id !== accountId)
-      : [...delegate.accountIds, accountId];
+  const grantFor = (
+    delegate: DelegateSummary,
+    accountId: string,
+  ): AccountGrant =>
+    delegate.grants.find((g) => g.accountId === accountId) ?? {
+      accountId,
+      canRead: false,
+      canCreate: false,
+      canEdit: false,
+      canDelete: false,
+    };
+
+  const updateGrant = async (
+    delegate: DelegateSummary,
+    accountId: string,
+    op: 'canRead' | 'canCreate' | 'canEdit' | 'canDelete',
+    value: boolean,
+  ) => {
+    const updated: AccountGrant = { ...grantFor(delegate, accountId), [op]: value };
+    if (op === 'canRead' && !value) {
+      updated.canCreate = false;
+      updated.canEdit = false;
+      updated.canDelete = false;
+    }
+    if (op !== 'canRead' && value) {
+      // CREATE/EDIT/DELETE require READ.
+      updated.canRead = true;
+    }
+    // Authoritative set: every still-readable account for this delegate.
+    const nextGrants = accounts
+      .map((a) =>
+        a.id === accountId ? updated : grantFor(delegate, a.id),
+      )
+      .filter((g) => g.canRead);
     try {
-      await delegationApi.setGrants(delegate.id, next);
+      await delegationApi.setGrants(delegate.id, nextGrants);
       setDelegates((prev) =>
         prev.map((d) =>
-          d.id === delegate.id ? { ...d, accountIds: next } : d,
+          d.id === delegate.id ? { ...d, grants: nextGrants } : d,
         ),
       );
     } catch (err) {
@@ -234,23 +267,45 @@ export function SharedAccessSection() {
                 </div>
               </div>
               <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
-                Accounts this delegate can read:
+                Per-account access (READ is required for the others):
               </p>
-              <div className="grid gap-2 sm:grid-cols-2">
-                {accounts.map((a) => (
-                  <div
-                    key={a.id}
-                    className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300"
-                  >
-                    <ToggleSwitch
-                      size="sm"
-                      checked={d.accountIds.includes(a.id)}
-                      onChange={() => toggleGrant(d, a.id)}
-                      label={`Read access to ${a.name}`}
-                    />
-                    <span>{a.name}</span>
-                  </div>
-                ))}
+              <div className="space-y-2">
+                {accounts.map((a) => {
+                  const g = grantFor(d, a.id);
+                  const ops = [
+                    { key: 'canRead' as const, label: 'Read' },
+                    { key: 'canCreate' as const, label: 'Create' },
+                    { key: 'canEdit' as const, label: 'Edit' },
+                    { key: 'canDelete' as const, label: 'Delete' },
+                  ];
+                  return (
+                    <div
+                      key={a.id}
+                      className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-700 dark:text-gray-300 border-b border-gray-100 dark:border-gray-700/50 pb-2"
+                    >
+                      <span className="w-40 truncate font-medium">
+                        {a.name}
+                      </span>
+                      {ops.map((op) => (
+                        <label
+                          key={op.key}
+                          className="flex items-center gap-1.5"
+                        >
+                          <ToggleSwitch
+                            size="sm"
+                            checked={!!g[op.key]}
+                            disabled={op.key !== 'canRead' && !g.canRead}
+                            onChange={(v) =>
+                              updateGrant(d, a.id, op.key, v)
+                            }
+                            label={`${op.label} access to ${a.name}`}
+                          />
+                          <span className="text-xs">{op.label}</span>
+                        </label>
+                      ))}
+                    </div>
+                  );
+                })}
               </div>
             </li>
           ))}

--- a/frontend/src/components/settings/SharedAccessSection.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.tsx
@@ -111,7 +111,11 @@ export function SharedAccessSection() {
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (!sendInvite && password) {
+    if (!sendInvite) {
+      if (!password) {
+        toast.error('Set a password or send an email invite.');
+        return;
+      }
       const parsed = passwordSchema.safeParse(password);
       if (!parsed.success) {
         toast.error(PASSWORD_REQUIREMENTS_TEXT);
@@ -319,14 +323,14 @@ export function SharedAccessSection() {
                   Password
                 </label>
                 <PasswordInput
-                  placeholder="Set a password (optional)"
+                  required
+                  placeholder="Set a password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   className={inputClass}
                 />
                 <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  {PASSWORD_REQUIREMENTS_TEXT} Leave blank to auto-generate a
-                  temporary password.
+                  {PASSWORD_REQUIREMENTS_TEXT}
                 </p>
               </div>
             )}

--- a/frontend/src/components/transactions/TransferTransactionFields.test.tsx
+++ b/frontend/src/components/transactions/TransferTransactionFields.test.tsx
@@ -499,4 +499,45 @@ describe('TransferTransactionFields', () => {
     expect(labels).toContain('CAD Account (CAD)');
     expect(labels).toContain('US Account (USD)');
   });
+
+  it('shows a "Hidden account" option when the To account is not accessible (delegate)', () => {
+    const accessible = createAccount({ id: 'acc-1', name: 'Chequing' });
+
+    render(
+      <TransferTransactionFields
+        {...defaultProps}
+        accounts={[accessible]}
+        transferToAccountId="acc-hidden"
+        transaction={
+          {
+            linkedTransaction: { account: { name: 'Hidden account' } },
+          } as never
+        }
+      />
+    );
+
+    const toSelect = screen.getByLabelText('To Account');
+    const labels = Array.from(toSelect.querySelectorAll('option')).map(
+      (o) => o.textContent,
+    );
+    expect(labels).toContain('Hidden account');
+  });
+
+  it('falls back to "Hidden account" for an inaccessible From account', () => {
+    const accessible = createAccount({ id: 'acc-1', name: 'Chequing' });
+
+    render(
+      <TransferTransactionFields
+        {...defaultProps}
+        accounts={[accessible]}
+        watchedAccountId="acc-hidden"
+      />
+    );
+
+    const fromSelect = screen.getByLabelText('From Account');
+    const labels = Array.from(fromSelect.querySelectorAll('option')).map(
+      (o) => o.textContent,
+    );
+    expect(labels).toContain('Hidden account');
+  });
 });

--- a/frontend/src/components/transactions/TransferTransactionFields.tsx
+++ b/frontend/src/components/transactions/TransferTransactionFields.tsx
@@ -62,9 +62,19 @@ export function TransferTransactionFields({
   crossCurrencyInfo,
   payees,
   payeeAliasMap,
-  transaction: _transaction,
+  transaction,
   createdAtSlot,
 }: TransferTransactionFieldsProps) {
+  // A delegate may only have READ on one side of a transfer; the other
+  // account is not in `accounts` (and the backend masked it). Surface it as
+  // a read-only "Hidden account" option so the field is not blank.
+  const hiddenAccountOption = (id: string) => {
+    if (!id || accounts.some((a) => a.id === id)) return [];
+    const masked =
+      transaction?.linkedTransaction?.account?.name || 'Hidden account';
+    return [{ value: id, label: masked, disabled: true }];
+  };
+
   return (
     <div className="space-y-4">
       {/* Row 1: Date and optionally Create Date */}
@@ -86,6 +96,7 @@ export function TransferTransactionFields({
           value={watchedAccountId || ''}
           options={[
             { value: '', label: 'Select account...' },
+            ...hiddenAccountOption(watchedAccountId),
             ...buildAccountDropdownOptions(
               accounts,
               (account) =>
@@ -104,6 +115,7 @@ export function TransferTransactionFields({
           }}
           options={[
             { value: '', label: 'Select destination account...' },
+            ...hiddenAccountOption(transferToAccountId),
             ...buildAccountDropdownOptions(
               accounts,
               (account) =>

--- a/frontend/src/components/ui/Input.test.tsx
+++ b/frontend/src/components/ui/Input.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { Input } from './Input';
 
 describe('Input', () => {
@@ -35,5 +35,25 @@ describe('Input', () => {
 
   it('has displayName', () => {
     expect(Input.displayName).toBe('Input');
+  });
+
+  it('toggles password visibility with the eye button', () => {
+    render(<Input label="Password" type="password" />);
+    const field = screen.getByLabelText('Password');
+    expect(field).toHaveAttribute('type', 'password');
+
+    const toggle = screen.getByRole('button', { name: 'Show input' });
+    fireEvent.click(toggle);
+    expect(field).toHaveAttribute('type', 'text');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide input' }));
+    expect(field).toHaveAttribute('type', 'password');
+  });
+
+  it('does not render the eye toggle for non-password inputs', () => {
+    render(<Input label="Email" type="email" />);
+    expect(
+      screen.queryByRole('button', { name: /input/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,4 +1,7 @@
-import { forwardRef, InputHTMLAttributes } from 'react';
+'use client';
+
+import { forwardRef, useState, InputHTMLAttributes } from 'react';
+import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
 import { cn, inputBaseClasses, inputErrorClasses } from '@/lib/utils';
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -11,6 +14,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ label, error, prefix, className, id, type, value, ...props }, ref) => {
     const inputId = id || `input-${label?.toLowerCase().replace(/\s+/g, '-')}`;
     const isEmptyDate = type === 'date' && value !== undefined && !value;
+    const isPassword = type === 'password';
+    const [revealed, setRevealed] = useState(false);
+    const effectiveType =
+      isPassword && revealed ? 'text' : type;
 
     return (
       <div className="w-full">
@@ -22,7 +29,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             {label}
           </label>
         )}
-        <div className={prefix ? 'relative' : undefined}>
+        <div className={prefix || isPassword ? 'relative' : undefined}>
           {prefix && (
             <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-500 dark:text-gray-400 pointer-events-none">
               {prefix}
@@ -31,18 +38,35 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           <input
             ref={ref}
             id={inputId}
-            type={type}
+            type={effectiveType}
             value={value}
             className={cn(
               inputBaseClasses,
               'border px-3 py-2 focus:ring-1 focus:outline-none',
               error && inputErrorClasses,
               prefix && 'pl-7',
+              isPassword && 'pr-10',
               isEmptyDate && 'date-empty',
               className
             )}
             {...props}
           />
+          {isPassword && (
+            <button
+              type="button"
+              tabIndex={-1}
+              onClick={() => setRevealed((v) => !v)}
+              aria-label={revealed ? 'Hide input' : 'Show input'}
+              title={revealed ? 'Hide input' : 'Show input'}
+              className="absolute inset-y-0 right-0 flex items-center px-3 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 focus:outline-none"
+            >
+              {revealed ? (
+                <EyeSlashIcon className="h-5 w-5" />
+              ) : (
+                <EyeIcon className="h-5 w-5" />
+              )}
+            </button>
+          )}
         </div>
         {error && (
           <p className="mt-1 text-sm text-red-600 dark:text-red-400">{error}</p>

--- a/frontend/src/components/ui/PasswordInput.test.tsx
+++ b/frontend/src/components/ui/PasswordInput.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useRef } from 'react';
+import { PasswordInput } from './PasswordInput';
+
+describe('PasswordInput', () => {
+  it('defaults to a hidden password field', () => {
+    render(<PasswordInput placeholder="Secret" />);
+    expect(screen.getByPlaceholderText('Secret')).toHaveAttribute(
+      'type',
+      'password',
+    );
+  });
+
+  it('toggles visibility via the eye button', () => {
+    render(<PasswordInput placeholder="Secret" />);
+    const field = screen.getByPlaceholderText('Secret');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show input' }));
+    expect(field).toHaveAttribute('type', 'text');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide input' }));
+    expect(field).toHaveAttribute('type', 'password');
+  });
+
+  it('forwards value/onChange and the ref', () => {
+    const onChange = vi.fn();
+    function Harness() {
+      const ref = useRef<HTMLInputElement>(null);
+      return (
+        <PasswordInput
+          ref={ref}
+          placeholder="Secret"
+          value="abc"
+          onChange={onChange}
+          data-ref-check
+        />
+      );
+    }
+    render(<Harness />);
+    const field = screen.getByPlaceholderText('Secret');
+    expect(field).toHaveValue('abc');
+    expect(field).toHaveAttribute('data-ref-check');
+    fireEvent.change(field, { target: { value: 'abcd' } });
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/ui/PasswordInput.tsx
+++ b/frontend/src/components/ui/PasswordInput.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { forwardRef, useState, InputHTMLAttributes } from 'react';
+import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
+import { cn } from '@/lib/utils';
+
+type PasswordInputProps = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'type'
+>;
+
+/**
+ * Password text field with a show/hide eye toggle. forwardRef so it works
+ * as a drop-in for both controlled inputs and react-hook-form
+ * `{...register()}` spreads. Pass the usual input className; an inner
+ * right-padding is added so the text never sits under the eye button.
+ */
+export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
+  function PasswordInput({ className, ...props }, ref) {
+    const [visible, setVisible] = useState(false);
+    return (
+      <div className="relative">
+        <input
+          ref={ref}
+          type={visible ? 'text' : 'password'}
+          className={cn(className, 'pr-10')}
+          {...props}
+        />
+        <button
+          type="button"
+          tabIndex={-1}
+          onClick={() => setVisible((v) => !v)}
+          aria-label={visible ? 'Hide input' : 'Show input'}
+          title={visible ? 'Hide input' : 'Show input'}
+          className="absolute inset-y-0 right-0 flex items-center px-3 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 focus:outline-none"
+        >
+          {visible ? (
+            <EyeSlashIcon className="h-5 w-5" />
+          ) : (
+            <EyeIcon className="h-5 w-5" />
+          )}
+        </button>
+      </div>
+    );
+  },
+);

--- a/frontend/src/hooks/useSwipeNavigation.test.ts
+++ b/frontend/src/hooks/useSwipeNavigation.test.ts
@@ -492,13 +492,13 @@ describe('useSwipeNavigation', () => {
 
   describe('delegate (acting-as) view', () => {
     afterEach(() => {
-      useAuthStore.getState().setDelegation(null, [], null);
+      useAuthStore.getState().setDelegation(null, [], null, null);
     });
 
     it('disables swipe navigation on the dashboard for a delegate', () => {
       mockPathname = '/dashboard';
       act(() => {
-        useAuthStore.getState().setDelegation('owner-1', [], null);
+        useAuthStore.getState().setDelegation('owner-1', [], null, null);
       });
 
       const { result } = renderHook(() => useSwipeNavigation());

--- a/frontend/src/hooks/useSwipeNavigation.test.ts
+++ b/frontend/src/hooks/useSwipeNavigation.test.ts
@@ -532,6 +532,45 @@ describe('useSwipeNavigation', () => {
       expect(result.current.currentIndex).toBe(0);
     });
 
+    it('includes Accounts when the delegate can read any account', () => {
+      mockPathname = '/accounts';
+      act(() => {
+        useAuthStore.getState().setDelegation('owner-1', [], null, {
+          bills: true,
+          investments: false,
+          budgets: false,
+          reports: false,
+          ai: false,
+          accounts: true,
+        });
+      });
+
+      const { result } = renderHook(() => useSwipeNavigation());
+
+      // Dashboard + Accounts + Bills.
+      expect(result.current.totalPages).toBe(3);
+      expect(result.current.isSwipePage).toBe(true);
+      expect(result.current.currentIndex).toBeGreaterThanOrEqual(0);
+    });
+
+    it('excludes Accounts when the delegate has no account access', () => {
+      mockPathname = '/accounts';
+      act(() => {
+        useAuthStore.getState().setDelegation('owner-1', [], null, {
+          bills: true,
+          investments: false,
+          budgets: false,
+          reports: false,
+          ai: false,
+        });
+      });
+
+      const { result } = renderHook(() => useSwipeNavigation());
+
+      expect(result.current.isSwipePage).toBe(false);
+      expect(result.current.currentIndex).toBe(-1);
+    });
+
     it('includes Transactions when the delegate has transactional access', () => {
       mockPathname = '/transactions';
       act(() => {

--- a/frontend/src/hooks/useSwipeNavigation.test.ts
+++ b/frontend/src/hooks/useSwipeNavigation.test.ts
@@ -492,13 +492,13 @@ describe('useSwipeNavigation', () => {
 
   describe('delegate (acting-as) view', () => {
     afterEach(() => {
-      useAuthStore.getState().setDelegation(null, []);
+      useAuthStore.getState().setDelegation(null, [], null);
     });
 
     it('disables swipe navigation on the dashboard for a delegate', () => {
       mockPathname = '/dashboard';
       act(() => {
-        useAuthStore.getState().setDelegation('owner-1', []);
+        useAuthStore.getState().setDelegation('owner-1', [], null);
       });
 
       const { result } = renderHook(() => useSwipeNavigation());

--- a/frontend/src/hooks/useSwipeNavigation.test.ts
+++ b/frontend/src/hooks/useSwipeNavigation.test.ts
@@ -495,7 +495,7 @@ describe('useSwipeNavigation', () => {
       useAuthStore.getState().setDelegation(null, [], null, null);
     });
 
-    it('disables swipe navigation on the dashboard for a delegate', () => {
+    it('disables swipe when a delegate has no granted sections', () => {
       mockPathname = '/dashboard';
       act(() => {
         useAuthStore.getState().setDelegation('owner-1', [], null, null);
@@ -503,14 +503,54 @@ describe('useSwipeNavigation', () => {
 
       const { result } = renderHook(() => useSwipeNavigation());
 
+      // Only the Dashboard is reachable -> nothing to swipe to.
       expect(result.current.isSwipePage).toBe(false);
+      expect(result.current.totalPages).toBe(1);
+    });
+
+    it('swipes only across the delegate-granted sections', () => {
+      mockPathname = '/dashboard';
+      act(() => {
+        useAuthStore.getState().setDelegation('owner-1', [], null, {
+          bills: true,
+          investments: false,
+          budgets: true,
+          reports: false,
+          ai: false,
+        });
+      });
+
+      const { result } = renderHook(() => useSwipeNavigation());
+
+      // Dashboard + Bills + Budgets only.
+      expect(result.current.totalPages).toBe(3);
+      expect(result.current.isSwipePage).toBe(true);
+      expect(result.current.currentIndex).toBe(0);
+    });
+
+    it('does not treat a non-granted section as a swipe page', () => {
+      mockPathname = '/investments';
+      act(() => {
+        useAuthStore.getState().setDelegation('owner-1', [], null, {
+          bills: true,
+          investments: false,
+          budgets: false,
+          reports: false,
+          ai: false,
+        });
+      });
+
+      const { result } = renderHook(() => useSwipeNavigation());
+
       expect(result.current.currentIndex).toBe(-1);
+      expect(result.current.isSwipePage).toBe(false);
     });
 
     it('keeps swipe navigation enabled for a normal (non-delegate) user', () => {
       mockPathname = '/dashboard';
       const { result } = renderHook(() => useSwipeNavigation());
       expect(result.current.isSwipePage).toBe(true);
+      expect(result.current.totalPages).toBe(7);
     });
   });
 });

--- a/frontend/src/hooks/useSwipeNavigation.test.ts
+++ b/frontend/src/hooks/useSwipeNavigation.test.ts
@@ -528,6 +528,27 @@ describe('useSwipeNavigation', () => {
       expect(result.current.currentIndex).toBe(0);
     });
 
+    it('includes Transactions when the delegate has transactional access', () => {
+      mockPathname = '/transactions';
+      act(() => {
+        useAuthStore.getState().setDelegation('owner-1', [], null, {
+          bills: true,
+          investments: false,
+          budgets: false,
+          reports: false,
+          ai: false,
+          transactions: true,
+        });
+      });
+
+      const { result } = renderHook(() => useSwipeNavigation());
+
+      // Dashboard + Transactions + Bills.
+      expect(result.current.totalPages).toBe(3);
+      expect(result.current.isSwipePage).toBe(true);
+      expect(result.current.currentIndex).toBeGreaterThanOrEqual(0);
+    });
+
     it('does not treat a non-granted section as a swipe page', () => {
       mockPathname = '/investments';
       act(() => {

--- a/frontend/src/hooks/useSwipeNavigation.test.ts
+++ b/frontend/src/hooks/useSwipeNavigation.test.ts
@@ -492,7 +492,11 @@ describe('useSwipeNavigation', () => {
 
   describe('delegate (acting-as) view', () => {
     afterEach(() => {
-      useAuthStore.getState().setDelegation(null, [], null, null);
+      // The hook is still mounted (RTL cleanup runs after this); resetting
+      // the store triggers a re-render, so wrap it in act().
+      act(() => {
+        useAuthStore.getState().setDelegation(null, [], null, null);
+      });
     });
 
     it('disables swipe when a delegate has no granted sections', () => {

--- a/frontend/src/hooks/useSwipeNavigation.test.ts
+++ b/frontend/src/hooks/useSwipeNavigation.test.ts
@@ -18,6 +18,7 @@ vi.mock('next/navigation', () => ({
 }));
 
 import { useSwipeNavigation } from './useSwipeNavigation';
+import { useAuthStore } from '@/store/authStore';
 
 // Helper to create touch events
 function createTouchEvent(
@@ -486,6 +487,30 @@ describe('useSwipeNavigation', () => {
       // Even if we tried to dispatch events, the hook would not attach listeners
       expect(result.current.isSwipePage).toBe(false);
       expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('delegate (acting-as) view', () => {
+    afterEach(() => {
+      useAuthStore.getState().setDelegation(null, []);
+    });
+
+    it('disables swipe navigation on the dashboard for a delegate', () => {
+      mockPathname = '/dashboard';
+      act(() => {
+        useAuthStore.getState().setDelegation('owner-1', []);
+      });
+
+      const { result } = renderHook(() => useSwipeNavigation());
+
+      expect(result.current.isSwipePage).toBe(false);
+      expect(result.current.currentIndex).toBe(-1);
+    });
+
+    it('keeps swipe navigation enabled for a normal (non-delegate) user', () => {
+      mockPathname = '/dashboard';
+      const { result } = renderHook(() => useSwipeNavigation());
+      expect(result.current.isSwipePage).toBe(true);
     });
   });
 });

--- a/frontend/src/hooks/useSwipeNavigation.ts
+++ b/frontend/src/hooks/useSwipeNavigation.ts
@@ -21,6 +21,7 @@ const SWIPE_PAGES = [
 // (delegateSections.transactions, derived server-side). Accounts stays
 // per-account scoped and out of the swipe set, mirroring the delegate nav.
 const DELEGATE_SECTION_BY_HREF: Record<string, keyof DelegateSectionGrants> = {
+  '/accounts': 'accounts',
   '/transactions': 'transactions',
   '/bills': 'bills',
   '/investments': 'investments',

--- a/frontend/src/hooks/useSwipeNavigation.ts
+++ b/frontend/src/hooks/useSwipeNavigation.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useLayoutEffect, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
+import { useAuthStore } from '@/store/authStore';
 
 const SWIPE_PAGES = [
   { href: '/dashboard', label: 'Dashboard' },
@@ -60,7 +61,13 @@ export function useSwipeNavigation(): UseSwipeNavigationReturn {
   const pathname = usePathname();
   const contentRef = useRef<HTMLDivElement>(null);
 
-  const currentIndex = SWIPE_PAGES.findIndex((p) => pathname === p.href);
+  // A delegate acting as an owner only has the Dashboard (Phase 1); disable
+  // swipe navigation entirely so they can't swipe into a section they have
+  // no access to.
+  const isDelegateView = useAuthStore((s) => !!s.actingAsUserId);
+  const currentIndex = isDelegateView
+    ? -1
+    : SWIPE_PAGES.findIndex((p) => pathname === p.href);
   const isSwipePage = currentIndex !== -1;
   const currentIndexRef = useRef(currentIndex);
 

--- a/frontend/src/hooks/useSwipeNavigation.ts
+++ b/frontend/src/hooks/useSwipeNavigation.ts
@@ -16,10 +16,12 @@ const SWIPE_PAGES = [
 ] as const;
 
 // Section-gated swipe pages for a delegate. The Dashboard is always
-// reachable; the rest require the matching owner section grant. Accounts &
-// Transactions are scoped per-account (not section-gated) and stay out of
-// the delegate swipe set, mirroring the delegate top-nav behaviour.
+// reachable; the rest require the matching owner grant. Transactions is
+// reachable when the delegate can read any non-investment account
+// (delegateSections.transactions, derived server-side). Accounts stays
+// per-account scoped and out of the swipe set, mirroring the delegate nav.
 const DELEGATE_SECTION_BY_HREF: Record<string, keyof DelegateSectionGrants> = {
+  '/transactions': 'transactions',
   '/bills': 'bills',
   '/investments': 'investments',
   '/budgets': 'budgets',

--- a/frontend/src/hooks/useSwipeNavigation.ts
+++ b/frontend/src/hooks/useSwipeNavigation.ts
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useLayoutEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { useAuthStore } from '@/store/authStore';
+import type { DelegateSectionGrants } from '@/lib/delegation';
 
 const SWIPE_PAGES = [
   { href: '/dashboard', label: 'Dashboard' },
@@ -13,6 +14,17 @@ const SWIPE_PAGES = [
   { href: '/budgets', label: 'Budgets' },
   { href: '/reports', label: 'Reports' },
 ] as const;
+
+// Section-gated swipe pages for a delegate. The Dashboard is always
+// reachable; the rest require the matching owner section grant. Accounts &
+// Transactions are scoped per-account (not section-gated) and stay out of
+// the delegate swipe set, mirroring the delegate top-nav behaviour.
+const DELEGATE_SECTION_BY_HREF: Record<string, keyof DelegateSectionGrants> = {
+  '/bills': 'bills',
+  '/investments': 'investments',
+  '/budgets': 'budgets',
+  '/reports': 'reports',
+};
 
 const DECISION_THRESHOLD = 10; // px movement before deciding horizontal vs vertical
 const COMMIT_THRESHOLD_RATIO = 0.25; // 25% of screen width to commit navigation
@@ -61,19 +73,31 @@ export function useSwipeNavigation(): UseSwipeNavigationReturn {
   const pathname = usePathname();
   const contentRef = useRef<HTMLDivElement>(null);
 
-  // A delegate acting as an owner only has the Dashboard (Phase 1); disable
-  // swipe navigation entirely so they can't swipe into a section they have
-  // no access to.
+  // A delegate acting as an owner can only swipe across the sections the
+  // owner granted them (plus the Dashboard). Non-delegates swipe all pages.
   const isDelegateView = useAuthStore((s) => !!s.actingAsUserId);
-  const currentIndex = isDelegateView
-    ? -1
-    : SWIPE_PAGES.findIndex((p) => pathname === p.href);
-  const isSwipePage = currentIndex !== -1;
+  const delegateSections = useAuthStore((s) => s.delegateSections);
+
+  const pages = useMemo(() => {
+    if (!isDelegateView) return SWIPE_PAGES.slice();
+    return SWIPE_PAGES.filter((p) => {
+      if (p.href === '/dashboard') return true;
+      const section = DELEGATE_SECTION_BY_HREF[p.href];
+      return !!section && !!delegateSections?.[section];
+    });
+  }, [isDelegateView, delegateSections]);
+
+  const currentIndex = pages.findIndex((p) => pathname === p.href);
+  // A lone page (e.g. a delegate granted no sections) has nothing to swipe
+  // to, so treat it as a non-swipe page.
+  const isSwipePage = currentIndex !== -1 && pages.length > 1;
   const currentIndexRef = useRef(currentIndex);
+  const pagesRef = useRef(pages);
 
   useEffect(() => {
     currentIndexRef.current = currentIndex;
-  }, [currentIndex]);
+    pagesRef.current = pages;
+  }, [currentIndex, pages]);
 
   // Entrance animation: set initial off-screen position before browser paints
   useLayoutEffect(() => {
@@ -157,7 +181,7 @@ export function useSwipeNavigation(): UseSwipeNavigationReturn {
           const direction = deltaX < 0 ? 1 : -1;
           const nextIdx = idx + direction;
 
-          if (nextIdx < 0 || nextIdx >= SWIPE_PAGES.length) {
+          if (nextIdx < 0 || nextIdx >= pagesRef.current.length) {
             state = { ...IDLE_STATE };
             return;
           }
@@ -205,7 +229,7 @@ export function useSwipeNavigation(): UseSwipeNavigationReturn {
         const idx = currentIndexRef.current;
         const nextIdx = idx + direction;
 
-        if (nextIdx >= 0 && nextIdx < SWIPE_PAGES.length) {
+        if (nextIdx >= 0 && nextIdx < pagesRef.current.length) {
           navigated = true;
           const targetX = deltaX < 0 ? -screenW : screenW;
           content.style.transition = `transform ${ANIMATION_MS}ms ease-out, opacity ${ANIMATION_MS}ms ease-out`;
@@ -220,7 +244,7 @@ export function useSwipeNavigation(): UseSwipeNavigationReturn {
             done = true;
             content.removeEventListener('transitionend', onEnd);
             // resetStyles();
-            router.push(SWIPE_PAGES[nextIdx].href);
+            router.push(pagesRef.current[nextIdx].href);
           };
           content.addEventListener('transitionend', onEnd, { once: true });
           setTimeout(onEnd, ANIMATION_MS + 50);
@@ -258,7 +282,7 @@ export function useSwipeNavigation(): UseSwipeNavigationReturn {
   return {
     contentRef,
     currentIndex,
-    totalPages: SWIPE_PAGES.length,
+    totalPages: pages.length,
     isSwipePage,
   };
 }

--- a/frontend/src/lib/accounts.ts
+++ b/frontend/src/lib/accounts.ts
@@ -83,6 +83,16 @@ export const accountsApi = {
     invalidateCache('accounts:');
   },
 
+  // Set the acting delegate's own favourite flag for an account. The
+  // owner's accounts.is_favourite is never touched by this.
+  setDelegateFavourite: async (
+    id: string,
+    isFavourite: boolean,
+  ): Promise<void> => {
+    await apiClient.put(`/accounts/${id}/favourite`, { isFavourite });
+    invalidateCache('accounts:');
+  },
+
   // Get account balance
   getBalance: async (id: string): Promise<{ balance: number }> => {
     const response = await apiClient.get<{ balance: number }>(`/accounts/${id}/balance`);

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -30,6 +30,14 @@ export const authApi = {
     return response.data;
   },
 
+  // Authenticated user's OWN profile (delegate id, never the owner) -- the
+  // Security view uses this while acting as a delegate so it manages the
+  // actor's credentials, not the owner's.
+  getSelfProfile: async () => {
+    const response = await apiClient.get('/auth/me-self');
+    return response.data;
+  },
+
   getAuthMethods: async (): Promise<AuthMethods> => {
     const response = await apiClient.get<AuthMethods>('/auth/methods');
     return response.data;
@@ -72,6 +80,11 @@ export const authApi = {
 
   disable2FA: async (code: string): Promise<{ message: string }> => {
     const response = await apiClient.post<{ message: string }>('/auth/2fa/disable', { code });
+    return response.data;
+  },
+
+  get2FAStatus: async (): Promise<{ enabled: boolean }> => {
+    const response = await apiClient.get<{ enabled: boolean }>('/auth/2fa/status');
     return response.data;
   },
 

--- a/frontend/src/lib/delegation.test.ts
+++ b/frontend/src/lib/delegation.test.ts
@@ -76,12 +76,12 @@ describe('delegationApi', () => {
     expect(res.temporaryPassword).toBe('Tiger!River42');
   });
 
-  it('setCapabilities PUTs the capability flags', async () => {
+  it('setCapabilities PUTs the granular capability flags', async () => {
     vi.mocked(apiClient.put).mockResolvedValue({ data: {} });
-    await delegationApi.setCapabilities('d-1', { canManagePayees: true });
+    await delegationApi.setCapabilities('d-1', { payeesCanEdit: true });
     expect(apiClient.put).toHaveBeenCalledWith(
       '/delegation/delegates/d-1/capabilities',
-      { canManagePayees: true },
+      { payeesCanEdit: true },
     );
   });
 });

--- a/frontend/src/lib/delegation.test.ts
+++ b/frontend/src/lib/delegation.test.ts
@@ -11,7 +11,7 @@ describe('delegationApi', () => {
 
   it('getContexts fetches /auth/contexts', async () => {
     vi.mocked(apiClient.get).mockResolvedValue({
-      data: { actingAsUserId: null, contexts: [] },
+      data: { actingAsUserId: null, contexts: [], capabilities: null },
     });
     const res = await delegationApi.getContexts();
     expect(apiClient.get).toHaveBeenCalledWith('/auth/contexts');

--- a/frontend/src/lib/delegation.test.ts
+++ b/frontend/src/lib/delegation.test.ts
@@ -75,4 +75,13 @@ describe('delegationApi', () => {
     );
     expect(res.temporaryPassword).toBe('Tiger!River42');
   });
+
+  it('setCapabilities PUTs the capability flags', async () => {
+    vi.mocked(apiClient.put).mockResolvedValue({ data: {} });
+    await delegationApi.setCapabilities('d-1', { canManagePayees: true });
+    expect(apiClient.put).toHaveBeenCalledWith(
+      '/delegation/delegates/d-1/capabilities',
+      { canManagePayees: true },
+    );
+  });
 });

--- a/frontend/src/lib/delegation.test.ts
+++ b/frontend/src/lib/delegation.test.ts
@@ -46,12 +46,16 @@ describe('delegationApi', () => {
     });
   });
 
-  it('setGrants PUTs the account ids', async () => {
+  it('setGrants PUTs the per-account grants', async () => {
     vi.mocked(apiClient.put).mockResolvedValue({ data: {} });
-    await delegationApi.setGrants('d-1', ['a-1', 'a-2']);
+    const grants = [
+      { accountId: 'a-1', canRead: true, canCreate: true },
+      { accountId: 'a-2', canRead: true },
+    ];
+    await delegationApi.setGrants('d-1', grants);
     expect(apiClient.put).toHaveBeenCalledWith(
       '/delegation/delegates/d-1/grants',
-      { accountIds: ['a-1', 'a-2'] },
+      { grants },
     );
   });
 

--- a/frontend/src/lib/delegation.test.ts
+++ b/frontend/src/lib/delegation.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import apiClient from './api';
+import { delegationApi } from './delegation';
+
+vi.mock('./api', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+
+describe('delegationApi', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('getContexts fetches /auth/contexts', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: { actingAsUserId: null, contexts: [] },
+    });
+    const res = await delegationApi.getContexts();
+    expect(apiClient.get).toHaveBeenCalledWith('/auth/contexts');
+    expect(res.actingAsUserId).toBeNull();
+  });
+
+  it('switchContext posts the target user id', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({
+      data: { actingAsUserId: 'owner-1' },
+    });
+    const res = await delegationApi.switchContext('owner-1');
+    expect(apiClient.post).toHaveBeenCalledWith('/auth/switch-context', {
+      targetUserId: 'owner-1',
+    });
+    expect(res.actingAsUserId).toBe('owner-1');
+  });
+
+  it('listDelegates fetches the delegate list', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: [{ id: 'd-1' }] });
+    const res = await delegationApi.listDelegates();
+    expect(apiClient.get).toHaveBeenCalledWith('/delegation/delegates');
+    expect(res).toHaveLength(1);
+  });
+
+  it('createDelegate posts the payload', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({
+      data: { id: 'd-1', delegateUserId: 'u-2', email: 'a@b.c', invited: false },
+    });
+    await delegationApi.createDelegate({ email: 'a@b.c' });
+    expect(apiClient.post).toHaveBeenCalledWith('/delegation/delegates', {
+      email: 'a@b.c',
+    });
+  });
+
+  it('setGrants PUTs the account ids', async () => {
+    vi.mocked(apiClient.put).mockResolvedValue({ data: {} });
+    await delegationApi.setGrants('d-1', ['a-1', 'a-2']);
+    expect(apiClient.put).toHaveBeenCalledWith(
+      '/delegation/delegates/d-1/grants',
+      { accountIds: ['a-1', 'a-2'] },
+    );
+  });
+
+  it('revokeDelegate calls DELETE', async () => {
+    vi.mocked(apiClient.delete).mockResolvedValue({});
+    await delegationApi.revokeDelegate('d-1');
+    expect(apiClient.delete).toHaveBeenCalledWith('/delegation/delegates/d-1');
+  });
+
+  it('resetPassword posts to the reset endpoint', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({
+      data: { temporaryPassword: 'Tiger!River42' },
+    });
+    const res = await delegationApi.resetPassword('d-1');
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/delegation/delegates/d-1/reset-password',
+    );
+    expect(res.temporaryPassword).toBe('Tiger!River42');
+  });
+});

--- a/frontend/src/lib/delegation.ts
+++ b/frontend/src/lib/delegation.ts
@@ -47,6 +47,12 @@ export interface DelegateSectionGrants {
    * Optional because the owner-facing delegate summary omits it.
    */
   transactions?: boolean;
+  /**
+   * Derived (not a stored section): true when the delegate can read any
+   * account at all, so the Accounts section/nav is reachable.
+   * Optional because the owner-facing delegate summary omits it.
+   */
+  accounts?: boolean;
 }
 
 /** Column-shaped partial used by the PUT /sections endpoint. */

--- a/frontend/src/lib/delegation.ts
+++ b/frontend/src/lib/delegation.ts
@@ -7,10 +7,16 @@ export interface DelegateContext {
   ownerHas2FA: boolean;
 }
 
+export interface ResourceCapabilities {
+  create: boolean;
+  edit: boolean;
+  delete: boolean;
+}
+
 export interface DelegateCapabilityFlags {
-  payees: boolean;
-  categories: boolean;
-  tags: boolean;
+  payees: ResourceCapabilities;
+  categories: ResourceCapabilities;
+  tags: ResourceCapabilities;
 }
 
 export interface ContextsResponse {
@@ -39,17 +45,19 @@ export interface DelegateSummary {
     hasPassword: boolean;
   };
   grants: AccountGrant[];
-  capabilities: {
-    payees: boolean;
-    categories: boolean;
-    tags: boolean;
-  };
+  capabilities: DelegateCapabilityFlags;
 }
 
 export interface DelegateCapabilities {
-  canManagePayees?: boolean;
-  canManageCategories?: boolean;
-  canManageTags?: boolean;
+  payeesCanCreate?: boolean;
+  payeesCanEdit?: boolean;
+  payeesCanDelete?: boolean;
+  categoriesCanCreate?: boolean;
+  categoriesCanEdit?: boolean;
+  categoriesCanDelete?: boolean;
+  tagsCanCreate?: boolean;
+  tagsCanEdit?: boolean;
+  tagsCanDelete?: boolean;
 }
 
 export interface CreateDelegatePayload {

--- a/frontend/src/lib/delegation.ts
+++ b/frontend/src/lib/delegation.ts
@@ -7,9 +7,16 @@ export interface DelegateContext {
   ownerHas2FA: boolean;
 }
 
+export interface DelegateCapabilityFlags {
+  payees: boolean;
+  categories: boolean;
+  tags: boolean;
+}
+
 export interface ContextsResponse {
   actingAsUserId: string | null;
   contexts: DelegateContext[];
+  capabilities: DelegateCapabilityFlags | null;
 }
 
 export interface AccountGrant {

--- a/frontend/src/lib/delegation.ts
+++ b/frontend/src/lib/delegation.ts
@@ -23,6 +23,7 @@ export interface ContextsResponse {
   actingAsUserId: string | null;
   contexts: DelegateContext[];
   capabilities: DelegateCapabilityFlags | null;
+  sections: DelegateSectionGrants | null;
 }
 
 export interface AccountGrant {

--- a/frontend/src/lib/delegation.ts
+++ b/frontend/src/lib/delegation.ts
@@ -12,6 +12,14 @@ export interface ContextsResponse {
   contexts: DelegateContext[];
 }
 
+export interface AccountGrant {
+  accountId: string;
+  canRead: boolean;
+  canCreate?: boolean;
+  canEdit?: boolean;
+  canDelete?: boolean;
+}
+
 export interface DelegateSummary {
   id: string;
   status: string;
@@ -23,7 +31,7 @@ export interface DelegateSummary {
     lastName: string | null;
     hasPassword: boolean;
   };
-  accountIds: string[];
+  grants: AccountGrant[];
 }
 
 export interface CreateDelegatePayload {
@@ -73,8 +81,8 @@ export const delegationApi = {
     await apiClient.delete(`/delegation/delegates/${id}`);
   },
 
-  setGrants: async (id: string, accountIds: string[]): Promise<void> => {
-    await apiClient.put(`/delegation/delegates/${id}/grants`, { accountIds });
+  setGrants: async (id: string, grants: AccountGrant[]): Promise<void> => {
+    await apiClient.put(`/delegation/delegates/${id}/grants`, { grants });
   },
 
   resetPassword: async (

--- a/frontend/src/lib/delegation.ts
+++ b/frontend/src/lib/delegation.ts
@@ -33,6 +33,24 @@ export interface AccountGrant {
   canDelete?: boolean;
 }
 
+/** Owner-grantable READ sections (gate tab visibility + section endpoints). */
+export interface DelegateSectionGrants {
+  bills: boolean;
+  investments: boolean;
+  budgets: boolean;
+  reports: boolean;
+  ai: boolean;
+}
+
+/** Column-shaped partial used by the PUT /sections endpoint. */
+export interface DelegateSectionFlags {
+  billsCanRead?: boolean;
+  investmentsCanRead?: boolean;
+  budgetsCanRead?: boolean;
+  reportsCanRead?: boolean;
+  aiCanRead?: boolean;
+}
+
 export interface DelegateSummary {
   id: string;
   status: string;
@@ -46,6 +64,7 @@ export interface DelegateSummary {
   };
   grants: AccountGrant[];
   capabilities: DelegateCapabilityFlags;
+  sections?: DelegateSectionGrants;
 }
 
 export interface DelegateCapabilities {
@@ -119,6 +138,13 @@ export const delegationApi = {
       `/delegation/delegates/${id}/capabilities`,
       capabilities,
     );
+  },
+
+  setSectionGrants: async (
+    id: string,
+    sections: DelegateSectionFlags,
+  ): Promise<void> => {
+    await apiClient.put(`/delegation/delegates/${id}/sections`, sections);
   },
 
   resetPassword: async (

--- a/frontend/src/lib/delegation.ts
+++ b/frontend/src/lib/delegation.ts
@@ -32,6 +32,17 @@ export interface DelegateSummary {
     hasPassword: boolean;
   };
   grants: AccountGrant[];
+  capabilities: {
+    payees: boolean;
+    categories: boolean;
+    tags: boolean;
+  };
+}
+
+export interface DelegateCapabilities {
+  canManagePayees?: boolean;
+  canManageCategories?: boolean;
+  canManageTags?: boolean;
 }
 
 export interface CreateDelegatePayload {
@@ -83,6 +94,16 @@ export const delegationApi = {
 
   setGrants: async (id: string, grants: AccountGrant[]): Promise<void> => {
     await apiClient.put(`/delegation/delegates/${id}/grants`, { grants });
+  },
+
+  setCapabilities: async (
+    id: string,
+    capabilities: DelegateCapabilities,
+  ): Promise<void> => {
+    await apiClient.put(
+      `/delegation/delegates/${id}/capabilities`,
+      capabilities,
+    );
   },
 
   resetPassword: async (

--- a/frontend/src/lib/delegation.ts
+++ b/frontend/src/lib/delegation.ts
@@ -74,6 +74,10 @@ export interface DelegateSummary {
     firstName: string | null;
     lastName: string | null;
     hasPassword: boolean;
+    // False when the delegate's password is their own (they have their own
+    // Monize account, or are a delegate for another owner too); the owner
+    // cannot reset it in that case.
+    canResetPassword: boolean;
   };
   grants: AccountGrant[];
   capabilities: DelegateCapabilityFlags;

--- a/frontend/src/lib/delegation.ts
+++ b/frontend/src/lib/delegation.ts
@@ -122,6 +122,14 @@ export const delegationApi = {
     return res.data;
   },
 
+  lookupEmail: async (email: string): Promise<{ exists: boolean }> => {
+    const res = await apiClient.get<{ exists: boolean }>(
+      '/delegation/delegates/lookup',
+      { params: { email } },
+    );
+    return res.data;
+  },
+
   createDelegate: async (
     payload: CreateDelegatePayload,
   ): Promise<CreateDelegateResponse> => {

--- a/frontend/src/lib/delegation.ts
+++ b/frontend/src/lib/delegation.ts
@@ -41,6 +41,12 @@ export interface DelegateSectionGrants {
   budgets: boolean;
   reports: boolean;
   ai: boolean;
+  /**
+   * Derived (not a stored section): true when the delegate can read any
+   * non-investment account, so the Transactions section/nav is reachable.
+   * Optional because the owner-facing delegate summary omits it.
+   */
+  transactions?: boolean;
 }
 
 /** Column-shaped partial used by the PUT /sections endpoint. */

--- a/frontend/src/lib/delegation.ts
+++ b/frontend/src/lib/delegation.ts
@@ -1,0 +1,88 @@
+import apiClient from './api';
+
+export interface DelegateContext {
+  userId: string;
+  label: string;
+  isSelf: boolean;
+  ownerHas2FA: boolean;
+}
+
+export interface ContextsResponse {
+  actingAsUserId: string | null;
+  contexts: DelegateContext[];
+}
+
+export interface DelegateSummary {
+  id: string;
+  status: string;
+  createdAt: string;
+  delegate: {
+    id: string;
+    email: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    hasPassword: boolean;
+  };
+  accountIds: string[];
+}
+
+export interface CreateDelegatePayload {
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  password?: string;
+  sendInvite?: boolean;
+}
+
+export interface CreateDelegateResponse {
+  id: string;
+  delegateUserId: string;
+  email: string;
+  temporaryPassword?: string;
+  invited: boolean;
+}
+
+export const delegationApi = {
+  getContexts: async (): Promise<ContextsResponse> => {
+    const res = await apiClient.get<ContextsResponse>('/auth/contexts');
+    return res.data;
+  },
+
+  switchContext: async (
+    targetUserId: string,
+  ): Promise<{ actingAsUserId: string | null }> => {
+    const res = await apiClient.post('/auth/switch-context', { targetUserId });
+    return res.data;
+  },
+
+  listDelegates: async (): Promise<DelegateSummary[]> => {
+    const res = await apiClient.get<DelegateSummary[]>(
+      '/delegation/delegates',
+    );
+    return res.data;
+  },
+
+  createDelegate: async (
+    payload: CreateDelegatePayload,
+  ): Promise<CreateDelegateResponse> => {
+    const res = await apiClient.post('/delegation/delegates', payload);
+    return res.data;
+  },
+
+  revokeDelegate: async (id: string): Promise<void> => {
+    await apiClient.delete(`/delegation/delegates/${id}`);
+  },
+
+  setGrants: async (id: string, accountIds: string[]): Promise<void> => {
+    await apiClient.put(`/delegation/delegates/${id}/grants`, { accountIds });
+  },
+
+  resetPassword: async (
+    id: string,
+  ): Promise<{ temporaryPassword: string }> => {
+    const res = await apiClient.post(
+      `/delegation/delegates/${id}/reset-password`,
+    );
+    return res.data;
+  },
+};

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -6,6 +6,7 @@ import { clearAllCache } from '@/lib/apiCache';
 import type {
   DelegateContext,
   DelegateCapabilityFlags,
+  DelegateSectionGrants,
 } from '@/lib/delegation';
 
 interface AuthState {
@@ -19,6 +20,7 @@ interface AuthState {
   actingAsUserId: string | null;
   availableContexts: DelegateContext[];
   delegateCapabilities: DelegateCapabilityFlags | null;
+  delegateSections: DelegateSectionGrants | null;
   setUser: (user: User | null) => void;
   setToken: (token: string | null) => void;
   setError: (error: string | null) => void;
@@ -27,6 +29,7 @@ interface AuthState {
     actingAsUserId: string | null,
     contexts: DelegateContext[],
     capabilities: DelegateCapabilityFlags | null,
+    sections: DelegateSectionGrants | null,
   ) => void;
   login: (user: User, token: string) => void;
   logout: () => void;
@@ -46,11 +49,22 @@ export const useAuthStore = create<AuthState>()(
       actingAsUserId: null,
       availableContexts: [],
       delegateCapabilities: null,
+      delegateSections: null,
 
       setUser: (user) => set({ user, isAuthenticated: !!user }),
 
-      setDelegation: (actingAsUserId, availableContexts, delegateCapabilities) =>
-        set({ actingAsUserId, availableContexts, delegateCapabilities }),
+      setDelegation: (
+        actingAsUserId,
+        availableContexts,
+        delegateCapabilities,
+        delegateSections,
+      ) =>
+        set({
+          actingAsUserId,
+          availableContexts,
+          delegateCapabilities,
+          delegateSections,
+        }),
 
       // auth_token is httpOnly — backend manages the cookie, not JS
       setToken: (token) => set({ token }),
@@ -95,6 +109,7 @@ export const useAuthStore = create<AuthState>()(
           actingAsUserId: null,
           availableContexts: [],
           delegateCapabilities: null,
+          delegateSections: null,
         });
       },
 

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -3,7 +3,10 @@ import { persist, createJSONStorage } from 'zustand/middleware';
 import { AxiosError } from 'axios';
 import { User } from '@/types/auth';
 import { clearAllCache } from '@/lib/apiCache';
-import type { DelegateContext } from '@/lib/delegation';
+import type {
+  DelegateContext,
+  DelegateCapabilityFlags,
+} from '@/lib/delegation';
 
 interface AuthState {
   user: User | null;
@@ -15,6 +18,7 @@ interface AuthState {
   // Delegate "acting as owner" context (Phase 1). null = acting as self.
   actingAsUserId: string | null;
   availableContexts: DelegateContext[];
+  delegateCapabilities: DelegateCapabilityFlags | null;
   setUser: (user: User | null) => void;
   setToken: (token: string | null) => void;
   setError: (error: string | null) => void;
@@ -22,6 +26,7 @@ interface AuthState {
   setDelegation: (
     actingAsUserId: string | null,
     contexts: DelegateContext[],
+    capabilities: DelegateCapabilityFlags | null,
   ) => void;
   login: (user: User, token: string) => void;
   logout: () => void;
@@ -40,11 +45,12 @@ export const useAuthStore = create<AuthState>()(
       _hasHydrated: false,
       actingAsUserId: null,
       availableContexts: [],
+      delegateCapabilities: null,
 
       setUser: (user) => set({ user, isAuthenticated: !!user }),
 
-      setDelegation: (actingAsUserId, availableContexts) =>
-        set({ actingAsUserId, availableContexts }),
+      setDelegation: (actingAsUserId, availableContexts, delegateCapabilities) =>
+        set({ actingAsUserId, availableContexts, delegateCapabilities }),
 
       // auth_token is httpOnly — backend manages the cookie, not JS
       setToken: (token) => set({ token }),
@@ -88,6 +94,7 @@ export const useAuthStore = create<AuthState>()(
           isLoading: false,
           actingAsUserId: null,
           availableContexts: [],
+          delegateCapabilities: null,
         });
       },
 

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -3,6 +3,7 @@ import { persist, createJSONStorage } from 'zustand/middleware';
 import { AxiosError } from 'axios';
 import { User } from '@/types/auth';
 import { clearAllCache } from '@/lib/apiCache';
+import type { DelegateContext } from '@/lib/delegation';
 
 interface AuthState {
   user: User | null;
@@ -11,10 +12,17 @@ interface AuthState {
   isLoading: boolean;
   error: string | null;
   _hasHydrated: boolean;
+  // Delegate "acting as owner" context (Phase 1). null = acting as self.
+  actingAsUserId: string | null;
+  availableContexts: DelegateContext[];
   setUser: (user: User | null) => void;
   setToken: (token: string | null) => void;
   setError: (error: string | null) => void;
   setLoading: (loading: boolean) => void;
+  setDelegation: (
+    actingAsUserId: string | null,
+    contexts: DelegateContext[],
+  ) => void;
   login: (user: User, token: string) => void;
   logout: () => void;
   clearError: () => void;
@@ -30,8 +38,13 @@ export const useAuthStore = create<AuthState>()(
       isLoading: true,
       error: null,
       _hasHydrated: false,
+      actingAsUserId: null,
+      availableContexts: [],
 
       setUser: (user) => set({ user, isAuthenticated: !!user }),
+
+      setDelegation: (actingAsUserId, availableContexts) =>
+        set({ actingAsUserId, availableContexts }),
 
       // auth_token is httpOnly — backend manages the cookie, not JS
       setToken: (token) => set({ token }),
@@ -73,6 +86,8 @@ export const useAuthStore = create<AuthState>()(
           isAuthenticated: false,
           error: null,
           isLoading: false,
+          actingAsUserId: null,
+          availableContexts: [],
         });
       },
 

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -130,10 +130,33 @@ export const useAuthStore = create<AuthState>()(
       }),
       onRehydrateStorage: () => (state) => {
         if (state?.isAuthenticated) {
-          // Fetch user profile from API to restore user object without persisting PII
-          import('@/lib/auth').then(({ authApi }) => {
-            authApi.getProfile().then((user: User) => {
-              state.setUser(user);
+          // Restore the user profile AND the delegation context together
+          // before flipping _hasHydrated. Anything that gates rendering on
+          // `isDelegateView` (DelegateSectionGuard, dashboard view split,
+          // nav visibility) would otherwise see actingAsUserId=null for one
+          // render and flash the wrong page before the contexts request
+          // settles.
+          Promise.all([
+            import('@/lib/auth'),
+            import('@/lib/delegation'),
+          ]).then(([{ authApi }, { delegationApi }]) => {
+            Promise.all([
+              authApi.getProfile(),
+              // Contexts is best-effort: a normal user with no delegations
+              // still gets a successful empty payload. Treat any failure
+              // here as "no delegation context" rather than blocking login
+              // restoration.
+              delegationApi.getContexts().catch(() => null),
+            ]).then(([user, contexts]) => {
+              state.setUser(user as User);
+              if (contexts) {
+                state.setDelegation(
+                  contexts.actingAsUserId,
+                  contexts.contexts,
+                  contexts.capabilities,
+                  contexts.sections,
+                );
+              }
               state.setHasHydrated(true);
             }).catch((error: unknown) => {
               const status = error instanceof AxiosError ? error.response?.status : undefined;

--- a/frontend/src/store/preferencesStore.test.ts
+++ b/frontend/src/store/preferencesStore.test.ts
@@ -87,4 +87,19 @@ describe('preferencesStore', () => {
     usePreferencesStore.getState().setHasHydrated(true);
     expect(usePreferencesStore.getState()._hasHydrated).toBe(true);
   });
+
+  it('does not persist isLoaded so prefs refetch for the effective user', () => {
+    const partialize = usePreferencesStore.persist.getOptions().partialize!;
+    const persisted = partialize({
+      preferences: { theme: 'dark', defaultCurrency: 'CAD' } as any,
+      isLoaded: true,
+      _hasHydrated: true,
+    } as any) as Record<string, unknown>;
+
+    expect(persisted).toHaveProperty('preferences');
+    // isLoaded must NOT be persisted: a delegate switching into an owner
+    // does a full reload, and a persisted isLoaded=true would skip the
+    // refetch, leaving the delegate on their own stale currency.
+    expect(persisted).not.toHaveProperty('isLoaded');
+  });
 });

--- a/frontend/src/store/preferencesStore.ts
+++ b/frontend/src/store/preferencesStore.ts
@@ -56,7 +56,11 @@ export const usePreferencesStore = create<PreferencesState>()(
     {
       name: 'monize-preferences',
       storage: createJSONStorage(() => localStorage),
-      partialize: (state) => ({ preferences: state.preferences, isLoaded: state.isLoaded }),
+      // Persist only the cached preferences, never `isLoaded`: it must
+      // start false on every load so PreferencesLoader refetches for the
+      // current effective user (e.g. the owner a delegate is acting as),
+      // otherwise a delegate keeps their own stale cached preferences.
+      partialize: (state) => ({ preferences: state.preferences }),
       onRehydrateStorage: () => (state) => {
         state?.setHasHydrated(true);
       },

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -39,6 +39,12 @@ export interface RegisterData {
   password: string;
   firstName?: string;
   lastName?: string;
+  /**
+   * Temporary password supplied by the registrant when their email is
+   * already a delegate row (so they can claim and upgrade it into a full
+   * account, preserving the existing delegate id).
+   */
+  currentPassword?: string;
 }
 
 export interface AuthResponse {


### PR DESCRIPTION
Lets an account owner grant another user scoped READ access to specific
accounts via an effective-user context model: the delegate logs in as
themselves and their session "acts as" the owner, so existing
where:{userId} scoping is untouched while a single fail-closed guard
gates per-account READ and the delegate-reachable surface.

- New delegation module: account_delegates + account_delegate_grants
  (migration 068 + schema.sql), owner-scoped management API, invite
  email, owner-driven password reset.
- JWT carries actingAsUserId/delegationId (across refresh rotation);
  JwtStrategy re-validates the delegation every request and enforces
  the owner-2FA -> delegate-own-2FA requirement.
- /auth/contexts + /auth/switch-context (no re-login); login behaviour
  unchanged for normal users.
- Frontend: "Viewing: X" banner + context switcher, Shared Access
  settings section, delegate-restricted dashboard.

https://claude.ai/code/session_01UwB66dhLpoZccyd4ckRu6P