### PR TITLE
Add split category filtering to transaction action sheet

### DIFF
--- a/frontend/src/components/transactions/TransactionActionSheet.test.tsx
+++ b/frontend/src/components/transactions/TransactionActionSheet.test.tsx
@@ -128,6 +128,32 @@ describe('TransactionActionSheet', () => {
     expect(onTagFilterClick).toHaveBeenCalledWith('tag1');
   });
 
+  it('renders a category filter for each unique split category', () => {
+    const onCategoryClick = vi.fn();
+    const splitTx: Transaction = {
+      ...tx,
+      categoryId: null,
+      category: null,
+      isSplit: true,
+      splits: [
+        { id: 's1', transactionId: 't1', kind: 'category', categoryId: 'c1', category: { id: 'c1', name: 'Groceries' } as any, transferAccountId: null, transferAccount: null, linkedTransactionId: null, amount: -5, memo: null, createdAt: '2025-06-15T00:00:00Z' },
+        { id: 's2', transactionId: 't1', kind: 'category', categoryId: 'c2', category: { id: 'c2', name: 'Household' } as any, transferAccountId: null, transferAccount: null, linkedTransactionId: null, amount: -3, memo: null, createdAt: '2025-06-15T00:00:00Z' },
+        // Duplicate category should not produce a second button
+        { id: 's3', transactionId: 't1', kind: 'category', categoryId: 'c1', category: { id: 'c1', name: 'Groceries' } as any, transferAccountId: null, transferAccount: null, linkedTransactionId: null, amount: -2, memo: null, createdAt: '2025-06-15T00:00:00Z' },
+        // Transfer split has no category and should be skipped
+        { id: 's4', transactionId: 't1', kind: 'transfer', categoryId: null, category: null, transferAccountId: 'a2', transferAccount: { id: 'a2', name: 'Savings' } as any, linkedTransactionId: 'l1', amount: -1, memo: null, createdAt: '2025-06-15T00:00:00Z' },
+      ],
+    };
+    render(<TransactionActionSheet {...baseProps} transaction={splitTx} onCategoryClick={onCategoryClick} />);
+    expect(screen.getByText(/Filter by .Groceries/)).toBeInTheDocument();
+    expect(screen.getByText(/Filter by .Household/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Filter by .Groceries/)).toHaveLength(1);
+    expect(screen.queryByText(/Filter by .Savings/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText(/Filter by .Household/));
+    expect(onCategoryClick).toHaveBeenCalledWith('c2');
+  });
+
   it('does not crash when transaction is null', () => {
     render(<TransactionActionSheet {...baseProps} transaction={null} />);
     expect(screen.getByText('Transaction')).toBeInTheDocument();

--- a/frontend/src/components/transactions/TransactionActionSheet.tsx
+++ b/frontend/src/components/transactions/TransactionActionSheet.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Transaction } from '@/types/transaction';
+import { Category } from '@/types/category';
 import { Modal } from '@/components/ui/Modal';
 
 interface TransactionActionSheetProps {
@@ -66,6 +67,28 @@ export function TransactionActionSheet({
       onCategoryClick(transaction.category.id);
     }
   }, [transaction, onClose, onCategoryClick]);
+
+  const handleFilterCategoryById = useCallback((categoryId: string) => {
+    onClose();
+    if (onCategoryClick) {
+      onCategoryClick(categoryId);
+    }
+  }, [onClose, onCategoryClick]);
+
+  // Unique categories drawn from a split transaction's category splits.
+  // Transfer and investment splits carry no regular category, so they are skipped.
+  const splitCategories = useMemo<Category[]>(() => {
+    if (!transaction?.isSplit || !transaction.splits) return [];
+    const seen = new Set<string>();
+    const result: Category[] = [];
+    for (const split of transaction.splits) {
+      if (split.category && split.categoryId && !seen.has(split.categoryId)) {
+        seen.add(split.categoryId);
+        result.push(split.category);
+      }
+    }
+    return result;
+  }, [transaction]);
 
   const handleFilterTag = useCallback((tagId: string) => {
     onClose();
@@ -135,6 +158,18 @@ export function TransactionActionSheet({
             Filter by &ldquo;{transaction.category.name}&rdquo;
           </button>
         )}
+        {onCategoryClick && splitCategories.map((category) => (
+          <button
+            key={category.id}
+            onClick={() => handleFilterCategoryById(category.id)}
+            className="w-full px-4 py-3 text-left text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
+          >
+            <svg className="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+            </svg>
+            Filter by &ldquo;{category.name}&rdquo;
+          </button>
+        ))}
         {onTagFilterClick && transaction?.tags && transaction.tags.length > 0 && (
           transaction.tags.map((tag) => (
             <button


### PR DESCRIPTION
## Summary
Extends the transaction action sheet to display filter buttons for each unique category in split transactions, allowing users to filter by individual split categories.

## Key Changes
- Added `useMemo` hook to extract unique categories from split transaction splits
- Created `handleFilterCategoryById` callback to handle category filter clicks
- Renders category filter buttons for each unique split category (skipping transfer and investment splits which have no category)
- Deduplicates categories by ID to avoid duplicate filter buttons
- Added comprehensive test coverage for split category filtering behavior

## Implementation Details
- The `splitCategories` memoized value iterates through transaction splits and collects unique categories, using a `Set` to track seen category IDs
- Transfer and investment splits are automatically skipped since they have `null` category values
- Filter buttons use the same styling and icon pattern as existing category and tag filters
- Test validates deduplication (duplicate categories produce only one button) and that transfer splits are excluded

https://claude.ai/code/session_01HL1hF31Tu697KxwW7dbRfN