### PR TITLE
Implement delegate account claim flow via registration

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monize-backend",
-  "version": "1.9.17",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monize-backend",
-      "version": "1.9.17",
+      "version": "1.10.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.75.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monize-backend",
-  "version": "1.9.17",
+  "version": "1.10.0",
   "description": "Personal Finance Management System - Backend API",
   "author": "",
   "private": true,

--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -141,12 +141,13 @@ describe("AdminService", () => {
       expect(result[0].hasPassword).toBe(false);
     });
 
-    it("returns every user (including pure delegates) ordered by createdAt ASC", async () => {
+    it("hides owner-managed delegate identities and orders by createdAt ASC", async () => {
       usersRepository.find.mockResolvedValue([]);
 
       await service.findAllUsers();
 
       expect(usersRepository.find).toHaveBeenCalledWith({
+        where: { isDelegateOnly: false },
         order: { createdAt: "ASC" },
       });
     });

--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -116,19 +116,8 @@ describe("AdminService", () => {
   });
 
   describe("findAllUsers", () => {
-    let qb: Record<string, jest.Mock>;
-
-    function mockQuery(rows: unknown[]) {
-      qb = {
-        where: jest.fn().mockReturnThis(),
-        orderBy: jest.fn().mockReturnThis(),
-        getMany: jest.fn().mockResolvedValue(rows),
-      };
-      usersRepository.createQueryBuilder.mockReturnValue(qb);
-    }
-
     it("returns users with sensitive fields stripped", async () => {
-      mockQuery([mockAdmin, mockTargetUser]);
+      usersRepository.find.mockResolvedValue([mockAdmin, mockTargetUser]);
 
       const result = await service.findAllUsers();
 
@@ -143,7 +132,7 @@ describe("AdminService", () => {
     });
 
     it("sets hasPassword false for OIDC users without password", async () => {
-      mockQuery([
+      usersRepository.find.mockResolvedValue([
         { ...mockTargetUser, passwordHash: null, authProvider: "oidc" },
       ]);
 
@@ -152,15 +141,14 @@ describe("AdminService", () => {
       expect(result[0].hasPassword).toBe(false);
     });
 
-    it("excludes pure delegates and orders by createdAt ASC", async () => {
-      mockQuery([]);
+    it("returns every user (including pure delegates) ordered by createdAt ASC", async () => {
+      usersRepository.find.mockResolvedValue([]);
 
       await service.findAllUsers();
 
-      const whereSql = qb.where.mock.calls[0][0] as string;
-      expect(whereSql).toContain("account_delegates");
-      expect(whereSql).toContain("delegate_user_id");
-      expect(qb.orderBy).toHaveBeenCalledWith("u.created_at", "ASC");
+      expect(usersRepository.find).toHaveBeenCalledWith({
+        order: { createdAt: "ASC" },
+      });
     });
   });
 

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -139,7 +139,10 @@ export class AdminService {
     return this.sanitizeUser(saved);
   }
 
-  async deleteUser(adminId: string, targetUserId: string): Promise<void> {
+  async deleteUser(
+    adminId: string,
+    targetUserId: string,
+  ): Promise<{ downgraded: boolean }> {
     if (adminId === targetUserId) {
       throw new ForbiddenException("You cannot delete your own account");
     }
@@ -179,12 +182,13 @@ export class AdminService {
     // their login and the delegate access others granted them stay.
     if (await this.usersService.isActingDelegate(targetUserId)) {
       await this.usersService.purgeForDowngrade(targetUserId);
-      return;
+      return { downgraded: true };
     }
 
     // Delete preferences first (FK constraint), then the user.
     await this.preferencesRepository.delete({ userId: targetUserId });
     await this.usersRepository.remove(targetUser);
+    return { downgraded: false };
   }
 
   async resetUserPassword(

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -31,15 +31,15 @@ export class AdminService {
   ) {}
 
   async findAllUsers() {
-    // List every user. An earlier version hid "pure delegate" rows (users
-    // that are in account_delegates as a delegate, own no accounts, and
-    // aren't admin) on the theory that owners manage them via Shared
-    // Access. That filter caught self-registered users who happened to be
-    // added as a delegate before creating any accounts -- their row
-    // disappeared from User Management even though the user still
-    // existed, which looked exactly like account deletion. The few extra
-    // rows are a much smaller cost than the perceived data loss.
+    // Hide owner-managed delegate identities -- users that exist solely
+    // because an account owner added them via Shared Access. Those rows
+    // are managed from the owner's Shared Access page. The is_delegate_only
+    // column is set when createDelegate provisions a new user and cleared
+    // when the user upgrades into a full account via the /register claim
+    // path, so a self-registered user who happens to also be a delegate
+    // still shows up here.
     const users = await this.usersRepository.find({
+      where: { isDelegateOnly: false },
       order: { createdAt: "ASC" },
     });
     return users.map((user) => {

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -31,21 +31,17 @@ export class AdminService {
   ) {}
 
   async findAllUsers() {
-    // Pure delegates (users that exist only because an account owner granted
-    // them Shared Access) must not appear here -- they are managed solely from
-    // the owner's Shared Access page. A user is still listed if they own data,
-    // own a delegation, are an admin, or simply are not a delegate at all.
-    const users = await this.usersRepository
-      .createQueryBuilder("u")
-      .where(
-        `(NOT EXISTS (SELECT 1 FROM account_delegates ad WHERE ad.delegate_user_id = u.id)
-          OR EXISTS (SELECT 1 FROM accounts a WHERE a.user_id = u.id)
-          OR EXISTS (SELECT 1 FROM account_delegates o WHERE o.owner_user_id = u.id)
-          OR u.role = :adminRole)`,
-        { adminRole: "admin" },
-      )
-      .orderBy("u.created_at", "ASC")
-      .getMany();
+    // List every user. An earlier version hid "pure delegate" rows (users
+    // that are in account_delegates as a delegate, own no accounts, and
+    // aren't admin) on the theory that owners manage them via Shared
+    // Access. That filter caught self-registered users who happened to be
+    // added as a delegate before creating any accounts -- their row
+    // disappeared from User Management even though the user still
+    // existed, which looked exactly like account deletion. The few extra
+    // rows are a much smaller cost than the perceived data loss.
+    const users = await this.usersRepository.find({
+      order: { createdAt: "ASC" },
+    });
     return users.map((user) => {
       const {
         passwordHash,

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -328,6 +328,37 @@ describe("AuthService", () => {
       expect(dataSource.transaction).not.toHaveBeenCalled();
     });
 
+    it("claims a delegate when the new account password happens to match the delegate's password (no currentPassword needed)", async () => {
+      const sharedPwHash = await bcrypt.hash("Temp-Pw-9!aB", 4);
+      const tempDelegate = {
+        id: "deleg-match",
+        email: "shared-match@example.com",
+        authProvider: "local",
+        passwordHash: sharedPwHash,
+        mustChangePassword: true,
+        failedLoginAttempts: 0,
+        lockedUntil: null,
+        resetToken: null,
+        resetTokenExpiry: null,
+      };
+      usersRepository.findOne.mockResolvedValue(tempDelegate);
+      delegationService.isDelegateUser.mockResolvedValue(true);
+      delegationService.isFullAccount.mockResolvedValue(false);
+      passwordBreachService.isBreached.mockResolvedValue(false);
+      usersRepository.save.mockImplementation(async (u: any) => u);
+
+      const result = await service.register({
+        email: "shared-match@example.com",
+        // No currentPassword: the front end skipped the second prompt
+        // because the new-account password already matches the delegate.
+        password: "Temp-Pw-9!aB",
+      });
+
+      expect(tempDelegate.mustChangePassword).toBe(false);
+      expect(result.user).not.toHaveProperty("passwordHash");
+      expect(result.accessToken).toBeDefined();
+    });
+
     it("rejects a delegate claim when the currentPassword is wrong or missing", async () => {
       const tempPwHash = await bcrypt.hash("Temp-Pw-9!aB", 4);
       usersRepository.findOne.mockResolvedValue({

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -146,6 +146,12 @@ export class AuthService {
       existingUser.resetTokenExpiry = null;
       existingUser.failedLoginAttempts = 0;
       existingUser.lockedUntil = null;
+      // Promote out of the owner-managed delegate state -- the user is
+      // claiming the row as their own account from here on, so they
+      // should show up in admin User Management and see a "self"
+      // context in the delegate banner even before they have any
+      // accounts of their own.
+      existingUser.isDelegateOnly = false;
       const upgraded = await this.usersRepository.save(existingUser);
 
       const { accessToken, refreshToken } =

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -106,11 +106,23 @@ export class AuthService {
       }
 
       if (existingUser.passwordHash) {
-        const supplied = (currentPassword ?? "").trim();
-        const ok =
-          supplied.length > 0 &&
-          (await bcrypt.compare(supplied, existingUser.passwordHash));
-        if (!ok) {
+        // The registrant proves they hold the delegate password in one of
+        // two ways: either they typed it into the dedicated "Delegate
+        // password" prompt (currentPassword), or the new-account password
+        // they typed up front happens to be the same value -- in which
+        // case the front end doesn't need to ask for it a second time.
+        const newPasswordMatches = await bcrypt.compare(
+          password,
+          existingUser.passwordHash,
+        );
+        let claimOk = newPasswordMatches;
+        if (!claimOk) {
+          const supplied = (currentPassword ?? "").trim();
+          claimOk =
+            supplied.length > 0 &&
+            (await bcrypt.compare(supplied, existingUser.passwordHash));
+        }
+        if (!claimOk) {
           throw new UnauthorizedException(
             "An account with this email already exists as a shared user. " +
               "Provide the temporary password your administrator gave you " +

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -872,6 +872,29 @@ describe("DelegationService", () => {
       });
     });
 
+    it("keeps a pure delegate (isDelegateOnly=true) when they still delegate for another owner", async () => {
+      // The isDelegateOnly check is an additional guard, not a
+      // replacement: an owner-managed identity that still has at least
+      // one OTHER active delegation must keep their login so the other
+      // owner's Shared Access continues to work.
+      delegatesRepo.findOne.mockResolvedValue({
+        id: "g1",
+        ownerUserId: "o1",
+        delegateUserId: "d1",
+      });
+      const manager = managerFor({
+        otherDelegations: 1,
+        ownsAccounts: 0,
+        ownsDelegations: 0,
+        isDelegateOnly: true,
+      });
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+
+      await service.revokeDelegate("o1", "g1");
+
+      expect(manager.delete).toHaveBeenCalledTimes(1); // delegation only
+    });
+
     it("keeps the user when they own data of their own", async () => {
       delegatesRepo.findOne.mockResolvedValue({
         id: "g1",

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -421,10 +421,15 @@ describe("DelegationService", () => {
       await expect(service.getAvailableContexts("u1")).resolves.toEqual([]);
     });
 
-    it("includes a self context only when the user owns data", async () => {
+    it("includes a self context when the user owns data", async () => {
       usersRepo.findOne.mockImplementation(({ where }: any) =>
         where.id === "u1"
-          ? { id: "u1", firstName: "Del", lastName: "Egate" }
+          ? {
+              id: "u1",
+              firstName: "Del",
+              lastName: "Egate",
+              isDelegateOnly: false,
+            }
           : {
               id: "o1",
               firstName: "Own",
@@ -451,9 +456,34 @@ describe("DelegationService", () => {
       );
     });
 
-    it("omits the self context when the user owns no data", async () => {
+    it("includes a self context for a self-registered user even when they own no data yet", async () => {
+      // Covers the claim-path bug: a user who upgraded out of a pure
+      // delegate row via /register has no accounts yet, but must still
+      // see a "self" context so the banner appears and they don't get
+      // auto-switched into the owner's account.
       usersRepo.findOne.mockImplementation(({ where }: any) =>
-        where.id === "u1" ? { id: "u1" } : { id: "o1", twoFactorSecret: null },
+        where.id === "u1"
+          ? { id: "u1", firstName: "Self", isDelegateOnly: false }
+          : { id: "o1", twoFactorSecret: null },
+      );
+      delegatesRepo.find.mockResolvedValue([
+        { ownerUserId: "o1", owner: null },
+      ]);
+      accountsRepo.exists.mockResolvedValue(false);
+      prefsRepo.findOne.mockResolvedValue({ twoFactorEnabled: false });
+
+      const res = await service.getAvailableContexts("u1");
+      expect(res).toHaveLength(2);
+      expect(res.find((c) => c.isSelf)).toEqual(
+        expect.objectContaining({ userId: "u1", isSelf: true }),
+      );
+    });
+
+    it("omits the self context for an owner-managed pure delegate with no data", async () => {
+      usersRepo.findOne.mockImplementation(({ where }: any) =>
+        where.id === "u1"
+          ? { id: "u1", isDelegateOnly: true }
+          : { id: "o1", twoFactorSecret: null },
       );
       delegatesRepo.find.mockResolvedValue([
         { ownerUserId: "o1", owner: null },

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -500,6 +500,11 @@ describe("DelegationService", () => {
 
   describe("listDelegates", () => {
     it("maps delegations to a safe summary", async () => {
+      usersRepo.findOne.mockResolvedValue({
+        id: "d1",
+        role: "user",
+        isDelegateOnly: true,
+      });
       delegatesRepo.find.mockResolvedValue([
         {
           id: "g1",
@@ -974,6 +979,7 @@ describe("DelegationService", () => {
         oidcSubject: null,
         failedLoginAttempts: 5,
         lockedUntil: new Date(Date.now() + 60000),
+        isDelegateOnly: true,
       };
       usersRepo.findOne.mockResolvedValue(delegate);
       usersRepo.save.mockResolvedValue(delegate);
@@ -1025,7 +1031,11 @@ describe("DelegationService", () => {
     it("is true for an owner-provisioned pure delegate", async () => {
       accountsRepo.count.mockResolvedValue(0);
       delegatesRepo.count = jest.fn().mockResolvedValue(0);
-      usersRepo.findOne.mockResolvedValue({ id: "d1", role: "user" });
+      usersRepo.findOne.mockResolvedValue({
+        id: "d1",
+        role: "user",
+        isDelegateOnly: true,
+      });
       await expect(service.canOwnerResetDelegatePassword("d1")).resolves.toBe(
         true,
       );
@@ -1037,7 +1047,33 @@ describe("DelegationService", () => {
         .fn()
         .mockResolvedValueOnce(0) // ownsDelegations (isFullAccount)
         .mockResolvedValueOnce(2); // delegations as delegate
-      usersRepo.findOne.mockResolvedValue({ id: "d1", role: "user" });
+      usersRepo.findOne.mockResolvedValue({
+        id: "d1",
+        role: "user",
+        isDelegateOnly: true,
+      });
+      await expect(service.canOwnerResetDelegatePassword("d1")).resolves.toBe(
+        false,
+      );
+    });
+
+    it("is false for a claimed / self-registered user even with no own data yet", async () => {
+      // A user who went through /register (either as a fresh signup or
+      // via the claim path) has isDelegateOnly=false from that moment
+      // on; their login is theirs, so the owner can't rotate it even
+      // before they have created any accounts of their own.
+      usersRepo.findOne.mockResolvedValue({
+        id: "d1",
+        role: "user",
+        isDelegateOnly: false,
+      });
+      await expect(service.canOwnerResetDelegatePassword("d1")).resolves.toBe(
+        false,
+      );
+    });
+
+    it("is false when the user record cannot be found", async () => {
+      usersRepo.findOne.mockResolvedValue(null);
       await expect(service.canOwnerResetDelegatePassword("d1")).resolves.toBe(
         false,
       );

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -783,6 +783,7 @@ describe("DelegationService", () => {
       ownsAccounts: number;
       ownsDelegations: number;
       role?: string;
+      isDelegateOnly?: boolean;
     }) {
       const manager: any = {
         delete: jest.fn(),
@@ -791,9 +792,11 @@ describe("DelegationService", () => {
           .mockResolvedValueOnce(counts.otherDelegations)
           .mockResolvedValueOnce(counts.ownsAccounts)
           .mockResolvedValueOnce(counts.ownsDelegations),
-        findOne: jest
-          .fn()
-          .mockResolvedValue({ id: "d1", role: counts.role ?? "user" }),
+        findOne: jest.fn().mockResolvedValue({
+          id: "d1",
+          role: counts.role ?? "user",
+          isDelegateOnly: counts.isDelegateOnly ?? true,
+        }),
       };
       return manager;
     }
@@ -808,6 +811,7 @@ describe("DelegationService", () => {
         otherDelegations: 0,
         ownsAccounts: 0,
         ownsDelegations: 0,
+        isDelegateOnly: true,
       });
       dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
 
@@ -818,6 +822,32 @@ describe("DelegationService", () => {
       });
       expect(manager.delete).toHaveBeenCalledWith(expect.anything(), {
         id: "d1",
+      });
+    });
+
+    it("keeps a self-registered / claimed user even with no accounts of their own", async () => {
+      // A user that has gone through /register (either as a fresh
+      // sign-up or by claiming a delegate row) is a full account, even
+      // if they haven't created any accounts yet. Revoking the
+      // delegation must not delete their login.
+      delegatesRepo.findOne.mockResolvedValue({
+        id: "g1",
+        ownerUserId: "o1",
+        delegateUserId: "d1",
+      });
+      const manager = managerFor({
+        otherDelegations: 0,
+        ownsAccounts: 0,
+        ownsDelegations: 0,
+        isDelegateOnly: false,
+      });
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+
+      await service.revokeDelegate("o1", "g1");
+
+      expect(manager.delete).toHaveBeenCalledTimes(1);
+      expect(manager.delete).toHaveBeenCalledWith(expect.anything(), {
+        id: "g1",
       });
     });
 

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -1015,7 +1015,7 @@ describe("DelegationService", () => {
       expect(res.invited).toBe(false);
     });
 
-    it("clears lockout when the owner sets a password for a locked delegate", async () => {
+    it("clears lockout when the owner sets a password for a locked pure-delegate", async () => {
       usersRepo.findOne.mockResolvedValue({ id: "o1", email: "own@x.y" });
       const lockedUser = {
         id: "d1",
@@ -1030,6 +1030,13 @@ describe("DelegationService", () => {
       manager.findOne
         .mockResolvedValueOnce(lockedUser) // User by email
         .mockResolvedValueOnce(null); // no existing delegation
+      // Mark as a pure delegate (already someone else's delegate row,
+      // owns no data) so credential management is allowed -- a fresh
+      // self-registered user with no delegate role would not be.
+      manager.count.mockImplementation((entity: any, opts: any) => {
+        if (opts?.where?.delegateUserId === "d1") return Promise.resolve(1);
+        return Promise.resolve(0);
+      });
       dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
       await service.createDelegate("o1", {
         email: "new@x.y",
@@ -1159,6 +1166,36 @@ describe("DelegationService", () => {
       } as any);
 
       expect(existing.passwordHash).toBe("ORIGINAL");
+      expect(res.temporaryPassword).toBeUndefined();
+    });
+
+    it("never touches credentials of a self-registered user with no data yet", async () => {
+      // Reproduces the race where the front-end clicks Add before the
+      // email-lookup debounce returns: dto.password is sent but the
+      // target email belongs to a real user that just hasn't created
+      // any accounts yet. mayManageCredentials must still be false.
+      usersRepo.findOne.mockResolvedValue({ id: "o1", email: "own@x.y" });
+      const existing = {
+        id: "d2",
+        passwordHash: "USER-CHOSEN",
+        oidcSubject: null,
+        role: "user",
+      };
+      const manager = makeManager();
+      manager.findOne
+        .mockResolvedValueOnce(existing)
+        .mockResolvedValueOnce(null);
+      // ownsAccounts=0, ownsDelegations=0, alreadyDelegate=0 -- a fresh
+      // self-registered user who is not yet anybody's delegate row.
+      manager.count.mockResolvedValue(0);
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+
+      const res = await service.createDelegate("o1", {
+        email: "fresh@x.y",
+        password: "OwnerWouldOverwrite1!",
+      } as any);
+
+      expect(existing.passwordHash).toBe("USER-CHOSEN");
       expect(res.temporaryPassword).toBeUndefined();
     });
 

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -464,10 +464,20 @@ export class DelegationService {
    * delegate is not a full account in their own right AND is not also a
    * delegate for any other owner. Otherwise the password belongs to the
    * person, not the owner, so only they may change it.
+   *
+   * "Full account" includes a delegate that has gone through the
+   * /register claim path (isDelegateOnly=false) but has not yet created
+   * any data of their own -- their login is theirs, not the owner's,
+   * even with zero accounts under their name.
    */
   async canOwnerResetDelegatePassword(
     delegateUserId: string,
   ): Promise<boolean> {
+    const user = await this.usersRepository.findOne({
+      where: { id: delegateUserId },
+      select: ["id", "isDelegateOnly"],
+    });
+    if (!user || !user.isDelegateOnly) return false;
     if (await this.isFullAccount(delegateUserId)) return false;
     const delegationCount = await this.delegatesRepository.count({
       where: { delegateUserId },

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -370,12 +370,20 @@ export class DelegationService {
 
     if (delegations.length === 0) return [];
 
+    // A user gets a "self" context whenever the row represents a real
+    // account in their own right -- they own data, or they claimed /
+    // self-registered (isDelegateOnly=false). A pure delegate identity
+    // (created via Shared Access, never claimed) deliberately has no
+    // self context so the front end auto-picks the owner on first
+    // login. Without this, a freshly-claimed delegate who has not yet
+    // created any accounts would have only the owner's context and the
+    // banner would never appear.
     const ownsData = await this.accountsRepository.exists({
       where: { userId: user.id },
     });
 
     const contexts: AvailableContext[] = [];
-    if (ownsData) {
+    if (ownsData || !user.isDelegateOnly) {
       contexts.push({
         userId: user.id,
         label: this.userLabel(user),
@@ -757,6 +765,11 @@ export class DelegationService {
           lastName: dto.lastName ?? null,
           authProvider: "local",
           role: "user",
+          // Marks the row as owner-managed -- hidden from admin User
+          // Management, no "self" context offered to the delegate.
+          // Cleared by the /register claim path the moment the user
+          // upgrades into a full account in their own right.
+          isDelegateOnly: true,
         });
       }
 

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -888,8 +888,11 @@ export class DelegationService {
       await manager.delete(AccountDelegate, { id: delegationId });
 
       // Entirely remove the delegate's login unless it has another reason to
-      // exist: a delegation elsewhere, its own data, it owns a delegation, or
-      // it is an admin (i.e. it is a full user in its own right).
+      // exist: a delegation elsewhere, its own data, it owns a delegation,
+      // it is an admin, or it has been claimed as a full account in its
+      // own right (isDelegateOnly=false). Without the isDelegateOnly
+      // check a self-registered user who hasn't created any accounts yet
+      // would be silently deleted on revoke.
       const [otherDelegations, ownsAccounts, ownsDelegations] =
         await Promise.all([
           manager.count(AccountDelegate, { where: { delegateUserId } }),
@@ -906,7 +909,8 @@ export class DelegationService {
         otherDelegations === 0 &&
         ownsAccounts === 0 &&
         ownsDelegations === 0 &&
-        delegateUser?.role !== "admin"
+        delegateUser?.role !== "admin" &&
+        delegateUser?.isDelegateOnly !== false
       ) {
         // FK ON DELETE CASCADE cleans preferences, tokens, trusted devices.
         await manager.delete(User, { id: delegateUserId });

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -713,20 +713,38 @@ export class DelegationService {
       // in with their own credentials; the owner only links the delegation.
       // New users and pure-delegate identities are owner-managed, so the
       // owner may set their password / send an invite.
+      //
+      // "Pure delegate" means the row already exists solely as some other
+      // owner's delegate (a record in account_delegates.delegate_user_id).
+      // A user that self-registered (passwordHash exists, not in any
+      // delegate row) is a full account even if they have not created any
+      // accounts yet -- their login is theirs, not ours to rotate. Without
+      // this check the front end's email-lookup race (Add clicked before
+      // the 400ms debounced lookup finishes) lets a stray dto.password
+      // overwrite a real user's password.
       let mayManageCredentials = true;
       if (delegateUser) {
         if (delegateUser.oidcSubject || delegateUser.role === "admin") {
           mayManageCredentials = false;
         } else {
-          const [ownsAccounts, ownsDelegations] = await Promise.all([
-            manager.count(Account, {
-              where: { userId: delegateUser.id },
-            }),
-            manager.count(AccountDelegate, {
-              where: { ownerUserId: delegateUser.id },
-            }),
-          ]);
-          if (ownsAccounts > 0 || ownsDelegations > 0) {
+          const [ownsAccounts, ownsDelegations, alreadyDelegate] =
+            await Promise.all([
+              manager.count(Account, {
+                where: { userId: delegateUser.id },
+              }),
+              manager.count(AccountDelegate, {
+                where: { ownerUserId: delegateUser.id },
+              }),
+              manager.count(AccountDelegate, {
+                where: { delegateUserId: delegateUser.id },
+              }),
+            ]);
+          const isPureDelegateRow = alreadyDelegate > 0;
+          if (
+            ownsAccounts > 0 ||
+            ownsDelegations > 0 ||
+            (!isPureDelegateRow && !!delegateUser.passwordHash)
+          ) {
             mayManageCredentials = false;
           }
         }

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -117,6 +117,14 @@ export class User {
   @Exclude()
   pendingOidcSubject: string | null;
 
+  // True when the row exists solely as an owner-managed delegate identity
+  // (created via the Shared Access flow, never claimed via /register).
+  // Hides the user from admin User Management and the delegate's own
+  // context list. Cleared the moment the row is claimed via /register so
+  // the user becomes a full account.
+  @Column({ name: "is_delegate_only", type: "boolean", default: false })
+  isDelegateOnly: boolean;
+
   @OneToOne(() => UserPreference, (preference) => preference.user)
   preferences: UserPreference;
 }

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -163,16 +163,32 @@ describe("UsersController", () => {
 
   describe("deleteAccount()", () => {
     it("delegates to usersService.deleteAccount and returns success message", async () => {
-      mockUsersService.deleteAccount.mockResolvedValue(undefined);
+      mockUsersService.deleteAccount.mockResolvedValue({ downgraded: false });
       const dto = { password: "mypass" };
 
       const result = await controller.deleteAccount(mockReq, dto);
 
-      expect(result).toEqual({ message: "Account deleted successfully" });
+      expect(result).toEqual({
+        message: "Account deleted successfully",
+        downgraded: false,
+      });
       expect(mockUsersService.deleteAccount).toHaveBeenCalledWith(
         "user-1",
         dto,
       );
+    });
+
+    it("returns a downgrade-aware message when the account is demoted to a delegate", async () => {
+      mockUsersService.deleteAccount.mockResolvedValue({ downgraded: true });
+      const dto = { password: "mypass" };
+
+      const result = await controller.deleteAccount(mockReq, dto);
+
+      expect(result).toEqual({
+        message:
+          "Your own data was removed. Your login and any shared access others granted you remain.",
+        downgraded: true,
+      });
     });
   });
 

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -100,8 +100,13 @@ export class UsersController {
   @ApiResponse({ status: 200, description: "Account deleted successfully" })
   @ApiResponse({ status: 401, description: "Invalid credentials" })
   async deleteAccount(@Request() req, @Body() dto: DeleteAccountDto) {
-    await this.usersService.deleteAccount(req.user.id, dto);
-    return { message: "Account deleted successfully" };
+    const result = await this.usersService.deleteAccount(req.user.id, dto);
+    return {
+      message: result.downgraded
+        ? "Your own data was removed. Your login and any shared access others granted you remain."
+        : "Account deleted successfully",
+      downgraded: result.downgraded,
+    };
   }
 
   @Post("delete-data")

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -658,14 +658,18 @@ describe("UsersService", () => {
       // isActingDelegate -> account_delegates lookup returns a row.
       mockDataSource.query.mockResolvedValue([{ "?column?": 1 }]);
 
-      await service.deleteAccount("user-1", { password: "CorrectPass123!" });
+      const result = await service.deleteAccount("user-1", {
+        password: "CorrectPass123!",
+      });
 
       // Sessions revoked, but the login and incoming delegations stay.
       expect(refreshTokensRepository.update).toHaveBeenCalled();
       expect(patRepository.update).toHaveBeenCalled();
       expect(preferencesRepository.delete).not.toHaveBeenCalled();
       expect(usersRepository.remove).not.toHaveBeenCalled();
-      // Owned data + owner-side delegations are purged in a transaction.
+      // Owned data + owner-side delegations are purged in a transaction,
+      // and the row is flipped back to is_delegate_only so admin User
+      // Management hides it again.
       expect(mockQueryRunner.startTransaction).toHaveBeenCalled();
       const queries = mockQueryRunner.query.mock.calls.map((c) => c[0]);
       expect(
@@ -673,6 +677,12 @@ describe("UsersService", () => {
           q.includes("DELETE FROM account_delegates WHERE owner_user_id"),
         ),
       ).toBe(true);
+      expect(
+        queries.some((q: string) =>
+          q.includes("UPDATE users SET is_delegate_only = true"),
+        ),
+      ).toBe(true);
+      expect(result).toEqual({ downgraded: true });
     });
 
     it("prevents the last admin from self-deleting", async () => {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -288,7 +288,7 @@ export class UsersService {
   async deleteAccount(
     userId: string,
     dto?: { password?: string; oidcIdToken?: string },
-  ): Promise<void> {
+  ): Promise<{ downgraded: boolean }> {
     const user = await this.usersRepository.findOne({ where: { id: userId } });
     if (!user) {
       throw new NotFoundException("User not found");
@@ -342,12 +342,13 @@ export class UsersService {
     // they can keep acting as a delegate.
     if (await this.isActingDelegate(userId)) {
       await this.purgeForDowngrade(userId);
-      return;
+      return { downgraded: true };
     }
 
     // Delete preferences first (due to FK constraint), then the user.
     await this.preferencesRepository.delete({ userId });
     await this.usersRepository.remove(user);
+    return { downgraded: false };
   }
 
   async deleteData(
@@ -649,7 +650,9 @@ export class UsersService {
    * Wipes everything the user owns but keeps their login and the delegate
    * access others granted them -- demoting a full account to a pure
    * delegate. Delegations the user owned are removed (their accounts are
-   * gone); the rows where they are the delegate are left untouched.
+   * gone); the rows where they are the delegate are left untouched, and
+   * is_delegate_only is flipped back to true so the row is hidden from
+   * admin User Management and no "self" context is offered.
    */
   async purgeForDowngrade(userId: string): Promise<void> {
     const queryRunner = this.dataSource.createQueryRunner();
@@ -668,6 +671,10 @@ export class UsersService {
       );
       await queryRunner.query(
         "DELETE FROM account_delegates WHERE owner_user_id = $1",
+        [userId],
+      );
+      await queryRunner.query(
+        "UPDATE users SET is_delegate_only = true WHERE id = $1",
         [userId],
       );
       await queryRunner.commitTransaction();

--- a/database/migrations/074_users_is_delegate_only.sql
+++ b/database/migrations/074_users_is_delegate_only.sql
@@ -1,0 +1,34 @@
+-- Track which users exist solely as owner-managed delegate identities
+-- (created via the Shared Access flow, never went through /register to
+-- become a full account in their own right). Hides them from admin
+-- User Management and the delegate's own context list -- both surfaces
+-- should treat them as "managed by their owner."
+--
+-- A delegate is no longer "only" when they claim the row via /register
+-- (the claim path in AuthService clears this flag).
+--
+-- Backfill marks every existing user that looks delegate-managed today
+-- (in account_delegates as delegate, owns no accounts, owns no
+-- delegations, isn't admin, is still in the mustChangePassword=true
+-- bootstrap state). That last filter keeps users who've actively chosen
+-- a new password -- the most reliable signal we have, without a column,
+-- that they're past the bootstrap phase.
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS is_delegate_only BOOLEAN NOT NULL DEFAULT false;
+
+UPDATE users u
+SET is_delegate_only = true
+WHERE u.is_delegate_only = false
+  AND u.must_change_password = true
+  AND u.role <> 'admin'
+  AND EXISTS (
+    SELECT 1 FROM account_delegates ad
+    WHERE ad.delegate_user_id = u.id
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM accounts a WHERE a.user_id = u.id
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM account_delegates o WHERE o.owner_user_id = u.id
+  );

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -36,7 +36,8 @@ CREATE TABLE users (
     oidc_link_pending BOOLEAN NOT NULL DEFAULT false,
     oidc_link_token VARCHAR(255),
     oidc_link_expires_at TIMESTAMP,
-    pending_oidc_subject VARCHAR(255)
+    pending_oidc_subject VARCHAR(255),
+    is_delegate_only BOOLEAN NOT NULL DEFAULT false -- true when the row exists solely as an owner-managed delegate identity (created via Shared Access, never claimed via /register)
 );
 
 CREATE INDEX IF NOT EXISTS idx_users_reset_token ON users(reset_token) WHERE reset_token IS NOT NULL;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monize-frontend",
-  "version": "1.9.17",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monize-frontend",
-      "version": "1.9.17",
+      "version": "1.10.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^5.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monize-frontend",
-  "version": "1.9.17",
+  "version": "1.10.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -166,14 +166,25 @@ export default function AdminUsersPage() {
     setConfirmDialog({
       isOpen: true,
       title: 'Delete User?',
-      message: `Are you sure you want to delete ${userName}? This will permanently remove their account and all associated data. This action cannot be undone.`,
+      message:
+        `Are you sure you want to delete ${userName}? This will permanently ` +
+        'remove their account and all associated data. This action cannot ' +
+        'be undone. If they are a delegate of another account, their own ' +
+        'data is removed but their login is kept so the delegation still ' +
+        'works -- they become a delegate-only user.',
       variant: 'danger',
       confirmLabel: 'Delete User',
       onConfirm: async () => {
         try {
-          await adminApi.deleteUser(user.id);
+          const res = await adminApi.deleteUser(user.id);
           setUsers((prev) => prev.filter((u) => u.id !== user.id));
-          toast.success(`${userName} has been deleted`);
+          if (res.downgraded) {
+            toast.success(
+              `${userName}'s own data was removed; their delegate access remains.`,
+            );
+          } else {
+            toast.success(`${userName} has been deleted`);
+          }
         } catch (error) {
           toast.error(getErrorMessage(error, 'Failed to delete user'));
         }

--- a/frontend/src/app/register/page.test.tsx
+++ b/frontend/src/app/register/page.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent, act } from '@/test/render';
+import { AxiosError, AxiosHeaders } from 'axios';
 import RegisterPage from './page';
 import toast from 'react-hot-toast';
 
@@ -71,6 +72,40 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(),
 }));
 
+// Build an AxiosError that mirrors what /auth/register returns when the
+// email already belongs to a pure delegate row that needs the delegate
+// password to be claimed.
+function delegateAxiosError(message = 'shared user'): AxiosError {
+  const err = new AxiosError(
+    'Request failed with status code 401',
+    'ERR_BAD_REQUEST',
+    undefined,
+    {},
+    {
+      data: { message },
+      status: 401,
+      statusText: 'Unauthorized',
+      headers: {},
+      config: { headers: new AxiosHeaders() },
+    },
+  );
+  return err;
+}
+
+async function fillBaseFields() {
+  await act(async () => {
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'shared@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/^password$/i), {
+      target: { value: 'StrongPass1!' },
+    });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: 'StrongPass1!' },
+    });
+  });
+}
+
 describe('RegisterPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -98,6 +133,14 @@ describe('RegisterPage', () => {
       expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
     });
+  });
+
+  it('does not show the delegate password field until a submit reveals it', async () => {
+    render(<RegisterPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText(/delegate password/i)).not.toBeInTheDocument();
   });
 
   it('renders create account button', async () => {
@@ -189,58 +232,18 @@ describe('RegisterPage', () => {
     });
   });
 
-  it('sends currentPassword when the registrant supplies a temporary password', async () => {
-    const mockUser = { id: 'd1', email: 'shared@example.com' };
-    (authApi.register as ReturnType<typeof vi.fn>).mockResolvedValue({ user: mockUser });
-
-    render(<RegisterPage />);
-
-    await waitFor(() => {
-      expect(screen.getByLabelText(/^email/i)).toBeInTheDocument();
-    });
-
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText(/^email/i), {
-        target: { value: 'shared@example.com' },
-      });
-      fireEvent.change(screen.getByLabelText(/^password$/i), {
-        target: { value: 'StrongPass1!' },
-      });
-      fireEvent.change(screen.getByLabelText(/confirm password/i), {
-        target: { value: 'StrongPass1!' },
-      });
-      fireEvent.change(screen.getByLabelText(/temporary password/i), {
-        target: { value: '  Temp-Pw-9!aB  ' },
-      });
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /create account/i }));
-    });
-
-    await waitFor(() =>
-      expect(authApi.register).toHaveBeenCalledWith(
-        expect.objectContaining({
-          email: 'shared@example.com',
-          password: 'StrongPass1!',
-          currentPassword: 'Temp-Pw-9!aB',
-        }),
-      ),
-    );
-  });
-
-  it('does not send currentPassword when the temp-password field is left blank', async () => {
+  it('does not include currentPassword on a normal first submit', async () => {
     const mockUser = { id: 'u2', email: 'new@example.com' };
     (authApi.register as ReturnType<typeof vi.fn>).mockResolvedValue({ user: mockUser });
 
     render(<RegisterPage />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText(/^email/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
     });
 
     await act(async () => {
-      fireEvent.change(screen.getByLabelText(/^email/i), {
+      fireEvent.change(screen.getByLabelText(/email/i), {
         target: { value: 'new@example.com' },
       });
       fireEvent.change(screen.getByLabelText(/^password$/i), {
@@ -248,10 +251,6 @@ describe('RegisterPage', () => {
       });
       fireEvent.change(screen.getByLabelText(/confirm password/i), {
         target: { value: 'StrongPass1!' },
-      });
-      // Whitespace-only temp password must NOT be sent.
-      fireEvent.change(screen.getByLabelText(/temporary password/i), {
-        target: { value: '   ' },
       });
     });
 
@@ -262,6 +261,173 @@ describe('RegisterPage', () => {
     await waitFor(() => expect(authApi.register).toHaveBeenCalled());
     const callArg = (authApi.register as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(callArg).not.toHaveProperty('currentPassword');
+  });
+
+  it('surfaces the delegate prompt and resubmits with currentPassword on 401', async () => {
+    const mockUser = { id: 'd1', email: 'shared@example.com' };
+    (authApi.register as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(delegateAxiosError())
+      .mockResolvedValueOnce({ user: mockUser });
+
+    render(<RegisterPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    });
+
+    await fillBaseFields();
+
+    // First submit: no delegate password yet, backend says it's a delegate.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    });
+    await act(async () => {}); // flush rejected promise handler
+
+    await waitFor(() => {
+      expect(screen.getByText(/already exists as a shared user/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/delegate password/i)).toBeInTheDocument();
+    });
+
+    // Second submit: registrant supplies the delegate password.
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/delegate password/i), {
+        target: { value: '  Temp-Pw-9!aB  ' },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    });
+
+    await waitFor(() => {
+      expect(
+        (authApi.register as ReturnType<typeof vi.fn>).mock.calls[1][0],
+      ).toEqual(
+        expect.objectContaining({
+          email: 'shared@example.com',
+          password: 'StrongPass1!',
+          currentPassword: 'Temp-Pw-9!aB',
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('two-factor-setup')).toBeInTheDocument();
+    });
+  });
+
+  it('keeps the prompt visible with an inline error when the delegate password is wrong', async () => {
+    (authApi.register as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(delegateAxiosError())
+      .mockRejectedValueOnce(delegateAxiosError('still wrong'));
+
+    render(<RegisterPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    });
+
+    await fillBaseFields();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    });
+    await act(async () => {});
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/delegate password/i)).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/delegate password/i), {
+        target: { value: 'WrongPw1!' },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    });
+    await act(async () => {});
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/delegate password is incorrect/i),
+      ).toBeInTheDocument();
+    });
+    // Backend has been called twice (initial detection + retry), but no
+    // account was ever created -- the inline prompt is still visible.
+    expect(
+      (authApi.register as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBe(2);
+    expect(screen.getByLabelText(/delegate password/i)).toBeInTheDocument();
+  });
+
+  it('dismisses the delegate prompt when the email is edited', async () => {
+    (authApi.register as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      delegateAxiosError(),
+    );
+
+    render(<RegisterPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    });
+
+    await fillBaseFields();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    });
+    await act(async () => {});
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/delegate password/i)).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/email/i), {
+        target: { value: 'different@example.com' },
+      });
+    });
+
+    expect(screen.queryByLabelText(/delegate password/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/already exists as a shared user/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows an inline error and does not call the API when the delegate prompt is visible but the password is blank', async () => {
+    (authApi.register as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      delegateAxiosError(),
+    );
+
+    render(<RegisterPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    });
+
+    await fillBaseFields();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    });
+    await act(async () => {});
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/delegate password/i)).toBeInTheDocument();
+    });
+
+    // Submit again without filling the delegate password.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/please enter your delegate password/i),
+      ).toBeInTheDocument();
+    });
+    expect(
+      (authApi.register as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBe(1);
   });
 
   it('shows error toast on registration failure', async () => {

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -26,9 +26,10 @@ const registerSchema = z.object({
   confirmPassword: z.string(),
   firstName: z.string().max(100, 'First name must be less than 100 characters').optional(),
   lastName: z.string().max(100, 'Last name must be less than 100 characters').optional(),
-  // Optional: lets a registrant whose email already belongs to a delegate
-  // row claim and upgrade it into a full account.
-  currentPassword: z.string().max(200).optional(),
+  // Surfaces only after a first submit reveals the email already belongs
+  // to a delegate row. Proves the registrant owns that row so the backend
+  // claims (joins) it into the new account instead of failing the submit.
+  delegatePassword: z.string().max(200).optional(),
 }).refine((data) => data.password === data.confirmPassword, {
   message: "Passwords don't match",
   path: ['confirmPassword'],
@@ -43,6 +44,12 @@ export default function RegisterPage() {
   const [showTwoFactorSetup, setShowTwoFactorSetup] = useState(false);
   const [authMethods, setAuthMethods] = useState<AuthMethods>({ local: true, oidc: false, registration: true, smtp: false, force2fa: false, demo: false });
   const [isLoadingMethods, setIsLoadingMethods] = useState(true);
+
+  // Set to the email when a submit reveals it's already a delegate row;
+  // surfaces the inline "Delegate password" prompt. Cleared when the
+  // registrant edits the email so they can try a different one cleanly.
+  const [delegateEmail, setDelegateEmail] = useState<string | null>(null);
+  const [delegatePasswordError, setDelegatePasswordError] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchAuthMethods = async () => {
@@ -66,18 +73,42 @@ export default function RegisterPage() {
     register,
     handleSubmit,
     formState: { errors },
+    watch,
   } = useForm<RegisterFormData>({
     resolver: zodResolver(registerSchema),
   });
 
+  // "Info from previous render" pattern (no setState in useEffect): when
+  // the email field is edited after we surfaced the delegate prompt, the
+  // prompt no longer applies, so drop it.
+  const watchedEmail = watch('email');
+  const [trackedEmail, setTrackedEmail] = useState(watchedEmail);
+  if (watchedEmail !== trackedEmail) {
+    setTrackedEmail(watchedEmail);
+    if (delegateEmail && watchedEmail !== delegateEmail) {
+      setDelegateEmail(null);
+      setDelegatePasswordError(null);
+    }
+  }
+
   const onSubmit = async (data: RegisterFormData) => {
+    const { confirmPassword, delegatePassword, ...rest } = data;
+    // Only include the delegate password when the inline prompt is
+    // active. react-hook-form keeps unmounted field values, so a stale
+    // value from a previous (now-dismissed) prompt would otherwise leak
+    // into the wrong code path.
+    const trimmed = delegateEmail ? delegatePassword?.trim() : undefined;
+    const sendingClaim = !!trimmed;
+
+    if (delegateEmail && !sendingClaim) {
+      setDelegatePasswordError('Please enter your delegate password.');
+      return;
+    }
+
     setIsLoading(true);
+    setDelegatePasswordError(null);
     try {
-      const { confirmPassword, currentPassword, ...rest } = data;
-      // Only include currentPassword when the registrant actually typed one
-      // (claim path); a blank value should send nothing.
-      const trimmed = currentPassword?.trim();
-      const registerData = trimmed
+      const registerData = sendingClaim
         ? { ...rest, currentPassword: trimmed }
         : rest;
       const response = await authApi.register(registerData);
@@ -87,19 +118,37 @@ export default function RegisterPage() {
       // Show 2FA setup after registration
       setShowTwoFactorSetup(true);
     } catch (error) {
-      // Show specific backend message only for 400 (e.g. breached password, validation)
-      // and for 401 on the delegate-claim path (so the user knows to supply the
-      // temporary password their administrator gave them). For everything else
-      // (409 duplicate email, 429 rate limit, 5xx), use the generic message to
-      // prevent account enumeration and hide internal details.
-      const fallback = 'Unable to create account. Please try again.';
+      // 401 from /auth/register means the email already belongs to a
+      // pure delegate row that the backend will join into the new
+      // account only when given the matching delegate password.
+      //   - no delegate password sent: first-time detection, surface the
+      //     inline prompt so the registrant can supply it.
+      //   - delegate password sent and still rejected: the password is
+      //     wrong; keep the prompt up with an inline error so they can
+      //     retry. The backend never creates a duplicate account in
+      //     either case.
+      // Other failures (409 duplicate, 429 rate limit, 5xx) use a
+      // generic message to avoid account enumeration.
       if (
         error instanceof AxiosError &&
-        (error.response?.status === 400 || error.response?.status === 401)
+        error.response?.status === 401
       ) {
+        if (sendingClaim) {
+          setDelegatePasswordError(
+            'The delegate password is incorrect. Please try again.',
+          );
+        } else {
+          setDelegateEmail(rest.email);
+          setTrackedEmail(rest.email);
+        }
+      } else if (
+        error instanceof AxiosError &&
+        error.response?.status === 400
+      ) {
+        const fallback = 'Unable to create account. Please try again.';
         toast.error(error.response.data?.message || fallback);
       } else {
-        toast.error(fallback);
+        toast.error('Unable to create account. Please try again.');
       }
     } finally {
       setIsLoading(false);
@@ -213,20 +262,38 @@ export default function RegisterPage() {
               {...register('confirmPassword')}
             />
 
-            <div>
-              <Input
-                label="Temporary password (optional)"
-                type="password"
-                autoComplete="off"
-                error={errors.currentPassword?.message}
-                {...register('currentPassword')}
-              />
-              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                Only fill this in if another Monize account holder invited
-                you as a shared user. We will use it to link this email to
-                the existing invitation instead of creating a duplicate.
-              </p>
-            </div>
+            {delegateEmail && (
+              <div
+                role="alert"
+                className="rounded border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 px-3 py-3 text-sm text-amber-900 dark:text-amber-100"
+              >
+                <p className="font-semibold">
+                  This email already exists as a shared user.
+                </p>
+                <p className="mt-1">
+                  Someone has already invited{' '}
+                  <span className="font-mono">{delegateEmail}</span> as a
+                  delegate on their account. Enter the delegate password
+                  you were given to join that access to this new account.
+                  If the password is wrong, no account will be created.
+                </p>
+              </div>
+            )}
+
+            {delegateEmail && (
+              <div>
+                <Input
+                  label="Delegate password"
+                  type="password"
+                  autoComplete="off"
+                  error={
+                    delegatePasswordError ||
+                    errors.delegatePassword?.message
+                  }
+                  {...register('delegatePassword')}
+                />
+              </div>
+            )}
           </div>
 
           <div className="space-y-3">

--- a/frontend/src/components/layout/DelegationBanner.test.tsx
+++ b/frontend/src/components/layout/DelegationBanner.test.tsx
@@ -33,7 +33,7 @@ vi.mock('@/store/authStore', () => ({
   useAuthStore: (selector: any) => selector(state),
 }));
 
-const assignMock = vi.fn();
+const reloadMock = vi.fn();
 
 describe('DelegationBanner', () => {
   beforeEach(() => {
@@ -46,7 +46,7 @@ describe('DelegationBanner', () => {
       state.availableContexts = c;
     });
     Object.defineProperty(window, 'location', {
-      value: { assign: assignMock },
+      value: { reload: reloadMock, pathname: '/transactions' },
       writable: true,
     });
   });
@@ -118,7 +118,9 @@ describe('DelegationBanner', () => {
     await waitFor(() =>
       expect(delegationApi.switchContext).toHaveBeenCalledWith('o1'),
     );
-    expect(assignMock).toHaveBeenCalledWith('/dashboard');
+    // Reload in place rather than bouncing to /dashboard so the
+    // delegate stays on whatever page they were already viewing.
+    expect(reloadMock).toHaveBeenCalledTimes(1);
   });
 
   it('auto-picks the only owner context for a pure delegate', async () => {
@@ -170,6 +172,6 @@ describe('DelegationBanner', () => {
     });
 
     await waitFor(() => expect(toast.error).toHaveBeenCalled());
-    expect(assignMock).not.toHaveBeenCalled();
+    expect(reloadMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/layout/DelegationBanner.tsx
+++ b/frontend/src/components/layout/DelegationBanner.tsx
@@ -24,8 +24,10 @@ export function DelegationBanner() {
     setSwitching(true);
     try {
       await delegationApi.switchContext(targetUserId);
-      // Full reload so every view re-fetches under the new context.
-      window.location.assign('/dashboard');
+      // Full reload so every view re-fetches under the new context, but
+      // stay on whatever page the user was on rather than bouncing back
+      // to /dashboard each time.
+      window.location.reload();
     } catch (err: unknown) {
       setSwitching(false);
       const status =

--- a/frontend/src/components/settings/DangerZoneSection.test.tsx
+++ b/frontend/src/components/settings/DangerZoneSection.test.tsx
@@ -16,10 +16,14 @@ vi.mock('@/lib/auth', () => ({
   },
 }));
 
+const authState = {
+  logout: vi.fn(),
+  availableContexts: [] as Array<{ isSelf: boolean }>,
+};
 vi.mock('@/store/authStore', () => ({
-  useAuthStore: vi.fn(() => ({
-    logout: vi.fn(),
-  })),
+  useAuthStore: vi.fn((selector?: (s: typeof authState) => unknown) =>
+    selector ? selector(authState) : authState,
+  ),
 }));
 
 vi.mock('@/lib/errors', () => ({
@@ -105,7 +109,9 @@ describe('DangerZoneSection', () => {
     });
 
     it('calls deleteAccount API with password when confirmed', async () => {
-      (userSettingsApi.deleteAccount as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+      (userSettingsApi.deleteAccount as ReturnType<typeof vi.fn>).mockResolvedValue({
+        downgraded: false,
+      });
 
       render(<DangerZoneSection user={localUser} />);
 
@@ -118,6 +124,50 @@ describe('DangerZoneSection', () => {
         expect(userSettingsApi.deleteAccount).toHaveBeenCalledWith({ password: 'mypass' });
         expect(toast.success).toHaveBeenCalledWith('Account deleted');
       });
+    });
+
+    it('shows a downgrade-aware toast when the backend reports downgraded=true', async () => {
+      (userSettingsApi.deleteAccount as ReturnType<typeof vi.fn>).mockResolvedValue({
+        downgraded: true,
+      });
+
+      render(<DangerZoneSection user={localUser} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Delete Account' }));
+      fireEvent.change(screen.getByPlaceholderText('Type DELETE'), {
+        target: { value: 'DELETE' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('Enter your password'), {
+        target: { value: 'mypass' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm Delete' }));
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith(
+          expect.stringMatching(/Your own data was removed/i),
+          expect.any(Object),
+        );
+      });
+    });
+
+    it('shows the delegate-aware notice when the user is a delegate elsewhere', () => {
+      authState.availableContexts = [
+        { isSelf: true },
+        { isSelf: false },
+      ];
+      render(<DangerZoneSection user={localUser} />);
+      expect(
+        screen.getByText(/You are a delegate of another account/i),
+      ).toBeInTheDocument();
+      authState.availableContexts = [];
+    });
+
+    it('hides the delegate-aware notice when the user is not a delegate', () => {
+      authState.availableContexts = [];
+      render(<DangerZoneSection user={localUser} />);
+      expect(
+        screen.queryByText(/You are a delegate of another account/i),
+      ).not.toBeInTheDocument();
     });
 
     it('hides confirmation when Cancel is clicked', () => {

--- a/frontend/src/components/settings/DangerZoneSection.tsx
+++ b/frontend/src/components/settings/DangerZoneSection.tsx
@@ -11,6 +11,25 @@ import { useAuthStore } from '@/store/authStore';
 import { getErrorMessage } from '@/lib/errors';
 import { User } from '@/types/auth';
 
+interface DowngradeNoticeProps {
+  isDelegate: boolean;
+}
+
+function DelegateDeleteNotice({ isDelegate }: DowngradeNoticeProps) {
+  if (!isDelegate) return null;
+  return (
+    <div className="mb-4 rounded border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 px-3 py-3 text-sm text-amber-900 dark:text-amber-100">
+      <p className="font-semibold">You are a delegate of another account.</p>
+      <p className="mt-1">
+        Deleting your account will remove your own data, but your login
+        and the shared access others granted you stay so the delegation
+        keeps working. To revoke that access, ask the owner to remove
+        you from their Shared Access list first.
+      </p>
+    </div>
+  );
+}
+
 interface DangerZoneSectionProps {
   user: User;
 }
@@ -18,6 +37,11 @@ interface DangerZoneSectionProps {
 export function DangerZoneSection({ user }: DangerZoneSectionProps) {
   const router = useRouter();
   const { logout } = useAuthStore();
+  // A delegate of another account sees a tailored warning explaining
+  // that Delete Account demotes them to delegate-only rather than
+  // truly removing their login.
+  const availableContexts = useAuthStore((s) => s.availableContexts);
+  const isDelegate = availableContexts.some((c) => !c.isSelf);
 
   // Delete account state
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -51,8 +75,15 @@ export function DangerZoneSection({ user }: DangerZoneSectionProps) {
       const authData = isOidc
         ? { oidcIdToken: 'oidc-session-confirmed' }
         : { password: deleteAccountPassword };
-      await userSettingsApi.deleteAccount(authData);
-      toast.success('Account deleted');
+      const res = await userSettingsApi.deleteAccount(authData);
+      if (res.downgraded) {
+        toast.success(
+          'Your own data was removed. Your login and shared access are kept so the delegation stays in place.',
+          { duration: 12000 },
+        );
+      } else {
+        toast.success('Account deleted');
+      }
       logout();
       router.push('/login');
     } catch (error) {
@@ -265,14 +296,11 @@ export function DangerZoneSection({ user }: DangerZoneSectionProps) {
       {/* Delete Account Section */}
       <div>
         <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-1">Delete Account</h3>
-        <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
           Permanently delete your account and all associated data. This cannot be undone.
         </p>
-        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-          If you have been granted delegate access to someone else&apos;s
-          accounts, that access and your login are kept: only your own data
-          is removed and your account becomes a delegate-only account.
-        </p>
+
+        <DelegateDeleteNotice isDelegate={isDelegate} />
 
         {!showDeleteConfirm ? (
           <Button

--- a/frontend/src/components/settings/DangerZoneSection.tsx
+++ b/frontend/src/components/settings/DangerZoneSection.tsx
@@ -39,9 +39,11 @@ export function DangerZoneSection({ user }: DangerZoneSectionProps) {
   const { logout } = useAuthStore();
   // A delegate of another account sees a tailored warning explaining
   // that Delete Account demotes them to delegate-only rather than
-  // truly removing their login.
+  // truly removing their login. Default to [] so tests that don't
+  // bother to seed the delegation slice of the auth store don't blow
+  // up on .some() -- the production store always initialises this.
   const availableContexts = useAuthStore((s) => s.availableContexts);
-  const isDelegate = availableContexts.some((c) => !c.isSelf);
+  const isDelegate = (availableContexts ?? []).some((c) => !c.isSelf);
 
   // Delete account state
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);

--- a/frontend/src/components/settings/SharedAccessSection.tsx
+++ b/frontend/src/components/settings/SharedAccessSection.tsx
@@ -428,8 +428,9 @@ export function SharedAccessSection() {
         title="Remove delegate"
         message={
           'Remove this delegate? They lose access to your account. If they ' +
-          'have no other shared access and no account of their own, their ' +
-          'login is deleted entirely.'
+          'have no other shared access and never claimed this email as ' +
+          'their own Monize account, their owner-managed login is removed ' +
+          'too.'
         }
         confirmLabel={revoking ? 'Removing...' : 'Remove'}
         variant="danger"

--- a/frontend/src/lib/admin.ts
+++ b/frontend/src/lib/admin.ts
@@ -33,8 +33,11 @@ export const adminApi = {
     return response.data;
   },
 
-  deleteUser: async (userId: string): Promise<void> => {
-    await apiClient.delete(`/admin/users/${userId}`);
+  deleteUser: async (userId: string): Promise<{ downgraded: boolean }> => {
+    const response = await apiClient.delete<{ downgraded: boolean }>(
+      `/admin/users/${userId}`,
+    );
+    return response.data;
   },
 
   resetUserPassword: async (

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -202,6 +202,55 @@ describe('apiClient', () => {
       axiosPostSpy.mockRestore();
     });
 
+    it.each([
+      '/auth/register',
+      '/auth/login',
+      '/auth/2fa/verify',
+      '/auth/forgot-password',
+      '/auth/reset-password',
+    ])(
+      'does not refresh or log out on 401 from %s (business error, not session expiry)',
+      async (url) => {
+        const axiosPostSpy = vi.spyOn(axios, 'post');
+        const logoutSpy = vi.fn();
+
+        vi.resetModules();
+        vi.doMock('@/store/authStore', () => ({
+          useAuthStore: {
+            getState: vi.fn(() => ({ logout: logoutSpy })),
+          },
+        }));
+
+        const { apiClient: freshClient } = await import('@/lib/api');
+        const interceptors = freshClient.interceptors.response as any;
+        const errorHandler = interceptors.handlers.find(
+          (h: any) => h?.rejected,
+        );
+
+        const mockError = {
+          response: { status: 401, data: { message: 'business error' } },
+          config: {
+            headers: new AxiosHeaders(),
+            method: 'post',
+            url,
+            _authRetried: false,
+          },
+        };
+
+        await expect(errorHandler.rejected(mockError)).rejects.toEqual(
+          mockError,
+        );
+        expect(axiosPostSpy).not.toHaveBeenCalledWith(
+          '/api/v1/auth/refresh',
+          expect.anything(),
+          expect.anything(),
+        );
+        expect(logoutSpy).not.toHaveBeenCalled();
+
+        axiosPostSpy.mockRestore();
+      },
+    );
+
     it('rejects non-auth/CSRF errors without interception', async () => {
       const { apiClient } = await import('@/lib/api');
       const interceptors = apiClient.interceptors.response as any;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -47,6 +47,26 @@ apiClient.interceptors.request.use(
   }
 );
 
+// Endpoints where a 401 is a business response (wrong credentials, wrong
+// 2FA code, email already belongs to a delegate that needs claiming, ...)
+// rather than an expired session. The refresh-and-retry dance below would
+// log the visitor out and bounce them to /login otherwise -- swallowing
+// the inline error the calling page needs to show.
+const UNAUTH_ENDPOINTS: ReadonlyArray<string> = [
+  '/auth/register',
+  '/auth/login',
+  '/auth/2fa/verify',
+  '/auth/forgot-password',
+  '/auth/reset-password',
+];
+
+function isUnauthEndpoint(url: string | undefined): boolean {
+  if (!url) return false;
+  return UNAUTH_ENDPOINTS.some(
+    (path) => url === path || url.startsWith(path + '?'),
+  );
+}
+
 // Response interceptor to handle errors
 let isLoggingOut = false;
 let isRefreshingCsrf = false;
@@ -157,7 +177,8 @@ apiClient.interceptors.response.use(
     if (
       error.response?.status === 401 &&
       !originalRequest?._authRetried &&
-      !isLoggingOut
+      !isLoggingOut &&
+      !isUnauthEndpoint(originalRequest?.url)
     ) {
       originalRequest._authRetried = true;
 

--- a/frontend/src/lib/user-settings.ts
+++ b/frontend/src/lib/user-settings.ts
@@ -45,8 +45,15 @@ export const userSettingsApi = {
     await apiClient.post('/users/change-password', data);
   },
 
-  deleteAccount: async (data: { password?: string; oidcIdToken?: string }): Promise<void> => {
-    await apiClient.post('/users/delete-account', data, { timeout: 120000 });
+  deleteAccount: async (
+    data: { password?: string; oidcIdToken?: string },
+  ): Promise<{ downgraded: boolean }> => {
+    const response = await apiClient.post<{ downgraded: boolean }>(
+      '/users/delete-account',
+      data,
+      { timeout: 120000 },
+    );
+    return response.data;
   },
 
   getSmtpStatus: async (): Promise<{ configured: boolean }> => {

--- a/frontend/src/store/authStore.test.ts
+++ b/frontend/src/store/authStore.test.ts
@@ -1,8 +1,23 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useAuthStore } from './authStore';
 
+// A single top-level mock for @/lib/auth -- the rehydration tests each
+// reconfigure rehydrateGetProfileMock to control how getProfile
+// resolves/rejects. The earlier per-test vi.doMock pattern was unreliable
+// because Vitest caches a module after its first dynamic import, so the
+// next test's vi.doMock would not take effect for the dynamic
+// import('@/lib/auth') inside onRehydrateStorage -- producing a flaky
+// failure on slower CI runners (see PR #556).
+const rehydrateGetProfileMock = vi.fn();
+vi.mock('@/lib/auth', () => ({
+  authApi: {
+    getProfile: rehydrateGetProfileMock,
+  },
+}));
+
 describe('authStore', () => {
   beforeEach(() => {
+    rehydrateGetProfileMock.mockReset();
     // Reset store to initial state
     useAuthStore.setState({
       user: null,
@@ -157,24 +172,24 @@ describe('authStore', () => {
       const onRehydrate = options.onRehydrateStorage();
 
       // Mock the auth module to return 502
-      vi.doMock('@/lib/auth', () => ({
-        authApi: {
-          getProfile: vi.fn().mockRejectedValue(error502),
-        },
-      }));
+      rehydrateGetProfileMock.mockRejectedValueOnce(error502);
 
       // Call onRehydrate with the current state
       onRehydrate(useAuthStore.getState());
 
-      // Wait for async operations (dynamic import + catch handler)
-      await new Promise(r => setTimeout(r, 50));
+      // Wait until the async rehydrate chain (two dynamic imports + a
+      // Promise.all over two API calls + the .catch handler) settles.
+      // The terminal state in every branch is _hasHydrated=true; a
+      // fixed setTimeout(50) was enough locally but flaked on slower
+      // CI runners (see PR #556).
+      await vi.waitFor(() =>
+        expect(useAuthStore.getState()._hasHydrated).toBe(true),
+      );
 
       const state = useAuthStore.getState();
       expect(state.isAuthenticated).toBe(true);
       expect(state._hasHydrated).toBe(true);
       expect(useConnectionStore.getState().isBackendDown).toBe(true);
-
-      vi.doUnmock('@/lib/auth');
     });
 
     it('logs out on non-502 error during rehydration', async () => {
@@ -199,21 +214,17 @@ describe('authStore', () => {
       const options = persistApi.getOptions();
       const onRehydrate = options.onRehydrateStorage();
 
-      vi.doMock('@/lib/auth', () => ({
-        authApi: {
-          getProfile: vi.fn().mockRejectedValue(error401),
-        },
-      }));
+      rehydrateGetProfileMock.mockRejectedValueOnce(error401);
 
       onRehydrate(useAuthStore.getState());
 
-      await new Promise(r => setTimeout(r, 50));
+      await vi.waitFor(() =>
+        expect(useAuthStore.getState()._hasHydrated).toBe(true),
+      );
 
       const state = useAuthStore.getState();
       expect(state.isAuthenticated).toBe(false);
       expect(state._hasHydrated).toBe(true);
-
-      vi.doUnmock('@/lib/auth');
     });
 
     it('keeps authenticated state on network error (no response)', async () => {
@@ -235,22 +246,18 @@ describe('authStore', () => {
       const options = persistApi.getOptions();
       const onRehydrate = options.onRehydrateStorage();
 
-      vi.doMock('@/lib/auth', () => ({
-        authApi: {
-          getProfile: vi.fn().mockRejectedValue(networkError),
-        },
-      }));
+      rehydrateGetProfileMock.mockRejectedValueOnce(networkError);
 
       onRehydrate(useAuthStore.getState());
 
-      await new Promise(r => setTimeout(r, 50));
+      await vi.waitFor(() =>
+        expect(useAuthStore.getState()._hasHydrated).toBe(true),
+      );
 
       const state = useAuthStore.getState();
       expect(state.isAuthenticated).toBe(true);
       expect(state._hasHydrated).toBe(true);
       expect(useConnectionStore.getState().isBackendDown).toBe(true);
-
-      vi.doUnmock('@/lib/auth');
     });
 
     it('logs out on non-AxiosError during rehydration', async () => {
@@ -265,21 +272,17 @@ describe('authStore', () => {
       const options = persistApi.getOptions();
       const onRehydrate = options.onRehydrateStorage();
 
-      vi.doMock('@/lib/auth', () => ({
-        authApi: {
-          getProfile: vi.fn().mockRejectedValue(new Error('unexpected')),
-        },
-      }));
+      rehydrateGetProfileMock.mockRejectedValueOnce(new Error('unexpected'));
 
       onRehydrate(useAuthStore.getState());
 
-      await new Promise(r => setTimeout(r, 50));
+      await vi.waitFor(() =>
+        expect(useAuthStore.getState()._hasHydrated).toBe(true),
+      );
 
       const state = useAuthStore.getState();
       expect(state.isAuthenticated).toBe(false);
       expect(state._hasHydrated).toBe(true);
-
-      vi.doUnmock('@/lib/auth');
     });
   });
 });


### PR DESCRIPTION
## Summary
Adds a complete flow for users to claim and upgrade owner-managed delegate identities into full accounts via the registration page. When an email already belongs to a pure delegate row, the backend returns 401 and the frontend surfaces an inline "Delegate password" prompt. The registrant proves ownership by supplying the delegate's temporary password, allowing the backend to join the delegate row into the new account.

## Key Changes

**Frontend Registration Flow**
- Renamed "Temporary password" field to "Delegate password" and made it surface only after a 401 response reveals the email is a delegate
- Added inline error handling for wrong delegate passwords and validation when the prompt is visible
- Dismiss the delegate prompt when the email field is edited, allowing the user to try a different email cleanly
- Updated API error handling to distinguish 401 (delegate claim needed) from 400 (validation errors) and 409 (duplicate email)
- Added test coverage for the full claim flow: initial detection, password submission, retry on wrong password, and prompt dismissal

**Backend Delegate Claim Logic**
- Extended `AuthService.register()` to accept `currentPassword` and attempt to claim a delegate row when the email matches an existing user with a password hash
- Supports two claim paths: explicit `currentPassword` from the prompt, or implicit match when the new account password happens to equal the delegate's password
- Returns 401 with "shared user" message when a delegate row is detected but no valid password is supplied
- Clears `isDelegateOnly` flag when a delegate is successfully claimed, marking them as a full account

**Delegate-Only User Tracking**
- Added `is_delegate_only` column to track users created solely via Shared Access (owner-managed) vs. those who self-registered or claimed a delegate row
- Backfill migration marks existing bootstrap-state delegates as `isDelegateOnly=true`
- Updated `DelegationService.getAvailableContexts()` to include a "self" context for claimed users even with zero accounts, preventing auto-switch to owner's context
- Updated `canOwnerResetDelegatePassword()` to check `isDelegateOnly` flag; owners cannot reset passwords for claimed users
- Updated `AdminService.findAllUsers()` to hide pure delegates from User Management (they're managed via Shared Access)

**Account Deletion Behavior**
- When a user with active delegations deletes their account, they're downgraded to delegate-only rather than fully deleted
- Backend returns `{ downgraded: boolean }` to signal this state
- Frontend shows a tailored toast and warning explaining that their login persists for the delegation to continue working
- Updated admin delete confirmation to explain the downgrade behavior

**API Error Handling**
- Added `UNAUTH_ENDPOINTS` list to prevent 401 responses from auth endpoints (register, login, 2FA, password reset) from triggering session refresh/logout
- These endpoints use 401 for business logic (wrong credentials, delegate claim needed) rather than session expiry
- Allows inline error messages to surface without bouncing the user to /login

## Implementation Details

- Used "info from previous render" pattern in registration form to dismiss delegate prompt when email changes without setState in useEffect
- Delegate password field only included in API payload when the inline prompt is active, preventing stale values from leaking into wrong code paths
- Whitespace-only delegate passwords are trimmed and treated as empty
- All delegate claim tests verify both the 401 detection and successful claim with password submission
- Migration backfill uses conservative heuristics (bootstrap state + delegate + no own data) to avoid false positives

https://claude.ai/code/session_01RqY7kCnAmM8QpKRF54ywKv