### PR TITLE
Handle sub-penny securities and sparse pricing in Top Movers

### DIFF
--- a/backend/src/common/gbx-currency.util.spec.ts
+++ b/backend/src/common/gbx-currency.util.spec.ts
@@ -112,9 +112,18 @@ describe("gbx-currency.util", () => {
       expect(convertGbxToGbp(0.5)).toBe(0.005);
     });
 
-    it("rounds to 4 decimal places", () => {
-      // 33.33 pence / 100 = 0.3333 GBP
-      expect(convertGbxToGbp(33.33)).toBe(0.3333);
+    it("rounds to 6 decimal places", () => {
+      // 33.333333 pence / 100 = 0.33333333 GBP, rounded to 6 places
+      expect(convertGbxToGbp(33.333333)).toBe(0.333333);
+    });
+
+    it("preserves sub-penny prices that 4-decimal rounding would zero out", () => {
+      // 0.0318 GBX = 0.000318 GBP. At 4 decimals this rounded to 0.0003,
+      // collapsing adjacent days to the same value and zeroing daily change.
+      expect(convertGbxToGbp(0.0318)).toBe(0.000318);
+      // A prior day ~11.4% lower must round to a distinct value, not the same.
+      expect(convertGbxToGbp(0.02854)).toBe(0.000285);
+      expect(convertGbxToGbp(0.0318)).not.toBe(convertGbxToGbp(0.02854));
     });
 
     it("handles large values", () => {

--- a/backend/src/common/gbx-currency.util.ts
+++ b/backend/src/common/gbx-currency.util.ts
@@ -32,8 +32,10 @@ export function isGbxExchange(exchange: string | null | undefined): boolean {
 
 /**
  * Convert a price from GBX (pence) to GBP (pounds).
- * Rounds to 4 decimal places to match DECIMAL(20,4) storage.
+ * Rounds to 6 decimal places to match NUMERIC(20,6) storage. Sub-penny LSE
+ * shares (e.g. 0.0318 GBX = 0.000318 GBP) need the full 6 places; rounding to
+ * 4 collapsed adjacent days to the same value, zeroing out daily change.
  */
 export function convertGbxToGbp(penceValue: number): number {
-  return Math.round((penceValue / 100) * 10000) / 10000;
+  return Math.round((penceValue / 100) * 1000000) / 1000000;
 }

--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -1517,11 +1517,31 @@ describe("PortfolioService", () => {
       it("returns movers sorted by absolute daily change percent descending", async () => {
         securityPriceRepository.query.mockResolvedValue([
           // AAPL: current=180, previous=175 => +2.86%
-          { security_id: "sec-1", close_price: "180", rn: "1" },
-          { security_id: "sec-1", close_price: "175", rn: "2" },
+          {
+            security_id: "sec-1",
+            close_price: "180",
+            price_date: "2026-02-07",
+            rn: "1",
+          },
+          {
+            security_id: "sec-1",
+            close_price: "175",
+            price_date: "2026-02-06",
+            rn: "2",
+          },
           // VFV: current=90, previous=95 => -5.26%
-          { security_id: "sec-2", close_price: "90", rn: "1" },
-          { security_id: "sec-2", close_price: "95", rn: "2" },
+          {
+            security_id: "sec-2",
+            close_price: "90",
+            price_date: "2026-02-07",
+            rn: "1",
+          },
+          {
+            security_id: "sec-2",
+            close_price: "95",
+            price_date: "2026-02-06",
+            rn: "2",
+          },
         ]);
 
         const result = await service.getTopMovers(userId);
@@ -1537,10 +1557,30 @@ describe("PortfolioService", () => {
 
       it("calculates market value using total quantity and current price", async () => {
         securityPriceRepository.query.mockResolvedValue([
-          { security_id: "sec-1", close_price: "180", rn: "1" },
-          { security_id: "sec-1", close_price: "175", rn: "2" },
-          { security_id: "sec-2", close_price: "90", rn: "1" },
-          { security_id: "sec-2", close_price: "95", rn: "2" },
+          {
+            security_id: "sec-1",
+            close_price: "180",
+            price_date: "2026-02-07",
+            rn: "1",
+          },
+          {
+            security_id: "sec-1",
+            close_price: "175",
+            price_date: "2026-02-06",
+            rn: "2",
+          },
+          {
+            security_id: "sec-2",
+            close_price: "90",
+            price_date: "2026-02-07",
+            rn: "1",
+          },
+          {
+            security_id: "sec-2",
+            close_price: "95",
+            price_date: "2026-02-06",
+            rn: "2",
+          },
         ]);
 
         const result = await service.getTopMovers(userId);
@@ -1605,8 +1645,18 @@ describe("PortfolioService", () => {
           mockHoldingVFV,
         ]);
         securityPriceRepository.query.mockResolvedValue([
-          { security_id: "sec-2", close_price: "90", rn: "1" },
-          { security_id: "sec-2", close_price: "95", rn: "2" },
+          {
+            security_id: "sec-2",
+            close_price: "90",
+            price_date: "2026-02-07",
+            rn: "1",
+          },
+          {
+            security_id: "sec-2",
+            close_price: "95",
+            price_date: "2026-02-06",
+            rn: "2",
+          },
         ]);
 
         const result = await service.getTopMovers(userId);
@@ -1628,10 +1678,25 @@ describe("PortfolioService", () => {
         ]);
         securityPriceRepository.query.mockResolvedValue([
           // Only one price for AAPL
-          { security_id: "sec-1", close_price: "180", rn: "1" },
+          {
+            security_id: "sec-1",
+            close_price: "180",
+            price_date: "2026-02-07",
+            rn: "1",
+          },
           // Two prices for VFV
-          { security_id: "sec-2", close_price: "90", rn: "1" },
-          { security_id: "sec-2", close_price: "95", rn: "2" },
+          {
+            security_id: "sec-2",
+            close_price: "90",
+            price_date: "2026-02-07",
+            rn: "1",
+          },
+          {
+            security_id: "sec-2",
+            close_price: "95",
+            price_date: "2026-02-06",
+            rn: "2",
+          },
         ]);
 
         const result = await service.getTopMovers(userId);
@@ -1649,8 +1714,18 @@ describe("PortfolioService", () => {
         ]);
         holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
         securityPriceRepository.query.mockResolvedValue([
-          { security_id: "sec-1", close_price: "180", rn: "1" },
-          { security_id: "sec-1", close_price: "0", rn: "2" },
+          {
+            security_id: "sec-1",
+            close_price: "180",
+            price_date: "2026-02-07",
+            rn: "1",
+          },
+          {
+            security_id: "sec-1",
+            close_price: "0",
+            price_date: "2026-02-06",
+            rn: "2",
+          },
         ]);
 
         const result = await service.getTopMovers(userId);
@@ -1684,8 +1759,18 @@ describe("PortfolioService", () => {
           holdingInAccount2,
         ]);
         securityPriceRepository.query.mockResolvedValue([
-          { security_id: "sec-2", close_price: "100", rn: "1" },
-          { security_id: "sec-2", close_price: "95", rn: "2" },
+          {
+            security_id: "sec-2",
+            close_price: "100",
+            price_date: "2026-02-07",
+            rn: "1",
+          },
+          {
+            security_id: "sec-2",
+            close_price: "95",
+            price_date: "2026-02-06",
+            rn: "2",
+          },
         ]);
 
         const result = await service.getTopMovers(userId);
@@ -1715,8 +1800,18 @@ describe("PortfolioService", () => {
         };
         holdingsRepository.find.mockResolvedValue([holdingWithMinimalSecurity]);
         securityPriceRepository.query.mockResolvedValue([
-          { security_id: "sec-1", close_price: "180", rn: "1" },
-          { security_id: "sec-1", close_price: "175", rn: "2" },
+          {
+            security_id: "sec-1",
+            close_price: "180",
+            price_date: "2026-02-07",
+            rn: "1",
+          },
+          {
+            security_id: "sec-1",
+            close_price: "175",
+            price_date: "2026-02-06",
+            rn: "2",
+          },
         ]);
 
         const result = await service.getTopMovers(userId);
@@ -1733,8 +1828,18 @@ describe("PortfolioService", () => {
         accountsRepository.find.mockResolvedValue([mockStandaloneAccount]);
         holdingsRepository.find.mockResolvedValue([mockHoldingXIC]);
         securityPriceRepository.query.mockResolvedValue([
-          { security_id: "sec-3", close_price: "36", rn: "1" },
-          { security_id: "sec-3", close_price: "35", rn: "2" },
+          {
+            security_id: "sec-3",
+            close_price: "36",
+            price_date: "2026-02-07",
+            rn: "1",
+          },
+          {
+            security_id: "sec-3",
+            close_price: "35",
+            price_date: "2026-02-06",
+            rn: "2",
+          },
         ]);
 
         const result = await service.getTopMovers(userId);
@@ -1743,6 +1848,64 @@ describe("PortfolioService", () => {
         expect(result[0].symbol).toBe("XIC.TO");
         expect(result[0].dailyChange).toBeCloseTo(1, 0);
         expect(result[0].marketValue).toBe(36 * 100);
+      });
+    });
+
+    describe("when the two most recent prices are far apart in time", () => {
+      it("skips the security so a sparsely priced holding (e.g. a GIC) is not a perpetual mover", async () => {
+        accountsRepository.find.mockResolvedValue([
+          mockBrokerageAccount,
+          mockCashAccount,
+        ]);
+        holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
+        // A matured GIC re-bought under the same symbol: the previous price
+        // (80,000, a year ago) and the current price (50,000) are not adjacent
+        // trading sessions, so the -37.5% delta is not a daily move.
+        securityPriceRepository.query.mockResolvedValue([
+          {
+            security_id: "sec-1",
+            close_price: "50000",
+            price_date: "2025-06-23",
+            rn: "1",
+          },
+          {
+            security_id: "sec-1",
+            close_price: "80000",
+            price_date: "2024-06-23",
+            rn: "2",
+          },
+        ]);
+
+        const result = await service.getTopMovers(userId);
+
+        expect(result).toHaveLength(0);
+      });
+
+      it("includes the security when the gap is within the daily window (e.g. a long weekend)", async () => {
+        accountsRepository.find.mockResolvedValue([
+          mockBrokerageAccount,
+          mockCashAccount,
+        ]);
+        holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
+        securityPriceRepository.query.mockResolvedValue([
+          {
+            security_id: "sec-1",
+            close_price: "180",
+            price_date: "2026-02-09",
+            rn: "1",
+          },
+          {
+            security_id: "sec-1",
+            close_price: "175",
+            price_date: "2026-02-06",
+            rn: "2",
+          },
+        ]);
+
+        const result = await service.getTopMovers(userId);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].symbol).toBe("AAPL");
       });
     });
   });

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -205,6 +205,13 @@ const RANGE_FALLBACKS: Record<
 
 const INTRADAY_CACHE_TTL_MS = 60_000;
 
+// Max gap (in days) between a security's two most recent prices for their
+// delta to count as a "daily" move in Top Movers. A normal daily-priced
+// security spans 1-4 days (weekends/holidays); a sparsely priced holding such
+// as a GIC can span months, which would otherwise surface a stale, perpetual
+// daily change.
+const MAX_DAILY_PRICE_GAP_DAYS = 7;
+
 @Injectable()
 export class PortfolioService {
   private readonly logger = new Logger(PortfolioService.name);
@@ -505,10 +512,11 @@ export class PortfolioService {
     const priceRows: Array<{
       security_id: string;
       close_price: string;
+      price_date: string;
       rn: string;
     }> = await this.securityPriceRepository.query(
-      `SELECT security_id, close_price, rn FROM (
-         SELECT security_id, close_price,
+      `SELECT security_id, close_price, price_date, rn FROM (
+         SELECT security_id, close_price, price_date,
                 ROW_NUMBER() OVER (PARTITION BY security_id ORDER BY price_date DESC) as rn
          FROM security_prices
          WHERE security_id = ANY($1)
@@ -518,11 +526,11 @@ export class PortfolioService {
       [securityIds],
     );
 
-    // Build a map: securityId -> [latestPrice, previousPrice]
-    const priceMap = new Map<string, number[]>();
+    // Build a map: securityId -> [latest, previous] price points (newest first)
+    const priceMap = new Map<string, Array<{ price: number; date: string }>>();
     for (const row of priceRows) {
       const existing = priceMap.get(row.security_id) || [];
-      existing.push(Number(row.close_price));
+      existing.push({ price: Number(row.close_price), date: row.price_date });
       priceMap.set(row.security_id, existing);
     }
 
@@ -543,9 +551,22 @@ export class PortfolioService {
       const prices = priceMap.get(securityId);
       if (!prices || prices.length < 2) continue;
 
-      const [currentPrice, previousPrice] = prices;
-      if (previousPrice === 0) continue;
+      const [current, previous] = prices;
+      if (previous.price === 0) continue;
 
+      // Skip securities whose two most recent prices are far apart: the
+      // "previous" close isn't an adjacent trading session, so the delta is a
+      // long-period change rather than a daily move. Without this a sparsely
+      // priced holding (e.g. a matured GIC re-bought under the same symbol)
+      // reports the same stale "daily" change every day.
+      const gapDays = Math.round(
+        (new Date(current.date).getTime() - new Date(previous.date).getTime()) /
+          86_400_000,
+      );
+      if (gapDays > MAX_DAILY_PRICE_GAP_DAYS) continue;
+
+      const currentPrice = current.price;
+      const previousPrice = previous.price;
       const dailyChange = currentPrice - previousPrice;
       const dailyChangePercent = (dailyChange / previousPrice) * 100;
       const security = securityLookup.get(securityId);

--- a/frontend/src/components/dashboard/AssetsVsLiabilities.tsx
+++ b/frontend/src/components/dashboard/AssetsVsLiabilities.tsx
@@ -96,7 +96,7 @@ export function AssetsVsLiabilities({ data, isLoading }: AssetsVsLiabilitiesProp
         </button>
         <span className="text-sm text-gray-500 dark:text-gray-400">Current</span>
       </div>
-      <div className="h-64 flex-1">
+      <div className="flex-1 min-h-[16rem]">
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           <PieChart>
             <Pie

--- a/frontend/src/components/dashboard/IncomeExpensesBarChart.tsx
+++ b/frontend/src/components/dashboard/IncomeExpensesBarChart.tsx
@@ -195,7 +195,7 @@ export function IncomeExpensesBarChart({
         </h3>
         <span className="text-sm text-gray-500 dark:text-gray-400">Last 5 weeks</span>
       </div>
-      <div className="h-64">
+      <div className="flex-1 min-h-[16rem]">
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           <BarChart
             data={chartData}
@@ -247,7 +247,7 @@ export function IncomeExpensesBarChart({
           </BarChart>
         </ResponsiveContainer>
       </div>
-      <div className="mt-auto pt-4 border-t border-gray-200 dark:border-gray-700 grid grid-cols-3 gap-4 text-center">
+      <div className="pt-4 border-t border-gray-200 dark:border-gray-700 grid grid-cols-3 gap-4 text-center">
         <div>
           <div className="text-sm text-gray-500 dark:text-gray-400">Income</div>
           <div className="font-semibold text-green-600 dark:text-green-400">

--- a/frontend/src/components/dashboard/TopMovers.test.tsx
+++ b/frontend/src/components/dashboard/TopMovers.test.tsx
@@ -10,6 +10,15 @@ vi.mock('next/navigation', () => ({
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
     formatCurrency: (n: number) => `$${n.toFixed(2)}`,
+    formatCurrencyPrecise: (n: number) => {
+      const abs = Math.abs(n);
+      let digits = 2;
+      if (n !== 0 && abs < 0.005) {
+        const exp = Math.floor(Math.log10(abs));
+        digits = Math.min(6, Math.max(2, -exp + 2));
+      }
+      return `$${n.toFixed(digits)}`;
+    },
     formatPercent: (n: number) => `${n.toFixed(2)}%`,
   }),
 }));
@@ -54,6 +63,17 @@ describe('TopMovers', () => {
     expect(screen.getByText('MSFT')).toBeInTheDocument();
     expect(screen.getByText('Microsoft')).toBeInTheDocument();
     expect(screen.getByText('$400.00')).toBeInTheDocument();
+  });
+
+  it('expands precision for sub-penny movers instead of showing 0.00', () => {
+    const movers = [
+      { securityId: '1', symbol: 'PENNY', name: 'Sub-penny Co', currentPrice: 0.000318, dailyChange: 0.000033, dailyChangePercent: 11.4, currencyCode: 'GBP' },
+    ] as any[];
+
+    render(<TopMovers movers={movers} isLoading={false} hasInvestmentAccounts={true} />);
+    // Price and change reveal their real figures rather than collapsing to 0.00.
+    expect(screen.getByText(/0\.000318/)).toBeInTheDocument();
+    expect(screen.getByText(/\+\$0\.000033 \(\+11\.40%\)/)).toBeInTheDocument();
   });
 
   it('shows positive change with plus sign and green color', () => {

--- a/frontend/src/components/dashboard/TopMovers.tsx
+++ b/frontend/src/components/dashboard/TopMovers.tsx
@@ -87,7 +87,7 @@ function RefreshButton({ onRefresh, isRefreshing }: { onRefresh?: () => void; is
 
 export function TopMovers({ movers, isLoading, hasInvestmentAccounts, onRefresh, isRefreshing }: TopMoversProps) {
   const router = useRouter();
-  const { formatCurrency, formatPercent } = useNumberFormat();
+  const { formatCurrencyPrecise, formatPercent } = useNumberFormat();
   const defaultCurrency = usePreferencesStore((s) => s.preferences?.defaultCurrency) || 'USD';
   const [filter, setFilter] = useState<MoverFilter>(getStoredFilter);
 
@@ -181,7 +181,7 @@ export function TopMovers({ movers, isLoading, hasInvestmentAccounts, onRefresh,
           const isPositive = mover.dailyChange >= 0;
           const isForeign = mover.currencyCode && mover.currencyCode !== defaultCurrency;
           const fmtPrice = (value: number) => {
-            const formatted = formatCurrency(value, mover.currencyCode);
+            const formatted = formatCurrencyPrecise(value, mover.currencyCode);
             return isForeign ? `${formatted} ${mover.currencyCode}` : formatted;
           };
           return (
@@ -208,7 +208,7 @@ export function TopMovers({ movers, isLoading, hasInvestmentAccounts, onRefresh,
                       : 'text-red-600 dark:text-red-400'
                   }`}
                 >
-                  {isPositive ? '+' : ''}{formatCurrency(mover.dailyChange, mover.currencyCode)} ({isPositive ? '+' : ''}{formatPercent(mover.dailyChangePercent)})
+                  {isPositive ? '+' : ''}{formatCurrencyPrecise(mover.dailyChange, mover.currencyCode)} ({isPositive ? '+' : ''}{formatPercent(mover.dailyChangePercent)})
                 </div>
               </div>
             </div>

--- a/frontend/src/components/investments/GroupedHoldingsList.test.tsx
+++ b/frontend/src/components/investments/GroupedHoldingsList.test.tsx
@@ -11,6 +11,15 @@ vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
     formatCurrency: (n: number, currencyCode?: string) =>
       currencyCode ? `${currencyCode} $${n.toFixed(2)}` : `$${n.toFixed(2)}`,
+    formatCurrencyPrecise: (n: number, currencyCode?: string) => {
+      const abs = Math.abs(n);
+      let digits = 2;
+      if (n !== 0 && abs < 0.005) {
+        digits = Math.min(6, Math.max(2, -Math.floor(Math.log10(abs)) + 2));
+      }
+      const s = `$${n.toFixed(digits)}`;
+      return currencyCode ? `${currencyCode} ${s}` : s;
+    },
     numberFormat: 'en-US',
   }),
 }));

--- a/frontend/src/components/investments/GroupedHoldingsList.tsx
+++ b/frontend/src/components/investments/GroupedHoldingsList.tsx
@@ -21,7 +21,7 @@ export function GroupedHoldingsList({
   onSymbolClick,
   onCashClick,
 }: GroupedHoldingsListProps) {
-  const { formatCurrency: formatCurrencyBase, numberFormat } = useNumberFormat();
+  const { formatCurrency: formatCurrencyBase, formatCurrencyPrecise, numberFormat } = useNumberFormat();
   const { convert, convertToDefault, defaultCurrency } = useExchangeRates();
 
   const [expandedAccounts, setExpandedAccounts] = useState<Set<string>>(
@@ -47,7 +47,9 @@ export function GroupedHoldingsList({
 
   const formatPrice = (value: number | null, currencyCode?: string) => {
     if (value === null) return '-';
-    return formatCurrencyBase(value, currencyCode, 4);
+    // Per-share prices display at 4dp, expanding further only when a sub-penny
+    // value would otherwise read as 0.0000.
+    return formatCurrencyPrecise(value, currencyCode, 4);
   };
 
   const formatPercent = (value: number | null, showSign = true) => {

--- a/frontend/src/components/investments/HoldingsList.test.tsx
+++ b/frontend/src/components/investments/HoldingsList.test.tsx
@@ -5,6 +5,14 @@ import { HoldingsList } from './HoldingsList';
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
     formatCurrency: (n: number) => `$${n.toFixed(2)}`,
+    formatCurrencyPrecise: (n: number) => {
+      const abs = Math.abs(n);
+      let digits = 2;
+      if (n !== 0 && abs < 0.005) {
+        digits = Math.min(6, Math.max(2, -Math.floor(Math.log10(abs)) + 2));
+      }
+      return `$${n.toFixed(digits)}`;
+    },
     numberFormat: 'en-US',
   }),
 }));

--- a/frontend/src/components/investments/HoldingsList.tsx
+++ b/frontend/src/components/investments/HoldingsList.tsx
@@ -9,11 +9,18 @@ interface HoldingsListProps {
 }
 
 export function HoldingsList({ holdings, isLoading }: HoldingsListProps) {
-  const { formatCurrency: formatCurrencyBase, numberFormat } = useNumberFormat();
+  const { formatCurrency: formatCurrencyBase, formatCurrencyPrecise, numberFormat } = useNumberFormat();
 
   const formatCurrency = (value: number | null) => {
     if (value === null) return '-';
     return formatCurrencyBase(value);
+  };
+
+  // Per-share prices can be sub-penny (e.g. LSE pennies); expand precision so
+  // they don't collapse to the currency's 2dp zero.
+  const formatPrice = (value: number | null) => {
+    if (value === null) return '-';
+    return formatCurrencyPrecise(value);
   };
 
   const formatPercent = (value: number | null) => {
@@ -107,10 +114,10 @@ export function HoldingsList({ holdings, isLoading }: HoldingsListProps) {
                   {formatQuantity(holding.quantity)}
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-right text-gray-900 dark:text-gray-100">
-                  {formatCurrency(holding.averageCost)}
+                  {formatPrice(holding.averageCost)}
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-right text-gray-900 dark:text-gray-100">
-                  {formatCurrency(holding.currentPrice)}
+                  {formatPrice(holding.currentPrice)}
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-right font-medium text-gray-900 dark:text-gray-100">
                   {formatCurrency(holding.marketValue)}

--- a/frontend/src/components/reports/CurrencyExposureReport.test.tsx
+++ b/frontend/src/components/reports/CurrencyExposureReport.test.tsx
@@ -172,6 +172,36 @@ describe('CurrencyExposureReport', () => {
     expect(screen.getByText('USD')).toBeInTheDocument();
   });
 
+  it('keeps content and the account dropdown mounted while a filter change reloads', async () => {
+    mockGetPortfolioSummary.mockResolvedValueOnce({ holdings: mockHoldings });
+    mockGetInvestmentAccounts.mockResolvedValue(mockAccounts);
+    render(<CurrencyExposureReport />);
+    await waitFor(() => {
+      expect(screen.getByText('Total Portfolio')).toBeInTheDocument();
+    });
+
+    // The reload triggered by the filter change hangs so isLoading stays true
+    // throughout the assertions below.
+    mockGetPortfolioSummary.mockReturnValueOnce(new Promise(() => {}));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filter by account' }));
+    await act(async () => {
+      fireEvent.click(screen.getByText('TFSA'));
+    });
+
+    // Wait for the debounced reload to actually fire (second summary fetch).
+    await waitFor(() => {
+      expect(mockGetPortfolioSummary).toHaveBeenCalledTimes(2);
+    });
+
+    // Mid-reload the report must update in place: existing content and the open
+    // account dropdown stay mounted instead of being replaced by the full-page
+    // skeleton (which would close the dropdown).
+    expect(screen.getByText('Total Portfolio')).toBeInTheDocument();
+    expect(document.querySelector('.animate-pulse')).toBeFalsy();
+    expect(screen.getByText('Select All')).toBeInTheDocument();
+  });
+
   it('shows correct number of currencies', async () => {
     mockGetPortfolioSummary.mockResolvedValue({ holdings: mockHoldings });
     mockGetInvestmentAccounts.mockResolvedValue([]);

--- a/frontend/src/components/reports/CurrencyExposureReport.tsx
+++ b/frontend/src/components/reports/CurrencyExposureReport.tsx
@@ -83,6 +83,10 @@ export function CurrencyExposureReport() {
   const [holdings, setHoldings] = useState<HoldingWithMarketValue[]>([]);
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  // Only the first load shows the full skeleton. Later reloads (e.g. changing
+  // the account filter) keep the existing content -- and the account dropdown --
+  // mounted so they update in place instead of unmounting the whole report.
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const chartRef = useRef<HTMLDivElement>(null);
   const { sortField, sortDirection, handleSort } = useSortableTable<CurrencyExposureSortField>(
     'reports.currency-exposure.sort',
@@ -107,6 +111,7 @@ export function CurrencyExposureReport() {
       logger.error('Failed to load data:', error);
     } finally {
       setIsLoading(false);
+      setHasLoadedOnce(true);
     }
   }, [selectedAccountIds]);
 
@@ -213,7 +218,7 @@ export function CurrencyExposureReport() {
     });
   };
 
-  if (isLoading) {
+  if (isLoading && !hasLoadedOnce) {
     return (
       <div className="space-y-6">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">

--- a/frontend/src/components/reports/DividendYieldGrowthReport.tsx
+++ b/frontend/src/components/reports/DividendYieldGrowthReport.tsx
@@ -77,6 +77,10 @@ export function DividendYieldGrowthReport() {
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
   const [reloadKey, setReloadKey] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
+  // Only the first load shows the full skeleton. Later reloads (e.g. changing
+  // the account filter) keep the existing content -- and the account dropdown --
+  // mounted so they update in place instead of unmounting the whole report.
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const [viewType, setViewType] = useState<'yield' | 'growth' | 'frequency'>('yield');
   const isSingleAccount = selectedAccountIds.length === 1;
   const yieldSort = useSortableTable<YieldSortField>(
@@ -161,6 +165,7 @@ export function DividendYieldGrowthReport() {
         logger.error('Failed to load data:', error);
       } finally {
         setIsLoading(false);
+        setHasLoadedOnce(true);
       }
     };
     loadData();
@@ -387,7 +392,7 @@ export function DividendYieldGrowthReport() {
     });
   };
 
-  if (isLoading) {
+  if (isLoading && !hasLoadedOnce) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
         <div className="animate-pulse space-y-4">

--- a/frontend/src/components/reports/GeographicAllocationReport.tsx
+++ b/frontend/src/components/reports/GeographicAllocationReport.tsx
@@ -123,6 +123,10 @@ export function GeographicAllocationReport() {
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
   const [viewType, setViewType] = useState<'region' | 'exchange'>('region');
   const [isLoading, setIsLoading] = useState(true);
+  // Only the first load shows the full skeleton. Later reloads (e.g. changing
+  // the account filter) keep the existing content -- and the account dropdown --
+  // mounted so they update in place instead of unmounting the whole report.
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const chartRef = useRef<HTMLDivElement>(null);
   const regionSort = useSortableTable<GeoRegionSortField>(
     'reports.geographic-allocation.region.sort',
@@ -157,6 +161,7 @@ export function GeographicAllocationReport() {
       logger.error('Failed to load data:', error);
     } finally {
       setIsLoading(false);
+      setHasLoadedOnce(true);
     }
   }, [selectedAccountIds]);
 
@@ -318,7 +323,7 @@ export function GeographicAllocationReport() {
     });
   };
 
-  if (isLoading) {
+  if (isLoading && !hasLoadedOnce) {
     return (
       <div className="space-y-6">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">

--- a/frontend/src/components/reports/InvestmentPerformanceReport.tsx
+++ b/frontend/src/components/reports/InvestmentPerformanceReport.tsx
@@ -37,6 +37,10 @@ export function InvestmentPerformanceReport() {
   const [reloadKey, setReloadKey] = useState(0);
   const [expandedSecurityId, setExpandedSecurityId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  // Only the first load shows the full skeleton. Later reloads (e.g. changing
+  // the account filter) keep the existing content -- and the account dropdown --
+  // mounted so they update in place instead of unmounting the whole report.
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const [viewType, setViewType] = useState<'performance' | 'allocation'>('performance');
   const isSingleAccount = selectedAccountIds.length === 1;
   const { sortField, sortDirection, handleSort } = useSortableTable<HoldingsSortField>(
@@ -58,6 +62,7 @@ export function InvestmentPerformanceReport() {
         logger.error('Failed to load investment data:', error);
       } finally {
         setIsLoading(false);
+        setHasLoadedOnce(true);
       }
     };
     loadData();
@@ -244,7 +249,7 @@ export function InvestmentPerformanceReport() {
     return null;
   };
 
-  if (isLoading) {
+  if (isLoading && !hasLoadedOnce) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
         <div className="animate-pulse space-y-4">

--- a/frontend/src/components/reports/InvestmentTransactionHistoryReport.tsx
+++ b/frontend/src/components/reports/InvestmentTransactionHistoryReport.tsx
@@ -77,6 +77,10 @@ export function InvestmentTransactionHistoryReport() {
   );
   const { dateRange, setDateRange, resolvedRange, isValid } = useDateRange({ defaultRange: '1y', alignment: 'month' });
   const [isLoading, setIsLoading] = useState(true);
+  // Only the first load shows the full skeleton. Later reloads (e.g. changing
+  // the account filter) keep the existing content -- and the account dropdown --
+  // mounted so they update in place instead of unmounting the whole report.
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const isSingleAccount = selectedAccountIds.length === 1;
   const { sortField, sortDirection, handleSort } = useSortableTable<InvestmentTxSortField>(
     'reports.investment-transactions.sort',
@@ -143,6 +147,7 @@ export function InvestmentTransactionHistoryReport() {
         logger.error('Failed to load investment transactions:', error);
       } finally {
         setIsLoading(false);
+        setHasLoadedOnce(true);
       }
     };
     loadData();
@@ -260,7 +265,7 @@ export function InvestmentTransactionHistoryReport() {
     });
   }, [getExportData, selectedAccount, filteredTransactions, fmtValue, totalAmount, actionSummaries]);
 
-  if (isLoading) {
+  if (isLoading && !hasLoadedOnce) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
         <div className="animate-pulse space-y-4">

--- a/frontend/src/components/reports/RealizedGainsReport.tsx
+++ b/frontend/src/components/reports/RealizedGainsReport.tsx
@@ -68,6 +68,10 @@ export function RealizedGainsReport() {
   const [reloadKey, setReloadKey] = useState(0);
   const { dateRange, setDateRange, resolvedRange, isValid } = useDateRange({ defaultRange: '1y', alignment: 'month' });
   const [isLoading, setIsLoading] = useState(true);
+  // Only the first load shows the full skeleton. Later reloads (e.g. changing
+  // the account filter) keep the existing content -- and the account dropdown --
+  // mounted so they update in place instead of unmounting the whole report.
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const [viewType, setViewType] = useState<'chart' | 'table'>('chart');
   const isSingleAccount = selectedAccountIds.length === 1;
   const securityGainsSort = useSortableTable<SecurityGainsSortField>(
@@ -123,6 +127,7 @@ export function RealizedGainsReport() {
         logger.error('Failed to load realized gains:', error);
       } finally {
         setIsLoading(false);
+        setHasLoadedOnce(true);
       }
     };
     loadData();
@@ -276,7 +281,7 @@ export function RealizedGainsReport() {
     });
   }, [getExportData, securityGains.length, fmtValue, totals]);
 
-  if (isLoading) {
+  if (isLoading && !hasLoadedOnce) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
         <div className="animate-pulse space-y-4">

--- a/frontend/src/components/reports/ReportAccountMultiSelect.test.tsx
+++ b/frontend/src/components/reports/ReportAccountMultiSelect.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/render';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@/test/render';
 import { ReportAccountMultiSelect } from './ReportAccountMultiSelect';
 import { Account } from '@/types/account';
 
@@ -10,6 +10,10 @@ const accounts = [
 ] as unknown as Account[];
 
 describe('ReportAccountMultiSelect', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('shows the All Accounts placeholder, strips name suffixes, and excludes brokerage by default', () => {
     render(<ReportAccountMultiSelect accounts={accounts} value={[]} onChange={() => {}} />);
     const trigger = screen.getByRole('button', { name: 'Filter by account' });
@@ -23,12 +27,58 @@ describe('ReportAccountMultiSelect', () => {
     expect(screen.queryByText('TFSA - Brokerage')).not.toBeInTheDocument();
   });
 
-  it('calls onChange when an option is toggled', () => {
+  it('reflects a toggle immediately but debounces the onChange notification', async () => {
+    vi.useFakeTimers();
     const onChange = vi.fn();
     render(<ReportAccountMultiSelect accounts={accounts} value={[]} onChange={onChange} />);
     fireEvent.click(screen.getByRole('button', { name: 'Filter by account' }));
     fireEvent.click(screen.getByText('RRSP'));
+
+    // The trigger reflects the selection right away, but the host report is not
+    // notified until the debounce window elapses.
+    expect(screen.getByRole('button', { name: 'Filter by account' })).toHaveTextContent('RRSP');
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(350);
+    });
+    expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith(['a3']);
+  });
+
+  it('keeps the dropdown open across rapid toggles and collapses them into one onChange', () => {
+    vi.useFakeTimers();
+    const onChange = vi.fn();
+    render(<ReportAccountMultiSelect accounts={accounts} value={[]} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Filter by account' }));
+
+    fireEvent.click(screen.getByText('RRSP'));
+    fireEvent.click(screen.getByText('TFSA'));
+
+    // The portal dropdown is still mounted (options remain queryable) between
+    // checkbox clicks, so the user can keep selecting without re-opening it.
+    expect(screen.getByText('Select All')).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(350);
+    });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(['a3', 'a2']);
+  });
+
+  it('adopts an external value reset', async () => {
+    const { rerender } = render(
+      <ReportAccountMultiSelect accounts={accounts} value={['a3']} onChange={() => {}} />,
+    );
+    expect(screen.getByRole('button', { name: 'Filter by account' })).toHaveTextContent('RRSP');
+
+    rerender(<ReportAccountMultiSelect accounts={accounts} value={[]} onChange={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Filter by account' })).toHaveTextContent(
+        'All Accounts',
+      );
+    });
   });
 
   it('honours a custom filter that excludes cash sub-accounts', () => {

--- a/frontend/src/components/reports/ReportAccountMultiSelect.tsx
+++ b/frontend/src/components/reports/ReportAccountMultiSelect.tsx
@@ -1,7 +1,15 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
 import { MultiSelect } from '@/components/ui/MultiSelect';
 import { Account } from '@/types/account';
+
+// Rapid checkbox toggles (the typical multi-account selection flow) should
+// collapse into a single reload once the user pauses, matching the debounce in
+// DividendIncomeReport. Without it, every checkbox click immediately re-renders
+// the host report into its loading skeleton, unmounting this dropdown and
+// forcing the user to re-open it for each account.
+const ACCOUNT_DEBOUNCE_MS = 350;
 
 interface ReportAccountMultiSelectProps {
   accounts: Account[];
@@ -20,6 +28,9 @@ interface ReportAccountMultiSelectProps {
 const defaultFilter = (account: Account) =>
   account.accountSubType !== 'INVESTMENT_BROKERAGE';
 
+const sameIds = (a: string[], b: string[]) =>
+  a.length === b.length && a.every((id, i) => id === b[i]);
+
 export function ReportAccountMultiSelect({
   accounts,
   value,
@@ -36,14 +47,43 @@ export function ReportAccountMultiSelect({
       label: account.name.replace(/ - (Brokerage|Cash)$/, ''),
     }));
 
+  // Local draft so checkbox toggles render instantly and the dropdown stays
+  // open while selecting. The host report (which reloads its data from this
+  // selection) is only notified after the user pauses.
+  const [draft, setDraft] = useState(value);
+  const [syncedValue, setSyncedValue] = useState(value);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Adopt external value changes (e.g. a reset) without a setState-in-effect.
+  if (value !== syncedValue && !sameIds(value, syncedValue)) {
+    setSyncedValue(value);
+    setDraft(value);
+  }
+
+  useEffect(
+    () => () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    },
+    [],
+  );
+
+  const handleChange = (next: string[]) => {
+    setDraft(next);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      debounceRef.current = null;
+      onChange(next);
+    }, ACCOUNT_DEBOUNCE_MS);
+  };
+
   return (
     <div className={className}>
       <MultiSelect
         ariaLabel="Filter by account"
         placeholder="All Accounts"
         options={options}
-        value={value}
-        onChange={onChange}
+        value={draft}
+        onChange={handleChange}
       />
     </div>
   );

--- a/frontend/src/components/reports/SectorWeightingsReport.tsx
+++ b/frontend/src/components/reports/SectorWeightingsReport.tsx
@@ -68,6 +68,10 @@ export function SectorWeightingsReport() {
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
   const [selectedSecurityIds, setSelectedSecurityIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  // Only the first load shows the full skeleton. Later reloads (e.g. changing
+  // the account filter) keep the existing content -- and the account dropdown --
+  // mounted so they update in place instead of unmounting the whole report.
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const chartRef = useRef<HTMLDivElement>(null);
 
   const securityOptions = useMemo(
@@ -135,6 +139,7 @@ export function SectorWeightingsReport() {
       logger.error('Failed to load sector weightings:', error);
     } finally {
       setIsLoading(false);
+      setHasLoadedOnce(true);
     }
   }, [selectedAccountIds, selectedSecurityIds]);
 
@@ -164,7 +169,7 @@ export function SectorWeightingsReport() {
     });
   };
 
-  if (isLoading) {
+  if (isLoading && !hasLoadedOnce) {
     return (
       <div className="space-y-6">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">

--- a/frontend/src/components/reports/SecurityTypeAllocationReport.tsx
+++ b/frontend/src/components/reports/SecurityTypeAllocationReport.tsx
@@ -86,6 +86,10 @@ export function SecurityTypeAllocationReport() {
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
   const [expandedType, setExpandedType] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  // Only the first load shows the full skeleton. Later reloads (e.g. changing
+  // the account filter) keep the existing content -- and the account dropdown --
+  // mounted so they update in place instead of unmounting the whole report.
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const chartRef = useRef<HTMLDivElement>(null);
   const { sortField, sortDirection, handleSort } = useSortableTable<SecurityTypeSortField>(
     'reports.security-type-allocation.sort',
@@ -110,6 +114,7 @@ export function SecurityTypeAllocationReport() {
       logger.error('Failed to load data:', error);
     } finally {
       setIsLoading(false);
+      setHasLoadedOnce(true);
     }
   }, [selectedAccountIds]);
 
@@ -212,7 +217,7 @@ export function SecurityTypeAllocationReport() {
     });
   };
 
-  if (isLoading) {
+  if (isLoading && !hasLoadedOnce) {
     return (
       <div className="space-y-6">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">

--- a/frontend/src/components/securities/SecurityTransactionHistory.test.tsx
+++ b/frontend/src/components/securities/SecurityTransactionHistory.test.tsx
@@ -41,6 +41,14 @@ vi.mock('@/hooks/useDateFormat', () => ({
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
     formatCurrency: (n: number) => `$${n.toFixed(2)}`,
+    formatCurrencyPrecise: (n: number) => {
+      const abs = Math.abs(n);
+      let digits = 2;
+      if (n !== 0 && abs < 0.005) {
+        digits = Math.min(6, Math.max(2, -Math.floor(Math.log10(abs)) + 2));
+      }
+      return `$${n.toFixed(digits)}`;
+    },
   }),
 }));
 

--- a/frontend/src/components/securities/SecurityTransactionHistory.tsx
+++ b/frontend/src/components/securities/SecurityTransactionHistory.tsx
@@ -52,7 +52,7 @@ export function SecurityTransactionHistory({
   onChanged,
 }: SecurityTransactionHistoryProps) {
   const { formatDate } = useDateFormat();
-  const { formatCurrency } = useNumberFormat();
+  const { formatCurrency, formatCurrencyPrecise } = useNumberFormat();
   const [history, setHistory] = useState<SecurityTransactionHistoryData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [selectedAccountId, setSelectedAccountId] = useState<string>('all');
@@ -252,7 +252,7 @@ export function SecurityTransactionHistory({
                       {formatShareQuantity(running)}
                     </td>
                     <td className="whitespace-nowrap px-3 py-2 text-right text-sm text-gray-700 dark:text-gray-300">
-                      {tx.price === null ? '-' : formatCurrency(tx.price, security.currencyCode, 4)}
+                      {tx.price === null ? '-' : formatCurrencyPrecise(tx.price, security.currencyCode, 4)}
                     </td>
                     <td className="whitespace-nowrap px-3 py-2 text-right text-sm text-gray-700 dark:text-gray-300">
                       {formatCurrency(tx.totalAmount, security.currencyCode)}

--- a/frontend/src/hooks/useNumberFormat.test.ts
+++ b/frontend/src/hooks/useNumberFormat.test.ts
@@ -31,6 +31,22 @@ describe('useNumberFormat', () => {
     expect(formatted).toContain('1,000.00');
   });
 
+  it('formatCurrencyPrecise matches formatCurrency for normal values', () => {
+    const { result } = renderHook(() => useNumberFormat());
+    expect(result.current.formatCurrencyPrecise(1234.56)).toBe(
+      result.current.formatCurrency(1234.56),
+    );
+  });
+
+  it('formatCurrencyPrecise expands precision for sub-penny values', () => {
+    const { result } = renderHook(() => useNumberFormat());
+    // Would render as $0.00 with the default 2dp formatter.
+    expect(result.current.formatCurrency(0.000318)).toContain('0.00');
+    const precise = result.current.formatCurrencyPrecise(0.000318);
+    expect(precise).toContain('0.000318');
+    expect(precise).not.toMatch(/0\.00($|[^0])/);
+  });
+
   it('formatCurrencyCompact omits decimals', () => {
     const { result } = renderHook(() => useNumberFormat());
     const formatted = result.current.formatCurrencyCompact(1234);

--- a/frontend/src/hooks/useNumberFormat.test.ts
+++ b/frontend/src/hooks/useNumberFormat.test.ts
@@ -47,6 +47,15 @@ describe('useNumberFormat', () => {
     expect(precise).not.toMatch(/0\.00($|[^0])/);
   });
 
+  it('formatCurrencyPrecise honours a higher base precision via minFractionDigits', () => {
+    const { result } = renderHook(() => useNumberFormat());
+    // A 4dp price column keeps 4 decimals for a normal value...
+    expect(result.current.formatCurrencyPrecise(12.3456, 'USD', 4)).toContain('12.3456');
+    // ...and only expands when even 4dp would read as zero.
+    const tiny = result.current.formatCurrencyPrecise(0.00001, 'USD', 4);
+    expect(tiny).toContain('0.00001');
+  });
+
   it('formatCurrencyCompact omits decimals', () => {
     const { result } = renderHook(() => useNumberFormat());
     const formatted = result.current.formatCurrencyCompact(1234);

--- a/frontend/src/hooks/useNumberFormat.ts
+++ b/frontend/src/hooks/useNumberFormat.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { usePreferencesStore } from '@/store/preferencesStore';
-import { roundToDecimals } from '@/lib/format';
+import { roundToDecimals, adaptiveFractionDigits } from '@/lib/format';
 
 /**
  * Get the effective locale for number formatting.
@@ -44,6 +44,27 @@ export function useNumberFormat() {
       return formatter.format(roundToDecimals(amount, decimals));
     },
     [numberFormat, defaultCurrency]
+  );
+
+  /**
+   * Currency format that expands precision for tiny values so a sub-penny
+   * amount (e.g. a 0.000342 GBP price or daily change) doesn't render as
+   * "0.00". Values that already show a figure at the currency's natural
+   * precision are formatted identically to formatCurrency.
+   */
+  const formatCurrencyPrecise = useCallback(
+    (amount: number, currencyCode?: string): string => {
+      const currency = currencyCode || defaultCurrency;
+      const locale = getEffectiveLocale(numberFormat);
+      const baseDigits =
+        new Intl.NumberFormat(locale, {
+          style: 'currency',
+          currency,
+          currencyDisplay: 'narrowSymbol',
+        }).resolvedOptions().minimumFractionDigits ?? 2;
+      return formatCurrency(amount, currency, adaptiveFractionDigits(amount, baseDigits));
+    },
+    [numberFormat, defaultCurrency, formatCurrency]
   );
 
   const formatCurrencyCompact = useCallback(
@@ -148,5 +169,5 @@ export function useNumberFormat() {
     [numberFormat, defaultCurrency]
   );
 
-  return { formatCurrency, formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag, formatCurrencyLabel, formatNumber, formatPercent, defaultCurrency, numberFormat };
+  return { formatCurrency, formatCurrencyPrecise, formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag, formatCurrencyLabel, formatNumber, formatPercent, defaultCurrency, numberFormat };
 }

--- a/frontend/src/hooks/useNumberFormat.ts
+++ b/frontend/src/hooks/useNumberFormat.ts
@@ -49,19 +49,25 @@ export function useNumberFormat() {
   /**
    * Currency format that expands precision for tiny values so a sub-penny
    * amount (e.g. a 0.000342 GBP price or daily change) doesn't render as
-   * "0.00". Values that already show a figure at the currency's natural
-   * precision are formatted identically to formatCurrency.
+   * "0.00". Values that already show a figure at the base precision are
+   * formatted identically to formatCurrency.
+   *
+   * `minFractionDigits` raises the base precision for columns that already
+   * display more than the currency's natural decimals (e.g. per-share price
+   * columns shown at 4dp); expansion then only kicks in when even that would
+   * round to zero.
    */
   const formatCurrencyPrecise = useCallback(
-    (amount: number, currencyCode?: string): string => {
+    (amount: number, currencyCode?: string, minFractionDigits?: number): string => {
       const currency = currencyCode || defaultCurrency;
       const locale = getEffectiveLocale(numberFormat);
-      const baseDigits =
+      const currencyDigits =
         new Intl.NumberFormat(locale, {
           style: 'currency',
           currency,
           currencyDisplay: 'narrowSymbol',
         }).resolvedOptions().minimumFractionDigits ?? 2;
+      const baseDigits = Math.max(currencyDigits, minFractionDigits ?? 0);
       return formatCurrency(amount, currency, adaptiveFractionDigits(amount, baseDigits));
     },
     [numberFormat, defaultCurrency, formatCurrency]

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -5,6 +5,7 @@ import {
   getDecimalPlacesForCurrency,
   roundToDecimals,
   roundToCents,
+  adaptiveFractionDigits,
   formatAmount,
   formatAmountWithCommas,
   parseAmount,
@@ -465,5 +466,38 @@ describe('formatRelativeTime', () => {
     const result = formatRelativeTime(monthAgo);
     // Should not match relative format
     expect(result).not.toMatch(/Just now|m ago|h ago|Yesterday|d ago/);
+  });
+});
+
+describe('adaptiveFractionDigits', () => {
+  it('keeps the base precision for values that show a figure at 2dp', () => {
+    expect(adaptiveFractionDigits(1234.56)).toBe(2);
+    expect(adaptiveFractionDigits(0.01)).toBe(2);
+    expect(adaptiveFractionDigits(0.005)).toBe(2); // rounds to 0.01
+  });
+
+  it('keeps the base precision for zero', () => {
+    expect(adaptiveFractionDigits(0)).toBe(2);
+  });
+
+  it('expands precision for sub-penny values that would read as 0.00', () => {
+    // 0.000318 GBP (0.0318 GBX) -> 6 places reveals the real figure.
+    expect(adaptiveFractionDigits(0.000318)).toBe(6);
+    expect(adaptiveFractionDigits(0.000342)).toBe(6);
+    expect(adaptiveFractionDigits(0.0042)).toBe(5);
+  });
+
+  it('handles negative values by magnitude', () => {
+    expect(adaptiveFractionDigits(-0.000318)).toBe(6);
+  });
+
+  it('caps at maxDigits', () => {
+    expect(adaptiveFractionDigits(0.00000001)).toBe(6);
+    expect(adaptiveFractionDigits(0.00000001, 2, 8)).toBe(8);
+  });
+
+  it('respects a non-2 base precision (e.g. JPY=0)', () => {
+    expect(adaptiveFractionDigits(123, 0)).toBe(0); // already non-zero at 0dp
+    expect(adaptiveFractionDigits(0.4, 0)).toBe(3); // expands to ~3 significant figures
   });
 });

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -92,6 +92,33 @@ export function roundToCents(value: number): number {
 }
 
 /**
+ * Pick how many fraction digits to show so a tiny non-zero value doesn't
+ * collapse to "0.00". When the value already shows a non-zero figure at the
+ * currency's natural precision (baseDigits), baseDigits is returned unchanged.
+ * Otherwise the precision is expanded to reveal `significantDigits` significant
+ * figures (e.g. 0.000342 -> 6 digits), capped at maxDigits.
+ *
+ * Used for sub-penny securities (e.g. LSE pennies quoted around 0.000318 GBP)
+ * where rounding the price or daily change to 2 places would read as zero.
+ */
+export function adaptiveFractionDigits(
+  value: number,
+  baseDigits = 2,
+  maxDigits = 6,
+  significantDigits = 3,
+): number {
+  if (!isFinite(value) || value === 0) return baseDigits;
+  const abs = Math.abs(value);
+  // Already non-zero at the natural precision: leave it alone.
+  if (roundToDecimals(abs, baseDigits) !== 0) return baseDigits;
+  // floor(log10(abs)) is the exponent of the first significant digit
+  // (negative for sub-1 values), e.g. 0.000342 -> -4.
+  const firstSignificantExp = Math.floor(Math.log10(abs));
+  const digits = -firstSignificantExp + (significantDigits - 1);
+  return Math.min(maxDigits, Math.max(baseDigits, digits));
+}
+
+/**
  * Format a number to the specified decimal places for display in inputs.
  * Defaults to 2 decimal places.
  */


### PR DESCRIPTION
## Summary
Fixes Top Movers to correctly handle sub-penny securities (e.g., LSE shares priced in pence) and sparsely-priced holdings (e.g., GICs) that would otherwise display stale daily changes perpetually.

## Key Changes

**Backend (Portfolio Service)**
- Added `price_date` to the Top Movers price query so we can validate price recency
- Introduced `MAX_DAILY_PRICE_GAP_DAYS = 7` constant to filter out securities whose two most recent prices are far apart (indicating sparse pricing rather than daily trading)
- Updated price map to store both price and date, then skip securities where the gap exceeds the threshold
- Updated `convertGbxToGbp()` to round to 6 decimal places (from 4) to preserve sub-penny LSE prices like 0.000318 GBP that would otherwise collapse to 0.0003

**Frontend (Number Formatting)**
- Added `adaptiveFractionDigits()` utility that expands decimal precision when a value would round to zero at the base precision, revealing sub-penny amounts (e.g., 0.000318 instead of 0.00)
- Added `formatCurrencyPrecise()` hook that uses adaptive precision for tiny values while keeping normal values at standard currency decimals
- Updated Top Movers, Holdings List, and Grouped Holdings List to use `formatCurrencyPrecise()` for per-share prices and daily changes
- Updated test mocks to include the new formatter

**Frontend (Report Account Filter)**
- Added debouncing (350ms) to `ReportAccountMultiSelect` so rapid checkbox toggles collapse into a single reload, keeping the dropdown mounted and open during filter changes
- Added external value reset handling so the component adopts parent-initiated clears (e.g., reset buttons)
- Updated all report components to keep content mounted during reloads instead of showing full skeleton, preserving the account dropdown state

**Tests**
- Added comprehensive test coverage for sparse pricing (GIC scenario) and long-weekend gaps
- Added tests for debounce behavior and dropdown persistence in account filter
- Updated all existing Top Movers tests to include `price_date` in mock data
- Added tests for `adaptiveFractionDigits()` and `formatCurrencyPrecise()` behavior

## Notable Implementation Details

- The price gap check uses `Math.round()` on millisecond differences to handle timezone edge cases
- Debounce cleanup is properly handled in useEffect to prevent memory leaks
- The adaptive precision algorithm uses `Math.log10()` to calculate significant figures dynamically
- All report components follow the same pattern: `isLoading` tracks only the first load, later reloads update in place

https://claude.ai/code/session_01CbdAvqNce7sKcRYAWWZVr6