### PR TITLE
Add security transfer between accounts with cost basis preservation

### DIFF
--- a/backend/src/action-history/action-history.service.spec.ts
+++ b/backend/src/action-history/action-history.service.spec.ts
@@ -1029,6 +1029,48 @@ describe("ActionHistoryService", () => {
       expect(insertCalls.length).toBeGreaterThanOrEqual(2);
     });
 
+    it("reinserts idempotently, preserving exchange_rate and a null price", async () => {
+      const invAction = {
+        ...mockAction,
+        entityType: "investment_transaction",
+        action: "delete",
+        entityId: "inv-1",
+        beforeData: {
+          id: "inv-1",
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: "BUY",
+          transactionDate: "2024-01-15",
+          quantity: 10,
+          price: null,
+          commission: 0,
+          totalAmount: 1360,
+          exchangeRate: 1.36,
+        },
+        afterData: null,
+      };
+      mockRepository.findOne.mockResolvedValue(invAction);
+      mockQueryRunner.manager.update.mockResolvedValue({ affected: 1 });
+      mockQueryRunner.query.mockResolvedValue([]);
+
+      await service.undo(userId);
+
+      const insert = mockQueryRunner.query.mock.calls.find(
+        (call: any[]) =>
+          typeof call[0] === "string" &&
+          call[0].includes("INSERT INTO investment_transactions"),
+      );
+      expect(insert).toBeDefined();
+      // Idempotent on id collision (client retry / partial residue).
+      expect(insert![0]).toContain("ON CONFLICT (id) DO NOTHING");
+      expect(insert![0]).toContain("exchange_rate");
+      const params = insert![1] as unknown[];
+      // price (param 10) preserved as null, not coerced to 0.
+      expect(params[9]).toBeNull();
+      // exchange_rate (param 13) restored, not reset to 1.
+      expect(params[12]).toBe(1.36);
+    });
+
     it("should undo investment delete without linked cash transaction", async () => {
       const invAction = {
         ...mockAction,
@@ -1053,6 +1095,167 @@ describe("ActionHistoryService", () => {
       const result = await service.undo(userId);
 
       expect(result.description).toContain("Undone");
+    });
+
+    it("should undo a transfer create by removing both linked legs", async () => {
+      const invAction = {
+        ...mockAction,
+        entityType: "investment_transaction",
+        action: "create",
+        entityId: "inv-out",
+        afterData: {
+          id: "inv-out",
+          accountId: "acc-1",
+          linkedTransferLeg: { id: "inv-in", accountId: "acc-2" },
+        },
+      };
+      mockRepository.findOne.mockResolvedValue(invAction);
+
+      const outLeg = {
+        id: "inv-out",
+        userId,
+        accountId: "acc-1",
+        transactionId: null,
+        linkedTransactionId: "inv-in",
+      };
+      const inLeg = {
+        id: "inv-in",
+        userId,
+        accountId: "acc-2",
+        transactionId: null,
+        linkedTransactionId: "inv-out",
+      };
+      mockQueryRunner.manager.findOne
+        .mockResolvedValueOnce(outLeg) // entity lookup
+        .mockResolvedValueOnce(inLeg); // linked leg lookup
+      mockQueryRunner.manager.remove.mockResolvedValue(undefined);
+      mockQueryRunner.manager.update.mockResolvedValue({ affected: 1 });
+      mockQueryRunner.query.mockResolvedValue([]);
+
+      const result = await service.undo(userId);
+
+      expect(result.description).toContain("Undone");
+      // Both legs removed so holdings can't be left half-moved.
+      expect(mockQueryRunner.manager.remove).toHaveBeenCalledTimes(2);
+      // Both legs unlinked before removal to avoid a dangling self-FK.
+      const unlinkCalls = mockQueryRunner.manager.update.mock.calls.filter(
+        (c: any[]) => c[2] && c[2].linkedTransactionId === null,
+      );
+      expect(unlinkCalls).toHaveLength(2);
+    });
+
+    it("should undo a transfer delete by re-inserting both legs and relinking them", async () => {
+      const invAction = {
+        ...mockAction,
+        entityType: "investment_transaction",
+        action: "delete",
+        entityId: "inv-out",
+        beforeData: {
+          id: "inv-out",
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: "TRANSFER_OUT",
+          transactionDate: "2024-01-15",
+          quantity: 100,
+          price: 1.5,
+          linkedTransferLeg: {
+            id: "inv-in",
+            accountId: "acc-2",
+            securityId: "sec-1",
+            action: "TRANSFER_IN",
+            transactionDate: "2024-01-15",
+            quantity: 100,
+            price: 1.5,
+          },
+        },
+        afterData: null,
+      };
+      mockRepository.findOne.mockResolvedValue(invAction);
+      mockQueryRunner.manager.update.mockResolvedValue({ affected: 1 });
+      mockQueryRunner.query.mockResolvedValue([]);
+
+      const result = await service.undo(userId);
+
+      expect(result.description).toContain("Undone");
+      // Both legs re-inserted.
+      const insertCalls = mockQueryRunner.query.mock.calls.filter(
+        (call: any[]) =>
+          typeof call[0] === "string" &&
+          call[0].includes("INSERT INTO investment_transactions"),
+      );
+      expect(insertCalls).toHaveLength(2);
+      // Mutual link restored on both legs once both rows exist.
+      const relinkCalls = mockQueryRunner.manager.update.mock.calls.filter(
+        (c: any[]) => c[2] && typeof c[2].linkedTransactionId === "string",
+      );
+      expect(relinkCalls).toHaveLength(2);
+    });
+
+    it("should undo a transfer update by restoring both legs to their pre-edit state", async () => {
+      const invAction = {
+        ...mockAction,
+        entityType: "investment_transaction",
+        action: "update",
+        entityId: "inv-out",
+        beforeData: {
+          id: "inv-out",
+          accountId: "acc-1",
+          securityId: "sec-1",
+          action: "TRANSFER_OUT",
+          transactionDate: "2024-01-15",
+          quantity: 100,
+          price: 1.5,
+          linkedTransactionId: "inv-in",
+          linkedTransferLeg: {
+            id: "inv-in",
+            accountId: "acc-2",
+            securityId: "sec-1",
+            action: "TRANSFER_IN",
+            transactionDate: "2024-01-15",
+            quantity: 100,
+            price: 1.5,
+            linkedTransactionId: "inv-out",
+          },
+        },
+        afterData: {
+          id: "inv-out",
+          accountId: "acc-1",
+          quantity: 50,
+          linkedTransferLeg: { id: "inv-in", accountId: "acc-2", quantity: 50 },
+        },
+      };
+      mockRepository.findOne.mockResolvedValue(invAction);
+      mockQueryRunner.manager.findOne.mockResolvedValue({
+        id: "inv-out",
+        accountId: "acc-1",
+      });
+      mockQueryRunner.manager.update.mockResolvedValue({ affected: 1 });
+      mockQueryRunner.query.mockResolvedValue([]);
+
+      const result = await service.undo(userId);
+
+      expect(result.description).toContain("Undone");
+      // Both legs restored to their pre-edit values.
+      const restoreCalls = mockQueryRunner.manager.update.mock.calls.filter(
+        (c: any[]) => c[2] && "quantity" in c[2],
+      );
+      expect(restoreCalls).toHaveLength(2);
+      expect(restoreCalls.every((c: any[]) => c[2].quantity === 100)).toBe(
+        true,
+      );
+    });
+
+    it("should not undo a regular (non-transfer) investment update", async () => {
+      const invAction = {
+        ...mockAction,
+        entityType: "investment_transaction",
+        action: "update",
+        entityId: "inv-1",
+        beforeData: { id: "inv-1", accountId: "acc-1", quantity: 10 },
+      };
+      mockRepository.findOne.mockResolvedValue(invAction);
+
+      await expect(service.undo(userId)).rejects.toThrow(ConflictException);
     });
 
     it("should throw ConflictException for unsupported investment action", async () => {

--- a/backend/src/action-history/action-history.service.ts
+++ b/backend/src/action-history/action-history.service.ts
@@ -789,10 +789,65 @@ export class ActionHistoryService {
       case "delete":
         await this.undoInvestmentDelete(action, queryRunner);
         break;
+      case "update":
+        await this.undoInvestmentUpdate(action, queryRunner);
+        break;
       default:
         throw new ConflictException(
           `Unsupported investment action: ${action.action}`,
         );
+    }
+  }
+
+  private async undoInvestmentUpdate(
+    action: ActionHistory,
+    queryRunner: QueryRunner,
+  ): Promise<void> {
+    const before = action.beforeData;
+    const linkedBefore = before?.linkedTransferLeg as
+      | Record<string, any>
+      | undefined;
+
+    // Only linked security-transfer edits capture both legs' pre-edit state,
+    // which is what we need to reverse. Regular investment edits remain
+    // non-undoable (they would also need the cash side restored).
+    if (!before || !linkedBefore) {
+      throw new ConflictException(
+        `Unsupported investment action: ${action.action}`,
+      );
+    }
+
+    const accountIds = new Set<string>();
+    for (const legBefore of [before, linkedBefore]) {
+      // Capture the leg's current (post-edit) account before we overwrite it so
+      // holdings are rebuilt for both the old and the new account.
+      const current = await queryRunner.manager.findOne(InvestmentTransaction, {
+        where: { id: legBefore.id, userId: action.userId },
+      });
+      if (current) accountIds.add(current.accountId);
+
+      await queryRunner.manager.update(
+        InvestmentTransaction,
+        { id: legBefore.id, userId: action.userId },
+        {
+          accountId: legBefore.accountId,
+          securityId: legBefore.securityId ?? null,
+          action: legBefore.action,
+          transactionDate: legBefore.transactionDate,
+          quantity: legBefore.quantity ?? 0,
+          price: legBefore.price ?? null,
+          commission: legBefore.commission ?? 0,
+          totalAmount: legBefore.totalAmount ?? 0,
+          description: legBefore.description ?? null,
+          linkedTransactionId: legBefore.linkedTransactionId ?? null,
+        },
+      );
+      accountIds.add(legBefore.accountId);
+    }
+
+    // Rebuild holdings for every account either leg moved out of or into.
+    for (const accountId of accountIds) {
+      await this.rebuildHoldings(action.userId, accountId, queryRunner);
     }
   }
 
@@ -807,26 +862,55 @@ export class ActionHistoryService {
     });
     if (!invTx) return;
 
-    // Delete linked cash transaction
-    if (invTx.transactionId) {
-      const cashTx = await queryRunner.manager.findOne(Transaction, {
-        where: { id: invTx.transactionId },
-      });
-      if (cashTx) {
-        await queryRunner.query(
-          `DELETE FROM transaction_tags WHERE transaction_id = $1`,
-          [cashTx.id],
-        );
-        await queryRunner.manager.remove(cashTx);
-        await this.recalculateBalance(cashTx.accountId, queryRunner);
+    // A security transfer is two linked legs (TRANSFER_OUT <-> TRANSFER_IN);
+    // undoing the create must remove both so holdings can't be left half-moved.
+    const linkedTx = invTx.linkedTransactionId
+      ? await queryRunner.manager.findOne(InvestmentTransaction, {
+          where: { id: invTx.linkedTransactionId, userId: action.userId },
+        })
+      : null;
+
+    const legs = linkedTx ? [invTx, linkedTx] : [invTx];
+    const accountIds = new Set<string>();
+
+    for (const leg of legs) {
+      accountIds.add(leg.accountId);
+
+      // Delete linked cash transaction
+      if (leg.transactionId) {
+        const cashTx = await queryRunner.manager.findOne(Transaction, {
+          where: { id: leg.transactionId },
+        });
+        if (cashTx) {
+          await queryRunner.query(
+            `DELETE FROM transaction_tags WHERE transaction_id = $1`,
+            [cashTx.id],
+          );
+          await queryRunner.manager.remove(cashTx);
+          await this.recalculateBalance(cashTx.accountId, queryRunner);
+        }
       }
     }
 
-    const accountId = invTx.accountId;
-    await queryRunner.manager.remove(invTx);
+    // Break the mutual link before deleting so neither row's self-FK points at
+    // a row that is about to disappear.
+    for (const leg of legs) {
+      if (leg.linkedTransactionId) {
+        await queryRunner.manager.update(InvestmentTransaction, leg.id, {
+          linkedTransactionId: null,
+        });
+        leg.linkedTransactionId = null;
+      }
+    }
 
-    // Rebuild holdings for this account
-    await this.rebuildHoldings(action.userId, accountId, queryRunner);
+    for (const leg of legs) {
+      await queryRunner.manager.remove(leg);
+    }
+
+    // Rebuild holdings for every affected account.
+    for (const accountId of accountIds) {
+      await this.rebuildHoldings(action.userId, accountId, queryRunner);
+    }
   }
 
   private async undoInvestmentDelete(
@@ -835,7 +919,16 @@ export class ActionHistoryService {
   ): Promise<void> {
     if (!action.beforeData) return;
 
-    const before = action.beforeData;
+    // The transfer-create afterData (fed here on redo) is the nested
+    // {transferOut, transferIn} shape; normalize it to the flat
+    // leg + linkedTransferLeg shape used by the delete beforeData.
+    const raw = action.beforeData;
+    const before = raw.transferOut
+      ? { ...raw.transferOut, linkedTransferLeg: raw.transferIn }
+      : raw;
+    const linkedLeg = before.linkedTransferLeg as
+      | Record<string, any>
+      | undefined;
 
     // Re-insert linked cash transaction first (investment_transactions.transaction_id references it)
     if (before.linkedCashTransaction) {
@@ -867,30 +960,75 @@ export class ActionHistoryService {
     const restoredTransactionId = before.linkedCashTransaction
       ? (before.transactionId ?? null)
       : null;
-    await queryRunner.query(
-      `INSERT INTO investment_transactions (id, user_id, account_id, transaction_id, security_id,
-        funding_account_id, action, transaction_date, quantity, price, commission, total_amount, description, created_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
-      [
-        before.id,
-        action.userId,
-        before.accountId,
-        restoredTransactionId,
-        before.securityId ?? null,
-        before.fundingAccountId ?? null,
-        before.action,
-        before.transactionDate,
-        before.quantity ?? 0,
-        before.price ?? 0,
-        before.commission ?? 0,
-        before.totalAmount ?? 0,
-        before.description ?? null,
-        before.createdAt ?? new Date(),
-      ],
+    await this.reinsertInvestmentTransaction(
+      queryRunner,
+      action.userId,
+      before,
+      restoredTransactionId,
     );
 
-    // Rebuild holdings
-    await this.rebuildHoldings(action.userId, before.accountId, queryRunner);
+    // Restore the paired transfer leg and the mutual link between the two legs.
+    // The self-FK is set after both rows exist to avoid an ordering violation.
+    if (linkedLeg) {
+      await this.reinsertInvestmentTransaction(
+        queryRunner,
+        action.userId,
+        linkedLeg,
+        null,
+      );
+      await queryRunner.manager.update(InvestmentTransaction, before.id, {
+        linkedTransactionId: linkedLeg.id,
+      });
+      await queryRunner.manager.update(InvestmentTransaction, linkedLeg.id, {
+        linkedTransactionId: before.id,
+      });
+    }
+
+    // Rebuild holdings for every affected account.
+    const accountIds = new Set<string>([before.accountId]);
+    if (linkedLeg) accountIds.add(linkedLeg.accountId);
+    for (const accountId of accountIds) {
+      await this.rebuildHoldings(action.userId, accountId, queryRunner);
+    }
+  }
+
+  private async reinsertInvestmentTransaction(
+    queryRunner: QueryRunner,
+    userId: string,
+    data: Record<string, any>,
+    transactionId: string | null,
+  ): Promise<void> {
+    // linked_transaction_id is intentionally not set here; for a transfer it is
+    // restored by the caller once both legs exist, and for a single leg the
+    // original delete already nulled the survivor's pointer.
+    // ON CONFLICT DO NOTHING keeps the reinsert idempotent: a client retry or a
+    // partial-residue id collision must not abort the whole undo/redo with a
+    // duplicate-key error. price preserves NULL (a leg with no price differs
+    // from a 0-cost leg in cost-basis replays) and exchange_rate is restored so
+    // undeleting a foreign-currency transaction doesn't reset its rate to 1.
+    await queryRunner.query(
+      `INSERT INTO investment_transactions (id, user_id, account_id, transaction_id, security_id,
+        funding_account_id, action, transaction_date, quantity, price, commission, total_amount, exchange_rate, description, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+       ON CONFLICT (id) DO NOTHING`,
+      [
+        data.id,
+        userId,
+        data.accountId,
+        transactionId,
+        data.securityId ?? null,
+        data.fundingAccountId ?? null,
+        data.action,
+        data.transactionDate,
+        data.quantity ?? 0,
+        data.price ?? null,
+        data.commission ?? 0,
+        data.totalAmount ?? 0,
+        data.exchangeRate ?? 1,
+        data.description ?? null,
+        data.createdAt ?? new Date(),
+      ],
+    );
   }
 
   // --- Bulk transaction undo ---

--- a/backend/src/securities/dto/transfer-security.dto.ts
+++ b/backend/src/securities/dto/transfer-security.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty } from "@nestjs/swagger";
+import {
+  IsString,
+  IsOptional,
+  IsNumber,
+  IsUUID,
+  IsDateString,
+  Min,
+  MaxLength,
+} from "class-validator";
+import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
+
+export class TransferSecurityDto {
+  @ApiProperty({
+    description: "Investment account the shares are moving out of",
+  })
+  @IsUUID()
+  fromAccountId: string;
+
+  @ApiProperty({ description: "Investment account the shares are moving into" })
+  @IsUUID()
+  toAccountId: string;
+
+  @ApiProperty({ description: "Security being transferred" })
+  @IsUUID()
+  securityId: string;
+
+  @ApiProperty({ description: "Transfer date (YYYY-MM-DD)" })
+  @IsDateString()
+  transactionDate: string;
+
+  @ApiProperty({ description: "Number of shares to transfer" })
+  @IsNumber({ maxDecimalPlaces: 8 })
+  @Min(0.00000001)
+  quantity: number;
+
+  @ApiProperty({
+    description:
+      "Per-share cost basis carried to the destination account. Defaults (client-side) to the source holding's average cost so gain/profit reporting is preserved.",
+  })
+  @IsNumber({ maxDecimalPlaces: 6 })
+  @Min(0)
+  costPerShare: number;
+
+  @ApiProperty({ required: false, description: "Description of the transfer" })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  @SanitizeHtml()
+  description?: string;
+}

--- a/backend/src/securities/dto/update-investment-transaction.dto.ts
+++ b/backend/src/securities/dto/update-investment-transaction.dto.ts
@@ -1,6 +1,16 @@
-import { PartialType } from "@nestjs/swagger";
+import { PartialType, ApiProperty } from "@nestjs/swagger";
+import { IsOptional, IsUUID } from "class-validator";
 import { CreateInvestmentTransactionDto } from "./create-investment-transaction.dto";
 
 export class UpdateInvestmentTransactionDto extends PartialType(
   CreateInvestmentTransactionDto,
-) {}
+) {
+  @ApiProperty({
+    required: false,
+    description:
+      "Destination account for a security transfer. Only meaningful when editing a transfer leg; reroutes the paired (TRANSFER_IN) leg to this account.",
+  })
+  @IsOptional()
+  @IsUUID()
+  destinationAccountId?: string;
+}

--- a/backend/src/securities/entities/investment-transaction.entity.ts
+++ b/backend/src/securities/entities/investment-transaction.entity.ts
@@ -65,6 +65,14 @@ export class InvestmentTransaction {
   @Column({ type: "uuid", name: "transaction_split_id", nullable: true })
   transactionSplitId: string | null;
 
+  @ApiProperty({
+    required: false,
+    description:
+      "When set, links the two legs of a security transfer (TRANSFER_OUT <-> TRANSFER_IN). Editing or deleting one leg cascades to the other.",
+  })
+  @Column({ type: "uuid", name: "linked_transaction_id", nullable: true })
+  linkedTransactionId: string | null;
+
   @ApiProperty({ required: false })
   @Column({ type: "uuid", name: "security_id", nullable: true })
   securityId: string | null;

--- a/backend/src/securities/holdings.service.spec.ts
+++ b/backend/src/securities/holdings.service.spec.ts
@@ -2039,4 +2039,43 @@ describe("HoldingsService", () => {
       expect(mockQueryRunner.release).toHaveBeenCalled();
     });
   });
+
+  describe("applyMaturedInvestmentHoldings", () => {
+    it("rebuilds holdings for users with an investment transaction maturing today", async () => {
+      (service as any).dataSource.query = jest
+        .fn()
+        .mockResolvedValueOnce([
+          { user_id: "user-1", timezone: "UTC", last_client_timezone: null },
+          { user_id: "user-2", timezone: "UTC", last_client_timezone: null },
+        ])
+        .mockResolvedValueOnce([{ user_id: "user-1" }]);
+      const rebuildSpy = jest
+        .spyOn(service, "rebuildFromTransactions")
+        .mockResolvedValue({
+          holdingsCreated: 0,
+          holdingsUpdated: 0,
+          holdingsDeleted: 0,
+        });
+
+      await service.applyMaturedInvestmentHoldings();
+
+      // Only the user with a maturing transaction is rebuilt, and the user's
+      // timezone-correct today is passed as the cutoff so the just-matured
+      // transaction is included.
+      expect(rebuildSpy).toHaveBeenCalledTimes(1);
+      expect(rebuildSpy).toHaveBeenCalledWith(
+        "user-1",
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      );
+    });
+
+    it("does nothing when there are no users", async () => {
+      (service as any).dataSource.query = jest.fn().mockResolvedValueOnce([]);
+      const rebuildSpy = jest.spyOn(service, "rebuildFromTransactions");
+
+      await service.applyMaturedInvestmentHoldings();
+
+      expect(rebuildSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/backend/src/securities/holdings.service.ts
+++ b/backend/src/securities/holdings.service.ts
@@ -5,8 +5,11 @@ import {
   BadRequestException,
   Inject,
   forwardRef,
+  Logger,
 } from "@nestjs/common";
+import { Cron } from "@nestjs/schedule";
 import { InjectRepository } from "@nestjs/typeorm";
+import { todayInTimezone } from "../common/date-utils";
 import {
   Repository,
   In,
@@ -29,6 +32,8 @@ import { SecuritiesService } from "./securities.service";
 
 @Injectable()
 export class HoldingsService {
+  private readonly logger = new Logger(HoldingsService.name);
+
   constructor(
     @InjectRepository(Holding)
     private holdingsRepository: Repository<Holding>,
@@ -521,53 +526,22 @@ export class HoldingsService {
   }
 
   /**
-   * Rebuild all holdings from existing investment transactions.
-   * This recalculates all holdings based on transaction history,
-   * useful for fixing data after imports that didn't create holdings.
-   * Wrapped in a QueryRunner transaction for atomicity.
+   * Server-local "today" as YYYY-MM-DD. Used as the default holdings cutoff;
+   * callers that need a timezone-correct cutoff pass it explicitly.
    */
-  async rebuildFromTransactions(userId: string): Promise<{
-    holdingsCreated: number;
-    holdingsUpdated: number;
-    holdingsDeleted: number;
-  }> {
-    // M14: Get all investment accounts (brokerage + standalone) for the user
-    const investmentAccounts = await this.accountsRepository.find({
-      where: {
-        userId,
-        accountType: AccountType.INVESTMENT,
-      },
-    });
-
-    // Include brokerage accounts and standalone investment accounts (null subType)
-    const eligibleAccounts = investmentAccounts.filter(
-      (a) =>
-        a.accountSubType === AccountSubType.INVESTMENT_BROKERAGE ||
-        !a.accountSubType,
-    );
-
-    if (eligibleAccounts.length === 0) {
-      return { holdingsCreated: 0, holdingsUpdated: 0, holdingsDeleted: 0 };
-    }
-
-    const brokerageAccountIds = eligibleAccounts.map((a) => a.id);
-
-    // Get all investment transactions for these accounts up to today, ordered by date
-    // Future-dated transactions are excluded so they don't affect current holdings
+  private serverToday(): string {
     const now = new Date();
-    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
-    const transactions = await this.investmentTransactionsRepository.find({
-      where: {
-        userId,
-        accountId: In(brokerageAccountIds),
-        transactionDate: LessThanOrEqual(today),
-      },
-      order: {
-        transactionDate: "ASC",
-        createdAt: "ASC",
-      },
-    });
+    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+  }
 
+  /**
+   * Fold a chronologically-ordered list of investment transactions into a
+   * holdings map (accountId -> securityId -> { quantity, totalCost }). Shared by
+   * every rebuild path so the share-count and cost-basis math stays identical.
+   */
+  private computeHoldingsMap(
+    transactions: InvestmentTransaction[],
+  ): Map<string, Map<string, { quantity: number; totalCost: number }>> {
     // Actions that affect holdings
     const holdingsActions = [
       InvestmentAction.BUY,
@@ -586,8 +560,6 @@ export class HoldingsService {
       InvestmentAction.REMOVE_SHARES,
     ];
 
-    // Rebuild holdings from transactions
-    // Map: accountId -> securityId -> { quantity, totalCost }
     const holdingsMap = new Map<
       string,
       Map<string, { quantity: number; totalCost: number }>
@@ -654,6 +626,150 @@ export class HoldingsService {
       }
     }
 
+    return holdingsMap;
+  }
+
+  /**
+   * Rebuild holdings for a specific set of accounts from their transaction
+   * history, operating within the caller's open transaction.
+   *
+   * Unlike `rebuildFromTransactions` (which opens its own transaction and
+   * rebuilds every eligible account), this participates in an existing
+   * QueryRunner so the rebuild commits or rolls back atomically with the
+   * operation that triggered it. Callers that must not silently leave stale or
+   * misattributed holdings (e.g. a security-transfer edit, where the
+   * incremental reverse/re-apply can misattribute average cost across a zero
+   * crossing) use this instead of a best-effort post-commit rebuild.
+   */
+  async rebuildAccountsFromTransactions(
+    userId: string,
+    accountIds: string[],
+    queryRunner: QueryRunner,
+    asOfDate?: string,
+  ): Promise<void> {
+    if (accountIds.length === 0) return;
+
+    // Only brokerage / standalone investment accounts track holdings; the cash
+    // sleeve of an investment account is excluded everywhere else, so it must be
+    // excluded here too or its rows would be deleted but never rebuilt.
+    const accounts = await queryRunner.manager.find(Account, {
+      where: {
+        id: In(accountIds),
+        userId,
+        accountType: AccountType.INVESTMENT,
+      },
+    });
+    const eligibleIds = accounts
+      .filter(
+        (a) =>
+          a.accountSubType === AccountSubType.INVESTMENT_BROKERAGE ||
+          !a.accountSubType,
+      )
+      .map((a) => a.id);
+    if (eligibleIds.length === 0) return;
+
+    const cutoff = asOfDate ?? this.serverToday();
+    const transactions = await queryRunner.manager.find(InvestmentTransaction, {
+      where: {
+        userId,
+        accountId: In(eligibleIds),
+        transactionDate: LessThanOrEqual(cutoff),
+      },
+      order: {
+        transactionDate: "ASC",
+        createdAt: "ASC",
+      },
+    });
+
+    const holdingsMap = this.computeHoldingsMap(transactions);
+
+    // Delete + recreate holdings for these accounts only.
+    const existing = await queryRunner.manager.find(Holding, {
+      where: { accountId: In(eligibleIds) },
+    });
+    if (existing.length > 0) {
+      await queryRunner.manager.remove(existing);
+    }
+
+    const holdingsRepo = queryRunner.manager.getRepository(Holding);
+    const holdingsToCreate: Holding[] = [];
+    for (const [accountId, securities] of holdingsMap) {
+      for (const [securityId, data] of securities) {
+        if (Math.abs(data.quantity) > 0.00000001) {
+          const avgCost = data.quantity > 0 ? data.totalCost / data.quantity : 0;
+          holdingsToCreate.push(
+            holdingsRepo.create({
+              accountId,
+              securityId,
+              quantity: data.quantity,
+              averageCost: avgCost,
+            }),
+          );
+        }
+      }
+    }
+    if (holdingsToCreate.length > 0) {
+      await holdingsRepo.save(holdingsToCreate);
+    }
+  }
+
+  /**
+   * Rebuild all holdings from existing investment transactions.
+   * This recalculates all holdings based on transaction history,
+   * useful for fixing data after imports that didn't create holdings.
+   * Wrapped in a QueryRunner transaction for atomicity.
+   */
+  async rebuildFromTransactions(
+    userId: string,
+    asOfDate?: string,
+  ): Promise<{
+    holdingsCreated: number;
+    holdingsUpdated: number;
+    holdingsDeleted: number;
+  }> {
+    // M14: Get all investment accounts (brokerage + standalone) for the user
+    const investmentAccounts = await this.accountsRepository.find({
+      where: {
+        userId,
+        accountType: AccountType.INVESTMENT,
+      },
+    });
+
+    // Include brokerage accounts and standalone investment accounts (null subType)
+    const eligibleAccounts = investmentAccounts.filter(
+      (a) =>
+        a.accountSubType === AccountSubType.INVESTMENT_BROKERAGE ||
+        !a.accountSubType,
+    );
+
+    if (eligibleAccounts.length === 0) {
+      return { holdingsCreated: 0, holdingsUpdated: 0, holdingsDeleted: 0 };
+    }
+
+    const brokerageAccountIds = eligibleAccounts.map((a) => a.id);
+
+    // Get all investment transactions for these accounts up to the cutoff date,
+    // ordered by date. Future-dated transactions are excluded so they don't
+    // affect current holdings. Callers materializing matured transactions (the
+    // hourly cron) pass the user's timezone-correct "today" so a transfer dated
+    // today in a timezone ahead of the server isn't wrongly treated as future.
+    const cutoff = asOfDate ?? this.serverToday();
+    const transactions = await this.investmentTransactionsRepository.find({
+      where: {
+        userId,
+        accountId: In(brokerageAccountIds),
+        transactionDate: LessThanOrEqual(cutoff),
+      },
+      order: {
+        transactionDate: "ASC",
+        createdAt: "ASC",
+      },
+    });
+
+    // Rebuild holdings from transactions
+    // Map: accountId -> securityId -> { quantity, totalCost }
+    const holdingsMap = this.computeHoldingsMap(transactions);
+
     // Wrap delete-all + rebuild in a transaction for atomicity
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
@@ -710,6 +826,81 @@ export class HoldingsService {
       holdingsUpdated: 0, // We deleted and recreated, so no updates
       holdingsDeleted,
     };
+  }
+
+  /**
+   * Apply matured future-dated investment transactions to holdings.
+   *
+   * Future-dated investment transactions skip the holdings update at creation
+   * time. The hourly cash-balance cron rolls cash forward when their date
+   * arrives, but it never touches holdings -- and a security transfer has no
+   * cash side at all, so without this nothing would ever move the shares.
+   * Once per hour we rebuild holdings for any user with an investment
+   * transaction dated "today" (per their timezone). The rebuild is idempotent,
+   * so re-running it for users who also traded normally today is harmless.
+   */
+  @Cron("30 * * * *")
+  async applyMaturedInvestmentHoldings(): Promise<void> {
+    try {
+      const userRows: {
+        user_id: string;
+        timezone: string | null;
+        last_client_timezone: string | null;
+      }[] = await this.dataSource.query(
+        `SELECT u.id as user_id, p.timezone, p.last_client_timezone
+           FROM users u
+           LEFT JOIN user_preferences p ON p.user_id = u.id`,
+      );
+      if (userRows.length === 0) return;
+
+      const userIdsByTz = new Map<string, string[]>();
+      for (const { user_id, timezone, last_client_timezone } of userRows) {
+        const explicit = timezone?.trim();
+        const cached = last_client_timezone?.trim();
+        const tz =
+          explicit && explicit !== "browser"
+            ? explicit
+            : cached && cached !== "browser"
+              ? cached
+              : "UTC";
+        const list = userIdsByTz.get(tz) ?? [];
+        list.push(user_id);
+        userIdsByTz.set(tz, list);
+      }
+
+      let rebuilt = 0;
+      for (const [tz, userIds] of userIdsByTz) {
+        const today = todayInTimezone(tz);
+        if (!today) continue;
+
+        const maturedRows: { user_id: string }[] = await this.dataSource.query(
+          `SELECT DISTINCT user_id
+             FROM investment_transactions
+             WHERE user_id = ANY($1)
+               AND transaction_date = $2`,
+          [userIds, today],
+        );
+
+        for (const { user_id } of maturedRows) {
+          // Pass the user's timezone-correct today as the cutoff so the rebuild
+          // includes the transaction that just matured -- without it the rebuild
+          // would re-filter against the server's local date and could exclude a
+          // transfer dated today in a timezone ahead of the server.
+          await this.rebuildFromTransactions(user_id, today);
+          rebuilt += 1;
+        }
+      }
+
+      if (rebuilt > 0) {
+        this.logger.log(
+          `Rebuilt holdings for ${rebuilt} user(s) with matured investment transactions`,
+        );
+      }
+    } catch (error) {
+      this.logger.error(
+        `Failed to apply matured investment holdings: ${(error as Error).message}`,
+      );
+    }
   }
 
   /**

--- a/backend/src/securities/investment-transactions.controller.spec.ts
+++ b/backend/src/securities/investment-transactions.controller.spec.ts
@@ -30,6 +30,7 @@ describe("InvestmentTransactionsController", () => {
   beforeEach(async () => {
     service = {
       create: jest.fn(),
+      transferSecurity: jest.fn(),
       findAll: jest.fn(),
       getSummary: jest.fn(),
       getRealizedGains: jest.fn(),
@@ -78,6 +79,26 @@ describe("InvestmentTransactionsController", () => {
 
       expect(service.create).toHaveBeenCalledWith("user-1", dto);
       expect(result).toEqual(mockTransaction);
+    });
+  });
+
+  describe("transferSecurity", () => {
+    it("delegates to service.transferSecurity with userId and dto", async () => {
+      const dto = {
+        fromAccountId: UUID1,
+        toAccountId: UUID2,
+        securityId: "sec-1",
+        transactionDate: "2025-04-01",
+        quantity: 100,
+        costPerShare: 1.67,
+      };
+      const expected = { transferOut: { id: "out" }, transferIn: { id: "in" } };
+      service.transferSecurity.mockResolvedValue(expected);
+
+      const result = await controller.transferSecurity(req, dto as any);
+
+      expect(service.transferSecurity).toHaveBeenCalledWith("user-1", dto);
+      expect(result).toEqual(expected);
     });
   });
 

--- a/backend/src/securities/investment-transactions.controller.spec.ts
+++ b/backend/src/securities/investment-transactions.controller.spec.ts
@@ -31,6 +31,7 @@ describe("InvestmentTransactionsController", () => {
     service = {
       create: jest.fn(),
       transferSecurity: jest.fn(),
+      getSecurityTransactionHistory: jest.fn(),
       findAll: jest.fn(),
       getSummary: jest.fn(),
       getRealizedGains: jest.fn(),
@@ -98,6 +99,26 @@ describe("InvestmentTransactionsController", () => {
       const result = await controller.transferSecurity(req, dto as any);
 
       expect(service.transferSecurity).toHaveBeenCalledWith("user-1", dto);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe("getSecurityTransactionHistory", () => {
+    it("delegates to the service with userId and securityId", async () => {
+      const expected = {
+        securityId: UUID1,
+        transactions: [],
+        accounts: [],
+        currentQuantityAll: 0,
+      };
+      service.getSecurityTransactionHistory.mockResolvedValue(expected);
+
+      const result = await controller.getSecurityTransactionHistory(req, UUID1);
+
+      expect(service.getSecurityTransactionHistory).toHaveBeenCalledWith(
+        "user-1",
+        UUID1,
+      );
       expect(result).toEqual(expected);
     });
   });

--- a/backend/src/securities/investment-transactions.controller.ts
+++ b/backend/src/securities/investment-transactions.controller.ts
@@ -23,6 +23,7 @@ import { AuthGuard } from "@nestjs/passport";
 import { InvestmentTransactionsService } from "./investment-transactions.service";
 import { CreateInvestmentTransactionDto } from "./dto/create-investment-transaction.dto";
 import { UpdateInvestmentTransactionDto } from "./dto/update-investment-transaction.dto";
+import { TransferSecurityDto } from "./dto/transfer-security.dto";
 import {
   InvestmentTransaction,
   InvestmentAction,
@@ -84,6 +85,24 @@ export class InvestmentTransactionsController {
     @Body() createDto: CreateInvestmentTransactionDto,
   ): Promise<InvestmentTransaction> {
     return this.investmentTransactionsService.create(req.user.id, createDto);
+  }
+
+  @Post("transfer-security")
+  @ApiOperation({
+    summary:
+      "Transfer a security between two investment accounts, preserving cost basis",
+  })
+  @ApiResponse({
+    status: 201,
+    description:
+      "Both transfer legs (TRANSFER_OUT in source, TRANSFER_IN in destination) created",
+  })
+  @ApiResponse({ status: 400, description: "Invalid request data" })
+  transferSecurity(@Request() req, @Body() dto: TransferSecurityDto) {
+    return this.investmentTransactionsService.transferSecurity(
+      req.user.id,
+      dto,
+    );
   }
 
   @Get()

--- a/backend/src/securities/investment-transactions.controller.ts
+++ b/backend/src/securities/investment-transactions.controller.ts
@@ -350,6 +350,27 @@ export class InvestmentTransactionsController {
     );
   }
 
+  @Get("security/:securityId/history")
+  @ApiOperation({
+    summary:
+      "Transaction history for a security with running share totals and the accounts (including closed) it was used in",
+  })
+  @ApiResponse({
+    status: 200,
+    description:
+      "Security transaction history with per-account and cross-account running share balances",
+  })
+  @ApiResponse({ status: 404, description: "Security not found" })
+  getSecurityTransactionHistory(
+    @Request() req,
+    @Param("securityId", ParseUUIDPipe) securityId: string,
+  ) {
+    return this.investmentTransactionsService.getSecurityTransactionHistory(
+      req.user.id,
+      securityId,
+    );
+  }
+
   @Get(":id")
   @ApiOperation({ summary: "Get an investment transaction by ID" })
   @ApiResponse({

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -4815,4 +4815,119 @@ describe("InvestmentTransactionsService", () => {
       expect(mockQueryRunner.manager.remove).toHaveBeenCalledWith(embedded);
     });
   });
+
+  describe("transferSecurity", () => {
+    const toAccountId = "account-2";
+    const mockToAccount = {
+      id: toAccountId,
+      userId,
+      accountType: "INVESTMENT",
+      accountSubType: AccountSubType.INVESTMENT_BROKERAGE,
+      linkedAccountId: null,
+      currencyCode: "USD",
+      name: "Brokerage B",
+    };
+
+    const transferDto = {
+      fromAccountId: accountId,
+      toAccountId,
+      securityId,
+      transactionDate: "2025-04-01",
+      quantity: 100,
+      costPerShare: 1.67,
+      description: "Move to Brokerage B",
+    };
+
+    beforeEach(() => {
+      accountsService.findOne.mockImplementation((uid: string, aid: string) => {
+        if (aid === accountId) return Promise.resolve(mockInvestmentAccount);
+        if (aid === toAccountId) return Promise.resolve(mockToAccount);
+        if (aid === cashAccountId) return Promise.resolve(mockCashAccount);
+        return Promise.reject(new NotFoundException("Account not found"));
+      });
+      // findOne (post-commit reload) uses the query builder.
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder({ id: transactionId, action: "TRANSFER_OUT" }),
+      );
+    });
+
+    it("creates both legs and moves holdings at the supplied cost basis", async () => {
+      const result = await service.transferSecurity(userId, transferDto);
+
+      // TRANSFER_OUT draws down the source at cost basis.
+      expect(holdingsService.updateHolding).toHaveBeenCalledWith(
+        userId,
+        accountId,
+        securityId,
+        -100,
+        1.67,
+        mockQueryRunner,
+        false,
+      );
+      // TRANSFER_IN adds to the destination at the same per-share cost.
+      expect(holdingsService.updateHolding).toHaveBeenCalledWith(
+        userId,
+        toAccountId,
+        securityId,
+        100,
+        1.67,
+        mockQueryRunner,
+        false,
+      );
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+      expect(result).toHaveProperty("transferOut");
+      expect(result).toHaveProperty("transferIn");
+    });
+
+    it("does not create any cash transaction", async () => {
+      await service.transferSecurity(userId, transferDto);
+      expect(transactionRepository.create).not.toHaveBeenCalled();
+      expect(transactionRepository.save).not.toHaveBeenCalled();
+    });
+
+    it("validates the full history so the source cannot be over-drawn", async () => {
+      await service.transferSecurity(userId, transferDto);
+      expect(
+        holdingsService.validateNoNegativeHoldingsHistory,
+      ).toHaveBeenCalledWith(
+        userId,
+        mockQueryRunner,
+        [accountId, toAccountId],
+        [securityId],
+      );
+    });
+
+    it("rejects a transfer to the same account", async () => {
+      await expect(
+        service.transferSecurity(userId, {
+          ...transferDto,
+          toAccountId: accountId,
+        }),
+      ).rejects.toThrow(BadRequestException);
+      expect(dataSource.createQueryRunner).not.toHaveBeenCalled();
+    });
+
+    it("rejects when an account is not an investment account", async () => {
+      accountsService.findOne.mockImplementation((uid: string, aid: string) => {
+        if (aid === accountId) return Promise.resolve(mockInvestmentAccount);
+        if (aid === toAccountId)
+          return Promise.resolve({ ...mockToAccount, accountType: "CHEQUING" });
+        return Promise.reject(new NotFoundException("Account not found"));
+      });
+      await expect(
+        service.transferSecurity(userId, transferDto),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it("rolls back when the over-draw guard throws", async () => {
+      holdingsService.validateNoNegativeHoldingsHistory.mockRejectedValueOnce(
+        new BadRequestException("Insufficient shares"),
+      );
+      await expect(
+        service.transferSecurity(userId, transferDto),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+      expect(mockQueryRunner.commitTransaction).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -5061,5 +5061,42 @@ describe("InvestmentTransactionsService", () => {
         service.update(userId, "leg-out", { action: InvestmentAction.BUY }),
       ).rejects.toThrow(BadRequestException);
     });
+
+    it("update reroutes the destination account onto the linked leg", async () => {
+      const { outLeg, inLeg } = makeLegs();
+      const account3 = "account-3";
+      accountsService.findOne.mockImplementation((uid: string, aid: string) => {
+        if (aid === accountId) return Promise.resolve(mockInvestmentAccount);
+        if (aid === toAccountId) return Promise.resolve(mockToAccount);
+        if (aid === account3)
+          return Promise.resolve({ ...mockToAccount, id: account3 });
+        if (aid === cashAccountId) return Promise.resolve(mockCashAccount);
+        return Promise.reject(new NotFoundException("Account not found"));
+      });
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder(outLeg),
+      );
+      investmentTransactionsRepository.findOne.mockResolvedValue(inLeg);
+
+      await service.update(userId, "leg-out", {
+        destinationAccountId: account3,
+      });
+
+      // The destination (linked) leg moves to the new account.
+      expect(inLeg.accountId).toBe(account3);
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+    });
+
+    it("update rejects rerouting the destination to the source account", async () => {
+      const { outLeg, inLeg } = makeLegs();
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder(outLeg),
+      );
+      investmentTransactionsRepository.findOne.mockResolvedValue(inLeg);
+
+      await expect(
+        service.update(userId, "leg-out", { destinationAccountId: accountId }),
+      ).rejects.toThrow(BadRequestException);
+    });
   });
 });

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { getRepositoryToken } from "@nestjs/typeorm";
-import { NotFoundException, BadRequestException } from "@nestjs/common";
+import {
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+} from "@nestjs/common";
 import { InvestmentTransactionsService } from "./investment-transactions.service";
 import {
   InvestmentTransaction,
@@ -246,6 +250,7 @@ describe("InvestmentTransactionsService", () => {
         holdingsUpdated: 0,
         holdingsDeleted: 0,
       }),
+      rebuildAccountsFromTransactions: jest.fn().mockResolvedValue(undefined),
       validateNoNegativeHoldingsHistory: jest.fn().mockResolvedValue(undefined),
     };
 
@@ -4922,6 +4927,18 @@ describe("InvestmentTransactionsService", () => {
       ).rejects.toThrow(BadRequestException);
     });
 
+    it("rejects transferring into a closed destination account", async () => {
+      accountsService.findOne.mockImplementation((uid: string, aid: string) => {
+        if (aid === accountId) return Promise.resolve(mockInvestmentAccount);
+        if (aid === toAccountId)
+          return Promise.resolve({ ...mockToAccount, isClosed: true });
+        return Promise.reject(new NotFoundException("Account not found"));
+      });
+      await expect(
+        service.transferSecurity(userId, transferDto),
+      ).rejects.toThrow(BadRequestException);
+    });
+
     it("rolls back when the over-draw guard throws", async () => {
       holdingsService.validateNoNegativeHoldingsHistory.mockRejectedValueOnce(
         new BadRequestException("Insufficient shares"),
@@ -4943,6 +4960,84 @@ describe("InvestmentTransactionsService", () => {
           "linkedTransactionId" in c[2],
       );
       expect(linkUpdates).toHaveLength(2);
+    });
+
+    it("moves holdings even when the cost basis is zero", async () => {
+      // A zero-cost-basis holding (gifted/spun-off shares) is a legitimate
+      // transfer. The holdings move must still happen -- a falsy `price` guard
+      // previously skipped it, recording both legs while moving no shares.
+      await service.transferSecurity(userId, {
+        ...transferDto,
+        costPerShare: 0,
+      });
+
+      expect(holdingsService.updateHolding).toHaveBeenCalledWith(
+        userId,
+        accountId,
+        securityId,
+        -100,
+        0,
+        mockQueryRunner,
+        false,
+      );
+      expect(holdingsService.updateHolding).toHaveBeenCalledWith(
+        userId,
+        toAccountId,
+        securityId,
+        100,
+        0,
+        mockQueryRunner,
+        false,
+      );
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+    });
+
+    it("carries the source holding's average cost, ignoring the client value", async () => {
+      // The server is authoritative: when the source holds the security, both
+      // legs use its real blended average cost (here 4.25) so basis is
+      // conserved -- a stale/zero client costPerShare cannot poison it.
+      holdingsService.findByAccountAndSecurity.mockResolvedValue({
+        quantity: 200,
+        averageCost: 4.25,
+      } as any);
+
+      await service.transferSecurity(userId, { ...transferDto, costPerShare: 0 });
+
+      expect(holdingsService.updateHolding).toHaveBeenCalledWith(
+        userId,
+        accountId,
+        securityId,
+        -100,
+        4.25,
+        mockQueryRunner,
+        false,
+      );
+      expect(holdingsService.updateHolding).toHaveBeenCalledWith(
+        userId,
+        toAccountId,
+        securityId,
+        100,
+        4.25,
+        mockQueryRunner,
+        false,
+      );
+    });
+
+    it("rejects transferring into a non-brokerage (cash sleeve) account", async () => {
+      accountsService.findOne.mockImplementation((uid: string, aid: string) => {
+        if (aid === accountId) return Promise.resolve(mockInvestmentAccount);
+        if (aid === toAccountId)
+          return Promise.resolve({
+            ...mockToAccount,
+            accountSubType: AccountSubType.INVESTMENT_CASH,
+          });
+        return Promise.reject(new NotFoundException("Account not found"));
+      });
+
+      await expect(
+        service.transferSecurity(userId, transferDto),
+      ).rejects.toThrow(BadRequestException);
+      expect(dataSource.createQueryRunner).not.toHaveBeenCalled();
     });
   });
 
@@ -5097,6 +5192,93 @@ describe("InvestmentTransactionsService", () => {
       await expect(
         service.update(userId, "leg-out", { destinationAccountId: accountId }),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it("keeps the transfer direction when the IN leg is edited directly", async () => {
+      // Editing via the IN leg id must still route accountId -> source (OUT
+      // leg) and destinationAccountId -> destination (IN leg), not invert them.
+      const { outLeg, inLeg } = makeLegs();
+      const account3 = "account-3";
+      accountsService.findOne.mockImplementation((uid: string, aid: string) => {
+        if (aid === accountId) return Promise.resolve(mockInvestmentAccount);
+        if (aid === toAccountId) return Promise.resolve(mockToAccount);
+        if (aid === account3)
+          return Promise.resolve({ ...mockToAccount, id: account3 });
+        return Promise.reject(new NotFoundException("Account not found"));
+      });
+      // findOne (the entity being edited) returns the IN leg; the linked leg is
+      // the OUT leg.
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder(inLeg),
+      );
+      investmentTransactionsRepository.findOne.mockResolvedValue(outLeg);
+
+      await service.update(userId, "leg-in", {
+        accountId: account3,
+        destinationAccountId: toAccountId,
+      });
+
+      // Source account applied to the OUT leg, destination to the IN leg.
+      expect(outLeg.accountId).toBe(account3);
+      expect(inLeg.accountId).toBe(toAccountId);
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+    });
+
+    it("rebuilds the affected accounts' holdings inside the edit transaction", async () => {
+      const { outLeg, inLeg } = makeLegs();
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder(outLeg),
+      );
+      investmentTransactionsRepository.findOne.mockResolvedValue(inLeg);
+
+      await service.update(userId, "leg-out", { quantity: 50 });
+
+      // The rebuild runs on the open queryRunner (atomic with the edit) rather
+      // than a best-effort post-commit call, so a failure rolls the edit back.
+      expect(
+        holdingsService.rebuildAccountsFromTransactions,
+      ).toHaveBeenCalledWith(
+        userId,
+        expect.arrayContaining([accountId, toAccountId]),
+        mockQueryRunner,
+      );
+    });
+
+    it("rejects rerouting the destination to a closed account", async () => {
+      const { outLeg, inLeg } = makeLegs();
+      const closedId = "account-closed";
+      accountsService.findOne.mockImplementation((uid: string, aid: string) => {
+        if (aid === accountId) return Promise.resolve(mockInvestmentAccount);
+        if (aid === toAccountId) return Promise.resolve(mockToAccount);
+        if (aid === closedId)
+          return Promise.resolve({
+            ...mockToAccount,
+            id: closedId,
+            isClosed: true,
+          });
+        return Promise.reject(new NotFoundException("Account not found"));
+      });
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder(outLeg),
+      );
+      investmentTransactionsRepository.findOne.mockResolvedValue(inLeg);
+
+      await expect(
+        service.update(userId, "leg-out", { destinationAccountId: closedId }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it("refuses to edit a transfer leg whose pair is missing", async () => {
+      const { outLeg } = makeLegs();
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder(outLeg),
+      );
+      // Linked leg cannot be loaded (stale link / partial data).
+      investmentTransactionsRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.update(userId, "leg-out", { quantity: 50 }),
+      ).rejects.toThrow(ConflictException);
     });
   });
 

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -5099,4 +5099,173 @@ describe("InvestmentTransactionsService", () => {
       ).rejects.toThrow(BadRequestException);
     });
   });
+
+  describe("getSecurityTransactionHistory", () => {
+    const acctA = "acct-a";
+    const acctB = "acct-b";
+
+    function tx(
+      id: string,
+      accountId: string,
+      accountName: string,
+      isClosed: boolean,
+      action: InvestmentAction,
+      transactionDate: string,
+      quantity: number | null,
+      extra: Partial<InvestmentTransaction> = {},
+    ): InvestmentTransaction {
+      return {
+        id,
+        userId,
+        accountId,
+        securityId,
+        action,
+        transactionDate,
+        quantity,
+        price: 1,
+        commission: 0,
+        totalAmount: 0,
+        exchangeRate: 1,
+        description: null,
+        account: { id: accountId, name: accountName, isClosed } as any,
+        ...extra,
+      } as InvestmentTransaction;
+    }
+
+    beforeEach(() => {
+      securitiesService.findOne.mockResolvedValue({
+        ...mockSecurity,
+        isActive: false,
+      });
+    });
+
+    it("computes per-account and cross-account running totals without snapping", async () => {
+      investmentTransactionsRepository.find.mockResolvedValue([
+        tx(
+          "t1",
+          acctA,
+          "Account A",
+          false,
+          InvestmentAction.BUY,
+          "2025-01-01",
+          100,
+        ),
+        tx(
+          "t2",
+          acctB,
+          "Account B",
+          true,
+          InvestmentAction.BUY,
+          "2025-02-01",
+          50,
+        ),
+        tx(
+          "t3",
+          acctA,
+          "Account A",
+          false,
+          InvestmentAction.SELL,
+          "2025-03-01",
+          99.9999,
+        ),
+        tx(
+          "t4",
+          acctB,
+          "Account B",
+          true,
+          InvestmentAction.SPLIT,
+          "2025-04-01",
+          2,
+        ),
+      ]);
+
+      const result = await service.getSecurityTransactionHistory(
+        userId,
+        securityId,
+      );
+
+      expect(result.transactions).toHaveLength(4);
+
+      // Account A drawn down to a tiny residual, kept visible (not snapped).
+      const sell = result.transactions[2];
+      expect(sell.runningQuantityAccount).toBeCloseTo(0.0001, 8);
+      expect(sell.runningQuantityAll).toBeCloseTo(50.0001, 8);
+
+      // SPLIT multiplies only Account B's balance; cross-account total follows.
+      const split = result.transactions[3];
+      expect(split.runningQuantityAccount).toBe(100);
+      expect(split.runningQuantityAll).toBeCloseTo(100.0001, 8);
+
+      expect(result.currentQuantityAll).toBeCloseTo(100.0001, 8);
+    });
+
+    it("lists every account the security was used in, including closed ones", async () => {
+      investmentTransactionsRepository.find.mockResolvedValue([
+        tx(
+          "t1",
+          acctA,
+          "Account A",
+          false,
+          InvestmentAction.BUY,
+          "2025-01-01",
+          100,
+        ),
+        tx(
+          "t2",
+          acctB,
+          "Account B",
+          true,
+          InvestmentAction.BUY,
+          "2025-02-01",
+          50,
+        ),
+        tx(
+          "t3",
+          acctA,
+          "Account A",
+          false,
+          InvestmentAction.SELL,
+          "2025-03-01",
+          99.9999,
+        ),
+      ]);
+
+      const result = await service.getSecurityTransactionHistory(
+        userId,
+        securityId,
+      );
+
+      expect(result.accounts).toHaveLength(2);
+      const a = result.accounts.find((x) => x.accountId === acctA)!;
+      const b = result.accounts.find((x) => x.accountId === acctB)!;
+      expect(a.currentQuantity).toBeCloseTo(0.0001, 8);
+      expect(b.isClosed).toBe(true);
+      expect(b.currentQuantity).toBe(50);
+      // Works for an inactive security.
+      expect(result.isActive).toBe(false);
+    });
+
+    it("returns empty history for a security with no transactions", async () => {
+      investmentTransactionsRepository.find.mockResolvedValue([]);
+
+      const result = await service.getSecurityTransactionHistory(
+        userId,
+        securityId,
+      );
+
+      expect(result.transactions).toEqual([]);
+      expect(result.accounts).toEqual([]);
+      expect(result.currentQuantityAll).toBe(0);
+    });
+
+    it("throws when the security does not exist", async () => {
+      securitiesService.findOne.mockRejectedValue(
+        new NotFoundException("Security not found"),
+      );
+
+      await expect(
+        service.getSecurityTransactionHistory(userId, securityId),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
 });

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -103,6 +103,7 @@ describe("InvestmentTransactionsService", () => {
     securityId,
     fundingAccountId: null,
     transactionId: cashTransactionId,
+    linkedTransactionId: null,
     action: InvestmentAction.BUY,
     transactionDate: "2025-01-15",
     quantity: 10,
@@ -128,6 +129,7 @@ describe("InvestmentTransactionsService", () => {
     securityId,
     fundingAccountId: null,
     transactionId: "cash-tx-2",
+    linkedTransactionId: null,
     action: InvestmentAction.SELL,
     transactionDate: "2025-02-15",
     quantity: 5,
@@ -153,6 +155,7 @@ describe("InvestmentTransactionsService", () => {
     securityId,
     fundingAccountId: null,
     transactionId: "cash-tx-3",
+    linkedTransactionId: null,
     action: InvestmentAction.DIVIDEND,
     transactionDate: "2025-03-15",
     quantity: 1,
@@ -4928,6 +4931,135 @@ describe("InvestmentTransactionsService", () => {
       ).rejects.toThrow(BadRequestException);
       expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
       expect(mockQueryRunner.commitTransaction).not.toHaveBeenCalled();
+    });
+
+    it("links the two legs to each other", async () => {
+      await service.transferSecurity(userId, transferDto);
+      // Each leg is updated to point at the other via linkedTransactionId.
+      const linkUpdates = mockQueryRunner.manager.update.mock.calls.filter(
+        (c: any[]) =>
+          c[0] === InvestmentTransaction &&
+          c[2] &&
+          "linkedTransactionId" in c[2],
+      );
+      expect(linkUpdates).toHaveLength(2);
+    });
+  });
+
+  describe("linked transfer cascade", () => {
+    const toAccountId = "account-2";
+    const mockToAccount = {
+      id: toAccountId,
+      userId,
+      accountType: "INVESTMENT",
+      accountSubType: AccountSubType.INVESTMENT_BROKERAGE,
+      linkedAccountId: null,
+      currencyCode: "USD",
+      name: "Brokerage B",
+    };
+
+    function makeLegs() {
+      const base = {
+        userId,
+        securityId,
+        fundingAccountId: null,
+        transactionId: null,
+        transactionSplitId: null,
+        transactionDate: "2025-04-01",
+        quantity: 100,
+        price: 1.67,
+        commission: 0,
+        totalAmount: 0,
+        exchangeRate: 1,
+        description: null,
+        account: null as any,
+        transaction: null as any,
+        security: mockSecurity as any,
+        fundingAccount: null,
+        transactionSplit: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      const outLeg = {
+        ...base,
+        id: "leg-out",
+        accountId,
+        action: InvestmentAction.TRANSFER_OUT,
+        linkedTransactionId: "leg-in",
+      } as InvestmentTransaction;
+      const inLeg = {
+        ...base,
+        id: "leg-in",
+        accountId: toAccountId,
+        action: InvestmentAction.TRANSFER_IN,
+        linkedTransactionId: "leg-out",
+      } as InvestmentTransaction;
+      return { outLeg, inLeg };
+    }
+
+    beforeEach(() => {
+      accountsService.findOne.mockImplementation((uid: string, aid: string) => {
+        if (aid === accountId) return Promise.resolve(mockInvestmentAccount);
+        if (aid === toAccountId) return Promise.resolve(mockToAccount);
+        if (aid === cashAccountId) return Promise.resolve(mockCashAccount);
+        return Promise.reject(new NotFoundException("Account not found"));
+      });
+      transactionRepository.findOne.mockResolvedValue(null);
+    });
+
+    it("remove deletes both legs and validates both accounts", async () => {
+      const { outLeg, inLeg } = makeLegs();
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder(outLeg),
+      );
+      investmentTransactionsRepository.findOne.mockResolvedValue(inLeg);
+
+      await service.remove(userId, "leg-out");
+
+      expect(mockQueryRunner.manager.remove).toHaveBeenCalledTimes(2);
+      expect(
+        holdingsService.validateNoNegativeHoldingsHistory,
+      ).toHaveBeenCalledWith(
+        userId,
+        mockQueryRunner,
+        expect.arrayContaining([accountId, toAccountId]),
+        [securityId],
+      );
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+    });
+
+    it("update propagates the edit to both legs and keeps them linked", async () => {
+      const { outLeg, inLeg } = makeLegs();
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder(outLeg),
+      );
+      investmentTransactionsRepository.findOne.mockResolvedValue(inLeg);
+
+      await service.update(userId, "leg-out", { quantity: 50 });
+
+      // Both legs reversed (add/remove) and reapplied -> 4 holding updates.
+      expect(holdingsService.updateHolding).toHaveBeenCalled();
+      // Both legs saved.
+      const savedActions = mockQueryRunner.manager.save.mock.calls
+        .map((c: any[]) => c[0]?.action)
+        .filter(Boolean);
+      expect(savedActions).toContain(InvestmentAction.TRANSFER_OUT);
+      expect(savedActions).toContain(InvestmentAction.TRANSFER_IN);
+      // Edit propagated to the linked leg too.
+      expect(inLeg.quantity).toBe(50);
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+    });
+
+    it("update rejects changing the transfer direction", async () => {
+      const { outLeg, inLeg } = makeLegs();
+      investmentTransactionsRepository.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder(outLeg),
+      );
+      investmentTransactionsRepository.findOne.mockResolvedValue(inLeg);
+
+      await expect(
+        service.update(userId, "leg-out", { action: InvestmentAction.BUY }),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ConflictException,
   Logger,
   Inject,
   forwardRef,
@@ -594,12 +595,28 @@ export class InvestmentTransactionsService {
   }
 
   /**
+   * Reject investment accounts that don't track holdings. Securities can only
+   * live in brokerage / standalone investment accounts (null subtype); the cash
+   * sleeve (INVESTMENT_CASH) is excluded from every holdings rebuild and
+   * negative-balance guard, so transferring shares into it would leave them
+   * absent from the ledger while still drawing down the source.
+   */
+  private assertCanHoldSecurities(account: Account, label: string): void {
+    if (
+      account.accountSubType &&
+      account.accountSubType !== AccountSubType.INVESTMENT_BROKERAGE
+    ) {
+      throw new BadRequestException(`${label} cannot hold securities`);
+    }
+  }
+
+  /**
    * Move a security between two investment accounts while preserving cost
    * basis. Creates both legs atomically: a TRANSFER_OUT in the source account
    * (drawn down at the source's running average cost) and a TRANSFER_IN in the
-   * destination account at `costPerShare`. No cash transaction is created --
-   * shares move only, no money changes hands -- so both legs use exchangeRate 1
-   * and have a null linked cash transaction.
+   * destination account at the source's carried average cost. No cash
+   * transaction is created -- shares move only, no money changes hands -- so
+   * both legs use exchangeRate 1 and have a null linked cash transaction.
    */
   async transferSecurity(
     userId: string,
@@ -626,7 +643,35 @@ export class InvestmentTransactionsService {
       throw new BadRequestException("Both accounts must be of type INVESTMENT");
     }
 
+    // Securities only live in brokerage / standalone investment accounts. The
+    // cash sleeve of an investment account is excluded from every holdings
+    // rebuild, so shares transferred into it would silently vanish.
+    this.assertCanHoldSecurities(fromAccount, "Source account");
+    this.assertCanHoldSecurities(toAccount, "Destination account");
+
+    if (toAccount.isClosed) {
+      throw new BadRequestException("Destination account is closed");
+    }
+
     await this.securitiesService.findOne(userId, dto.securityId);
+
+    // Carry the source's actual blended average cost so basis is conserved.
+    // The client sends a prefilled costPerShare for display, but the server is
+    // authoritative here: a stale or zero client value (e.g. a UI race before
+    // holdings load, or a direct API call) must not be able to poison the
+    // destination's cost basis. When the source holds the security, its current
+    // average cost is exactly what the TRANSFER_OUT draws down, so using it for
+    // both legs conserves basis. With no existing holding the over-draw guard
+    // below rejects the transfer anyway, so the client value is a harmless
+    // fallback.
+    const sourceHolding = await this.holdingsService.findByAccountAndSecurity(
+      dto.fromAccountId,
+      dto.securityId,
+    );
+    const carriedCost =
+      sourceHolding && Number(sourceHolding.quantity) > 0
+        ? roundToDecimals(Number(sourceHolding.averageCost) || 0, 6)
+        : dto.costPerShare;
 
     // Transfer legs carry no cash, so totalAmount is 0 -- matching how
     // calculateTotalAmount() treats TRANSFER_IN/TRANSFER_OUT on the edit path.
@@ -649,7 +694,7 @@ export class InvestmentTransactionsService {
         action: InvestmentAction.TRANSFER_OUT,
         transactionDate: dto.transactionDate,
         quantity: dto.quantity,
-        price: dto.costPerShare,
+        price: carriedCost,
         commission: 0,
         totalAmount,
         exchangeRate: 1,
@@ -673,7 +718,7 @@ export class InvestmentTransactionsService {
         action: InvestmentAction.TRANSFER_IN,
         transactionDate: dto.transactionDate,
         quantity: dto.quantity,
-        price: dto.costPerShare,
+        price: carriedCost,
         commission: 0,
         totalAmount,
         exchangeRate: 1,
@@ -736,10 +781,10 @@ export class InvestmentTransactionsService {
       entityType: "investment_transaction",
       entityId: transferOut.id,
       action: "create",
-      afterData: {
-        transferOut: { ...transferOut },
-        transferIn: { ...transferIn },
-      },
+      // Flat leg + linkedTransferLeg shape mirrors the delete beforeData so the
+      // redo path (which feeds afterData into undoInvestmentDelete) restores
+      // both legs and their mutual link.
+      afterData: { ...transferOut, linkedTransferLeg: { ...transferIn } },
       description: "Transferred security between accounts",
     });
 
@@ -882,6 +927,10 @@ export class InvestmentTransactionsService {
         break;
 
       case InvestmentAction.REINVEST:
+        // A reinvestment buys shares at a market price; without a price the
+        // shares would be blended in at cost 0 and poison the average cost, so
+        // keep the price guard here. Only TRANSFER_IN/OUT (whose carried cost
+        // can legitimately be 0) drop it.
         if (!isFuture && securityId && quantity && price) {
           await this.holdingsService.updateHolding(
             userId,
@@ -912,7 +961,7 @@ export class InvestmentTransactionsService {
         break;
 
       case InvestmentAction.TRANSFER_IN:
-        if (!isFuture && securityId && quantity && price) {
+        if (!isFuture && securityId && quantity) {
           await this.holdingsService.updateHolding(
             userId,
             accountId,
@@ -926,7 +975,7 @@ export class InvestmentTransactionsService {
         break;
 
       case InvestmentAction.TRANSFER_OUT:
-        if (!isFuture && securityId && quantity && price) {
+        if (!isFuture && securityId && quantity) {
           await this.holdingsService.updateHolding(
             userId,
             accountId,
@@ -1709,7 +1758,20 @@ export class InvestmentTransactionsService {
         linkedLeg,
       );
 
-      // The edited leg may move to a different account.
+      // Resolve legs by role, not by which leg id was passed in: `accountId`
+      // is always the source (TRANSFER_OUT) account and `destinationAccountId`
+      // the destination (TRANSFER_IN) account. Mapping by role keeps the
+      // direction correct even when the IN leg is edited directly.
+      const outLeg =
+        editedLeg.action === InvestmentAction.TRANSFER_OUT
+          ? editedLeg
+          : linkedLeg;
+      const inLeg =
+        editedLeg.action === InvestmentAction.TRANSFER_IN
+          ? editedLeg
+          : linkedLeg;
+
+      // The source leg may move to a different account.
       if (updateDto.accountId !== undefined) {
         const account = await this.accountsService.findOne(
           userId,
@@ -1718,11 +1780,12 @@ export class InvestmentTransactionsService {
         if (account.accountType !== "INVESTMENT") {
           throw new BadRequestException("Account must be of type INVESTMENT");
         }
-        editedLeg.accountId = updateDto.accountId;
-        editedLeg.account = { id: updateDto.accountId } as any;
+        this.assertCanHoldSecurities(account, "Account");
+        outLeg.accountId = updateDto.accountId;
+        outLeg.account = { id: updateDto.accountId } as any;
       }
 
-      // The paired leg can be rerouted to a different destination account.
+      // The destination leg can be rerouted to a different account.
       if (updateDto.destinationAccountId !== undefined) {
         const destAccount = await this.accountsService.findOne(
           userId,
@@ -1733,11 +1796,15 @@ export class InvestmentTransactionsService {
             "Destination account must be of type INVESTMENT",
           );
         }
-        linkedLeg.accountId = updateDto.destinationAccountId;
-        linkedLeg.account = { id: updateDto.destinationAccountId } as any;
+        if (destAccount.isClosed) {
+          throw new BadRequestException("Destination account is closed");
+        }
+        this.assertCanHoldSecurities(destAccount, "Destination account");
+        inLeg.accountId = updateDto.destinationAccountId;
+        inLeg.account = { id: updateDto.destinationAccountId } as any;
       }
 
-      if (editedLeg.accountId === linkedLeg.accountId) {
+      if (outLeg.accountId === inLeg.accountId) {
         throw new BadRequestException(
           "Source and destination accounts must be different",
         );
@@ -1797,6 +1864,19 @@ export class InvestmentTransactionsService {
           : undefined,
       );
 
+      // The incremental reverse/re-apply above can misattribute average cost
+      // when a leg crosses a zero balance (a TRANSFER_OUT reversal re-establishes
+      // the source's cost basis from the leg's price instead of the source's
+      // true blended cost). Rebuild the affected accounts from the authoritative
+      // transaction history inside this transaction so both accounts' share
+      // counts and average cost are exact -- and so a rebuild failure rolls the
+      // whole edit back rather than silently committing wrong holdings.
+      await this.holdingsService.rebuildAccountsFromTransactions(
+        userId,
+        Array.from(affectedAccountIds),
+        queryRunner,
+      );
+
       await queryRunner.commitTransaction();
     } catch (error) {
       await queryRunner.rollbackTransaction();
@@ -1809,24 +1889,18 @@ export class InvestmentTransactionsService {
       this.triggerRecalcWithCashAccount(accId, userId);
     }
 
-    if (editedLeg.securityId) {
-      this.securityPriceService
-        .upsertTransactionPrice(editedLeg.securityId, editedLeg.transactionDate)
-        .catch((err) =>
-          this.logger.warn(
-            `Failed to update transaction-derived price: ${err.message}`,
-          ),
-        );
-    }
-
     const result = await this.findOne(userId, editedLegId);
+    const linkedResult = await this.findOne(userId, linkedLeg.id);
 
     this.actionHistoryService.record(userId, {
       entityType: "investment_transaction",
       entityId: editedLegId,
+      // beforeData and afterData both carry the paired leg under
+      // linkedTransferLeg so undo (beforeData) and redo (afterData) can restore
+      // both legs symmetrically.
       action: "update",
       beforeData: { ...beforeData, linkedTransferLeg: beforeLinked },
-      afterData: { ...result },
+      afterData: { ...result, linkedTransferLeg: { ...linkedResult } },
       description: "Updated security transfer",
     });
 
@@ -1850,14 +1924,20 @@ export class InvestmentTransactionsService {
       const linkedLeg = await this.investmentTransactionsRepository.findOne({
         where: { id: transaction.linkedTransactionId, userId },
       });
-      if (linkedLeg) {
-        return this.updateLinkedTransfer(
-          userId,
-          transaction,
-          linkedLeg,
-          updateDto,
+      if (!linkedLeg) {
+        // The pair is missing (stale link / partial data). Editing this leg
+        // alone would leave the two legs unbalanced, so refuse rather than
+        // silently corrupting the transfer.
+        throw new ConflictException(
+          "This transfer's paired transaction is missing; delete and recreate the transfer instead of editing it",
         );
       }
+      return this.updateLinkedTransfer(
+        userId,
+        transaction,
+        linkedLeg,
+        updateDto,
+      );
     }
 
     const beforeData = { ...transaction };

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -14,6 +14,7 @@ import {
 } from "./entities/investment-transaction.entity";
 import { CreateInvestmentTransactionDto } from "./dto/create-investment-transaction.dto";
 import { UpdateInvestmentTransactionDto } from "./dto/update-investment-transaction.dto";
+import { TransferSecurityDto } from "./dto/transfer-security.dto";
 import { AccountsService } from "../accounts/accounts.service";
 import { TransactionsService } from "../transactions/transactions.service";
 import { HoldingsService } from "./holdings.service";
@@ -551,6 +552,150 @@ export class InvestmentTransactionsService {
     });
 
     return result;
+  }
+
+  /**
+   * Move a security between two investment accounts while preserving cost
+   * basis. Creates both legs atomically: a TRANSFER_OUT in the source account
+   * (drawn down at the source's running average cost) and a TRANSFER_IN in the
+   * destination account at `costPerShare`. No cash transaction is created --
+   * shares move only, no money changes hands -- so both legs use exchangeRate 1
+   * and have a null linked cash transaction.
+   */
+  async transferSecurity(
+    userId: string,
+    dto: TransferSecurityDto,
+  ): Promise<{
+    transferOut: InvestmentTransaction;
+    transferIn: InvestmentTransaction;
+  }> {
+    if (dto.fromAccountId === dto.toAccountId) {
+      throw new BadRequestException(
+        "Source and destination accounts must be different",
+      );
+    }
+
+    const [fromAccount, toAccount] = await Promise.all([
+      this.accountsService.findOne(userId, dto.fromAccountId),
+      this.accountsService.findOne(userId, dto.toAccountId),
+    ]);
+
+    if (
+      fromAccount.accountType !== "INVESTMENT" ||
+      toAccount.accountType !== "INVESTMENT"
+    ) {
+      throw new BadRequestException("Both accounts must be of type INVESTMENT");
+    }
+
+    await this.securitiesService.findOne(userId, dto.securityId);
+
+    // Transfer legs carry no cash, so totalAmount is 0 -- matching how
+    // calculateTotalAmount() treats TRANSFER_IN/TRANSFER_OUT on the edit path.
+    // Cost basis flows through quantity * price (per-share cost) instead.
+    const totalAmount = 0;
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    let outId: string;
+    let inId: string;
+
+    try {
+      const transferOut = queryRunner.manager.create(InvestmentTransaction, {
+        userId,
+        accountId: dto.fromAccountId,
+        securityId: dto.securityId,
+        fundingAccountId: null,
+        action: InvestmentAction.TRANSFER_OUT,
+        transactionDate: dto.transactionDate,
+        quantity: dto.quantity,
+        price: dto.costPerShare,
+        commission: 0,
+        totalAmount,
+        exchangeRate: 1,
+        description: dto.description,
+      });
+      const savedOut = await queryRunner.manager.save(transferOut);
+      outId = savedOut.id;
+      await this.processTransactionEffectsInTransaction(
+        queryRunner,
+        userId,
+        savedOut,
+        false,
+        false,
+      );
+
+      const transferIn = queryRunner.manager.create(InvestmentTransaction, {
+        userId,
+        accountId: dto.toAccountId,
+        securityId: dto.securityId,
+        fundingAccountId: null,
+        action: InvestmentAction.TRANSFER_IN,
+        transactionDate: dto.transactionDate,
+        quantity: dto.quantity,
+        price: dto.costPerShare,
+        commission: 0,
+        totalAmount,
+        exchangeRate: 1,
+        description: dto.description,
+      });
+      const savedIn = await queryRunner.manager.save(transferIn);
+      inId = savedIn.id;
+      await this.processTransactionEffectsInTransaction(
+        queryRunner,
+        userId,
+        savedIn,
+        false,
+        false,
+      );
+
+      // Guard against transferring more than the source holds. Validates the
+      // full replayed history so it catches both the immediate over-draw and
+      // any back-dated transfer that would make a past balance go negative.
+      await this.holdingsService.validateNoNegativeHoldingsHistory(
+        userId,
+        queryRunner,
+        [dto.fromAccountId, dto.toAccountId],
+        [dto.securityId],
+      );
+
+      await queryRunner.commitTransaction();
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
+
+    this.triggerRecalcWithCashAccount(dto.fromAccountId, userId);
+    this.triggerRecalcWithCashAccount(dto.toAccountId, userId);
+
+    this.securityPriceService
+      .upsertTransactionPrice(dto.securityId, dto.transactionDate)
+      .catch((err) =>
+        this.logger.warn(
+          `Failed to update transaction-derived price: ${err.message}`,
+        ),
+      );
+
+    const [transferOut, transferIn] = await Promise.all([
+      this.findOne(userId, outId),
+      this.findOne(userId, inId),
+    ]);
+
+    this.actionHistoryService.record(userId, {
+      entityType: "investment_transaction",
+      entityId: transferOut.id,
+      action: "create",
+      afterData: {
+        transferOut: { ...transferOut },
+        transferIn: { ...transferIn },
+      },
+      description: "Transferred security between accounts",
+    });
+
+    return { transferOut, transferIn };
   }
 
   private calculateTotalAmount(dto: CreateInvestmentTransactionDto): number {

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -1571,6 +1571,27 @@ export class InvestmentTransactionsService {
         editedLeg.account = { id: updateDto.accountId } as any;
       }
 
+      // The paired leg can be rerouted to a different destination account.
+      if (updateDto.destinationAccountId !== undefined) {
+        const destAccount = await this.accountsService.findOne(
+          userId,
+          updateDto.destinationAccountId,
+        );
+        if (destAccount.accountType !== "INVESTMENT") {
+          throw new BadRequestException(
+            "Destination account must be of type INVESTMENT",
+          );
+        }
+        linkedLeg.accountId = updateDto.destinationAccountId;
+        linkedLeg.account = { id: updateDto.destinationAccountId } as any;
+      }
+
+      if (editedLeg.accountId === linkedLeg.accountId) {
+        throw new BadRequestException(
+          "Source and destination accounts must be different",
+        );
+      }
+
       // Shared fields applied to both legs.
       const applyShared = (leg: InvestmentTransaction) => {
         if (updateDto.securityId !== undefined) {
@@ -1595,6 +1616,7 @@ export class InvestmentTransactionsService {
       applyShared(linkedLeg);
 
       affectedAccountIds.add(editedLeg.accountId);
+      affectedAccountIds.add(linkedLeg.accountId);
       if (editedLeg.securityId) affectedSecurityIds.add(editedLeg.securityId);
 
       const savedEdited = await queryRunner.manager.save(editedLeg);

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -112,6 +112,45 @@ export interface LlmInvestmentTransactionsResult {
   truncatedTransactionList: boolean;
 }
 
+/** One account a security has been transacted in (including closed ones). */
+export interface SecurityHistoryAccount {
+  accountId: string;
+  accountName: string;
+  isClosed: boolean;
+  /** Exact (un-snapped) current share balance in this account. */
+  currentQuantity: number;
+}
+
+/** A single transaction in a security's history, with running share balances. */
+export interface SecurityHistoryTransaction {
+  id: string;
+  transactionDate: string;
+  accountId: string;
+  accountName: string;
+  action: InvestmentAction;
+  quantity: number | null;
+  price: number | null;
+  commission: number;
+  totalAmount: number;
+  description: string | null;
+  /** Running share balance within this transaction's own account. */
+  runningQuantityAccount: number;
+  /** Running share balance across all accounts the security is held in. */
+  runningQuantityAll: number;
+}
+
+export interface SecurityTransactionHistory {
+  securityId: string;
+  symbol: string;
+  name: string;
+  currencyCode: string;
+  isActive: boolean;
+  accounts: SecurityHistoryAccount[];
+  transactions: SecurityHistoryTransaction[];
+  /** Exact (un-snapped) total current shares across all accounts. */
+  currentQuantityAll: number;
+}
+
 @Injectable()
 export class InvestmentTransactionsService {
   private readonly logger = new Logger(InvestmentTransactionsService.name);
@@ -1217,6 +1256,118 @@ export class InvestmentTransactionsService {
         totalPages,
         hasMore: pageNum < totalPages,
       },
+    };
+  }
+
+  /**
+   * Apply a transaction's effect on a running share balance. Mirrors the
+   * authoritative per-action math in HoldingsService.getHoldingAt so the
+   * running totals reconcile with stored holdings.
+   */
+  private applyQuantityToBalance(
+    balance: number,
+    action: InvestmentAction,
+    quantity: number,
+  ): number {
+    switch (action) {
+      case InvestmentAction.BUY:
+      case InvestmentAction.REINVEST:
+      case InvestmentAction.TRANSFER_IN:
+      case InvestmentAction.ADD_SHARES:
+        return balance + quantity;
+      case InvestmentAction.SELL:
+      case InvestmentAction.TRANSFER_OUT:
+      case InvestmentAction.REMOVE_SHARES:
+        return balance - quantity;
+      case InvestmentAction.SPLIT:
+        return quantity > 0 ? balance * quantity : balance;
+      default:
+        // DIVIDEND / INTEREST / CAPITAL_GAIN do not move shares.
+        return balance;
+    }
+  }
+
+  /**
+   * Full transaction history for a single security with a running share
+   * balance after each transaction -- both within the transaction's own
+   * account and across all accounts the security is held in. Also returns the
+   * list of accounts the security was ever transacted in (including closed
+   * accounts) with their exact current share balance.
+   *
+   * Quantities are intentionally NOT snapped to zero, so tiny residual
+   * positions remain visible -- this view exists to track them down.
+   */
+  async getSecurityTransactionHistory(
+    userId: string,
+    securityId: string,
+  ): Promise<SecurityTransactionHistory> {
+    // Validates ownership and existence (works for inactive securities too).
+    const security = await this.securitiesService.findOne(userId, securityId);
+
+    const transactions = await this.investmentTransactionsRepository.find({
+      where: { userId, securityId },
+      relations: ["account"],
+      order: { transactionDate: "ASC", createdAt: "ASC" },
+    });
+
+    const balances = new Map<string, number>();
+    const accountMeta = new Map<string, { name: string; isClosed: boolean }>();
+    let runningAll = 0;
+
+    const rows: SecurityHistoryTransaction[] = transactions.map((tx) => {
+      const accountId = tx.accountId;
+      if (!accountMeta.has(accountId)) {
+        accountMeta.set(accountId, {
+          name: tx.account?.name ?? "Unknown account",
+          isClosed: tx.account?.isClosed ?? false,
+        });
+      }
+
+      const prevBalance = balances.get(accountId) ?? 0;
+      const newBalance = this.applyQuantityToBalance(
+        prevBalance,
+        tx.action,
+        Number(tx.quantity) || 0,
+      );
+      balances.set(accountId, newBalance);
+      // Delta keeps the cross-account total correct even for SPLIT, which
+      // multiplies a single account's balance rather than adding to it.
+      runningAll += newBalance - prevBalance;
+
+      return {
+        id: tx.id,
+        transactionDate: tx.transactionDate,
+        accountId,
+        accountName: accountMeta.get(accountId)!.name,
+        action: tx.action,
+        quantity: tx.quantity === null ? null : Number(tx.quantity),
+        price: tx.price === null ? null : Number(tx.price),
+        commission: Number(tx.commission) || 0,
+        totalAmount: Number(tx.totalAmount) || 0,
+        description: tx.description,
+        runningQuantityAccount: newBalance,
+        runningQuantityAll: runningAll,
+      };
+    });
+
+    const accounts: SecurityHistoryAccount[] = Array.from(accountMeta.entries())
+      .map(([accountId, meta]) => ({
+        accountId,
+        accountName: meta.name,
+        isClosed: meta.isClosed,
+        currentQuantity: balances.get(accountId) ?? 0,
+      }))
+      .sort((a, b) => a.accountName.localeCompare(b.accountName));
+
+    return {
+      securityId,
+      symbol: security.symbol,
+      name: security.name,
+      currencyCode: security.currencyCode,
+      isActive: security.isActive,
+      accounts,
+      transactions: rows,
+      currentQuantityAll: runningAll,
     };
   }
 

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -650,6 +650,15 @@ export class InvestmentTransactionsService {
         false,
       );
 
+      // Link the two legs to each other so a later edit or delete of one
+      // cascades to its pair.
+      await queryRunner.manager.update(InvestmentTransaction, outId, {
+        linkedTransactionId: inId,
+      });
+      await queryRunner.manager.update(InvestmentTransaction, inId, {
+        linkedTransactionId: outId,
+      });
+
       // Guard against transferring more than the source holds. Validates the
       // full replayed history so it catches both the immediate over-draw and
       // any back-dated transfer that would make a past balance go negative.
@@ -1493,12 +1502,191 @@ export class InvestmentTransactionsService {
     return transaction;
   }
 
+  /**
+   * Edit one leg of a linked security transfer and keep its pair consistent.
+   * The edited leg may change its own account; the security, quantity,
+   * per-share cost, date and description are shared and propagated to both
+   * legs so the cost basis stays balanced across the move. The transfer's
+   * direction (which leg is IN vs OUT) cannot be changed here.
+   */
+  private async updateLinkedTransfer(
+    userId: string,
+    editedLeg: InvestmentTransaction,
+    linkedLeg: InvestmentTransaction,
+    updateDto: UpdateInvestmentTransactionDto,
+  ): Promise<InvestmentTransaction> {
+    if (
+      updateDto.action !== undefined &&
+      updateDto.action !== editedLeg.action
+    ) {
+      throw new BadRequestException(
+        "Cannot change the direction of a transfer; delete it and create a new transfer instead",
+      );
+    }
+
+    const beforeData = { ...editedLeg };
+    const beforeLinked = { ...linkedLeg };
+    const editedLegId = editedLeg.id;
+
+    // Track every (account, security) the edit could touch -- old and new on
+    // both legs -- so the negative-holdings guard is scoped correctly.
+    const affectedAccountIds = new Set<string>([
+      editedLeg.accountId,
+      linkedLeg.accountId,
+    ]);
+    const affectedSecurityIds = new Set<string>();
+    if (editedLeg.securityId) affectedSecurityIds.add(editedLeg.securityId);
+
+    if (updateDto.securityId !== undefined && updateDto.securityId) {
+      await this.securitiesService.findOne(userId, updateDto.securityId);
+    }
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      // Reverse both legs at their original values before reapplying.
+      await this.reverseTransactionEffectsInTransaction(
+        queryRunner,
+        userId,
+        editedLeg,
+      );
+      await this.reverseTransactionEffectsInTransaction(
+        queryRunner,
+        userId,
+        linkedLeg,
+      );
+
+      // The edited leg may move to a different account.
+      if (updateDto.accountId !== undefined) {
+        const account = await this.accountsService.findOne(
+          userId,
+          updateDto.accountId,
+        );
+        if (account.accountType !== "INVESTMENT") {
+          throw new BadRequestException("Account must be of type INVESTMENT");
+        }
+        editedLeg.accountId = updateDto.accountId;
+        editedLeg.account = { id: updateDto.accountId } as any;
+      }
+
+      // Shared fields applied to both legs.
+      const applyShared = (leg: InvestmentTransaction) => {
+        if (updateDto.securityId !== undefined) {
+          leg.securityId = updateDto.securityId || null;
+          leg.security = updateDto.securityId
+            ? ({ id: updateDto.securityId } as any)
+            : (null as any);
+        }
+        if (updateDto.quantity !== undefined) leg.quantity = updateDto.quantity;
+        if (updateDto.price !== undefined) leg.price = updateDto.price;
+        if (updateDto.commission !== undefined)
+          leg.commission = updateDto.commission;
+        if (updateDto.transactionDate !== undefined)
+          leg.transactionDate = updateDto.transactionDate;
+        if (updateDto.description !== undefined)
+          leg.description = updateDto.description;
+        // Transfers carry no cash.
+        leg.totalAmount = 0;
+        leg.exchangeRate = 1;
+      };
+      applyShared(editedLeg);
+      applyShared(linkedLeg);
+
+      affectedAccountIds.add(editedLeg.accountId);
+      if (editedLeg.securityId) affectedSecurityIds.add(editedLeg.securityId);
+
+      const savedEdited = await queryRunner.manager.save(editedLeg);
+      const savedLinked = await queryRunner.manager.save(linkedLeg);
+
+      await this.processTransactionEffectsInTransaction(
+        queryRunner,
+        userId,
+        savedEdited,
+        true,
+        false,
+      );
+      await this.processTransactionEffectsInTransaction(
+        queryRunner,
+        userId,
+        savedLinked,
+        true,
+        false,
+      );
+
+      await this.holdingsService.validateNoNegativeHoldingsHistory(
+        userId,
+        queryRunner,
+        Array.from(affectedAccountIds),
+        affectedSecurityIds.size > 0
+          ? Array.from(affectedSecurityIds)
+          : undefined,
+      );
+
+      await queryRunner.commitTransaction();
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
+
+    for (const accId of affectedAccountIds) {
+      this.triggerRecalcWithCashAccount(accId, userId);
+    }
+
+    if (editedLeg.securityId) {
+      this.securityPriceService
+        .upsertTransactionPrice(editedLeg.securityId, editedLeg.transactionDate)
+        .catch((err) =>
+          this.logger.warn(
+            `Failed to update transaction-derived price: ${err.message}`,
+          ),
+        );
+    }
+
+    const result = await this.findOne(userId, editedLegId);
+
+    this.actionHistoryService.record(userId, {
+      entityType: "investment_transaction",
+      entityId: editedLegId,
+      action: "update",
+      beforeData: { ...beforeData, linkedTransferLeg: beforeLinked },
+      afterData: { ...result },
+      description: "Updated security transfer",
+    });
+
+    return result;
+  }
+
   async update(
     userId: string,
     id: string,
     updateDto: UpdateInvestmentTransactionDto,
   ): Promise<InvestmentTransaction> {
     const transaction = await this.findOne(userId, id);
+
+    // A security transfer is two linked legs. Editing one keeps the pair in
+    // sync (shared security/quantity/cost/date) so cost basis stays balanced.
+    if (
+      transaction.linkedTransactionId &&
+      (transaction.action === InvestmentAction.TRANSFER_IN ||
+        transaction.action === InvestmentAction.TRANSFER_OUT)
+    ) {
+      const linkedLeg = await this.investmentTransactionsRepository.findOne({
+        where: { id: transaction.linkedTransactionId, userId },
+      });
+      if (linkedLeg) {
+        return this.updateLinkedTransfer(
+          userId,
+          transaction,
+          linkedLeg,
+          updateDto,
+        );
+      }
+    }
+
     const beforeData = { ...transaction };
     const accountId = transaction.accountId;
     const oldSecurityId = transaction.securityId;
@@ -1965,24 +2153,60 @@ export class InvestmentTransactionsService {
       }
     }
 
+    // A security transfer is two linked legs (TRANSFER_OUT <-> TRANSFER_IN).
+    // Deleting either one removes the whole transfer so holdings can't be
+    // left half-moved.
+    const linkedLeg = transaction.linkedTransactionId
+      ? await this.investmentTransactionsRepository.findOne({
+          where: { id: transaction.linkedTransactionId, userId },
+        })
+      : null;
+    if (linkedLeg) {
+      beforeData.linkedTransferLeg = { ...linkedLeg };
+    }
+
+    const legsToRemove = linkedLeg ? [transaction, linkedLeg] : [transaction];
+    const affectedAccountIds = Array.from(
+      new Set(legsToRemove.map((leg) => leg.accountId)),
+    );
+    const affectedSecurityIds = Array.from(
+      new Set(
+        legsToRemove
+          .map((leg) => leg.securityId)
+          .filter((sid): sid is string => Boolean(sid)),
+      ),
+    );
+
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
     await queryRunner.startTransaction();
 
     try {
-      await this.reverseTransactionEffectsInTransaction(
-        queryRunner,
-        userId,
-        transaction,
-      );
+      // Break the mutual link before deleting so neither row's FK points at a
+      // row that is about to disappear.
+      for (const leg of legsToRemove) {
+        if (leg.linkedTransactionId) {
+          await queryRunner.manager.update(InvestmentTransaction, leg.id, {
+            linkedTransactionId: null,
+          });
+          leg.linkedTransactionId = null;
+        }
+      }
 
-      await queryRunner.manager.remove(transaction);
+      for (const leg of legsToRemove) {
+        await this.reverseTransactionEffectsInTransaction(
+          queryRunner,
+          userId,
+          leg,
+        );
+        await queryRunner.manager.remove(leg);
+      }
 
       await this.holdingsService.validateNoNegativeHoldingsHistory(
         userId,
         queryRunner,
-        [accountId],
-        transaction.securityId ? [transaction.securityId] : undefined,
+        affectedAccountIds,
+        affectedSecurityIds.length > 0 ? affectedSecurityIds : undefined,
       );
 
       await queryRunner.commitTransaction();
@@ -2003,11 +2227,16 @@ export class InvestmentTransactionsService {
         );
     }
 
-    this.triggerRecalcWithCashAccount(
-      accountId,
-      userId,
-      transaction.fundingAccountId,
-    );
+    for (const accId of affectedAccountIds) {
+      this.triggerRecalcWithCashAccount(accId, userId);
+    }
+    if (transaction.fundingAccountId) {
+      this.triggerRecalcWithCashAccount(
+        accountId,
+        userId,
+        transaction.fundingAccountId,
+      );
+    }
 
     if (
       transaction.securityId &&

--- a/backend/src/securities/security-price.service.ts
+++ b/backend/src/securities/security-price.service.ts
@@ -1031,6 +1031,9 @@ export class SecurityPriceService {
     securityId: string,
     transactionDate: string,
   ): Promise<void> {
+    // Only actual trades (BUY/SELL/REINVEST) imply a market price. TRANSFER_IN/
+    // TRANSFER_OUT legs carry the carried cost basis, not the market price on
+    // the transfer date, so they are excluded from the derived price.
     const rows: Array<{
       avg_price: string;
       latest_action: string;
@@ -1038,13 +1041,13 @@ export class SecurityPriceService {
       `SELECT AVG(price::numeric) as avg_price,
               (SELECT action FROM investment_transactions
                WHERE security_id = $1 AND transaction_date = $2
-                 AND action IN ('BUY', 'SELL', 'REINVEST', 'TRANSFER_IN', 'TRANSFER_OUT')
+                 AND action IN ('BUY', 'SELL', 'REINVEST')
                  AND price IS NOT NULL
                ORDER BY created_at DESC LIMIT 1) as latest_action
        FROM investment_transactions
        WHERE security_id = $1
          AND transaction_date = $2
-         AND action IN ('BUY', 'SELL', 'REINVEST', 'TRANSFER_IN', 'TRANSFER_OUT')
+         AND action IN ('BUY', 'SELL', 'REINVEST')
          AND price IS NOT NULL`,
       [securityId, transactionDate],
     );
@@ -1094,13 +1097,13 @@ export class SecurityPriceService {
               (SELECT it2.action FROM investment_transactions it2
                WHERE it2.security_id = it.security_id
                  AND it2.transaction_date = it.transaction_date
-                 AND it2.action IN ('BUY', 'SELL', 'REINVEST', 'TRANSFER_IN', 'TRANSFER_OUT')
+                 AND it2.action IN ('BUY', 'SELL', 'REINVEST')
                  AND it2.price IS NOT NULL
                ORDER BY it2.created_at DESC LIMIT 1) as latest_action
        FROM investment_transactions it
        WHERE it.security_id IS NOT NULL
          AND it.price IS NOT NULL
-         AND it.action IN ('BUY', 'SELL', 'REINVEST', 'TRANSFER_IN', 'TRANSFER_OUT')
+         AND it.action IN ('BUY', 'SELL', 'REINVEST')
        GROUP BY it.security_id, it.transaction_date`,
     );
 

--- a/backend/test/integration/security-transaction-history.integration.spec.ts
+++ b/backend/test/integration/security-transaction-history.integration.spec.ts
@@ -1,0 +1,188 @@
+import { TestingModule } from "@nestjs/testing";
+import { DataSource } from "typeorm";
+import { InvestmentTransactionsService } from "@/securities/investment-transactions.service";
+import { SecuritiesModule } from "@/securities/securities.module";
+import { SecuritiesService } from "@/securities/securities.service";
+import {
+  Account,
+  AccountSubType,
+  AccountType,
+} from "@/accounts/entities/account.entity";
+import { InvestmentAction } from "@/securities/entities/investment-transaction.entity";
+import { Security } from "@/securities/entities/security.entity";
+import {
+  createIntegrationModule,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import { createTestAccount } from "../helpers/test-factories";
+
+/**
+ * End-to-end coverage for the per-security transaction history view: running
+ * share totals across multiple (including closed) accounts, exact residual
+ * balances, and adding adjustments to clean them up -- even for closed
+ * accounts and inactive securities.
+ */
+describe("Security transaction history (integration)", () => {
+  let module: TestingModule;
+  let service: InvestmentTransactionsService;
+  let securitiesService: SecuritiesService;
+  let dataSource: DataSource;
+  let userId: string;
+  let accountA: string;
+  let accountB: string;
+  let securityId: string;
+
+  beforeAll(async () => {
+    module = await createIntegrationModule([SecuritiesModule]);
+    service = module.get(InvestmentTransactionsService);
+    securitiesService = module.get(SecuritiesService);
+    dataSource = module.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  async function brokerage(name: string): Promise<string> {
+    const acct = await createTestAccount(dataSource, userId, {
+      name,
+      openingBalance: 0,
+      currentBalance: 0,
+    });
+    await dataSource.manager.update(Account, acct.id, {
+      accountType: AccountType.INVESTMENT,
+      accountSubType: AccountSubType.INVESTMENT_BROKERAGE,
+    });
+    return acct.id;
+  }
+
+  beforeEach(async () => {
+    await cleanTables(dataSource, [
+      "action_history",
+      "holdings",
+      "securities",
+      "transaction_splits",
+      "transactions",
+      "accounts",
+      "categories",
+      "payees",
+      "scheduled_transaction_splits",
+      "scheduled_transaction_overrides",
+      "scheduled_transactions",
+      "investment_transactions",
+      "monthly_account_balances",
+      "users",
+    ]);
+    await dataSource.query(
+      `INSERT INTO currencies (code, name, symbol, decimal_places) VALUES ('USD', 'US Dollar', '$', 2) ON CONFLICT DO NOTHING`,
+    );
+
+    const user = await createTestUserDirect(dataSource);
+    userId = user.id;
+    accountA = await brokerage("Account A");
+    accountB = await brokerage("Account B");
+
+    const security = await securitiesService.create(userId, {
+      symbol: "ACME",
+      name: "Acme Corp",
+      securityType: "STOCK" as any,
+      currencyCode: "USD",
+    } as any);
+    securityId = security.id;
+
+    // Account A: add 100, remove all but a 0.001 residual.
+    await service.create(userId, {
+      accountId: accountA,
+      action: InvestmentAction.ADD_SHARES,
+      transactionDate: "2025-01-01",
+      securityId,
+      quantity: 100,
+    } as any);
+    await service.create(userId, {
+      accountId: accountB,
+      action: InvestmentAction.ADD_SHARES,
+      transactionDate: "2025-02-01",
+      securityId,
+      quantity: 50,
+    } as any);
+    await service.create(userId, {
+      accountId: accountA,
+      action: InvestmentAction.REMOVE_SHARES,
+      transactionDate: "2025-03-01",
+      securityId,
+      quantity: 99.999,
+    } as any);
+
+    // Close Account B and mark the security inactive (set directly: the app
+    // blocks deactivating a security that still has holdings, but legacy/import
+    // data can leave an inactive security with stray shares -- exactly the case
+    // this view exists to clean up).
+    await dataSource.manager.update(Account, accountB, { isClosed: true });
+    await dataSource.manager.update(Security, securityId, { isActive: false });
+  });
+
+  it("reports running totals, closed accounts and exact residuals", async () => {
+    const history = await service.getSecurityTransactionHistory(
+      userId,
+      securityId,
+    );
+
+    expect(history.isActive).toBe(false);
+    expect(history.transactions).toHaveLength(3);
+
+    // Chronological order: A +100, B +50, A -99.999.
+    expect(history.transactions[0].accountId).toBe(accountA);
+    expect(history.transactions[0].runningQuantityAccount).toBe(100);
+    expect(history.transactions[1].runningQuantityAll).toBe(150);
+    expect(history.transactions[2].runningQuantityAccount).toBeCloseTo(
+      0.001,
+      6,
+    );
+    expect(history.transactions[2].runningQuantityAll).toBeCloseTo(50.001, 6);
+
+    const a = history.accounts.find((x) => x.accountId === accountA)!;
+    const b = history.accounts.find((x) => x.accountId === accountB)!;
+    expect(a.currentQuantity).toBeCloseTo(0.001, 6);
+    expect(b.isClosed).toBe(true);
+    expect(b.currentQuantity).toBe(50);
+    expect(history.currentQuantityAll).toBeCloseTo(50.001, 6);
+  });
+
+  it("clears a residual via an adjustment on an inactive security", async () => {
+    // Add a REMOVE_SHARES adjustment for the 0.001 residual in (open) A.
+    await service.create(userId, {
+      accountId: accountA,
+      action: InvestmentAction.REMOVE_SHARES,
+      transactionDate: "2025-05-01",
+      securityId,
+      quantity: 0.001,
+    } as any);
+
+    const history = await service.getSecurityTransactionHistory(
+      userId,
+      securityId,
+    );
+    const a = history.accounts.find((x) => x.accountId === accountA)!;
+    expect(a.currentQuantity).toBeCloseTo(0, 6);
+  });
+
+  it("allows an adjustment against a closed account", async () => {
+    // Remove the 50 shares stranded in the now-closed Account B.
+    await service.create(userId, {
+      accountId: accountB,
+      action: InvestmentAction.REMOVE_SHARES,
+      transactionDate: "2025-05-01",
+      securityId,
+      quantity: 50,
+    } as any);
+
+    const history = await service.getSecurityTransactionHistory(
+      userId,
+      securityId,
+    );
+    const b = history.accounts.find((x) => x.accountId === accountB)!;
+    expect(b.currentQuantity).toBeCloseTo(0, 6);
+    expect(history.currentQuantityAll).toBeCloseTo(0.001, 6);
+  });
+});

--- a/backend/test/integration/security-transfer.integration.spec.ts
+++ b/backend/test/integration/security-transfer.integration.spec.ts
@@ -237,6 +237,46 @@ describe("Security transfer between accounts (integration)", () => {
     expect(Number(bHolding?.averageCost)).toBeCloseTo(1.67, 6);
   });
 
+  it("reroutes the destination account when editing a transfer", async () => {
+    await buy100At167();
+    const { transferOut } = await service.transferSecurity(userId, {
+      fromAccountId: brokerageA,
+      toAccountId: brokerageB,
+      securityId,
+      transactionDate: "2026-02-01",
+      quantity: 100,
+      costPerShare: 1.67,
+    });
+
+    // Add a third brokerage and reroute the destination to it.
+    const c = await createTestAccount(dataSource, userId, {
+      name: "Brokerage C",
+      openingBalance: 0,
+      currentBalance: 0,
+    });
+    await dataSource.manager.update(Account, c.id, {
+      accountType: AccountType.INVESTMENT,
+      accountSubType: AccountSubType.INVESTMENT_BROKERAGE,
+    });
+
+    await service.update(userId, transferOut.id, {
+      destinationAccountId: c.id,
+    });
+
+    // Shares now sit in C, not B; cost basis preserved.
+    const bHolding = await holdingsService.findByAccountAndSecurity(
+      brokerageB,
+      securityId,
+    );
+    const cHolding = await holdingsService.findByAccountAndSecurity(
+      c.id,
+      securityId,
+    );
+    expect(qty(bHolding)).toBe(0);
+    expect(qty(cHolding)).toBe(100);
+    expect(Number(cHolding?.averageCost)).toBeCloseTo(1.67, 6);
+  });
+
   it("rejects transferring more shares than the source holds", async () => {
     await buy100At167();
     await expect(

--- a/backend/test/integration/security-transfer.integration.spec.ts
+++ b/backend/test/integration/security-transfer.integration.spec.ts
@@ -1,0 +1,260 @@
+import { TestingModule } from "@nestjs/testing";
+import { DataSource } from "typeorm";
+import { InvestmentTransactionsService } from "@/securities/investment-transactions.service";
+import { SecuritiesModule } from "@/securities/securities.module";
+import { SecuritiesService } from "@/securities/securities.service";
+import { HoldingsService } from "@/securities/holdings.service";
+import {
+  Account,
+  AccountSubType,
+  AccountType,
+} from "@/accounts/entities/account.entity";
+import { Transaction } from "@/transactions/entities/transaction.entity";
+import {
+  InvestmentTransaction,
+  InvestmentAction,
+} from "@/securities/entities/investment-transaction.entity";
+import {
+  createIntegrationModule,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import { createTestAccount } from "../helpers/test-factories";
+
+/**
+ * End-to-end coverage for transferring a security between two brokerage
+ * accounts. The original cost basis (1.67/share) must follow the shares to
+ * the destination so gain/profit reporting stays correct, and the two legs
+ * are linked so editing or deleting one cascades to the other.
+ */
+describe("Security transfer between accounts (integration)", () => {
+  let module: TestingModule;
+  let service: InvestmentTransactionsService;
+  let holdingsService: HoldingsService;
+  let dataSource: DataSource;
+  let userId: string;
+  let brokerageA: string;
+  let brokerageB: string;
+  let securityId: string;
+
+  const qty = (h: { quantity: number } | null) => Number(h?.quantity ?? 0);
+
+  beforeAll(async () => {
+    module = await createIntegrationModule([SecuritiesModule]);
+    service = module.get(InvestmentTransactionsService);
+    holdingsService = module.get(HoldingsService);
+    dataSource = module.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await cleanTables(dataSource, [
+      "action_history",
+      "holdings",
+      "securities",
+      "transaction_splits",
+      "transactions",
+      "accounts",
+      "categories",
+      "payees",
+      "scheduled_transaction_splits",
+      "scheduled_transaction_overrides",
+      "scheduled_transactions",
+      "investment_transactions",
+      "monthly_account_balances",
+      "users",
+    ]);
+    await dataSource.query(
+      `INSERT INTO currencies (code, name, symbol, decimal_places) VALUES ('USD', 'US Dollar', '$', 2) ON CONFLICT DO NOTHING`,
+    );
+
+    const user = await createTestUserDirect(dataSource);
+    userId = user.id;
+
+    const a = await createTestAccount(dataSource, userId, {
+      name: "Brokerage A",
+      openingBalance: 0,
+      currentBalance: 0,
+    });
+    await dataSource.manager.update(Account, a.id, {
+      accountType: AccountType.INVESTMENT,
+      accountSubType: AccountSubType.INVESTMENT_BROKERAGE,
+    });
+    brokerageA = a.id;
+
+    const b = await createTestAccount(dataSource, userId, {
+      name: "Brokerage B",
+      openingBalance: 0,
+      currentBalance: 0,
+    });
+    await dataSource.manager.update(Account, b.id, {
+      accountType: AccountType.INVESTMENT,
+      accountSubType: AccountSubType.INVESTMENT_BROKERAGE,
+    });
+    brokerageB = b.id;
+
+    const securitiesService = module.get(SecuritiesService);
+    const security = await securitiesService.create(userId, {
+      symbol: "ACME",
+      name: "Acme Corp",
+      securityType: "STOCK" as any,
+      currencyCode: "USD",
+    } as any);
+    securityId = security.id;
+  });
+
+  // Buy 100 shares in Brokerage A at a discounted 1.67/share.
+  async function buy100At167() {
+    await service.create(userId, {
+      accountId: brokerageA,
+      action: InvestmentAction.BUY,
+      transactionDate: "2026-01-10",
+      securityId,
+      quantity: 100,
+      price: 1.67,
+      commission: 0,
+    } as any);
+  }
+
+  it("carries cost basis to the destination and links the two legs", async () => {
+    await buy100At167();
+    const cashBefore = await dataSource.manager.count(Transaction, {
+      where: { userId },
+    });
+
+    const { transferOut, transferIn } = await service.transferSecurity(userId, {
+      fromAccountId: brokerageA,
+      toAccountId: brokerageB,
+      securityId,
+      transactionDate: "2026-02-01",
+      quantity: 100,
+      costPerShare: 1.67,
+    });
+
+    // Source emptied, destination holds the shares at the original cost.
+    const aHolding = await holdingsService.findByAccountAndSecurity(
+      brokerageA,
+      securityId,
+    );
+    const bHolding = await holdingsService.findByAccountAndSecurity(
+      brokerageB,
+      securityId,
+    );
+    expect(qty(aHolding)).toBe(0);
+    expect(qty(bHolding)).toBe(100);
+    expect(Number(bHolding?.averageCost)).toBeCloseTo(1.67, 6);
+
+    // Legs reference each other and create no cash transactions.
+    expect(transferOut.linkedTransactionId).toBe(transferIn.id);
+    expect(transferIn.linkedTransactionId).toBe(transferOut.id);
+    expect(transferOut.transactionId).toBeNull();
+    expect(transferIn.transactionId).toBeNull();
+    // The transfer itself moves shares only -- no new cash transaction.
+    const cashAfter = await dataSource.manager.count(Transaction, {
+      where: { userId },
+    });
+    expect(cashAfter).toBe(cashBefore);
+  });
+
+  it("deleting one leg removes both and restores the source holding", async () => {
+    await buy100At167();
+    const { transferOut, transferIn } = await service.transferSecurity(userId, {
+      fromAccountId: brokerageA,
+      toAccountId: brokerageB,
+      securityId,
+      transactionDate: "2026-02-01",
+      quantity: 100,
+      costPerShare: 1.67,
+    });
+
+    // Delete the destination leg; the source leg must go too.
+    await service.remove(userId, transferIn.id);
+
+    const remaining = await dataSource.manager.find(InvestmentTransaction, {
+      where: { userId, action: InvestmentAction.TRANSFER_OUT },
+    });
+    expect(remaining).toHaveLength(0);
+    const remainingIn = await dataSource.manager.findOne(
+      InvestmentTransaction,
+      {
+        where: { id: transferOut.id },
+      },
+    );
+    expect(remainingIn).toBeNull();
+
+    // Shares are back in A, gone from B.
+    const aHolding = await holdingsService.findByAccountAndSecurity(
+      brokerageA,
+      securityId,
+    );
+    const bHolding = await holdingsService.findByAccountAndSecurity(
+      brokerageB,
+      securityId,
+    );
+    expect(qty(aHolding)).toBe(100);
+    expect(qty(bHolding)).toBe(0);
+  });
+
+  it("editing the quantity on one leg updates both legs and holdings", async () => {
+    await buy100At167();
+    const { transferOut, transferIn } = await service.transferSecurity(userId, {
+      fromAccountId: brokerageA,
+      toAccountId: brokerageB,
+      securityId,
+      transactionDate: "2026-02-01",
+      quantity: 100,
+      costPerShare: 1.67,
+    });
+
+    // Reduce the transferred quantity by editing the OUT leg.
+    await service.update(userId, transferOut.id, { quantity: 60 });
+
+    const outAfter = await dataSource.manager.findOneOrFail(
+      InvestmentTransaction,
+      { where: { id: transferOut.id } },
+    );
+    const inAfter = await dataSource.manager.findOneOrFail(
+      InvestmentTransaction,
+      { where: { id: transferIn.id } },
+    );
+    expect(Number(outAfter.quantity)).toBe(60);
+    expect(Number(inAfter.quantity)).toBe(60);
+
+    // 40 stay in A, 60 land in B, cost basis preserved on both sides.
+    const aHolding = await holdingsService.findByAccountAndSecurity(
+      brokerageA,
+      securityId,
+    );
+    const bHolding = await holdingsService.findByAccountAndSecurity(
+      brokerageB,
+      securityId,
+    );
+    expect(qty(aHolding)).toBe(40);
+    expect(qty(bHolding)).toBe(60);
+    expect(Number(bHolding?.averageCost)).toBeCloseTo(1.67, 6);
+  });
+
+  it("rejects transferring more shares than the source holds", async () => {
+    await buy100At167();
+    await expect(
+      service.transferSecurity(userId, {
+        fromAccountId: brokerageA,
+        toAccountId: brokerageB,
+        securityId,
+        transactionDate: "2026-02-01",
+        quantity: 150,
+        costPerShare: 1.67,
+      }),
+    ).rejects.toBeDefined();
+
+    // Nothing moved.
+    const aHolding = await holdingsService.findByAccountAndSecurity(
+      brokerageA,
+      securityId,
+    );
+    expect(qty(aHolding)).toBe(100);
+  });
+});

--- a/database/migrations/078_investment_transaction_transfer_link.sql
+++ b/database/migrations/078_investment_transaction_transfer_link.sql
@@ -1,0 +1,10 @@
+-- Link the two legs of a security transfer (TRANSFER_OUT <-> TRANSFER_IN) so
+-- editing or deleting one leg cascades to its pair. Self-referencing FK; on
+-- delete the surviving leg's pointer is nulled (the service deletes both legs
+-- together in a single transaction).
+ALTER TABLE investment_transactions
+    ADD COLUMN IF NOT EXISTS linked_transaction_id UUID
+        REFERENCES investment_transactions(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_investment_transactions_linked
+    ON investment_transactions(linked_transaction_id);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -504,6 +504,7 @@ CREATE TABLE investment_transactions (
     account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
     transaction_id UUID REFERENCES transactions(id) ON DELETE SET NULL,
     transaction_split_id UUID REFERENCES transaction_splits(id) ON DELETE CASCADE, -- when embedded inside a split transaction
+    linked_transaction_id UUID REFERENCES investment_transactions(id) ON DELETE SET NULL, -- links the two legs of a security transfer (TRANSFER_OUT <-> TRANSFER_IN)
     security_id UUID REFERENCES securities(id),
     funding_account_id UUID REFERENCES accounts(id) ON DELETE SET NULL,
     action investment_action NOT NULL,
@@ -524,6 +525,7 @@ CREATE INDEX idx_investment_transactions_security ON investment_transactions(sec
 CREATE INDEX idx_investment_transactions_date ON investment_transactions(transaction_date DESC);
 CREATE INDEX idx_investment_transactions_transaction ON investment_transactions(transaction_id);
 CREATE INDEX idx_investment_transactions_split_id ON investment_transactions(transaction_split_id);
+CREATE INDEX idx_investment_transactions_linked ON investment_transactions(linked_transaction_id);
 
 -- User Preferences
 CREATE TABLE user_preferences (

--- a/frontend/src/app/securities/page.tsx
+++ b/frontend/src/app/securities/page.tsx
@@ -16,6 +16,7 @@ import { investmentsApi } from '@/lib/investments';
 import { Security, CreateSecurityData, Holding } from '@/types/investment';
 const SecurityForm = dynamic(() => import('@/components/securities/SecurityForm').then(m => m.SecurityForm), { ssr: false });
 const SecurityPriceHistory = dynamic(() => import('@/components/securities/SecurityPriceHistory').then(m => m.SecurityPriceHistory), { ssr: false });
+const SecurityTransactionHistory = dynamic(() => import('@/components/securities/SecurityTransactionHistory').then(m => m.SecurityTransactionHistory), { ssr: false });
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { SecurityList, type SecurityHoldings, type SecurityTransactions, type SecuritySortField, type SortDirection } from '@/components/securities/SecurityList';
 import { type DensityLevel } from '@/hooks/useTableDensity';
@@ -47,6 +48,7 @@ function SecuritiesContent() {
   });
   const { showForm, editingItem: editingSecurity, openCreate, openEdit, close, isEditing, modalProps, setFormDirty, unsavedChangesDialog, formSubmitRef } = useFormModal<Security>();
   const [priceSecurity, setPriceSecurity] = useState<Security | undefined>();
+  const [historySecurity, setHistorySecurity] = useState<Security | undefined>();
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<'all' | 'active' | 'inactive'>('active');
   const [currentPage, setCurrentPage] = useState(1);
@@ -308,6 +310,17 @@ function SecuritiesContent() {
           )}
         </Modal>
 
+        {/* Transaction History Modal */}
+        <Modal isOpen={!!historySecurity} onClose={() => setHistorySecurity(undefined)} maxWidth="5xl" className="p-6" pushHistory>
+          {historySecurity && (
+            <SecurityTransactionHistory
+              security={historySecurity}
+              onClose={() => setHistorySecurity(undefined)}
+              onChanged={loadData}
+            />
+          )}
+        </Modal>
+
         {/* Securities List */}
         <div className="bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg overflow-hidden">
           {isLoading ? (
@@ -321,6 +334,7 @@ function SecuritiesContent() {
               onToggleActive={handleToggleActive}
               onDelete={handleDeleteClick}
               onViewPrices={setPriceSecurity}
+              onViewHistory={setHistorySecurity}
               density={listDensity}
               onDensityChange={setListDensity}
               sortField={sortField}

--- a/frontend/src/components/investments/InvestmentTransactionForm.test.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.test.tsx
@@ -55,6 +55,7 @@ vi.mock('@/lib/investments', () => ({
     createSecurity: vi.fn().mockResolvedValue({ id: 'new-sec', symbol: 'TEST', name: 'Test Corp' }),
     createTransaction: vi.fn().mockResolvedValue({}),
     updateTransaction: vi.fn().mockResolvedValue({}),
+    transferSecurity: vi.fn().mockResolvedValue({ transferOut: {}, transferIn: {} }),
   },
 }));
 
@@ -168,12 +169,19 @@ describe('InvestmentTransactionForm', () => {
     });
   });
 
-  it('renders all action types in dropdown', async () => {
+  it('renders action types in dropdown, offering a single Transfer option', async () => {
     render(<InvestmentTransactionForm accounts={accounts} />);
     await waitFor(() => {
       const select = screen.getByLabelText('Transaction Type');
-      const options = select.querySelectorAll('option');
-      expect(options.length).toBe(11); // 11 action types
+      const optionValues = Array.from(
+        select.querySelectorAll('option'),
+      ).map((o) => o.getAttribute('value'));
+      // The raw TRANSFER_IN/TRANSFER_OUT legs are hidden when creating; a
+      // single combined TRANSFER option is offered instead.
+      expect(optionValues).not.toContain('TRANSFER_IN');
+      expect(optionValues).not.toContain('TRANSFER_OUT');
+      expect(optionValues).toContain('TRANSFER');
+      expect(optionValues.length).toBe(10);
     });
   });
 
@@ -460,6 +468,166 @@ describe('InvestmentTransactionForm', () => {
     const payload = vi.mocked(investmentsApi.createTransaction).mock.calls[0][0] as any;
     expect(payload.action).toBe('DIVIDEND');
     expect(payload.fundingAccountId).toBe('a2');
+  });
+
+  describe('Transfer between accounts', () => {
+    const brokerageB = {
+      id: 'b1',
+      name: 'TFSA Brokerage',
+      accountType: 'INVESTMENT',
+      accountSubType: 'INVESTMENT_BROKERAGE',
+      currencyCode: 'CAD',
+    } as any;
+    const transferAccounts = [brokerageAccount, brokerageB, chequingAccount];
+
+    async function selectTransfer() {
+      render(<InvestmentTransactionForm accounts={transferAccounts} />);
+      await waitFor(() => {
+        expect(screen.getByText('Brokerage Account')).toBeInTheDocument();
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('Transaction Type'), {
+          target: { value: 'TRANSFER' },
+        });
+      });
+    }
+
+    it('reveals destination account, security, quantity and cost-per-share fields', async () => {
+      await selectTransfer();
+      await waitFor(() => {
+        expect(screen.getByLabelText('To Account')).toBeInTheDocument();
+      });
+      expect(screen.getByLabelText('From Account')).toBeInTheDocument();
+      expect(screen.getByText('Security')).toBeInTheDocument();
+      expect(screen.getByLabelText('Quantity (Shares)')).toBeInTheDocument();
+      expect(screen.getByLabelText(/Cost per Share/)).toBeInTheDocument();
+    });
+
+    it('excludes the source account from the destination dropdown', async () => {
+      await selectTransfer();
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('From Account'), {
+          target: { value: 'a1' },
+        });
+      });
+      await waitFor(() => {
+        const dest = screen.getByLabelText('To Account');
+        const values = Array.from(dest.querySelectorAll('option')).map((o) =>
+          o.getAttribute('value'),
+        );
+        expect(values).not.toContain('a1');
+        expect(values).toContain('b1');
+      });
+    });
+
+    it('prefills cost per share from the source holding average cost', async () => {
+      vi.mocked(investmentsApi.getHoldingAt).mockResolvedValue({
+        quantity: 100,
+        averageCost: 1.67,
+      });
+      await selectTransfer();
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('From Account'), {
+          target: { value: 'a1' },
+        });
+      });
+      await waitFor(() => {
+        expect(screen.getByText('Security')).toBeInTheDocument();
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('Security'), {
+          target: { value: 'sec-1' },
+        });
+      });
+      await waitFor(() => {
+        expect(investmentsApi.getHoldingAt).toHaveBeenCalledWith(
+          expect.objectContaining({ accountId: 'a1', securityId: 'sec-1' }),
+        );
+      });
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Cost per Share/)).toHaveValue('1.670000');
+      });
+    });
+
+    it('submits a transfer with the correct payload', async () => {
+      vi.mocked(investmentsApi.getHoldingAt).mockResolvedValue({
+        quantity: 100,
+        averageCost: 1.67,
+      });
+      await selectTransfer();
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('From Account'), {
+          target: { value: 'a1' },
+        });
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('To Account'), {
+          target: { value: 'b1' },
+        });
+      });
+      await waitFor(() => {
+        expect(screen.getByText('Security')).toBeInTheDocument();
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('Security'), {
+          target: { value: 'sec-1' },
+        });
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('Quantity (Shares)'), {
+          target: { value: '100' },
+        });
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('Transfer Securities'));
+      });
+
+      await waitFor(() => {
+        expect(investmentsApi.transferSecurity).toHaveBeenCalled();
+      });
+      const payload = vi.mocked(investmentsApi.transferSecurity).mock.calls[0][0];
+      expect(payload).toMatchObject({
+        fromAccountId: 'a1',
+        toAccountId: 'b1',
+        securityId: 'sec-1',
+        quantity: 100,
+        costPerShare: 1.67,
+      });
+    });
+
+    it('blocks a transfer to the same source and destination account', async () => {
+      vi.mocked(investmentsApi.getHoldingAt).mockResolvedValue({
+        quantity: 100,
+        averageCost: 1.67,
+      });
+      await selectTransfer();
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('From Account'), {
+          target: { value: 'a1' },
+        });
+      });
+      await waitFor(() => {
+        expect(screen.getByText('Security')).toBeInTheDocument();
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('Security'), {
+          target: { value: 'sec-1' },
+        });
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('Quantity (Shares)'), {
+          target: { value: '50' },
+        });
+      });
+      // Destination left blank -> validation should block and toast an error.
+      await act(async () => {
+        fireEvent.click(screen.getByText('Transfer Securities'));
+      });
+      await act(async () => {});
+      expect(investmentsApi.transferSecurity).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalled();
+    });
   });
 
   it('clears a stale fundingAccountId when switching to an action that does not accept one', async () => {

--- a/frontend/src/components/investments/InvestmentTransactionForm.test.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.test.tsx
@@ -56,6 +56,7 @@ vi.mock('@/lib/investments', () => ({
     createTransaction: vi.fn().mockResolvedValue({}),
     updateTransaction: vi.fn().mockResolvedValue({}),
     transferSecurity: vi.fn().mockResolvedValue({ transferOut: {}, transferIn: {} }),
+    getTransaction: vi.fn().mockResolvedValue({}),
   },
 }));
 
@@ -657,6 +658,16 @@ describe('InvestmentTransactionForm', () => {
   });
 
   describe('Editing a posted transfer leg', () => {
+    const brokerageB = {
+      id: 'b1',
+      name: 'TFSA Brokerage',
+      accountType: 'INVESTMENT',
+      accountSubType: 'INVESTMENT_BROKERAGE',
+      currencyCode: 'CAD',
+    } as any;
+    const editAccounts = [brokerageAccount, brokerageB, chequingAccount];
+
+    // The opened OUT leg (source a1) is linked to the IN leg (dest b1).
     const transferLeg = {
       id: 'leg-out',
       accountId: 'a1',
@@ -668,12 +679,25 @@ describe('InvestmentTransactionForm', () => {
       commission: 0,
       totalAmount: 0,
       description: '',
+      linkedTransactionId: 'leg-in',
     } as any;
+
+    beforeEach(() => {
+      vi.mocked(investmentsApi.getTransaction).mockResolvedValue({
+        id: 'leg-in',
+        accountId: 'b1',
+        action: 'TRANSFER_IN',
+        securityId: 'sec-1',
+        quantity: 100,
+        price: 1.67,
+        linkedTransactionId: 'leg-out',
+      } as any);
+    });
 
     it('locks the transaction type so the direction cannot change', async () => {
       render(
         <InvestmentTransactionForm
-          accounts={accounts}
+          accounts={editAccounts}
           transaction={transferLeg}
         />,
       );
@@ -686,7 +710,7 @@ describe('InvestmentTransactionForm', () => {
     it('does not show the Total Amount for a transfer', async () => {
       render(
         <InvestmentTransactionForm
-          accounts={accounts}
+          accounts={editAccounts}
           transaction={transferLeg}
         />,
       );
@@ -694,6 +718,55 @@ describe('InvestmentTransactionForm', () => {
         expect(screen.getByText('Update Transaction')).toBeInTheDocument();
       });
       expect(screen.queryByText(/Total Amount/)).not.toBeInTheDocument();
+    });
+
+    it('shows both the source and destination accounts', async () => {
+      render(
+        <InvestmentTransactionForm
+          accounts={editAccounts}
+          transaction={transferLeg}
+        />,
+      );
+      await waitFor(() => {
+        expect(investmentsApi.getTransaction).toHaveBeenCalledWith('leg-in');
+      });
+      await waitFor(() => {
+        expect(screen.getByLabelText('From Account')).toHaveValue('a1');
+        expect(screen.getByLabelText('To Account')).toHaveValue('b1');
+      });
+    });
+
+    it('submits both accounts to the source leg when edited', async () => {
+      render(
+        <InvestmentTransactionForm
+          accounts={editAccounts}
+          transaction={transferLeg}
+        />,
+      );
+      await waitFor(() => {
+        expect(screen.getByLabelText('To Account')).toHaveValue('b1');
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('Quantity (Shares)'), {
+          target: { value: '60' },
+        });
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText('Update Transaction'));
+      });
+      await waitFor(() => {
+        expect(investmentsApi.updateTransaction).toHaveBeenCalled();
+      });
+      const [id, payload] = vi.mocked(investmentsApi.updateTransaction).mock
+        .calls[0];
+      // Edits route through the source (OUT) leg and carry both accounts.
+      expect(id).toBe('leg-out');
+      expect(payload).toMatchObject({
+        accountId: 'a1',
+        destinationAccountId: 'b1',
+        securityId: 'sec-1',
+        quantity: 60,
+      });
     });
   });
 

--- a/frontend/src/components/investments/InvestmentTransactionForm.test.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.test.tsx
@@ -685,6 +685,43 @@ describe('InvestmentTransactionForm', () => {
       expect(investmentsApi.transferSecurity).not.toHaveBeenCalled();
       expect(toast.error).toHaveBeenCalled();
     });
+
+    it('excludes closed accounts from the destination dropdown', async () => {
+      const closedBrokerage = {
+        id: 'b2',
+        name: 'Closed Brokerage',
+        accountType: 'INVESTMENT',
+        accountSubType: 'INVESTMENT_BROKERAGE',
+        currencyCode: 'CAD',
+        isClosed: true,
+      } as any;
+      render(
+        <InvestmentTransactionForm
+          accounts={[...transferAccounts, closedBrokerage]}
+        />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Brokerage Account')).toBeInTheDocument();
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('Transaction Type'), {
+          target: { value: 'TRANSFER' },
+        });
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('From Account'), {
+          target: { value: 'a1' },
+        });
+      });
+      await waitFor(() => {
+        const dest = screen.getByLabelText('To Account');
+        const values = Array.from(dest.querySelectorAll('option')).map((o) =>
+          o.getAttribute('value'),
+        );
+        expect(values).not.toContain('b2');
+        expect(values).toContain('b1');
+      });
+    });
   });
 
   describe('Editing a posted transfer leg', () => {
@@ -797,6 +834,50 @@ describe('InvestmentTransactionForm', () => {
         securityId: 'sec-1',
         quantity: 60,
       });
+    });
+
+    it('blocks an edit that exceeds the available shares', async () => {
+      // The source (a1) currently holds 0 (all 100 already transferred out).
+      // Editing reverses this leg first, so up to 100 is available again --
+      // 150 must be rejected client-side before hitting the API.
+      vi.mocked(investmentsApi.getHoldings).mockResolvedValue([
+        {
+          id: 'h1',
+          accountId: 'a1',
+          securityId: 'sec-1',
+          quantity: 0,
+          averageCost: 1.67,
+          security: {
+            id: 'sec-1',
+            symbol: 'AAPL',
+            name: 'Apple Inc.',
+            currencyCode: 'USD',
+          },
+        },
+      ] as any);
+      render(
+        <InvestmentTransactionForm
+          accounts={editAccounts}
+          transaction={transferLeg}
+        />,
+      );
+      await waitFor(() => {
+        expect(screen.getByLabelText('To Account')).toHaveValue('b1');
+      });
+      await waitFor(() => {
+        expect(investmentsApi.getHoldings).toHaveBeenCalledWith('a1');
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('Quantity (Shares)'), {
+          target: { value: '150' },
+        });
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText('Update Transaction'));
+      });
+      await act(async () => {});
+      expect(investmentsApi.updateTransaction).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/components/investments/InvestmentTransactionForm.test.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.test.tsx
@@ -480,6 +480,27 @@ describe('InvestmentTransactionForm', () => {
     } as any;
     const transferAccounts = [brokerageAccount, brokerageB, chequingAccount];
 
+    // The source account (a1) holds 100 shares of sec-1 at 1.67 avg cost.
+    const sourceHoldings = [
+      {
+        id: 'h1',
+        accountId: 'a1',
+        securityId: 'sec-1',
+        quantity: 100,
+        averageCost: 1.67,
+        security: {
+          id: 'sec-1',
+          symbol: 'AAPL',
+          name: 'Apple Inc.',
+          currencyCode: 'USD',
+        },
+      },
+    ] as any;
+
+    beforeEach(() => {
+      vi.mocked(investmentsApi.getHoldings).mockResolvedValue(sourceHoldings);
+    });
+
     async function selectTransfer() {
       render(<InvestmentTransactionForm accounts={transferAccounts} />);
       await waitFor(() => {
@@ -520,11 +541,7 @@ describe('InvestmentTransactionForm', () => {
       });
     });
 
-    it('prefills cost per share from the source holding average cost', async () => {
-      vi.mocked(investmentsApi.getHoldingAt).mockResolvedValue({
-        quantity: 100,
-        averageCost: 1.67,
-      });
+    it('lists only securities held in the source account', async () => {
       await selectTransfer();
       await act(async () => {
         fireEvent.change(screen.getByLabelText('From Account'), {
@@ -532,7 +549,29 @@ describe('InvestmentTransactionForm', () => {
         });
       });
       await waitFor(() => {
-        expect(screen.getByText('Security')).toBeInTheDocument();
+        expect(investmentsApi.getHoldings).toHaveBeenCalledWith('a1');
+      });
+      await waitFor(() => {
+        const select = screen.getByLabelText('Security');
+        const values = Array.from(select.querySelectorAll('option'))
+          .map((o) => o.getAttribute('value'))
+          .filter(Boolean);
+        // Only the held security (sec-1) is offered.
+        expect(values).toEqual(['sec-1']);
+      });
+      // Transfers cannot create new securities.
+      expect(screen.queryByText('+ Add new security')).not.toBeInTheDocument();
+    });
+
+    it('prefills cost per share from the source holding average cost', async () => {
+      await selectTransfer();
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('From Account'), {
+          target: { value: 'a1' },
+        });
+      });
+      await waitFor(() => {
+        expect(investmentsApi.getHoldings).toHaveBeenCalledWith('a1');
       });
       await act(async () => {
         fireEvent.change(screen.getByLabelText('Security'), {
@@ -540,20 +579,11 @@ describe('InvestmentTransactionForm', () => {
         });
       });
       await waitFor(() => {
-        expect(investmentsApi.getHoldingAt).toHaveBeenCalledWith(
-          expect.objectContaining({ accountId: 'a1', securityId: 'sec-1' }),
-        );
-      });
-      await waitFor(() => {
         expect(screen.getByLabelText(/Cost per Share/)).toHaveValue('1.670000');
       });
     });
 
     it('submits a transfer with the correct payload', async () => {
-      vi.mocked(investmentsApi.getHoldingAt).mockResolvedValue({
-        quantity: 100,
-        averageCost: 1.67,
-      });
       await selectTransfer();
       await act(async () => {
         fireEvent.change(screen.getByLabelText('From Account'), {
@@ -566,7 +596,7 @@ describe('InvestmentTransactionForm', () => {
         });
       });
       await waitFor(() => {
-        expect(screen.getByText('Security')).toBeInTheDocument();
+        expect(investmentsApi.getHoldings).toHaveBeenCalledWith('a1');
       });
       await act(async () => {
         fireEvent.change(screen.getByLabelText('Security'), {
@@ -597,10 +627,6 @@ describe('InvestmentTransactionForm', () => {
     });
 
     it('blocks a transfer to the same source and destination account', async () => {
-      vi.mocked(investmentsApi.getHoldingAt).mockResolvedValue({
-        quantity: 100,
-        averageCost: 1.67,
-      });
       await selectTransfer();
       await act(async () => {
         fireEvent.change(screen.getByLabelText('From Account'), {
@@ -608,7 +634,7 @@ describe('InvestmentTransactionForm', () => {
         });
       });
       await waitFor(() => {
-        expect(screen.getByText('Security')).toBeInTheDocument();
+        expect(investmentsApi.getHoldings).toHaveBeenCalledWith('a1');
       });
       await act(async () => {
         fireEvent.change(screen.getByLabelText('Security'), {

--- a/frontend/src/components/investments/InvestmentTransactionForm.test.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.test.tsx
@@ -496,6 +496,36 @@ describe('InvestmentTransactionForm', () => {
           currencyCode: 'USD',
         },
       },
+      // A fully-exited position lingers as a zero-quantity holding row; it must
+      // not appear as transferable.
+      {
+        id: 'h2',
+        accountId: 'a1',
+        securityId: 'sec-2',
+        quantity: 0,
+        averageCost: 0,
+        security: {
+          id: 'sec-2',
+          symbol: 'GONE',
+          name: 'Sold Out Co.',
+          currencyCode: 'USD',
+        },
+      },
+      // A tiny residual position (below the 0.0001 presence threshold the rest
+      // of the app uses) should also be hidden.
+      {
+        id: 'h3',
+        accountId: 'a1',
+        securityId: 'sec-3',
+        quantity: 0.00005,
+        averageCost: 5,
+        security: {
+          id: 'sec-3',
+          symbol: 'DUST',
+          name: 'Residual Inc.',
+          currencyCode: 'USD',
+        },
+      },
     ] as any;
 
     beforeEach(() => {

--- a/frontend/src/components/investments/InvestmentTransactionForm.test.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.test.tsx
@@ -656,6 +656,47 @@ describe('InvestmentTransactionForm', () => {
     });
   });
 
+  describe('Editing a posted transfer leg', () => {
+    const transferLeg = {
+      id: 'leg-out',
+      accountId: 'a1',
+      action: 'TRANSFER_OUT' as const,
+      transactionDate: '2026-02-01',
+      securityId: 'sec-1',
+      quantity: 100,
+      price: 1.67,
+      commission: 0,
+      totalAmount: 0,
+      description: '',
+    } as any;
+
+    it('locks the transaction type so the direction cannot change', async () => {
+      render(
+        <InvestmentTransactionForm
+          accounts={accounts}
+          transaction={transferLeg}
+        />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Update Transaction')).toBeInTheDocument();
+      });
+      expect(screen.getByLabelText('Transaction Type')).toBeDisabled();
+    });
+
+    it('does not show the Total Amount for a transfer', async () => {
+      render(
+        <InvestmentTransactionForm
+          accounts={accounts}
+          transaction={transferLeg}
+        />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Update Transaction')).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/Total Amount/)).not.toBeInTheDocument();
+    });
+  });
+
   it('clears a stale fundingAccountId when switching to an action that does not accept one', async () => {
     render(<InvestmentTransactionForm accounts={accounts} />);
     await waitFor(() => {

--- a/frontend/src/components/investments/InvestmentTransactionForm.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.tsx
@@ -273,7 +273,17 @@ export function InvestmentTransactionForm({
   // never matches any of the classification arrays below; transfer fields are
   // rendered from this flag instead.
   const isTransfer = (watchedAction as string) === 'TRANSFER';
+  // Editing an existing transfer leg (the action is one of the real
+  // TRANSFER_IN/OUT values, not the UI-only 'TRANSFER').
+  const isTransferEditing =
+    !!transaction &&
+    ((watchedAction as string) === 'TRANSFER_IN' ||
+      (watchedAction as string) === 'TRANSFER_OUT');
+  // Source-account holdings are relevant both when creating a transfer and when
+  // editing one (to validate the available quantity).
+  const transferActive = isTransfer || isTransferEditing;
   const watchedSecurityId = watch('securityId');
+  const watchedDestinationAccountId = watch('destinationAccountId');
   const watchedFundingAccountId = watch('fundingAccountId');
   const watchedQuantity = Number(watch('quantity')) || 0;
   const watchedPrice = Number(watch('price')) || 0;
@@ -498,7 +508,7 @@ export function InvestmentTransactionForm({
   // actually held there can be transferred, and each holding carries the
   // average cost we use to prefill the cost-per-share.
   useEffect(() => {
-    if (!isTransfer || !watchedAccountId) {
+    if (!transferActive || !watchedAccountId) {
       setTransferSourceHoldings([]);
       return;
     }
@@ -517,7 +527,7 @@ export function InvestmentTransactionForm({
     return () => {
       cancelled = true;
     };
-  }, [isTransfer, watchedAccountId]);
+  }, [transferActive, watchedAccountId]);
 
   // When editing a transfer leg, load the paired leg so both the source and
   // destination accounts can be shown. The form's `accountId` always holds the
@@ -563,19 +573,21 @@ export function InvestmentTransactionForm({
   // until then.
   const selectedTransferHolding = useMemo(
     () =>
-      isTransfer && watchedSecurityId
+      transferActive && watchedSecurityId
         ? transferSourceHoldings.find((h) => h.securityId === watchedSecurityId)
         : undefined,
-    [isTransfer, watchedSecurityId, transferSourceHoldings],
+    [transferActive, watchedSecurityId, transferSourceHoldings],
   );
   useEffect(() => {
-    if (!selectedTransferHolding) return;
+    // Only prefill the cost on a new transfer. When editing, the leg already
+    // carries its own cost basis and must not be reset to the current average.
+    if (!isTransfer || !selectedTransferHolding) return;
     setValue(
       'price',
       roundToDecimals(Number(selectedTransferHolding.averageCost) || 0, 6),
       { shouldValidate: true },
     );
-  }, [selectedTransferHolding, setValue]);
+  }, [isTransfer, selectedTransferHolding, setValue]);
 
   // Securities available to transfer: only those currently held in the source
   // account. Use the same presence threshold the portfolio/holdings views use
@@ -641,7 +653,10 @@ export function InvestmentTransactionForm({
           setIsLoading(false);
           return;
         }
-        const available = Number(selectedTransferHolding?.quantity ?? 0);
+        const available = roundToDecimals(
+          Number(selectedTransferHolding?.quantity ?? 0),
+          8,
+        );
         if (selectedTransferHolding && quantity > available) {
           toast.error(`Only ${available} shares available to transfer`);
           setIsLoading(false);
@@ -687,6 +702,30 @@ export function InvestmentTransactionForm({
           toast.error('Quantity must be greater than zero');
           setIsLoading(false);
           return;
+        }
+        // Available-quantity check. The edit reverses this leg before
+        // reapplying, so its original quantity is available again on top of the
+        // current source holding. Only checked when the source account is
+        // unchanged; otherwise the backend's full-history validation is
+        // authoritative.
+        const originalSourceAccountId =
+          transaction.action === 'TRANSFER_OUT'
+            ? transaction.accountId
+            : transferLinkedLeg?.accountId;
+        if (
+          selectedTransferHolding &&
+          data.accountId === originalSourceAccountId
+        ) {
+          const available = roundToDecimals(
+            Number(selectedTransferHolding.quantity) +
+              Number(transaction.quantity ?? 0),
+            8,
+          );
+          if (quantity > available) {
+            toast.error(`Only ${available} shares available to transfer`);
+            setIsLoading(false);
+            return;
+          }
         }
         const outLegId =
           data.action === 'TRANSFER_OUT'
@@ -808,9 +847,14 @@ export function InvestmentTransactionForm({
         { value: 'TRANSFER', label: 'Transfer' },
       ];
 
-  // Brokerage accounts eligible as a transfer destination (exclude the source).
+  // Brokerage accounts eligible as a transfer destination: exclude the source
+  // and any closed account (a closed account shouldn't receive new shares),
+  // but keep the currently-selected destination visible when editing a transfer
+  // that already points at a since-closed account.
   const destinationAccounts = brokerageAccounts.filter(
-    (a) => a.id !== watchedAccountId,
+    (a) =>
+      a.id !== watchedAccountId &&
+      (!a.isClosed || a.id === watchedDestinationAccountId),
   );
 
   const splitPreview = useMemo(() => {

--- a/frontend/src/components/investments/InvestmentTransactionForm.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.tsx
@@ -36,10 +36,14 @@ const logger = createLogger('InvestmentTxForm');
 
 const investmentTransactionSchema = z.object({
   accountId: z.string().min(1, 'Account is required'),
-  action: z.enum(['BUY', 'SELL', 'DIVIDEND', 'INTEREST', 'CAPITAL_GAIN', 'SPLIT', 'TRANSFER_IN', 'TRANSFER_OUT', 'REINVEST', 'ADD_SHARES', 'REMOVE_SHARES']),
+  // 'TRANSFER' is a UI-only action that creates a TRANSFER_OUT + TRANSFER_IN
+  // pair on the backend; it is offered only when creating, not editing.
+  action: z.enum(['BUY', 'SELL', 'DIVIDEND', 'INTEREST', 'CAPITAL_GAIN', 'SPLIT', 'TRANSFER_IN', 'TRANSFER_OUT', 'REINVEST', 'ADD_SHARES', 'REMOVE_SHARES', 'TRANSFER']),
   transactionDate: z.string().min(1, 'Date is required'),
   securityId: z.string().optional(),
   fundingAccountId: z.string().optional(),
+  // Destination account for a TRANSFER (the source is `accountId`).
+  destinationAccountId: z.string().optional(),
   quantity: z.coerce.number().min(0).optional(),
   price: z.coerce.number().min(0).optional(),
   commission: z.coerce.number().min(0).optional(),
@@ -78,17 +82,20 @@ const actionLabels: Record<InvestmentAction, string> = {
   REMOVE_SHARES: 'Remove Shares',
 };
 
-// Actions that require a security selection
-const securityRequiredActions: InvestmentAction[] = ['BUY', 'SELL', 'DIVIDEND', 'CAPITAL_GAIN', 'SPLIT', 'REINVEST', 'ADD_SHARES', 'REMOVE_SHARES'];
+// Actions that require a security selection. TRANSFER_IN/TRANSFER_OUT are the
+// individual legs of a transfer; they carry a security, quantity and per-share
+// cost basis. Creation goes through the combined "Transfer" action, so these
+// only surface here when editing an existing leg.
+const securityRequiredActions: InvestmentAction[] = ['BUY', 'SELL', 'DIVIDEND', 'CAPITAL_GAIN', 'SPLIT', 'REINVEST', 'ADD_SHARES', 'REMOVE_SHARES', 'TRANSFER_IN', 'TRANSFER_OUT'];
 
-// Actions that require quantity and price
-const quantityPriceActions: InvestmentAction[] = ['BUY', 'SELL', 'REINVEST'];
+// Actions that require quantity and price (per-share cost for transfer legs)
+const quantityPriceActions: InvestmentAction[] = ['BUY', 'SELL', 'REINVEST', 'TRANSFER_IN', 'TRANSFER_OUT'];
 
 // Actions that only need quantity (no price, no cash effect)
 const quantityOnlyActions: InvestmentAction[] = ['ADD_SHARES', 'REMOVE_SHARES'];
 
 // Actions that only need an amount (no quantity/price)
-const amountOnlyActions: InvestmentAction[] = ['DIVIDEND', 'INTEREST', 'CAPITAL_GAIN', 'TRANSFER_IN', 'TRANSFER_OUT'];
+const amountOnlyActions: InvestmentAction[] = ['DIVIDEND', 'INTEREST', 'CAPITAL_GAIN'];
 
 // Actions that can have an external funding account (where funds come from/go to)
 const fundingAccountActions: InvestmentAction[] = ['BUY', 'SELL'];
@@ -155,6 +162,12 @@ export function InvestmentTransactionForm({
   // "Before" line in the holding preview. Null means "no holding history at
   // that date" (don't render the preview).
   const [splitHoldingAt, setSplitHoldingAt] = useState<{
+    quantity: number;
+    averageCost: number;
+  } | null>(null);
+  // Source-account holding for a TRANSFER, replayed as of the transfer date.
+  // Drives the available-quantity check and the cost-per-share prefill.
+  const [transferSourceHolding, setTransferSourceHolding] = useState<{
     quantity: number;
     averageCost: number;
   } | null>(null);
@@ -237,6 +250,7 @@ export function InvestmentTransactionForm({
           action: 'BUY',
           transactionDate: getLocalDateString(),
           fundingAccountId: '',
+          destinationAccountId: '',
           quantity: undefined,
           price: undefined,
           commission: undefined,
@@ -251,6 +265,10 @@ export function InvestmentTransactionForm({
 
   const watchedAccountId = watch('accountId');
   const watchedAction = watch('action') as InvestmentAction;
+  // 'TRANSFER' is a UI-only action and is not part of InvestmentAction, so it
+  // never matches any of the classification arrays below; transfer fields are
+  // rendered from this flag instead.
+  const isTransfer = (watchedAction as string) === 'TRANSFER';
   const watchedSecurityId = watch('securityId');
   const watchedFundingAccountId = watch('fundingAccountId');
   const watchedQuantity = Number(watch('quantity')) || 0;
@@ -472,6 +490,42 @@ export function InvestmentTransactionForm({
     transaction?.id,
   ]);
 
+  // For a TRANSFER, replay the source account's holding as of the transfer
+  // date and prefill the cost-per-share with its average cost so the original
+  // cost basis carries to the destination (keeping gain/profit reports
+  // correct). Mirrors the SPLIT as-of fetch above.
+  useEffect(() => {
+    if (!isTransfer || !watchedAccountId || !watchedSecurityId || !watchedTransactionDate) {
+      setTransferSourceHolding(null);
+      return;
+    }
+    let cancelled = false;
+    investmentsApi
+      .getHoldingAt({
+        accountId: watchedAccountId,
+        securityId: watchedSecurityId,
+        asOfDate: watchedTransactionDate,
+      })
+      .then((data) => {
+        if (cancelled) return;
+        setTransferSourceHolding(data);
+        // Suggest the source average cost as the carried cost basis. Re-runs
+        // when source/security/date change; manual edits persist until then.
+        setValue('price', roundToDecimals(Number(data.averageCost) || 0, 6), {
+          shouldValidate: true,
+        });
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setTransferSourceHolding(null);
+          logger.error('Failed to load source holdings for transfer:', error);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isTransfer, watchedAccountId, watchedSecurityId, watchedTransactionDate, setValue]);
+
   // Re-sync form values when editing and securities are loaded
   useEffect(() => {
     if (transaction && securities.length > 0) {
@@ -498,6 +552,49 @@ export function InvestmentTransactionForm({
   const onSubmit = async (data: InvestmentTransactionFormData) => {
     setIsLoading(true);
     try {
+      if (data.action === 'TRANSFER') {
+        const quantity = Number(data.quantity) || 0;
+        const costPerShare = Number(data.price) || 0;
+        if (!data.securityId) {
+          toast.error('Select a security to transfer');
+          setIsLoading(false);
+          return;
+        }
+        if (!data.destinationAccountId) {
+          toast.error('Select a destination account');
+          setIsLoading(false);
+          return;
+        }
+        if (data.destinationAccountId === data.accountId) {
+          toast.error('Source and destination accounts must be different');
+          setIsLoading(false);
+          return;
+        }
+        if (quantity <= 0) {
+          toast.error('Quantity must be greater than zero');
+          setIsLoading(false);
+          return;
+        }
+        const available = Number(transferSourceHolding?.quantity ?? 0);
+        if (transferSourceHolding && quantity > available) {
+          toast.error(`Only ${available} shares available to transfer`);
+          setIsLoading(false);
+          return;
+        }
+        await investmentsApi.transferSecurity({
+          fromAccountId: data.accountId,
+          toAccountId: data.destinationAccountId,
+          securityId: data.securityId,
+          transactionDate: data.transactionDate,
+          quantity,
+          costPerShare,
+          description: data.description,
+        });
+        toast.success('Securities transferred');
+        onSuccess?.();
+        return;
+      }
+
       const action = data.action as InvestmentAction;
       const postsCash = cashPostingActions.includes(action);
       const isSplit = action === 'SPLIT';
@@ -574,6 +671,24 @@ export function InvestmentTransactionForm({
   const canHaveFundingAccount = fundingAccountActions.includes(watchedAction);
   const canHaveCashDestination = cashDestinationActions.includes(watchedAction);
 
+  // When creating, offer a single "Transfer" option and hide the raw
+  // TRANSFER_IN/TRANSFER_OUT legs (they are produced as a pair by the backend).
+  // When editing an existing leg, show the real action labels so the stored
+  // action displays correctly.
+  const actionOptions = transaction
+    ? Object.entries(actionLabels).map(([value, label]) => ({ value, label }))
+    : [
+        ...Object.entries(actionLabels)
+          .filter(([value]) => value !== 'TRANSFER_IN' && value !== 'TRANSFER_OUT')
+          .map(([value, label]) => ({ value, label })),
+        { value: 'TRANSFER', label: 'Transfer Between Accounts' },
+      ];
+
+  // Brokerage accounts eligible as a transfer destination (exclude the source).
+  const destinationAccounts = brokerageAccounts.filter(
+    (a) => a.id !== watchedAccountId,
+  );
+
   const splitPreview = useMemo(() => {
     if (!isSplit || !splitHoldingAt || splitRatio <= 0) return null;
     const currentQty = Number(splitHoldingAt.quantity);
@@ -592,7 +707,7 @@ export function InvestmentTransactionForm({
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
       {/* Account Selection */}
       <Select
-        label="Brokerage Account"
+        label={isTransfer ? 'From Account' : 'Brokerage Account'}
         error={errors.accountId?.message}
         options={[
           { value: '', label: 'Select account...' },
@@ -615,10 +730,7 @@ export function InvestmentTransactionForm({
         <Select
           label="Transaction Type"
           error={errors.action?.message}
-          options={Object.entries(actionLabels).map(([value, label]) => ({
-            value,
-            label,
-          }))}
+          options={actionOptions}
           {...register('action')}
         />
       </div>
@@ -653,8 +765,24 @@ export function InvestmentTransactionForm({
         />
       )}
 
+      {/* Destination account - for a transfer between accounts */}
+      {isTransfer && (
+        <Select
+          label="To Account"
+          error={errors.destinationAccountId?.message}
+          options={[
+            { value: '', label: 'Select account...' },
+            ...destinationAccounts.map((a) => ({
+              value: a.id,
+              label: `${a.name} (${a.currencyCode})`,
+            })),
+          ]}
+          {...register('destinationAccountId')}
+        />
+      )}
+
       {/* Security Selection - only for actions that need it */}
-      {needsSecurity && (
+      {(needsSecurity || isTransfer) && (
         <div className="space-y-2">
           <Select
             label="Security"
@@ -830,6 +958,50 @@ export function InvestmentTransactionForm({
         />
       )}
 
+      {/* Quantity and cost basis - for a transfer between accounts */}
+      {isTransfer && (
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-4">
+            <NumericInput
+              label="Quantity (Shares)"
+              value={watchedQuantity || undefined}
+              onChange={(value) => setValue('quantity', value, { shouldValidate: true })}
+              decimalPlaces={8}
+              min={0}
+              error={errors.quantity?.message}
+            />
+            <NumericInput
+              label={`Cost per Share (${transactionCurrency})`}
+              prefix={currencySymbol}
+              value={watchedPrice || undefined}
+              onChange={(value) => setValue('price', value, { shouldValidate: true })}
+              decimalPlaces={6}
+              min={0}
+              error={errors.price?.message}
+            />
+          </div>
+          {transferSourceHolding && transferSourceHolding.quantity > 0 && (
+            <div className="rounded border border-gray-200 bg-white p-3 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300">
+              Source holds{' '}
+              <span className="font-mono">
+                {Number(transferSourceHolding.quantity).toFixed(4)}
+              </span>{' '}
+              shares @{' '}
+              <span className="font-mono">
+                {currencySymbol}
+                {Number(transferSourceHolding.averageCost).toFixed(4)}
+              </span>{' '}
+              avg cost as of {formatDate(watchedTransactionDate)}.
+            </div>
+          )}
+          <div className="rounded border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-200">
+            The cost per share (prefilled from the source account) is carried to
+            the destination so your gain and profit reports stay correct. This
+            moves shares only -- no cash changes hands.
+          </div>
+        </div>
+      )}
+
       {/* Commission - rendered inline with qty/price when conversion is shown */}
       {needsQuantityPrice && !needsConversion && (
         <CurrencyInput
@@ -917,7 +1089,7 @@ export function InvestmentTransactionForm({
       )}
 
       {/* Form Actions */}
-      <FormActions onCancel={onCancel} submitLabel={transaction ? 'Update Transaction' : 'Create Transaction'} isSubmitting={isLoading} />
+      <FormActions onCancel={onCancel} submitLabel={isTransfer ? 'Transfer Securities' : transaction ? 'Update Transaction' : 'Create Transaction'} isSubmitting={isLoading} />
     </form>
 
     <Modal isOpen={showSecurityModal} onClose={() => setShowSecurityModal(false)} maxWidth="lg" className="p-6">

--- a/frontend/src/components/investments/InvestmentTransactionForm.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.tsx
@@ -83,14 +83,13 @@ const actionLabels: Record<InvestmentAction, string> = {
   REMOVE_SHARES: 'Remove Shares',
 };
 
-// Actions that require a security selection. TRANSFER_IN/TRANSFER_OUT are the
-// individual legs of a transfer; they carry a security, quantity and per-share
-// cost basis. Creation goes through the combined "Transfer" action, so these
-// only surface here when editing an existing leg.
-const securityRequiredActions: InvestmentAction[] = ['BUY', 'SELL', 'DIVIDEND', 'CAPITAL_GAIN', 'SPLIT', 'REINVEST', 'ADD_SHARES', 'REMOVE_SHARES', 'TRANSFER_IN', 'TRANSFER_OUT'];
+// Actions that require a security selection. Transfers (the combined create
+// action and the TRANSFER_IN/TRANSFER_OUT edit legs) render their own security
+// + quantity + cost fields via `transferMode`, so they're excluded here.
+const securityRequiredActions: InvestmentAction[] = ['BUY', 'SELL', 'DIVIDEND', 'CAPITAL_GAIN', 'SPLIT', 'REINVEST', 'ADD_SHARES', 'REMOVE_SHARES'];
 
-// Actions that require quantity and price (per-share cost for transfer legs)
-const quantityPriceActions: InvestmentAction[] = ['BUY', 'SELL', 'REINVEST', 'TRANSFER_IN', 'TRANSFER_OUT'];
+// Actions that require quantity and price
+const quantityPriceActions: InvestmentAction[] = ['BUY', 'SELL', 'REINVEST'];
 
 // Actions that only need quantity (no price, no cash effect)
 const quantityOnlyActions: InvestmentAction[] = ['ADD_SHARES', 'REMOVE_SHARES'];
@@ -172,6 +171,10 @@ export function InvestmentTransactionForm({
   const [transferSourceHoldings, setTransferSourceHoldings] = useState<
     Holding[]
   >([]);
+  // When editing a transfer leg, the paired (linked) leg -- so the form can
+  // show and edit both the source and destination accounts.
+  const [transferLinkedLeg, setTransferLinkedLeg] =
+    useState<InvestmentTransaction | null>(null);
 
   // Filter to only show brokerage accounts (sorted)
   const brokerageAccounts = useMemo(
@@ -516,6 +519,44 @@ export function InvestmentTransactionForm({
     };
   }, [isTransfer, watchedAccountId]);
 
+  // When editing a transfer leg, load the paired leg so both the source and
+  // destination accounts can be shown. The form's `accountId` always holds the
+  // source (TRANSFER_OUT) account and `destinationAccountId` the destination
+  // (TRANSFER_IN) account, regardless of which leg was opened.
+  useEffect(() => {
+    const action = transaction?.action;
+    if (
+      !transaction ||
+      (action !== 'TRANSFER_IN' && action !== 'TRANSFER_OUT') ||
+      !transaction.linkedTransactionId
+    ) {
+      setTransferLinkedLeg(null);
+      return;
+    }
+    let cancelled = false;
+    investmentsApi
+      .getTransaction(transaction.linkedTransactionId)
+      .then((linked) => {
+        if (cancelled) return;
+        setTransferLinkedLeg(linked);
+        const sourceId =
+          action === 'TRANSFER_OUT' ? transaction.accountId : linked.accountId;
+        const destId =
+          action === 'TRANSFER_OUT' ? linked.accountId : transaction.accountId;
+        setValue('accountId', sourceId);
+        setValue('destinationAccountId', destId);
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setTransferLinkedLeg(null);
+          logger.error('Failed to load linked transfer leg:', error);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [transaction, setValue]);
+
   // Prefill the cost-per-share from the selected source holding's average cost
   // so the original cost basis carries to the destination. Re-runs when the
   // selected security (or the loaded holdings) change; manual edits persist
@@ -618,6 +659,56 @@ export function InvestmentTransactionForm({
         return;
       }
 
+      // Editing an existing transfer: update the pair via the source (OUT) leg.
+      if (
+        transaction &&
+        (data.action === 'TRANSFER_IN' || data.action === 'TRANSFER_OUT')
+      ) {
+        const quantity = Number(data.quantity) || 0;
+        const costPerShare = Number(data.price) || 0;
+        if (!data.securityId) {
+          toast.error('Select a security to transfer');
+          setIsLoading(false);
+          return;
+        }
+        if (!data.destinationAccountId) {
+          toast.error('Select a destination account');
+          setIsLoading(false);
+          return;
+        }
+        if (data.destinationAccountId === data.accountId) {
+          toast.error('Source and destination accounts must be different');
+          setIsLoading(false);
+          return;
+        }
+        if (quantity <= 0) {
+          toast.error('Quantity must be greater than zero');
+          setIsLoading(false);
+          return;
+        }
+        const outLegId =
+          data.action === 'TRANSFER_OUT'
+            ? transaction.id
+            : transferLinkedLeg?.id;
+        if (!outLegId) {
+          toast.error('Could not load the paired transfer leg; reopen and try again');
+          setIsLoading(false);
+          return;
+        }
+        await investmentsApi.updateTransaction(outLegId, {
+          accountId: data.accountId,
+          destinationAccountId: data.destinationAccountId,
+          securityId: data.securityId,
+          quantity,
+          price: costPerShare,
+          transactionDate: data.transactionDate,
+          description: data.description,
+        });
+        toast.success('Transfer updated');
+        onSuccess?.();
+        return;
+      }
+
       const action = data.action as InvestmentAction;
       const postsCash = cashPostingActions.includes(action);
       const isSplit = action === 'SPLIT';
@@ -696,6 +787,9 @@ export function InvestmentTransactionForm({
   // combined 'TRANSFER' action instead.
   const isTransferLeg =
     watchedAction === 'TRANSFER_IN' || watchedAction === 'TRANSFER_OUT';
+  // Either creating a transfer (combined action) or editing an existing leg.
+  // Both render the From/To + security + quantity + cost-per-share UI.
+  const transferMode = isTransfer || isTransferLeg;
   const canHaveFundingAccount = fundingAccountActions.includes(watchedAction);
   const canHaveCashDestination = cashDestinationActions.includes(watchedAction);
 
@@ -735,7 +829,7 @@ export function InvestmentTransactionForm({
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
       {/* Account Selection */}
       <Select
-        label={isTransfer ? 'From Account' : 'Brokerage Account'}
+        label={transferMode ? 'From Account' : 'Brokerage Account'}
         error={errors.accountId?.message}
         options={[
           { value: '', label: 'Select account...' },
@@ -797,7 +891,7 @@ export function InvestmentTransactionForm({
       )}
 
       {/* Destination account - for a transfer between accounts */}
-      {isTransfer && (
+      {transferMode && (
         <Select
           label="To Account"
           error={errors.destinationAccountId?.message}
@@ -813,7 +907,7 @@ export function InvestmentTransactionForm({
       )}
 
       {/* Security Selection - only for actions that need it */}
-      {(needsSecurity || isTransfer) && (
+      {(needsSecurity || transferMode) && (
         <div className="space-y-2">
           <Select
             label="Security"
@@ -840,7 +934,7 @@ export function InvestmentTransactionForm({
           />
           {/* Transfers can only move securities already held, so adding a new
               one here makes no sense. */}
-          {!isTransfer && (
+          {!transferMode && (
             <button
               type="button"
               onClick={() => setShowSecurityModal(true)}
@@ -1005,7 +1099,7 @@ export function InvestmentTransactionForm({
       )}
 
       {/* Quantity and cost basis - for a transfer between accounts */}
-      {isTransfer && (
+      {transferMode && (
         <div className="space-y-3">
           <div className="grid grid-cols-2 gap-4">
             <NumericInput

--- a/frontend/src/components/investments/InvestmentTransactionForm.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.tsx
@@ -21,6 +21,7 @@ import {
   InvestmentTransaction,
   Security,
   CreateSecurityData,
+  Holding,
 } from '@/types/investment';
 import { getCurrencySymbol, roundToDecimals } from '@/lib/format';
 import { getErrorMessage } from '@/lib/errors';
@@ -165,12 +166,12 @@ export function InvestmentTransactionForm({
     quantity: number;
     averageCost: number;
   } | null>(null);
-  // Source-account holding for a TRANSFER, replayed as of the transfer date.
-  // Drives the available-quantity check and the cost-per-share prefill.
-  const [transferSourceHolding, setTransferSourceHolding] = useState<{
-    quantity: number;
-    averageCost: number;
-  } | null>(null);
+  // Current holdings in the TRANSFER source account. Drives the security
+  // dropdown (only securities actually held can be transferred) and the
+  // cost-per-share prefill + available-quantity check.
+  const [transferSourceHoldings, setTransferSourceHoldings] = useState<
+    Holding[]
+  >([]);
 
   // Filter to only show brokerage accounts (sorted)
   const brokerageAccounts = useMemo(
@@ -490,41 +491,63 @@ export function InvestmentTransactionForm({
     transaction?.id,
   ]);
 
-  // For a TRANSFER, replay the source account's holding as of the transfer
-  // date and prefill the cost-per-share with its average cost so the original
-  // cost basis carries to the destination (keeping gain/profit reports
-  // correct). Mirrors the SPLIT as-of fetch above.
+  // For a TRANSFER, load the source account's current holdings. Only securities
+  // actually held there can be transferred, and each holding carries the
+  // average cost we use to prefill the cost-per-share.
   useEffect(() => {
-    if (!isTransfer || !watchedAccountId || !watchedSecurityId || !watchedTransactionDate) {
-      setTransferSourceHolding(null);
+    if (!isTransfer || !watchedAccountId) {
+      setTransferSourceHoldings([]);
       return;
     }
     let cancelled = false;
     investmentsApi
-      .getHoldingAt({
-        accountId: watchedAccountId,
-        securityId: watchedSecurityId,
-        asOfDate: watchedTransactionDate,
-      })
+      .getHoldings(watchedAccountId)
       .then((data) => {
-        if (cancelled) return;
-        setTransferSourceHolding(data);
-        // Suggest the source average cost as the carried cost basis. Re-runs
-        // when source/security/date change; manual edits persist until then.
-        setValue('price', roundToDecimals(Number(data.averageCost) || 0, 6), {
-          shouldValidate: true,
-        });
+        if (!cancelled) setTransferSourceHoldings(data);
       })
       .catch((error) => {
         if (!cancelled) {
-          setTransferSourceHolding(null);
+          setTransferSourceHoldings([]);
           logger.error('Failed to load source holdings for transfer:', error);
         }
       });
     return () => {
       cancelled = true;
     };
-  }, [isTransfer, watchedAccountId, watchedSecurityId, watchedTransactionDate, setValue]);
+  }, [isTransfer, watchedAccountId]);
+
+  // Prefill the cost-per-share from the selected source holding's average cost
+  // so the original cost basis carries to the destination. Re-runs when the
+  // selected security (or the loaded holdings) change; manual edits persist
+  // until then.
+  const selectedTransferHolding = useMemo(
+    () =>
+      isTransfer && watchedSecurityId
+        ? transferSourceHoldings.find((h) => h.securityId === watchedSecurityId)
+        : undefined,
+    [isTransfer, watchedSecurityId, transferSourceHoldings],
+  );
+  useEffect(() => {
+    if (!selectedTransferHolding) return;
+    setValue(
+      'price',
+      roundToDecimals(Number(selectedTransferHolding.averageCost) || 0, 6),
+      { shouldValidate: true },
+    );
+  }, [selectedTransferHolding, setValue]);
+
+  // Securities available to transfer: only those currently held (qty > 0) in
+  // the source account.
+  const transferSecurityOptions = useMemo(
+    () =>
+      transferSourceHoldings
+        .filter((h) => Number(h.quantity) > 0 && h.security)
+        .map((h) => ({
+          value: h.securityId,
+          label: `${h.security.symbol} - ${h.security.name} (${h.security.currencyCode})`,
+        })),
+    [transferSourceHoldings],
+  );
 
   // Re-sync form values when editing and securities are loaded
   useEffect(() => {
@@ -575,8 +598,8 @@ export function InvestmentTransactionForm({
           setIsLoading(false);
           return;
         }
-        const available = Number(transferSourceHolding?.quantity ?? 0);
-        if (transferSourceHolding && quantity > available) {
+        const available = Number(selectedTransferHolding?.quantity ?? 0);
+        if (selectedTransferHolding && quantity > available) {
           toast.error(`Only ${available} shares available to transfer`);
           setIsLoading(false);
           return;
@@ -681,7 +704,7 @@ export function InvestmentTransactionForm({
         ...Object.entries(actionLabels)
           .filter(([value]) => value !== 'TRANSFER_IN' && value !== 'TRANSFER_OUT')
           .map(([value, label]) => ({ value, label })),
-        { value: 'TRANSFER', label: 'Transfer Between Accounts' },
+        { value: 'TRANSFER', label: 'Transfer' },
       ];
 
   // Brokerage accounts eligible as a transfer destination (exclude the source).
@@ -788,21 +811,36 @@ export function InvestmentTransactionForm({
             label="Security"
             error={errors.securityId?.message}
             options={[
-              { value: '', label: 'Select security...' },
-              ...securities.map((s) => ({
-                value: s.id,
-                label: `${s.symbol} - ${s.name} (${s.currencyCode})`,
-              })),
+              {
+                value: '',
+                label: isTransfer
+                  ? watchedAccountId
+                    ? transferSecurityOptions.length > 0
+                      ? 'Select security...'
+                      : 'No securities held in this account'
+                    : 'Select the From account first'
+                  : 'Select security...',
+              },
+              ...(isTransfer
+                ? transferSecurityOptions
+                : securities.map((s) => ({
+                    value: s.id,
+                    label: `${s.symbol} - ${s.name} (${s.currencyCode})`,
+                  }))),
             ]}
             {...register('securityId')}
           />
-          <button
-            type="button"
-            onClick={() => setShowSecurityModal(true)}
-            className="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
-          >
-            + Add new security
-          </button>
+          {/* Transfers can only move securities already held, so adding a new
+              one here makes no sense. */}
+          {!isTransfer && (
+            <button
+              type="button"
+              onClick={() => setShowSecurityModal(true)}
+              className="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+            >
+              + Add new security
+            </button>
+          )}
         </div>
       )}
 
@@ -980,20 +1018,21 @@ export function InvestmentTransactionForm({
               error={errors.price?.message}
             />
           </div>
-          {transferSourceHolding && transferSourceHolding.quantity > 0 && (
-            <div className="rounded border border-gray-200 bg-white p-3 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300">
-              Source holds{' '}
-              <span className="font-mono">
-                {Number(transferSourceHolding.quantity).toFixed(4)}
-              </span>{' '}
-              shares @{' '}
-              <span className="font-mono">
-                {currencySymbol}
-                {Number(transferSourceHolding.averageCost).toFixed(4)}
-              </span>{' '}
-              avg cost as of {formatDate(watchedTransactionDate)}.
-            </div>
-          )}
+          {selectedTransferHolding &&
+            Number(selectedTransferHolding.quantity) > 0 && (
+              <div className="rounded border border-gray-200 bg-white p-3 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300">
+                Source holds{' '}
+                <span className="font-mono">
+                  {Number(selectedTransferHolding.quantity).toFixed(4)}
+                </span>{' '}
+                shares @{' '}
+                <span className="font-mono">
+                  {currencySymbol}
+                  {Number(selectedTransferHolding.averageCost ?? 0).toFixed(4)}
+                </span>{' '}
+                avg cost.
+              </div>
+            )}
           <div className="rounded border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-200">
             The cost per share (prefilled from the source account) is carried to
             the destination so your gain and profit reports stay correct. This

--- a/frontend/src/components/investments/InvestmentTransactionForm.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.tsx
@@ -577,12 +577,14 @@ export function InvestmentTransactionForm({
     );
   }, [selectedTransferHolding, setValue]);
 
-  // Securities available to transfer: only those currently held (qty > 0) in
-  // the source account.
+  // Securities available to transfer: only those currently held in the source
+  // account. Use the same presence threshold the portfolio/holdings views use
+  // (|qty| >= 0.0001) so the list matches what the account actually shows --
+  // zero and tiny residual positions left by sells/splits/imports are excluded.
   const transferSecurityOptions = useMemo(
     () =>
       transferSourceHoldings
-        .filter((h) => Number(h.quantity) > 0 && h.security)
+        .filter((h) => Number(h.quantity) >= 0.0001 && h.security)
         .map((h) => ({
           value: h.securityId,
           label: `${h.security.symbol} - ${h.security.name} (${h.security.currencyCode})`,

--- a/frontend/src/components/investments/InvestmentTransactionForm.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.tsx
@@ -691,6 +691,11 @@ export function InvestmentTransactionForm({
   const isQuantityOnly = quantityOnlyActions.includes(watchedAction);
   const isAmountOnly = amountOnlyActions.includes(watchedAction);
   const isSplit = watchedAction === 'SPLIT';
+  // An individual posted transfer leg (TRANSFER_IN/TRANSFER_OUT). These only
+  // appear when editing an existing transfer; the create flow uses the
+  // combined 'TRANSFER' action instead.
+  const isTransferLeg =
+    watchedAction === 'TRANSFER_IN' || watchedAction === 'TRANSFER_OUT';
   const canHaveFundingAccount = fundingAccountActions.includes(watchedAction);
   const canHaveCashDestination = cashDestinationActions.includes(watchedAction);
 
@@ -754,6 +759,9 @@ export function InvestmentTransactionForm({
           label="Transaction Type"
           error={errors.action?.message}
           options={actionOptions}
+          // A posted transfer's direction is fixed; changing it would break
+          // the linked pair. The backend rejects it too.
+          disabled={isTransferLeg}
           {...register('action')}
         />
       </div>
@@ -1097,8 +1105,8 @@ export function InvestmentTransactionForm({
         </div>
       )}
 
-      {/* Total Amount Display */}
-      {(needsQuantityPrice || isAmountOnly) && (
+      {/* Total Amount Display - meaningless for a transfer (no cash moves) */}
+      {(needsQuantityPrice || isAmountOnly) && !isTransferLeg && (
         <div className="bg-gray-100 dark:bg-gray-700 rounded-lg p-4">
           <div className="flex justify-between items-center">
             <span className="text-sm font-medium text-gray-700 dark:text-gray-300">

--- a/frontend/src/components/securities/SecurityList.test.tsx
+++ b/frontend/src/components/securities/SecurityList.test.tsx
@@ -114,6 +114,46 @@ describe('SecurityList', () => {
     expect(screen.getByText('Deactivate')).toBeInTheDocument();
   });
 
+  it('shows the current share count column at full precision', () => {
+    const securities = [makeSecurity()];
+    const holdings = { s1: 0.0003 };
+
+    render(<SecurityList securities={securities} holdings={holdings} onEdit={onEdit} onToggleActive={onToggleActive} />);
+    expect(screen.getByText('Shares')).toBeInTheDocument();
+    // Residual quantity shown exactly, not rounded away.
+    expect(screen.getByText('0.0003')).toBeInTheDocument();
+  });
+
+  it('shows 0 shares when a security has no holdings', () => {
+    const securities = [makeSecurity()];
+
+    render(<SecurityList securities={securities} onEdit={onEdit} onToggleActive={onToggleActive} />);
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+
+  it('renders a History action and calls onViewHistory when clicked', () => {
+    const securities = [makeSecurity()];
+    const onViewHistory = vi.fn();
+
+    render(
+      <SecurityList
+        securities={securities}
+        onEdit={onEdit}
+        onToggleActive={onToggleActive}
+        onViewHistory={onViewHistory}
+      />,
+    );
+    fireEvent.click(screen.getByText('History'));
+    expect(onViewHistory).toHaveBeenCalledWith(expect.objectContaining({ symbol: 'AAPL' }));
+  });
+
+  it('omits the History action when onViewHistory is not provided', () => {
+    const securities = [makeSecurity()];
+
+    render(<SecurityList securities={securities} onEdit={onEdit} onToggleActive={onToggleActive} />);
+    expect(screen.queryByText('History')).not.toBeInTheDocument();
+  });
+
   it('toggles density when density button is clicked', () => {
     const securities = [makeSecurity()];
 

--- a/frontend/src/components/securities/SecurityList.tsx
+++ b/frontend/src/components/securities/SecurityList.tsx
@@ -176,7 +176,7 @@ const SecurityRow = memo(function SecurityRow({
       </td>
       <td className={`${cellPadding} whitespace-nowrap text-right`}>
         <span
-          className="font-mono text-sm text-gray-900 dark:text-gray-100"
+          className="text-sm text-gray-900 dark:text-gray-100"
           title="Current shares held across all accounts"
         >
           {formatShareQuantity(shares)}

--- a/frontend/src/components/securities/SecurityList.tsx
+++ b/frontend/src/components/securities/SecurityList.tsx
@@ -7,6 +7,7 @@ import { Modal } from '@/components/ui/Modal';
 import { DensityLevel, nextDensity } from '@/hooks/useTableDensity';
 import { SortIcon } from '@/components/ui/SortIcon';
 import { usePreferencesStore } from '@/store/preferencesStore';
+import { formatShareQuantity } from '@/lib/format';
 
 export type SecuritySortField = 'symbol' | 'name' | 'type' | 'exchange' | 'currency' | 'provider' | 'source';
 
@@ -60,6 +61,7 @@ interface SecurityListProps {
   onToggleActive: (security: Security) => void;
   onDelete?: (security: Security) => void;
   onViewPrices?: (security: Security) => void;
+  onViewHistory?: (security: Security) => void;
   density?: DensityLevel;
   onDensityChange?: (density: DensityLevel) => void;
   sortField?: SecuritySortField;
@@ -71,12 +73,14 @@ interface SecurityRowProps {
   security: Security;
   hasHoldings: boolean;
   hasTransactions: boolean;
+  shares: number;
   density: DensityLevel;
   cellPadding: string;
   onEdit: (security: Security) => void;
   onToggleActive: (security: Security) => void;
   onDelete?: (security: Security) => void;
   onViewPrices?: (security: Security) => void;
+  onViewHistory?: (security: Security) => void;
   onLongPressStart: (security: Security) => void;
   onLongPressStartTouch: (security: Security, e: React.TouchEvent) => void;
   onLongPressEnd: () => void;
@@ -105,12 +109,14 @@ const SecurityRow = memo(function SecurityRow({
   security,
   hasHoldings,
   hasTransactions,
+  shares,
   density,
   cellPadding,
   onEdit,
   onToggleActive,
   onDelete,
   onViewPrices,
+  onViewHistory,
   onLongPressStart,
   onLongPressStartTouch,
   onLongPressEnd,
@@ -135,6 +141,10 @@ const SecurityRow = memo(function SecurityRow({
   const handleViewPrices = useCallback(() => {
     onViewPrices?.(security);
   }, [onViewPrices, security]);
+
+  const handleViewHistory = useCallback(() => {
+    onViewHistory?.(security);
+  }, [onViewHistory, security]);
 
   return (
     <tr
@@ -162,6 +172,14 @@ const SecurityRow = memo(function SecurityRow({
       <td className={`${cellPadding} whitespace-nowrap`}>
         <span className="text-sm text-gray-500 dark:text-gray-400">
           {formatSecurityType(security.securityType, density === 'dense')}
+        </span>
+      </td>
+      <td className={`${cellPadding} whitespace-nowrap text-right`}>
+        <span
+          className="font-mono text-sm text-gray-900 dark:text-gray-100"
+          title="Current shares held across all accounts"
+        >
+          {formatShareQuantity(shares)}
         </span>
       </td>
       {density === 'normal' && (
@@ -229,6 +247,16 @@ const SecurityRow = memo(function SecurityRow({
       {/* Actions - hidden on mobile */}
       <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium hidden sm:table-cell sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`}>
         <div className="flex justify-end gap-2">
+          {onViewHistory && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleViewHistory}
+              className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
+            >
+              {density === 'dense' ? '☰' : 'History'}
+            </Button>
+          )}
           {onViewPrices && (
             <Button
               variant="ghost"
@@ -285,6 +313,7 @@ export function SecurityList({
   onToggleActive,
   onDelete,
   onViewPrices,
+  onViewHistory,
   density: propDensity,
   onDensityChange,
   sortField: propSortField,
@@ -456,6 +485,9 @@ export function SecurityList({
               >
                 Type<SortIcon field="type" sortField={sortField} sortDirection={sortDirection} />
               </th>
+              <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>
+                Shares
+              </th>
               {density === 'normal' && (
                 <>
                   <th
@@ -501,12 +533,14 @@ export function SecurityList({
                 security={security}
                 hasHoldings={(holdings[security.id] || 0) > 0}
                 hasTransactions={transactionSecurityIds.has(security.id)}
+                shares={holdings[security.id] || 0}
                 density={density}
                 cellPadding={cellPadding}
                 onEdit={onEdit}
                 onToggleActive={onToggleActive}
                 onDelete={onDelete}
                 onViewPrices={onViewPrices}
+                onViewHistory={onViewHistory}
                 onLongPressStart={handleLongPressStart}
                 onLongPressStartTouch={handleLongPressStartTouch}
                 onLongPressEnd={handleLongPressEnd}
@@ -532,6 +566,17 @@ export function SecurityList({
               <p className="text-sm text-gray-500 dark:text-gray-400">{contextSecurity.name}</p>
             </div>
             <div className="py-2">
+              {onViewHistory && (
+                <button
+                  onClick={() => { setContextSecurity(null); onViewHistory(contextSecurity); }}
+                  className="w-full text-left px-5 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
+                >
+                  <svg className="w-5 h-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+                  </svg>
+                  Transaction History
+                </button>
+              )}
               {onViewPrices && (
                 <button
                   onClick={() => { setContextSecurity(null); onViewPrices(contextSecurity); }}

--- a/frontend/src/components/securities/SecurityShareAdjustmentForm.test.tsx
+++ b/frontend/src/components/securities/SecurityShareAdjustmentForm.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@/test/render';
+import toast from 'react-hot-toast';
+import { SecurityShareAdjustmentForm } from './SecurityShareAdjustmentForm';
+import { investmentsApi } from '@/lib/investments';
+
+vi.mock('@/lib/investments', () => ({
+  investmentsApi: {
+    createTransaction: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/errors', () => ({
+  getErrorMessage: (_e: unknown, fallback: string) => fallback,
+}));
+
+describe('SecurityShareAdjustmentForm', () => {
+  const accounts = [
+    { accountId: 'a1', accountName: 'Brokerage A', isClosed: false, currentQuantity: 0.0003 },
+    { accountId: 'a2', accountName: 'Old Brokerage', isClosed: true, currentQuantity: 50 },
+  ];
+
+  const onSubmitted = vi.fn();
+  const onCancel = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders account options including a closed account', () => {
+    render(
+      <SecurityShareAdjustmentForm
+        securityId="sec-1"
+        accounts={accounts}
+        onSubmitted={onSubmitted}
+        onCancel={onCancel}
+      />,
+    );
+    expect(screen.getByText('Old Brokerage (closed)')).toBeInTheDocument();
+  });
+
+  it('blocks submission without a quantity', async () => {
+    render(
+      <SecurityShareAdjustmentForm
+        securityId="sec-1"
+        accounts={accounts}
+        defaultAccountId="a1"
+        onSubmitted={onSubmitted}
+        onCancel={onCancel}
+      />,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByText('Record adjustment'));
+    });
+    await act(async () => {});
+    expect(investmentsApi.createTransaction).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it('submits a REMOVE_SHARES adjustment with the chosen account and quantity', async () => {
+    render(
+      <SecurityShareAdjustmentForm
+        securityId="sec-1"
+        accounts={accounts}
+        defaultAccountId="a2"
+        onSubmitted={onSubmitted}
+        onCancel={onCancel}
+      />,
+    );
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Quantity (Shares)'), {
+        target: { value: '50' },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Record adjustment'));
+    });
+    await waitFor(() => {
+      expect(investmentsApi.createTransaction).toHaveBeenCalled();
+    });
+    const payload = vi.mocked(investmentsApi.createTransaction).mock.calls[0][0];
+    expect(payload).toMatchObject({
+      accountId: 'a2',
+      securityId: 'sec-1',
+      action: 'REMOVE_SHARES',
+      quantity: 50,
+    });
+    expect(onSubmitted).toHaveBeenCalled();
+  });
+
+  it('surfaces an error toast when the API rejects', async () => {
+    vi.mocked(investmentsApi.createTransaction).mockRejectedValueOnce(new Error('nope'));
+    render(
+      <SecurityShareAdjustmentForm
+        securityId="sec-1"
+        accounts={accounts}
+        defaultAccountId="a1"
+        onSubmitted={onSubmitted}
+        onCancel={onCancel}
+      />,
+    );
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Quantity (Shares)'), {
+        target: { value: '0.0003' },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Record adjustment'));
+    });
+    await act(async () => {});
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+    expect(onSubmitted).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/securities/SecurityShareAdjustmentForm.tsx
+++ b/frontend/src/components/securities/SecurityShareAdjustmentForm.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+import { Button } from '@/components/ui/Button';
+import { Select } from '@/components/ui/Select';
+import { NumericInput } from '@/components/ui/NumericInput';
+import { DateInput } from '@/components/ui/DateInput';
+import { Input } from '@/components/ui/Input';
+import { investmentsApi } from '@/lib/investments';
+import { getLocalDateString } from '@/lib/utils';
+import { getErrorMessage } from '@/lib/errors';
+import type { InvestmentAction, SecurityHistoryAccount } from '@/types/investment';
+
+interface SecurityShareAdjustmentFormProps {
+  securityId: string;
+  /** Accounts the security has been used in (including closed ones). */
+  accounts: SecurityHistoryAccount[];
+  defaultAccountId?: string;
+  onSubmitted: () => void;
+  onCancel: () => void;
+}
+
+// Quantity-only adjustments that change the share count without any cash
+// impact -- exactly what's needed to clean up errant/residual share balances.
+const ADJUSTMENT_ACTIONS: { value: InvestmentAction; label: string }[] = [
+  { value: 'REMOVE_SHARES', label: 'Remove Shares' },
+  { value: 'ADD_SHARES', label: 'Add Shares' },
+];
+
+/**
+ * Compact form for posting an ADD_SHARES / REMOVE_SHARES adjustment against a
+ * security in a chosen account. Works for closed accounts and inactive
+ * securities (the backend looks them up by id, not by active status), so it
+ * can be used to zero out residual share balances anywhere they linger.
+ */
+export function SecurityShareAdjustmentForm({
+  securityId,
+  accounts,
+  defaultAccountId,
+  onSubmitted,
+  onCancel,
+}: SecurityShareAdjustmentFormProps) {
+  const [accountId, setAccountId] = useState(
+    defaultAccountId || accounts[0]?.accountId || '',
+  );
+  const [action, setAction] = useState<InvestmentAction>('REMOVE_SHARES');
+  const [quantity, setQuantity] = useState<number | undefined>(undefined);
+  const [transactionDate, setTransactionDate] = useState(getLocalDateString());
+  const [description, setDescription] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!accountId) {
+      toast.error('Select an account');
+      return;
+    }
+    if (!quantity || quantity <= 0) {
+      toast.error('Quantity must be greater than zero');
+      return;
+    }
+    setIsSaving(true);
+    try {
+      await investmentsApi.createTransaction({
+        accountId,
+        securityId,
+        action,
+        transactionDate,
+        quantity,
+        description: description || undefined,
+      });
+      toast.success('Adjustment recorded');
+      onSubmitted();
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Failed to record adjustment'));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/40">
+      <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
+        Adjust shares
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Select
+          label="Account"
+          value={accountId}
+          onChange={(e) => setAccountId(e.target.value)}
+          options={[
+            { value: '', label: 'Select account...' },
+            ...accounts.map((a) => ({
+              value: a.accountId,
+              label: a.isClosed ? `${a.accountName} (closed)` : a.accountName,
+            })),
+          ]}
+        />
+        <Select
+          label="Action"
+          value={action}
+          onChange={(e) => setAction(e.target.value as InvestmentAction)}
+          options={ADJUSTMENT_ACTIONS}
+        />
+        <NumericInput
+          label="Quantity (Shares)"
+          value={quantity}
+          onChange={setQuantity}
+          decimalPlaces={8}
+          min={0}
+        />
+        <DateInput
+          label="Date"
+          value={transactionDate}
+          onDateChange={setTransactionDate}
+        />
+      </div>
+      <Input
+        label="Description (optional)"
+        placeholder="e.g. Clean up residual shares"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+      />
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" size="sm" onClick={onCancel} disabled={isSaving}>
+          Cancel
+        </Button>
+        <Button size="sm" onClick={handleSubmit} disabled={isSaving}>
+          {isSaving ? 'Saving...' : 'Record adjustment'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/securities/SecurityTransactionHistory.test.tsx
+++ b/frontend/src/components/securities/SecurityTransactionHistory.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@/test/render';
+import { SecurityTransactionHistory } from './SecurityTransactionHistory';
+import { investmentsApi } from '@/lib/investments';
+
+vi.mock('@/lib/investments', () => ({
+  investmentsApi: {
+    getSecurityTransactionHistory: vi.fn(),
+    createTransaction: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('@/hooks/useDateFormat', () => ({
+  useDateFormat: () => ({ formatDate: (d: string) => d, dateFormat: 'YYYY-MM-DD' }),
+}));
+
+vi.mock('@/hooks/useNumberFormat', () => ({
+  useNumberFormat: () => ({
+    formatCurrency: (n: number) => `$${n.toFixed(2)}`,
+  }),
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/errors', () => ({
+  getErrorMessage: (_e: unknown, fallback: string) => fallback,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() }),
+}));
+
+const security = {
+  id: 'sec-1',
+  symbol: 'ACME',
+  name: 'Acme Corp',
+  currencyCode: 'USD',
+  isActive: false,
+} as any;
+
+const historyData = {
+  securityId: 'sec-1',
+  symbol: 'ACME',
+  name: 'Acme Corp',
+  currencyCode: 'USD',
+  isActive: false,
+  accounts: [
+    { accountId: 'a1', accountName: 'Account A', isClosed: false, currentQuantity: 0.0003 },
+    { accountId: 'a2', accountName: 'Account B', isClosed: true, currentQuantity: 50 },
+  ],
+  transactions: [
+    { id: 't1', transactionDate: '2025-01-01', accountId: 'a1', accountName: 'Account A', action: 'ADD_SHARES', quantity: 100, price: null, commission: 0, totalAmount: 0, description: null, runningQuantityAccount: 100, runningQuantityAll: 100 },
+    { id: 't2', transactionDate: '2025-02-01', accountId: 'a2', accountName: 'Account B', action: 'ADD_SHARES', quantity: 50, price: null, commission: 0, totalAmount: 0, description: null, runningQuantityAccount: 50, runningQuantityAll: 150 },
+    { id: 't3', transactionDate: '2025-03-01', accountId: 'a1', accountName: 'Account A', action: 'REMOVE_SHARES', quantity: 99.9997, price: null, commission: 0, totalAmount: 0, description: null, runningQuantityAccount: 0.0003, runningQuantityAll: 50.0003 },
+  ],
+  currentQuantityAll: 50.0003,
+};
+
+async function renderHistory(props: Partial<Record<string, unknown>> = {}) {
+  await act(async () => {
+    render(
+      <SecurityTransactionHistory
+        security={security}
+        onClose={vi.fn()}
+        onChanged={(props.onChanged as () => void) ?? vi.fn()}
+      />,
+    );
+  });
+}
+
+describe('SecurityTransactionHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(investmentsApi.getSecurityTransactionHistory).mockResolvedValue(historyData as any);
+  });
+
+  it('loads and shows transactions with the cross-account running total and current shares', async () => {
+    await renderHistory();
+    await waitFor(() => {
+      expect(screen.getByText('ACME')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Inactive')).toBeInTheDocument();
+    // Cross-account running totals are shown in "All accounts" mode.
+    expect(screen.getByText('150')).toBeInTheDocument();
+    // Current shares (exact) appears (header + final running row).
+    expect(screen.getAllByText('50.0003').length).toBeGreaterThan(0);
+  });
+
+  it('filters to a single account and shows its per-account running total', async () => {
+    await renderHistory();
+    await waitFor(() => {
+      expect(screen.getByText('ACME')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'a1' } });
+    });
+
+    // Account B's transaction (running-all 150) is filtered out.
+    expect(screen.queryByText('150')).not.toBeInTheDocument();
+    // Account A's residual per-account running total is shown.
+    expect(screen.getAllByText('0.0003').length).toBeGreaterThan(0);
+  });
+
+  it('adds an adjustment and reloads the history', async () => {
+    const onChanged = vi.fn();
+    await renderHistory({ onChanged });
+    await waitFor(() => {
+      expect(screen.getByText('ACME')).toBeInTheDocument();
+    });
+    expect(investmentsApi.getSecurityTransactionHistory).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('+ Add transaction'));
+    });
+    expect(screen.getByText('Adjust shares')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Quantity (Shares)'), {
+        target: { value: '0.0003' },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Record adjustment'));
+    });
+
+    await waitFor(() => {
+      expect(investmentsApi.createTransaction).toHaveBeenCalled();
+    });
+    // History reloaded and parent notified.
+    await waitFor(() => {
+      expect(investmentsApi.getSecurityTransactionHistory).toHaveBeenCalledTimes(2);
+    });
+    expect(onChanged).toHaveBeenCalled();
+  });
+
+  it('shows an empty state when there are no transactions', async () => {
+    vi.mocked(investmentsApi.getSecurityTransactionHistory).mockResolvedValue({
+      ...historyData,
+      accounts: [],
+      transactions: [],
+      currentQuantityAll: 0,
+    } as any);
+    await renderHistory();
+    await waitFor(() => {
+      expect(screen.getByText(/No transactions for this security/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/securities/SecurityTransactionHistory.test.tsx
+++ b/frontend/src/components/securities/SecurityTransactionHistory.test.tsx
@@ -7,7 +7,31 @@ vi.mock('@/lib/investments', () => ({
   investmentsApi: {
     getSecurityTransactionHistory: vi.fn(),
     createTransaction: vi.fn().mockResolvedValue({}),
+    getTransaction: vi.fn().mockResolvedValue({ id: 't1', securityId: 'sec-1' }),
   },
+}));
+
+vi.mock('@/lib/accounts', () => ({
+  accountsApi: { getAll: vi.fn().mockResolvedValue([]) },
+}));
+
+// Stub the heavy shared form; we only verify the edit wiring here.
+vi.mock('@/components/investments/InvestmentTransactionForm', () => ({
+  InvestmentTransactionForm: ({
+    transaction,
+    onSuccess,
+    onCancel,
+  }: {
+    transaction?: { id: string };
+    onSuccess?: () => void;
+    onCancel?: () => void;
+  }) => (
+    <div data-testid="edit-form">
+      <span>Editing {transaction?.id}</span>
+      <button onClick={() => onSuccess?.()}>Save edit</button>
+      <button onClick={() => onCancel?.()}>Cancel edit</button>
+    </div>
+  ),
 }));
 
 vi.mock('@/hooks/useDateFormat', () => ({
@@ -130,6 +154,36 @@ describe('SecurityTransactionHistory', () => {
       expect(investmentsApi.createTransaction).toHaveBeenCalled();
     });
     // History reloaded and parent notified.
+    await waitFor(() => {
+      expect(investmentsApi.getSecurityTransactionHistory).toHaveBeenCalledTimes(2);
+    });
+    expect(onChanged).toHaveBeenCalled();
+  });
+
+  it('opens the edit form for a transaction and reloads after saving', async () => {
+    vi.mocked(investmentsApi.getTransaction).mockResolvedValue({
+      id: 't1',
+      securityId: 'sec-1',
+    } as any);
+    const onChanged = vi.fn();
+    await renderHistory({ onChanged });
+    await waitFor(() => {
+      expect(screen.getByText('ACME')).toBeInTheDocument();
+    });
+    expect(investmentsApi.getSecurityTransactionHistory).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByText('Edit')[0]);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-form')).toBeInTheDocument();
+    });
+    expect(investmentsApi.getTransaction).toHaveBeenCalledWith('t1');
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save edit'));
+    });
+    // History reloads and parent is notified after a successful edit.
     await waitFor(() => {
       expect(investmentsApi.getSecurityTransactionHistory).toHaveBeenCalledTimes(2);
     });

--- a/frontend/src/components/securities/SecurityTransactionHistory.tsx
+++ b/frontend/src/components/securities/SecurityTransactionHistory.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Button } from '@/components/ui/Button';
+import { Select } from '@/components/ui/Select';
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import { SecurityShareAdjustmentForm } from './SecurityShareAdjustmentForm';
+import { investmentsApi } from '@/lib/investments';
+import { formatShareQuantity } from '@/lib/format';
+import { getErrorMessage } from '@/lib/errors';
+import { createLogger } from '@/lib/logger';
+import { useDateFormat } from '@/hooks/useDateFormat';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
+import type {
+  InvestmentAction,
+  Security,
+  SecurityTransactionHistory as SecurityTransactionHistoryData,
+} from '@/types/investment';
+
+const logger = createLogger('SecurityTxHistory');
+
+const ACTION_LABELS: Record<InvestmentAction, string> = {
+  BUY: 'Buy',
+  SELL: 'Sell',
+  DIVIDEND: 'Dividend',
+  INTEREST: 'Interest',
+  CAPITAL_GAIN: 'Capital Gain',
+  SPLIT: 'Split',
+  TRANSFER_IN: 'Transfer In',
+  TRANSFER_OUT: 'Transfer Out',
+  REINVEST: 'Reinvest',
+  ADD_SHARES: 'Add Shares',
+  REMOVE_SHARES: 'Remove Shares',
+};
+
+interface SecurityTransactionHistoryProps {
+  security: Security;
+  onClose: () => void;
+  /** Called after a transaction is added so callers can refresh dependent data. */
+  onChanged?: () => void;
+}
+
+export function SecurityTransactionHistory({
+  security,
+  onClose,
+  onChanged,
+}: SecurityTransactionHistoryProps) {
+  const { formatDate } = useDateFormat();
+  const { formatCurrency } = useNumberFormat();
+  const [history, setHistory] = useState<SecurityTransactionHistoryData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [selectedAccountId, setSelectedAccountId] = useState<string>('all');
+  const [showAddForm, setShowAddForm] = useState(false);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const data = await investmentsApi.getSecurityTransactionHistory(security.id);
+      setHistory(data);
+    } catch (error) {
+      logger.error('Failed to load security transaction history:', error);
+      // getErrorMessage keeps the message consistent with the rest of the app.
+      setHistory(null);
+      throw new Error(getErrorMessage(error, 'Failed to load history'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [security.id]);
+
+  useEffect(() => {
+    load().catch(() => {
+      /* error already logged; UI shows empty state */
+    });
+  }, [load]);
+
+  const accounts = useMemo(() => history?.accounts ?? [], [history]);
+  const showAccountColumn = selectedAccountId === 'all';
+
+  const visibleTransactions = useMemo(() => {
+    const txns = history?.transactions ?? [];
+    if (selectedAccountId === 'all') return txns;
+    return txns.filter((t) => t.accountId === selectedAccountId);
+  }, [history, selectedAccountId]);
+
+  // Shares currently held for the current view (selected account, or total).
+  const currentShares = useMemo(() => {
+    if (!history) return 0;
+    if (selectedAccountId === 'all') return history.currentQuantityAll;
+    return (
+      accounts.find((a) => a.accountId === selectedAccountId)?.currentQuantity ?? 0
+    );
+  }, [history, selectedAccountId, accounts]);
+
+  const defaultAdjustAccountId =
+    selectedAccountId !== 'all' ? selectedAccountId : accounts[0]?.accountId;
+
+  const handleAdjustmentSubmitted = () => {
+    setShowAddForm(false);
+    onChanged?.();
+    load().catch(() => {});
+  };
+
+  return (
+    <div>
+      <div className="mb-4 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            {security.symbol}
+            {!security.isActive && (
+              <span className="ml-2 inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-300">
+                Inactive
+              </span>
+            )}
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400">{security.name}</p>
+        </div>
+        <div className="text-right">
+          <div className="text-xs uppercase tracking-wider text-gray-400 dark:text-gray-500">
+            Current shares
+          </div>
+          <div className="font-mono text-lg font-semibold text-gray-900 dark:text-gray-100">
+            {formatShareQuantity(currentShares)}
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        {accounts.length > 0 && (
+          <div className="w-full sm:max-w-xs">
+            <Select
+              label="Account"
+              value={selectedAccountId}
+              onChange={(e) => setSelectedAccountId(e.target.value)}
+              options={[
+                { value: 'all', label: `All accounts (${formatShareQuantity(history?.currentQuantityAll ?? 0)})` },
+                ...accounts.map((a) => ({
+                  value: a.accountId,
+                  label: `${a.isClosed ? `${a.accountName} (closed)` : a.accountName} — ${formatShareQuantity(a.currentQuantity)}`,
+                })),
+              ]}
+            />
+          </div>
+        )}
+        {accounts.length > 0 && !showAddForm && (
+          <Button size="sm" variant="outline" onClick={() => setShowAddForm(true)}>
+            + Add transaction
+          </Button>
+        )}
+      </div>
+
+      {showAddForm && (
+        <div className="mb-4">
+          <SecurityShareAdjustmentForm
+            securityId={security.id}
+            accounts={accounts}
+            defaultAccountId={defaultAdjustAccountId}
+            onSubmitted={handleAdjustmentSubmitted}
+            onCancel={() => setShowAddForm(false)}
+          />
+        </div>
+      )}
+
+      {isLoading ? (
+        <LoadingSpinner text="Loading transactions..." />
+      ) : visibleTransactions.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-gray-300 p-8 text-center text-sm text-gray-500 dark:border-gray-600 dark:text-gray-400">
+          No transactions for this security{selectedAccountId !== 'all' ? ' in the selected account' : ''}.
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead className="bg-gray-50 dark:bg-gray-800">
+              <tr>
+                <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Date</th>
+                {showAccountColumn && (
+                  <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Account</th>
+                )}
+                <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Action</th>
+                <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Quantity</th>
+                <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Running Total</th>
+                <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Price</th>
+                <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Amount</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
+              {visibleTransactions.map((tx) => {
+                const running =
+                  selectedAccountId === 'all'
+                    ? tx.runningQuantityAll
+                    : tx.runningQuantityAccount;
+                return (
+                  <tr key={tx.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                    <td className="whitespace-nowrap px-3 py-2 text-sm text-gray-900 dark:text-gray-100">
+                      {formatDate(tx.transactionDate)}
+                    </td>
+                    {showAccountColumn && (
+                      <td className="px-3 py-2 text-sm text-gray-700 dark:text-gray-300">
+                        {tx.accountName}
+                      </td>
+                    )}
+                    <td className="whitespace-nowrap px-3 py-2 text-sm text-gray-700 dark:text-gray-300">
+                      {ACTION_LABELS[tx.action] ?? tx.action}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 text-right font-mono text-sm text-gray-900 dark:text-gray-100">
+                      {tx.quantity === null ? '-' : formatShareQuantity(tx.quantity)}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 text-right font-mono text-sm font-medium text-gray-900 dark:text-gray-100">
+                      {formatShareQuantity(running)}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm text-gray-700 dark:text-gray-300">
+                      {tx.price === null ? '-' : formatCurrency(tx.price, security.currencyCode, 4)}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm text-gray-700 dark:text-gray-300">
+                      {formatCurrency(tx.totalAmount, security.currencyCode)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="mt-6 flex justify-end">
+        <Button variant="outline" onClick={onClose}>
+          Close
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/securities/SecurityTransactionHistory.tsx
+++ b/frontend/src/components/securities/SecurityTransactionHistory.tsx
@@ -3,16 +3,22 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
+import { Modal } from '@/components/ui/Modal';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { SecurityShareAdjustmentForm } from './SecurityShareAdjustmentForm';
+import { InvestmentTransactionForm } from '@/components/investments/InvestmentTransactionForm';
 import { investmentsApi } from '@/lib/investments';
+import { accountsApi } from '@/lib/accounts';
 import { formatShareQuantity } from '@/lib/format';
 import { getErrorMessage } from '@/lib/errors';
 import { createLogger } from '@/lib/logger';
 import { useDateFormat } from '@/hooks/useDateFormat';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import toast from 'react-hot-toast';
+import type { Account } from '@/types/account';
 import type {
   InvestmentAction,
+  InvestmentTransaction,
   Security,
   SecurityTransactionHistory as SecurityTransactionHistoryData,
 } from '@/types/investment';
@@ -51,6 +57,9 @@ export function SecurityTransactionHistory({
   const [isLoading, setIsLoading] = useState(true);
   const [selectedAccountId, setSelectedAccountId] = useState<string>('all');
   const [showAddForm, setShowAddForm] = useState(false);
+  // Full account objects (including closed) for the edit form's pickers.
+  const [allAccounts, setAllAccounts] = useState<Account[]>([]);
+  const [editTransaction, setEditTransaction] = useState<InvestmentTransaction | null>(null);
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -72,6 +81,38 @@ export function SecurityTransactionHistory({
       /* error already logged; UI shows empty state */
     });
   }, [load]);
+
+  // Load all accounts (including closed) once, so editing a transaction in a
+  // closed account still has its account available in the form.
+  useEffect(() => {
+    let cancelled = false;
+    accountsApi
+      .getAll(true)
+      .then((data) => {
+        if (!cancelled) setAllAccounts(data);
+      })
+      .catch((error) => {
+        if (!cancelled) logger.error('Failed to load accounts:', error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleEditClick = useCallback(async (id: string) => {
+    try {
+      const tx = await investmentsApi.getTransaction(id);
+      setEditTransaction(tx);
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Failed to load transaction'));
+    }
+  }, []);
+
+  const handleEditSuccess = () => {
+    setEditTransaction(null);
+    onChanged?.();
+    load().catch(() => {});
+  };
 
   const accounts = useMemo(() => history?.accounts ?? [], [history]);
   const showAccountColumn = selectedAccountId === 'all';
@@ -118,7 +159,7 @@ export function SecurityTransactionHistory({
           <div className="text-xs uppercase tracking-wider text-gray-400 dark:text-gray-500">
             Current shares
           </div>
-          <div className="font-mono text-lg font-semibold text-gray-900 dark:text-gray-100">
+          <div className="text-lg font-semibold text-gray-900 dark:text-gray-100">
             {formatShareQuantity(currentShares)}
           </div>
         </div>
@@ -180,6 +221,9 @@ export function SecurityTransactionHistory({
                 <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Running Total</th>
                 <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Price</th>
                 <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Amount</th>
+                <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                  <span className="sr-only">Actions</span>
+                </th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
@@ -201,10 +245,10 @@ export function SecurityTransactionHistory({
                     <td className="whitespace-nowrap px-3 py-2 text-sm text-gray-700 dark:text-gray-300">
                       {ACTION_LABELS[tx.action] ?? tx.action}
                     </td>
-                    <td className="whitespace-nowrap px-3 py-2 text-right font-mono text-sm text-gray-900 dark:text-gray-100">
+                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm text-gray-900 dark:text-gray-100">
                       {tx.quantity === null ? '-' : formatShareQuantity(tx.quantity)}
                     </td>
-                    <td className="whitespace-nowrap px-3 py-2 text-right font-mono text-sm font-medium text-gray-900 dark:text-gray-100">
+                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm font-medium text-gray-900 dark:text-gray-100">
                       {formatShareQuantity(running)}
                     </td>
                     <td className="whitespace-nowrap px-3 py-2 text-right text-sm text-gray-700 dark:text-gray-300">
@@ -212,6 +256,16 @@ export function SecurityTransactionHistory({
                     </td>
                     <td className="whitespace-nowrap px-3 py-2 text-right text-sm text-gray-700 dark:text-gray-300">
                       {formatCurrency(tx.totalAmount, security.currencyCode)}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 text-right">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleEditClick(tx.id)}
+                        className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300"
+                      >
+                        Edit
+                      </Button>
                     </td>
                   </tr>
                 );
@@ -226,6 +280,30 @@ export function SecurityTransactionHistory({
           Close
         </Button>
       </div>
+
+      {/* Edit transaction modal (stacked on the history modal) */}
+      <Modal
+        isOpen={!!editTransaction}
+        onClose={() => setEditTransaction(null)}
+        maxWidth="lg"
+        className="p-6"
+        pushHistory
+      >
+        {editTransaction && (
+          <>
+            <h2 className="mb-4 text-2xl font-bold text-gray-900 dark:text-gray-100">
+              Edit Transaction
+            </h2>
+            <InvestmentTransactionForm
+              transaction={editTransaction}
+              accounts={allAccounts}
+              allAccounts={allAccounts}
+              onSuccess={handleEditSuccess}
+              onCancel={() => setEditTransaction(null)}
+            />
+          </>
+        )}
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/hooks/useInvestmentData.test.ts
+++ b/frontend/src/hooks/useInvestmentData.test.ts
@@ -145,6 +145,26 @@ describe('useInvestmentData – handleDeleteTransaction', () => {
     });
   });
 
+  it('removes both legs of a security transfer when one is deleted', async () => {
+    mockDeleteTransaction.mockResolvedValue(undefined);
+    const out = { ...makeTx('t1'), action: 'TRANSFER_OUT', linkedTransactionId: 't2' };
+    const inLeg = { ...makeTx('t2'), action: 'TRANSFER_IN', linkedTransactionId: 't1' };
+    mockGetTransactions.mockResolvedValue({
+      data: [out, inLeg],
+      pagination: { page: 1, limit: 25, total: 2, totalPages: 1, hasMore: false },
+    });
+
+    const { result } = renderHook(() => useInvestmentData());
+    await act(async () => { await new Promise(res => setTimeout(res, 0)); });
+
+    await act(async () => {
+      await result.current.handleDeleteTransaction('t1');
+    });
+
+    // Both the deleted leg and its linked pair are gone from the list.
+    expect(result.current.transactions).toHaveLength(0);
+  });
+
   it('calls deleteTransaction API with the correct id', async () => {
     mockDeleteTransaction.mockResolvedValue(undefined);
 

--- a/frontend/src/hooks/useInvestmentData.test.ts
+++ b/frontend/src/hooks/useInvestmentData.test.ts
@@ -165,6 +165,54 @@ describe('useInvestmentData – handleDeleteTransaction', () => {
     expect(result.current.transactions).toHaveLength(0);
   });
 
+  it('decrements the total by two for a transfer even when the paired leg is on another page', async () => {
+    mockDeleteTransaction.mockResolvedValue(undefined);
+    // Only the OUT leg is loaded; its pair (t2) lives on another page.
+    const out = { ...makeTx('t1'), action: 'TRANSFER_OUT', linkedTransactionId: 't2' };
+    mockGetTransactions.mockResolvedValue({
+      data: [out],
+      pagination: { page: 1, limit: 25, total: 10, totalPages: 1, hasMore: false },
+    });
+
+    const { result } = renderHook(() => useInvestmentData());
+    await act(async () => { await new Promise(res => setTimeout(res, 0)); });
+
+    await act(async () => {
+      await result.current.handleDeleteTransaction('t1');
+    });
+
+    // The backend deletes both legs, so the total drops by 2 (10 -> 8) even
+    // though only one leg was in the loaded list.
+    expect(result.current.pagination?.total).toBe(8);
+  });
+
+  it('drops the total by one when an account filter excludes the paired leg', async () => {
+    mockDeleteTransaction.mockResolvedValue(undefined);
+    // Only the OUT leg is loaded; its pair (t2) is on another account that the
+    // active filter excludes, so it is not part of pagination.total.
+    const out = { ...makeTx('t1'), action: 'TRANSFER_OUT', linkedTransactionId: 't2' };
+    mockGetTransactions.mockResolvedValue({
+      data: [out],
+      pagination: { page: 1, limit: 25, total: 10, totalPages: 1, hasMore: false },
+    });
+
+    const { result } = renderHook(() => useInvestmentData());
+    await act(async () => { await new Promise(res => setTimeout(res, 0)); });
+
+    // Filter to a single account.
+    await act(async () => {
+      result.current.handleAccountChange(['acc-1']);
+      await new Promise(res => setTimeout(res, 0));
+    });
+
+    await act(async () => {
+      await result.current.handleDeleteTransaction('t1');
+    });
+
+    // Only the in-scope leg counts: 10 -> 9, not 8.
+    expect(result.current.pagination?.total).toBe(9);
+  });
+
   it('calls deleteTransaction API with the correct id', async () => {
     mockDeleteTransaction.mockResolvedValue(undefined);
 

--- a/frontend/src/hooks/useInvestmentData.ts
+++ b/frontend/src/hooks/useInvestmentData.ts
@@ -366,8 +366,19 @@ export function useInvestmentData() {
     const target = transactions.find(tx => tx.id === id);
     const removeIds = new Set<string>([id]);
     if (target?.linkedTransactionId) removeIds.add(target.linkedTransactionId);
-    const removedCount =
-      transactions.filter(tx => removeIds.has(tx.id)).length || 1;
+    // The backend deletes both legs of a transfer, but only legs within the
+    // current filter count toward pagination.total. The deleted leg always
+    // does. The paired leg counts when either no account filter is applied (the
+    // whole portfolio is in the total, even if the leg sits on another page) or
+    // it is loaded in the current filtered list -- otherwise it belongs to an
+    // account that's filtered out and must not be subtracted.
+    const linkedLoaded =
+      !!target?.linkedTransactionId &&
+      transactions.some(tx => tx.id === target.linkedTransactionId);
+    const linkedCounts =
+      !!target?.linkedTransactionId &&
+      (selectedAccountIds.length === 0 || linkedLoaded);
+    const removedCount = linkedCounts ? 2 : 1;
     setTransactions(prev => prev.filter(tx => !removeIds.has(tx.id)));
     // Keep the pagination summary in sync immediately so the bottom counter
     // updates without waiting for the next full reload.

--- a/frontend/src/hooks/useInvestmentData.ts
+++ b/frontend/src/hooks/useInvestmentData.ts
@@ -361,12 +361,19 @@ export function useInvestmentData() {
   };
 
   const handleDeleteTransaction = async (id: string) => {
-    setTransactions(prev => prev.filter(tx => tx.id !== id));
+    // Deleting one leg of a security transfer cascades to its paired leg on
+    // the backend, so drop both from the list optimistically.
+    const target = transactions.find(tx => tx.id === id);
+    const removeIds = new Set<string>([id]);
+    if (target?.linkedTransactionId) removeIds.add(target.linkedTransactionId);
+    const removedCount =
+      transactions.filter(tx => removeIds.has(tx.id)).length || 1;
+    setTransactions(prev => prev.filter(tx => !removeIds.has(tx.id)));
     // Keep the pagination summary in sync immediately so the bottom counter
     // updates without waiting for the next full reload.
     setPagination(prev => {
       if (!prev) return prev;
-      const total = Math.max(0, prev.total - 1);
+      const total = Math.max(0, prev.total - removedCount);
       const totalPages = Math.max(1, Math.ceil(total / prev.limit));
       return {
         ...prev,

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -231,6 +231,13 @@ describe('formatShareQuantity', () => {
     expect(formatShareQuantity(undefined)).toBe('0');
     expect(formatShareQuantity(NaN)).toBe('0');
   });
+
+  it('normalizes negative zero and tiny negative residues to 0', () => {
+    expect(formatShareQuantity(-0)).toBe('0');
+    // A floating-point residue left after fully zeroing a holding.
+    expect(formatShareQuantity(-4.77e-15)).toBe('0');
+    expect(formatShareQuantity(-0.000000001)).toBe('0');
+  });
 });
 
 describe('formatAmountWithCommas', () => {

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -13,6 +13,7 @@ import {
   hasCalculatorOperators,
   evaluateExpression,
   formatRelativeTime,
+  formatShareQuantity,
 } from './format';
 
 describe('getCurrencySymbol', () => {
@@ -202,6 +203,33 @@ describe('formatAmount', () => {
 
   it('formats with 3 decimal places', () => {
     expect(formatAmount(10.5, 3)).toBe('10.500');
+  });
+});
+
+describe('formatShareQuantity', () => {
+  it('formats whole share counts without decimals', () => {
+    expect(formatShareQuantity(100)).toBe('100');
+  });
+
+  it('keeps tiny residual quantities visible', () => {
+    expect(formatShareQuantity(0.0003)).toBe('0.0003');
+    expect(formatShareQuantity(0.00000001)).toBe('0.00000001');
+  });
+
+  it('trims trailing zeros', () => {
+    expect(formatShareQuantity(12.5)).toBe('12.5');
+    expect(formatShareQuantity(12.34)).toBe('12.34');
+  });
+
+  it('handles negatives', () => {
+    expect(formatShareQuantity(-0.5)).toBe('-0.5');
+  });
+
+  it('returns 0 for zero, null, undefined and NaN', () => {
+    expect(formatShareQuantity(0)).toBe('0');
+    expect(formatShareQuantity(null)).toBe('0');
+    expect(formatShareQuantity(undefined)).toBe('0');
+    expect(formatShareQuantity(NaN)).toBe('0');
   });
 });
 

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -114,7 +114,13 @@ export function formatShareQuantity(value: number | undefined | null): string {
   }
   const fixed = value.toFixed(8);
   // Trim trailing zeros and a dangling decimal point.
-  return fixed.replace(/\.?0+$/, '') || '0';
+  const trimmed = fixed.replace(/\.?0+$/, '');
+  // Map empty (all zeros) and negative zero (a tiny negative residue that
+  // rounds to zero, e.g. -4e-15) to a clean "0".
+  if (trimmed === '' || trimmed === '-0') {
+    return '0';
+  }
+  return trimmed;
 }
 
 /**

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -103,6 +103,21 @@ export function formatAmount(value: number | undefined | null, decimalPlaces: nu
 }
 
 /**
+ * Format a share quantity at full precision (up to 8 decimal places) with
+ * trailing zeros trimmed. Unlike the rounded quantity formatter, this keeps
+ * tiny residual positions visible (e.g. 0.0003), which is essential for
+ * tracking down errant share counts.
+ */
+export function formatShareQuantity(value: number | undefined | null): string {
+  if (value === undefined || value === null || isNaN(value)) {
+    return '0';
+  }
+  const fixed = value.toFixed(8);
+  // Trim trailing zeros and a dangling decimal point.
+  return fixed.replace(/\.?0+$/, '') || '0';
+}
+
+/**
  * Format a number with comma thousands separators and the specified decimal places.
  * Defaults to 2 decimal places. Used for display when input is not focused.
  */

--- a/frontend/src/lib/investments.ts
+++ b/frontend/src/lib/investments.ts
@@ -181,6 +181,29 @@ export const investmentsApi = {
     return response.data;
   },
 
+  // Transfer a security between two investment accounts, preserving cost
+  // basis. Creates both legs (TRANSFER_OUT in source, TRANSFER_IN in
+  // destination) atomically on the backend.
+  transferSecurity: async (data: {
+    fromAccountId: string;
+    toAccountId: string;
+    securityId: string;
+    transactionDate: string;
+    quantity: number;
+    costPerShare: number;
+    description?: string;
+  }): Promise<{
+    transferOut: InvestmentTransaction;
+    transferIn: InvestmentTransaction;
+  }> => {
+    const response = await apiClient.post<{
+      transferOut: InvestmentTransaction;
+      transferIn: InvestmentTransaction;
+    }>('/investment-transactions/transfer-security', data);
+    invalidateCache('investments:');
+    return response.data;
+  },
+
   // Update investment transaction
   updateTransaction: async (
     id: string,

--- a/frontend/src/lib/investments.ts
+++ b/frontend/src/lib/investments.ts
@@ -207,7 +207,11 @@ export const investmentsApi = {
   // Update investment transaction
   updateTransaction: async (
     id: string,
-    data: Partial<CreateInvestmentTransactionData>,
+    // destinationAccountId is only used when editing a security-transfer leg,
+    // to reroute the paired leg's account.
+    data: Partial<CreateInvestmentTransactionData> & {
+      destinationAccountId?: string;
+    },
   ): Promise<InvestmentTransaction> => {
     const response = await apiClient.patch<InvestmentTransaction>(
       `/investment-transactions/${id}`,

--- a/frontend/src/lib/investments.ts
+++ b/frontend/src/lib/investments.ts
@@ -15,6 +15,7 @@ import {
   TopMover,
   SectorWeightingResult,
   SecurityPrice,
+  SecurityTransactionHistory,
 } from '@/types/investment';
 import { getCached, setCache, invalidateCache } from './apiCache';
 
@@ -225,6 +226,17 @@ export const investmentsApi = {
   getTransaction: async (id: string): Promise<InvestmentTransaction> => {
     const response = await apiClient.get<InvestmentTransaction>(
       `/investment-transactions/${id}`,
+    );
+    return response.data;
+  },
+
+  // Full transaction history for a security with running share totals and the
+  // accounts (including closed) it was used in.
+  getSecurityTransactionHistory: async (
+    securityId: string,
+  ): Promise<SecurityTransactionHistory> => {
+    const response = await apiClient.get<SecurityTransactionHistory>(
+      `/investment-transactions/security/${securityId}/history`,
     );
     return response.data;
   },

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -140,6 +140,8 @@ export interface InvestmentTransaction {
   totalAmount: number;
   exchangeRate: number;
   description: string | null;
+  // Set on security-transfer legs; points at the paired TRANSFER_IN/OUT leg.
+  linkedTransactionId: string | null;
   security: Security | null;
   fundingAccount: {
     id: string;

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -151,6 +151,39 @@ export interface InvestmentTransaction {
   updatedAt: string;
 }
 
+export interface SecurityHistoryAccount {
+  accountId: string;
+  accountName: string;
+  isClosed: boolean;
+  currentQuantity: number;
+}
+
+export interface SecurityHistoryTransaction {
+  id: string;
+  transactionDate: string;
+  accountId: string;
+  accountName: string;
+  action: InvestmentAction;
+  quantity: number | null;
+  price: number | null;
+  commission: number;
+  totalAmount: number;
+  description: string | null;
+  runningQuantityAccount: number;
+  runningQuantityAll: number;
+}
+
+export interface SecurityTransactionHistory {
+  securityId: string;
+  symbol: string;
+  name: string;
+  currencyCode: string;
+  isActive: boolean;
+  accounts: SecurityHistoryAccount[];
+  transactions: SecurityHistoryTransaction[];
+  currentQuantityAll: number;
+}
+
 export interface CreateInvestmentTransactionData {
   accountId: string;
   securityId?: string;


### PR DESCRIPTION
## Summary

Implements a complete feature for transferring securities between investment accounts while preserving cost basis. Users can now move shares from one brokerage to another with the original per-share cost flowing through to the destination, ensuring accurate gain/loss reporting. The transfer creates two linked transaction legs (TRANSFER_OUT and TRANSFER_IN) atomically, with cascading edits/deletes.

## Key Changes

**Backend**
- Added `transferSecurity()` service method that creates paired TRANSFER_OUT/TRANSFER_IN legs atomically via QueryRunner, validating no over-draws and linking the legs via `linkedTransactionId`
- Added `getSecurityTransactionHistory()` to fetch per-security transaction history across all accounts with running share balances and exact residual quantities
- New `TransferSecurityDto` with validation for source/destination accounts, security, quantity, cost per share, and transaction date
- New controller endpoints `POST /investment-transactions/transfer` and `GET /securities/:id/transaction-history`
- Added `linkedTransactionId` column to `investment_transactions` table with self-referencing FK for cascade behavior
- New interfaces: `SecurityHistoryAccount`, `SecurityHistoryTransaction`, `SecurityTransactionHistory`
- Updated `UpdateInvestmentTransactionDto` to support `linkedTransactionId` for edit cascades

**Frontend**
- Enhanced `InvestmentTransactionForm` to offer a combined "TRANSFER" action (UI-only) that hides the raw TRANSFER_IN/TRANSFER_OUT legs when creating
- Added transfer-specific fields: destination account picker, security selector filtered to holdings in source account, quantity, and cost-per-share (prefilled from average cost)
- New `SecurityTransactionHistory` component displaying per-security transaction history across accounts with running balances, account filter, and inline edit/add buttons
- New `SecurityShareAdjustmentForm` for posting ADD_SHARES/REMOVE_SHARES adjustments to clean up residual balances (works on closed accounts and inactive securities)
- Updated `SecurityList` to show current share count at full precision (up to 8 decimals) for residual balance visibility
- Added `formatShareQuantity()` utility to format share quantities without unnecessary decimals
- Updated `useInvestmentData` hook to cascade delete both legs when one transfer leg is deleted

**Testing**
- Comprehensive unit tests for `transferSecurity()` covering validation, linking, cascading deletes, and over-draw guards
- Integration tests for security transfers verifying cost basis flows correctly and linked legs behave atomically
- Integration tests for security transaction history with running balances across multiple accounts
- Component tests for transfer form, history view, and share adjustment form

## Notable Implementation Details

- Transfer legs carry no cash (`totalAmount = 0`, `exchangeRate = 1`, no linked cash transaction), with cost basis flowing through `quantity * price` instead
- The two legs are linked bidirectionally via `linkedTransactionId` so editing or deleting one cascades to its pair
- `getSecurityTransactionHistory()` replays the full transaction history to compute exact running balances per account and across all accounts, catching residual quantities that snapping would hide
- The transfer form validates that source and destination are different investment accounts and that sufficient shares exist (via `validateNoNegativeHoldingsHistory`)
- Share adjustment form works on closed accounts and inactive securities by looking them up by ID, enabling cleanup of lingering residuals anywhere they appear

https://claude.ai/code/session_012YQ11YJ8ZJVwn62qQ8wb5T