### PR TITLE
Add step-up re-authentication for emergency access message reveal

### DIFF
--- a/backend/src/accounts/accounts.service.spec.ts
+++ b/backend/src/accounts/accounts.service.spec.ts
@@ -2714,7 +2714,9 @@ describe("AccountsService", () => {
         .fn()
         .mockResolvedValue([{ assets: 800, liabilities: 0, netWorth: 800 }]);
       (
-        service["portfolioService"] as unknown as { getAccountMarketValues: jest.Mock }
+        service["portfolioService"] as unknown as {
+          getAccountMarketValues: jest.Mock;
+        }
       ).getAccountMarketValues = jest
         .fn()
         .mockResolvedValue(new Map([["a3", 750]]));
@@ -2784,12 +2786,9 @@ describe("AccountsService", () => {
     it("uses provided endDate without extending", async () => {
       const ds = service["dataSource"] as unknown as { query: jest.Mock };
       ds.query = jest.fn().mockResolvedValue([]);
-      await service.getDailyBalances(
-        "user-1",
-        "2024-01-01",
-        "2024-12-31",
-        ["a1"],
-      );
+      await service.getDailyBalances("user-1", "2024-01-01", "2024-12-31", [
+        "a1",
+      ]);
       // Only the main rows query runs; no max-date probing
       expect(ds.query).toHaveBeenCalledTimes(1);
     });

--- a/backend/src/ai/providers/ollama.provider.spec.ts
+++ b/backend/src/ai/providers/ollama.provider.spec.ts
@@ -832,9 +832,7 @@ describe("OllamaProvider", () => {
     });
 
     it("complete throws and logs when fetch rejects (Error)", async () => {
-      global.fetch = jest
-        .fn()
-        .mockRejectedValue(new Error("connect refused"));
+      global.fetch = jest.fn().mockRejectedValue(new Error("connect refused"));
       await expect(
         provider.complete({
           systemPrompt: "sys",
@@ -879,9 +877,7 @@ describe("OllamaProvider", () => {
           {
             role: "assistant",
             content: "a1",
-            toolCalls: [
-              { id: "tc1", name: "do_thing", input: { x: 1 } },
-            ],
+            toolCalls: [{ id: "tc1", name: "do_thing", input: { x: 1 } }],
           },
           {
             role: "tool",
@@ -895,7 +891,9 @@ describe("OllamaProvider", () => {
       const msgs = body.messages as Array<{ role: string }>;
       expect(msgs.find((m) => m.role === "tool")).toBeTruthy();
       const assistant = msgs.find(
-        (m) => m.role === "assistant" && (m as { tool_calls?: unknown[] }).tool_calls,
+        (m) =>
+          m.role === "assistant" &&
+          (m as { tool_calls?: unknown[] }).tool_calls,
       );
       expect(assistant).toBeTruthy();
     });

--- a/backend/src/ai/providers/openai-compatible.provider.spec.ts
+++ b/backend/src/ai/providers/openai-compatible.provider.spec.ts
@@ -606,15 +606,11 @@ describe("OpenAiCompatibleProvider", () => {
       const r = parseInlineToolCalls(
         '{"type":"function","function":{"name":"x","arguments":null}}',
       );
-      expect(r).toEqual([
-        expect.objectContaining({ name: "x", input: {} }),
-      ]);
+      expect(r).toEqual([expect.objectContaining({ name: "x", input: {} })]);
     });
 
     it("returns null if function is non-object", () => {
-      const r = parseInlineToolCalls(
-        '{"type":"function","function":"hello"}',
-      );
+      const r = parseInlineToolCalls('{"type":"function","function":"hello"}');
       expect(r).toBeNull();
     });
 
@@ -649,7 +645,7 @@ describe("OpenAiCompatibleProvider", () => {
         },
       ];
       const r = flattenToolMessages(m);
-      expect(r[0].content).toContain("\"name\":\"n\"");
+      expect(r[0].content).toContain('"name":"n"');
       // No leading content+\n
       expect(r[0].content.startsWith("\n")).toBe(false);
     });

--- a/backend/src/ai/providers/openai.provider.spec.ts
+++ b/backend/src/ai/providers/openai.provider.spec.ts
@@ -750,8 +750,9 @@ describe("OpenAiProvider", () => {
         ],
       );
       const args = mockCreate.mock.calls[0][0];
-      expect(args.messages.find((m: { role: string }) => m.role === "tool"))
-        .toBeTruthy();
+      expect(
+        args.messages.find((m: { role: string }) => m.role === "tool"),
+      ).toBeTruthy();
     });
 
     it("uses simple assistant content path when no toolCalls", async () => {
@@ -768,9 +769,7 @@ describe("OpenAiProvider", () => {
       await provider.completeWithTools(
         {
           systemPrompt: "s",
-          messages: [
-            { role: "assistant", content: "I'm ready" },
-          ],
+          messages: [{ role: "assistant", content: "I'm ready" }],
         },
         [
           {

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -20,6 +20,9 @@ import { TokenService } from "./token.service";
 import { TwoFactorService } from "./two-factor.service";
 import { AuthEmailService } from "./auth-email.service";
 import { PatController } from "./pat.controller";
+import { StepUpAuthService } from "./step-up/step-up.service";
+import { StepUpAuthController } from "./step-up/step-up.controller";
+import { StepUpGuard } from "./step-up/step-up.guard";
 import { UsersModule } from "../users/users.module";
 import { NotificationsModule } from "../notifications/notifications.module";
 import { DelegationModule } from "../delegation/delegation.module";
@@ -62,8 +65,10 @@ import { DelegationModule } from "../delegation/delegation.module";
     OidcService,
     PatService,
     PasswordBreachService,
+    StepUpAuthService,
+    StepUpGuard,
   ],
-  controllers: [AuthController, PatController],
+  controllers: [AuthController, PatController, StepUpAuthController],
   exports: [
     AuthService,
     TokenService,
@@ -72,6 +77,8 @@ import { DelegationModule } from "../delegation/delegation.module";
     OidcService,
     PatService,
     PasswordBreachService,
+    StepUpAuthService,
+    StepUpGuard,
     JwtModule,
   ],
 })

--- a/backend/src/auth/step-up/dto/verify-step-up.dto.ts
+++ b/backend/src/auth/step-up/dto/verify-step-up.dto.ts
@@ -1,0 +1,45 @@
+import {
+  IsIn,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+} from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+
+/**
+ * Purposes for which a step-up token can be issued. Adding a new sensitive
+ * surface means adding a new value here and decorating its handlers with
+ * `@RequireStepUp(purpose)`.
+ */
+export const STEP_UP_PURPOSES = ["emergency-access"] as const;
+export type StepUpPurpose = (typeof STEP_UP_PURPOSES)[number];
+
+export class VerifyStepUpDto {
+  @ApiProperty({
+    description: "Sensitive surface this step-up token will unlock",
+    enum: STEP_UP_PURPOSES,
+  })
+  @IsString()
+  @IsIn(STEP_UP_PURPOSES as unknown as string[])
+  purpose: StepUpPurpose;
+
+  @ApiProperty({
+    description: "Current account password (local users without 2FA)",
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(256)
+  password?: string;
+
+  @ApiProperty({
+    description: "6-digit TOTP code (users with 2FA enabled)",
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(6)
+  @Matches(/^\d{6}$/, { message: "TOTP code must be 6 digits" })
+  totpCode?: string;
+}

--- a/backend/src/auth/step-up/dto/verify-step-up.dto.ts
+++ b/backend/src/auth/step-up/dto/verify-step-up.dto.ts
@@ -1,4 +1,5 @@
 import {
+  IsBoolean,
   IsIn,
   IsOptional,
   IsString,
@@ -42,4 +43,13 @@ export class VerifyStepUpDto {
   @MaxLength(6)
   @Matches(/^\d{6}$/, { message: "TOTP code must be 6 digits" })
   totpCode?: string;
+
+  @ApiProperty({
+    description:
+      "OIDC users only: set true after the frontend has completed a fresh redirect through the identity provider. Mirrors the soft-check used by /users/delete-account.",
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  oidcConfirmed?: boolean;
 }

--- a/backend/src/auth/step-up/require-step-up.decorator.ts
+++ b/backend/src/auth/step-up/require-step-up.decorator.ts
@@ -1,0 +1,13 @@
+import { SetMetadata } from "@nestjs/common";
+import type { StepUpPurpose } from "./dto/verify-step-up.dto";
+
+export const REQUIRE_STEP_UP_KEY = "requireStepUp";
+
+/**
+ * Marks a controller handler as requiring a valid step-up token for the
+ * given purpose. The `StepUpGuard` reads this metadata and rejects requests
+ * whose `X-Step-Up-Token` header is missing, expired, or scoped to a
+ * different purpose.
+ */
+export const RequireStepUp = (purpose: StepUpPurpose) =>
+  SetMetadata(REQUIRE_STEP_UP_KEY, purpose);

--- a/backend/src/auth/step-up/step-up.controller.spec.ts
+++ b/backend/src/auth/step-up/step-up.controller.spec.ts
@@ -1,0 +1,38 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { StepUpAuthController } from "./step-up.controller";
+import { StepUpAuthService } from "./step-up.service";
+
+describe("StepUpAuthController", () => {
+  let controller: StepUpAuthController;
+  let service: Record<string, jest.Mock>;
+  const req = { user: { id: "user-1" } };
+
+  beforeEach(async () => {
+    service = {
+      verifyAndIssue: jest.fn().mockResolvedValue({
+        stepUpToken: "tok",
+        expiresAt: "2026-05-21T00:05:00.000Z",
+        expiresInSeconds: 300,
+      }),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [StepUpAuthController],
+      providers: [{ provide: StepUpAuthService, useValue: service }],
+    }).compile();
+    controller = module.get(StepUpAuthController);
+  });
+
+  it("forwards purpose, password and totpCode to the service", async () => {
+    const result = await controller.verify(req, {
+      purpose: "emergency-access",
+      password: "hunter2",
+      totpCode: "123456",
+    });
+    expect(service.verifyAndIssue).toHaveBeenCalledWith(
+      "user-1",
+      "emergency-access",
+      { password: "hunter2", totpCode: "123456" },
+    );
+    expect(result.stepUpToken).toBe("tok");
+  });
+});

--- a/backend/src/auth/step-up/step-up.controller.ts
+++ b/backend/src/auth/step-up/step-up.controller.ts
@@ -24,6 +24,7 @@ export class StepUpAuthController {
     return this.service.verifyAndIssue(req.user.id, dto.purpose, {
       password: dto.password,
       totpCode: dto.totpCode,
+      oidcConfirmed: dto.oidcConfirmed,
     });
   }
 }

--- a/backend/src/auth/step-up/step-up.controller.ts
+++ b/backend/src/auth/step-up/step-up.controller.ts
@@ -1,0 +1,29 @@
+import { Body, Controller, Post, Request, UseGuards } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import { ApiOperation, ApiTags } from "@nestjs/swagger";
+import { Throttle } from "@nestjs/throttler";
+import { StepUpAuthService } from "./step-up.service";
+import { VerifyStepUpDto } from "./dto/verify-step-up.dto";
+
+@ApiTags("Authentication")
+@Controller("auth/step-up")
+@UseGuards(AuthGuard("jwt"))
+export class StepUpAuthController {
+  constructor(private readonly service: StepUpAuthService) {}
+
+  @Post()
+  @Throttle({ default: { limit: 10, ttl: 60_000 } })
+  @ApiOperation({
+    summary:
+      "Verify the user's strongest auth factor and issue a step-up token",
+  })
+  async verify(
+    @Request() req: { user: { id: string } },
+    @Body() dto: VerifyStepUpDto,
+  ) {
+    return this.service.verifyAndIssue(req.user.id, dto.purpose, {
+      password: dto.password,
+      totpCode: dto.totpCode,
+    });
+  }
+}

--- a/backend/src/auth/step-up/step-up.guard.spec.ts
+++ b/backend/src/auth/step-up/step-up.guard.spec.ts
@@ -1,0 +1,136 @@
+import { ExecutionContext, ForbiddenException } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { JwtService, TokenExpiredError } from "@nestjs/jwt";
+import { StepUpGuard } from "./step-up.guard";
+import { REQUIRE_STEP_UP_KEY } from "./require-step-up.decorator";
+
+function buildContext(
+  headers: Record<string, string | undefined>,
+  user: { id?: string } | undefined,
+): ExecutionContext {
+  const handler = function handler() {};
+  class Cls {}
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ headers, user }),
+    }),
+    getHandler: () => handler,
+    getClass: () => Cls,
+  } as unknown as ExecutionContext;
+}
+
+describe("StepUpGuard", () => {
+  let reflector: Reflector;
+  let jwt: Record<string, jest.Mock>;
+  let guard: StepUpGuard;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    jwt = { verify: jest.fn() };
+    guard = new StepUpGuard(reflector, jwt as unknown as JwtService);
+  });
+
+  it("returns true when no @RequireStepUp metadata is present", () => {
+    const ctx = buildContext({}, { id: "u1" });
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  describe("with @RequireStepUp('emergency-access')", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(reflector, "getAllAndOverride")
+        .mockImplementation((key) =>
+          key === REQUIRE_STEP_UP_KEY ? "emergency-access" : undefined,
+        );
+    });
+
+    it("rejects when user is missing on request", () => {
+      const ctx = buildContext({}, undefined);
+      expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
+    });
+
+    it("rejects when the header is missing", () => {
+      const ctx = buildContext({}, { id: "u1" });
+      try {
+        guard.canActivate(ctx);
+        fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ForbiddenException);
+        expect((err as ForbiddenException).getResponse()).toMatchObject({
+          code: "STEP_UP_REQUIRED",
+        });
+      }
+    });
+
+    it("rejects when the token is expired", () => {
+      jwt.verify.mockImplementation(() => {
+        throw new TokenExpiredError("jwt expired", new Date());
+      });
+      const ctx = buildContext({ "x-step-up-token": "expired" }, { id: "u1" });
+      try {
+        guard.canActivate(ctx);
+        fail("should have thrown");
+      } catch (err) {
+        expect((err as ForbiddenException).getResponse()).toMatchObject({
+          code: "STEP_UP_EXPIRED",
+        });
+      }
+    });
+
+    it("rejects when the token has a different type claim", () => {
+      jwt.verify.mockReturnValue({
+        sub: "u1",
+        type: "refresh",
+        purpose: "emergency-access",
+      });
+      const ctx = buildContext(
+        { "x-step-up-token": "wrong-type" },
+        { id: "u1" },
+      );
+      expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
+    });
+
+    it("rejects when the token is scoped to a different purpose", () => {
+      jwt.verify.mockReturnValue({
+        sub: "u1",
+        type: "step_up",
+        purpose: "other-action",
+      });
+      const ctx = buildContext(
+        { "x-step-up-token": "wrong-purpose" },
+        { id: "u1" },
+      );
+      try {
+        guard.canActivate(ctx);
+        fail("should have thrown");
+      } catch (err) {
+        expect((err as ForbiddenException).getResponse()).toMatchObject({
+          code: "STEP_UP_INVALID",
+        });
+      }
+    });
+
+    it("rejects when the token sub does not match the request user", () => {
+      jwt.verify.mockReturnValue({
+        sub: "attacker",
+        type: "step_up",
+        purpose: "emergency-access",
+      });
+      const ctx = buildContext(
+        { "x-step-up-token": "swapped" },
+        { id: "victim" },
+      );
+      expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
+    });
+
+    it("accepts a valid token", () => {
+      jwt.verify.mockReturnValue({
+        sub: "u1",
+        type: "step_up",
+        purpose: "emergency-access",
+      });
+      const ctx = buildContext({ "x-step-up-token": "valid" }, { id: "u1" });
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
+  });
+});

--- a/backend/src/auth/step-up/step-up.guard.ts
+++ b/backend/src/auth/step-up/step-up.guard.ts
@@ -49,6 +49,12 @@ export class StepUpGuard implements CanActivate {
 
     const headerValue = request.headers?.[STEP_UP_HEADER];
     const token = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+    // CWE-208 (Bearer rule): this is a presence/type check on an
+    // attacker-supplied request header, not a comparison against a secret.
+    // The branch outcome is fully determined by the caller's own input, so
+    // a timing side-channel here reveals nothing the attacker doesn't
+    // already know.
+    // bearer:disable javascript_lang_observable_timing
     if (!token || typeof token !== "string") {
       throw new ForbiddenException({
         code: "STEP_UP_REQUIRED",

--- a/backend/src/auth/step-up/step-up.guard.ts
+++ b/backend/src/auth/step-up/step-up.guard.ts
@@ -1,0 +1,118 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  Logger,
+} from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { JwtService, TokenExpiredError } from "@nestjs/jwt";
+import { REQUIRE_STEP_UP_KEY } from "./require-step-up.decorator";
+import type { StepUpPurpose } from "./dto/verify-step-up.dto";
+
+const STEP_UP_HEADER = "x-step-up-token";
+
+interface StepUpPayload {
+  sub: string;
+  type: string;
+  purpose: string;
+  jti?: string;
+  exp?: number;
+}
+
+@Injectable()
+export class StepUpGuard implements CanActivate {
+  private readonly logger = new Logger(StepUpGuard.name);
+
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly jwtService: JwtService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredPurpose = this.reflector.getAllAndOverride<StepUpPurpose>(
+      REQUIRE_STEP_UP_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (!requiredPurpose) return true;
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user as { id?: string } | undefined;
+    if (!user?.id) {
+      // JwtAuthGuard should run before this guard. If we got here without a
+      // user the request is malformed; fail closed.
+      throw new ForbiddenException({
+        code: "STEP_UP_INVALID",
+        message: "Step-up token requires an authenticated session",
+      });
+    }
+
+    const headerValue = request.headers?.[STEP_UP_HEADER];
+    const token = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+    if (!token || typeof token !== "string") {
+      throw new ForbiddenException({
+        code: "STEP_UP_REQUIRED",
+        message: "Step-up verification required",
+        purpose: requiredPurpose,
+      });
+    }
+
+    let payload: StepUpPayload;
+    try {
+      payload = this.jwtService.verify<StepUpPayload>(token);
+    } catch (err) {
+      if (err instanceof TokenExpiredError) {
+        throw new ForbiddenException({
+          code: "STEP_UP_EXPIRED",
+          message: "Step-up verification expired",
+          purpose: requiredPurpose,
+        });
+      }
+      this.logger.warn(
+        `Step-up token rejected: invalid signature for user ${user.id}`,
+      );
+      throw new ForbiddenException({
+        code: "STEP_UP_INVALID",
+        message: "Step-up token is invalid",
+        purpose: requiredPurpose,
+      });
+    }
+
+    if (payload.type !== "step_up") {
+      this.logger.warn(
+        `Step-up token rejected: wrong type '${payload.type}' for user ${user.id}`,
+      );
+      throw new ForbiddenException({
+        code: "STEP_UP_INVALID",
+        message: "Step-up token is invalid",
+        purpose: requiredPurpose,
+      });
+    }
+
+    if (payload.purpose !== requiredPurpose) {
+      this.logger.warn(
+        `Step-up token rejected: purpose '${payload.purpose}' does not match '${requiredPurpose}' for user ${user.id}`,
+      );
+      throw new ForbiddenException({
+        code: "STEP_UP_INVALID",
+        message: "Step-up token is scoped to a different action",
+        purpose: requiredPurpose,
+      });
+    }
+
+    if (payload.sub !== user.id) {
+      // Bound to the user who verified -- stealing one user's step-up token
+      // and swapping JWTs cannot unlock another account.
+      this.logger.warn(
+        `Step-up token rejected: sub mismatch (token=${payload.sub}, user=${user.id})`,
+      );
+      throw new ForbiddenException({
+        code: "STEP_UP_INVALID",
+        message: "Step-up token does not belong to this user",
+        purpose: requiredPurpose,
+      });
+    }
+
+    return true;
+  }
+}

--- a/backend/src/auth/step-up/step-up.service.spec.ts
+++ b/backend/src/auth/step-up/step-up.service.spec.ts
@@ -144,7 +144,7 @@ describe("StepUpAuthService", () => {
     });
   });
 
-  describe("OIDC users without 2FA", () => {
+  describe("OIDC users", () => {
     beforeEach(() => {
       usersRepo.findOne.mockResolvedValue({
         id: userId,
@@ -155,7 +155,38 @@ describe("StepUpAuthService", () => {
       preferencesRepo.findOne.mockResolvedValue({ twoFactorEnabled: false });
     });
 
+    it("requires oidcConfirmed and otherwise rejects with OIDC_REAUTH_REQUIRED", async () => {
+      await expect(
+        service.verifyAndIssue(userId, "emergency-access", { password: "x" }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      await expect(
+        service.verifyAndIssue(userId, "emergency-access", {}),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it("issues a token when oidcConfirmed=true after a fresh IdP roundtrip", async () => {
+      const result = await service.verifyAndIssue(userId, "emergency-access", {
+        oidcConfirmed: true,
+      });
+      expect(result.stepUpToken).toBe("signed.jwt.token");
+      const payload = jwt.sign.mock.calls[0][0];
+      expect(payload).toMatchObject({
+        sub: userId,
+        type: "step_up",
+        purpose: "emergency-access",
+      });
+    });
+  });
+
+  describe("local user with no password (incomplete onboarding)", () => {
     it("rejects with STEP_UP_FACTOR_UNAVAILABLE", async () => {
+      usersRepo.findOne.mockResolvedValue({
+        id: userId,
+        authProvider: "local",
+        passwordHash: null,
+        twoFactorSecret: null,
+      });
+      preferencesRepo.findOne.mockResolvedValue({ twoFactorEnabled: false });
       await expect(
         service.verifyAndIssue(userId, "emergency-access", { password: "x" }),
       ).rejects.toBeInstanceOf(BadRequestException);

--- a/backend/src/auth/step-up/step-up.service.spec.ts
+++ b/backend/src/auth/step-up/step-up.service.spec.ts
@@ -1,0 +1,220 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { JwtService } from "@nestjs/jwt";
+import { ConfigService } from "@nestjs/config";
+import {
+  BadRequestException,
+  NotFoundException,
+  UnauthorizedException,
+} from "@nestjs/common";
+import * as bcrypt from "bcryptjs";
+
+import { StepUpAuthService } from "./step-up.service";
+import { TwoFactorService } from "../two-factor.service";
+import { User } from "../../users/entities/user.entity";
+import { UserPreference } from "../../users/entities/user-preference.entity";
+
+describe("StepUpAuthService", () => {
+  let service: StepUpAuthService;
+  let usersRepo: Record<string, jest.Mock>;
+  let preferencesRepo: Record<string, jest.Mock>;
+  let twoFactor: Record<string, jest.Mock>;
+  let jwt: Record<string, jest.Mock>;
+
+  const userId = "11111111-1111-1111-1111-111111111111";
+
+  beforeEach(async () => {
+    usersRepo = { findOne: jest.fn() };
+    preferencesRepo = { findOne: jest.fn() };
+    twoFactor = { verifyTotpForUser: jest.fn() };
+    jwt = { sign: jest.fn().mockReturnValue("signed.jwt.token") };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StepUpAuthService,
+        { provide: getRepositoryToken(User), useValue: usersRepo },
+        {
+          provide: getRepositoryToken(UserPreference),
+          useValue: preferencesRepo,
+        },
+        { provide: TwoFactorService, useValue: twoFactor },
+        { provide: JwtService, useValue: jwt },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get(StepUpAuthService);
+  });
+
+  it("throws NotFoundException when the user is missing", async () => {
+    usersRepo.findOne.mockResolvedValue(null);
+    await expect(
+      service.verifyAndIssue(userId, "emergency-access", {
+        password: "x",
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  describe("2FA-enabled users", () => {
+    beforeEach(() => {
+      usersRepo.findOne.mockResolvedValue({
+        id: userId,
+        authProvider: "local",
+        passwordHash: "irrelevant",
+        twoFactorSecret: "enc-secret",
+      });
+      preferencesRepo.findOne.mockResolvedValue({ twoFactorEnabled: true });
+    });
+
+    it("requires totpCode and rejects password-only attempts", async () => {
+      await expect(
+        service.verifyAndIssue(userId, "emergency-access", {
+          password: "hunter2",
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(twoFactor.verifyTotpForUser).not.toHaveBeenCalled();
+    });
+
+    it("issues a token when the TOTP code is valid", async () => {
+      twoFactor.verifyTotpForUser.mockResolvedValue(true);
+      const result = await service.verifyAndIssue(userId, "emergency-access", {
+        totpCode: "123456",
+      });
+
+      expect(twoFactor.verifyTotpForUser).toHaveBeenCalledWith(
+        userId,
+        "123456",
+      );
+      expect(jwt.sign).toHaveBeenCalled();
+      const payload = jwt.sign.mock.calls[0][0];
+      expect(payload).toMatchObject({
+        sub: userId,
+        type: "step_up",
+        purpose: "emergency-access",
+      });
+      expect(typeof payload.jti).toBe("string");
+      expect(result.stepUpToken).toBe("signed.jwt.token");
+      expect(result.expiresInSeconds).toBe(300);
+      expect(new Date(result.expiresAt).getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it("rejects invalid TOTP codes", async () => {
+      twoFactor.verifyTotpForUser.mockResolvedValue(false);
+      await expect(
+        service.verifyAndIssue(userId, "emergency-access", {
+          totpCode: "999999",
+        }),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+  });
+
+  describe("local users without 2FA", () => {
+    beforeEach(async () => {
+      const hash = await bcrypt.hash("hunter2", 4);
+      usersRepo.findOne.mockResolvedValue({
+        id: userId,
+        authProvider: "local",
+        passwordHash: hash,
+        twoFactorSecret: null,
+      });
+      preferencesRepo.findOne.mockResolvedValue({ twoFactorEnabled: false });
+    });
+
+    it("requires password and rejects totp-only attempts", async () => {
+      await expect(
+        service.verifyAndIssue(userId, "emergency-access", {
+          totpCode: "123456",
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it("issues a token when the password is correct", async () => {
+      const result = await service.verifyAndIssue(userId, "emergency-access", {
+        password: "hunter2",
+      });
+      expect(result.stepUpToken).toBe("signed.jwt.token");
+    });
+
+    it("rejects wrong passwords", async () => {
+      await expect(
+        service.verifyAndIssue(userId, "emergency-access", {
+          password: "wrong",
+        }),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+  });
+
+  describe("OIDC users without 2FA", () => {
+    beforeEach(() => {
+      usersRepo.findOne.mockResolvedValue({
+        id: userId,
+        authProvider: "oidc",
+        passwordHash: null,
+        twoFactorSecret: null,
+      });
+      preferencesRepo.findOne.mockResolvedValue({ twoFactorEnabled: false });
+    });
+
+    it("rejects with STEP_UP_FACTOR_UNAVAILABLE", async () => {
+      await expect(
+        service.verifyAndIssue(userId, "emergency-access", { password: "x" }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe("rate limiting", () => {
+    beforeEach(async () => {
+      const hash = await bcrypt.hash("hunter2", 4);
+      usersRepo.findOne.mockResolvedValue({
+        id: userId,
+        authProvider: "local",
+        passwordHash: hash,
+        twoFactorSecret: null,
+      });
+      preferencesRepo.findOne.mockResolvedValue({ twoFactorEnabled: false });
+    });
+
+    it("locks out after 10 failed attempts", async () => {
+      for (let i = 0; i < 10; i++) {
+        await expect(
+          service.verifyAndIssue(userId, "emergency-access", {
+            password: "wrong",
+          }),
+        ).rejects.toBeInstanceOf(UnauthorizedException);
+      }
+      // 11th attempt -- even with the correct password -- should be locked out.
+      await expect(
+        service.verifyAndIssue(userId, "emergency-access", {
+          password: "hunter2",
+        }),
+      ).rejects.toThrow(/too many/i);
+    });
+
+    it("clears the attempt counter after a successful verification", async () => {
+      // First a few failures
+      for (let i = 0; i < 3; i++) {
+        await service
+          .verifyAndIssue(userId, "emergency-access", { password: "wrong" })
+          .catch(() => undefined);
+      }
+      // Then a success
+      await expect(
+        service.verifyAndIssue(userId, "emergency-access", {
+          password: "hunter2",
+        }),
+      ).resolves.toBeDefined();
+
+      // Counter is reset -- another 10 failures should be needed to lock out.
+      for (let i = 0; i < 9; i++) {
+        await service
+          .verifyAndIssue(userId, "emergency-access", { password: "wrong" })
+          .catch(() => undefined);
+      }
+      await expect(
+        service.verifyAndIssue(userId, "emergency-access", {
+          password: "hunter2",
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
+});

--- a/backend/src/auth/step-up/step-up.service.ts
+++ b/backend/src/auth/step-up/step-up.service.ts
@@ -1,0 +1,175 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { JwtService } from "@nestjs/jwt";
+import { ConfigService } from "@nestjs/config";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import * as bcrypt from "bcryptjs";
+import * as crypto from "crypto";
+
+import { User } from "../../users/entities/user.entity";
+import { UserPreference } from "../../users/entities/user-preference.entity";
+import { TwoFactorService } from "../two-factor.service";
+import type { StepUpPurpose } from "./dto/verify-step-up.dto";
+
+interface VerifyArgs {
+  password?: string;
+  totpCode?: string;
+}
+
+export interface StepUpVerificationResult {
+  stepUpToken: string;
+  expiresAt: string;
+  expiresInSeconds: number;
+}
+
+/**
+ * Step-up re-authentication. The user is already authenticated (JWT
+ * session); for a small set of high-sensitivity surfaces we re-prompt for
+ * their strongest factor and hand back a short-lived token scoped to that
+ * surface only.
+ */
+@Injectable()
+export class StepUpAuthService {
+  private readonly logger = new Logger(StepUpAuthService.name);
+  private readonly STEP_UP_TTL_SECONDS = 5 * 60;
+  private readonly MAX_ATTEMPTS = 10;
+  private readonly LOCKOUT_WINDOW_MS = 30 * 60 * 1000;
+  private readonly attempts = new Map<
+    string,
+    { count: number; expiresAt: number }
+  >();
+
+  constructor(
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+    @InjectRepository(UserPreference)
+    private readonly preferencesRepository: Repository<UserPreference>,
+    private readonly twoFactorService: TwoFactorService,
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {
+    // Forces ConfigService to be retained so step-up TTL can be tuned later
+    // via env without changing the constructor signature.
+    void this.configService;
+  }
+
+  async verifyAndIssue(
+    userId: string,
+    purpose: StepUpPurpose,
+    args: VerifyArgs,
+  ): Promise<StepUpVerificationResult> {
+    this.cleanupExpiredAttempts();
+    const attemptKey = `${userId}:${purpose}`;
+    const record = this.attempts.get(attemptKey);
+    if (record && record.count >= this.MAX_ATTEMPTS) {
+      this.logger.warn(
+        `Step-up rejected: too many attempts for user ${userId} purpose ${purpose}`,
+      );
+      throw new UnauthorizedException(
+        "Too many verification attempts. Please try again later.",
+      );
+    }
+
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException("User not found");
+    }
+
+    const preferences = await this.preferencesRepository.findOne({
+      where: { userId },
+    });
+    const twoFactorEnabled =
+      !!preferences?.twoFactorEnabled && !!user.twoFactorSecret;
+
+    let verified = false;
+
+    if (twoFactorEnabled) {
+      // Strongest available: TOTP. Password is not accepted as a fallback for
+      // users who have enrolled 2FA.
+      if (!args.totpCode) {
+        throw new BadRequestException({
+          code: "TOTP_REQUIRED",
+          message: "Enter your 6-digit authenticator code to continue",
+        });
+      }
+      verified = await this.twoFactorService.verifyTotpForUser(
+        userId,
+        args.totpCode,
+      );
+    } else if (user.authProvider === "local" && user.passwordHash) {
+      if (!args.password) {
+        throw new BadRequestException({
+          code: "PASSWORD_REQUIRED",
+          message: "Enter your current password to continue",
+        });
+      }
+      verified = await bcrypt.compare(args.password, user.passwordHash);
+    } else {
+      // OIDC user without 2FA. We cannot prove they're still in possession
+      // of the account without a redirect to the identity provider, which
+      // isn't wired up yet. Direct them to enable 2FA so we can use TOTP.
+      this.logger.warn(
+        `Step-up unavailable for user ${userId}: OIDC without 2FA`,
+      );
+      throw new BadRequestException({
+        code: "STEP_UP_FACTOR_UNAVAILABLE",
+        message:
+          "Enable two-factor authentication to access this protected setting.",
+      });
+    }
+
+    if (!verified) {
+      this.recordFailure(attemptKey);
+      this.logger.warn(
+        `Step-up verification failed for user ${userId} purpose ${purpose}`,
+      );
+      throw new UnauthorizedException(
+        twoFactorEnabled ? "Invalid authenticator code" : "Incorrect password",
+      );
+    }
+
+    this.attempts.delete(attemptKey);
+
+    const jti = crypto.randomUUID();
+    const stepUpToken = this.jwtService.sign(
+      { sub: userId, type: "step_up", purpose, jti },
+      { expiresIn: this.STEP_UP_TTL_SECONDS },
+    );
+    const expiresAt = new Date(
+      Date.now() + this.STEP_UP_TTL_SECONDS * 1000,
+    ).toISOString();
+
+    this.logger.log(
+      `Step-up verification succeeded for user ${userId} purpose ${purpose}`,
+    );
+
+    return {
+      stepUpToken,
+      expiresAt,
+      expiresInSeconds: this.STEP_UP_TTL_SECONDS,
+    };
+  }
+
+  private recordFailure(key: string): void {
+    const existing = this.attempts.get(key);
+    this.attempts.set(key, {
+      count: (existing?.count ?? 0) + 1,
+      expiresAt: Date.now() + this.LOCKOUT_WINDOW_MS,
+    });
+  }
+
+  private cleanupExpiredAttempts(): void {
+    const now = Date.now();
+    for (const [key, value] of this.attempts.entries()) {
+      if (value.expiresAt <= now) {
+        this.attempts.delete(key);
+      }
+    }
+  }
+}

--- a/backend/src/auth/step-up/step-up.service.ts
+++ b/backend/src/auth/step-up/step-up.service.ts
@@ -20,6 +20,7 @@ import type { StepUpPurpose } from "./dto/verify-step-up.dto";
 interface VerifyArgs {
   password?: string;
   totpCode?: string;
+  oidcConfirmed?: boolean;
 }
 
 export interface StepUpVerificationResult {
@@ -102,7 +103,22 @@ export class StepUpAuthService {
         userId,
         args.totpCode,
       );
-    } else if (user.authProvider === "local" && user.passwordHash) {
+    } else if (user.authProvider === "oidc") {
+      // OIDC users have no Monize-managed password and cannot enroll Monize
+      // 2FA (see two-factor.service.ts:283). Mirror the soft-check pattern
+      // used by /users/delete-account and /backup/restore: the frontend
+      // redirects the user through the identity provider via
+      // authApi.initiateOidc(), then sets oidcConfirmed=true on return.
+      // The presence of that flag combined with the freshly-rotated session
+      // cookies stands in for a re-auth challenge.
+      if (!args.oidcConfirmed) {
+        throw new BadRequestException({
+          code: "OIDC_REAUTH_REQUIRED",
+          message: "Re-authenticate with your identity provider to continue.",
+        });
+      }
+      verified = true;
+    } else if (user.passwordHash) {
       if (!args.password) {
         throw new BadRequestException({
           code: "PASSWORD_REQUIRED",
@@ -111,16 +127,16 @@ export class StepUpAuthService {
       }
       verified = await bcrypt.compare(args.password, user.passwordHash);
     } else {
-      // OIDC user without 2FA. We cannot prove they're still in possession
-      // of the account without a redirect to the identity provider, which
-      // isn't wired up yet. Direct them to enable 2FA so we can use TOTP.
+      // Local account with no password set (admin-provisioned via reset
+      // flow that hasn't completed yet) -- step-up isn't available until
+      // the user finishes onboarding.
       this.logger.warn(
-        `Step-up unavailable for user ${userId}: OIDC without 2FA`,
+        `Step-up unavailable for user ${userId}: no password and not OIDC`,
       );
       throw new BadRequestException({
         code: "STEP_UP_FACTOR_UNAVAILABLE",
         message:
-          "Enable two-factor authentication to access this protected setting.",
+          "Finish setting up your account password to access this setting.",
       });
     }
 

--- a/backend/src/auth/two-factor.service.spec.ts
+++ b/backend/src/auth/two-factor.service.spec.ts
@@ -1087,4 +1087,70 @@ describe("TwoFactorService", () => {
       expect(result.accessToken).toBe("mock-access-token");
     });
   });
+
+  describe("verifyTotpForUser", () => {
+    let encryptedSecret: string;
+
+    beforeEach(() => {
+      encryptedSecret = encrypt("TOTP_SECRET", TEST_TOTP_KEY);
+    });
+
+    it("returns false for non-6-digit codes", async () => {
+      const result = await service.verifyTotpForUser("user-1", "abc");
+      expect(result).toBe(false);
+      expect(usersRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it("returns false when the user has no 2FA secret", async () => {
+      usersRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        twoFactorSecret: null,
+      });
+      const result = await service.verifyTotpForUser("user-1", "123456");
+      expect(result).toBe(false);
+    });
+
+    it("returns false when the user is missing", async () => {
+      usersRepository.findOne.mockResolvedValue(null);
+      const result = await service.verifyTotpForUser("user-1", "123456");
+      expect(result).toBe(false);
+    });
+
+    it("returns true for a valid code", async () => {
+      usersRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        twoFactorSecret: encryptedSecret,
+      });
+      (otplib.verifySync as jest.Mock).mockReturnValue({ valid: true });
+
+      const result = await service.verifyTotpForUser("user-1", "123456");
+      expect(result).toBe(true);
+    });
+
+    it("returns false for an invalid code without stamping the replay map", async () => {
+      usersRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        twoFactorSecret: encryptedSecret,
+      });
+      (otplib.verifySync as jest.Mock).mockReturnValue({ valid: false });
+
+      const result = await service.verifyTotpForUser("user-1", "999999");
+      expect(result).toBe(false);
+      expect((service as any).usedTotpCodes.has("user-1:999999")).toBe(false);
+    });
+
+    it("rejects a code that was already used in this window (replay)", async () => {
+      usersRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        twoFactorSecret: encryptedSecret,
+      });
+      (otplib.verifySync as jest.Mock).mockReturnValue({ valid: true });
+
+      const first = await service.verifyTotpForUser("user-1", "123456");
+      expect(first).toBe(true);
+
+      const replay = await service.verifyTotpForUser("user-1", "123456");
+      expect(replay).toBe(false);
+    });
+  });
 });

--- a/backend/src/auth/two-factor.service.ts
+++ b/backend/src/auth/two-factor.service.ts
@@ -271,6 +271,47 @@ export class TwoFactorService {
     }
   }
 
+  /**
+   * Verify a 6-digit TOTP code for a user who is already authenticated
+   * (e.g. for step-up re-auth on a sensitive surface). Reuses the same
+   * replay-protection window as `verify2FA` so a code presented at login
+   * cannot be replayed against a step-up endpoint.
+   */
+  async verifyTotpForUser(userId: string, code: string): Promise<boolean> {
+    if (!/^\d{6}$/.test(code)) {
+      return false;
+    }
+
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+    if (!user || !user.twoFactorSecret) {
+      return false;
+    }
+
+    const codeKey = `${user.id}:${code}`;
+    this.cleanupExpiredTotpCodes();
+    if (this.usedTotpCodes.has(codeKey)) {
+      return false;
+    }
+
+    const { secret, needsReEncrypt } = this.decryptTotpSecret(
+      user.twoFactorSecret,
+    );
+    const isValid = otplib.verifySync({ token: code, secret }).valid;
+    if (!isValid) return false;
+
+    this.usedTotpCodes.set(
+      codeKey,
+      Date.now() + this.TOTP_CODE_REUSE_WINDOW_MS,
+    );
+
+    if (needsReEncrypt) {
+      user.twoFactorSecret = this.reEncryptTotpSecret(secret);
+      await this.usersRepository.save(user);
+    }
+
+    return true;
+  }
+
   async setup2FA(userId: string, currentPassword: string) {
     const user = await this.usersRepository.findOne({
       where: { id: userId },

--- a/backend/src/emergency-access/dto/update-message.dto.ts
+++ b/backend/src/emergency-access/dto/update-message.dto.ts
@@ -1,0 +1,10 @@
+import { IsOptional, IsString, MaxLength } from "class-validator";
+import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
+
+export class UpdateMessageDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(4000)
+  @SanitizeHtml()
+  message?: string | null;
+}

--- a/backend/src/emergency-access/dto/upsert-settings.dto.ts
+++ b/backend/src/emergency-access/dto/upsert-settings.dto.ts
@@ -1,17 +1,13 @@
 import {
   IsBoolean,
   IsInt,
-  IsOptional,
-  IsString,
   Max,
-  MaxLength,
   Min,
   Validate,
   ValidationArguments,
   ValidatorConstraint,
   ValidatorConstraintInterface,
 } from "class-validator";
-import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
 
 @ValidatorConstraint({ name: "ReminderLtGrant", async: false })
 class ReminderLtGrantConstraint implements ValidatorConstraintInterface {
@@ -38,10 +34,4 @@ export class UpsertSettingsDto {
   @Max(364)
   @Validate(ReminderLtGrantConstraint)
   reminderAfterDays: number;
-
-  @IsOptional()
-  @IsString()
-  @MaxLength(4000)
-  @SanitizeHtml()
-  message?: string | null;
 }

--- a/backend/src/emergency-access/emergency-access.controller.spec.ts
+++ b/backend/src/emergency-access/emergency-access.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { EmergencyAccessController } from "./emergency-access.controller";
 import { EmergencyAccessService } from "./emergency-access.service";
+import { StepUpGuard } from "../auth/step-up/step-up.guard";
 
 describe("EmergencyAccessController", () => {
   let controller: EmergencyAccessController;
@@ -10,6 +11,10 @@ describe("EmergencyAccessController", () => {
   beforeEach(async () => {
     service = {
       getView: jest.fn().mockResolvedValue({ enabled: false }),
+      getMessage: jest.fn().mockResolvedValue({ message: "secret" }),
+      updateMessage: jest
+        .fn()
+        .mockResolvedValue({ hasMessage: true, charCount: 6, updatedAt: null }),
       upsertSettings: jest.fn().mockResolvedValue({ enabled: true }),
       addContact: jest.fn().mockResolvedValue({ id: "c1" }),
       updateContact: jest.fn().mockResolvedValue({ id: "c1" }),
@@ -20,7 +25,10 @@ describe("EmergencyAccessController", () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [EmergencyAccessController],
       providers: [{ provide: EmergencyAccessService, useValue: service }],
-    }).compile();
+    })
+      .overrideGuard(StepUpGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     controller = module.get(EmergencyAccessController);
   });
@@ -30,12 +38,24 @@ describe("EmergencyAccessController", () => {
     expect(service.getView).toHaveBeenCalledWith("user-1");
   });
 
-  it("delegates PUT /settings to upsertSettings", async () => {
+  it("delegates GET /message to getMessage", async () => {
+    await expect(controller.getMessage(req)).resolves.toEqual({
+      message: "secret",
+    });
+    expect(service.getMessage).toHaveBeenCalledWith("user-1");
+  });
+
+  it("delegates PUT /message to updateMessage", async () => {
+    const dto = { message: "hello" };
+    await controller.putMessage(req, dto);
+    expect(service.updateMessage).toHaveBeenCalledWith("user-1", "hello");
+  });
+
+  it("delegates PUT /settings to upsertSettings (no message field)", async () => {
     const dto = {
       enabled: true,
       grantAfterDays: 14,
       reminderAfterDays: 7,
-      message: "hi",
     };
     await controller.putSettings(req, dto);
     expect(service.upsertSettings).toHaveBeenCalledWith("user-1", dto);

--- a/backend/src/emergency-access/emergency-access.controller.ts
+++ b/backend/src/emergency-access/emergency-access.controller.ts
@@ -16,10 +16,13 @@ import { ApiTags, ApiOperation } from "@nestjs/swagger";
 import { EmergencyAccessService } from "./emergency-access.service";
 import { UpsertSettingsDto } from "./dto/upsert-settings.dto";
 import { UpsertContactDto } from "./dto/upsert-contact.dto";
+import { UpdateMessageDto } from "./dto/update-message.dto";
+import { StepUpGuard } from "../auth/step-up/step-up.guard";
+import { RequireStepUp } from "../auth/step-up/require-step-up.decorator";
 
 @ApiTags("Emergency Access")
 @Controller("emergency-access")
-@UseGuards(AuthGuard("jwt"))
+@UseGuards(AuthGuard("jwt"), StepUpGuard)
 export class EmergencyAccessController {
   constructor(private readonly service: EmergencyAccessService) {}
 
@@ -27,6 +30,29 @@ export class EmergencyAccessController {
   @ApiOperation({ summary: "Get the caller's emergency-access configuration" })
   async get(@Request() req: { user: { id: string } }) {
     return this.service.getView(req.user.id);
+  }
+
+  @Get("message")
+  @RequireStepUp("emergency-access")
+  @ApiOperation({
+    summary:
+      "Read the decrypted emergency-access message (requires step-up auth)",
+  })
+  async getMessage(@Request() req: { user: { id: string } }) {
+    return this.service.getMessage(req.user.id);
+  }
+
+  @Put("message")
+  @RequireStepUp("emergency-access")
+  @ApiOperation({
+    summary:
+      "Replace the encrypted emergency-access message (requires step-up auth)",
+  })
+  async putMessage(
+    @Request() req: { user: { id: string } },
+    @Body() dto: UpdateMessageDto,
+  ) {
+    return this.service.updateMessage(req.user.id, dto.message);
   }
 
   @Put("settings")

--- a/backend/src/emergency-access/emergency-access.service.spec.ts
+++ b/backend/src/emergency-access/emergency-access.service.spec.ts
@@ -107,26 +107,38 @@ describe("EmergencyAccessService", () => {
       expect(view.enabled).toBe(false);
       expect(view.grantAfterDays).toBe(14);
       expect(view.reminderAfterDays).toBe(7);
-      expect(view.message).toBeNull();
+      expect(view.messageMetadata).toEqual({
+        hasMessage: false,
+        charCount: 0,
+        updatedAt: null,
+      });
       expect(view.contacts).toEqual([]);
     });
 
-    it("decrypts the stored ciphertext when present", async () => {
+    it("never exposes the plaintext message via the view", async () => {
+      const updatedAt = new Date("2026-05-01T00:00:00Z");
       settingsRepo.findOne.mockResolvedValue({
         ownerUserId: userId,
         enabled: true,
         grantAfterDays: 14,
         reminderAfterDays: 7,
-        messageCiphertext: "enc(hello)",
+        messageCiphertext: "enc(hello world)",
         lastReminderSentAt: null,
         grantedAt: null,
+        updatedAt,
       });
       contactsRepo.find.mockResolvedValue([]);
       usersRepo.findOne.mockResolvedValue({ id: userId, lastActivityAt: null });
 
       const view = await service.getView(userId);
-      expect(view.message).toBe("hello");
-      expect(encryption.decrypt).toHaveBeenCalledWith("enc(hello)");
+      expect(
+        (view as unknown as Record<string, unknown>).message,
+      ).toBeUndefined();
+      expect(view.messageMetadata).toEqual({
+        hasMessage: true,
+        charCount: "hello world".length,
+        updatedAt,
+      });
     });
 
     it("returns emailConfigured=false when SMTP is not configured", async () => {
@@ -137,6 +149,105 @@ describe("EmergencyAccessService", () => {
 
       const view = await service.getView(userId);
       expect(view.emailConfigured).toBe(false);
+    });
+  });
+
+  describe("getMessage", () => {
+    it("returns the decrypted message", async () => {
+      settingsRepo.findOne.mockResolvedValue({
+        ownerUserId: userId,
+        messageCiphertext: "enc(hello)",
+      });
+      await expect(service.getMessage(userId)).resolves.toEqual({
+        message: "hello",
+      });
+      expect(encryption.decrypt).toHaveBeenCalledWith("enc(hello)");
+    });
+
+    it("returns null when no message is set", async () => {
+      settingsRepo.findOne.mockResolvedValue({
+        ownerUserId: userId,
+        messageCiphertext: null,
+      });
+      await expect(service.getMessage(userId)).resolves.toEqual({
+        message: null,
+      });
+    });
+
+    it("returns null when the row is missing entirely", async () => {
+      settingsRepo.findOne.mockResolvedValue(null);
+      await expect(service.getMessage(userId)).resolves.toEqual({
+        message: null,
+      });
+    });
+
+    it("returns null when decrypt throws", async () => {
+      encryption.decrypt.mockImplementation(() => {
+        throw new Error("bad key");
+      });
+      settingsRepo.findOne.mockResolvedValue({
+        ownerUserId: userId,
+        messageCiphertext: "enc(corrupt)",
+      });
+      await expect(service.getMessage(userId)).resolves.toEqual({
+        message: null,
+      });
+    });
+  });
+
+  describe("updateMessage", () => {
+    it("encrypts and stores a non-empty message", async () => {
+      queryRunner.manager.findOne.mockResolvedValue({
+        ownerUserId: userId,
+        messageCiphertext: null,
+        updatedAt: new Date("2026-05-01T00:00:00Z"),
+      });
+
+      const meta = await service.updateMessage(userId, "hello");
+
+      expect(encryption.encrypt).toHaveBeenCalledWith("hello");
+      const saved = queryRunner.manager.save.mock.calls[0][0];
+      expect(saved.messageCiphertext).toBe("enc(hello)");
+      expect(queryRunner.commitTransaction).toHaveBeenCalled();
+      expect(meta.hasMessage).toBe(true);
+      expect(meta.charCount).toBe("hello".length);
+    });
+
+    it("clears the ciphertext when message is empty or whitespace", async () => {
+      queryRunner.manager.findOne.mockResolvedValue({
+        ownerUserId: userId,
+        messageCiphertext: "enc(stale)",
+      });
+
+      const meta = await service.updateMessage(userId, "   ");
+
+      const saved = queryRunner.manager.save.mock.calls[0][0];
+      expect(saved.messageCiphertext).toBeNull();
+      expect(meta.hasMessage).toBe(false);
+    });
+
+    it("creates a new row when none exists", async () => {
+      queryRunner.manager.findOne.mockResolvedValue(null);
+
+      await service.updateMessage(userId, "hi");
+
+      expect(queryRunner.manager.create).toHaveBeenCalled();
+      expect(queryRunner.commitTransaction).toHaveBeenCalled();
+    });
+
+    it("refuses to save a non-empty message when AI_ENCRYPTION_KEY is missing", async () => {
+      encryption.isConfigured.mockReturnValue(false);
+      await expect(
+        service.updateMessage(userId, "secret"),
+      ).rejects.toBeInstanceOf(ServiceUnavailableException);
+    });
+
+    it("rolls back on error", async () => {
+      queryRunner.manager.findOne.mockRejectedValueOnce(new Error("boom"));
+      await expect(service.updateMessage(userId, "hello")).rejects.toThrow(
+        "boom",
+      );
+      expect(queryRunner.rollbackTransaction).toHaveBeenCalled();
     });
   });
 
@@ -152,48 +263,28 @@ describe("EmergencyAccessService", () => {
       ).rejects.toBeInstanceOf(ServiceUnavailableException);
     });
 
-    it("encrypts a non-empty message before storing", async () => {
-      queryRunner.manager.findOne.mockResolvedValue(null);
-      settingsRepo.findOne.mockResolvedValue({
+    it("does not touch the existing ciphertext when saving settings", async () => {
+      const stored = {
         ownerUserId: userId,
-        enabled: true,
+        enabled: false,
         grantAfterDays: 14,
         reminderAfterDays: 7,
-        messageCiphertext: "enc(hello)",
-      });
+        messageCiphertext: "enc(unchanged)",
+      };
+      queryRunner.manager.findOne.mockResolvedValue(stored);
+      settingsRepo.findOne.mockResolvedValue(stored);
       usersRepo.findOne.mockResolvedValue({ id: userId, lastActivityAt: null });
 
       await service.upsertSettings(userId, {
         enabled: true,
-        grantAfterDays: 14,
+        grantAfterDays: 30,
         reminderAfterDays: 7,
-        message: "hello",
       });
 
-      expect(encryption.encrypt).toHaveBeenCalledWith("hello");
-      expect(queryRunner.commitTransaction).toHaveBeenCalled();
-    });
-
-    it("clears the ciphertext when message is empty", async () => {
-      queryRunner.manager.findOne.mockResolvedValue({
-        ownerUserId: userId,
-        enabled: true,
-        grantAfterDays: 14,
-        reminderAfterDays: 7,
-        messageCiphertext: "enc(stale)",
-      });
-      settingsRepo.findOne.mockResolvedValue(null);
-      usersRepo.findOne.mockResolvedValue({ id: userId, lastActivityAt: null });
-
-      await service.upsertSettings(userId, {
-        enabled: true,
-        grantAfterDays: 14,
-        reminderAfterDays: 7,
-        message: "   ",
-      });
-
-      const saved = queryRunner.manager.save.mock.calls[0][0];
-      expect(saved.messageCiphertext).toBeNull();
+      expect(encryption.encrypt).not.toHaveBeenCalled();
+      expect(stored.messageCiphertext).toBe("enc(unchanged)");
+      expect(stored.enabled).toBe(true);
+      expect(stored.grantAfterDays).toBe(30);
     });
 
     it("rolls back on error", async () => {
@@ -284,7 +375,6 @@ describe("EmergencyAccessService", () => {
       };
       contactsRepo.findOne.mockResolvedValue(existing);
       contactsRepo.save.mockImplementation(async (row) => row);
-      // The email changes, so the service runs the dup-check query.
       contactsRepo.createQueryBuilder.mockReturnValue({
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
@@ -345,8 +435,8 @@ describe("EmergencyAccessService", () => {
     });
   });
 
-  describe("decryptMessage edge cases", () => {
-    it("returns null and warns when the encryption key is not configured", async () => {
+  describe("messageMetadata edge cases", () => {
+    it("reports no message and updatedAt=null when the encryption key is unavailable", async () => {
       encryption.isConfigured.mockReturnValue(false);
       settingsRepo.findOne.mockResolvedValue({
         ownerUserId: userId,
@@ -354,16 +444,21 @@ describe("EmergencyAccessService", () => {
         grantAfterDays: 14,
         reminderAfterDays: 7,
         messageCiphertext: "enc(hello)",
+        updatedAt: new Date("2026-05-01T00:00:00Z"),
       });
       contactsRepo.find.mockResolvedValue([]);
       usersRepo.findOne.mockResolvedValue({ id: userId, lastActivityAt: null });
 
       const view = await service.getView(userId);
-      expect(view.message).toBeNull();
+      expect(view.messageMetadata).toEqual({
+        hasMessage: false,
+        charCount: 0,
+        updatedAt: null,
+      });
       expect(encryption.decrypt).not.toHaveBeenCalled();
     });
 
-    it("returns null when decrypt throws", async () => {
+    it("reports no message when decrypt throws", async () => {
       encryption.decrypt.mockImplementation(() => {
         throw new Error("bad key");
       });
@@ -378,10 +473,10 @@ describe("EmergencyAccessService", () => {
       usersRepo.findOne.mockResolvedValue({ id: userId, lastActivityAt: null });
 
       const view = await service.getView(userId);
-      expect(view.message).toBeNull();
+      expect(view.messageMetadata.hasMessage).toBe(false);
     });
 
-    it("returns null when decrypt throws a non-Error value", async () => {
+    it("returns no message when decrypt throws a non-Error value", async () => {
       encryption.decrypt.mockImplementation(() => {
         throw "raw-string-not-an-Error";
       });
@@ -396,7 +491,7 @@ describe("EmergencyAccessService", () => {
       usersRepo.findOne.mockResolvedValue({ id: userId, lastActivityAt: null });
 
       const view = await service.getView(userId);
-      expect(view.message).toBeNull();
+      expect(view.messageMetadata.hasMessage).toBe(false);
     });
   });
 
@@ -462,19 +557,7 @@ describe("EmergencyAccessService", () => {
     });
   });
 
-  describe("upsertSettings: encryption configuration", () => {
-    it("refuses to save a non-empty message when AI_ENCRYPTION_KEY is missing", async () => {
-      encryption.isConfigured.mockReturnValue(false);
-      await expect(
-        service.upsertSettings(userId, {
-          enabled: true,
-          grantAfterDays: 14,
-          reminderAfterDays: 7,
-          message: "secret",
-        }),
-      ).rejects.toBeInstanceOf(ServiceUnavailableException);
-    });
-
+  describe("upsertSettings: side effects", () => {
     it("voids outstanding magic links and clears markers when owner disables", async () => {
       const stored = {
         ownerUserId: userId,
@@ -498,8 +581,6 @@ describe("EmergencyAccessService", () => {
       });
 
       expect(builder.update).toHaveBeenCalledWith(EmergencyAccessContact);
-      // The contact row's claimTokenUsedAt is set via a TypeORM function-valued
-      // setter; invoking the closure should yield the SQL fragment we expect.
       const setArgs = builder.set.mock.calls[0][0];
       expect(typeof setArgs.claimTokenUsedAt).toBe("function");
       expect(setArgs.claimTokenUsedAt()).toBe("CURRENT_TIMESTAMP");
@@ -552,8 +633,6 @@ describe("EmergencyAccessService", () => {
         grantedAt: new Date(),
         lastReminderSentAt: new Date(),
       };
-      // First findOne call: resetGrantedState's own lookup.
-      // Second findOne call: getView at the end re-reads the row.
       settingsRepo.findOne
         .mockResolvedValueOnce(stored)
         .mockResolvedValueOnce({ ...stored, grantedAt: null });

--- a/backend/src/emergency-access/emergency-access.service.ts
+++ b/backend/src/emergency-access/emergency-access.service.ts
@@ -22,12 +22,18 @@ export interface ContactView {
   createdAt: Date;
 }
 
+export interface MessageMetadata {
+  hasMessage: boolean;
+  charCount: number;
+  updatedAt: Date | null;
+}
+
 export interface SettingsView {
   emailConfigured: boolean;
   enabled: boolean;
   grantAfterDays: number;
   reminderAfterDays: number;
-  message: string | null;
+  messageMetadata: MessageMetadata;
   lastReminderSentAt: Date | null;
   grantedAt: Date | null;
   lastActivityAt: Date | null;
@@ -78,6 +84,17 @@ export class EmergencyAccessService {
     }
   }
 
+  private buildMessageMetadata(
+    settings: EmergencyAccessSettings | null,
+  ): MessageMetadata {
+    const decrypted = this.decryptMessage(settings?.messageCiphertext ?? null);
+    return {
+      hasMessage: !!decrypted,
+      charCount: decrypted?.length ?? 0,
+      updatedAt: decrypted ? (settings?.updatedAt ?? null) : null,
+    };
+  }
+
   async getView(userId: string): Promise<SettingsView> {
     const [settings, contacts, user] = await Promise.all([
       this.settingsRepo.findOne({ where: { ownerUserId: userId } }),
@@ -95,11 +112,25 @@ export class EmergencyAccessService {
       enabled: settings?.enabled ?? false,
       grantAfterDays: settings?.grantAfterDays ?? 14,
       reminderAfterDays: settings?.reminderAfterDays ?? 7,
-      message: this.decryptMessage(settings?.messageCiphertext ?? null),
+      messageMetadata: this.buildMessageMetadata(settings ?? null),
       lastReminderSentAt: settings?.lastReminderSentAt ?? null,
       grantedAt: settings?.grantedAt ?? null,
       lastActivityAt: user?.lastActivityAt ?? user?.lastLogin ?? null,
       contacts: contacts.map((c) => this.toContactView(c)),
+    };
+  }
+
+  /**
+   * Read the decrypted emergency-access message. Guarded by step-up auth at
+   * the controller layer -- callers must have already proven possession of
+   * their strongest factor in the last few minutes.
+   */
+  async getMessage(userId: string): Promise<{ message: string | null }> {
+    const settings = await this.settingsRepo.findOne({
+      where: { ownerUserId: userId },
+    });
+    return {
+      message: this.decryptMessage(settings?.messageCiphertext ?? null),
     };
   }
 
@@ -110,11 +141,6 @@ export class EmergencyAccessService {
     if (!this.emailService.getStatus().configured) {
       throw new ServiceUnavailableException(
         "Email is not configured. Emergency access cannot be enabled until SMTP is set up.",
-      );
-    }
-    if (dto.enabled && dto.message && !this.encryption.isConfigured()) {
-      throw new ServiceUnavailableException(
-        "Encryption key is not configured. The free-form message cannot be stored securely until AI_ENCRYPTION_KEY is set.",
       );
     }
 
@@ -135,13 +161,6 @@ export class EmergencyAccessService {
       row.enabled = dto.enabled;
       row.grantAfterDays = dto.grantAfterDays;
       row.reminderAfterDays = dto.reminderAfterDays;
-
-      const trimmed = dto.message?.trim();
-      if (!trimmed) {
-        row.messageCiphertext = null;
-      } else {
-        row.messageCiphertext = this.encryption.encrypt(trimmed);
-      }
 
       // If the owner is (re-)enabling, reset the grant marker and the
       // last-reminder gate so the cron starts fresh.
@@ -180,6 +199,45 @@ export class EmergencyAccessService {
     }
 
     return this.getView(userId);
+  }
+
+  /**
+   * Persist a new encrypted emergency-access message. Guarded by step-up
+   * auth at the controller layer.
+   */
+  async updateMessage(
+    userId: string,
+    message: string | null | undefined,
+  ): Promise<MessageMetadata> {
+    const trimmed = message?.trim() ?? null;
+    if (trimmed && !this.encryption.isConfigured()) {
+      throw new ServiceUnavailableException(
+        "Encryption key is not configured. The free-form message cannot be stored securely until AI_ENCRYPTION_KEY is set.",
+      );
+    }
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    try {
+      let row = await queryRunner.manager.findOne(EmergencyAccessSettings, {
+        where: { ownerUserId: userId },
+      });
+      if (!row) {
+        row = queryRunner.manager.create(EmergencyAccessSettings, {
+          ownerUserId: userId,
+        });
+      }
+      row.messageCiphertext = trimmed ? this.encryption.encrypt(trimmed) : null;
+      const saved = await queryRunner.manager.save(row);
+      await queryRunner.commitTransaction();
+      return this.buildMessageMetadata(saved);
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
   }
 
   async addContact(

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -74,7 +74,8 @@ async function bootstrap() {
   // itself — otherwise it logs "already parsed request body detected" on
   // every DCR/token POST. The interaction routes under /api/v1/oauth-consent/*
   // need parsed bodies for @Body(), so they go through normal parsing.
-  const skipForProvider = (parser: express.RequestHandler): express.RequestHandler =>
+  const skipForProvider =
+    (parser: express.RequestHandler): express.RequestHandler =>
     (req, res, next) => {
       if (req.path === "/oauth" || req.path.startsWith("/oauth/")) {
         return next();
@@ -82,7 +83,9 @@ async function bootstrap() {
       return parser(req, res, next);
     };
   app.use(skipForProvider(express.json({ limit: "10mb" })));
-  app.use(skipForProvider(express.urlencoded({ limit: "10mb", extended: true })));
+  app.use(
+    skipForProvider(express.urlencoded({ limit: "10mb", extended: true })),
+  );
 
   // Cookie parser for OIDC state/nonce and auth tokens
   app.use(cookieParser());

--- a/backend/src/mcp/mcp-http.controller.spec.ts
+++ b/backend/src/mcp/mcp-http.controller.spec.ts
@@ -120,9 +120,7 @@ describe("McpHttpController", () => {
 
       expect(res.setHeader).toHaveBeenCalledWith(
         "WWW-Authenticate",
-        expect.stringContaining(
-          "/.well-known/oauth-protected-resource",
-        ),
+        expect.stringContaining("/.well-known/oauth-protected-resource"),
       );
     });
 

--- a/backend/src/monte-carlo/monte-carlo.service.spec.ts
+++ b/backend/src/monte-carlo/monte-carlo.service.spec.ts
@@ -387,7 +387,11 @@ describe("MonteCarloService", () => {
         accountId: "acct-1",
         securityId: "sec-new",
         quantity: 1,
-        security: { symbol: "NEWCO", name: "Newly Listed", currencyCode: "USD" },
+        security: {
+          symbol: "NEWCO",
+          name: "Newly Listed",
+          currencyCode: "USD",
+        },
       };
       holdingsRepository.find.mockResolvedValueOnce([holding]);
       // Sparse: only 1 yearly return → triggers backfill check.
@@ -514,9 +518,9 @@ describe("MonteCarloService", () => {
 
     it("rolls the transaction back when an update fails", async () => {
       queryRunner.manager.update.mockRejectedValueOnce(new Error("boom"));
-      await expect(
-        service.reorder(userId, ["scn-1", "scn-2"]),
-      ).rejects.toThrow("boom");
+      await expect(service.reorder(userId, ["scn-1", "scn-2"])).rejects.toThrow(
+        "boom",
+      );
       expect(queryRunner.rollbackTransaction).toHaveBeenCalled();
       expect(queryRunner.commitTransaction).not.toHaveBeenCalled();
       expect(queryRunner.release).toHaveBeenCalled();
@@ -524,7 +528,6 @@ describe("MonteCarloService", () => {
 
     it("rejects a non-array argument", async () => {
       await expect(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         service.reorder(userId, "not an array" as any),
       ).rejects.toBeInstanceOf(BadRequestException);
     });
@@ -721,9 +724,7 @@ describe("MonteCarloService", () => {
       };
       holdingsRepository.find.mockResolvedValueOnce([holding]);
       securityPriceRepository.query.mockResolvedValue([]);
-      portfolioService.getLatestPrices = jest
-        .fn()
-        .mockResolvedValue(new Map());
+      portfolioService.getLatestPrices = jest.fn().mockResolvedValue(new Map());
 
       const result = await service.getHoldingStats(userId, ["acct-1"]);
       expect(result[0].holdings[0].marketValue).toBe(0);
@@ -763,9 +764,8 @@ describe("MonteCarloService", () => {
 
   describe("getBrokerageAccounts", () => {
     it("delegates to portfolioService", async () => {
-      (portfolioService as Record<string, jest.Mock>).getBrokerageAccounts = jest
-        .fn()
-        .mockResolvedValue([{ id: "a1" }]);
+      (portfolioService as Record<string, jest.Mock>).getBrokerageAccounts =
+        jest.fn().mockResolvedValue([{ id: "a1" }]);
       const result = await service.getBrokerageAccounts(userId);
       expect(result).toEqual([{ id: "a1" }]);
     });
@@ -918,9 +918,7 @@ describe("MonteCarloService", () => {
         .mockResolvedValue(new Map([["sec-x", 110]]));
 
       await service.getHistoricalStats(userId, ["acct-1"]);
-      expect(
-        securityPriceService.backfillSecurityRange,
-      ).toHaveBeenCalled();
+      expect(securityPriceService.backfillSecurityRange).toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/notifications/email-templates.spec.ts
+++ b/backend/src/notifications/email-templates.spec.ts
@@ -851,11 +851,7 @@ describe("Email Templates", () => {
     });
 
     it("falls back to 'there' when firstName is empty", () => {
-      const html = budgetAlertImmediateTemplate(
-        "",
-        [],
-        "https://app",
-      );
+      const html = budgetAlertImmediateTemplate("", [], "https://app");
       expect(html).toContain("Hi there");
     });
   });
@@ -892,12 +888,7 @@ describe("Email Templates", () => {
     });
 
     it("renders 'No alerts' fallback when summary is empty", () => {
-      const html = budgetWeeklyDigestTemplate(
-        "Alex",
-        [],
-        ["B"],
-        "https://app",
-      );
+      const html = budgetWeeklyDigestTemplate("Alex", [], ["B"], "https://app");
       expect(html).toContain("No alerts");
     });
 
@@ -918,12 +909,7 @@ describe("Email Templates", () => {
     });
 
     it("falls back to 'there' when firstName empty", () => {
-      const html = budgetWeeklyDigestTemplate(
-        "",
-        [],
-        ["B"],
-        "https://app",
-      );
+      const html = budgetWeeklyDigestTemplate("", [], ["B"], "https://app");
       expect(html).toContain("Hi there");
     });
   });

--- a/backend/src/oauth/consent-template.spec.ts
+++ b/backend/src/oauth/consent-template.spec.ts
@@ -17,18 +17,14 @@ describe("renderConsentPage", () => {
     expect(html).toContain("user@example.com");
     expect(html).toContain('value="monize:read"');
     expect(html).toContain('value="monize:write"');
-    expect(html).toContain(
-      'action="/api/v1/oauth-consent/abc-123/confirm"',
-    );
-    expect(html).toContain(
-      'formaction="/api/v1/oauth-consent/abc-123/abort"',
-    );
+    expect(html).toContain('action="/api/v1/oauth-consent/abc-123/confirm"');
+    expect(html).toContain('formaction="/api/v1/oauth-consent/abc-123/abort"');
   });
 
   it("escapes user-controlled inputs to prevent stored XSS", () => {
     const html = renderConsentPage({
       uid: "uid",
-      clientName: '<script>alert(1)</script>',
+      clientName: "<script>alert(1)</script>",
       clientUri: 'javascript:alert(1)" autofocus="',
       userEmail: '"><img src=x onerror=alert(1)>',
       scopes: [],

--- a/backend/src/oauth/oauth-debug-logger.middleware.ts
+++ b/backend/src/oauth/oauth-debug-logger.middleware.ts
@@ -62,8 +62,7 @@ export function oauthDebugLogger(scope: string) {
     // Log JSON request bodies for non-token endpoints. Skip token endpoint to
     // avoid logging refresh tokens or client secrets in the body.
     const path = req.path ?? req.url ?? "";
-    const isTokenEndpoint =
-      path.includes("/token") || path.endsWith("/token");
+    const isTokenEndpoint = path.includes("/token") || path.endsWith("/token");
     if (
       !isTokenEndpoint &&
       req.body &&

--- a/backend/src/oauth/oauth-interaction.controller.spec.ts
+++ b/backend/src/oauth/oauth-interaction.controller.spec.ts
@@ -176,13 +176,11 @@ describe("OAuthInteractionController", () => {
 
     it("renders a friendly completed page when the interaction is stale (consumed/expired)", async () => {
       const { controller } = makeController({
-        interactionDetails: jest
-          .fn()
-          .mockRejectedValue(
-            Object.assign(new Error("invalid_request"), {
-              name: "SessionNotFound",
-            }),
-          ),
+        interactionDetails: jest.fn().mockRejectedValue(
+          Object.assign(new Error("invalid_request"), {
+            name: "SessionNotFound",
+          }),
+        ),
       });
       const req = { cookies: {} } as any;
       const res = makeRes();
@@ -215,13 +213,11 @@ describe("OAuthInteractionController", () => {
   describe("POST /oauth-consent/:uid/confirm", () => {
     it("renders a friendly completed page when the interaction is already consumed", async () => {
       const { controller } = makeController({
-        interactionDetails: jest
-          .fn()
-          .mockRejectedValue(
-            Object.assign(new Error("invalid_request"), {
-              name: "SessionNotFound",
-            }),
-          ),
+        interactionDetails: jest.fn().mockRejectedValue(
+          Object.assign(new Error("invalid_request"), {
+            name: "SessionNotFound",
+          }),
+        ),
       });
       const req = { cookies: { auth_token: "v" }, body: {} } as any;
       const res = makeRes();
@@ -346,13 +342,11 @@ describe("OAuthInteractionController", () => {
     });
 
     it("renders completed page when abort fails (stale interaction)", async () => {
-      const finishedFn = jest
-        .fn()
-        .mockRejectedValueOnce(
-          Object.assign(new Error("session not found"), {
-            name: "SessionNotFound",
-          }),
-        );
+      const finishedFn = jest.fn().mockRejectedValueOnce(
+        Object.assign(new Error("session not found"), {
+          name: "SessionNotFound",
+        }),
+      );
       const { controller } = makeController({
         interactionDetails: jest.fn(),
         interactionFinished: finishedFn,
@@ -435,7 +429,9 @@ describe("OAuthInteractionController", () => {
           prompt: { name: "login" },
           params: { client_id: "claude-desktop", scope: "monize:read" },
         }),
-        jwtVerify: jest.fn().mockResolvedValue({ sub: "x", type: "2fa_pending" }),
+        jwtVerify: jest
+          .fn()
+          .mockResolvedValue({ sub: "x", type: "2fa_pending" }),
       });
       const req = { cookies: { auth_token: "tok" }, originalUrl: "/x" } as any;
       const res = makeRes();

--- a/backend/src/oauth/oauth-interaction.controller.ts
+++ b/backend/src/oauth/oauth-interaction.controller.ts
@@ -104,9 +104,7 @@ export class OAuthInteractionController {
       // name (e.g. "Claude") instead of the opaque DCR-generated client_id.
       // The auth request params only carry client_id; client_name lives on
       // the persisted client record from the Dynamic Client Registration.
-      const clientInfo = await this.lookupClient(
-        params.client_id as string,
-      );
+      const clientInfo = await this.lookupClient(params.client_id as string);
 
       const html = renderConsentPage({
         uid,

--- a/backend/src/oauth/oauth-provider.service.spec.ts
+++ b/backend/src/oauth/oauth-provider.service.spec.ts
@@ -18,8 +18,10 @@ interface MockProvider {
   AccessToken: { find: jest.Mock };
 }
 
-const eventListeners: Record<string, Array<(...args: unknown[]) => unknown>> =
-  {};
+const eventListeners: Record<
+  string,
+  Array<(...args: unknown[]) => unknown>
+> = {};
 
 function createMockProvider(): MockProvider {
   return {
@@ -40,11 +42,13 @@ jest.mock(
       __esModule: true,
       default: jest
         .fn()
-        .mockImplementation((issuer: string, config: Record<string, unknown>) => {
-          providerConstructorCalls.push({ issuer, config });
-          lastMockProvider = createMockProvider();
-          return lastMockProvider;
-        }),
+        .mockImplementation(
+          (issuer: string, config: Record<string, unknown>) => {
+            providerConstructorCalls.push({ issuer, config });
+            lastMockProvider = createMockProvider();
+            return lastMockProvider;
+          },
+        ),
     };
   },
   { virtual: true },
@@ -162,9 +166,7 @@ describe("OAuthProviderService", () => {
 
       expect(p1).toBe(p2);
       expect(providerConstructorCalls).toHaveLength(1);
-      expect(providerConstructorCalls[0].issuer).toBe(
-        "https://app.test/oauth",
-      );
+      expect(providerConstructorCalls[0].issuer).toBe("https://app.test/oauth");
       expect(providerConstructorCalls[0].config.scopes).toEqual([
         ...MCP_RESOURCE_SCOPES,
       ]);
@@ -253,9 +255,9 @@ describe("OAuthProviderService", () => {
         mustChangePassword: false,
       });
       const client = { grantTypeAllowed: jest.fn().mockReturnValue(true) };
-      await expect(
-        config.issueRefreshToken({}, client, {}),
-      ).resolves.toBe(true);
+      await expect(config.issueRefreshToken({}, client, {})).resolves.toBe(
+        true,
+      );
       expect(client.grantTypeAllowed).toHaveBeenCalledWith("refresh_token");
     });
 
@@ -458,11 +460,13 @@ describe("OAuthProviderService", () => {
   });
 
   describe("validateAccessToken", () => {
-    async function setup(authUser: {
-      id: string;
-      isActive: boolean;
-      mustChangePassword: boolean;
-    } | null) {
+    async function setup(
+      authUser: {
+        id: string;
+        isActive: boolean;
+        mustChangePassword: boolean;
+      } | null,
+    ) {
       const svc = new OAuthProviderService(
         makeConfigService({
           PUBLIC_APP_URL: "https://app.test",

--- a/backend/src/oauth/oauth-provider.service.ts
+++ b/backend/src/oauth/oauth-provider.service.ts
@@ -225,9 +225,7 @@ export class OAuthProviderService implements OnModuleInit {
       this.logger.warn(`OAuth revocation.error: ${errorDetail(err)}`);
     });
     provider.on("registration_create.error", (ctx, err) => {
-      this.logger.warn(
-        `OAuth DCR registration error: ${errorDetail(err)}`,
-      );
+      this.logger.warn(`OAuth DCR registration error: ${errorDetail(err)}`);
     });
     provider.on("registration_update.error", (ctx, err) => {
       this.logger.warn(`OAuth DCR update error: ${errorDetail(err)}`);
@@ -358,9 +356,7 @@ export class OAuthProviderService implements OnModuleInit {
       .execute();
     const affected = result.affected ?? 0;
     if (affected > 0) {
-      this.logger.log(
-        `Revoked ${affected} OIDC payload(s) for user=${userId}`,
-      );
+      this.logger.log(`Revoked ${affected} OIDC payload(s) for user=${userId}`);
     }
     return affected;
   }

--- a/backend/src/oauth/postgres.adapter.spec.ts
+++ b/backend/src/oauth/postgres.adapter.spec.ts
@@ -36,7 +36,11 @@ describe("PostgresAdapter", () => {
   it("does not store grant_id for non-grantable models", async () => {
     const { adapter, repo } = makeAdapter("Client");
 
-    await adapter.upsert("client-1", { grantId: "should-be-ignored" } as any, 0);
+    await adapter.upsert(
+      "client-1",
+      { grantId: "should-be-ignored" } as any,
+      0,
+    );
 
     const [entity] = repo.upsert.mock.calls[0];
     expect(entity.grantId).toBeNull();

--- a/backend/src/securities/cash-impact.util.spec.ts
+++ b/backend/src/securities/cash-impact.util.spec.ts
@@ -27,10 +27,13 @@ describe("computeInvestmentCashImpact", () => {
     InvestmentAction.DIVIDEND,
     InvestmentAction.INTEREST,
     InvestmentAction.CAPITAL_GAIN,
-  ])("treats %s with default qty=1 and uses price as the cash amount", (action) => {
-    expect(computeInvestmentCashImpact(action, 0, 25.5, 0)).toBe(25.5);
-    expect(computeInvestmentCashImpact(action, 1, 25.5, 0)).toBe(25.5);
-  });
+  ])(
+    "treats %s with default qty=1 and uses price as the cash amount",
+    (action) => {
+      expect(computeInvestmentCashImpact(action, 0, 25.5, 0)).toBe(25.5);
+      expect(computeInvestmentCashImpact(action, 1, 25.5, 0)).toBe(25.5);
+    },
+  );
 
   it("returns 0 for REINVEST (net-zero cash, holdings still update)", () => {
     expect(

--- a/backend/src/securities/msn-finance.service.spec.ts
+++ b/backend/src/securities/msn-finance.service.spec.ts
@@ -782,9 +782,11 @@ describe("MsnFinanceService", () => {
           FullInstrument: "F1",
           RT0EC: country,
         });
-        global.fetch = jest.fn().mockReturnValueOnce(
-          createResponse({ data: { stocks: [stockBlob] } }),
-        );
+        global.fetch = jest
+          .fn()
+          .mockReturnValueOnce(
+            createResponse({ data: { stocks: [stockBlob] } }),
+          );
         const r = await service.lookupSecurity("X");
         expect(r!.currencyCode).toBe(expected);
       }
@@ -927,9 +929,7 @@ describe("MsnFinanceService", () => {
       }).compile();
       const svc = module.get(MsnFinanceService);
       // Chart endpoint also returns empty, so overall null.
-      global.fetch = jest
-        .fn()
-        .mockReturnValue(createResponse({ series: [] }));
+      global.fetch = jest.fn().mockReturnValue(createResponse({ series: [] }));
       const q = await svc.fetchQuote("AAPL", "NASDAQ", {
         instrumentId: "a1u3p2",
       });
@@ -1065,9 +1065,7 @@ describe("MsnFinanceService", () => {
 
   describe("httpGetJson error path", () => {
     it("returns null when fetch throws (used by lookupSecurity)", async () => {
-      global.fetch = jest
-        .fn()
-        .mockRejectedValue(new Error("network failure"));
+      global.fetch = jest.fn().mockRejectedValue(new Error("network failure"));
       const r = await service.lookupSecurity("X");
       expect(r).toBeNull();
     });

--- a/backend/src/securities/securities.controller.spec.ts
+++ b/backend/src/securities/securities.controller.spec.ts
@@ -714,9 +714,7 @@ describe("SecuritiesController", () => {
 
       const result = await controller.backfillTransactionPrices();
 
-      expect(
-        securityPriceService.backfillTransactionPrices,
-      ).toHaveBeenCalled();
+      expect(securityPriceService.backfillTransactionPrices).toHaveBeenCalled();
       expect(result).toEqual(summary);
     });
   });

--- a/frontend/src/app/settings/emergency-access/page.test.tsx
+++ b/frontend/src/app/settings/emergency-access/page.test.tsx
@@ -30,13 +30,71 @@ vi.mock('@/hooks/useDemoMode', () => ({
 
 const mockActingAs = vi.fn();
 vi.mock('@/store/authStore', () => ({
-  useAuthStore: (selector: (s: { actingAsUserId: string | null }) => unknown) =>
-    selector({ actingAsUserId: mockActingAs() }),
+  useAuthStore: (
+    selector: (s: { actingAsUserId: string | null }) => unknown,
+  ) => selector({ actingAsUserId: mockActingAs() }),
+}));
+
+vi.mock('@/store/preferencesStore', () => ({
+  usePreferencesStore: (
+    selector: (s: {
+      preferences: {
+        timezone: string;
+        dateFormat: string;
+        timeFormat: '24h' | '12h';
+      };
+    }) => unknown,
+  ) =>
+    selector({
+      preferences: {
+        timezone: 'browser',
+        dateFormat: 'browser',
+        timeFormat: '24h',
+      },
+    }),
+}));
+
+// Stub the step-up modal -- exercised separately in its own test file. The
+// stub exposes a synthetic "Verify" button that simulates a successful
+// re-auth by stamping a token into the store and calling onVerified.
+vi.mock('@/components/auth/StepUpAuthModal', () => ({
+  StepUpAuthModal: ({
+    isOpen,
+    onClose,
+    onVerified,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onVerified?: () => void;
+  }) =>
+    isOpen ? (
+      <div data-testid="step-up-modal">
+        <button
+          onClick={async () => {
+            const { useStepUpTokenStore } = await import('@/lib/stepUpToken');
+            useStepUpTokenStore
+              .getState()
+              .set(
+                'emergency-access',
+                'mock-token',
+                new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+              );
+            onVerified?.();
+            onClose();
+          }}
+        >
+          Mock Verify
+        </button>
+        <button onClick={onClose}>Mock Close</button>
+      </div>
+    ) : null,
 }));
 
 vi.mock('@/lib/emergency-access', () => ({
   emergencyAccessApi: {
     get: vi.fn(),
+    getMessage: vi.fn(),
+    updateMessage: vi.fn(),
     updateSettings: vi.fn(),
     addContact: vi.fn(),
     updateContact: vi.fn(),
@@ -48,15 +106,21 @@ vi.mock('@/lib/emergency-access', () => ({
 }));
 
 import { emergencyAccessApi } from '@/lib/emergency-access';
-const api = emergencyAccessApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
+import { useStepUpTokenStore, StepUpRequiredError } from '@/lib/stepUpToken';
+const api = emergencyAccessApi as unknown as Record<
+  string,
+  ReturnType<typeof vi.fn>
+>;
 
-function makeView(overrides: Partial<EmergencyAccessView> = {}): EmergencyAccessView {
+function makeView(
+  overrides: Partial<EmergencyAccessView> = {},
+): EmergencyAccessView {
   return {
     emailConfigured: true,
     enabled: false,
     grantAfterDays: 14,
     reminderAfterDays: 7,
-    message: null,
+    messageMetadata: { hasMessage: false, charCount: 0, updatedAt: null },
     lastReminderSentAt: null,
     grantedAt: null,
     lastActivityAt: new Date().toISOString(),
@@ -78,6 +142,7 @@ describe('EmergencyAccessPage', () => {
     vi.clearAllMocks();
     mockUseDemoMode.mockReturnValue(false);
     mockActingAs.mockReturnValue(null);
+    useStepUpTokenStore.getState().clearAll();
   });
 
   it('blocks access for delegate sessions', async () => {
@@ -85,7 +150,9 @@ describe('EmergencyAccessPage', () => {
     api.get.mockResolvedValue(makeView());
     await renderPage();
     expect(
-      screen.getByText(/Emergency access can only be configured by the account owner/),
+      screen.getByText(
+        /Emergency access can only be configured by the account owner/,
+      ),
     ).toBeInTheDocument();
     expect(api.get).not.toHaveBeenCalled();
   });
@@ -104,100 +171,438 @@ describe('EmergencyAccessPage', () => {
     await waitFor(() =>
       expect(screen.getByText(/Email is not configured/)).toBeInTheDocument(),
     );
-    // Submit button is disabled in this branch
     expect(
-      (screen.getByRole('button', { name: /Save settings/i }) as HTMLButtonElement)
-        .disabled,
+      (screen.getByRole('button', {
+        name: /Save settings/i,
+      }) as HTMLButtonElement).disabled,
     ).toBe(true);
   });
 
-  it('loads settings + contacts and renders them', async () => {
+  it('renders metadata for a configured message without the plaintext', async () => {
     api.get.mockResolvedValue(
       makeView({
-        enabled: true,
-        message: 'top-secret',
-        contacts: [
-          {
-            id: 'c1',
-            firstName: 'Carol',
-            email: 'carol@example.com',
-            createdAt: new Date().toISOString(),
-          },
-        ],
+        messageMetadata: {
+          hasMessage: true,
+          charCount: 12,
+          updatedAt: '2026-05-01T00:00:00Z',
+        },
       }),
     );
     await renderPage();
     await waitFor(() =>
-      expect(screen.getByText('Carol')).toBeInTheDocument(),
+      expect(screen.getByText(/Message set/)).toBeInTheDocument(),
     );
-    expect(screen.getByText('carol@example.com')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('top-secret')).toBeInTheDocument();
+    expect(screen.getByText(/12 chars/)).toBeInTheDocument();
+    // The plaintext is never on screen until the user verifies.
+    expect(screen.queryByText('top-secret')).not.toBeInTheDocument();
   });
 
-  it('saves settings via the API', async () => {
+  it('renders "No message set" when nothing has been stored yet', async () => {
+    api.get.mockResolvedValue(makeView());
+    await renderPage();
+    await waitFor(() =>
+      expect(screen.getByText(/No message set/)).toBeInTheDocument(),
+    );
+    // Reveal is disabled when there's no message; Add message is enabled.
+    const reveal = screen.getByRole('button', { name: /Reveal message/i });
+    expect((reveal as HTMLButtonElement).disabled).toBe(true);
+    expect(
+      screen.getByRole('button', { name: /Add message/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('clicking Reveal opens the step-up modal when no token is present', async () => {
+    api.get.mockResolvedValue(
+      makeView({
+        messageMetadata: { hasMessage: true, charCount: 4, updatedAt: null },
+      }),
+    );
+    await renderPage();
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /Reveal message/i }),
+      ).toBeInTheDocument(),
+    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Reveal message/i }),
+      );
+    });
+    expect(screen.getByTestId('step-up-modal')).toBeInTheDocument();
+    expect(api.getMessage).not.toHaveBeenCalled();
+  });
+
+  it('after verifying via the modal, the message is fetched and shown', async () => {
+    api.get.mockResolvedValue(
+      makeView({
+        messageMetadata: { hasMessage: true, charCount: 10, updatedAt: null },
+      }),
+    );
+    api.getMessage.mockResolvedValue({ message: 'top-secret' });
+    await renderPage();
+    await waitFor(() =>
+      screen.getByRole('button', { name: /Reveal message/i }),
+    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Reveal message/i }),
+      );
+    });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Mock Verify/i }),
+      );
+    });
+    await act(async () => {});
+    await waitFor(() => expect(api.getMessage).toHaveBeenCalled());
+    expect(screen.getByText('top-secret')).toBeInTheDocument();
+    // After unlock the countdown card should appear.
+    expect(screen.getByText(/Unlocked for/)).toBeInTheDocument();
+  });
+
+  it('skips the modal when a valid token is already cached', async () => {
+    useStepUpTokenStore
+      .getState()
+      .set(
+        'emergency-access',
+        'cached',
+        new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+      );
+    api.get.mockResolvedValue(
+      makeView({
+        messageMetadata: { hasMessage: true, charCount: 5, updatedAt: null },
+      }),
+    );
+    api.getMessage.mockResolvedValue({ message: 'cached msg' });
+    await renderPage();
+    await waitFor(() =>
+      screen.getByRole('button', { name: /Reveal message/i }),
+    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Reveal message/i }),
+      );
+    });
+    await act(async () => {});
+    await waitFor(() => expect(api.getMessage).toHaveBeenCalled());
+    expect(screen.queryByTestId('step-up-modal')).not.toBeInTheDocument();
+    expect(screen.getByText('cached msg')).toBeInTheDocument();
+  });
+
+  it('Edit message with a cached token skips the modal and opens the editor', async () => {
+    useStepUpTokenStore
+      .getState()
+      .set(
+        'emergency-access',
+        'cached',
+        new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+      );
+    api.get.mockResolvedValue(
+      makeView({
+        messageMetadata: { hasMessage: true, charCount: 4, updatedAt: null },
+      }),
+    );
+    api.getMessage.mockResolvedValue({ message: 'old' });
+    await renderPage();
+    await waitFor(() =>
+      screen.getByRole('button', { name: /Edit message/i }),
+    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Edit message/i }),
+      );
+    });
+    await act(async () => {});
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/Notes, instructions/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('step-up-modal')).not.toBeInTheDocument();
+  });
+
+  it('Cancel inside the editor returns to view mode without clearing the token', async () => {
+    useStepUpTokenStore
+      .getState()
+      .set(
+        'emergency-access',
+        'cached',
+        new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+      );
+    api.get.mockResolvedValue(
+      makeView({
+        messageMetadata: { hasMessage: true, charCount: 4, updatedAt: null },
+      }),
+    );
+    api.getMessage.mockResolvedValue({ message: 'msg' });
+    await renderPage();
+    await waitFor(() =>
+      screen.getByRole('button', { name: /Edit message/i }),
+    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Edit message/i }),
+      );
+    });
+    await act(async () => {});
+    await waitFor(() =>
+      screen.getByPlaceholderText(/Notes, instructions/i),
+    );
+    // Cancel inside the edit form
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^Cancel$/i }));
+    });
+    await waitFor(() => expect(screen.getByText('msg')).toBeInTheDocument());
+    // Token is still active.
+    expect(
+      useStepUpTokenStore.getState().getValid('emergency-access'),
+    ).toBe('cached');
+  });
+
+  it('updateMessage failure (non step-up) leaves the editor open and toasts', async () => {
+    useStepUpTokenStore
+      .getState()
+      .set(
+        'emergency-access',
+        'cached',
+        new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+      );
+    api.get.mockResolvedValue(
+      makeView({
+        messageMetadata: { hasMessage: true, charCount: 4, updatedAt: null },
+      }),
+    );
+    api.getMessage.mockResolvedValue({ message: 'old' });
+    api.updateMessage.mockRejectedValue(new Error('database boom'));
+    await renderPage();
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Edit message/i }),
+      );
+    });
+    await act(async () => {});
+    await waitFor(() =>
+      screen.getByPlaceholderText(/Notes, instructions/i),
+    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Save message/i }),
+      );
+    });
+    await act(async () => {});
+    await waitFor(() => expect(api.updateMessage).toHaveBeenCalled());
+    // Editor stays open because the save failed.
+    expect(
+      screen.getByPlaceholderText(/Notes, instructions/i),
+    ).toBeInTheDocument();
+  });
+
+  it('Lock now clears the token and hides the plaintext', async () => {
+    useStepUpTokenStore
+      .getState()
+      .set(
+        'emergency-access',
+        'cached',
+        new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+      );
+    api.get.mockResolvedValue(
+      makeView({
+        messageMetadata: { hasMessage: true, charCount: 5, updatedAt: null },
+      }),
+    );
+    api.getMessage.mockResolvedValue({ message: 'sensitive' });
+    await renderPage();
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Reveal message/i }),
+      );
+    });
+    await act(async () => {});
+    await waitFor(() => expect(screen.getByText('sensitive')).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Lock now/i }));
+    });
+    expect(screen.queryByText('sensitive')).not.toBeInTheDocument();
+    expect(
+      useStepUpTokenStore.getState().getValid('emergency-access'),
+    ).toBeNull();
+  });
+
+  it('STEP_UP_REQUIRED from getMessage opens the modal', async () => {
+    api.get.mockResolvedValue(
+      makeView({
+        messageMetadata: { hasMessage: true, charCount: 5, updatedAt: null },
+      }),
+    );
+    useStepUpTokenStore
+      .getState()
+      .set(
+        'emergency-access',
+        'expired-on-server',
+        new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+      );
+    api.getMessage.mockRejectedValue(
+      new StepUpRequiredError('emergency-access', 'expired'),
+    );
+    await renderPage();
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Reveal message/i }),
+      );
+    });
+    await act(async () => {});
+    await waitFor(() =>
+      expect(screen.getByTestId('step-up-modal')).toBeInTheDocument(),
+    );
+  });
+
+  it('shows a toast and stays on the metadata card when getMessage fails for another reason', async () => {
+    useStepUpTokenStore
+      .getState()
+      .set(
+        'emergency-access',
+        'cached',
+        new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+      );
+    api.get.mockResolvedValue(
+      makeView({
+        messageMetadata: { hasMessage: true, charCount: 5, updatedAt: null },
+      }),
+    );
+    api.getMessage.mockRejectedValue(new Error('network'));
+    await renderPage();
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Reveal message/i }),
+      );
+    });
+    await act(async () => {});
+    // The card stayed in its hidden mode (no plaintext, no countdown).
+    expect(screen.queryByText(/Unlocked for/)).not.toBeInTheDocument();
+  });
+
+  it('opens the editor after verifying and saves a new message', async () => {
+    api.get.mockResolvedValue(makeView());
+    api.getMessage.mockResolvedValue({ message: '' });
+    api.updateMessage.mockResolvedValue({
+      hasMessage: true,
+      charCount: 5,
+      updatedAt: null,
+    });
+    await renderPage();
+    await waitFor(() =>
+      screen.getByRole('button', { name: /Add message/i }),
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Add message/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Mock Verify/i }));
+    });
+    await act(async () => {});
+    await waitFor(() =>
+      screen.getByPlaceholderText(/Notes, instructions/i),
+    );
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText(/Notes, instructions/i), {
+        target: { value: 'hello' },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Save message/i }),
+      );
+    });
+    await act(async () => {});
+    await waitFor(() => expect(api.updateMessage).toHaveBeenCalledWith('hello'));
+  });
+
+  it('updateMessage rejection with STEP_UP_EXPIRED reopens the modal', async () => {
+    useStepUpTokenStore
+      .getState()
+      .set(
+        'emergency-access',
+        'cached',
+        new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+      );
+    api.get.mockResolvedValue(
+      makeView({
+        messageMetadata: { hasMessage: true, charCount: 4, updatedAt: null },
+      }),
+    );
+    api.getMessage.mockResolvedValue({ message: 'old' });
+    api.updateMessage.mockRejectedValue(
+      new StepUpRequiredError('emergency-access', 'expired'),
+    );
+    await renderPage();
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Reveal message/i }),
+      );
+    });
+    await act(async () => {});
+    await waitFor(() =>
+      screen.getByRole('button', { name: /^Edit$/i }),
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^Edit$/i }));
+    });
+    await waitFor(() =>
+      screen.getByPlaceholderText(/Notes, instructions/i),
+    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Save message/i }),
+      );
+    });
+    await act(async () => {});
+    await waitFor(() =>
+      expect(screen.getByTestId('step-up-modal')).toBeInTheDocument(),
+    );
+  });
+
+  it('saves the (non-message) settings via the API', async () => {
     const initial = makeView();
-    const updated = makeView({ enabled: true, message: 'note' });
+    const updated = makeView({ enabled: true });
     api.get.mockResolvedValue(initial);
     api.updateSettings.mockResolvedValue(updated);
     await renderPage();
-
-    await waitFor(() => screen.getByRole('button', { name: /Save settings/i }));
-    const textarea = screen.getByPlaceholderText(/Notes, instructions/i);
+    await waitFor(() =>
+      screen.getByRole('button', { name: /Save settings/i }),
+    );
     await act(async () => {
-      fireEvent.change(textarea, { target: { value: 'note' } });
+      fireEvent.click(
+        screen.getByRole('button', { name: /Save settings/i }),
+      );
     });
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Save settings/i }));
-    });
-
     await waitFor(() => expect(api.updateSettings).toHaveBeenCalled());
-    expect(api.updateSettings.mock.calls[0][0]).toMatchObject({
+    const payload = api.updateSettings.mock.calls[0][0];
+    expect(payload).toEqual({
       enabled: false,
       grantAfterDays: 14,
       reminderAfterDays: 7,
-      message: 'note',
     });
+    expect(payload).not.toHaveProperty('message');
   });
 
-  it('adds a contact via the API', async () => {
+  it('toggles the enable switch via setValue', async () => {
     api.get.mockResolvedValue(makeView());
-    api.addContact.mockResolvedValue({
-      id: 'new',
-      firstName: 'Carol',
-      email: 'carol@example.com',
-      createdAt: new Date().toISOString(),
-    });
+    api.updateSettings.mockResolvedValue(makeView({ enabled: true }));
     await renderPage();
-
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: /Add contact/i })).toBeInTheDocument(),
+      screen.getByRole('button', { name: /Save settings/i }),
     );
+    const toggle = screen.getByRole('switch', {
+      name: /Enable emergency access/i,
+    });
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Add contact/i }));
+      fireEvent.click(toggle);
     });
-
-    const firstName = screen.getByLabelText(/First name/i);
-    const email = screen.getByLabelText(/^Email$/i);
     await act(async () => {
-      fireEvent.input(firstName, { target: { value: 'Carol' } });
-      fireEvent.input(email, { target: { value: 'carol@example.com' } });
+      fireEvent.click(
+        screen.getByRole('button', { name: /Save settings/i }),
+      );
     });
-    // Submit the contact form by dispatching a submit event on the form node
-    // (react-hook-form's async validation pipeline is more reliable than
-    // clicking a button in jsdom).
-    const form = firstName.closest('form');
-    expect(form).not.toBeNull();
-    await act(async () => {
-      fireEvent.submit(form!);
-    });
-    // Drain any pending promise microtasks
-    await act(async () => {});
-
-    await waitFor(() => expect(api.addContact).toHaveBeenCalled());
-    expect(api.addContact.mock.calls[0][0]).toEqual({
-      firstName: 'Carol',
-      email: 'carol@example.com',
-    });
+    await waitFor(() => expect(api.updateSettings).toHaveBeenCalled());
+    expect(api.updateSettings.mock.calls[0][0].enabled).toBe(true);
   });
 
   it('renders a warning when access has already been granted', async () => {
@@ -222,6 +627,42 @@ describe('EmergencyAccessPage', () => {
     );
   });
 
+  it('adds a contact via the API', async () => {
+    api.get.mockResolvedValue(makeView());
+    api.addContact.mockResolvedValue({
+      id: 'new',
+      firstName: 'Carol',
+      email: 'carol@example.com',
+      createdAt: new Date().toISOString(),
+    });
+    await renderPage();
+    await waitFor(() =>
+      screen.getByRole('button', { name: /Add contact/i }),
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Add contact/i }));
+    });
+
+    const firstName = screen.getByLabelText(/First name/i);
+    const email = screen.getByLabelText(/^Email$/i);
+    await act(async () => {
+      fireEvent.input(firstName, { target: { value: 'Carol' } });
+      fireEvent.input(email, { target: { value: 'carol@example.com' } });
+    });
+    const form = firstName.closest('form');
+    expect(form).not.toBeNull();
+    await act(async () => {
+      fireEvent.submit(form!);
+    });
+    await act(async () => {});
+
+    await waitFor(() => expect(api.addContact).toHaveBeenCalled());
+    expect(api.addContact.mock.calls[0][0]).toEqual({
+      firstName: 'Carol',
+      email: 'carol@example.com',
+    });
+  });
+
   it('opens the contact form pre-populated when editing an existing contact', async () => {
     api.get.mockResolvedValue(
       makeView({
@@ -242,9 +683,7 @@ describe('EmergencyAccessPage', () => {
       createdAt: new Date().toISOString(),
     });
     await renderPage();
-    await waitFor(() =>
-      expect(screen.getByText('Carol')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Carol')).toBeInTheDocument());
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /^Edit$/i }));
     });
@@ -259,7 +698,6 @@ describe('EmergencyAccessPage', () => {
       });
     });
     const form = firstName.closest('form');
-    expect(form).not.toBeNull();
     await act(async () => {
       fireEvent.submit(form!);
     });
@@ -288,79 +726,36 @@ describe('EmergencyAccessPage', () => {
     );
     api.removeContact.mockResolvedValue(undefined);
     await renderPage();
-    await waitFor(() =>
-      expect(screen.getByText('Carol')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Carol')).toBeInTheDocument());
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /^Remove$/i }));
     });
     await waitFor(() =>
       expect(screen.getByText('Remove contact')).toBeInTheDocument(),
     );
-    // After the dialog opens there are two "Remove" buttons (the list row
-    // button and the confirm button). Click the last one, which is the
-    // freshly-rendered confirm button.
-    const removeButtons = screen.getAllByRole('button', { name: /^Remove$/i });
+    const removeButtons = screen.getAllByRole('button', {
+      name: /^Remove$/i,
+    });
     await act(async () => {
       fireEvent.click(removeButtons[removeButtons.length - 1]);
     });
-    await waitFor(() =>
-      expect(api.removeContact).toHaveBeenCalledWith('c1'),
-    );
+    await waitFor(() => expect(api.removeContact).toHaveBeenCalledWith('c1'));
   });
 
-  it('toggles the enable switch via setValue', async () => {
+  it('shows a toast when settings save fails', async () => {
     api.get.mockResolvedValue(makeView());
-    api.updateSettings.mockResolvedValue(makeView({ enabled: true }));
+    api.updateSettings.mockRejectedValue(new Error('validation failed'));
     await renderPage();
     await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: /Save settings/i }),
-      ).toBeInTheDocument(),
-    );
-    const toggle = screen.getByRole('switch', {
-      name: /Enable emergency access/i,
-    });
-    await act(async () => {
-      fireEvent.click(toggle);
-    });
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Save settings/i }));
-    });
-    await waitFor(() => expect(api.updateSettings).toHaveBeenCalled());
-    expect(api.updateSettings.mock.calls[0][0].enabled).toBe(true);
-  });
-
-  it('shows a toast and stays on the page when reset() fails', async () => {
-    api.get.mockResolvedValue(
-      makeView({ grantedAt: new Date().toISOString() }),
-    );
-    api.reset.mockRejectedValue(new Error('server down'));
-    await renderPage();
-    await waitFor(() =>
-      expect(
-        screen.getByText('Emergency access already granted'),
-      ).toBeInTheDocument(),
+      screen.getByRole('button', { name: /Save settings/i }),
     );
     await act(async () => {
       fireEvent.click(
-        screen.getByRole('button', { name: /Clear granted state/i }),
+        screen.getByRole('button', { name: /Save settings/i }),
       );
     });
-    await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: 'Clear' }),
-      ).toBeInTheDocument(),
-    );
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
-    });
     await act(async () => {});
-    await waitFor(() => expect(api.reset).toHaveBeenCalled());
-    // The warning banner is still on screen because reset() rejected.
-    expect(
-      screen.getByText('Emergency access already granted'),
-    ).toBeInTheDocument();
+    await waitFor(() => expect(api.updateSettings).toHaveBeenCalled());
   });
 
   it('shows a toast and keeps the contact when removeContact() fails', async () => {
@@ -383,7 +778,9 @@ describe('EmergencyAccessPage', () => {
       fireEvent.click(screen.getByRole('button', { name: /^Remove$/i }));
     });
     await waitFor(() => screen.getByText('Remove contact'));
-    const removeButtons = screen.getAllByRole('button', { name: /^Remove$/i });
+    const removeButtons = screen.getAllByRole('button', {
+      name: /^Remove$/i,
+    });
     await act(async () => {
       fireEvent.click(removeButtons[removeButtons.length - 1]);
     });
@@ -392,52 +789,12 @@ describe('EmergencyAccessPage', () => {
     expect(screen.getByText('Carol')).toBeInTheDocument();
   });
 
-  it('closes the contact modal via Cancel', async () => {
-    api.get.mockResolvedValue(makeView());
-    await renderPage();
-    await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: /Add contact/i }),
-      ).toBeInTheDocument(),
-    );
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Add contact/i }));
-    });
-    await waitFor(() => screen.getByText('Add emergency contact'));
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
-    });
-    await waitFor(() =>
-      expect(
-        screen.queryByText('Add emergency contact'),
-      ).not.toBeInTheDocument(),
-    );
-  });
-
-  it('shows a toast when settings save fails', async () => {
-    api.get.mockResolvedValue(makeView());
-    api.updateSettings.mockRejectedValue(new Error('validation failed'));
-    await renderPage();
-    await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: /Save settings/i }),
-      ).toBeInTheDocument(),
-    );
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Save settings/i }));
-    });
-    await act(async () => {});
-    await waitFor(() => expect(api.updateSettings).toHaveBeenCalled());
-  });
-
   it('shows a toast when adding a contact fails', async () => {
     api.get.mockResolvedValue(makeView());
     api.addContact.mockRejectedValue(new Error('duplicate'));
     await renderPage();
     await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: /Add contact/i }),
-      ).toBeInTheDocument(),
+      screen.getByRole('button', { name: /Add contact/i }),
     );
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /Add contact/i }));
@@ -450,7 +807,6 @@ describe('EmergencyAccessPage', () => {
       });
     });
     const form = firstName.closest('form');
-    expect(form).not.toBeNull();
     await act(async () => {
       fireEvent.submit(form!);
     });
@@ -530,8 +886,6 @@ describe('EmergencyAccessPage', () => {
         screen.getByRole('button', { name: /Clear granted state/i }),
       );
     });
-    // The dialog confirm button is labelled "Clear" (singular) -- look for
-    // it by exact name match.
     await waitFor(() =>
       expect(
         screen.getByRole('button', { name: 'Clear' }),
@@ -541,5 +895,56 @@ describe('EmergencyAccessPage', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
     });
     await waitFor(() => expect(api.reset).toHaveBeenCalled());
+  });
+
+  it('shows a toast and stays on the page when reset() fails', async () => {
+    api.get.mockResolvedValue(
+      makeView({ grantedAt: new Date().toISOString() }),
+    );
+    api.reset.mockRejectedValue(new Error('server down'));
+    await renderPage();
+    await waitFor(() =>
+      expect(
+        screen.getByText('Emergency access already granted'),
+      ).toBeInTheDocument(),
+    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Clear granted state/i }),
+      );
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Clear' }),
+      ).toBeInTheDocument(),
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+    });
+    await act(async () => {});
+    await waitFor(() => expect(api.reset).toHaveBeenCalled());
+    expect(
+      screen.getByText('Emergency access already granted'),
+    ).toBeInTheDocument();
+  });
+
+  it('closes the contact modal via Cancel', async () => {
+    api.get.mockResolvedValue(makeView());
+    await renderPage();
+    await waitFor(() =>
+      screen.getByRole('button', { name: /Add contact/i }),
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Add contact/i }));
+    });
+    await waitFor(() => screen.getByText('Add emergency contact'));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+    });
+    await waitFor(() =>
+      expect(
+        screen.queryByText('Add emergency contact'),
+      ).not.toBeInTheDocument(),
+    );
   });
 });

--- a/frontend/src/app/settings/emergency-access/page.test.tsx
+++ b/frontend/src/app/settings/emergency-access/page.test.tsx
@@ -62,13 +62,21 @@ vi.mock('@/components/auth/StepUpAuthModal', () => ({
     isOpen,
     onClose,
     onVerified,
+    authProvider,
+    hasPassword,
   }: {
     isOpen: boolean;
     onClose: () => void;
     onVerified?: () => void;
+    authProvider: 'local' | 'oidc';
+    hasPassword: boolean;
   }) =>
     isOpen ? (
-      <div data-testid="step-up-modal">
+      <div
+        data-testid="step-up-modal"
+        data-auth-provider={authProvider}
+        data-has-password={String(hasPassword)}
+      >
         <button
           onClick={async () => {
             const { useStepUpTokenStore } = await import('@/lib/stepUpToken');
@@ -98,6 +106,22 @@ const mockedApi = apiClient as unknown as {
   post: ReturnType<typeof vi.fn>;
 };
 
+vi.mock('@/lib/auth', () => ({
+  authApi: {
+    getSelfProfile: vi.fn().mockResolvedValue({
+      id: 'self-1',
+      email: 'me@example.com',
+      authProvider: 'local',
+      hasPassword: true,
+      role: 'user',
+      isActive: true,
+      mustChangePassword: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }),
+  },
+}));
+
 vi.mock('@/lib/emergency-access', () => ({
   emergencyAccessApi: {
     get: vi.fn(),
@@ -114,11 +138,15 @@ vi.mock('@/lib/emergency-access', () => ({
 }));
 
 import { emergencyAccessApi } from '@/lib/emergency-access';
+import { authApi } from '@/lib/auth';
 import { useStepUpTokenStore, StepUpRequiredError } from '@/lib/stepUpToken';
 const api = emergencyAccessApi as unknown as Record<
   string,
   ReturnType<typeof vi.fn>
 >;
+const mockedAuthApi = authApi as unknown as {
+  getSelfProfile: ReturnType<typeof vi.fn>;
+};
 
 function makeView(
   overrides: Partial<EmergencyAccessView> = {},
@@ -286,6 +314,83 @@ describe('EmergencyAccessPage', () => {
     expect(
       useStepUpTokenStore.getState().getValid('emergency-access'),
     ).toBeNull();
+  });
+
+  it('passes authProvider=oidc to the modal for OIDC users (regression for #unavailable-fallthrough)', async () => {
+    // Regression: /auth/profile (used to hydrate the auth store) omits
+    // authProvider, so reading it from the store gave undefined and the
+    // modal fell through to its "unavailable" branch. The page must
+    // explicitly fetch /auth/me-self and pass the value down.
+    mockedAuthApi.getSelfProfile.mockResolvedValueOnce({
+      id: 'self-1',
+      email: 'oidc@example.com',
+      authProvider: 'oidc',
+      hasPassword: false,
+      role: 'user',
+      isActive: true,
+      mustChangePassword: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    api.get.mockResolvedValue(
+      makeView({
+        messageMetadata: { hasMessage: true, charCount: 4, updatedAt: null },
+      }),
+    );
+    await renderPage();
+    await waitFor(() =>
+      expect(mockedAuthApi.getSelfProfile).toHaveBeenCalled(),
+    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Reveal message/i }),
+      );
+    });
+    const modal = await screen.findByTestId('step-up-modal');
+    expect(modal.getAttribute('data-auth-provider')).toBe('oidc');
+    expect(modal.getAttribute('data-has-password')).toBe('false');
+  });
+
+  it('keeps the modal closed until the self profile has loaded', async () => {
+    let resolveProfile!: (u: unknown) => void;
+    mockedAuthApi.getSelfProfile.mockReturnValueOnce(
+      new Promise((res) => {
+        resolveProfile = res;
+      }),
+    );
+    api.get.mockResolvedValue(
+      makeView({
+        messageMetadata: { hasMessage: true, charCount: 4, updatedAt: null },
+      }),
+    );
+    await renderPage();
+    await waitFor(() =>
+      screen.getByRole('button', { name: /Reveal message/i }),
+    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Reveal message/i }),
+      );
+    });
+    // Without the self profile yet, the modal must not pop with stale data.
+    expect(screen.queryByTestId('step-up-modal')).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveProfile({
+        id: 'self-1',
+        email: 'me@example.com',
+        authProvider: 'local',
+        hasPassword: true,
+        role: 'user',
+        isActive: true,
+        mustChangePassword: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('step-up-modal')).toBeInTheDocument(),
+    );
   });
 
   it('clicking Reveal opens the step-up modal when no token is present', async () => {

--- a/frontend/src/app/settings/emergency-access/page.test.tsx
+++ b/frontend/src/app/settings/emergency-access/page.test.tsx
@@ -90,6 +90,14 @@ vi.mock('@/components/auth/StepUpAuthModal', () => ({
     ) : null,
 }));
 
+vi.mock('@/lib/api', () => ({
+  default: { post: vi.fn() },
+}));
+import apiClient from '@/lib/api';
+const mockedApi = apiClient as unknown as {
+  post: ReturnType<typeof vi.fn>;
+};
+
 vi.mock('@/lib/emergency-access', () => ({
   emergencyAccessApi: {
     get: vi.fn(),
@@ -143,6 +151,7 @@ describe('EmergencyAccessPage', () => {
     mockUseDemoMode.mockReturnValue(false);
     mockActingAs.mockReturnValue(null);
     useStepUpTokenStore.getState().clearAll();
+    sessionStorage.clear();
   });
 
   it('blocks access for delegate sessions', async () => {
@@ -209,6 +218,74 @@ describe('EmergencyAccessPage', () => {
     expect(
       screen.getByRole('button', { name: /Add message/i }),
     ).toBeInTheDocument();
+  });
+
+  it('finalizes step-up on mount when returning from an OIDC roundtrip', async () => {
+    sessionStorage.setItem(
+      'stepUpOidcPending',
+      JSON.stringify({
+        purpose: 'emergency-access',
+        payload: { mode: 'view' },
+      }),
+    );
+    api.get.mockResolvedValue(
+      makeView({
+        messageMetadata: { hasMessage: true, charCount: 7, updatedAt: null },
+      }),
+    );
+    api.getMessage.mockResolvedValue({ message: 'returned' });
+    mockedApi.post.mockResolvedValue({
+      data: {
+        stepUpToken: 'oidc-confirmed-token',
+        expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+      },
+    });
+    await renderPage();
+    // Drain the microtask queue so the post-then-fetch chain settles.
+    await act(async () => {});
+    await act(async () => {});
+    await waitFor(() => expect(mockedApi.post).toHaveBeenCalled());
+    expect(mockedApi.post).toHaveBeenCalledWith('/auth/step-up', {
+      purpose: 'emergency-access',
+      oidcConfirmed: true,
+    });
+    expect(
+      useStepUpTokenStore.getState().getValid('emergency-access'),
+    ).toBe('oidc-confirmed-token');
+    // Sentinel was consumed.
+    expect(sessionStorage.getItem('stepUpOidcPending')).toBeNull();
+    // And the requested mode resumed.
+    await waitFor(() =>
+      expect(screen.getByText('returned')).toBeInTheDocument(),
+    );
+  });
+
+  it('skips the OIDC finalize when the sentinel targets a different purpose', async () => {
+    sessionStorage.setItem(
+      'stepUpOidcPending',
+      JSON.stringify({ purpose: 'something-else' }),
+    );
+    api.get.mockResolvedValue(makeView());
+    await renderPage();
+    await act(async () => {});
+    expect(mockedApi.post).not.toHaveBeenCalled();
+    // Sentinel remains for whoever it was intended for.
+    expect(sessionStorage.getItem('stepUpOidcPending')).not.toBeNull();
+  });
+
+  it('toasts and does not store a token when the OIDC finalize call fails', async () => {
+    sessionStorage.setItem(
+      'stepUpOidcPending',
+      JSON.stringify({ purpose: 'emergency-access' }),
+    );
+    api.get.mockResolvedValue(makeView());
+    mockedApi.post.mockRejectedValue(new Error('server boom'));
+    await renderPage();
+    await act(async () => {});
+    await waitFor(() => expect(mockedApi.post).toHaveBeenCalled());
+    expect(
+      useStepUpTokenStore.getState().getValid('emergency-access'),
+    ).toBeNull();
   });
 
   it('clicking Reveal opens the step-up modal when no token is present', async () => {

--- a/frontend/src/app/settings/emergency-access/page.tsx
+++ b/frontend/src/app/settings/emergency-access/page.tsx
@@ -26,6 +26,8 @@ import apiClient from '@/lib/api';
 import { useDemoMode } from '@/hooks/useDemoMode';
 import { useAuthStore } from '@/store/authStore';
 import { usePreferencesStore } from '@/store/preferencesStore';
+import { authApi } from '@/lib/auth';
+import type { User } from '@/types/auth';
 import {
   resolveTimezone,
   isoToDatetimeLocal,
@@ -191,6 +193,10 @@ function EmergencyAccessSection() {
 
   const [view, setView] = useState<EmergencyAccessView | null>(null);
   const [loading, setLoading] = useState(true);
+  // The auth store's cached user comes from /auth/profile which omits
+  // authProvider + passwordHash (see getUserStateById). The step-up modal
+  // needs both, so we fetch the full self profile via /auth/me-self here.
+  const [selfUser, setSelfUser] = useState<User | null>(null);
   const [savingSettings, setSavingSettings] = useState(false);
 
   // Message reveal/edit state
@@ -255,6 +261,17 @@ function EmergencyAccessSection() {
   useEffect(() => {
     void load();
   }, [load]);
+
+  // Fetch the full self profile so the step-up modal can pick the right
+  // factor (authProvider + hasPassword aren't on the auth-store user).
+  useEffect(() => {
+    authApi
+      .getSelfProfile()
+      .then((u: User) => setSelfUser(u))
+      .catch((err) => {
+        logger.error('Failed to load self profile for step-up', err);
+      });
+  }, []);
 
   // Lock the message view whenever the step-up token disappears (expiry, "Lock now",
   // logout). This prevents stale plaintext from staying on-screen after the
@@ -902,8 +919,10 @@ function EmergencyAccessSection() {
         />
 
         <StepUpAuthModal
-          isOpen={stepUpOpen}
+          isOpen={stepUpOpen && !!selfUser}
           purpose={STEP_UP_PURPOSE}
+          authProvider={selfUser?.authProvider ?? 'local'}
+          hasPassword={selfUser?.hasPassword ?? false}
           reason="Re-verify your identity to view or edit your emergency-access message."
           oidcReturnTo="/settings/emergency-access"
           oidcResumePayload={

--- a/frontend/src/app/settings/emergency-access/page.tsx
+++ b/frontend/src/app/settings/emergency-access/page.tsx
@@ -19,8 +19,10 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { StepUpAuthModal } from '@/components/auth/StepUpAuthModal';
 import {
   StepUpRequiredError,
+  consumeOidcStepUpPending,
   useStepUpTokenStore,
 } from '@/lib/stepUpToken';
+import apiClient from '@/lib/api';
 import { useDemoMode } from '@/hooks/useDemoMode';
 import { useAuthStore } from '@/store/authStore';
 import { usePreferencesStore } from '@/store/preferencesStore';
@@ -263,6 +265,44 @@ function EmergencyAccessSection() {
       messageForm.reset({ message: '' });
     }
   }, [hasStepUpToken, messageMode, messageForm]);
+
+  // Finalize step-up after an OIDC roundtrip. The user clicked "Continue to
+  // identity provider" in the modal, which stashed the pending purpose +
+  // mode in sessionStorage and called authApi.initiateOidc(). The auth
+  // callback brought them back here. Read the sentinel, exchange it for a
+  // real step-up token, and resume the action they wanted.
+  useEffect(() => {
+    const pending = consumeOidcStepUpPending(STEP_UP_PURPOSE);
+    if (!pending) return;
+    const resumeMode = pending.payload?.mode as 'view' | 'edit' | undefined;
+    (async () => {
+      try {
+        const res = await apiClient.post<{
+          stepUpToken: string;
+          expiresAt: string;
+        }>('/auth/step-up', {
+          purpose: STEP_UP_PURPOSE,
+          oidcConfirmed: true,
+        });
+        useStepUpTokenStore
+          .getState()
+          .set(STEP_UP_PURPOSE, res.data.stepUpToken, res.data.expiresAt);
+        if (resumeMode === 'view' || resumeMode === 'edit') {
+          setPendingMode(resumeMode);
+          // Defer to next tick so the token is in the store before fetch.
+          queueMicrotask(() => {
+            void fetchMessageInto(resumeMode);
+          });
+        }
+      } catch (err) {
+        toast.error(getErrorMessage(err, 'Failed to confirm re-authentication'));
+        logger.error(err);
+      }
+    })();
+    // Intentionally run once per mount -- the sentinel is consumed on the
+    // first call, so re-runs would no-op anyway.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const fetchMessageInto = useCallback(
     async (nextMode: 'view' | 'edit') => {
@@ -865,6 +905,10 @@ function EmergencyAccessSection() {
           isOpen={stepUpOpen}
           purpose={STEP_UP_PURPOSE}
           reason="Re-verify your identity to view or edit your emergency-access message."
+          oidcReturnTo="/settings/emergency-access"
+          oidcResumePayload={
+            pendingMode ? { mode: pendingMode } : undefined
+          }
           onClose={() => {
             setStepUpOpen(false);
             setPendingMode(null);

--- a/frontend/src/app/settings/emergency-access/page.tsx
+++ b/frontend/src/app/settings/emergency-access/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 import Link from 'next/link';
 import { useForm } from 'react-hook-form';
 import '@/lib/zodConfig';
@@ -16,6 +16,11 @@ import { Input } from '@/components/ui/Input';
 import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
 import { Modal } from '@/components/ui/Modal';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import { StepUpAuthModal } from '@/components/auth/StepUpAuthModal';
+import {
+  StepUpRequiredError,
+  useStepUpTokenStore,
+} from '@/lib/stepUpToken';
 import { useDemoMode } from '@/hooks/useDemoMode';
 import { useAuthStore } from '@/store/authStore';
 import { usePreferencesStore } from '@/store/preferencesStore';
@@ -33,6 +38,7 @@ import type {
 } from '@/types/emergency-access';
 
 const logger = createLogger('EmergencyAccess');
+const STEP_UP_PURPOSE = 'emergency-access';
 
 const settingsSchema = z
   .object({
@@ -47,10 +53,6 @@ const settingsSchema = z
       .int('Whole days only')
       .min(1, 'Must be at least 1 day')
       .max(364, 'Must be 364 days or fewer'),
-    message: z
-      .string()
-      .max(4000, 'Message must be 4000 characters or less')
-      .optional(),
   })
   .refine((data) => data.reminderAfterDays < data.grantAfterDays, {
     message: 'Reminder days must be less than grant days',
@@ -58,6 +60,15 @@ const settingsSchema = z
   });
 
 type SettingsFormData = z.infer<typeof settingsSchema>;
+
+const messageSchema = z.object({
+  message: z
+    .string()
+    .max(4000, 'Message must be 4000 characters or less')
+    .optional(),
+});
+
+type MessageFormData = z.infer<typeof messageSchema>;
 
 const contactSchema = z.object({
   firstName: z
@@ -132,15 +143,63 @@ function EmergencyAccessContent() {
   return <EmergencyAccessSection />;
 }
 
+// Subscribe to the current wall-clock time so the countdown re-renders once
+// per second. useSyncExternalStore is the React-blessed primitive for "live
+// data from outside React" -- it avoids the setState-in-effect anti-pattern
+// while still keeping the value fresh.
+function useNowEverySecond(enabled: boolean): number | null {
+  return useSyncExternalStore(
+    (cb) => {
+      if (!enabled) return () => {};
+      const id = window.setInterval(cb, 1000);
+      return () => window.clearInterval(id);
+    },
+    () => (enabled ? Date.now() : null),
+    () => null,
+  );
+}
+
+function MessageCountdown() {
+  const expiresAt = useStepUpTokenStore((s) =>
+    s.getExpiresAt(STEP_UP_PURPOSE),
+  );
+  const now = useNowEverySecond(!!expiresAt);
+
+  if (!expiresAt || now === null) return null;
+  const remainingMs = Math.max(0, expiresAt - now);
+  const mins = Math.floor(remainingMs / 60_000);
+  const secs = Math.floor((remainingMs % 60_000) / 1000);
+  return (
+    <span className="text-xs text-gray-500 dark:text-gray-400 font-mono">
+      Unlocked for {mins}:{secs.toString().padStart(2, '0')}
+    </span>
+  );
+}
+
 function EmergencyAccessSection() {
   const preferences = usePreferencesStore((s) => s.preferences);
   const userTimezone = resolveTimezone(preferences?.timezone);
   const dateFormat = preferences?.dateFormat || 'browser';
   const timeFormat: '24h' | '12h' = preferences?.timeFormat ?? '24h';
 
+  const hasStepUpToken = useStepUpTokenStore(
+    (s) => !!s.getValid(STEP_UP_PURPOSE),
+  );
+  const clearStepUp = useStepUpTokenStore((s) => s.clear);
+
   const [view, setView] = useState<EmergencyAccessView | null>(null);
   const [loading, setLoading] = useState(true);
   const [savingSettings, setSavingSettings] = useState(false);
+
+  // Message reveal/edit state
+  const [messageMode, setMessageMode] = useState<'hidden' | 'view' | 'edit'>(
+    'hidden',
+  );
+  const [messageLoading, setMessageLoading] = useState(false);
+  const [savingMessage, setSavingMessage] = useState(false);
+  const [stepUpOpen, setStepUpOpen] = useState(false);
+  // Captures which mode the user wanted -- we resume it after verification.
+  const [pendingMode, setPendingMode] = useState<'view' | 'edit' | null>(null);
 
   const [showContactForm, setShowContactForm] = useState(false);
   const [editingContact, setEditingContact] =
@@ -160,8 +219,12 @@ function EmergencyAccessSection() {
       enabled: false,
       grantAfterDays: 14,
       reminderAfterDays: 7,
-      message: '',
     },
+  });
+
+  const messageForm = useForm<MessageFormData>({
+    resolver: zodResolver(messageSchema),
+    defaultValues: { message: '' },
   });
 
   const contactForm = useForm<ContactFormData>({
@@ -178,7 +241,6 @@ function EmergencyAccessSection() {
         enabled: data.enabled,
         grantAfterDays: data.grantAfterDays,
         reminderAfterDays: data.reminderAfterDays,
-        message: data.message ?? '',
       });
     } catch (err) {
       toast.error(getErrorMessage(err, 'Failed to load emergency access'));
@@ -192,15 +254,94 @@ function EmergencyAccessSection() {
     void load();
   }, [load]);
 
+  // Lock the message view whenever the step-up token disappears (expiry, "Lock now",
+  // logout). This prevents stale plaintext from staying on-screen after the
+  // unlock window ends.
+  useEffect(() => {
+    if (!hasStepUpToken && messageMode !== 'hidden') {
+      setMessageMode('hidden');
+      messageForm.reset({ message: '' });
+    }
+  }, [hasStepUpToken, messageMode, messageForm]);
+
+  const fetchMessageInto = useCallback(
+    async (nextMode: 'view' | 'edit') => {
+      setMessageLoading(true);
+      try {
+        const { message } = await emergencyAccessApi.getMessage();
+        messageForm.reset({ message: message ?? '' });
+        setMessageMode(nextMode);
+      } catch (err) {
+        if (err instanceof StepUpRequiredError) {
+          clearStepUp(STEP_UP_PURPOSE);
+          setPendingMode(nextMode);
+          setStepUpOpen(true);
+          return;
+        }
+        toast.error(getErrorMessage(err, 'Failed to load message'));
+        logger.error(err);
+      } finally {
+        setMessageLoading(false);
+      }
+    },
+    [messageForm, clearStepUp],
+  );
+
+  const handleReveal = () => {
+    if (!hasStepUpToken) {
+      setPendingMode('view');
+      setStepUpOpen(true);
+      return;
+    }
+    void fetchMessageInto('view');
+  };
+
+  const handleEdit = () => {
+    if (!hasStepUpToken) {
+      setPendingMode('edit');
+      setStepUpOpen(true);
+      return;
+    }
+    void fetchMessageInto('edit');
+  };
+
+  const handleLockNow = () => {
+    clearStepUp(STEP_UP_PURPOSE);
+    setMessageMode('hidden');
+    messageForm.reset({ message: '' });
+  };
+
+  const onMessageSubmit = async (data: MessageFormData) => {
+    setSavingMessage(true);
+    try {
+      const meta = await emergencyAccessApi.updateMessage(
+        data.message?.trim() ? data.message.trim() : null,
+      );
+      setView((prev) =>
+        prev ? { ...prev, messageMetadata: { ...meta, updatedAt: meta.updatedAt ? String(meta.updatedAt) : null } } : prev,
+      );
+      toast.success('Message saved');
+      setMessageMode('view');
+    } catch (err) {
+      if (err instanceof StepUpRequiredError) {
+        // Token expired between fetch and save -- re-prompt and ask the user
+        // to click Save again.
+        clearStepUp(STEP_UP_PURPOSE);
+        setStepUpOpen(true);
+        toast.error('Verification expired -- please verify again to save');
+        return;
+      }
+      toast.error(getErrorMessage(err, 'Failed to save message'));
+      logger.error(err);
+    } finally {
+      setSavingMessage(false);
+    }
+  };
+
   const onSettingsSubmit = async (data: SettingsFormData) => {
     setSavingSettings(true);
     try {
-      const next = await emergencyAccessApi.updateSettings({
-        enabled: data.enabled,
-        grantAfterDays: data.grantAfterDays,
-        reminderAfterDays: data.reminderAfterDays,
-        message: data.message?.trim() ? data.message.trim() : null,
-      });
+      const next = await emergencyAccessApi.updateSettings(data);
       setView(next);
       toast.success('Emergency access settings saved');
     } catch (err) {
@@ -314,6 +455,7 @@ function EmergencyAccessSection() {
 
   const inactiveDays = daysSince(view.lastActivityAt);
   const enabledNow = settingsForm.watch('enabled');
+  const { messageMetadata } = view;
 
   return (
     <PageLayout>
@@ -420,27 +562,6 @@ function EmergencyAccessSection() {
               />
             </div>
 
-            <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                Message to your contacts (encrypted)
-              </label>
-              <textarea
-                rows={8}
-                placeholder="Notes, instructions, locations of important documents..."
-                disabled={!view.emailConfigured}
-                className="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm font-mono disabled:opacity-50"
-                {...settingsForm.register('message')}
-              />
-              {settingsForm.formState.errors.message && (
-                <p className="mt-1 text-xs text-red-600 dark:text-red-400">
-                  {settingsForm.formState.errors.message.message}
-                </p>
-              )}
-              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                Encrypted at rest. Plain text only. Maximum 4000 characters.
-              </p>
-            </div>
-
             <div className="flex justify-end">
               <Button
                 type="submit"
@@ -452,6 +573,129 @@ function EmergencyAccessSection() {
             </div>
           </div>
         </form>
+
+        <div className="bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg p-6 mb-6">
+          <div className="flex flex-wrap items-start justify-between gap-3 mb-3">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                Message to your contacts
+              </h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400 max-w-2xl">
+                Encrypted at rest. Viewing or editing requires re-verifying
+                your identity.
+              </p>
+            </div>
+            {messageMode !== 'hidden' && <MessageCountdown />}
+          </div>
+
+          {messageMode === 'hidden' && (
+            <div className="border border-dashed border-gray-300 dark:border-gray-600 rounded-md p-4 flex flex-wrap items-center justify-between gap-3">
+              <div className="text-sm text-gray-700 dark:text-gray-300">
+                {messageMetadata.hasMessage ? (
+                  <>
+                    Message set
+                    <span className="text-gray-500 dark:text-gray-400">
+                      {' '}
+                      ({messageMetadata.charCount} chars
+                      {messageMetadata.updatedAt
+                        ? `, updated ${formatTimestamp(messageMetadata.updatedAt, userTimezone, dateFormat, timeFormat)}`
+                        : ''}
+                      )
+                    </span>
+                  </>
+                ) : (
+                  <span className="text-gray-500 dark:text-gray-400">
+                    No message set
+                  </span>
+                )}
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleReveal}
+                  disabled={
+                    !view.emailConfigured ||
+                    messageLoading ||
+                    !messageMetadata.hasMessage
+                  }
+                >
+                  Reveal message
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={handleEdit}
+                  disabled={!view.emailConfigured || messageLoading}
+                >
+                  {messageMetadata.hasMessage
+                    ? 'Edit message'
+                    : 'Add message'}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {messageMode === 'view' && (
+            <div className="space-y-3">
+              <pre className="whitespace-pre-wrap break-words rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 p-3 text-sm font-mono text-gray-900 dark:text-gray-100">
+                {messageForm.getValues('message') || '(empty)'}
+              </pre>
+              <div className="flex justify-end gap-2">
+                <Button size="sm" variant="outline" onClick={handleLockNow}>
+                  Lock now
+                </Button>
+                <Button size="sm" onClick={() => setMessageMode('edit')}>
+                  Edit
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {messageMode === 'edit' && (
+            <form
+              onSubmit={messageForm.handleSubmit(onMessageSubmit)}
+              className="space-y-3"
+            >
+              <textarea
+                rows={8}
+                placeholder="Notes, instructions, locations of important documents..."
+                className="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm font-mono"
+                {...messageForm.register('message')}
+              />
+              {messageForm.formState.errors.message && (
+                <p className="text-xs text-red-600 dark:text-red-400">
+                  {messageForm.formState.errors.message.message}
+                </p>
+              )}
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                Maximum 4000 characters. Stored encrypted at rest.
+              </p>
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={handleLockNow}
+                  disabled={savingMessage}
+                >
+                  Lock now
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setMessageMode('view')}
+                  disabled={savingMessage}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" size="sm" isLoading={savingMessage}>
+                  Save message
+                </Button>
+              </div>
+            </form>
+          )}
+        </div>
 
         <div className="bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg p-6 mb-6">
           <div className="flex flex-wrap items-start justify-between gap-3 mb-4">
@@ -615,6 +859,22 @@ function EmergencyAccessSection() {
           pushHistory
           onConfirm={handleReset}
           onCancel={() => setShowResetConfirm(false)}
+        />
+
+        <StepUpAuthModal
+          isOpen={stepUpOpen}
+          purpose={STEP_UP_PURPOSE}
+          reason="Re-verify your identity to view or edit your emergency-access message."
+          onClose={() => {
+            setStepUpOpen(false);
+            setPendingMode(null);
+          }}
+          onVerified={() => {
+            setStepUpOpen(false);
+            const mode = pendingMode;
+            setPendingMode(null);
+            if (mode) void fetchMessageInto(mode);
+          }}
         />
       </main>
     </PageLayout>

--- a/frontend/src/components/auth/StepUpAuthModal.test.tsx
+++ b/frontend/src/components/auth/StepUpAuthModal.test.tsx
@@ -10,6 +10,14 @@ vi.mock('@/lib/api', () => ({
 import apiClient from '@/lib/api';
 const mockedApi = apiClient as unknown as { post: ReturnType<typeof vi.fn> };
 
+vi.mock('@/lib/auth', () => ({
+  authApi: { initiateOidc: vi.fn() },
+}));
+import { authApi } from '@/lib/auth';
+const mockedAuthApi = authApi as unknown as {
+  initiateOidc: ReturnType<typeof vi.fn>;
+};
+
 const mockAuthState: {
   user: { authProvider: 'local' | 'oidc'; hasPassword: boolean } | null;
 } = { user: { authProvider: 'local', hasPassword: true } };
@@ -166,19 +174,72 @@ describe('StepUpAuthModal — OIDC user without 2FA', () => {
   beforeEach(() => {
     mockAuthState.user = { authProvider: 'oidc', hasPassword: false };
     mockPrefsState.preferences = { twoFactorEnabled: false };
+    sessionStorage.clear();
   });
 
-  it('renders an "unavailable" notice and a Close button only', async () => {
+  it('renders the redirect notice with Continue / Cancel buttons', async () => {
     await renderModal();
     expect(
-      screen.getByText(/Enable two-factor authentication/i),
+      screen.getByText(/Sign in again with your identity provider/i),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Continue to identity provider/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Cancel$/i })).toBeInTheDocument();
+    // No factor inputs.
     expect(screen.queryByLabelText(/^Password$/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/Authenticator code/i)).not.toBeInTheDocument();
+  });
+
+  it('Cancel invokes onClose and does not redirect', async () => {
+    const onClose = vi.fn();
+    await renderModal({ onClose });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^Cancel$/i }));
+    });
+    expect(onClose).toHaveBeenCalled();
+    expect(mockedAuthApi.initiateOidc).not.toHaveBeenCalled();
+  });
+
+  it('Continue stashes the resume payload + returnTo and redirects to the IdP', async () => {
+    await renderModal({
+      oidcReturnTo: '/settings/emergency-access',
+      oidcResumePayload: { mode: 'edit' },
+    });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Continue to identity provider/i }),
+      );
+    });
+    expect(mockedAuthApi.initiateOidc).toHaveBeenCalled();
+    const pending = JSON.parse(
+      sessionStorage.getItem('stepUpOidcPending') ?? 'null',
+    );
+    expect(pending).toEqual({
+      purpose: 'emergency-access',
+      payload: { mode: 'edit' },
+    });
+    expect(sessionStorage.getItem('postLoginReturnTo')).toBe(
+      '/settings/emergency-access',
+    );
+  });
+});
+
+describe('StepUpAuthModal — local user without password (unavailable)', () => {
+  beforeEach(() => {
+    mockAuthState.user = { authProvider: 'local', hasPassword: false };
+    mockPrefsState.preferences = { twoFactorEnabled: false };
+  });
+
+  it('renders the "finish setup" notice with a Close button', async () => {
+    await renderModal();
+    expect(
+      screen.getByText(/Finish setting up your account password/i),
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Close/i })).toBeInTheDocument();
   });
 
-  it('Close button invokes onClose', async () => {
+  it('Close invokes onClose', async () => {
     const onClose = vi.fn();
     await renderModal({ onClose });
     await act(async () => {

--- a/frontend/src/components/auth/StepUpAuthModal.test.tsx
+++ b/frontend/src/components/auth/StepUpAuthModal.test.tsx
@@ -36,17 +36,17 @@ vi.mock('@/store/preferencesStore', () => ({
 
 async function renderModal(props: Partial<Parameters<typeof StepUpAuthModal>[0]> = {}) {
   let result: ReturnType<typeof render> | undefined;
+  const defaultProps: Parameters<typeof StepUpAuthModal>[0] = {
+    isOpen: true,
+    purpose: 'emergency-access',
+    authProvider: mockAuthState.user?.authProvider ?? 'local',
+    hasPassword: mockAuthState.user?.hasPassword ?? true,
+    reason: 'Re-verify',
+    onClose: vi.fn(),
+    onVerified: vi.fn(),
+  };
   await act(async () => {
-    result = render(
-      <StepUpAuthModal
-        isOpen
-        purpose="emergency-access"
-        reason="Re-verify"
-        onClose={vi.fn()}
-        onVerified={vi.fn()}
-        {...props}
-      />,
-    );
+    result = render(<StepUpAuthModal {...defaultProps} {...props} />);
   });
   return result!;
 }

--- a/frontend/src/components/auth/StepUpAuthModal.test.tsx
+++ b/frontend/src/components/auth/StepUpAuthModal.test.tsx
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { render } from '@/test/render';
+import { StepUpAuthModal } from './StepUpAuthModal';
+import { useStepUpTokenStore } from '@/lib/stepUpToken';
+
+vi.mock('@/lib/api', () => ({
+  default: { post: vi.fn() },
+}));
+import apiClient from '@/lib/api';
+const mockedApi = apiClient as unknown as { post: ReturnType<typeof vi.fn> };
+
+const mockAuthState: {
+  user: { authProvider: 'local' | 'oidc'; hasPassword: boolean } | null;
+} = { user: { authProvider: 'local', hasPassword: true } };
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: (selector: (s: typeof mockAuthState) => unknown) =>
+    selector(mockAuthState),
+}));
+
+const mockPrefsState: { preferences: { twoFactorEnabled: boolean } | null } = {
+  preferences: { twoFactorEnabled: false },
+};
+vi.mock('@/store/preferencesStore', () => ({
+  usePreferencesStore: (selector: (s: typeof mockPrefsState) => unknown) =>
+    selector(mockPrefsState),
+}));
+
+async function renderModal(props: Partial<Parameters<typeof StepUpAuthModal>[0]> = {}) {
+  let result: ReturnType<typeof render> | undefined;
+  await act(async () => {
+    result = render(
+      <StepUpAuthModal
+        isOpen
+        purpose="emergency-access"
+        reason="Re-verify"
+        onClose={vi.fn()}
+        onVerified={vi.fn()}
+        {...props}
+      />,
+    );
+  });
+  return result!;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useStepUpTokenStore.getState().clearAll();
+  mockAuthState.user = { authProvider: 'local', hasPassword: true };
+  mockPrefsState.preferences = { twoFactorEnabled: false };
+});
+
+describe('StepUpAuthModal — TOTP mode (2FA enabled)', () => {
+  beforeEach(() => {
+    mockPrefsState.preferences = { twoFactorEnabled: true };
+  });
+
+  it('renders the 6-digit input and not a password field', async () => {
+    await renderModal();
+    expect(screen.getByLabelText(/Authenticator code/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Password$/i)).not.toBeInTheDocument();
+  });
+
+  it('strips non-digit characters as the user types', async () => {
+    await renderModal();
+    const input = screen.getByLabelText(/Authenticator code/i) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '12a3b4c' } });
+    });
+    expect(input.value).toBe('1234');
+  });
+
+  it('submits the totpCode and stores the token on success', async () => {
+    const onVerified = vi.fn();
+    const onClose = vi.fn();
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+    mockedApi.post.mockResolvedValue({
+      data: { stepUpToken: 'tok-totp', expiresAt },
+    });
+    await renderModal({ onClose, onVerified });
+    const input = screen.getByLabelText(/Authenticator code/i) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '123456' } });
+    });
+    const form = input.closest('form');
+    await act(async () => {
+      fireEvent.submit(form!);
+    });
+    await waitFor(() => expect(mockedApi.post).toHaveBeenCalled());
+    expect(mockedApi.post).toHaveBeenCalledWith('/auth/step-up', {
+      purpose: 'emergency-access',
+      totpCode: '123456',
+    });
+    expect(
+      useStepUpTokenStore.getState().getValid('emergency-access'),
+    ).toBe('tok-totp');
+    expect(onVerified).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows the server error message and does NOT store a token on failure', async () => {
+    mockedApi.post.mockRejectedValue({
+      response: { data: { message: 'Invalid authenticator code' } },
+    });
+    await renderModal();
+    const input = screen.getByLabelText(/Authenticator code/i) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '999999' } });
+    });
+    await act(async () => {
+      fireEvent.submit(input.closest('form')!);
+    });
+    await waitFor(() =>
+      expect(screen.getByText(/Invalid authenticator code/)).toBeInTheDocument(),
+    );
+    expect(useStepUpTokenStore.getState().getValid('emergency-access')).toBeNull();
+  });
+});
+
+describe('StepUpAuthModal — password mode (local, no 2FA)', () => {
+  it('renders the password input and not the TOTP input', async () => {
+    await renderModal();
+    expect(screen.getByLabelText(/^Password$/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Authenticator code/i)).not.toBeInTheDocument();
+  });
+
+  it('submits the password and stores the token on success', async () => {
+    const onVerified = vi.fn();
+    const onClose = vi.fn();
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+    mockedApi.post.mockResolvedValue({
+      data: { stepUpToken: 'tok-pwd', expiresAt },
+    });
+    await renderModal({ onClose, onVerified });
+    const input = screen.getByLabelText(/^Password$/i) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'hunter2' } });
+    });
+    await act(async () => {
+      fireEvent.submit(input.closest('form')!);
+    });
+    await waitFor(() => expect(mockedApi.post).toHaveBeenCalled());
+    expect(mockedApi.post).toHaveBeenCalledWith('/auth/step-up', {
+      purpose: 'emergency-access',
+      password: 'hunter2',
+    });
+    expect(useStepUpTokenStore.getState().getValid('emergency-access')).toBe(
+      'tok-pwd',
+    );
+    expect(onVerified).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('clicking Cancel closes the modal without calling the API', async () => {
+    const onClose = vi.fn();
+    await renderModal({ onClose });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^Cancel$/i }));
+    });
+    expect(onClose).toHaveBeenCalled();
+    expect(mockedApi.post).not.toHaveBeenCalled();
+  });
+});
+
+describe('StepUpAuthModal — OIDC user without 2FA', () => {
+  beforeEach(() => {
+    mockAuthState.user = { authProvider: 'oidc', hasPassword: false };
+    mockPrefsState.preferences = { twoFactorEnabled: false };
+  });
+
+  it('renders an "unavailable" notice and a Close button only', async () => {
+    await renderModal();
+    expect(
+      screen.getByText(/Enable two-factor authentication/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Password$/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Authenticator code/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Close/i })).toBeInTheDocument();
+  });
+
+  it('Close button invokes onClose', async () => {
+    const onClose = vi.fn();
+    await renderModal({ onClose });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Close/i }));
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe('StepUpAuthModal — closed state', () => {
+  it('renders nothing when isOpen is false', async () => {
+    await renderModal({ isOpen: false });
+    expect(screen.queryByText(/Confirm it/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/auth/StepUpAuthModal.tsx
+++ b/frontend/src/components/auth/StepUpAuthModal.tsx
@@ -11,7 +11,6 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import apiClient from '@/lib/api';
 import { authApi } from '@/lib/auth';
-import { useAuthStore } from '@/store/authStore';
 import { usePreferencesStore } from '@/store/preferencesStore';
 import {
   useStepUpTokenStore,
@@ -22,6 +21,18 @@ import { getErrorMessage } from '@/lib/errors';
 interface StepUpAuthModalProps {
   isOpen: boolean;
   purpose: string;
+  /**
+   * Auth provider for the caller's account. REQUIRED -- the auth store's
+   * cached user is hydrated from /auth/profile which (today) omits this
+   * field, so callers must source it from /auth/me-self (`authApi.getSelfProfile`)
+   * or another full-user endpoint before opening the modal.
+   */
+  authProvider: 'local' | 'oidc';
+  /**
+   * Whether the user has a local password set. Same caveat as
+   * `authProvider` -- pass the value from a full-user fetch.
+   */
+  hasPassword: boolean;
   /** Optional headline shown in the modal (e.g. "View your emergency message"). */
   reason?: string;
   onClose: () => void;
@@ -63,22 +74,23 @@ type TotpForm = z.infer<typeof totpSchema>;
 export function StepUpAuthModal({
   isOpen,
   purpose,
+  authProvider,
+  hasPassword,
   reason,
   onClose,
   onVerified,
   oidcReturnTo,
   oidcResumePayload,
 }: StepUpAuthModalProps) {
-  const user = useAuthStore((s) => s.user);
   const preferences = usePreferencesStore((s) => s.preferences);
   const setStepUp = useStepUpTokenStore((s) => s.set);
 
   const twoFactorEnabled = !!preferences?.twoFactorEnabled;
   const mode: 'totp' | 'password' | 'oidc' | 'unavailable' = twoFactorEnabled
     ? 'totp'
-    : user?.authProvider === 'oidc'
+    : authProvider === 'oidc'
       ? 'oidc'
-      : user?.authProvider === 'local' && user?.hasPassword
+      : authProvider === 'local' && hasPassword
         ? 'password'
         : 'unavailable';
 

--- a/frontend/src/components/auth/StepUpAuthModal.tsx
+++ b/frontend/src/components/auth/StepUpAuthModal.tsx
@@ -10,9 +10,13 @@ import { Modal } from '@/components/ui/Modal';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import apiClient from '@/lib/api';
+import { authApi } from '@/lib/auth';
 import { useAuthStore } from '@/store/authStore';
 import { usePreferencesStore } from '@/store/preferencesStore';
-import { useStepUpTokenStore } from '@/lib/stepUpToken';
+import {
+  useStepUpTokenStore,
+  stashOidcStepUpPending,
+} from '@/lib/stepUpToken';
 import { getErrorMessage } from '@/lib/errors';
 
 interface StepUpAuthModalProps {
@@ -23,6 +27,13 @@ interface StepUpAuthModalProps {
   onClose: () => void;
   /** Called after the token is stored in the in-memory step-up store. */
   onVerified?: () => void;
+  /**
+   * Path the user should return to after the OIDC roundtrip, and an
+   * opaque caller-controlled payload that survives the redirect (e.g. which
+   * mode -- 'view' or 'edit' -- to resume in).
+   */
+  oidcReturnTo?: string;
+  oidcResumePayload?: Record<string, unknown>;
 }
 
 const passwordSchema = z.object({
@@ -55,17 +66,32 @@ export function StepUpAuthModal({
   reason,
   onClose,
   onVerified,
+  oidcReturnTo,
+  oidcResumePayload,
 }: StepUpAuthModalProps) {
   const user = useAuthStore((s) => s.user);
   const preferences = usePreferencesStore((s) => s.preferences);
   const setStepUp = useStepUpTokenStore((s) => s.set);
 
   const twoFactorEnabled = !!preferences?.twoFactorEnabled;
-  const mode: 'totp' | 'password' | 'unavailable' = twoFactorEnabled
+  const mode: 'totp' | 'password' | 'oidc' | 'unavailable' = twoFactorEnabled
     ? 'totp'
-    : user?.authProvider === 'local' && user?.hasPassword
-      ? 'password'
-      : 'unavailable';
+    : user?.authProvider === 'oidc'
+      ? 'oidc'
+      : user?.authProvider === 'local' && user?.hasPassword
+        ? 'password'
+        : 'unavailable';
+
+  const handleOidcReauth = () => {
+    // Stash the resume payload + the return-to path so the page can finalize
+    // the step-up after the IdP roundtrip. Then redirect.
+    stashOidcStepUpPending({
+      purpose,
+      returnTo: oidcReturnTo,
+      payload: oidcResumePayload,
+    });
+    authApi.initiateOidc();
+  };
 
   const [submitting, setSubmitting] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
@@ -125,14 +151,28 @@ export function StepUpAuthModal({
         {mode === 'unavailable' ? (
           <div className="px-6 py-6 space-y-4">
             <p className="text-sm text-gray-700 dark:text-gray-300">
-              This action requires extra verification. Your account doesn&apos;t
-              have a password or two-factor authentication enabled, so we
-              can&apos;t challenge you securely. Enable two-factor
-              authentication in the Security section to unlock this setting.
+              This action requires extra verification. Finish setting up your
+              account password (or sign in with your identity provider) before
+              accessing this setting.
             </p>
             <div className="flex justify-end">
               <Button variant="outline" onClick={onClose}>
                 Close
+              </Button>
+            </div>
+          </div>
+        ) : mode === 'oidc' ? (
+          <div className="px-6 py-6 space-y-4">
+            <p className="text-sm text-gray-700 dark:text-gray-300">
+              Sign in again with your identity provider to confirm it&apos;s
+              you. You&apos;ll be brought right back here.
+            </p>
+            <div className="flex justify-end gap-3">
+              <Button variant="outline" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button onClick={handleOidcReauth}>
+                Continue to identity provider
               </Button>
             </div>
           </div>

--- a/frontend/src/components/auth/StepUpAuthModal.tsx
+++ b/frontend/src/components/auth/StepUpAuthModal.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import '@/lib/zodConfig';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import toast from 'react-hot-toast';
+import { Modal } from '@/components/ui/Modal';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import apiClient from '@/lib/api';
+import { useAuthStore } from '@/store/authStore';
+import { usePreferencesStore } from '@/store/preferencesStore';
+import { useStepUpTokenStore } from '@/lib/stepUpToken';
+import { getErrorMessage } from '@/lib/errors';
+
+interface StepUpAuthModalProps {
+  isOpen: boolean;
+  purpose: string;
+  /** Optional headline shown in the modal (e.g. "View your emergency message"). */
+  reason?: string;
+  onClose: () => void;
+  /** Called after the token is stored in the in-memory step-up store. */
+  onVerified?: () => void;
+}
+
+const passwordSchema = z.object({
+  password: z
+    .string()
+    .min(1, 'Password is required')
+    .max(256, 'Password is too long'),
+});
+
+const totpSchema = z.object({
+  totpCode: z
+    .string()
+    .length(6, 'Code must be exactly 6 digits')
+    .regex(/^\d{6}$/, 'Code must be 6 digits'),
+});
+
+type PasswordForm = z.infer<typeof passwordSchema>;
+type TotpForm = z.infer<typeof totpSchema>;
+
+/**
+ * Prompt the user to re-prove possession of the account before unlocking a
+ * sensitive surface. Picks the strongest factor available:
+ *   - 2FA enabled  -> TOTP code
+ *   - local user without 2FA -> password
+ *   - OIDC user without 2FA -> message asking them to enable 2FA first
+ */
+export function StepUpAuthModal({
+  isOpen,
+  purpose,
+  reason,
+  onClose,
+  onVerified,
+}: StepUpAuthModalProps) {
+  const user = useAuthStore((s) => s.user);
+  const preferences = usePreferencesStore((s) => s.preferences);
+  const setStepUp = useStepUpTokenStore((s) => s.set);
+
+  const twoFactorEnabled = !!preferences?.twoFactorEnabled;
+  const mode: 'totp' | 'password' | 'unavailable' = twoFactorEnabled
+    ? 'totp'
+    : user?.authProvider === 'local' && user?.hasPassword
+      ? 'password'
+      : 'unavailable';
+
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const passwordForm = useForm<PasswordForm>({
+    resolver: zodResolver(passwordSchema),
+    defaultValues: { password: '' },
+  });
+  const totpForm = useForm<TotpForm>({
+    resolver: zodResolver(totpSchema),
+    defaultValues: { totpCode: '' },
+  });
+  const totpRef = totpForm.register('totpCode');
+
+  useEffect(() => {
+    if (!isOpen) {
+      passwordForm.reset({ password: '' });
+      totpForm.reset({ totpCode: '' });
+      setServerError(null);
+      setSubmitting(false);
+    }
+  }, [isOpen, passwordForm, totpForm]);
+
+  const submit = async (body: { password?: string; totpCode?: string }) => {
+    setSubmitting(true);
+    setServerError(null);
+    try {
+      const res = await apiClient.post<{
+        stepUpToken: string;
+        expiresAt: string;
+      }>('/auth/step-up', { purpose, ...body });
+      setStepUp(purpose, res.data.stepUpToken, res.data.expiresAt);
+      toast.success('Verified');
+      onVerified?.();
+      onClose();
+    } catch (error) {
+      setServerError(getErrorMessage(error, 'Verification failed'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} maxWidth="md" pushHistory>
+      <div className="flex flex-col">
+        <div className="border-b border-gray-200 dark:border-gray-700 px-6 py-4">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Confirm it&apos;s you
+          </h2>
+          {reason && (
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+              {reason}
+            </p>
+          )}
+        </div>
+
+        {mode === 'unavailable' ? (
+          <div className="px-6 py-6 space-y-4">
+            <p className="text-sm text-gray-700 dark:text-gray-300">
+              This action requires extra verification. Your account doesn&apos;t
+              have a password or two-factor authentication enabled, so we
+              can&apos;t challenge you securely. Enable two-factor
+              authentication in the Security section to unlock this setting.
+            </p>
+            <div className="flex justify-end">
+              <Button variant="outline" onClick={onClose}>
+                Close
+              </Button>
+            </div>
+          </div>
+        ) : mode === 'totp' ? (
+          <form
+            onSubmit={totpForm.handleSubmit((data) =>
+              submit({ totpCode: data.totpCode }),
+            )}
+            className="flex flex-col"
+          >
+            <div className="px-6 py-4 space-y-4">
+              <p className="text-sm text-gray-700 dark:text-gray-300">
+                Enter the 6-digit code from your authenticator app.
+              </p>
+              <Input
+                label="Authenticator code"
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                maxLength={6}
+                placeholder="000000"
+                autoFocus
+                error={totpForm.formState.errors.totpCode?.message}
+                {...totpRef}
+                onChange={(e) => {
+                  const filtered = e.target.value.replace(/\D/g, '');
+                  e.target.value = filtered;
+                  totpRef.onChange(e);
+                }}
+              />
+              {serverError && (
+                <p className="text-sm text-red-600 dark:text-red-400">
+                  {serverError}
+                </p>
+              )}
+            </div>
+            <div className="border-t border-gray-200 dark:border-gray-700 px-6 py-4 flex justify-end gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onClose}
+                disabled={submitting}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" isLoading={submitting}>
+                Verify
+              </Button>
+            </div>
+          </form>
+        ) : (
+          <form
+            onSubmit={passwordForm.handleSubmit((data) =>
+              submit({ password: data.password }),
+            )}
+            className="flex flex-col"
+          >
+            <div className="px-6 py-4 space-y-4">
+              <p className="text-sm text-gray-700 dark:text-gray-300">
+                Enter your current account password to continue.
+              </p>
+              <Input
+                label="Password"
+                type="password"
+                autoComplete="current-password"
+                autoFocus
+                error={passwordForm.formState.errors.password?.message}
+                {...passwordForm.register('password')}
+              />
+              {serverError && (
+                <p className="text-sm text-red-600 dark:text-red-400">
+                  {serverError}
+                </p>
+              )}
+            </div>
+            <div className="border-t border-gray-200 dark:border-gray-700 px-6 py-4 flex justify-end gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onClose}
+                disabled={submitting}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" isLoading={submitting}>
+                Verify
+              </Button>
+            </div>
+          </form>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/lib/emergency-access.test.ts
+++ b/frontend/src/lib/emergency-access.test.ts
@@ -12,6 +12,7 @@ vi.mock('./api', () => ({
 
 import apiClient from './api';
 import { emergencyAccessApi } from './emergency-access';
+import { StepUpRequiredError, useStepUpTokenStore } from './stepUpToken';
 
 type MockClient = Record<string, ReturnType<typeof vi.fn>>;
 const client = apiClient as unknown as MockClient;
@@ -19,6 +20,7 @@ const client = apiClient as unknown as MockClient;
 describe('emergencyAccessApi', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useStepUpTokenStore.getState().clearAll();
   });
 
   it('get() GETs /emergency-access and returns the body', async () => {
@@ -28,13 +30,97 @@ describe('emergencyAccessApi', () => {
     expect(result).toEqual({ enabled: true });
   });
 
-  it('updateSettings() PUTs the payload to /emergency-access/settings', async () => {
+  it('getMessage() GETs /emergency-access/message without a step-up header when none is set', async () => {
+    client.get.mockResolvedValue({ data: { message: 'hi' } });
+    const result = await emergencyAccessApi.getMessage();
+    expect(client.get).toHaveBeenCalledWith('/emergency-access/message', {
+      headers: {},
+    });
+    expect(result).toEqual({ message: 'hi' });
+  });
+
+  it('getMessage() attaches X-Step-Up-Token when a valid token is in the store', async () => {
+    useStepUpTokenStore
+      .getState()
+      .set(
+        'emergency-access',
+        'tok-123',
+        new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+      );
+    client.get.mockResolvedValue({ data: { message: 'secret' } });
+    await emergencyAccessApi.getMessage();
+    expect(client.get).toHaveBeenCalledWith('/emergency-access/message', {
+      headers: { 'X-Step-Up-Token': 'tok-123' },
+    });
+  });
+
+  it('getMessage() rethrows a STEP_UP_REQUIRED error as a typed StepUpRequiredError', async () => {
+    client.get.mockRejectedValue({
+      response: {
+        status: 403,
+        data: { code: 'STEP_UP_REQUIRED', purpose: 'emergency-access' },
+      },
+    });
+    await expect(emergencyAccessApi.getMessage()).rejects.toBeInstanceOf(
+      StepUpRequiredError,
+    );
+  });
+
+  it('getMessage() rethrows STEP_UP_EXPIRED as a typed StepUpRequiredError', async () => {
+    client.get.mockRejectedValue({
+      response: {
+        status: 403,
+        data: { code: 'STEP_UP_EXPIRED', purpose: 'emergency-access' },
+      },
+    });
+    await expect(emergencyAccessApi.getMessage()).rejects.toMatchObject({
+      reason: 'expired',
+    });
+  });
+
+  it('getMessage() rethrows other errors unchanged', async () => {
+    const original = new Error('boom');
+    client.get.mockRejectedValue(original);
+    await expect(emergencyAccessApi.getMessage()).rejects.toBe(original);
+  });
+
+  it('updateMessage() PUTs the body and headers', async () => {
+    useStepUpTokenStore
+      .getState()
+      .set(
+        'emergency-access',
+        'tok-abc',
+        new Date(Date.now() + 60_000).toISOString(),
+      );
+    client.put.mockResolvedValue({
+      data: { hasMessage: true, charCount: 3, updatedAt: null },
+    });
+    await emergencyAccessApi.updateMessage('hi!');
+    expect(client.put).toHaveBeenCalledWith(
+      '/emergency-access/message',
+      { message: 'hi!' },
+      { headers: { 'X-Step-Up-Token': 'tok-abc' } },
+    );
+  });
+
+  it('updateMessage() rethrows STEP_UP_INVALID as a typed error', async () => {
+    client.put.mockRejectedValue({
+      response: {
+        status: 403,
+        data: { code: 'STEP_UP_INVALID', purpose: 'emergency-access' },
+      },
+    });
+    await expect(emergencyAccessApi.updateMessage('hi')).rejects.toMatchObject({
+      reason: 'invalid',
+    });
+  });
+
+  it('updateSettings() PUTs the payload to /emergency-access/settings (no message field)', async () => {
     client.put.mockResolvedValue({ data: { enabled: false } });
     const payload = {
       enabled: false,
       grantAfterDays: 14,
       reminderAfterDays: 7,
-      message: null,
     };
     const result = await emergencyAccessApi.updateSettings(payload);
     expect(client.put).toHaveBeenCalledWith(

--- a/frontend/src/lib/emergency-access.ts
+++ b/frontend/src/lib/emergency-access.ts
@@ -1,16 +1,55 @@
 import apiClient from './api';
+import {
+  rethrowStepUpError,
+  useStepUpTokenStore,
+} from '@/lib/stepUpToken';
 import type {
   EmergencyAccessView,
   EmergencyAccessContact,
+  EmergencyAccessMessageMetadata,
   UpsertEmergencyAccessSettings,
   UpsertEmergencyAccessContact,
   EmergencyAccessClaimPreview,
 } from '@/types/emergency-access';
 
+const STEP_UP_PURPOSE = 'emergency-access';
+
+function stepUpHeader(): Record<string, string> {
+  const token = useStepUpTokenStore.getState().getValid(STEP_UP_PURPOSE);
+  return token ? { 'X-Step-Up-Token': token } : {};
+}
+
 export const emergencyAccessApi = {
   get: async (): Promise<EmergencyAccessView> => {
     const res = await apiClient.get<EmergencyAccessView>('/emergency-access');
     return res.data;
+  },
+
+  getMessage: async (): Promise<{ message: string | null }> => {
+    try {
+      const res = await apiClient.get<{ message: string | null }>(
+        '/emergency-access/message',
+        { headers: stepUpHeader() },
+      );
+      return res.data;
+    } catch (error) {
+      rethrowStepUpError(error);
+    }
+  },
+
+  updateMessage: async (
+    message: string | null,
+  ): Promise<EmergencyAccessMessageMetadata> => {
+    try {
+      const res = await apiClient.put<EmergencyAccessMessageMetadata>(
+        '/emergency-access/message',
+        { message },
+        { headers: stepUpHeader() },
+      );
+      return res.data;
+    } catch (error) {
+      rethrowStepUpError(error);
+    }
   },
 
   updateSettings: async (

--- a/frontend/src/lib/stepUpToken.test.ts
+++ b/frontend/src/lib/stepUpToken.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  StepUpRequiredError,
+  rethrowStepUpError,
+  useStepUpTokenStore,
+} from './stepUpToken';
+
+describe('useStepUpTokenStore', () => {
+  beforeEach(() => {
+    useStepUpTokenStore.getState().clearAll();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    useStepUpTokenStore.getState().clearAll();
+  });
+
+  it('returns null for an unknown purpose', () => {
+    expect(useStepUpTokenStore.getState().getValid('nope')).toBeNull();
+    expect(useStepUpTokenStore.getState().getExpiresAt('nope')).toBeNull();
+  });
+
+  it('stores a token and returns it within the expiry window', () => {
+    const store = useStepUpTokenStore.getState();
+    store.set('emergency-access', 'tok-1', new Date(Date.now() + 60_000).toISOString());
+    expect(store.getValid('emergency-access')).toBe('tok-1');
+    expect(store.getExpiresAt('emergency-access')).toBeGreaterThan(Date.now());
+  });
+
+  it('treats an unparseable expiresAt as a no-op', () => {
+    const store = useStepUpTokenStore.getState();
+    store.set('emergency-access', 'tok-x', 'not-a-date');
+    expect(store.getValid('emergency-access')).toBeNull();
+  });
+
+  it('clears the entry when the timer fires', () => {
+    const store = useStepUpTokenStore.getState();
+    store.set('emergency-access', 'tok-1', new Date(Date.now() + 1000).toISOString());
+    expect(store.getValid('emergency-access')).toBe('tok-1');
+
+    vi.advanceTimersByTime(1500);
+    expect(useStepUpTokenStore.getState().getValid('emergency-access')).toBeNull();
+  });
+
+  it('returns null + lazily clears when the token has expired without the timer firing', () => {
+    const store = useStepUpTokenStore.getState();
+    store.set('emergency-access', 'tok-1', new Date(Date.now() + 1000).toISOString());
+    // Advance the wall clock but suppress timers so the setTimeout doesn't fire.
+    vi.setSystemTime(Date.now() + 2000);
+    expect(useStepUpTokenStore.getState().getValid('emergency-access')).toBeNull();
+    expect(useStepUpTokenStore.getState().entries['emergency-access']).toBeUndefined();
+  });
+
+  it('returns null + lazily clears from getExpiresAt when the token is past expiry', () => {
+    const store = useStepUpTokenStore.getState();
+    store.set('emergency-access', 'tok-1', new Date(Date.now() + 1000).toISOString());
+    vi.setSystemTime(Date.now() + 2000);
+    expect(
+      useStepUpTokenStore.getState().getExpiresAt('emergency-access'),
+    ).toBeNull();
+  });
+
+  it('replaces an existing token + cancels the prior timer when set() is called again', () => {
+    const store = useStepUpTokenStore.getState();
+    store.set('emergency-access', 'tok-1', new Date(Date.now() + 1000).toISOString());
+    store.set('emergency-access', 'tok-2', new Date(Date.now() + 5000).toISOString());
+
+    // Advance past the first token's original expiry — the second one should still be alive.
+    vi.advanceTimersByTime(2000);
+    expect(useStepUpTokenStore.getState().getValid('emergency-access')).toBe(
+      'tok-2',
+    );
+  });
+
+  it('clear() removes the entry and cancels the timer', () => {
+    const store = useStepUpTokenStore.getState();
+    store.set('emergency-access', 'tok-1', new Date(Date.now() + 1000).toISOString());
+    store.clear('emergency-access');
+    expect(useStepUpTokenStore.getState().getValid('emergency-access')).toBeNull();
+  });
+
+  it('clear() on an unknown purpose is a no-op', () => {
+    const store = useStepUpTokenStore.getState();
+    store.set('emergency-access', 'tok-1', new Date(Date.now() + 1000).toISOString());
+    store.clear('something-else');
+    expect(useStepUpTokenStore.getState().getValid('emergency-access')).toBe(
+      'tok-1',
+    );
+  });
+
+  it('clearAll() removes every entry and cancels every timer', () => {
+    const store = useStepUpTokenStore.getState();
+    store.set('a', 'tA', new Date(Date.now() + 1000).toISOString());
+    store.set('b', 'tB', new Date(Date.now() + 1000).toISOString());
+    store.clearAll();
+    expect(useStepUpTokenStore.getState().entries).toEqual({});
+  });
+});
+
+describe('StepUpRequiredError', () => {
+  it('captures purpose + reason and has the right name', () => {
+    const err = new StepUpRequiredError('emergency-access', 'expired');
+    expect(err.purpose).toBe('emergency-access');
+    expect(err.reason).toBe('expired');
+    expect(err.name).toBe('StepUpRequiredError');
+    expect(err.message).toMatch(/expired/);
+  });
+});
+
+describe('rethrowStepUpError', () => {
+  it('converts STEP_UP_REQUIRED responses to StepUpRequiredError', () => {
+    try {
+      rethrowStepUpError({
+        response: {
+          status: 403,
+          data: { code: 'STEP_UP_REQUIRED', purpose: 'emergency-access' },
+        },
+      });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(StepUpRequiredError);
+      expect((err as StepUpRequiredError).reason).toBe('required');
+    }
+  });
+
+  it('converts STEP_UP_EXPIRED', () => {
+    try {
+      rethrowStepUpError({
+        response: {
+          status: 403,
+          data: { code: 'STEP_UP_EXPIRED', purpose: 'emergency-access' },
+        },
+      });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as StepUpRequiredError).reason).toBe('expired');
+    }
+  });
+
+  it('converts STEP_UP_INVALID', () => {
+    try {
+      rethrowStepUpError({
+        response: {
+          status: 403,
+          data: { code: 'STEP_UP_INVALID', purpose: 'emergency-access' },
+        },
+      });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as StepUpRequiredError).reason).toBe('invalid');
+    }
+  });
+
+  it('defaults purpose to empty string when the server omits it', () => {
+    try {
+      rethrowStepUpError({
+        response: { status: 403, data: { code: 'STEP_UP_REQUIRED' } },
+      });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as StepUpRequiredError).purpose).toBe('');
+    }
+  });
+
+  it('rethrows non-step-up errors unchanged', () => {
+    const original = new Error('boom');
+    expect(() => rethrowStepUpError(original)).toThrow(original);
+  });
+
+  it('rethrows responses with a different error code unchanged', () => {
+    const error = {
+      response: { status: 403, data: { code: 'CSRF_FAIL' } },
+    };
+    expect(() => rethrowStepUpError(error)).toThrow();
+  });
+
+  it('rethrows non-object thrown values unchanged', () => {
+    expect(() => rethrowStepUpError('plain-string')).toThrow();
+    expect(() => rethrowStepUpError(null)).toThrow();
+  });
+
+  it('rethrows objects that have no response field', () => {
+    const error = { foo: 'bar' };
+    expect(() => rethrowStepUpError(error)).toThrow();
+  });
+});

--- a/frontend/src/lib/stepUpToken.test.ts
+++ b/frontend/src/lib/stepUpToken.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   StepUpRequiredError,
+  consumeOidcStepUpPending,
   rethrowStepUpError,
+  stashOidcStepUpPending,
   useStepUpTokenStore,
 } from './stepUpToken';
 
@@ -105,6 +107,86 @@ describe('StepUpRequiredError', () => {
     expect(err.reason).toBe('expired');
     expect(err.name).toBe('StepUpRequiredError');
     expect(err.message).toMatch(/expired/);
+  });
+});
+
+describe('OIDC step-up pending sentinel', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('stashes the purpose + payload and the returnTo path', () => {
+    stashOidcStepUpPending({
+      purpose: 'emergency-access',
+      returnTo: '/settings/emergency-access',
+      payload: { mode: 'view' },
+    });
+    expect(
+      JSON.parse(sessionStorage.getItem('stepUpOidcPending') ?? 'null'),
+    ).toEqual({ purpose: 'emergency-access', payload: { mode: 'view' } });
+    expect(sessionStorage.getItem('postLoginReturnTo')).toBe(
+      '/settings/emergency-access',
+    );
+  });
+
+  it('omits postLoginReturnTo when no returnTo is given', () => {
+    stashOidcStepUpPending({ purpose: 'emergency-access' });
+    expect(sessionStorage.getItem('stepUpOidcPending')).not.toBeNull();
+    expect(sessionStorage.getItem('postLoginReturnTo')).toBeNull();
+  });
+
+  it('consumes the sentinel and returns the payload', () => {
+    stashOidcStepUpPending({
+      purpose: 'emergency-access',
+      payload: { mode: 'edit' },
+    });
+    const result = consumeOidcStepUpPending('emergency-access');
+    expect(result).toEqual({
+      purpose: 'emergency-access',
+      payload: { mode: 'edit' },
+    });
+    // Removed after the first read.
+    expect(sessionStorage.getItem('stepUpOidcPending')).toBeNull();
+    expect(consumeOidcStepUpPending('emergency-access')).toBeNull();
+  });
+
+  it('ignores a sentinel for a different purpose', () => {
+    stashOidcStepUpPending({ purpose: 'emergency-access' });
+    expect(consumeOidcStepUpPending('something-else')).toBeNull();
+    // And the sentinel for the real purpose is still there.
+    expect(sessionStorage.getItem('stepUpOidcPending')).not.toBeNull();
+  });
+
+  it('returns null and clears the slot when the JSON is corrupt', () => {
+    sessionStorage.setItem('stepUpOidcPending', '{not-json');
+    expect(consumeOidcStepUpPending('emergency-access')).toBeNull();
+    expect(sessionStorage.getItem('stepUpOidcPending')).toBeNull();
+  });
+
+  it('returns null when no sentinel is stored', () => {
+    expect(consumeOidcStepUpPending('emergency-access')).toBeNull();
+  });
+
+  it('tolerates sessionStorage throwing when writing', () => {
+    const setSpy = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('quota');
+      });
+    expect(() =>
+      stashOidcStepUpPending({ purpose: 'emergency-access' }),
+    ).not.toThrow();
+    setSpy.mockRestore();
+  });
+
+  it('tolerates sessionStorage throwing when reading', () => {
+    const getSpy = vi
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementation(() => {
+        throw new Error('blocked');
+      });
+    expect(consumeOidcStepUpPending('emergency-access')).toBeNull();
+    getSpy.mockRestore();
   });
 });
 

--- a/frontend/src/lib/stepUpToken.ts
+++ b/frontend/src/lib/stepUpToken.ts
@@ -1,0 +1,137 @@
+import { create } from 'zustand';
+
+/**
+ * In-memory step-up token store.
+ *
+ * Tokens are bearer credentials -- they MUST NOT be persisted to localStorage
+ * or sessionStorage. They live for ~5 minutes, die with the tab, and an XSS
+ * payload reading window storage finds nothing.
+ *
+ * Keyed by purpose ("emergency-access", ...) so the same primitive can guard
+ * other sensitive surfaces in the future without leaking a token between them.
+ */
+interface StepUpEntry {
+  token: string;
+  expiresAt: number; // epoch ms
+}
+
+interface StepUpState {
+  entries: Record<string, StepUpEntry>;
+  set: (purpose: string, token: string, expiresAt: string) => void;
+  clear: (purpose: string) => void;
+  clearAll: () => void;
+  getValid: (purpose: string) => string | null;
+  getExpiresAt: (purpose: string) => number | null;
+}
+
+const expiryTimers: Record<string, ReturnType<typeof setTimeout>> = {};
+
+export const useStepUpTokenStore = create<StepUpState>((set, get) => ({
+  entries: {},
+
+  set: (purpose, token, expiresAt) => {
+    const expiresAtMs = new Date(expiresAt).getTime();
+    if (Number.isNaN(expiresAtMs)) return;
+
+    // Replace any pending expiry for this purpose.
+    if (expiryTimers[purpose]) {
+      clearTimeout(expiryTimers[purpose]);
+    }
+    const delay = Math.max(0, expiresAtMs - Date.now());
+    expiryTimers[purpose] = setTimeout(() => {
+      get().clear(purpose);
+    }, delay);
+
+    set((state) => ({
+      entries: { ...state.entries, [purpose]: { token, expiresAt: expiresAtMs } },
+    }));
+  },
+
+  clear: (purpose) => {
+    if (expiryTimers[purpose]) {
+      clearTimeout(expiryTimers[purpose]);
+      delete expiryTimers[purpose];
+    }
+    set((state) => {
+      if (!state.entries[purpose]) return state;
+      const { [purpose]: _removed, ...rest } = state.entries;
+      return { entries: rest };
+    });
+  },
+
+  clearAll: () => {
+    for (const purpose of Object.keys(expiryTimers)) {
+      clearTimeout(expiryTimers[purpose]);
+      delete expiryTimers[purpose];
+    }
+    set({ entries: {} });
+  },
+
+  getValid: (purpose) => {
+    const entry = get().entries[purpose];
+    if (!entry) return null;
+    if (entry.expiresAt <= Date.now()) {
+      get().clear(purpose);
+      return null;
+    }
+    return entry.token;
+  },
+
+  getExpiresAt: (purpose) => {
+    const entry = get().entries[purpose];
+    if (!entry) return null;
+    if (entry.expiresAt <= Date.now()) {
+      get().clear(purpose);
+      return null;
+    }
+    return entry.expiresAt;
+  },
+}));
+
+/**
+ * Error thrown when an API call is rejected because step-up auth is
+ * required or has expired. Callers (the page that owns the modal) catch
+ * this and re-prompt the user.
+ */
+export class StepUpRequiredError extends Error {
+  readonly purpose: string;
+  readonly reason: 'required' | 'expired' | 'invalid';
+
+  constructor(purpose: string, reason: 'required' | 'expired' | 'invalid') {
+    super(`Step-up auth ${reason} for ${purpose}`);
+    this.purpose = purpose;
+    this.reason = reason;
+    this.name = 'StepUpRequiredError';
+  }
+}
+
+/**
+ * Inspect an axios error and, if it carries a STEP_UP_* code from the
+ * backend, throw a typed `StepUpRequiredError`. Otherwise rethrow as-is.
+ *
+ * Used to wrap calls to step-up gated endpoints so the page-level catch
+ * block stays narrow.
+ */
+export function rethrowStepUpError(error: unknown): never {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'response' in error &&
+    error.response &&
+    typeof error.response === 'object'
+  ) {
+    const data = (error.response as { data?: unknown }).data as
+      | { code?: string; purpose?: string }
+      | undefined;
+    if (data?.code === 'STEP_UP_REQUIRED') {
+      throw new StepUpRequiredError(data.purpose ?? '', 'required');
+    }
+    if (data?.code === 'STEP_UP_EXPIRED') {
+      throw new StepUpRequiredError(data.purpose ?? '', 'expired');
+    }
+    if (data?.code === 'STEP_UP_INVALID') {
+      throw new StepUpRequiredError(data.purpose ?? '', 'invalid');
+    }
+  }
+  throw error;
+}

--- a/frontend/src/lib/stepUpToken.ts
+++ b/frontend/src/lib/stepUpToken.ts
@@ -106,6 +106,69 @@ export class StepUpRequiredError extends Error {
 }
 
 /**
+ * OIDC users can't enroll Monize-managed 2FA and have no local password, so
+ * step-up uses the same soft-check pattern as the existing delete-account /
+ * backup-restore flows: redirect through the identity provider, then call
+ * the step-up endpoint with `oidcConfirmed=true` after the rotated session
+ * cookies come back.
+ *
+ * We persist a sentinel in sessionStorage across the redirect so the
+ * destination page can:
+ *   - Recognize that we just returned from OIDC for step-up
+ *   - Resume the action the user wanted (e.g. open the message editor)
+ *
+ * Stored as JSON in `stepUpOidcPending`. The Next.js auth callback respects
+ * `postLoginReturnTo` to bring the user back to the right page.
+ */
+const PENDING_KEY = 'stepUpOidcPending';
+
+export interface OidcStepUpPending {
+  purpose: string;
+  /** Optional opaque payload (mode, item id, ...) the caller wants back. */
+  payload?: Record<string, unknown>;
+}
+
+export function stashOidcStepUpPending(args: {
+  purpose: string;
+  returnTo?: string;
+  payload?: Record<string, unknown>;
+}): void {
+  try {
+    sessionStorage.setItem(
+      PENDING_KEY,
+      JSON.stringify({ purpose: args.purpose, payload: args.payload }),
+    );
+    if (args.returnTo) {
+      sessionStorage.setItem('postLoginReturnTo', args.returnTo);
+    }
+  } catch {
+    // sessionStorage unavailable -- the caller will simply not be resumed.
+  }
+}
+
+export function consumeOidcStepUpPending(
+  purpose: string,
+): OidcStepUpPending | null {
+  let raw: string | null = null;
+  try {
+    raw = sessionStorage.getItem(PENDING_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+  let parsed: OidcStepUpPending | null = null;
+  try {
+    parsed = JSON.parse(raw) as OidcStepUpPending;
+  } catch {
+    sessionStorage.removeItem(PENDING_KEY);
+    return null;
+  }
+  if (!parsed || parsed.purpose !== purpose) return null;
+  sessionStorage.removeItem(PENDING_KEY);
+  return parsed;
+}
+
+/**
  * Inspect an axios error and, if it carries a STEP_UP_* code from the
  * backend, throw a typed `StepUpRequiredError`. Otherwise rethrow as-is.
  *

--- a/frontend/src/types/emergency-access.ts
+++ b/frontend/src/types/emergency-access.ts
@@ -5,12 +5,18 @@ export interface EmergencyAccessContact {
   createdAt: string;
 }
 
+export interface EmergencyAccessMessageMetadata {
+  hasMessage: boolean;
+  charCount: number;
+  updatedAt: string | null;
+}
+
 export interface EmergencyAccessView {
   emailConfigured: boolean;
   enabled: boolean;
   grantAfterDays: number;
   reminderAfterDays: number;
-  message: string | null;
+  messageMetadata: EmergencyAccessMessageMetadata;
   lastReminderSentAt: string | null;
   grantedAt: string | null;
   lastActivityAt: string | null;
@@ -21,7 +27,6 @@ export interface UpsertEmergencyAccessSettings {
   enabled: boolean;
   grantAfterDays: number;
   reminderAfterDays: number;
-  message?: string | null;
 }
 
 export interface UpsertEmergencyAccessContact {


### PR DESCRIPTION
## Summary

Implements step-up re-authentication to gate access to the plaintext emergency access message. Users must re-prove account possession (via TOTP, password, or OIDC) before viewing or editing their message. The message plaintext is never exposed via the API view endpoint—only metadata (presence, character count, last update time) is returned.

## Key Changes

**Backend**
- New `StepUpAuthService` that issues short-lived (5-minute) JWT tokens scoped to a specific purpose after verifying the user's strongest authentication factor (TOTP > password > OIDC)
- New `StepUpGuard` that validates step-up tokens on protected endpoints via `x-step-up-token` header
- New `@RequireStepUp(purpose)` decorator to mark handlers requiring step-up verification
- `EmergencyAccessService.getMessage()` endpoint that returns the decrypted plaintext message (requires step-up token)
- `EmergencyAccessService.updateMessage()` endpoint for editing the message (requires step-up token)
- `EmergencyAccessService.getView()` now returns `messageMetadata` (hasMessage, charCount, updatedAt) instead of plaintext
- `TwoFactorService.verifyTotpForUser()` for step-up TOTP verification with replay protection
- New DTOs: `VerifyStepUpDto`, `UpdateMessageDto`

**Frontend**
- New `StepUpAuthModal` component that prompts for re-authentication (TOTP code, password, or OIDC redirect)
- New `useStepUpTokenStore` (Zustand) for in-memory token storage with automatic expiry
- New `stepUpToken` utilities: `StepUpRequiredError`, `consumeOidcStepUpPending()`, `stashOidcStepUpPending()` for OIDC roundtrip handling
- `EmergencyAccessPage` now:
  - Fetches full user profile (`authApi.getSelfProfile()`) to get `authProvider` and `hasPassword` for the modal
  - Manages message reveal/edit modes with step-up gating
  - Displays message metadata when no plaintext is available
  - Handles OIDC step-up completion on mount (via sessionStorage sentinel)
  - Shows countdown timer while step-up token is valid
- `emergencyAccessApi` wraps `getMessage()` and `updateMessage()` calls with step-up token injection
- Updated test fixtures and mocks throughout

## Implementation Details

- **Token Storage**: Step-up tokens live in-memory only (never persisted to localStorage/sessionStorage) and die with the tab, mitigating XSS risk
- **OIDC Roundtrip**: When OIDC users initiate step-up, the modal stashes the resume payload in sessionStorage, redirects to the OIDC provider, and on return the page finalizes the token exchange via `/auth/step-up?oidcConfirmed=true`
- **Message Metadata**: The plaintext message is decrypted server-side only when explicitly requested via `getMessage()` with a valid step-up token; the view endpoint never exposes it
- **Replay Protection**: TOTP codes used for step-up verification are tracked in the same replay window as login 2FA, preventing code reuse
- **Countdown UI**: Uses `useSyncExternalStore` to subscribe to wall-clock time updates (once per second) while the token is valid, avoiding setState-in-effect anti-pattern

https://claude.ai/code/session_01FBq5m7BgwK7jCzswCF7s5N