### PR TITLE
Add filter controls to TopMovers dashboard component

### DIFF
--- a/frontend/src/components/dashboard/TopMovers.test.tsx
+++ b/frontend/src/components/dashboard/TopMovers.test.tsx
@@ -21,6 +21,7 @@ vi.mock('@/store/preferencesStore', () => ({
 describe('TopMovers', () => {
   beforeEach(() => {
     mockPush.mockClear();
+    localStorage.clear();
   });
 
   it('renders loading state with title and pulse skeleton', () => {
@@ -138,6 +139,22 @@ describe('TopMovers', () => {
 
     render(<TopMovers movers={movers} isLoading={false} hasInvestmentAccounts={true} />);
     fireEvent.click(screen.getByText('Losers'));
+    expect(screen.getByText('MSFT')).toBeInTheDocument();
+    expect(screen.queryByText('AAPL')).not.toBeInTheDocument();
+  });
+
+  it('persists the selected filter to localStorage and restores it on remount', () => {
+    const movers = [
+      { securityId: '1', symbol: 'AAPL', name: 'Apple', currentPrice: 180, dailyChange: 5, dailyChangePercent: 2.8, currencyCode: 'USD' },
+      { securityId: '2', symbol: 'MSFT', name: 'Microsoft', currentPrice: 400, dailyChange: -2, dailyChangePercent: -0.5, currencyCode: 'USD' },
+    ] as any[];
+
+    const { unmount } = render(<TopMovers movers={movers} isLoading={false} hasInvestmentAccounts={true} />);
+    fireEvent.click(screen.getByText('Losers'));
+    expect(localStorage.getItem('dashboard.topMovers.filter')).toBe('losers');
+    unmount();
+
+    render(<TopMovers movers={movers} isLoading={false} hasInvestmentAccounts={true} />);
     expect(screen.getByText('MSFT')).toBeInTheDocument();
     expect(screen.queryByText('AAPL')).not.toBeInTheDocument();
   });

--- a/frontend/src/components/dashboard/TopMovers.test.tsx
+++ b/frontend/src/components/dashboard/TopMovers.test.tsx
@@ -107,6 +107,51 @@ describe('TopMovers', () => {
     expect(screen.queryByText('SYM5')).not.toBeInTheDocument();
   });
 
+  it('renders the All/Gainers/Losers filter selector', () => {
+    const movers = [
+      { securityId: '1', symbol: 'AAPL', name: 'Apple', currentPrice: 180, dailyChange: 5, dailyChangePercent: 2.8, currencyCode: 'USD' },
+    ] as any[];
+
+    render(<TopMovers movers={movers} isLoading={false} hasInvestmentAccounts={true} />);
+    expect(screen.getByText('All')).toBeInTheDocument();
+    expect(screen.getByText('Gainers')).toBeInTheDocument();
+    expect(screen.getByText('Losers')).toBeInTheDocument();
+  });
+
+  it('filters to only gainers when Gainers is selected', () => {
+    const movers = [
+      { securityId: '1', symbol: 'AAPL', name: 'Apple', currentPrice: 180, dailyChange: 5, dailyChangePercent: 2.8, currencyCode: 'USD' },
+      { securityId: '2', symbol: 'MSFT', name: 'Microsoft', currentPrice: 400, dailyChange: -2, dailyChangePercent: -0.5, currencyCode: 'USD' },
+    ] as any[];
+
+    render(<TopMovers movers={movers} isLoading={false} hasInvestmentAccounts={true} />);
+    fireEvent.click(screen.getByText('Gainers'));
+    expect(screen.getByText('AAPL')).toBeInTheDocument();
+    expect(screen.queryByText('MSFT')).not.toBeInTheDocument();
+  });
+
+  it('filters to only losers when Losers is selected', () => {
+    const movers = [
+      { securityId: '1', symbol: 'AAPL', name: 'Apple', currentPrice: 180, dailyChange: 5, dailyChangePercent: 2.8, currencyCode: 'USD' },
+      { securityId: '2', symbol: 'MSFT', name: 'Microsoft', currentPrice: 400, dailyChange: -2, dailyChangePercent: -0.5, currencyCode: 'USD' },
+    ] as any[];
+
+    render(<TopMovers movers={movers} isLoading={false} hasInvestmentAccounts={true} />);
+    fireEvent.click(screen.getByText('Losers'));
+    expect(screen.getByText('MSFT')).toBeInTheDocument();
+    expect(screen.queryByText('AAPL')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty message when the selected filter has no matches', () => {
+    const movers = [
+      { securityId: '1', symbol: 'AAPL', name: 'Apple', currentPrice: 180, dailyChange: 5, dailyChangePercent: 2.8, currencyCode: 'USD' },
+    ] as any[];
+
+    render(<TopMovers movers={movers} isLoading={false} hasInvestmentAccounts={true} />);
+    fireEvent.click(screen.getByText('Losers'));
+    expect(screen.getByText('No losers today.')).toBeInTheDocument();
+  });
+
   it('shows refresh button when onRefresh is provided', () => {
     const onRefresh = vi.fn();
     const movers = [

--- a/frontend/src/components/dashboard/TopMovers.tsx
+++ b/frontend/src/components/dashboard/TopMovers.tsx
@@ -1,12 +1,20 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { TopMover } from '@/types/investment';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { usePreferencesStore } from '@/store/preferencesStore';
 
 type MoverFilter = 'all' | 'gainers' | 'losers';
+
+const FILTER_STORAGE_KEY = 'dashboard.topMovers.filter';
+
+function getStoredFilter(): MoverFilter {
+  if (typeof window === 'undefined') return 'all';
+  const stored = localStorage.getItem(FILTER_STORAGE_KEY);
+  return stored === 'gainers' || stored === 'losers' || stored === 'all' ? stored : 'all';
+}
 
 interface TopMoversProps {
   movers: TopMover[];
@@ -77,7 +85,11 @@ export function TopMovers({ movers, isLoading, hasInvestmentAccounts, onRefresh,
   const router = useRouter();
   const { formatCurrency, formatPercent } = useNumberFormat();
   const defaultCurrency = usePreferencesStore((s) => s.preferences?.defaultCurrency) || 'USD';
-  const [filter, setFilter] = useState<MoverFilter>('all');
+  const [filter, setFilter] = useState<MoverFilter>(getStoredFilter);
+
+  useEffect(() => {
+    localStorage.setItem(FILTER_STORAGE_KEY, filter);
+  }, [filter]);
 
   if (isLoading) {
     return (

--- a/frontend/src/components/dashboard/TopMovers.tsx
+++ b/frontend/src/components/dashboard/TopMovers.tsx
@@ -1,9 +1,12 @@
 'use client';
 
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { TopMover } from '@/types/investment';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { usePreferencesStore } from '@/store/preferencesStore';
+
+type MoverFilter = 'all' | 'gainers' | 'losers';
 
 interface TopMoversProps {
   movers: TopMover[];
@@ -11,6 +14,37 @@ interface TopMoversProps {
   hasInvestmentAccounts: boolean;
   onRefresh?: () => void;
   isRefreshing?: boolean;
+}
+
+function MoverFilterControl({
+  filter,
+  onChange,
+}: {
+  filter: MoverFilter;
+  onChange: (filter: MoverFilter) => void;
+}) {
+  const options: { value: MoverFilter; label: string; rounded: string }[] = [
+    { value: 'all', label: 'All', rounded: 'rounded-l-md border' },
+    { value: 'gainers', label: 'Gainers', rounded: 'border-t border-b' },
+    { value: 'losers', label: 'Losers', rounded: 'rounded-r-md border' },
+  ];
+  return (
+    <div className="inline-flex rounded-md shadow-sm">
+      {options.map((option) => (
+        <button
+          key={option.value}
+          onClick={() => onChange(option.value)}
+          className={`px-3 py-1.5 text-sm font-medium ${option.rounded} ${
+            filter === option.value
+              ? 'bg-blue-600 text-white border-blue-600'
+              : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+          }`}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
 }
 
 function RefreshButton({ onRefresh, isRefreshing }: { onRefresh?: () => void; isRefreshing?: boolean }) {
@@ -43,6 +77,7 @@ export function TopMovers({ movers, isLoading, hasInvestmentAccounts, onRefresh,
   const router = useRouter();
   const { formatCurrency, formatPercent } = useNumberFormat();
   const defaultCurrency = usePreferencesStore((s) => s.preferences?.defaultCurrency) || 'USD';
+  const [filter, setFilter] = useState<MoverFilter>('all');
 
   if (isLoading) {
     return (
@@ -89,8 +124,15 @@ export function TopMovers({ movers, isLoading, hasInvestmentAccounts, onRefresh,
     );
   }
 
-  // Show top 5 movers
-  const topMovers = movers.slice(0, 5);
+  // Apply filter, then show top 5. Movers arrive pre-sorted by absolute daily
+  // change, so 'all' keeps that order; gainers/losers re-sort directionally.
+  const filteredMovers =
+    filter === 'gainers'
+      ? movers.filter((m) => m.dailyChange > 0).sort((a, b) => b.dailyChangePercent - a.dailyChangePercent)
+      : filter === 'losers'
+        ? movers.filter((m) => m.dailyChange < 0).sort((a, b) => a.dailyChangePercent - b.dailyChangePercent)
+        : movers;
+  const topMovers = filteredMovers.slice(0, 5);
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[500px]">
@@ -106,6 +148,14 @@ export function TopMovers({ movers, isLoading, hasInvestmentAccounts, onRefresh,
           <span className="text-sm text-gray-500 dark:text-gray-400">Daily change</span>
         </div>
       </div>
+      <div className="mb-4">
+        <MoverFilterControl filter={filter} onChange={setFilter} />
+      </div>
+      {topMovers.length === 0 ? (
+        <p className="text-gray-500 dark:text-gray-400 text-sm">
+          {filter === 'gainers' ? 'No gainers today.' : 'No losers today.'}
+        </p>
+      ) : (
       <div className="space-y-2 sm:space-y-3">
         {topMovers.map((mover) => {
           const isPositive = mover.dailyChange >= 0;
@@ -145,6 +195,7 @@ export function TopMovers({ movers, isLoading, hasInvestmentAccounts, onRefresh,
           );
         })}
       </div>
+      )}
       <button
         onClick={() => router.push('/investments')}
         className="mt-3 w-full text-center text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"

--- a/frontend/src/components/dashboard/TopMovers.tsx
+++ b/frontend/src/components/dashboard/TopMovers.tsx
@@ -12,8 +12,12 @@ const FILTER_STORAGE_KEY = 'dashboard.topMovers.filter';
 
 function getStoredFilter(): MoverFilter {
   if (typeof window === 'undefined') return 'all';
-  const stored = localStorage.getItem(FILTER_STORAGE_KEY);
-  return stored === 'gainers' || stored === 'losers' || stored === 'all' ? stored : 'all';
+  try {
+    const stored = localStorage.getItem(FILTER_STORAGE_KEY);
+    return stored === 'gainers' || stored === 'losers' || stored === 'all' ? stored : 'all';
+  } catch {
+    return 'all';
+  }
 }
 
 interface TopMoversProps {
@@ -88,7 +92,11 @@ export function TopMovers({ movers, isLoading, hasInvestmentAccounts, onRefresh,
   const [filter, setFilter] = useState<MoverFilter>(getStoredFilter);
 
   useEffect(() => {
-    localStorage.setItem(FILTER_STORAGE_KEY, filter);
+    try {
+      localStorage.setItem(FILTER_STORAGE_KEY, filter);
+    } catch {
+      // Ignore storage failures (e.g. disabled/blocked storage); persistence is best-effort.
+    }
   }, [filter]);
 
   if (isLoading) {


### PR DESCRIPTION
## Summary
Added All/Gainers/Losers filter controls to the TopMovers dashboard component, with persistent filter selection via localStorage and empty state messaging.

## Key Changes
- **Filter UI**: New `MoverFilterControl` component with three toggle buttons (All, Gainers, Losers) styled with Tailwind CSS
- **Filter Logic**: 
  - "All" preserves original pre-sorted order (by absolute daily change)
  - "Gainers" filters to positive daily change and sorts by percent change descending
  - "Losers" filters to negative daily change and sorts by percent change ascending
- **Persistence**: Filter selection saved to localStorage (`dashboard.topMovers.filter`) and restored on component remount
- **Empty State**: Shows contextual message ("No gainers today." / "No losers today.") when filtered results are empty
- **Tests**: Added four new test cases covering filter rendering, gainers/losers filtering, localStorage persistence, and empty state messaging

## Implementation Details
- Used `useState` with `getStoredFilter()` helper to safely read localStorage (handles SSR and storage errors gracefully)
- `useEffect` hook persists filter changes to localStorage with try-catch error handling (best-effort persistence)
- Filter control positioned above the mover list with conditional rendering of empty state or mover list
- All existing functionality preserved; filter defaults to "all" on first load

https://claude.ai/code/session_017hNuq4c7XVRNKzDQvLfoSr