### PR TITLE
Remove max-width constraints from report viewer pages

### DIFF
--- a/frontend/src/app/reports/custom/[id]/page.tsx
+++ b/frontend/src/app/reports/custom/[id]/page.tsx
@@ -15,7 +15,7 @@ export default function ViewCustomReportPage({ params }: PageProps) {
   return (
     <ProtectedRoute>
       <PageLayout>
-        <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-8">
+        <main className="px-4 sm:px-6 lg:px-8 pt-6 pb-8">
           <CustomReportViewer reportId={id} />
         </main>
       </PageLayout>

--- a/frontend/src/app/reports/investment/[id]/page.tsx
+++ b/frontend/src/app/reports/investment/[id]/page.tsx
@@ -15,7 +15,7 @@ export default function ViewInvestmentReportPage({ params }: PageProps) {
   return (
     <ProtectedRoute>
       <PageLayout>
-        <main className="max-w-[1800px] mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-8">
+        <main className="px-4 sm:px-6 lg:px-8 pt-6 pb-8">
           <InvestmentReportViewer reportId={id} />
         </main>
       </PageLayout>


### PR DESCRIPTION
## Summary
Removes fixed max-width constraints from the main container of custom and investment report viewer pages, allowing them to use the full available width within the responsive padding.

## Changes
- **Custom Report Page**: Removed `max-w-7xl mx-auto` from main element, keeping responsive padding (`px-4 sm:px-6 lg:px-8`)
- **Investment Report Page**: Removed `max-w-[1800px] mx-auto` from main element, keeping responsive padding (`px-4 sm:px-6 lg:px-8`)

## Details
Both report viewers previously had explicit max-width constraints that limited their horizontal expansion. This change allows the report content to scale more flexibly based on the viewport and parent container, while maintaining proper responsive padding at smaller screen sizes. The `PageLayout` wrapper likely provides any necessary outer constraints if needed.

https://claude.ai/code/session_013dnaCCcRAJSF3Wya7HaUHj