### PR TITLE
Standardize money rounding/summation on shared 4dp helpers

### DIFF
--- a/backend/src/accounts/account-export.service.ts
+++ b/backend/src/accounts/account-export.service.ts
@@ -5,6 +5,7 @@ import { Transaction } from "../transactions/entities/transaction.entity";
 import { Category } from "../categories/entities/category.entity";
 import { Account, AccountType } from "./entities/account.entity";
 import { AccountsService } from "./accounts.service";
+import { roundMoney } from "../common/round.util";
 
 interface ExportTransaction {
   date: string;
@@ -68,8 +69,7 @@ export class AccountExportService {
 
     for (const tx of transactions) {
       if (tx.status !== "VOID") {
-        runningBalance =
-          Math.round((runningBalance + tx.amount) * 10000) / 10000;
+        runningBalance = roundMoney(runningBalance + tx.amount);
       }
       const balance = tx.status === "VOID" ? runningBalance : runningBalance;
 

--- a/backend/src/accounts/accounts.service.ts
+++ b/backend/src/accounts/accounts.service.ts
@@ -28,6 +28,7 @@ import {
   MortgageAmortizationResult,
 } from "./mortgage-amortization.util";
 import { Cron } from "@nestjs/schedule";
+import { roundMoney } from "../common/round.util";
 import { formatDateYMD, todayInTimezone, todayYMD } from "../common/date-utils";
 import { ActionHistoryService } from "../action-history/action-history.service";
 
@@ -264,15 +265,12 @@ export class AccountsService {
       invTxCountMap.set(row.accountId, parseInt(row.cnt, 10));
     const futureSumMap = new Map<string, number>();
     for (const row of futureSums)
-      futureSumMap.set(
-        row.accountId,
-        Math.round(Number(row.futureSum) * 10000) / 10000,
-      );
+      futureSumMap.set(row.accountId, roundMoney(Number(row.futureSum)));
     const currentBalanceMap = new Map<string, number>();
     for (const row of currentSums)
       currentBalanceMap.set(
         row.accountId,
-        Math.round(Number(row.currentBalance) * 10000) / 10000,
+        roundMoney(Number(row.currentBalance)),
       );
 
     return accounts.map((account) => ({
@@ -460,9 +458,9 @@ export class AccountsService {
         const difference = newOpeningBalance - oldOpeningBalance;
 
         // Adjust currentBalance by the difference
-        account.currentBalance =
-          Math.round((Number(account.currentBalance) + difference) * 10000) /
-          10000;
+        account.currentBalance = roundMoney(
+          Number(account.currentBalance) + difference,
+        );
       }
 
       // SECURITY: Explicit property mapping instead of Object.assign to prevent mass assignment
@@ -798,8 +796,8 @@ export class AccountsService {
 
     const newBalance =
       result.length > 0
-        ? Math.round(Number(result[0].balance) * 10000) / 10000
-        : Math.round(Number(account.openingBalance) * 10000) / 10000;
+        ? roundMoney(Number(result[0].balance))
+        : roundMoney(Number(account.openingBalance));
 
     if (queryRunner) {
       await queryRunner.query(
@@ -835,7 +833,7 @@ export class AccountsService {
         GROUP BY a.id, a.opening_balance`,
       [accountId, userId],
     );
-    return Math.round(Number(result?.[0]?.balance ?? 0) * 10000) / 10000;
+    return roundMoney(Number(result?.[0]?.balance ?? 0));
   }
 
   /**
@@ -936,8 +934,6 @@ export class AccountsService {
       const lowerNames = new Set(accountNames.map((n) => n.toLowerCase()));
       accounts = accounts.filter((a) => lowerNames.has(a.name.toLowerCase()));
     }
-
-    const roundMoney = (v: number): number => Math.round(v * 100) / 100;
 
     const accountList = accounts.map((a) => {
       const balance =
@@ -1300,7 +1296,7 @@ export class AccountsService {
           );
 
         for (const row of balances) {
-          const newBalance = Math.round(Number(row.balance) * 10000) / 10000;
+          const newBalance = roundMoney(Number(row.balance));
           await this.accountsRepository.update(row.account_id, {
             currentBalance: newBalance,
           });

--- a/backend/src/accounts/loan-amortization.util.spec.ts
+++ b/backend/src/accounts/loan-amortization.util.spec.ts
@@ -63,10 +63,12 @@ describe("Loan Amortization Utility", () => {
       expect(result.principal).toBe(100);
     });
 
-    it("rounds to 2 decimal places", () => {
+    it("rounds to 4 decimal places (storage precision)", () => {
       const result = calculatePaymentSplit(10000, 3.333, 500, "MONTHLY");
-      expect(result.interest).toBe(Math.round(result.interest * 100) / 100);
-      expect(result.principal).toBe(Math.round(result.principal * 100) / 100);
+      expect(result.interest).toBe(Math.round(result.interest * 10000) / 10000);
+      expect(result.principal).toBe(
+        Math.round(result.principal * 10000) / 10000,
+      );
     });
 
     it("works with biweekly frequency", () => {
@@ -233,9 +235,9 @@ describe("Loan Amortization Utility", () => {
       expect(result).toBe(100.0);
     });
 
-    it("rounds to 2 decimal places", () => {
+    it("rounds to 4 decimal places (storage precision)", () => {
       const result = calculateFinalPayment(333.33, 7.77, "MONTHLY");
-      expect(result).toBe(Math.round(result * 100) / 100);
+      expect(result).toBe(Math.round(result * 10000) / 10000);
     });
   });
 });

--- a/backend/src/accounts/loan-amortization.util.ts
+++ b/backend/src/accounts/loan-amortization.util.ts
@@ -7,6 +7,8 @@
  * - End date calculation
  */
 
+import { roundMoney } from "../common/round.util";
+
 export type PaymentFrequency =
   | "WEEKLY"
   | "BIWEEKLY"
@@ -88,10 +90,10 @@ export function calculatePaymentSplit(
     principal = remainingBalance;
   }
 
-  // Round to 2 decimal places for currency
+  // Round to storage precision for currency
   return {
-    principal: Math.round(principal * 100) / 100,
-    interest: Math.round(interest * 100) / 100,
+    principal: roundMoney(principal),
+    interest: roundMoney(interest),
   };
 }
 
@@ -212,7 +214,7 @@ export function calculateAmortization(
   // Calculate remaining balance after first payment
   const remainingBalance = Math.max(
     0,
-    Math.round((principal - principalPayment) * 100) / 100,
+    roundMoney(principal - principalPayment),
   );
 
   // Calculate total payments
@@ -255,5 +257,5 @@ export function calculateFinalPayment(
   const interest = remainingBalance * periodicRate;
   const finalPayment = remainingBalance + interest;
 
-  return Math.round(finalPayment * 100) / 100;
+  return roundMoney(finalPayment);
 }

--- a/backend/src/accounts/loan-mortgage-account.service.ts
+++ b/backend/src/accounts/loan-mortgage-account.service.ts
@@ -25,6 +25,7 @@ import {
   MortgageAmortizationResult,
 } from "./mortgage-amortization.util";
 import { formatDateYMD } from "../common/date-utils";
+import { roundMoney } from "../common/round.util";
 
 @Injectable()
 export class LoanMortgageAccountService {
@@ -383,9 +384,8 @@ export class LoanMortgageAccountService {
         periodicRate = newRate / 100 / periodsPerYear;
       }
 
-      interestPayment = Math.round(currentBalance * periodicRate * 100) / 100;
-      principalPayment =
-        Math.round((paymentAmount - interestPayment) * 100) / 100;
+      interestPayment = roundMoney(currentBalance * periodicRate);
+      principalPayment = roundMoney(paymentAmount - interestPayment);
     } else {
       const result = recalculateMortgageAfterRateChange(
         currentBalance,

--- a/backend/src/accounts/loan-payment-detector.service.ts
+++ b/backend/src/accounts/loan-payment-detector.service.ts
@@ -4,6 +4,7 @@ import { Repository } from "typeorm";
 import { Account, AccountType } from "./entities/account.entity";
 import { Transaction } from "../transactions/entities/transaction.entity";
 import { TransactionSplit } from "../transactions/entities/transaction-split.entity";
+import { roundMoney, sumMoney } from "../common/round.util";
 
 export interface DetectedLoanPayment {
   /** Detected regular payment amount (positive) */
@@ -180,9 +181,7 @@ export class LoanPaymentDetectorService {
     // Subtract extra principal to get the base payment (principal + interest only).
     const basePaymentAmount =
       extraPrincipal.averageExtraPrincipal > 0
-        ? Math.round(
-            (regularAmount - extraPrincipal.averageExtraPrincipal) * 100,
-          ) / 100
+        ? roundMoney(regularAmount - extraPrincipal.averageExtraPrincipal)
         : regularAmount;
 
     // Analyze the recent P/I split trend from several payments.
@@ -358,10 +357,7 @@ export class LoanPaymentDetectorService {
                 // Sum all into principalAmount for now; detectExtraPrincipal will
                 // use principalSplitAmounts to separate them.
                 principalSplitAmounts = principalSplits.map((ps) => ps.amount);
-                principalAmount = principalSplitAmounts.reduce(
-                  (s, a) => s + a,
-                  0,
-                );
+                principalAmount = sumMoney(principalSplitAmounts);
               }
             }
           }
@@ -495,8 +491,8 @@ export class LoanPaymentDetectorService {
 
     if (nearMedian.length >= 2) {
       // Return the average of the near-median amounts
-      const sum = nearMedian.reduce((s, a) => s + a, 0);
-      return Math.round((sum / nearMedian.length) * 100) / 100;
+      const sum = sumMoney(nearMedian);
+      return roundMoney(sum / nearMedian.length);
     }
 
     return null;
@@ -834,11 +830,10 @@ export class LoanPaymentDetectorService {
       memoBasedExtras.length >= 3 &&
       memoBasedExtras.length / allPayments.length >= 0.5
     ) {
-      const totalExtra = memoBasedExtras.reduce(
-        (sum, p) => sum + p.extraPrincipalAmount!,
-        0,
+      const totalExtra = sumMoney(
+        memoBasedExtras.map((p) => p.extraPrincipalAmount!),
       );
-      const avg = Math.round((totalExtra / memoBasedExtras.length) * 100) / 100;
+      const avg = roundMoney(totalExtra / memoBasedExtras.length);
       return {
         averageExtraPrincipal: avg,
         extraPrincipalCount: memoBasedExtras.length,
@@ -889,8 +884,8 @@ export class LoanPaymentDetectorService {
         }
 
         if (extraGroup) {
-          const avg = extraGroup.reduce((s, e) => s + e, 0) / extraGroup.length;
-          const extraAmount = Math.round(avg * 100) / 100;
+          const avg = sumMoney(extraGroup) / extraGroup.length;
+          const extraAmount = roundMoney(avg);
           if (extraAmount > 0.01) {
             return {
               averageExtraPrincipal: extraAmount,
@@ -985,11 +980,10 @@ export class LoanPaymentDetectorService {
       const lastPrincipal = principals[principals.length - 1];
       const lastInterest = interests[interests.length - 1];
 
-      const projectedPrincipal =
-        Math.round((lastPrincipal + avgPrincipalStep) * 100) / 100;
+      const projectedPrincipal = roundMoney(lastPrincipal + avgPrincipalStep);
       const projectedInterest = Math.max(
         0,
-        Math.round((lastInterest + avgInterestStep) * 100) / 100,
+        roundMoney(lastInterest + avgInterestStep),
       );
 
       return { projectedPrincipal, projectedInterest };
@@ -1086,7 +1080,7 @@ export class LoanPaymentDetectorService {
     const extraAmount = payment.extraPrincipalAmount ?? 0;
     const baseAmount =
       extraAmount > 0
-        ? Math.round((payment.amount - extraAmount) * 100) / 100
+        ? roundMoney(payment.amount - extraAmount)
         : payment.amount;
     return {
       paymentAmount: baseAmount,

--- a/backend/src/accounts/mortgage-amortization.util.spec.ts
+++ b/backend/src/accounts/mortgage-amortization.util.spec.ts
@@ -111,9 +111,9 @@ describe("Mortgage Amortization Utility", () => {
       expect(payment).toBe(400);
     });
 
-    it("rounds to 2 decimal places", () => {
+    it("rounds to 4 decimal places (storage precision)", () => {
       const payment = calculatePaymentAmount(100000, 0.004, 360);
-      const rounded = Math.round(payment * 100) / 100;
+      const rounded = Math.round(payment * 10000) / 10000;
       expect(payment).toBe(rounded);
     });
 

--- a/backend/src/accounts/mortgage-amortization.util.ts
+++ b/backend/src/accounts/mortgage-amortization.util.ts
@@ -9,6 +9,8 @@
  * - Calculates payment amount based on amortization period
  */
 
+import { roundMoney } from "../common/round.util";
+
 export type MortgagePaymentFrequency =
   | "MONTHLY"
   | "SEMI_MONTHLY" // 24 payments/year (1st and 15th)
@@ -133,14 +135,14 @@ export function calculatePaymentAmount(
 ): number {
   // Handle 0% interest
   if (periodicRate === 0) {
-    return Math.round((principal / totalPayments) * 100) / 100;
+    return roundMoney(principal / totalPayments);
   }
 
   const payment =
     (principal * (periodicRate * Math.pow(1 + periodicRate, totalPayments))) /
     (Math.pow(1 + periodicRate, totalPayments) - 1);
 
-  return Math.round(payment * 100) / 100;
+  return roundMoney(payment);
 }
 
 /**
@@ -186,7 +188,7 @@ export function calculateMortgagePayment(
       isCanadian,
       isVariableRate,
     );
-    return Math.round((monthlyPayment / 2) * 100) / 100;
+    return roundMoney(monthlyPayment / 2);
   }
 
   if (paymentFrequency === "ACCELERATED_WEEKLY") {
@@ -197,7 +199,7 @@ export function calculateMortgagePayment(
       isCanadian,
       isVariableRate,
     );
-    return Math.round((monthlyPayment / 4) * 100) / 100;
+    return roundMoney(monthlyPayment / 4);
   }
 
   // For standard frequencies, calculate based on that frequency's periods
@@ -368,9 +370,8 @@ export function calculateMortgageAmortization(
     isCanadian,
     isVariableRate,
   );
-  const interestPayment = Math.round(principal * periodicRate * 100) / 100;
-  const principalPayment =
-    Math.round((paymentAmount - interestPayment) * 100) / 100;
+  const interestPayment = roundMoney(principal * periodicRate);
+  const principalPayment = roundMoney(paymentAmount - interestPayment);
 
   // Calculate end date
   const endDate = calculateMortgageEndDate(
@@ -381,7 +382,7 @@ export function calculateMortgageAmortization(
 
   // Calculate total interest
   const totalPaid = paymentAmount * totalPayments;
-  const totalInterest = Math.round((totalPaid - principal) * 100) / 100;
+  const totalInterest = roundMoney(totalPaid - principal);
 
   // Calculate effective annual rate
   const effectiveAnnualRate = calculateEffectiveAnnualRate(
@@ -471,7 +472,7 @@ export function calculateMortgagePaymentSplit(
   }
 
   return {
-    principal: Math.round(principal * 100) / 100,
-    interest: Math.round(interest * 100) / 100,
+    principal: roundMoney(principal),
+    interest: roundMoney(interest),
   };
 }

--- a/backend/src/budgets/budget-activity-reports.service.spec.ts
+++ b/backend/src/budgets/budget-activity-reports.service.spec.ts
@@ -545,7 +545,7 @@ describe("BudgetActivityReportsService", () => {
       expect(result[2].date).toBe("2026-02-20");
     });
 
-    it("should round amounts to two decimal places", async () => {
+    it("should round amounts to storage precision (4 decimal places)", async () => {
       periodsRepository.findOne.mockResolvedValueOnce({
         id: "p-1",
         budgetId: "budget-1",
@@ -568,7 +568,7 @@ describe("BudgetActivityReportsService", () => {
 
       const result = await service.getDailySpending("user-1", "budget-1");
 
-      expect(result[0].amount).toBe(33.34);
+      expect(result[0].amount).toBe(33.335);
     });
 
     it("should handle budget with no categories array", async () => {

--- a/backend/src/budgets/budget-activity-reports.service.ts
+++ b/backend/src/budgets/budget-activity-reports.service.ts
@@ -11,6 +11,7 @@ import {
   FlexGroupStatusResult,
 } from "./budget-reports.service";
 import { formatDateYMD } from "../common/date-utils";
+import { roundMoney, roundToDecimals, sumMoney } from "../common/round.util";
 
 const MONTH_NAMES = [
   "January",
@@ -141,15 +142,12 @@ export class BudgetActivityReportsService {
         monthlyAverages.push({
           month: m,
           monthName: MONTH_NAMES[m - 1],
-          average: this.round(avg),
+          average: roundMoney(avg),
         });
       }
 
       const nonZero = amounts.filter((a) => a > 0);
-      const mean =
-        nonZero.length > 0
-          ? nonZero.reduce((s, v) => s + v, 0) / nonZero.length
-          : 0;
+      const mean = nonZero.length > 0 ? sumMoney(nonZero) / nonZero.length : 0;
       const stdDev = this.standardDeviation(nonZero);
 
       // High months: > mean + 1.5 * stdDev
@@ -163,7 +161,7 @@ export class BudgetActivityReportsService {
         categoryName: categoryNameMap.get(catId) || "Unknown",
         monthlyAverages,
         highMonths,
-        typicalMonthlySpend: this.round(mean),
+        typicalMonthlySpend: roundMoney(mean),
       });
     }
 
@@ -277,7 +275,7 @@ export class BudgetActivityReportsService {
 
     // Convert map to sorted array
     return Array.from(spendingMap.entries())
-      .map(([date, amount]) => ({ date, amount: this.round(amount) }))
+      .map(([date, amount]) => ({ date, amount: roundMoney(amount) }))
       .sort((a, b) => a.date.localeCompare(b.date));
   }
 
@@ -337,14 +335,14 @@ export class BudgetActivityReportsService {
       const remaining = data.totalBudgeted - data.totalSpent;
       const percentUsed =
         data.totalBudgeted > 0
-          ? this.round((data.totalSpent / data.totalBudgeted) * 100)
+          ? roundToDecimals((data.totalSpent / data.totalBudgeted) * 100, 2)
           : 0;
 
       results.push({
         groupName,
-        totalBudgeted: this.round(data.totalBudgeted),
-        totalSpent: this.round(data.totalSpent),
-        remaining: this.round(remaining),
+        totalBudgeted: roundMoney(data.totalBudgeted),
+        totalSpent: roundMoney(data.totalSpent),
+        remaining: roundMoney(remaining),
         percentUsed,
         categories: data.categories,
       });
@@ -372,9 +370,5 @@ export class BudgetActivityReportsService {
     const squaredDiffs = values.map((v) => (v - avg) ** 2);
     const variance = squaredDiffs.reduce((s, v) => s + v, 0) / values.length;
     return Math.sqrt(variance);
-  }
-
-  private round(value: number): number {
-    return Math.round(value * 100) / 100;
   }
 }

--- a/backend/src/budgets/budget-alert.service.ts
+++ b/backend/src/budgets/budget-alert.service.ts
@@ -29,6 +29,7 @@ import {
   resolveCategorySpent,
 } from "./budget-spending.util";
 import { formatCurrency } from "../common/format-currency.util";
+import { roundMoney, sumMoney } from "../common/round.util";
 
 interface SeasonalProfile {
   budgetCategoryId: string;
@@ -428,9 +429,9 @@ export class BudgetAlertService {
         message: `At your current pace, ${cat.categoryName} is projected to reach ${formatCurrency(projectedTotal, cat.currencyCode)} by the end of the period (budget: ${formatCurrency(cat.budgeted, cat.currencyCode)}).`,
         data: {
           categoryName: cat.categoryName,
-          projectedTotal: Math.round(projectedTotal * 100) / 100,
+          projectedTotal: roundMoney(projectedTotal),
           budgeted: cat.budgeted,
-          dailyRate: Math.round(dailyRate * 100) / 100,
+          dailyRate: roundMoney(dailyRate),
           projectedPercent: Math.round(projectedPercent * 10) / 10,
         },
       };
@@ -491,10 +492,7 @@ export class BudgetAlertService {
   ): AlertCandidate | null {
     if (periodProgress < 0.5) return null;
 
-    const totalActualIncome = incomeActuals.reduce(
-      (sum, cat) => sum + cat.spent,
-      0,
-    );
+    const totalActualIncome = sumMoney(incomeActuals.map((cat) => cat.spent));
     const expectedSoFar = expectedIncome * periodProgress;
     const incomeRatio = totalActualIncome / expectedSoFar;
 
@@ -525,8 +523,8 @@ export class BudgetAlertService {
   ): AlertCandidate[] {
     if (periodProgress < 0.5 || daysRemaining <= 0) return [];
 
-    const totalBudgeted = actuals.reduce((sum, c) => sum + c.budgeted, 0);
-    const totalSpent = actuals.reduce((sum, c) => sum + c.spent, 0);
+    const totalBudgeted = sumMoney(actuals.map((c) => c.budgeted));
+    const totalSpent = sumMoney(actuals.map((c) => c.spent));
 
     if (totalBudgeted <= 0) return [];
 
@@ -773,10 +771,9 @@ export class BudgetAlertService {
             highMonthName: monthName,
             typicalMonthlySpend: profile.typicalMonthlySpend,
             typicalIncrease: profile.typicalIncrease,
-            suggestedBudget:
-              Math.round(
-                profile.typicalMonthlySpend * profile.typicalIncrease * 100,
-              ) / 100,
+            suggestedBudget: roundMoney(
+              profile.typicalMonthlySpend * profile.typicalIncrease,
+            ),
           },
         });
       }
@@ -868,7 +865,7 @@ export class BudgetAlertService {
       const nonZero = amounts.filter((a) => a > 0);
       if (nonZero.length < 3) continue;
 
-      const mean = nonZero.reduce((s, v) => s + v, 0) / nonZero.length;
+      const mean = sumMoney(nonZero) / nonZero.length;
       const stdDev = this.standardDeviation(nonZero);
       const threshold = mean + 1.5 * stdDev;
 
@@ -893,7 +890,7 @@ export class BudgetAlertService {
         categoryId: catId,
         categoryName: info.name,
         highMonths,
-        typicalMonthlySpend: Math.round(mean * 100) / 100,
+        typicalMonthlySpend: roundMoney(mean),
         typicalIncrease: Math.round(maxIncrease * 10) / 10,
       });
     }

--- a/backend/src/budgets/budget-generator.service.ts
+++ b/backend/src/budgets/budget-generator.service.ts
@@ -9,6 +9,7 @@ import { Budget } from "./entities/budget.entity";
 import { BudgetCategory } from "./entities/budget-category.entity";
 import { GenerateBudgetDto, BudgetProfile } from "./dto/generate-budget.dto";
 import { ApplyGeneratedBudgetDto } from "./dto/apply-generated-budget.dto";
+import { roundMoney, sumMoney } from "../common/round.util";
 
 export interface CategoryAnalysis {
   categoryId: string;
@@ -150,15 +151,12 @@ export class BudgetGeneratorService {
 
     const estimatedMonthlyIncome =
       incomeAnalysis.length > 0
-        ? incomeAnalysis.reduce((sum, i) => sum + i.median, 0)
+        ? sumMoney(incomeAnalysis.map((i) => i.median))
         : 0;
 
-    const totalBudgeted = expenseAnalysis.reduce(
-      (sum, c) => sum + c.suggested,
-      0,
-    );
+    const totalBudgeted = sumMoney(expenseAnalysis.map((c) => c.suggested));
 
-    const totalTransfers = transfers.reduce((sum, t) => sum + t.suggested, 0);
+    const totalTransfers = sumMoney(transfers.map((t) => t.suggested));
 
     return {
       categories: allCategories,
@@ -166,8 +164,9 @@ export class BudgetGeneratorService {
       estimatedMonthlyIncome,
       totalBudgeted,
       totalTransfers,
-      projectedMonthlySavings:
+      projectedMonthlySavings: roundMoney(
         estimatedMonthlyIncome - totalBudgeted - totalTransfers,
+      ),
       analysisWindow: {
         startDate: startDateStr,
         endDate: endDateStr,
@@ -360,13 +359,13 @@ export class BudgetGeneratorService {
         categoryId: entry.categoryId,
         categoryName: entry.categoryName,
         isIncome: entry.isIncome,
-        average: this.round(this.mean(monthlyAmounts)),
-        median: this.round(this.percentile(sortedForPercentiles, 50)),
-        p25: this.round(this.percentile(sortedForPercentiles, 25)),
-        p75: this.round(this.percentile(sortedForPercentiles, 75)),
-        min: this.round(sortedAll[0] ?? 0),
-        max: this.round(sortedAll[sortedAll.length - 1] ?? 0),
-        stdDev: this.round(this.standardDeviation(monthlyAmounts)),
+        average: roundMoney(this.mean(monthlyAmounts)),
+        median: roundMoney(this.percentile(sortedForPercentiles, 50)),
+        p25: roundMoney(this.percentile(sortedForPercentiles, 25)),
+        p75: roundMoney(this.percentile(sortedForPercentiles, 75)),
+        min: roundMoney(sortedAll[0] ?? 0),
+        max: roundMoney(sortedAll[sortedAll.length - 1] ?? 0),
+        stdDev: roundMoney(this.standardDeviation(monthlyAmounts)),
         monthlyAmounts,
         monthlyOccurrences: nonZeroMonths,
         isFixed: this.isFixedExpense(monthlyAmounts),
@@ -414,10 +413,10 @@ export class BudgetGeneratorService {
     // This handles categories that don't occur every month -- the average
     // distributes total spending across all months in the analysis window.
     if (base === 0 && cat.average > 0) {
-      return this.round(cat.average);
+      return roundMoney(cat.average);
     }
 
-    return this.round(base);
+    return roundMoney(base);
   }
 
   percentile(sorted: number[], p: number): number {
@@ -558,15 +557,15 @@ export class BudgetGeneratorService {
         accountId: entry.accountId,
         accountName: entry.accountName,
         accountType: entry.accountType,
-        average: this.round(this.mean(monthlyAmounts)),
-        median: this.round(this.percentile(sortedForPercentiles, 50)),
-        p25: this.round(this.percentile(sortedForPercentiles, 25)),
-        p75: this.round(this.percentile(sortedForPercentiles, 75)),
-        min: this.round(sortedForPercentiles[0] ?? 0),
-        max: this.round(
+        average: roundMoney(this.mean(monthlyAmounts)),
+        median: roundMoney(this.percentile(sortedForPercentiles, 50)),
+        p25: roundMoney(this.percentile(sortedForPercentiles, 25)),
+        p75: roundMoney(this.percentile(sortedForPercentiles, 75)),
+        min: roundMoney(sortedForPercentiles[0] ?? 0),
+        max: roundMoney(
           sortedForPercentiles[sortedForPercentiles.length - 1] ?? 0,
         ),
-        stdDev: this.round(this.standardDeviation(monthlyAmounts)),
+        stdDev: roundMoney(this.standardDeviation(monthlyAmounts)),
         monthlyAmounts,
         monthlyOccurrences: nonZeroMonths,
         isFixed: this.isFixedExpense(monthlyAmounts),
@@ -595,14 +594,10 @@ export class BudgetGeneratorService {
     }
 
     if (base === 0 && stats.average > 0) {
-      return this.round(stats.average);
+      return roundMoney(stats.average);
     }
 
-    return this.round(base);
-  }
-
-  private round(value: number): number {
-    return Math.round(value * 100) / 100;
+    return roundMoney(base);
   }
 
   private formatDate(date: Date): string {

--- a/backend/src/budgets/budget-health-reports.service.ts
+++ b/backend/src/budgets/budget-health-reports.service.ts
@@ -14,6 +14,7 @@ import {
   HealthScoreHistoryPoint,
   SavingsRatePoint,
 } from "./budget-reports.service";
+import { roundMoney, roundToDecimals } from "../common/round.util";
 
 const MONTH_NAMES = [
   "January",
@@ -101,7 +102,7 @@ export class BudgetHealthReportsService {
         categoryId: cat.categoryId || "",
         categoryName: cat.categoryName,
         percentUsed: cat.percentUsed,
-        impact: this.round(impact),
+        impact: roundToDecimals(impact, 2),
         categoryGroup: group,
       });
     }
@@ -124,10 +125,10 @@ export class BudgetHealthReportsService {
       label,
       breakdown: {
         baseScore,
-        overBudgetDeductions: this.round(overBudgetDeductions),
-        underBudgetBonus: this.round(underBudgetBonus),
-        trendBonus: this.round(trendBonus),
-        essentialWeightPenalty: this.round(essentialWeightPenalty),
+        overBudgetDeductions: roundToDecimals(overBudgetDeductions, 2),
+        underBudgetBonus: roundToDecimals(underBudgetBonus, 2),
+        trendBonus: roundToDecimals(trendBonus, 2),
+        essentialWeightPenalty: roundToDecimals(essentialWeightPenalty, 2),
       },
       categoryScores,
     };
@@ -436,13 +437,14 @@ export class BudgetHealthReportsService {
       const income = incomeByMonth.get(monthKey) || 0;
       const expenses = expenseByMonth.get(monthKey) || 0;
       const savings = income - expenses;
-      const savingsRate = income > 0 ? this.round((savings / income) * 100) : 0;
+      const savingsRate =
+        income > 0 ? roundToDecimals((savings / income) * 100, 2) : 0;
 
       result.push({
         month: monthLabel,
-        income: this.round(income),
-        expenses: this.round(expenses),
-        savings: this.round(savings),
+        income: roundMoney(income),
+        expenses: roundMoney(expenses),
+        savings: roundMoney(savings),
         savingsRate,
       });
     }
@@ -533,9 +535,5 @@ export class BudgetHealthReportsService {
     const year = parseInt(parts[0], 10);
     const month = parseInt(parts[1], 10);
     return `${MONTH_NAMES[month - 1].substring(0, 3)} ${year}`;
-  }
-
-  private round(value: number): number {
-    return Math.round(value * 100) / 100;
   }
 }

--- a/backend/src/budgets/budget-period.service.ts
+++ b/backend/src/budgets/budget-period.service.ts
@@ -13,6 +13,7 @@ import { Transaction } from "../transactions/entities/transaction.entity";
 import { TransactionSplit } from "../transactions/entities/transaction-split.entity";
 import { BudgetsService } from "./budgets.service";
 import { getCurrentMonthPeriodDates } from "./budget-date.utils";
+import { roundMoney, sumMoney } from "../common/round.util";
 
 @Injectable()
 export class BudgetPeriodService {
@@ -158,9 +159,11 @@ export class BudgetPeriodService {
 
     const budgetCategories = budget.categories || [];
 
-    const totalBudgeted = budgetCategories
-      .filter((bc) => !bc.isIncome)
-      .reduce((sum, bc) => sum + Number(bc.amount), 0);
+    const totalBudgeted = sumMoney(
+      budgetCategories
+        .filter((bc) => !bc.isIncome)
+        .map((bc) => Number(bc.amount)),
+    );
 
     const periodsRepo = queryRunner
       ? queryRunner.manager.getRepository(BudgetPeriod)
@@ -228,7 +231,7 @@ export class BudgetPeriodService {
       rollover = Math.min(rollover, Number(budgetCategory.rolloverCap));
     }
 
-    return Math.round(rollover * 10000) / 10000;
+    return roundMoney(rollover);
   }
 
   private async createNextPeriod(

--- a/backend/src/budgets/budget-trend-reports.service.ts
+++ b/backend/src/budgets/budget-trend-reports.service.ts
@@ -11,6 +11,7 @@ import {
   BudgetTrendPoint,
   CategoryTrendSeries,
 } from "./budget-reports.service";
+import { roundMoney, roundToDecimals, sumMoney } from "../common/round.util";
 
 const MONTH_NAMES = [
   "January",
@@ -61,13 +62,13 @@ export class BudgetTrendReportsService {
       const actual = Number(period.actualExpenses) || 0;
       const variance = actual - budgeted;
       const percentUsed =
-        budgeted > 0 ? this.round((actual / budgeted) * 100) : 0;
+        budgeted > 0 ? roundToDecimals((actual / budgeted) * 100, 2) : 0;
 
       return {
         month: this.formatPeriodMonth(period.periodStart),
-        budgeted: this.round(budgeted),
-        actual: this.round(actual),
-        variance: this.round(variance),
+        budgeted: roundMoney(budgeted),
+        actual: roundMoney(actual),
+        variance: roundMoney(variance),
         percentUsed,
       };
     });
@@ -83,13 +84,15 @@ export class BudgetTrendReportsService {
       const budgeted = Number(currentPeriod.totalBudgeted) || 0;
       const variance = currentActuals - budgeted;
       const percentUsed =
-        budgeted > 0 ? this.round((currentActuals / budgeted) * 100) : 0;
+        budgeted > 0
+          ? roundToDecimals((currentActuals / budgeted) * 100, 2)
+          : 0;
 
       result.push({
         month: this.formatPeriodMonth(currentPeriod.periodStart),
-        budgeted: this.round(budgeted),
-        actual: this.round(currentActuals),
-        variance: this.round(variance),
+        budgeted: roundMoney(budgeted),
+        actual: roundMoney(currentActuals),
+        variance: roundMoney(variance),
         percentUsed,
       });
     }
@@ -174,13 +177,13 @@ export class BudgetTrendReportsService {
 
         const variance = actual - budgeted;
         const percentUsed =
-          budgeted > 0 ? this.round((actual / budgeted) * 100) : 0;
+          budgeted > 0 ? roundToDecimals((actual / budgeted) * 100, 2) : 0;
 
         seriesMap.get(catId)!.data.push({
           month: periodMonth,
-          budgeted: this.round(budgeted),
-          actual: this.round(actual),
-          variance: this.round(variance),
+          budgeted: roundMoney(budgeted),
+          actual: roundMoney(actual),
+          variance: roundMoney(variance),
           percentUsed,
         });
       }
@@ -452,13 +455,13 @@ export class BudgetTrendReportsService {
         const actual = actualMap.get(catId)?.get(monthKey) || 0;
         const variance = actual - budgeted;
         const percentUsed =
-          budgeted > 0 ? this.round((actual / budgeted) * 100) : 0;
+          budgeted > 0 ? roundToDecimals((actual / budgeted) * 100, 2) : 0;
 
         data.push({
           month: monthLabel,
-          budgeted: this.round(budgeted),
-          actual: this.round(actual),
-          variance: this.round(variance),
+          budgeted: roundMoney(budgeted),
+          actual: roundMoney(actual),
+          variance: roundMoney(variance),
           percentUsed,
         });
       }
@@ -486,10 +489,7 @@ export class BudgetTrendReportsService {
 
     if (categoryIds.length === 0 && transferAccountIds.length === 0) return [];
 
-    const totalBudgeted = categories.reduce(
-      (sum, bc) => sum + Number(bc.amount),
-      0,
-    );
+    const totalBudgeted = sumMoney(categories.map((bc) => Number(bc.amount)));
 
     const today = new Date();
 
@@ -621,13 +621,15 @@ export class BudgetTrendReportsService {
       const actual = actualByMonth.get(monthKey) || 0;
       const variance = actual - totalBudgeted;
       const percentUsed =
-        totalBudgeted > 0 ? this.round((actual / totalBudgeted) * 100) : 0;
+        totalBudgeted > 0
+          ? roundToDecimals((actual / totalBudgeted) * 100, 2)
+          : 0;
 
       result.push({
         month: monthLabel,
-        budgeted: this.round(totalBudgeted),
-        actual: this.round(actual),
-        variance: this.round(variance),
+        budgeted: roundMoney(totalBudgeted),
+        actual: roundMoney(actual),
+        variance: roundMoney(variance),
         percentUsed,
       });
     }
@@ -640,9 +642,5 @@ export class BudgetTrendReportsService {
     const year = parseInt(parts[0], 10);
     const month = parseInt(parts[1], 10);
     return `${MONTH_NAMES[month - 1].substring(0, 3)} ${year}`;
-  }
-
-  private round(value: number): number {
-    return Math.round(value * 100) / 100;
   }
 }

--- a/backend/src/budgets/budgets.service.ts
+++ b/backend/src/budgets/budgets.service.ts
@@ -33,6 +33,7 @@ import {
 } from "./budget-spending.util";
 import { formatDateYMD, todayYMD } from "../common/date-utils";
 import { formatCurrency } from "../common/format-currency.util";
+import { roundMoney, sumMoney } from "../common/round.util";
 import { ActionHistoryService } from "../action-history/action-history.service";
 
 export interface UpcomingBill {
@@ -366,13 +367,10 @@ export class BudgetsService {
     const expenseCategories = categoryBreakdown.filter((c) => !c.isIncome);
     const incomeCategories = categoryBreakdown.filter((c) => c.isIncome);
 
-    const totalBudgeted = expenseCategories.reduce(
-      (sum, c) => sum + c.budgeted,
-      0,
-    );
-    const totalSpent = expenseCategories.reduce((sum, c) => sum + c.spent, 0);
-    const totalIncome = incomeCategories.reduce((sum, c) => sum + c.spent, 0);
-    const remaining = totalBudgeted - totalSpent;
+    const totalBudgeted = sumMoney(expenseCategories.map((c) => c.budgeted));
+    const totalSpent = sumMoney(expenseCategories.map((c) => c.spent));
+    const totalIncome = sumMoney(incomeCategories.map((c) => c.spent));
+    const remaining = roundMoney(totalBudgeted - totalSpent);
     const percentUsed =
       totalBudgeted > 0
         ? Math.round((totalSpent / totalBudgeted) * 10000) / 100
@@ -468,22 +466,16 @@ export class BudgetsService {
     );
 
     const expenseCategories = categoryBreakdown.filter((c) => !c.isIncome);
-    const currentSpent = expenseCategories.reduce((sum, c) => sum + c.spent, 0);
-    const budgetTotal = expenseCategories.reduce(
-      (sum, c) => sum + c.budgeted,
-      0,
-    );
+    const currentSpent = sumMoney(expenseCategories.map((c) => c.spent));
+    const budgetTotal = sumMoney(expenseCategories.map((c) => c.budgeted));
 
     const upcomingBills = await this.getUpcomingBills(userId, periodEnd);
-    const totalUpcomingBills = upcomingBills.reduce(
-      (sum, b) => sum + b.amount,
-      0,
-    );
+    const totalUpcomingBills = sumMoney(upcomingBills.map((b) => b.amount));
 
     const dailyBurnRate = currentSpent / daysElapsed;
     const projectedTotal = dailyBurnRate * totalDays;
     const projectedVariance = projectedTotal - budgetTotal;
-    const remaining = budgetTotal - currentSpent;
+    const remaining = roundMoney(budgetTotal - currentSpent);
     const trulyAvailable = remaining - totalUpcomingBills;
     const safeDailySpend =
       daysRemaining > 0 ? Math.max(0, trulyAvailable / daysRemaining) : 0;
@@ -499,19 +491,19 @@ export class BudgetsService {
     }
 
     return {
-      dailyBurnRate: Math.round(dailyBurnRate * 100) / 100,
-      projectedTotal: Math.round(projectedTotal * 100) / 100,
+      dailyBurnRate: roundMoney(dailyBurnRate),
+      projectedTotal: roundMoney(projectedTotal),
       budgetTotal,
-      projectedVariance: Math.round(projectedVariance * 100) / 100,
-      safeDailySpend: Math.round(safeDailySpend * 100) / 100,
+      projectedVariance: roundMoney(projectedVariance),
+      safeDailySpend: roundMoney(safeDailySpend),
       daysElapsed,
       daysRemaining,
       totalDays,
       currentSpent,
       paceStatus,
       upcomingBills,
-      totalUpcomingBills: Math.round(totalUpcomingBills * 100) / 100,
-      trulyAvailable: Math.round(trulyAvailable * 100) / 100,
+      totalUpcomingBills: roundMoney(totalUpcomingBills),
+      trulyAvailable: roundMoney(trulyAvailable),
     };
   }
 
@@ -742,12 +734,9 @@ export class BudgetsService {
 
     const expenseCategories = categoryBreakdown.filter((c) => !c.isIncome);
 
-    const totalBudgeted = expenseCategories.reduce(
-      (sum, c) => sum + c.budgeted,
-      0,
-    );
-    const totalSpent = expenseCategories.reduce((sum, c) => sum + c.spent, 0);
-    const remaining = totalBudgeted - totalSpent;
+    const totalBudgeted = sumMoney(expenseCategories.map((c) => c.budgeted));
+    const totalSpent = sumMoney(expenseCategories.map((c) => c.spent));
+    const remaining = roundMoney(totalBudgeted - totalSpent);
     const percentUsed =
       totalBudgeted > 0
         ? Math.round((totalSpent / totalBudgeted) * 10000) / 100
@@ -787,7 +776,7 @@ export class BudgetsService {
       totalSpent,
       remaining,
       percentUsed,
-      safeDailySpend: Math.round(safeDailySpend * 100) / 100,
+      safeDailySpend: roundMoney(safeDailySpend),
       daysRemaining,
       topCategories,
     };
@@ -996,14 +985,14 @@ export class BudgetsService {
 
       if (budget.incomeLinked && !bc.isIncome) {
         percentage = rawAmount;
-        budgeted = Math.round(((actualIncome * rawAmount) / 100) * 100) / 100;
+        budgeted = roundMoney((actualIncome * rawAmount) / 100);
       } else {
         budgeted = rawAmount;
       }
 
       const spent = resolveCategorySpent(bc, spendingMap, transferSpendingMap);
       const categoryName = resolveCategoryName(bc);
-      const remaining = budgeted - spent;
+      const remaining = roundMoney(budgeted - spent);
       const percentUsed =
         budgeted > 0 ? Math.round((spent / budgeted) * 10000) / 100 : 0;
 

--- a/backend/src/built-in-reports/anomaly-reports.service.ts
+++ b/backend/src/built-in-reports/anomaly-reports.service.ts
@@ -10,6 +10,7 @@ import {
   AnomalySeverity,
 } from "./dto";
 import { formatDateYMD } from "../common/date-utils";
+import { roundMoney, sumMoney } from "../common/round.util";
 
 @Injectable()
 export class AnomalyReportsService {
@@ -95,7 +96,7 @@ export class AnomalyReportsService {
         rateMap,
       ),
     );
-    const mean = amounts.reduce((sum, a) => sum + a, 0) / amounts.length;
+    const mean = sumMoney(amounts) / amounts.length;
     const variance =
       amounts.reduce((sum, a) => sum + Math.pow(a - mean, 2), 0) /
       amounts.length;
@@ -126,7 +127,7 @@ export class AnomalyReportsService {
           severity,
           title: "Unusually large transaction",
           description: `${row.payee_name || "Unknown payee"} - ${txDate.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`,
-          amount: Math.round(amount * 100) / 100,
+          amount: roundMoney(amount),
           transactionId: row.id,
           transactionDate: row.transaction_date.toString().split("T")[0],
           payeeName: row.payee_name || undefined,
@@ -162,8 +163,8 @@ export class AnomalyReportsService {
 
     return {
       statistics: {
-        mean: Math.round(mean * 100) / 100,
-        stdDev: Math.round(stdDev * 100) / 100,
+        mean: roundMoney(mean),
+        stdDev: roundMoney(stdDev),
       },
       anomalies,
       counts: {
@@ -236,8 +237,8 @@ export class AnomalyReportsService {
           description: `${Math.round(percentChange)}% increase from last month`,
           categoryId: categoryId === "uncategorized" ? undefined : categoryId,
           categoryName: category?.name || "Uncategorized",
-          currentPeriodAmount: Math.round(currentAmount * 100) / 100,
-          previousPeriodAmount: Math.round(previousAmount * 100) / 100,
+          currentPeriodAmount: roundMoney(currentAmount),
+          previousPeriodAmount: roundMoney(previousAmount),
           percentChange: Math.round(percentChange),
         });
       }
@@ -316,7 +317,7 @@ export class AnomalyReportsService {
             severity,
             title: "New payee detected",
             description: `${recent.name} - ${recent.count} transaction(s)`,
-            amount: Math.round(recent.total * 100) / 100,
+            amount: roundMoney(recent.total),
             transactionId: recent.txId,
             payeeName: recent.name,
           });

--- a/backend/src/built-in-reports/built-in-reports.service.spec.ts
+++ b/backend/src/built-in-reports/built-in-reports.service.spec.ts
@@ -897,8 +897,8 @@ describe("BuiltInReportsService", () => {
 
       const result = await service.getYearOverYear(mockUserId, 1);
 
-      expect(yearData(result, currentYear).totals.income).toBe(100.33);
-      expect(yearData(result, currentYear).totals.expenses).toBe(50.67);
+      expect(yearData(result, currentYear).totals.income).toBe(100.333);
+      expect(yearData(result, currentYear).totals.expenses).toBe(50.666);
     });
 
     it("sorts year data in ascending order", async () => {
@@ -1441,8 +1441,8 @@ describe("BuiltInReportsService", () => {
       // USD: 100 + EUR: 50 * 1.1 = 155
       expect(result.data[0].totalAmount).toBe(155);
       expect(result.data[0].occurrences).toBe(6);
-      // Average: 155 / 6 = 25.83
-      expect(result.data[0].averageAmount).toBe(25.83);
+      // Average: 155 / 6 = 25.8333 (4dp storage precision)
+      expect(result.data[0].averageAmount).toBe(25.8333);
     });
 
     it("calculates summary correctly", async () => {

--- a/backend/src/built-in-reports/comparison-reports.service.spec.ts
+++ b/backend/src/built-in-reports/comparison-reports.service.spec.ts
@@ -271,9 +271,9 @@ describe("ComparisonReportsService", () => {
       const result = await service.getYearOverYear(mockUserId, 1);
       const jan = result.data[0].months[0];
 
-      expect(jan.income).toBe(100.56);
-      expect(jan.expenses).toBe(50.44);
-      expect(jan.savings).toBe(50.12);
+      expect(jan.income).toBe(100.555);
+      expect(jan.expenses).toBe(50.444);
+      expect(jan.savings).toBe(50.111);
     });
 
     it("rounds year totals to 2 decimal places", async () => {
@@ -298,9 +298,9 @@ describe("ComparisonReportsService", () => {
       const result = await service.getYearOverYear(mockUserId, 1);
       const totals = result.data[0].totals;
 
-      expect(totals.income).toBe(66.67);
-      expect(totals.expenses).toBe(22.22);
-      expect(totals.savings).toBe(44.44);
+      expect(totals.income).toBe(66.666);
+      expect(totals.expenses).toBe(22.222);
+      expect(totals.savings).toBe(44.444);
     });
 
     it("initializes all 12 months for each year", async () => {
@@ -634,8 +634,8 @@ describe("ComparisonReportsService", () => {
       );
 
       expect(result.summary.weekendTotal).toBe(100);
-      expect(result.byDay[0].total).toBe(33.34);
-      expect(result.byDay[6].total).toBe(66.66);
+      expect(result.byDay[0].total).toBe(33.337);
+      expect(result.byDay[6].total).toBe(66.663);
     });
 
     it("includes startDate filter when provided", async () => {

--- a/backend/src/built-in-reports/comparison-reports.service.ts
+++ b/backend/src/built-in-reports/comparison-reports.service.ts
@@ -4,6 +4,7 @@ import { Repository } from "typeorm";
 import { Transaction } from "../transactions/entities/transaction.entity";
 import { Category } from "../categories/entities/category.entity";
 import { ReportCurrencyService } from "./report-currency.service";
+import { roundMoney, sumMoney } from "../common/round.util";
 import {
   YearOverYearResponse,
   YearData,
@@ -98,10 +99,9 @@ export class ComparisonReportsService {
           defaultCurrency,
           rateMap,
         );
-        monthData.income += Math.round(income * 100) / 100;
-        monthData.expenses += Math.round(expenses * 100) / 100;
-        monthData.savings =
-          Math.round((monthData.income - monthData.expenses) * 100) / 100;
+        monthData.income = roundMoney(monthData.income + income);
+        monthData.expenses = roundMoney(monthData.expenses + expenses);
+        monthData.savings = roundMoney(monthData.income - monthData.expenses);
 
         yearData.totals.income += income;
         yearData.totals.expenses += expenses;
@@ -110,10 +110,9 @@ export class ComparisonReportsService {
     });
 
     yearMap.forEach((yearData) => {
-      yearData.totals.income = Math.round(yearData.totals.income * 100) / 100;
-      yearData.totals.expenses =
-        Math.round(yearData.totals.expenses * 100) / 100;
-      yearData.totals.savings = Math.round(yearData.totals.savings * 100) / 100;
+      yearData.totals.income = roundMoney(yearData.totals.income);
+      yearData.totals.expenses = roundMoney(yearData.totals.expenses);
+      yearData.totals.savings = roundMoney(yearData.totals.savings);
     });
 
     return {
@@ -223,23 +222,21 @@ export class ComparisonReportsService {
       }
     });
 
-    const weekendTotal = Math.round((dayTotals[0] + dayTotals[6]) * 100) / 100;
-    const weekdayTotal =
-      Math.round(
-        (dayTotals[1] +
-          dayTotals[2] +
-          dayTotals[3] +
-          dayTotals[4] +
-          dayTotals[5]) *
-          100,
-      ) / 100;
+    const weekendTotal = sumMoney([dayTotals[0], dayTotals[6]]);
+    const weekdayTotal = sumMoney([
+      dayTotals[1],
+      dayTotals[2],
+      dayTotals[3],
+      dayTotals[4],
+      dayTotals[5],
+    ]);
     const weekendCount = dayCounts[0] + dayCounts[6];
     const weekdayCount =
       dayCounts[1] + dayCounts[2] + dayCounts[3] + dayCounts[4] + dayCounts[5];
 
     const byDay: DaySpending[] = dayTotals.map((total, index) => ({
       dayOfWeek: index,
-      total: Math.round(total * 100) / 100,
+      total: roundMoney(total),
       count: dayCounts[index],
     }));
 
@@ -254,8 +251,8 @@ export class ComparisonReportsService {
         return {
           categoryId: catId === "uncategorized" ? null : catId,
           categoryName: weekend?.name || weekday?.name || "Unknown",
-          weekendTotal: Math.round((weekend?.total || 0) * 100) / 100,
-          weekdayTotal: Math.round((weekday?.total || 0) * 100) / 100,
+          weekendTotal: roundMoney(weekend?.total || 0),
+          weekdayTotal: roundMoney(weekday?.total || 0),
         };
       })
       .sort(

--- a/backend/src/built-in-reports/data-quality-reports.service.spec.ts
+++ b/backend/src/built-in-reports/data-quality-reports.service.spec.ts
@@ -273,8 +273,8 @@ describe("DataQualityReportsService", () => {
         "2025-12-31",
       );
 
-      expect(result.summary.expenseTotal).toBe(33.34);
-      expect(result.summary.incomeTotal).toBe(66.66);
+      expect(result.summary.expenseTotal).toBe(33.337);
+      expect(result.summary.incomeTotal).toBe(66.663);
     });
 
     it("formats transaction dates as YYYY-MM-DD", async () => {

--- a/backend/src/built-in-reports/data-quality-reports.service.ts
+++ b/backend/src/built-in-reports/data-quality-reports.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { Transaction } from "../transactions/entities/transaction.entity";
 import { ReportCurrencyService } from "./report-currency.service";
+import { roundMoney, sumMoney } from "../common/round.util";
 import {
   UncategorizedTransactionsResponse,
   UncategorizedTransactionItem,
@@ -175,9 +176,9 @@ export class DataQualityReportsService {
       summary: {
         totalCount,
         expenseCount,
-        expenseTotal: Math.round(expenseTotal * 100) / 100,
+        expenseTotal: roundMoney(expenseTotal),
         incomeCount,
-        incomeTotal: Math.round(incomeTotal * 100) / 100,
+        incomeTotal: roundMoney(incomeTotal),
       },
     };
   }
@@ -383,10 +384,12 @@ export class DataQualityReportsService {
     const medium = groups.filter((g) => g.confidence === "medium");
     const low = groups.filter((g) => g.confidence === "low");
 
-    const potentialSavings = groups.reduce((sum, group) => {
-      const duplicateCount = group.transactions.length - 1;
-      return sum + Math.abs(group.transactions[0].amount) * duplicateCount;
-    }, 0);
+    const potentialSavings = sumMoney(
+      groups.map((group) => {
+        const duplicateCount = group.transactions.length - 1;
+        return Math.abs(group.transactions[0].amount) * duplicateCount;
+      }),
+    );
 
     return {
       groups,
@@ -395,7 +398,7 @@ export class DataQualityReportsService {
         highCount: high.length,
         mediumCount: medium.length,
         lowCount: low.length,
-        potentialSavings: Math.round(potentialSavings * 100) / 100,
+        potentialSavings: roundMoney(potentialSavings),
       },
     };
   }

--- a/backend/src/built-in-reports/income-reports.service.spec.ts
+++ b/backend/src/built-in-reports/income-reports.service.spec.ts
@@ -322,7 +322,7 @@ describe("IncomeReportsService", () => {
         "2025-12-31",
       );
 
-      expect(result.data[0].total).toBe(33.33);
+      expect(result.data[0].total).toBe(33.333);
     });
 
     it("filters out the asset value change category in the SQL query", async () => {
@@ -489,8 +489,8 @@ describe("IncomeReportsService", () => {
         "2025-12-31",
       );
 
-      expect(result.data[0].income).toBe(100.56);
-      expect(result.data[0].expenses).toBe(50.44);
+      expect(result.data[0].income).toBe(100.555);
+      expect(result.data[0].expenses).toBe(50.444);
     });
 
     it("passes startDate parameter when provided", async () => {

--- a/backend/src/built-in-reports/income-reports.service.ts
+++ b/backend/src/built-in-reports/income-reports.service.ts
@@ -8,6 +8,7 @@ import {
   RawCategoryAggregate,
   RawMonthlyAggregate,
 } from "./report-currency.service";
+import { roundMoney, sumMoney } from "../common/round.util";
 import {
   IncomeBySourceResponse,
   IncomeSourceItem,
@@ -118,16 +119,16 @@ export class IncomeReportsService {
         categoryId: id,
         categoryName: category.name,
         color: category.color || null,
-        total: Math.round(total * 100) / 100,
+        total: roundMoney(total),
       }))
       .sort((a, b) => b.total - a.total)
       .slice(0, 15);
 
-    const totalIncome = data.reduce((sum, item) => sum + item.total, 0);
+    const totalIncome = sumMoney(data.map((item) => item.total));
 
     return {
       data,
-      totalIncome: Math.round(totalIncome * 100) / 100,
+      totalIncome: roundMoney(totalIncome),
     };
   }
 
@@ -217,26 +218,23 @@ export class IncomeReportsService {
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([month, { income, expenses }]) => ({
         month,
-        income: Math.round(income * 100) / 100,
-        expenses: Math.round(expenses * 100) / 100,
-        net: Math.round((income - expenses) * 100) / 100,
+        income: roundMoney(income),
+        expenses: roundMoney(expenses),
+        net: roundMoney(income - expenses),
       }));
 
-    const totals = data.reduce(
-      (acc, item) => ({
-        income: acc.income + item.income,
-        expenses: acc.expenses + item.expenses,
-        net: acc.net + item.net,
-      }),
-      { income: 0, expenses: 0, net: 0 },
-    );
+    const totals = {
+      income: sumMoney(data.map((item) => item.income)),
+      expenses: sumMoney(data.map((item) => item.expenses)),
+      net: sumMoney(data.map((item) => item.net)),
+    };
 
     return {
       data,
       totals: {
-        income: Math.round(totals.income * 100) / 100,
-        expenses: Math.round(totals.expenses * 100) / 100,
-        net: Math.round(totals.net * 100) / 100,
+        income: roundMoney(totals.income),
+        expenses: roundMoney(totals.expenses),
+        net: roundMoney(totals.net),
       },
     };
   }

--- a/backend/src/built-in-reports/monthly-comparison.service.ts
+++ b/backend/src/built-in-reports/monthly-comparison.service.ts
@@ -4,6 +4,7 @@ import { Repository, DataSource } from "typeorm";
 import { SpendingReportsService } from "./spending-reports.service";
 import { IncomeReportsService } from "./income-reports.service";
 import { ReportCurrencyService } from "./report-currency.service";
+import { roundMoney, sumMoney } from "../common/round.util";
 import { NetWorthService } from "../net-worth/net-worth.service";
 import { PortfolioService, TopMover } from "../securities/portfolio.service";
 import {
@@ -293,20 +294,20 @@ export class MonthlyComparisonService {
         color: c.color,
         currentTotal: c.currentTotal,
         previousTotal: c.previousTotal,
-        change: Math.round((c.currentTotal - c.previousTotal) * 100) / 100,
+        change: roundMoney(c.currentTotal - c.previousTotal),
         changePercent: this.percentChange(c.previousTotal, c.currentTotal),
       }))
       .sort((a, b) => b.currentTotal - a.currentTotal);
 
-    const currentTotal = currentData.reduce((sum, c) => sum + c.total, 0);
-    const previousTotal = previousData.reduce((sum, c) => sum + c.total, 0);
+    const currentTotal = sumMoney(currentData.map((c) => c.total));
+    const previousTotal = sumMoney(previousData.map((c) => c.total));
 
     return {
       currentMonth,
       previousMonth,
       comparison,
-      currentTotal: Math.round(currentTotal * 100) / 100,
-      previousTotal: Math.round(previousTotal * 100) / 100,
+      currentTotal: roundMoney(currentTotal),
+      previousTotal: roundMoney(previousTotal),
     };
   }
 

--- a/backend/src/built-in-reports/spending-reports.service.ts
+++ b/backend/src/built-in-reports/spending-reports.service.ts
@@ -10,6 +10,7 @@ import {
   RawPayeeAggregate,
   RawMonthlyCategoryAggregate,
 } from "./report-currency.service";
+import { roundMoney, sumMoney } from "../common/round.util";
 import {
   SpendingByCategoryResponse,
   CategorySpendingItem,
@@ -157,16 +158,16 @@ export class SpendingReportsService {
         categoryId: id === "uncategorized" ? null : id,
         categoryName: category?.name || "Uncategorized",
         color: category?.color || null,
-        total: Math.round(total * 100) / 100,
+        total: roundMoney(total),
       }))
       .sort((a, b) => b.total - a.total)
       .slice(0, 15);
 
-    const totalSpending = data.reduce((sum, item) => sum + item.total, 0);
+    const totalSpending = sumMoney(data.map((item) => item.total));
 
     return {
       data,
-      totalSpending: Math.round(totalSpending * 100) / 100,
+      totalSpending: roundMoney(totalSpending),
     };
   }
 
@@ -253,16 +254,16 @@ export class SpendingReportsService {
       .map((row) => ({
         payeeId: row.payeeId,
         payeeName: row.payeeName,
-        total: Math.round(row.total * 100) / 100,
+        total: roundMoney(row.total),
       }))
       .sort((a, b) => b.total - a.total)
       .slice(0, 20);
 
-    const totalSpending = data.reduce((sum, item) => sum + item.total, 0);
+    const totalSpending = sumMoney(data.map((item) => item.total));
 
     return {
       data,
-      totalSpending: Math.round(totalSpending * 100) / 100,
+      totalSpending: roundMoney(totalSpending),
     };
   }
 
@@ -388,20 +389,17 @@ export class SpendingReportsService {
               categoryId: catId === "uncategorized" ? null : catId,
               categoryName: category?.name || "Uncategorized",
               color: category?.color || null,
-              total: Math.round((catData?.total || 0) * 100) / 100,
+              total: roundMoney(catData?.total || 0),
             };
           },
         );
 
-        const totalSpending = categories.reduce(
-          (sum, cat) => sum + cat.total,
-          0,
-        );
+        const totalSpending = sumMoney(categories.map((cat) => cat.total));
 
         return {
           month,
           categories,
-          totalSpending: Math.round(totalSpending * 100) / 100,
+          totalSpending: roundMoney(totalSpending),
         };
       });
 

--- a/backend/src/built-in-reports/tax-recurring-reports.service.spec.ts
+++ b/backend/src/built-in-reports/tax-recurring-reports.service.spec.ts
@@ -355,9 +355,9 @@ describe("TaxRecurringReportsService", () => {
 
       const result = await service.getTaxSummary(mockUserId, 2025);
 
-      expect(result.incomeBySource[0].total).toBe(3333.33);
-      expect(result.totals.income).toBe(3333.33);
-      expect(result.deductibleExpenses[0].total).toBe(111.12);
+      expect(result.incomeBySource[0].total).toBe(3333.333);
+      expect(result.totals.income).toBe(3333.333);
+      expect(result.deductibleExpenses[0].total).toBe(111.115);
     });
 
     it("passes correct year date range to the query", async () => {
@@ -556,8 +556,8 @@ describe("TaxRecurringReportsService", () => {
       expect(result.data).toHaveLength(1);
       expect(result.data[0].payeeName).toBe("Spotify");
       expect(result.data[0].occurrences).toBe(6);
-      // 30 USD + 27.27 EUR * 1.1 = 30 + 29.997
-      expect(result.data[0].totalAmount).toBe(60);
+      // 30 USD + 27.27 EUR * 1.1 = 30 + 29.997 = 59.997 (4dp storage precision)
+      expect(result.data[0].totalAmount).toBe(59.997);
     });
 
     it("uses the most recent last_transaction_date when merging", async () => {
@@ -660,8 +660,8 @@ describe("TaxRecurringReportsService", () => {
 
       const result = await service.getRecurringExpenses(mockUserId);
 
-      expect(result.data[0].totalAmount).toBe(33.33);
-      expect(result.data[0].averageAmount).toBe(11.11);
+      expect(result.data[0].totalAmount).toBe(33.333);
+      expect(result.data[0].averageAmount).toBe(11.111);
     });
 
     it("uses 'Uncategorized' when category_name is null", async () => {
@@ -1211,7 +1211,7 @@ describe("TaxRecurringReportsService", () => {
       );
 
       expect(result.billPayments[0].totalPaid).toBe(100);
-      expect(result.billPayments[0].averagePayment).toBe(33.33);
+      expect(result.billPayments[0].averagePayment).toBe(33.3333);
     });
   });
 });

--- a/backend/src/built-in-reports/tax-recurring-reports.service.ts
+++ b/backend/src/built-in-reports/tax-recurring-reports.service.ts
@@ -13,6 +13,7 @@ import {
   MonthlyBillTotal,
 } from "./dto";
 import { formatDateYMD } from "../common/date-utils";
+import { roundMoney, sumMoney } from "../common/round.util";
 
 @Injectable()
 export class TaxRecurringReportsService {
@@ -144,34 +145,31 @@ export class TaxRecurringReportsService {
       }
     });
 
-    const totalDeductible = Array.from(deductibleExpenses.values()).reduce(
-      (sum, v) => sum + v,
-      0,
-    );
+    const totalDeductible = sumMoney(Array.from(deductibleExpenses.values()));
 
     return {
       incomeBySource: Array.from(incomeBySource.entries())
         .map(([name, total]) => ({
           name,
-          total: Math.round(total * 100) / 100,
+          total: roundMoney(total),
         }))
         .sort((a, b) => b.total - a.total),
       deductibleExpenses: Array.from(deductibleExpenses.entries())
         .map(([name, total]) => ({
           name,
-          total: Math.round(total * 100) / 100,
+          total: roundMoney(total),
         }))
         .sort((a, b) => b.total - a.total),
       allExpenses: Array.from(allExpensesByCategory.entries())
         .map(([name, total]) => ({
           name,
-          total: Math.round(total * 100) / 100,
+          total: roundMoney(total),
         }))
         .sort((a, b) => b.total - a.total),
       totals: {
-        income: Math.round(totalIncome * 100) / 100,
-        expenses: Math.round(totalExpenses * 100) / 100,
-        deductible: Math.round(totalDeductible * 100) / 100,
+        income: roundMoney(totalIncome),
+        expenses: roundMoney(totalExpenses),
+        deductible: roundMoney(totalDeductible),
       },
     };
   }
@@ -290,8 +288,8 @@ export class TaxRecurringReportsService {
           payeeName: row.payeeName,
           payeeId: row.payeeId,
           occurrences,
-          totalAmount: Math.round(totalAmount * 100) / 100,
-          averageAmount: Math.round((totalAmount / occurrences) * 100) / 100,
+          totalAmount: roundMoney(totalAmount),
+          averageAmount: roundMoney(totalAmount / occurrences),
           lastTransactionDate: formatDateYMD(row.lastTransactionDate),
           frequency,
           categoryName: row.categoryName || "Uncategorized",
@@ -299,16 +297,13 @@ export class TaxRecurringReportsService {
       },
     );
 
-    const totalRecurring = data.reduce(
-      (sum, item) => sum + item.totalAmount,
-      0,
-    );
+    const totalRecurring = sumMoney(data.map((item) => item.totalAmount));
 
     return {
       data,
       summary: {
-        totalRecurring: Math.round(totalRecurring * 100) / 100,
-        monthlyEstimate: Math.round((totalRecurring / 6) * 100) / 100,
+        totalRecurring: roundMoney(totalRecurring),
+        monthlyEstimate: roundMoney(totalRecurring / 6),
         uniquePayees: data.length,
       },
     };
@@ -457,7 +452,7 @@ export class TaxRecurringReportsService {
     const billPayments: BillPaymentItem[] = Array.from(billPaymentMap.values())
       .filter((bp) => bp.payments.length > 0)
       .map((bp) => {
-        const totalPaid = bp.payments.reduce((sum, p) => sum + p.amount, 0);
+        const totalPaid = sumMoney(bp.payments.map((p) => p.amount));
         const sortedPayments = [...bp.payments].sort(
           (a, b) => b.date.getTime() - a.date.getTime(),
         );
@@ -465,10 +460,9 @@ export class TaxRecurringReportsService {
           scheduledTransactionId: bp.id,
           scheduledTransactionName: bp.name,
           payeeName: bp.payeeName,
-          totalPaid: Math.round(totalPaid * 100) / 100,
+          totalPaid: roundMoney(totalPaid),
           paymentCount: bp.payments.length,
-          averagePayment:
-            Math.round((totalPaid / bp.payments.length) * 100) / 100,
+          averagePayment: roundMoney(totalPaid / bp.payments.length),
           lastPaymentDate: sortedPayments[0]
             ? formatDateYMD(sortedPayments[0].date)
             : null,
@@ -500,11 +494,11 @@ export class TaxRecurringReportsService {
       .map(([month, data]) => ({
         month,
         label: data.label,
-        total: Math.round(data.total * 100) / 100,
+        total: roundMoney(data.total),
       }))
       .sort((a, b) => a.month.localeCompare(b.month));
 
-    const totalPaid = billPayments.reduce((sum, bp) => sum + bp.totalPaid, 0);
+    const totalPaid = sumMoney(billPayments.map((bp) => bp.totalPaid));
     const totalPayments = billPayments.reduce(
       (sum, bp) => sum + bp.paymentCount,
       0,
@@ -515,10 +509,10 @@ export class TaxRecurringReportsService {
       billPayments,
       monthlyTotals,
       summary: {
-        totalPaid: Math.round(totalPaid * 100) / 100,
+        totalPaid: roundMoney(totalPaid),
         totalPayments,
         uniqueBills: billPayments.length,
-        monthlyAverage: Math.round((totalPaid / monthCount) * 100) / 100,
+        monthlyAverage: roundMoney(totalPaid / monthCount),
       },
     };
   }

--- a/backend/src/common/round.util.spec.ts
+++ b/backend/src/common/round.util.spec.ts
@@ -81,6 +81,25 @@ describe("roundToDecimals", () => {
       expect(roundToDecimals(1.2345, 3)).toBe(1.235);
       expect(roundToDecimals(1.2344, 3)).toBe(1.234);
     });
+
+    it("handles tiny magnitudes that stringify in exponential notation", () => {
+      // toString() would give "1e-7", and "1e-7e8" parses to NaN; the
+      // exponential decomposition handles it.
+      expect(roundToDecimals(1e-7, 8)).toBe(1e-7);
+      expect(roundToDecimals(1.2345e-5, 8)).toBe(0.00001235);
+      expect(roundToDecimals(8e-7, 6)).toBe(0.000001);
+      expect(roundToDecimals(-1e-7, 8)).toBe(-1e-7);
+    });
+
+    it("rounds tiny magnitudes to zero at coarser precision", () => {
+      expect(roundToDecimals(1e-7, 4)).toBe(0);
+      expect(roundToDecimals(8e-7, 4)).toBe(0);
+    });
+
+    it("handles zero without producing -0 or NaN", () => {
+      expect(roundToDecimals(0, 4)).toBe(0);
+      expect(Object.is(roundToDecimals(0, 4), 0)).toBe(true);
+    });
   });
 });
 

--- a/backend/src/common/round.util.spec.ts
+++ b/backend/src/common/round.util.spec.ts
@@ -1,4 +1,4 @@
-import { roundToDecimals } from "./round.util";
+import { roundToDecimals, roundMoney, sumMoney } from "./round.util";
 
 describe("roundToDecimals", () => {
   describe("basic rounding", () => {
@@ -81,5 +81,54 @@ describe("roundToDecimals", () => {
       expect(roundToDecimals(1.2345, 3)).toBe(1.235);
       expect(roundToDecimals(1.2344, 3)).toBe(1.234);
     });
+  });
+});
+
+describe("roundMoney", () => {
+  it("rounds to 4 decimal places (storage precision)", () => {
+    expect(roundMoney(1.23456)).toBe(1.2346);
+    expect(roundMoney(1.23454)).toBe(1.2345);
+    expect(roundMoney(1000)).toBe(1000);
+    expect(roundMoney(17.99)).toBe(17.99);
+  });
+
+  it("preserves sub-cent precision that 2dp rounding would lose", () => {
+    expect(roundMoney(1234.5678)).toBe(1234.5678);
+    expect(roundMoney(0.0001)).toBe(0.0001);
+  });
+
+  it("rounds half away from zero, fixing IEEE 754 midpoints", () => {
+    // 10 * 1.59735 = 15.9735 mathematically; naive *10000 would drop the digit
+    expect(roundMoney(1.23455)).toBe(1.2346);
+    expect(roundMoney(-1.23455)).toBe(-1.2346);
+  });
+
+  it("passes through non-finite values", () => {
+    expect(roundMoney(Infinity)).toBe(Infinity);
+    expect(roundMoney(NaN)).toBeNaN();
+  });
+});
+
+describe("sumMoney", () => {
+  it("sums without floating-point drift", () => {
+    expect(sumMoney([0.1, 0.2])).toBe(0.3);
+    expect(sumMoney([10.0001, 20.0002])).toBe(30.0003);
+  });
+
+  it("returns 0 for an empty array", () => {
+    expect(sumMoney([])).toBe(0);
+  });
+
+  it("matches a careful reduce over many sub-cent values", () => {
+    const values = Array.from({ length: 1000 }, () => 0.0001);
+    expect(sumMoney(values)).toBe(0.1);
+  });
+
+  it("handles negative values", () => {
+    expect(sumMoney([100, -33.33, -33.33, -33.34])).toBe(0);
+  });
+
+  it("ignores non-finite entries", () => {
+    expect(sumMoney([1.5, NaN, 2.5, Infinity])).toBe(4);
   });
 });

--- a/backend/src/common/round.util.ts
+++ b/backend/src/common/round.util.ts
@@ -15,23 +15,32 @@
  * IEEE 754 but should round as 159.735 -> 159.74). The nudge is smaller
  * than any legitimate distance from a midpoint in financial arithmetic.
  *
+ * The shift is performed via `toExponential()` (which always yields a
+ * `d.ddde±N` form, parseable and exponent-shiftable) rather than `toString()`
+ * concatenation. `toString()` switches to exponential notation for magnitudes
+ * below 1e-6, producing un-parseable strings like "1e-7e4" that evaluate to
+ * NaN; decomposing the exponential form avoids that for any decimalPlaces
+ * (e.g. share quantities rounded at 8dp).
+ *
  * Examples:
  *   roundToDecimals(159.735, 2)       => 159.74   (not 159.73)
  *   roundToDecimals(10 * 15.9735, 2)  => 159.74   (not 159.73)
  *   roundToDecimals(-159.735, 2)      => -159.74  (not -159.73)
  *   roundToDecimals(1.005, 2)         => 1.01     (not 1.00)
+ *   roundToDecimals(1e-7, 8)          => 1e-7     (not NaN)
  */
 export function roundToDecimals(value: number, decimalPlaces: number): number {
   if (!isFinite(value)) return value;
+  if (value === 0) return 0;
   const sign = value < 0 ? -1 : 1;
   const abs = Math.abs(value);
   const nudged = abs + Number.EPSILON * abs;
-  return (
-    sign *
-    Number(
-      Math.round(Number(nudged + "e" + decimalPlaces)) + "e-" + decimalPlaces,
-    )
-  );
+  // Decompose into mantissa/exponent so the decimal-point shift works
+  // regardless of whether the value would stringify in exponential notation.
+  const [mantissa, exp] = nudged.toExponential().split("e");
+  const shiftedExp = Number(exp) + decimalPlaces;
+  const rounded = Math.round(Number(mantissa + "e" + shiftedExp));
+  return sign * Number(rounded + "e-" + decimalPlaces);
 }
 
 /**
@@ -75,4 +84,3 @@ export function sumMoney(values: number[]): number {
   }, 0);
   return totalUnits / scale;
 }
-

--- a/backend/src/common/round.util.ts
+++ b/backend/src/common/round.util.ts
@@ -33,3 +33,46 @@ export function roundToDecimals(value: number, decimalPlaces: number): number {
     )
   );
 }
+
+/**
+ * Number of decimal places money is stored at in PostgreSQL (`decimal(20,4)`).
+ * All monetary aggregation in JS rounds to this precision so derived totals
+ * stay consistent with the ledger; values are only rounded to a currency's
+ * display precision (typically 2dp) at the formatting layer.
+ */
+export const MONEY_DECIMALS = 4;
+
+/**
+ * Round a monetary value to the canonical storage precision (4 decimals).
+ *
+ * This is the single helper every service should use for money rounding,
+ * replacing the various ad-hoc `Math.round(x * 100) / 100` (2dp) and
+ * `Math.round(x * 10000) / 10000` (4dp) snippets that previously diverged
+ * across the codebase. Built on `roundToDecimals`, so it also fixes the
+ * IEEE 754 midpoint errors those naive snippets had.
+ */
+export function roundMoney(value: number): number {
+  return roundToDecimals(value, MONEY_DECIMALS);
+}
+
+/**
+ * Sum an array of monetary values without floating-point drift by accumulating
+ * in integer "ten-thousandths" (the 4dp storage unit) and converting back.
+ *
+ * Prefer this over `values.reduce((s, v) => s + v, 0)` for money: naive float
+ * accumulation lets sub-cent errors compound across many rows. Non-finite
+ * entries (NaN/Infinity) contribute 0.
+ *
+ * Examples:
+ *   sumMoney([0.1, 0.2])            => 0.3      (not 0.30000000000000004)
+ *   sumMoney([10.0001, 20.0002])   => 30.0003
+ */
+export function sumMoney(values: number[]): number {
+  const scale = 10 ** MONEY_DECIMALS;
+  const totalUnits = values.reduce((sum, v) => {
+    if (!isFinite(v)) return sum;
+    return sum + Math.round(v * scale);
+  }, 0);
+  return totalUnits / scale;
+}
+

--- a/backend/src/investment-reports/investment-report-data.service.ts
+++ b/backend/src/investment-reports/investment-report-data.service.ts
@@ -10,6 +10,7 @@ import {
 import { Account } from "../accounts/entities/account.entity";
 import { ExchangeRateService } from "../currencies/exchange-rate.service";
 import { InvestmentCellValue } from "./dto/execute-investment-report.dto";
+import { roundToDecimals, sumMoney } from "../common/round.util";
 import { todayYMD } from "../common/date-utils";
 
 /** One computed holding row plus the fields needed to group it. */
@@ -52,11 +53,6 @@ interface GroupRecord {
   securityId: string;
   txs: InvestmentTransaction[];
   state: ReplayState;
-}
-
-function round(value: number, dp = 4): number {
-  const f = Math.pow(10, dp);
-  return Math.round(value * f) / f;
 }
 
 function isoAddDays(iso: string, days: number): string {
@@ -192,14 +188,26 @@ export class InvestmentReportDataService {
     const holdings = await this.holdingsRepository.find({
       where: { accountId: In(accountIds) },
     });
-    const holdingsMap = new Map<string, { quantity: number; averageCost: number }>();
+    const holdingsMap = new Map<
+      string,
+      { quantity: number; averageCost: number }
+    >();
     // Summed across accounts per security, for the merged (cross-account) view.
-    const summedHoldings = new Map<string, { quantity: number; costBasis: number }>();
+    const summedHoldings = new Map<
+      string,
+      { quantity: number; costBasis: number }
+    >();
     for (const h of holdings) {
       const quantity = Number(h.quantity) || 0;
       const averageCost = Number(h.averageCost) || 0;
-      holdingsMap.set(`${h.accountId}:${h.securityId}`, { quantity, averageCost });
-      const summed = summedHoldings.get(h.securityId) ?? { quantity: 0, costBasis: 0 };
+      holdingsMap.set(`${h.accountId}:${h.securityId}`, {
+        quantity,
+        averageCost,
+      });
+      const summed = summedHoldings.get(h.securityId) ?? {
+        quantity: 0,
+        costBasis: 0,
+      };
       summed.quantity += quantity;
       summed.costBasis += quantity * averageCost;
       summedHoldings.set(h.securityId, summed);
@@ -258,8 +266,8 @@ export class InvestmentReportDataService {
       const lastPrice = asOfRow ? asOfRow.close : null;
       const previousClose = prevRow ? prevRow.close : null;
 
-      let quantity = round(group.state.quantity, 8);
-      let costBasis = round(group.state.costBasis, 4);
+      let quantity = roundToDecimals(group.state.quantity, 8);
+      let costBasis = roundToDecimals(group.state.costBasis, 4);
 
       // When no transactions occur after the as-of date, the maintained
       // holdings table is the authoritative snapshot of this position. Defer to
@@ -273,43 +281,50 @@ export class InvestmentReportDataService {
         if (mergeAccounts) {
           const current = summedHoldings.get(group.securityId);
           if (!current || Math.abs(current.quantity) < 0.0001) continue;
-          quantity = round(current.quantity, 8);
-          costBasis = round(current.costBasis, 4);
+          quantity = roundToDecimals(current.quantity, 8);
+          costBasis = roundToDecimals(current.costBasis, 4);
         } else {
-          const current = holdingsMap.get(`${group.accountId}:${group.securityId}`);
+          const current = holdingsMap.get(
+            `${group.accountId}:${group.securityId}`,
+          );
           if (!current || Math.abs(current.quantity) < 0.0001) continue;
-          quantity = round(current.quantity, 8);
-          costBasis = round(current.quantity * current.averageCost, 4);
+          quantity = roundToDecimals(current.quantity, 8);
+          costBasis = roundToDecimals(
+            current.quantity * current.averageCost,
+            4,
+          );
         }
       } else if (Math.abs(quantity) < 0.0001) {
         continue;
       }
 
       const averageCost =
-        quantity !== 0 ? round(costBasis / quantity, 6) : null;
+        quantity !== 0 ? roundToDecimals(costBasis / quantity, 6) : null;
       const marketValue =
-        lastPrice !== null ? round(quantity * lastPrice, 4) : null;
-      const income = round(group.state.income, 4);
+        lastPrice !== null ? roundToDecimals(quantity * lastPrice, 4) : null;
+      const income = roundToDecimals(group.state.income, 4);
       const gain =
         marketValue !== null
-          ? round(marketValue + income - costBasis, 4)
+          ? roundToDecimals(marketValue + income - costBasis, 4)
           : null;
       const priceAppreciation =
-        marketValue !== null ? round(marketValue - costBasis, 4) : null;
+        marketValue !== null
+          ? roundToDecimals(marketValue - costBasis, 4)
+          : null;
       const gainPercent =
         gain !== null && costBasis > 0
-          ? round((gain / costBasis) * 100, 4)
+          ? roundToDecimals((gain / costBasis) * 100, 4)
           : null;
       const change =
         lastPrice !== null && previousClose !== null
-          ? round(lastPrice - previousClose, 6)
+          ? roundToDecimals(lastPrice - previousClose, 6)
           : null;
       const changePercent =
         change !== null && previousClose
-          ? round((change / previousClose) * 100, 4)
+          ? roundToDecimals((change / previousClose) * 100, 4)
           : null;
       const todaysTotalChange =
-        change !== null ? round(change * quantity, 4) : null;
+        change !== null ? roundToDecimals(change * quantity, 4) : null;
 
       const fxRate = await this.fxRate(
         security.currencyCode,
@@ -350,12 +365,12 @@ export class InvestmentReportDataService {
         volume: asOfRow?.volume ?? null,
         lastTransactionDate: group.state.lastTransactionDate,
         income,
-        commissions: round(group.state.commissions, 4),
-        purchases: round(group.state.purchases, 4),
-        sales: round(group.state.sales, 4),
-        reinvestments: round(group.state.reinvestments, 4),
-        realizedGains: round(group.state.realizedGains, 4),
-        exchangeRate: round(fxRate, 6),
+        commissions: roundToDecimals(group.state.commissions, 4),
+        purchases: roundToDecimals(group.state.purchases, 4),
+        sales: roundToDecimals(group.state.sales, 4),
+        reinvestments: roundToDecimals(group.state.reinvestments, 4),
+        realizedGains: roundToDecimals(group.state.realizedGains, 4),
+        exchangeRate: roundToDecimals(fxRate, 6),
         lastUpdated: asOfRow?.date ?? null,
         fiftyTwoWeekHigh: high52,
         fiftyTwoWeekLow: low52,
@@ -385,13 +400,10 @@ export class InvestmentReportDataService {
     }
 
     // Second pass: % of portfolio against total (base-currency) market value.
-    const totalBase = computed.reduce(
-      (sum, c) => sum + (c.marketValueBase ?? 0),
-      0,
-    );
+    const totalBase = sumMoney(computed.map((c) => c.marketValueBase ?? 0));
     for (const c of computed) {
       if (c.marketValueBase !== null && totalBase > 0) {
-        c.holding.values.portfolioPercent = round(
+        c.holding.values.portfolioPercent = roundToDecimals(
           (c.marketValueBase / totalBase) * 100,
           4,
         );
@@ -521,7 +533,9 @@ export class InvestmentReportDataService {
         if (a.transactionDate !== b.transactionDate) {
           return a.transactionDate < b.transactionDate ? -1 : 1;
         }
-        return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+        return (
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+        );
       });
       for (const tx of m.txs) {
         if (tx.transactionDate <= asOfDate) this.applyToState(m.state, tx);
@@ -643,8 +657,8 @@ export class InvestmentReportDataService {
       if (low === null || l < low) low = l;
     }
     return {
-      high: high === null ? null : round(high, 6),
-      low: low === null ? null : round(low, 6),
+      high: high === null ? null : roundToDecimals(high, 6),
+      low: low === null ? null : roundToDecimals(low, 6),
     };
   }
 
@@ -728,7 +742,7 @@ export class InvestmentReportDataService {
       const beginValue = beginQty * beginPrice;
       if (beginValue <= 0) continue;
       const income = this.incomeBetween(group, start, asOfDate);
-      result[key] = round(
+      result[key] = roundToDecimals(
         ((marketValue + income - beginValue) / beginValue) * 100,
         4,
       );
@@ -739,7 +753,7 @@ export class InvestmentReportDataService {
       const allIncome = group.state.income;
       const allDates =
         ((marketValue + allIncome - costBasis) / costBasis) * 100;
-      result.totalReturnAllDates = round(allDates, 4);
+      result.totalReturnAllDates = roundToDecimals(allDates, 4);
 
       const firstDate = group.txs[0]?.transactionDate;
       if (firstDate) {
@@ -750,7 +764,7 @@ export class InvestmentReportDataService {
           const growth = 1 + allDates / 100;
           result.totalAnnualizedReturn =
             growth > 0
-              ? round((Math.pow(growth, 1 / years) - 1) * 100, 4)
+              ? roundToDecimals((Math.pow(growth, 1 / years) - 1) * 100, 4)
               : -100;
         }
       }

--- a/backend/src/monte-carlo/monte-carlo-simulation.service.ts
+++ b/backend/src/monte-carlo/monte-carlo-simulation.service.ts
@@ -6,6 +6,7 @@ import {
   SimulationPercentiles,
   SimulationResult,
 } from "./dto/simulation-result.dto";
+import { roundMoney } from "../common/round.util";
 
 export interface CashFlowSpec {
   /** Signed amount: positive = income, negative = expense. */
@@ -356,13 +357,15 @@ export class MonteCarloSimulationService {
       variance += d * d;
     }
     variance /= n;
+    const stdev = Math.sqrt(variance);
 
     return {
-      min: this.round(min),
-      max: this.round(max),
-      mean: this.round(mean),
-      median: this.round(this.quantile(sorted, 0.5)),
-      stdev: this.round(Math.sqrt(variance)),
+      min: roundMoney(min),
+      max: roundMoney(max),
+      mean: roundMoney(mean),
+      median: roundMoney(this.quantile(sorted, 0.5)),
+      // Float-noise residue (e.g. a "zero volatility" run) rounds cleanly to 0.
+      stdev: roundMoney(stdev),
       depletionRate: depleted / n,
     };
   }
@@ -372,12 +375,8 @@ export class MonteCarloSimulationService {
     const pos = (sorted.length - 1) * q;
     const lo = Math.floor(pos);
     const hi = Math.ceil(pos);
-    if (lo === hi) return this.round(sorted[lo]);
-    return this.round(sorted[lo] + (sorted[hi] - sorted[lo]) * (pos - lo));
-  }
-
-  private round(v: number): number {
-    return Math.round(v * 10000) / 10000;
+    if (lo === hi) return roundMoney(sorted[lo]);
+    return roundMoney(sorted[lo] + (sorted[hi] - sorted[lo]) * (pos - lo));
   }
 
   private makeYearLabels(totalYears: number): string[] {

--- a/backend/src/monte-carlo/monte-carlo.service.ts
+++ b/backend/src/monte-carlo/monte-carlo.service.ts
@@ -23,6 +23,7 @@ import { Holding } from "../securities/entities/holding.entity";
 import { Security } from "../securities/entities/security.entity";
 import { SecurityPrice } from "../securities/entities/security-price.entity";
 import { Account } from "../accounts/entities/account.entity";
+import { roundMoney } from "../common/round.util";
 
 export interface HistoricalStats {
   /** Number of full calendar years of data used to compute the stats. */
@@ -503,10 +504,7 @@ export class MonteCarloService {
         name: h.security?.name ?? "Unknown",
         currencyCode: h.security?.currencyCode ?? "USD",
         quantity: Number(h.quantity),
-        marketValue:
-          price == null
-            ? 0
-            : Math.round(Number(h.quantity) * price * 100) / 100,
+        marketValue: price == null ? 0 : roundMoney(Number(h.quantity) * price),
         yearsObserved: series.length,
         meanReturn: stats.mean,
         volatility: stats.stdev,
@@ -650,7 +648,7 @@ export class MonteCarloService {
       // with more than 4 decimals fail the DTO's @IsNumber maxDecimalPlaces
       // check. Clamp non-finite values to 0 and round to 4 decimal places.
       if (!Number.isFinite(value)) return 0;
-      return Math.round(value * 10000) / 10000;
+      return roundMoney(value);
     } catch (err) {
       this.logger.warn(
         `Failed to compute current portfolio value for accounts ${accountIds.join(",")}: ${

--- a/backend/src/reports/reports.service.spec.ts
+++ b/backend/src/reports/reports.service.spec.ts
@@ -2190,7 +2190,7 @@ describe("ReportsService", () => {
         expect(result.data[0].label).toBe("Transaction");
       });
 
-      it("rounds metric values to 2 decimal places", async () => {
+      it("rounds metric values to 4 decimal places (storage precision)", async () => {
         const transactions = [
           createMockTransaction({ id: "tx-1", amount: -33.33 }),
           createMockTransaction({ id: "tx-2", amount: -33.33 }),
@@ -2207,10 +2207,11 @@ describe("ReportsService", () => {
         const result = await service.execute("user-1", "report-1");
 
         // Average of 33.33, 33.33, 33.34 = 33.3333...
-        // Should be rounded to 2 decimal places
+        // Rounded to 4 decimal places (storage precision); display layer trims to 2
         const value = result.data[0].value;
+        expect(value).toBe(33.3333);
         const decimals = value.toString().split(".")[1] || "";
-        expect(decimals.length).toBeLessThanOrEqual(2);
+        expect(decimals.length).toBeLessThanOrEqual(4);
       });
 
       it("does not fetch categories or payees when groupBy is NONE", async () => {
@@ -2963,9 +2964,9 @@ describe("ReportsService", () => {
 
         const result = await service.execute("user-1", "report-1");
 
-        // Value should be rounded to 2 decimal places
+        // Value should be rounded to 4 decimal places (storage precision)
         expect(result.data).toHaveLength(1);
-        expect(result.data[0].value).toBe(75.56);
+        expect(result.data[0].value).toBe(75.555);
       });
     });
 

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -27,6 +27,7 @@ import {
   AggregatedDataPoint,
   ReportSummary,
 } from "./dto/execute-report.dto";
+import { roundMoney, sumMoney } from "../common/round.util";
 import { BudgetsService } from "../budgets/budgets.service";
 import { ActionHistoryService } from "../action-history/action-history.service";
 import {
@@ -637,20 +638,20 @@ export class ReportsService {
     }
 
     // For other metrics, aggregate into a single total
-    let sum = 0;
-    let count = 0;
+    const amounts: number[] = [];
 
     for (const tx of transactions) {
       if (tx.isSplit && tx.splits && tx.splits.length > 0) {
         for (const split of tx.splits) {
-          sum += Math.abs(Number(split.amount));
-          count += 1;
+          amounts.push(Math.abs(Number(split.amount)));
         }
       } else {
-        sum += Math.abs(Number(tx.amount));
-        count += 1;
+        amounts.push(Math.abs(Number(tx.amount)));
       }
     }
+
+    const count = amounts.length;
+    const sum = sumMoney(amounts);
 
     if (count === 0) {
       return [];
@@ -680,7 +681,9 @@ export class ReportsService {
         for (const split of tx.splits) {
           const categoryId = split.categoryId || "uncategorized";
           const existing = dataMap.get(categoryId) || { sum: 0, count: 0 };
-          existing.sum += Math.abs(Number(split.amount));
+          existing.sum = roundMoney(
+            existing.sum + Math.abs(Number(split.amount)),
+          );
           existing.count += 1;
           dataMap.set(categoryId, existing);
         }
@@ -688,16 +691,13 @@ export class ReportsService {
         // Regular transaction
         const categoryId = tx.categoryId || "uncategorized";
         const existing = dataMap.get(categoryId) || { sum: 0, count: 0 };
-        existing.sum += Math.abs(Number(tx.amount));
+        existing.sum = roundMoney(existing.sum + Math.abs(Number(tx.amount)));
         existing.count += 1;
         dataMap.set(categoryId, existing);
       }
     }
 
-    const totalSum = Array.from(dataMap.values()).reduce(
-      (acc, v) => acc + v.sum,
-      0,
-    );
+    const totalSum = sumMoney(Array.from(dataMap.values()).map((v) => v.sum));
 
     const result: AggregatedDataPoint[] = [];
     for (const [categoryId, data] of dataMap) {
@@ -732,7 +732,7 @@ export class ReportsService {
         count: 0,
         payeeName: tx.payeeName ?? undefined,
       };
-      existing.sum += Math.abs(Number(tx.amount));
+      existing.sum = roundMoney(existing.sum + Math.abs(Number(tx.amount)));
       existing.count += 1;
       if (!existing.payeeName && tx.payeeName) {
         existing.payeeName = tx.payeeName;
@@ -740,10 +740,7 @@ export class ReportsService {
       dataMap.set(payeeId, existing);
     }
 
-    const totalSum = Array.from(dataMap.values()).reduce(
-      (acc, v) => acc + v.sum,
-      0,
-    );
+    const totalSum = sumMoney(Array.from(dataMap.values()).map((v) => v.sum));
 
     const result: AggregatedDataPoint[] = [];
     for (const [payeeId, data] of dataMap) {
@@ -791,7 +788,7 @@ export class ReportsService {
           count: 0,
           tagName: "Untagged",
         };
-        existing.sum += Math.abs(Number(tx.amount));
+        existing.sum = roundMoney(existing.sum + Math.abs(Number(tx.amount)));
         existing.count += 1;
         dataMap.set("untagged", existing);
       } else {
@@ -802,17 +799,14 @@ export class ReportsService {
             tagName: tag.name,
             color: tag.color ?? undefined,
           };
-          existing.sum += Math.abs(Number(tx.amount));
+          existing.sum = roundMoney(existing.sum + Math.abs(Number(tx.amount)));
           existing.count += 1;
           dataMap.set(tag.id, existing);
         }
       }
     }
 
-    const totalSum = Array.from(dataMap.values()).reduce(
-      (acc, v) => acc + v.sum,
-      0,
-    );
+    const totalSum = sumMoney(Array.from(dataMap.values()).map((v) => v.sum));
 
     const result: AggregatedDataPoint[] = [];
     for (const [tagId, data] of dataMap) {
@@ -864,7 +858,7 @@ export class ReportsService {
       }
 
       const existing = dataMap.get(key) || { sum: 0, count: 0, label };
-      existing.sum += Math.abs(Number(tx.amount));
+      existing.sum = roundMoney(existing.sum + Math.abs(Number(tx.amount)));
       existing.count += 1;
       dataMap.set(key, existing);
     }
@@ -890,16 +884,16 @@ export class ReportsService {
   ): number {
     switch (metric) {
       case MetricType.NONE:
-        return Math.round(sum * 100) / 100;
+        return roundMoney(sum);
       case MetricType.TOTAL_AMOUNT:
-        return Math.round(sum * 100) / 100;
+        return roundMoney(sum);
       case MetricType.COUNT:
         return count;
       case MetricType.AVERAGE:
-        return count > 0 ? Math.round((sum / count) * 100) / 100 : 0;
+        return count > 0 ? roundMoney(sum / count) : 0;
       case MetricType.BUDGET_VARIANCE:
         // For budget variance, sum contains the variance (actual - budgeted)
-        return Math.round(sum * 100) / 100;
+        return roundMoney(sum);
       default:
         return sum;
     }
@@ -927,9 +921,9 @@ export class ReportsService {
         const variance = point.value - budgeted;
         return {
           ...point,
-          value: Math.round(variance * 100) / 100,
-          budgeted: Math.round(budgeted * 100) / 100,
-          actual: Math.round(point.value * 100) / 100,
+          value: roundMoney(variance),
+          budgeted: roundMoney(budgeted),
+          actual: roundMoney(point.value),
         };
       });
     } catch {
@@ -938,14 +932,14 @@ export class ReportsService {
   }
 
   private calculateSummary(data: AggregatedDataPoint[]): ReportSummary {
-    const total = data.reduce((acc, d) => acc + d.value, 0);
+    const total = sumMoney(data.map((d) => d.value));
     const count = data.reduce((acc, d) => acc + (d.count || 1), 0);
     const average = count > 0 ? total / count : 0;
 
     return {
-      total: Math.round(total * 100) / 100,
+      total: roundMoney(total),
       count,
-      average: Math.round(average * 100) / 100,
+      average: roundMoney(average),
     };
   }
 

--- a/backend/src/scheduled-transactions/scheduled-transaction-loan.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transaction-loan.service.ts
@@ -11,6 +11,7 @@ import {
   MortgagePaymentFrequency,
 } from "../accounts/mortgage-amortization.util";
 import { getPeriodsPerYear } from "../accounts/loan-amortization.util";
+import { roundMoney } from "../common/round.util";
 
 @Injectable()
 export class ScheduledTransactionLoanService {
@@ -127,8 +128,8 @@ export class ScheduledTransactionLoanService {
 
       const totalPrevPrincipal = prevPrincipal + extraPrincipalAmount;
       newInterest = prevInterest - totalPrevPrincipal * periodicRate;
-      newInterest = Math.max(0, Math.round(newInterest * 100) / 100);
-      newPrincipal = Math.round((basePaymentAmount - newInterest) * 100) / 100;
+      newInterest = Math.max(0, roundMoney(newInterest));
+      newPrincipal = roundMoney(basePaymentAmount - newInterest);
 
       if (newPrincipal < 0) {
         newPrincipal = 0;
@@ -150,8 +151,8 @@ export class ScheduledTransactionLoanService {
             )
           : interestRate / 100 / periodsPerYear;
 
-      newInterest = Math.round(currentBalance * periodicRate * 100) / 100;
-      newPrincipal = Math.round((basePaymentAmount - newInterest) * 100) / 100;
+      newInterest = roundMoney(currentBalance * periodicRate);
+      newPrincipal = roundMoney(basePaymentAmount - newInterest);
       if (newPrincipal < 0) newPrincipal = 0;
       if (newPrincipal > currentBalance) newPrincipal = currentBalance;
     }

--- a/backend/src/scheduled-transactions/scheduled-transaction-override.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transaction-override.service.ts
@@ -11,6 +11,7 @@ import {
   CreateScheduledTransactionOverrideDto,
   UpdateScheduledTransactionOverrideDto,
 } from "./dto/scheduled-transaction-override.dto";
+import { roundMoney, sumMoney } from "../common/round.util";
 
 @Injectable()
 export class ScheduledTransactionOverrideService {
@@ -224,12 +225,8 @@ export class ScheduledTransactionOverrideService {
       );
     }
 
-    const splitsSum = splits.reduce(
-      (sum, split) => sum + Number(split.amount),
-      0,
-    );
-    const roundedSum = Math.round(splitsSum * 10000) / 10000;
-    const roundedAmount = Math.round(Number(transactionAmount) * 10000) / 10000;
+    const roundedSum = sumMoney(splits.map((split) => Number(split.amount)));
+    const roundedAmount = roundMoney(Number(transactionAmount));
 
     if (roundedSum !== roundedAmount) {
       throw new BadRequestException(

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -44,6 +44,7 @@ import {
   ensureYMD,
 } from "../common/recurrence";
 import { ActionHistoryService } from "../action-history/action-history.service";
+import { roundMoney, sumMoney } from "../common/round.util";
 
 const INVESTMENT_RELATIONS = [
   "account",
@@ -444,12 +445,8 @@ export class ScheduledTransactionsService {
       );
     }
 
-    const splitsSum = splits.reduce(
-      (sum, split) => sum + Number(split.amount),
-      0,
-    );
-    const roundedSum = Math.round(splitsSum * 10000) / 10000;
-    const roundedAmount = Math.round(Number(transactionAmount) * 10000) / 10000;
+    const roundedSum = sumMoney(splits.map((split) => Number(split.amount)));
+    const roundedAmount = roundMoney(Number(transactionAmount));
 
     if (roundedSum !== roundedAmount) {
       throw new BadRequestException(

--- a/backend/src/securities/holdings.service.ts
+++ b/backend/src/securities/holdings.service.ts
@@ -10,6 +10,7 @@ import {
 import { Cron } from "@nestjs/schedule";
 import { InjectRepository } from "@nestjs/typeorm";
 import { todayInTimezone } from "../common/date-utils";
+import { sumMoney } from "../common/round.util";
 import {
   Repository,
   In,
@@ -374,9 +375,8 @@ export class HoldingsService {
     const summary = {
       totalHoldings: holdings.length,
       totalQuantity: holdings.reduce((sum, h) => sum + Number(h.quantity), 0),
-      totalCostBasis: holdings.reduce(
-        (sum, h) => sum + Number(h.quantity) * Number(h.averageCost || 0),
-        0,
+      totalCostBasis: sumMoney(
+        holdings.map((h) => Number(h.quantity) * Number(h.averageCost || 0)),
       ),
       holdings: holdings.map((h) => ({
         id: h.id,
@@ -696,7 +696,8 @@ export class HoldingsService {
     for (const [accountId, securities] of holdingsMap) {
       for (const [securityId, data] of securities) {
         if (Math.abs(data.quantity) > 0.00000001) {
-          const avgCost = data.quantity > 0 ? data.totalCost / data.quantity : 0;
+          const avgCost =
+            data.quantity > 0 ? data.totalCost / data.quantity : 0;
           holdingsToCreate.push(
             holdingsRepo.create({
               accountId,

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -29,7 +29,7 @@ import { SecurityPriceService } from "./security-price.service";
 import { NetWorthService } from "../net-worth/net-worth.service";
 import { ExchangeRateService } from "../currencies/exchange-rate.service";
 import { CurrenciesService } from "../currencies/currencies.service";
-import { roundToDecimals } from "../common/round.util";
+import { roundToDecimals, roundMoney, sumMoney } from "../common/round.util";
 import {
   Transaction,
   TransactionStatus,
@@ -818,8 +818,8 @@ export class InvestmentTransactionsService {
         return 0;
     }
 
-    // M13: Round to 4 decimal places to avoid floating-point drift
-    return roundToDecimals(result, 4);
+    // M13: Round to money storage precision (4dp) to avoid floating-point drift
+    return roundMoney(result);
   }
 
   private async processTransactionEffectsInTransaction(
@@ -1169,9 +1169,8 @@ export class InvestmentTransactionsService {
       Number(saved.price ?? 0),
       Number(saved.commission ?? 0),
     );
-    const newSplitAmount = roundToDecimals(
+    const newSplitAmount = roundMoney(
       cashImpactInSecurity * Number(saved.exchangeRate),
-      4,
     );
 
     const split = await queryRunner.manager.findOne(TransactionSplit, {
@@ -1199,13 +1198,13 @@ export class InvestmentTransactionsService {
     const siblingSplits = await queryRunner.manager.find(TransactionSplit, {
       where: { transactionId: split.transactionId },
     });
-    const newParentTotalCents = siblingSplits.reduce((sum, s) => {
-      const amt = s.id === splitId ? newSplitAmount : Number(s.amount);
-      return sum + Math.round(amt * 10000);
-    }, 0);
-    const newParentAmount = newParentTotalCents / 10000;
+    const newParentAmount = sumMoney(
+      siblingSplits.map((s) =>
+        s.id === splitId ? newSplitAmount : Number(s.amount),
+      ),
+    );
     const oldParentAmount = Number(parentTransaction.amount);
-    const delta = roundToDecimals(newParentAmount - oldParentAmount, 4);
+    const delta = roundMoney(newParentAmount - oldParentAmount);
 
     await queryRunner.manager.update(Transaction, parentTransaction.id, {
       amount: newParentAmount,
@@ -1565,7 +1564,6 @@ export class InvestmentTransactionsService {
     const groupBy: LlmCapitalGainsGroupBy = options.groupBy ?? "month";
 
     // Aggregate in integer 1e-4 units so sums stay free of float drift.
-    const round4 = (n: number): number => Math.round(n * 10000) / 10000;
     interface Bucket {
       month: string | null;
       accountName: string | null;
@@ -1655,11 +1653,11 @@ export class InvestmentTransactionsService {
         symbol: b.symbol,
         securityName: b.securityName,
         currency: b.currency ?? null,
-        startValue: round4(b.startValueScaled / 10000),
-        endValue: round4(b.endValueScaled / 10000),
-        realizedGain: round4(b.realizedScaled / 10000),
-        unrealizedGain: round4(b.unrealizedScaled / 10000),
-        totalCapitalGain: round4(b.totalScaled / 10000),
+        startValue: roundMoney(b.startValueScaled / 10000),
+        endValue: roundMoney(b.endValueScaled / 10000),
+        realizedGain: roundMoney(b.realizedScaled / 10000),
+        unrealizedGain: roundMoney(b.unrealizedScaled / 10000),
+        totalCapitalGain: roundMoney(b.totalScaled / 10000),
       }),
     );
     allEntries.sort((a, b) => {
@@ -1672,9 +1670,9 @@ export class InvestmentTransactionsService {
       startDate: options.startDate,
       endDate: options.endDate,
       totals: {
-        realizedGain: round4(totalsRealizedScaled / 10000),
-        unrealizedGain: round4(totalsUnrealizedScaled / 10000),
-        totalCapitalGain: round4(totalsCapitalScaled / 10000),
+        realizedGain: roundMoney(totalsRealizedScaled / 10000),
+        unrealizedGain: roundMoney(totalsUnrealizedScaled / 10000),
+        totalCapitalGain: roundMoney(totalsCapitalScaled / 10000),
       },
       groupedBy: groupBy,
       entries: allEntries.slice(0, MAX_ENTRIES),
@@ -2586,6 +2584,8 @@ export class InvestmentTransactionsService {
 
     const rows = await query.getMany();
 
+    // round4 here is reserved for per-share prices (4dp price precision);
+    // monetary amounts use the shared roundMoney, quantities use round8 (1e-8).
     const round4 = (n: number): number => Math.round(n * 10000) / 10000;
     const round8 = (n: number): number => Math.round(n * 1e8) / 1e8;
 
@@ -2620,8 +2620,8 @@ export class InvestmentTransactionsService {
           r.price !== null && r.price !== undefined
             ? round4(Number(r.price))
             : null,
-        commission: round4(Number(r.commission || 0)),
-        totalAmount: round4(Number(r.totalAmount)),
+        commission: roundMoney(Number(r.commission || 0)),
+        totalAmount: roundMoney(Number(r.totalAmount)),
         currency: r.account?.currencyCode ?? null,
         description: r.description ?? null,
       }));
@@ -2658,8 +2658,8 @@ export class InvestmentTransactionsService {
           key,
           transactionCount: b.count,
           totalQuantity: round8(b.quantityScaled / 1e8),
-          totalAmount: round4(b.amountScaled / 10000),
-          totalCommission: round4(b.commissionScaled / 10000),
+          totalAmount: roundMoney(b.amountScaled / 10000),
+          totalCommission: roundMoney(b.commissionScaled / 10000),
         }))
         .sort((a, b) =>
           options.groupBy === "date"
@@ -2670,8 +2670,8 @@ export class InvestmentTransactionsService {
 
     return {
       transactionCount: rows.length,
-      totalAmount: round4(totalAmountScaled / 10000),
-      totalCommission: round4(totalCommissionScaled / 10000),
+      totalAmount: roundMoney(totalAmountScaled / 10000),
+      totalCommission: roundMoney(totalCommissionScaled / 10000),
       totalQuantity: round8(totalQuantityScaled / 1e8),
       actionCounts,
       groupedBy: options.groupBy ?? null,
@@ -2722,18 +2722,23 @@ export class InvestmentTransactionsService {
         .length,
       totalSells: transactions.filter((t) => t.action === InvestmentAction.SELL)
         .length,
-      totalDividends: transactions
-        .filter((t) => t.action === InvestmentAction.DIVIDEND)
-        .reduce((sum, t) => sum + Number(t.totalAmount), 0),
-      totalInterest: transactions
-        .filter((t) => t.action === InvestmentAction.INTEREST)
-        .reduce((sum, t) => sum + Number(t.totalAmount), 0),
-      totalCapitalGains: transactions
-        .filter((t) => t.action === InvestmentAction.CAPITAL_GAIN)
-        .reduce((sum, t) => sum + Number(t.totalAmount), 0),
-      totalCommissions: transactions.reduce(
-        (sum, t) => sum + Number(t.commission || 0),
-        0,
+      totalDividends: sumMoney(
+        transactions
+          .filter((t) => t.action === InvestmentAction.DIVIDEND)
+          .map((t) => Number(t.totalAmount)),
+      ),
+      totalInterest: sumMoney(
+        transactions
+          .filter((t) => t.action === InvestmentAction.INTEREST)
+          .map((t) => Number(t.totalAmount)),
+      ),
+      totalCapitalGains: sumMoney(
+        transactions
+          .filter((t) => t.action === InvestmentAction.CAPITAL_GAIN)
+          .map((t) => Number(t.totalAmount)),
+      ),
+      totalCommissions: sumMoney(
+        transactions.map((t) => Number(t.commission || 0)),
       ),
     };
 

--- a/backend/src/securities/portfolio-calculation.service.ts
+++ b/backend/src/securities/portfolio-calculation.service.ts
@@ -14,6 +14,7 @@ import {
   AccountHoldings,
   AllocationItem,
 } from "./portfolio.service";
+import { roundMoney } from "../common/round.util";
 
 /**
  * Categorised investment accounts: brokerage, standalone, and cash accounts
@@ -79,10 +80,6 @@ export interface CapitalGainEntry {
   realizedGain: number;
   unrealizedGain: number;
   totalCapitalGain: number;
-}
-
-function roundMoney(value: number): number {
-  return Math.round(value * 10000) / 10000;
 }
 
 /**
@@ -311,7 +308,7 @@ export class PortfolioCalculationService {
     for (const account of accounts) {
       effectiveBalances.set(
         account.id,
-        Math.round(Number(account.currentBalance) * 10000) / 10000,
+        roundMoney(Number(account.currentBalance)),
       );
     }
     return effectiveBalances;
@@ -492,7 +489,7 @@ export class PortfolioCalculationService {
     }
 
     for (const [key, entry] of state) {
-      result.set(key, Math.round(entry.costBasis * 10000) / 10000);
+      result.set(key, roundMoney(entry.costBasis));
     }
 
     return result;
@@ -1107,7 +1104,7 @@ export class PortfolioCalculationService {
         totalMarketValue: accountMarketValue,
         totalGainLoss: accountGainLoss,
         totalGainLossPercent: accountGainLossPercent,
-        netInvested: Math.round(accountNetInvested * 100) / 100,
+        netInvested: roundMoney(accountNetInvested),
       });
     }
 
@@ -1159,7 +1156,7 @@ export class PortfolioCalculationService {
         totalMarketValue: accountMarketValue,
         totalGainLoss: accountGainLoss,
         totalGainLossPercent: accountGainLossPercent,
-        netInvested: Math.round(standaloneNetInvested * 100) / 100,
+        netInvested: roundMoney(standaloneNetInvested),
       });
     }
 

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -8,6 +8,7 @@ import { UserPreference } from "../users/entities/user-preference.entity";
 import { PortfolioCalculationService } from "./portfolio-calculation.service";
 import { YahooFinanceService } from "./yahoo-finance.service";
 import { QuoteProviderRegistry } from "./providers/quote-provider.registry";
+import { roundMoney } from "../common/round.util";
 import {
   IntradayInterval,
   IntradayPoint,
@@ -432,12 +433,10 @@ export class PortfolioService {
   ): Promise<LlmPortfolioSummary> {
     const summary = await this.getPortfolioSummary(userId, accountIds);
 
-    const roundMoney = (v: number | null | undefined): number =>
-      v === null || v === undefined ? 0 : Math.round(Number(v) * 10000) / 10000;
+    const roundMoneyValue = (v: number | null | undefined): number =>
+      v === null || v === undefined ? 0 : roundMoney(Number(v));
     const roundMoneyNullable = (v: number | null | undefined): number | null =>
-      v === null || v === undefined
-        ? null
-        : Math.round(Number(v) * 10000) / 10000;
+      v === null || v === undefined ? null : roundMoney(Number(v));
     const roundPct = (v: number | null | undefined): number | null =>
       v === null || v === undefined ? null : Math.round(Number(v) * 100) / 100;
 
@@ -448,7 +447,7 @@ export class PortfolioService {
       currency: h.currencyCode,
       quantity: h.quantity,
       averageCost: roundMoneyNullable(h.averageCost),
-      costBasis: roundMoney(h.costBasis),
+      costBasis: roundMoneyValue(h.costBasis),
       marketValue: roundMoneyNullable(h.marketValue),
       gainLoss: roundMoneyNullable(h.gainLoss),
       gainLossPercent: roundPct(h.gainLossPercent),
@@ -459,18 +458,18 @@ export class PortfolioService {
         name: a.name,
         symbol: a.symbol,
         type: a.type,
-        value: roundMoney(a.value),
+        value: roundMoneyValue(a.value),
         percentage: roundPct(a.percentage) ?? 0,
       }),
     );
 
     return {
       holdingCount: holdings.length,
-      totalCashValue: roundMoney(summary.totalCashValue),
-      totalHoldingsValue: roundMoney(summary.totalHoldingsValue),
-      totalCostBasis: roundMoney(summary.totalCostBasis),
-      totalPortfolioValue: roundMoney(summary.totalPortfolioValue),
-      totalGainLoss: roundMoney(summary.totalGainLoss),
+      totalCashValue: roundMoneyValue(summary.totalCashValue),
+      totalHoldingsValue: roundMoneyValue(summary.totalHoldingsValue),
+      totalCostBasis: roundMoneyValue(summary.totalCostBasis),
+      totalPortfolioValue: roundMoneyValue(summary.totalPortfolioValue),
+      totalGainLoss: roundMoneyValue(summary.totalGainLoss),
       totalGainLossPercent: roundPct(summary.totalGainLossPercent) ?? 0,
       timeWeightedReturn: roundPct(summary.timeWeightedReturn),
       cagr: roundPct(summary.cagr),

--- a/backend/src/securities/sector-weighting.service.ts
+++ b/backend/src/securities/sector-weighting.service.ts
@@ -7,6 +7,7 @@ import { Account, AccountType } from "../accounts/entities/account.entity";
 import { SecurityPrice } from "./entities/security-price.entity";
 import { YahooFinanceService } from "./yahoo-finance.service";
 import { PortfolioCalculationService } from "./portfolio-calculation.service";
+import { roundMoney, sumMoney } from "../common/round.util";
 
 export interface SectorWeightingItem {
   sector: string;
@@ -271,26 +272,27 @@ export class SectorWeightingService {
 
     // 6. Merge maps and compute percentages
     const allSectors = new Set([...directMap.keys(), ...etfMap.keys()]);
-    let totalDirectValue = 0;
-    let totalEtfValue = 0;
 
     const items: SectorWeightingItem[] = [];
     for (const sector of allSectors) {
       const dv = directMap.get(sector) || 0;
       const ev = etfMap.get(sector) || 0;
-      totalDirectValue += dv;
-      totalEtfValue += ev;
       items.push({
         sector,
-        directValue: Math.round(dv * 100) / 100,
-        etfValue: Math.round(ev * 100) / 100,
-        totalValue: Math.round((dv + ev) * 100) / 100,
+        directValue: roundMoney(dv),
+        etfValue: roundMoney(ev),
+        totalValue: roundMoney(dv + ev),
         percentage: 0, // computed below
       });
     }
 
-    const totalPortfolioValue =
-      totalDirectValue + totalEtfValue + unclassifiedValue;
+    const totalDirectValue = sumMoney([...directMap.values()]);
+    const totalEtfValue = sumMoney([...etfMap.values()]);
+    const totalPortfolioValue = sumMoney([
+      totalDirectValue,
+      totalEtfValue,
+      unclassifiedValue,
+    ]);
 
     // Compute percentages
     for (const item of items) {
@@ -305,10 +307,10 @@ export class SectorWeightingService {
 
     return {
       items,
-      totalPortfolioValue: Math.round(totalPortfolioValue * 100) / 100,
-      totalDirectValue: Math.round(totalDirectValue * 100) / 100,
-      totalEtfValue: Math.round(totalEtfValue * 100) / 100,
-      unclassifiedValue: Math.round(unclassifiedValue * 100) / 100,
+      totalPortfolioValue: roundMoney(totalPortfolioValue),
+      totalDirectValue: roundMoney(totalDirectValue),
+      totalEtfValue: roundMoney(totalEtfValue),
+      unclassifiedValue: roundMoney(unclassifiedValue),
     };
   }
 }

--- a/backend/src/transactions/transaction-analytics.service.spec.ts
+++ b/backend/src/transactions/transaction-analytics.service.spec.ts
@@ -1077,14 +1077,14 @@ describe("TransactionAnalyticsService", () => {
       ]);
     });
 
-    it("rounds totals to two decimal places", async () => {
+    it("rounds totals to storage precision (four decimal places)", async () => {
       mockQueryBuilder.getRawMany.mockResolvedValue([
         { month: "2025-01", total: "-123.456", count: "3" },
       ]);
 
       const result = await service.getMonthlyTotals(userId);
 
-      expect(result[0].total).toBe(-123.46);
+      expect(result[0].total).toBe(-123.456);
     });
 
     it("handles null values in raw query results", async () => {

--- a/backend/src/transactions/transaction-analytics.service.ts
+++ b/backend/src/transactions/transaction-analytics.service.ts
@@ -15,6 +15,7 @@ import {
   escapeLikePattern,
 } from "./transaction-search.util";
 import { RecurringCharge, detectFrequency } from "./recurring-charges.util";
+import { roundMoney, sumMoney } from "../common/round.util";
 
 export interface TransferAccountSummary {
   accountName: string;
@@ -114,14 +115,6 @@ export interface LlmPeriodComparisonResult {
   }>;
 }
 
-function sumMoney(values: number[]): number {
-  return values.reduce((sum, v) => sum + Math.round(v * 10000), 0) / 10000;
-}
-
-function roundMoney(value: number): number {
-  return Math.round(value * 100) / 100;
-}
-
 function sanitizeLikePattern(input: string | undefined): string | undefined {
   if (!input) return undefined;
   return input
@@ -183,10 +176,6 @@ export class TransactionAnalyticsService {
     }
 
     const rows = await qb.getRawMany();
-
-    const roundMoney = (v: number): number => Math.round(v * 10000) / 10000;
-    const sumMoney = (values: number[]): number =>
-      values.reduce((s, v) => s + Math.round(v * 10000), 0) / 10000;
 
     const accounts: TransferAccountSummary[] = rows.map((r) => {
       const inbound = roundMoney(Number(r.inbound) || 0);
@@ -613,7 +602,7 @@ export class TransactionAnalyticsService {
 
     return rows.map((row) => ({
       month: row.month,
-      total: Math.round((Number(row.total) || 0) * 100) / 100,
+      total: roundMoney(Number(row.total) || 0),
       count: Number(row.count) || 0,
     }));
   }

--- a/backend/src/transactions/transaction-split.service.ts
+++ b/backend/src/transactions/transaction-split.service.ts
@@ -21,6 +21,7 @@ import {
   isInvestmentActionAllowedInSplit,
 } from "../securities/cash-impact.util";
 import { NetWorthService } from "../net-worth/net-worth.service";
+import { roundMoney, sumMoney } from "../common/round.util";
 
 function inferSplitKind(split: CreateTransactionSplitDto): SplitKind {
   if (split.splitKind) return split.splitKind;
@@ -73,15 +74,12 @@ export class TransactionSplitService {
       );
     }
 
-    const splitsSumCents = splits.reduce(
-      (sum, split) => sum + Math.round(Number(split.amount) * 10000),
-      0,
-    );
-    const expectedSumCents = Math.round(Number(transactionAmount) * 10000);
+    const splitsSum = sumMoney(splits.map((split) => Number(split.amount)));
+    const expectedSum = roundMoney(Number(transactionAmount));
 
-    if (splitsSumCents !== expectedSumCents) {
+    if (splitsSum !== expectedSum) {
       throw new BadRequestException(
-        `Split amounts (${splitsSumCents / 10000}) must equal transaction amount (${expectedSumCents / 10000})`,
+        `Split amounts (${splitsSum}) must equal transaction amount (${expectedSum})`,
       );
     }
 
@@ -118,10 +116,10 @@ export class TransactionSplitService {
           : 1;
       const expectedAmount = cashImpactInSecurity * exchangeRate;
 
-      const expectedCents = Math.round(expectedAmount * 10000);
-      const actualCents = Math.round(Number(split.amount) * 10000);
+      const expectedRounded = roundMoney(expectedAmount);
+      const actualRounded = roundMoney(Number(split.amount));
 
-      if (expectedCents !== actualCents) {
+      if (expectedRounded !== actualRounded) {
         throw new BadRequestException(
           `Investment split amount (${split.amount}) does not match the cash impact ` +
             `of ${inv.action} ${inv.quantity ?? 0} @ ${inv.price ?? 0} ` +
@@ -550,20 +548,14 @@ export class TransactionSplitService {
     }
 
     const existingSplits = await this.getSplits(transaction.id);
-    const existingTotalCents = existingSplits.reduce(
-      (sum, s) => sum + Math.round(Number(s.amount) * 10000),
-      0,
-    );
-    const newTotalCents =
-      existingTotalCents + Math.round(Number(splitDto.amount) * 10000);
-    const transactionAmountCents = Math.round(
-      Number(transaction.amount) * 10000,
-    );
+    const existingTotal = sumMoney(existingSplits.map((s) => Number(s.amount)));
+    const newTotal = sumMoney([existingTotal, Number(splitDto.amount)]);
+    const transactionAmount = roundMoney(Number(transaction.amount));
 
-    if (Math.abs(newTotalCents) > Math.abs(transactionAmountCents)) {
+    if (Math.abs(newTotal) > Math.abs(transactionAmount)) {
       throw new BadRequestException(
         `Adding this split would exceed the transaction amount. ` +
-          `Current total: ${existingTotalCents / 10000}, New split: ${splitDto.amount}, ` +
+          `Current total: ${existingTotal}, New split: ${splitDto.amount}, ` +
           `Transaction amount: ${transaction.amount}`,
       );
     }

--- a/backend/src/transactions/transaction-transfer.service.ts
+++ b/backend/src/transactions/transaction-transfer.service.ts
@@ -16,6 +16,7 @@ import { NetWorthService } from "../net-worth/net-worth.service";
 import { isTransactionInFuture } from "../common/date-utils";
 import { ActionHistoryService } from "../action-history/action-history.service";
 import { formatCurrency } from "../common/format-currency.util";
+import { roundMoney } from "../common/round.util";
 
 export interface TransferResult {
   fromTransaction: Transaction;
@@ -82,8 +83,8 @@ export class TransactionTransferService {
 
     const toAmount =
       explicitToAmount !== undefined
-        ? Math.round(explicitToAmount * 10000) / 10000
-        : Math.round(amount * exchangeRate * 10000) / 10000;
+        ? roundMoney(explicitToAmount)
+        : roundMoney(amount * exchangeRate);
     const destinationCurrency = toCurrencyCode || fromCurrencyCode;
 
     const fromPayeeName = customPayeeName || `Transfer to ${toAccount.name}`;
@@ -456,8 +457,8 @@ export class TransactionTransferService {
       updateDto.exchangeRate ?? toTransaction.exchangeRate;
     const newToAmount =
       updateDto.toAmount !== undefined
-        ? Math.round(updateDto.toAmount * 10000) / 10000
-        : Math.round(newAmount * newExchangeRate * 10000) / 10000;
+        ? roundMoney(updateDto.toAmount)
+        : roundMoney(newAmount * newExchangeRate);
 
     const accountsOrAmountsChanged =
       updateDto.fromAccountId ||


### PR DESCRIPTION
## What & why

Implements audit finding **#1** (money rounding & summation consolidation) from `CODE_AUDIT_EFFICIENCY.md`. The backend previously reimplemented money rounding ~9 times with **three incompatible conventions** — 2dp `Math.round(x*100)/100`, 4dp `Math.round(x*10000)/10000`, and naive float `reduce()` sums — and the one careful helper (`roundToDecimals`) was barely used. This caused report/budget totals to drift from the 4-decimal (`decimal(20,4)`) ledger and left rounding without IEEE-754 midpoint protection.

This PR consolidates everything onto two shared helpers in `common/round.util.ts`:
- **`roundMoney(v)`** — rounds to the 4-decimal storage precision, built on the IEEE-754-safe `roundToDecimals`.
- **`sumMoney(values)`** — sums money in integer ten-thousandths (no float drift).

**Policy (confirmed with maintainer): all monetary aggregation rounds at 4dp; values are only rounded to a currency's display precision at the formatting layer (`format-currency.util`, unchanged).**

## Domains migrated
- **accounts** — `getLlmBalances` (was 2dp), loan/mortgage amortization utils, loan-payment-detector
- **budgets** — removed 4 duplicate `private round()` helpers; budgets/generator/trend/health/activity/alert/period totals and float reduces
- **built-in-reports + reports** — spending/income/comparison/tax/monthly/anomaly/data-quality + `reports.service` aggregation
- **securities + monte-carlo** — portfolio, portfolio-calculation, sector-weighting, investment-transactions (dividend/interest/gain/commission totals), holdings, monte-carlo distribution stats
- **transactions** — fixed the `transaction-analytics` self-contradiction (module-level `roundMoney` was 2dp while a shadowing local copy was 4dp), split-amount validation, transfer amounts
- **investment-reports** — `investment-report-data` replay rounding + portfolio total

## Bonus bug fix
`roundToDecimals` returned **`NaN`** for magnitudes below `1e-6` (whose `toString()` is exponential, producing un-parseable strings like `"1e-7e4"`). It now decomposes via `toExponential()`, so share quantities rounded at 8dp and other tiny values round correctly. Added regression tests.

## Behavioral note (please review)
Report/budget/LLM **JSON responses may now carry up to 4 decimals** where they previously carried 2 (e.g. an averaged category total `33.33` → `33.3333`). On-screen values are unchanged because the frontend formats to each currency's precision regardless. Affected unit specs were re-baselined to the corrected 4dp values.

## Intentionally left out of scope (non-money or other domains)
Percentages, interest rates, confidence scores, share quantities (8dp), per-share prices (4–6dp), exchange rates, cent-bucket grouping keys, and seed scripts were left at their existing precision. The `import/` (`import-entity-creator`, `ofx-parser`) and `ai/query/calculate-tool` money sites were left untouched — they're outside the audit's #1 enumeration and `import/` reconciliation behavior isn't covered by unit tests here; happy to do them as a follow-up.

## Testing
- **All 6976 backend unit tests pass** (`npx jest`). The only failures in the full run are the 6 integration suites that require a live PostgreSQL (`ECONNREFUSED`), unrelated to this change.
- Typecheck (`tsc --noEmit`) and ESLint clean across all 47 changed files.

This is independent of the audit's #2–#4 fixes (separate branch).

https://claude.ai/code/session_01TDrtddZbnjaYy4zGyFQuS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDrtddZbnjaYy4zGyFQuS2)_