### PR TITLE
Lock currency field when account has transactions

### DIFF
--- a/backend/src/accounts/accounts.service.spec.ts
+++ b/backend/src/accounts/accounts.service.spec.ts
@@ -126,6 +126,7 @@ describe("AccountsService", () => {
         findOneOrFail: jest.fn(),
         save: jest.fn().mockImplementation((data) => data),
         remove: jest.fn().mockImplementation((data) => data),
+        count: jest.fn().mockResolvedValue(0),
       },
     };
 
@@ -594,6 +595,67 @@ describe("AccountsService", () => {
           description: expect.stringContaining("Updated Name"),
         }),
       );
+    });
+
+    describe("currency lock", () => {
+      it("allows currency change when account has no transactions", async () => {
+        mockQueryRunner.manager.findOne.mockResolvedValue({ ...mockAccount });
+        mockQueryRunner.manager.count.mockResolvedValue(0);
+
+        await service.update("user-1", "account-1", { currencyCode: "CAD" });
+
+        const saved = mockQueryRunner.manager.save.mock.calls[0][0];
+        expect(saved.currencyCode).toBe("CAD");
+        expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+      });
+
+      it("rejects currency change when account has regular transactions", async () => {
+        mockQueryRunner.manager.findOne.mockResolvedValue({ ...mockAccount });
+        mockQueryRunner.manager.count
+          .mockResolvedValueOnce(3) // transactions
+          .mockResolvedValueOnce(0); // investment transactions
+
+        await expect(
+          service.update("user-1", "account-1", { currencyCode: "CAD" }),
+        ).rejects.toThrow(BadRequestException);
+        expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+        expect(mockQueryRunner.manager.save).not.toHaveBeenCalled();
+      });
+
+      it("rejects currency change when account has investment transactions", async () => {
+        mockQueryRunner.manager.findOne.mockResolvedValue({ ...mockAccount });
+        mockQueryRunner.manager.count
+          .mockResolvedValueOnce(0) // transactions
+          .mockResolvedValueOnce(2); // investment transactions
+
+        await expect(
+          service.update("user-1", "account-1", { currencyCode: "CAD" }),
+        ).rejects.toThrow(BadRequestException);
+        expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+        expect(mockQueryRunner.manager.save).not.toHaveBeenCalled();
+      });
+
+      it("allows other field updates on accounts with transactions when currency is unchanged", async () => {
+        mockQueryRunner.manager.findOne.mockResolvedValue({ ...mockAccount });
+        mockQueryRunner.manager.count.mockResolvedValue(5);
+
+        await service.update("user-1", "account-1", { name: "Renamed" });
+
+        const saved = mockQueryRunner.manager.save.mock.calls[0][0];
+        expect(saved.name).toBe("Renamed");
+        expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+      });
+
+      it("allows passing the same currency on an account with transactions (no-op)", async () => {
+        mockQueryRunner.manager.findOne.mockResolvedValue({ ...mockAccount });
+        mockQueryRunner.manager.count.mockResolvedValue(5);
+
+        await service.update("user-1", "account-1", {
+          currencyCode: mockAccount.currencyCode,
+        });
+
+        expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+      });
     });
   });
 

--- a/backend/src/accounts/accounts.service.ts
+++ b/backend/src/accounts/accounts.service.ts
@@ -446,6 +446,29 @@ export class AccountsService {
         throw new BadRequestException("Cannot update a closed account");
       }
 
+      // Currency is locked once the account has transactions. Allowing it to
+      // change after that would silently re-denominate existing balances.
+      if (
+        updateAccountDto.currencyCode !== undefined &&
+        updateAccountDto.currencyCode !== account.currencyCode
+      ) {
+        const [transactionCount, investmentTransactionCount] =
+          await Promise.all([
+            queryRunner.manager.count(Transaction, {
+              where: { accountId: id },
+            }),
+            queryRunner.manager.count(InvestmentTransaction, {
+              where: { accountId: id },
+            }),
+          ]);
+
+        if (transactionCount > 0 || investmentTransactionCount > 0) {
+          throw new BadRequestException(
+            "Cannot change the currency of an account that has transactions.",
+          );
+        }
+      }
+
       const beforeData = { ...account };
 
       // If openingBalance is being changed, we need to recalculate currentBalance

--- a/frontend/src/components/accounts/AccountForm.test.tsx
+++ b/frontend/src/components/accounts/AccountForm.test.tsx
@@ -12,6 +12,11 @@ vi.mock('@/lib/accounts', () => ({
     getAll: vi.fn().mockResolvedValue([]),
     previewLoanAmortization: vi.fn(),
     previewMortgageAmortization: vi.fn(),
+    canDelete: vi.fn().mockResolvedValue({
+      transactionCount: 0,
+      investmentTransactionCount: 0,
+      canDelete: true,
+    }),
   },
 }));
 
@@ -1561,6 +1566,89 @@ describe('AccountForm', () => {
 
       const mortgageInput = screen.getByLabelText('Mortgage Amount') as HTMLInputElement;
       await act(async () => { fireEvent.change(mortgageInput, { target: { value: '350000' } }); });
+    });
+  });
+
+  describe('currency lock for accounts with transactions', () => {
+    it('does not check transaction count for new accounts', async () => {
+      render(<AccountForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Currency')).toBeInTheDocument();
+      });
+
+      expect(accountsApi.canDelete).not.toHaveBeenCalled();
+      const currencySelect = screen.getByLabelText('Currency') as HTMLSelectElement;
+      expect(currencySelect.disabled).toBe(false);
+    });
+
+    it('leaves currency enabled when editing an account with no transactions', async () => {
+      (accountsApi.canDelete as any).mockResolvedValue({
+        transactionCount: 0,
+        investmentTransactionCount: 0,
+        canDelete: true,
+      });
+      const account = createExistingAccount();
+
+      render(<AccountForm account={account} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+      await waitFor(() => {
+        expect(accountsApi.canDelete).toHaveBeenCalledWith(account.id);
+      });
+
+      const currencySelect = screen.getByLabelText('Currency') as HTMLSelectElement;
+      await waitFor(() => {
+        expect(currencySelect.disabled).toBe(false);
+      });
+      expect(screen.queryByLabelText(/Currency is locked/i)).not.toBeInTheDocument();
+    });
+
+    it('disables currency and shows tooltip when the account has regular transactions', async () => {
+      (accountsApi.canDelete as any).mockResolvedValue({
+        transactionCount: 7,
+        investmentTransactionCount: 0,
+        canDelete: false,
+      });
+      const account = createExistingAccount();
+
+      render(<AccountForm account={account} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+      const currencySelect = screen.getByLabelText('Currency') as HTMLSelectElement;
+      await waitFor(() => {
+        expect(currencySelect.disabled).toBe(true);
+      });
+      expect(screen.getByLabelText(/Currency is locked/i)).toBeInTheDocument();
+    });
+
+    it('disables currency when the account has only investment transactions', async () => {
+      (accountsApi.canDelete as any).mockResolvedValue({
+        transactionCount: 0,
+        investmentTransactionCount: 3,
+        canDelete: false,
+      });
+      const account = createExistingAccount({ accountType: 'INVESTMENT' });
+
+      render(<AccountForm account={account} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+      const currencySelect = screen.getByLabelText('Currency') as HTMLSelectElement;
+      await waitFor(() => {
+        expect(currencySelect.disabled).toBe(true);
+      });
+      expect(screen.getByLabelText(/Currency is locked/i)).toBeInTheDocument();
+    });
+
+    it('keeps currency enabled if the transaction-count lookup fails', async () => {
+      (accountsApi.canDelete as any).mockRejectedValue(new Error('boom'));
+      const account = createExistingAccount();
+
+      render(<AccountForm account={account} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+      await waitFor(() => {
+        expect(accountsApi.canDelete).toHaveBeenCalled();
+      });
+
+      const currencySelect = screen.getByLabelText('Currency') as HTMLSelectElement;
+      expect(currencySelect.disabled).toBe(false);
     });
   });
 

--- a/frontend/src/components/accounts/AccountForm.test.tsx
+++ b/frontend/src/components/accounts/AccountForm.test.tsx
@@ -1617,7 +1617,27 @@ describe('AccountForm', () => {
       await waitFor(() => {
         expect(currencySelect.disabled).toBe(true);
       });
+      // Dimmed to visually signal it cannot be changed
+      expect(currencySelect.className).toContain('opacity-60');
       expect(screen.getByLabelText(/Currency is locked/i)).toBeInTheDocument();
+    });
+
+    it('does not dim the currency select when it is unlocked', async () => {
+      (accountsApi.canDelete as any).mockResolvedValue({
+        transactionCount: 0,
+        investmentTransactionCount: 0,
+        canDelete: true,
+      });
+      const account = createExistingAccount();
+
+      render(<AccountForm account={account} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+      await waitFor(() => {
+        expect(accountsApi.canDelete).toHaveBeenCalledWith(account.id);
+      });
+
+      const currencySelect = screen.getByLabelText('Currency') as HTMLSelectElement;
+      expect(currencySelect.className).not.toContain('opacity-60');
     });
 
     it('disables currency when the account has only investment transactions', async () => {

--- a/frontend/src/components/accounts/AccountForm.tsx
+++ b/frontend/src/components/accounts/AccountForm.tsx
@@ -497,6 +497,7 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
             options={currencyOptions}
             error={errors.currencyCode?.message}
             disabled={isCurrencyLocked}
+            className={isCurrencyLocked ? 'opacity-60' : undefined}
             {...register('currencyCode')}
           />
         </div>

--- a/frontend/src/components/accounts/AccountForm.tsx
+++ b/frontend/src/components/accounts/AccountForm.tsx
@@ -134,6 +134,9 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
   const [selectedInterestCategoryId, setSelectedInterestCategoryId] = useState<string>(account?.interestCategoryId || '');
   const [showLoanSetupDialog, setShowLoanSetupDialog] = useState(false);
   const [hasScheduledPayment, setHasScheduledPayment] = useState(!!account?.scheduledTransactionId);
+  // Currency becomes locked once the account has any transactions so existing
+  // balances are not silently re-denominated. Stays unlocked while loading.
+  const [isCurrencyLocked, setIsCurrencyLocked] = useState(false);
 
   const {
     register,
@@ -234,6 +237,23 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
   useEffect(() => {
     exchangeRatesApi.getCurrencies().then(setCurrencies).catch(() => {});
   }, []);
+
+  // For existing accounts, check whether any transactions exist. The backend
+  // rejects currency changes once transactions are present; mirror that in the
+  // UI by locking the field with an explanatory tooltip.
+  useEffect(() => {
+    if (!account?.id) return;
+    accountsApi
+      .canDelete(account.id)
+      .then(({ transactionCount, investmentTransactionCount }) => {
+        setIsCurrencyLocked(
+          transactionCount > 0 || investmentTransactionCount > 0,
+        );
+      })
+      .catch((error) => {
+        logger.error('Failed to load account transaction count:', error);
+      });
+  }, [account?.id]);
 
   // Re-sync the currency select value after options load.
   // react-hook-form's register sets the select value on mount, but if options
@@ -460,12 +480,26 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
       )}
 
       <div className="grid grid-cols-2 gap-4">
-        <Select
-          label="Currency"
-          options={currencyOptions}
-          error={errors.currencyCode?.message}
-          {...register('currencyCode')}
-        />
+        <div>
+          <div className="flex items-center mb-1">
+            <label
+              htmlFor="select-currency"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              Currency
+            </label>
+            {isCurrencyLocked && (
+              <InfoTooltip text="Currency is locked because this account already has transactions. Changing it would silently re-denominate existing balances." />
+            )}
+          </div>
+          <Select
+            id="select-currency"
+            options={currencyOptions}
+            error={errors.currencyCode?.message}
+            disabled={isCurrencyLocked}
+            {...register('currencyCode')}
+          />
+        </div>
 
         <CurrencyInput
           label={isLoanAccount ? 'Loan Amount' : isMortgageAccount ? 'Mortgage Amount' : 'Opening Balance'}


### PR DESCRIPTION
## Summary
Prevent users from changing an account's currency after transactions have been recorded, since allowing this would silently re-denominate existing balances. The backend now rejects currency changes on accounts with transactions, and the frontend mirrors this by disabling the currency field with an explanatory tooltip.

## Changes
- **Backend (`accounts.service.ts`)**: Added validation in the `update()` method to reject currency changes when an account has any regular or investment transactions. Uses QueryRunner to maintain transaction safety.
- **Backend tests (`accounts.service.spec.ts`)**: Added comprehensive test suite for currency lock behavior, covering allowed updates, rejected changes, and edge cases (same currency, other field updates).
- **Frontend (`AccountForm.tsx`)**: 
  - Added `isCurrencyLocked` state that checks transaction count via `accountsApi.canDelete()` when editing existing accounts
  - Disabled the currency select and wrapped it with an `InfoTooltip` explaining why it's locked
  - Only checks transaction count for existing accounts (new accounts have currency unlocked)
  - Gracefully handles API failures by keeping currency enabled
- **Frontend tests (`AccountForm.test.tsx`)**: Added test suite covering new account creation, accounts with no transactions, accounts with regular/investment transactions, and API failure scenarios. Mocked `canDelete` in the accounts API mock.

## Implementation Details
- The frontend reuses the existing `canDelete()` API endpoint (which already returns transaction counts) rather than creating a new endpoint
- Currency changes are only rejected if the new currency differs from the existing one; updating to the same currency is allowed (no-op)
- Other account fields can still be updated even when currency is locked
- Error handling is defensive: if the transaction count lookup fails, the currency field remains enabled to avoid blocking legitimate updates

https://claude.ai/code/session_019JN5fs7QKtAD8UNRWumSs8