### PR TITLE
feat(ai): add bills & deposits tools to AI Assistant and MCP

### DIFF
--- a/backend/src/ai/ai.module.ts
+++ b/backend/src/ai/ai.module.ts
@@ -30,6 +30,7 @@ import { TransactionsModule } from "../transactions/transactions.module";
 import { NetWorthModule } from "../net-worth/net-worth.module";
 import { BudgetsModule } from "../budgets/budgets.module";
 import { SecuritiesModule } from "../securities/securities.module";
+import { ScheduledTransactionsModule } from "../scheduled-transactions/scheduled-transactions.module";
 
 @Module({
   imports: [
@@ -49,6 +50,7 @@ import { SecuritiesModule } from "../securities/securities.module";
     forwardRef(() => NetWorthModule),
     forwardRef(() => BudgetsModule),
     SecuritiesModule,
+    forwardRef(() => ScheduledTransactionsModule),
   ],
   providers: [
     AiService,

--- a/backend/src/ai/query/tool-definitions.spec.ts
+++ b/backend/src/ai/query/tool-definitions.spec.ts
@@ -1,8 +1,8 @@
 import { FINANCIAL_TOOLS } from "./tool-definitions";
 
 describe("FINANCIAL_TOOLS", () => {
-  it("defines exactly 14 tools", () => {
-    expect(FINANCIAL_TOOLS).toHaveLength(14);
+  it("defines exactly 16 tools", () => {
+    expect(FINANCIAL_TOOLS).toHaveLength(16);
   });
 
   it("has unique tool names", () => {
@@ -23,6 +23,8 @@ describe("FINANCIAL_TOOLS", () => {
     "get_capital_gains",
     "get_transfers",
     "get_budget_status",
+    "get_upcoming_bills",
+    "get_scheduled_transactions",
     "calculate",
     "render_chart",
   ];
@@ -295,6 +297,82 @@ describe("FINANCIAL_TOOLS", () => {
       >;
       expect(props.accountNames).toBeDefined();
       expect(props.accountNames.type).toBe("array");
+    });
+  });
+
+  describe("get_upcoming_bills", () => {
+    it("has no required fields (days defaults to 30)", () => {
+      const tool = FINANCIAL_TOOLS.find(
+        (t) => t.name === "get_upcoming_bills",
+      )!;
+      expect(tool.inputSchema.required).toBeUndefined();
+    });
+
+    it("supports kind with bill/deposit/transfer/investment/all", () => {
+      const tool = FINANCIAL_TOOLS.find(
+        (t) => t.name === "get_upcoming_bills",
+      )!;
+      const props = tool.inputSchema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.kind.enum).toEqual([
+        "bill",
+        "deposit",
+        "transfer",
+        "investment",
+        "all",
+      ]);
+    });
+
+    it("supports optional accountNames filter", () => {
+      const tool = FINANCIAL_TOOLS.find(
+        (t) => t.name === "get_upcoming_bills",
+      )!;
+      const props = tool.inputSchema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.accountNames).toBeDefined();
+      expect(props.accountNames.type).toBe("array");
+    });
+  });
+
+  describe("get_scheduled_transactions", () => {
+    it("has no required fields", () => {
+      const tool = FINANCIAL_TOOLS.find(
+        (t) => t.name === "get_scheduled_transactions",
+      )!;
+      expect(tool.inputSchema.required).toBeUndefined();
+    });
+
+    it("supports kind with bill/deposit/transfer/investment/all", () => {
+      const tool = FINANCIAL_TOOLS.find(
+        (t) => t.name === "get_scheduled_transactions",
+      )!;
+      const props = tool.inputSchema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.kind.enum).toEqual([
+        "bill",
+        "deposit",
+        "transfer",
+        "investment",
+        "all",
+      ]);
+    });
+
+    it("exposes optional isActive boolean filter", () => {
+      const tool = FINANCIAL_TOOLS.find(
+        (t) => t.name === "get_scheduled_transactions",
+      )!;
+      const props = tool.inputSchema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.isActive).toBeDefined();
+      expect(props.isActive.type).toBe("boolean");
     });
   });
 

--- a/backend/src/ai/query/tool-definitions.ts
+++ b/backend/src/ai/query/tool-definitions.ts
@@ -355,6 +355,62 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
     },
   },
   {
+    name: "get_upcoming_bills",
+    description:
+      "Get upcoming scheduled bills and deposits due within a date window. Each item is classified as bill (scheduled outflow), deposit (scheduled inflow), transfer, or investment, and includes a daysUntilDue value (negative when overdue). Returns rollup totals for upcoming bills and deposits plus the per-item list. Use for questions like 'what bills are coming up', 'when is rent due', or 'what deposits am I expecting this month'.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        days: {
+          type: "integer",
+          minimum: 1,
+          maximum: 365,
+          description:
+            "Number of days to look ahead from today. Defaults to 30. Includes overdue items (daysUntilDue < 0) that have not been posted yet.",
+        },
+        kind: {
+          type: "string",
+          enum: ["bill", "deposit", "transfer", "investment", "all"],
+          description:
+            "Narrow to a single kind: 'bill' (scheduled outflow), 'deposit' (scheduled inflow), 'transfer' (between own accounts), or 'investment'. Omit or pass 'all' to include everything.",
+        },
+        accountNames: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Optional: filter to specific account names. Use exact names from the user's account list.",
+        },
+      },
+    },
+  },
+  {
+    name: "get_scheduled_transactions",
+    description:
+      "List all scheduled/recurring transactions (bills, deposits, transfers, investments), regardless of whether they're due soon. Returns rollup counts plus a curated per-item payload with kind, frequency, next due date, account, and amount. Use for questions like 'what recurring bills do I have', 'list all my scheduled deposits', or 'which schedules are paused'.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        kind: {
+          type: "string",
+          enum: ["bill", "deposit", "transfer", "investment", "all"],
+          description:
+            "Narrow to a single kind: 'bill' (scheduled outflow), 'deposit' (scheduled inflow), 'transfer' (between own accounts), or 'investment'. Omit or pass 'all' to include everything.",
+        },
+        accountNames: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Optional: filter to specific account names. Use exact names from the user's account list.",
+        },
+        isActive: {
+          type: "boolean",
+          description:
+            "Filter by active status. true = only active schedules, false = only paused. Omit to include both.",
+        },
+      },
+    },
+  },
+  {
     name: "get_budget_status",
     description:
       "Get budget status for a specific period. Returns total budgeted vs actual spending, per-category breakdowns, spending velocity, safe daily spend, and health score. Use for questions like 'how am I doing on my budget?', 'which categories am I overspending in?', or 'how much can I still spend this month?'.",

--- a/backend/src/ai/query/tool-executor.service.spec.ts
+++ b/backend/src/ai/query/tool-executor.service.spec.ts
@@ -7,6 +7,7 @@ import { NetWorthService } from "../../net-worth/net-worth.service";
 import { BudgetReportsService } from "../../budgets/budget-reports.service";
 import { PortfolioService } from "../../securities/portfolio.service";
 import { InvestmentTransactionsService } from "../../securities/investment-transactions.service";
+import { ScheduledTransactionsService } from "../../scheduled-transactions/scheduled-transactions.service";
 
 describe("ToolExecutorService", () => {
   let service: ToolExecutorService;
@@ -17,6 +18,7 @@ describe("ToolExecutorService", () => {
   let portfolio: Record<string, jest.Mock>;
   let investmentTransactions: Record<string, jest.Mock>;
   let categories: Record<string, jest.Mock>;
+  let scheduledTransactions: Record<string, jest.Mock>;
 
   const userId = "user-1";
 
@@ -181,6 +183,25 @@ describe("ToolExecutorService", () => {
       }),
     };
 
+    scheduledTransactions = {
+      getLlmUpcomingBillsAndDeposits: jest.fn().mockResolvedValue({
+        daysWindow: 30,
+        itemCount: 2,
+        overdueCount: 1,
+        totalUpcomingBills: 1200,
+        totalUpcomingDeposits: 3000,
+        items: [],
+      }),
+      getLlmScheduledList: jest.fn().mockResolvedValue({
+        totalCount: 3,
+        activeCount: 2,
+        autoPostCount: 1,
+        billCount: 2,
+        depositCount: 1,
+        items: [],
+      }),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ToolExecutorService,
@@ -193,6 +214,10 @@ describe("ToolExecutorService", () => {
         {
           provide: InvestmentTransactionsService,
           useValue: investmentTransactions,
+        },
+        {
+          provide: ScheduledTransactionsService,
+          useValue: scheduledTransactions,
         },
       ],
     }).compile();
@@ -622,6 +647,69 @@ describe("ToolExecutorService", () => {
         undefined,
       );
       expect(result.sources[0].type).toBe("budget");
+    });
+
+    it("get_upcoming_bills delegates to scheduledTransactions.getLlmUpcomingBillsAndDeposits", async () => {
+      const result = await service.execute(userId, "get_upcoming_bills", {});
+
+      expect(
+        scheduledTransactions.getLlmUpcomingBillsAndDeposits,
+      ).toHaveBeenCalledWith(userId, {
+        days: 30,
+        kind: undefined,
+        accountIds: undefined,
+      });
+      expect(result.sources[0].type).toBe("scheduled_transactions");
+      expect(result.summary).toContain("upcoming");
+      expect(result.summary).toContain("Bills: 1200.00");
+      expect(result.summary).toContain("Deposits: 3000.00");
+      expect(result.summary).toContain("1 overdue");
+    });
+
+    it("get_upcoming_bills passes through days, kind, and resolves account names", async () => {
+      await service.execute(userId, "get_upcoming_bills", {
+        days: 7,
+        kind: "bill",
+        accountNames: ["Checking"],
+      });
+
+      expect(accounts.findAll).toHaveBeenCalledWith(userId, false);
+      expect(
+        scheduledTransactions.getLlmUpcomingBillsAndDeposits,
+      ).toHaveBeenCalledWith(userId, {
+        days: 7,
+        kind: "bill",
+        accountIds: ["acc-1"],
+      });
+    });
+
+    it("get_scheduled_transactions delegates to scheduledTransactions.getLlmScheduledList", async () => {
+      const result = await service.execute(
+        userId,
+        "get_scheduled_transactions",
+        {},
+      );
+
+      expect(scheduledTransactions.getLlmScheduledList).toHaveBeenCalledWith(
+        userId,
+        { kind: undefined, accountIds: undefined, isActive: undefined },
+      );
+      expect(result.sources[0].type).toBe("scheduled_transactions");
+      expect(result.summary).toContain("2 active");
+      expect(result.summary).toContain("1 auto-posting");
+    });
+
+    it("get_scheduled_transactions passes kind, account names, and isActive filter", async () => {
+      await service.execute(userId, "get_scheduled_transactions", {
+        kind: "deposit",
+        accountNames: ["Checking"],
+        isActive: false,
+      });
+
+      expect(scheduledTransactions.getLlmScheduledList).toHaveBeenCalledWith(
+        userId,
+        { kind: "deposit", accountIds: ["acc-1"], isActive: false },
+      );
     });
 
     it("calculate runs locally without hitting any service", async () => {

--- a/backend/src/ai/query/tool-executor.service.ts
+++ b/backend/src/ai/query/tool-executor.service.ts
@@ -12,6 +12,10 @@ import {
   LlmInvestmentTxGroupBy,
 } from "../../securities/investment-transactions.service";
 import { InvestmentAction } from "../../securities/entities/investment-transaction.entity";
+import {
+  ScheduledTransactionsService,
+  LlmScheduledKind,
+} from "../../scheduled-transactions/scheduled-transactions.service";
 import { validateToolInput } from "./tool-input-schemas";
 import { executeCalculation, CalculateInput } from "./calculate-tool";
 import { sanitizePromptValue } from "../../common/sanitization.util";
@@ -45,6 +49,8 @@ export class ToolExecutorService {
     private readonly budgetReportsService: BudgetReportsService,
     private readonly portfolioService: PortfolioService,
     private readonly investmentTransactionsService: InvestmentTransactionsService,
+    @Inject(forwardRef(() => ScheduledTransactionsService))
+    private readonly scheduledTransactionsService: ScheduledTransactionsService,
   ) {}
 
   async execute(
@@ -113,6 +119,12 @@ export class ToolExecutorService {
           break;
         case "get_budget_status":
           result = await this.getBudgetStatus(userId, validatedInput);
+          break;
+        case "get_upcoming_bills":
+          result = await this.getUpcomingBills(userId, validatedInput);
+          break;
+        case "get_scheduled_transactions":
+          result = await this.getScheduledTransactions(userId, validatedInput);
           break;
         case "calculate":
           result = this.calculate(validatedInput);
@@ -645,6 +657,72 @@ export class ToolExecutorService {
           type: "budget",
           description: `Budget status for "${data.budgetName}"`,
           dateRange: `${data.period.start} to ${data.period.end}`,
+        },
+      ],
+    };
+  }
+
+  private async getUpcomingBills(
+    userId: string,
+    input: Record<string, unknown>,
+  ): Promise<ToolResult> {
+    const days = (input.days as number | undefined) ?? 30;
+    const kind = input.kind as LlmScheduledKind | "all" | undefined;
+    const accountNames = input.accountNames as string[] | undefined;
+    const accountIds = await this.resolveAccountIds(userId, accountNames);
+
+    const data =
+      await this.scheduledTransactionsService.getLlmUpcomingBillsAndDeposits(
+        userId,
+        { days, kind, accountIds },
+      );
+
+    const kindDesc =
+      !kind || kind === "all" ? "bills and deposits" : `${kind}s`;
+    const overduePart =
+      data.overdueCount > 0 ? `, ${data.overdueCount} overdue` : "";
+    return {
+      data,
+      summary: `${data.itemCount} upcoming ${kindDesc} in the next ${days} day${days === 1 ? "" : "s"}${overduePart}. Bills: ${data.totalUpcomingBills.toFixed(2)}, Deposits: ${data.totalUpcomingDeposits.toFixed(2)}.`,
+      sources: [
+        {
+          type: "scheduled_transactions",
+          description: accountNames
+            ? `Upcoming ${kindDesc} for ${accountNames.join(", ")}`
+            : `Upcoming ${kindDesc}`,
+          dateRange: `next ${days} day${days === 1 ? "" : "s"}`,
+        },
+      ],
+    };
+  }
+
+  private async getScheduledTransactions(
+    userId: string,
+    input: Record<string, unknown>,
+  ): Promise<ToolResult> {
+    const kind = input.kind as LlmScheduledKind | "all" | undefined;
+    const accountNames = input.accountNames as string[] | undefined;
+    const isActive = input.isActive as boolean | undefined;
+    const accountIds = await this.resolveAccountIds(userId, accountNames);
+
+    const data = await this.scheduledTransactionsService.getLlmScheduledList(
+      userId,
+      { kind, accountIds, isActive },
+    );
+
+    const kindDesc =
+      !kind || kind === "all" ? "scheduled transactions" : `scheduled ${kind}s`;
+    const statusDesc =
+      isActive === true ? " active" : isActive === false ? " paused" : "";
+    return {
+      data,
+      summary: `${data.totalCount}${statusDesc} ${kindDesc} (${data.activeCount} active, ${data.autoPostCount} auto-posting, ${data.billCount} bills, ${data.depositCount} deposits).`,
+      sources: [
+        {
+          type: "scheduled_transactions",
+          description: accountNames
+            ? `Scheduled ${kindDesc} for ${accountNames.join(", ")}`
+            : `All scheduled ${kindDesc}`,
         },
       ],
     };

--- a/backend/src/ai/query/tool-input-schemas.spec.ts
+++ b/backend/src/ai/query/tool-input-schemas.spec.ts
@@ -11,6 +11,8 @@ import {
   queryInvestmentTransactionsSchema,
   getTransfersSchema,
   getBudgetStatusSchema,
+  getUpcomingBillsSchema,
+  getScheduledTransactionsSchema,
   calculateSchema,
   renderChartSchema,
 } from "./tool-input-schemas";
@@ -550,6 +552,92 @@ describe("tool-input-schemas", () => {
         budgetName: "a".repeat(101),
       });
       expect(result.success).toBe(false);
+    });
+  });
+
+  describe("getUpcomingBillsSchema", () => {
+    it("accepts empty input (days defaults via executor)", () => {
+      const result = getUpcomingBillsSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts days within range", () => {
+      const result = getUpcomingBillsSchema.safeParse({ days: 7 });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects days over 365", () => {
+      const result = getUpcomingBillsSchema.safeParse({ days: 400 });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects days of 0", () => {
+      const result = getUpcomingBillsSchema.safeParse({ days: 0 });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts every valid kind", () => {
+      for (const kind of ["bill", "deposit", "transfer", "investment", "all"]) {
+        const result = getUpcomingBillsSchema.safeParse({ kind });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it("normalizes uppercase/whitespace kind via preprocess", () => {
+      const result = getUpcomingBillsSchema.safeParse({ kind: " BILL " });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.kind).toBe("bill");
+      }
+    });
+
+    it("rejects unknown kind", () => {
+      const result = getUpcomingBillsSchema.safeParse({ kind: "loan" });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts accountNames filter", () => {
+      const result = getUpcomingBillsSchema.safeParse({
+        accountNames: ["Checking"],
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("getScheduledTransactionsSchema", () => {
+    it("accepts empty input", () => {
+      const result = getScheduledTransactionsSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts kind, accountNames, and isActive", () => {
+      const result = getScheduledTransactionsSchema.safeParse({
+        kind: "deposit",
+        accountNames: ["Savings"],
+        isActive: true,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects unknown kind", () => {
+      const result = getScheduledTransactionsSchema.safeParse({
+        kind: "subscription",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects non-boolean isActive", () => {
+      const result = getScheduledTransactionsSchema.safeParse({
+        isActive: "yes",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("routes through validateToolInput", () => {
+      const result = validateToolInput("get_scheduled_transactions", {
+        kind: "bill",
+      });
+      expect(result.success).toBe(true);
     });
   });
 

--- a/backend/src/ai/query/tool-input-schemas.ts
+++ b/backend/src/ai/query/tool-input-schemas.ts
@@ -130,6 +130,31 @@ export const getBudgetStatusSchema = z.object({
   budgetName: z.string().max(100).optional(),
 });
 
+export const SCHEDULED_KINDS = [
+  "bill",
+  "deposit",
+  "transfer",
+  "investment",
+  "all",
+] as const;
+
+const scheduledKindSchema = z.preprocess(
+  (val) => (typeof val === "string" ? val.toLowerCase().trim() : val),
+  z.enum(SCHEDULED_KINDS),
+);
+
+export const getUpcomingBillsSchema = z.object({
+  days: positiveIntSchema(1, 365).optional(),
+  kind: scheduledKindSchema.optional(),
+  accountNames: z.array(z.string().max(100)).max(50).optional(),
+});
+
+export const getScheduledTransactionsSchema = z.object({
+  kind: scheduledKindSchema.optional(),
+  accountNames: z.array(z.string().max(100)).max(50).optional(),
+  isActive: z.boolean().optional(),
+});
+
 export const calculateSchema = z.object({
   operation: z.enum(["percentage", "difference", "ratio", "sum", "average"]),
   values: z.array(z.number()).min(1).max(100),
@@ -169,6 +194,8 @@ export const toolInputSchemas: Record<string, z.ZodSchema> = {
   get_capital_gains: getCapitalGainsSchema,
   get_transfers: getTransfersSchema,
   get_budget_status: getBudgetStatusSchema,
+  get_upcoming_bills: getUpcomingBillsSchema,
+  get_scheduled_transactions: getScheduledTransactionsSchema,
   calculate: calculateSchema,
   render_chart: renderChartSchema,
 };

--- a/backend/src/mcp/tools/scheduled.tool.spec.ts
+++ b/backend/src/mcp/tools/scheduled.tool.spec.ts
@@ -10,8 +10,8 @@ describe("McpScheduledTools", () => {
 
   beforeEach(() => {
     scheduledService = {
-      findUpcoming: jest.fn(),
-      findAll: jest.fn(),
+      getLlmUpcomingBillsAndDeposits: jest.fn(),
+      getLlmScheduledList: jest.fn(),
     };
 
     tool = new McpScheduledTools(scheduledService as any);
@@ -31,7 +31,7 @@ describe("McpScheduledTools", () => {
   });
 
   describe("get_upcoming_bills", () => {
-    it("should return error when no user context", async () => {
+    it("returns error when no user context", async () => {
       resolve.mockReturnValue(undefined);
       const result = await handlers["get_upcoming_bills"](
         {},
@@ -40,50 +40,178 @@ describe("McpScheduledTools", () => {
       expect(result.isError).toBe(true);
     });
 
-    it("should return upcoming bills with default days", async () => {
+    it("calls the shared LLM helper with default days=30", async () => {
       resolve.mockReturnValue({ userId: "u1", scopes: "read" });
-      scheduledService.findUpcoming.mockResolvedValue([
-        { id: "s1", name: "Rent", amount: -1200 },
-      ]);
+      scheduledService.getLlmUpcomingBillsAndDeposits.mockResolvedValue({
+        daysWindow: 30,
+        itemCount: 1,
+        overdueCount: 0,
+        totalUpcomingBills: 1200,
+        totalUpcomingDeposits: 0,
+        items: [
+          {
+            id: "s1",
+            name: "Rent",
+            accountId: "a1",
+            accountName: "Checking",
+            payeeName: "Landlord",
+            categoryName: "Housing",
+            amount: -1200,
+            currency: "USD",
+            frequency: "MONTHLY",
+            nextDueDate: "2026-06-15",
+            daysUntilDue: 13,
+            isActive: true,
+            autoPost: false,
+            kind: "bill",
+            description: null,
+          },
+        ],
+      });
 
       const result = await handlers["get_upcoming_bills"](
         {},
         { sessionId: "s1" },
       );
-      expect(scheduledService.findUpcoming).toHaveBeenCalledWith("u1", 30);
+
+      expect(
+        scheduledService.getLlmUpcomingBillsAndDeposits,
+      ).toHaveBeenCalledWith("u1", {
+        days: 30,
+        kind: undefined,
+        accountIds: undefined,
+      });
       const parsed = JSON.parse(result.content[0].text);
-      expect(parsed[0].name).toBe("Rent");
+      expect(parsed.itemCount).toBe(1);
+      expect(parsed.items[0].kind).toBe("bill");
     });
 
-    it("should use custom days parameter", async () => {
+    it("passes through days, kind, and accountIds", async () => {
       resolve.mockReturnValue({ userId: "u1", scopes: "read" });
-      scheduledService.findUpcoming.mockResolvedValue([]);
+      scheduledService.getLlmUpcomingBillsAndDeposits.mockResolvedValue({
+        daysWindow: 7,
+        itemCount: 0,
+        overdueCount: 0,
+        totalUpcomingBills: 0,
+        totalUpcomingDeposits: 0,
+        items: [],
+      });
 
-      await handlers["get_upcoming_bills"]({ days: 7 }, { sessionId: "s1" });
-      expect(scheduledService.findUpcoming).toHaveBeenCalledWith("u1", 7);
+      await handlers["get_upcoming_bills"](
+        { days: 7, kind: "deposit", accountIds: ["acc-1"] },
+        { sessionId: "s1" },
+      );
+      expect(
+        scheduledService.getLlmUpcomingBillsAndDeposits,
+      ).toHaveBeenCalledWith("u1", {
+        days: 7,
+        kind: "deposit",
+        accountIds: ["acc-1"],
+      });
+    });
+
+    it("returns error when service throws", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      scheduledService.getLlmUpcomingBillsAndDeposits.mockRejectedValue(
+        new Error("DB error"),
+      );
+      const result = await handlers["get_upcoming_bills"](
+        {},
+        { sessionId: "s1" },
+      );
+      expect(result.isError).toBe(true);
     });
   });
 
   describe("get_scheduled_transactions", () => {
-    it("should return all scheduled transactions", async () => {
+    it("returns curated list payload", async () => {
       resolve.mockReturnValue({ userId: "u1", scopes: "read" });
-      scheduledService.findAll.mockResolvedValue([
-        { id: "s1", name: "Netflix" },
-        { id: "s2", name: "Gym" },
-      ]);
+      scheduledService.getLlmScheduledList.mockResolvedValue({
+        totalCount: 2,
+        activeCount: 2,
+        autoPostCount: 1,
+        billCount: 1,
+        depositCount: 1,
+        items: [
+          {
+            id: "s1",
+            name: "Netflix",
+            kind: "bill",
+            amount: -15,
+            accountId: "a1",
+            accountName: "Checking",
+            payeeName: "Netflix",
+            categoryName: "Entertainment",
+            currency: "USD",
+            frequency: "MONTHLY",
+            nextDueDate: "2026-06-10",
+            daysUntilDue: 8,
+            isActive: true,
+            autoPost: true,
+            description: null,
+          },
+          {
+            id: "s2",
+            name: "Paycheck",
+            kind: "deposit",
+            amount: 3000,
+            accountId: "a1",
+            accountName: "Checking",
+            payeeName: "Employer",
+            categoryName: "Salary",
+            currency: "USD",
+            frequency: "BIWEEKLY",
+            nextDueDate: "2026-06-05",
+            daysUntilDue: 3,
+            isActive: true,
+            autoPost: false,
+            description: null,
+          },
+        ],
+      });
 
       const result = await handlers["get_scheduled_transactions"](
         {},
         { sessionId: "s1" },
       );
+      expect(scheduledService.getLlmScheduledList).toHaveBeenCalledWith("u1", {
+        kind: undefined,
+        accountIds: undefined,
+        isActive: undefined,
+      });
       const parsed = JSON.parse(result.content[0].text);
-      expect(parsed).toHaveLength(2);
+      expect(parsed.totalCount).toBe(2);
+      expect(parsed.billCount).toBe(1);
+      expect(parsed.depositCount).toBe(1);
     });
 
-    it("should handle service errors", async () => {
+    it("passes through kind, accountIds, and isActive filter", async () => {
       resolve.mockReturnValue({ userId: "u1", scopes: "read" });
-      scheduledService.findAll.mockRejectedValue(new Error("DB error"));
+      scheduledService.getLlmScheduledList.mockResolvedValue({
+        totalCount: 0,
+        activeCount: 0,
+        autoPostCount: 0,
+        billCount: 0,
+        depositCount: 0,
+        items: [],
+      });
 
+      await handlers["get_scheduled_transactions"](
+        { kind: "bill", accountIds: ["acc-1"], isActive: false },
+        { sessionId: "s1" },
+      );
+      expect(scheduledService.getLlmScheduledList).toHaveBeenCalledWith("u1", {
+        kind: "bill",
+        accountIds: ["acc-1"],
+        isActive: false,
+      });
+    });
+
+    it("returns error when service throws", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
+      scheduledService.getLlmScheduledList.mockRejectedValue(
+        new Error("DB error"),
+      );
       const result = await handlers["get_scheduled_transactions"](
         {},
         { sessionId: "s1" },
@@ -94,18 +222,6 @@ describe("McpScheduledTools", () => {
     it("returns error when no user context", async () => {
       resolve.mockReturnValue(undefined);
       const result = await handlers["get_scheduled_transactions"](
-        {},
-        { sessionId: "s1" },
-      );
-      expect(result.isError).toBe(true);
-    });
-  });
-
-  describe("get_upcoming_bills error paths", () => {
-    it("returns error when service throws", async () => {
-      resolve.mockReturnValue({ userId: "u1", scopes: "read" });
-      scheduledService.findUpcoming.mockRejectedValue(new Error("oh no"));
-      const result = await handlers["get_upcoming_bills"](
         {},
         { sessionId: "s1" },
       );

--- a/backend/src/mcp/tools/scheduled.tool.ts
+++ b/backend/src/mcp/tools/scheduled.tool.ts
@@ -10,6 +10,14 @@ import {
   safeToolError,
 } from "../mcp-context";
 
+const SCHEDULED_KIND_VALUES = [
+  "bill",
+  "deposit",
+  "transfer",
+  "investment",
+  "all",
+] as const;
+
 @Injectable()
 export class McpScheduledTools {
   constructor(
@@ -20,7 +28,8 @@ export class McpScheduledTools {
     server.registerTool(
       "get_upcoming_bills",
       {
-        description: "Get scheduled transactions due soon",
+        description:
+          "Get upcoming scheduled bills and deposits due within a date window. Each item is classified as bill / deposit / transfer / investment and includes a daysUntilDue value (negative when overdue). Returns the same shape as the AI Assistant's get_upcoming_bills tool.",
         inputSchema: {
           days: z
             .number()
@@ -29,6 +38,17 @@ export class McpScheduledTools {
             .optional()
             .default(30)
             .describe("Number of days to look ahead (default 30)"),
+          kind: z
+            .enum(SCHEDULED_KIND_VALUES)
+            .optional()
+            .describe(
+              "Narrow to a single kind: 'bill', 'deposit', 'transfer', 'investment'. Omit or pass 'all' for everything.",
+            ),
+          accountIds: z
+            .array(z.string().uuid())
+            .max(50)
+            .optional()
+            .describe("Optional account IDs to filter to."),
         },
       },
       async (args, extra) => {
@@ -38,10 +58,15 @@ export class McpScheduledTools {
         if (check.error) return check.result;
 
         try {
-          const upcoming = await this.scheduledService.findUpcoming(
-            ctx.userId,
-            args.days || 30,
-          );
+          const upcoming =
+            await this.scheduledService.getLlmUpcomingBillsAndDeposits(
+              ctx.userId,
+              {
+                days: args.days ?? 30,
+                kind: args.kind,
+                accountIds: args.accountIds,
+              },
+            );
           return toolResult(upcoming);
         } catch (err: unknown) {
           return safeToolError(err);
@@ -52,17 +77,43 @@ export class McpScheduledTools {
     server.registerTool(
       "get_scheduled_transactions",
       {
-        description: "List all scheduled/recurring transactions",
-        inputSchema: {},
+        description:
+          "List all scheduled/recurring transactions (bills, deposits, transfers, investments). Returns rollup counts plus a curated per-item payload. Returns the same shape as the AI Assistant's get_scheduled_transactions tool.",
+        inputSchema: {
+          kind: z
+            .enum(SCHEDULED_KIND_VALUES)
+            .optional()
+            .describe(
+              "Narrow to a single kind: 'bill', 'deposit', 'transfer', 'investment'. Omit or pass 'all' for everything.",
+            ),
+          accountIds: z
+            .array(z.string().uuid())
+            .max(50)
+            .optional()
+            .describe("Optional account IDs to filter to."),
+          isActive: z
+            .boolean()
+            .optional()
+            .describe(
+              "Filter by active status. Omit to include both active and paused schedules.",
+            ),
+        },
       },
-      async (_args, extra) => {
+      async (args, extra) => {
         const ctx = resolve(extra.sessionId);
         if (!ctx) return toolError("No user context");
         const check = requireScope(ctx.scopes, "read");
         if (check.error) return check.result;
 
         try {
-          const scheduled = await this.scheduledService.findAll(ctx.userId);
+          const scheduled = await this.scheduledService.getLlmScheduledList(
+            ctx.userId,
+            {
+              kind: args.kind,
+              accountIds: args.accountIds,
+              isActive: args.isActive,
+            },
+          );
           return toolResult(scheduled);
         } catch (err: unknown) {
           return safeToolError(err);

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.spec.ts
@@ -579,6 +579,183 @@ describe("ScheduledTransactionsService", () => {
     });
   });
 
+  describe("getLlmUpcomingBillsAndDeposits", () => {
+    it("classifies bills, deposits, transfers, and investments", async () => {
+      const rows = [
+        makeScheduled({
+          id: "s1",
+          name: "Rent",
+          amount: -1200,
+          account: { name: "Checking" } as any,
+        }),
+        makeScheduled({
+          id: "s2",
+          name: "Paycheck",
+          amount: 3000,
+          account: { name: "Checking" } as any,
+        }),
+        makeScheduled({
+          id: "s3",
+          name: "Move to Savings",
+          amount: -500,
+          isTransfer: true,
+          transferAccountId: "acc-2",
+          account: { name: "Checking" } as any,
+        }),
+        makeScheduled({
+          id: "s4",
+          name: "DRIP",
+          amount: -100,
+          isInvestment: true,
+          investmentAction: "BUY" as any,
+          account: { name: "Brokerage" } as any,
+        }),
+      ];
+      const qb = mockQueryBuilder(rows);
+      scheduledRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getLlmUpcomingBillsAndDeposits(userId);
+
+      expect(result.itemCount).toBe(4);
+      const kinds = result.items.map((i) => i.kind).sort();
+      expect(kinds).toEqual(["bill", "deposit", "investment", "transfer"]);
+      expect(result.totalUpcomingBills).toBe(1200);
+      expect(result.totalUpcomingDeposits).toBe(3000);
+    });
+
+    it("filters by kind", async () => {
+      const rows = [
+        makeScheduled({ id: "s1", amount: -100 }),
+        makeScheduled({ id: "s2", amount: 200 }),
+      ];
+      const qb = mockQueryBuilder(rows);
+      scheduledRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getLlmUpcomingBillsAndDeposits(userId, {
+        kind: "bill",
+      });
+
+      expect(result.itemCount).toBe(1);
+      expect(result.items[0].kind).toBe("bill");
+      expect(result.totalUpcomingDeposits).toBe(0);
+    });
+
+    it("filters by accountIds", async () => {
+      const rows = [
+        makeScheduled({ id: "s1", accountId: "acc-1", amount: -100 }),
+        makeScheduled({ id: "s2", accountId: "acc-2", amount: -200 }),
+      ];
+      const qb = mockQueryBuilder(rows);
+      scheduledRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getLlmUpcomingBillsAndDeposits(userId, {
+        accountIds: ["acc-2"],
+      });
+
+      expect(result.itemCount).toBe(1);
+      expect(result.items[0].id).toBe("s2");
+    });
+
+    it("counts overdue items (negative daysUntilDue)", async () => {
+      const rows = [
+        makeScheduled({
+          id: "s1",
+          amount: -100,
+          nextDueDate: "2000-01-01",
+        }),
+      ];
+      const qb = mockQueryBuilder(rows);
+      scheduledRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getLlmUpcomingBillsAndDeposits(userId);
+
+      expect(result.overdueCount).toBe(1);
+      expect(result.items[0].daysUntilDue).toBeLessThan(0);
+    });
+
+    it("returns daysWindow matching the days argument", async () => {
+      const qb = mockQueryBuilder([]);
+      scheduledRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getLlmUpcomingBillsAndDeposits(userId, {
+        days: 14,
+      });
+
+      expect(result.daysWindow).toBe(14);
+    });
+  });
+
+  describe("getLlmScheduledList", () => {
+    const stubFindAllReturns = (rows: ScheduledTransaction[]) => {
+      const stQb = mockQueryBuilder(rows);
+      scheduledRepo.createQueryBuilder.mockReturnValue(stQb);
+      const nextQb = mockQueryBuilder([]);
+      nextQb.getMany.mockResolvedValue([]);
+      const futureQb = mockQueryBuilder([]);
+      futureQb.getMany.mockResolvedValue([]);
+      overridesRepo.createQueryBuilder
+        .mockReturnValueOnce(nextQb)
+        .mockReturnValueOnce(futureQb);
+    };
+
+    it("returns rollup counts and curated items", async () => {
+      stubFindAllReturns([
+        makeScheduled({ id: "s1", amount: -100, autoPost: true }),
+        makeScheduled({ id: "s2", amount: 500, autoPost: false }),
+        makeScheduled({ id: "s3", amount: -200, isActive: false }),
+      ]);
+
+      const result = await service.getLlmScheduledList(userId);
+
+      expect(result.totalCount).toBe(3);
+      expect(result.activeCount).toBe(2);
+      expect(result.autoPostCount).toBe(1);
+      expect(result.billCount).toBe(2);
+      expect(result.depositCount).toBe(1);
+    });
+
+    it("filters by isActive=false", async () => {
+      stubFindAllReturns([
+        makeScheduled({ id: "s1", amount: -100, isActive: true }),
+        makeScheduled({ id: "s2", amount: -200, isActive: false }),
+      ]);
+
+      const result = await service.getLlmScheduledList(userId, {
+        isActive: false,
+      });
+
+      expect(result.totalCount).toBe(1);
+      expect(result.items[0].id).toBe("s2");
+    });
+
+    it("filters by kind=deposit", async () => {
+      stubFindAllReturns([
+        makeScheduled({ id: "s1", amount: -100 }),
+        makeScheduled({ id: "s2", amount: 500 }),
+      ]);
+
+      const result = await service.getLlmScheduledList(userId, {
+        kind: "deposit",
+      });
+
+      expect(result.totalCount).toBe(1);
+      expect(result.items[0].kind).toBe("deposit");
+    });
+
+    it("treats kind='all' as no filter", async () => {
+      stubFindAllReturns([
+        makeScheduled({ id: "s1", amount: -100 }),
+        makeScheduled({ id: "s2", amount: 500 }),
+      ]);
+
+      const result = await service.getLlmScheduledList(userId, {
+        kind: "all",
+      });
+
+      expect(result.totalCount).toBe(2);
+    });
+  });
+
   // ==================== update ====================
   describe("update", () => {
     it("should update simple fields", async () => {

--- a/backend/src/scheduled-transactions/scheduled-transactions.service.ts
+++ b/backend/src/scheduled-transactions/scheduled-transactions.service.ts
@@ -46,6 +46,55 @@ import {
 import { ActionHistoryService } from "../action-history/action-history.service";
 import { getUsersByEffectiveTimezone } from "../common/users-by-timezone.util";
 import { validateSplitAmountSum } from "../common/split-amount.util";
+import { roundMoney, sumMoney } from "../common/round.util";
+
+export type LlmScheduledKind = "bill" | "deposit" | "transfer" | "investment";
+
+export interface LlmScheduledItem {
+  id: string;
+  name: string;
+  accountId: string;
+  accountName: string;
+  payeeName: string | null;
+  categoryName: string | null;
+  amount: number;
+  currency: string;
+  frequency: FrequencyType;
+  nextDueDate: string;
+  daysUntilDue: number;
+  isActive: boolean;
+  autoPost: boolean;
+  kind: LlmScheduledKind;
+  description: string | null;
+}
+
+export interface LlmUpcomingScheduledResult {
+  daysWindow: number;
+  itemCount: number;
+  overdueCount: number;
+  totalUpcomingBills: number;
+  totalUpcomingDeposits: number;
+  items: LlmScheduledItem[];
+}
+
+export interface LlmScheduledListResult {
+  totalCount: number;
+  activeCount: number;
+  autoPostCount: number;
+  billCount: number;
+  depositCount: number;
+  items: LlmScheduledItem[];
+}
+
+export interface LlmScheduledFilter {
+  kind?: LlmScheduledKind | "all";
+  accountIds?: string[];
+  isActive?: boolean;
+}
+
+export interface LlmUpcomingFilter extends LlmScheduledFilter {
+  days?: number;
+}
 
 const INVESTMENT_RELATIONS = [
   "account",
@@ -682,6 +731,68 @@ export class ScheduledTransactionsService {
       .andWhere("st.nextDueDate <= :futureDate", { futureDate })
       .orderBy("st.nextDueDate", "ASC")
       .getMany();
+  }
+
+  /**
+   * Curated upcoming bills/deposits payload for AI Assistant and MCP. Both
+   * surfaces must return the same shape; the executor and MCP tool are thin
+   * adapters around this method.
+   *
+   * Items are classified by `kind` (bill / deposit / transfer / investment)
+   * so the LLM can answer "what bills are due" or "what deposits are coming
+   * in" without re-deriving sign or transfer/investment flags.
+   */
+  async getLlmUpcomingBillsAndDeposits(
+    userId: string,
+    filter: LlmUpcomingFilter = {},
+  ): Promise<LlmUpcomingScheduledResult> {
+    const days = filter.days ?? 30;
+    const rows = await this.findUpcoming(userId, days);
+    const today = todayYMD();
+    const items = rows
+      .map((r) => toLlmScheduledItem(r, today))
+      .filter((item) => matchesScheduledFilter(item, filter));
+
+    const billAmounts = items
+      .filter((i) => i.kind === "bill")
+      .map((i) => Math.abs(i.amount));
+    const depositAmounts = items
+      .filter((i) => i.kind === "deposit")
+      .map((i) => i.amount);
+
+    return {
+      daysWindow: days,
+      itemCount: items.length,
+      overdueCount: items.filter((i) => i.daysUntilDue < 0).length,
+      totalUpcomingBills: sumMoney(billAmounts),
+      totalUpcomingDeposits: sumMoney(depositAmounts),
+      items,
+    };
+  }
+
+  /**
+   * Curated list of all scheduled transactions (bills, deposits, transfers,
+   * investments) shaped for LLM consumption. Used by the AI Assistant and
+   * MCP `get_scheduled_transactions` tools so both return the same payload.
+   */
+  async getLlmScheduledList(
+    userId: string,
+    filter: LlmScheduledFilter = {},
+  ): Promise<LlmScheduledListResult> {
+    const rows = await this.findAll(userId);
+    const today = todayYMD();
+    const items = rows
+      .map((r) => toLlmScheduledItem(r, today))
+      .filter((item) => matchesScheduledFilter(item, filter));
+
+    return {
+      totalCount: items.length,
+      activeCount: items.filter((i) => i.isActive).length,
+      autoPostCount: items.filter((i) => i.autoPost).length,
+      billCount: items.filter((i) => i.kind === "bill").length,
+      depositCount: items.filter((i) => i.kind === "deposit").length,
+      items,
+    };
   }
 
   async update(
@@ -1432,4 +1543,60 @@ export class ScheduledTransactionsService {
       loanAccountId,
     );
   }
+}
+
+function classifyScheduledKind(row: ScheduledTransaction): LlmScheduledKind {
+  if (row.isTransfer) return "transfer";
+  if (row.isInvestment) return "investment";
+  return Number(row.amount) < 0 ? "bill" : "deposit";
+}
+
+function daysBetweenYMD(fromYMD: string, toYMD: string): number {
+  const from = new Date(`${fromYMD}T00:00:00.000Z`).getTime();
+  const to = new Date(`${toYMD}T00:00:00.000Z`).getTime();
+  return Math.round((to - from) / (1000 * 60 * 60 * 24));
+}
+
+function toLlmScheduledItem(
+  row: ScheduledTransaction,
+  todayYMDStr: string,
+): LlmScheduledItem {
+  const nextDueDate = ensureYMD(row.nextDueDate);
+  return {
+    id: row.id,
+    name: row.name,
+    accountId: row.accountId,
+    accountName: row.account?.name ?? "",
+    payeeName: row.payee?.name ?? row.payeeName ?? null,
+    categoryName: row.category?.name ?? null,
+    amount: roundMoney(Number(row.amount)),
+    currency: row.currencyCode,
+    frequency: row.frequency,
+    nextDueDate,
+    daysUntilDue: daysBetweenYMD(todayYMDStr, nextDueDate),
+    isActive: row.isActive,
+    autoPost: row.autoPost,
+    kind: classifyScheduledKind(row),
+    description: row.description ?? null,
+  };
+}
+
+function matchesScheduledFilter(
+  item: LlmScheduledItem,
+  filter: LlmScheduledFilter,
+): boolean {
+  if (filter.kind && filter.kind !== "all" && item.kind !== filter.kind) {
+    return false;
+  }
+  if (filter.isActive !== undefined && item.isActive !== filter.isActive) {
+    return false;
+  }
+  if (
+    filter.accountIds &&
+    filter.accountIds.length > 0 &&
+    !filter.accountIds.includes(item.accountId)
+  ) {
+    return false;
+  }
+  return true;
 }


### PR DESCRIPTION
Both surfaces now share the same scheduled-transaction shape (curated
LlmScheduledItem with bill/deposit/transfer/investment kind, daysUntilDue,
and amount/account/category fields) by routing through new
ScheduledTransactionsService.getLlmUpcomingBillsAndDeposits() and
getLlmScheduledList() helpers. The AI Assistant gains get_upcoming_bills
and get_scheduled_transactions tools, and the MCP scheduled tools now
return the same shape instead of raw entities.

https://claude.ai/code/session_01CqMUCBUgYeR1gT9BPw2c41