### PR TITLE
Apply tight Y-axis domain to all screen sizes in NetWorthChart

### DIFF
--- a/frontend/src/components/dashboard/NetWorthChart.test.tsx
+++ b/frontend/src/components/dashboard/NetWorthChart.test.tsx
@@ -161,7 +161,7 @@ describe('NetWorthChart', () => {
     expect(currentEl.className).toContain('text-red');
   });
 
-  it('anchors the Y-axis at 0 on non-mobile screens', () => {
+  it('uses a tight Y-axis domain above 0 on desktop to surface differences', () => {
     setMobile(false);
     const data = [
       { month: '2024-01-01', netWorth: 500000 },
@@ -169,10 +169,14 @@ describe('NetWorthChart', () => {
     ] as any[];
 
     render(<NetWorthChart data={data} isLoading={false} />);
-    // The anchored domain's lower bound is a function, which JSON.stringify
-    // drops to null, leaving [null, "auto"].
-    const domain = screen.getByTestId('y-axis').getAttribute('data-domain');
-    expect(domain).toBe('[null,"auto"]');
+    const domain = JSON.parse(
+      screen.getByTestId('y-axis').getAttribute('data-domain') as string,
+    );
+    // Lower bound is a concrete number padded below the minimum (not 0).
+    expect(typeof domain[0]).toBe('number');
+    expect(domain[0]).toBeGreaterThan(0);
+    expect(domain[0]).toBeLessThan(500000);
+    expect(domain[1]).toBe('auto');
   });
 
   it('uses a tight Y-axis domain above 0 on mobile to surface differences', () => {
@@ -193,8 +197,7 @@ describe('NetWorthChart', () => {
     expect(domain[1]).toBe('auto');
   });
 
-  it('falls back to the anchored domain on mobile when all values are equal', () => {
-    setMobile(true);
+  it('falls back to the anchored domain when all values are equal', () => {
     const data = [
       { month: '2024-01-01', netWorth: 500000 },
       { month: '2024-06-01', netWorth: 500000 },

--- a/frontend/src/components/dashboard/NetWorthChart.tsx
+++ b/frontend/src/components/dashboard/NetWorthChart.tsx
@@ -15,7 +15,6 @@ import { format } from 'date-fns';
 import { MonthlyNetWorth } from '@/types/net-worth';
 import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
-import { useIsMobile } from '@/hooks/useIsMobile';
 
 type YDomain = [number | ((dataMin: number) => number), number | 'auto'];
 
@@ -49,7 +48,6 @@ interface NetWorthChartProps {
 
 export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
   const router = useRouter();
-  const isMobile = useIsMobile();
   const { formatCurrencyCompact: formatCurrency, formatCurrencyLabel } = useNumberFormat();
 
   const chartData = useMemo(() =>
@@ -69,12 +67,11 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
     return { current, change, changePercent };
   }, [chartData]);
 
-  // On larger screens anchor the axis at 0. On mobile the chart is short, so a
-  // 0-anchored axis flattens every bar to nearly the same height; use a tight
+  // A 0-anchored axis flattens every bar to nearly the same height; use a tight
   // domain padded below the minimum so month-to-month differences are visible.
   const yAxisDomain = useMemo<YDomain>(() => {
     const anchoredAtZero: YDomain = [(min: number) => Math.min(0, min), 'auto'];
-    if (!isMobile || chartData.length === 0) return anchoredAtZero;
+    if (chartData.length === 0) return anchoredAtZero;
 
     const values = chartData.map((d) => d.netWorth);
     const minValue = Math.min(...values);
@@ -86,7 +83,7 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
     const magnitude = Math.pow(10, Math.floor(Math.log10(Math.abs(rawMin) || 1)));
     const niceMin = Math.floor(rawMin / magnitude) * magnitude;
     return [niceMin, 'auto'];
-  }, [chartData, isMobile]);
+  }, [chartData]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
Removes mobile-specific logic from the NetWorthChart Y-axis domain calculation, applying the tight domain (padded below minimum) consistently across all screen sizes instead of only on mobile.

## Changes
- **Removed `useIsMobile` hook** from NetWorthChart component — no longer needed to conditionally apply axis behavior
- **Unified Y-axis domain logic** to always use tight domain padding for non-empty data, regardless of screen size
- **Updated test expectations**:
  - Changed desktop test from expecting anchored-at-zero domain to expecting tight domain with concrete lower bound
  - Removed mobile-specific condition from fallback test (now applies to all sizes when data values are equal)
  - Updated test assertions to verify the lower bound is a concrete number between 0 and the minimum value

## Implementation Details
The tight domain approach (padding below the minimum value rather than anchoring at 0) surfaces month-to-month differences better across all screen sizes. The previous logic only applied this on mobile due to space constraints, but the improved visualization benefits all users. The fallback to anchored-at-zero domain still applies when all data values are equal (no variance to display).

https://claude.ai/code/session_019RCMNhCbYekpSotUsSARMV