### PR TITLE
Add investment_reports to backup/restore functionality

### DIFF
--- a/backend/src/backup/backup.service.spec.ts
+++ b/backend/src/backup/backup.service.spec.ts
@@ -286,6 +286,20 @@ describe("BackupService", () => {
       "created_at",
       "updated_at",
     ],
+    investment_reports: [
+      "id",
+      "user_id",
+      "name",
+      "description",
+      "icon",
+      "background_color",
+      "group_by",
+      "config",
+      "is_favourite",
+      "sort_order",
+      "created_at",
+      "updated_at",
+    ],
     import_column_mappings: [
       "id",
       "user_id",
@@ -444,6 +458,25 @@ describe("BackupService", () => {
       expect(result.accounts).toEqual([]);
     });
 
+    it("should include investment_reports in the exported payload", async () => {
+      const mockInvestmentReports = [
+        { id: "ir-1", name: "By Symbol", user_id: userId },
+      ];
+      mockDataSource.query.mockImplementation((sql: string) => {
+        if (sql.includes("investment_reports")) {
+          return Promise.resolve(mockInvestmentReports);
+        }
+        return Promise.resolve([]);
+      });
+
+      const mockRes = new PassThrough();
+      const resultPromise = collectGzipOutput(mockRes);
+      await service.streamExport(userId, mockRes as any);
+      const result = await resultPromise;
+
+      expect(result.investment_reports).toEqual(mockInvestmentReports);
+    });
+
     it("writes an encrypted envelope when a password is provided", async () => {
       mockDataSource.query.mockResolvedValue([]);
       const mockCategories = [{ id: "cat-1", name: "Food", user_id: userId }];
@@ -554,6 +587,7 @@ describe("BackupService", () => {
       budget_period_categories: [],
       budget_alerts: [],
       custom_reports: [],
+      investment_reports: [],
       import_column_mappings: [],
       monthly_account_balances: [],
     };
@@ -696,6 +730,62 @@ describe("BackupService", () => {
       expect(mockQueryRunner.startTransaction).toHaveBeenCalled();
       expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
       expect(mockQueryRunner.release).toHaveBeenCalled();
+    });
+
+    it("should restore investment_reports rows and scope them to the current user", async () => {
+      mockUserRepo.findOne.mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const backupWithInvestmentReports = {
+        ...validBackupData,
+        investment_reports: [
+          {
+            id: "ir-1",
+            user_id: "different-user-id",
+            name: "By Symbol",
+            description: null,
+            icon: null,
+            background_color: null,
+            group_by: "SYMBOL",
+            config: { columns: ["symbol"], accountIds: [] },
+            is_favourite: false,
+            sort_order: 0,
+          },
+        ],
+      };
+
+      const result = await service.restoreData(
+        userId,
+        makeInput({ password: "test", data: backupWithInvestmentReports }),
+      );
+
+      expect(result.restored.investmentReports).toBe(1);
+
+      const insertCalls = mockQueryRunner.query.mock.calls.filter(
+        (call: unknown[]) =>
+          typeof call[0] === "string" &&
+          call[0].includes('INSERT INTO "investment_reports"'),
+      );
+      expect(insertCalls).toHaveLength(1);
+      const inserted = insertColumnMap(insertCalls[0]);
+      expect(inserted.user_id).toBe(userId);
+      expect(inserted.name).toBe("By Symbol");
+      expect(inserted.group_by).toBe("SYMBOL");
+    });
+
+    it("should delete existing investment_reports during restore wipe", async () => {
+      mockUserRepo.findOne.mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await service.restoreData(userId, makeInput({ password: "test" }));
+
+      const deleteCalls = mockQueryRunner.query.mock.calls.filter(
+        (call: unknown[]) =>
+          typeof call[0] === "string" &&
+          call[0].includes("DELETE FROM investment_reports"),
+      );
+      expect(deleteCalls).toHaveLength(1);
+      expect(deleteCalls[0][1]).toEqual([userId]);
     });
 
     it("should rollback transaction on error", async () => {

--- a/backend/src/backup/backup.service.ts
+++ b/backend/src/backup/backup.service.ts
@@ -69,6 +69,7 @@ interface BackupData {
   budget_period_categories: Record<string, unknown>[];
   budget_alerts: Record<string, unknown>[];
   custom_reports: Record<string, unknown>[];
+  investment_reports: Record<string, unknown>[];
   import_column_mappings: Record<string, unknown>[];
   monthly_account_balances: Record<string, unknown>[];
   auto_backup_settings: Record<string, unknown>[];
@@ -302,6 +303,10 @@ export class BackupService {
       {
         key: "custom_reports",
         sql: "SELECT * FROM custom_reports WHERE user_id = $1",
+      },
+      {
+        key: "investment_reports",
+        sql: "SELECT * FROM investment_reports WHERE user_id = $1",
       },
       {
         key: "import_column_mappings",
@@ -543,6 +548,12 @@ export class BackupService {
         queryRunner,
         "custom_reports",
         data.custom_reports,
+        userId,
+      );
+      restored.investmentReports = await this.insertRows(
+        queryRunner,
+        "investment_reports",
+        data.investment_reports,
         userId,
       );
       restored.importColumnMappings = await this.insertRows(
@@ -938,6 +949,10 @@ export class BackupService {
       userId,
     ]);
     await queryRunner.query(
+      "DELETE FROM investment_reports WHERE user_id = $1",
+      [userId],
+    );
+    await queryRunner.query(
       "DELETE FROM import_column_mappings WHERE user_id = $1",
       [userId],
     );
@@ -1242,6 +1257,7 @@ export class BackupService {
       "budget_period_categories",
       "budget_alerts",
       "custom_reports",
+      "investment_reports",
       "import_column_mappings",
       "monthly_account_balances",
       "auto_backup_settings",


### PR DESCRIPTION
## Summary
Extends the backup and restore service to include `investment_reports` table data, ensuring investment reports are properly exported and imported during backup operations.

## Changes
- **BackupData interface**: Added `investment_reports` field to the backup data structure
- **Export functionality**: Added SQL query to fetch all investment reports for a user during backup export
- **Restore functionality**: 
  - Added logic to insert investment reports during data restoration
  - Added cleanup to delete existing investment reports scoped to the current user during restore wipe
- **Test coverage**: 
  - Added test for investment_reports export inclusion
  - Added test for investment_reports restoration with user scoping
  - Added test for investment_reports deletion during restore wipe
  - Updated existing restore test to include empty investment_reports array in expected payload

## Implementation Details
- Investment reports are exported via `SELECT * FROM investment_reports WHERE user_id = $1`
- During restore, investment reports are inserted with the current user's ID (ensuring proper scoping even if backup contains different user IDs)
- Existing investment reports are deleted before restore to prevent duplicates
- Follows existing patterns for other user-scoped entities (custom_reports, budget_alerts, etc.)

https://claude.ai/code/session_016phRZxmzbXkMh2okF3f2jz