### PR TITLE
fix(db): cascade-delete transfer splits when their target account is removed

### DIFF
--- a/backend/src/scheduled-transactions/entities/scheduled-transaction-split.entity.ts
+++ b/backend/src/scheduled-transactions/entities/scheduled-transaction-split.entity.ts
@@ -43,7 +43,7 @@ export class ScheduledTransactionSplit {
   @Column({ type: "uuid", name: "transfer_account_id", nullable: true })
   transferAccountId: string | null;
 
-  @ManyToOne(() => Account, { nullable: true })
+  @ManyToOne(() => Account, { nullable: true, onDelete: "CASCADE" })
   @JoinColumn({ name: "transfer_account_id" })
   transferAccount: Account | null;
 

--- a/backend/src/transactions/entities/transaction-split.entity.ts
+++ b/backend/src/transactions/entities/transaction-split.entity.ts
@@ -55,7 +55,7 @@ export class TransactionSplit {
   @Column({ type: "uuid", name: "transfer_account_id", nullable: true })
   transferAccountId: string | null;
 
-  @ManyToOne(() => Account, { nullable: true })
+  @ManyToOne(() => Account, { nullable: true, onDelete: "CASCADE" })
   @JoinColumn({ name: "transfer_account_id" })
   transferAccount: Account | null;
 

--- a/database/migrations/068_transaction_split_transfer_account_cascade.sql
+++ b/database/migrations/068_transaction_split_transfer_account_cascade.sql
@@ -1,0 +1,38 @@
+-- Fix: deleting a user/account fails with
+--   new row for relation "transaction_splits" violates check constraint
+--   "chk_split_kind_exclusive"
+-- (and the equivalent on scheduled_transaction_splits).
+--
+-- transfer_account_id on the split tables referenced accounts(id) with
+-- ON DELETE SET NULL. When an account is removed (e.g. cascading from a
+-- user deletion) a transfer split pointing at it had its
+-- transfer_account_id set to NULL while kind stayed 'transfer', which
+-- violates the kind-exclusive CHECK (kind='transfer' requires
+-- transfer_account_id IS NOT NULL) and aborts the delete.
+--
+-- A transfer split whose target account no longer exists is meaningless,
+-- so it should be removed with the account: switch the FK to
+-- ON DELETE CASCADE. Idempotent: safe to run multiple times.
+--
+-- (scheduled_transactions is intentionally untouched: it has no `kind`
+-- column and its check does not constrain transfer_account_id.)
+
+-- Remove any pre-existing invalid transfer splits (target already lost)
+-- so the constraints stay satisfiable and data is consistent.
+DELETE FROM transaction_splits
+WHERE kind = 'transfer' AND transfer_account_id IS NULL;
+
+DELETE FROM scheduled_transaction_splits
+WHERE kind = 'transfer' AND transfer_account_id IS NULL;
+
+ALTER TABLE transaction_splits
+    DROP CONSTRAINT IF EXISTS transaction_splits_transfer_account_id_fkey;
+ALTER TABLE transaction_splits
+    ADD CONSTRAINT transaction_splits_transfer_account_id_fkey
+    FOREIGN KEY (transfer_account_id) REFERENCES accounts(id) ON DELETE CASCADE;
+
+ALTER TABLE scheduled_transaction_splits
+    DROP CONSTRAINT IF EXISTS scheduled_transaction_splits_transfer_account_id_fkey;
+ALTER TABLE scheduled_transaction_splits
+    ADD CONSTRAINT scheduled_transaction_splits_transfer_account_id_fkey
+    FOREIGN KEY (transfer_account_id) REFERENCES accounts(id) ON DELETE CASCADE;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -240,7 +240,7 @@ CREATE TABLE transaction_splits (
     transaction_id UUID NOT NULL REFERENCES transactions(id) ON DELETE CASCADE,
     kind VARCHAR(20) NOT NULL DEFAULT 'category', -- 'category', 'transfer', or 'investment'
     category_id UUID REFERENCES categories(id),
-    transfer_account_id UUID REFERENCES accounts(id) ON DELETE SET NULL, -- target account for transfer splits
+    transfer_account_id UUID REFERENCES accounts(id) ON DELETE CASCADE, -- target account for transfer splits
     linked_transaction_id UUID REFERENCES transactions(id) ON DELETE SET NULL, -- linked transaction in target account
     amount NUMERIC(20, 4) NOT NULL,
     memo TEXT,
@@ -345,7 +345,7 @@ CREATE TABLE scheduled_transaction_splits (
     scheduled_transaction_id UUID NOT NULL REFERENCES scheduled_transactions(id) ON DELETE CASCADE,
     kind VARCHAR(20) NOT NULL DEFAULT 'category', -- 'category', 'transfer', or 'investment'
     category_id UUID REFERENCES categories(id),
-    transfer_account_id UUID REFERENCES accounts(id) ON DELETE SET NULL, -- target account for transfer splits
+    transfer_account_id UUID REFERENCES accounts(id) ON DELETE CASCADE, -- target account for transfer splits
     amount NUMERIC(20, 4) NOT NULL,
     memo TEXT,
     -- Investment-split fields (populated when kind='investment'):


### PR DESCRIPTION
## Problem

Deleting a user (or any account) fails with:

```
new row for relation "transaction_splits" violates check constraint "chk_split_kind_exclusive"
QueryFailedError ... at AdminService.deleteUser (admin.service.ts:172)
```

`transaction_splits.transfer_account_id` (and `scheduled_transaction_splits.transfer_account_id`) referenced `accounts(id)` with `ON DELETE SET NULL`. When an account is removed — e.g. cascading from a user deletion — a transfer split pointing at it had `transfer_account_id` set to `NULL` while `kind` stayed `'transfer'`, which violates `chk_split_kind_exclusive` (`kind='transfer'` requires `transfer_account_id IS NOT NULL`) and aborts the whole delete.

This is a pre-existing schema/FK conflict (the exclusive check was added later, in migration `062`), surfaced while exercising user deletion. It is unrelated to the in-flight delegate-access work, so it is split out into its own branch/PR.

## Fix

A transfer split whose target account no longer exists is meaningless, so it should be removed with the account.

- **Migration `068_transaction_split_transfer_account_cascade.sql`**: switch the `transfer_account_id` FK on `transaction_splits` and `scheduled_transaction_splits` to `ON DELETE CASCADE`; first delete any pre-existing orphaned transfer splits (`kind='transfer' AND transfer_account_id IS NULL`). Idempotent.
- `database/schema.sql` updated to match (both split tables).
- TypeORM `transferAccount` relations on both split entities set to `onDelete: "CASCADE"`.

`scheduled_transactions` is intentionally untouched: it has no `kind` column and its check does not constrain `transfer_account_id`, so it is not affected.

## Test plan

- [ ] Fresh install from `schema.sql` works.
- [ ] Existing DB: migration `068` applies cleanly and is idempotent on re-run.
- [ ] Delete a user/account that owns accounts referenced by transfer splits (and scheduled transfer splits) — deletion succeeds; the dependent transfer splits are removed.
- [ ] Non-transfer (category/investment) splits are unaffected.

https://claude.ai/code/session_01UwB66dhLpoZccyd4ckRu6P

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwB66dhLpoZccyd4ckRu6P)_