### PR TITLE
Upgrade actions/cache to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
         run: npm ci
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-firefox-${{ runner.os }}-${{ hashFiles('e2e/package-lock.json') }}


### PR DESCRIPTION
## Summary
Updates the GitHub Actions cache action from v4 to v5 in the CI workflow for Playwright browser caching.

## Changes
- Upgraded `actions/cache` from v4 to v5 in the e2e Playwright browser caching step

## Details
This is a routine dependency update for the CI/CD pipeline. The v5 release of `actions/cache` includes performance improvements and bug fixes. The cache configuration remains unchanged—it continues to cache Playwright browsers at `~/.cache/ms-playwright` using the e2e package-lock.json as the cache key.

https://claude.ai/code/session_01SsMtRm9Lhu8CqdB4fedtQ7