### PR TITLE
Remap backup primary keys to prevent multi-user restore collisions

### DIFF
--- a/backend/src/backup/backup.service.spec.ts
+++ b/backend/src/backup/backup.service.spec.ts
@@ -21,6 +21,18 @@ function compressBackupData(data: Record<string, unknown>): Buffer {
   return gzipSync(Buffer.from(JSON.stringify(data), "utf-8"));
 }
 
+// Parses an INSERT call captured by the query mock into a { column: value }
+// map, pairing the column list in the SQL with the parameter array. Used to
+// read back the (remapped) values the restore actually inserted.
+function insertColumnMap(call: unknown[]): Record<string, unknown> {
+  const sql = call[0] as string;
+  const colMatch = sql.match(/\(([^)]*)\)\s*VALUES/i);
+  if (!colMatch) return {};
+  const columns = colMatch[1].split(",").map((c) => c.trim().replace(/"/g, ""));
+  const values = (call[1] as unknown[]) ?? [];
+  return Object.fromEntries(columns.map((col, i) => [col, values[i]]));
+}
+
 describe("BackupService", () => {
   let service: BackupService;
   let mockUserRepo: Record<string, jest.Mock>;
@@ -198,6 +210,7 @@ describe("BackupService", () => {
       "is_active",
       "type",
       "investment_security_id",
+      "tag_ids",
       "created_at",
       "updated_at",
     ],
@@ -808,7 +821,19 @@ describe("BackupService", () => {
       // The forward FK to securities(id) must be stripped from the INSERT.
       expect(splitInsert![0]).not.toContain("investment_security_id");
 
-      // ...and restored via a Phase-3 UPDATE keyed by the split id.
+      // Primary keys are remapped to fresh UUIDs on restore, so read back the
+      // ids the inserts actually used to verify the deferred UPDATE keeps the
+      // security -> split relationship intact.
+      const securityInsert = insertCalls.find(
+        (c: unknown[]) =>
+          typeof c[0] === "string" && c[0].includes('"securities"'),
+      );
+      const newSecurityId = insertColumnMap(securityInsert!).id;
+      const newSplitId = insertColumnMap(splitInsert!).id;
+      expect(newSecurityId).not.toBe("sec-1");
+      expect(newSplitId).not.toBe("ss-1");
+
+      // ...and restored via a Phase-3 UPDATE keyed by the (remapped) split id.
       const update = mockQueryRunner.query.mock.calls.find(
         (c: unknown[]) =>
           typeof c[0] === "string" &&
@@ -816,7 +841,7 @@ describe("BackupService", () => {
           c[0].includes('"investment_security_id"'),
       );
       expect(update).toBeDefined();
-      expect(update![1]).toEqual(["sec-1", "ss-1"]);
+      expect(update![1]).toEqual([newSecurityId, newSplitId]);
     });
 
     it("should defer circular FK columns and update them after all inserts", async () => {
@@ -903,7 +928,14 @@ describe("BackupService", () => {
           call[0].includes('"parent_id"'),
       );
       expect(parentIdUpdate).toBeDefined();
-      expect(parentIdUpdate![1]).toEqual(["cat-parent", "cat-child"]);
+      // Ids are remapped to fresh UUIDs, so the deferred parent_id UPDATE must
+      // key off the remapped ids the inserts used -- never the backup ids.
+      const catRows = categoryInserts.map(insertColumnMap);
+      const parent = catRows.find((r) => r.name === "Parent");
+      const child = catRows.find((r) => r.name === "Child");
+      expect(parent!.id).not.toBe("cat-parent");
+      expect(child!.id).not.toBe("cat-child");
+      expect(parentIdUpdate![1]).toEqual([parent!.id, child!.id]);
 
       const linkedAccountUpdate = updateCalls.find(
         (call: unknown[]) =>
@@ -912,6 +944,96 @@ describe("BackupService", () => {
           call[0].includes('"linked_account_id"'),
       );
       expect(linkedAccountUpdate).toBeDefined();
+    });
+
+    it("remaps backup primary keys so a restore never reuses another user's row ids", async () => {
+      // Reproduces the multi-user restore bug: UserB restoring UserA's backup
+      // must NOT write using UserA's original row ids (which would collide with
+      // or mutate UserA's existing rows). Every id must be remapped to a fresh
+      // UUID, and all references -- FK columns and ids nested in JSONB -- must
+      // be rewritten to match.
+      mockUserRepo.findOne.mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const backup = {
+        ...validBackupData,
+        tags: [{ id: "tag-1", user_id: "other-user", name: "Bills" }],
+        categories: [
+          { id: "cat-1", user_id: "other-user", name: "Food", parent_id: null },
+        ],
+        accounts: [{ id: "acc-1", user_id: "other-user", name: "Checking" }],
+        transactions: [
+          {
+            id: "txn-1",
+            user_id: "other-user",
+            account_id: "acc-1",
+            category_id: "cat-1",
+          },
+        ],
+        transaction_tags: [{ transaction_id: "txn-1", tag_id: "tag-1" }],
+        scheduled_transactions: [
+          {
+            id: "sched-1",
+            user_id: "other-user",
+            account_id: "acc-1",
+            tag_ids: ["tag-1"],
+          },
+        ],
+      };
+
+      await service.restoreData(
+        userId,
+        makeInput({ password: "test", data: backup }),
+      );
+
+      const backupIds = ["cat-1", "acc-1", "txn-1", "tag-1", "sched-1"];
+      const writeCalls = mockQueryRunner.query.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0].includes("INSERT INTO") || c[0].startsWith('UPDATE "')),
+      );
+
+      // No INSERT/UPDATE may reference any original backup id, even nested in a
+      // serialised JSONB value.
+      for (const call of writeCalls) {
+        const params = (call[1] as unknown[]) ?? [];
+        const flat = params.flatMap((p) => (Array.isArray(p) ? p : [p]));
+        for (const id of backupIds) {
+          expect(flat).not.toContain(id);
+        }
+        for (const p of params) {
+          if (typeof p === "string") {
+            for (const id of backupIds) {
+              expect(p.includes(id)).toBe(false);
+            }
+          }
+        }
+      }
+
+      // References stay internally consistent across the remap.
+      const inserts = writeCalls.filter((c: unknown[]) =>
+        (c[0] as string).includes("INSERT INTO"),
+      );
+      const findInsert = (table: string) =>
+        insertColumnMap(
+          inserts.find((c: unknown[]) =>
+            (c[0] as string).includes(`"${table}"`),
+          )!,
+        );
+
+      const acctRow = findInsert("accounts");
+      const txnRow = findInsert("transactions");
+      expect(acctRow.id).not.toBe("acc-1");
+      expect(txnRow.account_id).toBe(acctRow.id);
+
+      const tagRow = findInsert("tags");
+      const txnTagRow = findInsert("transaction_tags");
+      expect(txnTagRow.tag_id).toBe(tagRow.id);
+      expect(txnTagRow.transaction_id).toBe(txnRow.id);
+
+      // The id nested in the scheduled transaction's JSONB tag_ids is remapped.
+      const schedRow = findInsert("scheduled_transactions");
+      expect(schedRow.tag_ids).toContain(tagRow.id as string);
     });
 
     it("should ensure referenced currencies exist before restoring data", async () => {

--- a/backend/src/backup/backup.service.ts
+++ b/backend/src/backup/backup.service.ts
@@ -8,6 +8,7 @@ import {
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository, DataSource } from "typeorm";
 import * as bcrypt from "bcryptjs";
+import { randomUUID } from "crypto";
 import { createGzip, gunzipSync, gzipSync } from "zlib";
 import { User } from "../users/entities/user.entity";
 import { OidcService } from "../auth/oidc/oidc.service";
@@ -358,8 +359,18 @@ export class BackupService {
     await this.verifyAuthentication(user, input);
 
     const gzippedPayload = this.maybeDecrypt(input, user);
-    const data = this.decompressAndParse(gzippedPayload);
-    this.validateBackupFormat(data);
+    const rawData = this.decompressAndParse(gzippedPayload);
+    this.validateBackupFormat(rawData);
+
+    // Remap every primary key in the backup to a fresh UUID (and rewrite all
+    // references to those keys, including ids embedded in JSONB columns) so the
+    // restore behaves as if the backup came from an entirely separate system.
+    // Without this, restoring one user's backup into another user's account on
+    // the SAME system would collide on the original UUIDs: the inserts would be
+    // silently skipped by ON CONFLICT DO NOTHING, and the Phase-3 deferred-FK
+    // UPDATEs (keyed only by id) would mutate the OTHER user's rows.
+    const idRemap = this.buildBackupIdRemap(rawData);
+    const data = this.remapBackupIds(rawData, idRemap);
 
     this.logger.log(`Starting backup restore for user ${userId}`);
 
@@ -702,6 +713,76 @@ export class BackupService {
         "Invalid backup format: missing exportedAt",
       );
     }
+  }
+
+  /**
+   * Builds a map from every primary-key UUID in the backup to a freshly
+   * generated UUID. Currencies are intentionally excluded: they are shared,
+   * global rows keyed by `code` (not by a per-user UUID) and are referenced by
+   * code, so they must keep their original identifiers.
+   */
+  private buildBackupIdRemap(data: BackupData): Map<string, string> {
+    const remap = new Map<string, string>();
+    for (const [table, rows] of Object.entries(data)) {
+      if (table === "currencies" || !Array.isArray(rows)) continue;
+      for (const row of rows) {
+        if (!row || typeof row !== "object") continue;
+        const id = (row as Record<string, unknown>).id;
+        if (typeof id === "string" && id.length > 0 && !remap.has(id)) {
+          remap.set(id, randomUUID());
+        }
+      }
+    }
+    return remap;
+  }
+
+  /**
+   * Returns a deep copy of the backup with every id and every reference to an
+   * id (FK columns plus ids embedded in JSONB values such as scheduled
+   * transaction `tag_ids` or override `splits`) rewritten via the remap. The
+   * `user_id` columns are never remapped here -- they are not backup row ids,
+   * and insertRows() forces them to the restoring user. Currencies are passed
+   * through unchanged.
+   */
+  private remapBackupIds(
+    data: BackupData,
+    remap: Map<string, string>,
+  ): BackupData {
+    if (remap.size === 0) return data;
+    const result: Record<string, unknown> = { ...data };
+    for (const [table, rows] of Object.entries(data)) {
+      if (table === "currencies" || !Array.isArray(rows)) continue;
+      result[table] = rows.map((row) => this.deepRemapIds(row, remap));
+    }
+    return result as unknown as BackupData;
+  }
+
+  /**
+   * Recursively rewrites any string that matches a remapped id. Recurses into
+   * arrays and plain objects (e.g. JSONB columns) so ids nested inside JSON are
+   * remapped too. Because the remap only contains genuine backup primary keys
+   * (random UUIDs), non-id strings such as names or memos are left untouched.
+   */
+  private deepRemapIds(value: unknown, remap: Map<string, string>): unknown {
+    if (typeof value === "string") {
+      return remap.get(value) ?? value;
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => this.deepRemapIds(item, remap));
+    }
+    if (
+      value !== null &&
+      typeof value === "object" &&
+      !(value instanceof Date)
+    ) {
+      return Object.fromEntries(
+        Object.entries(value).map(([key, val]) => [
+          key,
+          this.deepRemapIds(val, remap),
+        ]),
+      );
+    }
+    return value;
   }
 
   private async deleteAllUserData(


### PR DESCRIPTION
## Summary

Fixes a critical multi-user restore bug where restoring one user's backup into another user's account would silently collide on the original row UUIDs. Every primary key in the backup is now remapped to a fresh UUID, and all references (FK columns and ids nested in JSONB) are rewritten to match.

## Key Changes

- **ID Remapping**: Added `buildBackupIdRemap()` to generate a map from every backup primary key to a fresh UUID (excluding currencies, which are global and keyed by code)
- **Deep Remapping**: Implemented `remapBackupIds()` and `deepRemapIds()` to recursively rewrite all id references throughout the backup data, including:
  - Direct id columns (primary keys)
  - Foreign key columns
  - IDs nested in JSONB values (e.g., `scheduled_transactions.tag_ids`, override `splits`)
- **Restore Flow**: Integrated remapping into `restoreData()` before validation and insertion
- **Test Coverage**: Added comprehensive test `remaps backup primary keys so a restore never reuses another user's row ids` that verifies:
  - No backup id appears in any INSERT or UPDATE parameter
  - References remain internally consistent across the remap
  - Nested JSONB ids are properly remapped

## Implementation Details

The remap is applied after decompression but before validation and insertion. This ensures:
- Phase-3 deferred FK UPDATEs use the remapped ids (not the original backup ids), preventing mutations of other users' rows
- ON CONFLICT DO NOTHING clauses work correctly since the inserts use fresh UUIDs
- All internal references stay consistent (e.g., transaction → account, transaction_tag → tag)
- Currencies pass through unchanged since they're global, shared rows keyed by code

The `insertColumnMap()` test helper was added to parse INSERT calls and verify the actual remapped values used by the restore.

https://claude.ai/code/session_0135drXu8NxHPdTF5RraKQxn