### PR TITLE
Code audit P2: efficiency & consistency fixes (follow-up to #593)

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -116,20 +116,28 @@ fail-fast, fully unit-tested). Applied to #5, #6, the FX refresh cron, and #17.
 - [ ] **15. Whole-store Zustand subscriptions** (destructuring instead of slice selectors);
   widest-reach is `ProtectedRoute.tsx:18-19` (wraps every authed page); also `AppHeader`,
   `FavouriteAccounts`, dashboard.
-- [ ] **16. Anthropic provider has no prompt caching** (`cache_control` zero hits repo-wide)
+- [x] **16. Anthropic provider has no prompt caching** (`cache_control` zero hits repo-wide)
   — resends large financial-context system prompts at full token cost every turn.
   `ai/providers/anthropic.provider.ts:98-107`
+  DONE: wrap the system prompt in a single `cache_control: ephemeral` text block across all
+  four call sites; since tools render before system, one breakpoint caches the tools+system
+  prefix so repeated multi-turn tool-use turns hit the prompt cache.
 - [x] **17. "Batched" AI-insights cron is actually fully sequential** (`for ... await` inside
   the batch) — batching is dead code. `ai-insights.service.ts:246-261`
   DONE: replaced the dead batch loop with `mapWithConcurrency` at a conservative limit of 5
   (LLM calls per user), preserving the per-user try/catch so one failure does not abort the run.
-- [ ] **18. `refreshAllPrices` re-scans everything** with no staleness filter.
+- [x] **18. `refreshAllPrices` re-scans everything** with no staleness filter.
   `security-price.service.ts:312-330`
+  DONE: skip securities that already have a price row dated today before fanning out, and
+  report the skipped count. Conservative: outside the post-close window nothing matches.
 - [x] **19. Two Yahoo crons collide at 17:00 ET** (price + FX refresh) — stagger them.
   `security-price.service.ts:947`, `exchange-rate.service.ts:609`
   DONE: FX refresh moved to 17:05 ET (`5 17 * * 1-5`); `docs/cron-jobs.md` updated.
-- [ ] **20. Report search `LOWER(col) LIKE '%term%'`** on un-indexed `payee_name`/`description`
+- [x] **20. Report search `LOWER(col) LIKE '%term%'`** on un-indexed `payee_name`/`description`
   -> seq scans. Add `pg_trgm` GIN indexes. `reports.service.ts:402, 545-549`
+  DONE: migration 080 enables `pg_trgm` and adds GIN trigram indexes on
+  transactions.payee_name/description and payees.name/categories.name (the search uses ILIKE,
+  which gin_trgm_ops accelerates directly); schema.sql updated for fresh installs.
 
 ---
 
@@ -154,19 +162,35 @@ fail-fast, fully unit-tested). Applied to #5, #6, the FX refresh cron, and #17.
 
 ### Backend (logic drift)
 
-- [ ] **27. `convertCurrency` reimplemented twice** with different fallback behavior — net-worth
+- [x] **27. `convertCurrency` reimplemented twice** with different fallback behavior — net-worth
   vs report-currency can convert the same amount differently.
   `net-worth.service.ts:1376-1398` vs `report-currency.service.ts:65+`
-- [ ] **28. YMD date formatting inlined ~12 times** despite `formatDateYMD` helper (add a
-  `formatDateYMDUtc` for the UTC variants).
-- [ ] **29. Inline `Math.round(x*10000)/10000`** alongside imported `roundMoney`
-  (investment-transactions has 13; exchange-rate doesn't import the util at all).
-- [ ] **30. MCP `search_transactions` re-implements split-expansion + amount-filter** in the
-  tool layer (CLAUDE.md violation) and has no AI-executor twin. `transactions.tool.ts:101-139`
-- [ ] **31. `parseFloat` vs `Number`** split for decimal parsing (67 vs 519), concentrated in
+  DONE: extracted `common/currency-conversion.util.ts` (`convertWithRateLookup`) as the single
+  direct/inverse decision; each service parameterizes it with its own rate source.
+- [x] **28. YMD date formatting inlined ~12 times** despite `formatDateYMD` helper.
+  DONE: added `formatDateYMDLocal` (local components, distinct from UTC `formatDateYMD` and
+  TZ-aware `todayYMD`) for the 5 inline local-time "today" sites; budget month-end sites now
+  use the existing `getMonthEndYMD`. Behavior preserved exactly.
+- [x] **29. Inline `Math.round(x*10000)/10000`** alongside imported `roundMoney`.
+  DONE: migrated the money-rounding sites (exchange-rate inverse rate, AI usage cost,
+  post-import balance, OFX parser amount) to `roundMoney`. The documented per-share-price
+  `round4` helper in investment-transactions is intentionally left (distinct semantics).
+- [x] **30. MCP `search_transactions` re-implements split-expansion + amount-filter** in the
+  tool layer (CLAUDE.md violation). `transactions.tool.ts:101-139`
+  DONE: moved to `TransactionsService.getLlmTransactionRows`; the MCP tool is now a thin
+  adapter. Behavioral tests live on the service spec.
+- [x] **31. `parseFloat` vs `Number`** split for decimal parsing, concentrated in
   `built-in-reports/*`. Standardize on a `toMoneyNumber()` helper.
+  DONE: added `common/round.util` `toMoneyNumber` (Number-based parse, NaN->0, 4dp round) and
+  applied it across the comparison/income/spending/anomaly/tax/data-quality report services.
 - [ ] **32. docker-compose backend `environment:` block copy-pasted across 4 files** (drift
   risk on new env vars). Extract a shared base via `extends`/`env_file`.
+  SKIPPED (judgment call): the dev/prod/e2e files differ substantially and intentionally
+  (network names, `build` vs `image`, and the `${VAR:-default}` vs `${VAR}` syntax IS the
+  per-environment behavior). `env_file` cannot express the compose-default interpolation, and
+  an `extends` base would still need per-file overrides for most vars while making any single
+  environment harder to read. The dedup value did not justify restructuring deployment-critical
+  files that can't be fully validated here. Left as-is.
 
 ---
 

--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -108,14 +108,20 @@ fail-fast, fully unit-tested). Applied to #5, #6, the FX refresh cron, and #17.
 
 ## P2 — Performance polish
 
-- [ ] **13. Reports page rebuilds map+filter+sort (and SVG icon nodes) on every keystroke**,
+- [x] **13. Reports page rebuilds map+filter+sort (and SVG icon nodes) on every keystroke**,
   no `useMemo`, no search debounce. `app/reports/page.tsx:722-772`
-- [ ] **14. DividendIncomeReport fetch waterfall:** accounts + capital-gains wait behind the
+  DONE: `useMemo` on the derived report arrays + `filteredReports`; new `useDebouncedValue`
+  hook (tested) debounces search 200ms; `favouriteReportIds` memoized.
+- [x] **14. DividendIncomeReport fetch waterfall:** accounts + capital-gains wait behind the
   sequential transaction-pagination loop; inline MultiSelect options rebuilt each render.
   `DividendIncomeReport.tsx:254-273, 989-995`
-- [ ] **15. Whole-store Zustand subscriptions** (destructuring instead of slice selectors);
+  DONE: the three fetches now run concurrently via `Promise.all`; MultiSelect options and the
+  negative-capital-gains scans are memoized.
+- [x] **15. Whole-store Zustand subscriptions** (destructuring instead of slice selectors);
   widest-reach is `ProtectedRoute.tsx:18-19` (wraps every authed page); also `AppHeader`,
   `FavouriteAccounts`, dashboard.
+  DONE: all 5 listed sites converted to slice selectors; the 8 other whole-store call sites
+  (out of scope) were verified and left.
 - [x] **16. Anthropic provider has no prompt caching** (`cache_control` zero hits repo-wide)
   — resends large financial-context system prompts at full token cost every turn.
   `ai/providers/anthropic.provider.ts:98-107`
@@ -145,20 +151,41 @@ fail-fast, fully unit-tested). Applied to #5, #6, the FX refresh cron, and #17.
 
 ### Frontend (presentation drift)
 
-- [ ] **21. `LoadingSkeleton.tsx` is dead code** — 0 imports, yet 63 components hand-roll
+- [~] **21. `LoadingSkeleton.tsx` is dead code** — 0 imports, yet 63 components hand-roll
   `animate-pulse` skeletons. Highest-leverage cleanup.
-- [ ] **22. Signed-percent formatting reimplemented 40+ times** as
+  PARTIAL: adopted the kit at 47 sites (40 report chart skeletons + 5 chart components +
+  HoldingsList + GroupedHoldingsList). The "zero imports" claim was inaccurate -- the 8
+  `loading.tsx` route files already used it. Remaining hand-rolled cases are bespoke per-widget
+  dashboard layouts (left for clarity) and `bg-gray-200` progress-bar backgrounds (not
+  skeletons).
+- [x] **22. Signed-percent formatting reimplemented 40+ times** as
   `${v>=0?'+':''}${v.toFixed(1)}%`, bypassing `useNumberFormat`. Add `formatSignedPercent`.
-- [ ] **23. Gain/loss green/red ternary inlined in 71 files** with no helper. Add
+  DONE: added `formatSignedPercent` to `lib/format.ts` + `useNumberFormat`; migrated the
+  signed-percent sites. CurrencyExposureReport was intentionally NOT migrated (its percents are
+  unsigned "% of portfolio" proportions, where a signed helper would be wrong).
+- [x] **23. Gain/loss green/red ternary inlined in 71 files** with no helper. Add
   `gainLossColor(value)` to `lib/format.ts`.
-- [ ] **24. ~40 report components duplicate fetch/loading boilerplate** — and none track an
+  DONE: added `gainLossColor`; migrated ~50 sites (investments/reports edits + a scripted pass
+  across 23 files). Inverted-logic ternaries (e.g. spending where `<= 0` is green) were
+  correctly left alone.
+- [~] **24. ~40 report components duplicate fetch/loading boilerplate** — and none track an
   error state (`setError` count = 0 across reports -> failed fetches silently show empty).
   Extract `useReportData(fetcher, deps)`.
-- [ ] **25. `SummaryCard`/`SummaryIcons` exist but reports hand-roll** the card container
+  PARTIAL: created the tested `useReportData` hook + `ReportError` component, which surface a
+  retryable error state (the key gap -- reports previously showed empty on failure). Migrated 6
+  reports as a template covering both single-fetch and multi-response patterns; ~34 remain
+  (many have bespoke conditional/multi-fetch shapes needing per-file care).
+- [~] **25. `SummaryCard`/`SummaryIcons` exist but reports hand-roll** the card container
   string (appears in 42 files); 23 reports define their own inline Recharts tooltip.
-- [ ] **26. 3 forms bypass mandated rhf+Zod** (`BulkUpdateModal`, `CreateUserModal`,
+  PARTIAL: created shared `ChartTooltip`/`ChartTooltipPanel`, adopted in the 6 migrated reports.
+  `SummaryCard` had no clean unmigrated cases (already used in 8 page stat rows; report summary
+  cards use a structurally different colored-background, icon-less layout).
+- [x] **26. 3 forms bypass mandated rhf+Zod** (`BulkUpdateModal`, `CreateUserModal`,
   `MonteCarloSaveAsDialog`); `formatQuantity` copied in 3 investment lists; email Zod schema
   duplicated in 3 auth pages.
+  DONE: all 3 forms migrated to react-hook-form + zodResolver; `emailSchema` added to
+  `zod-helpers` and used in login/register/forgot-password; `formatQuantity` added to
+  `useNumberFormat` and the 3 inline copies removed.
 
 ### Backend (logic drift)
 

--- a/backend/src/ai/ai-usage.service.ts
+++ b/backend/src/ai/ai-usage.service.ts
@@ -5,6 +5,7 @@ import { Cron } from "@nestjs/schedule";
 import { AiUsageLog } from "./entities/ai-usage-log.entity";
 import { AiProviderConfig } from "./entities/ai-provider-config.entity";
 import { AiUsageSummary, EstimatedCostByCurrency } from "./dto/ai-response.dto";
+import { roundMoney } from "../common/round.util";
 
 interface CostRate {
   inputCostPer1M: number | null;
@@ -35,7 +36,7 @@ function computeCost(
     rate.outputCostPer1M !== null
       ? (outputTokens / TOKENS_PER_UNIT) * rate.outputCostPer1M
       : 0;
-  return Math.round((inputCost + outputCost) * 10000) / 10000;
+  return roundMoney(inputCost + outputCost);
 }
 
 function addCostToBucket(
@@ -44,7 +45,7 @@ function addCostToBucket(
   cost: number,
 ): void {
   const prev = bucket[currency] ?? 0;
-  bucket[currency] = Math.round((prev + cost) * 10000) / 10000;
+  bucket[currency] = roundMoney(prev + cost);
 }
 
 interface LogUsageParams {

--- a/backend/src/ai/providers/anthropic.provider.spec.ts
+++ b/backend/src/ai/providers/anthropic.provider.spec.ts
@@ -93,6 +93,22 @@ describe("AnthropicProvider", () => {
       expect(result.provider).toBe("anthropic");
       expect(result.model).toBe("claude-sonnet-4-20250514");
     });
+
+    it("sends the system prompt as a cached text block for prompt caching", async () => {
+      await provider.complete({
+        systemPrompt: "You are helpful.",
+        messages: [{ role: "user", content: "Hello" }],
+      });
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.system).toEqual([
+        {
+          type: "text",
+          text: "You are helpful.",
+          cache_control: { type: "ephemeral" },
+        },
+      ]);
+    });
   });
 
   describe("stream()", () => {
@@ -156,6 +172,11 @@ describe("AnthropicProvider", () => {
       expect(result.usage.outputTokens).toBe(25);
       expect(result.provider).toBe("anthropic");
       expect(result.stopReason).toBe("end_turn");
+
+      // The cached system block also caches the tools prefix that renders
+      // before it, so multi-turn tool-use conversations hit the prompt cache.
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.system[0].cache_control).toEqual({ type: "ephemeral" });
     });
 
     it("maps stop_reason tool_use correctly", async () => {

--- a/backend/src/ai/providers/anthropic.provider.ts
+++ b/backend/src/ai/providers/anthropic.provider.ts
@@ -95,11 +95,35 @@ export class AnthropicProvider implements AiProvider {
       }));
   }
 
+  /**
+   * Build the `system` parameter as a single cached text block so the large,
+   * stable financial-context prompt (and the tool definitions, which render
+   * before `system`) are served from Anthropic's prompt cache on repeated turns
+   * of a multi-turn tool-use conversation instead of being re-billed at full
+   * input cost every turn. A breakpoint on the last system block caches the
+   * tools + system prefix together. Returns the bare string when there is no
+   * prompt to cache.
+   */
+  private toCachedSystem(
+    systemPrompt: string,
+  ): string | Anthropic.TextBlockParam[] {
+    if (!systemPrompt) {
+      return systemPrompt;
+    }
+    return [
+      {
+        type: "text",
+        text: systemPrompt,
+        cache_control: { type: "ephemeral" },
+      },
+    ];
+  }
+
   async complete(request: AiCompletionRequest): Promise<AiCompletionResponse> {
     const response = await this.client.messages.create({
       model: this.modelId,
       max_tokens: request.maxTokens || 1024,
-      system: request.systemPrompt,
+      system: this.toCachedSystem(request.systemPrompt),
       messages: this.toSimpleMessages(request.messages),
       ...(request.temperature !== undefined && {
         temperature: request.temperature,
@@ -131,7 +155,7 @@ export class AnthropicProvider implements AiProvider {
         {
           model: this.modelId,
           max_tokens: request.maxTokens || 1024,
-          system: request.systemPrompt,
+          system: this.toCachedSystem(request.systemPrompt),
           messages: this.toSimpleMessages(request.messages),
           ...(request.temperature !== undefined && {
             temperature: request.temperature,
@@ -162,7 +186,7 @@ export class AnthropicProvider implements AiProvider {
     const response = await this.client.messages.create({
       model: this.modelId,
       max_tokens: request.maxTokens || 4096,
-      system: request.systemPrompt,
+      system: this.toCachedSystem(request.systemPrompt),
       messages: this.toAnthropicMessages(request.messages),
       tools: tools.map((tool) => ({
         name: tool.name,
@@ -224,7 +248,7 @@ export class AnthropicProvider implements AiProvider {
       stream = this.client.messages.stream({
         model: this.modelId,
         max_tokens: request.maxTokens || 4096,
-        system: request.systemPrompt,
+        system: this.toCachedSystem(request.systemPrompt),
         messages: this.toAnthropicMessages(request.messages),
         tools: tools.map((tool) => ({
           name: tool.name,

--- a/backend/src/budgets/budget-activity-reports.service.ts
+++ b/backend/src/budgets/budget-activity-reports.service.ts
@@ -10,7 +10,7 @@ import {
   SeasonalPattern,
   FlexGroupStatusResult,
 } from "./budget-reports.service";
-import { formatDateYMD } from "../common/date-utils";
+import { formatDateYMD, getMonthEndYMD } from "../common/date-utils";
 import { roundMoney, roundToDecimals, sumMoney } from "../common/round.util";
 
 const MONTH_NAMES = [
@@ -62,7 +62,10 @@ export class BudgetActivityReportsService {
     const startDate = new Date();
     startDate.setMonth(startDate.getMonth() - 12);
     const startStr = `${startDate.getFullYear()}-${String(startDate.getMonth() + 1).padStart(2, "0")}-01`;
-    const endStr = `${endDate.getFullYear()}-${String(endDate.getMonth() + 1).padStart(2, "0")}-${String(new Date(endDate.getFullYear(), endDate.getMonth() + 1, 0).getDate()).padStart(2, "0")}`;
+    const endStr = getMonthEndYMD(
+      endDate.getFullYear(),
+      endDate.getMonth() + 1,
+    );
 
     // Query monthly spending per category
     const directSpending = await this.transactionsRepository

--- a/backend/src/budgets/budget-alert.service.ts
+++ b/backend/src/budgets/budget-alert.service.ts
@@ -3,6 +3,7 @@ import { Cron } from "@nestjs/schedule";
 import { InjectRepository } from "@nestjs/typeorm";
 import { LessThan, IsNull, Repository } from "typeorm";
 import { ConfigService } from "@nestjs/config";
+import { getMonthEndYMD } from "../common/date-utils";
 import { Budget } from "./entities/budget.entity";
 import {
   BudgetAlert,
@@ -795,7 +796,10 @@ export class BudgetAlertService {
     const startDate = new Date();
     startDate.setMonth(startDate.getMonth() - 12);
     const startStr = `${startDate.getFullYear()}-${String(startDate.getMonth() + 1).padStart(2, "0")}-01`;
-    const endStr = `${endDate.getFullYear()}-${String(endDate.getMonth() + 1).padStart(2, "0")}-${String(new Date(endDate.getFullYear(), endDate.getMonth() + 1, 0).getDate()).padStart(2, "0")}`;
+    const endStr = getMonthEndYMD(
+      endDate.getFullYear(),
+      endDate.getMonth() + 1,
+    );
 
     const directSpending = await this.transactionsRepository
       .createQueryBuilder("t")

--- a/backend/src/budgets/budget-health-reports.service.ts
+++ b/backend/src/budgets/budget-health-reports.service.ts
@@ -9,6 +9,7 @@ import { BudgetPeriod, PeriodStatus } from "./entities/budget-period.entity";
 import { Transaction } from "../transactions/entities/transaction.entity";
 import { TransactionSplit } from "../transactions/entities/transaction-split.entity";
 import { BudgetsService } from "./budgets.service";
+import { getMonthEndYMD } from "../common/date-utils";
 import {
   HealthScoreResult,
   HealthScoreHistoryPoint,
@@ -249,12 +250,7 @@ export class BudgetHealthReportsService {
       1,
     );
     const rangeStart = `${startD.getFullYear()}-${String(startD.getMonth() + 1).padStart(2, "0")}-01`;
-    const lastDay = new Date(
-      today.getFullYear(),
-      today.getMonth() + 1,
-      0,
-    ).getDate();
-    const rangeEnd = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
+    const rangeEnd = getMonthEndYMD(today.getFullYear(), today.getMonth() + 1);
 
     // Batch queries: group by month across entire range
     const incomeByMonth = new Map<string, number>();

--- a/backend/src/budgets/budget-trend-reports.service.ts
+++ b/backend/src/budgets/budget-trend-reports.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { Budget } from "./entities/budget.entity";
 import { BudgetPeriod, PeriodStatus } from "./entities/budget-period.entity";
+import { getMonthEndYMD } from "../common/date-utils";
 import { BudgetPeriodCategory } from "./entities/budget-period-category.entity";
 import { Transaction } from "../transactions/entities/transaction.entity";
 import { TransactionSplit } from "../transactions/entities/transaction-split.entity";
@@ -363,12 +364,7 @@ export class BudgetTrendReportsService {
       1,
     );
     const rangeStart = `${startD.getFullYear()}-${String(startD.getMonth() + 1).padStart(2, "0")}-01`;
-    const lastDay = new Date(
-      today.getFullYear(),
-      today.getMonth() + 1,
-      0,
-    ).getDate();
-    const rangeEnd = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
+    const rangeEnd = getMonthEndYMD(today.getFullYear(), today.getMonth() + 1);
 
     // Batch query: per-category, per-month actuals in 2 parallel queries
     // Map<categoryId, Map<monthKey, amount>>
@@ -500,12 +496,7 @@ export class BudgetTrendReportsService {
       1,
     );
     const rangeStart = `${startD.getFullYear()}-${String(startD.getMonth() + 1).padStart(2, "0")}-01`;
-    const lastDay = new Date(
-      today.getFullYear(),
-      today.getMonth() + 1,
-      0,
-    ).getDate();
-    const rangeEnd = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
+    const rangeEnd = getMonthEndYMD(today.getFullYear(), today.getMonth() + 1);
 
     // Batch queries grouped by month
     const actualByMonth = new Map<string, number>();

--- a/backend/src/built-in-reports/anomaly-reports.service.ts
+++ b/backend/src/built-in-reports/anomaly-reports.service.ts
@@ -10,7 +10,7 @@ import {
   AnomalySeverity,
 } from "./dto";
 import { formatDateYMD } from "../common/date-utils";
-import { roundMoney, sumMoney } from "../common/round.util";
+import { roundMoney, sumMoney, toMoneyNumber } from "../common/round.util";
 
 @Injectable()
 export class AnomalyReportsService {
@@ -90,7 +90,7 @@ export class AnomalyReportsService {
 
     const amounts = rawResults.map((r) =>
       this.currencyService.convertAmount(
-        parseFloat(r.amount) || 0,
+        toMoneyNumber(r.amount),
         r.currency_code,
         defaultCurrency,
         rateMap,
@@ -107,7 +107,7 @@ export class AnomalyReportsService {
     // 1. Large single transactions
     rawResults.forEach((row) => {
       const amount = this.currencyService.convertAmount(
-        parseFloat(row.amount) || 0,
+        toMoneyNumber(row.amount),
         row.currency_code,
         defaultCurrency,
         rateMap,
@@ -198,7 +198,7 @@ export class AnomalyReportsService {
     rawResults.forEach((row) => {
       const txDate = new Date(row.transaction_date);
       const amount = this.currencyService.convertAmount(
-        parseFloat(row.amount) || 0,
+        toMoneyNumber(row.amount),
         row.currency_code,
         defaultCurrency,
         rateMap,
@@ -284,7 +284,7 @@ export class AnomalyReportsService {
         const existing = payeeRecentSpending.get(payeeName);
         if (existing) {
           existing.total += this.currencyService.convertAmount(
-            parseFloat(row.amount) || 0,
+            toMoneyNumber(row.amount),
             row.currency_code,
             defaultCurrency,
             rateMap,
@@ -294,7 +294,7 @@ export class AnomalyReportsService {
           payeeRecentSpending.set(payeeName, {
             name: row.payee_name || "Unknown",
             total: this.currencyService.convertAmount(
-              parseFloat(row.amount) || 0,
+              toMoneyNumber(row.amount),
               row.currency_code,
               defaultCurrency,
               rateMap,

--- a/backend/src/built-in-reports/comparison-reports.service.ts
+++ b/backend/src/built-in-reports/comparison-reports.service.ts
@@ -4,7 +4,7 @@ import { Repository } from "typeorm";
 import { Transaction } from "../transactions/entities/transaction.entity";
 import { Category } from "../categories/entities/category.entity";
 import { ReportCurrencyService } from "./report-currency.service";
-import { roundMoney, sumMoney } from "../common/round.util";
+import { roundMoney, sumMoney, toMoneyNumber } from "../common/round.util";
 import {
   YearOverYearResponse,
   YearData,
@@ -88,13 +88,13 @@ export class ComparisonReportsService {
       if (yearData) {
         const monthData = yearData.months[row.month - 1];
         const income = this.currencyService.convertAmount(
-          parseFloat(row.income) || 0,
+          toMoneyNumber(row.income),
           row.currency_code,
           defaultCurrency,
           rateMap,
         );
         const expenses = this.currencyService.convertAmount(
-          parseFloat(row.expenses) || 0,
+          toMoneyNumber(row.expenses),
           row.currency_code,
           defaultCurrency,
           rateMap,
@@ -188,7 +188,7 @@ export class ComparisonReportsService {
 
     rawResults.forEach((row) => {
       const total = this.currencyService.convertAmount(
-        parseFloat(row.total) || 0,
+        toMoneyNumber(row.total),
         row.currency_code,
         defaultCurrency,
         rateMap,

--- a/backend/src/built-in-reports/data-quality-reports.service.ts
+++ b/backend/src/built-in-reports/data-quality-reports.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { Transaction } from "../transactions/entities/transaction.entity";
 import { ReportCurrencyService } from "./report-currency.service";
-import { roundMoney, sumMoney } from "../common/round.util";
+import { roundMoney, sumMoney, toMoneyNumber } from "../common/round.util";
 import {
   UncategorizedTransactionsResponse,
   UncategorizedTransactionItem,
@@ -91,7 +91,7 @@ export class DataQualityReportsService {
         .toISOString()
         .split("T")[0],
       amount: this.currencyService.convertAmount(
-        parseFloat(row.amount) || 0,
+        toMoneyNumber(row.amount),
         row.currency_code,
         defaultCurrency,
         rateMap,
@@ -157,14 +157,14 @@ export class DataQualityReportsService {
       totalCount += parseInt(row.total_count, 10);
       expenseCount += parseInt(row.expense_count, 10);
       expenseTotal += this.currencyService.convertAmount(
-        parseFloat(row.expense_total) || 0,
+        toMoneyNumber(row.expense_total),
         row.currency_code,
         defaultCurrency,
         rateMap,
       );
       incomeCount += parseInt(row.income_count, 10);
       incomeTotal += this.currencyService.convertAmount(
-        parseFloat(row.income_total) || 0,
+        toMoneyNumber(row.income_total),
         row.currency_code,
         defaultCurrency,
         rateMap,
@@ -241,7 +241,7 @@ export class DataQualityReportsService {
       transactionDate: new Date(row.transaction_date)
         .toISOString()
         .split("T")[0],
-      amount: parseFloat(row.amount),
+      amount: toMoneyNumber(row.amount),
       payeeName: row.payee_name,
       description: row.description,
       accountName: row.account_name,

--- a/backend/src/built-in-reports/income-reports.service.ts
+++ b/backend/src/built-in-reports/income-reports.service.ts
@@ -8,7 +8,7 @@ import {
   RawCategoryAggregate,
   RawMonthlyAggregate,
 } from "./report-currency.service";
-import { roundMoney, sumMoney } from "../common/round.util";
+import { roundMoney, sumMoney, toMoneyNumber } from "../common/round.util";
 import {
   IncomeBySourceResponse,
   IncomeSourceItem,
@@ -85,7 +85,7 @@ export class IncomeReportsService {
 
     for (const row of rawResults) {
       const total = this.currencyService.convertAmount(
-        parseFloat(row.total) || 0,
+        toMoneyNumber(row.total),
         row.currency_code,
         defaultCurrency,
         rateMap,
@@ -194,13 +194,13 @@ export class IncomeReportsService {
     const monthlyMap = new Map<string, { income: number; expenses: number }>();
     for (const row of rawResults) {
       const income = this.currencyService.convertAmount(
-        parseFloat(row.income) || 0,
+        toMoneyNumber(row.income),
         row.currency_code,
         defaultCurrency,
         rateMap,
       );
       const expenses = this.currencyService.convertAmount(
-        parseFloat(row.expenses) || 0,
+        toMoneyNumber(row.expenses),
         row.currency_code,
         defaultCurrency,
         rateMap,

--- a/backend/src/built-in-reports/report-currency.service.ts
+++ b/backend/src/built-in-reports/report-currency.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { ExchangeRateService } from "../currencies/exchange-rate.service";
+import { convertWithRateLookup } from "../common/currency-conversion.util";
 
 export interface RawCategoryAggregate {
   category_id: string | null;
@@ -68,17 +69,21 @@ export class ReportCurrencyService {
     defaultCurrency: string,
     rateMap: RateMap,
   ): number {
-    if (!fromCurrency || fromCurrency === defaultCurrency) return amount;
-    const directKey = `${fromCurrency}->${defaultCurrency}`;
-    const directRate = rateMap.get(directKey);
-    if (directRate) return amount * directRate;
-    const inverseKey = `${defaultCurrency}->${fromCurrency}`;
-    const inverseRate = rateMap.get(inverseKey);
-    if (inverseRate && inverseRate !== 0) return amount / inverseRate;
-    // M30: Log warning when no conversion rate is found instead of silently returning unconverted amount
-    this.logger.warn(
-      `No exchange rate found for ${fromCurrency} -> ${defaultCurrency}, returning unconverted amount`,
+    // Flat latest-rate lookup; the direct/inverse decision is shared with
+    // net worth via convertWithRateLookup so the two surfaces stay consistent.
+    const result = convertWithRateLookup(
+      amount,
+      fromCurrency,
+      defaultCurrency,
+      (f, t) => rateMap.get(`${f}->${t}`),
     );
-    return amount;
+    if (result == null) {
+      // M30: Log warning when no conversion rate is found instead of silently returning unconverted amount
+      this.logger.warn(
+        `No exchange rate found for ${fromCurrency} -> ${defaultCurrency}, returning unconverted amount`,
+      );
+      return amount;
+    }
+    return result;
   }
 }

--- a/backend/src/built-in-reports/spending-reports.service.ts
+++ b/backend/src/built-in-reports/spending-reports.service.ts
@@ -10,7 +10,7 @@ import {
   RawPayeeAggregate,
   RawMonthlyCategoryAggregate,
 } from "./report-currency.service";
-import { roundMoney, sumMoney } from "../common/round.util";
+import { roundMoney, sumMoney, toMoneyNumber } from "../common/round.util";
 import {
   SpendingByCategoryResponse,
   CategorySpendingItem,
@@ -91,7 +91,7 @@ export class SpendingReportsService {
 
     for (const row of rawResults) {
       const total = this.currencyService.convertAmount(
-        parseFloat(row.total) || 0,
+        toMoneyNumber(row.total),
         row.currency_code,
         defaultCurrency,
         rateMap,
@@ -231,7 +231,7 @@ export class SpendingReportsService {
     >();
     for (const row of rawResults) {
       const total = this.currencyService.convertAmount(
-        parseFloat(row.total) || 0,
+        toMoneyNumber(row.total),
         row.currency_code,
         defaultCurrency,
         rateMap,
@@ -329,7 +329,7 @@ export class SpendingReportsService {
     for (const row of rawResults) {
       const month = row.month;
       const total = this.currencyService.convertAmount(
-        parseFloat(row.total) || 0,
+        toMoneyNumber(row.total),
         row.currency_code,
         defaultCurrency,
         rateMap,

--- a/backend/src/built-in-reports/tax-recurring-reports.service.ts
+++ b/backend/src/built-in-reports/tax-recurring-reports.service.ts
@@ -13,7 +13,7 @@ import {
   MonthlyBillTotal,
 } from "./dto";
 import { formatDateYMD } from "../common/date-utils";
-import { roundMoney, sumMoney } from "../common/round.util";
+import { roundMoney, sumMoney, toMoneyNumber } from "../common/round.util";
 
 @Injectable()
 export class TaxRecurringReportsService {
@@ -109,7 +109,7 @@ export class TaxRecurringReportsService {
 
     rawResults.forEach((row) => {
       const amount = this.currencyService.convertAmount(
-        parseFloat(row.amount) || 0,
+        toMoneyNumber(row.amount),
         row.currency_code,
         defaultCurrency,
         rateMap,
@@ -246,7 +246,7 @@ export class TaxRecurringReportsService {
 
     for (const row of rawResults) {
       const totalAmount = this.currencyService.convertAmount(
-        parseFloat(row.total_amount) || 0,
+        toMoneyNumber(row.total_amount),
         row.currency_code,
         defaultCurrency,
         rateMap,
@@ -364,7 +364,7 @@ export class TaxRecurringReportsService {
         payeeToScheduled.set(st.payee_name.toLowerCase().trim(), {
           id: st.id,
           name: st.name,
-          amount: Math.abs(parseFloat(st.amount)),
+          amount: Math.abs(toMoneyNumber(st.amount)),
         });
       }
     });
@@ -423,7 +423,7 @@ export class TaxRecurringReportsService {
       if (!scheduled) return;
 
       const txAmount = this.currencyService.convertAmount(
-        parseFloat(tx.amount) || 0,
+        toMoneyNumber(tx.amount),
         tx.currency_code,
         defaultCurrency,
         rateMap,

--- a/backend/src/common/concurrency.util.spec.ts
+++ b/backend/src/common/concurrency.util.spec.ts
@@ -71,8 +71,8 @@ describe("mapWithConcurrency", () => {
   });
 
   it("throws when the limit is less than 1", async () => {
-    await expect(
-      mapWithConcurrency([1], 0, async (x) => x),
-    ).rejects.toThrow("limit must be at least 1");
+    await expect(mapWithConcurrency([1], 0, async (x) => x)).rejects.toThrow(
+      "limit must be at least 1",
+    );
   });
 });

--- a/backend/src/common/currency-conversion.util.spec.ts
+++ b/backend/src/common/currency-conversion.util.spec.ts
@@ -1,0 +1,47 @@
+import { convertWithRateLookup } from "./currency-conversion.util";
+
+describe("convertWithRateLookup", () => {
+  const rates = new Map<string, number>([
+    ["USD->CAD", 1.35],
+    ["EUR->USD", 1.1],
+  ]);
+  const getRate = (from: string, to: string) => rates.get(`${from}->${to}`);
+
+  it("returns the amount unchanged when currencies match", () => {
+    expect(convertWithRateLookup(100, "USD", "USD", getRate)).toBe(100);
+  });
+
+  it("returns the amount unchanged when the from currency is empty", () => {
+    expect(convertWithRateLookup(100, "", "USD", getRate)).toBe(100);
+  });
+
+  it("applies the direct rate when available", () => {
+    expect(convertWithRateLookup(100, "USD", "CAD", getRate)).toBeCloseTo(135);
+  });
+
+  it("falls back to the inverse (reciprocal) rate", () => {
+    // No CAD->USD rate, but USD->CAD = 1.35, so CAD->USD = 1/1.35
+    expect(convertWithRateLookup(135, "CAD", "USD", getRate)).toBeCloseTo(100);
+  });
+
+  it("prefers the direct rate over the inverse when both exist", () => {
+    const both = new Map<string, number>([
+      ["USD->CAD", 1.35],
+      ["CAD->USD", 0.8], // intentionally inconsistent
+    ]);
+    expect(
+      convertWithRateLookup(100, "USD", "CAD", (f, t) => both.get(`${f}->${t}`)),
+    ).toBeCloseTo(135);
+  });
+
+  it("returns null when no rate is available in either direction", () => {
+    expect(convertWithRateLookup(100, "GBP", "JPY", getRate)).toBeNull();
+  });
+
+  it("returns null rather than dividing by a zero inverse rate", () => {
+    const zero = new Map<string, number>([["USD->CAD", 0]]);
+    expect(
+      convertWithRateLookup(100, "CAD", "USD", (f, t) => zero.get(`${f}->${t}`)),
+    ).toBeNull();
+  });
+});

--- a/backend/src/common/currency-conversion.util.spec.ts
+++ b/backend/src/common/currency-conversion.util.spec.ts
@@ -30,7 +30,9 @@ describe("convertWithRateLookup", () => {
       ["CAD->USD", 0.8], // intentionally inconsistent
     ]);
     expect(
-      convertWithRateLookup(100, "USD", "CAD", (f, t) => both.get(`${f}->${t}`)),
+      convertWithRateLookup(100, "USD", "CAD", (f, t) =>
+        both.get(`${f}->${t}`),
+      ),
     ).toBeCloseTo(135);
   });
 
@@ -41,7 +43,9 @@ describe("convertWithRateLookup", () => {
   it("returns null rather than dividing by a zero inverse rate", () => {
     const zero = new Map<string, number>([["USD->CAD", 0]]);
     expect(
-      convertWithRateLookup(100, "CAD", "USD", (f, t) => zero.get(`${f}->${t}`)),
+      convertWithRateLookup(100, "CAD", "USD", (f, t) =>
+        zero.get(`${f}->${t}`),
+      ),
     ).toBeNull();
   });
 });

--- a/backend/src/common/currency-conversion.util.ts
+++ b/backend/src/common/currency-conversion.util.ts
@@ -1,0 +1,35 @@
+/**
+ * Convert `amount` from one currency to another using a caller-supplied rate
+ * lookup. Tries the direct pair first, then falls back to the inverse pair
+ * (the reciprocal of the reverse rate). Returns `null` when neither rate is
+ * available so the caller decides how to handle a missing rate (log a warning,
+ * return the amount unconverted, etc).
+ *
+ * This is the single source of truth for the "direct then inverse" conversion
+ * decision. Callers differ only in where rates come from -- a flat map of the
+ * latest rates, or a date-indexed history resolved as-of a given date -- which
+ * they express through the `getRate` function. Keeping the decision here means
+ * reports and net worth can never diverge on how a pair is converted.
+ */
+export function convertWithRateLookup(
+  amount: number,
+  from: string,
+  to: string,
+  getRate: (from: string, to: string) => number | undefined,
+): number | null {
+  if (!from || from === to) {
+    return amount;
+  }
+
+  const direct = getRate(from, to);
+  if (direct != null) {
+    return amount * direct;
+  }
+
+  const inverse = getRate(to, from);
+  if (inverse != null && inverse !== 0) {
+    return amount / inverse;
+  }
+
+  return null;
+}

--- a/backend/src/common/date-utils.spec.ts
+++ b/backend/src/common/date-utils.spec.ts
@@ -1,5 +1,6 @@
 import {
   formatDateYMD,
+  formatDateYMDLocal,
   formatMonthKey,
   getMonthEndYMD,
   isTransactionInFuture,
@@ -23,6 +24,20 @@ describe("formatDateYMD", () => {
   it("does not shift dates due to local timezone", () => {
     const d = new Date("2026-12-31T23:59:59Z");
     expect(formatDateYMD(d)).toBe("2026-12-31");
+  });
+});
+
+describe("formatDateYMDLocal", () => {
+  it("formats using local components and zero-pads", () => {
+    // Construct from local year/month/day so the result is timezone-independent
+    const d = new Date(2026, 0, 5); // 2026-01-05 local
+    expect(formatDateYMDLocal(d)).toBe("2026-01-05");
+  });
+
+  it("matches the inline local-time template it replaces", () => {
+    const d = new Date(2026, 11, 31, 23, 59);
+    const expected = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    expect(formatDateYMDLocal(d)).toBe(expected);
   });
 });
 

--- a/backend/src/common/date-utils.ts
+++ b/backend/src/common/date-utils.ts
@@ -15,6 +15,23 @@ export function formatDateYMD(date: Date): string {
 }
 
 /**
+ * Format a Date object as YYYY-MM-DD using its LOCAL components.
+ *
+ * Use this for values derived from local-time arithmetic (e.g. `new Date()`
+ * representing "now" in the server's local time, or a Date built from local
+ * year/month/day). It is distinct from `formatDateYMD` (UTC components) and
+ * from `todayYMD` (request-timezone aware) -- replacing inline local-time
+ * `${d.getFullYear()}-...` template literals with this preserves their exact
+ * behavior without pulling in UTC or request-timezone semantics.
+ */
+export function formatDateYMDLocal(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
  * True iff the given string is a non-empty, well-formed IANA timezone name.
  * Lets us reject the "browser" sentinel and obvious junk before persisting
  * or scheduling against it.

--- a/backend/src/common/round.util.spec.ts
+++ b/backend/src/common/round.util.spec.ts
@@ -1,4 +1,35 @@
-import { roundToDecimals, roundMoney, sumMoney } from "./round.util";
+import {
+  roundToDecimals,
+  roundMoney,
+  sumMoney,
+  toMoneyNumber,
+} from "./round.util";
+
+describe("toMoneyNumber", () => {
+  it("parses a decimal SQL string to a number", () => {
+    expect(toMoneyNumber("12.3400")).toBe(12.34);
+  });
+
+  it("maps null/undefined/empty to 0", () => {
+    expect(toMoneyNumber(null)).toBe(0);
+    expect(toMoneyNumber(undefined)).toBe(0);
+    expect(toMoneyNumber("")).toBe(0);
+  });
+
+  it("maps non-numeric garbage to 0 (unlike parseFloat)", () => {
+    expect(toMoneyNumber("abc")).toBe(0);
+    // parseFloat("12.34abc") would be 12.34; Number() rejects it -> 0
+    expect(toMoneyNumber("12.34abc")).toBe(0);
+  });
+
+  it("rounds to 4dp money precision", () => {
+    expect(toMoneyNumber(1.234567)).toBe(1.2346);
+  });
+
+  it("passes through plain numbers", () => {
+    expect(toMoneyNumber(42)).toBe(42);
+  });
+});
 
 describe("roundToDecimals", () => {
   describe("basic rounding", () => {

--- a/backend/src/common/round.util.ts
+++ b/backend/src/common/round.util.ts
@@ -65,6 +65,20 @@ export function roundMoney(value: number): number {
 }
 
 /**
+ * Parse a money value coming from a `decimal(20,4)` SQL aggregate (a string,
+ * number, null, or undefined) into a rounded number. Standardizes the mix of
+ * `parseFloat(row.x) || 0` and `Number(row.x)` across report aggregation code:
+ * `Number` rejects trailing garbage that `parseFloat` would silently accept,
+ * the `|| 0` equivalent maps null/NaN to 0, and the result is rounded to the
+ * 4dp money precision. Inputs that are already 4dp (the DB representation) are
+ * unchanged numerically.
+ */
+export function toMoneyNumber(value: unknown): number {
+  const n = Number(value);
+  return isFinite(n) ? roundMoney(n) : 0;
+}
+
+/**
  * Sum an array of monetary values without floating-point drift by accumulating
  * in integer "ten-thousandths" (the 4dp storage unit) and converting back.
  *

--- a/backend/src/currencies/exchange-rate.service.ts
+++ b/backend/src/currencies/exchange-rate.service.ts
@@ -20,6 +20,7 @@ import { Account } from "../accounts/entities/account.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { YahooFinanceService } from "../securities/yahoo-finance.service";
 import { mapWithConcurrency } from "../common/concurrency.util";
+import { roundMoney } from "../common/round.util";
 
 // Cap concurrent Yahoo FX fetches so the daily refresh does not burst every
 // currency pair at once (this cron also runs alongside the security price
@@ -182,7 +183,7 @@ export class ExchangeRateService implements OnModuleInit {
     const result = await this.saveOneDirection(from, to, rate, date);
 
     // Also save the inverse rate so both directions stay current
-    const inverseRate = Math.round((1 / rate) * 10000) / 10000;
+    const inverseRate = roundMoney(1 / rate);
     await this.saveOneDirection(to, from, inverseRate, date);
 
     return result;

--- a/backend/src/import/import.service.ts
+++ b/backend/src/import/import.service.ts
@@ -61,6 +61,7 @@ import { ImportRegularProcessorService } from "./import-regular-processor.servic
 import { Tag } from "../tags/entities/tag.entity";
 import { Transaction } from "../transactions/entities/transaction.entity";
 import { TransactionSplit } from "../transactions/entities/transaction-split.entity";
+import { roundMoney } from "../common/round.util";
 
 @Injectable()
 export class ImportService {
@@ -1676,7 +1677,7 @@ export class ImportService {
             .join(", ");
           const params = balances.flatMap((row) => [
             row.account_id,
-            Math.round(Number(row.balance) * 10000) / 10000,
+            roundMoney(Number(row.balance)),
           ]);
           await this.dataSource.query(
             `UPDATE accounts SET current_balance = v.balance

--- a/backend/src/import/ofx-parser.ts
+++ b/backend/src/import/ofx-parser.ts
@@ -19,6 +19,7 @@
  */
 
 import type { QifTransaction, QifParseResult } from "./qif-parser";
+import { roundMoney } from "../common/round.util";
 
 // Strip HTML angle brackets to prevent stored XSS.
 function stripHtml(value: string): string {
@@ -219,7 +220,7 @@ export function parseOfx(content: string): QifParseResult {
 
     const tx: QifTransaction = {
       date,
-      amount: Math.round(amount * 10000) / 10000,
+      amount: roundMoney(amount),
       payee,
       memo: memoText,
       number: truncate(checkNum, 100),

--- a/backend/src/mcp/tools/transactions.tool.spec.ts
+++ b/backend/src/mcp/tools/transactions.tool.spec.ts
@@ -14,6 +14,7 @@ describe("McpTransactionsTools", () => {
   beforeEach(() => {
     transactionsService = {
       findAll: jest.fn(),
+      getLlmTransactionRows: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
     };
@@ -338,22 +339,23 @@ describe("McpTransactionsTools", () => {
       expect(result.isError).toBe(true);
     });
 
-    it("should search transactions with filters", async () => {
+    it("returns the rows the domain service produces", async () => {
       resolve.mockReturnValue({ userId: "u1", scopes: "read" });
-      transactionsService.findAll.mockResolvedValue({
-        data: [
+      transactionsService.getLlmTransactionRows.mockResolvedValue({
+        transactions: [
           {
             id: "t1",
-            transactionDate: "2025-01-15",
+            date: "2025-01-15",
             payeeName: "Store",
-            category: { name: "Food" },
+            categoryName: "Food",
             amount: -50,
-            account: { name: "Checking" },
+            accountName: "Checking",
             description: "Groceries",
             status: "cleared",
           },
         ],
-        pagination: { total: 1, hasMore: false },
+        total: 1,
+        hasMore: false,
       });
 
       const result = await handlers["search_transactions"](
@@ -363,156 +365,45 @@ describe("McpTransactionsTools", () => {
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed.transactions).toHaveLength(1);
       expect(parsed.transactions[0].payeeName).toBe("Store");
+      expect(parsed.total).toBe(1);
     });
 
-    it("should cap limit at 100", async () => {
+    it("delegates the filter args to the domain service (thin adapter)", async () => {
       resolve.mockReturnValue({ userId: "u1", scopes: "read" });
-      transactionsService.findAll.mockResolvedValue({
-        data: [],
-        pagination: { total: 0, hasMore: false },
+      transactionsService.getLlmTransactionRows.mockResolvedValue({
+        transactions: [],
+        total: 0,
+        hasMore: false,
       });
 
       await handlers["search_transactions"](
-        { limit: 999 },
+        {
+          query: "q",
+          accountId: "a1",
+          categoryId: "c1",
+          payeeId: "p1",
+          startDate: "2025-01-01",
+          endDate: "2025-01-31",
+          minAmount: -150,
+          maxAmount: -10,
+          limit: 999,
+        },
         { sessionId: "s1" },
       );
-      expect(transactionsService.findAll).toHaveBeenCalledWith(
+      expect(transactionsService.getLlmTransactionRows).toHaveBeenCalledWith(
         "u1",
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        1,
-        100,
-        false,
-        undefined,
+        {
+          query: "q",
+          accountId: "a1",
+          categoryId: "c1",
+          payeeId: "p1",
+          startDate: "2025-01-01",
+          endDate: "2025-01-31",
+          minAmount: -150,
+          maxAmount: -10,
+          limit: 999,
+        },
       );
-    });
-
-    it("should apply min/max amount filters", async () => {
-      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
-      transactionsService.findAll.mockResolvedValue({
-        data: [
-          { id: "t1", amount: -20, transactionDate: "2025-01-15" },
-          { id: "t2", amount: -100, transactionDate: "2025-01-14" },
-          { id: "t3", amount: -200, transactionDate: "2025-01-13" },
-        ],
-        pagination: { total: 3, hasMore: false },
-      });
-
-      const result = await handlers["search_transactions"](
-        { minAmount: -150, maxAmount: -10 },
-        { sessionId: "s1" },
-      );
-      const parsed = JSON.parse(result.content[0].text);
-      expect(parsed.transactions).toHaveLength(2);
-    });
-
-    it("should expand split transactions into per-split rows", async () => {
-      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
-      transactionsService.findAll.mockResolvedValue({
-        data: [
-          {
-            id: "t-split",
-            transactionDate: "2025-01-15",
-            payeeName: "Costco",
-            category: null,
-            amount: -150,
-            account: { name: "Checking" },
-            description: "Warehouse run",
-            status: "cleared",
-            isSplit: true,
-            splits: [
-              {
-                id: "s1",
-                amount: -100,
-                memo: "Groceries portion",
-                category: { name: "Groceries" },
-              },
-              {
-                id: "s2",
-                amount: -50,
-                memo: null,
-                category: { name: "Household" },
-              },
-            ],
-          },
-          {
-            id: "t-plain",
-            transactionDate: "2025-01-14",
-            payeeName: "Coffee",
-            category: { name: "Dining" },
-            amount: -5,
-            account: { name: "Checking" },
-            description: null,
-            status: "cleared",
-            isSplit: false,
-          },
-        ],
-        pagination: { total: 2, hasMore: false },
-      });
-
-      const result = await handlers["search_transactions"](
-        {},
-        { sessionId: "s1" },
-      );
-      const parsed = JSON.parse(result.content[0].text);
-      expect(parsed.transactions).toHaveLength(3);
-
-      const splitRows = parsed.transactions.filter(
-        (r: any) => r.id === "t-split",
-      );
-      expect(splitRows).toHaveLength(2);
-      expect(splitRows[0].categoryName).toBe("Groceries");
-      expect(splitRows[0].amount).toBe(-100);
-      expect(splitRows[0].splitId).toBe("s1");
-      expect(splitRows[0].isSplit).toBe(true);
-      expect(splitRows[0].description).toBe("Groceries portion");
-      expect(splitRows[1].categoryName).toBe("Household");
-      expect(splitRows[1].amount).toBe(-50);
-      expect(splitRows[1].description).toBe("Warehouse run");
-
-      const plainRow = parsed.transactions.find((r: any) => r.id === "t-plain");
-      expect(plainRow.categoryName).toBe("Dining");
-      expect(plainRow.isSplit).toBeUndefined();
-    });
-
-    it("should apply amount filter to unpacked splits", async () => {
-      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
-      transactionsService.findAll.mockResolvedValue({
-        data: [
-          {
-            id: "t-split",
-            transactionDate: "2025-01-15",
-            payeeName: "Costco",
-            amount: -150,
-            account: { name: "Checking" },
-            isSplit: true,
-            splits: [
-              {
-                id: "s1",
-                amount: -100,
-                category: { name: "Groceries" },
-              },
-              {
-                id: "s2",
-                amount: -50,
-                category: { name: "Household" },
-              },
-            ],
-          },
-        ],
-        pagination: { total: 1, hasMore: false },
-      });
-
-      const result = await handlers["search_transactions"](
-        { minAmount: -75 },
-        { sessionId: "s1" },
-      );
-      const parsed = JSON.parse(result.content[0].text);
-      expect(parsed.transactions).toHaveLength(1);
-      expect(parsed.transactions[0].amount).toBe(-50);
     });
   });
 

--- a/backend/src/mcp/tools/transactions.tool.ts
+++ b/backend/src/mcp/tools/transactions.tool.ts
@@ -85,63 +85,24 @@ export class McpTransactionsTools {
         if (check.error) return check.result;
 
         try {
-          const limit = Math.min(args.limit || 50, 100);
-          const result = await this.transactionsService.findAll(
+          // Split-expansion + amount filtering live on the domain service so
+          // this tool stays a thin adapter and any AI Assistant equivalent
+          // returns the same shape.
+          const result = await this.transactionsService.getLlmTransactionRows(
             ctx.userId,
-            args.accountId ? [args.accountId] : undefined,
-            args.startDate,
-            args.endDate,
-            args.categoryId ? [args.categoryId] : undefined,
-            args.payeeId ? [args.payeeId] : undefined,
-            1,
-            limit,
-            false,
-            args.query,
+            {
+              accountId: args.accountId,
+              categoryId: args.categoryId,
+              payeeId: args.payeeId,
+              startDate: args.startDate,
+              endDate: args.endDate,
+              query: args.query,
+              minAmount: args.minAmount,
+              maxAmount: args.maxAmount,
+              limit: args.limit,
+            },
           );
-          const transactions = result.data.flatMap((t: any) => {
-            // Expand split transactions so each split appears as its own row
-            // with its real category. The parent of a split has categoryId
-            // NULL by design; reporting it as-is makes the AI think it is
-            // uncategorized.
-            const rows =
-              t.isSplit && Array.isArray(t.splits) && t.splits.length > 0
-                ? t.splits.map((s: any) => ({
-                    id: t.id,
-                    splitId: s.id,
-                    date: t.transactionDate,
-                    payeeName: t.payeeName,
-                    categoryName: s.category?.name,
-                    amount: Number(s.amount),
-                    accountName: t.account?.name,
-                    description: s.memo ?? t.description,
-                    status: t.status,
-                    isSplit: true,
-                  }))
-                : [
-                    {
-                      id: t.id,
-                      date: t.transactionDate,
-                      payeeName: t.payeeName,
-                      categoryName: t.category?.name,
-                      amount: Number(t.amount),
-                      accountName: t.account?.name,
-                      description: t.description,
-                      status: t.status,
-                    },
-                  ];
-            return rows.filter((row: any) => {
-              if (args.minAmount !== undefined && row.amount < args.minAmount)
-                return false;
-              if (args.maxAmount !== undefined && row.amount > args.maxAmount)
-                return false;
-              return true;
-            });
-          });
-          return toolResult({
-            transactions,
-            total: result.pagination.total,
-            hasMore: result.pagination.hasMore,
-          });
+          return toolResult(result);
         } catch (err: unknown) {
           return safeToolError(err);
         }

--- a/backend/src/net-worth/net-worth.service.ts
+++ b/backend/src/net-worth/net-worth.service.ts
@@ -15,6 +15,7 @@ import { SecurityPrice } from "../securities/entities/security-price.entity";
 import { Security } from "../securities/entities/security.entity";
 import { ExchangeRate } from "../currencies/entities/exchange-rate.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
+import { convertWithRateLookup } from "../common/currency-conversion.util";
 
 const LIABILITY_TYPES: AccountType[] = [
   AccountType.CREDIT_CARD,
@@ -1390,21 +1391,14 @@ export class NetWorthService {
     monthEnd: string,
     rateIndex: RateIndex,
   ): number {
-    if (from === to) return amount;
-
-    const directRates = rateIndex.get(`${from}->${to}`);
-    if (directRates) {
-      const rate = this.findBestRate(directRates, monthEnd);
-      if (rate != null) return amount * rate;
-    }
-
-    const reverseRates = rateIndex.get(`${to}->${from}`);
-    if (reverseRates) {
-      const rate = this.findBestRate(reverseRates, monthEnd);
-      if (rate != null) return amount / rate;
-    }
-
-    return amount;
+    // Date-aware rate lookup: resolve the best rate on or before monthEnd from
+    // the historical index. The direct/inverse decision lives in the shared
+    // convertWithRateLookup helper so reports and net worth stay consistent.
+    const result = convertWithRateLookup(amount, from, to, (f, t) => {
+      const rates = rateIndex.get(`${f}->${t}`);
+      return rates ? this.findBestRate(rates, monthEnd) : undefined;
+    });
+    return result ?? amount;
   }
 
   private findBestRate(

--- a/backend/src/net-worth/net-worth.service.ts
+++ b/backend/src/net-worth/net-worth.service.ts
@@ -16,6 +16,7 @@ import { Security } from "../securities/entities/security.entity";
 import { ExchangeRate } from "../currencies/entities/exchange-rate.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { convertWithRateLookup } from "../common/currency-conversion.util";
+import { formatDateYMDLocal } from "../common/date-utils";
 
 const LIABILITY_TYPES: AccountType[] = [
   AccountType.CREDIT_CARD,
@@ -1102,8 +1103,7 @@ export class NetWorthService {
     }
 
     // Load investment transactions for holdings replay (exclude future-dated)
-    const now = new Date();
-    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+    const today = formatDateYMDLocal(new Date());
     const invTxs = await this.invTxRepo.find({
       where: {
         accountId: account.id,

--- a/backend/src/securities/holdings.service.ts
+++ b/backend/src/securities/holdings.service.ts
@@ -9,7 +9,7 @@ import {
 } from "@nestjs/common";
 import { Cron } from "@nestjs/schedule";
 import { InjectRepository } from "@nestjs/typeorm";
-import { todayInTimezone } from "../common/date-utils";
+import { todayInTimezone, formatDateYMDLocal } from "../common/date-utils";
 import { sumMoney } from "../common/round.util";
 import { getUsersByEffectiveTimezone } from "../common/users-by-timezone.util";
 import {
@@ -531,8 +531,7 @@ export class HoldingsService {
    * callers that need a timezone-correct cutoff pass it explicitly.
    */
   private serverToday(): string {
-    const now = new Date();
-    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+    return formatDateYMDLocal(new Date());
   }
 
   /**

--- a/backend/src/securities/portfolio-calculation.service.ts
+++ b/backend/src/securities/portfolio-calculation.service.ts
@@ -15,6 +15,7 @@ import {
   AllocationItem,
 } from "./portfolio.service";
 import { roundMoney } from "../common/round.util";
+import { formatDateYMDLocal } from "../common/date-utils";
 
 /**
  * Categorised investment accounts: brokerage, standalone, and cash accounts
@@ -418,8 +419,7 @@ export class PortfolioCalculationService {
     const result = new Map<string, number>();
     if (holdingsAccountIds.length === 0) return result;
 
-    const now = new Date();
-    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+    const today = formatDateYMDLocal(new Date());
 
     const transactions = await this.investmentTransactionRepository.find({
       where: {

--- a/backend/src/securities/security-price.service.spec.ts
+++ b/backend/src/securities/security-price.service.spec.ts
@@ -390,6 +390,24 @@ describe("SecurityPriceService", () => {
       expect(result.lastUpdated).toBeInstanceOf(Date);
     });
 
+    it("skips securities that already have a price for today", async () => {
+      securitiesRepository.find.mockResolvedValue([mockSecurity]);
+      // staleness query reports this security as already fresh today
+      dataSourceMock.query.mockResolvedValueOnce([
+        { security_id: mockSecurity.id },
+      ]);
+      global.fetch = jest.fn() as jest.Mock;
+
+      const result = await service.refreshAllPrices();
+
+      expect(result.totalSecurities).toBe(1);
+      expect(result.skipped).toBe(1);
+      expect(result.updated).toBe(0);
+      expect(result.results).toHaveLength(0);
+      // no external fetch when everything is already fresh
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
     it("successfully refreshes prices for a US security", async () => {
       securitiesRepository.find.mockResolvedValue([mockSecurity]);
 

--- a/backend/src/securities/security-price.service.ts
+++ b/backend/src/securities/security-price.service.ts
@@ -321,14 +321,37 @@ export class SecurityPriceService {
     const allActive = await this.securitiesRepository.find({
       where: { isActive: true },
     });
-    const securities = allActive.filter((s) => isRefreshEligible(s));
+    const eligible = allActive.filter((s) => isRefreshEligible(s));
+
+    // Skip securities that already have a price stored for today's date so a
+    // re-run after the daily close (or an on-demand refresh) doesn't re-fetch
+    // quotes that are already current. UTC "today" matches the US trading date
+    // at the 17:00 ET cron; outside that window nothing matches and we refresh
+    // everything, so this only ever avoids redundant work, never skips a
+    // security that needs updating.
+    let securities = eligible;
+    let skipped = 0;
+    if (eligible.length > 0) {
+      const today = formatDateYMD(new Date());
+      const freshRows: { security_id: string }[] =
+        (await this.dataSource.query(
+          `SELECT DISTINCT security_id FROM security_prices
+           WHERE security_id = ANY($1) AND price_date >= $2`,
+          [eligible.map((s) => s.id), today],
+        )) ?? [];
+      const freshIds = new Set(freshRows.map((r) => r.security_id));
+      if (freshIds.size > 0) {
+        securities = eligible.filter((s) => !freshIds.has(s.id));
+        skipped = eligible.length - securities.length;
+      }
+    }
 
     if (securities.length === 0) {
       return {
-        totalSecurities: 0,
+        totalSecurities: eligible.length,
         updated: 0,
         failed: 0,
-        skipped: 0,
+        skipped,
         results: [],
         lastUpdated: new Date(),
       };
@@ -341,7 +364,6 @@ export class SecurityPriceService {
     const results: PriceUpdateResult[] = [];
     let updated = 0;
     let failed = 0;
-    const skipped = 0;
 
     const symbolGroups = new Map<string, Security[]>();
     for (const security of securities) {

--- a/backend/src/transactions/transaction-bulk-update.service.spec.ts
+++ b/backend/src/transactions/transaction-bulk-update.service.spec.ts
@@ -13,6 +13,7 @@ import { BulkUpdateDto, BulkDeleteDto } from "./dto/bulk-update.dto";
 import { Brackets, DataSource } from "typeorm";
 
 jest.mock("../common/date-utils", () => ({
+  ...jest.requireActual("../common/date-utils"),
   isTransactionInFuture: jest.fn().mockReturnValue(false),
 }));
 

--- a/backend/src/transactions/transaction-bulk-update.service.ts
+++ b/backend/src/transactions/transaction-bulk-update.service.ts
@@ -20,7 +20,10 @@ import {
   BulkUpdateFilterDto,
 } from "./dto/bulk-update.dto";
 import { getAllCategoryIdsWithChildren } from "../common/category-tree.util";
-import { isTransactionInFuture } from "../common/date-utils";
+import {
+  isTransactionInFuture,
+  formatDateYMDLocal,
+} from "../common/date-utils";
 import {
   buildTransactionSearchClause,
   escapeLikePattern,
@@ -483,8 +486,7 @@ export class TransactionBulkUpdateService {
       : "transaction.status = :voidStatus";
 
     // Only include non-future transactions in balance changes
-    const now = new Date();
-    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+    const today = formatDateYMDLocal(new Date());
 
     const repo = queryRunner
       ? queryRunner.manager.getRepository(Transaction)

--- a/backend/src/transactions/transaction-reconciliation.service.spec.ts
+++ b/backend/src/transactions/transaction-reconciliation.service.spec.ts
@@ -8,6 +8,7 @@ import { AccountsService } from "../accounts/accounts.service";
 import { isTransactionInFuture } from "../common/date-utils";
 
 jest.mock("../common/date-utils", () => ({
+  ...jest.requireActual("../common/date-utils"),
   isTransactionInFuture: jest.fn().mockReturnValue(false),
 }));
 

--- a/backend/src/transactions/transaction-reconciliation.service.ts
+++ b/backend/src/transactions/transaction-reconciliation.service.ts
@@ -8,7 +8,10 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { DataSource, Repository } from "typeorm";
 import { Transaction, TransactionStatus } from "./entities/transaction.entity";
 import { AccountsService } from "../accounts/accounts.service";
-import { isTransactionInFuture } from "../common/date-utils";
+import {
+  isTransactionInFuture,
+  formatDateYMDLocal,
+} from "../common/date-utils";
 
 @Injectable()
 export class TransactionReconciliationService {
@@ -71,8 +74,7 @@ export class TransactionReconciliationService {
         status === TransactionStatus.RECONCILED &&
         oldStatus !== TransactionStatus.RECONCILED
       ) {
-        const now = new Date();
-        const reconciledDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+        const reconciledDate = formatDateYMDLocal(new Date());
         await queryRunner.manager.update(Transaction, transaction.id, {
           reconciledDate,
         });

--- a/backend/src/transactions/transactions.service.spec.ts
+++ b/backend/src/transactions/transactions.service.spec.ts
@@ -22,6 +22,7 @@ import { isTransactionInFuture } from "../common/date-utils";
 import { buildTransactionSearchClause } from "./transaction-search.util";
 
 jest.mock("../common/date-utils", () => ({
+  ...jest.requireActual("../common/date-utils"),
   isTransactionInFuture: jest.fn().mockReturnValue(false),
   todayYMD: jest.fn().mockReturnValue("2026-01-01"),
 }));
@@ -5397,6 +5398,123 @@ describe("TransactionsService", () => {
       expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
       expect(mockQueryRunner.commitTransaction).not.toHaveBeenCalled();
       expect(mockQueryRunner.release).toHaveBeenCalled();
+    });
+  });
+
+  describe("getLlmTransactionRows", () => {
+    it("expands split transactions into per-split rows with their real category", async () => {
+      jest.spyOn(service, "findAll").mockResolvedValue({
+        data: [
+          {
+            id: "t-split",
+            transactionDate: "2025-01-15",
+            payeeName: "Costco",
+            category: null,
+            amount: -150,
+            account: { name: "Checking" },
+            description: "Warehouse run",
+            status: "cleared",
+            isSplit: true,
+            splits: [
+              {
+                id: "s1",
+                amount: -100,
+                memo: "Groceries portion",
+                category: { name: "Groceries" },
+              },
+              {
+                id: "s2",
+                amount: -50,
+                memo: null,
+                category: { name: "Household" },
+              },
+            ],
+          },
+          {
+            id: "t-plain",
+            transactionDate: "2025-01-14",
+            payeeName: "Coffee",
+            category: { name: "Dining" },
+            amount: -5,
+            account: { name: "Checking" },
+            description: null,
+            status: "cleared",
+            isSplit: false,
+          },
+        ],
+        pagination: { total: 2, hasMore: false },
+      } as any);
+
+      const result = await service.getLlmTransactionRows("user-1", {});
+
+      expect(result.transactions).toHaveLength(3);
+      const splitRows = result.transactions.filter((r) => r.id === "t-split");
+      expect(splitRows[0].categoryName).toBe("Groceries");
+      expect(splitRows[0].splitId).toBe("s1");
+      expect(splitRows[0].isSplit).toBe(true);
+      expect(splitRows[0].description).toBe("Groceries portion");
+      expect(splitRows[1].description).toBe("Warehouse run"); // falls back to parent
+      const plain = result.transactions.find((r) => r.id === "t-plain");
+      expect(plain?.categoryName).toBe("Dining");
+      expect(plain?.isSplit).toBeUndefined();
+      expect(result.total).toBe(2);
+    });
+
+    it("applies min/max amount filters to the expanded rows", async () => {
+      jest.spyOn(service, "findAll").mockResolvedValue({
+        data: [
+          {
+            id: "t-split",
+            transactionDate: "2025-01-15",
+            payeeName: "Costco",
+            amount: -150,
+            account: { name: "Checking" },
+            isSplit: true,
+            splits: [
+              { id: "s1", amount: -100, category: { name: "Groceries" } },
+              { id: "s2", amount: -50, category: { name: "Household" } },
+            ],
+          },
+        ],
+        pagination: { total: 1, hasMore: false },
+      } as any);
+
+      const result = await service.getLlmTransactionRows("user-1", {
+        minAmount: -75,
+      });
+
+      expect(result.transactions).toHaveLength(1);
+      expect(result.transactions[0].amount).toBe(-50);
+    });
+
+    it("caps the limit at 100 and passes filters to findAll", async () => {
+      const spy = jest.spyOn(service, "findAll").mockResolvedValue({
+        data: [],
+        pagination: { total: 0, hasMore: false },
+      } as any);
+
+      await service.getLlmTransactionRows("user-1", {
+        accountId: "a1",
+        startDate: "2025-01-01",
+        endDate: "2025-01-31",
+        categoryId: "c1",
+        payeeId: "p1",
+        query: "q",
+        limit: 999,
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        "user-1",
+        ["a1"],
+        "2025-01-01",
+        "2025-01-31",
+        ["c1"],
+        ["p1"],
+        1,
+        100,
+        false,
+        "q",
+      );
     });
   });
 });

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -55,6 +55,25 @@ export interface PaginatedTransactions extends PaginatedResult<TransactionWithIn
   startingBalance?: number;
 }
 
+export interface LlmTransactionRow {
+  id: string;
+  splitId?: string;
+  date: string;
+  payeeName: string | null;
+  categoryName?: string;
+  amount: number;
+  accountName?: string;
+  description: string | null;
+  status: string;
+  isSplit?: boolean;
+}
+
+export interface LlmTransactionSearch {
+  transactions: LlmTransactionRow[];
+  total: number;
+  hasMore: boolean;
+}
+
 export { TransferResult };
 
 @Injectable()
@@ -1923,5 +1942,87 @@ export class TransactionsService {
       afterData: action === "delete" ? undefined : snapshot,
       description: `${action === "create" ? "Created" : action === "update" ? "Updated" : "Deleted"} transaction ${tx.payeeName || ""} ${formatCurrency(Number(tx.amount), tx.currencyCode)}`,
     });
+  }
+
+  /**
+   * Search transactions and shape them as flat rows for LLM tools (the MCP
+   * server's search_transactions tool and any AI Assistant equivalent). Split
+   * transactions are expanded so each split appears as its own row with its
+   * real category -- the parent of a split has categoryId NULL by design, so
+   * reporting it as-is would make the model think it is uncategorized. Amount
+   * filters are applied per expanded row. Keeping this on the domain service
+   * (rather than in the tool layer) keeps both surfaces consistent.
+   */
+  async getLlmTransactionRows(
+    userId: string,
+    filters: {
+      accountId?: string;
+      categoryId?: string;
+      payeeId?: string;
+      startDate?: string;
+      endDate?: string;
+      query?: string;
+      minAmount?: number;
+      maxAmount?: number;
+      limit?: number;
+    },
+  ): Promise<LlmTransactionSearch> {
+    const limit = Math.min(filters.limit || 50, 100);
+    const result = await this.findAll(
+      userId,
+      filters.accountId ? [filters.accountId] : undefined,
+      filters.startDate,
+      filters.endDate,
+      filters.categoryId ? [filters.categoryId] : undefined,
+      filters.payeeId ? [filters.payeeId] : undefined,
+      1,
+      limit,
+      false,
+      filters.query,
+    );
+
+    const transactions = result.data.flatMap((t): LlmTransactionRow[] => {
+      const rows: LlmTransactionRow[] =
+        t.isSplit && Array.isArray(t.splits) && t.splits.length > 0
+          ? t.splits.map((s) => ({
+              id: t.id,
+              splitId: s.id,
+              date: t.transactionDate,
+              payeeName: t.payeeName,
+              categoryName: s.category?.name,
+              amount: Number(s.amount),
+              accountName: t.account?.name,
+              description: s.memo ?? t.description,
+              status: t.status,
+              isSplit: true,
+            }))
+          : [
+              {
+                id: t.id,
+                date: t.transactionDate,
+                payeeName: t.payeeName,
+                categoryName: t.category?.name,
+                amount: Number(t.amount),
+                accountName: t.account?.name,
+                description: t.description,
+                status: t.status,
+              },
+            ];
+      return rows.filter((row) => {
+        if (filters.minAmount !== undefined && row.amount < filters.minAmount) {
+          return false;
+        }
+        if (filters.maxAmount !== undefined && row.amount > filters.maxAmount) {
+          return false;
+        }
+        return true;
+      });
+    });
+
+    return {
+      transactions,
+      total: result.pagination.total,
+      hasMore: result.pagination.hasMore,
+    };
   }
 }

--- a/database/migrations/080_transaction_search_trgm_indexes.sql
+++ b/database/migrations/080_transaction_search_trgm_indexes.sql
@@ -1,0 +1,18 @@
+-- Accelerate the transaction search (ILIKE '%term%') used by the register and
+-- the report search. Without trigram indexes, leading-wildcard ILIKE forces a
+-- sequential scan of the transactions table on every search keystroke.
+-- pg_trgm GIN indexes support ILIKE directly (no LOWER() needed).
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_payee_name_trgm
+    ON transactions USING gin (payee_name gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_transactions_description_trgm
+    ON transactions USING gin (description gin_trgm_ops);
+
+-- The same search clause filters payee and category names via EXISTS subqueries.
+CREATE INDEX IF NOT EXISTS idx_payees_name_trgm
+    ON payees USING gin (name gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_categories_name_trgm
+    ON categories USING gin (name gin_trgm_ops);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -4,6 +4,7 @@
 -- Extensions
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+CREATE EXTENSION IF NOT EXISTS pg_trgm; -- trigram indexes for transaction search
 
 -- Schema migration tracking (used by db-migrate to track applied migrations)
 CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -173,6 +174,7 @@ CREATE TABLE categories (
 
 CREATE INDEX idx_categories_user ON categories(user_id);
 CREATE INDEX idx_categories_parent ON categories(parent_id);
+CREATE INDEX idx_categories_name_trgm ON categories USING gin (name gin_trgm_ops);
 
 -- Payees
 CREATE TABLE payees (
@@ -188,6 +190,7 @@ CREATE TABLE payees (
 
 CREATE INDEX idx_payees_user ON payees(user_id);
 CREATE INDEX idx_payees_user_active ON payees(user_id, is_active);
+CREATE INDEX idx_payees_name_trgm ON payees USING gin (name gin_trgm_ops);
 
 -- Payee Aliases (for mapping imported payee names to canonical payees)
 CREATE TABLE payee_aliases (
@@ -238,6 +241,9 @@ CREATE INDEX idx_transactions_linked ON transactions(linked_transaction_id);
 CREATE INDEX idx_transactions_cleared ON transactions(is_cleared); -- LEGACY
 CREATE INDEX idx_transactions_reconciled ON transactions(is_reconciled); -- LEGACY
 CREATE INDEX idx_transactions_user_cleared ON transactions(user_id, is_cleared); -- LEGACY
+-- Trigram indexes accelerate the register/report search (ILIKE '%term%')
+CREATE INDEX idx_transactions_payee_name_trgm ON transactions USING gin (payee_name gin_trgm_ops);
+CREATE INDEX idx_transactions_description_trgm ON transactions USING gin (description gin_trgm_ops);
 
 -- Transaction Splits (details for split transactions)
 CREATE TABLE transaction_splits (

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -60,7 +60,7 @@ export default function DashboardPage() {
 }
 
 function DashboardContent() {
-  const { user } = useAuthStore();
+  const user = useAuthStore((s) => s.user);
   const actingAsUserId = useAuthStore((s) => s.actingAsUserId);
   const isDelegateView = !!actingAsUserId;
   const delegateSections = useAuthStore((s) => s.delegateSections);

--- a/frontend/src/app/forgot-password/page.tsx
+++ b/frontend/src/app/forgot-password/page.tsx
@@ -11,9 +11,10 @@ import Image from 'next/image';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { authApi } from '@/lib/auth';
+import { emailSchema } from '@/lib/zod-helpers';
 
 const schema = z.object({
-  email: z.string().email('Please enter a valid email address'),
+  email: emailSchema,
 });
 
 type FormData = z.infer<typeof schema>;

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -17,11 +17,12 @@ import { authApi, AuthMethods } from '@/lib/auth';
 import { TwoFactorVerify } from '@/components/auth/TwoFactorVerify';
 import { User } from '@/types/auth';
 import { createLogger } from '@/lib/logger';
+import { emailSchema } from '@/lib/zod-helpers';
 
 const logger = createLogger('Login');
 
 const loginSchema = z.object({
-  email: z.string().email('Please enter a valid email address'),
+  email: emailSchema,
   password: z.string().min(1, 'Password is required'),
   rememberMe: z.boolean(),
 });

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -14,14 +14,14 @@ import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { useAuthStore } from '@/store/authStore';
 import { authApi, AuthMethods } from '@/lib/auth';
-import { passwordSchema, PASSWORD_REQUIREMENTS_TEXT } from '@/lib/zod-helpers';
+import { passwordSchema, PASSWORD_REQUIREMENTS_TEXT, emailSchema } from '@/lib/zod-helpers';
 import { TwoFactorSetup } from '@/components/auth/TwoFactorSetup';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('Register');
 
 const registerSchema = z.object({
-  email: z.string().email('Please enter a valid email address'),
+  email: emailSchema,
   password: passwordSchema,
   confirmPassword: z.string(),
   firstName: z.string().max(100, 'First name must be less than 100 characters').optional(),

--- a/frontend/src/app/reports/page.test.tsx
+++ b/frontend/src/app/reports/page.test.tsx
@@ -374,8 +374,11 @@ describe('ReportsPage', () => {
     fireEvent.change(screen.getByPlaceholderText(/search reports/i), {
       target: { value: 'Tax Summary' },
     });
+    // Search is debounced, so wait for the filtered list to settle.
+    await waitFor(() => {
+      expect(screen.queryByText('Spending by Category')).not.toBeInTheDocument();
+    });
     expect(screen.getByText('Tax Summary')).toBeInTheDocument();
-    expect(screen.queryByText('Spending by Category')).not.toBeInTheDocument();
     expect(screen.queryByText('Income vs Expenses')).not.toBeInTheDocument();
   });
 
@@ -387,9 +390,12 @@ describe('ReportsPage', () => {
     fireEvent.change(screen.getByPlaceholderText(/search reports/i), {
       target: { value: 'subscriptions' },
     });
-    // "Recurring Expenses Tracker" has "subscriptions" in its description
+    // "Recurring Expenses Tracker" has "subscriptions" in its description.
+    // Search is debounced, so wait for the filtered list to settle.
+    await waitFor(() => {
+      expect(screen.queryByText('Spending by Category')).not.toBeInTheDocument();
+    });
     expect(screen.getByText('Recurring Expenses Tracker')).toBeInTheDocument();
-    expect(screen.queryByText('Spending by Category')).not.toBeInTheDocument();
   });
 
   it('search is case-insensitive', async () => {
@@ -411,7 +417,10 @@ describe('ReportsPage', () => {
     fireEvent.change(screen.getByPlaceholderText(/search reports/i), {
       target: { value: 'xyznonexistent' },
     });
-    expect(screen.getByText('0 reports available')).toBeInTheDocument();
+    // Search is debounced, so wait for the filtered list to settle.
+    await waitFor(() => {
+      expect(screen.getByText('0 reports available')).toBeInTheDocument();
+    });
   });
 
   it('search works combined with category filter', async () => {
@@ -455,8 +464,11 @@ describe('ReportsPage', () => {
     fireEvent.change(screen.getByPlaceholderText(/search reports/i), {
       target: { value: 'My Custom' },
     });
+    // Search is debounced, so wait for the filtered list to settle.
+    await waitFor(() => {
+      expect(screen.queryByText('Spending by Category')).not.toBeInTheDocument();
+    });
     expect(screen.getByText('My Custom Report')).toBeInTheDocument();
-    expect(screen.queryByText('Spending by Category')).not.toBeInTheDocument();
   });
 
   it('filters to custom category shows only custom reports', async () => {

--- a/frontend/src/app/reports/page.tsx
+++ b/frontend/src/app/reports/page.tsx
@@ -585,7 +585,12 @@ function ReportsContent() {
   const preferences = usePreferencesStore((s) => s.preferences);
   const updateStorePreferences = usePreferencesStore((s) => s.updatePreferences);
   const loadPreferences = usePreferencesStore((s) => s.loadPreferences);
-  const favouriteReportIds = preferences?.favouriteReportIds ?? [];
+  // Memoized so the `??[]` fallback does not create a new array reference each
+  // render, which would otherwise invalidate the filteredReports memo.
+  const favouriteReportIds = useMemo(
+    () => preferences?.favouriteReportIds ?? [],
+    [preferences?.favouriteReportIds],
+  );
 
   // Refresh preferences from server on mount to pick up changes from other devices
   useEffect(() => {

--- a/frontend/src/app/reports/page.tsx
+++ b/frontend/src/app/reports/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { NewReportButton } from '@/components/reports/NewReportButton';
@@ -718,58 +719,80 @@ function ReportsContent() {
     dense: 'Dense',
   };
 
-  // Convert custom reports to the Report interface
-  const customReportsAsReports: Report[] = customReports.map((cr) => {
-    const iconNode = cr.icon ? getIconComponent(cr.icon) : null;
-    return {
-      id: `custom/${cr.id}`,
-      name: cr.name,
-      description: cr.description || `${VIEW_TYPE_LABELS[cr.viewType]} · ${TIMEFRAME_LABELS[cr.timeframeType]}`,
-      category: 'custom' as ReportCategory,
-      color: cr.backgroundColor ? '' : 'bg-purple-500',
-      isCustom: true,
-      isFavourite: cr.isFavourite,
-      icon: iconNode || (
-        <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-        </svg>
-      ),
-    };
-  });
+  // Convert custom reports to the Report interface. Memoized so the SVG icon
+  // nodes are not rebuilt on every render (e.g. each search keystroke).
+  const customReportsAsReports: Report[] = useMemo(
+    () =>
+      customReports.map((cr) => {
+        const iconNode = cr.icon ? getIconComponent(cr.icon) : null;
+        return {
+          id: `custom/${cr.id}`,
+          name: cr.name,
+          description: cr.description || `${VIEW_TYPE_LABELS[cr.viewType]} · ${TIMEFRAME_LABELS[cr.timeframeType]}`,
+          category: 'custom' as ReportCategory,
+          color: cr.backgroundColor ? '' : 'bg-purple-500',
+          isCustom: true,
+          isFavourite: cr.isFavourite,
+          icon: iconNode || (
+            <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+          ),
+        };
+      }),
+    [customReports],
+  );
 
-  // Convert investment reports to the Report interface
-  const investmentReportsAsReports: Report[] = investmentReports.map((ir) => {
-    const iconNode = ir.icon ? getIconComponent(ir.icon) : null;
-    return {
-      id: `investment/${ir.id}`,
-      name: ir.name,
-      description:
-        ir.description ||
-        `Investment report · ${ir.config.columns?.length ?? 0} columns`,
-      category: 'investment' as ReportCategory,
-      color: ir.backgroundColor ? '' : 'bg-lime-500',
-      isInvestment: true,
-      isFavourite: ir.isFavourite,
-      icon: iconNode || (
-        <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
-        </svg>
-      ),
-    };
-  });
+  // Convert investment reports to the Report interface (memoized, see above).
+  const investmentReportsAsReports: Report[] = useMemo(
+    () =>
+      investmentReports.map((ir) => {
+        const iconNode = ir.icon ? getIconComponent(ir.icon) : null;
+        return {
+          id: `investment/${ir.id}`,
+          name: ir.name,
+          description:
+            ir.description ||
+            `Investment report · ${ir.config.columns?.length ?? 0} columns`,
+          category: 'investment' as ReportCategory,
+          color: ir.backgroundColor ? '' : 'bg-lime-500',
+          isInvestment: true,
+          isFavourite: ir.isFavourite,
+          icon: iconNode || (
+            <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+            </svg>
+          ),
+        };
+      }),
+    [investmentReports],
+  );
 
-  const allReports = [...reports, ...customReportsAsReports, ...investmentReportsAsReports];
+  const allReports = useMemo(
+    () => [...reports, ...customReportsAsReports, ...investmentReportsAsReports],
+    [customReportsAsReports, investmentReportsAsReports],
+  );
 
-  const filteredReports = allReports
-    .filter(r => {
-      if (categoryFilter !== 'all' && r.category !== categoryFilter) return false;
-      if (searchQuery) {
-        const q = searchQuery.toLowerCase();
-        return r.name.toLowerCase().includes(q) || r.description.toLowerCase().includes(q);
-      }
-      return true;
-    })
-    .sort((a, b) => Number(isReportFavourite(b)) - Number(isReportFavourite(a)));
+  // Debounce the search term so filter + sort does not re-run on every
+  // keystroke. The input stays bound to the immediate `searchQuery` value.
+  const debouncedSearchQuery = useDebouncedValue(searchQuery, 200);
+
+  const filteredReports = useMemo(() => {
+    const isFavourite = (report: Report): boolean =>
+      report.isCustom || report.isInvestment
+        ? report.isFavourite ?? false
+        : favouriteReportIds.includes(report.id);
+    const q = debouncedSearchQuery.toLowerCase();
+    return allReports
+      .filter(r => {
+        if (categoryFilter !== 'all' && r.category !== categoryFilter) return false;
+        if (debouncedSearchQuery) {
+          return r.name.toLowerCase().includes(q) || r.description.toLowerCase().includes(q);
+        }
+        return true;
+      })
+      .sort((a, b) => Number(isFavourite(b)) - Number(isFavourite(a)));
+  }, [allReports, categoryFilter, debouncedSearchQuery, favouriteReportIds]);
 
   const handleReportClick = (reportId: string) => {
     router.push(`/reports/${reportId}`);

--- a/frontend/src/components/accounts/AccountRow.tsx
+++ b/frontend/src/components/accounts/AccountRow.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { memo } from 'react';
+import { gainLossColor } from '@/lib/format';
 import { Account, AccountType } from '@/types/account';
 import { Button } from '@/components/ui/Button';
 
@@ -187,7 +188,7 @@ export const AccountRow = memo(function AccountRow({
                 <>
                   <div
                     className={`text-sm font-medium ${
-                      totalBalance >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+                      gainLossColor(totalBalance)
                     }`}
                   >
                     {formatCurrency(totalBalance, account.currencyCode)}

--- a/frontend/src/components/admin/CreateUserModal.test.tsx
+++ b/frontend/src/components/admin/CreateUserModal.test.tsx
@@ -76,7 +76,6 @@ describe('CreateUserModal', () => {
   });
 
   it('rejects a weak password without calling the API', async () => {
-    const toast = await import('react-hot-toast');
     renderModal(false);
 
     fireEvent.change(screen.getByPlaceholderText('user@example.com'), {
@@ -90,7 +89,10 @@ describe('CreateUserModal', () => {
     });
 
     expect(mockCreateUser).not.toHaveBeenCalled();
-    expect(toast.default.error).toHaveBeenCalled();
+    // The shared passwordSchema surfaces an inline validation error.
+    await waitFor(() =>
+      expect(screen.getByText(/at least 12 characters/i)).toBeInTheDocument(),
+    );
   });
 
   it('sends the chosen role and a valid password', async () => {

--- a/frontend/src/components/admin/CreateUserModal.tsx
+++ b/frontend/src/components/admin/CreateUserModal.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import { useState } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
 import toast from 'react-hot-toast';
 import { Modal } from '@/components/ui/Modal';
 import { Button } from '@/components/ui/Button';
@@ -8,10 +11,37 @@ import { Input } from '@/components/ui/Input';
 import { Select } from '@/components/ui/Select';
 import { PasswordInput } from '@/components/ui/PasswordInput';
 import { adminApi, CreateUserResponse } from '@/lib/admin';
-import { passwordSchema, PASSWORD_REQUIREMENTS_TEXT } from '@/lib/zod-helpers';
+import { passwordSchema, PASSWORD_REQUIREMENTS_TEXT, emailSchema } from '@/lib/zod-helpers';
 import { getErrorMessage } from '@/lib/errors';
 
 type CredentialMethod = 'invite' | 'password' | 'temporary';
+
+// The password field is only validated when the "password" credential method
+// is chosen; for invite/temporary it is left blank. A superRefine keeps the
+// shared passwordSchema rules without forcing a password for the other methods.
+const createUserSchema = z
+  .object({
+    email: emailSchema,
+    firstName: z.string().optional(),
+    lastName: z.string().optional(),
+    role: z.enum(['user', 'admin']),
+    method: z.enum(['invite', 'password', 'temporary']),
+    password: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.method === 'password') {
+      const result = passwordSchema.safeParse(data.password ?? '');
+      if (!result.success) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['password'],
+          message: result.error.issues[0]?.message ?? 'Invalid password.',
+        });
+      }
+    }
+  });
+
+type CreateUserFormData = z.infer<typeof createUserSchema>;
 
 interface CreateUserModalProps {
   isOpen: boolean;
@@ -26,64 +56,59 @@ export function CreateUserModal({
   onClose,
   onCreated,
 }: CreateUserModalProps) {
-  const [email, setEmail] = useState('');
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
-  const [role, setRole] = useState<'admin' | 'user'>('user');
-  const [method, setMethod] = useState<CredentialMethod>(
-    smtpConfigured ? 'invite' : 'password',
-  );
-  const [password, setPassword] = useState('');
-  const [submitting, setSubmitting] = useState(false);
+  const defaultMethod: CredentialMethod = smtpConfigured ? 'invite' : 'password';
+
+  const {
+    control,
+    register,
+    handleSubmit,
+    setValue,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<CreateUserFormData>({
+    resolver: zodResolver(createUserSchema),
+    defaultValues: {
+      email: '',
+      firstName: '',
+      lastName: '',
+      role: 'user',
+      method: defaultMethod,
+      password: '',
+    },
+  });
+
+  const method = useWatch({ control, name: 'method' });
 
   // Reset the form to its initial state whenever the modal transitions open.
   const [wasOpen, setWasOpen] = useState(isOpen);
   if (isOpen !== wasOpen) {
     setWasOpen(isOpen);
     if (isOpen) {
-      setEmail('');
-      setFirstName('');
-      setLastName('');
-      setRole('user');
-      setMethod(smtpConfigured ? 'invite' : 'password');
-      setPassword('');
+      reset({
+        email: '',
+        firstName: '',
+        lastName: '',
+        role: 'user',
+        method: defaultMethod,
+        password: '',
+      });
     }
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (submitting) return;
-
-    const trimmedEmail = email.trim();
-    if (!trimmedEmail) {
-      toast.error('Email is required.');
-      return;
-    }
-
-    if (method === 'password') {
-      const parsed = passwordSchema.safeParse(password);
-      if (!parsed.success) {
-        toast.error(parsed.error.issues[0]?.message ?? 'Invalid password.');
-        return;
-      }
-    }
-
-    setSubmitting(true);
+  const onSubmit = async (data: CreateUserFormData) => {
     try {
       const result = await adminApi.createUser({
-        email: trimmedEmail,
-        firstName: firstName.trim() || undefined,
-        lastName: lastName.trim() || undefined,
-        role,
-        password: method === 'password' ? password : undefined,
-        sendInvite: method === 'invite',
+        email: data.email.trim(),
+        firstName: data.firstName?.trim() || undefined,
+        lastName: data.lastName?.trim() || undefined,
+        role: data.role,
+        password: data.method === 'password' ? data.password : undefined,
+        sendInvite: data.method === 'invite',
       });
       onCreated(result);
       onClose();
     } catch (err) {
       toast.error(getErrorMessage(err, 'Failed to create user'));
-    } finally {
-      setSubmitting(false);
     }
   };
 
@@ -92,7 +117,7 @@ export function CreateUserModal({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} maxWidth="lg" pushHistory>
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit(onSubmit)}>
         <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
           <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
             Add User
@@ -109,33 +134,30 @@ export function CreateUserModal({
             label="Email"
             required
             placeholder="user@example.com"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            error={errors.email?.message}
+            {...register('email')}
           />
 
           <div className="grid grid-cols-2 gap-3">
             <Input
               label="First name (optional)"
               placeholder="First name"
-              value={firstName}
-              onChange={(e) => setFirstName(e.target.value)}
+              {...register('firstName')}
             />
             <Input
               label="Last name (optional)"
               placeholder="Last name"
-              value={lastName}
-              onChange={(e) => setLastName(e.target.value)}
+              {...register('lastName')}
             />
           </div>
 
           <Select
             label="Role"
-            value={role}
-            onChange={(e) => setRole(e.target.value as 'admin' | 'user')}
             options={[
               { value: 'user', label: 'User' },
               { value: 'admin', label: 'Admin' },
             ]}
+            {...register('role')}
           />
 
           <fieldset className="space-y-2">
@@ -150,7 +172,7 @@ export function CreateUserModal({
                 className="mt-1"
                 checked={method === 'invite'}
                 disabled={!smtpConfigured}
-                onChange={() => setMethod('invite')}
+                onChange={() => setValue('method', 'invite')}
               />
               <span className="text-sm text-gray-700 dark:text-gray-300">
                 Send an email invite to set a password
@@ -168,7 +190,7 @@ export function CreateUserModal({
                 name="credential-method"
                 className="mt-1"
                 checked={method === 'password'}
-                onChange={() => setMethod('password')}
+                onChange={() => setValue('method', 'password')}
               />
               <span className="text-sm text-gray-700 dark:text-gray-300">
                 Set a password now
@@ -181,7 +203,7 @@ export function CreateUserModal({
                 name="credential-method"
                 className="mt-1"
                 checked={method === 'temporary'}
-                onChange={() => setMethod('temporary')}
+                onChange={() => setValue('method', 'temporary')}
               />
               <span className="text-sm text-gray-700 dark:text-gray-300">
                 Generate a temporary password
@@ -201,13 +223,18 @@ export function CreateUserModal({
               <PasswordInput
                 required
                 placeholder="Set a password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
                 className={inputClass}
+                {...register('password')}
               />
-              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                {PASSWORD_REQUIREMENTS_TEXT}
-              </p>
+              {errors.password?.message ? (
+                <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+                  {errors.password.message}
+                </p>
+              ) : (
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  {PASSWORD_REQUIREMENTS_TEXT}
+                </p>
+              )}
             </div>
           )}
         </div>
@@ -217,11 +244,11 @@ export function CreateUserModal({
             type="button"
             variant="outline"
             onClick={onClose}
-            disabled={submitting}
+            disabled={isSubmitting}
           >
             Cancel
           </Button>
-          <Button type="submit" isLoading={submitting}>
+          <Button type="submit" isLoading={isSubmitting}>
             Create User
           </Button>
         </div>

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -15,8 +15,11 @@ interface ProtectedRouteProps {
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
   const router = useRouter();
   const pathname = usePathname();
-  const { user, isAuthenticated, isLoading, _hasHydrated } = useAuthStore();
-  const { preferences } = usePreferencesStore();
+  const user = useAuthStore((s) => s.user);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const isLoading = useAuthStore((s) => s.isLoading);
+  const _hasHydrated = useAuthStore((s) => s._hasHydrated);
+  const preferences = usePreferencesStore((s) => s.preferences);
   const [force2fa, setForce2fa] = useState(false);
   useUndoRedo();
 

--- a/frontend/src/components/bills/CashFlowForecastChart.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo, useEffect, useCallback } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   LineChart,
   Line,
@@ -193,7 +194,7 @@ export function CashFlowForecastChart({
           </h3>
         </div>
         <div className="h-72 flex items-center justify-center">
-          <div className="animate-pulse w-full h-full bg-gray-200 dark:bg-gray-700 rounded" />
+          <Skeleton className="w-full h-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/bills/CashFlowForecastChart.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo, useEffect, useCallback } from 'react';
+import { gainLossColor } from '@/lib/format';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   LineChart,
@@ -52,9 +53,7 @@ function CashFlowTooltip({
         </p>
         <p
           className={`text-lg font-semibold ${
-            data.balance >= 0
-              ? 'text-green-600 dark:text-green-400'
-              : 'text-red-600 dark:text-red-400'
+            gainLossColor(data.balance)
           }`}
         >
           {formatCurrency(data.balance)}
@@ -68,9 +67,7 @@ function CashFlowTooltip({
               <p key={i} className="text-sm text-gray-700 dark:text-gray-300">
                 <span
                   className={
-                    tx.amount >= 0
-                      ? 'text-green-600 dark:text-green-400'
-                      : 'text-red-600 dark:text-red-400'
+                    gainLossColor(tx.amount)
                   }
                 >
                   {formatCurrency(tx.amount)}
@@ -395,9 +392,7 @@ export function CashFlowForecastChart({
             <div className="text-sm text-gray-500 dark:text-gray-400">Ending</div>
             <div
               className={`font-semibold ${
-                summary.endingBalance >= 0
-                  ? 'text-green-600 dark:text-green-400'
-                  : 'text-red-600 dark:text-red-400'
+                gainLossColor(summary.endingBalance)
               }`}
             >
               {formatCurrency(summary.endingBalance)}

--- a/frontend/src/components/budgets/BudgetPeriodDetail.tsx
+++ b/frontend/src/components/budgets/BudgetPeriodDetail.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { format, parseISO } from 'date-fns';
+import { gainLossColor } from '@/lib/format';
 import { BudgetProgressBar } from './BudgetProgressBar';
 import type { BudgetPeriod, BudgetPeriodCategory } from '@/types/budget';
 
@@ -92,9 +93,7 @@ export function BudgetPeriodDetail({
           value={formatCurrency(Math.abs(remaining))}
           sublabel={remaining >= 0 ? 'saved' : 'overspent'}
           valueColor={
-            remaining >= 0
-              ? 'text-green-600 dark:text-green-400'
-              : 'text-red-600 dark:text-red-400'
+            gainLossColor(remaining)
           }
         />
         <SummaryCard

--- a/frontend/src/components/budgets/BudgetScenarioPlanner.tsx
+++ b/frontend/src/components/budgets/BudgetScenarioPlanner.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo, useCallback } from 'react';
+import { gainLossColor } from '@/lib/format';
 import type { CategoryBreakdown } from '@/types/budget';
 
 interface BudgetScenarioPlannerProps {
@@ -173,9 +174,7 @@ export function BudgetScenarioPlanner({
           <p className="text-xs text-gray-500 dark:text-gray-400">Projected Savings</p>
           <p
             className={`text-base font-semibold ${
-              adjustedSavings >= 0
-                ? 'text-green-600 dark:text-green-400'
-                : 'text-red-600 dark:text-red-400'
+              gainLossColor(adjustedSavings)
             }`}
             data-testid="projected-savings"
           >

--- a/frontend/src/components/budgets/BudgetUpcomingBills.tsx
+++ b/frontend/src/components/budgets/BudgetUpcomingBills.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
+import { gainLossColor } from '@/lib/format';
 import { differenceInDays, startOfDay, parseISO } from 'date-fns';
 import type { ScheduledTransaction } from '@/types/scheduled-transaction';
 
@@ -96,9 +97,7 @@ export function BudgetUpcomingBills({
           <span className="text-gray-600 dark:text-gray-400">Truly available</span>
           <span
             className={`font-semibold ${
-              trulyAvailable >= 0
-                ? 'text-green-600 dark:text-green-400'
-                : 'text-red-600 dark:text-red-400'
+              gainLossColor(trulyAvailable)
             }`}
           >
             {formatCurrency(Math.abs(trulyAvailable))}

--- a/frontend/src/components/budgets/BudgetVelocityWidget.tsx
+++ b/frontend/src/components/budgets/BudgetVelocityWidget.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { BudgetVelocity } from '@/types/budget';
+import { gainLossColor } from '@/lib/format';
 
 interface BudgetVelocityWidgetProps {
   velocity: BudgetVelocity;
@@ -111,9 +112,7 @@ export function BudgetVelocityWidget({
               Truly available
             </div>
             <div className={`text-lg font-semibold ${
-              velocity.trulyAvailable >= 0
-                ? 'text-green-600 dark:text-green-400'
-                : 'text-red-600 dark:text-red-400'
+              gainLossColor(velocity.trulyAvailable)
             }`}>
               {formatCurrency(Math.abs(velocity.trulyAvailable))}
               {velocity.trulyAvailable < 0 && ' over'}

--- a/frontend/src/components/budgets/BudgetWizardCategories.test.tsx
+++ b/frontend/src/components/budgets/BudgetWizardCategories.test.tsx
@@ -11,6 +11,9 @@ vi.mock('@/lib/format', () => ({
   getDecimalPlacesForCurrency: vi.fn(() => 2),
   formatAmount: vi.fn((v: number | undefined | null) => (v === undefined || v === null || isNaN(v)) ? '' : (Math.round(v * 100) / 100).toFixed(2)),
   roundToDecimals: vi.fn((v: number) => v),
+  gainLossColor: vi.fn((v: number) =>
+    v >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400',
+  ),
 }));
 
 describe('BudgetWizardCategories', () => {

--- a/frontend/src/components/budgets/BudgetWizardCategories.tsx
+++ b/frontend/src/components/budgets/BudgetWizardCategories.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/Button';
 import { Sparkline } from './Sparkline';
-import { getCurrencySymbol, formatAmount, getDecimalPlacesForCurrency } from '@/lib/format';
+import { getCurrencySymbol, formatAmount, getDecimalPlacesForCurrency, gainLossColor } from '@/lib/format';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import type { WizardState } from './BudgetWizard';
 import type { BudgetProfile, CategoryGroup, TransferAnalysis } from '@/types/budget';
@@ -604,9 +604,7 @@ export function BudgetWizardCategories({
             </div>
             <div
               className={`text-lg font-semibold ${
-                totals.net >= 0
-                  ? 'text-green-600 dark:text-green-400'
-                  : 'text-red-600 dark:text-red-400'
+                gainLossColor(totals.net)
               }`}
             >
               {formatCurrency(totals.net, currencyCode)}

--- a/frontend/src/components/budgets/BudgetWizardReview.test.tsx
+++ b/frontend/src/components/budgets/BudgetWizardReview.test.tsx
@@ -17,6 +17,9 @@ vi.mock('@/lib/format', () => ({
   formatCurrency: vi.fn((amount: number) => `$${amount.toFixed(2)}`),
   getDecimalPlacesForCurrency: vi.fn(() => 2),
   roundToDecimals: vi.fn((v: number) => v),
+  gainLossColor: vi.fn((v: number) =>
+    v >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400',
+  ),
 }));
 
 // Mock errors

--- a/frontend/src/components/budgets/BudgetWizardReview.tsx
+++ b/frontend/src/components/budgets/BudgetWizardReview.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { gainLossColor } from '@/lib/format';
 import toast from 'react-hot-toast';
 import { Button } from '@/components/ui/Button';
 import { budgetsApi } from '@/lib/budgets';
@@ -201,9 +202,7 @@ export function BudgetWizardReview({
           </div>
           <div
             className={`text-lg sm:text-xl font-bold ${
-              net >= 0
-                ? 'text-green-600 dark:text-green-400'
-                : 'text-red-600 dark:text-red-400'
+              gainLossColor(net)
             }`}
           >
             {formatCurrency(net, state.currencyCode)}

--- a/frontend/src/components/dashboard/FavouriteAccounts.tsx
+++ b/frontend/src/components/dashboard/FavouriteAccounts.tsx
@@ -31,7 +31,7 @@ interface FavouriteAccountsProps {
 
 export function FavouriteAccounts({ accounts, brokerageMarketValues, isLoading, onAccountsChanged: _onAccountsChanged }: FavouriteAccountsProps) {
   const router = useRouter();
-  const { preferences } = usePreferencesStore();
+  const preferences = usePreferencesStore((s) => s.preferences);
   const { formatCurrency: formatCurrencyBase } = useNumberFormat();
   const defaultCurrency = preferences?.defaultCurrency || 'CAD';
   const [reordering, setReordering] = useState(false);

--- a/frontend/src/components/dashboard/FavouriteAccounts.tsx
+++ b/frontend/src/components/dashboard/FavouriteAccounts.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useCallback } from 'react';
+import { gainLossColor } from '@/lib/format';
 import { useRouter } from 'next/navigation';
 import { Account } from '@/types/account';
 import { usePreferencesStore } from '@/store/preferencesStore';
@@ -215,9 +216,7 @@ export function FavouriteAccounts({ accounts, brokerageMarketValues, isLoading, 
                   <div className="text-right ml-2">
                     <div
                       className={`font-semibold whitespace-nowrap ${
-                        displayValue >= 0
-                          ? 'text-green-600 dark:text-green-400'
-                          : 'text-red-600 dark:text-red-400'
+                        gainLossColor(displayValue)
                       }`}
                     >
                       {formatCurrency(displayValue, account.currencyCode)}

--- a/frontend/src/components/dashboard/GettingStarted.test.tsx
+++ b/frontend/src/components/dashboard/GettingStarted.test.tsx
@@ -5,10 +5,13 @@ import { GettingStarted } from './GettingStarted';
 const mockUpdatePreferences = vi.fn();
 
 vi.mock('@/store/preferencesStore', () => ({
-  usePreferencesStore: () => ({
-    preferences: { gettingStartedDismissed: false },
-    updatePreferences: mockUpdatePreferences,
-  }),
+  usePreferencesStore: (selector?: (state: Record<string, unknown>) => unknown) => {
+    const state = {
+      preferences: { gettingStartedDismissed: false },
+      updatePreferences: mockUpdatePreferences,
+    };
+    return selector ? selector(state) : state;
+  },
 }));
 
 vi.mock('@/lib/user-settings', () => ({

--- a/frontend/src/components/dashboard/GettingStarted.tsx
+++ b/frontend/src/components/dashboard/GettingStarted.tsx
@@ -50,7 +50,8 @@ const steps = [
 ];
 
 export function GettingStarted() {
-  const { preferences, updatePreferences } = usePreferencesStore();
+  const preferences = usePreferencesStore((s) => s.preferences);
+  const updatePreferences = usePreferencesStore((s) => s.updatePreferences);
   const [dismissing, setDismissing] = useState(false);
 
   if (!preferences || preferences.gettingStartedDismissed || dismissing) {

--- a/frontend/src/components/dashboard/IncomeExpensesBarChart.tsx
+++ b/frontend/src/components/dashboard/IncomeExpensesBarChart.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from 'next/navigation';
 import {
   BarChart,
@@ -181,7 +182,7 @@ export function IncomeExpensesBarChart({
           Income vs Expenses
         </h3>
         <div className="h-64 flex items-center justify-center">
-          <div className="animate-pulse w-full h-full bg-gray-200 dark:bg-gray-700 rounded" />
+          <Skeleton className="w-full h-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/dashboard/IncomeExpensesBarChart.tsx
+++ b/frontend/src/components/dashboard/IncomeExpensesBarChart.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useRef } from 'react';
+import { gainLossColor } from '@/lib/format';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from 'next/navigation';
 import {
@@ -264,11 +265,7 @@ export function IncomeExpensesBarChart({
         <div>
           <div className="text-sm text-gray-500 dark:text-gray-400">Net</div>
           <div
-            className={`font-semibold ${
-              totals.income - totals.expenses >= 0
-                ? 'text-green-600 dark:text-green-400'
-                : 'text-red-600 dark:text-red-400'
-            }`}
+            className={`font-semibold ${gainLossColor(totals.income - totals.expenses)}`}
           >
             {formatCurrency(totals.income - totals.expenses)}
           </div>

--- a/frontend/src/components/investments/GroupedHoldingsList.test.tsx
+++ b/frontend/src/components/investments/GroupedHoldingsList.test.tsx
@@ -20,6 +20,11 @@ vi.mock('@/hooks/useNumberFormat', () => ({
       const s = `$${n.toFixed(digits)}`;
       return currencyCode ? `${currencyCode} ${s}` : s;
     },
+    formatSignedPercent: (n: number, decimals = 2) =>
+      `${n >= 0 ? '+' : ''}${n.toFixed(decimals)}%`,
+    formatNumber: (n: number, decimals = 2) => n.toFixed(decimals),
+    formatQuantity: (n: number) =>
+      new Intl.NumberFormat('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 4 }).format(n),
     numberFormat: 'en-US',
   }),
 }));

--- a/frontend/src/components/investments/GroupedHoldingsList.tsx
+++ b/frontend/src/components/investments/GroupedHoldingsList.tsx
@@ -5,6 +5,7 @@ import { AccountHoldings, HoldingWithMarketValue } from '@/types/investment';
 import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
+import { gainLossColor } from '@/lib/format';
 
 interface GroupedHoldingsListProps {
   holdingsByAccount: AccountHoldings[];
@@ -21,7 +22,7 @@ export function GroupedHoldingsList({
   onSymbolClick,
   onCashClick,
 }: GroupedHoldingsListProps) {
-  const { formatCurrency: formatCurrencyBase, formatCurrencyPrecise, numberFormat } = useNumberFormat();
+  const { formatCurrency: formatCurrencyBase, formatCurrencyPrecise, formatSignedPercent, formatNumber, formatQuantity } = useNumberFormat();
   const { convert, convertToDefault, defaultCurrency } = useExchangeRates();
 
   const [expandedAccounts, setExpandedAccounts] = useState<Set<string>>(
@@ -54,23 +55,12 @@ export function GroupedHoldingsList({
 
   const formatPercent = (value: number | null, showSign = true) => {
     if (value === null) return '-';
-    const sign = showSign && value >= 0 ? '+' : '';
-    return `${sign}${value.toFixed(2)}%`;
-  };
-
-  const formatQuantity = (value: number) => {
-    const locale = numberFormat === 'browser' ? undefined : numberFormat;
-    return new Intl.NumberFormat(locale, {
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 4,
-    }).format(value);
+    return showSign ? formatSignedPercent(value) : `${formatNumber(value, 2)}%`;
   };
 
   const getGainLossColor = (value: number | null) => {
     if (value === null) return 'text-gray-500 dark:text-gray-400';
-    return value >= 0
-      ? 'text-green-600 dark:text-green-400'
-      : 'text-red-600 dark:text-red-400';
+    return gainLossColor(value);
   };
 
   const getPortfolioPercent = (value: number | null, currencyCode?: string): string => {

--- a/frontend/src/components/investments/GroupedHoldingsList.tsx
+++ b/frontend/src/components/investments/GroupedHoldingsList.tsx
@@ -6,6 +6,7 @@ import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { gainLossColor } from '@/lib/format';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 
 interface GroupedHoldingsListProps {
   holdingsByAccount: AccountHoldings[];
@@ -79,13 +80,13 @@ export function GroupedHoldingsList({
         </h3>
         <div className="space-y-4">
           {[1, 2].map((i) => (
-            <div key={i} className="animate-pulse">
-              <div className="h-6 bg-gray-200 dark:bg-gray-700 rounded w-1/3 mb-3" />
+            <div key={i}>
+              <Skeleton className="h-6 w-1/3 mb-3" />
               <div className="space-y-2">
                 {[1, 2, 3].map((j) => (
                   <div key={j} className="flex justify-between">
-                    <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/4" />
-                    <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/4" />
+                    <Skeleton className="h-4 w-1/4" />
+                    <Skeleton className="h-4 w-1/4" />
                   </div>
                 ))}
               </div>

--- a/frontend/src/components/investments/HoldingsList.test.tsx
+++ b/frontend/src/components/investments/HoldingsList.test.tsx
@@ -13,6 +13,10 @@ vi.mock('@/hooks/useNumberFormat', () => ({
       }
       return `$${n.toFixed(digits)}`;
     },
+    formatSignedPercent: (n: number, decimals = 2) =>
+      `${n >= 0 ? '+' : ''}${n.toFixed(decimals)}%`,
+    formatQuantity: (n: number) =>
+      new Intl.NumberFormat('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 4 }).format(n),
     numberFormat: 'en-US',
   }),
 }));

--- a/frontend/src/components/investments/HoldingsList.tsx
+++ b/frontend/src/components/investments/HoldingsList.tsx
@@ -2,6 +2,7 @@
 
 import { HoldingWithMarketValue } from '@/types/investment';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { gainLossColor } from '@/lib/format';
 
 interface HoldingsListProps {
   holdings: HoldingWithMarketValue[];
@@ -9,7 +10,7 @@ interface HoldingsListProps {
 }
 
 export function HoldingsList({ holdings, isLoading }: HoldingsListProps) {
-  const { formatCurrency: formatCurrencyBase, formatCurrencyPrecise, numberFormat } = useNumberFormat();
+  const { formatCurrency: formatCurrencyBase, formatCurrencyPrecise, formatSignedPercent, formatQuantity } = useNumberFormat();
 
   const formatCurrency = (value: number | null) => {
     if (value === null) return '-';
@@ -25,16 +26,7 @@ export function HoldingsList({ holdings, isLoading }: HoldingsListProps) {
 
   const formatPercent = (value: number | null) => {
     if (value === null) return '-';
-    const sign = value >= 0 ? '+' : '';
-    return `${sign}${value.toFixed(2)}%`;
-  };
-
-  const formatQuantity = (value: number) => {
-    const locale = numberFormat === 'browser' ? undefined : numberFormat;
-    return new Intl.NumberFormat(locale, {
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 4,
-    }).format(value);
+    return formatSignedPercent(value);
   };
 
   if (isLoading) {
@@ -123,22 +115,10 @@ export function HoldingsList({ holdings, isLoading }: HoldingsListProps) {
                   {formatCurrency(holding.marketValue)}
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-right">
-                  <div
-                    className={`font-medium ${
-                      (holding.gainLoss ?? 0) >= 0
-                        ? 'text-green-600 dark:text-green-400'
-                        : 'text-red-600 dark:text-red-400'
-                    }`}
-                  >
+                  <div className={`font-medium ${gainLossColor(holding.gainLoss ?? 0)}`}>
                     {formatCurrency(holding.gainLoss)}
                   </div>
-                  <div
-                    className={`text-sm ${
-                      (holding.gainLossPercent ?? 0) >= 0
-                        ? 'text-green-600 dark:text-green-400'
-                        : 'text-red-600 dark:text-red-400'
-                    }`}
-                  >
+                  <div className={`text-sm ${gainLossColor(holding.gainLossPercent ?? 0)}`}>
                     {formatPercent(holding.gainLossPercent)}
                   </div>
                 </td>

--- a/frontend/src/components/investments/HoldingsList.tsx
+++ b/frontend/src/components/investments/HoldingsList.tsx
@@ -3,6 +3,7 @@
 import { HoldingWithMarketValue } from '@/types/investment';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { gainLossColor } from '@/lib/format';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 
 interface HoldingsListProps {
   holdings: HoldingWithMarketValue[];
@@ -37,9 +38,9 @@ export function HoldingsList({ holdings, isLoading }: HoldingsListProps) {
         </h3>
         <div className="space-y-3">
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="animate-pulse flex justify-between">
-              <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/4" />
-              <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/4" />
+            <div key={i} className="flex justify-between">
+              <Skeleton className="h-4 w-1/4" />
+              <Skeleton className="h-4 w-1/4" />
             </div>
           ))}
         </div>

--- a/frontend/src/components/investments/InvestmentTransactionList.test.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionList.test.tsx
@@ -9,6 +9,8 @@ vi.mock('@/hooks/useDateFormat', () => ({
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
     formatCurrency: (n: number) => `$${n.toFixed(2)}`,
+    formatQuantity: (n: number) =>
+      new Intl.NumberFormat('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 4 }).format(n),
     numberFormat: 'en-US',
   }),
 }));

--- a/frontend/src/components/investments/InvestmentTransactionList.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionList.tsx
@@ -237,7 +237,7 @@ export function InvestmentTransactionList({
   availableSymbols = [],
   viewToggle,
 }: InvestmentTransactionListProps) {
-  const { formatCurrency, numberFormat } = useNumberFormat();
+  const { formatCurrency, formatQuantity } = useNumberFormat();
   const { formatDate } = useDateFormat();
   const { defaultCurrency } = useExchangeRates();
   const accountMap = useMemo(() => new Map(accounts.map(a => [a.id, a.name])), [accounts]);
@@ -357,14 +357,6 @@ export function InvestmentTransactionList({
       setLocalDensity(next);
     }
   }, [density, onDensityChange]);
-
-  const formatQuantity = useCallback((value: number) => {
-    const locale = numberFormat === 'browser' ? undefined : numberFormat;
-    return new Intl.NumberFormat(locale, {
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 4,
-    }).format(value);
-  }, [numberFormat]);
 
   if (isLoading) {
     return (

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -23,6 +23,7 @@ vi.mock('recharts', () => ({
 
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
+    formatSignedPercent: (n: number, decimals = 2) => `${n >= 0 ? '+' : ''}${n.toFixed(decimals)}%`,
     formatCurrency: (n: number) => `$${n.toFixed(2)}`,
     formatCurrencyCompact: (n: number) => `$${n.toFixed(0)}`,
     formatCurrencyAxis: (n: number) => `$${n}`,

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -15,6 +15,7 @@ import { netWorthApi } from '@/lib/net-worth';
 import { investmentsApi } from '@/lib/investments';
 import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { gainLossColor } from '@/lib/format';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useDateRange } from '@/hooks/useDateRange';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
@@ -50,7 +51,7 @@ interface InvestmentValueChartProps {
 }
 
 export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix }: InvestmentValueChartProps) {
-  const { formatCurrency, formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag } = useNumberFormat();
+  const { formatCurrency, formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag, formatSignedPercent } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
   const [chartPoints, setChartPoints] = useState<Array<{ name: string; Value: number }>>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -451,18 +452,14 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
         </div>
         <div>
           <div className="text-xs text-gray-500 dark:text-gray-400">Change</div>
-          <div className={`text-lg font-bold ${
-            summary.change >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
-          }`}>
+          <div className={`text-lg font-bold ${gainLossColor(summary.change)}`}>
             {summary.change >= 0 ? '+' : ''}{fmtFull(summary.change)}
           </div>
         </div>
         <div>
           <div className="text-xs text-gray-500 dark:text-gray-400">Change %</div>
-          <div className={`text-lg font-bold ${
-            summary.changePercent >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
-          }`}>
-            {summary.changePercent >= 0 ? '+' : ''}{summary.changePercent.toFixed(1)}%
+          <div className={`text-lg font-bold ${gainLossColor(summary.changePercent)}`}>
+            {formatSignedPercent(summary.changePercent, 1)}
           </div>
         </div>
       </div>

--- a/frontend/src/components/investments/PortfolioSummaryCard.test.tsx
+++ b/frontend/src/components/investments/PortfolioSummaryCard.test.tsx
@@ -8,6 +8,8 @@ let mockDefaultCurrency = 'CAD';
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
     formatCurrency: (n: number, _currency?: string) => `$${n.toFixed(2)}`,
+    formatSignedPercent: (n: number, decimals = 2) =>
+      `${n >= 0 ? '+' : ''}${n.toFixed(decimals)}%`,
   }),
 }));
 

--- a/frontend/src/components/investments/PortfolioSummaryCard.tsx
+++ b/frontend/src/components/investments/PortfolioSummaryCard.tsx
@@ -5,6 +5,7 @@ import { PortfolioSummary } from '@/types/investment';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
+import { gainLossColor } from '@/lib/format';
 
 interface PortfolioSummaryCardProps {
   summary: PortfolioSummary | null;
@@ -19,7 +20,7 @@ export function PortfolioSummaryCard({
   singleAccountCurrency,
   titleSuffix,
 }: PortfolioSummaryCardProps) {
-  const { formatCurrency } = useNumberFormat();
+  const { formatCurrency, formatSignedPercent } = useNumberFormat();
   const { convertToDefault, defaultCurrency } = useExchangeRates();
 
   // When viewing a single foreign-currency account, show values in that currency
@@ -80,16 +81,11 @@ export function PortfolioSummaryCard({
     return formatCurrency(value);
   };
 
-  const formatPercent = (value: number) => {
-    const sign = value >= 0 ? '+' : '';
-    return `${sign}${value.toFixed(2)}%`;
-  };
+  const formatPercent = (value: number) => formatSignedPercent(value);
 
   const returnColorClass = (value: number | null | undefined) => {
     if (value == null) return 'text-gray-400 dark:text-gray-500';
-    return value >= 0
-      ? 'text-green-600 dark:text-green-400'
-      : 'text-red-600 dark:text-red-400';
+    return gainLossColor(value);
   };
 
   if (isLoading) {

--- a/frontend/src/components/layout/AppHeader.test.tsx
+++ b/frontend/src/components/layout/AppHeader.test.tsx
@@ -51,10 +51,16 @@ let mockUser: any = {
 };
 
 vi.mock('@/store/authStore', () => ({
-  useAuthStore: () => ({
-    user: mockUser,
-    logout: mockLogout,
-  }),
+  useAuthStore: (selector?: (state: Record<string, unknown>) => unknown) => {
+    const state = {
+      user: mockUser,
+      logout: mockLogout,
+      actingAsUserId: null,
+      delegateCapabilities: null,
+      delegateSections: null,
+    };
+    return selector ? selector(state) : state;
+  },
 }));
 
 // Mock BudgetAlertBadge to avoid async act() warnings (tested in its own file)

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -42,13 +42,11 @@ const aiLinks: { href: string; label: string }[] = [
 export function AppHeader() {
   const router = useRouter();
   const pathname = usePathname();
-  const {
-    user,
-    logout,
-    actingAsUserId,
-    delegateCapabilities,
-    delegateSections,
-  } = useAuthStore();
+  const user = useAuthStore((s) => s.user);
+  const logout = useAuthStore((s) => s.logout);
+  const actingAsUserId = useAuthStore((s) => s.actingAsUserId);
+  const delegateCapabilities = useAuthStore((s) => s.delegateCapabilities);
+  const delegateSections = useAuthStore((s) => s.delegateSections);
   const isDelegateView = !!actingAsUserId;
   // A delegate sees a top-nav entry only if it is reachable: granted
   // sections (bills/investments/budgets/reports) plus Transactions when

--- a/frontend/src/components/reports/AccountBalancesReport.tsx
+++ b/frontend/src/components/reports/AccountBalancesReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from 'next/navigation';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
 import { accountsApi } from '@/lib/accounts';
@@ -235,8 +236,8 @@ export function AccountBalancesReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
           <div className="space-y-3">
             {[1, 2, 3, 4, 5].map((i) => (
               <div key={i} className="h-16 bg-gray-200 dark:bg-gray-700 rounded" />

--- a/frontend/src/components/reports/BillPaymentHistoryReport.tsx
+++ b/frontend/src/components/reports/BillPaymentHistoryReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from 'next/navigation';
 import {
   BarChart,
@@ -147,9 +148,9 @@ export function BillPaymentHistoryReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/BudgetHealthScoreReport.tsx
+++ b/frontend/src/components/reports/BudgetHealthScoreReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { budgetsApi } from '@/lib/budgets';
 import type { Budget, HealthScoreResult } from '@/types/budget';
 import { BudgetHealthGauge } from '@/components/budgets/BudgetHealthGauge';
@@ -149,10 +150,10 @@ export function BudgetHealthScoreReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
           <div className="h-40 w-40 bg-gray-200 dark:bg-gray-700 rounded-full mx-auto" />
-          <div className="h-32 bg-gray-200 dark:bg-gray-700 rounded" />
+          <Skeleton className="h-32 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/BudgetSeasonalPatternsReport.tsx
+++ b/frontend/src/components/reports/BudgetSeasonalPatternsReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
   Bar,
@@ -133,9 +134,9 @@ export function BudgetSeasonalPatternsReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/BudgetTrendReport.tsx
+++ b/frontend/src/components/reports/BudgetTrendReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   LineChart,
   Line,
@@ -90,9 +91,9 @@ export function BudgetTrendReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/BudgetVsActualReport.tsx
+++ b/frontend/src/components/reports/BudgetVsActualReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
   Bar,
@@ -130,9 +131,9 @@ export function BudgetVsActualReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/CashFlowReport.test.tsx
+++ b/frontend/src/components/reports/CashFlowReport.test.tsx
@@ -169,15 +169,15 @@ describe("CashFlowReport", () => {
     expect(screen.getByText("No expenses in this period")).toBeInTheDocument();
   });
 
-  it("handles API error gracefully", async () => {
+  it("surfaces a retryable error state when the API fails", async () => {
     mockGetCashFlow.mockRejectedValue(new Error("Network error"));
     mockGetIncomeBySource.mockRejectedValue(new Error("Network error"));
     mockGetSpendingByCategory.mockRejectedValue(new Error("Network error"));
     render(<CashFlowReport />);
     await waitFor(() => {
-      // After error, should render with zero totals
-      expect(screen.getByText("Total Inflows")).toBeInTheDocument();
+      expect(screen.getByText(/failed to load report data/i)).toBeInTheDocument();
     });
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
   });
 
   it("navigates to transactions page with date range on chart bar click", async () => {

--- a/frontend/src/components/reports/CashFlowReport.tsx
+++ b/frontend/src/components/reports/CashFlowReport.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import {
   BarChart,
@@ -22,11 +22,11 @@ import {
 } from "@/types/built-in-reports";
 import { useNumberFormat } from "@/hooks/useNumberFormat";
 import { useDateRange } from "@/hooks/useDateRange";
+import { useReportData } from "@/hooks/useReportData";
 import { DateRangeSelector } from "@/components/ui/DateRangeSelector";
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
-import { createLogger } from "@/lib/logger";
-
-const logger = createLogger("CashFlowReport");
+import { ChartTooltip } from "@/components/reports/ChartTooltip";
+import { ReportError } from "@/components/reports/ReportError";
 
 interface ChartDataItem {
   name: string;
@@ -43,15 +43,6 @@ export function CashFlowReport() {
   const chartRef = useRef<HTMLDivElement>(null);
   const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis } =
     useNumberFormat();
-  const [monthlyData, setMonthlyData] = useState<ChartDataItem[]>([]);
-  const [incomeItems, setIncomeItems] = useState<IncomeSourceItem[]>([]);
-  const [expenseItems, setExpenseItems] = useState<CategorySpendingItem[]>([]);
-  const [totals, setTotals] = useState({
-    totalIncome: 0,
-    totalExpenses: 0,
-    netCashFlow: 0,
-  });
-  const [isLoading, setIsLoading] = useState(true);
   const {
     dateRange,
     setDateRange,
@@ -63,15 +54,12 @@ export function CashFlowReport() {
     isValid,
   } = useDateRange({ defaultRange: "6m", alignment: "month" });
 
-  const loadData = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const { start, end } = resolvedRange;
-      const params = {
-        startDate: start || undefined,
-        endDate: end,
-      };
+  const { start: rangeStart, end: rangeEnd } = resolvedRange;
 
+  const { data: response, isLoading, error, reload } = useReportData(
+    async () => {
+      if (!isValid) return null;
+      const params = { startDate: rangeStart || undefined, endDate: rangeEnd };
       // Fetch all data in parallel
       const [cashFlowResponse, incomeResponse, spendingResponse] =
         await Promise.all([
@@ -79,44 +67,39 @@ export function CashFlowReport() {
           builtInReportsApi.getIncomeBySource(params),
           builtInReportsApi.getSpendingByCategory(params),
         ]);
+      return { cashFlowResponse, incomeResponse, spendingResponse };
+    },
+    [isValid, rangeStart, rangeEnd],
+  );
 
-      // Map monthly data. `name` must be unique across the dataset (used as
-      // the XAxis category key); a non-unique value like "May" causes
-      // Recharts to resolve the tooltip's payload to the first matching row,
-      // showing data from the wrong year on multi-year ranges.
-      const data: ChartDataItem[] = cashFlowResponse.data.map(
-        (item: MonthlyIncomeExpenseItem) => {
-          const monthDate = parseISO(item.month + "-01");
-          return {
-            name: item.month,
-            fullName: format(monthDate, "MMM yyyy"),
-            Income: Math.round(item.income),
-            Expenses: Math.round(item.expenses),
-            Net: Math.round(item.net),
-            monthStart: format(startOfMonth(monthDate), "yyyy-MM-dd"),
-            monthEnd: format(endOfMonth(monthDate), "yyyy-MM-dd"),
-          };
-        },
-      );
+  // Map monthly data. `name` must be unique across the dataset (used as
+  // the XAxis category key); a non-unique value like "May" causes Recharts
+  // to resolve the tooltip's payload to the first matching row, showing data
+  // from the wrong year on multi-year ranges.
+  const monthlyData = useMemo<ChartDataItem[]>(
+    () =>
+      (response?.cashFlowResponse.data ?? []).map((item: MonthlyIncomeExpenseItem) => {
+        const monthDate = parseISO(item.month + "-01");
+        return {
+          name: item.month,
+          fullName: format(monthDate, "MMM yyyy"),
+          Income: Math.round(item.income),
+          Expenses: Math.round(item.expenses),
+          Net: Math.round(item.net),
+          monthStart: format(startOfMonth(monthDate), "yyyy-MM-dd"),
+          monthEnd: format(endOfMonth(monthDate), "yyyy-MM-dd"),
+        };
+      }),
+    [response],
+  );
 
-      setMonthlyData(data);
-      setIncomeItems(incomeResponse.data);
-      setExpenseItems(spendingResponse.data);
-      setTotals({
-        totalIncome: cashFlowResponse.totals.income,
-        totalExpenses: cashFlowResponse.totals.expenses,
-        netCashFlow: cashFlowResponse.totals.net,
-      });
-    } catch (error) {
-      logger.error("Failed to load data:", error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [resolvedRange]);
-
-  useEffect(() => {
-    if (isValid) loadData();
-  }, [isValid, loadData]);
+  const incomeItems: IncomeSourceItem[] = response?.incomeResponse.data ?? [];
+  const expenseItems: CategorySpendingItem[] = response?.spendingResponse.data ?? [];
+  const totals = {
+    totalIncome: response?.cashFlowResponse.totals.income ?? 0,
+    totalExpenses: response?.cashFlowResponse.totals.expenses ?? 0,
+    netCashFlow: response?.cashFlowResponse.totals.net ?? 0,
+  };
 
   const handleExportPdf = async () => {
     const { exportToPdf } = await import("@/lib/pdf-export");
@@ -182,24 +165,18 @@ export function CashFlowReport() {
       color: string;
       payload: { fullName: string };
     }>;
-  }) => {
-    if (active && payload && payload.length) {
-      const data = payload[0]?.payload;
-      return (
-        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
-          <p className="font-medium text-gray-900 dark:text-gray-100 mb-1">
-            {data?.fullName}
-          </p>
-          {payload.map((entry, index) => (
-            <p key={index} className="text-sm" style={{ color: entry.color }}>
-              {entry.name}: {formatCurrency(entry.value)}
-            </p>
-          ))}
-        </div>
-      );
-    }
-    return null;
-  };
+  }) => (
+    <ChartTooltip
+      active={active}
+      label={payload?.[0]?.payload?.fullName}
+      payload={payload}
+      formatValue={(v) => formatCurrency(v)}
+    />
+  );
+
+  if (error) {
+    return <ReportError onRetry={reload} />;
+  }
 
   if (isLoading) {
     // Render the controls block too so focus inside DateInput survives

--- a/frontend/src/components/reports/CashFlowReport.tsx
+++ b/frontend/src/components/reports/CashFlowReport.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useRef } from "react";
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from "next/navigation";
 import {
   BarChart,
@@ -199,9 +200,9 @@ export function CashFlowReport() {
           </div>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-          <div className="animate-pulse space-y-4">
-            <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-            <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="space-y-4">
+            <Skeleton className="h-8 w-1/3" />
+            <Skeleton className="h-64 w-full" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/CategoryPerformanceReport.tsx
+++ b/frontend/src/components/reports/CategoryPerformanceReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { budgetsApi } from '@/lib/budgets';
 import type { Budget, CategoryTrendSeries } from '@/types/budget';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
@@ -192,9 +193,9 @@ export function CategoryPerformanceReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/ChartTooltip.test.tsx
+++ b/frontend/src/components/reports/ChartTooltip.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@/test/render';
+import { ChartTooltip, ChartTooltipPanel } from './ChartTooltip';
+
+describe('ChartTooltip', () => {
+  it('renders nothing when inactive', () => {
+    const { container } = render(
+      <ChartTooltip active={false} payload={[{ name: 'A', value: 1 }]} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when payload is empty', () => {
+    const { container } = render(<ChartTooltip active payload={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the label and entries with the formatter', () => {
+    const { getByText } = render(
+      <ChartTooltip
+        active
+        label="March"
+        payload={[
+          { name: 'Income', value: 1000, color: '#0a0' },
+          { name: 'Expenses', value: 400, color: '#a00' },
+        ]}
+        formatValue={(v) => `$${v}`}
+      />,
+    );
+    expect(getByText('March')).toBeInTheDocument();
+    expect(getByText('Income: $1000')).toBeInTheDocument();
+    expect(getByText('Expenses: $400')).toBeInTheDocument();
+  });
+
+  it('applies the entry colour to each line', () => {
+    const { getByText } = render(
+      <ChartTooltip active payload={[{ name: 'X', value: 5, color: 'rgb(255, 0, 0)' }]} />,
+    );
+    expect(getByText('X: 5')).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+  });
+
+  it('renders extra children below the entries', () => {
+    const { getByText } = render(
+      <ChartTooltip active label="Cat" payload={[{ name: 'Spend', value: 10 }]}>
+        <p>extra line</p>
+      </ChartTooltip>,
+    );
+    expect(getByText('extra line')).toBeInTheDocument();
+  });
+
+  it('ChartTooltipPanel renders its children', () => {
+    const { getByText } = render(
+      <ChartTooltipPanel>
+        <span>panel body</span>
+      </ChartTooltipPanel>,
+    );
+    expect(getByText('panel body')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/reports/ChartTooltip.tsx
+++ b/frontend/src/components/reports/ChartTooltip.tsx
@@ -1,0 +1,69 @@
+import { ReactNode } from 'react';
+
+/** One series entry as Recharts hands it to a tooltip `content` renderer. */
+export interface ChartTooltipEntry {
+  name?: string;
+  value?: number;
+  color?: string;
+}
+
+interface ChartTooltipProps {
+  /** Recharts sets this true only while the tooltip is visible. */
+  active?: boolean;
+  /** Heading shown above the entries (e.g. the category/month name). */
+  label?: ReactNode;
+  /** Series rows to render as "name: value" lines. */
+  payload?: ChartTooltipEntry[];
+  /** Formats each entry's numeric value (defaults to String). */
+  formatValue?: (value: number, entry: ChartTooltipEntry) => string;
+  /** Extra content rendered below the entries (e.g. a percentage line). */
+  children?: ReactNode;
+}
+
+/**
+ * Shared dark-mode-aware panel used as the Recharts `<Tooltip content={...}>`
+ * across the report charts. Replaces the ~23 hand-rolled `CustomTooltip`
+ * components that all repeated the same
+ * `bg-white dark:bg-gray-800 border ... rounded-lg shadow-lg p-3` panel with a
+ * bold label and per-entry coloured `name: value` lines.
+ *
+ * Returns null when inactive (matching the Recharts contract). For tooltips
+ * that need fully custom inner markup, use `<ChartTooltipPanel>` directly and
+ * compose your own body.
+ */
+export function ChartTooltip({
+  active,
+  label,
+  payload,
+  formatValue = (v) => String(v),
+  children,
+}: ChartTooltipProps) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+  return (
+    <ChartTooltipPanel>
+      {label !== undefined && label !== null && (
+        <p className="font-medium text-gray-900 dark:text-gray-100 mb-1">{label}</p>
+      )}
+      {payload.map((entry, index) => (
+        <p key={index} className="text-sm" style={{ color: entry.color }}>
+          {entry.name}: {entry.value === undefined ? '' : formatValue(entry.value, entry)}
+        </p>
+      ))}
+      {children}
+    </ChartTooltipPanel>
+  );
+}
+
+/**
+ * The bare tooltip panel (dark-mode card). Use when a chart's tooltip body is
+ * too bespoke for `<ChartTooltip>` but should still share the panel chrome.
+ */
+export function ChartTooltipPanel({ children }: { children: ReactNode }) {
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/reports/CurrencyExposureReport.tsx
+++ b/frontend/src/components/reports/CurrencyExposureReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   PieChart,
   Pie,
@@ -222,9 +223,9 @@ export function CurrencyExposureReport() {
     return (
       <div className="space-y-6">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-          <div className="animate-pulse space-y-4">
-            <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-            <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="space-y-4">
+            <Skeleton className="h-8 w-1/3" />
+            <Skeleton className="h-64 w-full" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/DebtPayoffTimelineReport.tsx
+++ b/frontend/src/components/reports/DebtPayoffTimelineReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
   Bar,
@@ -454,9 +455,9 @@ export function DebtPayoffTimelineReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
   Bar,
@@ -967,9 +968,9 @@ export function DividendIncomeReport() {
   if (isLoading && !hasLoadedOnce) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -250,24 +250,31 @@ export function DividendIncomeReport() {
           endDate: end,
         });
 
-        // Paginate through all transactions (API limit is 200 per page)
-        let allTransactions: InvestmentTransaction[] = [];
-        let page = 1;
-        let hasMore = true;
-        while (hasMore) {
-          const result = await investmentsApi.getTransactions({
-            accountIds: accountIdsParam,
-            startDate: start || undefined,
-            endDate: end,
-            limit: 200,
-            page,
-          });
-          allTransactions = allTransactions.concat(result.data);
-          hasMore = result.pagination.hasMore;
-          page++;
-        }
+        // Paginate through all transactions (API limit is 200 per page).
+        // Run the pagination loop concurrently with the accounts and capital
+        // gains requests instead of awaiting it first -- otherwise the three
+        // fetches serialize and the slowest path is the sum of all of them.
+        const transactionsPromise = (async () => {
+          let allTransactions: InvestmentTransaction[] = [];
+          let page = 1;
+          let hasMore = true;
+          while (hasMore) {
+            const result = await investmentsApi.getTransactions({
+              accountIds: accountIdsParam,
+              startDate: start || undefined,
+              endDate: end,
+              limit: 200,
+              page,
+            });
+            allTransactions = allTransactions.concat(result.data);
+            hasMore = result.pagination.hasMore;
+            page++;
+          }
+          return allTransactions;
+        })();
 
-        const [accountsData, capitalGainsData] = await Promise.all([
+        const [allTransactions, accountsData, capitalGainsData] = await Promise.all([
+          transactionsPromise,
           accountsPromise,
           capitalGainsPromise,
         ]);
@@ -480,6 +487,33 @@ export function DividendIncomeReport() {
           )
         : dailyData,
     [dailyData, hideInactiveDays],
+  );
+
+  // Only stack series where every value is non-negative; once losses appear
+  // we render bars side-by-side so negatives can drop below the zero line
+  // instead of being hidden inside a stack. Memoized so the per-render array
+  // scans don't run on every keystroke/interaction.
+  const hasNegativeCapitalGains = useMemo(
+    () => monthlyData.some((m) => m.capitalGains < 0),
+    [monthlyData],
+  );
+  const dailyHasNegativeCapitalGains = useMemo(
+    () => displayedDailyData.some((d) => d.capitalGains < 0),
+    [displayedDailyData],
+  );
+
+  // Account filter options for the MultiSelect, memoized so the filter/sort/map
+  // chain (and the new array of option objects) is not rebuilt every render.
+  const accountOptions = useMemo(
+    () =>
+      accounts
+        .filter((a) => a.accountSubType !== 'INVESTMENT_BROKERAGE')
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((account) => ({
+          value: account.id,
+          label: account.name.replace(/ - (Brokerage|Cash)$/, ''),
+        })),
+    [accounts],
   );
 
   const securityData = useMemo((): SecurityIncome[] => {
@@ -941,12 +975,7 @@ export function DividendIncomeReport() {
     );
   }
 
-  // Only stack series where every value is non-negative; once losses appear
-  // we render bars side-by-side so negatives can drop below the zero line
-  // instead of being hidden inside a stack.
-  const hasNegativeCapitalGains = monthlyData.some((m) => m.capitalGains < 0);
   const stackId = hasNegativeCapitalGains ? undefined : 'a';
-  const dailyHasNegativeCapitalGains = displayedDailyData.some((d) => d.capitalGains < 0);
   const dailyStackId = dailyHasNegativeCapitalGains ? undefined : 'a';
 
   return (
@@ -986,13 +1015,7 @@ export function DividendIncomeReport() {
             <MultiSelect
               ariaLabel="Filter by account"
               placeholder="All Accounts"
-              options={accounts
-                .filter((a) => a.accountSubType !== 'INVESTMENT_BROKERAGE')
-                .sort((a, b) => a.name.localeCompare(b.name))
-                .map((account) => ({
-                  value: account.id,
-                  label: account.name.replace(/ - (Brokerage|Cash)$/, ''),
-                }))}
+              options={accountOptions}
               value={selectedAccountIds}
               onChange={(values) => {
                 setSelectedAccountIds(values);

--- a/frontend/src/components/reports/DividendYieldGrowthReport.test.tsx
+++ b/frontend/src/components/reports/DividendYieldGrowthReport.test.tsx
@@ -8,6 +8,7 @@ vi.mock('@/lib/pdf-export', () => ({
 
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
+    formatSignedPercent: (n: number, decimals = 2) => `${n >= 0 ? '+' : ''}${n.toFixed(decimals)}%`,
     formatCurrency: (n: number) => `$${n.toFixed(2)}`,
     formatCurrencyCompact: (n: number) => `$${n.toFixed(0)}`,
     formatCurrencyAxis: (n: number) => `$${n}`,

--- a/frontend/src/components/reports/DividendYieldGrowthReport.tsx
+++ b/frontend/src/components/reports/DividendYieldGrowthReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
   Bar,
@@ -396,9 +397,9 @@ export function DividendYieldGrowthReport() {
   if (isLoading && !hasLoadedOnce) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/DividendYieldGrowthReport.tsx
+++ b/frontend/src/components/reports/DividendYieldGrowthReport.tsx
@@ -16,6 +16,7 @@ import { InvestmentTransaction, HoldingWithMarketValue } from '@/types/investmen
 import { Account } from '@/types/account';
 import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { gainLossColor } from '@/lib/format';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
@@ -68,7 +69,7 @@ function detectFrequency(dates: Date[]): string {
 }
 
 export function DividendYieldGrowthReport() {
-  const { formatCurrency: formatCurrencyFull, formatCurrencyAxis } = useNumberFormat();
+  const { formatCurrency: formatCurrencyFull, formatCurrencyAxis, formatSignedPercent } = useNumberFormat();
   const { defaultCurrency, convertToDefault } = useExchangeRates();
   const chartRef = useRef<HTMLDivElement>(null);
   const [transactions, setTransactions] = useState<InvestmentTransaction[]>([]);
@@ -361,7 +362,7 @@ export function DividendYieldGrowthReport() {
         rows: annualData.map((row) => [
           row.year,
           fmtValue(row.amount),
-          row.growth !== null ? `${row.growth >= 0 ? '+' : ''}${row.growth.toFixed(1)}%` : '-',
+          row.growth !== null ? formatSignedPercent(row.growth, 1) : '-',
         ]),
       };
     } else {
@@ -593,8 +594,8 @@ export function DividendYieldGrowthReport() {
                               Dividends: {fmtValue(d.amount)}
                             </p>
                             {d.growth !== null && (
-                              <p className={`text-sm ${d.growth >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                                Growth: {d.growth >= 0 ? '+' : ''}{d.growth.toFixed(1)}%
+                              <p className={`text-sm ${gainLossColor(d.growth)}`}>
+                                Growth: {formatSignedPercent(d.growth, 1)}
                               </p>
                             )}
                           </div>
@@ -647,7 +648,7 @@ export function DividendYieldGrowthReport() {
                         <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">{row.year}</td>
                         <td className="px-4 py-3 text-sm text-right text-green-600 dark:text-green-400">{fmtValue(row.amount)}</td>
                         <td className={`px-4 py-3 text-sm text-right ${row.growth !== null ? (row.growth >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400') : 'text-gray-400'}`}>
-                          {row.growth !== null ? `${row.growth >= 0 ? '+' : ''}${row.growth.toFixed(1)}%` : '-'}
+                          {row.growth !== null ? formatSignedPercent(row.growth, 1) : '-'}
                         </td>
                       </tr>
                     ))}

--- a/frontend/src/components/reports/DividendYieldGrowthReport.tsx
+++ b/frontend/src/components/reports/DividendYieldGrowthReport.tsx
@@ -648,7 +648,7 @@ export function DividendYieldGrowthReport() {
                       <tr key={row.year} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
                         <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">{row.year}</td>
                         <td className="px-4 py-3 text-sm text-right text-green-600 dark:text-green-400">{fmtValue(row.amount)}</td>
-                        <td className={`px-4 py-3 text-sm text-right ${row.growth !== null ? (row.growth >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400') : 'text-gray-400'}`}>
+                        <td className={`px-4 py-3 text-sm text-right ${row.growth !== null ? (gainLossColor(row.growth)) : 'text-gray-400'}`}>
                           {row.growth !== null ? formatSignedPercent(row.growth, 1) : '-'}
                         </td>
                       </tr>

--- a/frontend/src/components/reports/DuplicateTransactionReport.tsx
+++ b/frontend/src/components/reports/DuplicateTransactionReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from 'next/navigation';
 import { format } from 'date-fns';
 import { builtInReportsApi } from '@/lib/built-in-reports';
@@ -73,9 +74,9 @@ export function DuplicateTransactionReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/DuplicateTransactionReport.tsx
+++ b/frontend/src/components/reports/DuplicateTransactionReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { gainLossColor } from '@/lib/format';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from 'next/navigation';
 import { format } from 'date-fns';
@@ -250,9 +251,7 @@ export function DuplicateTransactionReport() {
                         </div>
                       </div>
                       <div className={`text-sm font-medium ${
-                        tx.amount >= 0
-                          ? 'text-green-600 dark:text-green-400'
-                          : 'text-red-600 dark:text-red-400'
+                        gainLossColor(tx.amount)
                       }`}>
                         {formatCurrency(tx.amount)}
                       </div>

--- a/frontend/src/components/reports/FlexGroupAnalysisReport.tsx
+++ b/frontend/src/components/reports/FlexGroupAnalysisReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
   Bar,
@@ -127,9 +128,9 @@ export function FlexGroupAnalysisReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/FlexGroupAnalysisReport.tsx
+++ b/frontend/src/components/reports/FlexGroupAnalysisReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { gainLossColor } from '@/lib/format';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
@@ -326,9 +327,7 @@ export function FlexGroupAnalysisReport() {
                       <td className="py-2 pr-4 text-gray-900 dark:text-gray-100">{cat.categoryName}</td>
                       <td className="py-2 pr-4 text-right text-gray-600 dark:text-gray-400">{formatCurrency(cat.budgeted)}</td>
                       <td className="py-2 pr-4 text-right text-gray-600 dark:text-gray-400">{formatCurrency(cat.spent)}</td>
-                      <td className={`py-2 pr-4 text-right font-medium ${
-                        cat.budgeted - cat.spent >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
-                      }`}>
+                      <td className={`py-2 pr-4 text-right font-medium ${gainLossColor(cat.budgeted - cat.spent)}`}>
                         {formatCurrency(cat.budgeted - cat.spent)}
                       </td>
                       <td className={`py-2 text-right font-medium ${

--- a/frontend/src/components/reports/GeographicAllocationReport.tsx
+++ b/frontend/src/components/reports/GeographicAllocationReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
   Bar,
@@ -327,9 +328,9 @@ export function GeographicAllocationReport() {
     return (
       <div className="space-y-6">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-          <div className="animate-pulse space-y-4">
-            <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-            <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="space-y-4">
+            <Skeleton className="h-8 w-1/3" />
+            <Skeleton className="h-64 w-full" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/HealthScoreHistoryReport.tsx
+++ b/frontend/src/components/reports/HealthScoreHistoryReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   LineChart,
   Line,
@@ -155,9 +156,9 @@ export function HealthScoreHistoryReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/IncomeBySourceReport.test.tsx
+++ b/frontend/src/components/reports/IncomeBySourceReport.test.tsx
@@ -203,14 +203,15 @@ describe("IncomeBySourceReport", () => {
     expect(screen.getByText("$2000.00 (20.0%)")).toBeInTheDocument();
   });
 
-  it("handles API error gracefully", async () => {
+  it("surfaces a retryable error state when the API fails", async () => {
     mockGetIncomeBySource.mockRejectedValue(new Error("Network error"));
     render(<IncomeBySourceReport />);
     await waitFor(() => {
       expect(
-        screen.getByText("No income data for this period."),
+        screen.getByText(/failed to load report data/i),
       ).toBeInTheDocument();
     });
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
   });
 
   it("navigates to transactions page on category legend click", async () => {

--- a/frontend/src/components/reports/IncomeBySourceReport.tsx
+++ b/frontend/src/components/reports/IncomeBySourceReport.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useMemo, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   PieChart,
@@ -18,17 +18,17 @@ import { builtInReportsApi } from '@/lib/built-in-reports';
 import { IncomeSourceItem } from '@/types/built-in-reports';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useDateRange } from '@/hooks/useDateRange';
+import { useReportData } from '@/hooks/useReportData';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { SortableHeader } from '@/components/ui/SortableHeader';
+import { ChartTooltipPanel } from '@/components/reports/ChartTooltip';
+import { ReportError } from '@/components/reports/ReportError';
 import { CHART_COLOURS_INCOME } from '@/lib/chart-colours';
 import { exportToCsv } from '@/lib/csv-export';
-import { createLogger } from '@/lib/logger';
 import type { ChartDatum } from '@/types/chart';
-
-const logger = createLogger('IncomeBySourceReport');
 
 type IncomeSourceSortField = 'name' | 'value' | 'percentage';
 
@@ -38,15 +38,45 @@ export function IncomeBySourceReport() {
   const router = useRouter();
   const chartRef = useRef<HTMLDivElement>(null);
   const { formatCurrencyCompact: formatCurrency } = useNumberFormat();
-  const [chartData, setChartData] = useState<ChartDataItem[]>([]);
-  const [totalIncome, setTotalIncome] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
   const { dateRange, setDateRange, startDate, setStartDate, endDate, setEndDate, resolvedRange, isValid } = useDateRange({ defaultRange: '1y', alignment: 'day' });
   const [viewType, setViewType] = useState<'pie' | 'bar' | 'table'>('pie');
   const { sortField, sortDirection, handleSort } = useSortableTable<IncomeSourceSortField>(
     'reports.income-by-source.table.sort',
     { field: 'value', direction: 'desc' },
   );
+
+  const { start: rangeStart, end: rangeEnd } = resolvedRange;
+
+  const { data: response, isLoading, error, reload } = useReportData(
+    () =>
+      isValid
+        ? builtInReportsApi.getIncomeBySource({
+            startDate: rangeStart || undefined,
+            endDate: rangeEnd,
+          })
+        : Promise.resolve(null),
+    [isValid, rangeStart, rangeEnd],
+  );
+
+  const chartData = useMemo<ChartDataItem[]>(() => {
+    if (!response) return [];
+    let colourIndex = 0;
+    return response.data.map((item: IncomeSourceItem) => {
+      let colour = item.color || '';
+      if (!colour) {
+        colour = CHART_COLOURS_INCOME[colourIndex % CHART_COLOURS_INCOME.length];
+        colourIndex++;
+      }
+      return {
+        id: item.categoryId || '',
+        name: item.categoryName,
+        value: item.total,
+        colour,
+      };
+    });
+  }, [response]);
+
+  const totalIncome = response?.totalIncome ?? 0;
 
   const sortedTableData = useMemo(() => {
     const sorted = [...chartData];
@@ -70,46 +100,6 @@ export function IncomeBySourceReport() {
     });
     return sorted;
   }, [chartData, sortField, sortDirection, totalIncome]);
-
-  const loadData = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const { start, end } = resolvedRange;
-      const response = await builtInReportsApi.getIncomeBySource({
-        startDate: start || undefined,
-        endDate: end,
-      });
-
-      // Map response to chart data with colours
-      let colourIndex = 0;
-      const data: ChartDataItem[] = response.data.map((item: IncomeSourceItem) => {
-        let colour = item.color || '';
-        if (!colour) {
-          colour = CHART_COLOURS_INCOME[colourIndex % CHART_COLOURS_INCOME.length];
-          colourIndex++;
-        }
-        return {
-          id: item.categoryId || '',
-          name: item.categoryName,
-          value: item.total,
-          colour,
-        };
-      });
-
-      setChartData(data);
-      setTotalIncome(response.totalIncome);
-    } catch (error) {
-      logger.error('Failed to load data:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [resolvedRange]);
-
-  useEffect(() => {
-    if (isValid) {
-      loadData();
-    }
-  }, [isValid, loadData]);
 
   const handleExportPdf = async () => {
     const { exportToPdf } = await import('@/lib/pdf-export');
@@ -150,20 +140,22 @@ export function IncomeBySourceReport() {
   };
 
   const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: Array<{ payload: { id: string; name: string; value: number } }> }) => {
-    if (active && payload && payload.length) {
-      const data = payload[0].payload;
-      const percentage = totalIncome > 0 ? ((data.value / totalIncome) * 100).toFixed(1) : '0';
-      return (
-        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
-          <p className="font-medium text-gray-900 dark:text-gray-100">{data.name}</p>
-          <p className="text-gray-600 dark:text-gray-400">
-            {formatCurrency(data.value)} ({percentage}%)
-          </p>
-        </div>
-      );
-    }
-    return null;
+    if (!active || !payload || !payload.length) return null;
+    const data = payload[0].payload;
+    const percentage = totalIncome > 0 ? ((data.value / totalIncome) * 100).toFixed(1) : '0';
+    return (
+      <ChartTooltipPanel>
+        <p className="font-medium text-gray-900 dark:text-gray-100">{data.name}</p>
+        <p className="text-gray-600 dark:text-gray-400">
+          {formatCurrency(data.value)} ({percentage}%)
+        </p>
+      </ChartTooltipPanel>
+    );
   };
+
+  if (error) {
+    return <ReportError onRetry={reload} />;
+  }
 
   if (isLoading) {
     return (

--- a/frontend/src/components/reports/IncomeBySourceReport.tsx
+++ b/frontend/src/components/reports/IncomeBySourceReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from 'next/navigation';
 import {
   PieChart,
@@ -160,9 +161,9 @@ export function IncomeBySourceReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/IncomeVsExpensesReport.test.tsx
+++ b/frontend/src/components/reports/IncomeVsExpensesReport.test.tsx
@@ -166,12 +166,13 @@ describe("IncomeVsExpensesReport", () => {
     expect(screen.getByText("Savings Rate")).toBeInTheDocument();
   });
 
-  it("handles API error gracefully", async () => {
+  it("surfaces a retryable error state when the API fails", async () => {
     mockGetIncomeVsExpenses.mockRejectedValue(new Error("Network error"));
     render(<IncomeVsExpensesReport />);
     await waitFor(() => {
-      expect(screen.getByText("No data for this period.")).toBeInTheDocument();
+      expect(screen.getByText(/failed to load report data/i)).toBeInTheDocument();
     });
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
   });
 
   it("renders bar chart with monthly data", async () => {

--- a/frontend/src/components/reports/IncomeVsExpensesReport.tsx
+++ b/frontend/src/components/reports/IncomeVsExpensesReport.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import { useState, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import {
   BarChart,
@@ -18,15 +18,15 @@ import { builtInReportsApi } from "@/lib/built-in-reports";
 import { MonthlyIncomeExpenseItem } from "@/types/built-in-reports";
 import { useNumberFormat } from "@/hooks/useNumberFormat";
 import { useDateRange } from "@/hooks/useDateRange";
+import { useReportData } from "@/hooks/useReportData";
 import { useSortableTable, compareValues } from "@/hooks/useSortableTable";
 import { DateRangeSelector } from "@/components/ui/DateRangeSelector";
 import { ChartViewToggle } from "@/components/ui/ChartViewToggle";
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { SortableHeader } from '@/components/ui/SortableHeader';
+import { ChartTooltip } from "@/components/reports/ChartTooltip";
+import { ReportError } from "@/components/reports/ReportError";
 import { exportToCsv } from "@/lib/csv-export";
-import { createLogger } from "@/lib/logger";
-
-const logger = createLogger("IncomeVsExpensesReport");
 
 type IncomeVsExpensesSortField = 'name' | 'income' | 'expenses' | 'savings' | 'savingsRate';
 
@@ -46,14 +46,6 @@ export function IncomeVsExpensesReport() {
   const chartRef = useRef<HTMLDivElement>(null);
   const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis } =
     useNumberFormat();
-  const [chartData, setChartData] = useState<ChartDataItem[]>([]);
-  const [totals, setTotals] = useState({
-    totalIncome: 0,
-    totalExpenses: 0,
-    totalSavings: 0,
-    savingsRate: 0,
-  });
-  const [isLoading, setIsLoading] = useState(true);
   const [viewType, setViewType] = useState<'bar' | 'table'>('bar');
   const {
     dateRange,
@@ -69,6 +61,52 @@ export function IncomeVsExpensesReport() {
     'reports.income-vs-expenses.table.sort',
     { field: 'name', direction: 'asc' },
   );
+
+  const { start: rangeStart, end: rangeEnd } = resolvedRange;
+
+  const { data: response, isLoading, error, reload } = useReportData(
+    () =>
+      isValid
+        ? builtInReportsApi.getIncomeVsExpenses({
+            startDate: rangeStart || undefined,
+            endDate: rangeEnd,
+          })
+        : Promise.resolve(null),
+    [isValid, rangeStart, rangeEnd],
+  );
+
+  // Map response to chart data. `name` must be unique across the dataset
+  // (used as the XAxis category key); a non-unique value like "May" causes
+  // Recharts to resolve the tooltip's payload to the first matching row,
+  // showing data from the wrong year on multi-year ranges.
+  const chartData = useMemo<ChartDataItem[]>(
+    () =>
+      (response?.data ?? []).map((item: MonthlyIncomeExpenseItem) => {
+        const monthDate = parseISO(item.month + "-01");
+        const savings = item.income - item.expenses;
+        const savingsRate =
+          item.income > 0 ? Math.round((savings / item.income) * 100) : 0;
+        return {
+          name: item.month,
+          fullName: format(monthDate, "MMM yyyy"),
+          Income: Math.round(item.income),
+          Expenses: Math.round(item.expenses),
+          Savings: Math.round(savings),
+          SavingsRate: savingsRate,
+          monthStart: format(startOfMonth(monthDate), "yyyy-MM-dd"),
+          monthEnd: format(endOfMonth(monthDate), "yyyy-MM-dd"),
+        };
+      }),
+    [response],
+  );
+
+  const totals = useMemo(() => {
+    const totalIncome = response?.totals.income ?? 0;
+    const totalExpenses = response?.totals.expenses ?? 0;
+    const totalSavings = totalIncome - totalExpenses;
+    const savingsRate = totalIncome > 0 ? (totalSavings / totalIncome) * 100 : 0;
+    return { totalIncome, totalExpenses, totalSavings, savingsRate };
+  }, [response]);
 
   const sortedTableData = useMemo(() => {
     const sorted = [...chartData];
@@ -95,57 +133,6 @@ export function IncomeVsExpensesReport() {
     });
     return sorted;
   }, [chartData, sortField, sortDirection]);
-
-  const loadData = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const { start, end } = resolvedRange;
-      const response = await builtInReportsApi.getIncomeVsExpenses({
-        startDate: start || undefined,
-        endDate: end,
-      });
-
-      // Map response to chart data. `name` must be unique across the dataset
-      // (used as the XAxis category key); a non-unique value like "May" causes
-      // Recharts to resolve the tooltip's payload to the first matching row,
-      // showing data from the wrong year on multi-year ranges.
-      const data: ChartDataItem[] = response.data.map(
-        (item: MonthlyIncomeExpenseItem) => {
-          const monthDate = parseISO(item.month + "-01");
-          const savings = item.income - item.expenses;
-          const savingsRate =
-            item.income > 0 ? Math.round((savings / item.income) * 100) : 0;
-          return {
-            name: item.month,
-            fullName: format(monthDate, "MMM yyyy"),
-            Income: Math.round(item.income),
-            Expenses: Math.round(item.expenses),
-            Savings: Math.round(savings),
-            SavingsRate: savingsRate,
-            monthStart: format(startOfMonth(monthDate), "yyyy-MM-dd"),
-            monthEnd: format(endOfMonth(monthDate), "yyyy-MM-dd"),
-          };
-        },
-      );
-
-      setChartData(data);
-
-      const totalIncome = response.totals.income;
-      const totalExpenses = response.totals.expenses;
-      const totalSavings = totalIncome - totalExpenses;
-      const savingsRate =
-        totalIncome > 0 ? (totalSavings / totalIncome) * 100 : 0;
-      setTotals({ totalIncome, totalExpenses, totalSavings, savingsRate });
-    } catch (error) {
-      logger.error("Failed to load data:", error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [resolvedRange]);
-
-  useEffect(() => {
-    if (isValid) loadData();
-  }, [isValid, loadData]);
 
   const handleExportPdf = async () => {
     const { exportToPdf } = await import("@/lib/pdf-export");
@@ -205,7 +192,6 @@ export function IncomeVsExpensesReport() {
   const CustomTooltip = ({
     active,
     payload,
-    label: _label,
   }: {
     active?: boolean;
     payload?: Array<{
@@ -216,25 +202,21 @@ export function IncomeVsExpensesReport() {
     }>;
     label?: string;
   }) => {
-    if (active && payload && payload.length) {
-      const data = payload[0]?.payload;
-      return (
-        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
-          <p className="font-medium text-gray-900 dark:text-gray-100 mb-1">
-            {data?.fullName}
-          </p>
-          {payload.map((entry, index) => (
-            <p key={index} className="text-sm" style={{ color: entry.color }}>
-              {entry.name}: {formatCurrency(entry.value)}
-            </p>
-          ))}
+    const data = payload?.[0]?.payload;
+    return (
+      <ChartTooltip
+        active={active}
+        label={data?.fullName}
+        payload={payload}
+        formatValue={(v) => formatCurrency(v)}
+      >
+        {data && (
           <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-            Savings Rate: {data?.SavingsRate}%
+            Savings Rate: {data.SavingsRate}%
           </p>
-        </div>
-      );
-    }
-    return null;
+        )}
+      </ChartTooltip>
+    );
   };
 
   return (
@@ -274,6 +256,8 @@ export function IncomeVsExpensesReport() {
             <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
             <div className="h-96 bg-gray-200 dark:bg-gray-700 rounded" />
           </div>
+        ) : error ? (
+          <ReportError onRetry={reload} />
         ) : chartData.length === 0 ? (
           <p className="text-gray-500 dark:text-gray-400 text-center py-8">
             No data for this period.

--- a/frontend/src/components/reports/IncomeVsExpensesReport.tsx
+++ b/frontend/src/components/reports/IncomeVsExpensesReport.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useRef } from "react";
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from "next/navigation";
 import {
   BarChart,
@@ -252,9 +253,9 @@ export function IncomeVsExpensesReport() {
       {/* Chart */}
       <div ref={chartRef} className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 px-2 py-4 sm:p-6">
         {isLoading ? (
-          <div className="animate-pulse space-y-4">
-            <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-            <div className="h-96 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="space-y-4">
+            <Skeleton className="h-8 w-1/3" />
+            <Skeleton className="h-96 w-full" />
           </div>
         ) : error ? (
           <ReportError onRetry={reload} />

--- a/frontend/src/components/reports/InvestmentPerformanceReport.test.tsx
+++ b/frontend/src/components/reports/InvestmentPerformanceReport.test.tsx
@@ -6,6 +6,8 @@ vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
     formatCurrencyCompact: (n: number) => `$${n.toFixed(0)}`,
     formatCurrency: (n: number, _currency?: string) => `$${n.toFixed(2)}`,
+    formatSignedPercent: (n: number, decimals = 2) =>
+      `${n >= 0 ? '+' : ''}${n.toFixed(decimals)}%`,
     defaultCurrency: 'CAD',
   }),
 }));

--- a/frontend/src/components/reports/InvestmentPerformanceReport.tsx
+++ b/frontend/src/components/reports/InvestmentPerformanceReport.tsx
@@ -15,6 +15,7 @@ import { Account } from '@/types/account';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { CHART_COLOURS } from '@/lib/chart-colours';
+import { gainLossColor } from '@/lib/format';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
 import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
@@ -28,7 +29,7 @@ const logger = createLogger('InvestmentPerformanceReport');
 type HoldingsSortField = 'symbol' | 'quantity' | 'averageCost' | 'currentPrice' | 'marketValue' | 'gainLoss' | 'gainLossPercent';
 
 export function InvestmentPerformanceReport() {
-  const { formatCurrency: formatCurrencyFull } = useNumberFormat();
+  const { formatCurrency: formatCurrencyFull, formatSignedPercent } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
   const chartRef = useRef<HTMLDivElement>(null);
   const [portfolio, setPortfolio] = useState<PortfolioSummary | null>(null);
@@ -68,10 +69,7 @@ export function InvestmentPerformanceReport() {
     loadData();
   }, [selectedAccountIds, reloadKey]);
 
-  const formatPercent = (value: number) => {
-    const sign = value >= 0 ? '+' : '';
-    return `${sign}${value.toFixed(2)}%`;
-  };
+  const formatPercent = (value: number) => formatSignedPercent(value);
 
   // When a single account is selected, show summary values in that account's native currency
   // (per-account totals are in native currency; top-level totals are converted to default)
@@ -189,7 +187,7 @@ export function InvestmentPerformanceReport() {
           <p className="text-sm text-gray-900 dark:text-gray-100 mt-1">
             Value: {fmtHolding(data.marketValue, data.currencyCode)}
           </p>
-          <p className={`text-sm ${(data.gainLoss || 0) >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+          <p className={`text-sm ${gainLossColor(data.gainLoss || 0)}`}>
             Gain/Loss: {fmtHolding(data.gainLoss, data.currencyCode)} ({formatPercent(data.gainLossPercent || 0)})
           </p>
         </div>
@@ -288,13 +286,13 @@ export function InvestmentPerformanceReport() {
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
           <div className="text-sm text-gray-500 dark:text-gray-400">Total Gain/Loss</div>
-          <div className={`text-xl font-bold ${summaryValues.totalGainLoss >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+          <div className={`text-xl font-bold ${gainLossColor(summaryValues.totalGainLoss)}`}>
             {summaryValues.totalGainLoss >= 0 ? '+' : ''}{fmtSummary(summaryValues.totalGainLoss)}
           </div>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
           <div className="text-sm text-gray-500 dark:text-gray-400">Return</div>
-          <div className={`text-xl font-bold ${summaryValues.totalGainLossPercent >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+          <div className={`text-xl font-bold ${gainLossColor(summaryValues.totalGainLossPercent)}`}>
             {formatPercent(summaryValues.totalGainLossPercent)}
           </div>
         </div>

--- a/frontend/src/components/reports/InvestmentPerformanceReport.tsx
+++ b/frontend/src/components/reports/InvestmentPerformanceReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   Tooltip,
   ResponsiveContainer,
@@ -250,9 +251,9 @@ export function InvestmentPerformanceReport() {
   if (isLoading && !hasLoadedOnce) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/InvestmentTransactionHistoryReport.tsx
+++ b/frontend/src/components/reports/InvestmentTransactionHistoryReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { format } from 'date-fns';
 import { investmentsApi } from '@/lib/investments';
 import { InvestmentTransaction, InvestmentAction } from '@/types/investment';
@@ -268,9 +269,9 @@ export function InvestmentTransactionHistoryReport() {
   if (isLoading && !hasLoadedOnce) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/LoanAmortizationReport.tsx
+++ b/frontend/src/components/reports/LoanAmortizationReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, Fragment } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { format, parseISO } from 'date-fns';
 import { accountsApi } from '@/lib/accounts';
 import { transactionsApi } from '@/lib/transactions';
@@ -399,9 +400,9 @@ export function LoanAmortizationReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/MonteCarloSaveAsDialog.test.tsx
+++ b/frontend/src/components/reports/MonteCarloSaveAsDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { MonteCarloSaveAsDialog } from './MonteCarloSaveAsDialog';
 import { __resetModalStateForTesting } from '@/components/ui/Modal';
 
@@ -66,7 +66,7 @@ describe('MonteCarloSaveAsDialog', () => {
     expect(screen.getByLabelText(/^Name$/)).toHaveValue('Second');
   });
 
-  it('submits the trimmed name', () => {
+  it('submits the trimmed name', async () => {
     const onSubmit = vi.fn();
     render(
       <MonteCarloSaveAsDialog
@@ -79,10 +79,11 @@ describe('MonteCarloSaveAsDialog', () => {
     const input = screen.getByLabelText(/^Name$/);
     fireEvent.change(input, { target: { value: '  Trimmed Name  ' } });
     fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
-    expect(onSubmit).toHaveBeenCalledWith('Trimmed Name');
+    // react-hook-form validation resolves asynchronously.
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('Trimmed Name'));
   });
 
-  it('truncates the submitted name at 255 characters', () => {
+  it('truncates the submitted name at 255 characters', async () => {
     const onSubmit = vi.fn();
     render(
       <MonteCarloSaveAsDialog
@@ -100,6 +101,7 @@ describe('MonteCarloSaveAsDialog', () => {
     Object.defineProperty(input, 'value', { value: long, configurable: true });
     fireEvent.change(input);
     fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
     expect(onSubmit.mock.calls[0][0]).toHaveLength(255);
   });
 

--- a/frontend/src/components/reports/MonteCarloSaveAsDialog.tsx
+++ b/frontend/src/components/reports/MonteCarloSaveAsDialog.tsx
@@ -1,8 +1,23 @@
 'use client';
 
-import { FormEvent, useState } from 'react';
+import { useState } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
 import { Button } from '@/components/ui/Button';
 import { Modal } from '@/components/ui/Modal';
+
+const saveAsSchema = z.object({
+  // Trim then cap at 255 chars so the submitted value is always clean and
+  // bounded, mirroring the backend column limit. A whitespace-only name
+  // collapses to '' and fails the min(1) rule.
+  name: z
+    .string()
+    .transform((v) => v.trim().slice(0, 255))
+    .pipe(z.string().min(1, 'Name is required')),
+});
+
+type SaveAsFormData = { name: string };
 
 interface MonteCarloSaveAsDialogProps {
   isOpen: boolean;
@@ -17,22 +32,30 @@ export function MonteCarloSaveAsDialog({
   onCancel,
   onSubmit,
 }: MonteCarloSaveAsDialogProps) {
+  const {
+    control,
+    register,
+    handleSubmit,
+    reset,
+  } = useForm<SaveAsFormData>({
+    resolver: zodResolver(saveAsSchema),
+    defaultValues: { name: initialName },
+  });
+
   // Reset the field whenever the dialog transitions from closed to open. We
   // store the previous open state and update during render so the field
   // already shows the correct value on the first paint -- no useEffect, no
   // cascading re-render.
   const [prevOpen, setPrevOpen] = useState(isOpen);
-  const [name, setName] = useState(initialName);
   if (prevOpen !== isOpen) {
     setPrevOpen(isOpen);
-    if (isOpen) setName(initialName);
+    if (isOpen) reset({ name: initialName });
   }
 
-  const handleSubmit = (e: FormEvent) => {
-    e.preventDefault();
-    const trimmed = name.trim();
-    if (!trimmed) return;
-    onSubmit(trimmed.slice(0, 255));
+  const name = useWatch({ control, name: 'name' });
+
+  const submit = ({ name: cleaned }: SaveAsFormData) => {
+    onSubmit(cleaned);
   };
 
   return (
@@ -43,7 +66,7 @@ export function MonteCarloSaveAsDialog({
       className="p-6"
       pushHistory
     >
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit(submit)}>
         <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
           Save scenario as
         </h3>
@@ -59,17 +82,16 @@ export function MonteCarloSaveAsDialog({
         <input
           id="mc-save-as-name"
           type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
           maxLength={255}
           autoFocus
           className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          {...register('name')}
         />
         <div className="mt-6 flex justify-end gap-3">
           <Button type="button" variant="outline" onClick={onCancel}>
             Cancel
           </Button>
-          <Button type="submit" variant="primary" disabled={!name.trim()}>
+          <Button type="submit" variant="primary" disabled={!name?.trim()}>
             Save
           </Button>
         </div>

--- a/frontend/src/components/reports/MonthlyComparisonReport.test.tsx
+++ b/frontend/src/components/reports/MonthlyComparisonReport.test.tsx
@@ -8,6 +8,7 @@ vi.mock('@/lib/pdf-export', () => ({
 
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
+    formatSignedPercent: (n: number, decimals = 2) => `${n >= 0 ? '+' : ''}${n.toFixed(decimals)}%`,
     formatCurrency: (n: number) => `$${n.toFixed(2)}`,
     formatCurrencyCompact: (n: number) => `$${Math.round(n)}`,
     formatCurrencyAxis: (n: number) => `$${n}`,

--- a/frontend/src/components/reports/MonthlyComparisonReport.tsx
+++ b/frontend/src/components/reports/MonthlyComparisonReport.tsx
@@ -20,6 +20,7 @@ import {
   CategorySpendingSnapshot,
 } from '@/types/monthly-comparison';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { gainLossColor } from '@/lib/format';
 import { CHART_COLOURS } from '@/lib/chart-colours';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { SortableHeader } from '@/components/ui/SortableHeader';
@@ -62,7 +63,7 @@ function DeltaBadge({ value, percent, invert = false }: { value: number; percent
 }
 
 export function MonthlyComparisonReport() {
-  const { formatCurrency, formatCurrencyCompact, formatCurrencyAxis } = useNumberFormat();
+  const { formatCurrency, formatCurrencyCompact, formatCurrencyAxis, formatSignedPercent } = useNumberFormat();
   const chartRef = useRef<HTMLDivElement>(null);
   const [month, setMonth] = useState(getDefaultMonth);
   const [data, setData] = useState<MonthlyComparisonResponse | null>(null);
@@ -171,7 +172,7 @@ export function MonthlyComparisonReport() {
         formatCurrency(item.currentTotal, cur),
         formatCurrency(item.previousTotal, cur),
         `${item.change >= 0 ? '+' : ''}${formatCurrency(item.change, cur)}`,
-        `${item.changePercent >= 0 ? '+' : ''}${item.changePercent.toFixed(1)}%`,
+        formatSignedPercent(item.changePercent, 1),
       ]),
     } : undefined;
 
@@ -226,7 +227,7 @@ export function MonthlyComparisonReport() {
           mover.name,
           formatCurrency(mover.currentPrice, cur),
           `${mover.change >= 0 ? '+' : ''}${formatCurrency(mover.change, cur)}`,
-          `${mover.changePercent >= 0 ? '+' : ''}${mover.changePercent.toFixed(2)}%`,
+          formatSignedPercent(mover.changePercent, 2),
         ]),
       });
     }
@@ -491,7 +492,7 @@ export function MonthlyComparisonReport() {
                       {item.change >= 0 ? '+' : ''}{formatCurrency(item.change, currency)}
                     </td>
                     <td className={`px-4 py-3 text-sm text-right font-medium ${item.changePercent <= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                      {item.changePercent >= 0 ? '+' : ''}{item.changePercent.toFixed(1)}%
+                      {formatSignedPercent(item.changePercent, 1)}
                     </td>
                   </tr>
                 ))}
@@ -545,8 +546,8 @@ export function MonthlyComparisonReport() {
             <div className="mt-4 p-4 bg-gray-50 dark:bg-gray-700/30 rounded-lg">
               <p className="text-sm text-gray-700 dark:text-gray-300">
                 Your net worth in {data.currentMonthLabel} was <span className="font-semibold">{formatCurrency(nw.currentNetWorth, currency)}</span>, which was{' '}
-                <span className={`font-semibold ${nw.netWorthChange >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                  {nw.netWorthChange >= 0 ? '+' : ''}{formatCurrency(nw.netWorthChange, currency)} ({nw.netWorthChange >= 0 ? '+' : ''}{nw.netWorthChangePercent.toFixed(1)}%)
+                <span className={`font-semibold ${gainLossColor(nw.netWorthChange)}`}>
+                  {nw.netWorthChange >= 0 ? '+' : ''}{formatCurrency(nw.netWorthChange, currency)} ({formatSignedPercent(nw.netWorthChangePercent, 1)})
                 </span>{' '}
                 compared to {data.previousMonthLabel}.
               </p>
@@ -660,11 +661,11 @@ export function MonthlyComparisonReport() {
                         <td className="px-4 py-3 text-sm text-right text-gray-900 dark:text-gray-100">
                           {formatCurrency(mover.currentPrice, currency)}
                         </td>
-                        <td className={`px-4 py-3 text-sm text-right font-medium ${mover.change >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                        <td className={`px-4 py-3 text-sm text-right font-medium ${gainLossColor(mover.change)}`}>
                           {mover.change >= 0 ? '+' : ''}{formatCurrency(mover.change, currency)}
                         </td>
-                        <td className={`px-4 py-3 text-sm text-right font-medium ${mover.changePercent >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                          {mover.changePercent >= 0 ? '+' : ''}{mover.changePercent.toFixed(2)}%
+                        <td className={`px-4 py-3 text-sm text-right font-medium ${gainLossColor(mover.changePercent)}`}>
+                          {formatSignedPercent(mover.changePercent, 2)}
                         </td>
                       </tr>
                     ))}

--- a/frontend/src/components/reports/MonthlyComparisonReport.tsx
+++ b/frontend/src/components/reports/MonthlyComparisonReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
   Bar,
@@ -283,9 +284,9 @@ export function MonthlyComparisonReport() {
           </div>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-          <div className="animate-pulse space-y-4">
-            <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-            <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="space-y-4">
+            <Skeleton className="h-8 w-1/3" />
+            <Skeleton className="h-64 w-full" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/MonthlySpendingTrendReport.test.tsx
+++ b/frontend/src/components/reports/MonthlySpendingTrendReport.test.tsx
@@ -147,12 +147,13 @@ describe("MonthlySpendingTrendReport", () => {
     });
   });
 
-  it("handles API error gracefully", async () => {
+  it("surfaces a retryable error state when the API fails", async () => {
     mockGetIncomeVsExpenses.mockRejectedValue(new Error("Network error"));
     render(<MonthlySpendingTrendReport />);
     await waitFor(() => {
-      expect(screen.getByText("No data for this period.")).toBeInTheDocument();
+      expect(screen.getByText(/failed to load report data/i)).toBeInTheDocument();
     });
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
   });
 
   it("navigates to transactions page with date range on chart click", async () => {

--- a/frontend/src/components/reports/MonthlySpendingTrendReport.tsx
+++ b/frontend/src/components/reports/MonthlySpendingTrendReport.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import { useState, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import {
   LineChart,
@@ -17,15 +17,15 @@ import { builtInReportsApi } from "@/lib/built-in-reports";
 import { MonthlyIncomeExpenseItem } from "@/types/built-in-reports";
 import { useNumberFormat } from "@/hooks/useNumberFormat";
 import { useDateRange } from "@/hooks/useDateRange";
+import { useReportData } from "@/hooks/useReportData";
 import { useSortableTable, compareValues } from "@/hooks/useSortableTable";
 import { DateRangeSelector } from "@/components/ui/DateRangeSelector";
 import { ChartViewToggle } from "@/components/ui/ChartViewToggle";
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { SortableHeader } from '@/components/ui/SortableHeader';
+import { ChartTooltip } from "@/components/reports/ChartTooltip";
+import { ReportError } from "@/components/reports/ReportError";
 import { exportToCsv } from "@/lib/csv-export";
-import { createLogger } from "@/lib/logger";
-
-const logger = createLogger("MonthlySpendingTrendReport");
 
 type MonthlySpendingSortField = 'name' | 'income' | 'expenses' | 'net';
 
@@ -44,8 +44,6 @@ export function MonthlySpendingTrendReport() {
   const chartRef = useRef<HTMLDivElement>(null);
   const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis } =
     useNumberFormat();
-  const [chartData, setChartData] = useState<ChartDataItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [viewType, setViewType] = useState<'line' | 'table'>('line');
   const {
     dateRange,
@@ -60,6 +58,40 @@ export function MonthlySpendingTrendReport() {
   const { sortField, sortDirection, handleSort } = useSortableTable<MonthlySpendingSortField>(
     'reports.monthly-spending-trend.table.sort',
     { field: 'name', direction: 'asc' },
+  );
+
+  const { start: rangeStart, end: rangeEnd } = resolvedRange;
+
+  const { data: response, isLoading, error, reload } = useReportData(
+    () =>
+      isValid
+        ? builtInReportsApi.getIncomeVsExpenses({
+            startDate: rangeStart || undefined,
+            endDate: rangeEnd,
+          })
+        : Promise.resolve(null),
+    [isValid, rangeStart, rangeEnd],
+  );
+
+  // Map response to chart data. `name` must be unique across the dataset
+  // (used as the XAxis category key); a non-unique value like "May" causes
+  // Recharts to resolve the tooltip's payload to the first matching row,
+  // showing data from the wrong year on multi-year ranges.
+  const chartData = useMemo<ChartDataItem[]>(
+    () =>
+      (response?.data ?? []).map((item: MonthlyIncomeExpenseItem) => {
+        const monthDate = parseISO(item.month + "-01");
+        return {
+          name: item.month,
+          fullName: format(monthDate, "MMM yyyy"),
+          Expenses: Math.round(item.expenses),
+          Income: Math.round(item.income),
+          Net: Math.round(item.net),
+          monthStart: format(startOfMonth(monthDate), "yyyy-MM-dd"),
+          monthEnd: format(endOfMonth(monthDate), "yyyy-MM-dd"),
+        };
+      }),
+    [response],
   );
 
   const sortedTableData = useMemo(() => {
@@ -84,46 +116,6 @@ export function MonthlySpendingTrendReport() {
     });
     return sorted;
   }, [chartData, sortField, sortDirection]);
-
-  const loadData = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const { start, end } = resolvedRange;
-      const response = await builtInReportsApi.getIncomeVsExpenses({
-        startDate: start || undefined,
-        endDate: end,
-      });
-
-      // Map response to chart data. `name` must be unique across the dataset
-      // (used as the XAxis category key); a non-unique value like "May" causes
-      // Recharts to resolve the tooltip's payload to the first matching row,
-      // showing data from the wrong year on multi-year ranges.
-      const data: ChartDataItem[] = response.data.map(
-        (item: MonthlyIncomeExpenseItem) => {
-          const monthDate = parseISO(item.month + "-01");
-          return {
-            name: item.month,
-            fullName: format(monthDate, "MMM yyyy"),
-            Expenses: Math.round(item.expenses),
-            Income: Math.round(item.income),
-            Net: Math.round(item.net),
-            monthStart: format(startOfMonth(monthDate), "yyyy-MM-dd"),
-            monthEnd: format(endOfMonth(monthDate), "yyyy-MM-dd"),
-          };
-        },
-      );
-
-      setChartData(data);
-    } catch (error) {
-      logger.error("Failed to load data:", error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [resolvedRange]);
-
-  useEffect(() => {
-    if (isValid) loadData();
-  }, [isValid, loadData]);
 
   const totals = useMemo(() => {
     const totalExpenses = chartData.reduce((sum, m) => sum + m.Expenses, 0);
@@ -173,7 +165,6 @@ export function MonthlySpendingTrendReport() {
   const CustomTooltip = ({
     active,
     payload,
-    label: _label,
   }: {
     active?: boolean;
     payload?: Array<{
@@ -183,24 +174,14 @@ export function MonthlySpendingTrendReport() {
       payload?: { fullName?: string };
     }>;
     label?: string;
-  }) => {
-    if (active && payload && payload.length) {
-      const data = payload[0]?.payload;
-      return (
-        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
-          <p className="font-medium text-gray-900 dark:text-gray-100 mb-1">
-            {data?.fullName}
-          </p>
-          {payload.map((entry, index) => (
-            <p key={index} className="text-sm" style={{ color: entry.color }}>
-              {entry.name}: {formatCurrency(entry.value)}
-            </p>
-          ))}
-        </div>
-      );
-    }
-    return null;
-  };
+  }) => (
+    <ChartTooltip
+      active={active}
+      label={payload?.[0]?.payload?.fullName}
+      payload={payload}
+      formatValue={(v) => formatCurrency(v)}
+    />
+  );
 
   return (
     <div className="space-y-6">
@@ -239,6 +220,8 @@ export function MonthlySpendingTrendReport() {
             <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
             <div className="h-96 bg-gray-200 dark:bg-gray-700 rounded" />
           </div>
+        ) : error ? (
+          <ReportError onRetry={reload} />
         ) : chartData.length === 0 ? (
           <p className="text-gray-500 dark:text-gray-400 text-center py-8">
             No data for this period.

--- a/frontend/src/components/reports/MonthlySpendingTrendReport.tsx
+++ b/frontend/src/components/reports/MonthlySpendingTrendReport.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useRef } from "react";
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from "next/navigation";
 import {
   LineChart,
@@ -216,9 +217,9 @@ export function MonthlySpendingTrendReport() {
       {/* Chart */}
       <div ref={chartRef} className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 px-2 py-4 sm:p-6">
         {isLoading ? (
-          <div className="animate-pulse space-y-4">
-            <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-            <div className="h-96 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="space-y-4">
+            <Skeleton className="h-8 w-1/3" />
+            <Skeleton className="h-96 w-full" />
           </div>
         ) : error ? (
           <ReportError onRetry={reload} />

--- a/frontend/src/components/reports/MonthlySpendingTrendReport.tsx
+++ b/frontend/src/components/reports/MonthlySpendingTrendReport.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useRef } from "react";
+import { gainLossColor } from '@/lib/format';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from "next/navigation";
 import {
@@ -295,7 +296,7 @@ export function MonthlySpendingTrendReport() {
                         {formatCurrency(row.Expenses)}
                       </td>
                       <td
-                        className={`px-4 py-3 text-right text-sm font-medium ${row.Net >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}
+                        className={`px-4 py-3 text-right text-sm font-medium ${gainLossColor(row.Net)}`}
                       >
                         {formatCurrency(row.Net)}
                       </td>
@@ -312,7 +313,7 @@ export function MonthlySpendingTrendReport() {
                       {formatCurrency(totals.totalExpenses)}
                     </td>
                     <td
-                      className={`px-4 py-3 text-right text-sm font-bold ${totals.totalIncome - totals.totalExpenses >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}
+                      className={`px-4 py-3 text-right text-sm font-bold ${gainLossColor(totals.totalIncome - totals.totalExpenses)}`}
                     >
                       {formatCurrency(totals.totalIncome - totals.totalExpenses)}
                     </td>

--- a/frontend/src/components/reports/NetWorthReport.test.tsx
+++ b/frontend/src/components/reports/NetWorthReport.test.tsx
@@ -19,6 +19,7 @@ vi.mock('@/components/ui/ChartViewToggle', () => ({
 
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
+    formatSignedPercent: (n: number, decimals = 2) => `${n >= 0 ? '+' : ''}${n.toFixed(decimals)}%`,
     formatCurrencyCompact: (n: number) => `$${n.toFixed(0)}`,
     formatCurrency: (n: number) => `$${n.toFixed(2)}`,
     formatCurrencyAxis: (n: number) => `$${n}`,

--- a/frontend/src/components/reports/NetWorthReport.tsx
+++ b/frontend/src/components/reports/NetWorthReport.tsx
@@ -21,6 +21,7 @@ import { netWorthApi } from '@/lib/net-worth';
 import { MonthlyNetWorth } from '@/types/net-worth';
 import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { gainLossColor } from '@/lib/format';
 import { useDateRange } from '@/hooks/useDateRange';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
@@ -36,7 +37,7 @@ const logger = createLogger('NetWorthReport');
 type NetWorthSortField = 'name' | 'assets' | 'liabilities' | 'netWorth';
 
 export function NetWorthReport() {
-  const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis, formatCurrencyLabel } = useNumberFormat();
+  const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis, formatCurrencyLabel, formatSignedPercent } = useNumberFormat();
   const isMobile = useIsMobile();
   const [monthlyData, setMonthlyData] = useState<MonthlyNetWorth[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -94,7 +95,7 @@ export function NetWorthReport() {
       summaryCards: [
         { label: 'Current Net Worth', value: formatCurrency(summary.current), color: summary.current >= 0 ? '#16a34a' : '#dc2626' },
         { label: 'Change', value: `${summary.change >= 0 ? '+' : ''}${formatCurrency(summary.change)}`, color: summary.change >= 0 ? '#16a34a' : '#dc2626' },
-        { label: 'Change %', value: `${summary.changePercent >= 0 ? '+' : ''}${summary.changePercent.toFixed(1)}%`, color: summary.changePercent >= 0 ? '#16a34a' : '#dc2626' },
+        { label: 'Change %', value: formatSignedPercent(summary.changePercent, 1), color: summary.changePercent >= 0 ? '#16a34a' : '#dc2626' },
       ],
       chartContainer: chartRef.current,
       filename: 'net-worth-report',
@@ -251,18 +252,14 @@ export function NetWorthReport() {
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
           <div className="text-sm text-gray-500 dark:text-gray-400">Change</div>
-          <div className={`text-2xl font-bold ${
-            summary.change >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
-          }`}>
+          <div className={`text-2xl font-bold ${gainLossColor(summary.change)}`}>
             {summary.change >= 0 ? '+' : ''}{formatCurrency(summary.change)}
           </div>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
           <div className="text-sm text-gray-500 dark:text-gray-400">Change %</div>
-          <div className={`text-2xl font-bold ${
-            summary.changePercent >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
-          }`}>
-            {summary.changePercent >= 0 ? '+' : ''}{summary.changePercent.toFixed(1)}%
+          <div className={`text-2xl font-bold ${gainLossColor(summary.changePercent)}`}>
+            {formatSignedPercent(summary.changePercent, 1)}
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/NetWorthReport.tsx
+++ b/frontend/src/components/reports/NetWorthReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   AreaChart,
   Area,
@@ -230,9 +231,9 @@ export function NetWorthReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-96 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-96 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/NetWorthReport.tsx
+++ b/frontend/src/components/reports/NetWorthReport.tsx
@@ -246,7 +246,7 @@ export function NetWorthReport() {
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
           <div className="text-sm text-gray-500 dark:text-gray-400">Current Net Worth</div>
           <div className={`text-2xl font-bold ${
-            summary.current >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+            gainLossColor(summary.current)
           }`}>
             {formatCurrency(summary.current)}
           </div>

--- a/frontend/src/components/reports/PortfolioValueReport.test.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.test.tsx
@@ -8,6 +8,7 @@ vi.mock('@/lib/pdf-export', () => ({
 
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
+    formatSignedPercent: (n: number, decimals = 2) => `${n >= 0 ? '+' : ''}${n.toFixed(decimals)}%`,
     formatCurrencyCompact: (n: number, _currency?: string) => `$${n.toFixed(0)}`,
     formatCurrency: (n: number, _currency?: string) => `$${n.toFixed(2)}`,
     formatCurrencyAxis: (n: number) => `$${n}`,

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -17,6 +17,7 @@ import { PortfolioSummary } from '@/types/investment';
 import { Account } from '@/types/account';
 import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { gainLossColor } from '@/lib/format';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useDateRange } from '@/hooks/useDateRange';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
@@ -65,7 +66,7 @@ function CustomTooltip({ active, payload, fmtFull }: {
 }
 
 export function PortfolioValueReport() {
-  const { formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag, formatCurrency: formatCurrencyFull } = useNumberFormat();
+  const { formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag, formatCurrency: formatCurrencyFull, formatSignedPercent } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
   const chartRef = useRef<HTMLDivElement>(null);
   const [chartPoints, setChartPoints] = useState<Array<{ name: string; Value: number }>>([]);
@@ -391,7 +392,7 @@ export function PortfolioValueReport() {
         { label: 'Highest Value', value: fmtVal(summary.highest), color: '#111827' },
         { label: 'Lowest Value', value: fmtVal(summary.lowest), color: '#111827' },
         { label: 'Period Change', value: `${summary.change >= 0 ? '+' : ''}${fmtVal(summary.change)}`, color: summary.change >= 0 ? '#16a34a' : '#dc2626' },
-        { label: 'Period Return', value: `${summary.changePercent >= 0 ? '+' : ''}${summary.changePercent.toFixed(1)}%`, color: summary.changePercent >= 0 ? '#16a34a' : '#dc2626' },
+        { label: 'Period Return', value: formatSignedPercent(summary.changePercent, 1), color: summary.changePercent >= 0 ? '#16a34a' : '#dc2626' },
       ],
       chartContainer: chartRef.current,
       additionalTables: breakdownRows.length > 0 ? [{
@@ -447,8 +448,8 @@ export function PortfolioValueReport() {
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
           <div className="text-sm text-gray-500 dark:text-gray-400">Period Return</div>
-          <div className={`text-xl font-bold ${summary.changePercent >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-            {summary.changePercent >= 0 ? '+' : ''}{summary.changePercent.toFixed(1)}%
+          <div className={`text-xl font-bold ${gainLossColor(summary.changePercent)}`}>
+            {formatSignedPercent(summary.changePercent, 1)}
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   AreaChart,
   Area,
@@ -416,9 +417,9 @@ export function PortfolioValueReport() {
   if (isLoading && chartPoints.length === 0 && !intradayUnavailable) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -443,7 +443,7 @@ export function PortfolioValueReport() {
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
           <div className="text-sm text-gray-500 dark:text-gray-400">Period Change</div>
-          <div className={`text-xl font-bold ${summary.change >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+          <div className={`text-xl font-bold ${gainLossColor(summary.change)}`}>
             {summary.change >= 0 ? '+' : ''}{fmtVal(summary.change)}
           </div>
         </div>
@@ -782,7 +782,7 @@ export function PortfolioValueReport() {
                     <td className="px-4 py-3 text-right text-sm font-medium text-gray-900 dark:text-gray-100">
                       {fmtFull(acct.totalMarketValue + acct.cashBalance)}
                     </td>
-                    <td className={`px-4 py-3 text-right text-sm font-medium ${acct.totalGainLoss >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                    <td className={`px-4 py-3 text-right text-sm font-medium ${gainLossColor(acct.totalGainLoss)}`}>
                       {acct.totalGainLoss >= 0 ? '+' : ''}{fmtFull(acct.totalGainLoss)}
                     </td>
                   </tr>

--- a/frontend/src/components/reports/RealizedGainsReport.tsx
+++ b/frontend/src/components/reports/RealizedGainsReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
   Bar,
@@ -284,9 +285,9 @@ export function RealizedGainsReport() {
   if (isLoading && !hasLoadedOnce) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/RealizedGainsReport.tsx
+++ b/frontend/src/components/reports/RealizedGainsReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
+import { gainLossColor } from '@/lib/format';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
@@ -44,7 +45,7 @@ function CustomTooltip({ active, payload, fmtValue }: {
   return (
     <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
       <p className="font-medium text-gray-900 dark:text-gray-100">{data.payload.symbol}</p>
-      <p className={`text-sm ${value >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+      <p className={`text-sm ${gainLossColor(value)}`}>
         {value >= 0 ? '+' : ''}{fmtValue(value)}
       </p>
     </div>
@@ -311,7 +312,7 @@ export function RealizedGainsReport() {
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
           <div className="text-sm text-gray-500 dark:text-gray-400">Realized Gain/Loss</div>
-          <div className={`text-xl font-bold ${totals.totalGain >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+          <div className={`text-xl font-bold ${gainLossColor(totals.totalGain)}`}>
             {totals.totalGain >= 0 ? '+' : ''}{fmtValue(totals.totalGain)}
           </div>
         </div>
@@ -490,7 +491,7 @@ export function RealizedGainsReport() {
                     <td className="px-4 py-3 text-right text-sm text-gray-900 dark:text-gray-100">
                       {fmtValue(sg.totalCostBasis)}
                     </td>
-                    <td className={`px-4 py-3 text-right text-sm font-medium ${sg.realizedGain >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                    <td className={`px-4 py-3 text-right text-sm font-medium ${gainLossColor(sg.realizedGain)}`}>
                       {sg.realizedGain >= 0 ? '+' : ''}{fmtValue(sg.realizedGain)}
                     </td>
                   </tr>
@@ -510,7 +511,7 @@ export function RealizedGainsReport() {
                   <td className="px-4 py-3 text-right text-sm font-semibold text-gray-900 dark:text-gray-100">
                     {fmtValue(totals.totalCostBasis)}
                   </td>
-                  <td className={`px-4 py-3 text-right text-sm font-bold ${totals.totalGain >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                  <td className={`px-4 py-3 text-right text-sm font-bold ${gainLossColor(totals.totalGain)}`}>
                     {totals.totalGain >= 0 ? '+' : ''}{fmtValue(totals.totalGain)}
                   </td>
                 </tr>

--- a/frontend/src/components/reports/RecurringExpensesReport.tsx
+++ b/frontend/src/components/reports/RecurringExpensesReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from 'next/navigation';
 import {
   PieChart,
@@ -164,9 +165,9 @@ export function RecurringExpensesReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/ReportError.test.tsx
+++ b/frontend/src/components/reports/ReportError.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@/test/render';
+import { ReportError } from './ReportError';
+
+describe('ReportError', () => {
+  it('renders a default message', () => {
+    render(<ReportError />);
+    expect(screen.getByText(/failed to load report data/i)).toBeInTheDocument();
+  });
+
+  it('renders a custom message', () => {
+    render(<ReportError message="Custom failure" />);
+    expect(screen.getByText('Custom failure')).toBeInTheDocument();
+  });
+
+  it('omits the retry button when no handler is given', () => {
+    render(<ReportError />);
+    expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
+  });
+
+  it('calls onRetry when the retry button is clicked', () => {
+    const onRetry = vi.fn();
+    render(<ReportError onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/reports/ReportError.tsx
+++ b/frontend/src/components/reports/ReportError.tsx
@@ -1,0 +1,31 @@
+interface ReportErrorProps {
+  /** Optional override message; defaults to a generic load-failure note. */
+  message?: string;
+  /** When provided, renders a "Try again" button that re-runs the fetch. */
+  onRetry?: () => void;
+}
+
+/**
+ * Shared error panel for report components. Reports previously swallowed fetch
+ * errors and rendered an empty state, leaving the user unsure whether there was
+ * genuinely no data or the request had failed. Paired with `useReportData`, this
+ * gives every adopting report a visible, retryable error state.
+ */
+export function ReportError({ message, onRetry }: ReportErrorProps) {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6 text-center">
+      <p className="text-sm text-red-600 dark:text-red-400">
+        {message || 'Failed to load report data. Please try again.'}
+      </p>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-3 inline-flex items-center rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          Try again
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/reports/SavingsRateReport.tsx
+++ b/frontend/src/components/reports/SavingsRateReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   LineChart,
   Line,
@@ -131,9 +132,9 @@ export function SavingsRateReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/SavingsRateReport.tsx
+++ b/frontend/src/components/reports/SavingsRateReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { gainLossColor } from '@/lib/format';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   LineChart,
@@ -223,7 +224,7 @@ export function SavingsRateReport() {
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 text-center">
           <p className="text-xs text-gray-500 dark:text-gray-400">Total Saved</p>
-          <p className={`text-2xl font-bold ${totalSaved >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+          <p className={`text-2xl font-bold ${gainLossColor(totalSaved)}`}>
             {formatCurrency(totalSaved)}
           </p>
         </div>
@@ -351,7 +352,7 @@ export function SavingsRateReport() {
                     <td className="py-2 pr-4 text-gray-900 dark:text-gray-100">{point.month}</td>
                     <td className="py-2 pr-4 text-right text-gray-600 dark:text-gray-400">{formatCurrency(point.income)}</td>
                     <td className="py-2 pr-4 text-right text-gray-600 dark:text-gray-400">{formatCurrency(point.expenses)}</td>
-                    <td className={`py-2 pr-4 text-right font-medium ${point.savings >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                    <td className={`py-2 pr-4 text-right font-medium ${gainLossColor(point.savings)}`}>
                       {formatCurrency(point.savings)}
                     </td>
                     <td className={`py-2 text-right font-medium ${point.savingsRate >= targetRate ? 'text-green-600 dark:text-green-400' : point.savingsRate >= 0 ? 'text-yellow-600 dark:text-yellow-400' : 'text-red-600 dark:text-red-400'}`}>

--- a/frontend/src/components/reports/SeasonalSpendingMapReport.tsx
+++ b/frontend/src/components/reports/SeasonalSpendingMapReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { budgetsApi } from '@/lib/budgets';
 import type { Budget, SeasonalPattern } from '@/types/budget';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
@@ -164,9 +165,9 @@ export function SeasonalSpendingMapReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/SectorWeightingsReport.tsx
+++ b/frontend/src/components/reports/SectorWeightingsReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
   Bar,
@@ -173,9 +174,9 @@ export function SectorWeightingsReport() {
     return (
       <div className="space-y-6">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-          <div className="animate-pulse space-y-4">
-            <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-            <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="space-y-4">
+            <Skeleton className="h-8 w-1/3" />
+            <Skeleton className="h-64 w-full" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/SecurityPerformanceReport.test.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.test.tsx
@@ -17,6 +17,7 @@ vi.mock('@/components/ui/ExportDropdown', () => ({
 
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
+    formatSignedPercent: (n: number, decimals = 2) => `${n >= 0 ? '+' : ''}${n.toFixed(decimals)}%`,
     formatCurrency: (n: number) => `$${n.toFixed(2)}`,
     formatCurrencyCompact: (n: number) => `$${n.toFixed(0)}`,
     formatCurrencyAxis: (n: number) => `$${n}`,

--- a/frontend/src/components/reports/SecurityPerformanceReport.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.tsx
@@ -41,7 +41,7 @@ interface PriceChartPoint {
 }
 
 export function SecurityPerformanceReport() {
-  const { formatCurrency: formatCurrencyFull, formatCurrencyAxis } = useNumberFormat();
+  const { formatCurrency: formatCurrencyFull, formatCurrencyAxis, formatSignedPercent } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
   const chartRef = useRef<HTMLDivElement>(null);
   const [securities, setSecurities] = useState<Security[]>([]);
@@ -288,8 +288,8 @@ export function SecurityPerformanceReport() {
     const summaryCards = stats ? [
       { label: 'Current Value', value: formatCurrencyFull(stats.currentValue, displayCurrency), color: '#111827' },
       { label: 'Cost Basis', value: formatCurrencyFull(stats.costBasis, displayCurrency), color: '#111827' },
-      { label: 'Total Return', value: `${stats.totalReturn >= 0 ? '+' : ''}${formatCurrencyFull(stats.totalReturn, displayCurrency)} (${stats.totalReturnPercent >= 0 ? '+' : ''}${stats.totalReturnPercent.toFixed(2)}%)`, color: stats.totalReturn >= 0 ? '#16a34a' : '#dc2626' },
-      { label: 'Annualized Return', value: stats.annualizedReturn !== null ? `${stats.annualizedReturn >= 0 ? '+' : ''}${stats.annualizedReturn.toFixed(2)}%` : '-', color: stats.annualizedReturn !== null ? (stats.annualizedReturn >= 0 ? '#16a34a' : '#dc2626') : '#9ca3af' },
+      { label: 'Total Return', value: `${stats.totalReturn >= 0 ? '+' : ''}${formatCurrencyFull(stats.totalReturn, displayCurrency)} (${formatSignedPercent(stats.totalReturnPercent)})`, color: stats.totalReturn >= 0 ? '#16a34a' : '#dc2626' },
+      { label: 'Annualized Return', value: stats.annualizedReturn !== null ? formatSignedPercent(stats.annualizedReturn) : '-', color: stats.annualizedReturn !== null ? (stats.annualizedReturn >= 0 ? '#16a34a' : '#dc2626') : '#9ca3af' },
     ] : undefined;
 
     let chartContainer: HTMLElement | null = null;
@@ -477,14 +477,14 @@ export function SecurityPerformanceReport() {
                   {stats.totalReturn >= 0 ? '+' : ''}{formatCurrencyFull(stats.totalReturn, displayCurrency)}
                 </div>
                 <div className={`text-xs mt-1 ${stats.totalReturn >= 0 ? 'text-green-500 dark:text-green-400' : 'text-red-500 dark:text-red-400'}`}>
-                  {stats.totalReturnPercent >= 0 ? '+' : ''}{stats.totalReturnPercent.toFixed(2)}%
+                  {formatSignedPercent(stats.totalReturnPercent)}
                 </div>
               </div>
               <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4">
                 <div className="text-sm text-gray-500 dark:text-gray-400">Annualized Return</div>
                 <div className={`text-xl font-bold ${stats.annualizedReturn !== null ? (stats.annualizedReturn >= 0 ? 'text-green-700 dark:text-green-300' : 'text-red-700 dark:text-red-300') : 'text-gray-400'}`}>
                   {stats.annualizedReturn !== null
-                    ? `${stats.annualizedReturn >= 0 ? '+' : ''}${stats.annualizedReturn.toFixed(2)}%`
+                    ? formatSignedPercent(stats.annualizedReturn)
                     : '-'}
                 </div>
                 {stats.annualizedReturn === null && (

--- a/frontend/src/components/reports/SecurityPerformanceReport.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   AreaChart,
   Area,
@@ -336,9 +337,9 @@ export function SecurityPerformanceReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );
@@ -408,9 +409,9 @@ export function SecurityPerformanceReport() {
         </div>
       ) : isLoadingDetail ? (
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-          <div className="animate-pulse space-y-4">
-            <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-            <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="space-y-4">
+            <Skeleton className="h-8 w-1/3" />
+            <Skeleton className="h-64 w-full" />
           </div>
         </div>
       ) : (

--- a/frontend/src/components/reports/SecurityPerformanceReport.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useRef } from 'react';
+import { gainLossColor } from '@/lib/format';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   AreaChart,
@@ -471,7 +472,7 @@ export function SecurityPerformanceReport() {
                 </div>
               </div>
               <div className={`rounded-lg shadow p-4 ${stats.totalReturn >= 0 ? 'bg-green-50 dark:bg-green-900/20' : 'bg-red-50 dark:bg-red-900/20'}`}>
-                <div className={`text-sm ${stats.totalReturn >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                <div className={`text-sm ${gainLossColor(stats.totalReturn)}`}>
                   Total Return
                 </div>
                 <div className={`text-xl font-bold ${stats.totalReturn >= 0 ? 'text-green-700 dark:text-green-300' : 'text-red-700 dark:text-red-300'}`}>

--- a/frontend/src/components/reports/SecurityTypeAllocationReport.tsx
+++ b/frontend/src/components/reports/SecurityTypeAllocationReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   PieChart,
   Pie,
@@ -221,9 +222,9 @@ export function SecurityTypeAllocationReport() {
     return (
       <div className="space-y-6">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-          <div className="animate-pulse space-y-4">
-            <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-            <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="space-y-4">
+            <Skeleton className="h-8 w-1/3" />
+            <Skeleton className="h-64 w-full" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/reports/SpendingAnomaliesReport.tsx
+++ b/frontend/src/components/reports/SpendingAnomaliesReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from 'next/navigation';
 import { builtInReportsApi } from '@/lib/built-in-reports';
 import { SpendingAnomaly, SpendingAnomaliesResponse } from '@/types/built-in-reports';
@@ -125,9 +126,9 @@ export function SpendingAnomaliesReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/SpendingByCategoryReport.test.tsx
+++ b/frontend/src/components/reports/SpendingByCategoryReport.test.tsx
@@ -215,14 +215,15 @@ describe("SpendingByCategoryReport", () => {
     expect(button).toBeDisabled();
   });
 
-  it("handles API error gracefully", async () => {
+  it("surfaces a retryable error state when the API fails", async () => {
     mockGetSpendingByCategory.mockRejectedValue(new Error("Network error"));
     render(<SpendingByCategoryReport />);
     await waitFor(() => {
       expect(
-        screen.getByText("No expense data for this period."),
+        screen.getByText(/failed to load report data/i),
       ).toBeInTheDocument();
     });
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
   });
 
   it("navigates to transactions page on category legend click", async () => {

--- a/frontend/src/components/reports/SpendingByCategoryReport.tsx
+++ b/frontend/src/components/reports/SpendingByCategoryReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from 'next/navigation';
 import {
   PieChart,
@@ -157,9 +158,9 @@ export function SpendingByCategoryReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/SpendingByCategoryReport.tsx
+++ b/frontend/src/components/reports/SpendingByCategoryReport.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useMemo, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   PieChart,
@@ -18,17 +18,17 @@ import { builtInReportsApi } from '@/lib/built-in-reports';
 import { CategorySpendingItem } from '@/types/built-in-reports';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useDateRange } from '@/hooks/useDateRange';
+import { useReportData } from '@/hooks/useReportData';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { CHART_COLOURS } from '@/lib/chart-colours';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { SortableHeader } from '@/components/ui/SortableHeader';
+import { ChartTooltipPanel } from '@/components/reports/ChartTooltip';
+import { ReportError } from '@/components/reports/ReportError';
 import { exportToCsv } from '@/lib/csv-export';
-import { createLogger } from '@/lib/logger';
 import type { ChartDatum } from '@/types/chart';
-
-const logger = createLogger('SpendingByCategoryReport');
 
 type SpendingCategorySortField = 'name' | 'value' | 'percentage';
 
@@ -38,9 +38,6 @@ export function SpendingByCategoryReport() {
   const router = useRouter();
   const chartRef = useRef<HTMLDivElement>(null);
   const { formatCurrencyCompact: formatCurrency } = useNumberFormat();
-  const [chartData, setChartData] = useState<ChartDataItem[]>([]);
-  const [totalExpenses, setTotalExpenses] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
   const [viewType, setViewType] = useState<'pie' | 'bar' | 'table'>('pie');
   const { dateRange, setDateRange, startDate, setStartDate, endDate, setEndDate, resolvedRange, isValid } =
     useDateRange({ defaultRange: '3m' });
@@ -48,6 +45,39 @@ export function SpendingByCategoryReport() {
     'reports.spending-by-category.table.sort',
     { field: 'value', direction: 'desc' },
   );
+
+  const { start: rangeStart, end: rangeEnd } = resolvedRange;
+
+  const { data: response, isLoading, error, reload } = useReportData(
+    () =>
+      isValid
+        ? builtInReportsApi.getSpendingByCategory({
+            startDate: rangeStart || undefined,
+            endDate: rangeEnd,
+          })
+        : Promise.resolve(null),
+    [isValid, rangeStart, rangeEnd],
+  );
+
+  const chartData = useMemo<ChartDataItem[]>(() => {
+    if (!response) return [];
+    let colourIndex = 0;
+    return response.data.map((item: CategorySpendingItem) => {
+      let colour = item.color || '';
+      if (!colour) {
+        colour = CHART_COLOURS[colourIndex % CHART_COLOURS.length];
+        colourIndex++;
+      }
+      return {
+        id: item.categoryId || '',
+        name: item.categoryName,
+        value: item.total,
+        colour,
+      };
+    });
+  }, [response]);
+
+  const totalExpenses = response?.totalSpending ?? 0;
 
   const sortedTableData = useMemo(() => {
     const sorted = [...chartData];
@@ -71,44 +101,6 @@ export function SpendingByCategoryReport() {
     });
     return sorted;
   }, [chartData, sortField, sortDirection, totalExpenses]);
-
-  const loadData = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const { start, end } = resolvedRange;
-      const response = await builtInReportsApi.getSpendingByCategory({
-        startDate: start || undefined,
-        endDate: end,
-      });
-
-      // Map response to chart data with colours
-      let colourIndex = 0;
-      const data: ChartDataItem[] = response.data.map((item: CategorySpendingItem) => {
-        let colour = item.color || '';
-        if (!colour) {
-          colour = CHART_COLOURS[colourIndex % CHART_COLOURS.length];
-          colourIndex++;
-        }
-        return {
-          id: item.categoryId || '',
-          name: item.categoryName,
-          value: item.total,
-          colour,
-        };
-      });
-
-      setChartData(data);
-      setTotalExpenses(response.totalSpending);
-    } catch (error) {
-      logger.error('Failed to load data:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [resolvedRange]);
-
-  useEffect(() => {
-    if (isValid) loadData();
-  }, [isValid, loadData]);
 
   const handleExportPdf = async () => {
     const { exportToPdf } = await import('@/lib/pdf-export');
@@ -149,19 +141,17 @@ export function SpendingByCategoryReport() {
   };
 
   const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: Array<{ payload: { id: string; name: string; value: number } }> }) => {
-    if (active && payload && payload.length) {
-      const data = payload[0].payload;
-      const percentage = totalExpenses > 0 ? ((data.value / totalExpenses) * 100).toFixed(1) : '0';
-      return (
-        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
-          <p className="font-medium text-gray-900 dark:text-gray-100">{data.name}</p>
-          <p className="text-gray-600 dark:text-gray-400">
-            {formatCurrency(data.value)} ({percentage}%)
-          </p>
-        </div>
-      );
-    }
-    return null;
+    if (!active || !payload || !payload.length) return null;
+    const data = payload[0].payload;
+    const percentage = totalExpenses > 0 ? ((data.value / totalExpenses) * 100).toFixed(1) : '0';
+    return (
+      <ChartTooltipPanel>
+        <p className="font-medium text-gray-900 dark:text-gray-100">{data.name}</p>
+        <p className="text-gray-600 dark:text-gray-400">
+          {formatCurrency(data.value)} ({percentage}%)
+        </p>
+      </ChartTooltipPanel>
+    );
   };
 
   if (isLoading) {
@@ -173,6 +163,10 @@ export function SpendingByCategoryReport() {
         </div>
       </div>
     );
+  }
+
+  if (error) {
+    return <ReportError onRetry={reload} />;
   }
 
   return (

--- a/frontend/src/components/reports/SpendingByPayeeReport.test.tsx
+++ b/frontend/src/components/reports/SpendingByPayeeReport.test.tsx
@@ -164,14 +164,15 @@ describe("SpendingByPayeeReport", () => {
     });
   });
 
-  it("handles API error gracefully", async () => {
+  it("surfaces a retryable error state when the API fails", async () => {
     mockGetSpendingByPayee.mockRejectedValue(new Error("Network error"));
     render(<SpendingByPayeeReport />);
     await waitFor(() => {
       expect(
-        screen.getByText("No expense data for this period."),
+        screen.getByText(/failed to load report data/i),
       ).toBeInTheDocument();
     });
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
   });
 
   it("navigates to transactions page with payee and date range on bar click", async () => {

--- a/frontend/src/components/reports/SpendingByPayeeReport.tsx
+++ b/frontend/src/components/reports/SpendingByPayeeReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from 'next/navigation';
 import {
   BarChart,
@@ -138,9 +139,9 @@ export function SpendingByPayeeReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-96 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-96 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/SpendingByPayeeReport.tsx
+++ b/frontend/src/components/reports/SpendingByPayeeReport.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useMemo, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   BarChart,
@@ -16,17 +16,17 @@ import { builtInReportsApi } from '@/lib/built-in-reports';
 import { PayeeSpendingItem } from '@/types/built-in-reports';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useDateRange } from '@/hooks/useDateRange';
+import { useReportData } from '@/hooks/useReportData';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
 import { CHART_COLOURS } from '@/lib/chart-colours';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { SortableHeader } from '@/components/ui/SortableHeader';
+import { ChartTooltipPanel } from '@/components/reports/ChartTooltip';
+import { ReportError } from '@/components/reports/ReportError';
 import { exportToCsv } from '@/lib/csv-export';
-import { createLogger } from '@/lib/logger';
 import type { ChartDatum } from '@/types/chart';
-
-const logger = createLogger('SpendingByPayeeReport');
 
 type SpendingPayeeSortField = 'name' | 'value' | 'percentage';
 
@@ -36,9 +36,6 @@ export function SpendingByPayeeReport() {
   const router = useRouter();
   const chartRef = useRef<HTMLDivElement>(null);
   const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis } = useNumberFormat();
-  const [chartData, setChartData] = useState<ChartDataItem[]>([]);
-  const [totalExpenses, setTotalExpenses] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
   const [viewType, setViewType] = useState<'bar' | 'table'>('bar');
   const { dateRange, setDateRange, startDate, setStartDate, endDate, setEndDate, resolvedRange, isValid } =
     useDateRange({ defaultRange: '3m' });
@@ -46,6 +43,31 @@ export function SpendingByPayeeReport() {
     'reports.spending-by-payee.table.sort',
     { field: 'value', direction: 'desc' },
   );
+
+  const { start: rangeStart, end: rangeEnd } = resolvedRange;
+
+  const { data: response, isLoading, error, reload } = useReportData(
+    () =>
+      isValid
+        ? builtInReportsApi.getSpendingByPayee({
+            startDate: rangeStart || undefined,
+            endDate: rangeEnd,
+          })
+        : Promise.resolve(null),
+    [isValid, rangeStart, rangeEnd],
+  );
+
+  const chartData = useMemo<ChartDataItem[]>(
+    () =>
+      (response?.data ?? []).map((item: PayeeSpendingItem) => ({
+        id: item.payeeId || '',
+        name: item.payeeName,
+        value: item.total,
+      })),
+    [response],
+  );
+
+  const totalExpenses = response?.totalSpending ?? 0;
 
   const sortedTableData = useMemo(() => {
     const sorted = [...chartData];
@@ -69,35 +91,6 @@ export function SpendingByPayeeReport() {
     });
     return sorted;
   }, [chartData, sortField, sortDirection, totalExpenses]);
-
-  const loadData = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const { start, end } = resolvedRange;
-      const response = await builtInReportsApi.getSpendingByPayee({
-        startDate: start || undefined,
-        endDate: end,
-      });
-
-      // Map response to chart data
-      const data: ChartDataItem[] = response.data.map((item: PayeeSpendingItem) => ({
-        id: item.payeeId || '',
-        name: item.payeeName,
-        value: item.total,
-      }));
-
-      setChartData(data);
-      setTotalExpenses(response.totalSpending);
-    } catch (error) {
-      logger.error('Failed to load data:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [resolvedRange]);
-
-  useEffect(() => {
-    if (isValid) loadData();
-  }, [isValid, loadData]);
 
   const handleExportPdf = async () => {
     const { exportToPdf } = await import('@/lib/pdf-export');
@@ -125,20 +118,22 @@ export function SpendingByPayeeReport() {
   };
 
   const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: Array<{ payload: { name: string; value: number } }> }) => {
-    if (active && payload && payload.length) {
-      const data = payload[0].payload;
-      const percentage = totalExpenses > 0 ? ((data.value / totalExpenses) * 100).toFixed(1) : '0';
-      return (
-        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
-          <p className="font-medium text-gray-900 dark:text-gray-100">{data.name}</p>
-          <p className="text-gray-600 dark:text-gray-400">
-            {formatCurrency(data.value)} ({percentage}%)
-          </p>
-        </div>
-      );
-    }
-    return null;
+    if (!active || !payload || !payload.length) return null;
+    const data = payload[0].payload;
+    const percentage = totalExpenses > 0 ? ((data.value / totalExpenses) * 100).toFixed(1) : '0';
+    return (
+      <ChartTooltipPanel>
+        <p className="font-medium text-gray-900 dark:text-gray-100">{data.name}</p>
+        <p className="text-gray-600 dark:text-gray-400">
+          {formatCurrency(data.value)} ({percentage}%)
+        </p>
+      </ChartTooltipPanel>
+    );
   };
+
+  if (error) {
+    return <ReportError onRetry={reload} />;
+  }
 
   if (isLoading) {
     return (

--- a/frontend/src/components/reports/TaxSummaryReport.tsx
+++ b/frontend/src/components/reports/TaxSummaryReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { builtInReportsApi } from '@/lib/built-in-reports';
 import { TaxSummaryResponse } from '@/types/built-in-reports';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
@@ -40,9 +41,9 @@ export function TaxSummaryReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/UncategorizedTransactionsReport.tsx
+++ b/frontend/src/components/reports/UncategorizedTransactionsReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from 'next/navigation';
 import { format } from 'date-fns';
 import { builtInReportsApi } from '@/lib/built-in-reports';
@@ -127,9 +128,9 @@ export function UncategorizedTransactionsReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/UncategorizedTransactionsReport.tsx
+++ b/frontend/src/components/reports/UncategorizedTransactionsReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
+import { gainLossColor } from '@/lib/format';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from 'next/navigation';
 import { format } from 'date-fns';
@@ -318,9 +319,7 @@ export function UncategorizedTransactionsReport() {
                       {tx.accountName || 'Unknown'}
                     </td>
                     <td className={`px-4 py-3 whitespace-nowrap text-sm text-right font-medium ${
-                      tx.amount >= 0
-                        ? 'text-green-600 dark:text-green-400'
-                        : 'text-red-600 dark:text-red-400'
+                      gainLossColor(tx.amount)
                     }`}>
                       {formatCurrency(tx.amount)}
                     </td>

--- a/frontend/src/components/reports/UpcomingBillsReport.tsx
+++ b/frontend/src/components/reports/UpcomingBillsReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from 'next/navigation';
 import {
   format,
@@ -231,9 +232,9 @@ export function UpcomingBillsReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/WeekendVsWeekdayReport.tsx
+++ b/frontend/src/components/reports/WeekendVsWeekdayReport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
   Bar,
@@ -164,9 +165,9 @@ export function WeekendVsWeekdayReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-96 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-96 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/YearOverYearReport.test.tsx
+++ b/frontend/src/components/reports/YearOverYearReport.test.tsx
@@ -9,6 +9,7 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("@/hooks/useNumberFormat", () => ({
   useNumberFormat: () => ({
+    formatSignedPercent: (n: number, decimals = 2) => `${n >= 0 ? '+' : ''}${n.toFixed(decimals)}%`,
     formatCurrencyCompact: (n: number) => `$${n.toFixed(0)}`,
     formatCurrency: (n: number) => `$${n.toFixed(2)}`,
     formatCurrencyAxis: (n: number) => `$${n}`,

--- a/frontend/src/components/reports/YearOverYearReport.tsx
+++ b/frontend/src/components/reports/YearOverYearReport.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from "next/navigation";
 import { endOfMonth, format } from "date-fns";
 import {
@@ -227,9 +228,9 @@ export function YearOverYearReport() {
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          <div className="h-96 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/3" />
+          <Skeleton className="h-96 w-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/reports/YearOverYearReport.tsx
+++ b/frontend/src/components/reports/YearOverYearReport.tsx
@@ -45,7 +45,7 @@ const MONTH_NAMES = [
 
 export function YearOverYearReport() {
   const router = useRouter();
-  const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis } =
+  const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis, formatSignedPercent } =
     useNumberFormat();
   const chartRef = useRef<HTMLDivElement>(null);
   const [yearData, setYearData] = useState<YearData[]>([]);
@@ -160,7 +160,7 @@ export function YearOverYearReport() {
         const currValue = yearTotals[_year]?.[m] || 0;
         const change = currValue - prevValue;
         const changePercent = prevValue !== 0 ? (change / Math.abs(prevValue)) * 100 : 0;
-        return `${change >= 0 ? "+" : ""}${formatCurrency(change)} (${changePercent >= 0 ? "+" : ""}${changePercent.toFixed(1)}%)`;
+        return `${change >= 0 ? "+" : ""}${formatCurrency(change)} (${formatSignedPercent(changePercent, 1)})`;
       });
       return [label, ...cells];
     });
@@ -500,8 +500,7 @@ export function YearOverYearReport() {
                               isPositive ? "text-green-500" : "text-red-500"
                             }`}
                           >
-                            ({changePercent >= 0 ? "+" : ""}
-                            {changePercent.toFixed(1)}%)
+                            ({formatSignedPercent(changePercent, 1)})
                           </div>
                         </td>
                       );

--- a/frontend/src/components/transactions/AccountBalancesBarChart.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useMemo, useRef, useState } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
   Bar,
@@ -182,7 +183,7 @@ export function AccountBalancesBarChart({
           {CHART_TITLE}
         </h3>
         <div className="h-72 flex items-center justify-center">
-          <div className="animate-pulse w-full h-full bg-gray-200 dark:bg-gray-700 rounded" />
+          <Skeleton className="w-full h-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/transactions/AccountBalancesBarChart.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useMemo, useRef, useState } from 'react';
+import { gainLossColor } from '@/lib/format';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
@@ -99,9 +100,7 @@ function AccountBalanceTooltip({
         </p>
         <p
           className={`text-lg font-semibold ${
-            data.balance >= 0
-              ? 'text-green-600 dark:text-green-400'
-              : 'text-red-600 dark:text-red-400'
+            gainLossColor(data.balance)
           }`}
         >
           {formatCurrency(data.balance)}
@@ -335,9 +334,7 @@ export function AccountBalancesBarChart({
             <div className="text-sm text-gray-500 dark:text-gray-400">Average</div>
             <div
               className={`font-semibold ${
-                summary.avgBalance >= 0
-                  ? 'text-green-600 dark:text-green-400'
-                  : 'text-red-600 dark:text-red-400'
+                gainLossColor(summary.avgBalance)
               }`}
             >
               {formatCurrency(summary.avgBalance)}
@@ -347,9 +344,7 @@ export function AccountBalancesBarChart({
             <div className="text-sm text-gray-500 dark:text-gray-400">Total</div>
             <div
               className={`font-semibold ${
-                summary.total >= 0
-                  ? 'text-green-600 dark:text-green-400'
-                  : 'text-red-600 dark:text-red-400'
+                gainLossColor(summary.total)
               }`}
             >
               {formatCurrency(summary.total)}

--- a/frontend/src/components/transactions/BalanceHistoryChart.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   LineChart,
   Line,
@@ -153,7 +154,7 @@ export function BalanceHistoryChart({
           {CHART_TITLE}
         </h3>
         <div className="h-72 flex items-center justify-center">
-          <div className="animate-pulse w-full h-full bg-gray-200 dark:bg-gray-700 rounded" />
+          <Skeleton className="w-full h-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/transactions/BalanceHistoryChart.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useMemo, useRef } from 'react';
+import { gainLossColor } from '@/lib/format';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   LineChart,
@@ -51,9 +52,7 @@ function BalanceTooltip({
         </p>
         <p
           className={`text-lg font-semibold ${
-            data.balance >= 0
-              ? 'text-green-600 dark:text-green-400'
-              : 'text-red-600 dark:text-red-400'
+            gainLossColor(data.balance)
           }`}
         >
           {formatCurrency(data.balance)}
@@ -252,9 +251,7 @@ export function BalanceHistoryChart({
             <div className="text-sm text-gray-500 dark:text-gray-400">Current</div>
             <div
               className={`font-semibold ${
-                summary.currentBalance >= 0
-                  ? 'text-green-600 dark:text-green-400'
-                  : 'text-red-600 dark:text-red-400'
+                gainLossColor(summary.currentBalance)
               }`}
             >
               {formatCurrency(summary.currentBalance)}

--- a/frontend/src/components/transactions/BulkUpdateModal.tsx
+++ b/frontend/src/components/transactions/BulkUpdateModal.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo } from 'react';
+import { useForm, useWatch, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
 import { Modal } from '@/components/ui/Modal';
 import { FormActions } from '@/components/ui/FormActions';
 import { Combobox } from '@/components/ui/Combobox';
@@ -22,13 +25,35 @@ interface BulkUpdateModalProps {
   selectionCount: number;
 }
 
-interface FieldToggle {
-  payee: boolean;
-  category: boolean;
-  description: boolean;
-  status: boolean;
-  tags: boolean;
-}
+const bulkUpdateSchema = z.object({
+  enablePayee: z.boolean(),
+  enableCategory: z.boolean(),
+  enableDescription: z.boolean(),
+  enableStatus: z.boolean(),
+  enableTags: z.boolean(),
+  payeeId: z.string(),
+  payeeName: z.string().max(255),
+  categoryId: z.string(),
+  description: z.string().max(500),
+  status: z.nativeEnum(TransactionStatus),
+  tagIds: z.array(z.string()),
+});
+
+type BulkUpdateFormData = z.infer<typeof bulkUpdateSchema>;
+
+const defaultValues: BulkUpdateFormData = {
+  enablePayee: false,
+  enableCategory: false,
+  enableDescription: false,
+  enableStatus: false,
+  enableTags: false,
+  payeeId: '',
+  payeeName: '',
+  categoryId: '',
+  description: '',
+  status: TransactionStatus.UNRECONCILED,
+  tagIds: [],
+};
 
 export function BulkUpdateModal({
   isOpen,
@@ -39,24 +64,18 @@ export function BulkUpdateModal({
   const [categories, setCategories] = useState<Category[]>([]);
   const [payees, setPayees] = useState<Payee[]>([]);
   const [tags, setTags] = useState<Tag[]>([]);
-  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // Field toggles
-  const [enabled, setEnabled] = useState<FieldToggle>({
-    payee: false,
-    category: false,
-    description: false,
-    status: false,
-    tags: false,
+  const {
+    control,
+    register,
+    handleSubmit,
+    setValue,
+    reset,
+    formState: { isSubmitting },
+  } = useForm<BulkUpdateFormData>({
+    resolver: zodResolver(bulkUpdateSchema),
+    defaultValues,
   });
-
-  // Field values
-  const [selectedPayeeId, setSelectedPayeeId] = useState('');
-  const [payeeName, setPayeeName] = useState('');
-  const [selectedCategoryId, setSelectedCategoryId] = useState('');
-  const [description, setDescription] = useState('');
-  const [status, setStatus] = useState<TransactionStatus>(TransactionStatus.UNRECONCILED);
-  const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
 
   // Load data when modal opens
   useEffect(() => {
@@ -76,15 +95,9 @@ export function BulkUpdateModal({
   // Reset form when modal closes
   useEffect(() => {
     if (!isOpen) {
-      setEnabled({ payee: false, category: false, description: false, status: false, tags: false });
-      setSelectedPayeeId('');
-      setPayeeName('');
-      setSelectedCategoryId('');
-      setDescription('');
-      setStatus(TransactionStatus.UNRECONCILED);
-      setSelectedTagIds([]);
+      reset(defaultValues);
     }
-  }, [isOpen]);
+  }, [isOpen, reset]);
 
   const categoryTree = useMemo(() => buildCategoryTree(categories), [categories]);
 
@@ -119,42 +132,30 @@ export function BulkUpdateModal({
         label: tag.name,
       })), [tags]);
 
-  const toggleField = useCallback((field: keyof FieldToggle) => {
-    setEnabled(prev => ({ ...prev, [field]: !prev[field] }));
-  }, []);
+  const enablePayee = useWatch({ control, name: 'enablePayee' });
+  const enableCategory = useWatch({ control, name: 'enableCategory' });
+  const enableDescription = useWatch({ control, name: 'enableDescription' });
+  const enableStatus = useWatch({ control, name: 'enableStatus' });
+  const enableTags = useWatch({ control, name: 'enableTags' });
 
-  const handlePayeeChange = useCallback((payeeId: string, name: string) => {
-    setSelectedPayeeId(payeeId);
-    setPayeeName(name);
-  }, []);
+  const hasAnyEnabled =
+    enablePayee || enableCategory || enableDescription || enableStatus || enableTags;
 
-  const handlePayeeCreate = useCallback((name: string) => {
-    setSelectedPayeeId('');
-    setPayeeName(name);
-  }, []);
-
-  const handleCategoryChange = useCallback((categoryId: string, _name: string) => {
-    setSelectedCategoryId(categoryId);
-  }, []);
-
-  const hasAnyEnabled = Object.values(enabled).some(Boolean);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const submit = async (data: BulkUpdateFormData) => {
     if (!hasAnyEnabled) return;
 
     const updateData: Partial<Pick<BulkUpdateData, 'payeeId' | 'payeeName' | 'categoryId' | 'description' | 'status' | 'tagIds'>> = {};
 
-    if (enabled.payee) {
-      if (selectedPayeeId) {
-        updateData.payeeId = selectedPayeeId;
+    if (data.enablePayee) {
+      if (data.payeeId) {
+        updateData.payeeId = data.payeeId;
         // Also send the payee name so the denormalized payeeName field is updated
-        const selectedPayee = payees.find(p => p.id === selectedPayeeId);
+        const selectedPayee = payees.find(p => p.id === data.payeeId);
         if (selectedPayee) {
           updateData.payeeName = selectedPayee.name;
         }
-      } else if (payeeName) {
-        updateData.payeeName = payeeName;
+      } else if (data.payeeName) {
+        updateData.payeeName = data.payeeName;
       } else {
         // Clear payee
         updateData.payeeId = null;
@@ -162,33 +163,28 @@ export function BulkUpdateModal({
       }
     }
 
-    if (enabled.category) {
-      updateData.categoryId = selectedCategoryId || null;
+    if (data.enableCategory) {
+      updateData.categoryId = data.categoryId || null;
     }
 
-    if (enabled.description) {
-      updateData.description = description || null;
+    if (data.enableDescription) {
+      updateData.description = data.description || null;
     }
 
-    if (enabled.status) {
-      updateData.status = status;
+    if (data.enableStatus) {
+      updateData.status = data.status;
     }
 
-    if (enabled.tags) {
-      updateData.tagIds = selectedTagIds;
+    if (data.enableTags) {
+      updateData.tagIds = data.tagIds;
     }
 
-    setIsSubmitting(true);
-    try {
-      await onSubmit(updateData);
-    } finally {
-      setIsSubmitting(false);
-    }
+    await onSubmit(updateData);
   };
 
   // Info notes about what gets skipped
-  const showTransferNote = enabled.payee;
-  const showSplitNote = enabled.category;
+  const showTransferNote = enablePayee;
+  const showSplitNote = enableCategory;
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} maxWidth="lg" className="p-6" allowOverflow>
@@ -199,47 +195,64 @@ export function BulkUpdateModal({
         Update {selectionCount} selected transaction{selectionCount !== 1 ? 's' : ''}. Toggle the fields you want to change.
       </p>
 
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit(submit)}>
         <div className="space-y-4">
           {/* Payee field */}
           <TogglableField
             label="Payee"
-            enabled={enabled.payee}
-            onToggle={() => toggleField('payee')}
+            enabled={enablePayee}
+            onToggle={() => setValue('enablePayee', !enablePayee)}
           >
-            <Combobox
-              placeholder="Select or type payee name..."
-              options={payeeOptions}
-              value={selectedPayeeId}
-              onChange={handlePayeeChange}
-              onCreateNew={handlePayeeCreate}
-              allowCustomValue
+            <Controller
+              control={control}
+              name="payeeId"
+              render={({ field }) => (
+                <Combobox
+                  placeholder="Select or type payee name..."
+                  options={payeeOptions}
+                  value={field.value}
+                  onChange={(payeeId, name) => {
+                    field.onChange(payeeId);
+                    setValue('payeeName', name);
+                  }}
+                  onCreateNew={(name) => {
+                    field.onChange('');
+                    setValue('payeeName', name);
+                  }}
+                  allowCustomValue
+                />
+              )}
             />
           </TogglableField>
 
           {/* Category field */}
           <TogglableField
             label="Category"
-            enabled={enabled.category}
-            onToggle={() => toggleField('category')}
+            enabled={enableCategory}
+            onToggle={() => setValue('enableCategory', !enableCategory)}
           >
-            <Combobox
-              placeholder="Select category..."
-              options={categoryOptions}
-              value={selectedCategoryId}
-              onChange={handleCategoryChange}
+            <Controller
+              control={control}
+              name="categoryId"
+              render={({ field }) => (
+                <Combobox
+                  placeholder="Select category..."
+                  options={categoryOptions}
+                  value={field.value}
+                  onChange={(categoryId) => field.onChange(categoryId)}
+                />
+              )}
             />
           </TogglableField>
 
           {/* Description field */}
           <TogglableField
             label="Description"
-            enabled={enabled.description}
-            onToggle={() => toggleField('description')}
+            enabled={enableDescription}
+            onToggle={() => setValue('enableDescription', !enableDescription)}
           >
             <textarea
-              value={description}
-              onChange={e => setDescription(e.target.value)}
+              {...register('description')}
               placeholder="Enter description (leave empty to clear)"
               rows={2}
               className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:ring-1 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
@@ -249,27 +262,32 @@ export function BulkUpdateModal({
           {/* Status field */}
           <TogglableField
             label="Status"
-            enabled={enabled.status}
-            onToggle={() => toggleField('status')}
+            enabled={enableStatus}
+            onToggle={() => setValue('enableStatus', !enableStatus)}
           >
             <Select
               options={statusOptions}
-              value={status}
-              onChange={e => setStatus(e.target.value as TransactionStatus)}
+              {...register('status')}
             />
           </TogglableField>
 
           {/* Tags field */}
           <TogglableField
             label="Tags"
-            enabled={enabled.tags}
-            onToggle={() => toggleField('tags')}
+            enabled={enableTags}
+            onToggle={() => setValue('enableTags', !enableTags)}
           >
-            <MultiSelect
-              options={tagOptions}
-              value={selectedTagIds}
-              onChange={setSelectedTagIds}
-              placeholder="Select tags (leave empty to clear all)..."
+            <Controller
+              control={control}
+              name="tagIds"
+              render={({ field }) => (
+                <MultiSelect
+                  options={tagOptions}
+                  value={field.value}
+                  onChange={field.onChange}
+                  placeholder="Select tags (leave empty to clear all)..."
+                />
+              )}
             />
           </TogglableField>
         </div>

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useRef } from 'react';
+import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
   Bar,
@@ -115,7 +116,7 @@ export function CategoryPayeeBarChart({
           {CHART_TITLE}
         </h3>
         <div className="h-72 flex items-center justify-center">
-          <div className="animate-pulse w-full h-full bg-gray-200 dark:bg-gray-700 rounded" />
+          <Skeleton className="w-full h-full" />
         </div>
       </div>
     );

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useRef } from 'react';
+import { gainLossColor } from '@/lib/format';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
@@ -58,9 +59,7 @@ function MonthlyTotalTooltip({
         </p>
         <p
           className={`text-lg font-semibold ${
-            data.total >= 0
-              ? 'text-green-600 dark:text-green-400'
-              : 'text-red-600 dark:text-red-400'
+            gainLossColor(data.total)
           }`}
         >
           {formatCurrency(data.total)}
@@ -228,9 +227,7 @@ export function CategoryPayeeBarChart({
             <div className="text-sm text-gray-500 dark:text-gray-400">Monthly Avg</div>
             <div
               className={`font-semibold ${
-                summary.monthlyAvg >= 0
-                  ? 'text-green-600 dark:text-green-400'
-                  : 'text-red-600 dark:text-red-400'
+                gainLossColor(summary.monthlyAvg)
               }`}
             >
               {formatCurrency(summary.monthlyAvg)}
@@ -240,9 +237,7 @@ export function CategoryPayeeBarChart({
             <div className="text-sm text-gray-500 dark:text-gray-400">Total</div>
             <div
               className={`font-semibold ${
-                summary.total >= 0
-                  ? 'text-green-600 dark:text-green-400'
-                  : 'text-red-600 dark:text-red-400'
+                gainLossColor(summary.total)
               }`}
             >
               {formatCurrency(summary.total)}

--- a/frontend/src/hooks/useDebouncedValue.test.ts
+++ b/frontend/src/hooks/useDebouncedValue.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDebouncedValue } from './useDebouncedValue';
+
+describe('useDebouncedValue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the initial value immediately', () => {
+    const { result } = renderHook(() => useDebouncedValue('a', 200));
+    expect(result.current).toBe('a');
+  });
+
+  it('updates only after the delay elapses', () => {
+    const { result, rerender } = renderHook(({ v }) => useDebouncedValue(v, 200), {
+      initialProps: { v: 'a' },
+    });
+    rerender({ v: 'b' });
+    expect(result.current).toBe('a');
+    act(() => {
+      vi.advanceTimersByTime(199);
+    });
+    expect(result.current).toBe('a');
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe('b');
+  });
+
+  it('resets the timer on rapid successive changes', () => {
+    const { result, rerender } = renderHook(({ v }) => useDebouncedValue(v, 200), {
+      initialProps: { v: 'a' },
+    });
+    rerender({ v: 'b' });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    rerender({ v: 'c' });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    // Still 'a' because the second change reset the timer before it fired.
+    expect(result.current).toBe('a');
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(result.current).toBe('c');
+  });
+
+  it('uses the default delay when none is given', () => {
+    const { result, rerender } = renderHook(({ v }) => useDebouncedValue(v), {
+      initialProps: { v: 1 },
+    });
+    rerender({ v: 2 });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current).toBe(2);
+  });
+});

--- a/frontend/src/hooks/useDebouncedValue.ts
+++ b/frontend/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns a debounced copy of `value` that only updates after `value` has
+ * stopped changing for `delayMs`. Useful for keeping an expensive derivation
+ * (filter + sort, network search) off the critical path of every keystroke
+ * while the bound input itself stays fully controlled and responsive.
+ *
+ * The update happens in a `setTimeout` callback (not synchronously during
+ * render), so it does not trip the `react-hooks/set-state-in-effect` rule.
+ */
+export function useDebouncedValue<T>(value: T, delayMs = 200): T {
+  const [debounced, setDebounced] = useState<T>(value);
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(handle);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/frontend/src/hooks/useNumberFormat.test.ts
+++ b/frontend/src/hooks/useNumberFormat.test.ts
@@ -148,6 +148,39 @@ describe('useNumberFormat', () => {
     const formatted = result.current.formatCurrencyLabel(50);
     expect(formatted).not.toMatch(/[KMBT]/);
   });
+
+  it('formatSignedPercent adds a leading + for non-negative values', () => {
+    const { result } = renderHook(() => useNumberFormat());
+    expect(result.current.formatSignedPercent(12.5)).toBe('+12.50%');
+    expect(result.current.formatSignedPercent(0)).toBe('+0.00%');
+  });
+
+  it('formatSignedPercent keeps the minus sign for negatives', () => {
+    const { result } = renderHook(() => useNumberFormat());
+    expect(result.current.formatSignedPercent(-3.4)).toBe('-3.40%');
+  });
+
+  it('formatSignedPercent honours the decimals argument', () => {
+    const { result } = renderHook(() => useNumberFormat());
+    expect(result.current.formatSignedPercent(7.123, 1)).toBe('+7.1%');
+  });
+
+  it('formatSignedPercent renders a sign-less zero for non-finite input', () => {
+    const { result } = renderHook(() => useNumberFormat());
+    expect(result.current.formatSignedPercent(NaN)).toBe('0.00%');
+  });
+
+  it('formatQuantity trims trailing zeros up to 4dp', () => {
+    const { result } = renderHook(() => useNumberFormat());
+    expect(result.current.formatQuantity(100)).toBe('100');
+    expect(result.current.formatQuantity(1.5)).toBe('1.5');
+    expect(result.current.formatQuantity(1.23456)).toBe('1.2346');
+  });
+
+  it('formatQuantity adds thousands separators', () => {
+    const { result } = renderHook(() => useNumberFormat());
+    expect(result.current.formatQuantity(1234.5)).toBe('1,234.5');
+  });
 });
 
 describe('useNumberFormat with browser locale', () => {

--- a/frontend/src/hooks/useNumberFormat.ts
+++ b/frontend/src/hooks/useNumberFormat.ts
@@ -154,6 +154,48 @@ export function useNumberFormat() {
     [numberFormat]
   );
 
+  /**
+   * Locale-aware signed percentage with an explicit leading sign
+   * (e.g. "+12.50%", "-3.40%"). Honours the user's number-format locale for
+   * grouping/decimal separators. Replaces the inline
+   * `${v >= 0 ? '+' : ''}${v.toFixed(n)}%` idiom in the report/holdings views.
+   * Non-finite input renders a sign-less zero so a broken datum never shows
+   * "NaN%".
+   */
+  const formatSignedPercent = useCallback(
+    (value: number, decimals: number = 2): string => {
+      const locale = getEffectiveLocale(numberFormat);
+      const magnitudeFormat = getNumberFormat(locale, {
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals,
+      });
+      if (!isFinite(value)) {
+        return `${magnitudeFormat.format(0)}%`;
+      }
+      const rounded = roundToDecimals(value, decimals);
+      const sign = rounded >= 0 ? '+' : '';
+      return `${sign}${magnitudeFormat.format(rounded)}%`;
+    },
+    [numberFormat]
+  );
+
+  /**
+   * Locale-aware share/quantity formatter: up to 4 decimal places with
+   * trailing zeros trimmed (minimumFractionDigits 0). Replaces the inline
+   * `new Intl.NumberFormat(locale, { ..., maximumFractionDigits: 4 })` copies
+   * in the holdings/transaction lists.
+   */
+  const formatQuantity = useCallback(
+    (value: number): string => {
+      const locale = getEffectiveLocale(numberFormat);
+      return getNumberFormat(locale, {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 4,
+      }).format(value);
+    },
+    [numberFormat]
+  );
+
   /** Compact currency for chart labels: K with 1dp, M/B/T with 2dp (e.g., "$123.5K", "$1.23M"). */
   const formatCurrencyLabel = useCallback(
     (value: number): string => {
@@ -200,5 +242,5 @@ export function useNumberFormat() {
     [numberFormat, defaultCurrency]
   );
 
-  return { formatCurrency, formatCurrencyPrecise, formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag, formatCurrencyLabel, formatNumber, formatPercent, defaultCurrency, numberFormat };
+  return { formatCurrency, formatCurrencyPrecise, formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag, formatCurrencyLabel, formatNumber, formatPercent, formatSignedPercent, formatQuantity, defaultCurrency, numberFormat };
 }

--- a/frontend/src/hooks/useReportData.test.ts
+++ b/frontend/src/hooks/useReportData.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useReportData } from './useReportData';
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}));
+
+describe('useReportData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts in a loading state with no data or error', () => {
+    const fetcher = vi.fn(() => new Promise<number>(() => {}));
+    const { result } = renderHook(() => useReportData(fetcher, []));
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('loads data and clears loading on success', async () => {
+    const fetcher = vi.fn(async () => ({ value: 42 }));
+    const { result } = renderHook(() => useReportData(fetcher, []));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual({ value: 42 });
+    expect(result.current.error).toBeNull();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces an Error on failure and stops loading', async () => {
+    const err = new Error('boom');
+    const fetcher = vi.fn(async () => {
+      throw err;
+    });
+    const { result } = renderHook(() => useReportData(fetcher, []));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBe(err);
+    expect(result.current.data).toBeNull();
+  });
+
+  it('wraps non-Error rejections in an Error', async () => {
+    const fetcher = vi.fn(async () => {
+      throw 'string failure';
+    });
+    const { result } = renderHook(() => useReportData(fetcher, []));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('string failure');
+  });
+
+  it('re-runs when deps change', async () => {
+    const fetcher = vi.fn(async (n: number) => n * 2);
+    let dep = 1;
+    const { result, rerender } = renderHook(() => useReportData(() => fetcher(dep), [dep]));
+    await waitFor(() => expect(result.current.data).toBe(2));
+    dep = 5;
+    rerender();
+    await waitFor(() => expect(result.current.data).toBe(10));
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('reload re-runs the fetcher and clears a prior error', async () => {
+    let shouldFail = true;
+    const fetcher = vi.fn(async () => {
+      if (shouldFail) throw new Error('fail');
+      return 'ok';
+    });
+    const { result } = renderHook(() => useReportData(fetcher, []));
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    shouldFail = false;
+    act(() => {
+      result.current.reload();
+    });
+    await waitFor(() => expect(result.current.data).toBe('ok'));
+    expect(result.current.error).toBeNull();
+  });
+
+  it('ignores a stale response when deps change mid-flight', async () => {
+    const resolvers: Array<(v: string) => void> = [];
+    const fetcher = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    let dep = 1;
+    const { result, rerender } = renderHook(() => useReportData(() => fetcher(), [dep]));
+    dep = 2;
+    rerender();
+    // Resolve the second (latest) call first, then the stale first call.
+    act(() => resolvers[1]('latest'));
+    await waitFor(() => expect(result.current.data).toBe('latest'));
+    act(() => resolvers[0]('stale'));
+    // Stale resolution must not overwrite the latest data.
+    expect(result.current.data).toBe('latest');
+  });
+});

--- a/frontend/src/hooks/useReportData.ts
+++ b/frontend/src/hooks/useReportData.ts
@@ -1,0 +1,76 @@
+import { useState, useEffect, useCallback, useRef, DependencyList } from 'react';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('useReportData');
+
+interface UseReportDataResult<T> {
+  /** The fetched data, or null before the first successful load. */
+  data: T | null;
+  /** True while a fetch is in flight (including the initial load). */
+  isLoading: boolean;
+  /**
+   * Error from the most recent failed fetch, or null. Reports previously
+   * swallowed fetch errors and rendered an empty state; surfacing this lets
+   * the UI show a proper error message instead.
+   */
+  error: Error | null;
+  /** Manually re-run the fetcher (e.g. after a mutation or a retry button). */
+  reload: () => void;
+}
+
+/**
+ * Shared data-loading hook for the report components. Collapses the repeated
+ * `setIsLoading(true); try { await api } catch { logger.error } finally
+ * { setIsLoading(false) }` block into one place AND, critically, tracks an
+ * error state that the reports never did -- so a failed fetch can render an
+ * error message instead of silently showing an empty report.
+ *
+ * The fetcher is re-run whenever `deps` change (same contract as useEffect's
+ * dependency array). A run counter guards against out-of-order responses: if
+ * deps change mid-flight, only the latest run is allowed to commit state.
+ */
+export function useReportData<T>(
+  fetcher: () => Promise<T>,
+  deps: DependencyList,
+): UseReportDataResult<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Keep the latest fetcher in a ref so changing its identity (common with
+  // inline closures) does not by itself retrigger a fetch -- only `deps` and
+  // explicit reloads do. This matches the manual loadData pattern it replaces.
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+
+  const runIdRef = useRef(0);
+
+  const run = useCallback(() => {
+    const runId = ++runIdRef.current;
+    setIsLoading(true);
+    setError(null);
+    fetcherRef.current()
+      .then((result) => {
+        if (runId !== runIdRef.current) return;
+        setData(result);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        if (runId !== runIdRef.current) return;
+        logger.error('Failed to load report data:', err);
+        setError(err instanceof Error ? err : new Error(String(err)));
+      })
+      .finally(() => {
+        if (runId !== runIdRef.current) return;
+        setIsLoading(false);
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    run();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return { data, isLoading, error, reload: run };
+}

--- a/frontend/src/hooks/useReportData.ts
+++ b/frontend/src/hooks/useReportData.ts
@@ -64,7 +64,6 @@ export function useReportData<T>(
         if (runId !== runIdRef.current) return;
         setIsLoading(false);
       });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -15,6 +15,8 @@ import {
   evaluateExpression,
   formatRelativeTime,
   formatShareQuantity,
+  formatSignedPercent,
+  gainLossColor,
 } from './format';
 
 describe('getCurrencySymbol', () => {
@@ -499,5 +501,49 @@ describe('adaptiveFractionDigits', () => {
   it('respects a non-2 base precision (e.g. JPY=0)', () => {
     expect(adaptiveFractionDigits(123, 0)).toBe(0); // already non-zero at 0dp
     expect(adaptiveFractionDigits(0.4, 0)).toBe(3); // expands to ~3 significant figures
+  });
+});
+
+describe('formatSignedPercent', () => {
+  it('adds a leading + for positive values', () => {
+    expect(formatSignedPercent(12.5)).toBe('+12.50%');
+  });
+
+  it('keeps the minus sign for negative values', () => {
+    expect(formatSignedPercent(-3.4)).toBe('-3.40%');
+  });
+
+  it('treats zero as positive (+0.00%)', () => {
+    expect(formatSignedPercent(0)).toBe('+0.00%');
+  });
+
+  it('honours the decimals option', () => {
+    expect(formatSignedPercent(7.1234, { decimals: 1 })).toBe('+7.1%');
+    expect(formatSignedPercent(7.1, { decimals: 0 })).toBe('+7%');
+  });
+
+  it('multiplies fractions when alreadyPercent is false', () => {
+    expect(formatSignedPercent(0.125, { alreadyPercent: false })).toBe('+12.50%');
+    expect(formatSignedPercent(-0.05, { alreadyPercent: false })).toBe('-5.00%');
+  });
+
+  it('renders a sign-less 0 for non-finite input', () => {
+    expect(formatSignedPercent(NaN)).toBe('0.00%');
+    expect(formatSignedPercent(Infinity)).toBe('0.00%');
+  });
+
+  it('rounds half away from zero before formatting', () => {
+    expect(formatSignedPercent(2.345, { decimals: 2 })).toBe('+2.35%');
+  });
+});
+
+describe('gainLossColor', () => {
+  it('returns green classes for non-negative values', () => {
+    expect(gainLossColor(0)).toBe('text-green-600 dark:text-green-400');
+    expect(gainLossColor(10)).toBe('text-green-600 dark:text-green-400');
+  });
+
+  it('returns red classes for negative values', () => {
+    expect(gainLossColor(-1)).toBe('text-red-600 dark:text-red-400');
   });
 });

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -125,6 +125,55 @@ export function adaptiveFractionDigits(
   return Math.max(baseDigits, Math.min(maxDigits, digits));
 }
 
+interface FormatSignedPercentOptions {
+  /** Number of decimal places to show (default 2). */
+  decimals?: number;
+  /**
+   * When true the value is already a percentage (e.g. 12.5 = 12.5%) and is
+   * used as-is. When false the value is a fraction (e.g. 0.125 = 12.5%) and is
+   * multiplied by 100. Defaults to true since most call sites already work in
+   * percentage units.
+   */
+  alreadyPercent?: boolean;
+}
+
+/**
+ * Format a percentage with an explicit leading sign (e.g. "+12.50%",
+ * "-3.40%", "0.00%"). Replaces the repeated
+ * `${v >= 0 ? '+' : ''}${v.toFixed(n)}%` idiom across the report components.
+ *
+ * The magnitude is rendered with the user-locale-agnostic `en-US` grouping so
+ * it matches the surrounding `toFixed` output it replaces. A leading "+" is
+ * added for values >= 0; negatives keep their intrinsic minus sign. NaN and
+ * non-finite inputs render as a sign-less "0.00%" so a broken datum never
+ * shows "NaN%".
+ */
+export function formatSignedPercent(
+  value: number,
+  options: FormatSignedPercentOptions = {},
+): string {
+  const { decimals = 2, alreadyPercent = true } = options;
+  const pct = alreadyPercent ? value : value * 100;
+  if (!isFinite(pct)) {
+    return `${(0).toFixed(decimals)}%`;
+  }
+  const rounded = roundToDecimals(pct, decimals);
+  const sign = rounded >= 0 ? '+' : '';
+  return `${sign}${rounded.toFixed(decimals)}%`;
+}
+
+/**
+ * Tailwind text-colour classes for a gain/loss value: green when >= 0, red
+ * when negative. Replaces the repeated
+ * `value >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'`
+ * ternary across the investment/report components.
+ */
+export function gainLossColor(value: number): string {
+  return value >= 0
+    ? 'text-green-600 dark:text-green-400'
+    : 'text-red-600 dark:text-red-400';
+}
+
 /**
  * Format a number to the specified decimal places for display in inputs.
  * Defaults to 2 decimal places.

--- a/frontend/src/lib/zod-helpers.test.ts
+++ b/frontend/src/lib/zod-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { optionalUuid, optionalString, optionalNumber } from './zod-helpers';
+import { optionalUuid, optionalString, optionalNumber, emailSchema } from './zod-helpers';
 
 describe('zod-helpers', () => {
   describe('optionalUuid', () => {
@@ -55,6 +55,20 @@ describe('zod-helpers', () => {
 
     it('accepts zero', () => {
       expect(optionalNumber.parse(0)).toBe(0);
+    });
+  });
+
+  describe('emailSchema', () => {
+    it('accepts a valid email', () => {
+      expect(emailSchema.parse('user@example.com')).toBe('user@example.com');
+    });
+
+    it('rejects an invalid email with a friendly message', () => {
+      const result = emailSchema.safeParse('not-an-email');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('Please enter a valid email address');
+      }
     });
   });
 });

--- a/frontend/src/lib/zod-helpers.ts
+++ b/frontend/src/lib/zod-helpers.ts
@@ -11,6 +11,11 @@ export const passwordSchema = z
   .regex(/(?=.*\d)/, 'Must contain a number')
   .regex(/(?=.*[^A-Za-z\d\s])/, 'Must contain a special character');
 
+/** Shared email validation used by the auth forms (login, register, forgot password). */
+export const emailSchema = z
+  .string()
+  .email('Please enter a valid email address');
+
 export const PASSWORD_REQUIREMENTS_TEXT =
   'Password must be at least 12 characters and contain an uppercase letter, a lowercase letter, a number, and a special character.';
 


### PR DESCRIPTION
Follow-up to #593, which merged the P0/P1 audit work. The same branch then gained 27 more commits implementing the **P2** findings, which never reached `main` because #593 was already closed. This PR lands those 27 commits.

All changes are individually committed and tested. Backend: **7067** unit tests passing, `eslint`/`tsc` clean. Frontend: **7764** tests passing, `eslint`/`tsc` clean.

### Backend P2
- **#16** Anthropic prompt caching — `cache_control: ephemeral` on the system block caches the tools+system prefix across multi-turn tool-use turns.
- **#18** `refreshAllPrices` staleness filter — skips securities already priced today before fanning out to external providers.
- **#20** `pg_trgm` GIN indexes (migration `080`) for the `ILIKE` transaction/report search; `schema.sql` updated.
- **#27** Consolidated the duplicated currency direct/inverse conversion into `common/currency-conversion.util.ts` (`convertWithRateLookup`).
- **#28** Replaced inline YMD date formatting with shared helpers (`formatDateYMDLocal`, `getMonthEndYMD`).
- **#29** Migrated inline `Math.round(x*10000)/10000` money rounding to the shared `roundMoney`.
- **#30** Moved MCP `search_transactions` split-expansion/amount-filter logic to `TransactionsService.getLlmTransactionRows` (CLAUDE.md shared-tool rule); the tool is now a thin adapter.
- **#31** Standardized report decimal parsing on `common/round.util` `toMoneyNumber`.
- **#32** Intentionally skipped (docker-compose env dedup) — rationale in `AUDIT_FINDINGS.md`.

### Frontend P2
- **#13** Reports page memoization + debounced search (`useDebouncedValue`).
- **#14** DividendIncomeReport concurrent fetches + memoized options.
- **#15** Zustand slice selectors at the 5 whole-store call sites.
- **#21** Adopted the shared `LoadingSkeleton` kit (47 sites).
- **#22** `formatSignedPercent` helper + migrations.
- **#23** `gainLossColor` helper (~50-site migration).
- **#24** `useReportData` hook with a retryable error state + `ReportError` (6 reports migrated as a template; the rest left as bespoke).
- **#25** Shared `ChartTooltip`.
- **#26** `BulkUpdateModal`/`CreateUserModal`/`MonteCarloSaveAsDialog` → react-hook-form + Zod; shared `emailSchema` + `formatQuantity`.

`AUDIT_FINDINGS.md` reflects the live status of every item, including the partials (#21/#24/#25) and deliberate skips (#3, #32).

### Deploy notes
- Migration `080` builds GIN indexes on startup — brief table lock on a very large `transactions` table.
- The DB-touching changes (bulk `UPDATE … FROM (VALUES …)`, `ANY($1)` linked-account resolution, grouped post-import balance query) are unit-tested against mocks; a post-deploy smoke test of the register, net-worth chart, and an import is worth doing.

https://claude.ai/code/session_01D54qq42w8cuSJiwCNUmoiE

---
_Generated by [Claude Code](https://claude.ai/code/session_01D54qq42w8cuSJiwCNUmoiE)_