### PR TITLE
fix: code-review findings in emergency access + investment reports

### DIFF
--- a/backend/src/emergency-access/emergency-access-claim.controller.spec.ts
+++ b/backend/src/emergency-access/emergency-access-claim.controller.spec.ts
@@ -38,7 +38,18 @@ describe("EmergencyAccessClaimController", () => {
   const TOKEN_HASH = hashToken(RAW_TOKEN);
 
   beforeEach(async () => {
-    contactsRepo = { findOne: jest.fn() };
+    contactsRepo = {
+      // complete() now pre-validates the link via contactsRepo.findOne before
+      // any expensive work; default to a valid contact so the existing
+      // transaction-path tests reach the in-transaction re-validation.
+      findOne: jest.fn().mockResolvedValue({
+        id: "c1",
+        ownerUserId: ownerId,
+        claimTokenHash: TOKEN_HASH,
+        claimTokenExpiresAt: new Date(Date.now() + 100000),
+        claimTokenUsedAt: null,
+      }),
+    };
     settingsRepo = { findOne: jest.fn() };
     usersRepo = { findOne: jest.fn() };
     tokenService = {
@@ -166,6 +177,21 @@ describe("EmergencyAccessClaimController", () => {
           res as never,
         ),
       ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it("rejects an invalid token before running the breach check", async () => {
+      // Unauthenticated callers must not be able to trigger the HIBP lookup
+      // or a bcrypt hash with a bogus token.
+      contactsRepo.findOne.mockResolvedValue(null);
+      const res = makeRes();
+      await expect(
+        controller.complete(
+          { token: RAW_TOKEN, newPassword: "Aa1!correcthorse" },
+          res as never,
+        ),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(passwordBreach.isBreached).not.toHaveBeenCalled();
+      expect(dataSource.createQueryRunner).not.toHaveBeenCalled();
     });
 
     it("replaces credentials, voids sibling tokens, and signs in", async () => {

--- a/backend/src/emergency-access/emergency-access-claim.controller.ts
+++ b/backend/src/emergency-access/emergency-access-claim.controller.ts
@@ -129,6 +129,12 @@ export class EmergencyAccessClaimController {
       "Consume the magic link, replace the owner's password, and sign in",
   })
   async complete(@Body() dto: ClaimCompleteDto, @Res() res: Response) {
+    // Validate the magic link before doing any expensive work. Otherwise an
+    // unauthenticated caller could force a breach lookup and a bcrypt hash
+    // (cost 12) on every request with a bogus token. The transaction below
+    // re-validates under lock to close the TOCTOU window.
+    await this.findValidContact(dto.token);
+
     const isBreached = await this.passwordBreachService.isBreached(
       dto.newPassword,
     );

--- a/backend/src/emergency-access/emergency-access-monitor.service.spec.ts
+++ b/backend/src/emergency-access/emergency-access-monitor.service.spec.ts
@@ -31,6 +31,13 @@ describe("EmergencyAccessMonitorService", () => {
     contactsRepo = {
       find: jest.fn().mockResolvedValue([]),
       save: jest.fn(async (row) => row),
+      createQueryBuilder: jest.fn(() => ({
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ affected: 1 }),
+      })),
     };
     usersRepo = { findOne: jest.fn() };
     emailService = {
@@ -562,5 +569,79 @@ describe("EmergencyAccessMonitorService", () => {
     await service.runDailyCheck();
     expect(emailService.sendMail).toHaveBeenCalledTimes(1);
     expect(emailService.sendMail.mock.calls[0][0]).toBe("two@example.com");
+  });
+
+  it("does not commit the grant when every contact email fails to send", async () => {
+    const settings = {
+      ownerUserId: userId,
+      enabled: true,
+      grantAfterDays: 14,
+      reminderAfterDays: 7,
+      messageCiphertext: null,
+      lastReminderSentAt: null,
+      grantedAt: null,
+    };
+    settingsRepo.find.mockResolvedValue([settings]);
+    usersRepo.findOne.mockResolvedValue({
+      id: userId,
+      email: "owner@example.com",
+      firstName: "Owner",
+      isActive: true,
+      lastActivityAt: daysAgo(20),
+    });
+    contactsRepo.find.mockResolvedValue([
+      { id: "c1", firstName: "Carol", email: "carol@example.com" },
+      { id: "c2", firstName: "Dave", email: "dave@example.com" },
+    ]);
+    emailService.sendMail.mockRejectedValue(new Error("smtp down"));
+
+    await service.runDailyCheck();
+
+    // Both sends attempted, but grantedAt must stay null so the next daily
+    // run retries instead of permanently disabling the safeguard.
+    expect(emailService.sendMail).toHaveBeenCalledTimes(2);
+    expect(settings.grantedAt).toBeNull();
+    expect(settingsRepo.save).not.toHaveBeenCalled();
+  });
+
+  it("voids outstanding links and notifies the owner when they return after a grant", async () => {
+    const settings = {
+      ownerUserId: userId,
+      enabled: true,
+      grantAfterDays: 14,
+      reminderAfterDays: 7,
+      messageCiphertext: null,
+      lastReminderSentAt: daysAgo(8),
+      grantedAt: daysAgo(3),
+    };
+    settingsRepo.find.mockResolvedValue([settings]);
+    usersRepo.findOne.mockResolvedValue({
+      id: userId,
+      email: "owner@example.com",
+      firstName: "Owner",
+      isActive: true,
+      // Active again: well under the 14-day grant threshold.
+      lastActivityAt: daysAgo(1),
+    });
+    const execute = jest.fn().mockResolvedValue({ affected: 2 });
+    contactsRepo.createQueryBuilder.mockReturnValue({
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      execute,
+    });
+
+    await service.runDailyCheck();
+
+    // Outstanding links voided, grant state re-armed, owner emailed.
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(settings.grantedAt).toBeNull();
+    expect(settings.lastReminderSentAt).toBeNull();
+    expect(settingsRepo.save).toHaveBeenCalledWith(settings);
+    expect(emailService.sendMail).toHaveBeenCalledTimes(1);
+    const [to, subject] = emailService.sendMail.mock.calls[0];
+    expect(to).toBe("owner@example.com");
+    expect(subject).toContain("while you were away");
   });
 });

--- a/backend/src/emergency-access/emergency-access-monitor.service.ts
+++ b/backend/src/emergency-access/emergency-access-monitor.service.ts
@@ -10,6 +10,7 @@ import { AiEncryptionService } from "../ai/ai-encryption.service";
 import { EmailService } from "../notifications/email.service";
 import {
   emergencyAccessGrantTemplate,
+  emergencyAccessGrantRevokedTemplate,
   emergencyAccessReminderTemplate,
 } from "../notifications/email-templates";
 import { hashToken } from "../auth/crypto.util";
@@ -99,6 +100,18 @@ export class EmergencyAccessMonitorService {
     const now = Date.now();
     const daysSinceLogin = Math.floor((now - lastSeen.getTime()) / MS_PER_DAY);
 
+    // Step 0: the owner is active again after a grant fired. Revoke the
+    // outstanding (unclaimed) magic links, re-arm monitoring, and tell the
+    // owner. Without this, a contact could take over a fully-active account
+    // for the entire 30-day link lifetime after the owner returned.
+    if (
+      settings.grantedAt !== null &&
+      daysSinceLogin < settings.grantAfterDays
+    ) {
+      await this.revokeAfterReturn(settings, owner, appUrl);
+      return "skipped";
+    }
+
     // Step 1: grant cascade (only if not already granted)
     if (
       settings.grantedAt === null &&
@@ -117,6 +130,7 @@ export class EmergencyAccessMonitorService {
         owner.email;
       const expiresAt = new Date(now + CLAIM_TOKEN_TTL_DAYS * MS_PER_DAY);
 
+      let delivered = 0;
       for (const contact of contacts) {
         try {
           const rawToken = crypto
@@ -141,12 +155,23 @@ export class EmergencyAccessMonitorService {
             `You have been granted emergency access to ${ownerFullName}'s Monize account`,
             html,
           );
+          delivered += 1;
         } catch (error) {
           this.logger.error(
             `Failed to issue emergency access grant for contact ${contact.id}`,
             error instanceof Error ? error.stack : error,
           );
         }
+      }
+
+      // Only commit the grant if at least one contact actually received a
+      // link. Otherwise leave grantedAt null so the next run retries -- a
+      // transient SMTP failure must not permanently disable the safeguard.
+      if (delivered === 0) {
+        this.logger.error(
+          `Emergency access grant for user ${settings.ownerUserId} delivered no contact emails; leaving grant un-set for retry`,
+        );
+        return "skipped";
       }
 
       settings.grantedAt = new Date(now);
@@ -199,6 +224,59 @@ export class EmergencyAccessMonitorService {
     }
 
     return "skipped";
+  }
+
+  /**
+   * The owner signed back in after a grant had fired. Void every outstanding
+   * (unclaimed) magic link, clear the grant marker so monitoring re-arms, and
+   * notify the owner that access had been granted in their absence.
+   */
+  private async revokeAfterReturn(
+    settings: EmergencyAccessSettings,
+    owner: User,
+    appUrl: string,
+  ): Promise<void> {
+    const result = await this.contactsRepo
+      .createQueryBuilder()
+      .update(EmergencyAccessContact)
+      .set({
+        claimTokenHash: null,
+        claimTokenExpiresAt: null,
+        claimTokenUsedAt: () => "CURRENT_TIMESTAMP",
+        claimVoidedReason: "owner_returned",
+      })
+      .where("owner_user_id = :userId", { userId: settings.ownerUserId })
+      .andWhere("claim_token_hash IS NOT NULL")
+      .andWhere("claim_token_used_at IS NULL")
+      .execute();
+
+    settings.grantedAt = null;
+    settings.lastReminderSentAt = null;
+    await this.settingsRepo.save(settings);
+
+    this.logger.warn(
+      `Owner ${settings.ownerUserId} active again after a grant; voided ${
+        result.affected ?? 0
+      } outstanding emergency-access link(s) and re-armed monitoring`,
+    );
+
+    if (!owner.email) return;
+    try {
+      const html = emergencyAccessGrantRevokedTemplate({
+        ownerFirstName: owner.firstName || "",
+        appUrl,
+      });
+      await this.emailService.sendMail(
+        owner.email,
+        "Monize: emergency access was granted while you were away",
+        html,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to send emergency-access revocation notice to owner ${settings.ownerUserId}`,
+        error instanceof Error ? error.stack : error,
+      );
+    }
   }
 
   private tryDecrypt(ciphertext: string): string | null {

--- a/backend/src/investment-reports/investment-report-data.service.spec.ts
+++ b/backend/src/investment-reports/investment-report-data.service.spec.ts
@@ -1,5 +1,7 @@
 import { InvestmentReportDataService } from "./investment-report-data.service";
 import { InvestmentAction } from "../securities/entities/investment-transaction.entity";
+import { requestContextStorage } from "../common/request-context";
+import { todayInTimezone, todayYMD } from "../common/date-utils";
 
 function makeTx(overrides: Record<string, unknown>): any {
   return {
@@ -400,8 +402,7 @@ describe("InvestmentReportDataService", () => {
 
   describe("getLatestMarketDay", () => {
     it("returns today when there are no accounts", async () => {
-      const today = new Date().toISOString().slice(0, 10);
-      expect(await service.getLatestMarketDay("u1", [])).toBe(today);
+      expect(await service.getLatestMarketDay("u1", [])).toBe(todayYMD());
     });
 
     it("returns the max stored price date", async () => {
@@ -410,9 +411,19 @@ describe("InvestmentReportDataService", () => {
     });
 
     it("falls back to today when no prices exist", async () => {
-      const today = new Date().toISOString().slice(0, 10);
       txRepository.query.mockResolvedValue([{ d: null }]);
-      expect(await service.getLatestMarketDay("u1", ["acc1"])).toBe(today);
+      expect(await service.getLatestMarketDay("u1", ["acc1"])).toBe(todayYMD());
+    });
+
+    it("uses the request-context timezone for the today fallback, not UTC", async () => {
+      // Kiritimata (UTC+14) is far enough that 'today' there can differ from
+      // the UTC date; the default must follow the caller's local day.
+      const tz = "Pacific/Kiritimati";
+      await requestContextStorage.run({ timezone: tz }, async () => {
+        expect(await service.getLatestMarketDay("u1", [])).toBe(
+          todayInTimezone(tz),
+        );
+      });
     });
   });
 });

--- a/backend/src/investment-reports/investment-report-data.service.ts
+++ b/backend/src/investment-reports/investment-report-data.service.ts
@@ -10,6 +10,7 @@ import {
 import { Account } from "../accounts/entities/account.entity";
 import { ExchangeRateService } from "../currencies/exchange-rate.service";
 import { InvestmentCellValue } from "./dto/execute-investment-report.dto";
+import { todayYMD } from "../common/date-utils";
 
 /** One computed holding row plus the fields needed to group it. */
 export interface ComputedHolding {
@@ -157,7 +158,10 @@ export class InvestmentReportDataService {
     userId: string,
     accountIds: string[],
   ): Promise<string> {
-    const today = new Date().toISOString().slice(0, 10);
+    // "Today" in the caller's timezone (RequestContext), not UTC -- otherwise
+    // the default as-of date can land a day off near midnight in the user's
+    // local time and replay the wrong set of transactions.
+    const today = todayYMD();
     if (accountIds.length === 0) return today;
     const rows: { d: string | null }[] = await this.txRepository.query(
       `SELECT MAX(sp.price_date)::text AS d

--- a/backend/src/investment-reports/investment-reports.service.spec.ts
+++ b/backend/src/investment-reports/investment-reports.service.spec.ts
@@ -196,6 +196,49 @@ describe("InvestmentReportsService", () => {
       expect(saved.config.columns).toEqual(["gain", "symbol"]);
       expect(saved.config.sortColumn).toBe("gain");
     });
+
+    it("preserves existing accountIds/sortColumn/asOfDate when the update omits them", async () => {
+      reportsRepository.findOne.mockResolvedValue({
+        id: "r1",
+        userId: "u1",
+        config: {
+          columns: ["symbol"],
+          accountIds: ["a1", "a2"],
+          sortColumn: "marketValue",
+          sortDirection: InvestmentSortDirection.DESC,
+          asOfDate: "2024-01-01",
+          mergeAccounts: true,
+        },
+      });
+      const saved = await service.update("u1", "r1", {
+        config: { columns: ["symbol", "gain"] } as any,
+      });
+      expect(saved.config.accountIds).toEqual(["a1", "a2"]);
+      expect(saved.config.sortColumn).toBe("marketValue");
+      expect(saved.config.sortDirection).toBe(InvestmentSortDirection.DESC);
+      expect(saved.config.asOfDate).toBe("2024-01-01");
+      expect(saved.config.mergeAccounts).toBe(true);
+    });
+
+    it("clears sortColumn/asOfDate when the update sends an explicit null", async () => {
+      reportsRepository.findOne.mockResolvedValue({
+        id: "r1",
+        userId: "u1",
+        config: {
+          columns: ["symbol"],
+          accountIds: ["a1"],
+          sortColumn: "gain",
+          asOfDate: "2024-01-01",
+        },
+      });
+      const saved = await service.update("u1", "r1", {
+        config: { columns: ["symbol"], sortColumn: null, asOfDate: null } as any,
+      });
+      expect(saved.config.sortColumn).toBeNull();
+      expect(saved.config.asOfDate).toBeNull();
+      // accountIds was omitted (undefined), so it stays as-is.
+      expect(saved.config.accountIds).toEqual(["a1"]);
+    });
   });
 
   describe("remove", () => {

--- a/backend/src/investment-reports/investment-reports.service.ts
+++ b/backend/src/investment-reports/investment-reports.service.ts
@@ -209,12 +209,27 @@ export class InvestmentReportsService {
     dto: CreateInvestmentReportDto["config"],
     existing?: InvestmentReportConfig,
   ): InvestmentReportConfig {
+    // On update, an absent field (undefined) keeps the existing value; an
+    // explicit null clears it. Using `??` would conflate the two and silently
+    // reset accountIds/sortColumn/asOfDate whenever a partial config is sent.
     return {
       columns: dto.columns ?? existing?.columns ?? [],
-      accountIds: dto.accountIds ?? [],
-      sortColumn: dto.sortColumn ?? null,
-      sortDirection: dto.sortDirection ?? InvestmentSortDirection.ASC,
-      asOfDate: dto.asOfDate ?? null,
+      accountIds:
+        dto.accountIds !== undefined
+          ? dto.accountIds
+          : (existing?.accountIds ?? []),
+      sortColumn:
+        dto.sortColumn !== undefined
+          ? dto.sortColumn
+          : (existing?.sortColumn ?? null),
+      sortDirection:
+        dto.sortDirection !== undefined
+          ? dto.sortDirection
+          : (existing?.sortDirection ?? InvestmentSortDirection.ASC),
+      asOfDate:
+        dto.asOfDate !== undefined
+          ? dto.asOfDate
+          : (existing?.asOfDate ?? null),
       mergeAccounts: dto.mergeAccounts ?? existing?.mergeAccounts ?? false,
     };
   }

--- a/backend/src/notifications/email-templates.spec.ts
+++ b/backend/src/notifications/email-templates.spec.ts
@@ -11,6 +11,7 @@ import {
   accountLockedTemplate,
   emergencyAccessReminderTemplate,
   emergencyAccessGrantTemplate,
+  emergencyAccessGrantRevokedTemplate,
 } from "./email-templates";
 
 describe("Email Templates", () => {
@@ -1084,6 +1085,37 @@ describe("Email Templates", () => {
     it("shows the expiry date in ISO-day form", () => {
       const html = emergencyAccessGrantTemplate(baseData);
       expect(html).toContain("2030-01-01");
+    });
+  });
+
+  describe("emergencyAccessGrantRevokedTemplate()", () => {
+    it("greets the owner and explains the links were revoked", () => {
+      const html = emergencyAccessGrantRevokedTemplate({
+        ownerFirstName: "Owner",
+        appUrl: "https://app.example.com",
+      });
+      expect(html).toContain("Hi Owner");
+      expect(html).toContain("revoked");
+      expect(html).toContain(
+        "https://app.example.com/settings/emergency-access",
+      );
+    });
+
+    it('falls back to "there" for a blank name', () => {
+      const html = emergencyAccessGrantRevokedTemplate({
+        ownerFirstName: "",
+        appUrl: "https://app.example.com",
+      });
+      expect(html).toContain("Hi there");
+    });
+
+    it("escapes HTML in the owner name", () => {
+      const html = emergencyAccessGrantRevokedTemplate({
+        ownerFirstName: "<img src=x onerror=alert(1)>",
+        appUrl: "https://app.example.com",
+      });
+      expect(html).not.toContain("<img src=x onerror=alert(1)>");
+      expect(html).toContain("&lt;img");
     });
   });
 });

--- a/backend/src/notifications/email-templates.ts
+++ b/backend/src/notifications/email-templates.ts
@@ -570,3 +570,26 @@ export function emergencyAccessGrantTemplate(
     </div>
   `;
 }
+
+interface EmergencyAccessGrantRevokedData {
+  ownerFirstName: string;
+  appUrl: string;
+}
+
+export function emergencyAccessGrantRevokedTemplate(
+  data: EmergencyAccessGrantRevokedData,
+): string {
+  const safeName = escapeHtml(data.ownerFirstName || "there");
+  return `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+      <h2 style="color: #b45309;">Emergency Access Was Granted While You Were Away</h2>
+      <p style="color: #374151;">Hi ${safeName},</p>
+      <p style="color: #374151;">Because your account had been inactive, your designated emergency contacts were sent links to take over your account. You have now signed back in, so <strong>those links have been revoked</strong> and the safeguard has been re-armed.</p>
+      <p style="color: #374151;">If this was expected, no action is needed. If you did not expect this, review your sign-in activity and your emergency-access settings.</p>
+      <p style="margin: 24px 0;">
+        <a href="${escapeHtml(data.appUrl)}/settings/emergency-access" style="display: inline-block; padding: 12px 24px; background: #2563eb; color: #ffffff; border-radius: 6px; text-decoration: none; font-weight: 500;">Review Emergency Access</a>
+      </p>
+      <p style="color: #6b7280; font-size: 14px; margin-top: 24px;">-- Monize</p>
+    </div>
+  `;
+}


### PR DESCRIPTION
Max-effort code review of the features shipped in 1.10.2 surfaced five correctness/security issues. Each is fixed with a unit test.

## Emergency access

1. **Grant silently dies on a transient SMTP failure.** The grant cascade set `grantedAt` unconditionally after the per-contact email loop, even if every send threw. Because later runs require `grantedAt === null`, the cron never retried -- no contact ever got a link and the safeguard was permanently disabled. Now `grantedAt` is committed only when at least one email was delivered.

2. **Account-takeover window after the owner returns.** Once a grant fired, the 30-day magic links stayed live with no owner notification. An owner who came back and resumed using the app could still be taken over by a contact (or anyone who got the emailed link) days/weeks later. New Step 0 in the daily check: when the owner is active again after a grant, void the outstanding unclaimed links (`owner_returned`), re-arm monitoring, and email the owner. Adds `emergencyAccessGrantRevokedTemplate` (HTML-escaped).
   - Note: this fires on the daily cron, so the window narrows to <= ~24h rather than closing instantly. A synchronous void on login would fully close it -- left for a follow-up.

3. **Unauthenticated work amplification on `/claim/complete`.** The HIBP breach lookup and `bcrypt.hash(cost 12)` ran before the claim token was validated, so a bogus token still forced that work (throttled 5/15min, but cheap to fix). Now the link is validated first; the in-transaction re-validation stays for TOCTOU.

## Investment reports

4. **Partial PATCH silently widened report scope.** `buildConfig` fell back to the existing config for `columns`/`mergeAccounts` but reset `accountIds`/`sortColumn`/`sortDirection`/`asOfDate` to defaults when omitted, so a partial config update reset the account filter to "all accounts" and dropped the sort/as-of date. Now uses `!== undefined` checks: absent keeps the existing value, explicit `null` clears.

5. **UTC off-by-one for the default as-of date.** `getLatestMarketDay` derived "today" from `new Date().toISOString()` (UTC), ignoring the request-timezone the rest of the app threads. Now uses the timezone-aware `todayYMD()`.

## Tests

Backend unit tests added for all five (monitor grant-all-fail + revoke-on-return, claim reject-before-breach, reports partial-config-preserves + explicit-null-clears, data-service tz-aware today, 3 cases for the revoked template). All affected suites pass (163 tests); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)