### PR TITLE
Top Movers GIC fix + Bills & Deposits filter persistence and toggle sliders

### DIFF
--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -1936,6 +1936,41 @@ describe("PortfolioService", () => {
         expect(result).toHaveLength(0);
       });
     });
+
+    describe("when a security has no regular price feed (skipPriceUpdates)", () => {
+      it("excludes it even when its two transaction prices are on adjacent days", async () => {
+        accountsRepository.find.mockResolvedValue([
+          mockBrokerageAccount,
+          mockCashAccount,
+        ]);
+        // A GIC whose only "prices" are buy/sell transactions. A sell on
+        // 2025-06-13 and a re-buy on 2025-06-14 land one day apart, so the
+        // date-gap check does not catch it; the skipPriceUpdates flag must.
+        const gicHolding = {
+          ...mockHoldingAAPL,
+          security: { ...mockSecurityAAPL, skipPriceUpdates: true },
+        };
+        holdingsRepository.find.mockResolvedValue([gicHolding]);
+        securityPriceRepository.query.mockResolvedValue([
+          {
+            security_id: "sec-1",
+            close_price: "50000",
+            price_date: "2025-06-14",
+            rn: "1",
+          },
+          {
+            security_id: "sec-1",
+            close_price: "80000",
+            price_date: "2025-06-13",
+            rn: "2",
+          },
+        ]);
+
+        const result = await service.getTopMovers(userId);
+
+        expect(result).toHaveLength(0);
+      });
+    });
   });
 
   describe("getMonthOverMonthMovers", () => {

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -498,7 +498,13 @@ export class PortfolioService {
     const activeHoldings = holdings.filter(
       (h) =>
         Math.abs(Number(h.quantity)) >= 0.0001 &&
-        h.security?.isActive !== false,
+        h.security?.isActive !== false &&
+        // Exclude securities with no regular price feed (e.g. GICs). Their only
+        // "prices" come from buy/sell transactions, so the latest two closes are
+        // a transaction-to-transaction delta, not a daily market move. The
+        // date-gap check below misses this when two transactions land on
+        // adjacent days, so filter on the flag that marks the security itself.
+        h.security?.skipPriceUpdates !== true,
     );
     if (activeHoldings.length === 0) return [];
 
@@ -617,7 +623,11 @@ export class PortfolioService {
     const activeHoldings = holdings.filter(
       (h) =>
         Math.abs(Number(h.quantity)) >= 0.0001 &&
-        h.security?.isActive !== false,
+        h.security?.isActive !== false &&
+        // Exclude securities with no regular price feed (e.g. GICs); their only
+        // "prices" are buy/sell transactions, not market moves. Same rationale
+        // as getTopMovers.
+        h.security?.skipPriceUpdates !== true,
     );
     if (activeHoldings.length === 0) return [];
 

--- a/frontend/src/app/bills/page.test.tsx
+++ b/frontend/src/app/bills/page.test.tsx
@@ -254,6 +254,9 @@ const mockScheduledTransactions = [
 describe('BillsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Filters (type tab + panel selections) now persist to localStorage;
+    // reset it so each case starts from the default unfiltered view.
+    localStorage.clear();
     nav.searchParams = new URLSearchParams();
     vi.useFakeTimers({ now, shouldAdvanceTime: true });
     mockGetAll.mockResolvedValue(mockScheduledTransactions);

--- a/frontend/src/app/bills/page.tsx
+++ b/frontend/src/app/bills/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 import toast from 'react-hot-toast';
 import {
   format,
@@ -83,7 +84,7 @@ function BillsContent() {
   const [futureTransactions, setFutureTransactions] = useState<FutureTransaction[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const { showForm, editingItem: editingTransaction, openCreate, openEdit, close, isEditing, modalProps, setFormDirty, unsavedChangesDialog, formSubmitRef } = useFormModal<ScheduledTransaction>();
-  const [filterType, setFilterType] = useState<'all' | 'bills' | 'deposits'>('all');
+  const [filterType, setFilterType] = useLocalStorage<'all' | 'bills' | 'deposits'>('monize-bills-filter-type', 'all');
   const [viewMode, setViewMode] = useState<'list' | 'calendar'>('list');
   const filters = useBillsFilters();
   const [calendarMonth, setCalendarMonth] = useState(new Date());

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.test.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.test.tsx
@@ -223,6 +223,11 @@ const mockSecurities = [
   },
 ];
 
+// The Active / Auto-post / End-condition controls render as ToggleSwitch
+// (role="switch") rather than checkboxes, so their state lives in aria-checked.
+const expectToggle = (el: HTMLElement, on: boolean) =>
+  expect(el).toHaveAttribute('aria-checked', String(on));
+
 describe('ScheduledTransactionForm', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -382,15 +387,15 @@ describe('ScheduledTransactionForm', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('End by date')).toBeInTheDocument();
     });
-    const endDateCheckbox = screen.getByLabelText('End by date') as HTMLInputElement;
-    const occurrencesCheckbox = screen.getByLabelText('Number of occurrences') as HTMLInputElement;
+    const endDateCheckbox = screen.getByLabelText('End by date');
+    const occurrencesCheckbox = screen.getByLabelText('Number of occurrences');
 
     fireEvent.click(endDateCheckbox);
-    expect(endDateCheckbox.checked).toBe(true);
+    expectToggle(endDateCheckbox, true);
 
     fireEvent.click(occurrencesCheckbox);
-    expect(occurrencesCheckbox.checked).toBe(true);
-    expect(endDateCheckbox.checked).toBe(false);
+    expectToggle(occurrencesCheckbox, true);
+    expectToggle(endDateCheckbox, false);
   });
 
   it('unchecks occurrences when end date is checked (mutual exclusion)', async () => {
@@ -398,15 +403,15 @@ describe('ScheduledTransactionForm', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('End by date')).toBeInTheDocument();
     });
-    const endDateCheckbox = screen.getByLabelText('End by date') as HTMLInputElement;
-    const occurrencesCheckbox = screen.getByLabelText('Number of occurrences') as HTMLInputElement;
+    const endDateCheckbox = screen.getByLabelText('End by date');
+    const occurrencesCheckbox = screen.getByLabelText('Number of occurrences');
 
     fireEvent.click(occurrencesCheckbox);
-    expect(occurrencesCheckbox.checked).toBe(true);
+    expectToggle(occurrencesCheckbox, true);
 
     fireEvent.click(endDateCheckbox);
-    expect(endDateCheckbox.checked).toBe(true);
-    expect(occurrencesCheckbox.checked).toBe(false);
+    expectToggle(endDateCheckbox, true);
+    expectToggle(occurrencesCheckbox, false);
   });
 
   // --- Auto-post checkbox ---
@@ -415,8 +420,8 @@ describe('ScheduledTransactionForm', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Auto-post on due date')).toBeInTheDocument();
     });
-    const autoPostCheckbox = screen.getByLabelText('Auto-post on due date') as HTMLInputElement;
-    expect(autoPostCheckbox.checked).toBe(false);
+    const autoPostCheckbox = screen.getByLabelText('Auto-post on due date');
+    expectToggle(autoPostCheckbox, false);
   });
 
   it('allows toggling auto-post checkbox', async () => {
@@ -424,11 +429,11 @@ describe('ScheduledTransactionForm', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Auto-post on due date')).toBeInTheDocument();
     });
-    const autoPostCheckbox = screen.getByLabelText('Auto-post on due date') as HTMLInputElement;
+    const autoPostCheckbox = screen.getByLabelText('Auto-post on due date');
     fireEvent.click(autoPostCheckbox);
-    expect(autoPostCheckbox.checked).toBe(true);
+    expectToggle(autoPostCheckbox, true);
     fireEvent.click(autoPostCheckbox);
-    expect(autoPostCheckbox.checked).toBe(false);
+    expectToggle(autoPostCheckbox, false);
   });
 
   // --- Active checkbox ---
@@ -437,8 +442,8 @@ describe('ScheduledTransactionForm', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Active')).toBeInTheDocument();
     });
-    const activeCheckbox = screen.getByLabelText('Active') as HTMLInputElement;
-    expect(activeCheckbox.checked).toBe(true);
+    const activeCheckbox = screen.getByLabelText('Active');
+    expectToggle(activeCheckbox, true);
   });
 
   // --- Reminder days input ---
@@ -583,8 +588,8 @@ describe('ScheduledTransactionForm', () => {
     expect(frequencySelect.value).toBe('MONTHLY');
 
     // Check pre-filled auto post
-    const autoPostCheckbox = screen.getByLabelText('Auto-post on due date') as HTMLInputElement;
-    expect(autoPostCheckbox.checked).toBe(true);
+    const autoPostCheckbox = screen.getByLabelText('Auto-post on due date');
+    expectToggle(autoPostCheckbox, true);
 
     // Check pre-filled reminder days
     const reminderInput = screen.getByLabelText('Remind Days Before') as HTMLInputElement;
@@ -768,8 +773,8 @@ describe('ScheduledTransactionForm', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Active')).toBeInTheDocument();
     });
-    const activeCheckbox = screen.getByLabelText('Active') as HTMLInputElement;
-    expect(activeCheckbox.checked).toBe(false);
+    const activeCheckbox = screen.getByLabelText('Active');
+    expectToggle(activeCheckbox, false);
   });
 
   it('pre-fills end date checkbox and value from existing scheduled transaction', async () => {
@@ -786,8 +791,8 @@ describe('ScheduledTransactionForm', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('End by date')).toBeInTheDocument();
     });
-    const endDateCheckbox = screen.getByLabelText('End by date') as HTMLInputElement;
-    expect(endDateCheckbox.checked).toBe(true);
+    const endDateCheckbox = screen.getByLabelText('End by date');
+    expectToggle(endDateCheckbox, true);
   });
 
   it('pre-fills occurrences remaining from existing scheduled transaction', async () => {
@@ -804,8 +809,8 @@ describe('ScheduledTransactionForm', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Number of occurrences')).toBeInTheDocument();
     });
-    const occurrencesCheckbox = screen.getByLabelText('Number of occurrences') as HTMLInputElement;
-    expect(occurrencesCheckbox.checked).toBe(true);
+    const occurrencesCheckbox = screen.getByLabelText('Number of occurrences');
+    expectToggle(occurrencesCheckbox, true);
     const occurrencesInput = screen.getByPlaceholderText('# remaining') as HTMLInputElement;
     expect(occurrencesInput.value).toBe('12');
   });

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx
@@ -13,6 +13,7 @@ import { Select } from '@/components/ui/Select';
 import { Combobox } from '@/components/ui/Combobox';
 import { MultiSelect } from '@/components/ui/MultiSelect';
 import { Modal } from '@/components/ui/Modal';
+import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
 import { TagForm } from '@/components/tags/TagForm';
 import { SplitEditor, SplitRow, createEmptySplits, toSplitRows, toCreateSplitData } from '@/components/transactions/SplitEditor';
 import { scheduledTransactionsApi } from '@/lib/scheduled-transactions';
@@ -834,28 +835,26 @@ export function ScheduledTransactionForm({
   }));
 
   // Shared End Condition section
-  const renderEndCondition = (idSuffix: string) => {
+  const renderEndCondition = (_idSuffix: string) => {
     if (watchedFrequency === 'ONCE') return null;
     return (
       <div className="border-t border-gray-200 dark:border-gray-700 pt-4 space-y-4">
         <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300">End Condition (optional)</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <div className="flex items-center mb-2">
-              <input
-                id={`useEndDate${idSuffix}`}
-                type="checkbox"
+            <label className="flex items-center gap-2 mb-2 cursor-pointer w-fit">
+              <ToggleSwitch
                 checked={useEndDate}
-                onChange={(e) => {
-                  setUseEndDate(e.target.checked);
-                  if (e.target.checked) setUseOccurrences(false);
+                onChange={(next) => {
+                  setUseEndDate(next);
+                  if (next) setUseOccurrences(false);
                 }}
-                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-gray-600 rounded"
+                label="End by date"
               />
-              <label htmlFor={`useEndDate${idSuffix}`} className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+              <span className="block text-sm text-gray-900 dark:text-gray-100">
                 End by date
-              </label>
-            </div>
+              </span>
+            </label>
             {useEndDate && (
               <DateInput
                 label="End Date"
@@ -866,21 +865,19 @@ export function ScheduledTransactionForm({
             )}
           </div>
           <div>
-            <div className="flex items-center mb-2">
-              <input
-                id={`useOccurrences${idSuffix}`}
-                type="checkbox"
+            <label className="flex items-center gap-2 mb-2 cursor-pointer w-fit">
+              <ToggleSwitch
                 checked={useOccurrences}
-                onChange={(e) => {
-                  setUseOccurrences(e.target.checked);
-                  if (e.target.checked) setUseEndDate(false);
+                onChange={(next) => {
+                  setUseOccurrences(next);
+                  if (next) setUseEndDate(false);
                 }}
-                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-gray-600 rounded"
+                label="Number of occurrences"
               />
-              <label htmlFor={`useOccurrences${idSuffix}`} className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+              <span className="block text-sm text-gray-900 dark:text-gray-100">
                 Number of occurrences
-              </label>
-            </div>
+              </span>
+            </label>
             {useOccurrences && (
               <Input
                 type="number"
@@ -897,30 +894,28 @@ export function ScheduledTransactionForm({
   };
 
   // Shared Active/Auto-post section
-  const renderOptions = (idSuffix: string) => (
+  const renderOptions = (_idSuffix: string) => (
     <div className="flex items-center space-x-6">
-      <div className="flex items-center">
-        <input
-          id={`isActive${idSuffix}`}
-          type="checkbox"
-          className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-gray-600 rounded"
-          {...register('isActive')}
+      <label className="flex items-center gap-2 cursor-pointer">
+        <ToggleSwitch
+          checked={!!watch('isActive')}
+          onChange={(next) => setValue('isActive', next, { shouldDirty: true })}
+          label="Active"
         />
-        <label htmlFor={`isActive${idSuffix}`} className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+        <span className="block text-sm text-gray-900 dark:text-gray-100">
           Active
-        </label>
-      </div>
-      <div className="flex items-center">
-        <input
-          id={`autoPost${idSuffix}`}
-          type="checkbox"
-          className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-gray-600 rounded"
-          {...register('autoPost')}
+        </span>
+      </label>
+      <label className="flex items-center gap-2 cursor-pointer">
+        <ToggleSwitch
+          checked={!!watch('autoPost')}
+          onChange={(next) => setValue('autoPost', next, { shouldDirty: true })}
+          label="Auto-post on due date"
         />
-        <label htmlFor={`autoPost${idSuffix}`} className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+        <span className="block text-sm text-gray-900 dark:text-gray-100">
           Auto-post on due date
-        </label>
-      </div>
+        </span>
+      </label>
     </div>
   );
 

--- a/frontend/src/hooks/useBillsFilters.test.ts
+++ b/frontend/src/hooks/useBillsFilters.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useBillsFilters } from './useBillsFilters';
 
 describe('useBillsFilters', () => {
+  beforeEach(() => {
+    // Filters persist to localStorage, so reset it to keep cases isolated.
+    localStorage.clear();
+  });
+
   it('initializes with empty filters', () => {
     const { result } = renderHook(() => useBillsFilters());
     expect(result.current.nameSearch).toBe('');
@@ -71,5 +76,43 @@ describe('useBillsFilters', () => {
     });
     expect(result.current.filtersExpanded).toBe(true);
     expect(result.current.activeFilterCount).toBe(0);
+  });
+
+  it('persists filter selections across remounts via localStorage', () => {
+    const first = renderHook(() => useBillsFilters());
+    act(() => {
+      first.result.current.setNameSearch('rent');
+      first.result.current.setSelectedPayeeIds(['p1']);
+      first.result.current.setSelectedAccountIds(['a1']);
+      first.result.current.setSelectedCategoryIds(['c1']);
+      first.result.current.setFiltersExpanded(true);
+    });
+    first.unmount();
+
+    // A fresh mount (simulating a page reload) reads the stored values.
+    const second = renderHook(() => useBillsFilters());
+    expect(second.result.current.nameSearch).toBe('rent');
+    expect(second.result.current.selectedPayeeIds).toEqual(['p1']);
+    expect(second.result.current.selectedAccountIds).toEqual(['a1']);
+    expect(second.result.current.selectedCategoryIds).toEqual(['c1']);
+    expect(second.result.current.filtersExpanded).toBe(true);
+    expect(second.result.current.activeFilterCount).toBe(4);
+  });
+
+  it('clearing filters also clears the persisted values', () => {
+    const first = renderHook(() => useBillsFilters());
+    act(() => {
+      first.result.current.setNameSearch('rent');
+      first.result.current.setSelectedPayeeIds(['p1']);
+    });
+    act(() => {
+      first.result.current.clearFilters();
+    });
+    first.unmount();
+
+    const second = renderHook(() => useBillsFilters());
+    expect(second.result.current.nameSearch).toBe('');
+    expect(second.result.current.selectedPayeeIds).toEqual([]);
+    expect(second.result.current.activeFilterCount).toBe(0);
   });
 });

--- a/frontend/src/hooks/useBillsFilters.ts
+++ b/frontend/src/hooks/useBillsFilters.ts
@@ -1,20 +1,43 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useMemo, useCallback } from 'react';
 import {
   BillsFilterState,
   countActiveBillsFilters,
 } from '@/lib/bills-filters';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+
+const STORAGE_KEYS = {
+  nameSearch: 'monize-bills-name-search',
+  payeeIds: 'monize-bills-payee-ids',
+  accountIds: 'monize-bills-account-ids',
+  categoryIds: 'monize-bills-category-ids',
+  filtersExpanded: 'monize-bills-filters-expanded',
+} as const;
 
 /**
  * State management for the Bills & Deposits filter panel. Mirrors the
- * useTransactionFilters pattern: plain useState with derived active count
- * and a clear helper.
+ * useTransactionFilters pattern: derived active count and a clear helper.
+ * Filter selections persist to localStorage so they survive page reloads.
  */
 export function useBillsFilters() {
-  const [nameSearch, setNameSearch] = useState('');
-  const [selectedPayeeIds, setSelectedPayeeIds] = useState<string[]>([]);
-  const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
-  const [selectedCategoryIds, setSelectedCategoryIds] = useState<string[]>([]);
-  const [filtersExpanded, setFiltersExpanded] = useState(false);
+  const [nameSearch, setNameSearch] = useLocalStorage(
+    STORAGE_KEYS.nameSearch,
+    '',
+  );
+  const [selectedPayeeIds, setSelectedPayeeIds] = useLocalStorage<string[]>(
+    STORAGE_KEYS.payeeIds,
+    [],
+  );
+  const [selectedAccountIds, setSelectedAccountIds] = useLocalStorage<string[]>(
+    STORAGE_KEYS.accountIds,
+    [],
+  );
+  const [selectedCategoryIds, setSelectedCategoryIds] = useLocalStorage<
+    string[]
+  >(STORAGE_KEYS.categoryIds, []);
+  const [filtersExpanded, setFiltersExpanded] = useLocalStorage(
+    STORAGE_KEYS.filtersExpanded,
+    false,
+  );
 
   const filterState: BillsFilterState = useMemo(
     () => ({
@@ -36,7 +59,12 @@ export function useBillsFilters() {
     setSelectedPayeeIds([]);
     setSelectedAccountIds([]);
     setSelectedCategoryIds([]);
-  }, []);
+  }, [
+    setNameSearch,
+    setSelectedPayeeIds,
+    setSelectedAccountIds,
+    setSelectedCategoryIds,
+  ]);
 
   return {
     nameSearch,


### PR DESCRIPTION
Three related Bills & Deposits / portfolio changes.

## 1. Exclude securities without a price feed (GICs) from Top Movers

GICs were still showing in the Top Movers widget (e.g. `G-E-3-1YD*` at -37.50%). Yesterday's date-gap heuristic (skip if the two most recent prices are >=7 days apart) missed GICs whose buy/sell transaction prices land on adjacent days — a Sell on 06/13 and a re-Buy on 06/14 made the latest two "prices" only 1 day apart, so the transaction-to-transaction delta surfaced as a daily move.

Fix: filter on the security's `skipPriceUpdates` flag, which directly marks holdings with no regular price feed (set on QIF/OFX import, cleared only when a real quote provider is assigned). Applied to both `getTopMovers` (daily) and `getMonthOverMonthMovers` (monthly). The date-gap check stays for weekly-priced funds that do have a feed.

## 2. Persist Bills & Deposits filters to localStorage

Filter selections (name search, payee/account/category, the bills/deposits/all tab, and the panel expanded state) now survive a page reload, routing through the existing `useLocalStorage` hook under a `monize-bills-*` key namespace.

## 3. Replace scheduled-transaction form checkboxes with ToggleSwitch

Swapped the four checkboxes in `ScheduledTransactionForm` (End by date, Number of occurrences, Active, Auto-post on due date) for the shared `ToggleSwitch` slider used elsewhere in Monize. Controlled-state toggles bind directly; the register-bound Active/Auto-post fields drive through `watch`/`setValue`.

## Tests

- Backend: `getTopMovers`/`getMonthOverMonthMovers` mover tests pass, including a new case for the adjacent-day transaction scenario.
- Frontend: `useBillsFilters` (persistence across remounts), bills page, and `ScheduledTransactionForm` (switch state via `aria-checked`) all pass. `type-check` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)