### PR TITLE
Improve net worth chart mobile scaling and label legibility

### DIFF
--- a/frontend/src/components/dashboard/NetWorthChart.test.tsx
+++ b/frontend/src/components/dashboard/NetWorthChart.test.tsx
@@ -15,9 +15,24 @@ vi.mock('recharts', () => ({
     <div data-testid="label-list">{formatter ? String(formatter(1000)) : ''}</div>
   ),
   XAxis: () => null,
-  YAxis: () => null,
+  YAxis: ({ domain }: any) => (
+    <div data-testid="y-axis" data-domain={JSON.stringify(domain)} />
+  ),
   Tooltip: () => null,
 }));
+
+function setMobile(isMobile: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: isMobile && query === '(max-width: 639px)',
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
 
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
@@ -33,6 +48,7 @@ vi.mock('@/lib/utils', () => ({
 describe('NetWorthChart', () => {
   beforeEach(() => {
     mockPush.mockClear();
+    setMobile(false);
   });
 
   it('renders loading state with title and pulse skeleton', () => {
@@ -143,6 +159,50 @@ describe('NetWorthChart', () => {
     render(<NetWorthChart data={data} isLoading={false} />);
     const currentEl = screen.getByText('$-3000');
     expect(currentEl.className).toContain('text-red');
+  });
+
+  it('anchors the Y-axis at 0 on non-mobile screens', () => {
+    setMobile(false);
+    const data = [
+      { month: '2024-01-01', netWorth: 500000 },
+      { month: '2024-06-01', netWorth: 520000 },
+    ] as any[];
+
+    render(<NetWorthChart data={data} isLoading={false} />);
+    // The anchored domain's lower bound is a function, which JSON.stringify
+    // drops to null, leaving [null, "auto"].
+    const domain = screen.getByTestId('y-axis').getAttribute('data-domain');
+    expect(domain).toBe('[null,"auto"]');
+  });
+
+  it('uses a tight Y-axis domain above 0 on mobile to surface differences', () => {
+    setMobile(true);
+    const data = [
+      { month: '2024-01-01', netWorth: 500000 },
+      { month: '2024-06-01', netWorth: 520000 },
+    ] as any[];
+
+    render(<NetWorthChart data={data} isLoading={false} />);
+    const domain = JSON.parse(
+      screen.getByTestId('y-axis').getAttribute('data-domain') as string,
+    );
+    // Lower bound is a concrete number padded below the minimum (not 0).
+    expect(typeof domain[0]).toBe('number');
+    expect(domain[0]).toBeGreaterThan(0);
+    expect(domain[0]).toBeLessThan(500000);
+    expect(domain[1]).toBe('auto');
+  });
+
+  it('falls back to the anchored domain on mobile when all values are equal', () => {
+    setMobile(true);
+    const data = [
+      { month: '2024-01-01', netWorth: 500000 },
+      { month: '2024-06-01', netWorth: 500000 },
+    ] as any[];
+
+    render(<NetWorthChart data={data} isLoading={false} />);
+    const domain = screen.getByTestId('y-axis').getAttribute('data-domain');
+    expect(domain).toBe('[null,"auto"]');
   });
 
   it('handles single data point correctly', () => {

--- a/frontend/src/components/dashboard/NetWorthChart.tsx
+++ b/frontend/src/components/dashboard/NetWorthChart.tsx
@@ -15,6 +15,9 @@ import { format } from 'date-fns';
 import { MonthlyNetWorth } from '@/types/net-worth';
 import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useIsMobile } from '@/hooks/useIsMobile';
+
+type YDomain = [number | ((dataMin: number) => number), number | 'auto'];
 
 function NetWorthTooltip({
   active,
@@ -46,6 +49,7 @@ interface NetWorthChartProps {
 
 export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
   const router = useRouter();
+  const isMobile = useIsMobile();
   const { formatCurrencyCompact: formatCurrency, formatCurrencyLabel } = useNumberFormat();
 
   const chartData = useMemo(() =>
@@ -64,6 +68,25 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
     const changePercent = initial !== 0 ? (change / Math.abs(initial)) * 100 : 0;
     return { current, change, changePercent };
   }, [chartData]);
+
+  // On larger screens anchor the axis at 0. On mobile the chart is short, so a
+  // 0-anchored axis flattens every bar to nearly the same height; use a tight
+  // domain padded below the minimum so month-to-month differences are visible.
+  const yAxisDomain = useMemo<YDomain>(() => {
+    const anchoredAtZero: YDomain = [(min: number) => Math.min(0, min), 'auto'];
+    if (!isMobile || chartData.length === 0) return anchoredAtZero;
+
+    const values = chartData.map((d) => d.netWorth);
+    const minValue = Math.min(...values);
+    const maxValue = Math.max(...values);
+    const range = maxValue - minValue;
+    if (range === 0) return anchoredAtZero;
+
+    const rawMin = minValue - range * 0.15;
+    const magnitude = Math.pow(10, Math.floor(Math.log10(Math.abs(rawMin) || 1)));
+    const niceMin = Math.floor(rawMin / magnitude) * magnitude;
+    return [niceMin, 'auto'];
+  }, [chartData, isMobile]);
 
   if (isLoading) {
     return (
@@ -126,7 +149,7 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
       <div className="h-80">
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           <BarChart data={chartData} margin={{ top: 52, right: 12, left: 12, bottom: 0 }}>
-            <YAxis hide domain={[(min: number) => Math.min(0, min), 'auto']} />
+            <YAxis hide domain={yAxisDomain} />
             <XAxis
               dataKey="name"
               tick={{ fill: '#6b7280', fontSize: 11 }}

--- a/frontend/src/components/reports/NetWorthReport.test.tsx
+++ b/frontend/src/components/reports/NetWorthReport.test.tsx
@@ -57,8 +57,8 @@ vi.mock('recharts', () => ({
   BarChart: ({ children }: any) => <div data-testid="bar-chart">{children}</div>,
   Area: () => null,
   Bar: ({ children }: any) => <div data-testid="bar">{children}</div>,
-  LabelList: ({ formatter }: any) => (
-    <div data-testid="label-list">{formatter ? String(formatter(1000)) : ''}</div>
+  LabelList: ({ formatter, angle }: any) => (
+    <div data-testid="label-list" data-angle={angle}>{formatter ? String(formatter(1000)) : ''}</div>
   ),
   XAxis: ({ tickFormatter }: any) => {
     if (tickFormatter) {
@@ -81,6 +81,19 @@ vi.mock('recharts', () => ({
   ReferenceLine: () => null,
   ReferenceDot: () => null,
 }));
+
+function setMobile(isMobile: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: isMobile && query === '(max-width: 639px)',
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
 
 const mockGetMonthly = vi.fn();
 const mockRecalculate = vi.fn();
@@ -105,6 +118,7 @@ describe('NetWorthReport', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     dateRangeMock.value = '1y';
+    setMobile(false);
   });
 
   it('shows loading state initially', () => {
@@ -237,6 +251,34 @@ describe('NetWorthReport', () => {
       expect(screen.getByText('Current Net Worth')).toBeInTheDocument();
     });
     expect(screen.getByTestId('label-list')).toBeInTheDocument();
+  });
+
+  it('keeps 1-year bar labels horizontal on non-mobile screens', async () => {
+    dateRangeMock.value = '1y';
+    setMobile(false);
+    mockGetMonthly.mockResolvedValue([
+      { month: '2024-01-01', assets: 50000, liabilities: 10000, netWorth: 40000 },
+      { month: '2024-06-01', assets: 55000, liabilities: 9000, netWorth: 46000 },
+    ]);
+    render(<NetWorthReport />);
+    await waitFor(() => {
+      expect(screen.getByText('Current Net Worth')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('label-list')).toHaveAttribute('data-angle', '0');
+  });
+
+  it('rotates 1-year bar labels vertical on mobile', async () => {
+    dateRangeMock.value = '1y';
+    setMobile(true);
+    mockGetMonthly.mockResolvedValue([
+      { month: '2024-01-01', assets: 50000, liabilities: 10000, netWorth: 40000 },
+      { month: '2024-06-01', assets: 55000, liabilities: 9000, netWorth: 46000 },
+    ]);
+    render(<NetWorthReport />);
+    await waitFor(() => {
+      expect(screen.getByText('Current Net Worth')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('label-list')).toHaveAttribute('data-angle', '-90');
   });
 
   it('shows abbreviated value labels above bars for the 2-year range', async () => {

--- a/frontend/src/components/reports/NetWorthReport.tsx
+++ b/frontend/src/components/reports/NetWorthReport.tsx
@@ -22,6 +22,7 @@ import { MonthlyNetWorth } from '@/types/net-worth';
 import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useDateRange } from '@/hooks/useDateRange';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
@@ -36,6 +37,7 @@ type NetWorthSortField = 'name' | 'assets' | 'liabilities' | 'netWorth';
 
 export function NetWorthReport() {
   const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis, formatCurrencyLabel } = useNumberFormat();
+  const isMobile = useIsMobile();
   const [monthlyData, setMonthlyData] = useState<MonthlyNetWorth[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isRecalculating, setIsRecalculating] = useState(false);
@@ -202,9 +204,10 @@ export function NetWorthReport() {
 
   // Per-bar value labels are only legible on the shorter (1y/2y) ranges; longer
   // ranges pack too many bars together. Beyond ~14 bars the labels are rotated
-  // vertical so the 2-year view doesn't overlap.
+  // vertical so the 2-year view doesn't overlap. On mobile the bars are narrow
+  // enough that even the 12-bar 1-year view needs vertical labels.
   const showBarLabels = dateRange === '1y' || dateRange === '2y';
-  const barLabelsVertical = showBarLabels && chartData.length > 14;
+  const barLabelsVertical = showBarLabels && (chartData.length > 14 || isMobile);
 
   const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: Array<{ name: string; value: number; color: string; payload: { name: string } }> }) => {
     if (active && payload && payload.length) {


### PR DESCRIPTION
On mobile the dashboard Net Worth widget now uses a tight Y-axis domain
padded below the minimum instead of anchoring at 0, so month-to-month
differences are visible in the limited vertical space. The full net
worth report rotates the per-bar value labels vertical on mobile for the
1-year range to avoid overlap.

https://claude.ai/code/session_011LEgHAM5BjNX5RLyhxBdaw