### PR TITLE
feat: show adaptive precision for sub-penny prices in Favourite Securities

### DIFF
--- a/frontend/src/components/dashboard/FavouriteSecurities.test.tsx
+++ b/frontend/src/components/dashboard/FavouriteSecurities.test.tsx
@@ -11,6 +11,15 @@ vi.mock('next/navigation', () => ({
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
     formatCurrency: (n: number) => `$${n.toFixed(2)}`,
+    formatCurrencyPrecise: (n: number) => {
+      const abs = Math.abs(n);
+      let digits = 2;
+      if (n !== 0 && abs < 0.005) {
+        const exp = Math.floor(Math.log10(abs));
+        digits = Math.min(6, Math.max(2, -exp + 2));
+      }
+      return `$${n.toFixed(digits)}`;
+    },
     formatPercent: (n: number) => `${n.toFixed(2)}%`,
   }),
 }));
@@ -54,6 +63,20 @@ describe('FavouriteSecurities', () => {
     expect(screen.getByText('AAPL')).toBeInTheDocument();
     expect(screen.getByText('Apple Inc.')).toBeInTheDocument();
     expect(screen.getByText('$180.00')).toBeInTheDocument();
+  });
+
+  it('expands precision for sub-penny securities instead of showing 0.00', () => {
+    render(
+      <FavouriteSecurities
+        securities={[
+          quote({ symbol: 'PENNY', name: 'Sub-penny Co', currencyCode: 'GBP', currentPrice: 0.000318, dailyChange: 0.000033, dailyChangePercent: 11.4 }),
+        ]}
+        isLoading={false}
+      />,
+    );
+    // Price and change reveal their real figures rather than collapsing to 0.00.
+    expect(screen.getByText(/0\.000318/)).toBeInTheDocument();
+    expect(screen.getByText(/\+\$0\.000033 \(\+11\.40%\)/)).toBeInTheDocument();
   });
 
   it('shows positive change in green with a plus sign', () => {

--- a/frontend/src/components/dashboard/FavouriteSecurities.tsx
+++ b/frontend/src/components/dashboard/FavouriteSecurities.tsx
@@ -40,7 +40,7 @@ function RefreshButton({ onRefresh, isRefreshing }: { onRefresh?: () => void; is
 
 export function FavouriteSecurities({ securities, isLoading, onRefresh, isRefreshing }: FavouriteSecuritiesProps) {
   const router = useRouter();
-  const { formatCurrency, formatPercent } = useNumberFormat();
+  const { formatCurrencyPrecise, formatPercent } = useNumberFormat();
   const defaultCurrency = usePreferencesStore((s) => s.preferences?.defaultCurrency) || 'USD';
 
   if (isLoading) {
@@ -103,7 +103,7 @@ export function FavouriteSecurities({ securities, isLoading, onRefresh, isRefres
           const isPositive = sec.dailyChange >= 0;
           const isForeign = sec.currencyCode && sec.currencyCode !== defaultCurrency;
           const fmtPrice = (value: number) => {
-            const formatted = formatCurrency(value, sec.currencyCode);
+            const formatted = formatCurrencyPrecise(value, sec.currencyCode);
             return isForeign ? `${formatted} ${sec.currencyCode}` : formatted;
           };
           return (
@@ -129,7 +129,7 @@ export function FavouriteSecurities({ securities, isLoading, onRefresh, isRefres
                       }`}
                     >
                       {isPositive ? '+' : ''}
-                      {formatCurrency(sec.dailyChange, sec.currencyCode)} ({isPositive ? '+' : ''}
+                      {formatCurrencyPrecise(sec.dailyChange, sec.currencyCode)} ({isPositive ? '+' : ''}
                       {formatPercent(sec.dailyChangePercent)})
                     </div>
                   </>


### PR DESCRIPTION
Mirror the Top Movers change by wiring formatCurrencyPrecise into the
Favourite Securities widget for the price and daily-change amounts, so
sub-penny securities (e.g. a 0.000318 GBP price) reveal their real figures
instead of collapsing to 0.00. Normal balances are unaffected.

https://claude.ai/code/session_016Mr3BwmHsVLxQN5ZUYHz9o