### PR TITLE
Fix backup restore to handle sequence-backed IDs correctly

### DIFF
--- a/backend/src/backup/backup.service.spec.ts
+++ b/backend/src/backup/backup.service.spec.ts
@@ -8,6 +8,7 @@ import {
 } from "@nestjs/common";
 import { gzipSync, gunzipSync } from "zlib";
 import { PassThrough } from "stream";
+import { randomUUID } from "crypto";
 import { BackupService, RestoreBackupInput } from "./backup.service";
 import { User } from "../users/entities/user.entity";
 import { OidcService } from "../auth/oidc/oidc.service";
@@ -780,25 +781,29 @@ describe("BackupService", () => {
       mockUserRepo.findOne.mockResolvedValue(mockUser);
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
 
+      const securityId = randomUUID();
+      const schedId = randomUUID();
+      const splitId = randomUUID();
+      const accountId = randomUUID();
       const backupWithInvSplit = {
         ...validBackupData,
         securities: [
-          { id: "sec-1", user_id: userId, symbol: "VEA", name: "Vanguard" },
+          { id: securityId, user_id: userId, symbol: "VEA", name: "Vanguard" },
         ],
         scheduled_transactions: [
           {
-            id: "sched-1",
+            id: schedId,
             user_id: userId,
-            account_id: "acc-1",
-            investment_security_id: "sec-1",
+            account_id: accountId,
+            investment_security_id: securityId,
           },
         ],
         scheduled_transaction_splits: [
           {
-            id: "ss-1",
-            scheduled_transaction_id: "sched-1",
+            id: splitId,
+            scheduled_transaction_id: schedId,
             amount: -5,
-            investment_security_id: "sec-1",
+            investment_security_id: securityId,
           },
         ],
       };
@@ -830,8 +835,8 @@ describe("BackupService", () => {
       );
       const newSecurityId = insertColumnMap(securityInsert!).id;
       const newSplitId = insertColumnMap(splitInsert!).id;
-      expect(newSecurityId).not.toBe("sec-1");
-      expect(newSplitId).not.toBe("ss-1");
+      expect(newSecurityId).not.toBe(securityId);
+      expect(newSplitId).not.toBe(splitId);
 
       // ...and restored via a Phase-3 UPDATE keyed by the (remapped) split id.
       const update = mockQueryRunner.query.mock.calls.find(
@@ -848,52 +853,59 @@ describe("BackupService", () => {
       mockUserRepo.findOne.mockResolvedValue(mockUser);
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
 
+      const catParentId = randomUUID();
+      const catChildId = randomUUID();
+      const acc1Id = randomUUID();
+      const acc2Id = randomUUID();
+      const schedId = randomUUID();
+      const txn1Id = randomUUID();
+      const txn2Id = randomUUID();
       const backupWithFks = {
         ...validBackupData,
         categories: [
           {
-            id: "cat-parent",
+            id: catParentId,
             user_id: userId,
             name: "Parent",
             parent_id: null,
           },
           {
-            id: "cat-child",
+            id: catChildId,
             user_id: userId,
             name: "Child",
-            parent_id: "cat-parent",
+            parent_id: catParentId,
           },
         ],
         accounts: [
           {
-            id: "acc-1",
+            id: acc1Id,
             user_id: userId,
             name: "Checking",
-            linked_account_id: "acc-2",
-            scheduled_transaction_id: "sched-1",
+            linked_account_id: acc2Id,
+            scheduled_transaction_id: schedId,
           },
           {
-            id: "acc-2",
+            id: acc2Id,
             user_id: userId,
             name: "Savings",
-            linked_account_id: "acc-1",
+            linked_account_id: acc1Id,
           },
         ],
         scheduled_transactions: [
-          { id: "sched-1", user_id: userId, account_id: "acc-1" },
+          { id: schedId, user_id: userId, account_id: acc1Id },
         ],
         transactions: [
           {
-            id: "txn-1",
+            id: txn1Id,
             user_id: userId,
-            account_id: "acc-1",
-            linked_transaction_id: "txn-2",
+            account_id: acc1Id,
+            linked_transaction_id: txn2Id,
           },
           {
-            id: "txn-2",
+            id: txn2Id,
             user_id: userId,
-            account_id: "acc-2",
-            linked_transaction_id: "txn-1",
+            account_id: acc2Id,
+            linked_transaction_id: txn1Id,
           },
         ],
       };
@@ -933,8 +945,8 @@ describe("BackupService", () => {
       const catRows = categoryInserts.map(insertColumnMap);
       const parent = catRows.find((r) => r.name === "Parent");
       const child = catRows.find((r) => r.name === "Child");
-      expect(parent!.id).not.toBe("cat-parent");
-      expect(child!.id).not.toBe("cat-child");
+      expect(parent!.id).not.toBe(catParentId);
+      expect(child!.id).not.toBe(catChildId);
       expect(parentIdUpdate![1]).toEqual([parent!.id, child!.id]);
 
       const linkedAccountUpdate = updateCalls.find(
@@ -955,28 +967,33 @@ describe("BackupService", () => {
       mockUserRepo.findOne.mockResolvedValue(mockUser);
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
 
+      const tagId = randomUUID();
+      const catId = randomUUID();
+      const acctId = randomUUID();
+      const txnId = randomUUID();
+      const schedId = randomUUID();
       const backup = {
         ...validBackupData,
-        tags: [{ id: "tag-1", user_id: "other-user", name: "Bills" }],
+        tags: [{ id: tagId, user_id: "other-user", name: "Bills" }],
         categories: [
-          { id: "cat-1", user_id: "other-user", name: "Food", parent_id: null },
+          { id: catId, user_id: "other-user", name: "Food", parent_id: null },
         ],
-        accounts: [{ id: "acc-1", user_id: "other-user", name: "Checking" }],
+        accounts: [{ id: acctId, user_id: "other-user", name: "Checking" }],
         transactions: [
           {
-            id: "txn-1",
+            id: txnId,
             user_id: "other-user",
-            account_id: "acc-1",
-            category_id: "cat-1",
+            account_id: acctId,
+            category_id: catId,
           },
         ],
-        transaction_tags: [{ transaction_id: "txn-1", tag_id: "tag-1" }],
+        transaction_tags: [{ transaction_id: txnId, tag_id: tagId }],
         scheduled_transactions: [
           {
-            id: "sched-1",
+            id: schedId,
             user_id: "other-user",
-            account_id: "acc-1",
-            tag_ids: ["tag-1"],
+            account_id: acctId,
+            tag_ids: [tagId],
           },
         ],
       };
@@ -986,7 +1003,7 @@ describe("BackupService", () => {
         makeInput({ password: "test", data: backup }),
       );
 
-      const backupIds = ["cat-1", "acc-1", "txn-1", "tag-1", "sched-1"];
+      const backupIds = [catId, acctId, txnId, tagId, schedId];
       const writeCalls = mockQueryRunner.query.mock.calls.filter(
         (c: unknown[]) =>
           typeof c[0] === "string" &&
@@ -1023,7 +1040,7 @@ describe("BackupService", () => {
 
       const acctRow = findInsert("accounts");
       const txnRow = findInsert("transactions");
-      expect(acctRow.id).not.toBe("acc-1");
+      expect(acctRow.id).not.toBe(acctId);
       expect(txnRow.account_id).toBe(acctRow.id);
 
       const tagRow = findInsert("tags");
@@ -1034,6 +1051,142 @@ describe("BackupService", () => {
       // The id nested in the scheduled transaction's JSONB tag_ids is remapped.
       const schedRow = findInsert("scheduled_transactions");
       expect(schedRow.tag_ids).toContain(tagRow.id as string);
+    });
+
+    it("strips sequence-backed id columns so PG auto-assigns fresh values on restore", async () => {
+      // security_prices.id is BIGSERIAL. If we passed the backup's bigint id
+      // through, it would either be remapped to a UUID (the original bug --
+      // "invalid input syntax for type bigint") or collide on the shared
+      // sequence with another user's row and be silently skipped by
+      // ON CONFLICT DO NOTHING. Stripping the column lets PG assign a fresh
+      // value, mirroring how UUID primary keys get remapped to fresh UUIDs.
+      mockUserRepo.findOne.mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const securityId = randomUUID();
+      mockQueryRunner.query.mockImplementation(
+        (sql: string, params?: unknown[]) => {
+          if (
+            typeof sql === "string" &&
+            sql.includes("information_schema.columns") &&
+            Array.isArray(params) &&
+            params[0] === "security_prices"
+          ) {
+            return Promise.resolve([
+              {
+                column_name: "id",
+                data_type: "bigint",
+                column_default: "nextval('security_prices_id_seq'::regclass)",
+              },
+              {
+                column_name: "security_id",
+                data_type: "uuid",
+                column_default: null,
+              },
+              {
+                column_name: "price_date",
+                data_type: "date",
+                column_default: null,
+              },
+              {
+                column_name: "close_price",
+                data_type: "numeric",
+                column_default: null,
+              },
+            ]);
+          }
+          return mockQueryHandler(sql, params);
+        },
+      );
+
+      const backup = {
+        ...validBackupData,
+        securities: [
+          {
+            id: securityId,
+            user_id: userId,
+            symbol: "VEA",
+            name: "Vanguard",
+          },
+        ],
+        security_prices: [
+          {
+            id: "5",
+            security_id: securityId,
+            price_date: "2024-06-01",
+            close_price: 100.5,
+          },
+          {
+            id: "6",
+            security_id: securityId,
+            price_date: "2024-06-02",
+            close_price: 101.25,
+          },
+        ],
+      };
+
+      await service.restoreData(
+        userId,
+        makeInput({ password: "test", data: backup }),
+      );
+
+      const priceInserts = mockQueryRunner.query.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          c[0].includes('INSERT INTO "security_prices"'),
+      );
+      expect(priceInserts.length).toBe(2);
+      for (const call of priceInserts) {
+        // id column is stripped entirely so PG assigns from the sequence.
+        // Without this, the original bug remapped the bigint id to a UUID
+        // and sent it into the bigint column.
+        expect(call[0]).not.toContain('"id"');
+        // The UUID FK to securities is still remapped to the new security id.
+        const row = insertColumnMap(call);
+        expect(row.security_id).not.toBe(securityId);
+      }
+    });
+
+    it("does not remap non-UUID string values that happen to match a bigint id", async () => {
+      // The original buildBackupIdRemap matched any string id, so a bigint
+      // like "5" would land in the remap and deepRemapIds would rewrite every
+      // string "5" in the backup -- including unrelated bigint values -- to
+      // a UUID. The UUID-only filter prevents that.
+      mockUserRepo.findOne.mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const acctId = randomUUID();
+      const backup = {
+        ...validBackupData,
+        // A bigserial-style id and a non-id field with the same string value.
+        // Neither should be rewritten as a UUID.
+        security_prices: [
+          { id: "5", security_id: acctId, price_date: "2024-06-01" },
+        ],
+        accounts: [
+          {
+            id: acctId,
+            user_id: userId,
+            name: "Checking",
+            account_number: "5",
+          },
+        ],
+      };
+
+      await service.restoreData(
+        userId,
+        makeInput({ password: "test", data: backup }),
+      );
+
+      const acctInsert = mockQueryRunner.query.mock.calls.find(
+        (c: unknown[]) =>
+          typeof c[0] === "string" && c[0].includes('INSERT INTO "accounts"'),
+      );
+      expect(acctInsert).toBeDefined();
+      const row = insertColumnMap(acctInsert!);
+      // The bigint-shaped string is preserved as-is; only UUID-format ids
+      // get remapped.
+      expect(row.account_number).toBe("5");
     });
 
     it("should ensure referenced currencies exist before restoring data", async () => {

--- a/backend/src/backup/backup.service.ts
+++ b/backend/src/backup/backup.service.ts
@@ -38,6 +38,9 @@ export class BackupPasswordRequiredError extends BadRequestException {
 
 const BACKUP_VERSION = 1;
 
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 interface BackupData {
   version: number;
   exportedAt: string;
@@ -719,7 +722,11 @@ export class BackupService {
    * Builds a map from every primary-key UUID in the backup to a freshly
    * generated UUID. Currencies are intentionally excluded: they are shared,
    * global rows keyed by `code` (not by a per-user UUID) and are referenced by
-   * code, so they must keep their original identifiers.
+   * code, so they must keep their original identifiers. Non-UUID ids (e.g.
+   * `security_prices.id` is BIGSERIAL) are also excluded -- they get a fresh
+   * value assigned by the DB on insert (see insertRows), and remapping them
+   * to UUIDs here would (a) corrupt them and (b) clobber unrelated bigint
+   * values in other columns that happen to share the same string form.
    */
   private buildBackupIdRemap(data: BackupData): Map<string, string> {
     const remap = new Map<string, string>();
@@ -728,7 +735,7 @@ export class BackupService {
       for (const row of rows) {
         if (!row || typeof row !== "object") continue;
         const id = (row as Record<string, unknown>).id;
-        if (typeof id === "string" && id.length > 0 && !remap.has(id)) {
+        if (typeof id === "string" && UUID_REGEX.test(id) && !remap.has(id)) {
           remap.set(id, randomUUID());
         }
       }
@@ -1271,22 +1278,39 @@ export class BackupService {
     const columnsToDefer = deferredFkColumns[table] ?? [];
 
     // Fetch all valid column names for this table from the schema. This serves
-    // two purposes: (1) detect native PostgreSQL array columns so we can pass JS
-    // arrays directly to the pg driver, and (2) validate that column names from
+    // three purposes: (1) detect native PostgreSQL array columns so we can pass
+    // JS arrays directly to the pg driver, (2) validate that column names from
     // the user-uploaded backup are real columns, preventing SQL injection via
-    // crafted column names with embedded double-quote characters.
-    const schemaColResult = await queryRunner.query(
-      `SELECT column_name, data_type FROM information_schema.columns
+    // crafted column names with embedded double-quote characters, and (3)
+    // detect sequence-backed columns (e.g. BIGSERIAL `id`) that must be stripped
+    // from the INSERT so PostgreSQL assigns a fresh value -- otherwise the
+    // backup's bigint ids would collide with other users' rows on the shared
+    // sequence and be silently skipped by ON CONFLICT DO NOTHING.
+    const schemaColResult: Array<{
+      column_name: string;
+      data_type: string;
+      column_default: string | null;
+    }> = await queryRunner.query(
+      `SELECT column_name, data_type, column_default FROM information_schema.columns
        WHERE table_name = $1 AND table_schema = 'public'`,
       [table],
     );
     const validColumns = new Set<string>(
-      schemaColResult.map((r: { column_name: string }) => r.column_name),
+      schemaColResult.map((r) => r.column_name),
     );
     const pgArrayColumns = new Set<string>(
       schemaColResult
-        .filter((r: { data_type: string }) => r.data_type === "ARRAY")
-        .map((r: { column_name: string }) => r.column_name),
+        .filter((r) => r.data_type === "ARRAY")
+        .map((r) => r.column_name),
+    );
+    const sequenceBackedColumns = new Set<string>(
+      schemaColResult
+        .filter(
+          (r) =>
+            typeof r.column_default === "string" &&
+            r.column_default.includes("nextval"),
+        )
+        .map((r) => r.column_name),
     );
 
     let count = 0;
@@ -1303,6 +1327,14 @@ export class BackupService {
 
       // Strip deferred FK columns to avoid circular reference violations
       for (const col of columnsToDefer) {
+        delete filteredRow[col];
+      }
+
+      // Strip sequence-backed columns (e.g. BIGSERIAL `id`) so the DB assigns
+      // a fresh value. Reusing the backup's value would collide with other
+      // users' rows on the shared sequence and be silently dropped by
+      // ON CONFLICT DO NOTHING.
+      for (const col of sequenceBackedColumns) {
         delete filteredRow[col];
       }
 


### PR DESCRIPTION
## Summary
Fixes a critical bug in backup restore where sequence-backed ID columns (e.g., `BIGSERIAL`) were being incorrectly remapped to UUIDs, causing type errors and silent data loss. The fix ensures only UUID-format IDs are remapped, while sequence-backed columns are stripped from INSERTs to let PostgreSQL assign fresh values.

## Key Changes
- **UUID-only ID remapping**: Added `UUID_REGEX` pattern to filter `buildBackupIdRemap()` so only valid UUID strings are remapped. Non-UUID IDs (like bigint "5") are now excluded, preventing corruption of sequence-backed columns and unrelated bigint fields that happen to share the same string value.
- **Sequence-backed column detection**: Enhanced schema introspection in `insertRows()` to detect columns with `nextval()` defaults (BIGSERIAL, SERIAL, etc.) and strip them from INSERT statements, allowing PostgreSQL to assign fresh values from the sequence instead of reusing the backup's values (which would collide with other users' rows).
- **Improved schema query**: Updated `information_schema.columns` query to fetch `column_default` in addition to `column_name` and `data_type`, enabling detection of sequence-backed columns.
- **Test coverage**: Added two new test cases:
  - "strips sequence-backed id columns so PG auto-assigns fresh values on restore" — verifies that `security_prices.id` (BIGSERIAL) is stripped and not remapped to UUID
  - "does not remap non-UUID string values that happen to match a bigint id" — ensures bigint-shaped strings like "5" in non-ID columns are preserved as-is

## Implementation Details
- The UUID regex pattern (`/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i`) is case-insensitive and matches the standard UUID v4 format used throughout the codebase.
- Sequence-backed columns are identified by checking if `column_default` contains `"nextval"`, which covers BIGSERIAL, SERIAL, and other sequence-backed types.
- The fix maintains backward compatibility: UUID primary keys continue to be remapped to fresh values, and currencies (which use string codes) are still excluded from remapping.

https://claude.ai/code/session_015nLzBQ7c3bh4Y71pRP3XLS