### PR TITLE
Cascade currency changes to transactions and scheduled transactions

### DIFF
--- a/backend/src/accounts/accounts.service.spec.ts
+++ b/backend/src/accounts/accounts.service.spec.ts
@@ -126,6 +126,7 @@ describe("AccountsService", () => {
         findOneOrFail: jest.fn(),
         save: jest.fn().mockImplementation((data) => data),
         remove: jest.fn().mockImplementation((data) => data),
+        query: jest.fn().mockResolvedValue(undefined),
       },
     };
 
@@ -1867,6 +1868,103 @@ describe("AccountsService", () => {
 
       // Only one save call for the main account
       expect(mockQueryRunner.manager.save).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("update - currency cascade to transactions and scheduled transactions", () => {
+    it("updates transactions and scheduled_transactions when account currency changes", async () => {
+      mockQueryRunner.manager.findOne.mockResolvedValue({
+        ...mockAccount,
+        accountType: AccountType.CHEQUING,
+        linkedAccountId: null,
+        currencyCode: "USD",
+      });
+
+      await service.update("user-1", "account-1", { currencyCode: "CAD" });
+
+      const queryCalls = (mockQueryRunner.manager.query as jest.Mock).mock
+        .calls;
+      // Should run an UPDATE on transactions
+      const txCall = queryCalls.find((c) =>
+        (c[0] as string).includes("UPDATE transactions"),
+      );
+      expect(txCall).toBeDefined();
+      expect(txCall![1]).toEqual(["CAD", "account-1", "user-1"]);
+
+      // ...and another on scheduled_transactions
+      const stxCall = queryCalls.find((c) =>
+        (c[0] as string).includes("UPDATE scheduled_transactions"),
+      );
+      expect(stxCall).toBeDefined();
+      expect(stxCall![1]).toEqual(["CAD", "account-1", "user-1"]);
+    });
+
+    it("does not run the cascade when currencyCode is not in the update DTO", async () => {
+      mockQueryRunner.manager.findOne.mockResolvedValue({
+        ...mockAccount,
+        currencyCode: "USD",
+      });
+
+      await service.update("user-1", "account-1", { name: "Rename" });
+
+      const queryCalls = (mockQueryRunner.manager.query as jest.Mock).mock
+        .calls;
+      const cascadeCall = queryCalls.find(
+        (c) =>
+          (c[0] as string).includes("UPDATE transactions") ||
+          (c[0] as string).includes("UPDATE scheduled_transactions"),
+      );
+      expect(cascadeCall).toBeUndefined();
+    });
+
+    it("does not run the cascade when the new currency matches the old", async () => {
+      mockQueryRunner.manager.findOne.mockResolvedValue({
+        ...mockAccount,
+        currencyCode: "USD",
+      });
+
+      await service.update("user-1", "account-1", { currencyCode: "USD" });
+
+      const queryCalls = (mockQueryRunner.manager.query as jest.Mock).mock
+        .calls;
+      const cascadeCall = queryCalls.find(
+        (c) =>
+          (c[0] as string).includes("UPDATE transactions") ||
+          (c[0] as string).includes("UPDATE scheduled_transactions"),
+      );
+      expect(cascadeCall).toBeUndefined();
+    });
+
+    it("also cascades to the linked account's rows for investment account pairs", async () => {
+      mockQueryRunner.manager.findOne
+        .mockResolvedValueOnce({
+          ...mockAccount,
+          accountType: AccountType.INVESTMENT,
+          linkedAccountId: "brokerage-1",
+          currencyCode: "USD",
+        })
+        .mockResolvedValueOnce({
+          id: "brokerage-1",
+          userId: "user-1",
+          currencyCode: "USD",
+        });
+
+      await service.update("user-1", "account-1", { currencyCode: "CAD" });
+
+      const queryCalls = (mockQueryRunner.manager.query as jest.Mock).mock
+        .calls;
+      // Should have updated transactions for BOTH accounts
+      const txUpdatesForBrokerage = queryCalls.filter(
+        (c) =>
+          (c[0] as string).includes("UPDATE transactions") &&
+          c[1][1] === "brokerage-1",
+      );
+      expect(txUpdatesForBrokerage).toHaveLength(1);
+      expect(txUpdatesForBrokerage[0][1]).toEqual([
+        "CAD",
+        "brokerage-1",
+        "user-1",
+      ]);
     });
   });
 

--- a/backend/src/accounts/accounts.service.ts
+++ b/backend/src/accounts/accounts.service.ts
@@ -545,6 +545,23 @@ export class AccountsService {
 
       const savedAccount = await queryRunner.manager.save(account);
 
+      // If currency changed, cascade it to every transaction and scheduled
+      // transaction tied to this account so existing rows stop displaying the
+      // old code. The amounts themselves are unchanged -- this is a relabel,
+      // not a conversion. The account's currentBalance was already saved
+      // above, so we don't need to touch it here.
+      if (
+        updateAccountDto.currencyCode !== undefined &&
+        beforeData.currencyCode !== updateAccountDto.currencyCode
+      ) {
+        await this.cascadeCurrencyToAccountRows(
+          queryRunner,
+          userId,
+          account.id,
+          updateAccountDto.currencyCode,
+        );
+      }
+
       // If currency changed on an investment account, update the linked account too
       if (
         updateAccountDto.currencyCode !== undefined &&
@@ -555,8 +572,18 @@ export class AccountsService {
           where: { id: account.linkedAccountId, userId },
         });
         if (linkedAccount) {
+          const linkedHadDifferentCurrency =
+            linkedAccount.currencyCode !== updateAccountDto.currencyCode;
           linkedAccount.currencyCode = updateAccountDto.currencyCode;
           await queryRunner.manager.save(linkedAccount);
+          if (linkedHadDifferentCurrency) {
+            await this.cascadeCurrencyToAccountRows(
+              queryRunner,
+              userId,
+              linkedAccount.id,
+              updateAccountDto.currencyCode,
+            );
+          }
         }
       }
 
@@ -592,6 +619,36 @@ export class AccountsService {
     } finally {
       await queryRunner.release();
     }
+  }
+
+  /**
+   * Update `currency_code` on every `transactions` and `scheduled_transactions`
+   * row tied to the given account so they reflect the account's new currency.
+   * Called from `update()` when an account's currencyCode changes -- the
+   * column is denormalized on those rows (originally to support cross-currency
+   * transactions on an account, where amounts can differ from the account's
+   * native code), so we must keep it in sync explicitly.
+   *
+   * Must be invoked inside the caller's QueryRunner transaction.
+   */
+  private async cascadeCurrencyToAccountRows(
+    queryRunner: QueryRunner,
+    userId: string,
+    accountId: string,
+    newCurrencyCode: string,
+  ): Promise<void> {
+    await queryRunner.manager.query(
+      `UPDATE transactions
+         SET currency_code = $1
+       WHERE account_id = $2 AND user_id = $3 AND currency_code <> $1`,
+      [newCurrencyCode, accountId, userId],
+    );
+    await queryRunner.manager.query(
+      `UPDATE scheduled_transactions
+         SET currency_code = $1
+       WHERE account_id = $2 AND user_id = $3 AND currency_code <> $1`,
+      [newCurrencyCode, accountId, userId],
+    );
   }
 
   /**

--- a/backend/test/integration/account-currency-cascade.integration.spec.ts
+++ b/backend/test/integration/account-currency-cascade.integration.spec.ts
@@ -1,0 +1,161 @@
+import { TestingModule } from "@nestjs/testing";
+import { DataSource } from "typeorm";
+import { AccountsService } from "@/accounts/accounts.service";
+import { AccountsModule } from "@/accounts/accounts.module";
+import { TransactionsModule } from "@/transactions/transactions.module";
+import { TransactionsService } from "@/transactions/transactions.service";
+import { Transaction } from "@/transactions/entities/transaction.entity";
+import { ScheduledTransaction } from "@/scheduled-transactions/entities/scheduled-transaction.entity";
+import {
+  createIntegrationModule,
+  cleanTables,
+  createTestUserDirect,
+} from "../helpers/integration-setup";
+import { createTestAccount } from "../helpers/test-factories";
+
+// Regression test for the bug where changing an account's currency left
+// existing transactions and scheduled transactions stuck on the old code.
+// The fix cascades the new currency to every row tied to the account in the
+// same QueryRunner transaction.
+describe("AccountsService.update currency cascade (integration)", () => {
+  let module: TestingModule;
+  let accountsService: AccountsService;
+  let transactionsService: TransactionsService;
+  let dataSource: DataSource;
+  let userId: string;
+  let accountId: string;
+
+  beforeAll(async () => {
+    module = await createIntegrationModule([
+      AccountsModule,
+      TransactionsModule,
+    ]);
+    accountsService = module.get(AccountsService);
+    transactionsService = module.get(TransactionsService);
+    dataSource = module.get(DataSource);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await cleanTables(dataSource, [
+      "action_history",
+      "transaction_splits",
+      "transactions",
+      "scheduled_transaction_splits",
+      "scheduled_transaction_overrides",
+      "scheduled_transactions",
+      "investment_transactions",
+      "monthly_account_balances",
+      "accounts",
+      "categories",
+      "payees",
+      "users",
+    ]);
+    const user = await createTestUserDirect(dataSource);
+    userId = user.id;
+    const account = await createTestAccount(dataSource, userId, {
+      currencyCode: "USD",
+      openingBalance: 1000,
+      currentBalance: 1000,
+    });
+    accountId = account.id;
+  });
+
+  it("updates every transaction on the account to the new currency", async () => {
+    await transactionsService.create(userId, {
+      accountId,
+      transactionDate: "2026-01-15",
+      amount: -50,
+      currencyCode: "USD",
+    });
+    await transactionsService.create(userId, {
+      accountId,
+      transactionDate: "2026-01-20",
+      amount: -25,
+      currencyCode: "USD",
+    });
+
+    await accountsService.update(userId, accountId, { currencyCode: "CAD" });
+
+    const rows = await dataSource.manager.find(Transaction, {
+      where: { accountId, userId },
+    });
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.currencyCode === "CAD")).toBe(true);
+  });
+
+  it("leaves transactions on other accounts untouched", async () => {
+    const otherAccount = await createTestAccount(dataSource, userId, {
+      currencyCode: "USD",
+      openingBalance: 0,
+      currentBalance: 0,
+    });
+    await transactionsService.create(userId, {
+      accountId,
+      transactionDate: "2026-01-15",
+      amount: -10,
+      currencyCode: "USD",
+    });
+    await transactionsService.create(userId, {
+      accountId: otherAccount.id,
+      transactionDate: "2026-01-15",
+      amount: -10,
+      currencyCode: "USD",
+    });
+
+    await accountsService.update(userId, accountId, { currencyCode: "CAD" });
+
+    const ours = await dataSource.manager.find(Transaction, {
+      where: { accountId, userId },
+    });
+    const others = await dataSource.manager.find(Transaction, {
+      where: { accountId: otherAccount.id, userId },
+    });
+    expect(ours.every((r) => r.currencyCode === "CAD")).toBe(true);
+    expect(others.every((r) => r.currencyCode === "USD")).toBe(true);
+  });
+
+  it("cascades the new currency to scheduled transactions tied to the account", async () => {
+    await dataSource.manager.save(
+      dataSource.manager.create(ScheduledTransaction, {
+        userId,
+        accountId,
+        name: "Monthly rent",
+        amount: -1200,
+        currencyCode: "USD",
+        frequency: "MONTHLY",
+        nextDueDate: "2026-02-01",
+        startDate: "2026-01-01",
+        isActive: true,
+        autoPost: false,
+      }),
+    );
+
+    await accountsService.update(userId, accountId, { currencyCode: "CAD" });
+
+    const rows = await dataSource.manager.find(ScheduledTransaction, {
+      where: { accountId, userId },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].currencyCode).toBe("CAD");
+  });
+
+  it("does not change anything when the currency is set to the same value", async () => {
+    await transactionsService.create(userId, {
+      accountId,
+      transactionDate: "2026-01-15",
+      amount: -50,
+      currencyCode: "USD",
+    });
+
+    await accountsService.update(userId, accountId, { currencyCode: "USD" });
+
+    const rows = await dataSource.manager.find(Transaction, {
+      where: { accountId, userId },
+    });
+    expect(rows[0].currencyCode).toBe("USD");
+  });
+});


### PR DESCRIPTION
## Summary
Fix a regression where changing an account's currency left existing transactions and scheduled transactions displaying the old currency code. The currency column is denormalized on those rows (to support cross-currency transactions), so it must be kept in sync explicitly when the account's currency changes.

## Changes
- **AccountsService.update()**: Added currency cascade logic that updates all `transactions` and `scheduled_transactions` rows tied to the account when its `currencyCode` changes. The cascade only runs if the new currency differs from the old, and is wrapped in the existing QueryRunner transaction to ensure atomicity.
- **cascadeCurrencyToAccountRows()**: New private method that executes parameterized SQL UPDATE statements for both tables, filtering by `account_id`, `user_id`, and only updating rows where the currency actually differs (to avoid unnecessary writes).
- **Investment account pairs**: When updating a linked account's currency, the cascade also applies to the linked account's transaction rows.
- **Unit tests**: Added comprehensive test coverage for the cascade logic, including edge cases (no change, currency unchanged, other accounts unaffected, linked accounts).
- **Integration tests**: Added regression test suite verifying the cascade works end-to-end with real database operations.

## Implementation Details
- The cascade uses raw parameterized SQL queries (`queryRunner.manager.query()`) with proper parameter binding to avoid SQL injection.
- The `currency_code <> $1` condition in the WHERE clause prevents unnecessary updates when the currency is already correct.
- All operations occur within the existing transaction context, ensuring consistency if any step fails.
- The feature is backward-compatible: accounts with unchanged currencies are unaffected.

https://claude.ai/code/session_01FyVe51ZT8M5KXhbdqLN5DD