### PR TITLE
Claude/standard account dropdown

### DIFF
--- a/backend/src/investment-reports/dto/execute-investment-report.dto.ts
+++ b/backend/src/investment-reports/dto/execute-investment-report.dto.ts
@@ -1,4 +1,10 @@
-import { IsOptional, Matches } from "class-validator";
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsOptional,
+  IsUUID,
+  Matches,
+} from "class-validator";
 import { ApiPropertyOptional } from "@nestjs/swagger";
 import { InvestmentGroupBy } from "../entities/investment-report.entity";
 
@@ -11,6 +17,18 @@ export class ExecuteInvestmentReportDto {
     message: "asOfDate must be in YYYY-MM-DD format",
   })
   asOfDate?: string;
+
+  @ApiPropertyOptional({
+    description:
+      "Override the accounts to include for this run (empty means all). " +
+      "Defaults to the report's saved accounts when omitted.",
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(500)
+  @IsUUID("4", { each: true })
+  accountIds?: string[];
 }
 
 /** A single computed value cell. Null means the value is not available. */

--- a/backend/src/investment-reports/investment-reports.service.spec.ts
+++ b/backend/src/investment-reports/investment-reports.service.spec.ts
@@ -321,6 +321,36 @@ describe("InvestmentReportsService", () => {
       );
     });
 
+    it("prefers a request-level account override over the saved config", async () => {
+      reportsRepository.findOne.mockResolvedValue({
+        ...baseReport,
+        config: { ...baseReport.config, accountIds: ["a1"] },
+      });
+      await service.execute("u1", "r1", { accountIds: ["a2"] });
+      expect(dataService.computeHoldings).toHaveBeenCalledWith(
+        "u1",
+        ["a2"], // override wins over the saved ["a1"]
+        "2024-06-10",
+        "USD",
+        false,
+      );
+    });
+
+    it("treats an empty account override as all holdings accounts", async () => {
+      reportsRepository.findOne.mockResolvedValue({
+        ...baseReport,
+        config: { ...baseReport.config, accountIds: ["a1"] },
+      });
+      await service.execute("u1", "r1", { accountIds: [] });
+      expect(dataService.computeHoldings).toHaveBeenCalledWith(
+        "u1",
+        ["a1", "a2"], // empty override -> every holdings account, ignoring config
+        "2024-06-10",
+        "USD",
+        false,
+      );
+    });
+
     it("prepends the account column when separating securities grouped by symbol", async () => {
       reportsRepository.findOne.mockResolvedValue({
         ...baseReport,

--- a/backend/src/investment-reports/investment-reports.service.ts
+++ b/backend/src/investment-reports/investment-reports.service.ts
@@ -143,9 +143,11 @@ export class InvestmentReportsService {
     overrides?: ExecuteInvestmentReportDto,
   ): Promise<InvestmentReportResult> {
     const report = await this.findOne(userId, id);
+    // A request-level account override (from the report viewer) takes
+    // precedence over the saved config; an empty array means "all accounts".
     const accountIds = await this.resolveAccountIds(
       userId,
-      report.config.accountIds ?? [],
+      overrides?.accountIds ?? report.config.accountIds ?? [],
     );
 
     const asOfDate =
@@ -177,10 +179,7 @@ export class InvestmentReportsService {
     // When securities from multiple accounts are listed separately, lead with
     // the account column so the user can tell the holdings apart.
     if (groupsAcross && !mergeAccounts) {
-      columns = [
-        "account",
-        ...columns.filter((c) => c !== "account"),
-      ];
+      columns = ["account", ...columns.filter((c) => c !== "account")];
     }
     const groups = this.buildGroups(
       holdings,

--- a/frontend/src/app/securities/page.tsx
+++ b/frontend/src/app/securities/page.tsx
@@ -186,6 +186,8 @@ function SecuritiesContent() {
         comparison = a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
       } else if (sortField === 'type') {
         comparison = (a.securityType || '').localeCompare(b.securityType || '', undefined, { sensitivity: 'base' });
+      } else if (sortField === 'shares') {
+        comparison = (holdings[a.id] || 0) - (holdings[b.id] || 0);
       } else if (sortField === 'exchange') {
         comparison = (a.exchange || '').localeCompare(b.exchange || '', undefined, { sensitivity: 'base' });
       } else if (sortField === 'currency') {
@@ -197,7 +199,7 @@ function SecuritiesContent() {
       }
       return sortDirection === 'asc' ? comparison : -comparison;
     });
-  }, [filteredSecurities, sortField, sortDirection]);
+  }, [filteredSecurities, sortField, sortDirection, holdings]);
 
   // Pagination logic
   const totalPages = Math.ceil(sortedSecurities.length / PAGE_SIZE);

--- a/frontend/src/components/reports/CurrencyExposureReport.test.tsx
+++ b/frontend/src/components/reports/CurrencyExposureReport.test.tsx
@@ -206,28 +206,24 @@ describe('CurrencyExposureReport', () => {
     mockGetPortfolioSummary.mockResolvedValue({ holdings: mockHoldings });
     mockGetInvestmentAccounts.mockResolvedValue(mockAccounts);
     render(<CurrencyExposureReport />);
-    await waitFor(() => {
-      expect(screen.getByText('Accounts')).toBeInTheDocument();
-    });
+    const trigger = await screen.findByRole('button', { name: 'Filter by account' });
 
-    fireEvent.click(screen.getByText('Accounts'));
+    fireEvent.click(trigger);
     expect(screen.getByText('TFSA')).toBeInTheDocument();
     expect(screen.queryByText('Cash Reserve')).not.toBeInTheDocument();
   });
 
-  it('shows clear filters button when filters are selected', async () => {
+  it('reflects the selected account in the filter trigger', async () => {
     mockGetPortfolioSummary.mockResolvedValue({ holdings: mockHoldings });
     mockGetInvestmentAccounts.mockResolvedValue(mockAccounts);
     render(<CurrencyExposureReport />);
-    await waitFor(() => {
-      expect(screen.getByText('Accounts')).toBeInTheDocument();
-    });
+    const trigger = await screen.findByRole('button', { name: 'Filter by account' });
 
-    fireEvent.click(screen.getByText('Accounts'));
-    fireEvent.click(screen.getByText('TFSA'));
+    fireEvent.click(trigger);
+    await act(async () => { fireEvent.click(screen.getByText('TFSA')); });
 
     await waitFor(() => {
-      expect(screen.getByText('Clear Filters')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Filter by account' })).toHaveTextContent('TFSA');
     });
   });
 
@@ -258,33 +254,32 @@ describe('CurrencyExposureReport', () => {
     });
   });
 
-  it('clears filters when Clear Filters clicked', async () => {
+  it('clears the account filter via the Clear action', async () => {
     mockGetPortfolioSummary.mockResolvedValue({ holdings: mockHoldings });
     mockGetInvestmentAccounts.mockResolvedValue(mockAccounts);
     render(<CurrencyExposureReport />);
+    const trigger = await screen.findByRole('button', { name: 'Filter by account' });
+    fireEvent.click(trigger);
+    await act(async () => { fireEvent.click(screen.getByText('TFSA')); });
     await waitFor(() => {
-      expect(screen.getByText('Accounts')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Filter by account' })).toHaveTextContent('TFSA');
     });
-    fireEvent.click(screen.getByText('Accounts'));
-    fireEvent.click(screen.getByText('TFSA'));
+    await act(async () => { fireEvent.click(screen.getByText('Clear')); });
     await waitFor(() => {
-      expect(screen.getByText('Clear Filters')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Filter by account' })).toHaveTextContent('All Accounts');
     });
-    await act(async () => { fireEvent.click(screen.getByText('Clear Filters')); });
   });
 
   it('closes dropdown when clicking outside', async () => {
     mockGetPortfolioSummary.mockResolvedValue({ holdings: mockHoldings });
     mockGetInvestmentAccounts.mockResolvedValue(mockAccounts);
     render(<CurrencyExposureReport />);
-    await waitFor(() => {
-      expect(screen.getByText('Accounts')).toBeInTheDocument();
-    });
+    const trigger = await screen.findByRole('button', { name: 'Filter by account' });
 
-    fireEvent.click(screen.getByText('Accounts'));
+    fireEvent.click(trigger);
     expect(screen.getByText('TFSA')).toBeInTheDocument();
 
     fireEvent.mouseDown(document.body);
-    expect(screen.queryByText('TFSA')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('TFSA')).not.toBeInTheDocument());
   });
 });

--- a/frontend/src/components/reports/CurrencyExposureReport.tsx
+++ b/frontend/src/components/reports/CurrencyExposureReport.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { useClickOutside } from '@/hooks/useClickOutside';
 import {
   PieChart,
   Pie,
@@ -16,11 +15,17 @@ import { Account } from '@/types/account';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('CurrencyExposureReport');
+
+// Holdings are keyed off the brokerage sub-account, so offer those (the
+// sibling cash account is excluded from the picker).
+const excludeCashAccounts = (a: Account) => a.accountSubType !== 'INVESTMENT_CASH';
 
 type CurrencyExposureSortField = 'currency' | 'nativeValue' | 'rate' | 'convertedValue' | 'percentage' | 'count';
 
@@ -78,15 +83,11 @@ export function CurrencyExposureReport() {
   const [holdings, setHoldings] = useState<HoldingWithMarketValue[]>([]);
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [showAccountFilter, setShowAccountFilter] = useState(false);
-  const accountFilterRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<HTMLDivElement>(null);
   const { sortField, sortDirection, handleSort } = useSortableTable<CurrencyExposureSortField>(
     'reports.currency-exposure.sort',
     { field: 'convertedValue', direction: 'desc' },
   );
-
-  useClickOutside(accountFilterRef, () => setShowAccountFilter(false), { enabled: showAccountFilter });
 
   // Fetch accounts once on mount
   useEffect(() => {
@@ -112,12 +113,6 @@ export function CurrencyExposureReport() {
   useEffect(() => {
     loadData();
   }, [loadData]);
-
-  const toggleAccountId = (id: string) => {
-    setSelectedAccountIds((prev) =>
-      prev.includes(id) ? prev.filter((a) => a !== id) : [...prev, id],
-    );
-  };
 
   const allocationData = useMemo((): CurrencyAllocation[] => {
     const currencyMap = new Map<string, { nativeValue: number; convertedValue: number; count: number }>();
@@ -246,51 +241,18 @@ export function CurrencyExposureReport() {
       {/* Account Filter */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-3 items-center justify-between">
-          <div className="flex flex-wrap gap-3">
-            <div className="relative" ref={accountFilterRef}>
-            <button
-              onClick={() => setShowAccountFilter(!showAccountFilter)}
-              className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-            >
-              Accounts{selectedAccountIds.length > 0 ? ` (${selectedAccountIds.length})` : ''}
-            </button>
-            {showAccountFilter && (
-              <div className="absolute top-full left-0 mt-1 w-64 bg-white dark:bg-gray-800 rounded-lg shadow-lg dark:shadow-gray-700/50 border border-gray-200 dark:border-gray-700 z-10 max-h-60 overflow-y-auto">
-                <div className="p-2">
-                  {accounts.filter((a) => a.accountSubType !== 'INVESTMENT_CASH').length === 0 ? (
-                    <p className="text-sm text-gray-500 dark:text-gray-400 p-2">No investment accounts</p>
-                  ) : (
-                    accounts.filter((a) => a.accountSubType !== 'INVESTMENT_CASH').map((acct) => (
-                      <label
-                        key={acct.id}
-                        className="flex items-center gap-2 p-2 hover:bg-gray-50 dark:hover:bg-gray-700 rounded cursor-pointer"
-                      >
-                        <input
-                          type="checkbox"
-                          checked={selectedAccountIds.includes(acct.id)}
-                          onChange={() => toggleAccountId(acct.id)}
-                          className="rounded border-gray-300 dark:border-gray-600"
-                        />
-                        <span className="text-sm text-gray-700 dark:text-gray-300 truncate">
-                          {acct.name}
-                        </span>
-                      </label>
-                    ))
-                  )}
-                </div>
-              </div>
-            )}
+          <div className="flex flex-wrap gap-3 items-center">
+            <ReportAccountMultiSelect
+              accounts={accounts}
+              value={selectedAccountIds}
+              onChange={setSelectedAccountIds}
+              filter={excludeCashAccounts}
+            />
           </div>
-          {selectedAccountIds.length > 0 && (
-            <button
-              onClick={() => setSelectedAccountIds([])}
-              className="px-4 py-2 text-sm font-medium rounded-lg text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
-            >
-              Clear Filters
-            </button>
-          )}
+          <div className="flex gap-2 items-center">
+            <RefreshPricesButton onRefreshComplete={loadData} />
+            <ExportDropdown onExportPdf={handleExportPdf} />
           </div>
-          <ExportDropdown onExportPdf={handleExportPdf} />
         </div>
       </div>
 

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -1033,7 +1033,6 @@ export function DividendIncomeReport() {
             onChange={setDateRange}
           />
           <div className="ml-auto shrink-0 flex gap-2 items-center">
-            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
             <button
               onClick={() => setViewType('monthly')}
               className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
@@ -1064,6 +1063,7 @@ export function DividendIncomeReport() {
             >
               By Security
             </button>
+            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
             <ExportDropdown
               onExportPdf={handleExportPdf}
               onExportCsv={isTableView ? handleExportCsv : undefined}

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -24,6 +24,7 @@ import { useDateRange } from '@/hooks/useDateRange';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { MultiSelect } from '@/components/ui/MultiSelect';
+import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { exportToCsv } from '@/lib/csv-export';
@@ -91,6 +92,8 @@ export function DividendIncomeReport() {
     if (accountDebounceRef.current) clearTimeout(accountDebounceRef.current);
   }, []);
   const [selectedSecurityId, setSelectedSecurityId] = useState<string>('');
+  // Bumped after a manual price refresh to force the data effects to re-fetch.
+  const [reloadKey, setReloadKey] = useState(0);
   // When exactly one account is selected we keep its native currency; with no
   // selection (all accounts) or several selected accounts we may have mixed
   // currencies, so we convert into the user's default currency.
@@ -290,7 +293,7 @@ export function DividendIncomeReport() {
       }
     };
     loadData();
-  }, [appliedAccountIds, resolvedRange, isValid]);
+  }, [appliedAccountIds, resolvedRange, isValid, reloadKey]);
 
   // Lazy-load daily capital gains only when the user switches to the daily view.
   useEffect(() => {
@@ -313,7 +316,7 @@ export function DividendIncomeReport() {
       }
     };
     load();
-  }, [viewType, appliedAccountIds, resolvedRange, isValid]);
+  }, [viewType, appliedAccountIds, resolvedRange, isValid, reloadKey]);
 
   const monthlyData = useMemo((): MonthlyIncome[] => {
     const { start, end } = resolvedRange;
@@ -1030,6 +1033,7 @@ export function DividendIncomeReport() {
             onChange={setDateRange}
           />
           <div className="ml-auto shrink-0 flex gap-2 items-center">
+            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
             <button
               onClick={() => setViewType('monthly')}
               className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${

--- a/frontend/src/components/reports/DividendYieldGrowthReport.test.tsx
+++ b/frontend/src/components/reports/DividendYieldGrowthReport.test.tsx
@@ -23,6 +23,7 @@ vi.mock('@/hooks/useExchangeRates', () => ({
 
 vi.mock('@/lib/utils', () => ({
   parseLocalDate: (d: string) => new Date(d + 'T00:00:00'),
+  cn: (...inputs: any[]) => inputs.flat(Infinity).filter(Boolean).join(' '),
 }));
 
 vi.mock('@/components/ui/ExportDropdown', () => ({
@@ -520,9 +521,11 @@ describe('DividendYieldGrowthReport', () => {
       expect(screen.getByText('All Accounts')).toBeInTheDocument();
     });
     const initialCallCount = mockGetTransactions.mock.calls.length;
-    const select = document.querySelector('select') as HTMLSelectElement;
     await act(async () => {
-      fireEvent.change(select, { target: { value: 'acc-1' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Filter by account' }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('TFSA'));
     });
     await waitFor(() => {
       expect(mockGetTransactions.mock.calls.length).toBeGreaterThan(initialCallCount);
@@ -662,12 +665,10 @@ describe('DividendYieldGrowthReport', () => {
     ]);
     mockGetPortfolioSummary.mockResolvedValue({ holdings: mockHoldings });
     render(<DividendYieldGrowthReport />);
-    await waitFor(() => {
-      expect(screen.getByText('All Accounts')).toBeInTheDocument();
-    });
-    const select = document.querySelector('select') as HTMLSelectElement;
+    const trigger = await screen.findByRole('button', { name: 'Filter by account' });
+    await act(async () => { fireEvent.click(trigger); });
     await act(async () => {
-      fireEvent.change(select, { target: { value: 'acc-1' } });
+      fireEvent.click(screen.getByText('TFSA'));
     });
     await waitFor(() => {
       // After selecting account, the yield table should still render with that account's data

--- a/frontend/src/components/reports/DividendYieldGrowthReport.tsx
+++ b/frontend/src/components/reports/DividendYieldGrowthReport.tsx
@@ -18,6 +18,8 @@ import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { createLogger } from '@/lib/logger';
@@ -72,9 +74,11 @@ export function DividendYieldGrowthReport() {
   const [transactions, setTransactions] = useState<InvestmentTransaction[]>([]);
   const [holdings, setHoldings] = useState<HoldingWithMarketValue[]>([]);
   const [accounts, setAccounts] = useState<Account[]>([]);
-  const [selectedAccountId, setSelectedAccountId] = useState<string>('');
+  const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
+  const [reloadKey, setReloadKey] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [viewType, setViewType] = useState<'yield' | 'growth' | 'frequency'>('yield');
+  const isSingleAccount = selectedAccountIds.length === 1;
   const yieldSort = useSortableTable<YieldSortField>(
     'reports.dividend-yield-growth.yield.sort',
     { field: 'yield', direction: 'desc' },
@@ -94,15 +98,17 @@ export function DividendYieldGrowthReport() {
     return map;
   }, [accounts]);
 
-  const selectedAccount = accounts.find((a) => a.id === selectedAccountId);
+  const selectedAccount = isSingleAccount
+    ? accounts.find((a) => a.id === selectedAccountIds[0])
+    : undefined;
   const displayCurrency = selectedAccount?.currencyCode || defaultCurrency;
 
   const getTxAmount = useCallback((tx: InvestmentTransaction): number => {
     const amount = Math.abs(tx.totalAmount);
-    if (selectedAccountId) return amount;
+    if (isSingleAccount) return amount;
     const txCurrency = accountCurrencyMap.get(tx.accountId) || defaultCurrency;
     return convertToDefault(amount, txCurrency);
-  }, [selectedAccountId, accountCurrencyMap, defaultCurrency, convertToDefault]);
+  }, [isSingleAccount, accountCurrencyMap, defaultCurrency, convertToDefault]);
 
   const fmtValue = useCallback((value: number): string => {
     const isForeign = displayCurrency !== defaultCurrency;
@@ -121,7 +127,7 @@ export function DividendYieldGrowthReport() {
     const loadData = async () => {
       setIsLoading(true);
       try {
-        const accountIds = selectedAccountId || undefined;
+        const accountIds = selectedAccountIds.length > 0 ? selectedAccountIds.join(',') : undefined;
 
         const fetchAllPages = async (action: string): Promise<InvestmentTransaction[]> => {
           const results: InvestmentTransaction[] = [];
@@ -143,7 +149,7 @@ export function DividendYieldGrowthReport() {
 
         const [summaryData, dividendTx, reinvestTx] = await Promise.all([
           investmentsApi.getPortfolioSummary(
-            selectedAccountId ? [selectedAccountId] : undefined,
+            selectedAccountIds.length > 0 ? selectedAccountIds : undefined,
           ),
           fetchAllPages('DIVIDEND'),
           fetchAllPages('REINVEST'),
@@ -158,7 +164,7 @@ export function DividendYieldGrowthReport() {
       }
     };
     loadData();
-  }, [selectedAccountId]);
+  }, [selectedAccountIds, reloadKey]);
 
   // Trailing 12-month portfolio yield
   const trailing12mTotal = useMemo(() => {
@@ -425,21 +431,11 @@ export function DividendYieldGrowthReport() {
       {/* Controls */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-4 items-center justify-between">
-          <select
-            value={selectedAccountId}
-            onChange={(e) => setSelectedAccountId(e.target.value)}
-            className="rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm"
-          >
-            <option value="">All Accounts</option>
-            {accounts
-              .filter((a) => a.accountSubType !== 'INVESTMENT_BROKERAGE')
-              .sort((a, b) => a.name.localeCompare(b.name))
-              .map((account) => (
-                <option key={account.id} value={account.id}>
-                  {account.name.replace(/ - (Brokerage|Cash)$/, '')}
-                </option>
-              ))}
-          </select>
+          <ReportAccountMultiSelect
+            accounts={accounts}
+            value={selectedAccountIds}
+            onChange={setSelectedAccountIds}
+          />
           <div className="flex gap-2 items-center">
             <button
               onClick={() => setViewType('yield')}
@@ -466,7 +462,8 @@ export function DividendYieldGrowthReport() {
               Frequency
             </button>
           </div>
-          <div className="ml-auto">
+          <div className="ml-auto flex gap-2 items-center">
+            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
             <ExportDropdown onExportPdf={handleExportPdf} />
           </div>
         </div>

--- a/frontend/src/components/reports/GeographicAllocationReport.test.tsx
+++ b/frontend/src/components/reports/GeographicAllocationReport.test.tsx
@@ -236,31 +236,22 @@ describe('GeographicAllocationReport', () => {
     await waitFor(() => {
       expect(screen.getByText('Total Portfolio')).toBeInTheDocument();
     });
-    await act(async () => {
-      fireEvent.click(screen.getByText(/^Accounts/));
+    const trigger = screen.getByRole('button', { name: 'Filter by account' });
+    await act(async () => { fireEvent.click(trigger); });
+    // Cash sub-account is hidden; only the brokerage account is offered.
+    expect(screen.queryByText('Cash Acc')).not.toBeInTheDocument();
+    // Toggle TFSA on, then clear it
+    await act(async () => { fireEvent.click(screen.getByText('TFSA')); });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Filter by account' })).toHaveTextContent('TFSA');
     });
-    // Toggle TFSA
-    const checkbox = document.querySelector('input[type="checkbox"]') as HTMLInputElement;
-    if (checkbox) {
-      await act(async () => {
-        fireEvent.click(checkbox);
-      });
-    }
-    // Click outside to close (mousedown)
-    await act(async () => {
-      document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    await act(async () => { fireEvent.click(screen.getByText('Clear')); });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Filter by account' })).toHaveTextContent('All Accounts');
     });
-    // Re-open and clear
-    if (screen.queryByText(/^Accounts/)) {
-      // Clear Filters button
-      const clearBtn = screen.queryByText('Clear Filters');
-      if (clearBtn) {
-        await act(async () => { fireEvent.click(clearBtn); });
-      }
-    }
   });
 
-  it('shows no investment accounts message when filter has none', async () => {
+  it('shows no options message when no investment accounts are available', async () => {
     mockGetPortfolioSummary.mockResolvedValue({ holdings: mockHoldings });
     mockGetInvestmentAccounts.mockResolvedValue([
       { id: 'acc-1', name: 'Cash', accountSubType: 'INVESTMENT_CASH' },
@@ -271,9 +262,9 @@ describe('GeographicAllocationReport', () => {
       expect(screen.getByText('Total Portfolio')).toBeInTheDocument();
     });
     await act(async () => {
-      fireEvent.click(screen.getByText(/^Accounts/));
+      fireEvent.click(screen.getByRole('button', { name: 'Filter by account' }));
     });
-    expect(screen.getByText('No investment accounts')).toBeInTheDocument();
+    expect(screen.getByText('No options found')).toBeInTheDocument();
   });
 
   it('exports pdf in region and exchange views', async () => {

--- a/frontend/src/components/reports/GeographicAllocationReport.tsx
+++ b/frontend/src/components/reports/GeographicAllocationReport.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { useClickOutside } from '@/hooks/useClickOutside';
 import {
   BarChart,
   Bar,
@@ -20,11 +19,17 @@ import { Account } from '@/types/account';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('GeographicAllocationReport');
+
+// Holdings are keyed off the brokerage sub-account, so offer those (the
+// sibling cash account is excluded from the picker).
+const excludeCashAccounts = (a: Account) => a.accountSubType !== 'INVESTMENT_CASH';
 
 type GeoRegionSortField = 'region' | 'count' | 'marketValue' | 'percentage';
 type GeoExchangeSortField = 'exchange' | 'country' | 'count' | 'marketValue' | 'percentage';
@@ -118,8 +123,6 @@ export function GeographicAllocationReport() {
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
   const [viewType, setViewType] = useState<'region' | 'exchange'>('region');
   const [isLoading, setIsLoading] = useState(true);
-  const [showAccountFilter, setShowAccountFilter] = useState(false);
-  const accountFilterRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<HTMLDivElement>(null);
   const regionSort = useSortableTable<GeoRegionSortField>(
     'reports.geographic-allocation.region.sort',
@@ -129,8 +132,6 @@ export function GeographicAllocationReport() {
     'reports.geographic-allocation.exchange.sort',
     { field: 'marketValue', direction: 'desc' },
   );
-
-  useClickOutside(accountFilterRef, () => setShowAccountFilter(false), { enabled: showAccountFilter });
 
   // Fetch accounts and securities once on mount (static data)
   useEffect(() => {
@@ -162,12 +163,6 @@ export function GeographicAllocationReport() {
   useEffect(() => {
     loadData();
   }, [loadData]);
-
-  const toggleAccountId = (id: string) => {
-    setSelectedAccountIds((prev) =>
-      prev.includes(id) ? prev.filter((a) => a !== id) : [...prev, id],
-    );
-  };
 
   const securityExchangeMap = useMemo(() => {
     const map = new Map<string, string>();
@@ -351,49 +346,13 @@ export function GeographicAllocationReport() {
       {/* Filters & View Toggle */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-3 items-center justify-between">
-          <div className="flex flex-wrap gap-3">
-            <div className="relative" ref={accountFilterRef}>
-              <button
-                onClick={() => setShowAccountFilter(!showAccountFilter)}
-                className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-              >
-                Accounts{selectedAccountIds.length > 0 ? ` (${selectedAccountIds.length})` : ''}
-              </button>
-              {showAccountFilter && (
-                <div className="absolute top-full left-0 mt-1 w-64 bg-white dark:bg-gray-800 rounded-lg shadow-lg dark:shadow-gray-700/50 border border-gray-200 dark:border-gray-700 z-10 max-h-60 overflow-y-auto">
-                  <div className="p-2">
-                    {accounts.filter((a) => a.accountSubType !== 'INVESTMENT_CASH').length === 0 ? (
-                      <p className="text-sm text-gray-500 dark:text-gray-400 p-2">No investment accounts</p>
-                    ) : (
-                      accounts.filter((a) => a.accountSubType !== 'INVESTMENT_CASH').map((acct) => (
-                        <label
-                          key={acct.id}
-                          className="flex items-center gap-2 p-2 hover:bg-gray-50 dark:hover:bg-gray-700 rounded cursor-pointer"
-                        >
-                          <input
-                            type="checkbox"
-                            checked={selectedAccountIds.includes(acct.id)}
-                            onChange={() => toggleAccountId(acct.id)}
-                            className="rounded border-gray-300 dark:border-gray-600"
-                          />
-                          <span className="text-sm text-gray-700 dark:text-gray-300 truncate">
-                            {acct.name}
-                          </span>
-                        </label>
-                      ))
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
-            {selectedAccountIds.length > 0 && (
-              <button
-                onClick={() => setSelectedAccountIds([])}
-                className="px-4 py-2 text-sm font-medium rounded-lg text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
-              >
-                Clear Filters
-              </button>
-            )}
+          <div className="flex flex-wrap gap-3 items-center">
+            <ReportAccountMultiSelect
+              accounts={accounts}
+              value={selectedAccountIds}
+              onChange={setSelectedAccountIds}
+              filter={excludeCashAccounts}
+            />
           </div>
           <div className="flex items-center gap-2">
             <button
@@ -416,6 +375,7 @@ export function GeographicAllocationReport() {
             >
               By Exchange
             </button>
+            <RefreshPricesButton onRefreshComplete={loadData} />
             <ExportDropdown onExportPdf={handleExportPdf} />
           </div>
         </div>

--- a/frontend/src/components/reports/InvestmentPerformanceReport.test.tsx
+++ b/frontend/src/components/reports/InvestmentPerformanceReport.test.tsx
@@ -213,14 +213,13 @@ describe('InvestmentPerformanceReport', () => {
     await act(async () => {
       fireEvent.click(screen.getByText('Holdings'));
     });
-    // change account filter
-    const select = document.querySelector('select') as HTMLSelectElement;
+    // change account filter via the multi-select; selecting the single USD
+    // account exercises the foreign-currency summary path
     await act(async () => {
-      fireEvent.change(select, { target: { value: 'acc-1' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Filter by account' }));
     });
-    // also test foreign currency summary by switching to USD-only account
     await act(async () => {
-      fireEvent.change(select, { target: { value: 'acc-3' } });
+      fireEvent.click(screen.getByText('RRSP'));
     });
     // export pdf
     const exportBtn = screen.getByRole('button', { name: /export/i });

--- a/frontend/src/components/reports/InvestmentPerformanceReport.tsx
+++ b/frontend/src/components/reports/InvestmentPerformanceReport.tsx
@@ -16,6 +16,8 @@ import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { CHART_COLOURS } from '@/lib/chart-colours';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { createLogger } from '@/lib/logger';
@@ -31,10 +33,12 @@ export function InvestmentPerformanceReport() {
   const chartRef = useRef<HTMLDivElement>(null);
   const [portfolio, setPortfolio] = useState<PortfolioSummary | null>(null);
   const [accounts, setAccounts] = useState<Account[]>([]);
-  const [selectedAccountId, setSelectedAccountId] = useState<string>('');
+  const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
+  const [reloadKey, setReloadKey] = useState(0);
   const [expandedSecurityId, setExpandedSecurityId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [viewType, setViewType] = useState<'performance' | 'allocation'>('performance');
+  const isSingleAccount = selectedAccountIds.length === 1;
   const { sortField, sortDirection, handleSort } = useSortableTable<HoldingsSortField>(
     'reports.investment-performance.holdings.sort',
     { field: 'marketValue', direction: 'desc' },
@@ -45,7 +49,7 @@ export function InvestmentPerformanceReport() {
       setIsLoading(true);
       try {
         const [portfolioData, accountsData] = await Promise.all([
-          investmentsApi.getPortfolioSummary(selectedAccountId ? [selectedAccountId] : undefined),
+          investmentsApi.getPortfolioSummary(selectedAccountIds.length > 0 ? selectedAccountIds : undefined),
           investmentsApi.getInvestmentAccounts(),
         ]);
         setPortfolio(portfolioData);
@@ -57,7 +61,7 @@ export function InvestmentPerformanceReport() {
       }
     };
     loadData();
-  }, [selectedAccountId]);
+  }, [selectedAccountIds, reloadKey]);
 
   const formatPercent = (value: number) => {
     const sign = value >= 0 ? '+' : '';
@@ -66,14 +70,16 @@ export function InvestmentPerformanceReport() {
 
   // When a single account is selected, show summary values in that account's native currency
   // (per-account totals are in native currency; top-level totals are converted to default)
-  const selectedAccount = accounts.find((a) => a.id === selectedAccountId);
+  const selectedAccount = isSingleAccount
+    ? accounts.find((a) => a.id === selectedAccountIds[0])
+    : undefined;
   const summaryCurrency = selectedAccount?.currencyCode || defaultCurrency;
   const isForeignSummary = summaryCurrency !== defaultCurrency;
 
   // Derive native-currency summary from holdingsByAccount when a single account is selected
   const summaryValues = useMemo(() => {
     if (!portfolio) return null;
-    if (selectedAccountId && portfolio.holdingsByAccount.length > 0) {
+    if (isSingleAccount && portfolio.holdingsByAccount.length > 0) {
       // Use per-account totals (native currency) instead of converted top-level totals
       let totalMarketValue = 0;
       let totalCashBalance = 0;
@@ -95,7 +101,7 @@ export function InvestmentPerformanceReport() {
       totalGainLoss: portfolio.totalGainLoss,
       totalGainLossPercent: portfolio.totalGainLossPercent,
     };
-  }, [portfolio, selectedAccountId]);
+  }, [portfolio, isSingleAccount]);
 
   const fmtSummary = (value: number) => {
     if (isForeignSummary) {
@@ -293,23 +299,14 @@ export function InvestmentPerformanceReport() {
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-4 items-center justify-between">
           <div className="flex flex-wrap gap-2">
-            <select
-              value={selectedAccountId}
-              onChange={(e) => setSelectedAccountId(e.target.value)}
-              className="rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm"
-            >
-              <option value="">All Accounts</option>
-              {accounts
-                .filter((a) => a.accountSubType !== 'INVESTMENT_BROKERAGE')
-                .sort((a, b) => a.name.localeCompare(b.name))
-                .map((account) => (
-                  <option key={account.id} value={account.id}>
-                    {account.name.replace(/ - (Brokerage|Cash)$/, '')}
-                  </option>
-                ))}
-            </select>
+            <ReportAccountMultiSelect
+              accounts={accounts}
+              value={selectedAccountIds}
+              onChange={setSelectedAccountIds}
+            />
           </div>
-          <div className="flex gap-2">
+          <div className="flex gap-2 items-center">
+            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
             <button
               onClick={() => setViewType('performance')}
               className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${

--- a/frontend/src/components/reports/InvestmentPerformanceReport.tsx
+++ b/frontend/src/components/reports/InvestmentPerformanceReport.tsx
@@ -306,7 +306,6 @@ export function InvestmentPerformanceReport() {
             />
           </div>
           <div className="flex gap-2 items-center">
-            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
             <button
               onClick={() => setViewType('performance')}
               className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
@@ -327,6 +326,7 @@ export function InvestmentPerformanceReport() {
             >
               Allocation
             </button>
+            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
             <ExportDropdown onExportPdf={handleExportPdf} />
           </div>
         </div>

--- a/frontend/src/components/reports/InvestmentReportViewer.test.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.test.tsx
@@ -16,6 +16,13 @@ vi.mock('@/lib/csv-export', () => ({
   exportToCsv: (...a: unknown[]) => mockExportToCsv(...a),
 }));
 
+const mockGetAllAccounts = vi.fn();
+vi.mock('@/lib/accounts', () => ({
+  accountsApi: {
+    getAll: (...a: unknown[]) => mockGetAllAccounts(...a),
+  },
+}));
+
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
     formatNumber: (n: number) => String(n),
@@ -69,6 +76,7 @@ describe('InvestmentReportViewer', () => {
     vi.clearAllMocks();
     mockGetById.mockResolvedValue(report);
     mockExecute.mockResolvedValue(result);
+    mockGetAllAccounts.mockResolvedValue([]);
   });
 
   it('runs the report and renders rows with the as-of date', async () => {
@@ -109,7 +117,7 @@ describe('InvestmentReportViewer', () => {
   it('re-runs the report when the as-of date is changed', async () => {
     await renderViewer();
     await screen.findByText('AAA');
-    expect(mockExecute).toHaveBeenCalledWith('r1', {});
+    expect(mockExecute).toHaveBeenCalledWith('r1', { accountIds: [] });
   });
 
   it('shows an empty state when there are no holdings', async () => {
@@ -172,13 +180,14 @@ describe('InvestmentReportViewer', () => {
     await waitFor(() =>
       expect(mockExecute).toHaveBeenCalledWith('r1', {
         asOfDate: '2024-03-15',
+        accountIds: [],
       }),
     );
     await act(async () => {
       fireEvent.click(screen.getByText('Reset to latest market day'));
     });
     await waitFor(() =>
-      expect(mockExecute).toHaveBeenLastCalledWith('r1', {}),
+      expect(mockExecute).toHaveBeenLastCalledWith('r1', { accountIds: [] }),
     );
   });
 

--- a/frontend/src/components/reports/InvestmentReportViewer.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.tsx
@@ -7,8 +7,12 @@ import Link from 'next/link';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { Button } from '@/components/ui/Button';
 import { DateInput } from '@/components/ui/DateInput';
+import { MultiSelect } from '@/components/ui/MultiSelect';
 import { SortableHeader } from '@/components/ui/SortableHeader';
+import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { investmentReportsApi } from '@/lib/investment-reports';
+import { accountsApi } from '@/lib/accounts';
+import { Account } from '@/types/account';
 import {
   InvestmentReport,
   InvestmentReportResult,
@@ -45,9 +49,22 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
   const { formatDate } = useDateFormat();
   const [report, setReport] = useState<InvestmentReport | null>(null);
   const [result, setResult] = useState<InvestmentReportResult | null>(null);
+  const [accounts, setAccounts] = useState<Account[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isExecuting, setIsExecuting] = useState(false);
   const [asOfOverride, setAsOfOverride] = useState('');
+  // View-time account override. Seeded from the report's saved config (below,
+  // once the report loads) but freely changeable without persisting.
+  const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
+  const [seededReportId, setSeededReportId] = useState<string | null>(null);
+
+  // Seed the account filter from the saved config the first time the report
+  // (or a different report) loads. Done during render, not in an effect, so
+  // the first execute already carries the saved accounts.
+  if (report && seededReportId !== report.id) {
+    setSeededReportId(report.id);
+    setSelectedAccountIds(report.config.accountIds ?? []);
+  }
   // Show monetary values in each holding's own currency, or convert to the
   // user's base currency.
   const [currencyMode, setCurrencyMode] = useState<'native' | 'base'>('native');
@@ -72,6 +89,7 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
     try {
       const data = await investmentReportsApi.execute(reportId, {
         ...(asOfOverride ? { asOfDate: asOfOverride } : {}),
+        accountIds: selectedAccountIds,
       });
       setResult(data);
     } catch (error) {
@@ -80,12 +98,27 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
     } finally {
       setIsExecuting(false);
     }
-  }, [reportId, asOfOverride]);
+  }, [reportId, asOfOverride, selectedAccountIds]);
 
   useEffect(() => {
     const init = async () => {
       setIsLoading(true);
-      await loadReport();
+      await Promise.all([
+        loadReport(),
+        accountsApi
+          .getAll()
+          .then((all) =>
+            setAccounts(
+              all.filter(
+                (a) =>
+                  a.accountType === 'INVESTMENT' &&
+                  a.accountSubType !== 'INVESTMENT_CASH' &&
+                  !a.isClosed,
+              ),
+            ),
+          )
+          .catch((error) => logger.error('Failed to load accounts:', error)),
+      ]);
       setIsLoading(false);
     };
     init();
@@ -218,6 +251,18 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-6">
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div className="flex flex-wrap items-end gap-4">
+            <div className="w-56">
+              <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Accounts
+              </span>
+              <MultiSelect
+                ariaLabel="Filter by account"
+                placeholder="All investment accounts"
+                options={accounts.map((a) => ({ value: a.id, label: a.name }))}
+                value={selectedAccountIds}
+                onChange={setSelectedAccountIds}
+              />
+            </div>
             <div className="w-48">
               <DateInput
                 label="As of date"
@@ -263,6 +308,7 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
                 <span>Updating...</span>
               </div>
             )}
+            <RefreshPricesButton onRefreshComplete={executeReport} />
             <Button
               variant="outline"
               onClick={handleExportCsv}

--- a/frontend/src/components/reports/InvestmentReportViewer.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.tsx
@@ -302,15 +302,10 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
             </div>
           </div>
           <div className="flex items-center gap-3">
-            {isExecuting && (
-              <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"></div>
-                <span>Updating...</span>
-              </div>
-            )}
             <RefreshPricesButton onRefreshComplete={executeReport} />
             <Button
               variant="outline"
+              size="sm"
               onClick={handleExportCsv}
               disabled={!result || result.rowCount === 0}
             >
@@ -352,6 +347,12 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
               As of {formatDate(result.asOfDate)} · {result.rowCount} holding
               {result.rowCount === 1 ? '' : 's'}
             </span>
+            {isExecuting && (
+              <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"></div>
+                <span>Updating...</span>
+              </div>
+            )}
           </div>
 
           {result.rowCount === 0 ? (

--- a/frontend/src/components/reports/InvestmentTransactionHistoryReport.test.tsx
+++ b/frontend/src/components/reports/InvestmentTransactionHistoryReport.test.tsx
@@ -34,6 +34,7 @@ vi.mock('@/hooks/useDateRange', () => ({
 
 vi.mock('@/lib/utils', () => ({
   parseLocalDate: (d: string) => new Date(d + 'T00:00:00'),
+  cn: (...inputs: any[]) => inputs.flat(Infinity).filter(Boolean).join(' '),
 }));
 
 vi.mock('@/components/ui/DateRangeSelector', () => ({

--- a/frontend/src/components/reports/InvestmentTransactionHistoryReport.test.tsx
+++ b/frontend/src/components/reports/InvestmentTransactionHistoryReport.test.tsx
@@ -206,6 +206,55 @@ describe('InvestmentTransactionHistoryReport', () => {
     expect(screen.getByTestId('date-range-selector')).toBeInTheDocument();
   });
 
+  it('filters transactions by action client-side without re-fetching', async () => {
+    mockGetTransactions.mockResolvedValue({
+      data: [
+        {
+          id: 'tx-1',
+          transactionDate: '2025-06-15',
+          action: 'BUY',
+          totalAmount: 5000,
+          quantity: 50,
+          price: 100,
+          accountId: 'acc-1',
+          security: { symbol: 'AAPL', name: 'Apple Inc.' },
+        },
+        {
+          id: 'tx-2',
+          transactionDate: '2025-08-20',
+          action: 'SELL',
+          totalAmount: -3000,
+          quantity: -30,
+          price: 100,
+          accountId: 'acc-1',
+          security: { symbol: 'MSFT', name: 'Microsoft Corp.' },
+        },
+      ],
+      pagination: { hasMore: false },
+    });
+    mockGetInvestmentAccounts.mockResolvedValue([
+      { id: 'acc-1', name: 'TFSA', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
+    ]);
+    render(<InvestmentTransactionHistoryReport />);
+    await waitFor(() => {
+      expect(screen.getByText('AAPL')).toBeInTheDocument();
+    });
+    expect(screen.getByText('MSFT')).toBeInTheDocument();
+    const fetchCallsBefore = mockGetTransactions.mock.calls.length;
+
+    // Open the action MultiSelect and select "Buy"
+    fireEvent.click(screen.getByRole('button', { name: 'Filter by action' }));
+    const buyLabels = screen.getAllByText('Buy');
+    await act(async () => { fireEvent.click(buyLabels[buyLabels.length - 1]); });
+
+    // SELL row is filtered out without any additional API call
+    await waitFor(() => {
+      expect(screen.queryByText('MSFT')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('AAPL')).toBeInTheDocument();
+    expect(mockGetTransactions.mock.calls.length).toBe(fetchCallsBefore);
+  });
+
   it('counts unique securities traded', async () => {
     mockGetTransactions.mockResolvedValue({
       data: [

--- a/frontend/src/components/reports/InvestmentTransactionHistoryReport.tsx
+++ b/frontend/src/components/reports/InvestmentTransactionHistoryReport.tsx
@@ -11,6 +11,7 @@ import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useDateRange } from '@/hooks/useDateRange';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { MultiSelect } from '@/components/ui/MultiSelect';
 import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
 import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { exportToCsv } from '@/lib/csv-export';
@@ -65,7 +66,15 @@ export function InvestmentTransactionHistoryReport() {
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
   const [reloadKey, setReloadKey] = useState(0);
-  const [selectedAction, setSelectedAction] = useState<string>('');
+  const [selectedActions, setSelectedActions] = useState<string[]>([]);
+  const actionOptions = useMemo(
+    () =>
+      (Object.keys(ACTION_LABELS) as InvestmentAction[]).map((action) => ({
+        value: action,
+        label: ACTION_LABELS[action],
+      })),
+    [],
+  );
   const { dateRange, setDateRange, resolvedRange, isValid } = useDateRange({ defaultRange: '1y', alignment: 'month' });
   const [isLoading, setIsLoading] = useState(true);
   const isSingleAccount = selectedAccountIds.length === 1;
@@ -121,7 +130,6 @@ export function InvestmentTransactionHistoryReport() {
             accountIds: selectedAccountIds.length > 0 ? selectedAccountIds.join(',') : undefined,
             startDate: start || undefined,
             endDate: end,
-            action: selectedAction || undefined,
             limit: 200,
             page,
           });
@@ -138,12 +146,19 @@ export function InvestmentTransactionHistoryReport() {
       }
     };
     loadData();
-  }, [selectedAccountIds, selectedAction, resolvedRange, isValid, reloadKey]);
+  }, [selectedAccountIds, resolvedRange, isValid, reloadKey]);
+
+  // Action filtering happens client-side so toggling actions never re-fetches.
+  const filteredTransactions = useMemo(() => {
+    if (selectedActions.length === 0) return transactions;
+    const set = new Set(selectedActions);
+    return transactions.filter((tx) => set.has(tx.action));
+  }, [transactions, selectedActions]);
 
   const actionSummaries = useMemo((): ActionSummary[] => {
     const map = new Map<InvestmentAction, ActionSummary>();
 
-    transactions.forEach((tx) => {
+    filteredTransactions.forEach((tx) => {
       let entry = map.get(tx.action);
       if (!entry) {
         entry = { action: tx.action, count: 0, totalAmount: 0 };
@@ -154,11 +169,11 @@ export function InvestmentTransactionHistoryReport() {
     });
 
     return Array.from(map.values()).sort((a, b) => b.totalAmount - a.totalAmount);
-  }, [transactions, getTxAmount]);
+  }, [filteredTransactions, getTxAmount]);
 
   const totalAmount = useMemo(
-    () => transactions.reduce((sum, tx) => sum + getTxAmount(tx), 0),
-    [transactions, getTxAmount],
+    () => filteredTransactions.reduce((sum, tx) => sum + getTxAmount(tx), 0),
+    [filteredTransactions, getTxAmount],
   );
 
   const accountNameMap = useMemo(() => {
@@ -168,7 +183,7 @@ export function InvestmentTransactionHistoryReport() {
   }, [accounts]);
 
   const sortedTransactions = useMemo(() => {
-    const sorted = [...transactions];
+    const sorted = [...filteredTransactions];
     sorted.sort((a, b) => {
       let comparison = 0;
       switch (sortField) {
@@ -203,7 +218,7 @@ export function InvestmentTransactionHistoryReport() {
       return sortDirection === 'asc' ? comparison : -comparison;
     });
     return sorted;
-  }, [transactions, sortField, sortDirection, accountNameMap, getTxAmount]);
+  }, [filteredTransactions, sortField, sortDirection, accountNameMap, getTxAmount]);
 
   const getExportData = useCallback((formatted: boolean) => {
     const headers = ['Date', 'Action', 'Security', 'Account', 'Quantity', 'Price', 'Total'];
@@ -230,12 +245,12 @@ export function InvestmentTransactionHistoryReport() {
     const accountLabel = selectedAccount
       ? selectedAccount.name.replace(/ - (Brokerage|Cash)$/, '')
       : 'All Accounts';
-    const uniqueSecurities = new Set(transactions.filter((tx) => tx.security).map((tx) => tx.security!.symbol)).size;
+    const uniqueSecurities = new Set(filteredTransactions.filter((tx) => tx.security).map((tx) => tx.security!.symbol)).size;
     await exportToPdf({
       title: 'Investment Transaction History',
-      subtitle: `${accountLabel} | ${transactions.length} transactions | Total volume: ${fmtValue(totalAmount)}`,
+      subtitle: `${accountLabel} | ${filteredTransactions.length} transactions | Total volume: ${fmtValue(totalAmount)}`,
       summaryCards: [
-        { label: 'Total Transactions', value: String(transactions.length), color: '#111827' },
+        { label: 'Total Transactions', value: String(filteredTransactions.length), color: '#111827' },
         { label: 'Total Volume', value: fmtValue(totalAmount), color: '#111827' },
         { label: 'Action Types', value: String(actionSummaries.length), color: '#111827' },
         { label: 'Securities Traded', value: String(uniqueSecurities), color: '#111827' },
@@ -243,7 +258,7 @@ export function InvestmentTransactionHistoryReport() {
       tableData: { headers, rows },
       filename: 'investment-transactions',
     });
-  }, [getExportData, selectedAccount, transactions, fmtValue, totalAmount, actionSummaries]);
+  }, [getExportData, selectedAccount, filteredTransactions, fmtValue, totalAmount, actionSummaries]);
 
   if (isLoading) {
     return (
@@ -263,7 +278,7 @@ export function InvestmentTransactionHistoryReport() {
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
           <div className="text-sm text-gray-500 dark:text-gray-400">Total Transactions</div>
           <div className="text-xl font-bold text-gray-900 dark:text-gray-100">
-            {transactions.length}
+            {filteredTransactions.length}
           </div>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
@@ -281,7 +296,7 @@ export function InvestmentTransactionHistoryReport() {
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
           <div className="text-sm text-gray-500 dark:text-gray-400">Securities Traded</div>
           <div className="text-xl font-bold text-gray-900 dark:text-gray-100">
-            {new Set(transactions.filter((tx) => tx.security).map((tx) => tx.security!.symbol)).size}
+            {new Set(filteredTransactions.filter((tx) => tx.security).map((tx) => tx.security!.symbol)).size}
           </div>
         </div>
       </div>
@@ -295,18 +310,16 @@ export function InvestmentTransactionHistoryReport() {
               value={selectedAccountIds}
               onChange={setSelectedAccountIds}
             />
-            <select
-              value={selectedAction}
-              onChange={(e) => setSelectedAction(e.target.value)}
-              className="rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm"
-            >
-              <option value="">All Actions</option>
-              {(Object.keys(ACTION_LABELS) as InvestmentAction[]).map((action) => (
-                <option key={action} value={action}>
-                  {ACTION_LABELS[action]}
-                </option>
-              ))}
-            </select>
+            <div className="w-48">
+              <MultiSelect
+                ariaLabel="Filter by action"
+                placeholder="All Actions"
+                showSearch={false}
+                options={actionOptions}
+                value={selectedActions}
+                onChange={setSelectedActions}
+              />
+            </div>
           </div>
           <DateRangeSelector
             ranges={['6m', '1y', '2y', 'all']}
@@ -315,7 +328,7 @@ export function InvestmentTransactionHistoryReport() {
           />
           <div className="ml-auto shrink-0 flex gap-2 items-center">
             <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
-            <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} disabled={transactions.length === 0} />
+            <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} disabled={filteredTransactions.length === 0} />
           </div>
         </div>
       </div>
@@ -348,7 +361,7 @@ export function InvestmentTransactionHistoryReport() {
       )}
 
       {/* Transaction List */}
-      {transactions.length === 0 ? (
+      {filteredTransactions.length === 0 ? (
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
           <p className="text-gray-500 dark:text-gray-400 text-center py-8">
             No investment transactions found for this period.
@@ -358,7 +371,7 @@ export function InvestmentTransactionHistoryReport() {
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 overflow-hidden">
           <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-              Transaction History ({transactions.length})
+              Transaction History ({filteredTransactions.length})
             </h3>
           </div>
           <div className="overflow-x-auto">

--- a/frontend/src/components/reports/InvestmentTransactionHistoryReport.tsx
+++ b/frontend/src/components/reports/InvestmentTransactionHistoryReport.tsx
@@ -11,6 +11,8 @@ import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useDateRange } from '@/hooks/useDateRange';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { exportToCsv } from '@/lib/csv-export';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
@@ -61,10 +63,12 @@ export function InvestmentTransactionHistoryReport() {
   const { defaultCurrency, convertToDefault } = useExchangeRates();
   const [transactions, setTransactions] = useState<InvestmentTransaction[]>([]);
   const [accounts, setAccounts] = useState<Account[]>([]);
-  const [selectedAccountId, setSelectedAccountId] = useState<string>('');
+  const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
+  const [reloadKey, setReloadKey] = useState(0);
   const [selectedAction, setSelectedAction] = useState<string>('');
   const { dateRange, setDateRange, resolvedRange, isValid } = useDateRange({ defaultRange: '1y', alignment: 'month' });
   const [isLoading, setIsLoading] = useState(true);
+  const isSingleAccount = selectedAccountIds.length === 1;
   const { sortField, sortDirection, handleSort } = useSortableTable<InvestmentTxSortField>(
     'reports.investment-transactions.sort',
     { field: 'date', direction: 'desc' },
@@ -76,16 +80,18 @@ export function InvestmentTransactionHistoryReport() {
     return map;
   }, [accounts]);
 
-  const selectedAccount = accounts.find((a) => a.id === selectedAccountId);
+  const selectedAccount = isSingleAccount
+    ? accounts.find((a) => a.id === selectedAccountIds[0])
+    : undefined;
   const displayCurrency = selectedAccount?.currencyCode || defaultCurrency;
   const isForeign = displayCurrency !== defaultCurrency;
 
   const getTxAmount = useCallback((tx: InvestmentTransaction): number => {
     const amount = Math.abs(tx.totalAmount);
-    if (selectedAccountId) return amount;
+    if (isSingleAccount) return amount;
     const txCurrency = accountCurrencyMap.get(tx.accountId) || defaultCurrency;
     return convertToDefault(amount, txCurrency);
-  }, [selectedAccountId, accountCurrencyMap, defaultCurrency, convertToDefault]);
+  }, [isSingleAccount, accountCurrencyMap, defaultCurrency, convertToDefault]);
 
   const fmtValue = useCallback((value: number): string => {
     if (isForeign) {
@@ -112,7 +118,7 @@ export function InvestmentTransactionHistoryReport() {
         let hasMore = true;
         while (hasMore && page <= MAX_PAGES) {
           const result = await investmentsApi.getTransactions({
-            accountIds: selectedAccountId || undefined,
+            accountIds: selectedAccountIds.length > 0 ? selectedAccountIds.join(',') : undefined,
             startDate: start || undefined,
             endDate: end,
             action: selectedAction || undefined,
@@ -132,7 +138,7 @@ export function InvestmentTransactionHistoryReport() {
       }
     };
     loadData();
-  }, [selectedAccountId, selectedAction, resolvedRange, isValid]);
+  }, [selectedAccountIds, selectedAction, resolvedRange, isValid, reloadKey]);
 
   const actionSummaries = useMemo((): ActionSummary[] => {
     const map = new Map<InvestmentAction, ActionSummary>();
@@ -284,21 +290,11 @@ export function InvestmentTransactionHistoryReport() {
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-3 items-center">
           <div className="flex gap-3 items-center">
-            <select
-              value={selectedAccountId}
-              onChange={(e) => setSelectedAccountId(e.target.value)}
-              className="rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm"
-            >
-              <option value="">All Accounts</option>
-              {accounts
-                .filter((a) => a.accountSubType !== 'INVESTMENT_BROKERAGE')
-                .sort((a, b) => a.name.localeCompare(b.name))
-                .map((account) => (
-                  <option key={account.id} value={account.id}>
-                    {account.name.replace(/ - (Brokerage|Cash)$/, '')}
-                  </option>
-                ))}
-            </select>
+            <ReportAccountMultiSelect
+              accounts={accounts}
+              value={selectedAccountIds}
+              onChange={setSelectedAccountIds}
+            />
             <select
               value={selectedAction}
               onChange={(e) => setSelectedAction(e.target.value)}
@@ -317,7 +313,8 @@ export function InvestmentTransactionHistoryReport() {
             value={dateRange}
             onChange={setDateRange}
           />
-          <div className="ml-auto shrink-0">
+          <div className="ml-auto shrink-0 flex gap-2 items-center">
+            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
             <ExportDropdown onExportCsv={handleExportCsv} onExportPdf={handleExportPdf} disabled={transactions.length === 0} />
           </div>
         </div>

--- a/frontend/src/components/reports/PortfolioValueReport.test.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.test.tsx
@@ -255,8 +255,9 @@ describe('PortfolioValueReport', () => {
     await waitFor(() => {
       expect(screen.getByText('Current Portfolio Breakdown')).toBeInTheDocument();
     });
-    // 'TFSA' appears in both the account selector dropdown and the breakdown table
-    expect(screen.getAllByText('TFSA').length).toBeGreaterThanOrEqual(2);
+    // 'TFSA' appears in the breakdown table (the account picker shows the
+    // "All Accounts" placeholder until opened).
+    expect(screen.getAllByText('TFSA').length).toBeGreaterThanOrEqual(1);
   });
 
   it('passes date filter ranges including 1w, 1m, 3m, ytd to DateRangeSelector', async () => {
@@ -345,12 +346,10 @@ describe('PortfolioValueReport', () => {
       { id: 'acc-1', name: 'TFSA - Cash', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
     ]);
     render(<PortfolioValueReport />);
-    await waitFor(() => {
-      expect(screen.getByText('All Accounts')).toBeInTheDocument();
-    });
-    const select = document.querySelector('select') as HTMLSelectElement;
+    const trigger = await screen.findByRole('button', { name: 'Filter by account' });
+    await act(async () => { fireEvent.click(trigger); });
     await act(async () => {
-      fireEvent.change(select, { target: { value: 'acc-1' } });
+      fireEvent.click(screen.getByText('TFSA'));
     });
   });
 
@@ -421,10 +420,10 @@ describe('PortfolioValueReport', () => {
       { id: 'acc-1', name: 'TFSA - Cash', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
     ]);
     render(<PortfolioValueReport />);
-    await waitFor(() => {
-      // The " - Cash" suffix should be stripped
-      expect(screen.getByText('TFSA')).toBeInTheDocument();
-    });
+    const trigger = await screen.findByRole('button', { name: 'Filter by account' });
+    fireEvent.click(trigger);
+    // The " - Cash" suffix should be stripped in the option label
+    expect(screen.getByText('TFSA')).toBeInTheDocument();
   });
 
   it('shows breakdown negative gain/loss in red colour class', async () => {
@@ -484,12 +483,10 @@ describe('PortfolioValueReport', () => {
       { id: 'acc-usd', name: 'USD Account - Cash', currencyCode: 'USD', accountSubType: 'INVESTMENT_CASH' },
     ]);
     render(<PortfolioValueReport />);
-    await waitFor(() => {
-      expect(screen.getByText('All Accounts')).toBeInTheDocument();
-    });
-    const select = document.querySelector('select') as HTMLSelectElement;
+    const trigger = await screen.findByRole('button', { name: 'Filter by account' });
+    await act(async () => { fireEvent.click(trigger); });
     await act(async () => {
-      fireEvent.change(select, { target: { value: 'acc-usd' } });
+      fireEvent.click(screen.getByText('USD Account'));
     });
     await waitFor(() => {
       // When foreign currency is active, values are formatted with the currency code suffix
@@ -624,9 +621,11 @@ describe('PortfolioValueReport', () => {
       expect(screen.getByText('Portfolio Value Over Time')).toBeInTheDocument();
     });
     // Trigger a reload by changing the account — new fetch hangs, but old points are shown
-    const select = document.querySelector('select') as HTMLSelectElement;
     await act(async () => {
-      fireEvent.change(select, { target: { value: 'acc-1' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Filter by account' }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('TFSA'));
     });
     await waitFor(() => {
       expect(screen.getByTestId('report-chart-loading-indicator')).toBeInTheDocument();
@@ -683,10 +682,12 @@ describe('PortfolioValueReport', () => {
     ]);
     render(<PortfolioValueReport />);
     // Select the USD account first to activate foreign currency path
-    await waitFor(() => expect(screen.getByText('All Accounts')).toBeInTheDocument());
-    const select = document.querySelector('select') as HTMLSelectElement;
+    const trigger = await screen.findByRole('button', { name: 'Filter by account' });
+    await act(async () => { fireEvent.click(trigger); });
+    // The account name also appears in the breakdown table, so target the
+    // option's checkbox inside the dropdown rather than matching by text.
     await act(async () => {
-      fireEvent.change(select, { target: { value: 'acc-usd' } });
+      fireEvent.click(screen.getByRole('checkbox'));
     });
     await waitFor(() => expect(screen.getByTestId('export-pdf')).toBeInTheDocument());
     await act(async () => {

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -23,6 +23,8 @@ import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { exportToCsv } from '@/lib/csv-export';
@@ -69,9 +71,11 @@ export function PortfolioValueReport() {
   const [chartPoints, setChartPoints] = useState<Array<{ name: string; Value: number }>>([]);
   const [portfolio, setPortfolio] = useState<PortfolioSummary | null>(null);
   const [accounts, setAccounts] = useState<Account[]>([]);
-  const [selectedAccountId, setSelectedAccountId] = useState<string>('');
+  const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
+  const [reloadKey, setReloadKey] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [chartViewType, setChartViewType] = useState<'area' | 'table'>('area');
+  const isSingleAccount = selectedAccountIds.length === 1;
   const { sortField, sortDirection, handleSort } = useSortableTable<PortfolioBreakdownSortField>(
     'reports.portfolio-value.breakdown.sort',
     { field: 'total', direction: 'desc' },
@@ -109,7 +113,9 @@ export function PortfolioValueReport() {
   const isIntraday = INTRADAY_RANGES.has(dateRange);
   const useDaily = !isIntraday && DAILY_RANGES.has(dateRange);
 
-  const selectedAccount = accounts.find((a) => a.id === selectedAccountId);
+  const selectedAccount = isSingleAccount
+    ? accounts.find((a) => a.id === selectedAccountIds[0])
+    : undefined;
   const foreignCurrency = selectedAccount?.currencyCode && selectedAccount.currencyCode !== defaultCurrency
     ? selectedAccount.currencyCode
     : null;
@@ -153,7 +159,7 @@ export function PortfolioValueReport() {
     if (!isValid) return;
     const seq = ++loadSeqRef.current;
 
-    const accountIds = selectedAccountId ? [selectedAccountId] : undefined;
+    const accountIds = selectedAccountIds.length > 0 ? selectedAccountIds : undefined;
     const accountIdsCsv = accountIds?.join(',');
 
     const loadDailyOrMonthly = async () => {
@@ -291,7 +297,8 @@ export function PortfolioValueReport() {
 
     loadData();
   }, [
-    selectedAccountId,
+    selectedAccountIds,
+    reloadKey,
     resolvedRange,
     isValid,
     foreignCurrency,
@@ -450,21 +457,11 @@ export function PortfolioValueReport() {
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-4 items-center justify-between">
           <div className="flex flex-wrap gap-2 items-center">
-            <select
-              value={selectedAccountId}
-              onChange={(e) => setSelectedAccountId(e.target.value)}
-              className="rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm"
-            >
-              <option value="">All Accounts</option>
-              {accounts
-                .filter((a) => a.accountSubType !== 'INVESTMENT_BROKERAGE')
-                .sort((a, b) => a.name.localeCompare(b.name))
-                .map((account) => (
-                  <option key={account.id} value={account.id}>
-                    {account.name.replace(/ - (Brokerage|Cash)$/, '')}
-                  </option>
-                ))}
-            </select>
+            <ReportAccountMultiSelect
+              accounts={accounts}
+              value={selectedAccountIds}
+              onChange={setSelectedAccountIds}
+            />
             <DateRangeSelector
               ranges={['1d', '1w', '1m', '3m', 'ytd', '1y', '2y', '5y', 'all']}
               value={dateRange}
@@ -473,6 +470,7 @@ export function PortfolioValueReport() {
             />
           </div>
           <div className="flex items-center gap-3">
+            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
             <ChartViewToggle
               value={chartViewType}
               onChange={(v) => setChartViewType(v as 'area' | 'table')}

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -470,13 +470,13 @@ export function PortfolioValueReport() {
             />
           </div>
           <div className="flex items-center gap-3">
-            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
             <ChartViewToggle
               value={chartViewType}
               onChange={(v) => setChartViewType(v as 'area' | 'table')}
               options={['area', 'table']}
               activeColour="bg-emerald-600"
             />
+            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
             <ExportDropdown
               onExportPdf={handleExportPdf}
               onExportCsv={handleExportCsv}

--- a/frontend/src/components/reports/RealizedGainsReport.test.tsx
+++ b/frontend/src/components/reports/RealizedGainsReport.test.tsx
@@ -36,6 +36,7 @@ vi.mock('@/hooks/useDateRange', () => {
 
 vi.mock('@/lib/utils', () => ({
   parseLocalDate: (d: string) => new Date(d + 'T00:00:00'),
+  cn: (...inputs: any[]) => inputs.flat(Infinity).filter(Boolean).join(' '),
 }));
 
 vi.mock('@/components/ui/DateRangeSelector', () => ({
@@ -402,7 +403,7 @@ describe('RealizedGainsReport', () => {
     expect(screen.getByText('Unknown Security')).toBeInTheDocument();
   });
 
-  it('filters out INVESTMENT_BROKERAGE accounts from select', async () => {
+  it('filters out INVESTMENT_BROKERAGE accounts from the account filter', async () => {
     mockGetRealizedGains.mockResolvedValue([]);
     mockGetInvestmentAccounts.mockResolvedValue([
       { id: 'acc-cash', name: 'TFSA Cash', currencyCode: 'CAD', accountSubType: 'INVESTMENT_CASH' },
@@ -412,7 +413,8 @@ describe('RealizedGainsReport', () => {
     await waitFor(() => {
       expect(screen.getByText('No sell transactions found for this period.')).toBeInTheDocument();
     });
-    // Cash account appears; brokerage should not
+    // Open the account filter: cash account appears; brokerage should not
+    fireEvent.click(screen.getByRole('button', { name: 'Filter by account' }));
     expect(screen.getByText('TFSA Cash')).toBeInTheDocument();
     expect(screen.queryByText('TFSA Brokerage')).not.toBeInTheDocument();
   });
@@ -441,12 +443,11 @@ describe('RealizedGainsReport', () => {
     ]);
     mockGetRealizedGains.mockResolvedValue([gainEntry({ accountCurrencyCode: 'USD' })]);
     render(<RealizedGainsReport />);
-    await waitFor(() => {
-      expect(screen.getByText('US Brokerage')).toBeInTheDocument();
-    });
+    const trigger = await screen.findByRole('button', { name: 'Filter by account' });
     // Select the USD account to trigger isForeign = true path
+    await act(async () => { fireEvent.click(trigger); });
     await act(async () => {
-      fireEvent.change(screen.getByRole('combobox'), { target: { value: 'acc-usd' } });
+      fireEvent.click(screen.getByText('US Brokerage'));
     });
     await waitFor(() => {
       // When isForeign, fmtValue appends the currency code

--- a/frontend/src/components/reports/RealizedGainsReport.tsx
+++ b/frontend/src/components/reports/RealizedGainsReport.tsx
@@ -20,6 +20,8 @@ import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useDateRange } from '@/hooks/useDateRange';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { exportToCsv } from '@/lib/csv-export';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
@@ -62,10 +64,12 @@ export function RealizedGainsReport() {
   const { defaultCurrency, convertToDefault } = useExchangeRates();
   const [entries, setEntries] = useState<RealizedGainEntry[]>([]);
   const [accounts, setAccounts] = useState<Account[]>([]);
-  const [selectedAccountId, setSelectedAccountId] = useState<string>('');
+  const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
+  const [reloadKey, setReloadKey] = useState(0);
   const { dateRange, setDateRange, resolvedRange, isValid } = useDateRange({ defaultRange: '1y', alignment: 'month' });
   const [isLoading, setIsLoading] = useState(true);
   const [viewType, setViewType] = useState<'chart' | 'table'>('chart');
+  const isSingleAccount = selectedAccountIds.length === 1;
   const securityGainsSort = useSortableTable<SecurityGainsSortField>(
     'reports.realized-gains.securities.sort',
     { field: 'realizedGain', direction: 'desc' },
@@ -75,16 +79,19 @@ export function RealizedGainsReport() {
     { field: 'date', direction: 'desc' },
   );
 
-  const selectedAccount = accounts.find((a) => a.id === selectedAccountId);
+  const selectedAccount = isSingleAccount
+    ? accounts.find((a) => a.id === selectedAccountIds[0])
+    : undefined;
   const displayCurrency = selectedAccount?.currencyCode || defaultCurrency;
   const isForeign = displayCurrency !== defaultCurrency;
 
   // Backend returns each figure in the holding account's currency. Convert to
-  // the default currency when viewing All Accounts; otherwise pass through.
+  // the default currency when viewing All Accounts or several accounts;
+  // otherwise (a single account) pass through in its native currency.
   const toDisplay = useCallback((amount: number, accountCurrencyCode: string | null): number => {
-    if (selectedAccountId) return amount;
+    if (isSingleAccount) return amount;
     return convertToDefault(amount, accountCurrencyCode || defaultCurrency);
-  }, [selectedAccountId, defaultCurrency, convertToDefault]);
+  }, [isSingleAccount, defaultCurrency, convertToDefault]);
 
   const fmtValue = useCallback((value: number): string => {
     if (isForeign) {
@@ -107,7 +114,7 @@ export function RealizedGainsReport() {
       try {
         const { start, end } = resolvedRange;
         const data = await investmentsApi.getRealizedGains({
-          accountIds: selectedAccountId || undefined,
+          accountIds: selectedAccountIds.length > 0 ? selectedAccountIds.join(',') : undefined,
           startDate: start || undefined,
           endDate: end,
         });
@@ -119,7 +126,7 @@ export function RealizedGainsReport() {
       }
     };
     loadData();
-  }, [selectedAccountId, resolvedRange, isValid]);
+  }, [selectedAccountIds, resolvedRange, isValid, reloadKey]);
 
   const securityGains = useMemo((): SecurityGain[] => {
     const map = new Map<string, SecurityGain>();
@@ -318,27 +325,18 @@ export function RealizedGainsReport() {
       {/* Controls */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-3 items-center">
-          <select
-            value={selectedAccountId}
-            onChange={(e) => setSelectedAccountId(e.target.value)}
-            className="max-w-48 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm"
-          >
-            <option value="">All Accounts</option>
-            {accounts
-              .filter((a) => a.accountSubType !== 'INVESTMENT_BROKERAGE')
-              .sort((a, b) => a.name.localeCompare(b.name))
-              .map((account) => (
-                <option key={account.id} value={account.id}>
-                  {account.name.replace(/ - (Brokerage|Cash)$/, '')}
-                </option>
-              ))}
-          </select>
+          <ReportAccountMultiSelect
+            accounts={accounts}
+            value={selectedAccountIds}
+            onChange={setSelectedAccountIds}
+          />
           <DateRangeSelector
             ranges={['6m', '1y', '2y', 'all']}
             value={dateRange}
             onChange={setDateRange}
           />
           <div className="ml-auto shrink-0 flex gap-2 items-center">
+            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
             <button
               onClick={() => setViewType('chart')}
               title="Chart"

--- a/frontend/src/components/reports/RefreshPricesButton.test.tsx
+++ b/frontend/src/components/reports/RefreshPricesButton.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@/test/render';
+
+const mockTrigger = vi.fn();
+const state = { isRefreshing: false, lastOptions: undefined as unknown };
+
+vi.mock('@/hooks/usePriceRefresh', () => ({
+  usePriceRefresh: (opts: unknown) => {
+    state.lastOptions = opts;
+    return { isRefreshing: state.isRefreshing, triggerManualRefresh: mockTrigger };
+  },
+}));
+
+import { RefreshPricesButton } from './RefreshPricesButton';
+
+describe('RefreshPricesButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.isRefreshing = false;
+    state.lastOptions = undefined;
+  });
+
+  it('renders a Refresh button and triggers a manual refresh on click', () => {
+    render(<RefreshPricesButton />);
+    const btn = screen.getByRole('button', { name: /refresh/i });
+    fireEvent.click(btn);
+    expect(mockTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the updating state and disables the button while refreshing', () => {
+    state.isRefreshing = true;
+    render(<RefreshPricesButton />);
+    const btn = screen.getByRole('button', { name: /updating/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('forwards onRefreshComplete to the price-refresh hook', () => {
+    const onRefreshComplete = vi.fn();
+    render(<RefreshPricesButton onRefreshComplete={onRefreshComplete} />);
+    expect((state.lastOptions as { onRefreshComplete?: unknown })?.onRefreshComplete).toBe(
+      onRefreshComplete,
+    );
+  });
+});

--- a/frontend/src/components/reports/RefreshPricesButton.tsx
+++ b/frontend/src/components/reports/RefreshPricesButton.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { Button } from '@/components/ui/Button';
+import { usePriceRefresh } from '@/hooks/usePriceRefresh';
+
+interface RefreshPricesButtonProps {
+  /**
+   * Called after a successful refresh so the host report can reload its data
+   * (prices are written to the DB, so the report must re-fetch to reflect them).
+   */
+  onRefreshComplete?: (lastUpdated?: string) => void | Promise<void>;
+  className?: string;
+}
+
+export function RefreshPricesButton({
+  onRefreshComplete,
+  className,
+}: RefreshPricesButtonProps) {
+  const { isRefreshing, triggerManualRefresh } = usePriceRefresh({
+    onRefreshComplete,
+  });
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => triggerManualRefresh()}
+      disabled={isRefreshing}
+      className={className}
+      title="Refresh security prices"
+    >
+      {isRefreshing ? (
+        <>
+          <svg
+            className="animate-spin -ml-0.5 mr-1.5 h-4 w-4"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+          </svg>
+          Updating...
+        </>
+      ) : (
+        <>
+          <svg
+            className="-ml-0.5 mr-1.5 h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
+          Refresh
+        </>
+      )}
+    </Button>
+  );
+}

--- a/frontend/src/components/reports/ReportAccountMultiSelect.test.tsx
+++ b/frontend/src/components/reports/ReportAccountMultiSelect.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@/test/render';
+import { ReportAccountMultiSelect } from './ReportAccountMultiSelect';
+import { Account } from '@/types/account';
+
+const accounts = [
+  { id: 'a1', name: 'TFSA - Brokerage', accountSubType: 'INVESTMENT_BROKERAGE' },
+  { id: 'a2', name: 'TFSA - Cash', accountSubType: 'INVESTMENT_CASH' },
+  { id: 'a3', name: 'RRSP', accountSubType: 'INVESTMENT_CASH' },
+] as unknown as Account[];
+
+describe('ReportAccountMultiSelect', () => {
+  it('shows the All Accounts placeholder, strips name suffixes, and excludes brokerage by default', () => {
+    render(<ReportAccountMultiSelect accounts={accounts} value={[]} onChange={() => {}} />);
+    const trigger = screen.getByRole('button', { name: 'Filter by account' });
+    expect(trigger).toHaveTextContent('All Accounts');
+
+    fireEvent.click(trigger);
+    // Cash sub-accounts are offered with the suffix stripped; the brokerage
+    // sub-account is excluded by the default filter.
+    expect(screen.getByText('TFSA')).toBeInTheDocument();
+    expect(screen.getByText('RRSP')).toBeInTheDocument();
+    expect(screen.queryByText('TFSA - Brokerage')).not.toBeInTheDocument();
+  });
+
+  it('calls onChange when an option is toggled', () => {
+    const onChange = vi.fn();
+    render(<ReportAccountMultiSelect accounts={accounts} value={[]} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Filter by account' }));
+    fireEvent.click(screen.getByText('RRSP'));
+    expect(onChange).toHaveBeenCalledWith(['a3']);
+  });
+
+  it('honours a custom filter that excludes cash sub-accounts', () => {
+    render(
+      <ReportAccountMultiSelect
+        accounts={accounts}
+        value={[]}
+        onChange={() => {}}
+        filter={(a) => a.accountSubType !== 'INVESTMENT_CASH'}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Filter by account' }));
+    // Only the brokerage account remains (label suffix stripped).
+    expect(screen.getByText('TFSA')).toBeInTheDocument();
+    expect(screen.queryByText('RRSP')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/reports/ReportAccountMultiSelect.tsx
+++ b/frontend/src/components/reports/ReportAccountMultiSelect.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { MultiSelect } from '@/components/ui/MultiSelect';
+import { Account } from '@/types/account';
+
+interface ReportAccountMultiSelectProps {
+  accounts: Account[];
+  value: string[];
+  onChange: (values: string[]) => void;
+  /**
+   * Which accounts to offer. Defaults to the set used by the transaction-based
+   * reports (every investment account except the brokerage sub-account, whose
+   * sibling cash account represents the holding). Portfolio-summary reports
+   * pass a predicate that excludes the cash sub-account instead.
+   */
+  filter?: (account: Account) => boolean;
+  className?: string;
+}
+
+const defaultFilter = (account: Account) =>
+  account.accountSubType !== 'INVESTMENT_BROKERAGE';
+
+export function ReportAccountMultiSelect({
+  accounts,
+  value,
+  onChange,
+  filter = defaultFilter,
+  className = 'w-48',
+}: ReportAccountMultiSelectProps) {
+  const options = accounts
+    .filter(filter)
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((account) => ({
+      value: account.id,
+      label: account.name.replace(/ - (Brokerage|Cash)$/, ''),
+    }));
+
+  return (
+    <div className={className}>
+      <MultiSelect
+        ariaLabel="Filter by account"
+        placeholder="All Accounts"
+        options={options}
+        value={value}
+        onChange={onChange}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/reports/SectorWeightingsReport.test.tsx
+++ b/frontend/src/components/reports/SectorWeightingsReport.test.tsx
@@ -178,11 +178,9 @@ describe('SectorWeightingsReport', () => {
     mockGetInvestmentAccounts.mockResolvedValue(mockAccounts);
     mockGetSecurities.mockResolvedValue(mockSecurities);
     render(<SectorWeightingsReport />);
-    await waitFor(() => {
-      expect(screen.getByText('Accounts')).toBeInTheDocument();
-    });
+    const trigger = await screen.findByRole('button', { name: 'Filter by account' });
 
-    fireEvent.click(screen.getByText('Accounts'));
+    fireEvent.click(trigger);
 
     // Brokerage account should be visible, cash account should not
     expect(screen.getByText('TFSA')).toBeInTheDocument();
@@ -210,19 +208,16 @@ describe('SectorWeightingsReport', () => {
     mockGetInvestmentAccounts.mockResolvedValue(mockAccounts);
     mockGetSecurities.mockResolvedValue(mockSecurities);
     render(<SectorWeightingsReport />);
-    await waitFor(() => {
-      expect(screen.getByText('Accounts')).toBeInTheDocument();
-    });
+    await screen.findByRole('button', { name: 'Filter by account' });
 
     // Open account filter and select an account
-    fireEvent.click(screen.getByText('Accounts'));
-    fireEvent.click(screen.getByText('TFSA'));
+    fireEvent.click(screen.getByRole('button', { name: 'Filter by account' }));
+    await act(async () => { fireEvent.click(screen.getByText('TFSA')); });
 
     // Selecting a filter triggers reload; wait for it to settle
     await waitFor(() => {
       expect(screen.getByText('Clear Filters')).toBeInTheDocument();
     });
-    expect(screen.getByText('Accounts (1)')).toBeInTheDocument();
   });
 
   it('exports pdf', async () => {
@@ -257,11 +252,9 @@ describe('SectorWeightingsReport', () => {
     mockGetInvestmentAccounts.mockResolvedValue(mockAccounts);
     mockGetSecurities.mockResolvedValue(mockSecurities);
     render(<SectorWeightingsReport />);
-    await waitFor(() => {
-      expect(screen.getByText('Accounts')).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByText('Accounts'));
-    fireEvent.click(screen.getByText('TFSA'));
+    const trigger = await screen.findByRole('button', { name: 'Filter by account' });
+    fireEvent.click(trigger);
+    await act(async () => { fireEvent.click(screen.getByText('TFSA')); });
     await waitFor(() => {
       expect(screen.getByText('Clear Filters')).toBeInTheDocument();
     });
@@ -273,17 +266,15 @@ describe('SectorWeightingsReport', () => {
     mockGetInvestmentAccounts.mockResolvedValue(mockAccounts);
     mockGetSecurities.mockResolvedValue(mockSecurities);
     render(<SectorWeightingsReport />);
-    await waitFor(() => {
-      expect(screen.getByText('Accounts')).toBeInTheDocument();
-    });
+    const trigger = await screen.findByRole('button', { name: 'Filter by account' });
 
     // Open account filter
-    fireEvent.click(screen.getByText('Accounts'));
+    fireEvent.click(trigger);
     expect(screen.getByText('TFSA')).toBeInTheDocument();
 
     // Click outside
     fireEvent.mouseDown(document.body);
-    expect(screen.queryByText('TFSA')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('TFSA')).not.toBeInTheDocument());
   });
 
   it('exercises every sortable column on the sector table', async () => {

--- a/frontend/src/components/reports/SectorWeightingsReport.test.tsx
+++ b/frontend/src/components/reports/SectorWeightingsReport.test.tsx
@@ -192,11 +192,9 @@ describe('SectorWeightingsReport', () => {
     mockGetInvestmentAccounts.mockResolvedValue([]);
     mockGetSecurities.mockResolvedValue(mockSecurities);
     render(<SectorWeightingsReport />);
-    await waitFor(() => {
-      expect(screen.getByText('Securities')).toBeInTheDocument();
-    });
+    const trigger = await screen.findByRole('button', { name: 'Filter by security' });
 
-    fireEvent.click(screen.getByText('Securities'));
+    fireEvent.click(trigger);
 
     expect(screen.getByText('AAPL - Apple Inc.')).toBeInTheDocument();
     expect(screen.getByText('VTI - Vanguard Total Stock')).toBeInTheDocument();

--- a/frontend/src/components/reports/SectorWeightingsReport.tsx
+++ b/frontend/src/components/reports/SectorWeightingsReport.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { useClickOutside } from '@/hooks/useClickOutside';
 import {
   BarChart,
   Bar,
@@ -17,6 +16,7 @@ import { Account } from '@/types/account';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { MultiSelect } from '@/components/ui/MultiSelect';
 import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
 import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
@@ -68,9 +68,15 @@ export function SectorWeightingsReport() {
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
   const [selectedSecurityIds, setSelectedSecurityIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [showSecurityFilter, setShowSecurityFilter] = useState(false);
-  const securityFilterRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<HTMLDivElement>(null);
+
+  const securityOptions = useMemo(
+    () =>
+      securities
+        .filter((s) => s.isActive)
+        .map((s) => ({ value: s.id, label: `${s.symbol} - ${s.name}` })),
+    [securities],
+  );
   const { sortField, sortDirection, handleSort } = useSortableTable<SectorSortField>(
     'reports.sector-weightings.sort',
     { field: 'total', direction: 'desc' },
@@ -102,8 +108,6 @@ export function SectorWeightingsReport() {
     });
     return items;
   }, [data, sortField, sortDirection]);
-
-  useClickOutside(securityFilterRef, () => setShowSecurityFilter(false), { enabled: showSecurityFilter });
 
   // Load accounts and securities once on mount
   useEffect(() => {
@@ -137,12 +141,6 @@ export function SectorWeightingsReport() {
   useEffect(() => {
     loadWeightings();
   }, [loadWeightings]);
-
-  const toggleSecurityId = (id: string) => {
-    setSelectedSecurityIds((prev) =>
-      prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id],
-    );
-  };
 
   const handleExportPdf = async () => {
     const { exportToPdf } = await import('@/lib/pdf-export');
@@ -213,43 +211,14 @@ export function SectorWeightingsReport() {
             />
 
             {/* Security Filter */}
-            <div className="relative" ref={securityFilterRef}>
-              <button
-                onClick={() => {
-                  setShowSecurityFilter(!showSecurityFilter);
-                }}
-                className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-              >
-                Securities{selectedSecurityIds.length > 0 ? ` (${selectedSecurityIds.length})` : ''}
-              </button>
-              {showSecurityFilter && (
-                <div className="absolute top-full left-0 mt-1 w-72 bg-white dark:bg-gray-800 rounded-lg shadow-lg dark:shadow-gray-700/50 border border-gray-200 dark:border-gray-700 z-10 max-h-60 overflow-y-auto">
-                  <div className="p-2">
-                    {securities.filter((s) => s.isActive).length === 0 ? (
-                      <p className="text-sm text-gray-500 dark:text-gray-400 p-2">No active securities</p>
-                    ) : (
-                      securities
-                        .filter((s) => s.isActive)
-                        .map((sec) => (
-                          <label
-                            key={sec.id}
-                            className="flex items-center gap-2 p-2 hover:bg-gray-50 dark:hover:bg-gray-700 rounded cursor-pointer"
-                          >
-                            <input
-                              type="checkbox"
-                              checked={selectedSecurityIds.includes(sec.id)}
-                              onChange={() => toggleSecurityId(sec.id)}
-                              className="rounded border-gray-300 dark:border-gray-600"
-                            />
-                            <span className="text-sm text-gray-700 dark:text-gray-300 truncate">
-                              {sec.symbol} - {sec.name}
-                            </span>
-                          </label>
-                        ))
-                    )}
-                  </div>
-                </div>
-              )}
+            <div className="w-48">
+              <MultiSelect
+                ariaLabel="Filter by security"
+                placeholder="All Securities"
+                options={securityOptions}
+                value={selectedSecurityIds}
+                onChange={setSelectedSecurityIds}
+              />
             </div>
 
             {(selectedAccountIds.length > 0 || selectedSecurityIds.length > 0) && (

--- a/frontend/src/components/reports/SectorWeightingsReport.tsx
+++ b/frontend/src/components/reports/SectorWeightingsReport.tsx
@@ -17,11 +17,17 @@ import { Account } from '@/types/account';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('SectorWeightingsReport');
+
+// Portfolio-summary reports key holdings off the brokerage sub-account, so the
+// account picker offers those (the sibling cash account is excluded).
+const excludeCashAccounts = (a: Account) => a.accountSubType !== 'INVESTMENT_CASH';
 
 type SectorSortField = 'sector' | 'direct' | 'etf' | 'total' | 'percentage';
 
@@ -62,9 +68,7 @@ export function SectorWeightingsReport() {
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
   const [selectedSecurityIds, setSelectedSecurityIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [showAccountFilter, setShowAccountFilter] = useState(false);
   const [showSecurityFilter, setShowSecurityFilter] = useState(false);
-  const accountFilterRef = useRef<HTMLDivElement>(null);
   const securityFilterRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<HTMLDivElement>(null);
   const { sortField, sortDirection, handleSort } = useSortableTable<SectorSortField>(
@@ -99,7 +103,6 @@ export function SectorWeightingsReport() {
     return items;
   }, [data, sortField, sortDirection]);
 
-  useClickOutside(accountFilterRef, () => setShowAccountFilter(false), { enabled: showAccountFilter });
   useClickOutside(securityFilterRef, () => setShowSecurityFilter(false), { enabled: showSecurityFilter });
 
   // Load accounts and securities once on mount
@@ -134,12 +137,6 @@ export function SectorWeightingsReport() {
   useEffect(() => {
     loadWeightings();
   }, [loadWeightings]);
-
-  const toggleAccountId = (id: string) => {
-    setSelectedAccountIds((prev) =>
-      prev.includes(id) ? prev.filter((a) => a !== id) : [...prev, id],
-    );
-  };
 
   const toggleSecurityId = (id: string) => {
     setSelectedSecurityIds((prev) =>
@@ -206,52 +203,20 @@ export function SectorWeightingsReport() {
       {/* Filters */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-3 items-center justify-between">
-          <div className="flex flex-wrap gap-3">
+          <div className="flex flex-wrap gap-3 items-center">
             {/* Account Filter */}
-            <div className="relative" ref={accountFilterRef}>
-              <button
-                onClick={() => {
-                  setShowAccountFilter(!showAccountFilter);
-                  setShowSecurityFilter(false);
-                }}
-                className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-              >
-                Accounts{selectedAccountIds.length > 0 ? ` (${selectedAccountIds.length})` : ''}
-              </button>
-              {showAccountFilter && (
-                <div className="absolute top-full left-0 mt-1 w-64 bg-white dark:bg-gray-800 rounded-lg shadow-lg dark:shadow-gray-700/50 border border-gray-200 dark:border-gray-700 z-10 max-h-60 overflow-y-auto">
-                  <div className="p-2">
-                    {accounts.filter((a) => a.accountSubType !== 'INVESTMENT_CASH').length === 0 ? (
-                      <p className="text-sm text-gray-500 dark:text-gray-400 p-2">No investment accounts</p>
-                    ) : (
-                      accounts.filter((a) => a.accountSubType !== 'INVESTMENT_CASH').map((acct) => (
-                        <label
-                          key={acct.id}
-                          className="flex items-center gap-2 p-2 hover:bg-gray-50 dark:hover:bg-gray-700 rounded cursor-pointer"
-                        >
-                          <input
-                            type="checkbox"
-                            checked={selectedAccountIds.includes(acct.id)}
-                            onChange={() => toggleAccountId(acct.id)}
-                            className="rounded border-gray-300 dark:border-gray-600"
-                          />
-                          <span className="text-sm text-gray-700 dark:text-gray-300 truncate">
-                            {acct.name}
-                          </span>
-                        </label>
-                      ))
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
+            <ReportAccountMultiSelect
+              accounts={accounts}
+              value={selectedAccountIds}
+              onChange={setSelectedAccountIds}
+              filter={excludeCashAccounts}
+            />
 
             {/* Security Filter */}
             <div className="relative" ref={securityFilterRef}>
               <button
                 onClick={() => {
                   setShowSecurityFilter(!showSecurityFilter);
-                  setShowAccountFilter(false);
                 }}
                 className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
               >
@@ -299,7 +264,10 @@ export function SectorWeightingsReport() {
               </button>
             )}
           </div>
-          <ExportDropdown onExportPdf={handleExportPdf} />
+          <div className="flex gap-2 items-center">
+            <RefreshPricesButton onRefreshComplete={loadWeightings} />
+            <ExportDropdown onExportPdf={handleExportPdf} />
+          </div>
         </div>
       </div>
 

--- a/frontend/src/components/reports/SecurityPerformanceReport.test.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.test.tsx
@@ -32,6 +32,7 @@ vi.mock('@/hooks/useExchangeRates', () => ({
 
 vi.mock('@/lib/utils', () => ({
   parseLocalDate: (d: string) => new Date(d + 'T00:00:00'),
+  cn: (...inputs: any[]) => inputs.flat(Infinity).filter(Boolean).join(' '),
 }));
 
 vi.mock('recharts', () => ({

--- a/frontend/src/components/reports/SecurityPerformanceReport.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.tsx
@@ -19,6 +19,7 @@ import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { createLogger } from '@/lib/logger';
@@ -51,6 +52,7 @@ export function SecurityPerformanceReport() {
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingDetail, setIsLoadingDetail] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
   const [viewType, setViewType] = useState<'chart' | 'transactions' | 'dividends'>('chart');
   const tradeSort = useSortableTable<TradeSortField>(
     'reports.security-performance.trades.sort',
@@ -80,7 +82,7 @@ export function SecurityPerformanceReport() {
       }
     };
     load();
-  }, []);
+  }, [reloadKey]);
 
   const selectedSecurity = securities.find((s) => s.id === selectedSecurityId);
 
@@ -133,7 +135,7 @@ export function SecurityPerformanceReport() {
       }
     };
     loadDetail();
-  }, [selectedSecurityId, securities]);
+  }, [selectedSecurityId, securities, reloadKey]);
   const selectedHolding = useMemo(() => {
     if (!selectedSecurityId) return null;
     const matches = holdings.filter((h) => h.securityId === selectedSecurityId);
@@ -347,20 +349,23 @@ export function SecurityPerformanceReport() {
       {/* Security Selector */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-4 items-center justify-between">
-          <select
-            value={selectedSecurityId}
-            onChange={(e) => setSelectedSecurityId(e.target.value)}
-            className="rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm min-w-[250px]"
-          >
-            <option value="">Select a security...</option>
-            {securities
-              .sort((a, b) => a.symbol.localeCompare(b.symbol))
-              .map((sec) => (
-                <option key={sec.id} value={sec.id}>
-                  {sec.symbol} - {sec.name}
-                </option>
-              ))}
-          </select>
+          <div className="flex gap-2 items-center">
+            <select
+              value={selectedSecurityId}
+              onChange={(e) => setSelectedSecurityId(e.target.value)}
+              className="rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm min-w-[250px]"
+            >
+              <option value="">Select a security...</option>
+              {securities
+                .sort((a, b) => a.symbol.localeCompare(b.symbol))
+                .map((sec) => (
+                  <option key={sec.id} value={sec.id}>
+                    {sec.symbol} - {sec.name}
+                  </option>
+                ))}
+            </select>
+            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
+          </div>
           {selectedSecurityId && (
             <div className="flex gap-2">
               <button

--- a/frontend/src/components/reports/SecurityPerformanceReport.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.tsx
@@ -364,37 +364,39 @@ export function SecurityPerformanceReport() {
                   </option>
                 ))}
             </select>
-            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
           </div>
-          {selectedSecurityId && (
-            <div className="flex gap-2">
-              <button
-                onClick={() => setViewType('chart')}
-                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
-                  viewType === 'chart' ? 'bg-blue-600 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
-                }`}
-              >
-                Price Chart
-              </button>
-              <button
-                onClick={() => setViewType('transactions')}
-                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
-                  viewType === 'transactions' ? 'bg-blue-600 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
-                }`}
-              >
-                Transactions
-              </button>
-              <button
-                onClick={() => setViewType('dividends')}
-                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
-                  viewType === 'dividends' ? 'bg-blue-600 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
-                }`}
-              >
-                Dividends
-              </button>
-              <ExportDropdown onExportPdf={handleExportPdf} />
-            </div>
-          )}
+          <div className="flex gap-2 items-center">
+            {selectedSecurityId && (
+              <>
+                <button
+                  onClick={() => setViewType('chart')}
+                  className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                    viewType === 'chart' ? 'bg-blue-600 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+                  }`}
+                >
+                  Price Chart
+                </button>
+                <button
+                  onClick={() => setViewType('transactions')}
+                  className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                    viewType === 'transactions' ? 'bg-blue-600 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+                  }`}
+                >
+                  Transactions
+                </button>
+                <button
+                  onClick={() => setViewType('dividends')}
+                  className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                    viewType === 'dividends' ? 'bg-blue-600 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+                  }`}
+                >
+                  Dividends
+                </button>
+              </>
+            )}
+            <RefreshPricesButton onRefreshComplete={() => setReloadKey((k) => k + 1)} />
+            {selectedSecurityId && <ExportDropdown onExportPdf={handleExportPdf} />}
+          </div>
         </div>
       </div>
 

--- a/frontend/src/components/reports/SecurityTypeAllocationReport.test.tsx
+++ b/frontend/src/components/reports/SecurityTypeAllocationReport.test.tsx
@@ -185,28 +185,24 @@ describe('SecurityTypeAllocationReport', () => {
     mockGetPortfolioSummary.mockResolvedValue({ holdings: mockHoldings });
     mockGetInvestmentAccounts.mockResolvedValue(mockAccounts);
     render(<SecurityTypeAllocationReport />);
-    await waitFor(() => {
-      expect(screen.getByText('Accounts')).toBeInTheDocument();
-    });
+    const trigger = await screen.findByRole('button', { name: 'Filter by account' });
 
-    fireEvent.click(screen.getByText('Accounts'));
+    fireEvent.click(trigger);
     expect(screen.getByText('TFSA')).toBeInTheDocument();
     expect(screen.queryByText('Cash Reserve')).not.toBeInTheDocument();
   });
 
-  it('shows clear filters button when filters are selected', async () => {
+  it('reflects the selected account in the filter trigger', async () => {
     mockGetPortfolioSummary.mockResolvedValue({ holdings: mockHoldings });
     mockGetInvestmentAccounts.mockResolvedValue(mockAccounts);
     render(<SecurityTypeAllocationReport />);
-    await waitFor(() => {
-      expect(screen.getByText('Accounts')).toBeInTheDocument();
-    });
+    const trigger = await screen.findByRole('button', { name: 'Filter by account' });
 
-    fireEvent.click(screen.getByText('Accounts'));
-    fireEvent.click(screen.getByText('TFSA'));
+    fireEvent.click(trigger);
+    await act(async () => { fireEvent.click(screen.getByText('TFSA')); });
 
     await waitFor(() => {
-      expect(screen.getByText('Clear Filters')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Filter by account' })).toHaveTextContent('TFSA');
     });
   });
 

--- a/frontend/src/components/reports/SecurityTypeAllocationReport.tsx
+++ b/frontend/src/components/reports/SecurityTypeAllocationReport.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { useClickOutside } from '@/hooks/useClickOutside';
 import {
   PieChart,
   Pie,
@@ -16,12 +15,18 @@ import { Account } from '@/types/account';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { createLogger } from '@/lib/logger';
 import { aggregateHoldingsBySecurity, AggregatedHolding } from '@/lib/aggregate-holdings';
 
 const logger = createLogger('SecurityTypeAllocationReport');
+
+// Holdings are keyed off the brokerage sub-account, so offer those (the
+// sibling cash account is excluded from the picker).
+const excludeCashAccounts = (a: Account) => a.accountSubType !== 'INVESTMENT_CASH';
 
 type SecurityTypeSortField = 'label' | 'totalValue' | 'percentage' | 'count';
 
@@ -81,15 +86,11 @@ export function SecurityTypeAllocationReport() {
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
   const [expandedType, setExpandedType] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [showAccountFilter, setShowAccountFilter] = useState(false);
-  const accountFilterRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<HTMLDivElement>(null);
   const { sortField, sortDirection, handleSort } = useSortableTable<SecurityTypeSortField>(
     'reports.security-type-allocation.sort',
     { field: 'totalValue', direction: 'desc' },
   );
-
-  useClickOutside(accountFilterRef, () => setShowAccountFilter(false), { enabled: showAccountFilter });
 
   // Fetch accounts once on mount
   useEffect(() => {
@@ -115,12 +116,6 @@ export function SecurityTypeAllocationReport() {
   useEffect(() => {
     loadData();
   }, [loadData]);
-
-  const toggleAccountId = (id: string) => {
-    setSelectedAccountIds((prev) =>
-      prev.includes(id) ? prev.filter((a) => a !== id) : [...prev, id],
-    );
-  };
 
   const allocationData = useMemo((): TypeAllocation[] => {
     // Aggregate holdings by security first so the same symbol held across
@@ -245,51 +240,18 @@ export function SecurityTypeAllocationReport() {
       {/* Account Filter */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
         <div className="flex flex-wrap gap-3 items-center justify-between">
-          <div className="flex flex-wrap gap-3">
-            <div className="relative" ref={accountFilterRef}>
-              <button
-                onClick={() => setShowAccountFilter(!showAccountFilter)}
-                className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-              >
-                Accounts{selectedAccountIds.length > 0 ? ` (${selectedAccountIds.length})` : ''}
-              </button>
-              {showAccountFilter && (
-                <div className="absolute top-full left-0 mt-1 w-64 bg-white dark:bg-gray-800 rounded-lg shadow-lg dark:shadow-gray-700/50 border border-gray-200 dark:border-gray-700 z-10 max-h-60 overflow-y-auto">
-                  <div className="p-2">
-                    {accounts.filter((a) => a.accountSubType !== 'INVESTMENT_CASH').length === 0 ? (
-                      <p className="text-sm text-gray-500 dark:text-gray-400 p-2">No investment accounts</p>
-                    ) : (
-                      accounts.filter((a) => a.accountSubType !== 'INVESTMENT_CASH').map((acct) => (
-                        <label
-                          key={acct.id}
-                          className="flex items-center gap-2 p-2 hover:bg-gray-50 dark:hover:bg-gray-700 rounded cursor-pointer"
-                        >
-                          <input
-                            type="checkbox"
-                            checked={selectedAccountIds.includes(acct.id)}
-                            onChange={() => toggleAccountId(acct.id)}
-                            className="rounded border-gray-300 dark:border-gray-600"
-                          />
-                          <span className="text-sm text-gray-700 dark:text-gray-300 truncate">
-                            {acct.name}
-                          </span>
-                        </label>
-                      ))
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
-            {selectedAccountIds.length > 0 && (
-              <button
-                onClick={() => setSelectedAccountIds([])}
-                className="px-4 py-2 text-sm font-medium rounded-lg text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
-              >
-                Clear Filters
-              </button>
-            )}
+          <div className="flex flex-wrap gap-3 items-center">
+            <ReportAccountMultiSelect
+              accounts={accounts}
+              value={selectedAccountIds}
+              onChange={setSelectedAccountIds}
+              filter={excludeCashAccounts}
+            />
           </div>
-          <ExportDropdown onExportPdf={handleExportPdf} />
+          <div className="flex gap-2 items-center">
+            <RefreshPricesButton onRefreshComplete={loadData} />
+            <ExportDropdown onExportPdf={handleExportPdf} />
+          </div>
         </div>
       </div>
 

--- a/frontend/src/components/securities/SecurityList.test.tsx
+++ b/frontend/src/components/securities/SecurityList.test.tsx
@@ -533,6 +533,15 @@ describe('SecurityList', () => {
       // Click Name header to sort - should not throw
       fireEvent.click(screen.getByText('Name'));
     });
+
+    it('calls onSort with "shares" when the Shares header is clicked', () => {
+      const onSort = vi.fn();
+      const securities = [makeSecurity()];
+
+      render(<SecurityList securities={securities} onEdit={onEdit} onToggleActive={onToggleActive} onSort={onSort} sortField="symbol" sortDirection="asc" />);
+      fireEvent.click(screen.getByText('Shares'));
+      expect(onSort).toHaveBeenCalledWith('shares');
+    });
   });
 
   describe('long-press with touch events', () => {

--- a/frontend/src/components/securities/SecurityList.tsx
+++ b/frontend/src/components/securities/SecurityList.tsx
@@ -9,7 +9,7 @@ import { SortIcon } from '@/components/ui/SortIcon';
 import { usePreferencesStore } from '@/store/preferencesStore';
 import { formatShareQuantity } from '@/lib/format';
 
-export type SecuritySortField = 'symbol' | 'name' | 'type' | 'exchange' | 'currency' | 'provider' | 'source';
+export type SecuritySortField = 'symbol' | 'name' | 'type' | 'shares' | 'exchange' | 'currency' | 'provider' | 'source';
 
 /** Format a security_prices.source value into a short human label. */
 function formatPriceSource(source: string | null | undefined): string {
@@ -485,8 +485,11 @@ export function SecurityList({
               >
                 Type<SortIcon field="type" sortField={sortField} sortDirection={sortDirection} />
               </th>
-              <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>
-                Shares
+              <th
+                className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer hover:text-gray-700 dark:hover:text-gray-200`}
+                onClick={() => handleSort('shares')}
+              >
+                Shares<SortIcon field="shares" sortField={sortField} sortDirection={sortDirection} />
               </th>
               {density === 'normal' && (
                 <>

--- a/frontend/src/lib/investment-reports.ts
+++ b/frontend/src/lib/investment-reports.ts
@@ -9,6 +9,11 @@ import { getCached, setCache, invalidateCache } from './apiCache';
 
 export interface ExecuteInvestmentReportParams {
   asOfDate?: string;
+  /**
+   * Override the accounts to run against for this execution. Empty array means
+   * all accounts. Omit to fall back to the report's saved config.
+   */
+  accountIds?: string[];
 }
 
 export const investmentReportsApi = {


### PR DESCRIPTION
## Summary
Builds on the shared `ReportAccountMultiSelect` standardization to finish
consolidating the investment report controls, plus a couple of smaller
Securities-page improvements.

### This batch
- Convert the last two bespoke pickers to the shared `MultiSelect`: the
  Sector Weightings **security** filter and the Investment Transaction
  History **action** filter. The action filter is now multi-select and
  filters client-side (no re-fetch on toggle).
- Place **Refresh** immediately left of **Export** on every investment
  report; on Individual Security Performance, move Refresh to the right
  side, left of Export.
- For custom investment reports, size **Export CSV** to match the Refresh
  button and drop the duplicate "Updating…" indicator.
- Make the **Shares** column on the Securities page sortable (numeric, by
  total holdings; persisted to localStorage).

## Test plan
- `npm run type-check`, `npm run lint` — clean
- `npx vitest run src/components/reports/` — 1013 passed
- Securities list + transaction-history filtering tests updated/added