### PR TITLE
Switch dashboard and report net worth charts to bar view by default

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -31,6 +31,7 @@ import { SecuritiesModule } from "./securities/securities.module";
 import { PayeesModule } from "./payees/payees.module";
 import { ScheduledTransactionsModule } from "./scheduled-transactions/scheduled-transactions.module";
 import { ReportsModule } from "./reports/reports.module";
+import { InvestmentReportsModule } from "./investment-reports/investment-reports.module";
 import { DatabaseModule } from "./database/database.module";
 import { ImportModule } from "./import/import.module";
 import { NetWorthModule } from "./net-worth/net-worth.module";
@@ -115,6 +116,7 @@ import { EmergencyAccessModule } from "./emergency-access/emergency-access.modul
     SecuritiesModule,
     ScheduledTransactionsModule,
     ReportsModule,
+    InvestmentReportsModule,
     DatabaseModule,
     ImportModule,
     NetWorthModule,

--- a/backend/src/investment-reports/dto/create-investment-report.dto.ts
+++ b/backend/src/investment-reports/dto/create-investment-report.dto.ts
@@ -94,6 +94,14 @@ export class InvestmentReportConfigDto {
     message: "asOfDate must be in YYYY-MM-DD format",
   })
   asOfDate?: string | null;
+
+  @ApiPropertyOptional({
+    description:
+      "Combine a security held across accounts into one row (non-account grouping only)",
+  })
+  @IsOptional()
+  @IsBoolean()
+  mergeAccounts?: boolean;
 }
 
 export class CreateInvestmentReportDto {

--- a/backend/src/investment-reports/dto/create-investment-report.dto.ts
+++ b/backend/src/investment-reports/dto/create-investment-report.dto.ts
@@ -1,0 +1,156 @@
+import {
+  IsString,
+  IsOptional,
+  IsEnum,
+  IsBoolean,
+  IsArray,
+  IsUUID,
+  IsObject,
+  MaxLength,
+  ArrayMaxSize,
+  ValidateNested,
+  IsNumber,
+  Matches,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  Validate,
+  ValidateIf,
+} from "class-validator";
+import { Type } from "class-transformer";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
+import {
+  InvestmentGroupBy,
+  InvestmentSortDirection,
+} from "../entities/investment-report.entity";
+import { isValidInvestmentColumn } from "../investment-report-columns";
+
+@ValidatorConstraint({ name: "areValidInvestmentColumns", async: false })
+class AreValidInvestmentColumns implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    return (
+      Array.isArray(value) &&
+      value.every((v) => typeof v === "string" && isValidInvestmentColumn(v))
+    );
+  }
+
+  defaultMessage(): string {
+    return "columns must be an array of known investment report column keys";
+  }
+}
+
+@ValidatorConstraint({ name: "isValidInvestmentColumn", async: false })
+class IsValidInvestmentColumn implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    return typeof value === "string" && isValidInvestmentColumn(value);
+  }
+
+  defaultMessage(): string {
+    return "must be a known investment report column key";
+  }
+}
+
+export class InvestmentReportConfigDto {
+  @ApiProperty({
+    description: "Ordered column keys to display (symbol is always included)",
+    type: [String],
+  })
+  @IsArray()
+  @ArrayMaxSize(60)
+  @Validate(AreValidInvestmentColumns)
+  columns: string[];
+
+  @ApiPropertyOptional({
+    description: "Holdings account IDs to include (empty means all accounts)",
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(500)
+  @IsUUID("4", { each: true })
+  accountIds?: string[];
+
+  @ApiPropertyOptional({ description: "Column key to sort by", nullable: true })
+  @IsOptional()
+  @ValidateIf((_o, v) => v !== null)
+  @Validate(IsValidInvestmentColumn)
+  sortColumn?: string | null;
+
+  @ApiPropertyOptional({
+    description: "Sort direction",
+    enum: InvestmentSortDirection,
+  })
+  @IsOptional()
+  @IsEnum(InvestmentSortDirection)
+  sortDirection?: InvestmentSortDirection;
+
+  @ApiPropertyOptional({
+    description: "As-of date (YYYY-MM-DD), null for the latest market day",
+    nullable: true,
+  })
+  @IsOptional()
+  @ValidateIf((_o, v) => v !== null)
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, {
+    message: "asOfDate must be in YYYY-MM-DD format",
+  })
+  asOfDate?: string | null;
+}
+
+export class CreateInvestmentReportDto {
+  @ApiProperty({ description: "Report name" })
+  @IsString()
+  @MaxLength(100)
+  @SanitizeHtml()
+  name: string;
+
+  @ApiPropertyOptional({ description: "Report description" })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  @SanitizeHtml()
+  description?: string;
+
+  @ApiPropertyOptional({ description: "Icon identifier (emoji or icon name)" })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  @SanitizeHtml()
+  icon?: string;
+
+  @ApiPropertyOptional({
+    description: "Background color as hex code (e.g., #3b82f6)",
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(/^#[0-9A-Fa-f]{6}$/, {
+    message: "Background color must be in hex format (e.g., #3b82f6)",
+  })
+  backgroundColor?: string;
+
+  @ApiPropertyOptional({
+    description: "How to group rows",
+    enum: InvestmentGroupBy,
+  })
+  @IsOptional()
+  @IsEnum(InvestmentGroupBy)
+  groupBy?: InvestmentGroupBy;
+
+  @ApiProperty({
+    description: "Report configuration",
+    type: InvestmentReportConfigDto,
+  })
+  @IsObject()
+  @ValidateNested()
+  @Type(() => InvestmentReportConfigDto)
+  config: InvestmentReportConfigDto;
+
+  @ApiPropertyOptional({ description: "Mark as favourite" })
+  @IsOptional()
+  @IsBoolean()
+  isFavourite?: boolean;
+
+  @ApiPropertyOptional({ description: "Sort order for display" })
+  @IsOptional()
+  @IsNumber()
+  sortOrder?: number;
+}

--- a/backend/src/investment-reports/dto/execute-investment-report.dto.ts
+++ b/backend/src/investment-reports/dto/execute-investment-report.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsBoolean, Matches } from "class-validator";
+import { IsOptional, Matches } from "class-validator";
 import { ApiPropertyOptional } from "@nestjs/swagger";
 import { InvestmentGroupBy } from "../entities/investment-report.entity";
 
@@ -11,14 +11,6 @@ export class ExecuteInvestmentReportDto {
     message: "asOfDate must be in YYYY-MM-DD format",
   })
   asOfDate?: string;
-
-  @ApiPropertyOptional({
-    description:
-      "Merge identical securities held across accounts into one combined row (symbol/currency grouping only)",
-  })
-  @IsOptional()
-  @IsBoolean()
-  mergeAccounts?: boolean;
 }
 
 /** A single computed value cell. Null means the value is not available. */

--- a/backend/src/investment-reports/dto/execute-investment-report.dto.ts
+++ b/backend/src/investment-reports/dto/execute-investment-report.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, Matches } from "class-validator";
+import { IsOptional, IsBoolean, Matches } from "class-validator";
 import { ApiPropertyOptional } from "@nestjs/swagger";
 import { InvestmentGroupBy } from "../entities/investment-report.entity";
 
@@ -11,6 +11,14 @@ export class ExecuteInvestmentReportDto {
     message: "asOfDate must be in YYYY-MM-DD format",
   })
   asOfDate?: string;
+
+  @ApiPropertyOptional({
+    description:
+      "Merge identical securities held across accounts into one combined row (symbol/currency grouping only)",
+  })
+  @IsOptional()
+  @IsBoolean()
+  mergeAccounts?: boolean;
 }
 
 /** A single computed value cell. Null means the value is not available. */

--- a/backend/src/investment-reports/dto/execute-investment-report.dto.ts
+++ b/backend/src/investment-reports/dto/execute-investment-report.dto.ts
@@ -20,7 +20,11 @@ export type InvestmentCellValue = string | number | null;
 export interface InvestmentReportRow {
   /** Stable row id (`${accountId}:${securityId}`). */
   id: string;
-  /** Column key -> computed value. */
+  /** The holding's own (security) currency, for formatting native values. */
+  currency: string;
+  /** Rate to multiply this row's native monetary values by to get base currency. */
+  baseExchangeRate: number;
+  /** Column key -> computed value (native currency). */
   values: Record<string, InvestmentCellValue>;
 }
 

--- a/backend/src/investment-reports/dto/execute-investment-report.dto.ts
+++ b/backend/src/investment-reports/dto/execute-investment-report.dto.ts
@@ -1,0 +1,48 @@
+import { IsOptional, Matches } from "class-validator";
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { InvestmentGroupBy } from "../entities/investment-report.entity";
+
+export class ExecuteInvestmentReportDto {
+  @ApiPropertyOptional({
+    description: "Override the as-of date (YYYY-MM-DD)",
+  })
+  @IsOptional()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, {
+    message: "asOfDate must be in YYYY-MM-DD format",
+  })
+  asOfDate?: string;
+}
+
+/** A single computed value cell. Null means the value is not available. */
+export type InvestmentCellValue = string | number | null;
+
+/** One report row: a holding (one security in one account) with its values. */
+export interface InvestmentReportRow {
+  /** Stable row id (`${accountId}:${securityId}`). */
+  id: string;
+  /** Column key -> computed value. */
+  values: Record<string, InvestmentCellValue>;
+}
+
+/** A group of rows when groupBy is set (one group when groupBy is NONE). */
+export interface InvestmentReportGroup {
+  /** Stable group key. */
+  key: string;
+  /** Human-readable group heading. */
+  label: string;
+  rows: InvestmentReportRow[];
+}
+
+export interface InvestmentReportResult {
+  reportId: string;
+  name: string;
+  /** The resolved as-of date the report was valued at (YYYY-MM-DD). */
+  asOfDate: string;
+  /** The user's base currency, used for % of portfolio and exchange rate. */
+  baseCurrency: string;
+  groupBy: InvestmentGroupBy;
+  /** Ordered column keys included in the report. */
+  columns: string[];
+  groups: InvestmentReportGroup[];
+  rowCount: number;
+}

--- a/backend/src/investment-reports/dto/update-investment-report.dto.ts
+++ b/backend/src/investment-reports/dto/update-investment-report.dto.ts
@@ -1,0 +1,6 @@
+import { PartialType } from "@nestjs/swagger";
+import { CreateInvestmentReportDto } from "./create-investment-report.dto";
+
+export class UpdateInvestmentReportDto extends PartialType(
+  CreateInvestmentReportDto,
+) {}

--- a/backend/src/investment-reports/entities/investment-report.entity.ts
+++ b/backend/src/investment-reports/entities/investment-report.entity.ts
@@ -41,6 +41,11 @@ export interface InvestmentReportConfig {
    * latest day the markets were open at run time.
    */
   asOfDate: string | null;
+  /**
+   * When grouping by something other than account, combine a security held in
+   * several accounts into one row instead of listing each account separately.
+   */
+  mergeAccounts?: boolean;
 }
 
 @Entity("investment_reports")

--- a/backend/src/investment-reports/entities/investment-report.entity.ts
+++ b/backend/src/investment-reports/entities/investment-report.entity.ts
@@ -1,0 +1,97 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from "typeorm";
+import { User } from "../../users/entities/user.entity";
+
+/** How report rows are grouped. */
+export enum InvestmentGroupBy {
+  NONE = "NONE",
+  ACCOUNT = "ACCOUNT",
+  SYMBOL = "SYMBOL",
+  CURRENCY = "CURRENCY",
+}
+
+export enum InvestmentSortDirection {
+  ASC = "ASC",
+  DESC = "DESC",
+}
+
+/**
+ * Saved configuration for an investment report. The selected columns are
+ * stored in display order (the array order doubles as the column ordering),
+ * always starting with "symbol".
+ */
+export interface InvestmentReportConfig {
+  /** Ordered column keys to display (always includes "symbol"). */
+  columns: string[];
+  /** Holdings accounts to include. Empty array means all investment accounts. */
+  accountIds: string[];
+  /** Column key to sort by, or null to keep the natural (grouped) order. */
+  sortColumn: string | null;
+  /** Sort direction applied to sortColumn. */
+  sortDirection: InvestmentSortDirection;
+  /**
+   * The "as of" date (YYYY-MM-DD) the report is valued at, or null to use the
+   * latest day the markets were open at run time.
+   */
+  asOfDate: string | null;
+}
+
+@Entity("investment_reports")
+export class InvestmentReport {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @Column({ type: "uuid", name: "user_id" })
+  userId: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: "user_id" })
+  user?: User;
+
+  @Column({ type: "varchar", length: 255 })
+  name: string;
+
+  @Column({ type: "text", nullable: true })
+  description: string | null;
+
+  @Column({ type: "varchar", length: 50, nullable: true })
+  icon: string | null;
+
+  @Column({
+    type: "varchar",
+    name: "background_color",
+    length: 7,
+    nullable: true,
+  })
+  backgroundColor: string | null;
+
+  @Column({
+    type: "varchar",
+    length: 20,
+    name: "group_by",
+    default: InvestmentGroupBy.NONE,
+  })
+  groupBy: InvestmentGroupBy;
+
+  @Column({ type: "jsonb", default: "{}" })
+  config: InvestmentReportConfig;
+
+  @Column({ name: "is_favourite", default: false })
+  isFavourite: boolean;
+
+  @Column({ name: "sort_order", type: "int", default: 0 })
+  sortOrder: number;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt: Date;
+}

--- a/backend/src/investment-reports/investment-report-columns.spec.ts
+++ b/backend/src/investment-reports/investment-report-columns.spec.ts
@@ -1,0 +1,49 @@
+import {
+  INVESTMENT_REPORT_COLUMNS,
+  INVESTMENT_REPORT_COLUMN_KEYS,
+  ALWAYS_INCLUDED_COLUMN,
+  isValidInvestmentColumn,
+} from "./investment-report-columns";
+
+describe("investment report columns catalogue", () => {
+  it("includes symbol as the always-included column", () => {
+    expect(ALWAYS_INCLUDED_COLUMN).toBe("symbol");
+    expect(INVESTMENT_REPORT_COLUMN_KEYS).toContain("symbol");
+  });
+
+  it("exposes the full populatable column set", () => {
+    expect(INVESTMENT_REPORT_COLUMNS).toHaveLength(40);
+    expect(new Set(INVESTMENT_REPORT_COLUMN_KEYS).size).toBe(40);
+  });
+
+  it("gives every column a label, type and description", () => {
+    for (const col of INVESTMENT_REPORT_COLUMNS) {
+      expect(col.key).toBeTruthy();
+      expect(col.label).toBeTruthy();
+      expect(col.type).toBeTruthy();
+      expect(col.description).toBeTruthy();
+    }
+  });
+
+  it("validates known and unknown column keys", () => {
+    expect(isValidInvestmentColumn("symbol")).toBe(true);
+    expect(isValidInvestmentColumn("totalReturnYtd")).toBe(true);
+    expect(isValidInvestmentColumn("peRatio")).toBe(false);
+    expect(isValidInvestmentColumn("")).toBe(false);
+  });
+
+  it("excludes market-data columns we cannot populate", () => {
+    const excluded = [
+      "peRatio",
+      "eps",
+      "beta",
+      "dividendYield",
+      "marketCap",
+      "bid",
+      "ask",
+    ];
+    for (const key of excluded) {
+      expect(INVESTMENT_REPORT_COLUMN_KEYS).not.toContain(key);
+    }
+  });
+});

--- a/backend/src/investment-reports/investment-report-columns.spec.ts
+++ b/backend/src/investment-reports/investment-report-columns.spec.ts
@@ -12,8 +12,8 @@ describe("investment report columns catalogue", () => {
   });
 
   it("exposes the full populatable column set", () => {
-    expect(INVESTMENT_REPORT_COLUMNS).toHaveLength(40);
-    expect(new Set(INVESTMENT_REPORT_COLUMN_KEYS).size).toBe(40);
+    expect(INVESTMENT_REPORT_COLUMNS).toHaveLength(41);
+    expect(new Set(INVESTMENT_REPORT_COLUMN_KEYS).size).toBe(41);
   });
 
   it("gives every column a label, type and description", () => {

--- a/backend/src/investment-reports/investment-report-columns.ts
+++ b/backend/src/investment-reports/investment-report-columns.ts
@@ -67,6 +67,12 @@ export const INVESTMENT_REPORT_COLUMNS: readonly InvestmentColumnDef[] = [
     type: "text",
     description: "The currency the information displayed is based on.",
   },
+  {
+    key: "account",
+    label: "Account",
+    type: "text",
+    description: "The investment account that holds this security.",
+  },
   // -- Position & cost -----------------------------------------------------
   {
     key: "quantity",

--- a/backend/src/investment-reports/investment-report-columns.ts
+++ b/backend/src/investment-reports/investment-report-columns.ts
@@ -1,0 +1,342 @@
+/**
+ * Catalogue of the columns a custom investment report can display.
+ *
+ * Modelled on the Microsoft Money "Portfolio Manager" column set
+ * (see ms_money_portfolio_columns.md). Only columns that can actually be
+ * populated from our data are included here: holdings + investment
+ * transactions + the daily OHLCV prices fetched from Yahoo Finance / MSN
+ * Money. Market-data columns our quote providers never return (PE, EPS,
+ * Beta, dividend yield, market cap, bid/ask, bond/option-specific fields,
+ * fund composition breakdowns, etc.) are intentionally excluded.
+ *
+ * This is the single source of truth on the backend: the DTO validates that
+ * every requested column key exists here, and the data service computes a
+ * value for each. The frontend mirrors this list (with the same keys) so the
+ * column chooser can show each column's description.
+ */
+
+export type InvestmentColumnType =
+  | "text"
+  | "shares"
+  | "currency"
+  | "percent"
+  | "integer"
+  | "number"
+  | "date";
+
+export interface InvestmentColumnDef {
+  /** Stable identifier persisted in the report definition. */
+  key: string;
+  /** MS Money column label shown in the UI. */
+  label: string;
+  /** Value formatting hint consumed by the frontend. */
+  type: InvestmentColumnType;
+  /** MS Money description shown in the column chooser. */
+  description: string;
+  /** True when the value is monetary and denominated in the holding's own currency. */
+  native?: boolean;
+}
+
+/** The column always present in every report (cannot be removed). */
+export const ALWAYS_INCLUDED_COLUMN = "symbol";
+
+export const INVESTMENT_REPORT_COLUMNS: readonly InvestmentColumnDef[] = [
+  // -- Identity ------------------------------------------------------------
+  {
+    key: "symbol",
+    label: "Symbol",
+    type: "text",
+    description: "Company ticker symbol.",
+  },
+  {
+    key: "name",
+    label: "Name",
+    type: "text",
+    description: "The name of the investment.",
+  },
+  {
+    key: "securityType",
+    label: "Type",
+    type: "text",
+    description:
+      "Type of investment, such as stock, ETF, mutual fund, or bond.",
+  },
+  {
+    key: "currency",
+    label: "Currency",
+    type: "text",
+    description: "The currency the information displayed is based on.",
+  },
+  // -- Position & cost -----------------------------------------------------
+  {
+    key: "quantity",
+    label: "Quantity",
+    type: "shares",
+    description: "The number of shares you hold of a given security.",
+  },
+  {
+    key: "averageCost",
+    label: "Average Cost",
+    type: "currency",
+    description:
+      "The average cost per share, including commissions, that you paid for this security.",
+    native: true,
+  },
+  {
+    key: "costBasis",
+    label: "Cost Basis",
+    type: "currency",
+    description:
+      "The total cost, including commissions and fees, of all shares of an investment.",
+    native: true,
+  },
+  // -- Valuation -----------------------------------------------------------
+  {
+    key: "lastPrice",
+    label: "Last Price",
+    type: "currency",
+    description: "The most recent price at which the security traded.",
+    native: true,
+  },
+  {
+    key: "marketValue",
+    label: "Market Value",
+    type: "currency",
+    description: "Market value of your investment at the last price.",
+    native: true,
+  },
+  {
+    key: "gain",
+    label: "Gain",
+    type: "currency",
+    description:
+      "Your gain or loss on this security. Current market value plus income, minus cost basis.",
+    native: true,
+  },
+  {
+    key: "gainPercent",
+    label: "%Gain",
+    type: "percent",
+    description:
+      "The percentage of profit or loss on an investment based on its cost.",
+  },
+  {
+    key: "priceAppreciation",
+    label: "Price Appreciation",
+    type: "currency",
+    description:
+      "Your gain or loss due to price fluctuations. Current market value minus cost basis.",
+    native: true,
+  },
+  {
+    key: "portfolioPercent",
+    label: "% of portfolio",
+    type: "percent",
+    description:
+      "The percentage of your total portfolio invested in this security by market value.",
+  },
+  // -- Quote (as of the report date) ---------------------------------------
+  {
+    key: "open",
+    label: "Open",
+    type: "currency",
+    description:
+      "The first price at which a security traded on the trading day.",
+    native: true,
+  },
+  {
+    key: "dayHigh",
+    label: "High (Day High)",
+    type: "currency",
+    description: "The highest price at which a security traded during the day.",
+    native: true,
+  },
+  {
+    key: "dayLow",
+    label: "Low (Day Low)",
+    type: "currency",
+    description: "The lowest price at which a security traded during the day.",
+    native: true,
+  },
+  {
+    key: "previousClose",
+    label: "Close",
+    type: "currency",
+    description:
+      "The last price at which a security traded on the previous trading day.",
+    native: true,
+  },
+  {
+    key: "change",
+    label: "Change",
+    type: "currency",
+    description:
+      "Per-share difference between the preceding day's close and the most recent price.",
+    native: true,
+  },
+  {
+    key: "changePercent",
+    label: "%Change",
+    type: "percent",
+    description:
+      "The percentage difference between the preceding day's close and the current price.",
+  },
+  {
+    key: "todaysTotalChange",
+    label: "Today's Total Change",
+    type: "currency",
+    description:
+      "Your gain or loss today: the per-share change since the previous close multiplied by your shares.",
+    native: true,
+  },
+  {
+    key: "volume",
+    label: "Volume",
+    type: "integer",
+    description:
+      "The total units of an investment traded on the most recent trading day.",
+  },
+  {
+    key: "lastTransactionDate",
+    label: "Last Transaction Date",
+    type: "date",
+    description: "The last date the investment was traded.",
+  },
+  // -- Transaction analytics ----------------------------------------------
+  {
+    key: "income",
+    label: "Income",
+    type: "currency",
+    description:
+      "Interest, dividends and capital gains distributions you have received for an investment.",
+    native: true,
+  },
+  {
+    key: "commissions",
+    label: "Commissions",
+    type: "currency",
+    description:
+      "The total brokerage fees you paid to buy or sell an investment.",
+    native: true,
+  },
+  {
+    key: "purchases",
+    label: "Purchases",
+    type: "currency",
+    description:
+      "The cost of your total purchases (excluding reinvested income) of this investment.",
+    native: true,
+  },
+  {
+    key: "sales",
+    label: "Sales",
+    type: "currency",
+    description: "The total sales you have made for this investment.",
+    native: true,
+  },
+  {
+    key: "reinvestments",
+    label: "Reinvestments",
+    type: "currency",
+    description: "The total reinvested income for this investment.",
+    native: true,
+  },
+  {
+    key: "realizedGains",
+    label: "Realized Gains",
+    type: "currency",
+    description:
+      "The gain from shares actually sold. Does not include the change in value of shares you still hold.",
+    native: true,
+  },
+  // -- Other ---------------------------------------------------------------
+  {
+    key: "exchangeRate",
+    label: "Exchange Rate",
+    type: "number",
+    description:
+      "Exchange rate used to convert this investment to your base currency.",
+  },
+  {
+    key: "lastUpdated",
+    label: "Last Updated",
+    type: "date",
+    description: "The date of the most recent stored price for this security.",
+  },
+  {
+    key: "fiftyTwoWeekHigh",
+    label: "52-Week High",
+    type: "currency",
+    description:
+      "The highest price at which a security traded over the past 52 weeks (from stored price history).",
+    native: true,
+  },
+  {
+    key: "fiftyTwoWeekLow",
+    label: "52-Week Low",
+    type: "currency",
+    description:
+      "The lowest price at which a security traded over the past 52 weeks (from stored price history).",
+    native: true,
+  },
+  // -- Period returns ------------------------------------------------------
+  {
+    key: "totalReturn1Week",
+    label: "Total Return - 1 Week",
+    type: "percent",
+    description:
+      "One-week percentage return: current market value plus income, minus beginning market value, divided by beginning market value.",
+  },
+  {
+    key: "totalReturn4Weeks",
+    label: "Total Return - 4 Weeks",
+    type: "percent",
+    description: "Four-week percentage return on investment.",
+  },
+  {
+    key: "totalReturn3Month",
+    label: "Total Return - 3 Month",
+    type: "percent",
+    description: "Three-month percentage return on investment.",
+  },
+  {
+    key: "totalReturn1Year",
+    label: "Total Return - 1 Year",
+    type: "percent",
+    description: "One-year percentage return on investment.",
+  },
+  {
+    key: "totalReturn3Year",
+    label: "Total Return - 3 Year",
+    type: "percent",
+    description: "Three-year percentage return on investment.",
+  },
+  {
+    key: "totalReturnYtd",
+    label: "Total Return - YTD",
+    type: "percent",
+    description: "Year-to-date percentage return on investment.",
+  },
+  {
+    key: "totalReturnAllDates",
+    label: "Total Return - All Dates",
+    type: "percent",
+    description: "Percentage return on investment across all dates held.",
+  },
+  {
+    key: "totalAnnualizedReturn",
+    label: "Total Annualized Return",
+    type: "percent",
+    description:
+      "Annual percentage return on investment, projected (short holdings) or averaged (long holdings) to one year.",
+  },
+] as const;
+
+export const INVESTMENT_REPORT_COLUMN_KEYS: readonly string[] =
+  INVESTMENT_REPORT_COLUMNS.map((c) => c.key);
+
+const COLUMN_KEY_SET = new Set(INVESTMENT_REPORT_COLUMN_KEYS);
+
+export function isValidInvestmentColumn(key: string): boolean {
+  return COLUMN_KEY_SET.has(key);
+}

--- a/backend/src/investment-reports/investment-report-data.service.spec.ts
+++ b/backend/src/investment-reports/investment-report-data.service.spec.ts
@@ -361,6 +361,46 @@ describe("InvestmentReportDataService", () => {
     expect(rows[0].values.totalReturn1Year).toBeNull();
   });
 
+  it("handles transfers, share removals, and 52-week lows from null-OHLC rows", async () => {
+    accountsRepository.find.mockResolvedValue([{ id: "acc1", name: "B" }]);
+    securitiesRepository.find.mockResolvedValue([
+      { id: "sec1", symbol: "AAA", name: "Alpha", securityType: "STOCK", currencyCode: "USD" },
+    ]);
+    txRepository.find.mockResolvedValue([
+      makeTx({ action: InvestmentAction.TRANSFER_IN, transactionDate: "2022-01-10", quantity: 20, price: 50, totalAmount: 1000 }),
+      makeTx({ action: InvestmentAction.REMOVE_SHARES, transactionDate: "2022-06-10", quantity: 5 }),
+      makeTx({ action: InvestmentAction.TRANSFER_OUT, transactionDate: "2023-01-10", quantity: 5, price: 60, totalAmount: 300 }),
+      makeTx({ action: InvestmentAction.BUY, transactionDate: "2023-06-10", quantity: 10, price: 70, totalAmount: 700 }),
+    ]);
+    txRepository.query.mockResolvedValue([
+      { security_id: "sec1", price_date: "2022-01-10", open_price: null, high_price: null, low_price: null, close_price: "50", volume: null },
+      { security_id: "sec1", price_date: "2023-06-09", open_price: "65", high_price: "66", low_price: "64", close_price: "65", volume: "10" },
+      { security_id: "sec1", price_date: "2024-01-15", open_price: "80", high_price: null, low_price: null, close_price: "80", volume: "10" },
+      { security_id: "sec1", price_date: "2024-06-10", open_price: "88", high_price: "91", low_price: "87", close_price: "90", volume: "100" },
+    ]);
+
+    const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
+    const v = rows[0].values;
+    // 20 in (transfer) - 5 (remove) - 5 (transfer out) + 10 (buy) = 20
+    expect(v.quantity).toBe(20);
+    // A TRANSFER_OUT is not a sale, so it does not create realized gains.
+    expect(v.realizedGains).toBe(0);
+    expect(v.fiftyTwoWeekHigh).toBe(91);
+    // The null-OHLC row falls back to its close (80) for the 52-week low.
+    expect(v.fiftyTwoWeekLow).toBe(80);
+  });
+
+  it("skips a holding whose security record is missing", async () => {
+    accountsRepository.find.mockResolvedValue([{ id: "acc1", name: "B" }]);
+    securitiesRepository.find.mockResolvedValue([]); // security not found
+    txRepository.find.mockResolvedValue([
+      makeTx({ action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 10, price: 100, totalAmount: 1000 }),
+    ]);
+    txRepository.query.mockResolvedValue([]);
+    const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
+    expect(rows).toHaveLength(0);
+  });
+
   describe("getLatestMarketDay", () => {
     it("returns today when there are no accounts", async () => {
       const today = new Date().toISOString().slice(0, 10);

--- a/backend/src/investment-reports/investment-report-data.service.spec.ts
+++ b/backend/src/investment-reports/investment-report-data.service.spec.ts
@@ -122,6 +122,7 @@ describe("InvestmentReportDataService", () => {
     expect(rows).toHaveLength(1);
     const v = rows[0].values;
     expect(v.symbol).toBe("AAA");
+    expect(v.securityType).toBe("Stock"); // STOCK -> friendly label
     expect(v.quantity).toBe(10);
     expect(v.costBasis).toBe(1000);
     expect(v.averageCost).toBe(100);
@@ -401,6 +402,26 @@ describe("InvestmentReportDataService", () => {
     txRepository.query.mockResolvedValue([]);
     const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
     expect(rows).toHaveLength(0);
+  });
+
+  it("maps raw security types to friendly labels", async () => {
+    accountsRepository.find.mockResolvedValue([{ id: "acc1", name: "B" }]);
+    securitiesRepository.find.mockResolvedValue([
+      { id: "sec1", symbol: "AAA", name: "A", securityType: "MUTUAL_FUND", currencyCode: "USD" },
+      { id: "sec2", symbol: "BBB", name: "B", securityType: "CUSTOM_TYPE", currencyCode: "USD" },
+    ]);
+    txRepository.find.mockResolvedValue([
+      makeTx({ securityId: "sec1", action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 10, price: 100, totalAmount: 1000 }),
+      makeTx({ securityId: "sec2", action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 5, price: 50, totalAmount: 250 }),
+    ]);
+    txRepository.query.mockResolvedValue([
+      { security_id: "sec1", price_date: "2024-06-10", open_price: "100", high_price: "100", low_price: "100", close_price: "100", volume: "1" },
+      { security_id: "sec2", price_date: "2024-06-10", open_price: "50", high_price: "50", low_price: "50", close_price: "50", volume: "1" },
+    ]);
+    const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
+    const types = rows.map((r) => r.values.securityType);
+    expect(types).toContain("Mutual Fund"); // known mapping
+    expect(types).toContain("Custom Type"); // unknown -> title-cased
   });
 
   describe("getLatestMarketDay", () => {

--- a/backend/src/investment-reports/investment-report-data.service.spec.ts
+++ b/backend/src/investment-reports/investment-report-data.service.spec.ts
@@ -16,6 +16,23 @@ function makeTx(overrides: Record<string, unknown>): any {
   };
 }
 
+function holding(over: Record<string, unknown> = {}): any {
+  return { accountId: "acc1", securityId: "sec1", quantity: 10, averageCost: 100, ...over };
+}
+
+function priceRow(over: Record<string, unknown>): any {
+  return {
+    security_id: "sec1",
+    price_date: "2024-06-10",
+    open_price: "100",
+    high_price: "100",
+    low_price: "100",
+    close_price: "100",
+    volume: "1",
+    ...over,
+  };
+}
+
 describe("InvestmentReportDataService", () => {
   let service: InvestmentReportDataService;
   let txRepository: { find: jest.Mock; query: jest.Mock };
@@ -28,7 +45,7 @@ describe("InvestmentReportDataService", () => {
     txRepository = { find: jest.fn(), query: jest.fn() };
     holdingsRepository = { find: jest.fn().mockResolvedValue([]) };
     securitiesRepository = { find: jest.fn() };
-    accountsRepository = { find: jest.fn() };
+    accountsRepository = { find: jest.fn().mockResolvedValue([{ id: "acc1", name: "Brokerage" }]) };
     exchangeRateService = { getLatestRate: jest.fn().mockResolvedValue(null) };
     service = new InvestmentReportDataService(
       txRepository as any,
@@ -45,79 +62,22 @@ describe("InvestmentReportDataService", () => {
   });
 
   it("computes position, valuation, change and analytics for a holding", async () => {
-    accountsRepository.find.mockResolvedValue([
-      { id: "acc1", name: "Brokerage" },
-    ]);
     securitiesRepository.find.mockResolvedValue([
-      {
-        id: "sec1",
-        symbol: "AAA",
-        name: "Alpha Inc",
-        securityType: "STOCK",
-        currencyCode: "USD",
-      },
+      { id: "sec1", symbol: "AAA", name: "Alpha Inc", securityType: "STOCK", currencyCode: "USD" },
     ]);
+    holdingsRepository.find.mockResolvedValue([holding({ quantity: 10, averageCost: 100 })]);
     txRepository.find.mockResolvedValue([
-      makeTx({
-        action: InvestmentAction.BUY,
-        transactionDate: "2024-01-10",
-        quantity: 10,
-        price: 100,
-        totalAmount: 1000,
-        commission: 5,
-      }),
-      makeTx({
-        action: InvestmentAction.DIVIDEND,
-        transactionDate: "2024-03-01",
-        quantity: 0,
-        totalAmount: 20,
-      }),
+      makeTx({ action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 10, price: 100, totalAmount: 1000, commission: 5 }),
+      makeTx({ action: InvestmentAction.DIVIDEND, transactionDate: "2024-03-01", quantity: 0, totalAmount: 20 }),
     ]);
     txRepository.query.mockResolvedValue([
-      {
-        security_id: "sec1",
-        price_date: "2024-01-10",
-        open_price: "100",
-        high_price: "101",
-        low_price: "99",
-        close_price: "100",
-        volume: "500",
-      },
-      {
-        security_id: "sec1",
-        price_date: "2024-06-03",
-        open_price: "117",
-        high_price: "119",
-        low_price: "116",
-        close_price: "118",
-        volume: "800",
-      },
-      {
-        security_id: "sec1",
-        price_date: "2024-06-07",
-        open_price: "118",
-        high_price: "120",
-        low_price: "117",
-        close_price: "119",
-        volume: "900",
-      },
-      {
-        security_id: "sec1",
-        price_date: "2024-06-10",
-        open_price: "119",
-        high_price: "121",
-        low_price: "118",
-        close_price: "120",
-        volume: "1000",
-      },
+      priceRow({ price_date: "2024-01-10", open_price: "100", high_price: "101", low_price: "99", close_price: "100", volume: "500" }),
+      priceRow({ price_date: "2024-06-03", open_price: "117", high_price: "119", low_price: "116", close_price: "118", volume: "800" }),
+      priceRow({ price_date: "2024-06-07", open_price: "118", high_price: "120", low_price: "117", close_price: "119", volume: "900" }),
+      priceRow({ price_date: "2024-06-10", open_price: "119", high_price: "121", low_price: "118", close_price: "120", volume: "1000" }),
     ]);
 
-    const rows = await service.computeHoldings(
-      "u1",
-      ["acc1"],
-      "2024-06-10",
-      "USD",
-    );
+    const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
 
     expect(rows).toHaveLength(1);
     const v = rows[0].values;
@@ -154,92 +114,84 @@ describe("InvestmentReportDataService", () => {
     expect(v.totalReturn1Week).toBeCloseTo(1.6949, 3);
   });
 
-  it("drops fully-sold positions and computes realized gains", async () => {
-    accountsRepository.find.mockResolvedValue([
-      { id: "acc1", name: "Brokerage" },
-    ]);
+  it("drops fully-sold positions (not in the holdings table)", async () => {
     securitiesRepository.find.mockResolvedValue([
-      {
-        id: "sec1",
-        symbol: "AAA",
-        name: "Alpha",
-        securityType: "STOCK",
-        currencyCode: "USD",
-      },
+      { id: "sec1", symbol: "AAA", name: "Alpha", securityType: "STOCK", currencyCode: "USD" },
     ]);
+    holdingsRepository.find.mockResolvedValue([]); // no current holding -> sold
     txRepository.find.mockResolvedValue([
-      makeTx({
-        action: InvestmentAction.BUY,
-        transactionDate: "2024-01-10",
-        quantity: 10,
-        price: 100,
-        totalAmount: 1000,
-      }),
-      makeTx({
-        action: InvestmentAction.SELL,
-        transactionDate: "2024-02-10",
-        quantity: 10,
-        price: 130,
-        totalAmount: 1300,
-      }),
+      makeTx({ action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 10, price: 100, totalAmount: 1000 }),
+      makeTx({ action: InvestmentAction.SELL, transactionDate: "2024-02-10", quantity: 10, price: 130, totalAmount: 1300 }),
     ]);
-    txRepository.query.mockResolvedValue([
-      {
-        security_id: "sec1",
-        price_date: "2024-02-10",
-        open_price: null,
-        high_price: null,
-        low_price: null,
-        close_price: "130",
-        volume: null,
-      },
-    ]);
+    txRepository.query.mockResolvedValue([priceRow({ price_date: "2024-02-10", close_price: "130" })]);
 
-    const rows = await service.computeHoldings(
-      "u1",
-      ["acc1"],
-      "2024-06-10",
-      "USD",
-    );
-    // Position fully closed -> no rows
+    const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
     expect(rows).toHaveLength(0);
   });
 
-  it("seeds holdings without transactions (imported positions)", async () => {
-    accountsRepository.find.mockResolvedValue([
-      { id: "acc1", name: "Brokerage" },
+  it("drops a position the holdings table reports as closed even if the replay is non-zero", async () => {
+    // Simulates the bug: transaction replay leaves a stale non-zero quantity,
+    // but the authoritative holdings table shows the position is closed/sold.
+    securitiesRepository.find.mockResolvedValue([
+      { id: "sec1", symbol: "AAA", name: "Alpha", securityType: "STOCK", currencyCode: "USD" },
     ]);
+    holdingsRepository.find.mockResolvedValue([holding({ quantity: 0, averageCost: 0 })]);
+    txRepository.find.mockResolvedValue([
+      makeTx({ action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 10, price: 100, totalAmount: 1000 }),
+    ]);
+    txRepository.query.mockResolvedValue([priceRow({ close_price: "120" })]);
+
+    const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
+    expect(rows).toHaveLength(0);
+  });
+
+  it("defers to the holdings table quantity when it differs from the replay", async () => {
+    securitiesRepository.find.mockResolvedValue([
+      { id: "sec1", symbol: "AAA", name: "Alpha", securityType: "STOCK", currencyCode: "USD" },
+    ]);
+    // Replay would compute 10, but the authoritative holdings table says 8.
+    holdingsRepository.find.mockResolvedValue([holding({ quantity: 8, averageCost: 100 })]);
+    txRepository.find.mockResolvedValue([
+      makeTx({ action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 10, price: 100, totalAmount: 1000 }),
+    ]);
+    txRepository.query.mockResolvedValue([priceRow({ close_price: "120" })]);
+
+    const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
+    expect(rows[0].values.quantity).toBe(8);
+    expect(rows[0].values.marketValue).toBe(960); // 8 * 120
+    expect(rows[0].values.costBasis).toBe(800); // 8 * 100
+  });
+
+  it("values a historical date from the replay even if currently sold", async () => {
+    securitiesRepository.find.mockResolvedValue([
+      { id: "sec1", symbol: "AAA", name: "Alpha", securityType: "STOCK", currencyCode: "USD" },
+    ]);
+    holdingsRepository.find.mockResolvedValue([]); // currently sold (no holding)
+    txRepository.find.mockResolvedValue([
+      makeTx({ action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 10, price: 100, totalAmount: 1000 }),
+      // Sale happens AFTER the as-of date, so the position was held then.
+      makeTx({ action: InvestmentAction.SELL, transactionDate: "2024-12-01", quantity: 10, price: 130, totalAmount: 1300 }),
+    ]);
+    txRepository.query.mockResolvedValue([priceRow({ price_date: "2024-05-01", close_price: "110" })]);
+
+    const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].values.quantity).toBe(10);
+  });
+
+  it("seeds holdings without transactions (imported positions)", async () => {
     txRepository.find.mockResolvedValue([]);
     holdingsRepository.find.mockResolvedValue([
       { accountId: "acc1", securityId: "sec2", quantity: 5, averageCost: 50 },
     ]);
     securitiesRepository.find.mockResolvedValue([
-      {
-        id: "sec2",
-        symbol: "BBB",
-        name: "Beta",
-        securityType: "ETF",
-        currencyCode: "USD",
-      },
+      { id: "sec2", symbol: "BBB", name: "Beta", securityType: "ETF", currencyCode: "USD" },
     ]);
     txRepository.query.mockResolvedValue([
-      {
-        security_id: "sec2",
-        price_date: "2024-06-10",
-        open_price: "60",
-        high_price: "61",
-        low_price: "59",
-        close_price: "60",
-        volume: "100",
-      },
+      { security_id: "sec2", price_date: "2024-06-10", open_price: "60", high_price: "61", low_price: "59", close_price: "60", volume: "100" },
     ]);
 
-    const rows = await service.computeHoldings(
-      "u1",
-      ["acc1"],
-      "2024-06-10",
-      "USD",
-    );
+    const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
     expect(rows).toHaveLength(1);
     expect(rows[0].values.symbol).toBe("BBB");
     expect(rows[0].values.quantity).toBe(5);
@@ -248,46 +200,19 @@ describe("InvestmentReportDataService", () => {
   });
 
   it("converts market value to base currency for exchange rate and % of portfolio", async () => {
-    accountsRepository.find.mockResolvedValue([
-      { id: "acc1", name: "Brokerage" },
-    ]);
     securitiesRepository.find.mockResolvedValue([
-      {
-        id: "sec1",
-        symbol: "AAA",
-        name: "Alpha",
-        securityType: "STOCK",
-        currencyCode: "CAD",
-      },
+      { id: "sec1", symbol: "AAA", name: "Alpha", securityType: "STOCK", currencyCode: "CAD" },
     ]);
+    holdingsRepository.find.mockResolvedValue([holding({ quantity: 10, averageCost: 100 })]);
     txRepository.find.mockResolvedValue([
-      makeTx({
-        action: InvestmentAction.BUY,
-        transactionDate: "2024-01-10",
-        quantity: 10,
-        price: 100,
-        totalAmount: 1000,
-      }),
+      makeTx({ action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 10, price: 100, totalAmount: 1000 }),
     ]);
     txRepository.query.mockResolvedValue([
-      {
-        security_id: "sec1",
-        price_date: "2024-06-10",
-        open_price: "120",
-        high_price: "121",
-        low_price: "119",
-        close_price: "120",
-        volume: "1000",
-      },
+      priceRow({ open_price: "120", high_price: "121", low_price: "119", close_price: "120", volume: "1000" }),
     ]);
     exchangeRateService.getLatestRate.mockResolvedValue(0.75); // CAD -> USD
 
-    const rows = await service.computeHoldings(
-      "u1",
-      ["acc1"],
-      "2024-06-10",
-      "USD",
-    );
+    const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
     expect(rows[0].values.exchangeRate).toBe(0.75);
     expect(rows[0].exchangeRate).toBe(0.75); // native -> base rate on the row
     expect(rows[0].currencyCode).toBe("CAD");
@@ -297,10 +222,10 @@ describe("InvestmentReportDataService", () => {
   });
 
   it("handles reinvest/interest/capital-gain/split/add actions and annualized return", async () => {
-    accountsRepository.find.mockResolvedValue([{ id: "acc1", name: "Brokerage" }]);
     securitiesRepository.find.mockResolvedValue([
       { id: "sec1", symbol: "AAA", name: "Alpha", securityType: "STOCK", currencyCode: "USD" },
     ]);
+    holdingsRepository.find.mockResolvedValue([holding({ quantity: 26, averageCost: 100 })]);
     txRepository.find.mockResolvedValue([
       makeTx({ action: InvestmentAction.BUY, transactionDate: "2021-01-04", quantity: 10, price: 100, totalAmount: 1000, commission: 2 }),
       makeTx({ action: InvestmentAction.REINVEST, transactionDate: "2021-06-01", quantity: 1, price: 110, totalAmount: 110 }),
@@ -310,14 +235,13 @@ describe("InvestmentReportDataService", () => {
       makeTx({ action: InvestmentAction.SPLIT, transactionDate: "2022-01-01", quantity: 2 }),
     ]);
     txRepository.query.mockResolvedValue([
-      { security_id: "sec1", price_date: "2021-01-04", open_price: "100", high_price: "100", low_price: "100", close_price: "100", volume: "10" },
-      { security_id: "sec1", price_date: "2024-06-10", open_price: "60", high_price: "61", low_price: "59", close_price: "60", volume: "10" },
+      priceRow({ price_date: "2021-01-04", close_price: "100", volume: "10" }),
+      priceRow({ price_date: "2024-06-10", open_price: "60", high_price: "61", low_price: "59", close_price: "60", volume: "10" }),
     ]);
 
     const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
     const v = rows[0].values;
-    // (10 + 1 reinvested + 2 added) * 2 (split) = 26 shares
-    expect(v.quantity).toBe(26);
+    expect(v.quantity).toBe(26); // from the holdings table
     expect(v.reinvestments).toBe(110);
     expect(v.income).toBe(12); // interest 5 + capital gain 7
     // Held > 0.5 years -> annualized return is computed (not null)
@@ -326,16 +250,14 @@ describe("InvestmentReportDataService", () => {
   });
 
   it("uses the reverse FX rate when only the inverse pair exists", async () => {
-    accountsRepository.find.mockResolvedValue([{ id: "acc1", name: "Brokerage" }]);
     securitiesRepository.find.mockResolvedValue([
       { id: "sec1", symbol: "AAA", name: "Alpha", securityType: "STOCK", currencyCode: "EUR" },
     ]);
+    holdingsRepository.find.mockResolvedValue([holding({ quantity: 10, averageCost: 100 })]);
     txRepository.find.mockResolvedValue([
       makeTx({ action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 10, price: 100, totalAmount: 1000 }),
     ]);
-    txRepository.query.mockResolvedValue([
-      { security_id: "sec1", price_date: "2024-06-10", open_price: "120", high_price: "121", low_price: "119", close_price: "120", volume: "1" },
-    ]);
+    txRepository.query.mockResolvedValue([priceRow({ close_price: "120" })]);
     // EUR->USD missing, USD->EUR = 0.8 -> rate = 1/0.8 = 1.25
     exchangeRateService.getLatestRate.mockImplementation((from: string) =>
       from === "EUR" ? Promise.resolve(null) : Promise.resolve(0.8),
@@ -346,10 +268,10 @@ describe("InvestmentReportDataService", () => {
   });
 
   it("returns null valuation columns when no price is available", async () => {
-    accountsRepository.find.mockResolvedValue([{ id: "acc1", name: "Brokerage" }]);
     securitiesRepository.find.mockResolvedValue([
       { id: "sec1", symbol: "AAA", name: "Alpha", securityType: "STOCK", currencyCode: "USD" },
     ]);
+    holdingsRepository.find.mockResolvedValue([holding({ quantity: 10, averageCost: 100 })]);
     txRepository.find.mockResolvedValue([
       makeTx({ action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 10, price: 100, totalAmount: 1000 }),
     ]);
@@ -365,10 +287,10 @@ describe("InvestmentReportDataService", () => {
   });
 
   it("handles transfers, share removals, and 52-week lows from null-OHLC rows", async () => {
-    accountsRepository.find.mockResolvedValue([{ id: "acc1", name: "B" }]);
     securitiesRepository.find.mockResolvedValue([
       { id: "sec1", symbol: "AAA", name: "Alpha", securityType: "STOCK", currencyCode: "USD" },
     ]);
+    holdingsRepository.find.mockResolvedValue([holding({ quantity: 20, averageCost: 50 })]);
     txRepository.find.mockResolvedValue([
       makeTx({ action: InvestmentAction.TRANSFER_IN, transactionDate: "2022-01-10", quantity: 20, price: 50, totalAmount: 1000 }),
       makeTx({ action: InvestmentAction.REMOVE_SHARES, transactionDate: "2022-06-10", quantity: 5 }),
@@ -376,15 +298,14 @@ describe("InvestmentReportDataService", () => {
       makeTx({ action: InvestmentAction.BUY, transactionDate: "2023-06-10", quantity: 10, price: 70, totalAmount: 700 }),
     ]);
     txRepository.query.mockResolvedValue([
-      { security_id: "sec1", price_date: "2022-01-10", open_price: null, high_price: null, low_price: null, close_price: "50", volume: null },
-      { security_id: "sec1", price_date: "2023-06-09", open_price: "65", high_price: "66", low_price: "64", close_price: "65", volume: "10" },
-      { security_id: "sec1", price_date: "2024-01-15", open_price: "80", high_price: null, low_price: null, close_price: "80", volume: "10" },
-      { security_id: "sec1", price_date: "2024-06-10", open_price: "88", high_price: "91", low_price: "87", close_price: "90", volume: "100" },
+      priceRow({ price_date: "2022-01-10", open_price: null, high_price: null, low_price: null, close_price: "50", volume: null }),
+      priceRow({ price_date: "2023-06-09", open_price: "65", high_price: "66", low_price: "64", close_price: "65", volume: "10" }),
+      priceRow({ price_date: "2024-01-15", open_price: "80", high_price: null, low_price: null, close_price: "80", volume: "10" }),
+      priceRow({ price_date: "2024-06-10", open_price: "88", high_price: "91", low_price: "87", close_price: "90", volume: "100" }),
     ]);
 
     const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
     const v = rows[0].values;
-    // 20 in (transfer) - 5 (remove) - 5 (transfer out) + 10 (buy) = 20
     expect(v.quantity).toBe(20);
     // A TRANSFER_OUT is not a sale, so it does not create realized gains.
     expect(v.realizedGains).toBe(0);
@@ -394,8 +315,8 @@ describe("InvestmentReportDataService", () => {
   });
 
   it("skips a holding whose security record is missing", async () => {
-    accountsRepository.find.mockResolvedValue([{ id: "acc1", name: "B" }]);
     securitiesRepository.find.mockResolvedValue([]); // security not found
+    holdingsRepository.find.mockResolvedValue([holding({ quantity: 10, averageCost: 100 })]);
     txRepository.find.mockResolvedValue([
       makeTx({ action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 10, price: 100, totalAmount: 1000 }),
     ]);
@@ -405,18 +326,21 @@ describe("InvestmentReportDataService", () => {
   });
 
   it("maps raw security types to friendly labels", async () => {
-    accountsRepository.find.mockResolvedValue([{ id: "acc1", name: "B" }]);
     securitiesRepository.find.mockResolvedValue([
       { id: "sec1", symbol: "AAA", name: "A", securityType: "MUTUAL_FUND", currencyCode: "USD" },
       { id: "sec2", symbol: "BBB", name: "B", securityType: "CUSTOM_TYPE", currencyCode: "USD" },
+    ]);
+    holdingsRepository.find.mockResolvedValue([
+      holding({ securityId: "sec1", quantity: 10, averageCost: 100 }),
+      holding({ securityId: "sec2", quantity: 5, averageCost: 50 }),
     ]);
     txRepository.find.mockResolvedValue([
       makeTx({ securityId: "sec1", action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 10, price: 100, totalAmount: 1000 }),
       makeTx({ securityId: "sec2", action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 5, price: 50, totalAmount: 250 }),
     ]);
     txRepository.query.mockResolvedValue([
-      { security_id: "sec1", price_date: "2024-06-10", open_price: "100", high_price: "100", low_price: "100", close_price: "100", volume: "1" },
-      { security_id: "sec2", price_date: "2024-06-10", open_price: "50", high_price: "50", low_price: "50", close_price: "50", volume: "1" },
+      priceRow({ security_id: "sec1", close_price: "100" }),
+      priceRow({ security_id: "sec2", close_price: "50" }),
     ]);
     const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
     const types = rows.map((r) => r.values.securityType);
@@ -432,9 +356,7 @@ describe("InvestmentReportDataService", () => {
 
     it("returns the max stored price date", async () => {
       txRepository.query.mockResolvedValue([{ d: "2024-06-10" }]);
-      expect(await service.getLatestMarketDay("u1", ["acc1"])).toBe(
-        "2024-06-10",
-      );
+      expect(await service.getLatestMarketDay("u1", ["acc1"])).toBe("2024-06-10");
     });
 
     it("falls back to today when no prices exist", async () => {

--- a/backend/src/investment-reports/investment-report-data.service.spec.ts
+++ b/backend/src/investment-reports/investment-report-data.service.spec.ts
@@ -1,0 +1,383 @@
+import { InvestmentReportDataService } from "./investment-report-data.service";
+import { InvestmentAction } from "../securities/entities/investment-transaction.entity";
+
+function makeTx(overrides: Record<string, unknown>): any {
+  return {
+    accountId: "acc1",
+    securityId: "sec1",
+    action: InvestmentAction.BUY,
+    transactionDate: "2024-01-10",
+    quantity: 0,
+    price: 0,
+    totalAmount: 0,
+    commission: 0,
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe("InvestmentReportDataService", () => {
+  let service: InvestmentReportDataService;
+  let txRepository: { find: jest.Mock; query: jest.Mock };
+  let holdingsRepository: { find: jest.Mock };
+  let securitiesRepository: { find: jest.Mock };
+  let accountsRepository: { find: jest.Mock };
+  let exchangeRateService: { getLatestRate: jest.Mock };
+
+  beforeEach(() => {
+    txRepository = { find: jest.fn(), query: jest.fn() };
+    holdingsRepository = { find: jest.fn().mockResolvedValue([]) };
+    securitiesRepository = { find: jest.fn() };
+    accountsRepository = { find: jest.fn() };
+    exchangeRateService = { getLatestRate: jest.fn().mockResolvedValue(null) };
+    service = new InvestmentReportDataService(
+      txRepository as any,
+      holdingsRepository as any,
+      securitiesRepository as any,
+      accountsRepository as any,
+      exchangeRateService as any,
+    );
+  });
+
+  it("returns no rows when there are no accounts", async () => {
+    const rows = await service.computeHoldings("u1", [], "2024-06-10", "USD");
+    expect(rows).toEqual([]);
+  });
+
+  it("computes position, valuation, change and analytics for a holding", async () => {
+    accountsRepository.find.mockResolvedValue([
+      { id: "acc1", name: "Brokerage" },
+    ]);
+    securitiesRepository.find.mockResolvedValue([
+      {
+        id: "sec1",
+        symbol: "AAA",
+        name: "Alpha Inc",
+        securityType: "STOCK",
+        currencyCode: "USD",
+      },
+    ]);
+    txRepository.find.mockResolvedValue([
+      makeTx({
+        action: InvestmentAction.BUY,
+        transactionDate: "2024-01-10",
+        quantity: 10,
+        price: 100,
+        totalAmount: 1000,
+        commission: 5,
+      }),
+      makeTx({
+        action: InvestmentAction.DIVIDEND,
+        transactionDate: "2024-03-01",
+        quantity: 0,
+        totalAmount: 20,
+      }),
+    ]);
+    txRepository.query.mockResolvedValue([
+      {
+        security_id: "sec1",
+        price_date: "2024-01-10",
+        open_price: "100",
+        high_price: "101",
+        low_price: "99",
+        close_price: "100",
+        volume: "500",
+      },
+      {
+        security_id: "sec1",
+        price_date: "2024-06-03",
+        open_price: "117",
+        high_price: "119",
+        low_price: "116",
+        close_price: "118",
+        volume: "800",
+      },
+      {
+        security_id: "sec1",
+        price_date: "2024-06-07",
+        open_price: "118",
+        high_price: "120",
+        low_price: "117",
+        close_price: "119",
+        volume: "900",
+      },
+      {
+        security_id: "sec1",
+        price_date: "2024-06-10",
+        open_price: "119",
+        high_price: "121",
+        low_price: "118",
+        close_price: "120",
+        volume: "1000",
+      },
+    ]);
+
+    const rows = await service.computeHoldings(
+      "u1",
+      ["acc1"],
+      "2024-06-10",
+      "USD",
+    );
+
+    expect(rows).toHaveLength(1);
+    const v = rows[0].values;
+    expect(v.symbol).toBe("AAA");
+    expect(v.quantity).toBe(10);
+    expect(v.costBasis).toBe(1000);
+    expect(v.averageCost).toBe(100);
+    expect(v.lastPrice).toBe(120);
+    expect(v.marketValue).toBe(1200);
+    expect(v.income).toBe(20);
+    expect(v.gain).toBe(220); // marketValue + income - costBasis
+    expect(v.priceAppreciation).toBe(200);
+    expect(v.gainPercent).toBe(22);
+    expect(v.previousClose).toBe(119);
+    expect(v.change).toBe(1);
+    expect(v.todaysTotalChange).toBe(10);
+    expect(v.open).toBe(119);
+    expect(v.dayHigh).toBe(121);
+    expect(v.dayLow).toBe(118);
+    expect(v.volume).toBe(1000);
+    expect(v.commissions).toBe(5);
+    expect(v.purchases).toBe(1000);
+    expect(v.sales).toBe(0);
+    expect(v.realizedGains).toBe(0);
+    expect(v.portfolioPercent).toBe(100);
+    expect(v.exchangeRate).toBe(1);
+    expect(v.lastUpdated).toBe("2024-06-10");
+    expect(v.fiftyTwoWeekHigh).toBe(121);
+    expect(v.fiftyTwoWeekLow).toBe(99);
+    expect(v.lastTransactionDate).toBe("2024-03-01");
+    expect(v.totalReturnAllDates).toBe(22);
+    // 1-week return: begin value 10*118=1180 -> (1200-1180)/1180*100
+    expect(v.totalReturn1Week).toBeCloseTo(1.6949, 3);
+  });
+
+  it("drops fully-sold positions and computes realized gains", async () => {
+    accountsRepository.find.mockResolvedValue([
+      { id: "acc1", name: "Brokerage" },
+    ]);
+    securitiesRepository.find.mockResolvedValue([
+      {
+        id: "sec1",
+        symbol: "AAA",
+        name: "Alpha",
+        securityType: "STOCK",
+        currencyCode: "USD",
+      },
+    ]);
+    txRepository.find.mockResolvedValue([
+      makeTx({
+        action: InvestmentAction.BUY,
+        transactionDate: "2024-01-10",
+        quantity: 10,
+        price: 100,
+        totalAmount: 1000,
+      }),
+      makeTx({
+        action: InvestmentAction.SELL,
+        transactionDate: "2024-02-10",
+        quantity: 10,
+        price: 130,
+        totalAmount: 1300,
+      }),
+    ]);
+    txRepository.query.mockResolvedValue([
+      {
+        security_id: "sec1",
+        price_date: "2024-02-10",
+        open_price: null,
+        high_price: null,
+        low_price: null,
+        close_price: "130",
+        volume: null,
+      },
+    ]);
+
+    const rows = await service.computeHoldings(
+      "u1",
+      ["acc1"],
+      "2024-06-10",
+      "USD",
+    );
+    // Position fully closed -> no rows
+    expect(rows).toHaveLength(0);
+  });
+
+  it("seeds holdings without transactions (imported positions)", async () => {
+    accountsRepository.find.mockResolvedValue([
+      { id: "acc1", name: "Brokerage" },
+    ]);
+    txRepository.find.mockResolvedValue([]);
+    holdingsRepository.find.mockResolvedValue([
+      { accountId: "acc1", securityId: "sec2", quantity: 5, averageCost: 50 },
+    ]);
+    securitiesRepository.find.mockResolvedValue([
+      {
+        id: "sec2",
+        symbol: "BBB",
+        name: "Beta",
+        securityType: "ETF",
+        currencyCode: "USD",
+      },
+    ]);
+    txRepository.query.mockResolvedValue([
+      {
+        security_id: "sec2",
+        price_date: "2024-06-10",
+        open_price: "60",
+        high_price: "61",
+        low_price: "59",
+        close_price: "60",
+        volume: "100",
+      },
+    ]);
+
+    const rows = await service.computeHoldings(
+      "u1",
+      ["acc1"],
+      "2024-06-10",
+      "USD",
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].values.symbol).toBe("BBB");
+    expect(rows[0].values.quantity).toBe(5);
+    expect(rows[0].values.costBasis).toBe(250);
+    expect(rows[0].values.marketValue).toBe(300);
+  });
+
+  it("converts market value to base currency for exchange rate and % of portfolio", async () => {
+    accountsRepository.find.mockResolvedValue([
+      { id: "acc1", name: "Brokerage" },
+    ]);
+    securitiesRepository.find.mockResolvedValue([
+      {
+        id: "sec1",
+        symbol: "AAA",
+        name: "Alpha",
+        securityType: "STOCK",
+        currencyCode: "CAD",
+      },
+    ]);
+    txRepository.find.mockResolvedValue([
+      makeTx({
+        action: InvestmentAction.BUY,
+        transactionDate: "2024-01-10",
+        quantity: 10,
+        price: 100,
+        totalAmount: 1000,
+      }),
+    ]);
+    txRepository.query.mockResolvedValue([
+      {
+        security_id: "sec1",
+        price_date: "2024-06-10",
+        open_price: "120",
+        high_price: "121",
+        low_price: "119",
+        close_price: "120",
+        volume: "1000",
+      },
+    ]);
+    exchangeRateService.getLatestRate.mockResolvedValue(0.75); // CAD -> USD
+
+    const rows = await service.computeHoldings(
+      "u1",
+      ["acc1"],
+      "2024-06-10",
+      "USD",
+    );
+    expect(rows[0].values.exchangeRate).toBe(0.75);
+    expect(rows[0].values.portfolioPercent).toBe(100);
+    // Monetary values stay in the holding's native (CAD) currency.
+    expect(rows[0].values.marketValue).toBe(1200);
+  });
+
+  it("handles reinvest/interest/capital-gain/split/add actions and annualized return", async () => {
+    accountsRepository.find.mockResolvedValue([{ id: "acc1", name: "Brokerage" }]);
+    securitiesRepository.find.mockResolvedValue([
+      { id: "sec1", symbol: "AAA", name: "Alpha", securityType: "STOCK", currencyCode: "USD" },
+    ]);
+    txRepository.find.mockResolvedValue([
+      makeTx({ action: InvestmentAction.BUY, transactionDate: "2021-01-04", quantity: 10, price: 100, totalAmount: 1000, commission: 2 }),
+      makeTx({ action: InvestmentAction.REINVEST, transactionDate: "2021-06-01", quantity: 1, price: 110, totalAmount: 110 }),
+      makeTx({ action: InvestmentAction.INTEREST, transactionDate: "2021-07-01", quantity: 0, totalAmount: 5 }),
+      makeTx({ action: InvestmentAction.CAPITAL_GAIN, transactionDate: "2021-08-01", quantity: 0, totalAmount: 7 }),
+      makeTx({ action: InvestmentAction.ADD_SHARES, transactionDate: "2021-09-01", quantity: 2 }),
+      makeTx({ action: InvestmentAction.SPLIT, transactionDate: "2022-01-01", quantity: 2 }),
+    ]);
+    txRepository.query.mockResolvedValue([
+      { security_id: "sec1", price_date: "2021-01-04", open_price: "100", high_price: "100", low_price: "100", close_price: "100", volume: "10" },
+      { security_id: "sec1", price_date: "2024-06-10", open_price: "60", high_price: "61", low_price: "59", close_price: "60", volume: "10" },
+    ]);
+
+    const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
+    const v = rows[0].values;
+    // (10 + 1 reinvested + 2 added) * 2 (split) = 26 shares
+    expect(v.quantity).toBe(26);
+    expect(v.reinvestments).toBe(110);
+    expect(v.income).toBe(12); // interest 5 + capital gain 7
+    // Held > 0.5 years -> annualized return is computed (not null)
+    expect(v.totalAnnualizedReturn).not.toBeNull();
+    expect(v.totalReturn3Year).not.toBeNull();
+  });
+
+  it("uses the reverse FX rate when only the inverse pair exists", async () => {
+    accountsRepository.find.mockResolvedValue([{ id: "acc1", name: "Brokerage" }]);
+    securitiesRepository.find.mockResolvedValue([
+      { id: "sec1", symbol: "AAA", name: "Alpha", securityType: "STOCK", currencyCode: "EUR" },
+    ]);
+    txRepository.find.mockResolvedValue([
+      makeTx({ action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 10, price: 100, totalAmount: 1000 }),
+    ]);
+    txRepository.query.mockResolvedValue([
+      { security_id: "sec1", price_date: "2024-06-10", open_price: "120", high_price: "121", low_price: "119", close_price: "120", volume: "1" },
+    ]);
+    // EUR->USD missing, USD->EUR = 0.8 -> rate = 1/0.8 = 1.25
+    exchangeRateService.getLatestRate.mockImplementation((from: string) =>
+      from === "EUR" ? Promise.resolve(null) : Promise.resolve(0.8),
+    );
+
+    const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
+    expect(rows[0].values.exchangeRate).toBe(1.25);
+  });
+
+  it("returns null valuation columns when no price is available", async () => {
+    accountsRepository.find.mockResolvedValue([{ id: "acc1", name: "Brokerage" }]);
+    securitiesRepository.find.mockResolvedValue([
+      { id: "sec1", symbol: "AAA", name: "Alpha", securityType: "STOCK", currencyCode: "USD" },
+    ]);
+    txRepository.find.mockResolvedValue([
+      makeTx({ action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 10, price: 100, totalAmount: 1000 }),
+    ]);
+    txRepository.query.mockResolvedValue([]); // no stored prices
+
+    const rows = await service.computeHoldings("u1", ["acc1"], "2024-06-10", "USD");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].values.lastPrice).toBeNull();
+    expect(rows[0].values.marketValue).toBeNull();
+    expect(rows[0].values.gain).toBeNull();
+    expect(rows[0].values.portfolioPercent).toBeNull();
+    expect(rows[0].values.totalReturn1Year).toBeNull();
+  });
+
+  describe("getLatestMarketDay", () => {
+    it("returns today when there are no accounts", async () => {
+      const today = new Date().toISOString().slice(0, 10);
+      expect(await service.getLatestMarketDay("u1", [])).toBe(today);
+    });
+
+    it("returns the max stored price date", async () => {
+      txRepository.query.mockResolvedValue([{ d: "2024-06-10" }]);
+      expect(await service.getLatestMarketDay("u1", ["acc1"])).toBe(
+        "2024-06-10",
+      );
+    });
+
+    it("falls back to today when no prices exist", async () => {
+      const today = new Date().toISOString().slice(0, 10);
+      txRepository.query.mockResolvedValue([{ d: null }]);
+      expect(await service.getLatestMarketDay("u1", ["acc1"])).toBe(today);
+    });
+  });
+});

--- a/backend/src/investment-reports/investment-report-data.service.spec.ts
+++ b/backend/src/investment-reports/investment-report-data.service.spec.ts
@@ -179,6 +179,56 @@ describe("InvestmentReportDataService", () => {
     expect(rows[0].values.quantity).toBe(10);
   });
 
+  it("merges identical securities across accounts when requested", async () => {
+    accountsRepository.find.mockResolvedValue([
+      { id: "acc1", name: "RRSP" },
+      { id: "acc2", name: "TFSA" },
+    ]);
+    securitiesRepository.find.mockResolvedValue([
+      { id: "sec1", symbol: "AAA", name: "Alpha", securityType: "STOCK", currencyCode: "USD" },
+    ]);
+    holdingsRepository.find.mockResolvedValue([
+      { accountId: "acc1", securityId: "sec1", quantity: 10, averageCost: 100 },
+      { accountId: "acc2", securityId: "sec1", quantity: 5, averageCost: 120 },
+    ]);
+    txRepository.find.mockResolvedValue([
+      makeTx({ accountId: "acc1", action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 10, price: 100, totalAmount: 1000 }),
+      makeTx({ accountId: "acc2", action: InvestmentAction.BUY, transactionDate: "2024-01-11", quantity: 5, price: 120, totalAmount: 600 }),
+    ]);
+    txRepository.query.mockResolvedValue([priceRow({ close_price: "130" })]);
+
+    const rows = await service.computeHoldings("u1", ["acc1", "acc2"], "2024-06-10", "USD", true);
+    expect(rows).toHaveLength(1); // combined into a single position
+    expect(rows[0].values.quantity).toBe(15); // 10 + 5
+    expect(rows[0].values.costBasis).toBe(1600); // 10*100 + 5*120
+    expect(rows[0].values.marketValue).toBe(1950); // 15 * 130
+    expect(rows[0].values.account).toBe("Multiple accounts");
+  });
+
+  it("keeps securities separate across accounts by default (account name per row)", async () => {
+    accountsRepository.find.mockResolvedValue([
+      { id: "acc1", name: "RRSP" },
+      { id: "acc2", name: "TFSA" },
+    ]);
+    securitiesRepository.find.mockResolvedValue([
+      { id: "sec1", symbol: "AAA", name: "Alpha", securityType: "STOCK", currencyCode: "USD" },
+    ]);
+    holdingsRepository.find.mockResolvedValue([
+      { accountId: "acc1", securityId: "sec1", quantity: 10, averageCost: 100 },
+      { accountId: "acc2", securityId: "sec1", quantity: 5, averageCost: 120 },
+    ]);
+    txRepository.find.mockResolvedValue([
+      makeTx({ accountId: "acc1", action: InvestmentAction.BUY, transactionDate: "2024-01-10", quantity: 10, price: 100, totalAmount: 1000 }),
+      makeTx({ accountId: "acc2", action: InvestmentAction.BUY, transactionDate: "2024-01-11", quantity: 5, price: 120, totalAmount: 600 }),
+    ]);
+    txRepository.query.mockResolvedValue([priceRow({ close_price: "130" })]);
+
+    const rows = await service.computeHoldings("u1", ["acc1", "acc2"], "2024-06-10", "USD", false);
+    expect(rows).toHaveLength(2);
+    const accounts = rows.map((r) => r.values.account).sort();
+    expect(accounts).toEqual(["RRSP", "TFSA"]);
+  });
+
   it("seeds holdings without transactions (imported positions)", async () => {
     txRepository.find.mockResolvedValue([]);
     holdingsRepository.find.mockResolvedValue([

--- a/backend/src/investment-reports/investment-report-data.service.spec.ts
+++ b/backend/src/investment-reports/investment-report-data.service.spec.ts
@@ -288,6 +288,8 @@ describe("InvestmentReportDataService", () => {
       "USD",
     );
     expect(rows[0].values.exchangeRate).toBe(0.75);
+    expect(rows[0].exchangeRate).toBe(0.75); // native -> base rate on the row
+    expect(rows[0].currencyCode).toBe("CAD");
     expect(rows[0].values.portfolioPercent).toBe(100);
     // Monetary values stay in the holding's native (CAD) currency.
     expect(rows[0].values.marketValue).toBe(1200);

--- a/backend/src/investment-reports/investment-report-data.service.ts
+++ b/backend/src/investment-reports/investment-report-data.service.ts
@@ -183,6 +183,18 @@ export class InvestmentReportDataService {
 
     const accountMap = await this.loadAccounts(accountIds);
 
+    // The maintained holdings table is the authoritative current snapshot.
+    const holdings = await this.holdingsRepository.find({
+      where: { accountId: In(accountIds) },
+    });
+    const holdingsMap = new Map<string, { quantity: number; averageCost: number }>();
+    for (const h of holdings) {
+      holdingsMap.set(`${h.accountId}:${h.securityId}`, {
+        quantity: Number(h.quantity) || 0,
+        averageCost: Number(h.averageCost) || 0,
+      });
+    }
+
     // Replay transactions up to the as-of date, grouped by (account, security).
     const transactions = await this.txRepository.find({
       where: { userId, accountId: In(accountIds) },
@@ -192,7 +204,7 @@ export class InvestmentReportDataService {
 
     // Holdings without any transactions (e.g. imported positions) still belong
     // in the report; seed them so they are not dropped.
-    await this.seedTransactionlessHoldings(accountIds, groups);
+    this.seedTransactionlessHoldings(holdings, groups);
 
     const securityIds = [
       ...new Set([...groups.values()].map((g) => g.securityId)),
@@ -230,10 +242,27 @@ export class InvestmentReportDataService {
       const lastPrice = asOfRow ? asOfRow.close : null;
       const previousClose = prevRow ? prevRow.close : null;
 
-      const quantity = round(group.state.quantity, 8);
-      if (Math.abs(quantity) < 0.0001) continue;
+      let quantity = round(group.state.quantity, 8);
+      let costBasis = round(group.state.costBasis, 4);
 
-      const costBasis = round(group.state.costBasis, 4);
+      // When no transactions occur after the as-of date, the maintained
+      // holdings table is the authoritative snapshot of this position. Defer to
+      // it (matching the portfolio view): drop positions it reports as closed
+      // (fully-sold/deactivated securities) and use its quantity and cost basis.
+      const holdingKey = `${group.accountId}:${group.securityId}`;
+      const lastTxDate = group.txs.length
+        ? group.txs[group.txs.length - 1].transactionDate
+        : null;
+      const reflectsPresent = !lastTxDate || lastTxDate <= asOfDate;
+      if (reflectsPresent) {
+        const current = holdingsMap.get(holdingKey);
+        if (!current || Math.abs(current.quantity) < 0.0001) continue;
+        quantity = round(current.quantity, 8);
+        costBasis = round(current.quantity * current.averageCost, 4);
+      } else if (Math.abs(quantity) < 0.0001) {
+        continue;
+      }
+
       const averageCost =
         quantity !== 0 ? round(costBasis / quantity, 6) : null;
       const marketValue =
@@ -512,13 +541,10 @@ export class InvestmentReportDataService {
    * Add synthetic groups for holdings that have no investment transactions so
    * imported positions still appear (valued at their stored average cost).
    */
-  private async seedTransactionlessHoldings(
-    accountIds: string[],
+  private seedTransactionlessHoldings(
+    holdings: Holding[],
     groups: Map<string, GroupRecord>,
-  ): Promise<void> {
-    const holdings = await this.holdingsRepository.find({
-      where: { accountId: In(accountIds) },
-    });
+  ): void {
     for (const h of holdings) {
       const key = `${h.accountId}:${h.securityId}`;
       if (groups.has(key)) continue;

--- a/backend/src/investment-reports/investment-report-data.service.ts
+++ b/backend/src/investment-reports/investment-report-data.service.ts
@@ -76,6 +76,31 @@ function isoAddYears(iso: string, years: number): string {
   return isoAddMonths(iso, years * 12);
 }
 
+const SECURITY_TYPE_LABELS: Record<string, string> = {
+  STOCK: "Stock",
+  EQUITY: "Equity",
+  ETF: "ETF",
+  MUTUAL_FUND: "Mutual Fund",
+  BOND: "Bond",
+  OPTION: "Option",
+  GIC: "GIC",
+  CRYPTO: "Cryptocurrency",
+  CASH: "Cash/Money Market",
+  INDEX: "Index",
+  OTHER: "Other",
+};
+
+/** Friendly display label for a raw security type (e.g. MUTUAL_FUND -> Mutual Fund). */
+function formatSecurityType(raw: string | null): string {
+  if (!raw) return "Stock";
+  const known = SECURITY_TYPE_LABELS[raw.toUpperCase()];
+  if (known) return known;
+  return raw
+    .split("_")
+    .map((w) => (w ? w.charAt(0).toUpperCase() + w.slice(1).toLowerCase() : w))
+    .join(" ");
+}
+
 /** Apply a transaction's quantity effect (used to reconstruct historical shares). */
 function applyQuantity(
   state: { quantity: number },
@@ -248,7 +273,7 @@ export class InvestmentReportDataService {
       const values: Record<string, InvestmentCellValue> = {
         symbol: security.symbol,
         name: security.name,
-        securityType: security.securityType || "STOCK",
+        securityType: formatSecurityType(security.securityType),
         currency: security.currencyCode,
         quantity,
         averageCost,

--- a/backend/src/investment-reports/investment-report-data.service.ts
+++ b/backend/src/investment-reports/investment-report-data.service.ts
@@ -19,6 +19,8 @@ export interface ComputedHolding {
   symbol: string;
   securityName: string;
   currencyCode: string;
+  /** Rate to convert this holding's native monetary values to the base currency. */
+  exchangeRate: number;
   /** Every column key -> computed value (null when unavailable). */
   values: Record<string, InvestmentCellValue>;
 }
@@ -294,6 +296,7 @@ export class InvestmentReportDataService {
           symbol: security.symbol,
           securityName: security.name,
           currencyCode: security.currencyCode,
+          exchangeRate: fxRate,
           values,
         },
         marketValueBase,

--- a/backend/src/investment-reports/investment-report-data.service.ts
+++ b/backend/src/investment-reports/investment-report-data.service.ts
@@ -1,0 +1,661 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository, In } from "typeorm";
+import { Holding } from "../securities/entities/holding.entity";
+import { Security } from "../securities/entities/security.entity";
+import {
+  InvestmentTransaction,
+  InvestmentAction,
+} from "../securities/entities/investment-transaction.entity";
+import { Account } from "../accounts/entities/account.entity";
+import { ExchangeRateService } from "../currencies/exchange-rate.service";
+import { InvestmentCellValue } from "./dto/execute-investment-report.dto";
+
+/** One computed holding row plus the fields needed to group it. */
+export interface ComputedHolding {
+  accountId: string;
+  accountName: string;
+  securityId: string;
+  symbol: string;
+  securityName: string;
+  currencyCode: string;
+  /** Every column key -> computed value (null when unavailable). */
+  values: Record<string, InvestmentCellValue>;
+}
+
+interface PriceRow {
+  date: string;
+  open: number | null;
+  high: number | null;
+  low: number | null;
+  close: number;
+  volume: number | null;
+}
+
+interface ReplayState {
+  quantity: number;
+  costBasis: number;
+  income: number;
+  commissions: number;
+  purchases: number;
+  sales: number;
+  reinvestments: number;
+  realizedGains: number;
+  lastTransactionDate: string | null;
+}
+
+interface GroupRecord {
+  accountId: string;
+  securityId: string;
+  txs: InvestmentTransaction[];
+  state: ReplayState;
+}
+
+function round(value: number, dp = 4): number {
+  const f = Math.pow(10, dp);
+  return Math.round(value * f) / f;
+}
+
+function isoAddDays(iso: string, days: number): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + days);
+  return dt.toISOString().slice(0, 10);
+}
+
+function isoAddMonths(iso: string, months: number): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCMonth(dt.getUTCMonth() + months);
+  return dt.toISOString().slice(0, 10);
+}
+
+function isoAddYears(iso: string, years: number): string {
+  return isoAddMonths(iso, years * 12);
+}
+
+/** Apply a transaction's quantity effect (used to reconstruct historical shares). */
+function applyQuantity(
+  state: { quantity: number },
+  tx: InvestmentTransaction,
+): void {
+  const quantity = Number(tx.quantity) || 0;
+  switch (tx.action) {
+    case InvestmentAction.BUY:
+    case InvestmentAction.REINVEST:
+    case InvestmentAction.TRANSFER_IN:
+    case InvestmentAction.ADD_SHARES:
+      state.quantity += quantity;
+      break;
+    case InvestmentAction.SELL:
+    case InvestmentAction.TRANSFER_OUT:
+    case InvestmentAction.REMOVE_SHARES:
+      state.quantity -= quantity;
+      break;
+    case InvestmentAction.SPLIT:
+      if (quantity > 0) state.quantity *= quantity;
+      break;
+  }
+}
+
+/**
+ * Computes the per-holding rows that back a custom investment report. Each row
+ * represents one security held in one account, valued as of a requested date.
+ * Positions and cost basis are reconstructed by replaying the user's
+ * investment transactions (so any historical date works); prices come from the
+ * stored daily OHLCV history. All monetary column values are denominated in the
+ * holding's own (security) currency; only "% of portfolio" and "exchange rate"
+ * use the base currency.
+ */
+@Injectable()
+export class InvestmentReportDataService {
+  constructor(
+    @InjectRepository(InvestmentTransaction)
+    private txRepository: Repository<InvestmentTransaction>,
+    @InjectRepository(Holding)
+    private holdingsRepository: Repository<Holding>,
+    @InjectRepository(Security)
+    private securitiesRepository: Repository<Security>,
+    @InjectRepository(Account)
+    private accountsRepository: Repository<Account>,
+    private exchangeRateService: ExchangeRateService,
+  ) {}
+
+  /**
+   * The latest day we hold any price for the given accounts' securities. Used
+   * to default the report's as-of date to the last day the markets were open.
+   * Falls back to today when there is no stored price history.
+   */
+  async getLatestMarketDay(
+    userId: string,
+    accountIds: string[],
+  ): Promise<string> {
+    const today = new Date().toISOString().slice(0, 10);
+    if (accountIds.length === 0) return today;
+    const rows: { d: string | null }[] = await this.txRepository.query(
+      `SELECT MAX(sp.price_date)::text AS d
+         FROM security_prices sp
+        WHERE sp.security_id IN (
+          SELECT security_id FROM holdings WHERE account_id = ANY($1)
+          UNION
+          SELECT security_id FROM investment_transactions
+            WHERE user_id = $2 AND account_id = ANY($1) AND security_id IS NOT NULL
+        )`,
+      [accountIds, userId],
+    );
+    return rows[0]?.d || today;
+  }
+
+  async computeHoldings(
+    userId: string,
+    accountIds: string[],
+    asOfDate: string,
+    baseCurrency: string,
+  ): Promise<ComputedHolding[]> {
+    if (accountIds.length === 0) return [];
+
+    const accountMap = await this.loadAccounts(accountIds);
+
+    // Replay transactions up to the as-of date, grouped by (account, security).
+    const transactions = await this.txRepository.find({
+      where: { userId, accountId: In(accountIds) },
+      order: { transactionDate: "ASC", createdAt: "ASC" },
+    });
+    const groups = this.groupTransactions(transactions, asOfDate);
+
+    // Holdings without any transactions (e.g. imported positions) still belong
+    // in the report; seed them so they are not dropped.
+    await this.seedTransactionlessHoldings(accountIds, groups);
+
+    const securityIds = [
+      ...new Set([...groups.values()].map((g) => g.securityId)),
+    ];
+    const [securityMap, priceMap] = await Promise.all([
+      this.loadSecurities(securityIds),
+      this.loadPrices(securityIds, asOfDate),
+    ]);
+
+    const fxCache = new Map<string, number>();
+    const year = Number(asOfDate.slice(0, 4));
+    const periodStarts: Record<string, string> = {
+      totalReturn1Week: isoAddDays(asOfDate, -7),
+      totalReturn4Weeks: isoAddDays(asOfDate, -28),
+      totalReturn3Month: isoAddMonths(asOfDate, -3),
+      totalReturn1Year: isoAddYears(asOfDate, -1),
+      totalReturn3Year: isoAddYears(asOfDate, -3),
+      totalReturnYtd: `${year - 1}-12-31`,
+    };
+
+    const computed: {
+      holding: ComputedHolding;
+      marketValueBase: number | null;
+    }[] = [];
+
+    for (const group of groups.values()) {
+      const security = securityMap.get(group.securityId);
+      if (!security) continue;
+
+      const prices = priceMap.get(group.securityId) ?? [];
+      const asOfIdx = prices.length - 1; // prices already filtered to <= asOfDate
+      const asOfRow = asOfIdx >= 0 ? prices[asOfIdx] : null;
+      const prevRow = asOfIdx >= 1 ? prices[asOfIdx - 1] : null;
+
+      const lastPrice = asOfRow ? asOfRow.close : null;
+      const previousClose = prevRow ? prevRow.close : null;
+
+      const quantity = round(group.state.quantity, 8);
+      if (Math.abs(quantity) < 0.0001) continue;
+
+      const costBasis = round(group.state.costBasis, 4);
+      const averageCost =
+        quantity !== 0 ? round(costBasis / quantity, 6) : null;
+      const marketValue =
+        lastPrice !== null ? round(quantity * lastPrice, 4) : null;
+      const income = round(group.state.income, 4);
+      const gain =
+        marketValue !== null
+          ? round(marketValue + income - costBasis, 4)
+          : null;
+      const priceAppreciation =
+        marketValue !== null ? round(marketValue - costBasis, 4) : null;
+      const gainPercent =
+        gain !== null && costBasis > 0
+          ? round((gain / costBasis) * 100, 4)
+          : null;
+      const change =
+        lastPrice !== null && previousClose !== null
+          ? round(lastPrice - previousClose, 6)
+          : null;
+      const changePercent =
+        change !== null && previousClose
+          ? round((change / previousClose) * 100, 4)
+          : null;
+      const todaysTotalChange =
+        change !== null ? round(change * quantity, 4) : null;
+
+      const fxRate = await this.fxRate(
+        security.currencyCode,
+        baseCurrency,
+        fxCache,
+      );
+      const marketValueBase =
+        marketValue !== null ? marketValue * fxRate : null;
+
+      const { high: high52, low: low52 } = this.fiftyTwoWeek(prices, asOfDate);
+
+      const values: Record<string, InvestmentCellValue> = {
+        symbol: security.symbol,
+        name: security.name,
+        securityType: security.securityType || "STOCK",
+        currency: security.currencyCode,
+        quantity,
+        averageCost,
+        costBasis,
+        lastPrice,
+        marketValue,
+        gain,
+        gainPercent,
+        priceAppreciation,
+        portfolioPercent: null, // filled in second pass
+        open: asOfRow?.open ?? null,
+        dayHigh: asOfRow?.high ?? null,
+        dayLow: asOfRow?.low ?? null,
+        previousClose,
+        change,
+        changePercent,
+        todaysTotalChange,
+        volume: asOfRow?.volume ?? null,
+        lastTransactionDate: group.state.lastTransactionDate,
+        income,
+        commissions: round(group.state.commissions, 4),
+        purchases: round(group.state.purchases, 4),
+        sales: round(group.state.sales, 4),
+        reinvestments: round(group.state.reinvestments, 4),
+        realizedGains: round(group.state.realizedGains, 4),
+        exchangeRate: round(fxRate, 6),
+        lastUpdated: asOfRow?.date ?? null,
+        fiftyTwoWeekHigh: high52,
+        fiftyTwoWeekLow: low52,
+        ...this.periodReturns(
+          group,
+          prices,
+          asOfDate,
+          periodStarts,
+          marketValue,
+          costBasis,
+        ),
+      };
+
+      computed.push({
+        holding: {
+          accountId: group.accountId,
+          accountName: accountMap.get(group.accountId) ?? "Unknown",
+          securityId: group.securityId,
+          symbol: security.symbol,
+          securityName: security.name,
+          currencyCode: security.currencyCode,
+          values,
+        },
+        marketValueBase,
+      });
+    }
+
+    // Second pass: % of portfolio against total (base-currency) market value.
+    const totalBase = computed.reduce(
+      (sum, c) => sum + (c.marketValueBase ?? 0),
+      0,
+    );
+    for (const c of computed) {
+      if (c.marketValueBase !== null && totalBase > 0) {
+        c.holding.values.portfolioPercent = round(
+          (c.marketValueBase / totalBase) * 100,
+          4,
+        );
+      }
+    }
+
+    return computed.map((c) => c.holding);
+  }
+
+  // ---------------------------------------------------------------------------
+
+  private async loadAccounts(
+    accountIds: string[],
+  ): Promise<Map<string, string>> {
+    const accounts = await this.accountsRepository.find({
+      where: { id: In(accountIds) },
+      select: ["id", "name"],
+    });
+    return new Map(accounts.map((a) => [a.id, a.name]));
+  }
+
+  private async loadSecurities(
+    securityIds: string[],
+  ): Promise<Map<string, Security>> {
+    if (securityIds.length === 0) return new Map();
+    const securities = await this.securitiesRepository.find({
+      where: { id: In(securityIds) },
+    });
+    return new Map(securities.map((s) => [s.id, s]));
+  }
+
+  /**
+   * Load OHLCV history (oldest first) for the given securities, limited to rows
+   * on or before the as-of date so the last element is the as-of quote.
+   */
+  private async loadPrices(
+    securityIds: string[],
+    asOfDate: string,
+  ): Promise<Map<string, PriceRow[]>> {
+    const result = new Map<string, PriceRow[]>();
+    if (securityIds.length === 0) return result;
+    const rows: {
+      security_id: string;
+      price_date: string;
+      open_price: string | null;
+      high_price: string | null;
+      low_price: string | null;
+      close_price: string;
+      volume: string | null;
+    }[] = await this.txRepository.query(
+      `SELECT security_id, price_date::text AS price_date,
+              open_price, high_price, low_price, close_price, volume
+         FROM security_prices
+        WHERE security_id = ANY($1) AND price_date <= $2
+        ORDER BY security_id, price_date ASC`,
+      [securityIds, asOfDate],
+    );
+    for (const row of rows) {
+      let arr = result.get(row.security_id);
+      if (!arr) {
+        arr = [];
+        result.set(row.security_id, arr);
+      }
+      arr.push({
+        date: row.price_date,
+        open: row.open_price === null ? null : Number(row.open_price),
+        high: row.high_price === null ? null : Number(row.high_price),
+        low: row.low_price === null ? null : Number(row.low_price),
+        close: Number(row.close_price),
+        volume: row.volume === null ? null : Number(row.volume),
+      });
+    }
+    return result;
+  }
+
+  private groupTransactions(
+    transactions: InvestmentTransaction[],
+    asOfDate: string,
+  ): Map<string, GroupRecord> {
+    const groups = new Map<string, GroupRecord>();
+    for (const tx of transactions) {
+      if (!tx.securityId) continue;
+      const key = `${tx.accountId}:${tx.securityId}`;
+      let group = groups.get(key);
+      if (!group) {
+        group = {
+          accountId: tx.accountId,
+          securityId: tx.securityId,
+          txs: [],
+          state: this.emptyState(),
+        };
+        groups.set(key, group);
+      }
+      group.txs.push(tx);
+      if (tx.transactionDate <= asOfDate) {
+        this.applyToState(group.state, tx);
+      }
+    }
+    return groups;
+  }
+
+  private emptyState(): ReplayState {
+    return {
+      quantity: 0,
+      costBasis: 0,
+      income: 0,
+      commissions: 0,
+      purchases: 0,
+      sales: 0,
+      reinvestments: 0,
+      realizedGains: 0,
+      lastTransactionDate: null,
+    };
+  }
+
+  /** Apply one transaction to the cumulative state (native security currency). */
+  private applyToState(state: ReplayState, tx: InvestmentTransaction): void {
+    const quantity = Number(tx.quantity) || 0;
+    const price = Number(tx.price) || 0;
+    const totalAmount = Number(tx.totalAmount) || 0;
+    const commission = Number(tx.commission) || 0;
+    state.commissions += commission;
+    state.lastTransactionDate = tx.transactionDate;
+
+    switch (tx.action) {
+      case InvestmentAction.BUY:
+      case InvestmentAction.TRANSFER_IN:
+        state.costBasis += quantity * price;
+        state.quantity += quantity;
+        if (tx.action === InvestmentAction.BUY) state.purchases += totalAmount;
+        break;
+      case InvestmentAction.REINVEST:
+        state.costBasis += quantity * price;
+        state.quantity += quantity;
+        state.reinvestments += totalAmount;
+        break;
+      case InvestmentAction.SELL:
+      case InvestmentAction.TRANSFER_OUT: {
+        const sellQty = Math.min(quantity, state.quantity);
+        const avgCost =
+          state.quantity > 0 ? state.costBasis / state.quantity : 0;
+        const costSold = sellQty * avgCost;
+        state.costBasis -= costSold;
+        state.quantity -= sellQty;
+        if (tx.action === InvestmentAction.SELL) {
+          state.sales += totalAmount;
+          state.realizedGains += totalAmount - costSold;
+        }
+        break;
+      }
+      case InvestmentAction.DIVIDEND:
+      case InvestmentAction.INTEREST:
+      case InvestmentAction.CAPITAL_GAIN:
+        state.income += totalAmount;
+        break;
+      case InvestmentAction.ADD_SHARES:
+        state.quantity += quantity;
+        break;
+      case InvestmentAction.REMOVE_SHARES:
+        state.quantity -= quantity;
+        break;
+      case InvestmentAction.SPLIT:
+        if (quantity > 0) state.quantity *= quantity;
+        break;
+    }
+
+    if (Math.abs(state.quantity) < 0.0001) {
+      state.quantity = 0;
+      state.costBasis = 0;
+    }
+  }
+
+  /**
+   * Add synthetic groups for holdings that have no investment transactions so
+   * imported positions still appear (valued at their stored average cost).
+   */
+  private async seedTransactionlessHoldings(
+    accountIds: string[],
+    groups: Map<string, GroupRecord>,
+  ): Promise<void> {
+    const holdings = await this.holdingsRepository.find({
+      where: { accountId: In(accountIds) },
+    });
+    for (const h of holdings) {
+      const key = `${h.accountId}:${h.securityId}`;
+      if (groups.has(key)) continue;
+      const quantity = Number(h.quantity) || 0;
+      if (Math.abs(quantity) < 0.0001) continue;
+      const averageCost = Number(h.averageCost) || 0;
+      const state = this.emptyState();
+      state.quantity = quantity;
+      state.costBasis = quantity * averageCost;
+      groups.set(key, {
+        accountId: h.accountId,
+        securityId: h.securityId,
+        txs: [],
+        state,
+      });
+    }
+  }
+
+  /** Highest day-high / lowest day-low over the trailing 52 weeks of stored prices. */
+  private fiftyTwoWeek(
+    prices: PriceRow[],
+    asOfDate: string,
+  ): { high: number | null; low: number | null } {
+    const start = isoAddDays(asOfDate, -364);
+    let high: number | null = null;
+    let low: number | null = null;
+    for (const p of prices) {
+      if (p.date < start) continue;
+      const h = p.high ?? p.close;
+      const l = p.low ?? p.close;
+      if (high === null || h > high) high = h;
+      if (low === null || l < low) low = l;
+    }
+    return {
+      high: high === null ? null : round(high, 6),
+      low: low === null ? null : round(low, 6),
+    };
+  }
+
+  /** Close price on or before a date (binary search over the ascending series). */
+  private priceOnOrBefore(prices: PriceRow[], date: string): number | null {
+    let lo = 0;
+    let hi = prices.length - 1;
+    let best = -1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (prices[mid].date <= date) {
+        best = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return best >= 0 ? prices[best].close : null;
+  }
+
+  /** Shares held as of a date, reconstructed from the group's transactions. */
+  private quantityAsOf(group: GroupRecord, date: string): number {
+    const s = { quantity: 0 };
+    for (const tx of group.txs) {
+      if (tx.transactionDate > date) break;
+      applyQuantity(s, tx);
+    }
+    return s.quantity;
+  }
+
+  /** Income (dividends/interest/capital gains) received in (after, upto]. */
+  private incomeBetween(
+    group: GroupRecord,
+    after: string,
+    upto: string,
+  ): number {
+    let income = 0;
+    for (const tx of group.txs) {
+      if (tx.transactionDate <= after || tx.transactionDate > upto) continue;
+      if (
+        tx.action === InvestmentAction.DIVIDEND ||
+        tx.action === InvestmentAction.INTEREST ||
+        tx.action === InvestmentAction.CAPITAL_GAIN
+      ) {
+        income += Number(tx.totalAmount) || 0;
+      }
+    }
+    return income;
+  }
+
+  /**
+   * Compute the MS Money-style total return columns:
+   *   (current value + income in period - beginning value) / beginning value.
+   * "All dates" measures against cost basis (return since inception); the
+   * annualized column annualizes that figure over the holding period.
+   */
+  private periodReturns(
+    group: GroupRecord,
+    prices: PriceRow[],
+    asOfDate: string,
+    periodStarts: Record<string, string>,
+    marketValue: number | null,
+    costBasis: number,
+  ): Record<string, number | null> {
+    const result: Record<string, number | null> = {
+      totalReturn1Week: null,
+      totalReturn4Weeks: null,
+      totalReturn3Month: null,
+      totalReturn1Year: null,
+      totalReturn3Year: null,
+      totalReturnYtd: null,
+      totalReturnAllDates: null,
+      totalAnnualizedReturn: null,
+    };
+
+    for (const [key, start] of Object.entries(periodStarts)) {
+      if (marketValue === null) continue;
+      const beginQty = this.quantityAsOf(group, start);
+      const beginPrice = this.priceOnOrBefore(prices, start);
+      if (beginPrice === null || beginQty === 0) continue;
+      const beginValue = beginQty * beginPrice;
+      if (beginValue <= 0) continue;
+      const income = this.incomeBetween(group, start, asOfDate);
+      result[key] = round(
+        ((marketValue + income - beginValue) / beginValue) * 100,
+        4,
+      );
+    }
+
+    // All-dates total return is measured against invested cost.
+    if (marketValue !== null && costBasis > 0) {
+      const allIncome = group.state.income;
+      const allDates =
+        ((marketValue + allIncome - costBasis) / costBasis) * 100;
+      result.totalReturnAllDates = round(allDates, 4);
+
+      const firstDate = group.txs[0]?.transactionDate;
+      if (firstDate) {
+        const years =
+          (Date.parse(asOfDate) - Date.parse(firstDate)) /
+          (365.25 * 24 * 60 * 60 * 1000);
+        if (years >= 0.5) {
+          const growth = 1 + allDates / 100;
+          result.totalAnnualizedReturn =
+            growth > 0
+              ? round((Math.pow(growth, 1 / years) - 1) * 100, 4)
+              : -100;
+        }
+      }
+    }
+
+    return result;
+  }
+
+  private async fxRate(
+    from: string,
+    to: string,
+    cache: Map<string, number>,
+  ): Promise<number> {
+    if (!from || !to || from === to) return 1;
+    const key = `${from}->${to}`;
+    const cached = cache.get(key);
+    if (cached !== undefined) return cached;
+    let rate = await this.exchangeRateService.getLatestRate(from, to);
+    if (rate === null) {
+      const reverse = await this.exchangeRateService.getLatestRate(to, from);
+      rate = reverse !== null ? 1 / reverse : 1;
+    }
+    cache.set(key, rate);
+    return rate;
+  }
+}

--- a/backend/src/investment-reports/investment-report-data.service.ts
+++ b/backend/src/investment-reports/investment-report-data.service.ts
@@ -178,6 +178,7 @@ export class InvestmentReportDataService {
     accountIds: string[],
     asOfDate: string,
     baseCurrency: string,
+    mergeAccounts = false,
   ): Promise<ComputedHolding[]> {
     if (accountIds.length === 0) return [];
 
@@ -188,11 +189,16 @@ export class InvestmentReportDataService {
       where: { accountId: In(accountIds) },
     });
     const holdingsMap = new Map<string, { quantity: number; averageCost: number }>();
+    // Summed across accounts per security, for the merged (cross-account) view.
+    const summedHoldings = new Map<string, { quantity: number; costBasis: number }>();
     for (const h of holdings) {
-      holdingsMap.set(`${h.accountId}:${h.securityId}`, {
-        quantity: Number(h.quantity) || 0,
-        averageCost: Number(h.averageCost) || 0,
-      });
+      const quantity = Number(h.quantity) || 0;
+      const averageCost = Number(h.averageCost) || 0;
+      holdingsMap.set(`${h.accountId}:${h.securityId}`, { quantity, averageCost });
+      const summed = summedHoldings.get(h.securityId) ?? { quantity: 0, costBasis: 0 };
+      summed.quantity += quantity;
+      summed.costBasis += quantity * averageCost;
+      summedHoldings.set(h.securityId, summed);
     }
 
     // Replay transactions up to the as-of date, grouped by (account, security).
@@ -200,11 +206,17 @@ export class InvestmentReportDataService {
       where: { userId, accountId: In(accountIds) },
       order: { transactionDate: "ASC", createdAt: "ASC" },
     });
-    const groups = this.groupTransactions(transactions, asOfDate);
+    let groups = this.groupTransactions(transactions, asOfDate);
 
     // Holdings without any transactions (e.g. imported positions) still belong
     // in the report; seed them so they are not dropped.
     this.seedTransactionlessHoldings(holdings, groups);
+
+    // Optionally merge identical securities held across multiple accounts into a
+    // single combined position (replaying their pooled transaction history).
+    if (mergeAccounts) {
+      groups = this.mergeGroupsBySecurity(groups, asOfDate);
+    }
 
     const securityIds = [
       ...new Set([...groups.values()].map((g) => g.securityId)),
@@ -249,16 +261,22 @@ export class InvestmentReportDataService {
       // holdings table is the authoritative snapshot of this position. Defer to
       // it (matching the portfolio view): drop positions it reports as closed
       // (fully-sold/deactivated securities) and use its quantity and cost basis.
-      const holdingKey = `${group.accountId}:${group.securityId}`;
       const lastTxDate = group.txs.length
         ? group.txs[group.txs.length - 1].transactionDate
         : null;
       const reflectsPresent = !lastTxDate || lastTxDate <= asOfDate;
       if (reflectsPresent) {
-        const current = holdingsMap.get(holdingKey);
-        if (!current || Math.abs(current.quantity) < 0.0001) continue;
-        quantity = round(current.quantity, 8);
-        costBasis = round(current.quantity * current.averageCost, 4);
+        if (mergeAccounts) {
+          const current = summedHoldings.get(group.securityId);
+          if (!current || Math.abs(current.quantity) < 0.0001) continue;
+          quantity = round(current.quantity, 8);
+          costBasis = round(current.costBasis, 4);
+        } else {
+          const current = holdingsMap.get(`${group.accountId}:${group.securityId}`);
+          if (!current || Math.abs(current.quantity) < 0.0001) continue;
+          quantity = round(current.quantity, 8);
+          costBasis = round(current.quantity * current.averageCost, 4);
+        }
       } else if (Math.abs(quantity) < 0.0001) {
         continue;
       }
@@ -299,11 +317,16 @@ export class InvestmentReportDataService {
 
       const { high: high52, low: low52 } = this.fiftyTwoWeek(prices, asOfDate);
 
+      const accountName = mergeAccounts
+        ? "Multiple accounts"
+        : (accountMap.get(group.accountId) ?? "Unknown");
+
       const values: Record<string, InvestmentCellValue> = {
         symbol: security.symbol,
         name: security.name,
         securityType: formatSecurityType(security.securityType),
         currency: security.currencyCode,
+        account: accountName,
         quantity,
         averageCost,
         costBasis,
@@ -345,7 +368,7 @@ export class InvestmentReportDataService {
       computed.push({
         holding: {
           accountId: group.accountId,
-          accountName: accountMap.get(group.accountId) ?? "Unknown",
+          accountName,
           securityId: group.securityId,
           symbol: security.symbol,
           securityName: security.name,
@@ -464,6 +487,43 @@ export class InvestmentReportDataService {
       }
     }
     return groups;
+  }
+
+  /**
+   * Combine per-(account, security) groups into one group per security by
+   * pooling their transactions and replaying the merged history. Used to show
+   * a single combined position for a security held across multiple accounts.
+   */
+  private mergeGroupsBySecurity(
+    groups: Map<string, GroupRecord>,
+    asOfDate: string,
+  ): Map<string, GroupRecord> {
+    const merged = new Map<string, GroupRecord>();
+    for (const g of groups.values()) {
+      let m = merged.get(g.securityId);
+      if (!m) {
+        m = {
+          accountId: "MERGED",
+          securityId: g.securityId,
+          txs: [],
+          state: this.emptyState(),
+        };
+        merged.set(g.securityId, m);
+      }
+      m.txs.push(...g.txs);
+    }
+    for (const m of merged.values()) {
+      m.txs.sort((a, b) => {
+        if (a.transactionDate !== b.transactionDate) {
+          return a.transactionDate < b.transactionDate ? -1 : 1;
+        }
+        return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+      });
+      for (const tx of m.txs) {
+        if (tx.transactionDate <= asOfDate) this.applyToState(m.state, tx);
+      }
+    }
+    return merged;
   }
 
   private emptyState(): ReplayState {

--- a/backend/src/investment-reports/investment-reports.controller.spec.ts
+++ b/backend/src/investment-reports/investment-reports.controller.spec.ts
@@ -1,0 +1,52 @@
+import { InvestmentReportsController } from "./investment-reports.controller";
+
+describe("InvestmentReportsController", () => {
+  let controller: InvestmentReportsController;
+  let service: Record<string, jest.Mock>;
+  const req = { user: { id: "u1" } } as any;
+
+  beforeEach(() => {
+    service = {
+      create: jest.fn().mockResolvedValue({ id: "r1" }),
+      findAll: jest.fn().mockResolvedValue([]),
+      findOne: jest.fn().mockResolvedValue({ id: "r1" }),
+      update: jest.fn().mockResolvedValue({ id: "r1" }),
+      remove: jest.fn().mockResolvedValue(undefined),
+      execute: jest.fn().mockResolvedValue({ reportId: "r1", groups: [] }),
+    };
+    controller = new InvestmentReportsController(service as any);
+  });
+
+  it("delegates create to the service with the user id", async () => {
+    const dto = { name: "R", config: { columns: ["symbol"] } } as any;
+    await controller.create(req, dto);
+    expect(service.create).toHaveBeenCalledWith("u1", dto);
+  });
+
+  it("delegates findAll", async () => {
+    await controller.findAll(req);
+    expect(service.findAll).toHaveBeenCalledWith("u1");
+  });
+
+  it("delegates findOne", async () => {
+    await controller.findOne(req, "r1");
+    expect(service.findOne).toHaveBeenCalledWith("u1", "r1");
+  });
+
+  it("delegates update", async () => {
+    const dto = { name: "New" } as any;
+    await controller.update(req, "r1", dto);
+    expect(service.update).toHaveBeenCalledWith("u1", "r1", dto);
+  });
+
+  it("delegates remove", async () => {
+    await controller.remove(req, "r1");
+    expect(service.remove).toHaveBeenCalledWith("u1", "r1");
+  });
+
+  it("delegates execute", async () => {
+    const dto = { asOfDate: "2024-06-10" } as any;
+    await controller.execute(req, "r1", dto);
+    expect(service.execute).toHaveBeenCalledWith("u1", "r1", dto);
+  });
+});

--- a/backend/src/investment-reports/investment-reports.controller.ts
+++ b/backend/src/investment-reports/investment-reports.controller.ts
@@ -1,0 +1,111 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+  Request,
+  ParseUUIDPipe,
+} from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from "@nestjs/swagger";
+import { InvestmentReportsService } from "./investment-reports.service";
+import { CreateInvestmentReportDto } from "./dto/create-investment-report.dto";
+import { UpdateInvestmentReportDto } from "./dto/update-investment-report.dto";
+import { ExecuteInvestmentReportDto } from "./dto/execute-investment-report.dto";
+import { InvestmentReport } from "./entities/investment-report.entity";
+import {
+  AllowDelegate,
+  DelegateRequiresSection,
+} from "../delegation/decorators/delegate-access.decorator";
+
+@ApiTags("Investment Reports")
+@Controller("reports/investment")
+@UseGuards(AuthGuard("jwt"))
+@ApiBearerAuth()
+// Read-only section for delegates: only the @AllowDelegate() GETs are
+// reachable, and only with the "reports" section grant. Writes fail closed.
+@DelegateRequiresSection("reports")
+export class InvestmentReportsController {
+  constructor(
+    private readonly investmentReportsService: InvestmentReportsService,
+  ) {}
+
+  @Post()
+  @ApiOperation({ summary: "Create a new investment report" })
+  @ApiResponse({ status: 201, type: InvestmentReport })
+  create(
+    @Request() req,
+    @Body() dto: CreateInvestmentReportDto,
+  ): Promise<InvestmentReport> {
+    return this.investmentReportsService.create(req.user.id, dto);
+  }
+
+  @Get()
+  @AllowDelegate()
+  @ApiOperation({ summary: "Get all investment reports for the current user" })
+  @ApiResponse({ status: 200, type: [InvestmentReport] })
+  findAll(@Request() req): Promise<InvestmentReport[]> {
+    return this.investmentReportsService.findAll(req.user.id);
+  }
+
+  @Get(":id")
+  @AllowDelegate()
+  @ApiOperation({ summary: "Get a specific investment report by ID" })
+  @ApiParam({ name: "id", description: "Report ID" })
+  @ApiResponse({ status: 200, type: InvestmentReport })
+  @ApiResponse({ status: 404, description: "Report not found" })
+  findOne(
+    @Request() req,
+    @Param("id", ParseUUIDPipe) id: string,
+  ): Promise<InvestmentReport> {
+    return this.investmentReportsService.findOne(req.user.id, id);
+  }
+
+  @Patch(":id")
+  @ApiOperation({ summary: "Update an investment report" })
+  @ApiParam({ name: "id", description: "Report ID" })
+  @ApiResponse({ status: 200, type: InvestmentReport })
+  @ApiResponse({ status: 404, description: "Report not found" })
+  update(
+    @Request() req,
+    @Param("id", ParseUUIDPipe) id: string,
+    @Body() dto: UpdateInvestmentReportDto,
+  ): Promise<InvestmentReport> {
+    return this.investmentReportsService.update(req.user.id, id, dto);
+  }
+
+  @Delete(":id")
+  @ApiOperation({ summary: "Delete an investment report" })
+  @ApiParam({ name: "id", description: "Report ID" })
+  @ApiResponse({ status: 200, description: "Report deleted" })
+  @ApiResponse({ status: 404, description: "Report not found" })
+  remove(
+    @Request() req,
+    @Param("id", ParseUUIDPipe) id: string,
+  ): Promise<void> {
+    return this.investmentReportsService.remove(req.user.id, id);
+  }
+
+  @Post(":id/execute")
+  @ApiOperation({ summary: "Run an investment report and get its rows" })
+  @ApiParam({ name: "id", description: "Report ID" })
+  @ApiResponse({ status: 200, description: "Report execution result" })
+  @ApiResponse({ status: 404, description: "Report not found" })
+  execute(
+    @Request() req,
+    @Param("id", ParseUUIDPipe) id: string,
+    @Body() dto: ExecuteInvestmentReportDto,
+  ) {
+    return this.investmentReportsService.execute(req.user.id, id, dto);
+  }
+}

--- a/backend/src/investment-reports/investment-reports.module.ts
+++ b/backend/src/investment-reports/investment-reports.module.ts
@@ -1,0 +1,32 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { InvestmentReportsService } from "./investment-reports.service";
+import { InvestmentReportDataService } from "./investment-report-data.service";
+import { InvestmentReportsController } from "./investment-reports.controller";
+import { InvestmentReport } from "./entities/investment-report.entity";
+import { InvestmentTransaction } from "../securities/entities/investment-transaction.entity";
+import { Holding } from "../securities/entities/holding.entity";
+import { Security } from "../securities/entities/security.entity";
+import { Account } from "../accounts/entities/account.entity";
+import { UserPreference } from "../users/entities/user-preference.entity";
+import { CurrenciesModule } from "../currencies/currencies.module";
+import { ActionHistoryModule } from "../action-history/action-history.module";
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      InvestmentReport,
+      InvestmentTransaction,
+      Holding,
+      Security,
+      Account,
+      UserPreference,
+    ]),
+    CurrenciesModule,
+    ActionHistoryModule,
+  ],
+  providers: [InvestmentReportsService, InvestmentReportDataService],
+  controllers: [InvestmentReportsController],
+  exports: [InvestmentReportsService],
+})
+export class InvestmentReportsModule {}

--- a/backend/src/investment-reports/investment-reports.service.spec.ts
+++ b/backend/src/investment-reports/investment-reports.service.spec.ts
@@ -64,12 +64,12 @@ describe("InvestmentReportsService", () => {
   });
 
   describe("create", () => {
-    it("forces symbol to the front of the column list and records history", async () => {
+    it("stores the configured columns as given and records history", async () => {
       const saved = await service.create("u1", {
         name: "My Report",
         config: { columns: ["marketValue", "gain"] } as any,
       });
-      expect(saved.config.columns).toEqual(["symbol", "marketValue", "gain"]);
+      expect(saved.config.columns).toEqual(["marketValue", "gain"]);
       expect(saved.config.sortDirection).toBe(InvestmentSortDirection.ASC);
       expect(saved.config.accountIds).toEqual([]);
       expect(actionHistoryService.record).toHaveBeenCalledWith(
@@ -162,7 +162,7 @@ describe("InvestmentReportsService", () => {
         config: { columns: ["gain", "symbol"], sortColumn: "gain" } as any,
       });
       expect(saved.name).toBe("New");
-      expect(saved.config.columns).toEqual(["symbol", "gain"]);
+      expect(saved.config.columns).toEqual(["gain", "symbol"]);
       expect(saved.config.sortColumn).toBe("gain");
     });
   });
@@ -220,7 +220,7 @@ describe("InvestmentReportsService", () => {
         false,
       );
       expect(result.asOfDate).toBe("2024-06-10");
-      expect(result.columns).toEqual(["symbol", "marketValue"]);
+      expect(result.columns).toEqual(["marketValue", "symbol"]);
       expect(result.groups).toHaveLength(1);
       // DESC by marketValue -> BBB first
       expect(result.groups[0].rows[0].values.symbol).toBe("BBB");
@@ -286,7 +286,7 @@ describe("InvestmentReportsService", () => {
       expect(result.columns[0]).not.toBe("account");
     });
 
-    it("ignores merge when grouping is none", async () => {
+    it("honours merge for no grouping (combine duplicate securities)", async () => {
       reportsRepository.findOne.mockResolvedValue(baseReport); // groupBy NONE
       await service.execute("u1", "r1", { mergeAccounts: true });
       expect(dataService.computeHoldings).toHaveBeenCalledWith(
@@ -294,7 +294,22 @@ describe("InvestmentReportsService", () => {
         expect.any(Array),
         "2024-06-10",
         "USD",
-        false, // merge ignored for NONE grouping
+        true,
+      );
+    });
+
+    it("ignores merge when grouping by account", async () => {
+      reportsRepository.findOne.mockResolvedValue({
+        ...baseReport,
+        groupBy: InvestmentGroupBy.ACCOUNT,
+      });
+      await service.execute("u1", "r1", { mergeAccounts: true });
+      expect(dataService.computeHoldings).toHaveBeenCalledWith(
+        "u1",
+        expect.any(Array),
+        "2024-06-10",
+        "USD",
+        false, // rows already keyed by account
       );
     });
 

--- a/backend/src/investment-reports/investment-reports.service.spec.ts
+++ b/backend/src/investment-reports/investment-reports.service.spec.ts
@@ -80,6 +80,14 @@ describe("InvestmentReportsService", () => {
         }),
       );
     });
+
+    it("persists the mergeAccounts config flag", async () => {
+      const saved = await service.create("u1", {
+        name: "My Report",
+        config: { columns: ["symbol"], mergeAccounts: true } as any,
+      });
+      expect(saved.config.mergeAccounts).toBe(true);
+    });
   });
 
   describe("findAll", () => {
@@ -141,6 +149,29 @@ describe("InvestmentReportsService", () => {
       expect(saved.isFavourite).toBe(true);
       expect(saved.sortOrder).toBe(3);
       expect(saved.config.columns).toEqual(["symbol", "gain"]);
+    });
+
+    it("preserves an existing mergeAccounts flag when the update omits it", async () => {
+      reportsRepository.findOne.mockResolvedValue({
+        id: "r1",
+        userId: "u1",
+        name: "Old",
+        groupBy: InvestmentGroupBy.SYMBOL,
+        isFavourite: false,
+        sortOrder: 0,
+        config: {
+          columns: ["symbol"],
+          accountIds: [],
+          sortColumn: null,
+          sortDirection: InvestmentSortDirection.ASC,
+          asOfDate: null,
+          mergeAccounts: true,
+        },
+      });
+      const saved = await service.update("u1", "r1", {
+        config: { columns: ["symbol", "gain"] } as any,
+      });
+      expect(saved.config.mergeAccounts).toBe(true);
     });
 
     it("merges provided fields and rebuilds config", async () => {
@@ -267,15 +298,16 @@ describe("InvestmentReportsService", () => {
       );
     });
 
-    it("merges across accounts when requested and omits the forced account column", async () => {
+    it("merges across accounts when configured and omits the forced account column", async () => {
       reportsRepository.findOne.mockResolvedValue({
         ...baseReport,
         groupBy: InvestmentGroupBy.SYMBOL,
+        config: { ...baseReport.config, mergeAccounts: true },
       });
       dataService.computeHoldings.mockResolvedValue([
         holding({ symbol: "AAA", values: { symbol: "AAA", marketValue: 100 } }),
       ]);
-      const result = await service.execute("u1", "r1", { mergeAccounts: true });
+      const result = await service.execute("u1", "r1");
       expect(dataService.computeHoldings).toHaveBeenCalledWith(
         "u1",
         expect.any(Array),
@@ -287,8 +319,11 @@ describe("InvestmentReportsService", () => {
     });
 
     it("honours merge for no grouping (combine duplicate securities)", async () => {
-      reportsRepository.findOne.mockResolvedValue(baseReport); // groupBy NONE
-      await service.execute("u1", "r1", { mergeAccounts: true });
+      reportsRepository.findOne.mockResolvedValue({
+        ...baseReport,
+        config: { ...baseReport.config, mergeAccounts: true },
+      }); // groupBy NONE
+      await service.execute("u1", "r1");
       expect(dataService.computeHoldings).toHaveBeenCalledWith(
         "u1",
         expect.any(Array),
@@ -302,8 +337,9 @@ describe("InvestmentReportsService", () => {
       reportsRepository.findOne.mockResolvedValue({
         ...baseReport,
         groupBy: InvestmentGroupBy.ACCOUNT,
+        config: { ...baseReport.config, mergeAccounts: true },
       });
-      await service.execute("u1", "r1", { mergeAccounts: true });
+      await service.execute("u1", "r1");
       expect(dataService.computeHoldings).toHaveBeenCalledWith(
         "u1",
         expect.any(Array),

--- a/backend/src/investment-reports/investment-reports.service.spec.ts
+++ b/backend/src/investment-reports/investment-reports.service.spec.ts
@@ -103,6 +103,45 @@ describe("InvestmentReportsService", () => {
   });
 
   describe("update", () => {
+    it("updates every editable field when provided", async () => {
+      reportsRepository.findOne.mockResolvedValue({
+        id: "r1",
+        userId: "u1",
+        name: "Old",
+        description: null,
+        icon: null,
+        backgroundColor: null,
+        groupBy: InvestmentGroupBy.NONE,
+        isFavourite: false,
+        sortOrder: 0,
+        config: {
+          columns: ["symbol"],
+          accountIds: [],
+          sortColumn: null,
+          sortDirection: InvestmentSortDirection.ASC,
+          asOfDate: null,
+        },
+      });
+      const saved = await service.update("u1", "r1", {
+        name: "New",
+        description: "d",
+        icon: "i",
+        backgroundColor: "#abcdef",
+        groupBy: InvestmentGroupBy.ACCOUNT,
+        isFavourite: true,
+        sortOrder: 3,
+        config: { columns: ["symbol", "gain"] } as any,
+      });
+      expect(saved.name).toBe("New");
+      expect(saved.description).toBe("d");
+      expect(saved.icon).toBe("i");
+      expect(saved.backgroundColor).toBe("#abcdef");
+      expect(saved.groupBy).toBe(InvestmentGroupBy.ACCOUNT);
+      expect(saved.isFavourite).toBe(true);
+      expect(saved.sortOrder).toBe(3);
+      expect(saved.config.columns).toEqual(["symbol", "gain"]);
+    });
+
     it("merges provided fields and rebuilds config", async () => {
       reportsRepository.findOne.mockResolvedValue({
         id: "r1",

--- a/backend/src/investment-reports/investment-reports.service.spec.ts
+++ b/backend/src/investment-reports/investment-reports.service.spec.ts
@@ -1,0 +1,277 @@
+import { NotFoundException } from "@nestjs/common";
+import { InvestmentReportsService } from "./investment-reports.service";
+import {
+  InvestmentGroupBy,
+  InvestmentSortDirection,
+} from "./entities/investment-report.entity";
+import { AccountSubType } from "../accounts/entities/account.entity";
+import { ComputedHolding } from "./investment-report-data.service";
+
+function holding(
+  over: Partial<ComputedHolding> & { values?: Record<string, unknown> },
+): ComputedHolding {
+  return {
+    accountId: "a1",
+    accountName: "Account One",
+    securityId: "s1",
+    symbol: "AAA",
+    securityName: "Alpha",
+    currencyCode: "USD",
+    values: { symbol: "AAA" },
+    ...over,
+  } as ComputedHolding;
+}
+
+describe("InvestmentReportsService", () => {
+  let service: InvestmentReportsService;
+  let reportsRepository: Record<string, jest.Mock>;
+  let accountsRepository: Record<string, jest.Mock>;
+  let prefRepository: Record<string, jest.Mock>;
+  let dataService: Record<string, jest.Mock>;
+  let actionHistoryService: Record<string, jest.Mock>;
+
+  beforeEach(() => {
+    reportsRepository = {
+      create: jest.fn((x) => x),
+      save: jest.fn((x) => Promise.resolve({ id: "r1", ...x })),
+      find: jest.fn(),
+      findOne: jest.fn(),
+      remove: jest.fn().mockResolvedValue(undefined),
+    };
+    accountsRepository = {
+      find: jest.fn().mockResolvedValue([
+        { id: "a1", accountSubType: AccountSubType.INVESTMENT_BROKERAGE },
+        { id: "a2", accountSubType: null },
+        { id: "cash1", accountSubType: AccountSubType.INVESTMENT_CASH },
+      ]),
+    };
+    prefRepository = {
+      findOne: jest.fn().mockResolvedValue({ defaultCurrency: "USD" }),
+    };
+    dataService = {
+      computeHoldings: jest.fn().mockResolvedValue([]),
+      getLatestMarketDay: jest.fn().mockResolvedValue("2024-06-10"),
+    };
+    actionHistoryService = { record: jest.fn() };
+    service = new InvestmentReportsService(
+      reportsRepository as any,
+      accountsRepository as any,
+      prefRepository as any,
+      dataService as any,
+      actionHistoryService as any,
+    );
+  });
+
+  describe("create", () => {
+    it("forces symbol to the front of the column list and records history", async () => {
+      const saved = await service.create("u1", {
+        name: "My Report",
+        config: { columns: ["marketValue", "gain"] } as any,
+      });
+      expect(saved.config.columns).toEqual(["symbol", "marketValue", "gain"]);
+      expect(saved.config.sortDirection).toBe(InvestmentSortDirection.ASC);
+      expect(saved.config.accountIds).toEqual([]);
+      expect(actionHistoryService.record).toHaveBeenCalledWith(
+        "u1",
+        expect.objectContaining({
+          entityType: "investment_report",
+          action: "create",
+        }),
+      );
+    });
+  });
+
+  describe("findAll", () => {
+    it("lists the user's reports ordered by sort order", async () => {
+      reportsRepository.find.mockResolvedValue([{ id: "r1" }]);
+      const result = await service.findAll("u1");
+      expect(result).toHaveLength(1);
+      expect(reportsRepository.find).toHaveBeenCalledWith({
+        where: { userId: "u1" },
+        order: { sortOrder: "ASC", createdAt: "DESC" },
+      });
+    });
+  });
+
+  describe("findOne", () => {
+    it("throws when the report does not belong to the user", async () => {
+      reportsRepository.findOne.mockResolvedValue(null);
+      await expect(service.findOne("u1", "missing")).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe("update", () => {
+    it("merges provided fields and rebuilds config", async () => {
+      reportsRepository.findOne.mockResolvedValue({
+        id: "r1",
+        userId: "u1",
+        name: "Old",
+        config: {
+          columns: ["symbol"],
+          accountIds: [],
+          sortColumn: null,
+          sortDirection: InvestmentSortDirection.ASC,
+          asOfDate: null,
+        },
+        groupBy: InvestmentGroupBy.NONE,
+      });
+      const saved = await service.update("u1", "r1", {
+        name: "New",
+        config: { columns: ["gain", "symbol"], sortColumn: "gain" } as any,
+      });
+      expect(saved.name).toBe("New");
+      expect(saved.config.columns).toEqual(["symbol", "gain"]);
+      expect(saved.config.sortColumn).toBe("gain");
+    });
+  });
+
+  describe("remove", () => {
+    it("removes the report and records history", async () => {
+      reportsRepository.findOne.mockResolvedValue({
+        id: "r1",
+        userId: "u1",
+        name: "X",
+      });
+      await service.remove("u1", "r1");
+      expect(reportsRepository.remove).toHaveBeenCalled();
+      expect(actionHistoryService.record).toHaveBeenCalledWith(
+        "u1",
+        expect.objectContaining({ action: "delete" }),
+      );
+    });
+  });
+
+  describe("execute", () => {
+    const baseReport = {
+      id: "r1",
+      userId: "u1",
+      name: "Report",
+      groupBy: InvestmentGroupBy.NONE,
+      config: {
+        columns: ["marketValue", "symbol"],
+        accountIds: [],
+        sortColumn: "marketValue",
+        sortDirection: InvestmentSortDirection.DESC,
+        asOfDate: null,
+      },
+    };
+
+    it("resolves all holdings accounts, defaults the date, sorts and picks columns", async () => {
+      reportsRepository.findOne.mockResolvedValue(baseReport);
+      dataService.computeHoldings.mockResolvedValue([
+        holding({ symbol: "AAA", values: { symbol: "AAA", marketValue: 100 } }),
+        holding({
+          symbol: "BBB",
+          securityId: "s2",
+          values: { symbol: "BBB", marketValue: 200 },
+        }),
+      ]);
+
+      const result = await service.execute("u1", "r1");
+
+      // Empty accountIds -> all holdings accounts (brokerage + standalone, no cash)
+      expect(dataService.computeHoldings).toHaveBeenCalledWith(
+        "u1",
+        ["a1", "a2"],
+        "2024-06-10",
+        "USD",
+      );
+      expect(result.asOfDate).toBe("2024-06-10");
+      expect(result.columns).toEqual(["symbol", "marketValue"]);
+      expect(result.groups).toHaveLength(1);
+      // DESC by marketValue -> BBB first
+      expect(result.groups[0].rows[0].values.symbol).toBe("BBB");
+      expect(result.groups[0].rows[1].values.symbol).toBe("AAA");
+      expect(result.rowCount).toBe(2);
+    });
+
+    it("honours an as-of date override and restricts requested accounts", async () => {
+      reportsRepository.findOne.mockResolvedValue({
+        ...baseReport,
+        config: { ...baseReport.config, accountIds: ["a1", "notmine"] },
+      });
+      await service.execute("u1", "r1", { asOfDate: "2024-01-01" });
+      expect(dataService.getLatestMarketDay).not.toHaveBeenCalled();
+      expect(dataService.computeHoldings).toHaveBeenCalledWith(
+        "u1",
+        ["a1"], // "notmine" filtered out
+        "2024-01-01",
+        "USD",
+      );
+    });
+
+    it("groups by symbol", async () => {
+      reportsRepository.findOne.mockResolvedValue({
+        ...baseReport,
+        groupBy: InvestmentGroupBy.SYMBOL,
+      });
+      dataService.computeHoldings.mockResolvedValue([
+        holding({
+          symbol: "AAA",
+          securityId: "s1",
+          values: { symbol: "AAA", marketValue: 100 },
+        }),
+        holding({
+          symbol: "BBB",
+          securityId: "s2",
+          values: { symbol: "BBB", marketValue: 200 },
+        }),
+      ]);
+      const result = await service.execute("u1", "r1");
+      expect(result.groups).toHaveLength(2);
+      expect(result.groups.map((g) => g.label)).toEqual(["AAA", "BBB"]);
+    });
+
+    it("groups by account and by currency", async () => {
+      dataService.computeHoldings.mockResolvedValue([
+        holding({ accountId: "a1", accountName: "Acc One", currencyCode: "USD", symbol: "AAA", values: { symbol: "AAA", marketValue: 100 } }),
+        holding({ accountId: "a2", accountName: "Acc Two", currencyCode: "CAD", symbol: "BBB", securityId: "s2", values: { symbol: "BBB", marketValue: 200 } }),
+      ]);
+
+      reportsRepository.findOne.mockResolvedValue({ ...baseReport, groupBy: InvestmentGroupBy.ACCOUNT });
+      const byAccount = await service.execute("u1", "r1");
+      expect(byAccount.groups.map((g) => g.label).sort()).toEqual(["Acc One", "Acc Two"]);
+
+      reportsRepository.findOne.mockResolvedValue({ ...baseReport, groupBy: InvestmentGroupBy.CURRENCY });
+      const byCurrency = await service.execute("u1", "r1");
+      expect(byCurrency.groups.map((g) => g.label).sort()).toEqual(["CAD", "USD"]);
+    });
+
+    it("defaults to sorting by symbol when no sort column is set", async () => {
+      reportsRepository.findOne.mockResolvedValue({
+        ...baseReport,
+        config: { ...baseReport.config, sortColumn: null, sortDirection: InvestmentSortDirection.ASC },
+      });
+      dataService.computeHoldings.mockResolvedValue([
+        holding({ symbol: "ZZZ", securityId: "s2", values: { symbol: "ZZZ" } }),
+        holding({ symbol: "AAA", values: { symbol: "AAA" } }),
+      ]);
+      const result = await service.execute("u1", "r1");
+      expect(result.groups[0].rows.map((r) => r.values.symbol)).toEqual(["AAA", "ZZZ"]);
+    });
+
+    it("sorts nulls last regardless of direction", async () => {
+      reportsRepository.findOne.mockResolvedValue({
+        ...baseReport,
+        config: {
+          ...baseReport.config,
+          sortColumn: "gain",
+          sortDirection: InvestmentSortDirection.DESC,
+        },
+      });
+      dataService.computeHoldings.mockResolvedValue([
+        holding({ symbol: "AAA", values: { symbol: "AAA", gain: null } }),
+        holding({
+          symbol: "BBB",
+          securityId: "s2",
+          values: { symbol: "BBB", gain: 5 },
+        }),
+      ]);
+      const result = await service.execute("u1", "r1");
+      expect(result.groups[0].rows[0].values.symbol).toBe("BBB"); // non-null first
+      expect(result.groups[0].rows[1].values.symbol).toBe("AAA"); // null last
+    });
+  });
+});

--- a/backend/src/investment-reports/investment-reports.service.spec.ts
+++ b/backend/src/investment-reports/investment-reports.service.spec.ts
@@ -17,6 +17,7 @@ function holding(
     symbol: "AAA",
     securityName: "Alpha",
     currencyCode: "USD",
+    exchangeRate: 1,
     values: { symbol: "AAA" },
     ...over,
   } as ComputedHolding;
@@ -224,6 +225,9 @@ describe("InvestmentReportsService", () => {
       expect(result.groups[0].rows[0].values.symbol).toBe("BBB");
       expect(result.groups[0].rows[1].values.symbol).toBe("AAA");
       expect(result.rowCount).toBe(2);
+      // Each row carries its native currency and base-currency conversion rate.
+      expect(result.groups[0].rows[0].currency).toBe("USD");
+      expect(result.groups[0].rows[0].baseExchangeRate).toBe(1);
     });
 
     it("honours an as-of date override and restricts requested accounts", async () => {

--- a/backend/src/investment-reports/investment-reports.service.spec.ts
+++ b/backend/src/investment-reports/investment-reports.service.spec.ts
@@ -217,6 +217,7 @@ describe("InvestmentReportsService", () => {
         ["a1", "a2"],
         "2024-06-10",
         "USD",
+        false,
       );
       expect(result.asOfDate).toBe("2024-06-10");
       expect(result.columns).toEqual(["symbol", "marketValue"]);
@@ -242,6 +243,58 @@ describe("InvestmentReportsService", () => {
         ["a1"], // "notmine" filtered out
         "2024-01-01",
         "USD",
+        false,
+      );
+    });
+
+    it("prepends the account column when separating securities grouped by symbol", async () => {
+      reportsRepository.findOne.mockResolvedValue({
+        ...baseReport,
+        groupBy: InvestmentGroupBy.SYMBOL,
+      });
+      dataService.computeHoldings.mockResolvedValue([
+        holding({ symbol: "AAA", values: { symbol: "AAA", marketValue: 100 } }),
+      ]);
+      const result = await service.execute("u1", "r1");
+      expect(result.columns[0]).toBe("account");
+      // separated (no merge) -> computeHoldings called with mergeAccounts=false
+      expect(dataService.computeHoldings).toHaveBeenCalledWith(
+        "u1",
+        expect.any(Array),
+        "2024-06-10",
+        "USD",
+        false,
+      );
+    });
+
+    it("merges across accounts when requested and omits the forced account column", async () => {
+      reportsRepository.findOne.mockResolvedValue({
+        ...baseReport,
+        groupBy: InvestmentGroupBy.SYMBOL,
+      });
+      dataService.computeHoldings.mockResolvedValue([
+        holding({ symbol: "AAA", values: { symbol: "AAA", marketValue: 100 } }),
+      ]);
+      const result = await service.execute("u1", "r1", { mergeAccounts: true });
+      expect(dataService.computeHoldings).toHaveBeenCalledWith(
+        "u1",
+        expect.any(Array),
+        "2024-06-10",
+        "USD",
+        true,
+      );
+      expect(result.columns[0]).not.toBe("account");
+    });
+
+    it("ignores merge when grouping is none", async () => {
+      reportsRepository.findOne.mockResolvedValue(baseReport); // groupBy NONE
+      await service.execute("u1", "r1", { mergeAccounts: true });
+      expect(dataService.computeHoldings).toHaveBeenCalledWith(
+        "u1",
+        expect.any(Array),
+        "2024-06-10",
+        "USD",
+        false, // merge ignored for NONE grouping
       );
     });
 

--- a/backend/src/investment-reports/investment-reports.service.ts
+++ b/backend/src/investment-reports/investment-reports.service.ts
@@ -163,7 +163,7 @@ export class InvestmentReportsService {
       report.groupBy === InvestmentGroupBy.CURRENCY;
     const mergeAccounts =
       report.groupBy !== InvestmentGroupBy.ACCOUNT &&
-      overrides?.mergeAccounts === true;
+      report.config.mergeAccounts === true;
 
     const holdings = await this.dataService.computeHoldings(
       userId,
@@ -215,6 +215,7 @@ export class InvestmentReportsService {
       sortColumn: dto.sortColumn ?? null,
       sortDirection: dto.sortDirection ?? InvestmentSortDirection.ASC,
       asOfDate: dto.asOfDate ?? null,
+      mergeAccounts: dto.mergeAccounts ?? existing?.mergeAccounts ?? false,
     };
   }
 

--- a/backend/src/investment-reports/investment-reports.service.ts
+++ b/backend/src/investment-reports/investment-reports.service.ts
@@ -156,11 +156,14 @@ export class InvestmentReportsService {
     const pref = await this.prefRepository.findOne({ where: { userId } });
     const baseCurrency = pref?.defaultCurrency || "CAD";
 
-    // Merging only makes sense when securities are grouped together.
+    // Combining duplicate securities across accounts is available everywhere
+    // except when rows are already keyed by account.
     const groupsAcross =
       report.groupBy === InvestmentGroupBy.SYMBOL ||
       report.groupBy === InvestmentGroupBy.CURRENCY;
-    const mergeAccounts = groupsAcross && overrides?.mergeAccounts === true;
+    const mergeAccounts =
+      report.groupBy !== InvestmentGroupBy.ACCOUNT &&
+      overrides?.mergeAccounts === true;
 
     const holdings = await this.dataService.computeHoldings(
       userId,
@@ -170,7 +173,7 @@ export class InvestmentReportsService {
       mergeAccounts,
     );
 
-    let columns = this.ensureSymbolFirst(report.config.columns);
+    let columns = [...report.config.columns];
     // When securities from multiple accounts are listed separately, lead with
     // the account column so the user can tell the holdings apart.
     if (groupsAcross && !mergeAccounts) {
@@ -207,18 +210,12 @@ export class InvestmentReportsService {
     existing?: InvestmentReportConfig,
   ): InvestmentReportConfig {
     return {
-      columns: this.ensureSymbolFirst(dto.columns ?? existing?.columns ?? []),
+      columns: dto.columns ?? existing?.columns ?? [],
       accountIds: dto.accountIds ?? [],
       sortColumn: dto.sortColumn ?? null,
       sortDirection: dto.sortDirection ?? InvestmentSortDirection.ASC,
       asOfDate: dto.asOfDate ?? null,
     };
-  }
-
-  /** Symbol is always present and shown first. */
-  private ensureSymbolFirst(columns: string[]): string[] {
-    const rest = columns.filter((c) => c !== ALWAYS_INCLUDED_COLUMN);
-    return [ALWAYS_INCLUDED_COLUMN, ...rest];
   }
 
   /**

--- a/backend/src/investment-reports/investment-reports.service.ts
+++ b/backend/src/investment-reports/investment-reports.service.ts
@@ -261,6 +261,8 @@ export class InvestmentReportsService {
       );
       const rows: InvestmentReportRow[] = sorted.map((h) => ({
         id: `${h.accountId}:${h.securityId}`,
+        currency: h.currencyCode,
+        baseExchangeRate: h.exchangeRate,
         values: this.pickColumns(h.values, columns),
       }));
       groups.push({ key, label: bucket.label, rows });

--- a/backend/src/investment-reports/investment-reports.service.ts
+++ b/backend/src/investment-reports/investment-reports.service.ts
@@ -156,14 +156,29 @@ export class InvestmentReportsService {
     const pref = await this.prefRepository.findOne({ where: { userId } });
     const baseCurrency = pref?.defaultCurrency || "CAD";
 
+    // Merging only makes sense when securities are grouped together.
+    const groupsAcross =
+      report.groupBy === InvestmentGroupBy.SYMBOL ||
+      report.groupBy === InvestmentGroupBy.CURRENCY;
+    const mergeAccounts = groupsAcross && overrides?.mergeAccounts === true;
+
     const holdings = await this.dataService.computeHoldings(
       userId,
       accountIds,
       asOfDate,
       baseCurrency,
+      mergeAccounts,
     );
 
-    const columns = this.ensureSymbolFirst(report.config.columns);
+    let columns = this.ensureSymbolFirst(report.config.columns);
+    // When securities from multiple accounts are listed separately, lead with
+    // the account column so the user can tell the holdings apart.
+    if (groupsAcross && !mergeAccounts) {
+      columns = [
+        "account",
+        ...columns.filter((c) => c !== "account"),
+      ];
+    }
     const groups = this.buildGroups(
       holdings,
       report.groupBy,

--- a/backend/src/investment-reports/investment-reports.service.ts
+++ b/backend/src/investment-reports/investment-reports.service.ts
@@ -1,0 +1,327 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import {
+  InvestmentReport,
+  InvestmentReportConfig,
+  InvestmentGroupBy,
+  InvestmentSortDirection,
+} from "./entities/investment-report.entity";
+import { CreateInvestmentReportDto } from "./dto/create-investment-report.dto";
+import { UpdateInvestmentReportDto } from "./dto/update-investment-report.dto";
+import {
+  ExecuteInvestmentReportDto,
+  InvestmentReportResult,
+  InvestmentReportRow,
+  InvestmentReportGroup,
+  InvestmentCellValue,
+} from "./dto/execute-investment-report.dto";
+import {
+  InvestmentReportDataService,
+  ComputedHolding,
+} from "./investment-report-data.service";
+import {
+  Account,
+  AccountType,
+  AccountSubType,
+} from "../accounts/entities/account.entity";
+import { UserPreference } from "../users/entities/user-preference.entity";
+import { ActionHistoryService } from "../action-history/action-history.service";
+import { ALWAYS_INCLUDED_COLUMN } from "./investment-report-columns";
+
+@Injectable()
+export class InvestmentReportsService {
+  constructor(
+    @InjectRepository(InvestmentReport)
+    private reportsRepository: Repository<InvestmentReport>,
+    @InjectRepository(Account)
+    private accountsRepository: Repository<Account>,
+    @InjectRepository(UserPreference)
+    private prefRepository: Repository<UserPreference>,
+    private dataService: InvestmentReportDataService,
+    private actionHistoryService: ActionHistoryService,
+  ) {}
+
+  async create(
+    userId: string,
+    dto: CreateInvestmentReportDto,
+  ): Promise<InvestmentReport> {
+    const config = this.buildConfig(dto.config);
+    const report = this.reportsRepository.create({
+      name: dto.name,
+      description: dto.description ?? null,
+      icon: dto.icon ?? null,
+      backgroundColor: dto.backgroundColor ?? null,
+      groupBy: dto.groupBy ?? InvestmentGroupBy.NONE,
+      config,
+      isFavourite: dto.isFavourite ?? false,
+      sortOrder: dto.sortOrder ?? 0,
+      userId,
+    });
+    const saved = await this.reportsRepository.save(report);
+
+    this.actionHistoryService.record(userId, {
+      entityType: "investment_report",
+      entityId: saved.id,
+      action: "create",
+      afterData: { ...saved },
+      description: `Created investment report "${saved.name}"`,
+    });
+
+    return saved;
+  }
+
+  async findAll(userId: string): Promise<InvestmentReport[]> {
+    return this.reportsRepository.find({
+      where: { userId },
+      order: { sortOrder: "ASC", createdAt: "DESC" },
+    });
+  }
+
+  async findOne(userId: string, id: string): Promise<InvestmentReport> {
+    const report = await this.reportsRepository.findOne({
+      where: { id, userId },
+    });
+    if (!report) {
+      throw new NotFoundException(`Investment report with ID ${id} not found`);
+    }
+    return report;
+  }
+
+  async update(
+    userId: string,
+    id: string,
+    dto: UpdateInvestmentReportDto,
+  ): Promise<InvestmentReport> {
+    const report = await this.findOne(userId, id);
+    const beforeData = { ...report };
+
+    if (dto.name !== undefined) report.name = dto.name;
+    if (dto.description !== undefined)
+      report.description = dto.description ?? null;
+    if (dto.icon !== undefined) report.icon = dto.icon ?? null;
+    if (dto.backgroundColor !== undefined)
+      report.backgroundColor = dto.backgroundColor ?? null;
+    if (dto.groupBy !== undefined) report.groupBy = dto.groupBy;
+    if (dto.isFavourite !== undefined) report.isFavourite = dto.isFavourite;
+    if (dto.sortOrder !== undefined) report.sortOrder = dto.sortOrder;
+    if (dto.config !== undefined) {
+      report.config = this.buildConfig(dto.config, report.config);
+    }
+
+    const saved = await this.reportsRepository.save(report);
+
+    this.actionHistoryService.record(userId, {
+      entityType: "investment_report",
+      entityId: id,
+      action: "update",
+      beforeData,
+      afterData: { ...saved },
+      description: `Updated investment report "${saved.name}"`,
+    });
+
+    return saved;
+  }
+
+  async remove(userId: string, id: string): Promise<void> {
+    const report = await this.findOne(userId, id);
+    const beforeData = { ...report };
+    await this.reportsRepository.remove(report);
+
+    this.actionHistoryService.record(userId, {
+      entityType: "investment_report",
+      entityId: beforeData.id,
+      action: "delete",
+      beforeData,
+      description: `Deleted investment report "${beforeData.name}"`,
+    });
+  }
+
+  async execute(
+    userId: string,
+    id: string,
+    overrides?: ExecuteInvestmentReportDto,
+  ): Promise<InvestmentReportResult> {
+    const report = await this.findOne(userId, id);
+    const accountIds = await this.resolveAccountIds(
+      userId,
+      report.config.accountIds ?? [],
+    );
+
+    const asOfDate =
+      overrides?.asOfDate ||
+      report.config.asOfDate ||
+      (await this.dataService.getLatestMarketDay(userId, accountIds));
+
+    const pref = await this.prefRepository.findOne({ where: { userId } });
+    const baseCurrency = pref?.defaultCurrency || "CAD";
+
+    const holdings = await this.dataService.computeHoldings(
+      userId,
+      accountIds,
+      asOfDate,
+      baseCurrency,
+    );
+
+    const columns = this.ensureSymbolFirst(report.config.columns);
+    const groups = this.buildGroups(
+      holdings,
+      report.groupBy,
+      columns,
+      report.config,
+    );
+
+    const rowCount = groups.reduce((sum, g) => sum + g.rows.length, 0);
+
+    return {
+      reportId: report.id,
+      name: report.name,
+      asOfDate,
+      baseCurrency,
+      groupBy: report.groupBy,
+      columns,
+      groups,
+      rowCount,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+
+  private buildConfig(
+    dto: CreateInvestmentReportDto["config"],
+    existing?: InvestmentReportConfig,
+  ): InvestmentReportConfig {
+    return {
+      columns: this.ensureSymbolFirst(dto.columns ?? existing?.columns ?? []),
+      accountIds: dto.accountIds ?? [],
+      sortColumn: dto.sortColumn ?? null,
+      sortDirection: dto.sortDirection ?? InvestmentSortDirection.ASC,
+      asOfDate: dto.asOfDate ?? null,
+    };
+  }
+
+  /** Symbol is always present and shown first. */
+  private ensureSymbolFirst(columns: string[]): string[] {
+    const rest = columns.filter((c) => c !== ALWAYS_INCLUDED_COLUMN);
+    return [ALWAYS_INCLUDED_COLUMN, ...rest];
+  }
+
+  /**
+   * Restrict the requested account IDs to the user's open holdings accounts
+   * (brokerage + standalone, excluding cash siblings). An empty request means
+   * "all holdings accounts".
+   */
+  private async resolveAccountIds(
+    userId: string,
+    requested: string[],
+  ): Promise<string[]> {
+    const accounts = await this.accountsRepository.find({
+      where: { userId, accountType: AccountType.INVESTMENT, isClosed: false },
+    });
+    const holdingsIds = accounts
+      .filter(
+        (a) =>
+          a.accountSubType === AccountSubType.INVESTMENT_BROKERAGE ||
+          a.accountSubType === null ||
+          a.accountSubType === undefined,
+      )
+      .map((a) => a.id);
+    if (requested.length === 0) return holdingsIds;
+    const allowed = new Set(holdingsIds);
+    return requested.filter((id) => allowed.has(id));
+  }
+
+  private buildGroups(
+    holdings: ComputedHolding[],
+    groupBy: InvestmentGroupBy,
+    columns: string[],
+    config: InvestmentReportConfig,
+  ): InvestmentReportGroup[] {
+    const buckets = new Map<
+      string,
+      { label: string; holdings: ComputedHolding[] }
+    >();
+
+    for (const h of holdings) {
+      const { key, label } = this.groupKey(h, groupBy);
+      let bucket = buckets.get(key);
+      if (!bucket) {
+        bucket = { label, holdings: [] };
+        buckets.set(key, bucket);
+      }
+      bucket.holdings.push(h);
+    }
+
+    const groups: InvestmentReportGroup[] = [];
+    for (const [key, bucket] of buckets) {
+      const sorted = this.sortHoldings(
+        bucket.holdings,
+        config.sortColumn,
+        config.sortDirection,
+      );
+      const rows: InvestmentReportRow[] = sorted.map((h) => ({
+        id: `${h.accountId}:${h.securityId}`,
+        values: this.pickColumns(h.values, columns),
+      }));
+      groups.push({ key, label: bucket.label, rows });
+    }
+
+    // Order groups alphabetically by label (single group when NONE).
+    groups.sort((a, b) => a.label.localeCompare(b.label));
+    return groups;
+  }
+
+  private groupKey(
+    h: ComputedHolding,
+    groupBy: InvestmentGroupBy,
+  ): { key: string; label: string } {
+    switch (groupBy) {
+      case InvestmentGroupBy.ACCOUNT:
+        return { key: h.accountId, label: h.accountName };
+      case InvestmentGroupBy.SYMBOL:
+        return { key: h.securityId, label: h.symbol };
+      case InvestmentGroupBy.CURRENCY:
+        return { key: h.currencyCode, label: h.currencyCode };
+      default:
+        return { key: "all", label: "" };
+    }
+  }
+
+  private pickColumns(
+    values: Record<string, InvestmentCellValue>,
+    columns: string[],
+  ): Record<string, InvestmentCellValue> {
+    const picked: Record<string, InvestmentCellValue> = {};
+    for (const col of columns) {
+      picked[col] = values[col] ?? null;
+    }
+    return picked;
+  }
+
+  private sortHoldings(
+    holdings: ComputedHolding[],
+    sortColumn: string | null,
+    direction: InvestmentSortDirection,
+  ): ComputedHolding[] {
+    const column = sortColumn ?? ALWAYS_INCLUDED_COLUMN;
+    const sign = direction === InvestmentSortDirection.DESC ? -1 : 1;
+    return [...holdings].sort((a, b) => {
+      const av = a.values[column];
+      const bv = b.values[column];
+      // Nulls always sort last, independent of the chosen direction.
+      if (av === null && bv === null) return 0;
+      if (av === null) return 1;
+      if (bv === null) return -1;
+      return sign * compareNonNull(av, bv);
+    });
+  }
+}
+
+/** Compare two non-null cell values (numbers numerically, otherwise as text). */
+function compareNonNull(
+  a: Exclude<InvestmentCellValue, null>,
+  b: Exclude<InvestmentCellValue, null>,
+): number {
+  if (typeof a === "number" && typeof b === "number") return a - b;
+  return String(a).localeCompare(String(b));
+}

--- a/database/migrations/077_investment_reports.sql
+++ b/database/migrations/077_investment_reports.sql
@@ -1,0 +1,24 @@
+-- Custom investment reports: user-defined MS Money-style portfolio column reports.
+-- The selected columns, included accounts, sort, and as-of date live in `config`.
+
+CREATE TABLE IF NOT EXISTS investment_reports (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    icon VARCHAR(50),
+    background_color VARCHAR(7),
+    group_by VARCHAR(20) NOT NULL DEFAULT 'NONE',
+    config JSONB NOT NULL DEFAULT '{}',
+    is_favourite BOOLEAN NOT NULL DEFAULT FALSE,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_investment_reports_user_id ON investment_reports(user_id);
+CREATE INDEX IF NOT EXISTS idx_investment_reports_user_favourite ON investment_reports(user_id, is_favourite);
+CREATE INDEX IF NOT EXISTS idx_investment_reports_user_sort ON investment_reports(user_id, sort_order);
+
+DROP TRIGGER IF EXISTS update_investment_reports_updated_at ON investment_reports;
+CREATE TRIGGER update_investment_reports_updated_at BEFORE UPDATE ON investment_reports FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -746,6 +746,34 @@ CREATE INDEX idx_custom_reports_user_id ON custom_reports(user_id);
 CREATE INDEX idx_custom_reports_user_favourite ON custom_reports(user_id, is_favourite);
 CREATE INDEX idx_custom_reports_user_sort ON custom_reports(user_id, sort_order);
 
+-- Custom investment reports (MS Money-style portfolio column reports).
+-- config JSONB shape:
+-- {
+--   columns: string[]      -- ordered column keys (always starts with "symbol")
+--   accountIds: string[]   -- holdings accounts to include ([] = all)
+--   sortColumn: string|null
+--   sortDirection: ASC | DESC
+--   asOfDate: string|null  -- YYYY-MM-DD, null = latest market day at run time
+-- }
+CREATE TABLE investment_reports (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    icon VARCHAR(50),
+    background_color VARCHAR(7),
+    group_by VARCHAR(20) NOT NULL DEFAULT 'NONE',
+    config JSONB NOT NULL DEFAULT '{}',
+    is_favourite BOOLEAN NOT NULL DEFAULT FALSE,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_investment_reports_user_id ON investment_reports(user_id);
+CREATE INDEX idx_investment_reports_user_favourite ON investment_reports(user_id, is_favourite);
+CREATE INDEX idx_investment_reports_user_sort ON investment_reports(user_id, sort_order);
+
 -- Triggers for updated_at timestamps
 CREATE OR REPLACE FUNCTION update_updated_at_column()
 RETURNS TRIGGER AS $$
@@ -767,6 +795,7 @@ CREATE TRIGGER update_user_preferences_updated_at BEFORE UPDATE ON user_preferen
 CREATE TRIGGER update_trusted_devices_updated_at BEFORE UPDATE ON trusted_devices FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_refresh_tokens_updated_at BEFORE UPDATE ON refresh_tokens FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_custom_reports_updated_at BEFORE UPDATE ON custom_reports FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_investment_reports_updated_at BEFORE UPDATE ON investment_reports FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
 -- NOTE: Account balances (current_balance) are managed by application code
 -- (accounts.service.ts, transactions.service.ts, import.service.ts) via updateBalance() calls.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -3,6 +3,11 @@ const packageJson = require('./package.json');
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // Pin the dev (Turbopack) workspace root to this app so it doesn't scan the
+  // whole monorepo (the backend tree) on every compile. The repo has multiple
+  // lockfiles, which otherwise makes Next infer the monorepo root and slows
+  // on-demand route compilation in dev.
+  turbopack: { root: __dirname },
   output: 'standalone', // Optimized for Docker deployment
   serverExternalPackages: ['jspdf', 'jspdf-autotable', 'fflate'],
   poweredByHeader: false, // Remove X-Powered-By: Next.js header

--- a/frontend/src/app/reports/investment/[id]/edit/page.test.tsx
+++ b/frontend/src/app/reports/investment/[id]/edit/page.test.tsx
@@ -21,8 +21,21 @@ vi.mock('@/components/layout/PageHeader', () => ({
 }));
 vi.mock('@/components/ui/LoadingSpinner', () => ({ LoadingSpinner: () => <div>spinner</div> }));
 vi.mock('@/components/ui/Modal', () => ({
-  Modal: ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) =>
-    isOpen ? <div data-testid="modal">{children}</div> : null,
+  Modal: ({
+    isOpen,
+    onClose,
+    children,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    children: React.ReactNode;
+  }) =>
+    isOpen ? (
+      <div data-testid="modal">
+        <button onClick={onClose}>modal-close</button>
+        {children}
+      </div>
+    ) : null,
 }));
 
 const mockGetById = vi.fn();
@@ -37,10 +50,23 @@ vi.mock('@/lib/investment-reports', () => ({
 }));
 
 vi.mock('@/components/reports/InvestmentReportForm', () => ({
-  InvestmentReportForm: ({ onSubmit }: { onSubmit: (d: unknown) => Promise<void> }) => (
-    <button onClick={() => onSubmit({ name: 'Updated', config: { columns: ['symbol'] } })}>
-      do-submit
-    </button>
+  InvestmentReportForm: ({
+    onSubmit,
+    onCancel,
+  }: {
+    onSubmit: (d: unknown) => Promise<void>;
+    onCancel: () => void;
+  }) => (
+    <div>
+      <button
+        onClick={() => {
+          void onSubmit({ name: 'Updated', config: { columns: ['symbol'] } }).catch(() => {});
+        }}
+      >
+        do-submit
+      </button>
+      <button onClick={onCancel}>do-cancel</button>
+    </div>
   ),
 }));
 
@@ -95,5 +121,76 @@ describe('EditInvestmentReportPage', () => {
     mockGetById.mockRejectedValue(new Error('boom'));
     await renderEdit();
     await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/reports'));
+  });
+
+  it('surfaces an error and stays on the page when the update fails', async () => {
+    mockGetById.mockResolvedValue(report);
+    mockUpdate.mockRejectedValue(new Error('boom'));
+    await renderEdit();
+    await screen.findByText('Edit Investment Report');
+    await act(async () => {
+      fireEvent.click(screen.getByText('do-submit'));
+    });
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    expect(mockPush).not.toHaveBeenCalledWith('/reports/investment/r1');
+  });
+
+  it('cancels editing and returns to the report view', async () => {
+    mockGetById.mockResolvedValue(report);
+    await renderEdit();
+    await screen.findByText('Edit Investment Report');
+    await act(async () => {
+      fireEvent.click(screen.getByText('do-cancel'));
+    });
+    expect(mockPush).toHaveBeenCalledWith('/reports/investment/r1');
+  });
+
+  it('closes the delete modal via the modal onClose handler', async () => {
+    mockGetById.mockResolvedValue(report);
+    await renderEdit();
+    await screen.findByText('Edit Investment Report');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Delete Report' }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'modal-close' }));
+    });
+    expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+  });
+
+  it('shows a loading spinner while the report loads', async () => {
+    mockGetById.mockReturnValue(new Promise(() => {})); // never resolves
+    await renderEdit();
+    expect(screen.getByText('spinner')).toBeInTheDocument();
+  });
+
+  it('closes the delete confirmation on cancel without deleting', async () => {
+    mockGetById.mockResolvedValue(report);
+    await renderEdit();
+    await screen.findByText('Edit Investment Report');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Delete Report' }));
+    });
+    expect(screen.getByTestId('modal')).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    });
+    expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it('keeps the user on the page when deletion fails', async () => {
+    mockGetById.mockResolvedValue(report);
+    mockDelete.mockRejectedValue(new Error('boom'));
+    await renderEdit();
+    await screen.findByText('Edit Investment Report');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Delete Report' }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    });
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith('r1'));
+    expect(mockPush).not.toHaveBeenCalledWith('/reports');
   });
 });

--- a/frontend/src/app/reports/investment/[id]/edit/page.test.tsx
+++ b/frontend/src/app/reports/investment/[id]/edit/page.test.tsx
@@ -1,0 +1,99 @@
+import { Suspense } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@/test/render';
+import EditInvestmentReportPage from './page';
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }));
+vi.mock('@/components/auth/ProtectedRoute', () => ({
+  ProtectedRoute: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/layout/PageLayout', () => ({
+  PageLayout: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/layout/PageHeader', () => ({
+  PageHeader: ({ title, actions }: { title: string; actions?: React.ReactNode }) => (
+    <div>
+      <h1>{title}</h1>
+      {actions}
+    </div>
+  ),
+}));
+vi.mock('@/components/ui/LoadingSpinner', () => ({ LoadingSpinner: () => <div>spinner</div> }));
+vi.mock('@/components/ui/Modal', () => ({
+  Modal: ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) =>
+    isOpen ? <div data-testid="modal">{children}</div> : null,
+}));
+
+const mockGetById = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
+vi.mock('@/lib/investment-reports', () => ({
+  investmentReportsApi: {
+    getById: (...a: unknown[]) => mockGetById(...a),
+    update: (...a: unknown[]) => mockUpdate(...a),
+    delete: (...a: unknown[]) => mockDelete(...a),
+  },
+}));
+
+vi.mock('@/components/reports/InvestmentReportForm', () => ({
+  InvestmentReportForm: ({ onSubmit }: { onSubmit: (d: unknown) => Promise<void> }) => (
+    <button onClick={() => onSubmit({ name: 'Updated', config: { columns: ['symbol'] } })}>
+      do-submit
+    </button>
+  ),
+}));
+
+async function renderEdit(id = 'r1') {
+  await act(async () => {
+    render(
+      <Suspense fallback={<div>suspense</div>}>
+        <EditInvestmentReportPage params={Promise.resolve({ id })} />
+      </Suspense>,
+    );
+  });
+}
+
+const report = {
+  id: 'r1',
+  name: 'My Report',
+  config: { columns: ['symbol'] },
+};
+
+describe('EditInvestmentReportPage', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('loads the report and updates it', async () => {
+    mockGetById.mockResolvedValue(report);
+    mockUpdate.mockResolvedValue(report);
+    await renderEdit();
+    expect(await screen.findByText('Edit Investment Report')).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByText('do-submit'));
+    });
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith('r1', expect.any(Object)));
+    expect(mockPush).toHaveBeenCalledWith('/reports/investment/r1');
+  });
+
+  it('deletes the report through the confirmation modal', async () => {
+    mockGetById.mockResolvedValue(report);
+    mockDelete.mockResolvedValue(undefined);
+    await renderEdit();
+    await screen.findByText('Edit Investment Report');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Delete Report' }));
+    });
+    expect(screen.getByTestId('modal')).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    });
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith('r1'));
+    expect(mockPush).toHaveBeenCalledWith('/reports');
+  });
+
+  it('redirects to reports when the report fails to load', async () => {
+    mockGetById.mockRejectedValue(new Error('boom'));
+    await renderEdit();
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/reports'));
+  });
+});

--- a/frontend/src/app/reports/investment/[id]/edit/page.tsx
+++ b/frontend/src/app/reports/investment/[id]/edit/page.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useState, useEffect, use } from 'react';
+import { useRouter } from 'next/navigation';
+import toast from 'react-hot-toast';
+import Link from 'next/link';
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { PageHeader } from '@/components/layout/PageHeader';
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import { Button } from '@/components/ui/Button';
+import { Modal } from '@/components/ui/Modal';
+import { InvestmentReportForm } from '@/components/reports/InvestmentReportForm';
+import { investmentReportsApi } from '@/lib/investment-reports';
+import { InvestmentReport, CreateInvestmentReportData } from '@/types/investment-report';
+import { createLogger } from '@/lib/logger';
+import { getErrorMessage } from '@/lib/errors';
+
+const logger = createLogger('InvestmentReportEdit');
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default function EditInvestmentReportPage({ params }: PageProps) {
+  const { id } = use(params);
+
+  return (
+    <ProtectedRoute>
+      <EditInvestmentReportContent reportId={id} />
+    </ProtectedRoute>
+  );
+}
+
+function EditInvestmentReportContent({ reportId }: { reportId: string }) {
+  const router = useRouter();
+  const [report, setReport] = useState<InvestmentReport | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  useEffect(() => {
+    const loadReport = async () => {
+      try {
+        const data = await investmentReportsApi.getById(reportId);
+        setReport(data);
+      } catch (error) {
+        toast.error(getErrorMessage(error, 'Failed to load report'));
+        router.push('/reports');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadReport();
+  }, [reportId, router]);
+
+  const handleSubmit = async (data: CreateInvestmentReportData) => {
+    try {
+      await investmentReportsApi.update(reportId, data);
+      toast.success('Report updated');
+      router.push(`/reports/investment/${reportId}`);
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Failed to update report'));
+      throw error;
+    }
+  };
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await investmentReportsApi.delete(reportId);
+      toast.success('Report deleted successfully');
+      router.push('/reports');
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Failed to delete report'));
+      logger.error(error);
+    } finally {
+      setIsDeleting(false);
+      setShowDeleteConfirm(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <PageLayout>
+        <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-12 pt-6 pb-8">
+          <div className="flex items-center justify-center py-12">
+            <LoadingSpinner />
+          </div>
+        </main>
+      </PageLayout>
+    );
+  }
+
+  if (!report) {
+    return null;
+  }
+
+  return (
+    <PageLayout>
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-12 pt-6 pb-8">
+        <PageHeader
+          title="Edit Investment Report"
+          subtitle="Modify your investment report configuration"
+          actions={
+            <>
+              <Button
+                variant="outline"
+                onClick={() => setShowDeleteConfirm(true)}
+                className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-red-900/20"
+              >
+                Delete Report
+              </Button>
+              <Link href="/reports">
+                <Button variant="outline">Back to Reports</Button>
+              </Link>
+            </>
+          }
+        />
+
+        <InvestmentReportForm
+          report={report}
+          onSubmit={handleSubmit}
+          onCancel={() => router.push(`/reports/investment/${reportId}`)}
+        />
+      </main>
+
+      <Modal
+        isOpen={showDeleteConfirm}
+        onClose={() => setShowDeleteConfirm(false)}
+        maxWidth="md"
+        className="p-6"
+      >
+        <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">
+          Delete Report
+        </h3>
+        <p className="text-gray-500 dark:text-gray-400 mb-6">
+          Are you sure you want to delete &quot;{report?.name}&quot;? This action cannot be undone.
+        </p>
+        <div className="flex justify-end gap-3">
+          <Button variant="outline" onClick={() => setShowDeleteConfirm(false)} disabled={isDeleting}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleDelete}
+            disabled={isDeleting}
+            className="bg-red-600 hover:bg-red-700 text-white"
+          >
+            {isDeleting ? 'Deleting...' : 'Delete'}
+          </Button>
+        </div>
+      </Modal>
+    </PageLayout>
+  );
+}

--- a/frontend/src/app/reports/investment/[id]/page.test.tsx
+++ b/frontend/src/app/reports/investment/[id]/page.test.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, act } from '@/test/render';
+import ViewInvestmentReportPage from './page';
+
+vi.mock('@/components/auth/ProtectedRoute', () => ({
+  ProtectedRoute: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/layout/PageLayout', () => ({
+  PageLayout: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/reports/InvestmentReportViewer', () => ({
+  InvestmentReportViewer: ({ reportId }: { reportId: string }) => (
+    <div data-testid="viewer">{reportId}</div>
+  ),
+}));
+
+describe('ViewInvestmentReportPage', () => {
+  it('renders the viewer for the route id', async () => {
+    await act(async () => {
+      render(
+        <Suspense fallback={<div>suspense</div>}>
+          <ViewInvestmentReportPage params={Promise.resolve({ id: 'r1' })} />
+        </Suspense>,
+      );
+    });
+    expect(await screen.findByTestId('viewer')).toHaveTextContent('r1');
+  });
+});

--- a/frontend/src/app/reports/investment/[id]/page.tsx
+++ b/frontend/src/app/reports/investment/[id]/page.tsx
@@ -15,7 +15,7 @@ export default function ViewInvestmentReportPage({ params }: PageProps) {
   return (
     <ProtectedRoute>
       <PageLayout>
-        <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-8">
+        <main className="max-w-[1800px] mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-8">
           <InvestmentReportViewer reportId={id} />
         </main>
       </PageLayout>

--- a/frontend/src/app/reports/investment/[id]/page.tsx
+++ b/frontend/src/app/reports/investment/[id]/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { use } from 'react';
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { InvestmentReportViewer } from '@/components/reports/InvestmentReportViewer';
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default function ViewInvestmentReportPage({ params }: PageProps) {
+  const { id } = use(params);
+
+  return (
+    <ProtectedRoute>
+      <PageLayout>
+        <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-8">
+          <InvestmentReportViewer reportId={id} />
+        </main>
+      </PageLayout>
+    </ProtectedRoute>
+  );
+}

--- a/frontend/src/app/reports/investment/new/page.test.tsx
+++ b/frontend/src/app/reports/investment/new/page.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@/test/render';
+import NewInvestmentReportPage from './page';
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }));
+vi.mock('@/components/auth/ProtectedRoute', () => ({
+  ProtectedRoute: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/layout/PageLayout', () => ({
+  PageLayout: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/layout/PageHeader', () => ({
+  PageHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
+}));
+
+const mockCreate = vi.fn();
+vi.mock('@/lib/investment-reports', () => ({
+  investmentReportsApi: { create: (...a: unknown[]) => mockCreate(...a) },
+}));
+
+vi.mock('@/components/reports/InvestmentReportForm', () => ({
+  InvestmentReportForm: ({
+    onSubmit,
+    onCancel,
+  }: {
+    onSubmit: (d: unknown) => Promise<void>;
+    onCancel: () => void;
+  }) => (
+    <div>
+      <button
+        onClick={() => {
+          void onSubmit({ name: 'X', config: { columns: ['symbol'] } }).catch(() => {});
+        }}
+      >
+        do-submit
+      </button>
+      <button onClick={onCancel}>do-cancel</button>
+    </div>
+  ),
+}));
+
+describe('NewInvestmentReportPage', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates a report and navigates to it', async () => {
+    mockCreate.mockResolvedValue({ id: 'r1' });
+    render(<NewInvestmentReportPage />);
+    expect(screen.getByText('Create Investment Report')).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByText('do-submit'));
+    });
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    expect(mockPush).toHaveBeenCalledWith('/reports/investment/r1');
+  });
+
+  it('navigates back to reports on cancel', () => {
+    render(<NewInvestmentReportPage />);
+    fireEvent.click(screen.getByText('do-cancel'));
+    expect(mockPush).toHaveBeenCalledWith('/reports');
+  });
+
+  it('surfaces an error when creation fails', async () => {
+    mockCreate.mockRejectedValue(new Error('boom'));
+    render(<NewInvestmentReportPage />);
+    await act(async () => {
+      fireEvent.click(screen.getByText('do-submit'));
+    });
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/reports/investment/new/page.tsx
+++ b/frontend/src/app/reports/investment/new/page.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import toast from 'react-hot-toast';
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { PageHeader } from '@/components/layout/PageHeader';
+import { Button } from '@/components/ui/Button';
+import { InvestmentReportForm } from '@/components/reports/InvestmentReportForm';
+import { investmentReportsApi } from '@/lib/investment-reports';
+import { getErrorMessage } from '@/lib/errors';
+import { CreateInvestmentReportData } from '@/types/investment-report';
+
+export default function NewInvestmentReportPage() {
+  return (
+    <ProtectedRoute>
+      <NewInvestmentReportContent />
+    </ProtectedRoute>
+  );
+}
+
+function NewInvestmentReportContent() {
+  const router = useRouter();
+
+  const handleSubmit = async (data: CreateInvestmentReportData) => {
+    try {
+      const report = await investmentReportsApi.create(data);
+      toast.success('Report created');
+      router.push(`/reports/investment/${report.id}`);
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Failed to create report'));
+      throw error;
+    }
+  };
+
+  return (
+    <PageLayout>
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-12 pt-6 pb-8">
+        <PageHeader
+          title="Create Investment Report"
+          subtitle="Build a custom portfolio report from your holdings"
+          actions={
+            <Link href="/reports">
+              <Button variant="outline">Back to Reports</Button>
+            </Link>
+          }
+        />
+
+        <InvestmentReportForm
+          onSubmit={handleSubmit}
+          onCancel={() => router.push('/reports')}
+        />
+      </main>
+    </PageLayout>
+  );
+}

--- a/frontend/src/app/reports/page.test.tsx
+++ b/frontend/src/app/reports/page.test.tsx
@@ -221,20 +221,31 @@ describe('ReportsPage', () => {
     expect(mockPush).toHaveBeenCalledWith('/reports/spending-by-category');
   });
 
-  it('renders New Custom Report button', async () => {
+  it('renders the New Report dropdown trigger', async () => {
     render(<ReportsPage />);
     await waitFor(() => {
-      expect(screen.getByText('New Custom Report')).toBeInTheDocument();
+      expect(screen.getByText('New Report')).toBeInTheDocument();
     });
   });
 
-  it('navigates to custom report creation when button is clicked', async () => {
+  it('navigates to standard report creation from the dropdown', async () => {
     render(<ReportsPage />);
     await waitFor(() => {
-      expect(screen.getByText('New Custom Report')).toBeInTheDocument();
+      expect(screen.getByText('New Report')).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByText('New Custom Report'));
+    fireEvent.click(screen.getByText('New Report'));
+    fireEvent.click(screen.getByText('Standard Report'));
     expect(mockPush).toHaveBeenCalledWith('/reports/custom/new');
+  });
+
+  it('navigates to investment report creation from the dropdown', async () => {
+    render(<ReportsPage />);
+    await waitFor(() => {
+      expect(screen.getByText('New Report')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('New Report'));
+    fireEvent.click(screen.getByText('Investment Report'));
+    expect(mockPush).toHaveBeenCalledWith('/reports/investment/new');
   });
 
   it('renders density toggle button', async () => {

--- a/frontend/src/app/reports/page.tsx
+++ b/frontend/src/app/reports/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { PageHeader } from '@/components/layout/PageHeader';
-import { Button } from '@/components/ui/Button';
+import { NewReportButton } from '@/components/reports/NewReportButton';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { usePreferencesStore } from '@/store/preferencesStore';
 import { userSettingsApi } from '@/lib/user-settings';
@@ -784,27 +784,10 @@ function ReportsContent() {
           subtitle="Generate insights about your financial health"
           helpUrl="https://github.com/kenlasko/monize/wiki/Reports"
           actions={
-            <>
-              <Button
-                variant="outline"
-                onClick={() => router.push('/reports/investment/new')}
-                className="inline-flex items-center justify-center gap-2"
-              >
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                </svg>
-                New Investment Report
-              </Button>
-              <Button
-                onClick={() => router.push('/reports/custom/new')}
-                className="inline-flex items-center justify-center gap-2"
-              >
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                </svg>
-                New Custom Report
-              </Button>
-            </>
+            <NewReportButton
+              onNewStandard={() => router.push('/reports/custom/new')}
+              onNewInvestment={() => router.push('/reports/investment/new')}
+            />
           }
         />
         {/* Search */}

--- a/frontend/src/app/reports/page.tsx
+++ b/frontend/src/app/reports/page.tsx
@@ -10,6 +10,8 @@ import { usePreferencesStore } from '@/store/preferencesStore';
 import { userSettingsApi } from '@/lib/user-settings';
 import { customReportsApi } from '@/lib/custom-reports';
 import { CustomReport, VIEW_TYPE_LABELS, TIMEFRAME_LABELS } from '@/types/custom-report';
+import { investmentReportsApi } from '@/lib/investment-reports';
+import { InvestmentReport } from '@/types/investment-report';
 import { getIconComponent } from '@/components/ui/IconPicker';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { createLogger } from '@/lib/logger';
@@ -27,6 +29,7 @@ interface Report {
   category: ReportCategory;
   color: string;
   isCustom?: boolean;
+  isInvestment?: boolean;
   isFavourite?: boolean;
 }
 
@@ -577,6 +580,7 @@ function ReportsContent() {
   const [searchQuery, setSearchQuery] = useState('');
   const [customReports, setCustomReports] = useState<CustomReport[]>([]);
   const [isLoadingCustom, setIsLoadingCustom] = useState(true);
+  const [investmentReports, setInvestmentReports] = useState<InvestmentReport[]>([]);
   const preferences = usePreferencesStore((s) => s.preferences);
   const updateStorePreferences = usePreferencesStore((s) => s.updatePreferences);
   const loadPreferences = usePreferencesStore((s) => s.loadPreferences);
@@ -627,10 +631,37 @@ function ReportsContent() {
     loadCustomReports();
   }, []);
 
+  useEffect(() => {
+    const loadInvestmentReports = async () => {
+      try {
+        const data = await investmentReportsApi.getAll();
+        setInvestmentReports(data);
+      } catch (error) {
+        logger.error('Failed to load investment reports:', error);
+      }
+    };
+    loadInvestmentReports();
+  }, []);
+
   const cycleDensity = () => setDensity(nextDensity(density));
 
-  const isReportFavourite = (report: Report): boolean => {
+  const managedBackgroundColor = (report: Report): string => {
     if (report.isCustom) {
+      return (
+        customReports.find((cr) => `custom/${cr.id}` === report.id)?.backgroundColor || ''
+      );
+    }
+    if (report.isInvestment) {
+      return (
+        investmentReports.find((ir) => `investment/${ir.id}` === report.id)
+          ?.backgroundColor || ''
+      );
+    }
+    return '';
+  };
+
+  const isReportFavourite = (report: Report): boolean => {
+    if (report.isCustom || report.isInvestment) {
       return report.isFavourite ?? false;
     }
     return favouriteReportIds.includes(report.id);
@@ -645,6 +676,16 @@ function ReportsContent() {
       try {
         await customReportsApi.toggleFavourite(cr.id, newValue);
         setCustomReports(prev => prev.map(c => c.id === cr.id ? { ...c, isFavourite: newValue } : c));
+      } catch (error) {
+        logger.error('Failed to toggle favourite:', error);
+      }
+    } else if (report.isInvestment) {
+      const ir = investmentReports.find(c => `investment/${c.id}` === report.id);
+      if (!ir) return;
+      const newValue = !ir.isFavourite;
+      try {
+        await investmentReportsApi.toggleFavourite(ir.id, newValue);
+        setInvestmentReports(prev => prev.map(c => c.id === ir.id ? { ...c, isFavourite: newValue } : c));
       } catch (error) {
         logger.error('Failed to toggle favourite:', error);
       }
@@ -696,7 +737,28 @@ function ReportsContent() {
     };
   });
 
-  const allReports = [...reports, ...customReportsAsReports];
+  // Convert investment reports to the Report interface
+  const investmentReportsAsReports: Report[] = investmentReports.map((ir) => {
+    const iconNode = ir.icon ? getIconComponent(ir.icon) : null;
+    return {
+      id: `investment/${ir.id}`,
+      name: ir.name,
+      description:
+        ir.description ||
+        `Investment report · ${ir.config.columns?.length ?? 0} columns`,
+      category: 'investment' as ReportCategory,
+      color: ir.backgroundColor ? '' : 'bg-lime-500',
+      isInvestment: true,
+      isFavourite: ir.isFavourite,
+      icon: iconNode || (
+        <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+        </svg>
+      ),
+    };
+  });
+
+  const allReports = [...reports, ...customReportsAsReports, ...investmentReportsAsReports];
 
   const filteredReports = allReports
     .filter(r => {
@@ -722,15 +784,27 @@ function ReportsContent() {
           subtitle="Generate insights about your financial health"
           helpUrl="https://github.com/kenlasko/monize/wiki/Reports"
           actions={
-            <Button
-              onClick={() => router.push('/reports/custom/new')}
-              className="inline-flex items-center justify-center gap-2"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-              </svg>
-              New Custom Report
-            </Button>
+            <>
+              <Button
+                variant="outline"
+                onClick={() => router.push('/reports/investment/new')}
+                className="inline-flex items-center justify-center gap-2"
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                New Investment Report
+              </Button>
+              <Button
+                onClick={() => router.push('/reports/custom/new')}
+                className="inline-flex items-center justify-center gap-2"
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                New Custom Report
+              </Button>
+            </>
           }
         />
         {/* Search */}
@@ -785,8 +859,7 @@ function ReportsContent() {
         {density === 'normal' && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {filteredReports.map((report) => {
-              const customReport = report.isCustom ? customReports.find(cr => `custom/${cr.id}` === report.id) : null;
-              const bgColor = customReport?.backgroundColor || '';
+              const bgColor = managedBackgroundColor(report);
               const colorClass = report.color || 'bg-purple-500';
 
               return (
@@ -847,8 +920,7 @@ function ReportsContent() {
         {density === 'compact' && (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {filteredReports.map((report) => {
-              const customReport = report.isCustom ? customReports.find(cr => `custom/${cr.id}` === report.id) : null;
-              const bgColor = customReport?.backgroundColor || '';
+              const bgColor = managedBackgroundColor(report);
               const colorClass = report.color || 'bg-purple-500';
 
               return (
@@ -920,8 +992,7 @@ function ReportsContent() {
               </thead>
               <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
                 {filteredReports.map((report) => {
-                  const customReport = report.isCustom ? customReports.find(cr => `custom/${cr.id}` === report.id) : null;
-                  const bgColor = customReport?.backgroundColor || '';
+                  const bgColor = managedBackgroundColor(report);
                   const colorClass = report.color || 'bg-purple-500';
 
                   return (

--- a/frontend/src/components/accounts/AccountForm.test.tsx
+++ b/frontend/src/components/accounts/AccountForm.test.tsx
@@ -1227,12 +1227,12 @@ describe('AccountForm', () => {
     });
   });
 
-  it('excludeFromNetWorth checkbox is checked for account with excludeFromNetWorth=true', async () => {
+  it('excludeFromNetWorth toggle is on for account with excludeFromNetWorth=true', async () => {
     const account = createExistingAccount({ excludeFromNetWorth: true });
     render(<AccountForm account={account} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
     await waitFor(() => {
-      const checkbox = screen.getByRole('checkbox', { name: /Exclude from Net Worth/i }) as HTMLInputElement;
-      expect(checkbox.checked).toBe(true);
+      const toggle = screen.getByRole('switch', { name: /Exclude from Net Worth/i });
+      expect(toggle).toHaveAttribute('aria-checked', 'true');
     });
   });
 

--- a/frontend/src/components/accounts/AccountForm.tsx
+++ b/frontend/src/components/accounts/AccountForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useForm, useWatch, Resolver } from 'react-hook-form';
+import { useForm, useWatch, Resolver, Controller } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import '@/lib/zodConfig';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -30,6 +30,7 @@ import { LoanPaymentSetupDialog } from './LoanPaymentSetupDialog';
 
 import { useFormSubmitRef } from '@/hooks/useFormSubmitRef';
 import { useFormDirtyNotify } from '@/hooks/useFormDirtyNotify';
+import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
 import { FormActions } from '@/components/ui/FormActions';
 
 const logger = createLogger('AccountForm');
@@ -688,16 +689,22 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
         {/* Hidden input for form registration */}
         <input type="hidden" {...register('isFavourite')} />
 
-        <label className="flex items-center gap-2 px-3 py-2 rounded-md border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors cursor-pointer">
-          <input
-            type="checkbox"
-            className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-            {...register('excludeFromNetWorth')}
+        <div className="flex items-center gap-3 px-3 py-2 rounded-md border border-gray-300 dark:border-gray-600">
+          <Controller
+            name="excludeFromNetWorth"
+            control={control}
+            render={({ field }) => (
+              <ToggleSwitch
+                checked={!!field.value}
+                onChange={field.onChange}
+                label="Exclude from Net Worth"
+              />
+            )}
           />
           <span className="text-sm text-gray-700 dark:text-gray-300">
             Exclude from Net Worth
           </span>
-        </label>
+        </div>
 
         {/* Import/Export buttons - only shown when editing */}
         {account && (

--- a/frontend/src/components/dashboard/NetWorthChart.test.tsx
+++ b/frontend/src/components/dashboard/NetWorthChart.test.tsx
@@ -9,12 +9,14 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
-  AreaChart: ({ children }: any) => <div data-testid="area-chart">{children}</div>,
-  Area: () => null,
+  BarChart: ({ children }: any) => <div data-testid="bar-chart">{children}</div>,
+  Bar: ({ children }: any) => <div data-testid="bar">{children}</div>,
+  LabelList: ({ formatter }: any) => (
+    <div data-testid="label-list">{formatter ? String(formatter(1000)) : ''}</div>
+  ),
   XAxis: () => null,
   YAxis: () => null,
   Tooltip: () => null,
-  ReferenceDot: () => null,
 }));
 
 vi.mock('@/hooks/useNumberFormat', () => ({
@@ -37,13 +39,13 @@ describe('NetWorthChart', () => {
     render(<NetWorthChart data={[]} isLoading={true} />);
     expect(screen.getByText('Net Worth')).toBeInTheDocument();
     expect(document.querySelector('.animate-pulse')).toBeInTheDocument();
-    expect(screen.queryByTestId('area-chart')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('bar-chart')).not.toBeInTheDocument();
   });
 
   it('renders empty state when no data', () => {
     render(<NetWorthChart data={[]} isLoading={false} />);
     expect(screen.getByText('No net worth data available yet.')).toBeInTheDocument();
-    expect(screen.queryByTestId('area-chart')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('bar-chart')).not.toBeInTheDocument();
   });
 
   it('renders chart with data and shows current net worth', () => {
@@ -53,10 +55,23 @@ describe('NetWorthChart', () => {
     ] as any[];
 
     render(<NetWorthChart data={data} isLoading={false} />);
-    expect(screen.getByTestId('area-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
     expect(screen.getByText('Past 12 months')).toBeInTheDocument();
     expect(screen.getByText('View full report')).toBeInTheDocument();
     expect(screen.getByText('$15000')).toBeInTheDocument();
+  });
+
+  it('renders abbreviated value labels above the bars', () => {
+    const data = [
+      { month: '2024-01-01', netWorth: 10000 },
+      { month: '2024-06-01', netWorth: 15000 },
+    ] as any[];
+
+    render(<NetWorthChart data={data} isLoading={false} />);
+    // The Bar renders a LabelList child that formats each value via
+    // formatCurrencyLabel (mocked here as `$<value>`).
+    expect(screen.getByTestId('label-list')).toBeInTheDocument();
+    expect(screen.getByText('$1000')).toBeInTheDocument();
   });
 
   it('shows positive change with plus sign and green styling', () => {
@@ -130,7 +145,7 @@ describe('NetWorthChart', () => {
     expect(currentEl.className).toContain('text-red');
   });
 
-  it('handles single data point correctly (no min/max dots)', () => {
+  it('handles single data point correctly', () => {
     const data = [
       { month: '2024-01-01', netWorth: 10000 },
     ] as any[];
@@ -138,6 +153,6 @@ describe('NetWorthChart', () => {
     render(<NetWorthChart data={data} isLoading={false} />);
     // Single data point: change = 0, percent = 0
     expect(screen.getByText('$10000')).toBeInTheDocument();
-    expect(screen.getByTestId('area-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/dashboard/NetWorthChart.tsx
+++ b/frontend/src/components/dashboard/NetWorthChart.tsx
@@ -3,13 +3,13 @@
 import { useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import {
-  AreaChart,
-  Area,
+  BarChart,
+  Bar,
   XAxis,
   YAxis,
   Tooltip,
   ResponsiveContainer,
-  ReferenceDot,
+  LabelList,
 } from 'recharts';
 import { format } from 'date-fns';
 import { MonthlyNetWorth } from '@/types/net-worth';
@@ -63,20 +63,6 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
     const change = current - initial;
     const changePercent = initial !== 0 ? (change / Math.abs(initial)) * 100 : 0;
     return { current, change, changePercent };
-  }, [chartData]);
-
-  const minMax = useMemo(() => {
-    if (chartData.length < 2) return null;
-    let minIdx = 0, maxIdx = 0;
-    for (let i = 1; i < chartData.length; i++) {
-      if (chartData[i].netWorth < chartData[minIdx].netWorth) minIdx = i;
-      if (chartData[i].netWorth > chartData[maxIdx].netWorth) maxIdx = i;
-    }
-    if (minIdx === maxIdx) return null;
-    return {
-      min: chartData[minIdx],
-      max: chartData[maxIdx],
-    };
   }, [chartData]);
 
   if (isLoading) {
@@ -139,14 +125,8 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
       </div>
       <div className="h-80">
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
-          <AreaChart data={chartData} margin={{ top: 5, right: 20, left: 20, bottom: 0 }}>
-            <defs>
-              <linearGradient id="dashboardNetWorthGradient" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.3} />
-                <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
-              </linearGradient>
-            </defs>
-            <YAxis hide domain={['auto', 'auto']} />
+          <BarChart data={chartData} margin={{ top: 52, right: 12, left: 12, bottom: 0 }}>
+            <YAxis hide domain={[(min: number) => Math.min(0, min), 'auto']} />
             <XAxis
               dataKey="name"
               tick={{ fill: '#6b7280', fontSize: 11 }}
@@ -155,38 +135,22 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
               interval="preserveStartEnd"
               tickFormatter={(value: string) => value.split(' ')[0]}
             />
-            <Tooltip content={<NetWorthTooltip formatCurrency={formatCurrency} />} />
-            <Area
-              type="monotone"
-              dataKey="netWorth"
-              stroke="#3b82f6"
-              strokeWidth={2}
-              fillOpacity={1}
-              fill="url(#dashboardNetWorthGradient)"
+            <Tooltip
+              content={<NetWorthTooltip formatCurrency={formatCurrency} />}
+              cursor={{ fill: '#e5e7eb', fillOpacity: 0.35 }}
             />
-            {minMax && (
-              <ReferenceDot
-                x={minMax.max.name}
-                y={minMax.max.netWorth}
-                r={5}
-                fill="#16a34a"
-                stroke="#fff"
-                strokeWidth={2}
-                label={{ value: formatCurrencyLabel(minMax.max.netWorth), position: 'bottom', fontSize: 11, fill: '#16a34a', fontWeight: 600, offset: 8 }}
+            <Bar dataKey="netWorth" fill="#3b82f6" radius={[4, 4, 0, 0]}>
+              <LabelList
+                dataKey="netWorth"
+                position="top"
+                angle={-90}
+                offset={6}
+                textAnchor="start"
+                formatter={(value: unknown) => formatCurrencyLabel(Number(value))}
+                style={{ fill: '#6b7280', fontSize: 11, fontWeight: 600, dominantBaseline: 'central' }}
               />
-            )}
-            {minMax && (
-              <ReferenceDot
-                x={minMax.min.name}
-                y={minMax.min.netWorth}
-                r={5}
-                fill="#dc2626"
-                stroke="#fff"
-                strokeWidth={2}
-                label={{ value: formatCurrencyLabel(minMax.min.netWorth), position: 'top', fontSize: 11, fill: '#dc2626', fontWeight: 600, offset: 8 }}
-              />
-            )}
-          </AreaChart>
+            </Bar>
+          </BarChart>
         </ResponsiveContainer>
       </div>
       <button

--- a/frontend/src/components/reports/InvestmentReportColumnChooser.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportColumnChooser.test.tsx
@@ -4,12 +4,11 @@ import { InvestmentReportColumnChooser } from './InvestmentReportColumnChooser';
 import { INVESTMENT_REPORT_COLUMNS } from '@/types/investment-report';
 
 describe('InvestmentReportColumnChooser', () => {
-  it('always pins symbol first and marks it as locked', () => {
-    const onChange = vi.fn();
-    render(<InvestmentReportColumnChooser value={['marketValue']} onChange={onChange} />);
-    expect(screen.getByText('(always shown)')).toBeInTheDocument();
-    // Symbol appears in the selected list even though it was not passed first
+  it('lists the selected columns in the given order', () => {
+    render(<InvestmentReportColumnChooser value={['symbol', 'marketValue']} onChange={vi.fn()} />);
     expect(screen.getByText('Selected columns (2)')).toBeInTheDocument();
+    expect(screen.getByTestId('selected-symbol')).toBeInTheDocument();
+    expect(screen.getByTestId('selected-marketValue')).toBeInTheDocument();
   });
 
   it('adds an available column', () => {
@@ -26,10 +25,11 @@ describe('InvestmentReportColumnChooser', () => {
     expect(onChange).toHaveBeenCalledWith(['symbol']);
   });
 
-  it('does not allow removing the symbol column', () => {
+  it('allows removing the symbol column', () => {
     const onChange = vi.fn();
     render(<InvestmentReportColumnChooser value={['symbol', 'gain']} onChange={onChange} />);
-    expect(screen.queryByLabelText('Remove Symbol')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Remove Symbol'));
+    expect(onChange).toHaveBeenCalledWith(['gain']);
   });
 
   it('reorders columns by dragging one onto another', () => {
@@ -48,44 +48,37 @@ describe('InvestmentReportColumnChooser', () => {
     expect(onChange).toHaveBeenCalledWith(['symbol', 'marketValue', 'gain']);
   });
 
-  it('never places a dragged column before the pinned symbol', () => {
+  it('can move a column ahead of symbol', () => {
     const onChange = vi.fn();
-    render(
-      <InvestmentReportColumnChooser
-        value={['symbol', 'gain', 'name']}
-        onChange={onChange}
-      />,
-    );
-    const source = screen.getByTestId('selected-name');
-    const target = screen.getByTestId('selected-symbol');
-    fireEvent.dragStart(source);
-    fireEvent.drop(target);
-    // Dropping onto symbol lands just after it; symbol stays first.
-    expect(onChange).toHaveBeenCalledWith(['symbol', 'name', 'gain']);
+    render(<InvestmentReportColumnChooser value={['symbol', 'gain']} onChange={onChange} />);
+    fireEvent.dragStart(screen.getByTestId('selected-gain'));
+    fireEvent.drop(screen.getByTestId('selected-symbol'));
+    expect(onChange).toHaveBeenCalledWith(['gain', 'symbol']);
   });
 
-  it('does not reorder when the dragged item is the pinned symbol', () => {
+  it('can drag the symbol column itself', () => {
     const onChange = vi.fn();
     render(
-      <InvestmentReportColumnChooser value={['symbol', 'gain']} onChange={onChange} />,
+      <InvestmentReportColumnChooser value={['symbol', 'gain', 'name']} onChange={onChange} />,
     );
-    // Symbol is not draggable, so dragStart sets no source; dropping is a no-op.
     fireEvent.dragStart(screen.getByTestId('selected-symbol'));
-    fireEvent.drop(screen.getByTestId('selected-gain'));
-    expect(onChange).not.toHaveBeenCalled();
+    fireEvent.drop(screen.getByTestId('selected-name'));
+    expect(onChange).toHaveBeenCalledWith(['gain', 'name', 'symbol']);
   });
 
   it('falls back to the raw key for an unknown selected column', () => {
-    const onChange = vi.fn();
-    render(<InvestmentReportColumnChooser value={['symbol', 'legacyKey']} onChange={onChange} />);
-    // A column key no longer in the catalogue still renders by its key.
+    render(<InvestmentReportColumnChooser value={['symbol', 'legacyKey']} onChange={vi.fn()} />);
     expect(screen.getByText('legacyKey')).toBeInTheDocument();
   });
 
+  it('prompts to add a column when none are selected', () => {
+    render(<InvestmentReportColumnChooser value={[]} onChange={vi.fn()} />);
+    expect(screen.getByText(/Add at least one column/)).toBeInTheDocument();
+  });
+
   it('shows an empty state when every column is selected', () => {
-    const onChange = vi.fn();
     const allKeys = INVESTMENT_REPORT_COLUMNS.map((c) => c.key);
-    render(<InvestmentReportColumnChooser value={allKeys} onChange={onChange} />);
+    render(<InvestmentReportColumnChooser value={allKeys} onChange={vi.fn()} />);
     expect(screen.getByText('All columns selected')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/reports/InvestmentReportColumnChooser.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportColumnChooser.test.tsx
@@ -65,6 +65,13 @@ describe('InvestmentReportColumnChooser', () => {
     expect(screen.getByLabelText('Move Gain up')).toBeDisabled();
   });
 
+  it('falls back to the raw key for an unknown selected column', () => {
+    const onChange = vi.fn();
+    render(<InvestmentReportColumnChooser value={['symbol', 'legacyKey']} onChange={onChange} />);
+    // A column key no longer in the catalogue still renders by its key.
+    expect(screen.getByText('legacyKey')).toBeInTheDocument();
+  });
+
   it('shows an empty state when every column is selected', () => {
     const onChange = vi.fn();
     const allKeys = INVESTMENT_REPORT_COLUMNS.map((c) => c.key);

--- a/frontend/src/components/reports/InvestmentReportColumnChooser.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportColumnChooser.test.tsx
@@ -32,7 +32,7 @@ describe('InvestmentReportColumnChooser', () => {
     expect(screen.queryByLabelText('Remove Symbol')).not.toBeInTheDocument();
   });
 
-  it('reorders columns with the move buttons', () => {
+  it('reorders columns by dragging one onto another', () => {
     const onChange = vi.fn();
     render(
       <InvestmentReportColumnChooser
@@ -40,29 +40,39 @@ describe('InvestmentReportColumnChooser', () => {
         onChange={onChange}
       />,
     );
-    // Move "Market Value" (index 2) up to index 1
-    fireEvent.click(screen.getByLabelText('Move Market Value up'));
+    const source = screen.getByTestId('selected-marketValue');
+    const target = screen.getByTestId('selected-gain');
+    fireEvent.dragStart(source);
+    fireEvent.dragOver(target);
+    fireEvent.drop(target);
     expect(onChange).toHaveBeenCalledWith(['symbol', 'marketValue', 'gain']);
   });
 
-  it('moves a column down with the down button', () => {
+  it('never places a dragged column before the pinned symbol', () => {
     const onChange = vi.fn();
     render(
       <InvestmentReportColumnChooser
-        value={['symbol', 'gain', 'marketValue']}
+        value={['symbol', 'gain', 'name']}
         onChange={onChange}
       />,
     );
-    // Move "Gain" (index 1) down to index 2
-    fireEvent.click(screen.getByLabelText('Move Gain down'));
-    expect(onChange).toHaveBeenCalledWith(['symbol', 'marketValue', 'gain']);
+    const source = screen.getByTestId('selected-name');
+    const target = screen.getByTestId('selected-symbol');
+    fireEvent.dragStart(source);
+    fireEvent.drop(target);
+    // Dropping onto symbol lands just after it; symbol stays first.
+    expect(onChange).toHaveBeenCalledWith(['symbol', 'name', 'gain']);
   });
 
-  it('never moves a column above the pinned symbol', () => {
+  it('does not reorder when the dragged item is the pinned symbol', () => {
     const onChange = vi.fn();
-    render(<InvestmentReportColumnChooser value={['symbol', 'gain']} onChange={onChange} />);
-    // The first non-symbol item's up button is disabled (cannot pass symbol)
-    expect(screen.getByLabelText('Move Gain up')).toBeDisabled();
+    render(
+      <InvestmentReportColumnChooser value={['symbol', 'gain']} onChange={onChange} />,
+    );
+    // Symbol is not draggable, so dragStart sets no source; dropping is a no-op.
+    fireEvent.dragStart(screen.getByTestId('selected-symbol'));
+    fireEvent.drop(screen.getByTestId('selected-gain'));
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it('falls back to the raw key for an unknown selected column', () => {

--- a/frontend/src/components/reports/InvestmentReportColumnChooser.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportColumnChooser.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@/test/render';
 import { InvestmentReportColumnChooser } from './InvestmentReportColumnChooser';
+import { INVESTMENT_REPORT_COLUMNS } from '@/types/investment-report';
 
 describe('InvestmentReportColumnChooser', () => {
   it('always pins symbol first and marks it as locked', () => {
@@ -44,10 +45,30 @@ describe('InvestmentReportColumnChooser', () => {
     expect(onChange).toHaveBeenCalledWith(['symbol', 'marketValue', 'gain']);
   });
 
+  it('moves a column down with the down button', () => {
+    const onChange = vi.fn();
+    render(
+      <InvestmentReportColumnChooser
+        value={['symbol', 'gain', 'marketValue']}
+        onChange={onChange}
+      />,
+    );
+    // Move "Gain" (index 1) down to index 2
+    fireEvent.click(screen.getByLabelText('Move Gain down'));
+    expect(onChange).toHaveBeenCalledWith(['symbol', 'marketValue', 'gain']);
+  });
+
   it('never moves a column above the pinned symbol', () => {
     const onChange = vi.fn();
     render(<InvestmentReportColumnChooser value={['symbol', 'gain']} onChange={onChange} />);
     // The first non-symbol item's up button is disabled (cannot pass symbol)
     expect(screen.getByLabelText('Move Gain up')).toBeDisabled();
+  });
+
+  it('shows an empty state when every column is selected', () => {
+    const onChange = vi.fn();
+    const allKeys = INVESTMENT_REPORT_COLUMNS.map((c) => c.key);
+    render(<InvestmentReportColumnChooser value={allKeys} onChange={onChange} />);
+    expect(screen.getByText('All columns selected')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/reports/InvestmentReportColumnChooser.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportColumnChooser.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@/test/render';
+import { InvestmentReportColumnChooser } from './InvestmentReportColumnChooser';
+
+describe('InvestmentReportColumnChooser', () => {
+  it('always pins symbol first and marks it as locked', () => {
+    const onChange = vi.fn();
+    render(<InvestmentReportColumnChooser value={['marketValue']} onChange={onChange} />);
+    expect(screen.getByText('(always shown)')).toBeInTheDocument();
+    // Symbol appears in the selected list even though it was not passed first
+    expect(screen.getByText('Selected columns (2)')).toBeInTheDocument();
+  });
+
+  it('adds an available column', () => {
+    const onChange = vi.fn();
+    render(<InvestmentReportColumnChooser value={['symbol']} onChange={onChange} />);
+    fireEvent.click(screen.getByLabelText('Add Market Value'));
+    expect(onChange).toHaveBeenCalledWith(['symbol', 'marketValue']);
+  });
+
+  it('removes a selected column', () => {
+    const onChange = vi.fn();
+    render(<InvestmentReportColumnChooser value={['symbol', 'gain']} onChange={onChange} />);
+    fireEvent.click(screen.getByLabelText('Remove Gain'));
+    expect(onChange).toHaveBeenCalledWith(['symbol']);
+  });
+
+  it('does not allow removing the symbol column', () => {
+    const onChange = vi.fn();
+    render(<InvestmentReportColumnChooser value={['symbol', 'gain']} onChange={onChange} />);
+    expect(screen.queryByLabelText('Remove Symbol')).not.toBeInTheDocument();
+  });
+
+  it('reorders columns with the move buttons', () => {
+    const onChange = vi.fn();
+    render(
+      <InvestmentReportColumnChooser
+        value={['symbol', 'gain', 'marketValue']}
+        onChange={onChange}
+      />,
+    );
+    // Move "Market Value" (index 2) up to index 1
+    fireEvent.click(screen.getByLabelText('Move Market Value up'));
+    expect(onChange).toHaveBeenCalledWith(['symbol', 'marketValue', 'gain']);
+  });
+
+  it('never moves a column above the pinned symbol', () => {
+    const onChange = vi.fn();
+    render(<InvestmentReportColumnChooser value={['symbol', 'gain']} onChange={onChange} />);
+    // The first non-symbol item's up button is disabled (cannot pass symbol)
+    expect(screen.getByLabelText('Move Gain up')).toBeDisabled();
+  });
+});

--- a/frontend/src/components/reports/InvestmentReportColumnChooser.tsx
+++ b/frontend/src/components/reports/InvestmentReportColumnChooser.tsx
@@ -4,19 +4,18 @@ import { useMemo, useState } from 'react';
 import {
   INVESTMENT_REPORT_COLUMNS,
   INVESTMENT_COLUMN_MAP,
-  ALWAYS_INCLUDED_COLUMN,
 } from '@/types/investment-report';
 
 interface InvestmentReportColumnChooserProps {
-  /** Ordered selected column keys (symbol is forced to the front). */
+  /** Ordered selected column keys. */
   value: string[];
   onChange: (columns: string[]) => void;
 }
 
 /**
  * Lets the user pick which MS Money-style columns appear in the report and the
- * order they appear in. Selected columns are reordered by dragging; the symbol
- * column is always present and pinned first.
+ * order they appear in. Columns are added from the available list, removed with
+ * the ✕, and reordered by dragging.
  */
 export function InvestmentReportColumnChooser({
   value,
@@ -25,30 +24,22 @@ export function InvestmentReportColumnChooser({
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [overIndex, setOverIndex] = useState<number | null>(null);
 
-  const selected = useMemo(() => {
-    const rest = value.filter((c) => c !== ALWAYS_INCLUDED_COLUMN);
-    return [ALWAYS_INCLUDED_COLUMN, ...rest];
-  }, [value]);
-
   const available = useMemo(
-    () => INVESTMENT_REPORT_COLUMNS.filter((c) => !selected.includes(c.key)),
-    [selected],
+    () => INVESTMENT_REPORT_COLUMNS.filter((c) => !value.includes(c.key)),
+    [value],
   );
 
-  const add = (key: string) => onChange([...selected, key]);
-  const remove = (key: string) => onChange(selected.filter((c) => c !== key));
+  const add = (key: string) => onChange([...value, key]);
+  const remove = (key: string) => onChange(value.filter((c) => c !== key));
 
-  // Reorder by dropping the dragged column onto another. The pinned symbol at
-  // index 0 never moves and nothing can be placed before it.
   const handleDrop = (targetIndex: number) => {
     setOverIndex(null);
     const from = dragIndex;
     setDragIndex(null);
-    if (from === null || from === 0 || from === targetIndex) return;
-    const dest = Math.max(1, targetIndex);
-    const next = [...selected];
+    if (from === null || from === targetIndex) return;
+    const next = [...value];
     const [moved] = next.splice(from, 1);
-    next.splice(dest, 0, moved);
+    next.splice(targetIndex, 0, moved);
     onChange(next);
   };
 
@@ -57,18 +48,22 @@ export function InvestmentReportColumnChooser({
       {/* Selected (ordered, drag to reorder) */}
       <div>
         <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-          Selected columns ({selected.length})
+          Selected columns ({value.length})
         </div>
         <ul className="border border-gray-200 dark:border-gray-700 rounded-md divide-y divide-gray-200 dark:divide-gray-700 max-h-96 overflow-auto">
-          {selected.map((key, index) => {
+          {value.length === 0 && (
+            <li className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
+              Add at least one column from the list.
+            </li>
+          )}
+          {value.map((key, index) => {
             const col = INVESTMENT_COLUMN_MAP[key];
-            const locked = key === ALWAYS_INCLUDED_COLUMN;
             return (
               <li
                 key={key}
                 data-testid={`selected-${key}`}
-                draggable={!locked}
-                onDragStart={() => !locked && setDragIndex(index)}
+                draggable
+                onDragStart={() => setDragIndex(index)}
                 onDragOver={(e) => {
                   e.preventDefault();
                   if (overIndex !== index) setOverIndex(index);
@@ -81,36 +76,28 @@ export function InvestmentReportColumnChooser({
                   setDragIndex(null);
                   setOverIndex(null);
                 }}
-                className={`flex items-center gap-2 px-3 py-2 text-sm ${
-                  locked ? '' : 'cursor-grab'
-                } ${dragIndex === index ? 'opacity-50' : ''} ${
+                className={`flex items-center gap-2 px-3 py-2 text-sm cursor-grab ${
+                  dragIndex === index ? 'opacity-50' : ''
+                } ${
                   overIndex === index && dragIndex !== null && dragIndex !== index
                     ? 'bg-blue-50 dark:bg-blue-900/20'
                     : ''
                 }`}
               >
-                <span
-                  aria-hidden="true"
-                  className={`select-none ${locked ? 'text-gray-300 dark:text-gray-600' : 'text-gray-400'}`}
-                >
+                <span aria-hidden="true" className="select-none text-gray-400">
                   ⠿
                 </span>
                 <span className="flex-1 text-gray-900 dark:text-gray-100">
                   {col?.label ?? key}
-                  {locked && (
-                    <span className="ml-2 text-xs text-gray-400">(always shown)</span>
-                  )}
                 </span>
-                {!locked && (
-                  <button
-                    type="button"
-                    aria-label={`Remove ${col?.label ?? key}`}
-                    onClick={() => remove(key)}
-                    className="text-gray-400 hover:text-red-600 dark:hover:text-red-400"
-                  >
-                    ✕
-                  </button>
-                )}
+                <button
+                  type="button"
+                  aria-label={`Remove ${col?.label ?? key}`}
+                  onClick={() => remove(key)}
+                  className="text-gray-400 hover:text-red-600 dark:hover:text-red-400"
+                >
+                  ✕
+                </button>
               </li>
             );
           })}

--- a/frontend/src/components/reports/InvestmentReportColumnChooser.tsx
+++ b/frontend/src/components/reports/InvestmentReportColumnChooser.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import {
   INVESTMENT_REPORT_COLUMNS,
   INVESTMENT_COLUMN_MAP,
@@ -15,12 +15,16 @@ interface InvestmentReportColumnChooserProps {
 
 /**
  * Lets the user pick which MS Money-style columns appear in the report and the
- * order they appear in. The symbol column is always present and pinned first.
+ * order they appear in. Selected columns are reordered by dragging; the symbol
+ * column is always present and pinned first.
  */
 export function InvestmentReportColumnChooser({
   value,
   onChange,
 }: InvestmentReportColumnChooserProps) {
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
+
   const selected = useMemo(() => {
     const rest = value.filter((c) => c !== ALWAYS_INCLUDED_COLUMN);
     return [ALWAYS_INCLUDED_COLUMN, ...rest];
@@ -32,21 +36,25 @@ export function InvestmentReportColumnChooser({
   );
 
   const add = (key: string) => onChange([...selected, key]);
-  const remove = (key: string) =>
-    onChange(selected.filter((c) => c !== key));
+  const remove = (key: string) => onChange(selected.filter((c) => c !== key));
 
-  // Reordering never touches the pinned symbol at index 0.
-  const move = (index: number, delta: number) => {
-    const target = index + delta;
-    if (index <= 0 || target <= 0 || target >= selected.length) return;
+  // Reorder by dropping the dragged column onto another. The pinned symbol at
+  // index 0 never moves and nothing can be placed before it.
+  const handleDrop = (targetIndex: number) => {
+    setOverIndex(null);
+    const from = dragIndex;
+    setDragIndex(null);
+    if (from === null || from === 0 || from === targetIndex) return;
+    const dest = Math.max(1, targetIndex);
     const next = [...selected];
-    [next[index], next[target]] = [next[target], next[index]];
+    const [moved] = next.splice(from, 1);
+    next.splice(dest, 0, moved);
     onChange(next);
   };
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-      {/* Selected (ordered) */}
+      {/* Selected (ordered, drag to reorder) */}
       <div>
         <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
           Selected columns ({selected.length})
@@ -58,28 +66,35 @@ export function InvestmentReportColumnChooser({
             return (
               <li
                 key={key}
-                className="flex items-center gap-2 px-3 py-2 text-sm"
+                data-testid={`selected-${key}`}
+                draggable={!locked}
+                onDragStart={() => !locked && setDragIndex(index)}
+                onDragOver={(e) => {
+                  e.preventDefault();
+                  if (overIndex !== index) setOverIndex(index);
+                }}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  handleDrop(index);
+                }}
+                onDragEnd={() => {
+                  setDragIndex(null);
+                  setOverIndex(null);
+                }}
+                className={`flex items-center gap-2 px-3 py-2 text-sm ${
+                  locked ? '' : 'cursor-grab'
+                } ${dragIndex === index ? 'opacity-50' : ''} ${
+                  overIndex === index && dragIndex !== null && dragIndex !== index
+                    ? 'bg-blue-50 dark:bg-blue-900/20'
+                    : ''
+                }`}
               >
-                <div className="flex flex-col">
-                  <button
-                    type="button"
-                    aria-label={`Move ${col?.label} up`}
-                    disabled={index <= 1}
-                    onClick={() => move(index, -1)}
-                    className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 disabled:opacity-30 disabled:cursor-not-allowed leading-none"
-                  >
-                    ▲
-                  </button>
-                  <button
-                    type="button"
-                    aria-label={`Move ${col?.label} down`}
-                    disabled={locked || index >= selected.length - 1}
-                    onClick={() => move(index, 1)}
-                    className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 disabled:opacity-30 disabled:cursor-not-allowed leading-none"
-                  >
-                    ▼
-                  </button>
-                </div>
+                <span
+                  aria-hidden="true"
+                  className={`select-none ${locked ? 'text-gray-300 dark:text-gray-600' : 'text-gray-400'}`}
+                >
+                  ⠿
+                </span>
                 <span className="flex-1 text-gray-900 dark:text-gray-100">
                   {col?.label ?? key}
                   {locked && (
@@ -89,7 +104,7 @@ export function InvestmentReportColumnChooser({
                 {!locked && (
                   <button
                     type="button"
-                    aria-label={`Remove ${col?.label}`}
+                    aria-label={`Remove ${col?.label ?? key}`}
                     onClick={() => remove(key)}
                     className="text-gray-400 hover:text-red-600 dark:hover:text-red-400"
                   >
@@ -100,6 +115,9 @@ export function InvestmentReportColumnChooser({
             );
           })}
         </ul>
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          Drag columns to reorder.
+        </p>
       </div>
 
       {/* Available */}

--- a/frontend/src/components/reports/InvestmentReportColumnChooser.tsx
+++ b/frontend/src/components/reports/InvestmentReportColumnChooser.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  INVESTMENT_REPORT_COLUMNS,
+  INVESTMENT_COLUMN_MAP,
+  ALWAYS_INCLUDED_COLUMN,
+} from '@/types/investment-report';
+
+interface InvestmentReportColumnChooserProps {
+  /** Ordered selected column keys (symbol is forced to the front). */
+  value: string[];
+  onChange: (columns: string[]) => void;
+}
+
+/**
+ * Lets the user pick which MS Money-style columns appear in the report and the
+ * order they appear in. The symbol column is always present and pinned first.
+ */
+export function InvestmentReportColumnChooser({
+  value,
+  onChange,
+}: InvestmentReportColumnChooserProps) {
+  const selected = useMemo(() => {
+    const rest = value.filter((c) => c !== ALWAYS_INCLUDED_COLUMN);
+    return [ALWAYS_INCLUDED_COLUMN, ...rest];
+  }, [value]);
+
+  const available = useMemo(
+    () => INVESTMENT_REPORT_COLUMNS.filter((c) => !selected.includes(c.key)),
+    [selected],
+  );
+
+  const add = (key: string) => onChange([...selected, key]);
+  const remove = (key: string) =>
+    onChange(selected.filter((c) => c !== key));
+
+  // Reordering never touches the pinned symbol at index 0.
+  const move = (index: number, delta: number) => {
+    const target = index + delta;
+    if (index <= 0 || target <= 0 || target >= selected.length) return;
+    const next = [...selected];
+    [next[index], next[target]] = [next[target], next[index]];
+    onChange(next);
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {/* Selected (ordered) */}
+      <div>
+        <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          Selected columns ({selected.length})
+        </div>
+        <ul className="border border-gray-200 dark:border-gray-700 rounded-md divide-y divide-gray-200 dark:divide-gray-700 max-h-96 overflow-auto">
+          {selected.map((key, index) => {
+            const col = INVESTMENT_COLUMN_MAP[key];
+            const locked = key === ALWAYS_INCLUDED_COLUMN;
+            return (
+              <li
+                key={key}
+                className="flex items-center gap-2 px-3 py-2 text-sm"
+              >
+                <div className="flex flex-col">
+                  <button
+                    type="button"
+                    aria-label={`Move ${col?.label} up`}
+                    disabled={index <= 1}
+                    onClick={() => move(index, -1)}
+                    className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 disabled:opacity-30 disabled:cursor-not-allowed leading-none"
+                  >
+                    ▲
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Move ${col?.label} down`}
+                    disabled={locked || index >= selected.length - 1}
+                    onClick={() => move(index, 1)}
+                    className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 disabled:opacity-30 disabled:cursor-not-allowed leading-none"
+                  >
+                    ▼
+                  </button>
+                </div>
+                <span className="flex-1 text-gray-900 dark:text-gray-100">
+                  {col?.label ?? key}
+                  {locked && (
+                    <span className="ml-2 text-xs text-gray-400">(always shown)</span>
+                  )}
+                </span>
+                {!locked && (
+                  <button
+                    type="button"
+                    aria-label={`Remove ${col?.label}`}
+                    onClick={() => remove(key)}
+                    className="text-gray-400 hover:text-red-600 dark:hover:text-red-400"
+                  >
+                    ✕
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      {/* Available */}
+      <div>
+        <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          Available columns ({available.length})
+        </div>
+        <ul className="border border-gray-200 dark:border-gray-700 rounded-md divide-y divide-gray-200 dark:divide-gray-700 max-h-96 overflow-auto">
+          {available.length === 0 && (
+            <li className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
+              All columns selected
+            </li>
+          )}
+          {available.map((col) => (
+            <li key={col.key} className="flex items-start gap-2 px-3 py-2 text-sm">
+              <button
+                type="button"
+                aria-label={`Add ${col.label}`}
+                onClick={() => add(col.key)}
+                className="mt-0.5 text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium leading-none"
+              >
+                +
+              </button>
+              <div className="flex-1">
+                <div className="text-gray-900 dark:text-gray-100">{col.label}</div>
+                <div className="text-xs text-gray-500 dark:text-gray-400">
+                  {col.description}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/reports/InvestmentReportForm.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportForm.test.tsx
@@ -202,4 +202,57 @@ describe('InvestmentReportForm', () => {
     expect(submitted.config.sortColumn).toBeNull();
     expect(submitted.config.asOfDate).toBeNull();
   });
+
+  it('saves the combine-across-accounts toggle into the config', async () => {
+    const onSubmit = await renderForm();
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText('e.g., Taxable Holdings Overview'), {
+        target: { value: 'Combined' },
+      });
+    });
+    // Default grouping is None, so the combine toggle is available.
+    const toggle = screen.getByRole('switch', {
+      name: /Combine the same security held in multiple accounts/i,
+    });
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Create Report' }));
+    });
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0].config.mergeAccounts).toBe(true);
+  });
+
+  it('hides the combine toggle when grouping by account', async () => {
+    const report = {
+      id: 'r1',
+      userId: 'u1',
+      name: 'Acct',
+      description: null,
+      icon: null,
+      backgroundColor: null,
+      groupBy: 'ACCOUNT',
+      config: {
+        columns: ['symbol'],
+        accountIds: [],
+        sortColumn: null,
+        sortDirection: 'ASC',
+        asOfDate: null,
+      },
+      isFavourite: false,
+      sortOrder: 0,
+      createdAt: '',
+      updatedAt: '',
+    } as never;
+    await act(async () => {
+      render(<InvestmentReportForm report={report} onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    });
+    await screen.findByText('Columns');
+    expect(
+      screen.queryByRole('switch', {
+        name: /Combine the same security held in multiple accounts/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/reports/InvestmentReportForm.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportForm.test.tsx
@@ -73,6 +73,7 @@ describe('InvestmentReportForm', () => {
     const submitted = onSubmit.mock.calls[0][0];
     expect(submitted.name).toBe('My Holdings');
     expect(submitted.config.columns[0]).toBe('symbol');
+    expect(submitted.config.columns[1]).toBe('name');
     expect(submitted.config.columns).toContain('marketValue');
     expect(submitted.config.sortColumn).toBe('marketValue');
     expect(submitted.config.accountIds).toEqual([]);

--- a/frontend/src/components/reports/InvestmentReportForm.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportForm.test.tsx
@@ -13,7 +13,26 @@ vi.mock('@/components/ui/ColorPicker', () => ({
   ColorPicker: () => <div data-testid="color-picker" />,
 }));
 vi.mock('@/components/ui/DateInput', () => ({
-  DateInput: ({ label }: { label?: string }) => <div>{label}</div>,
+  DateInput: ({
+    label,
+    onChange,
+    onDateChange,
+  }: {
+    label?: string;
+    onChange?: (e: { target: { value: string } }) => void;
+    onDateChange?: (date: string) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="date-change"
+      onClick={() => {
+        onChange?.({ target: { value: '2024-02-02' } });
+        onDateChange?.('2024-02-02');
+      }}
+    >
+      {label}
+    </button>
+  ),
 }));
 vi.mock('@/components/ui/MultiSelect', () => ({
   MultiSelect: ({ label }: { label?: string }) => <div>{label}</div>,
@@ -69,5 +88,117 @@ describe('InvestmentReportForm', () => {
       expect(screen.getByText('Name is required')).toBeInTheDocument(),
     );
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('populates fields from an existing report and submits its config in edit mode', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const report = {
+      id: 'r1',
+      userId: 'u1',
+      name: 'Existing',
+      description: 'desc',
+      icon: 'chart-bar',
+      backgroundColor: '#123456',
+      groupBy: 'ACCOUNT',
+      config: {
+        columns: ['symbol', 'gain'],
+        accountIds: ['acc1'],
+        sortColumn: 'gain',
+        sortDirection: 'DESC',
+        asOfDate: '2024-01-31',
+      },
+      isFavourite: true,
+      sortOrder: 0,
+      createdAt: '',
+      updatedAt: '',
+    } as never;
+    await act(async () => {
+      render(<InvestmentReportForm report={report} onSubmit={onSubmit} onCancel={vi.fn()} />);
+    });
+    // Grouping hint renders for a grouped report
+    expect(await screen.findByText(/Rows are grouped by account/)).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Update Report' }));
+    });
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    const submitted = onSubmit.mock.calls[0][0];
+    expect(submitted.name).toBe('Existing');
+    expect(submitted.config.columns).toEqual(['symbol', 'gain']);
+    expect(submitted.config.sortColumn).toBe('gain');
+    expect(submitted.config.accountIds).toEqual(['acc1']);
+    expect(submitted.config.asOfDate).toBe('2024-01-31');
+    expect(submitted.groupBy).toBe('ACCOUNT');
+  });
+
+  it('still renders when accounts fail to load', async () => {
+    const { accountsApi } = await import('@/lib/accounts');
+    vi.mocked(accountsApi.getAll).mockRejectedValueOnce(new Error('boom'));
+    await renderForm();
+    expect(await screen.findByText('Columns')).toBeInTheDocument();
+  });
+
+  it('filters the account list to open non-cash investment accounts', async () => {
+    const { accountsApi } = await import('@/lib/accounts');
+    vi.mocked(accountsApi.getAll).mockResolvedValueOnce([
+      { id: 'a1', accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_BROKERAGE', isClosed: false },
+      { id: 'a2', accountType: 'CHECKING', accountSubType: null, isClosed: false },
+      { id: 'a3', accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_CASH', isClosed: false },
+      { id: 'a4', accountType: 'INVESTMENT', accountSubType: null, isClosed: true },
+    ] as never);
+    await renderForm();
+    // The account predicate runs across all branches without throwing.
+    expect(await screen.findByText('Accounts')).toBeInTheDocument();
+  });
+
+  it('captures the chosen as-of date on submit', async () => {
+    const onSubmit = await renderForm();
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText('e.g., Taxable Holdings Overview'), {
+        target: { value: 'Dated' },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('date-change'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Create Report' }));
+    });
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0].config.asOfDate).toBe('2024-02-02');
+  });
+
+  it('applies fallbacks for null fields and drops an invalid saved sort column', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const report = {
+      id: 'r1',
+      userId: 'u1',
+      name: 'Minimal',
+      description: null,
+      icon: null,
+      backgroundColor: null,
+      groupBy: 'NONE',
+      config: {
+        columns: ['symbol', 'quantity'],
+        accountIds: [],
+        sortColumn: 'gain', // not in columns -> must be dropped on submit
+        sortDirection: 'ASC',
+        asOfDate: null,
+      },
+      isFavourite: false,
+      sortOrder: 0,
+      createdAt: '',
+      updatedAt: '',
+    } as never;
+    await act(async () => {
+      render(<InvestmentReportForm report={report} onSubmit={onSubmit} onCancel={vi.fn()} />);
+    });
+    await screen.findByText('Columns');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Update Report' }));
+    });
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    const submitted = onSubmit.mock.calls[0][0];
+    expect(submitted.config.sortColumn).toBeNull();
+    expect(submitted.config.asOfDate).toBeNull();
   });
 });

--- a/frontend/src/components/reports/InvestmentReportForm.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportForm.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@/test/render';
+import { InvestmentReportForm } from './InvestmentReportForm';
+
+vi.mock('@/lib/accounts', () => ({
+  accountsApi: { getAll: vi.fn().mockResolvedValue([]) },
+}));
+
+vi.mock('@/components/ui/IconPicker', () => ({
+  IconPicker: () => <div data-testid="icon-picker" />,
+}));
+vi.mock('@/components/ui/ColorPicker', () => ({
+  ColorPicker: () => <div data-testid="color-picker" />,
+}));
+vi.mock('@/components/ui/DateInput', () => ({
+  DateInput: ({ label }: { label?: string }) => <div>{label}</div>,
+}));
+vi.mock('@/components/ui/MultiSelect', () => ({
+  MultiSelect: ({ label }: { label?: string }) => <div>{label}</div>,
+}));
+vi.mock('./InvestmentReportColumnChooser', () => ({
+  InvestmentReportColumnChooser: () => <div data-testid="column-chooser" />,
+}));
+
+describe('InvestmentReportForm', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  async function renderForm(onSubmit = vi.fn().mockResolvedValue(undefined)) {
+    await act(async () => {
+      render(<InvestmentReportForm onSubmit={onSubmit} onCancel={vi.fn()} />);
+    });
+    return onSubmit;
+  }
+
+  it('renders the builder sections after loading', async () => {
+    await renderForm();
+    expect(await screen.findByText('Columns')).toBeInTheDocument();
+    expect(screen.getByText('Accounts')).toBeInTheDocument();
+    expect(screen.getByText('Grouping & Sorting')).toBeInTheDocument();
+    expect(screen.getByText('Report Date')).toBeInTheDocument();
+    expect(screen.getByTestId('column-chooser')).toBeInTheDocument();
+  });
+
+  it('submits the assembled report configuration with symbol-led default columns', async () => {
+    const onSubmit = await renderForm();
+    const nameInput = screen.getByPlaceholderText('e.g., Taxable Holdings Overview');
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: 'My Holdings' } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Create Report' }));
+    });
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    const submitted = onSubmit.mock.calls[0][0];
+    expect(submitted.name).toBe('My Holdings');
+    expect(submitted.config.columns[0]).toBe('symbol');
+    expect(submitted.config.columns).toContain('marketValue');
+    expect(submitted.config.sortColumn).toBe('marketValue');
+    expect(submitted.config.accountIds).toEqual([]);
+    expect(submitted.config.asOfDate).toBeNull();
+  });
+
+  it('requires a name', async () => {
+    const onSubmit = await renderForm();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Create Report' }));
+    });
+    await waitFor(() =>
+      expect(screen.getByText('Name is required')).toBeInTheDocument(),
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/reports/InvestmentReportForm.tsx
+++ b/frontend/src/components/reports/InvestmentReportForm.tsx
@@ -49,6 +49,7 @@ const schema = z.object({
   groupBy: z.nativeEnum(InvestmentGroupBy),
   sortColumn: z.string().optional(),
   sortDirection: z.nativeEnum(InvestmentSortDirection),
+  mergeAccounts: z.boolean().optional(),
   isFavourite: z.boolean().optional(),
 });
 
@@ -92,6 +93,7 @@ export function InvestmentReportForm({
           groupBy: report.groupBy,
           sortColumn: report.config.sortColumn || '',
           sortDirection: report.config.sortDirection || InvestmentSortDirection.ASC,
+          mergeAccounts: report.config.mergeAccounts ?? false,
           isFavourite: report.isFavourite,
         }
       : {
@@ -102,6 +104,7 @@ export function InvestmentReportForm({
           groupBy: InvestmentGroupBy.NONE,
           sortColumn: 'marketValue',
           sortDirection: InvestmentSortDirection.DESC,
+          mergeAccounts: false,
           isFavourite: false,
         },
   });
@@ -143,6 +146,7 @@ export function InvestmentReportForm({
         sortColumn,
         sortDirection: data.sortDirection,
         asOfDate: asOfDate || null,
+        mergeAccounts: data.mergeAccounts ?? false,
       },
       isFavourite: data.isFavourite,
     };
@@ -266,6 +270,30 @@ export function InvestmentReportForm({
             Rows are grouped by {GROUP_BY_LABELS[watchGroupBy].toLowerCase()} and sorted
             within each group.
           </p>
+        )}
+        {watchGroupBy !== InvestmentGroupBy.ACCOUNT && (
+          <div className="mt-4 flex items-start gap-3">
+            <Controller
+              name="mergeAccounts"
+              control={control}
+              render={({ field }) => (
+                <ToggleSwitch
+                  checked={!!field.value}
+                  onChange={field.onChange}
+                  label="Combine the same security held in multiple accounts"
+                />
+              )}
+            />
+            <div>
+              <span className="text-sm text-gray-700 dark:text-gray-300">
+                Combine the same security held in multiple accounts
+              </span>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                When off, each account&apos;s holding is listed separately with an
+                Account column.
+              </p>
+            </div>
+          </div>
         )}
       </div>
 

--- a/frontend/src/components/reports/InvestmentReportForm.tsx
+++ b/frontend/src/components/reports/InvestmentReportForm.tsx
@@ -11,6 +11,7 @@ import { Select } from '@/components/ui/Select';
 import { IconPicker } from '@/components/ui/IconPicker';
 import { ColorPicker } from '@/components/ui/ColorPicker';
 import { MultiSelect } from '@/components/ui/MultiSelect';
+import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
 import { FormActions } from '@/components/ui/FormActions';
 import { InvestmentReportColumnChooser } from '@/components/reports/InvestmentReportColumnChooser';
 import {
@@ -19,7 +20,6 @@ import {
   InvestmentGroupBy,
   InvestmentSortDirection,
   INVESTMENT_COLUMN_MAP,
-  ALWAYS_INCLUDED_COLUMN,
   GROUP_BY_LABELS,
   SORT_DIRECTION_LABELS,
 } from '@/types/investment-report';
@@ -289,16 +289,22 @@ export function InvestmentReportForm({
 
       {/* Favourite */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
-        <label className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            {...register('isFavourite')}
-            className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+        <div className="flex items-center gap-3">
+          <Controller
+            name="isFavourite"
+            control={control}
+            render={({ field }) => (
+              <ToggleSwitch
+                checked={!!field.value}
+                onChange={field.onChange}
+                label="Add to favourites"
+              />
+            )}
           />
           <span className="text-sm text-gray-700 dark:text-gray-300">
             Add to favourites
           </span>
-        </label>
+        </div>
       </div>
 
       <FormActions

--- a/frontend/src/components/reports/InvestmentReportForm.tsx
+++ b/frontend/src/components/reports/InvestmentReportForm.tsx
@@ -31,6 +31,7 @@ const logger = createLogger('InvestmentReportForm');
 
 const DEFAULT_COLUMNS = [
   'symbol',
+  'name',
   'quantity',
   'averageCost',
   'costBasis',

--- a/frontend/src/components/reports/InvestmentReportForm.tsx
+++ b/frontend/src/components/reports/InvestmentReportForm.tsx
@@ -1,0 +1,310 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import '@/lib/zodConfig';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Input } from '@/components/ui/Input';
+import { DateInput } from '@/components/ui/DateInput';
+import { Select } from '@/components/ui/Select';
+import { IconPicker } from '@/components/ui/IconPicker';
+import { ColorPicker } from '@/components/ui/ColorPicker';
+import { MultiSelect } from '@/components/ui/MultiSelect';
+import { FormActions } from '@/components/ui/FormActions';
+import { InvestmentReportColumnChooser } from '@/components/reports/InvestmentReportColumnChooser';
+import {
+  InvestmentReport,
+  CreateInvestmentReportData,
+  InvestmentGroupBy,
+  InvestmentSortDirection,
+  INVESTMENT_COLUMN_MAP,
+  ALWAYS_INCLUDED_COLUMN,
+  GROUP_BY_LABELS,
+  SORT_DIRECTION_LABELS,
+} from '@/types/investment-report';
+import { Account } from '@/types/account';
+import { accountsApi } from '@/lib/accounts';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('InvestmentReportForm');
+
+const DEFAULT_COLUMNS = [
+  'symbol',
+  'quantity',
+  'averageCost',
+  'costBasis',
+  'lastPrice',
+  'marketValue',
+  'gain',
+  'gainPercent',
+];
+
+const schema = z.object({
+  name: z.string().min(1, 'Name is required').max(100),
+  description: z.string().optional(),
+  icon: z.string().optional(),
+  backgroundColor: z.string().regex(/^#[0-9A-Fa-f]{6}$/).optional().nullable(),
+  groupBy: z.nativeEnum(InvestmentGroupBy),
+  sortColumn: z.string().optional(),
+  sortDirection: z.nativeEnum(InvestmentSortDirection),
+  isFavourite: z.boolean().optional(),
+});
+
+type FormData = z.infer<typeof schema>;
+
+interface InvestmentReportFormProps {
+  report?: InvestmentReport;
+  onSubmit: (data: CreateInvestmentReportData) => Promise<void>;
+  onCancel: () => void;
+}
+
+export function InvestmentReportForm({
+  report,
+  onSubmit,
+  onCancel,
+}: InvestmentReportFormProps) {
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [isLoadingData, setIsLoadingData] = useState(true);
+  const [columns, setColumns] = useState<string[]>(
+    report?.config.columns?.length ? report.config.columns : DEFAULT_COLUMNS,
+  );
+  const [accountIds, setAccountIds] = useState<string[]>(
+    report?.config.accountIds ?? [],
+  );
+  const [asOfDate, setAsOfDate] = useState<string>(report?.config.asOfDate ?? '');
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: report
+      ? {
+          name: report.name,
+          description: report.description || '',
+          icon: report.icon || 'chart-bar',
+          backgroundColor: report.backgroundColor || '#3b82f6',
+          groupBy: report.groupBy,
+          sortColumn: report.config.sortColumn || '',
+          sortDirection: report.config.sortDirection || InvestmentSortDirection.ASC,
+          isFavourite: report.isFavourite,
+        }
+      : {
+          name: '',
+          description: '',
+          icon: 'chart-bar',
+          backgroundColor: '#3b82f6',
+          groupBy: InvestmentGroupBy.NONE,
+          sortColumn: 'marketValue',
+          sortDirection: InvestmentSortDirection.DESC,
+          isFavourite: false,
+        },
+  });
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const all = await accountsApi.getAll();
+        setAccounts(
+          all.filter(
+            (a) =>
+              a.accountType === 'INVESTMENT' &&
+              a.accountSubType !== 'INVESTMENT_CASH' &&
+              !a.isClosed,
+          ),
+        );
+      } catch (error) {
+        logger.error('Failed to load accounts:', error);
+      } finally {
+        setIsLoadingData(false);
+      }
+    };
+    loadData();
+  }, []);
+
+  const handleFormSubmit = async (data: FormData) => {
+    // A removed column can no longer be the sort column.
+    const sortColumn =
+      data.sortColumn && columns.includes(data.sortColumn) ? data.sortColumn : null;
+    const submitData: CreateInvestmentReportData = {
+      name: data.name,
+      description: data.description || undefined,
+      icon: data.icon || undefined,
+      backgroundColor: data.backgroundColor || undefined,
+      groupBy: data.groupBy,
+      config: {
+        columns,
+        accountIds,
+        sortColumn,
+        sortDirection: data.sortDirection,
+        asOfDate: asOfDate || null,
+      },
+      isFavourite: data.isFavourite,
+    };
+    await onSubmit(submitData);
+  };
+
+  const groupByOptions = Object.entries(GROUP_BY_LABELS).map(([value, label]) => ({
+    value,
+    label,
+  }));
+  const sortDirectionOptions = Object.entries(SORT_DIRECTION_LABELS).map(
+    ([value, label]) => ({ value, label }),
+  );
+  const sortByOptions = [
+    { value: '', label: 'Default (Symbol)' },
+    ...columns.map((key) => ({
+      value: key,
+      label: INVESTMENT_COLUMN_MAP[key]?.label ?? key,
+    })),
+  ];
+  const accountOptions = accounts.map((a) => ({ value: a.id, label: a.name }));
+  const watchGroupBy = watch('groupBy');
+
+  if (isLoadingData) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-6">
+      {/* Basic Information */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
+          Basic Information
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="md:col-span-2">
+            <Input
+              label="Report Name"
+              {...register('name')}
+              error={errors.name?.message}
+              placeholder="e.g., Taxable Holdings Overview"
+            />
+          </div>
+          <div className="md:col-span-2">
+            <Input
+              label="Description (optional)"
+              {...register('description')}
+              placeholder="Brief description of what this report shows"
+            />
+          </div>
+          <Controller
+            name="icon"
+            control={control}
+            render={({ field }) => (
+              <IconPicker label="Icon" value={field.value || null} onChange={field.onChange} />
+            )}
+          />
+          <Controller
+            name="backgroundColor"
+            control={control}
+            render={({ field }) => (
+              <ColorPicker
+                label="Background Color"
+                value={field.value || null}
+                onChange={field.onChange}
+              />
+            )}
+          />
+        </div>
+      </div>
+
+      {/* Columns */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-1">
+          Columns
+        </h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+          Choose which columns to show and drag the order with the arrows. Symbol is
+          always included.
+        </p>
+        <InvestmentReportColumnChooser value={columns} onChange={setColumns} />
+      </div>
+
+      {/* Accounts */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
+          Accounts
+        </h3>
+        <MultiSelect
+          label="Investment accounts to include"
+          options={accountOptions}
+          value={accountIds}
+          onChange={setAccountIds}
+          placeholder="All investment accounts"
+        />
+        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          Leave empty to include all of your investment accounts.
+        </p>
+      </div>
+
+      {/* Grouping & Sorting */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
+          Grouping &amp; Sorting
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <Select label="Group By" options={groupByOptions} {...register('groupBy')} />
+          <Select label="Sort By" options={sortByOptions} {...register('sortColumn')} />
+          <Select
+            label="Sort Direction"
+            options={sortDirectionOptions}
+            {...register('sortDirection')}
+          />
+        </div>
+        {watchGroupBy !== InvestmentGroupBy.NONE && (
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+            Rows are grouped by {GROUP_BY_LABELS[watchGroupBy].toLowerCase()} and sorted
+            within each group.
+          </p>
+        )}
+      </div>
+
+      {/* Report Date */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
+          Report Date
+        </h3>
+        <div className="max-w-xs">
+          <DateInput
+            label="As of date"
+            value={asOfDate}
+            onChange={(e) => setAsOfDate(e.target.value)}
+            onDateChange={(date) => setAsOfDate(date)}
+          />
+        </div>
+        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          Leave empty to always value the report as of the last day the markets were open.
+        </p>
+      </div>
+
+      {/* Favourite */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            {...register('isFavourite')}
+            className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+          />
+          <span className="text-sm text-gray-700 dark:text-gray-300">
+            Add to favourites
+          </span>
+        </label>
+      </div>
+
+      <FormActions
+        onCancel={onCancel}
+        submitLabel={report ? 'Update Report' : 'Create Report'}
+        isSubmitting={isSubmitting}
+      />
+    </form>
+  );
+}

--- a/frontend/src/components/reports/InvestmentReportViewer.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.test.tsx
@@ -20,8 +20,7 @@ vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
     formatNumber: (n: number) => String(n),
     formatPercent: (n: number) => `${n}%`,
-    formatCurrency: (n: number, code?: string, _fd?: number, display = 'narrowSymbol') =>
-      display === 'code' ? `${code} ${n}` : `$${n}`,
+    formatCurrency: (n: number) => `$${n}`,
   }),
 }));
 vi.mock('@/hooks/useDateFormat', () => ({
@@ -254,8 +253,8 @@ describe('InvestmentReportViewer', () => {
     });
     await renderViewer();
     await screen.findByText('AAA');
-    // Native USD holding with CAD base -> shown with its ISO code (USD)
-    expect(screen.getByText('USD 100')).toBeInTheDocument();
+    // Native USD holding with CAD base -> symbol then ISO code, like other pages
+    expect(screen.getByText('$100 USD')).toBeInTheDocument();
     // Switch to base currency (CAD): 100 * 1.25 = 125, base shows narrow symbol
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'CAD' }));
@@ -273,7 +272,7 @@ describe('InvestmentReportViewer', () => {
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Native' }));
     });
-    expect(screen.getByText('USD 100')).toBeInTheDocument();
+    expect(screen.getByText('$100 USD')).toBeInTheDocument();
   });
 
   it('exports group headings for symbol and currency groupings', async () => {

--- a/frontend/src/components/reports/InvestmentReportViewer.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.test.tsx
@@ -109,7 +109,7 @@ describe('InvestmentReportViewer', () => {
   it('re-runs the report when the as-of date is changed', async () => {
     await renderViewer();
     await screen.findByText('AAA');
-    expect(mockExecute).toHaveBeenCalledWith('r1', { mergeAccounts: false });
+    expect(mockExecute).toHaveBeenCalledWith('r1', {});
   });
 
   it('shows an empty state when there are no holdings', async () => {
@@ -172,47 +172,14 @@ describe('InvestmentReportViewer', () => {
     await waitFor(() =>
       expect(mockExecute).toHaveBeenCalledWith('r1', {
         asOfDate: '2024-03-15',
-        mergeAccounts: false,
       }),
     );
     await act(async () => {
       fireEvent.click(screen.getByText('Reset to latest market day'));
     });
     await waitFor(() =>
-      expect(mockExecute).toHaveBeenLastCalledWith('r1', { mergeAccounts: false }),
+      expect(mockExecute).toHaveBeenLastCalledWith('r1', {}),
     );
-  });
-
-  it('offers a merge toggle for symbol grouping and re-runs merged', async () => {
-    mockGetById.mockResolvedValue({ ...report, groupBy: 'SYMBOL' });
-    mockExecute.mockResolvedValue({
-      ...result,
-      groupBy: 'SYMBOL',
-      groups: [
-        { key: 's1', label: 'AAA', rows: [{ id: '1', currency: 'USD', baseExchangeRate: 1, values: { symbol: 'AAA', marketValue: 200 } }] },
-      ],
-    });
-    await renderViewer();
-    const mergeBtn = await screen.findByRole('button', { name: 'Merge' });
-    await act(async () => {
-      fireEvent.click(mergeBtn);
-    });
-    await waitFor(() =>
-      expect(mockExecute).toHaveBeenLastCalledWith('r1', { mergeAccounts: true }),
-    );
-  });
-
-  it('offers the merge toggle for no grouping (combine duplicates)', async () => {
-    await renderViewer();
-    await screen.findByText('AAA');
-    expect(screen.getByRole('button', { name: 'Merge' })).toBeInTheDocument();
-  });
-
-  it('hides the merge toggle when grouping by account', async () => {
-    mockGetById.mockResolvedValue({ ...report, groupBy: 'ACCOUNT' });
-    await renderViewer();
-    await screen.findByText('AAA');
-    expect(screen.queryByRole('button', { name: 'Merge' })).not.toBeInTheDocument();
   });
 
   it('formats each column type and renders a dash for missing values', async () => {

--- a/frontend/src/components/reports/InvestmentReportViewer.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.test.tsx
@@ -182,7 +182,14 @@ describe('InvestmentReportViewer', () => {
     );
   });
 
-  it('hides the merge toggle when grouping is none', async () => {
+  it('offers the merge toggle for no grouping (combine duplicates)', async () => {
+    await renderViewer();
+    await screen.findByText('AAA');
+    expect(screen.getByRole('button', { name: 'Merge' })).toBeInTheDocument();
+  });
+
+  it('hides the merge toggle when grouping by account', async () => {
+    mockGetById.mockResolvedValue({ ...report, groupBy: 'ACCOUNT' });
     await renderViewer();
     await screen.findByText('AAA');
     expect(screen.queryByRole('button', { name: 'Merge' })).not.toBeInTheDocument();

--- a/frontend/src/components/reports/InvestmentReportViewer.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.test.tsx
@@ -20,7 +20,8 @@ vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
     formatNumber: (n: number) => String(n),
     formatPercent: (n: number) => `${n}%`,
-    formatCurrency: (n: number, code?: string) => `${code ?? 'USD'} ${n}`,
+    formatCurrency: (n: number, code?: string, _fd?: number, display = 'narrowSymbol') =>
+      display === 'code' ? `${code} ${n}` : `$${n}`,
   }),
 }));
 vi.mock('@/hooks/useDateFormat', () => ({
@@ -194,7 +195,8 @@ describe('InvestmentReportViewer', () => {
     });
     await renderViewer();
     await screen.findByText('AAA');
-    expect(screen.getByText('USD 1000.5')).toBeInTheDocument(); // currency -> formatCurrency
+    // USD holding with USD base -> narrow symbol
+    expect(screen.getByText('$1000.5')).toBeInTheDocument();
     expect(screen.getByText('12.34%')).toBeInTheDocument(); // percent
     expect(screen.getByText('5000')).toBeInTheDocument(); // integer
     expect(screen.getByText('10.25')).toBeInTheDocument(); // shares
@@ -222,13 +224,13 @@ describe('InvestmentReportViewer', () => {
     });
     await renderViewer();
     await screen.findByText('AAA');
-    // Native: shown in the holding's own currency (USD)
+    // Native USD holding with CAD base -> shown with its ISO code (USD)
     expect(screen.getByText('USD 100')).toBeInTheDocument();
-    // Switch to base currency (CAD): 100 * 1.25 = 125
+    // Switch to base currency (CAD): 100 * 1.25 = 125, base shows narrow symbol
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'CAD' }));
     });
-    expect(screen.getByText('CAD 125')).toBeInTheDocument();
+    expect(screen.getByText('$125')).toBeInTheDocument();
 
     // CSV export reflects the base-currency conversion.
     await act(async () => {

--- a/frontend/src/components/reports/InvestmentReportViewer.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.test.tsx
@@ -110,7 +110,7 @@ describe('InvestmentReportViewer', () => {
   it('re-runs the report when the as-of date is changed', async () => {
     await renderViewer();
     await screen.findByText('AAA');
-    expect(mockExecute).toHaveBeenCalledWith('r1', {});
+    expect(mockExecute).toHaveBeenCalledWith('r1', { mergeAccounts: false });
   });
 
   it('shows an empty state when there are no holdings', async () => {
@@ -151,12 +151,42 @@ describe('InvestmentReportViewer', () => {
       fireEvent.change(dateInput, { target: { value: '2024-03-15' } });
     });
     await waitFor(() =>
-      expect(mockExecute).toHaveBeenCalledWith('r1', { asOfDate: '2024-03-15' }),
+      expect(mockExecute).toHaveBeenCalledWith('r1', {
+        asOfDate: '2024-03-15',
+        mergeAccounts: false,
+      }),
     );
     await act(async () => {
       fireEvent.click(screen.getByText('Reset to latest market day'));
     });
-    await waitFor(() => expect(mockExecute).toHaveBeenLastCalledWith('r1', {}));
+    await waitFor(() =>
+      expect(mockExecute).toHaveBeenLastCalledWith('r1', { mergeAccounts: false }),
+    );
+  });
+
+  it('offers a merge toggle for symbol grouping and re-runs merged', async () => {
+    mockGetById.mockResolvedValue({ ...report, groupBy: 'SYMBOL' });
+    mockExecute.mockResolvedValue({
+      ...result,
+      groupBy: 'SYMBOL',
+      groups: [
+        { key: 's1', label: 'AAA', rows: [{ id: '1', currency: 'USD', baseExchangeRate: 1, values: { symbol: 'AAA', marketValue: 200 } }] },
+      ],
+    });
+    await renderViewer();
+    const mergeBtn = await screen.findByRole('button', { name: 'Merge' });
+    await act(async () => {
+      fireEvent.click(mergeBtn);
+    });
+    await waitFor(() =>
+      expect(mockExecute).toHaveBeenLastCalledWith('r1', { mergeAccounts: true }),
+    );
+  });
+
+  it('hides the merge toggle when grouping is none', async () => {
+    await renderViewer();
+    await screen.findByText('AAA');
+    expect(screen.queryByRole('button', { name: 'Merge' })).not.toBeInTheDocument();
   });
 
   it('formats each column type and renders a dash for missing values', async () => {

--- a/frontend/src/components/reports/InvestmentReportViewer.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.test.tsx
@@ -118,4 +118,149 @@ describe('InvestmentReportViewer', () => {
       await screen.findByText(/No holdings found/),
     ).toBeInTheDocument();
   });
+
+  it('renders group headings when grouped', async () => {
+    mockGetById.mockResolvedValue({ ...report, groupBy: 'ACCOUNT' });
+    mockExecute.mockResolvedValue({
+      ...result,
+      groupBy: 'ACCOUNT',
+      groups: [
+        { key: 'a1', label: 'Acc One', rows: [{ id: '1', values: { symbol: 'AAA', marketValue: 200 } }] },
+        { key: 'a2', label: 'Acc Two', rows: [{ id: '2', values: { symbol: 'BBB', marketValue: 100 } }] },
+      ],
+    });
+    await renderViewer();
+    expect(await screen.findByText('Acc One')).toBeInTheDocument();
+    expect(screen.getByText('Acc Two')).toBeInTheDocument();
+
+    // Exporting a grouped report prepends the group heading column.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));
+    });
+    const [, headers] = mockExportToCsv.mock.calls[0];
+    expect(headers[0]).toBe('Account');
+  });
+
+  it('re-runs with an as-of override and resets to the latest', async () => {
+    await renderViewer();
+    await screen.findByText('AAA');
+    const dateInput = screen.getByLabelText('As of date');
+    await act(async () => {
+      fireEvent.change(dateInput, { target: { value: '2024-03-15' } });
+    });
+    await waitFor(() =>
+      expect(mockExecute).toHaveBeenCalledWith('r1', { asOfDate: '2024-03-15' }),
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByText('Reset to latest market day'));
+    });
+    await waitFor(() => expect(mockExecute).toHaveBeenLastCalledWith('r1', {}));
+  });
+
+  it('formats each column type and renders a dash for missing values', async () => {
+    mockGetById.mockResolvedValue({
+      ...report,
+      config: { ...report.config, columns: ['symbol', 'marketValue', 'gainPercent', 'volume', 'quantity', 'lastTransactionDate', 'exchangeRate', 'name'] },
+    });
+    mockExecute.mockResolvedValue({
+      ...result,
+      columns: ['symbol', 'marketValue', 'gainPercent', 'volume', 'quantity', 'lastTransactionDate', 'exchangeRate', 'name', 'currency'],
+      groups: [
+        {
+          key: 'all',
+          label: '',
+          rows: [
+            {
+              id: '1',
+              values: {
+                symbol: 'AAA',
+                marketValue: 1000.5,
+                gainPercent: 12.34,
+                volume: 5000,
+                quantity: 10.25,
+                lastTransactionDate: '2024-05-01',
+                exchangeRate: 1.25,
+                name: null, // null -> dash
+                currency: '', // empty string -> dash
+              },
+            },
+          ],
+        },
+      ],
+      rowCount: 1,
+    });
+    await renderViewer();
+    await screen.findByText('AAA');
+    expect(screen.getByText('1000.5')).toBeInTheDocument(); // currency -> formatNumber
+    expect(screen.getByText('12.34%')).toBeInTheDocument(); // percent
+    expect(screen.getByText('5000')).toBeInTheDocument(); // integer
+    expect(screen.getByText('10.25')).toBeInTheDocument(); // shares
+    expect(screen.getByText('2024-05-01')).toBeInTheDocument(); // date
+    expect(screen.getByText('1.25')).toBeInTheDocument(); // number
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2); // null and empty
+  });
+
+  it('exports group headings for symbol and currency groupings', async () => {
+    for (const [groupBy, heading] of [
+      ['SYMBOL', 'Symbol'],
+      ['CURRENCY', 'Currency'],
+    ] as const) {
+      mockExportToCsv.mockClear();
+      mockGetById.mockResolvedValue({ ...report, groupBy });
+      mockExecute.mockResolvedValue({
+        ...result,
+        groupBy,
+        groups: [{ key: 'g', label: 'G', rows: [{ id: '1', values: { symbol: 'AAA', marketValue: 200 } }] }],
+      });
+      const { unmount } = render(<InvestmentReportViewer reportId="r1" />);
+      await screen.findByText('AAA');
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));
+      });
+      expect(mockExportToCsv.mock.calls[0][1][0]).toBe(heading);
+      unmount();
+    }
+  });
+
+  it('shows a not-found state when the report fails to load', async () => {
+    mockGetById.mockRejectedValue(new Error('boom'));
+    await renderViewer();
+    expect(await screen.findByText('Report not found')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Back to Reports' }));
+    expect(mockPush).toHaveBeenCalledWith('/reports');
+  });
+
+  it('does not crash when execution fails', async () => {
+    mockExecute.mockRejectedValue(new Error('exec failed'));
+    await renderViewer();
+    // The report header still renders even though execution failed.
+    expect(await screen.findByText('Holdings')).toBeInTheDocument();
+  });
+
+  it('falls back to the raw key and text formatting for unknown columns', async () => {
+    mockGetById.mockResolvedValue({
+      ...report,
+      config: { ...report.config, columns: ['symbol', 'mysteryCol'] },
+    });
+    mockExecute.mockResolvedValue({
+      ...result,
+      columns: ['symbol', 'mysteryCol'],
+      groups: [
+        { key: 'all', label: '', rows: [{ id: '1', values: { symbol: 'AAA', mysteryCol: 'hello' } }] },
+      ],
+      rowCount: 1,
+    });
+    await renderViewer();
+    await screen.findByText('AAA');
+    // Unknown column header renders the raw key and its value as plain text.
+    expect(screen.getByText('mysteryCol')).toBeInTheDocument();
+    expect(screen.getByText('hello')).toBeInTheDocument();
+  });
+
+  it('navigates to edit when Edit is clicked', async () => {
+    await renderViewer();
+    await screen.findByText('AAA');
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(mockPush).toHaveBeenCalledWith('/reports/investment/r1/edit');
+  });
 });

--- a/frontend/src/components/reports/InvestmentReportViewer.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act, within } from '@/test/render';
+import { InvestmentReportViewer } from './InvestmentReportViewer';
+
+const mockGetById = vi.fn();
+const mockExecute = vi.fn();
+vi.mock('@/lib/investment-reports', () => ({
+  investmentReportsApi: {
+    getById: (...a: unknown[]) => mockGetById(...a),
+    execute: (...a: unknown[]) => mockExecute(...a),
+  },
+}));
+
+const mockExportToCsv = vi.fn();
+vi.mock('@/lib/csv-export', () => ({
+  exportToCsv: (...a: unknown[]) => mockExportToCsv(...a),
+}));
+
+vi.mock('@/hooks/useNumberFormat', () => ({
+  useNumberFormat: () => ({
+    formatNumber: (n: number) => String(n),
+    formatPercent: (n: number) => `${n}%`,
+  }),
+}));
+vi.mock('@/hooks/useDateFormat', () => ({
+  useDateFormat: () => ({ formatDate: (d: string) => d, dateFormat: 'browser' }),
+}));
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }));
+
+const report = {
+  id: 'r1',
+  name: 'Holdings',
+  description: 'My holdings',
+  groupBy: 'NONE',
+  config: { columns: ['symbol', 'marketValue'], accountIds: [], sortColumn: 'symbol', sortDirection: 'ASC', asOfDate: null },
+};
+
+const result = {
+  reportId: 'r1',
+  name: 'Holdings',
+  asOfDate: '2024-06-10',
+  baseCurrency: 'USD',
+  groupBy: 'NONE',
+  columns: ['symbol', 'marketValue'],
+  groups: [
+    {
+      key: 'all',
+      label: '',
+      rows: [
+        { id: '1', values: { symbol: 'AAA', marketValue: 200 } },
+        { id: '2', values: { symbol: 'BBB', marketValue: 100 } },
+      ],
+    },
+  ],
+  rowCount: 2,
+};
+
+async function renderViewer() {
+  await act(async () => {
+    render(<InvestmentReportViewer reportId="r1" />);
+  });
+}
+
+describe('InvestmentReportViewer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetById.mockResolvedValue(report);
+    mockExecute.mockResolvedValue(result);
+  });
+
+  it('runs the report and renders rows with the as-of date', async () => {
+    await renderViewer();
+    expect(await screen.findByText('AAA')).toBeInTheDocument();
+    expect(screen.getByText('BBB')).toBeInTheDocument();
+    expect(screen.getByText(/As of 2024-06-10/)).toBeInTheDocument();
+    expect(screen.getByText(/2 holdings/)).toBeInTheDocument();
+  });
+
+  it('sorts rows when a column header is clicked', async () => {
+    await renderViewer();
+    await screen.findByText('AAA');
+    // Default sort is by symbol asc -> AAA before BBB
+    let bodyRows = screen.getAllByRole('row').slice(1);
+    expect(within(bodyRows[0]).getByText('AAA')).toBeInTheDocument();
+
+    // Sort by Market Value ascending -> BBB (100) before AAA (200)
+    await act(async () => {
+      fireEvent.click(screen.getByText('Market Value'));
+    });
+    bodyRows = screen.getAllByRole('row').slice(1);
+    expect(within(bodyRows[0]).getByText('BBB')).toBeInTheDocument();
+  });
+
+  it('exports the visible rows to CSV', async () => {
+    await renderViewer();
+    await screen.findByText('AAA');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));
+    });
+    expect(mockExportToCsv).toHaveBeenCalled();
+    const [, headers, rows] = mockExportToCsv.mock.calls[0];
+    expect(headers).toEqual(['Symbol', 'Market Value']);
+    expect(rows).toHaveLength(2);
+  });
+
+  it('re-runs the report when the as-of date is changed', async () => {
+    await renderViewer();
+    await screen.findByText('AAA');
+    expect(mockExecute).toHaveBeenCalledWith('r1', {});
+  });
+
+  it('shows an empty state when there are no holdings', async () => {
+    mockExecute.mockResolvedValue({ ...result, groups: [], rowCount: 0 });
+    await renderViewer();
+    expect(
+      await screen.findByText(/No holdings found/),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/reports/InvestmentReportViewer.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.test.tsx
@@ -20,6 +20,7 @@ vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
     formatNumber: (n: number) => String(n),
     formatPercent: (n: number) => `${n}%`,
+    formatCurrency: (n: number, code?: string) => `${code ?? 'USD'} ${n}`,
   }),
 }));
 vi.mock('@/hooks/useDateFormat', () => ({
@@ -49,8 +50,8 @@ const result = {
       key: 'all',
       label: '',
       rows: [
-        { id: '1', values: { symbol: 'AAA', marketValue: 200 } },
-        { id: '2', values: { symbol: 'BBB', marketValue: 100 } },
+        { id: '1', currency: 'USD', baseExchangeRate: 1, values: { symbol: 'AAA', marketValue: 200 } },
+        { id: '2', currency: 'USD', baseExchangeRate: 1, values: { symbol: 'BBB', marketValue: 100 } },
       ],
     },
   ],
@@ -172,6 +173,8 @@ describe('InvestmentReportViewer', () => {
           rows: [
             {
               id: '1',
+              currency: 'USD',
+              baseExchangeRate: 1,
               values: {
                 symbol: 'AAA',
                 marketValue: 1000.5,
@@ -191,13 +194,54 @@ describe('InvestmentReportViewer', () => {
     });
     await renderViewer();
     await screen.findByText('AAA');
-    expect(screen.getByText('1000.5')).toBeInTheDocument(); // currency -> formatNumber
+    expect(screen.getByText('USD 1000.5')).toBeInTheDocument(); // currency -> formatCurrency
     expect(screen.getByText('12.34%')).toBeInTheDocument(); // percent
     expect(screen.getByText('5000')).toBeInTheDocument(); // integer
     expect(screen.getByText('10.25')).toBeInTheDocument(); // shares
     expect(screen.getByText('2024-05-01')).toBeInTheDocument(); // date
     expect(screen.getByText('1.25')).toBeInTheDocument(); // number
     expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2); // null and empty
+  });
+
+  it('toggles monetary values between native and base currency', async () => {
+    mockGetById.mockResolvedValue(report);
+    mockExecute.mockResolvedValue({
+      ...result,
+      baseCurrency: 'CAD',
+      columns: ['symbol', 'marketValue'],
+      groups: [
+        {
+          key: 'all',
+          label: '',
+          rows: [
+            { id: '1', currency: 'USD', baseExchangeRate: 1.25, values: { symbol: 'AAA', marketValue: 100 } },
+          ],
+        },
+      ],
+      rowCount: 1,
+    });
+    await renderViewer();
+    await screen.findByText('AAA');
+    // Native: shown in the holding's own currency (USD)
+    expect(screen.getByText('USD 100')).toBeInTheDocument();
+    // Switch to base currency (CAD): 100 * 1.25 = 125
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'CAD' }));
+    });
+    expect(screen.getByText('CAD 125')).toBeInTheDocument();
+
+    // CSV export reflects the base-currency conversion.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));
+    });
+    const exportedRows = mockExportToCsv.mock.calls.at(-1)?.[2];
+    expect(exportedRows[0]).toContain(125);
+
+    // Switch back to native.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Native' }));
+    });
+    expect(screen.getByText('USD 100')).toBeInTheDocument();
   });
 
   it('exports group headings for symbol and currency groupings', async () => {

--- a/frontend/src/components/reports/InvestmentReportViewer.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.test.tsx
@@ -142,6 +142,26 @@ describe('InvestmentReportViewer', () => {
     expect(headers[0]).toBe('Account');
   });
 
+  it('renders all groups in a single table so columns line up', async () => {
+    mockGetById.mockResolvedValue({ ...report, groupBy: 'ACCOUNT' });
+    mockExecute.mockResolvedValue({
+      ...result,
+      groupBy: 'ACCOUNT',
+      columns: ['symbol', 'marketValue'],
+      groups: [
+        { key: 'a1', label: 'Acc One', rows: [{ id: '1', currency: 'USD', baseExchangeRate: 1, values: { symbol: 'AAA', marketValue: 200 } }] },
+        { key: 'a2', label: 'Acc Two', rows: [{ id: '2', currency: 'USD', baseExchangeRate: 1, values: { symbol: 'BBB', marketValue: 100 } }] },
+      ],
+    });
+    await renderViewer();
+    await screen.findByText('Acc One');
+    // A single shared table guarantees identical column widths across groups.
+    expect(screen.getAllByRole('table')).toHaveLength(1);
+    // Each group label is a full-width row spanning every column.
+    const groupCell = screen.getByText('Acc One').closest('td');
+    expect(groupCell).toHaveAttribute('colspan', '2');
+  });
+
   it('re-runs with an as-of override and resets to the latest', async () => {
     await renderViewer();
     await screen.findByText('AAA');

--- a/frontend/src/components/reports/InvestmentReportViewer.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.tsx
@@ -110,7 +110,15 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
         if (currencyMode === 'base' && result) {
           return formatCurrency(num * row.baseExchangeRate, result.baseCurrency);
         }
-        return formatCurrency(num, row.currency);
+        // Show the ISO code for non-base currencies so a USD value isn't mistaken
+        // for the base currency (both may render with a "$" narrow symbol).
+        const explicit = !!result && row.currency !== result.baseCurrency;
+        return formatCurrency(
+          num,
+          row.currency,
+          undefined,
+          explicit ? 'code' : 'narrowSymbol',
+        );
       }
       case 'number':
         return formatNumber(Number(value), 4);

--- a/frontend/src/components/reports/InvestmentReportViewer.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.tsx
@@ -259,8 +259,7 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
                 </button>
               </div>
             </div>
-            {(report.groupBy === InvestmentGroupBy.SYMBOL ||
-              report.groupBy === InvestmentGroupBy.CURRENCY) && (
+            {report.groupBy !== InvestmentGroupBy.ACCOUNT && (
               <div>
                 <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Across accounts

--- a/frontend/src/components/reports/InvestmentReportViewer.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.tsx
@@ -113,15 +113,12 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
         if (currencyMode === 'base' && result) {
           return formatCurrency(num * row.baseExchangeRate, result.baseCurrency);
         }
-        // Show the ISO code for non-base currencies so a USD value isn't mistaken
-        // for the base currency (both may render with a "$" narrow symbol).
-        const explicit = !!result && row.currency !== result.baseCurrency;
-        return formatCurrency(
-          num,
-          row.currency,
-          undefined,
-          explicit ? 'code' : 'narrowSymbol',
-        );
+        const formatted = formatCurrency(num, row.currency);
+        // Match other pages: append the ISO code only for non-base currencies
+        // (e.g. "$99,999.99 USD") so they aren't mistaken for the base currency.
+        return result && row.currency !== result.baseCurrency
+          ? `${formatted} ${row.currency}`
+          : formatted;
       }
       case 'number':
         return formatNumber(Number(value), 4);

--- a/frontend/src/components/reports/InvestmentReportViewer.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.tsx
@@ -131,7 +131,7 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
     const cols = result.columns;
     const grouped = result.groupBy !== InvestmentGroupBy.NONE;
     const headers = [
-      ...(grouped ? [groupHeading(result.groupBy)] : []),
+      ...(grouped ? [GROUP_HEADINGS[result.groupBy]] : []),
       ...cols.map((key) => INVESTMENT_COLUMN_MAP[key]?.label ?? key),
     ];
     const rows = result.groups.flatMap((g) =>
@@ -321,15 +321,9 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
   );
 }
 
-function groupHeading(groupBy: InvestmentGroupBy): string {
-  switch (groupBy) {
-    case InvestmentGroupBy.ACCOUNT:
-      return 'Account';
-    case InvestmentGroupBy.SYMBOL:
-      return 'Symbol';
-    case InvestmentGroupBy.CURRENCY:
-      return 'Currency';
-    default:
-      return 'Group';
-  }
-}
+const GROUP_HEADINGS: Record<InvestmentGroupBy, string> = {
+  [InvestmentGroupBy.NONE]: 'Group',
+  [InvestmentGroupBy.ACCOUNT]: 'Account',
+  [InvestmentGroupBy.SYMBOL]: 'Symbol',
+  [InvestmentGroupBy.CURRENCY]: 'Currency',
+};

--- a/frontend/src/components/reports/InvestmentReportViewer.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.tsx
@@ -51,9 +51,6 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
   // Show monetary values in each holding's own currency, or convert to the
   // user's base currency.
   const [currencyMode, setCurrencyMode] = useState<'native' | 'base'>('native');
-  // For symbol/currency grouping: merge a security held across accounts into one
-  // combined row, or keep each account's holding separate.
-  const [mergeAccounts, setMergeAccounts] = useState(false);
 
   const { sortField, sortDirection, handleSort } = useSortableTable<string>(
     'reports.investment.table.sort',
@@ -75,7 +72,6 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
     try {
       const data = await investmentReportsApi.execute(reportId, {
         ...(asOfOverride ? { asOfDate: asOfOverride } : {}),
-        mergeAccounts,
       });
       setResult(data);
     } catch (error) {
@@ -84,7 +80,7 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
     } finally {
       setIsExecuting(false);
     }
-  }, [reportId, asOfOverride, mergeAccounts]);
+  }, [reportId, asOfOverride]);
 
   useEffect(() => {
     const init = async () => {
@@ -259,37 +255,6 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
                 </button>
               </div>
             </div>
-            {report.groupBy !== InvestmentGroupBy.ACCOUNT && (
-              <div>
-                <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Across accounts
-                </span>
-                <div className="inline-flex rounded-md border border-gray-300 dark:border-gray-600 overflow-hidden">
-                  <button
-                    type="button"
-                    onClick={() => setMergeAccounts(false)}
-                    className={`px-3 py-2 text-sm transition-colors ${
-                      !mergeAccounts
-                        ? 'bg-blue-600 text-white'
-                        : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300'
-                    }`}
-                  >
-                    Separate
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setMergeAccounts(true)}
-                    className={`px-3 py-2 text-sm border-l border-gray-300 dark:border-gray-600 transition-colors ${
-                      mergeAccounts
-                        ? 'bg-blue-600 text-white'
-                        : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300'
-                    }`}
-                  >
-                    Merge
-                  </button>
-                </div>
-              </div>
-            )}
           </div>
           <div className="flex items-center gap-3">
             {isExecuting && (

--- a/frontend/src/components/reports/InvestmentReportViewer.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.tsx
@@ -51,6 +51,9 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
   // Show monetary values in each holding's own currency, or convert to the
   // user's base currency.
   const [currencyMode, setCurrencyMode] = useState<'native' | 'base'>('native');
+  // For symbol/currency grouping: merge a security held across accounts into one
+  // combined row, or keep each account's holding separate.
+  const [mergeAccounts, setMergeAccounts] = useState(false);
 
   const { sortField, sortDirection, handleSort } = useSortableTable<string>(
     'reports.investment.table.sort',
@@ -70,10 +73,10 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
   const executeReport = useCallback(async () => {
     setIsExecuting(true);
     try {
-      const data = await investmentReportsApi.execute(
-        reportId,
-        asOfOverride ? { asOfDate: asOfOverride } : {},
-      );
+      const data = await investmentReportsApi.execute(reportId, {
+        ...(asOfOverride ? { asOfDate: asOfOverride } : {}),
+        mergeAccounts,
+      });
       setResult(data);
     } catch (error) {
       toast.error(getErrorMessage(error, 'Failed to run report'));
@@ -81,7 +84,7 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
     } finally {
       setIsExecuting(false);
     }
-  }, [reportId, asOfOverride]);
+  }, [reportId, asOfOverride, mergeAccounts]);
 
   useEffect(() => {
     const init = async () => {
@@ -259,6 +262,38 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
                 </button>
               </div>
             </div>
+            {(report.groupBy === InvestmentGroupBy.SYMBOL ||
+              report.groupBy === InvestmentGroupBy.CURRENCY) && (
+              <div>
+                <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Across accounts
+                </span>
+                <div className="inline-flex rounded-md border border-gray-300 dark:border-gray-600 overflow-hidden">
+                  <button
+                    type="button"
+                    onClick={() => setMergeAccounts(false)}
+                    className={`px-3 py-2 text-sm transition-colors ${
+                      !mergeAccounts
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300'
+                    }`}
+                  >
+                    Separate
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setMergeAccounts(true)}
+                    className={`px-3 py-2 text-sm border-l border-gray-300 dark:border-gray-600 transition-colors ${
+                      mergeAccounts
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300'
+                    }`}
+                  >
+                    Merge
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
           <div className="flex items-center gap-3">
             {isExecuting && (

--- a/frontend/src/components/reports/InvestmentReportViewer.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.tsx
@@ -348,66 +348,72 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
               No holdings found for the selected accounts and date.
             </div>
           ) : (
-            <div className="space-y-6">
-              {result.groups.map((group) => (
-                <div key={group.key}>
-                  {result.groupBy !== InvestmentGroupBy.NONE && (
-                    <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">
-                      {group.label || 'Ungrouped'}
-                    </h4>
-                  )}
-                  <div className="overflow-x-auto">
-                    <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                      <thead className="bg-gray-50 dark:bg-gray-900/50">
-                        <tr>
-                          {columns.map((key) => {
-                            const col = INVESTMENT_COLUMN_MAP[key];
-                            const numeric = col && NUMERIC_TYPES.includes(col.type);
-                            return (
-                              <SortableHeader<string>
-                                key={key}
-                                field={key}
-                                sortField={sortField}
-                                sortDirection={sortDirection}
-                                onSort={handleSort}
-                                align={numeric ? 'right' : 'left'}
-                                className="px-3 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase whitespace-nowrap"
-                              >
-                                {col?.label ?? key}
-                              </SortableHeader>
-                            );
-                          })}
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-                        {sortRows(group.rows).map((row) => (
-                          <tr
-                            key={row.id}
-                            className="hover:bg-gray-50 dark:hover:bg-gray-700/50"
-                          >
-                            {columns.map((key) => {
-                              const col = INVESTMENT_COLUMN_MAP[key];
-                              const numeric = col && NUMERIC_TYPES.includes(col.type);
-                              return (
-                                <td
-                                  key={key}
-                                  className={`px-3 py-2 text-sm whitespace-nowrap ${
-                                    numeric
-                                      ? 'text-right tabular-nums text-gray-900 dark:text-gray-100'
-                                      : 'text-gray-700 dark:text-gray-300'
-                                  }`}
-                                >
-                                  {formatCell(row.values[key], col?.type ?? 'text', row)}
-                                </td>
-                              );
-                            })}
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                </div>
-              ))}
+            <div className="overflow-x-auto">
+              {/* A single table (one header, one tbody per group) so every group
+                  shares the same column widths and lines up vertically. */}
+              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead className="bg-gray-50 dark:bg-gray-900/50">
+                  <tr>
+                    {columns.map((key) => {
+                      const col = INVESTMENT_COLUMN_MAP[key];
+                      const numeric = col && NUMERIC_TYPES.includes(col.type);
+                      return (
+                        <SortableHeader<string>
+                          key={key}
+                          field={key}
+                          sortField={sortField}
+                          sortDirection={sortDirection}
+                          onSort={handleSort}
+                          align={numeric ? 'right' : 'left'}
+                          className="px-3 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase whitespace-nowrap"
+                        >
+                          {col?.label ?? key}
+                        </SortableHeader>
+                      );
+                    })}
+                  </tr>
+                </thead>
+                {result.groups.map((group) => (
+                  <tbody
+                    key={group.key}
+                    className="divide-y divide-gray-200 dark:divide-gray-700"
+                  >
+                    {result.groupBy !== InvestmentGroupBy.NONE && (
+                      <tr className="bg-gray-50 dark:bg-gray-900/40">
+                        <td
+                          colSpan={columns.length}
+                          className="px-3 py-2 text-sm font-semibold text-gray-900 dark:text-gray-100"
+                        >
+                          {group.label || 'Ungrouped'}
+                        </td>
+                      </tr>
+                    )}
+                    {sortRows(group.rows).map((row) => (
+                      <tr
+                        key={row.id}
+                        className="hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                      >
+                        {columns.map((key) => {
+                          const col = INVESTMENT_COLUMN_MAP[key];
+                          const numeric = col && NUMERIC_TYPES.includes(col.type);
+                          return (
+                            <td
+                              key={key}
+                              className={`px-3 py-2 text-sm whitespace-nowrap ${
+                                numeric
+                                  ? 'text-right tabular-nums text-gray-900 dark:text-gray-100'
+                                  : 'text-gray-700 dark:text-gray-300'
+                              }`}
+                            >
+                              {formatCell(row.values[key], col?.type ?? 'text', row)}
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    ))}
+                  </tbody>
+                ))}
+              </table>
             </div>
           )}
         </div>

--- a/frontend/src/components/reports/InvestmentReportViewer.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.tsx
@@ -41,13 +41,16 @@ interface InvestmentReportViewerProps {
 
 export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps) {
   const router = useRouter();
-  const { formatNumber, formatPercent } = useNumberFormat();
+  const { formatNumber, formatPercent, formatCurrency } = useNumberFormat();
   const { formatDate } = useDateFormat();
   const [report, setReport] = useState<InvestmentReport | null>(null);
   const [result, setResult] = useState<InvestmentReportResult | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isExecuting, setIsExecuting] = useState(false);
   const [asOfOverride, setAsOfOverride] = useState('');
+  // Show monetary values in each holding's own currency, or convert to the
+  // user's base currency.
+  const [currencyMode, setCurrencyMode] = useState<'native' | 'base'>('native');
 
   const { sortField, sortDirection, handleSort } = useSortableTable<string>(
     'reports.investment.table.sort',
@@ -94,11 +97,21 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
     executeReport();
   }, [report, executeReport]);
 
-  const formatCell = (value: InvestmentCellValue, type: InvestmentColumnType): string => {
+  const formatCell = (
+    value: InvestmentCellValue,
+    type: InvestmentColumnType,
+    row: InvestmentReportRow,
+  ): string => {
     if (value === null || value === undefined || value === '') return '—';
     switch (type) {
-      case 'currency':
-        return formatNumber(Number(value), 2);
+      case 'currency': {
+        const num = Number(value);
+        // Native values are in the holding's currency; convert to base when toggled.
+        if (currencyMode === 'base' && result) {
+          return formatCurrency(num * row.baseExchangeRate, result.baseCurrency);
+        }
+        return formatCurrency(num, row.currency);
+      }
       case 'number':
         return formatNumber(Number(value), 4);
       case 'integer':
@@ -139,7 +152,15 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
         ...(grouped ? [g.label] : []),
         ...cols.map((key) => {
           const v = row.values[key];
-          return v === null || v === undefined ? '' : v;
+          if (v === null || v === undefined) return '';
+          // Mirror the on-screen currency mode in the exported numbers.
+          if (
+            currencyMode === 'base' &&
+            INVESTMENT_COLUMN_MAP[key]?.type === 'currency'
+          ) {
+            return Number(v) * row.baseExchangeRate;
+          }
+          return v;
         }),
       ]),
     );
@@ -190,28 +211,46 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
       />
 
       {/* Controls */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-6">
         <div className="flex flex-wrap items-end justify-between gap-4">
-          <div className="w-56">
-            <DateInput
-              label="As of date"
-              value={asOfOverride}
-              onChange={(e) => setAsOfOverride(e.target.value)}
-              onDateChange={(date) => setAsOfOverride(date)}
-            />
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              {asOfOverride ? (
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="w-48">
+              <DateInput
+                label="As of date"
+                value={asOfOverride}
+                onChange={(e) => setAsOfOverride(e.target.value)}
+                onDateChange={(date) => setAsOfOverride(date)}
+              />
+            </div>
+            <div>
+              <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Currency
+              </span>
+              <div className="inline-flex rounded-md border border-gray-300 dark:border-gray-600 overflow-hidden">
                 <button
                   type="button"
-                  className="text-blue-600 dark:text-blue-400 hover:underline"
-                  onClick={() => setAsOfOverride('')}
+                  onClick={() => setCurrencyMode('native')}
+                  className={`px-3 py-2 text-sm transition-colors ${
+                    currencyMode === 'native'
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300'
+                  }`}
                 >
-                  Reset to latest market day
+                  Native
                 </button>
-              ) : (
-                'Showing the latest market day.'
-              )}
-            </p>
+                <button
+                  type="button"
+                  onClick={() => setCurrencyMode('base')}
+                  className={`px-3 py-2 text-sm border-l border-gray-300 dark:border-gray-600 transition-colors ${
+                    currencyMode === 'base'
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300'
+                  }`}
+                >
+                  {result?.baseCurrency || 'Base'}
+                </button>
+              </div>
+            </div>
           </div>
           <div className="flex items-center gap-3">
             {isExecuting && (
@@ -229,6 +268,23 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
             </Button>
           </div>
         </div>
+        <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+          {asOfOverride ? (
+            <button
+              type="button"
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+              onClick={() => setAsOfOverride('')}
+            >
+              Reset to latest market day
+            </button>
+          ) : (
+            'Showing the latest market day.'
+          )}
+          {' · '}
+          {currencyMode === 'base' && result
+            ? `Values shown in ${result.baseCurrency}.`
+            : "Values shown in each holding's native currency."}
+        </p>
       </div>
 
       {/* Results */}
@@ -302,7 +358,7 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
                                       : 'text-gray-700 dark:text-gray-300'
                                   }`}
                                 >
-                                  {formatCell(row.values[key], col?.type ?? 'text')}
+                                  {formatCell(row.values[key], col?.type ?? 'text', row)}
                                 </td>
                               );
                             })}

--- a/frontend/src/components/reports/InvestmentReportViewer.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.tsx
@@ -1,0 +1,335 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import toast from 'react-hot-toast';
+import Link from 'next/link';
+import { PageHeader } from '@/components/layout/PageHeader';
+import { Button } from '@/components/ui/Button';
+import { DateInput } from '@/components/ui/DateInput';
+import { SortableHeader } from '@/components/ui/SortableHeader';
+import { investmentReportsApi } from '@/lib/investment-reports';
+import {
+  InvestmentReport,
+  InvestmentReportResult,
+  InvestmentReportRow,
+  InvestmentGroupBy,
+  INVESTMENT_COLUMN_MAP,
+  InvestmentColumnType,
+  InvestmentCellValue,
+} from '@/types/investment-report';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useDateFormat } from '@/hooks/useDateFormat';
+import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
+import { exportToCsv } from '@/lib/csv-export';
+import { createLogger } from '@/lib/logger';
+import { getErrorMessage } from '@/lib/errors';
+
+const logger = createLogger('InvestmentReportViewer');
+
+const NUMERIC_TYPES: InvestmentColumnType[] = [
+  'currency',
+  'percent',
+  'integer',
+  'number',
+  'shares',
+];
+
+interface InvestmentReportViewerProps {
+  reportId: string;
+}
+
+export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps) {
+  const router = useRouter();
+  const { formatNumber, formatPercent } = useNumberFormat();
+  const { formatDate } = useDateFormat();
+  const [report, setReport] = useState<InvestmentReport | null>(null);
+  const [result, setResult] = useState<InvestmentReportResult | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isExecuting, setIsExecuting] = useState(false);
+  const [asOfOverride, setAsOfOverride] = useState('');
+
+  const { sortField, sortDirection, handleSort } = useSortableTable<string>(
+    'reports.investment.table.sort',
+    { field: 'symbol', direction: 'asc' },
+  );
+
+  const loadReport = useCallback(async () => {
+    try {
+      const data = await investmentReportsApi.getById(reportId);
+      setReport(data);
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Failed to load report'));
+      logger.error(error);
+    }
+  }, [reportId]);
+
+  const executeReport = useCallback(async () => {
+    setIsExecuting(true);
+    try {
+      const data = await investmentReportsApi.execute(
+        reportId,
+        asOfOverride ? { asOfDate: asOfOverride } : {},
+      );
+      setResult(data);
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Failed to run report'));
+      logger.error(error);
+    } finally {
+      setIsExecuting(false);
+    }
+  }, [reportId, asOfOverride]);
+
+  useEffect(() => {
+    const init = async () => {
+      setIsLoading(true);
+      await loadReport();
+      setIsLoading(false);
+    };
+    init();
+  }, [loadReport]);
+
+  useEffect(() => {
+    if (!report) return;
+    executeReport();
+  }, [report, executeReport]);
+
+  const formatCell = (value: InvestmentCellValue, type: InvestmentColumnType): string => {
+    if (value === null || value === undefined || value === '') return '—';
+    switch (type) {
+      case 'currency':
+        return formatNumber(Number(value), 2);
+      case 'number':
+        return formatNumber(Number(value), 4);
+      case 'integer':
+        return formatNumber(Number(value), 0);
+      case 'percent':
+        return formatPercent(Number(value), 2);
+      case 'shares':
+        return Number(value).toLocaleString(undefined, { maximumFractionDigits: 4 });
+      case 'date':
+        return formatDate(String(value));
+      default:
+        return String(value);
+    }
+  };
+
+  const sortRows = (rows: InvestmentReportRow[]): InvestmentReportRow[] => {
+    return [...rows].sort((a, b) => {
+      const av = a.values[sortField];
+      const bv = b.values[sortField];
+      if (av === null && bv === null) return 0;
+      if (av === null || av === undefined) return 1;
+      if (bv === null || bv === undefined) return -1;
+      const cmp = compareValues(av, bv);
+      return sortDirection === 'asc' ? cmp : -cmp;
+    });
+  };
+
+  const handleExportCsv = () => {
+    if (!result) return;
+    const cols = result.columns;
+    const grouped = result.groupBy !== InvestmentGroupBy.NONE;
+    const headers = [
+      ...(grouped ? [groupHeading(result.groupBy)] : []),
+      ...cols.map((key) => INVESTMENT_COLUMN_MAP[key]?.label ?? key),
+    ];
+    const rows = result.groups.flatMap((g) =>
+      g.rows.map((row) => [
+        ...(grouped ? [g.label] : []),
+        ...cols.map((key) => {
+          const v = row.values[key];
+          return v === null || v === undefined ? '' : v;
+        }),
+      ]),
+    );
+    const filename = `${report?.name.replace(/[^a-zA-Z0-9]/g, '-').toLowerCase() || 'investment-report'}`;
+    exportToCsv(filename, headers, rows);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  if (!report) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-gray-500 dark:text-gray-400">Report not found</p>
+        <Button variant="outline" onClick={() => router.push('/reports')} className="mt-4">
+          Back to Reports
+        </Button>
+      </div>
+    );
+  }
+
+  const columns = result?.columns ?? [];
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={report.name}
+        subtitle={report.description ?? undefined}
+        actions={
+          <>
+            <Button
+              variant="outline"
+              className="shrink-0"
+              onClick={() => router.push(`/reports/investment/${reportId}/edit`)}
+            >
+              Edit
+            </Button>
+            <Link href="/reports">
+              <Button variant="outline">Back to Reports</Button>
+            </Link>
+          </>
+        }
+      />
+
+      {/* Controls */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div className="w-56">
+            <DateInput
+              label="As of date"
+              value={asOfOverride}
+              onChange={(e) => setAsOfOverride(e.target.value)}
+              onDateChange={(date) => setAsOfOverride(date)}
+            />
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {asOfOverride ? (
+                <button
+                  type="button"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                  onClick={() => setAsOfOverride('')}
+                >
+                  Reset to latest market day
+                </button>
+              ) : (
+                'Showing the latest market day.'
+              )}
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            {isExecuting && (
+              <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"></div>
+                <span>Updating...</span>
+              </div>
+            )}
+            <Button
+              variant="outline"
+              onClick={handleExportCsv}
+              disabled={!result || result.rowCount === 0}
+            >
+              Export CSV
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Results */}
+      {isExecuting && !result ? (
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-12">
+          <div className="flex flex-col items-center justify-center">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mb-4"></div>
+            <p className="text-gray-500 dark:text-gray-400">Generating report...</p>
+          </div>
+        </div>
+      ) : result ? (
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-6">
+          <div className="flex items-center justify-between mb-4">
+            <span className="text-sm text-gray-500 dark:text-gray-400">
+              As of {formatDate(result.asOfDate)} · {result.rowCount} holding
+              {result.rowCount === 1 ? '' : 's'}
+            </span>
+          </div>
+
+          {result.rowCount === 0 ? (
+            <div className="py-12 text-center text-gray-500 dark:text-gray-400">
+              No holdings found for the selected accounts and date.
+            </div>
+          ) : (
+            <div className="space-y-6">
+              {result.groups.map((group) => (
+                <div key={group.key}>
+                  {result.groupBy !== InvestmentGroupBy.NONE && (
+                    <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">
+                      {group.label || 'Ungrouped'}
+                    </h4>
+                  )}
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                      <thead className="bg-gray-50 dark:bg-gray-900/50">
+                        <tr>
+                          {columns.map((key) => {
+                            const col = INVESTMENT_COLUMN_MAP[key];
+                            const numeric = col && NUMERIC_TYPES.includes(col.type);
+                            return (
+                              <SortableHeader<string>
+                                key={key}
+                                field={key}
+                                sortField={sortField}
+                                sortDirection={sortDirection}
+                                onSort={handleSort}
+                                align={numeric ? 'right' : 'left'}
+                                className="px-3 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase whitespace-nowrap"
+                              >
+                                {col?.label ?? key}
+                              </SortableHeader>
+                            );
+                          })}
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                        {sortRows(group.rows).map((row) => (
+                          <tr
+                            key={row.id}
+                            className="hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                          >
+                            {columns.map((key) => {
+                              const col = INVESTMENT_COLUMN_MAP[key];
+                              const numeric = col && NUMERIC_TYPES.includes(col.type);
+                              return (
+                                <td
+                                  key={key}
+                                  className={`px-3 py-2 text-sm whitespace-nowrap ${
+                                    numeric
+                                      ? 'text-right tabular-nums text-gray-900 dark:text-gray-100'
+                                      : 'text-gray-700 dark:text-gray-300'
+                                  }`}
+                                >
+                                  {formatCell(row.values[key], col?.type ?? 'text')}
+                                </td>
+                              );
+                            })}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function groupHeading(groupBy: InvestmentGroupBy): string {
+  switch (groupBy) {
+    case InvestmentGroupBy.ACCOUNT:
+      return 'Account';
+    case InvestmentGroupBy.SYMBOL:
+      return 'Symbol';
+    case InvestmentGroupBy.CURRENCY:
+      return 'Currency';
+    default:
+      return 'Group';
+  }
+}

--- a/frontend/src/components/reports/NetWorthReport.test.tsx
+++ b/frontend/src/components/reports/NetWorthReport.test.tsx
@@ -27,10 +27,11 @@ vi.mock('@/hooks/useNumberFormat', () => ({
   }),
 }));
 
+const dateRangeMock = vi.hoisted(() => ({ value: '1y' }));
 const STABLE_RANGE = { start: '2024-01-01', end: '2025-01-01' };
 vi.mock('@/hooks/useDateRange', () => ({
   useDateRange: () => ({
-    dateRange: '1y',
+    dateRange: dateRangeMock.value,
     setDateRange: vi.fn(),
     startDate: '',
     setStartDate: vi.fn(),
@@ -55,7 +56,10 @@ vi.mock('recharts', () => ({
   AreaChart: ({ children }: any) => <div data-testid="area-chart">{children}</div>,
   BarChart: ({ children }: any) => <div data-testid="bar-chart">{children}</div>,
   Area: () => null,
-  Bar: () => null,
+  Bar: ({ children }: any) => <div data-testid="bar">{children}</div>,
+  LabelList: ({ formatter }: any) => (
+    <div data-testid="label-list">{formatter ? String(formatter(1000)) : ''}</div>
+  ),
   XAxis: ({ tickFormatter }: any) => {
     if (tickFormatter) {
       try { tickFormatter('Jan 2024'); tickFormatter('Jul 2024'); tickFormatter('NoSpace'); } catch {}
@@ -100,6 +104,7 @@ vi.mock('@/lib/logger', () => ({
 describe('NetWorthReport', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    dateRangeMock.value = '1y';
   });
 
   it('shows loading state initially', () => {
@@ -173,7 +178,7 @@ describe('NetWorthReport', () => {
     await waitFor(() => {
       expect(screen.getByText('Current Net Worth')).toBeInTheDocument();
     });
-    expect(screen.getByTestId('area-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
   });
 
   it('handles recalculate error', async () => {
@@ -206,6 +211,59 @@ describe('NetWorthReport', () => {
       fireEvent.click(screen.getByText('line'));
     });
     expect(screen.getByTestId('area-chart')).toBeInTheDocument();
+  });
+
+  it('defaults to the bar chart view', async () => {
+    mockGetMonthly.mockResolvedValue([
+      { month: '2024-01-01', assets: 50000, liabilities: 10000, netWorth: 40000 },
+      { month: '2024-06-01', assets: 55000, liabilities: 9000, netWorth: 46000 },
+    ]);
+    render(<NetWorthReport />);
+    await waitFor(() => {
+      expect(screen.getByText('Current Net Worth')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+    expect(screen.queryByTestId('area-chart')).not.toBeInTheDocument();
+  });
+
+  it('shows abbreviated value labels above bars for the 1-year range', async () => {
+    dateRangeMock.value = '1y';
+    mockGetMonthly.mockResolvedValue([
+      { month: '2024-01-01', assets: 50000, liabilities: 10000, netWorth: 40000 },
+      { month: '2024-06-01', assets: 55000, liabilities: 9000, netWorth: 46000 },
+    ]);
+    render(<NetWorthReport />);
+    await waitFor(() => {
+      expect(screen.getByText('Current Net Worth')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('label-list')).toBeInTheDocument();
+  });
+
+  it('shows abbreviated value labels above bars for the 2-year range', async () => {
+    dateRangeMock.value = '2y';
+    mockGetMonthly.mockResolvedValue([
+      { month: '2024-01-01', assets: 50000, liabilities: 10000, netWorth: 40000 },
+      { month: '2024-06-01', assets: 55000, liabilities: 9000, netWorth: 46000 },
+    ]);
+    render(<NetWorthReport />);
+    await waitFor(() => {
+      expect(screen.getByText('Current Net Worth')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('label-list')).toBeInTheDocument();
+  });
+
+  it('hides bar value labels for ranges longer than two years', async () => {
+    dateRangeMock.value = '5y';
+    mockGetMonthly.mockResolvedValue([
+      { month: '2024-01-01', assets: 50000, liabilities: 10000, netWorth: 40000 },
+      { month: '2024-06-01', assets: 55000, liabilities: 9000, netWorth: 46000 },
+    ]);
+    render(<NetWorthReport />);
+    await waitFor(() => {
+      expect(screen.getByText('Current Net Worth')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+    expect(screen.queryByTestId('label-list')).not.toBeInTheDocument();
   });
 
   it('exports pdf', async () => {

--- a/frontend/src/components/reports/NetWorthReport.tsx
+++ b/frontend/src/components/reports/NetWorthReport.tsx
@@ -281,7 +281,7 @@ export function NetWorthReport() {
             <ChartViewToggle
               value={chartType}
               onChange={(v) => setChartType(v as 'line' | 'bar' | 'table')}
-              options={['line', 'bar', 'table']}
+              options={['bar', 'line', 'table']}
             />
             <button
               onClick={handleRecalculate}
@@ -435,7 +435,7 @@ export function NetWorthReport() {
               </AreaChart>
               ) : (
               <BarChart data={chartData} margin={{ top: showBarLabels ? (barLabelsVertical ? 52 : 22) : 10, right: 10, left: 0, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" vertical={false} />
                 <XAxis
                   dataKey="name"
                   tick={{ fontSize: 12 }}

--- a/frontend/src/components/reports/NetWorthReport.tsx
+++ b/frontend/src/components/reports/NetWorthReport.tsx
@@ -14,6 +14,7 @@ import {
   Legend,
   ReferenceLine,
   ReferenceDot,
+  LabelList,
 } from 'recharts';
 import { format } from 'date-fns';
 import { netWorthApi } from '@/lib/net-worth';
@@ -38,7 +39,7 @@ export function NetWorthReport() {
   const [monthlyData, setMonthlyData] = useState<MonthlyNetWorth[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isRecalculating, setIsRecalculating] = useState(false);
-  const [chartType, setChartType] = useState<'line' | 'bar' | 'table'>('line');
+  const [chartType, setChartType] = useState<'line' | 'bar' | 'table'>('bar');
   const chartRef = useRef<HTMLDivElement>(null);
   const { dateRange, setDateRange, startDate, setStartDate, endDate, setEndDate, resolvedRange, isValid } = useDateRange({ defaultRange: '1y', alignment: 'month' });
   const { sortField, sortDirection, handleSort } = useSortableTable<NetWorthSortField>(
@@ -198,6 +199,12 @@ export function NetWorthReport() {
       max: chartData[maxIdx],
     };
   }, [chartData]);
+
+  // Per-bar value labels are only legible on the shorter (1y/2y) ranges; longer
+  // ranges pack too many bars together. Beyond ~14 bars the labels are rotated
+  // vertical so the 2-year view doesn't overlap.
+  const showBarLabels = dateRange === '1y' || dateRange === '2y';
+  const barLabelsVertical = showBarLabels && chartData.length > 14;
 
   const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: Array<{ name: string; value: number; color: string; payload: { name: string } }> }) => {
     if (active && payload && payload.length) {
@@ -427,7 +434,7 @@ export function NetWorthReport() {
                 )}
               </AreaChart>
               ) : (
-              <BarChart data={chartData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+              <BarChart data={chartData} margin={{ top: showBarLabels ? (barLabelsVertical ? 52 : 22) : 10, right: 10, left: 0, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
                 <XAxis
                   dataKey="name"
@@ -451,7 +458,24 @@ export function NetWorthReport() {
                 <Tooltip content={<CustomTooltip />} />
                 <Legend />
                 <ReferenceLine y={0} stroke="#9ca3af" strokeDasharray="3 3" />
-                <Bar dataKey="NetWorth" fill="#3b82f6" name="Net Worth" />
+                <Bar dataKey="NetWorth" fill="#3b82f6" name="Net Worth" radius={[4, 4, 0, 0]}>
+                  {showBarLabels && (
+                    <LabelList
+                      dataKey="NetWorth"
+                      position="top"
+                      angle={barLabelsVertical ? -90 : 0}
+                      offset={barLabelsVertical ? 6 : 5}
+                      textAnchor={barLabelsVertical ? 'start' : 'middle'}
+                      formatter={(value: unknown) => formatCurrencyLabel(Number(value))}
+                      style={{
+                        fill: '#6b7280',
+                        fontSize: 11,
+                        fontWeight: 600,
+                        ...(barLabelsVertical && { dominantBaseline: 'central' as const }),
+                      }}
+                    />
+                  )}
+                </Bar>
               </BarChart>
               )}
             </ResponsiveContainer>

--- a/frontend/src/components/reports/NewReportButton.test.tsx
+++ b/frontend/src/components/reports/NewReportButton.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@/test/render';
+import { fireEvent, screen } from '@testing-library/react';
+import { NewReportButton } from './NewReportButton';
+
+describe('NewReportButton', () => {
+  it('renders the New Report trigger', () => {
+    render(<NewReportButton onNewStandard={vi.fn()} onNewInvestment={vi.fn()} />);
+    expect(screen.getByText('New Report')).toBeInTheDocument();
+  });
+
+  it('shows both options when clicked', () => {
+    render(<NewReportButton onNewStandard={vi.fn()} onNewInvestment={vi.fn()} />);
+    fireEvent.click(screen.getByText('New Report'));
+    expect(screen.getByText('Standard Report')).toBeInTheDocument();
+    expect(screen.getByText('Investment Report')).toBeInTheDocument();
+  });
+
+  it('calls onNewStandard when Standard Report is clicked', () => {
+    const onNewStandard = vi.fn();
+    render(<NewReportButton onNewStandard={onNewStandard} onNewInvestment={vi.fn()} />);
+    fireEvent.click(screen.getByText('New Report'));
+    fireEvent.click(screen.getByText('Standard Report'));
+    expect(onNewStandard).toHaveBeenCalledOnce();
+  });
+
+  it('calls onNewInvestment when Investment Report is clicked', () => {
+    const onNewInvestment = vi.fn();
+    render(<NewReportButton onNewStandard={vi.fn()} onNewInvestment={onNewInvestment} />);
+    fireEvent.click(screen.getByText('New Report'));
+    fireEvent.click(screen.getByText('Investment Report'));
+    expect(onNewInvestment).toHaveBeenCalledOnce();
+  });
+
+  it('closes the menu after selecting an option', () => {
+    render(<NewReportButton onNewStandard={vi.fn()} onNewInvestment={vi.fn()} />);
+    fireEvent.click(screen.getByText('New Report'));
+    expect(screen.getByText('Standard Report')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Standard Report'));
+    expect(screen.queryByText('Standard Report')).not.toBeInTheDocument();
+  });
+
+  it('closes the menu on Escape', () => {
+    render(<NewReportButton onNewStandard={vi.fn()} onNewInvestment={vi.fn()} />);
+    fireEvent.click(screen.getByText('New Report'));
+    expect(screen.getByText('Investment Report')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByText('Investment Report')).not.toBeInTheDocument();
+  });
+
+  it('closes the menu when clicking outside', () => {
+    render(
+      <div>
+        <NewReportButton onNewStandard={vi.fn()} onNewInvestment={vi.fn()} />
+        <span data-testid="outside">outside</span>
+      </div>,
+    );
+    fireEvent.click(screen.getByText('New Report'));
+    expect(screen.getByText('Investment Report')).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+    expect(screen.queryByText('Investment Report')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/reports/NewReportButton.tsx
+++ b/frontend/src/components/reports/NewReportButton.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState, useRef, useCallback } from 'react';
+import { Button } from '@/components/ui/Button';
+import { useClickOutside } from '@/hooks/useClickOutside';
+
+interface NewReportButtonProps {
+  onNewStandard: () => void;
+  onNewInvestment: () => void;
+}
+
+const menuItemClass =
+  'w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700';
+
+export function NewReportButton({ onNewStandard, onNewInvestment }: NewReportButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const close = useCallback(() => setIsOpen(false), []);
+
+  useClickOutside(dropdownRef, close, {
+    enabled: isOpen,
+    onEscape: () => {
+      close();
+      triggerRef.current?.focus();
+    },
+  });
+
+  const handleStandard = () => {
+    close();
+    onNewStandard();
+  };
+
+  const handleInvestment = () => {
+    close();
+    onNewInvestment();
+  };
+
+  return (
+    <div ref={dropdownRef} className="relative block w-full sm:inline-block sm:w-auto">
+      <Button
+        ref={triggerRef}
+        onClick={() => setIsOpen((open) => !open)}
+        className="w-full whitespace-nowrap sm:w-auto inline-flex items-center justify-center gap-1.5"
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+      >
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+        </svg>
+        New Report
+        <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </Button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-1 w-full sm:w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg z-50">
+          <button onClick={handleStandard} className={`${menuItemClass} rounded-t-md`}>
+            Standard Report
+          </button>
+          <button onClick={handleInvestment} className={`${menuItemClass} rounded-b-md`}>
+            Investment Report
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/CalendarPopover.test.tsx
+++ b/frontend/src/components/ui/CalendarPopover.test.tsx
@@ -181,9 +181,6 @@ describe('CalendarPopover', () => {
   });
 
   it('flips above the anchor when there is not enough room below', () => {
-    const offsetSpy = vi
-      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
-      .mockReturnValue(340);
     // Anchor near the bottom of the viewport (jsdom innerHeight is 768)
     Element.prototype.getBoundingClientRect = vi.fn().mockReturnValue({
       top: 700,
@@ -199,20 +196,14 @@ describe('CalendarPopover', () => {
     render(<Wrapper value="2025-06-15" onSelect={vi.fn()} onClose={vi.fn()} />);
     const popover = document.querySelector('.z-50') as HTMLElement;
     // spaceBelow (38) < height + gap + 8, spaceAbove (700) is larger, so flip up:
-    // top = 700 - 340 - 4 = 356
+    // top = 700 - POPOVER_HEIGHT (340) - 4 = 356
     expect(popover.style.top).toBe('356px');
-    offsetSpy.mockRestore();
   });
 
   it('opens below the anchor when there is room', () => {
-    const offsetSpy = vi
-      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
-      .mockReturnValue(340);
     render(<Wrapper value="2025-06-15" onSelect={vi.fn()} onClose={vi.fn()} />);
     const popover = document.querySelector('.z-50') as HTMLElement;
     // Default anchor bottom is 130, plenty of room below: top = 130 + 4 = 134
     expect(popover.style.top).toBe('134px');
-    expect(popover.style.visibility).toBe('visible');
-    offsetSpy.mockRestore();
   });
 });

--- a/frontend/src/components/ui/CalendarPopover.test.tsx
+++ b/frontend/src/components/ui/CalendarPopover.test.tsx
@@ -179,4 +179,40 @@ describe('CalendarPopover', () => {
     render(<Wrapper value="2025-06-15" onSelect={vi.fn()} onClose={vi.fn()} />);
     expect(screen.getByText('Jun 2025')).toBeInTheDocument();
   });
+
+  it('flips above the anchor when there is not enough room below', () => {
+    const offsetSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+      .mockReturnValue(340);
+    // Anchor near the bottom of the viewport (jsdom innerHeight is 768)
+    Element.prototype.getBoundingClientRect = vi.fn().mockReturnValue({
+      top: 700,
+      left: 50,
+      bottom: 730,
+      right: 100,
+      width: 50,
+      height: 30,
+      x: 50,
+      y: 700,
+      toJSON: () => ({}),
+    });
+    render(<Wrapper value="2025-06-15" onSelect={vi.fn()} onClose={vi.fn()} />);
+    const popover = document.querySelector('.z-50') as HTMLElement;
+    // spaceBelow (38) < height + gap + 8, spaceAbove (700) is larger, so flip up:
+    // top = 700 - 340 - 4 = 356
+    expect(popover.style.top).toBe('356px');
+    offsetSpy.mockRestore();
+  });
+
+  it('opens below the anchor when there is room', () => {
+    const offsetSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+      .mockReturnValue(340);
+    render(<Wrapper value="2025-06-15" onSelect={vi.fn()} onClose={vi.fn()} />);
+    const popover = document.querySelector('.z-50') as HTMLElement;
+    // Default anchor bottom is 130, plenty of room below: top = 130 + 4 = 134
+    expect(popover.style.top).toBe('134px');
+    expect(popover.style.visibility).toBe('visible');
+    offsetSpy.mockRestore();
+  });
 });

--- a/frontend/src/components/ui/CalendarPopover.tsx
+++ b/frontend/src/components/ui/CalendarPopover.tsx
@@ -19,6 +19,10 @@ interface CalendarPopoverProps {
 const DAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
+// Approximate rendered height of the fixed-size calendar, used only to decide
+// whether to open below the field or flip above it near the page bottom.
+const POPOVER_HEIGHT = 340;
+
 function toIso(year: number, month: number, day: number): string {
   return `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
 }
@@ -46,13 +50,12 @@ export function CalendarPopover({ value, onSelect, onClose, anchorRef }: Calenda
 
   // Position relative to anchor element, flipping above the field when there
   // isn't enough room below (e.g. the field sits near the bottom of the page).
+  // The anchor rect is only known after mount, so the position is measured here.
   useEffect(() => {
     const anchor = anchorRef.current;
-    const popover = popoverRef.current;
-    if (!anchor || !popover) return;
+    if (!anchor) return;
     const rect = anchor.getBoundingClientRect();
     const popoverWidth = 280;
-    const popoverHeight = popover.offsetHeight || 340;
     const gap = 4;
     let left = rect.left;
     // Keep within viewport
@@ -64,9 +67,10 @@ export function CalendarPopover({ value, onSelect, onClose, anchorRef }: Calenda
     const spaceBelow = window.innerHeight - rect.bottom;
     const spaceAbove = rect.top;
     let top = rect.bottom + gap;
-    if (spaceBelow < popoverHeight + gap + 8 && spaceAbove > spaceBelow) {
-      top = Math.max(8, rect.top - popoverHeight - gap);
+    if (spaceBelow < POPOVER_HEIGHT + gap + 8 && spaceAbove > spaceBelow) {
+      top = Math.max(8, rect.top - POPOVER_HEIGHT - gap);
     }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time position derived from the mounted anchor's DOM rect
     setPosition({ top, left });
   }, [anchorRef]);
 
@@ -108,6 +112,8 @@ export function CalendarPopover({ value, onSelect, onClose, anchorRef }: Calenda
     onClose();
   }, [onSelect, onClose]);
 
+  if (!position) return null;
+
   const daysInMonth = getDaysInMonth(viewYear, viewMonth);
   const firstDay = getFirstDayOfWeek(viewYear, viewMonth);
   const selectedDay = parsed && parsed[0] === viewYear && parsed[1] - 1 === viewMonth ? parsed[2] : null;
@@ -135,11 +141,7 @@ export function CalendarPopover({ value, onSelect, onClose, anchorRef }: Calenda
     <div
       ref={popoverRef}
       className="fixed z-50 w-[280px] bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-xl"
-      style={{
-        top: position?.top ?? 0,
-        left: position?.left ?? 0,
-        visibility: position ? 'visible' : 'hidden',
-      }}
+      style={{ top: position.top, left: position.left }}
     >
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-2 border-b border-gray-200 dark:border-gray-700">

--- a/frontend/src/components/ui/CalendarPopover.tsx
+++ b/frontend/src/components/ui/CalendarPopover.tsx
@@ -44,19 +44,30 @@ export function CalendarPopover({ value, onSelect, onClose, anchorRef }: Calenda
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
 
-  // Position relative to anchor element
+  // Position relative to anchor element, flipping above the field when there
+  // isn't enough room below (e.g. the field sits near the bottom of the page).
   useEffect(() => {
     const anchor = anchorRef.current;
-    if (!anchor) return;
+    const popover = popoverRef.current;
+    if (!anchor || !popover) return;
     const rect = anchor.getBoundingClientRect();
     const popoverWidth = 280;
+    const popoverHeight = popover.offsetHeight || 340;
+    const gap = 4;
     let left = rect.left;
     // Keep within viewport
     if (left + popoverWidth > window.innerWidth - 8) {
       left = window.innerWidth - popoverWidth - 8;
     }
     if (left < 8) left = 8;
-    setPosition({ top: rect.bottom + 4, left });
+
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+    let top = rect.bottom + gap;
+    if (spaceBelow < popoverHeight + gap + 8 && spaceAbove > spaceBelow) {
+      top = Math.max(8, rect.top - popoverHeight - gap);
+    }
+    setPosition({ top, left });
   }, [anchorRef]);
 
   // Close on outside click or Escape
@@ -97,8 +108,6 @@ export function CalendarPopover({ value, onSelect, onClose, anchorRef }: Calenda
     onClose();
   }, [onSelect, onClose]);
 
-  if (!position) return null;
-
   const daysInMonth = getDaysInMonth(viewYear, viewMonth);
   const firstDay = getFirstDayOfWeek(viewYear, viewMonth);
   const selectedDay = parsed && parsed[0] === viewYear && parsed[1] - 1 === viewMonth ? parsed[2] : null;
@@ -126,7 +135,11 @@ export function CalendarPopover({ value, onSelect, onClose, anchorRef }: Calenda
     <div
       ref={popoverRef}
       className="fixed z-50 w-[280px] bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-xl"
-      style={{ top: position.top, left: position.left }}
+      style={{
+        top: position?.top ?? 0,
+        left: position?.left ?? 0,
+        visibility: position ? 'visible' : 'hidden',
+      }}
     >
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-2 border-b border-gray-200 dark:border-gray-700">

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -10,7 +10,10 @@ interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
   ({ label, error, options, className, id, ...props }, ref) => {
     const selectId = id || `select-${label?.toLowerCase().replace(/\s+/g, '-')}`;
-    const isPlaceholder = props.value === '' || props.value === undefined;
+    // Only grey-out when the value is explicitly the empty placeholder option.
+    // Uncontrolled selects (react-hook-form register) leave value undefined yet
+    // still show a real selected value, so they must not look like placeholders.
+    const isPlaceholder = props.value === '';
 
     return (
       <div className="w-full">

--- a/frontend/src/hooks/useNumberFormat.test.ts
+++ b/frontend/src/hooks/useNumberFormat.test.ts
@@ -31,13 +31,6 @@ describe('useNumberFormat', () => {
     expect(formatted).toContain('1,000.00');
   });
 
-  it('formatCurrency can render the ISO code instead of the symbol', () => {
-    const { result } = renderHook(() => useNumberFormat());
-    const formatted = result.current.formatCurrency(1000, 'USD', undefined, 'code');
-    expect(formatted).toContain('USD');
-    expect(formatted).toContain('1,000.00');
-  });
-
   it('formatCurrencyCompact omits decimals', () => {
     const { result } = renderHook(() => useNumberFormat());
     const formatted = result.current.formatCurrencyCompact(1234);

--- a/frontend/src/hooks/useNumberFormat.test.ts
+++ b/frontend/src/hooks/useNumberFormat.test.ts
@@ -31,6 +31,13 @@ describe('useNumberFormat', () => {
     expect(formatted).toContain('1,000.00');
   });
 
+  it('formatCurrency can render the ISO code instead of the symbol', () => {
+    const { result } = renderHook(() => useNumberFormat());
+    const formatted = result.current.formatCurrency(1000, 'USD', undefined, 'code');
+    expect(formatted).toContain('USD');
+    expect(formatted).toContain('1,000.00');
+  });
+
   it('formatCurrencyCompact omits decimals', () => {
     const { result } = renderHook(() => useNumberFormat());
     const formatted = result.current.formatCurrencyCompact(1234);

--- a/frontend/src/hooks/useNumberFormat.ts
+++ b/frontend/src/hooks/useNumberFormat.ts
@@ -24,18 +24,13 @@ export function useNumberFormat() {
   const defaultCurrency = usePreferencesStore((state) => state.preferences?.defaultCurrency) || 'CAD';
 
   const formatCurrency = useCallback(
-    (
-      amount: number,
-      currencyCode?: string,
-      fractionDigits?: number,
-      currencyDisplay: 'narrowSymbol' | 'symbol' | 'code' | 'name' = 'narrowSymbol',
-    ): string => {
+    (amount: number, currencyCode?: string, fractionDigits?: number): string => {
       const currency = currencyCode || defaultCurrency;
       const locale = getEffectiveLocale(numberFormat);
       const options: Intl.NumberFormatOptions = {
         style: 'currency',
         currency,
-        currencyDisplay,
+        currencyDisplay: 'narrowSymbol',
       };
       if (fractionDigits !== undefined) {
         options.minimumFractionDigits = fractionDigits;

--- a/frontend/src/hooks/useNumberFormat.ts
+++ b/frontend/src/hooks/useNumberFormat.ts
@@ -24,13 +24,18 @@ export function useNumberFormat() {
   const defaultCurrency = usePreferencesStore((state) => state.preferences?.defaultCurrency) || 'CAD';
 
   const formatCurrency = useCallback(
-    (amount: number, currencyCode?: string, fractionDigits?: number): string => {
+    (
+      amount: number,
+      currencyCode?: string,
+      fractionDigits?: number,
+      currencyDisplay: 'narrowSymbol' | 'symbol' | 'code' | 'name' = 'narrowSymbol',
+    ): string => {
       const currency = currencyCode || defaultCurrency;
       const locale = getEffectiveLocale(numberFormat);
       const options: Intl.NumberFormatOptions = {
         style: 'currency',
         currency,
-        currencyDisplay: 'narrowSymbol',
+        currencyDisplay,
       };
       if (fractionDigits !== undefined) {
         options.minimumFractionDigits = fractionDigits;

--- a/frontend/src/lib/investment-reports.test.ts
+++ b/frontend/src/lib/investment-reports.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import apiClient from './api';
+import { getCached } from './apiCache';
+import { investmentReportsApi } from './investment-reports';
+
+vi.mock('./api', () => ({
+  default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('./apiCache', () => ({
+  getCached: vi.fn(() => undefined),
+  setCache: vi.fn(),
+  invalidateCache: vi.fn(),
+}));
+
+describe('investmentReportsApi', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('create posts to /reports/investment', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { id: 'r1' } });
+    const result = await investmentReportsApi.create({ name: 'R', config: { columns: ['symbol'] } });
+    expect(apiClient.post).toHaveBeenCalledWith('/reports/investment', {
+      name: 'R',
+      config: { columns: ['symbol'] },
+    });
+    expect(result).toEqual({ id: 'r1' });
+  });
+
+  it('getAll fetches and caches', async () => {
+    vi.mocked(getCached).mockReturnValue(undefined);
+    vi.mocked(apiClient.get).mockResolvedValue({ data: [{ id: 'r1' }] });
+    const result = await investmentReportsApi.getAll();
+    expect(apiClient.get).toHaveBeenCalledWith('/reports/investment');
+    expect(result).toHaveLength(1);
+  });
+
+  it('getAll returns cached data without a request', async () => {
+    vi.mocked(getCached).mockReturnValue([{ id: 'cached' }] as never);
+    const result = await investmentReportsApi.getAll();
+    expect(apiClient.get).not.toHaveBeenCalled();
+    expect(result).toEqual([{ id: 'cached' }]);
+  });
+
+  it('getById fetches by id', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { id: 'r1' } });
+    await investmentReportsApi.getById('r1');
+    expect(apiClient.get).toHaveBeenCalledWith('/reports/investment/r1');
+  });
+
+  it('update patches the report', async () => {
+    vi.mocked(apiClient.patch).mockResolvedValue({ data: { id: 'r1' } });
+    await investmentReportsApi.update('r1', { name: 'New' });
+    expect(apiClient.patch).toHaveBeenCalledWith('/reports/investment/r1', { name: 'New' });
+  });
+
+  it('delete removes the report', async () => {
+    vi.mocked(apiClient.delete).mockResolvedValue({ data: {} });
+    await investmentReportsApi.delete('r1');
+    expect(apiClient.delete).toHaveBeenCalledWith('/reports/investment/r1');
+  });
+
+  it('execute posts with as-of date params', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { groups: [] } });
+    await investmentReportsApi.execute('r1', { asOfDate: '2024-06-10' });
+    expect(apiClient.post).toHaveBeenCalledWith('/reports/investment/r1/execute', {
+      asOfDate: '2024-06-10',
+    });
+  });
+
+  it('execute posts an empty body when no params', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { groups: [] } });
+    await investmentReportsApi.execute('r1');
+    expect(apiClient.post).toHaveBeenCalledWith('/reports/investment/r1/execute', {});
+  });
+
+  it('toggleFavourite patches isFavourite', async () => {
+    vi.mocked(apiClient.patch).mockResolvedValue({ data: { id: 'r1' } });
+    await investmentReportsApi.toggleFavourite('r1', true);
+    expect(apiClient.patch).toHaveBeenCalledWith('/reports/investment/r1', { isFavourite: true });
+  });
+});

--- a/frontend/src/lib/investment-reports.ts
+++ b/frontend/src/lib/investment-reports.ts
@@ -9,7 +9,6 @@ import { getCached, setCache, invalidateCache } from './apiCache';
 
 export interface ExecuteInvestmentReportParams {
   asOfDate?: string;
-  mergeAccounts?: boolean;
 }
 
 export const investmentReportsApi = {

--- a/frontend/src/lib/investment-reports.ts
+++ b/frontend/src/lib/investment-reports.ts
@@ -9,6 +9,7 @@ import { getCached, setCache, invalidateCache } from './apiCache';
 
 export interface ExecuteInvestmentReportParams {
   asOfDate?: string;
+  mergeAccounts?: boolean;
 }
 
 export const investmentReportsApi = {

--- a/frontend/src/lib/investment-reports.ts
+++ b/frontend/src/lib/investment-reports.ts
@@ -1,0 +1,66 @@
+import apiClient from './api';
+import {
+  InvestmentReport,
+  CreateInvestmentReportData,
+  UpdateInvestmentReportData,
+  InvestmentReportResult,
+} from '@/types/investment-report';
+import { getCached, setCache, invalidateCache } from './apiCache';
+
+export interface ExecuteInvestmentReportParams {
+  asOfDate?: string;
+}
+
+export const investmentReportsApi = {
+  create: async (data: CreateInvestmentReportData): Promise<InvestmentReport> => {
+    const response = await apiClient.post<InvestmentReport>('/reports/investment', data);
+    invalidateCache('investment-reports:');
+    return response.data;
+  },
+
+  getAll: async (): Promise<InvestmentReport[]> => {
+    const cached = getCached<InvestmentReport[]>('investment-reports:all');
+    if (cached) return cached;
+    const response = await apiClient.get<InvestmentReport[]>('/reports/investment');
+    setCache('investment-reports:all', response.data, 300_000);
+    return response.data;
+  },
+
+  getById: async (id: string): Promise<InvestmentReport> => {
+    const response = await apiClient.get<InvestmentReport>(`/reports/investment/${id}`);
+    return response.data;
+  },
+
+  update: async (
+    id: string,
+    data: UpdateInvestmentReportData,
+  ): Promise<InvestmentReport> => {
+    const response = await apiClient.patch<InvestmentReport>(`/reports/investment/${id}`, data);
+    invalidateCache('investment-reports:');
+    return response.data;
+  },
+
+  delete: async (id: string): Promise<void> => {
+    await apiClient.delete(`/reports/investment/${id}`);
+    invalidateCache('investment-reports:');
+  },
+
+  execute: async (
+    id: string,
+    params?: ExecuteInvestmentReportParams,
+  ): Promise<InvestmentReportResult> => {
+    const response = await apiClient.post<InvestmentReportResult>(
+      `/reports/investment/${id}/execute`,
+      params || {},
+    );
+    return response.data;
+  },
+
+  toggleFavourite: async (id: string, isFavourite: boolean): Promise<InvestmentReport> => {
+    const response = await apiClient.patch<InvestmentReport>(`/reports/investment/${id}`, {
+      isFavourite,
+    });
+    invalidateCache('investment-reports:');
+    return response.data;
+  },
+};

--- a/frontend/src/types/investment-report.ts
+++ b/frontend/src/types/investment-report.ts
@@ -96,6 +96,7 @@ export interface InvestmentReportConfig {
   sortColumn: string | null;
   sortDirection: InvestmentSortDirection;
   asOfDate: string | null;
+  mergeAccounts?: boolean;
 }
 
 export interface InvestmentReport {
@@ -125,6 +126,7 @@ export interface CreateInvestmentReportData {
     sortColumn?: string | null;
     sortDirection?: InvestmentSortDirection;
     asOfDate?: string | null;
+    mergeAccounts?: boolean;
   };
   isFavourite?: boolean;
   sortOrder?: number;

--- a/frontend/src/types/investment-report.ts
+++ b/frontend/src/types/investment-report.ts
@@ -36,6 +36,7 @@ export const INVESTMENT_REPORT_COLUMNS: InvestmentColumnDef[] = [
   { key: 'name', label: 'Name', type: 'text', description: 'The name of the investment.' },
   { key: 'securityType', label: 'Type', type: 'text', description: 'Type of investment, such as stock, ETF, mutual fund, or bond.' },
   { key: 'currency', label: 'Currency', type: 'text', description: 'The currency the information displayed is based on.' },
+  { key: 'account', label: 'Account', type: 'text', description: 'The investment account that holds this security.' },
   { key: 'quantity', label: 'Quantity', type: 'shares', description: 'The number of shares you hold of a given security.' },
   { key: 'averageCost', label: 'Average Cost', type: 'currency', description: 'The average cost per share, including commissions, that you paid for this security.' },
   { key: 'costBasis', label: 'Cost Basis', type: 'currency', description: 'The total cost, including commissions and fees, of all shares of an investment.' },

--- a/frontend/src/types/investment-report.ts
+++ b/frontend/src/types/investment-report.ts
@@ -135,6 +135,10 @@ export type InvestmentCellValue = string | number | null;
 
 export interface InvestmentReportRow {
   id: string;
+  /** The holding's own (security) currency, for formatting native values. */
+  currency: string;
+  /** Multiply this row's native monetary values by this to get base currency. */
+  baseExchangeRate: number;
   values: Record<string, InvestmentCellValue>;
 }
 

--- a/frontend/src/types/investment-report.ts
+++ b/frontend/src/types/investment-report.ts
@@ -1,0 +1,156 @@
+// Mirrors backend/src/investment-reports. The column catalogue below must stay
+// in sync with backend/src/investment-reports/investment-report-columns.ts.
+
+export enum InvestmentGroupBy {
+  NONE = 'NONE',
+  ACCOUNT = 'ACCOUNT',
+  SYMBOL = 'SYMBOL',
+  CURRENCY = 'CURRENCY',
+}
+
+export enum InvestmentSortDirection {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}
+
+export type InvestmentColumnType =
+  | 'text'
+  | 'shares'
+  | 'currency'
+  | 'percent'
+  | 'integer'
+  | 'number'
+  | 'date';
+
+export interface InvestmentColumnDef {
+  key: string;
+  label: string;
+  type: InvestmentColumnType;
+  description: string;
+}
+
+export const ALWAYS_INCLUDED_COLUMN = 'symbol';
+
+export const INVESTMENT_REPORT_COLUMNS: InvestmentColumnDef[] = [
+  { key: 'symbol', label: 'Symbol', type: 'text', description: 'Company ticker symbol.' },
+  { key: 'name', label: 'Name', type: 'text', description: 'The name of the investment.' },
+  { key: 'securityType', label: 'Type', type: 'text', description: 'Type of investment, such as stock, ETF, mutual fund, or bond.' },
+  { key: 'currency', label: 'Currency', type: 'text', description: 'The currency the information displayed is based on.' },
+  { key: 'quantity', label: 'Quantity', type: 'shares', description: 'The number of shares you hold of a given security.' },
+  { key: 'averageCost', label: 'Average Cost', type: 'currency', description: 'The average cost per share, including commissions, that you paid for this security.' },
+  { key: 'costBasis', label: 'Cost Basis', type: 'currency', description: 'The total cost, including commissions and fees, of all shares of an investment.' },
+  { key: 'lastPrice', label: 'Last Price', type: 'currency', description: 'The most recent price at which the security traded.' },
+  { key: 'marketValue', label: 'Market Value', type: 'currency', description: 'Market value of your investment at the last price.' },
+  { key: 'gain', label: 'Gain', type: 'currency', description: 'Your gain or loss on this security. Current market value plus income, minus cost basis.' },
+  { key: 'gainPercent', label: '%Gain', type: 'percent', description: 'The percentage of profit or loss on an investment based on its cost.' },
+  { key: 'priceAppreciation', label: 'Price Appreciation', type: 'currency', description: 'Your gain or loss due to price fluctuations. Current market value minus cost basis.' },
+  { key: 'portfolioPercent', label: '% of portfolio', type: 'percent', description: 'The percentage of your total portfolio invested in this security by market value.' },
+  { key: 'open', label: 'Open', type: 'currency', description: 'The first price at which a security traded on the trading day.' },
+  { key: 'dayHigh', label: 'High (Day High)', type: 'currency', description: 'The highest price at which a security traded during the day.' },
+  { key: 'dayLow', label: 'Low (Day Low)', type: 'currency', description: 'The lowest price at which a security traded during the day.' },
+  { key: 'previousClose', label: 'Close', type: 'currency', description: 'The last price at which a security traded on the previous trading day.' },
+  { key: 'change', label: 'Change', type: 'currency', description: "Per-share difference between the preceding day's close and the most recent price." },
+  { key: 'changePercent', label: '%Change', type: 'percent', description: "The percentage difference between the preceding day's close and the current price." },
+  { key: 'todaysTotalChange', label: "Today's Total Change", type: 'currency', description: 'Your gain or loss today: the per-share change since the previous close multiplied by your shares.' },
+  { key: 'volume', label: 'Volume', type: 'integer', description: 'The total units of an investment traded on the most recent trading day.' },
+  { key: 'lastTransactionDate', label: 'Last Transaction Date', type: 'date', description: 'The last date the investment was traded.' },
+  { key: 'income', label: 'Income', type: 'currency', description: 'Interest, dividends and capital gains distributions you have received for an investment.' },
+  { key: 'commissions', label: 'Commissions', type: 'currency', description: 'The total brokerage fees you paid to buy or sell an investment.' },
+  { key: 'purchases', label: 'Purchases', type: 'currency', description: 'The cost of your total purchases (excluding reinvested income) of this investment.' },
+  { key: 'sales', label: 'Sales', type: 'currency', description: 'The total sales you have made for this investment.' },
+  { key: 'reinvestments', label: 'Reinvestments', type: 'currency', description: 'The total reinvested income for this investment.' },
+  { key: 'realizedGains', label: 'Realized Gains', type: 'currency', description: 'The gain from shares actually sold. Does not include the change in value of shares you still hold.' },
+  { key: 'exchangeRate', label: 'Exchange Rate', type: 'number', description: 'Exchange rate used to convert this investment to your base currency.' },
+  { key: 'lastUpdated', label: 'Last Updated', type: 'date', description: 'The date of the most recent stored price for this security.' },
+  { key: 'fiftyTwoWeekHigh', label: '52-Week High', type: 'currency', description: 'The highest price at which a security traded over the past 52 weeks (from stored price history).' },
+  { key: 'fiftyTwoWeekLow', label: '52-Week Low', type: 'currency', description: 'The lowest price at which a security traded over the past 52 weeks (from stored price history).' },
+  { key: 'totalReturn1Week', label: 'Total Return - 1 Week', type: 'percent', description: 'One-week percentage return: current market value plus income, minus beginning market value, divided by beginning market value.' },
+  { key: 'totalReturn4Weeks', label: 'Total Return - 4 Weeks', type: 'percent', description: 'Four-week percentage return on investment.' },
+  { key: 'totalReturn3Month', label: 'Total Return - 3 Month', type: 'percent', description: 'Three-month percentage return on investment.' },
+  { key: 'totalReturn1Year', label: 'Total Return - 1 Year', type: 'percent', description: 'One-year percentage return on investment.' },
+  { key: 'totalReturn3Year', label: 'Total Return - 3 Year', type: 'percent', description: 'Three-year percentage return on investment.' },
+  { key: 'totalReturnYtd', label: 'Total Return - YTD', type: 'percent', description: 'Year-to-date percentage return on investment.' },
+  { key: 'totalReturnAllDates', label: 'Total Return - All Dates', type: 'percent', description: 'Percentage return on investment across all dates held.' },
+  { key: 'totalAnnualizedReturn', label: 'Total Annualized Return', type: 'percent', description: 'Annual percentage return on investment, projected or averaged to one year.' },
+];
+
+export const INVESTMENT_COLUMN_MAP: Record<string, InvestmentColumnDef> =
+  Object.fromEntries(INVESTMENT_REPORT_COLUMNS.map((c) => [c.key, c]));
+
+export const GROUP_BY_LABELS: Record<InvestmentGroupBy, string> = {
+  [InvestmentGroupBy.NONE]: 'No Grouping',
+  [InvestmentGroupBy.ACCOUNT]: 'Account',
+  [InvestmentGroupBy.SYMBOL]: 'Symbol',
+  [InvestmentGroupBy.CURRENCY]: 'Currency',
+};
+
+export const SORT_DIRECTION_LABELS: Record<InvestmentSortDirection, string> = {
+  [InvestmentSortDirection.ASC]: 'Ascending',
+  [InvestmentSortDirection.DESC]: 'Descending',
+};
+
+export interface InvestmentReportConfig {
+  columns: string[];
+  accountIds: string[];
+  sortColumn: string | null;
+  sortDirection: InvestmentSortDirection;
+  asOfDate: string | null;
+}
+
+export interface InvestmentReport {
+  id: string;
+  userId: string;
+  name: string;
+  description: string | null;
+  icon: string | null;
+  backgroundColor: string | null;
+  groupBy: InvestmentGroupBy;
+  config: InvestmentReportConfig;
+  isFavourite: boolean;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateInvestmentReportData {
+  name: string;
+  description?: string;
+  icon?: string;
+  backgroundColor?: string;
+  groupBy?: InvestmentGroupBy;
+  config: {
+    columns: string[];
+    accountIds?: string[];
+    sortColumn?: string | null;
+    sortDirection?: InvestmentSortDirection;
+    asOfDate?: string | null;
+  };
+  isFavourite?: boolean;
+  sortOrder?: number;
+}
+
+export type UpdateInvestmentReportData = Partial<CreateInvestmentReportData>;
+
+export type InvestmentCellValue = string | number | null;
+
+export interface InvestmentReportRow {
+  id: string;
+  values: Record<string, InvestmentCellValue>;
+}
+
+export interface InvestmentReportGroup {
+  key: string;
+  label: string;
+  rows: InvestmentReportRow[];
+}
+
+export interface InvestmentReportResult {
+  reportId: string;
+  name: string;
+  asOfDate: string;
+  baseCurrency: string;
+  groupBy: InvestmentGroupBy;
+  columns: string[];
+  groups: InvestmentReportGroup[];
+  rowCount: number;
+}

--- a/ms_money_portfolio_columns.md
+++ b/ms_money_portfolio_columns.md
@@ -1,0 +1,88 @@
+# Microsoft Money — Portfolio Manager Column Reference
+
+The Portfolio Manager in MS Money supports **75+ customizable columns**. Some columns are relevant to particular investment types; others are populated via an online update from MSN Money.
+
+> **Note:** Columns marked with `*` do not have the option to select a number of decimal places. All other columns allow you to choose a decimal value.
+
+To view descriptions within Money itself: go to **Portfolio Manager → Customize any view → Change → Portfolio Columns tab**, then click a column name to see its description.
+
+---
+
+## Full Column List
+
+| Column Name | Description |
+|---|---|
+| % of portfolio | The percentage of your total portfolio invested in this security by market value. Market value of the security divided by amount invested in your total portfolio. |
+| %Cash | Percentage of this investment that is invested in cash. |
+| %Change | The percentage difference between the preceding day's close and the current price. |
+| %Debt | Percentage of this investment that is invested in debt. |
+| %Equity | Percentage of this investment that is invested in shares (equity). |
+| %Gain | The percentage of profit or loss on an investment based on its cost. |
+| %Other | The percentage of this investment that is invested in assets other than equities, debt, or cash. |
+| 52-Week High | The highest price at which a security traded over the past 52 weeks. |
+| 52-Week Low | The lowest price at which a security traded over the past 52 weeks. |
+| Ask | The price at which a holder of an investment is willing to sell a specific quantity. |
+| Average Cost | The average cost per share, including commissions, that you paid for this security. |
+| Beta | The measure of an investment's volatility relative to the rest of the stock market. Shares with a beta higher than 1 are more volatile than the S&P Stock Index. |
+| Bid | The price at which a buyer of an investment is willing to purchase a specific quantity. |
+| Bond Type* | Type of bond, such as corporate bond, municipal bond, Treasury Bill or zero coupon bond. |
+| Call Date* | Date upon which a bond may be redeemed (called) before maturity. |
+| Cash | The amount of this investment that is invested in cash. |
+| Change | Per share difference between the preceding day's close and the most recent price. |
+| Close | The last price at which a security traded on the previous trading day. |
+| Commissions | The total brokerage fees you paid to buy or sell an investment. |
+| Cost Basis | The total cost, including commissions and fees, of all shares of an investment. |
+| Coupon | The interest rate of a bond. |
+| Credit Rating* | Bond ratings based on the bond issue's credit history and ability to repay its obligations, assigned by rating agencies such as Standard & Poor's and Moody's. |
+| Currency* | The currency on which the information displayed is based. |
+| Current Yield | Annual interest paid on a bond divided by the current market price. |
+| Debt | The amount of this investment that is invested in debt. |
+| Dividend Yield (Rate) | Percentage of the current market value of an investment that is paid in dividends. Annual dividends divided by current market price. |
+| EPS | Earnings per Share. Ratio of a company's net after-tax income divided by the number of common shares outstanding. |
+| Equity | The amount of this investment that is invested in stocks (equity). |
+| Exchange Rate | Currency exchange rate for this investment. |
+| Expiration Date* | Last day on which an option can be exercised. |
+| Forward PE | Current price per share divided by the earnings per share. |
+| Gain | Your gain or loss on this security before capital gains tax. Current market value plus income, minus cost basis. |
+| High (Day High) | The highest price at which a security traded during the current day. |
+| Income | Interest, dividends and capital gains distributions you have received for an investment. |
+| Last Price | The most recent price at which the security traded. |
+| Last Transaction Date* | The last date the investment was traded. |
+| Last Updated* | The time an online price was provided (prices are delayed at least 20 minutes). |
+| Low (Day Low) | The lowest price at which a security traded during the current day. |
+| Market Capitalization | The current value of a corporation. The current market price of one share multiplied by the number of common shares outstanding. |
+| Market Value | Market value of your investment at the last price. |
+| Maturity Date* | The date when the bond must be repaid; the face amount, regardless of what was paid at issue. |
+| Name* | The name of the investment. |
+| News* | Recent news available on this investment. |
+| Open | The first price at which a security traded on the current trading day. |
+| Open Interest | Number of contracts outstanding on the underlying security. |
+| Other | The amount of this investment that is invested in assets other than equities, debt, or cash. |
+| PE Ratio | Price to earnings ratio. Current price per share divided by the last 12 months' Earnings per Share (EPS). Also known as the multiple. |
+| Price Appreciation | Your gain or loss on this security due to price fluctuations. Current market value minus cost basis. |
+| Purchases | The cost of your total purchases (excluding reinvested income) of this investment, including shares you have since sold. |
+| Quantity | The number of shares you hold of a given security. |
+| Realized Gains | The gain from shares actually sold. Does not include the increase in value of shares you still hold. |
+| Reinvestments | The total reinvested income for this investment. |
+| Risk Category* | Category of risk for this investment compared to the rest of the stock market: Low Risk, Medium Risk, or High Risk. |
+| Sales | The total sales you have made for this investment. |
+| Shares Outstanding | The total number of a company's publicly traded shares. |
+| Size of Last Sale | The number of shares traded in the most recent transaction made by anyone for this investment. |
+| Strike Price | Price at which stocks underlying a call or put option can be purchased or sold. |
+| Symbol* | Company ticker symbol. |
+| Today's Total Change | Your gain or loss on this investment today. The difference between the previous day's closing price and the most recent price, multiplied by your number of shares. |
+| Total Annualized Return | Annual percentage return on investment. Returns for short-term investments are projected to one year; returns for long-term investments are averaged to one year. |
+| Total Return - 1 Week | One-week percentage return on investment. Current market value plus income, minus beginning market value, divided by beginning market value. |
+| Total Return - 1 Year | One-year percentage return on investment. Current market value plus income, minus beginning market value, divided by beginning market value. |
+| Total Return - 3 Month | Three-month percentage return on investment. Current market value plus income, minus beginning market value, divided by beginning market value. |
+| Total Return - 3 Year | Three-year percentage return on investment. Current market value plus income, minus beginning market value, divided by beginning market value. |
+| Total Return - 4 Weeks | Four-week percentage return on investment. Current market value plus income, minus beginning market value, divided by beginning market value. |
+| Total Return - All Dates | Percentage return on investment across all dates. Current market value plus income, minus beginning market value, divided by beginning market value. |
+| Total Return - YTD | Year-to-date percentage return on investment. Current market value plus income, minus beginning market value, divided by beginning market value. |
+| Type* | Type of investment, such as stocks, unit trust, bond, cash, or index fund. |
+| Volume | The total units of an investment traded on the most recent trading day. |
+| Yield to Maturity | Rate of return yielded by a debt security held to maturity. Includes interest payments and capital gain or loss. |
+
+---
+
+*Source: [moneymvps.org/articles/portfolio_columns.aspx](http://moneymvps.org/articles/portfolio_columns.aspx)*


### PR DESCRIPTION
## Summary
Changes the default chart visualization for net worth data from area/line charts to bar charts across the dashboard and reports. Updates the NetWorthChart component to use a bar chart with value labels, and changes the NetWorthReport default view to bar with conditional label visibility based on date range.

## Key Changes

- **Dashboard NetWorthChart**: Replaced AreaChart with BarChart, removed min/max reference dots, added abbreviated value labels above bars with proper formatting and rotation handling
- **NetWorthReport**: Changed default chart type from 'line' to 'bar', reordered chart type options to show 'bar' first
- **Label visibility logic**: Bar value labels only display for 1-year and 2-year ranges (where they remain legible); labels rotate vertically when more than 14 bars are present to prevent overlap
- **Chart styling**: Updated margins, grid rendering (vertical grid removed from bar chart), and tooltip cursor styling for better visual clarity
- **Tests**: Updated all chart type assertions from 'area-chart' to 'bar-chart', added new tests for label visibility across different date ranges, added test for abbreviated value label rendering

## Implementation Details

- Removed the `minMax` calculation logic that tracked min/max net worth points for reference dots (no longer needed with bar chart)
- Bar labels use `formatCurrencyLabel()` for abbreviated currency display (e.g., "$40K" instead of "$40000")
- Conditional rendering of `LabelList` component based on `showBarLabels` flag, with angle and text anchor adjustments for vertical orientation
- Chart margins dynamically adjust based on whether labels are shown and whether they're vertical (52px top for vertical labels, 22px for horizontal)
- All existing functionality (tooltips, legends, reference lines) preserved and working with bar chart

https://claude.ai/code/session_017gc39wMiVHWJpa2q5JFsbT