### PR TITLE
Add transaction-type selector to Investments New Transaction button

### DIFF
--- a/frontend/src/app/admin/users/page.test.tsx
+++ b/frontend/src/app/admin/users/page.test.tsx
@@ -438,10 +438,10 @@ describe('AdminUsersPage', () => {
   });
 
   describe('Create User', () => {
-    it('opens the create user modal from the Add User button', async () => {
+    it('opens the create user modal from the New User button', async () => {
       render(<AdminUsersPage />);
       await waitFor(() => expect(screen.getByTestId('user-table')).toBeInTheDocument());
-      fireEvent.click(screen.getByText('Add User'));
+      fireEvent.click(screen.getByText('+ New User'));
       await waitFor(() => expect(screen.getByTestId('create-user-modal')).toBeInTheDocument());
     });
 
@@ -449,14 +449,14 @@ describe('AdminUsersPage', () => {
       mockGetSmtpStatus.mockResolvedValue({ configured: false });
       render(<AdminUsersPage />);
       await waitFor(() => expect(screen.getByTestId('user-table')).toBeInTheDocument());
-      fireEvent.click(screen.getByText('Add User'));
+      fireEvent.click(screen.getByText('+ New User'));
       await waitFor(() => expect(screen.getByText('smtp:false')).toBeInTheDocument());
     });
 
     it('shows the temporary password modal and reloads after creation', async () => {
       render(<AdminUsersPage />);
       await waitFor(() => expect(screen.getByTestId('user-table')).toBeInTheDocument());
-      fireEvent.click(screen.getByText('Add User'));
+      fireEvent.click(screen.getByText('+ New User'));
       await waitFor(() => expect(screen.getByTestId('create-user-modal')).toBeInTheDocument());
       fireEvent.click(screen.getByText('Created With Temp'));
       await waitFor(() => {
@@ -470,7 +470,7 @@ describe('AdminUsersPage', () => {
       const toast = await import('react-hot-toast');
       render(<AdminUsersPage />);
       await waitFor(() => expect(screen.getByTestId('user-table')).toBeInTheDocument());
-      fireEvent.click(screen.getByText('Add User'));
+      fireEvent.click(screen.getByText('+ New User'));
       await waitFor(() => expect(screen.getByTestId('create-user-modal')).toBeInTheDocument());
       fireEvent.click(screen.getByText('Created With Invite'));
       await waitFor(() =>

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -247,7 +247,7 @@ export default function AdminUsersPage() {
             title="User Management"
             subtitle={`${users.length} user${users.length !== 1 ? 's' : ''}`}
             actions={
-              <Button onClick={() => setCreateModalOpen(true)}>Add User</Button>
+              <Button onClick={() => setCreateModalOpen(true)}>+ New User</Button>
             }
           />
 

--- a/frontend/src/app/investments/page.test.tsx
+++ b/frontend/src/app/investments/page.test.tsx
@@ -632,6 +632,7 @@ describe('InvestmentsPage', () => {
       });
 
       fireEvent.click(screen.getByText('+ New Transaction'));
+      fireEvent.click(screen.getByText('Investment Transaction'));
 
       expect(mockOpenCreate).toHaveBeenCalled();
     });

--- a/frontend/src/app/investments/page.tsx
+++ b/frontend/src/app/investments/page.tsx
@@ -15,6 +15,7 @@ import { PortfolioSummaryCard } from '@/components/investments/PortfolioSummaryC
 import { GroupedHoldingsList } from '@/components/investments/GroupedHoldingsList';
 import { AssetAllocationChart } from '@/components/investments/AssetAllocationChart';
 import { InvestmentTransactionList } from '@/components/investments/InvestmentTransactionList';
+import { NewTransactionButton } from '@/components/investments/NewTransactionButton';
 import { DensityLevel, nextDensity } from '@/hooks/useTableDensity';
 import { InvestmentTransactionForm } from '@/components/investments/InvestmentTransactionForm';
 import {
@@ -214,7 +215,10 @@ function InvestmentsContent() {
                     )}
                   </Button>
                 </div>
-                <Button onClick={data.handleNewTransaction} className="whitespace-nowrap">+ New Transaction</Button>
+                <NewTransactionButton
+                  onNewInvestment={data.handleNewTransaction}
+                  onNewCash={data.openCashCreate}
+                />
               </>
             }
           />

--- a/frontend/src/components/admin/UserManagementTable.tsx
+++ b/frontend/src/components/admin/UserManagementTable.tsx
@@ -75,7 +75,7 @@ export function UserManagementTable({
           {sortedUsers.map((user) => {
             const isSelf = user.id === currentUserId;
             return (
-              <tr key={user.id} className={`group hover:bg-gray-100 dark:hover:bg-gray-800 ${isSelf ? 'bg-blue-50/50 dark:bg-blue-900/10' : 'bg-white dark:bg-gray-900'}`}>
+              <tr key={user.id} className={`group hover:bg-gray-100 dark:hover:bg-gray-800 ${isSelf ? 'bg-blue-50 dark:bg-blue-950' : 'bg-white dark:bg-gray-900'}`}>
                 {/* User info */}
                 <td className="px-6 py-4 whitespace-nowrap">
                   <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
@@ -137,7 +137,7 @@ export function UserManagementTable({
                 </td>
 
                 {/* Actions */}
-                <td className={`px-6 py-4 whitespace-nowrap text-right text-sm space-x-2 sticky right-0 ${isSelf ? 'bg-blue-50/50 dark:bg-blue-900/10' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`}>
+                <td className={`px-6 py-4 whitespace-nowrap text-right text-sm space-x-2 sticky right-0 ${isSelf ? 'bg-blue-50 dark:bg-blue-950' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`}>
                   {!isSelf && (
                     <>
                       {user.hasPassword && (

--- a/frontend/src/components/bills/CashFlowForecastChart.test.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.test.tsx
@@ -122,6 +122,20 @@ describe('CashFlowForecastChart', () => {
     expect(screen.getByText('All Accounts')).toBeInTheDocument();
   });
 
+  it('lists favourite accounts above non-favourites in the account selector', () => {
+    const accounts = [
+      makeAccount({ id: 'a1', name: 'Apple', isFavourite: false }),
+      makeAccount({ id: 'a2', name: 'Zebra', isFavourite: true, favouriteSortOrder: 0 }),
+    ];
+    render(
+      <CashFlowForecastChart scheduledTransactions={[]} accounts={accounts} isLoading={false} />
+    );
+    const select = screen.getByRole('combobox') as HTMLSelectElement;
+    const labels = Array.from(select.options).map((o) => o.textContent);
+    expect(labels[0]).toBe('All Accounts');
+    expect(labels.indexOf('Zebra')).toBeLessThan(labels.indexOf('Apple'));
+  });
+
   it('renders chart with forecast data and summary footer', () => {
     const forecastData = [
       { label: 'Today', balance: 1000, transactions: [] },

--- a/frontend/src/components/bills/CashFlowForecastChart.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.tsx
@@ -14,6 +14,7 @@ import {
 import { ScheduledTransaction } from '@/types/scheduled-transaction';
 import { Account } from '@/types/account';
 import { Select } from '@/components/ui/Select';
+import { buildAccountDropdownOptions } from '@/lib/account-utils';
 import {
   buildForecast,
   getForecastSummary,
@@ -131,10 +132,11 @@ export function CashFlowForecastChart({
   const accountOptions = useMemo(() => {
     return [
       { value: 'all', label: 'All Accounts' },
-      ...accounts
-        .filter(a => !a.isClosed && a.accountType !== 'ASSET' && a.accountSubType !== 'INVESTMENT_BROKERAGE')
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map(a => ({ value: a.id, label: a.name })),
+      ...buildAccountDropdownOptions(
+        accounts,
+        a => !a.isClosed && a.accountType !== 'ASSET' && a.accountSubType !== 'INVESTMENT_BROKERAGE',
+        a => a.name,
+      ),
     ];
   }, [accounts]);
 

--- a/frontend/src/components/budgets/BudgetAlertBadge.tsx
+++ b/frontend/src/components/budgets/BudgetAlertBadge.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import { budgetsApi } from '@/lib/budgets';
 import type { BudgetAlert } from '@/types/budget';
 import { BudgetAlertList } from './BudgetAlertList';
@@ -32,18 +33,7 @@ export function BudgetAlertBadge() {
     fetchAlerts();
   }, [fetchAlerts]);
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
-      ) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  useClickOutside(dropdownRef, () => setIsOpen(false));
 
   const handleMarkRead = async (alertId: string) => {
     try {

--- a/frontend/src/components/investments/NewTransactionButton.test.tsx
+++ b/frontend/src/components/investments/NewTransactionButton.test.tsx
@@ -47,4 +47,17 @@ describe('NewTransactionButton', () => {
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(screen.queryByText('Investment Transaction')).not.toBeInTheDocument();
   });
+
+  it('closes the menu when clicking outside', () => {
+    render(
+      <div>
+        <NewTransactionButton onNewInvestment={vi.fn()} onNewCash={vi.fn()} />
+        <span data-testid="outside">outside</span>
+      </div>
+    );
+    fireEvent.click(screen.getByText('+ New Transaction'));
+    expect(screen.getByText('Investment Transaction')).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+    expect(screen.queryByText('Investment Transaction')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/investments/NewTransactionButton.test.tsx
+++ b/frontend/src/components/investments/NewTransactionButton.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@/test/render';
+import { fireEvent, screen } from '@testing-library/react';
+import { NewTransactionButton } from './NewTransactionButton';
+
+describe('NewTransactionButton', () => {
+  it('renders the New Transaction trigger', () => {
+    render(<NewTransactionButton onNewInvestment={vi.fn()} onNewCash={vi.fn()} />);
+    expect(screen.getByText('+ New Transaction')).toBeInTheDocument();
+  });
+
+  it('shows both options when clicked', () => {
+    render(<NewTransactionButton onNewInvestment={vi.fn()} onNewCash={vi.fn()} />);
+    fireEvent.click(screen.getByText('+ New Transaction'));
+    expect(screen.getByText('Investment Transaction')).toBeInTheDocument();
+    expect(screen.getByText('Cash Transaction')).toBeInTheDocument();
+  });
+
+  it('calls onNewInvestment when Investment Transaction is clicked', () => {
+    const onNewInvestment = vi.fn();
+    render(<NewTransactionButton onNewInvestment={onNewInvestment} onNewCash={vi.fn()} />);
+    fireEvent.click(screen.getByText('+ New Transaction'));
+    fireEvent.click(screen.getByText('Investment Transaction'));
+    expect(onNewInvestment).toHaveBeenCalledOnce();
+  });
+
+  it('calls onNewCash when Cash Transaction is clicked', () => {
+    const onNewCash = vi.fn();
+    render(<NewTransactionButton onNewInvestment={vi.fn()} onNewCash={onNewCash} />);
+    fireEvent.click(screen.getByText('+ New Transaction'));
+    fireEvent.click(screen.getByText('Cash Transaction'));
+    expect(onNewCash).toHaveBeenCalledOnce();
+  });
+
+  it('closes the menu after selecting an option', () => {
+    render(<NewTransactionButton onNewInvestment={vi.fn()} onNewCash={vi.fn()} />);
+    fireEvent.click(screen.getByText('+ New Transaction'));
+    expect(screen.getByText('Cash Transaction')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Cash Transaction'));
+    expect(screen.queryByText('Cash Transaction')).not.toBeInTheDocument();
+  });
+
+  it('closes the menu on Escape', () => {
+    render(<NewTransactionButton onNewInvestment={vi.fn()} onNewCash={vi.fn()} />);
+    fireEvent.click(screen.getByText('+ New Transaction'));
+    expect(screen.getByText('Investment Transaction')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByText('Investment Transaction')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/investments/NewTransactionButton.tsx
+++ b/frontend/src/components/investments/NewTransactionButton.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import { Button } from '@/components/ui/Button';
+import { useClickOutside } from '@/hooks/useClickOutside';
 
 interface NewTransactionButtonProps {
   onNewInvestment: () => void;
@@ -18,26 +19,13 @@ export function NewTransactionButton({ onNewInvestment, onNewCash }: NewTransact
 
   const close = useCallback(() => setIsOpen(false), []);
 
-  useEffect(() => {
-    if (!isOpen) return;
-    function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        close();
-      }
-    }
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        close();
-        triggerRef.current?.focus();
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [isOpen, close]);
+  useClickOutside(dropdownRef, close, {
+    enabled: isOpen,
+    onEscape: () => {
+      close();
+      triggerRef.current?.focus();
+    },
+  });
 
   const handleInvestment = () => {
     close();

--- a/frontend/src/components/investments/NewTransactionButton.tsx
+++ b/frontend/src/components/investments/NewTransactionButton.tsx
@@ -8,9 +8,13 @@ interface NewTransactionButtonProps {
   onNewCash: () => void;
 }
 
+const menuItemClass =
+  'w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700';
+
 export function NewTransactionButton({ onNewInvestment, onNewCash }: NewTransactionButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   const close = useCallback(() => setIsOpen(false), []);
 
@@ -22,7 +26,10 @@ export function NewTransactionButton({ onNewInvestment, onNewCash }: NewTransact
       }
     }
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === 'Escape') close();
+      if (event.key === 'Escape') {
+        close();
+        triggerRef.current?.focus();
+      }
     }
     document.addEventListener('mousedown', handleClickOutside);
     document.addEventListener('keydown', handleKeyDown);
@@ -45,9 +52,10 @@ export function NewTransactionButton({ onNewInvestment, onNewCash }: NewTransact
   return (
     <div ref={dropdownRef} className="relative block w-full sm:inline-block sm:w-auto">
       <Button
+        ref={triggerRef}
         onClick={() => setIsOpen((open) => !open)}
         className="w-full whitespace-nowrap sm:w-auto"
-        aria-haspopup="menu"
+        aria-haspopup="true"
         aria-expanded={isOpen}
       >
         + New Transaction
@@ -57,22 +65,11 @@ export function NewTransactionButton({ onNewInvestment, onNewCash }: NewTransact
       </Button>
 
       {isOpen && (
-        <div
-          role="menu"
-          className="absolute right-0 mt-1 w-full sm:w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg z-50"
-        >
-          <button
-            role="menuitem"
-            onClick={handleInvestment}
-            className="w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-t-md"
-          >
+        <div className="absolute right-0 mt-1 w-full sm:w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg z-50">
+          <button onClick={handleInvestment} className={`${menuItemClass} rounded-t-md`}>
             Investment Transaction
           </button>
-          <button
-            role="menuitem"
-            onClick={handleCash}
-            className="w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-b-md"
-          >
+          <button onClick={handleCash} className={`${menuItemClass} rounded-b-md`}>
             Cash Transaction
           </button>
         </div>

--- a/frontend/src/components/investments/NewTransactionButton.tsx
+++ b/frontend/src/components/investments/NewTransactionButton.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { Button } from '@/components/ui/Button';
+
+interface NewTransactionButtonProps {
+  onNewInvestment: () => void;
+  onNewCash: () => void;
+}
+
+export function NewTransactionButton({ onNewInvestment, onNewCash }: NewTransactionButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => setIsOpen(false), []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        close();
+      }
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') close();
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, close]);
+
+  const handleInvestment = () => {
+    close();
+    onNewInvestment();
+  };
+
+  const handleCash = () => {
+    close();
+    onNewCash();
+  };
+
+  return (
+    <div ref={dropdownRef} className="relative inline-block">
+      <Button
+        onClick={() => setIsOpen((open) => !open)}
+        className="whitespace-nowrap"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+      >
+        + New Transaction
+        <svg className="ml-1.5 h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </Button>
+
+      {isOpen && (
+        <div
+          role="menu"
+          className="absolute right-0 mt-1 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg z-50"
+        >
+          <button
+            role="menuitem"
+            onClick={handleInvestment}
+            className="w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-t-md"
+          >
+            Investment Transaction
+          </button>
+          <button
+            role="menuitem"
+            onClick={handleCash}
+            className="w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-b-md"
+          >
+            Cash Transaction
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/investments/NewTransactionButton.tsx
+++ b/frontend/src/components/investments/NewTransactionButton.tsx
@@ -43,10 +43,10 @@ export function NewTransactionButton({ onNewInvestment, onNewCash }: NewTransact
   };
 
   return (
-    <div ref={dropdownRef} className="relative inline-block">
+    <div ref={dropdownRef} className="relative block w-full sm:inline-block sm:w-auto">
       <Button
         onClick={() => setIsOpen((open) => !open)}
-        className="whitespace-nowrap"
+        className="w-full whitespace-nowrap sm:w-auto"
         aria-haspopup="menu"
         aria-expanded={isOpen}
       >
@@ -59,7 +59,7 @@ export function NewTransactionButton({ onNewInvestment, onNewCash }: NewTransact
       {isOpen && (
         <div
           role="menu"
-          className="absolute right-0 mt-1 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg z-50"
+          className="absolute right-0 mt-1 w-full sm:w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg z-50"
         >
           <button
             role="menuitem"

--- a/frontend/src/components/layout/ActionHistoryPanel.tsx
+++ b/frontend/src/components/layout/ActionHistoryPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import toast from 'react-hot-toast';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import { actionHistoryApi, type ActionHistoryItem } from '@/lib/action-history';
 import { clearAllCache } from '@/lib/apiCache';
 import { notifyUndoRedo, subscribeUndoRedo } from '@/lib/undoRedoSignal';
@@ -73,18 +74,7 @@ export function ActionHistoryPanel() {
   }, [isOpen, fetchHistory]);
 
   // Close on click outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
-      ) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  useClickOutside(dropdownRef, () => setIsOpen(false));
 
   const handleUndo = async () => {
     if (pendingRef.current) return;

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import { useRouter, usePathname } from 'next/navigation';
 import { useAuthStore } from '@/store/authStore';
 import { authApi } from '@/lib/auth';
@@ -102,24 +103,10 @@ export function AppHeader() {
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   // Close dropdowns when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (toolsRef.current && !toolsRef.current.contains(event.target as Node)) {
-        setToolsOpen(false);
-      }
-      if (aiRef.current && !aiRef.current.contains(event.target as Node)) {
-        setAiOpen(false);
-      }
-      if (mobileMenuRef.current && !mobileMenuRef.current.contains(event.target as Node)) {
-        setMobileMenuOpen(false);
-      }
-      if (searchRef.current && !searchRef.current.contains(event.target as Node)) {
-        setSearchOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  useClickOutside(toolsRef, () => setToolsOpen(false));
+  useClickOutside(aiRef, () => setAiOpen(false));
+  useClickOutside(mobileMenuRef, () => setMobileMenuOpen(false));
+  useClickOutside(searchRef, () => setSearchOpen(false));
 
   // Focus the search input as it slides open.
   useEffect(() => {

--- a/frontend/src/components/reports/CurrencyExposureReport.tsx
+++ b/frontend/src/components/reports/CurrencyExposureReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import {
   PieChart,
   Pie,
@@ -85,15 +86,7 @@ export function CurrencyExposureReport() {
     { field: 'convertedValue', direction: 'desc' },
   );
 
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (showAccountFilter && accountFilterRef.current && !accountFilterRef.current.contains(e.target as Node)) {
-        setShowAccountFilter(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [showAccountFilter]);
+  useClickOutside(accountFilterRef, () => setShowAccountFilter(false), { enabled: showAccountFilter });
 
   // Fetch accounts once on mount
   useEffect(() => {

--- a/frontend/src/components/reports/GeographicAllocationReport.tsx
+++ b/frontend/src/components/reports/GeographicAllocationReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import {
   BarChart,
   Bar,
@@ -129,15 +130,7 @@ export function GeographicAllocationReport() {
     { field: 'marketValue', direction: 'desc' },
   );
 
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (showAccountFilter && accountFilterRef.current && !accountFilterRef.current.contains(e.target as Node)) {
-        setShowAccountFilter(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [showAccountFilter]);
+  useClickOutside(accountFilterRef, () => setShowAccountFilter(false), { enabled: showAccountFilter });
 
   // Fetch accounts and securities once on mount (static data)
   useEffect(() => {

--- a/frontend/src/components/reports/MonteCarloReport.tsx
+++ b/frontend/src/components/reports/MonteCarloReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import { useRouter } from 'next/navigation';
 import {
   Area,
@@ -129,16 +130,7 @@ export function MonteCarloReport() {
   const [holdingStatsLoading, setHoldingStatsLoading] = useState(false);
   const [saveMenuOpen, setSaveMenuOpen] = useState(false);
   const saveMenuRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (!saveMenuOpen) return;
-    const onClick = (e: MouseEvent) => {
-      if (saveMenuRef.current && !saveMenuRef.current.contains(e.target as Node)) {
-        setSaveMenuOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', onClick);
-    return () => document.removeEventListener('mousedown', onClick);
-  }, [saveMenuOpen]);
+  useClickOutside(saveMenuRef, () => setSaveMenuOpen(false), { enabled: saveMenuOpen });
   const [viewMode, setViewMode] = useState<'chart' | 'table'>('chart');
   const chartRef = useRef<HTMLDivElement>(null);
 

--- a/frontend/src/components/reports/SectorWeightingsReport.tsx
+++ b/frontend/src/components/reports/SectorWeightingsReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import {
   BarChart,
   Bar,
@@ -98,18 +99,8 @@ export function SectorWeightingsReport() {
     return items;
   }, [data, sortField, sortDirection]);
 
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (showAccountFilter && accountFilterRef.current && !accountFilterRef.current.contains(e.target as Node)) {
-        setShowAccountFilter(false);
-      }
-      if (showSecurityFilter && securityFilterRef.current && !securityFilterRef.current.contains(e.target as Node)) {
-        setShowSecurityFilter(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [showAccountFilter, showSecurityFilter]);
+  useClickOutside(accountFilterRef, () => setShowAccountFilter(false), { enabled: showAccountFilter });
+  useClickOutside(securityFilterRef, () => setShowSecurityFilter(false), { enabled: showSecurityFilter });
 
   // Load accounts and securities once on mount
   useEffect(() => {

--- a/frontend/src/components/reports/SecurityTypeAllocationReport.tsx
+++ b/frontend/src/components/reports/SecurityTypeAllocationReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import {
   PieChart,
   Pie,
@@ -88,15 +89,7 @@ export function SecurityTypeAllocationReport() {
     { field: 'totalValue', direction: 'desc' },
   );
 
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (showAccountFilter && accountFilterRef.current && !accountFilterRef.current.contains(e.target as Node)) {
-        setShowAccountFilter(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [showAccountFilter]);
+  useClickOutside(accountFilterRef, () => setShowAccountFilter(false), { enabled: showAccountFilter });
 
   // Fetch accounts once on mount
   useEffect(() => {

--- a/frontend/src/components/transactions/RecentTransactionsPopover.tsx
+++ b/frontend/src/components/transactions/RecentTransactionsPopover.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState, RefObject } from 'react';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import { createPortal } from 'react-dom';
 import { transactionsApi } from '@/lib/transactions';
 import { Transaction } from '@/types/transaction';
@@ -93,23 +94,7 @@ export function RecentTransactionsPopover({
   }, [payeeId, payeeName, limit]);
 
   // Outside-click and escape
-  useEffect(() => {
-    const handleMouse = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (popoverRef.current?.contains(target)) return;
-      if (anchorRef.current?.contains(target)) return;
-      onClose();
-    };
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('mousedown', handleMouse);
-    document.addEventListener('keydown', handleKey);
-    return () => {
-      document.removeEventListener('mousedown', handleMouse);
-      document.removeEventListener('keydown', handleKey);
-    };
-  }, [anchorRef, onClose]);
+  useClickOutside([popoverRef, anchorRef], onClose, { onEscape: onClose });
 
   if (!position) return null;
 

--- a/frontend/src/components/transactions/TransactionRow.tsx
+++ b/frontend/src/components/transactions/TransactionRow.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { memo, useState, useRef, useEffect, useCallback, type JSX } from 'react';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import { createPortal } from 'react-dom';
 import { getIconComponent } from '@/components/ui/IconPicker';
 import { Transaction, TransactionSplit, TransactionStatus } from '@/types/transaction';
@@ -47,22 +48,14 @@ function CopyDropdown({ density, onDuplicate, onScheduleRecurring }: {
     }
   }, []);
 
+  useClickOutside([dropdownRef, buttonRef], () => setIsOpen(false), { enabled: isOpen });
+
   useEffect(() => {
     if (!isOpen) return;
     updatePosition();
-    const handleClickOutside = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node) &&
-          buttonRef.current && !buttonRef.current.contains(e.target as Node)) {
-        setIsOpen(false);
-      }
-    };
     const handleScroll = () => setIsOpen(false);
-    document.addEventListener('mousedown', handleClickOutside);
     window.addEventListener('scroll', handleScroll, true);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      window.removeEventListener('scroll', handleScroll, true);
-    };
+    return () => window.removeEventListener('scroll', handleScroll, true);
   }, [isOpen, updatePosition]);
 
   // If only one action is available, render a simple button

--- a/frontend/src/components/ui/CalendarPopover.tsx
+++ b/frontend/src/components/ui/CalendarPopover.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useCallback, useEffect, useRef } from 'react';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import { createPortal } from 'react-dom';
 import { cn } from '@/lib/utils';
 
@@ -58,25 +59,8 @@ export function CalendarPopover({ value, onSelect, onClose, anchorRef }: Calenda
     setPosition({ top: rect.bottom + 4, left });
   }, [anchorRef]);
 
-  // Close on outside click
-  useEffect(() => {
-    const handle = (e: MouseEvent) => {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-    document.addEventListener('mousedown', handle);
-    return () => document.removeEventListener('mousedown', handle);
-  }, [onClose]);
-
-  // Close on Escape
-  useEffect(() => {
-    const handle = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', handle);
-    return () => document.removeEventListener('keydown', handle);
-  }, [onClose]);
+  // Close on outside click or Escape
+  useClickOutside(popoverRef, onClose, { onEscape: onClose });
 
   const prevMonth = useCallback(() => {
     setViewMonth((m) => {

--- a/frontend/src/components/ui/Combobox.tsx
+++ b/frontend/src/components/ui/Combobox.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect, useCallback } from 'react';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import { createPortal } from 'react-dom';
 import { cn, inputBaseClasses, inputErrorClasses } from '@/lib/utils';
 
@@ -139,55 +140,47 @@ export function Combobox({
   }, [value, options, isTyping, allowCustomValue, initialDisplayValue, hasInitialized]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      const isInsideWrapper = wrapperRef.current && wrapperRef.current.contains(event.target as Node);
-      const isInsideDropdown = usePortal && listRef.current && listRef.current.contains(event.target as Node);
+  // Close dropdown when clicking outside. In portal mode the list renders
+  // outside wrapperRef, so it is checked separately; otherwise it lives inside
+  // the wrapper and the listRef check is harmlessly redundant.
+  useClickOutside([wrapperRef, listRef], (event) => {
+    setIsOpen(false);
+    // Only process if user was actively typing AND the click is not on a form submit button
+    // This prevents the click-outside handler from interfering with form submission
+    const target = event.target as HTMLElement;
+    const isSubmitButton = target.closest('button[type="submit"]');
 
-      if (!isInsideWrapper && !isInsideDropdown) {
-        setIsOpen(false);
-        // Only process if user was actively typing AND the click is not on a form submit button
-        // This prevents the click-outside handler from interfering with form submission
-        const target = event.target as HTMLElement;
-        const isSubmitButton = target.closest('button[type="submit"]');
+    if (isTyping) {
+      setIsTyping(false);
 
-        if (isTyping) {
-          setIsTyping(false);
-
-          if (!inputValue.trim()) {
-            // User erased the text -- clear the selection
-            if (selectedLabel) {
-              setSelectedLabel('');
-              setInputValue('');
-              onChange('', '');
-            }
-          } else if (!isSubmitButton) {
-            if (!allowCustomValue && selectedLabel) {
-              // Reset to selected value if not allowing custom
-              setInputValue(selectedLabel);
-            } else if (allowCustomValue) {
-              // For custom values, check if input matches an option exactly
-              const matchedOption = options.find(
-                opt => opt.label.toLowerCase() === inputValue.toLowerCase()
-              );
-              if (matchedOption) {
-                setSelectedLabel(matchedOption.label);
-                setInputValue(matchedOption.label);
-                onChange(matchedOption.value, matchedOption.label);
-              } else if (inputValue.trim() !== selectedLabel) {
-                setSelectedLabel(inputValue.trim());
-                onChange('', inputValue.trim());
-              }
-            }
+      if (!inputValue.trim()) {
+        // User erased the text -- clear the selection
+        if (selectedLabel) {
+          setSelectedLabel('');
+          setInputValue('');
+          onChange('', '');
+        }
+      } else if (!isSubmitButton) {
+        if (!allowCustomValue && selectedLabel) {
+          // Reset to selected value if not allowing custom
+          setInputValue(selectedLabel);
+        } else if (allowCustomValue) {
+          // For custom values, check if input matches an option exactly
+          const matchedOption = options.find(
+            opt => opt.label.toLowerCase() === inputValue.toLowerCase()
+          );
+          if (matchedOption) {
+            setSelectedLabel(matchedOption.label);
+            setInputValue(matchedOption.label);
+            onChange(matchedOption.value, matchedOption.label);
+          } else if (inputValue.trim() !== selectedLabel) {
+            setSelectedLabel(inputValue.trim());
+            onChange('', inputValue.trim());
           }
         }
       }
     }
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [selectedLabel, allowCustomValue, inputValue, options, onChange, isTyping, usePortal]);
+  });
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     // Ignore input changes right after opening (caused by select())

--- a/frontend/src/components/ui/ExportDropdown.tsx
+++ b/frontend/src/components/ui/ExportDropdown.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import toast from 'react-hot-toast';
+import { useClickOutside } from '@/hooks/useClickOutside';
 
 interface ExportDropdownProps {
   onExportCsv?: () => void;
@@ -16,16 +17,7 @@ export function ExportDropdown({ onExportCsv, onExportPdf, disabled }: ExportDro
 
   const close = useCallback(() => setIsOpen(false), []);
 
-  useEffect(() => {
-    if (!isOpen) return;
-    function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        close();
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [isOpen, close]);
+  useClickOutside(dropdownRef, close, { enabled: isOpen });
 
   const handleExportCsv = () => {
     close();

--- a/frontend/src/components/ui/MultiSelect.tsx
+++ b/frontend/src/components/ui/MultiSelect.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import { createPortal } from 'react-dom';
 import { cn } from '@/lib/utils';
 
@@ -209,20 +210,10 @@ export function MultiSelect({
   }, [isOpen]);
 
   // Close on click outside
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      const target = event.target as Node;
-      if (
-        wrapperRef.current && !wrapperRef.current.contains(target) &&
-        (!dropdownRef.current || !dropdownRef.current.contains(target))
-      ) {
-        setIsOpen(false);
-        setSearchText('');
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  useClickOutside([wrapperRef, dropdownRef], () => {
+    setIsOpen(false);
+    setSearchText('');
+  });
 
   // Focus search input when opening
   useEffect(() => {

--- a/frontend/src/hooks/useClickOutside.test.ts
+++ b/frontend/src/hooks/useClickOutside.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { createRef } from 'react';
+import { useClickOutside } from './useClickOutside';
+
+function mountRef() {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  const ref = createRef<HTMLElement>();
+  (ref as { current: HTMLElement }).current = el;
+  return { el, ref };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('useClickOutside', () => {
+  it('fires the handler on mousedown outside the ref', () => {
+    const { ref } = mountRef();
+    const handler = vi.fn();
+    renderHook(() => useClickOutside(ref, handler));
+
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('does not fire when mousedown lands inside the ref', () => {
+    const { el, ref } = mountRef();
+    const handler = vi.fn();
+    renderHook(() => useClickOutside(ref, handler));
+
+    el.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('treats a click inside any of multiple refs as inside', () => {
+    const a = mountRef();
+    const b = mountRef();
+    const handler = vi.fn();
+    renderHook(() => useClickOutside([a.ref, b.ref], handler));
+
+    b.el.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(handler).not.toHaveBeenCalled();
+
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('does not attach listeners when disabled', () => {
+    const { ref } = mountRef();
+    const handler = vi.fn();
+    renderHook(() => useClickOutside(ref, handler, { enabled: false }));
+
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('calls onEscape on Escape keydown when provided', () => {
+    const { ref } = mountRef();
+    const onEscape = vi.fn();
+    renderHook(() => useClickOutside(ref, vi.fn(), { onEscape }));
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(onEscape).toHaveBeenCalledOnce();
+  });
+
+  it('ignores non-Escape keys', () => {
+    const { ref } = mountRef();
+    const onEscape = vi.fn();
+    renderHook(() => useClickOutside(ref, vi.fn(), { onEscape }));
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(onEscape).not.toHaveBeenCalled();
+  });
+
+  it('reads the latest handler without re-subscribing', () => {
+    const { ref } = mountRef();
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(({ h }) => useClickOutside(ref, h), {
+      initialProps: { h: first },
+    });
+
+    rerender({ h: second });
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+  });
+
+  it('removes listeners on unmount', () => {
+    const { ref } = mountRef();
+    const handler = vi.fn();
+    const { unmount } = renderHook(() => useClickOutside(ref, handler));
+
+    unmount();
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useClickOutside.test.ts
+++ b/frontend/src/hooks/useClickOutside.test.ts
@@ -74,6 +74,22 @@ describe('useClickOutside', () => {
     expect(onEscape).not.toHaveBeenCalled();
   });
 
+  it('attaches the keydown listener when onEscape becomes defined after mount', () => {
+    const { ref } = mountRef();
+    const onEscape = vi.fn();
+    const { rerender } = renderHook(
+      ({ esc }: { esc?: () => void }) => useClickOutside(ref, vi.fn(), { onEscape: esc }),
+      { initialProps: { esc: undefined as (() => void) | undefined } }
+    );
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(onEscape).not.toHaveBeenCalled();
+
+    rerender({ esc: onEscape });
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(onEscape).toHaveBeenCalledOnce();
+  });
+
   it('reads the latest handler without re-subscribing', () => {
     const { ref } = mountRef();
     const first = vi.fn();

--- a/frontend/src/hooks/useClickOutside.ts
+++ b/frontend/src/hooks/useClickOutside.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+
+// Read-only structural ref so refs of any element subtype (HTMLDivElement,
+// HTMLButtonElement, ...) are accepted -- RefObject<T>.current is mutable and
+// therefore invariant, which would reject subtypes.
+type ElementRef = { readonly current: HTMLElement | null };
+
+interface UseClickOutsideOptions {
+  /** When false, no listeners are attached (e.g. while the menu is closed). Defaults to true. */
+  enabled?: boolean;
+  /** When provided, also attaches a keydown listener that calls this on Escape. */
+  onEscape?: () => void;
+}
+
+/**
+ * Attach a document `mousedown` listener that fires `handler` when the click
+ * lands outside every supplied ref. Optionally also closes on Escape.
+ *
+ * The handler and onEscape callbacks are read through a ref, so passing inline
+ * closures does not re-subscribe the listeners on every render -- only the
+ * `enabled` flag drives attach/detach.
+ */
+export function useClickOutside(
+  refs: ElementRef | ElementRef[],
+  handler: (event: MouseEvent) => void,
+  options: UseClickOutsideOptions = {},
+): void {
+  const { enabled = true, onEscape } = options;
+
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+  const escapeRef = useRef(onEscape);
+  escapeRef.current = onEscape;
+
+  const refList = Array.isArray(refs) ? refs : [refs];
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    function handleMouseDown(event: MouseEvent) {
+      const target = event.target as Node;
+      const inside = refList.some((ref) => ref.current?.contains(target));
+      if (!inside) handlerRef.current(event);
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') escapeRef.current?.();
+    }
+
+    document.addEventListener('mousedown', handleMouseDown);
+    if (escapeRef.current) document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+    // Spread the individual refs: their identities are stable across renders,
+    // so inline array literals at the call site do not re-subscribe.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, Boolean(onEscape), ...refList]);
+}


### PR DESCRIPTION
Replace the single "+ New Transaction" button on the Investments page
with a dropdown that lets the user choose between creating an investment
transaction or a cash transaction.

https://claude.ai/code/session_01QbS2H1QoQTzPMy2kAfwKDY