### PR TITLE
Scroll to top on forward navigation, fix sticky header positioning

### DIFF
--- a/backend/src/securities/security-price.service.spec.ts
+++ b/backend/src/securities/security-price.service.spec.ts
@@ -1044,8 +1044,14 @@ describe("SecurityPriceService", () => {
       // No transactions for this security
       dataSourceMock.query.mockResolvedValueOnce([]);
 
+      // Timestamps relative to "now" so the prices always land inside the
+      // rolling 1-year backfill window (cutoff = today - 1y), regardless of
+      // when the test runs. Hardcoded dates here rot once the window passes
+      // them.
+      const daySeconds = 24 * 60 * 60;
+      const nowSeconds = Math.floor(Date.now() / 1000);
       const historicalData = makeYahooHistoricalResponse({
-        timestamps: [1748700000, 1748800000],
+        timestamps: [nowSeconds - 2 * daySeconds, nowSeconds - daySeconds],
         closes: [193.0, 194.0],
       });
       global.fetch = jest

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -233,7 +233,7 @@ function OwnerSettingsView() {
         )}
 
         {/* Mobile horizontal tabs */}
-        <div className="lg:hidden sticky top-0 z-10 -mx-4 px-4 py-2 bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 mb-6">
+        <div className="lg:hidden sticky top-16 z-10 -mx-4 px-4 py-2 bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 mb-6">
           <SettingsNav
             sections={visibleSections}
             activeSection={activeSection}
@@ -245,7 +245,7 @@ function OwnerSettingsView() {
         <div className="lg:flex lg:gap-10">
           {/* Desktop sidebar */}
           <aside className="hidden lg:block lg:w-52 shrink-0">
-            <div className="sticky top-6">
+            <div className="sticky top-22">
               <SettingsNav
                 sections={visibleSections}
                 activeSection={activeSection}
@@ -258,7 +258,7 @@ function OwnerSettingsView() {
           {/* Content column */}
           <div className="flex-1 min-w-0">
             {user && !isDemoMode && (
-              <div id="profile" className="scroll-mt-16 lg:scroll-mt-6">
+              <div id="profile" className="scroll-mt-32 lg:scroll-mt-22">
                 <ProfileSection
                   user={user}
                   onUserUpdated={setUser}
@@ -267,7 +267,7 @@ function OwnerSettingsView() {
             )}
 
             {preferences && (
-              <div id="preferences" className="scroll-mt-16 lg:scroll-mt-6">
+              <div id="preferences" className="scroll-mt-32 lg:scroll-mt-22">
                 <PreferencesSection
                   preferences={preferences}
                   onPreferencesUpdated={setPreferences}
@@ -276,7 +276,7 @@ function OwnerSettingsView() {
             )}
 
             {preferences && (
-              <div id="notifications" className="scroll-mt-16 lg:scroll-mt-6">
+              <div id="notifications" className="scroll-mt-32 lg:scroll-mt-22">
                 <NotificationsSection
                   initialNotificationEmail={preferences.notificationEmail}
                   smtpConfigured={smtpConfigured}
@@ -287,7 +287,7 @@ function OwnerSettingsView() {
             )}
 
             {user && preferences && !isDemoMode && (
-              <div id="security" className="scroll-mt-16 lg:scroll-mt-6">
+              <div id="security" className="scroll-mt-32 lg:scroll-mt-22">
                 <SecuritySection
                   user={user}
                   preferences={preferences}
@@ -298,7 +298,7 @@ function OwnerSettingsView() {
             )}
 
             {!isDemoMode && (
-              <div id="shared-access" className="scroll-mt-16 lg:scroll-mt-6">
+              <div id="shared-access" className="scroll-mt-32 lg:scroll-mt-22">
                 <Link
                   href="/settings/shared-access"
                   className="block bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg p-6 mb-6 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
@@ -314,7 +314,7 @@ function OwnerSettingsView() {
             )}
 
             {!isDemoMode && (
-              <div id="emergency-access" className="scroll-mt-16 lg:scroll-mt-6">
+              <div id="emergency-access" className="scroll-mt-32 lg:scroll-mt-22">
                 <Link
                   href="/settings/emergency-access"
                   className="block bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg p-6 mb-6 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
@@ -331,13 +331,13 @@ function OwnerSettingsView() {
             )}
 
             {!isDemoMode && (
-              <div id="api-access" className="scroll-mt-16 lg:scroll-mt-6">
+              <div id="api-access" className="scroll-mt-32 lg:scroll-mt-22">
                 <ApiAccessSection />
               </div>
             )}
 
             {!isDemoMode && (
-              <div id="ai-settings" className="scroll-mt-16 lg:scroll-mt-6">
+              <div id="ai-settings" className="scroll-mt-32 lg:scroll-mt-22">
                 <Link
                   href="/settings/ai"
                   className="block bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg p-6 mb-6 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
@@ -353,19 +353,19 @@ function OwnerSettingsView() {
             )}
 
             {!isDemoMode && user && (
-              <div id="backup-restore" className="scroll-mt-16 lg:scroll-mt-6">
+              <div id="backup-restore" className="scroll-mt-32 lg:scroll-mt-22">
                 <BackupRestoreSection user={user} />
               </div>
             )}
 
             {!isDemoMode && (
-              <div id="auto-backup" className="scroll-mt-16 lg:scroll-mt-6">
+              <div id="auto-backup" className="scroll-mt-32 lg:scroll-mt-22">
                 <AutoBackupSection />
               </div>
             )}
 
             {!isDemoMode && user && (
-              <div id="danger-zone" className="scroll-mt-16 lg:scroll-mt-6">
+              <div id="danger-zone" className="scroll-mt-32 lg:scroll-mt-22">
                 <DangerZoneSection user={user} />
               </div>
             )}

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -161,7 +161,7 @@ export function AppHeader() {
   };
 
   return (
-    <header className="bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50">
+    <header className="sticky top-0 z-40 bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50">
       <div className="px-4 sm:px-6 lg:px-12">
         <div className="flex justify-between h-16">
           <div className="flex items-center">

--- a/frontend/src/components/layout/SwipeShell.tsx
+++ b/frontend/src/components/layout/SwipeShell.tsx
@@ -10,6 +10,7 @@ import { HttpWarningBanner } from './HttpWarningBanner';
 import { SwipeIndicator } from './SwipeIndicator';
 import { UpdateAvailableBanner } from './UpdateAvailableBanner';
 import { useSwipeNavigation } from '@/hooks/useSwipeNavigation';
+import { useScrollToTopOnNavigation } from '@/hooks/useScrollToTopOnNavigation';
 
 const AUTH_ROUTES = ['/login', '/register', '/forgot-password', '/reset-password', '/setup-2fa', '/change-password'];
 
@@ -21,6 +22,10 @@ interface SwipeShellProps {
 export function SwipeShell({ children, httpsHeadersActive = false }: SwipeShellProps) {
   const pathname = usePathname();
   const { contentRef, currentIndex, totalPages, isSwipePage } = useSwipeNavigation();
+  // Land at the top of the page on forward tab/swipe navigation so the
+  // title and action buttons are always in view. Back/Forward keep their
+  // restored scroll position.
+  useScrollToTopOnNavigation();
 
   const isAuthRoute = AUTH_ROUTES.some(r => pathname === r || pathname.startsWith(r + '/'));
 

--- a/frontend/src/hooks/useScrollToTopOnNavigation.test.ts
+++ b/frontend/src/hooks/useScrollToTopOnNavigation.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+let mockPathname = '/dashboard';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+import { useScrollToTopOnNavigation } from './useScrollToTopOnNavigation';
+
+const scrollToMock = () => window.scrollTo as unknown as ReturnType<typeof vi.fn>;
+
+describe('useScrollToTopOnNavigation', () => {
+  let nowValue: number;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPathname = '/dashboard';
+    nowValue = 10_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => nowValue);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not scroll on initial mount', () => {
+    renderHook(() => useScrollToTopOnNavigation());
+    expect(scrollToMock()).not.toHaveBeenCalled();
+  });
+
+  it('scrolls to the top on a forward navigation (pathname change)', () => {
+    const { rerender } = renderHook(() => useScrollToTopOnNavigation());
+    act(() => {
+      mockPathname = '/transactions';
+      rerender();
+    });
+    expect(scrollToMock()).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('does not scroll when the pathname is unchanged', () => {
+    const { rerender } = renderHook(() => useScrollToTopOnNavigation());
+    act(() => {
+      rerender();
+    });
+    expect(scrollToMock()).not.toHaveBeenCalled();
+  });
+
+  it('does not scroll on a Back/Forward navigation (recent popstate)', () => {
+    const { rerender } = renderHook(() => useScrollToTopOnNavigation());
+    act(() => {
+      window.dispatchEvent(new PopStateEvent('popstate'));
+      mockPathname = '/transactions';
+      rerender();
+    });
+    expect(scrollToMock()).not.toHaveBeenCalled();
+  });
+
+  it('still scrolls on a forward navigation after a stale popstate', () => {
+    const { rerender } = renderHook(() => useScrollToTopOnNavigation());
+    // A popstate that did not change the route (e.g. closing a modal that
+    // pushed a history entry) must not get "stuck" and suppress a later tab.
+    act(() => {
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+    // A genuine forward navigation well outside the Back/Forward window.
+    nowValue += 5_000;
+    act(() => {
+      mockPathname = '/reports';
+      rerender();
+    });
+    expect(scrollToMock()).toHaveBeenCalledWith(0, 0);
+  });
+});

--- a/frontend/src/hooks/useScrollToTopOnNavigation.ts
+++ b/frontend/src/hooks/useScrollToTopOnNavigation.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
+
+// Browser Back/Forward fire `popstate` immediately before the route
+// updates. If a popstate landed within this window of the path change we
+// treat the navigation as Back/Forward and leave the browser's own scroll
+// restoration alone. A timestamp (rather than a boolean flag) means a
+// popstate that does not change the route -- e.g. closing a modal that
+// pushed a history entry -- expires on its own and cannot suppress a later
+// forward navigation.
+const BACK_FORWARD_WINDOW_MS = 200;
+
+/**
+ * Scrolls the window to the top when navigating forward to a new route -- a
+ * top-nav tab click or a swipe between pages -- so the page title and its
+ * action buttons are always in view. Browser Back/Forward navigations are
+ * left untouched so their previous scroll position is restored.
+ */
+export function useScrollToTopOnNavigation(): void {
+  const pathname = usePathname();
+  const previousPathname = useRef(pathname);
+  const lastPopStateAt = useRef(0);
+
+  useEffect(() => {
+    const onPopState = () => {
+      lastPopStateAt.current = Date.now();
+    };
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
+
+  useEffect(() => {
+    if (pathname === previousPathname.current) return;
+    previousPathname.current = pathname;
+
+    const isBackForward =
+      Date.now() - lastPopStateAt.current < BACK_FORWARD_WINDOW_MS;
+    if (isBackForward) return;
+
+    window.scrollTo(0, 0);
+  }, [pathname]);
+}


### PR DESCRIPTION
## Summary
Adds automatic scroll-to-top behavior on forward navigation (tab clicks, swipes) while preserving browser Back/Forward scroll restoration. Also fixes sticky header and navigation positioning to account for the fixed app header.

## Changes

### New Hook: `useScrollToTopOnNavigation`
- Created `useScrollToTopOnNavigation` hook that scrolls to top when navigating to a new route
- Distinguishes between forward navigation and Back/Forward browser actions using a 200ms `popstate` event window
- Prevents scroll suppression from stale popstate events (e.g., closing modals that pushed history)
- Includes comprehensive test coverage for all navigation scenarios

### Layout Updates
- **AppHeader**: Made sticky (`top-0 z-40`) so it stays visible while scrolling
- **SwipeShell**: Integrated `useScrollToTopOnNavigation` hook to apply scroll behavior across all main navigation
- **Settings page**: Updated sticky positioning and scroll margins to account for fixed header:
  - Mobile tabs: `top-0` → `top-16` (below header)
  - Desktop sidebar: `top-6` → `top-22` (below header with padding)
  - Section anchors: `scroll-mt-16` → `scroll-mt-32` (mobile), `scroll-mt-6` → `scroll-mt-22` (desktop)

## Implementation Details
- The hook uses `Date.now()` timestamps to detect Back/Forward navigation within a narrow window, avoiding false positives from unrelated popstate events
- Scroll behavior only applies on pathname changes; rerenders without route changes are ignored
- All scroll margin adjustments use Tailwind spacing units (16 = 4rem, 22 = 5.5rem, 32 = 8rem) to maintain visual consistency

https://claude.ai/code/session_01JoVtFe2katPrb7seB5NaLo