### PR TITLE
Display subcategories with parent prefix in reports

### DIFF
--- a/backend/src/reports/reports.service.spec.ts
+++ b/backend/src/reports/reports.service.spec.ts
@@ -888,6 +888,68 @@ describe("ReportsService", () => {
         expect(result.data[1].memo).toBe("Cleaning supplies");
       });
 
+      it("renders category as 'Parent: Child' for subcategories on individual transactions", async () => {
+        const parentCategory = {
+          ...mockCategory,
+          id: "cat-parent",
+          name: "Food",
+          parentId: null,
+          parent: null,
+        };
+        const childCategory = {
+          ...mockCategory,
+          id: "cat-child",
+          name: "Fast Food",
+          parentId: "cat-parent",
+          parent: parentCategory,
+        };
+        const transactions = [
+          createMockTransaction({
+            id: "tx-1",
+            amount: -25,
+            categoryId: "cat-child",
+            category: childCategory,
+          }),
+          createMockTransaction({
+            id: "tx-2",
+            amount: -10,
+            categoryId: "cat-1",
+            category: { ...mockCategory, parent: null } as Category,
+          }),
+          createMockTransaction({
+            id: "tx-3",
+            amount: -100,
+            isSplit: true,
+            splits: [
+              {
+                id: "split-1",
+                transactionId: "tx-3",
+                categoryId: "cat-child",
+                category: childCategory,
+                amount: -60,
+                memo: "Burgers",
+              } as any,
+            ],
+          }),
+        ];
+        setupExecuteMocks(
+          {
+            groupBy: GroupByType.NONE,
+            config: { ...defaultConfig, metric: MetricType.NONE },
+          },
+          transactions,
+        );
+
+        const result = await service.execute("user-1", "report-1");
+
+        expect(result.data).toHaveLength(3);
+        expect(result.data[0].category).toBe("Food: Fast Food");
+        // Top-level category keeps just its name
+        expect(result.data[1].category).toBe("Groceries");
+        // Split with subcategory also includes parent prefix
+        expect(result.data[2].category).toBe("Food: Fast Food");
+      });
+
       it("handles split transactions with TOTAL_AMOUNT metric by summing split amounts", async () => {
         const transactions = [
           createMockTransaction({
@@ -1011,6 +1073,50 @@ describe("ReportsService", () => {
         const dining = result.data.find((d) => d.label === "Dining");
         expect(groceries!.value).toBe(60);
         expect(dining!.value).toBe(40);
+      });
+
+      it("labels subcategories with their parent in 'Parent: Child' format", async () => {
+        const transactions = [
+          createMockTransaction({
+            id: "tx-1",
+            categoryId: "cat-child",
+            amount: -40,
+          }),
+          createMockTransaction({
+            id: "tx-2",
+            categoryId: "cat-1",
+            amount: -10,
+          }),
+        ];
+        const categories = [
+          mockCategory,
+          {
+            ...mockCategory,
+            id: "cat-child",
+            name: "Fast Food",
+            parentId: "cat-parent",
+          },
+          { ...mockCategory, id: "cat-parent", name: "Food", parentId: null },
+        ];
+        setupExecuteMocks(
+          {
+            groupBy: GroupByType.CATEGORY,
+            config: { ...defaultConfig, metric: MetricType.TOTAL_AMOUNT },
+          },
+          transactions,
+        );
+        categoriesRepository.find.mockResolvedValue(categories);
+
+        const result = await service.execute("user-1", "report-1");
+
+        expect(result.data).toHaveLength(2);
+        expect(result.data.find((d) => d.id === "cat-child")!.label).toBe(
+          "Food: Fast Food",
+        );
+        // Top-level category keeps its simple name
+        expect(result.data.find((d) => d.id === "cat-1")!.label).toBe(
+          "Groceries",
+        );
       });
 
       it("calculates percentages for category aggregation", async () => {
@@ -1949,9 +2055,11 @@ describe("ReportsService", () => {
         );
         expect(joinCalls).toContain("transaction.account");
         expect(joinCalls).toContain("transaction.category");
+        expect(joinCalls).toContain("category.parent");
         expect(joinCalls).toContain("transaction.payee");
         expect(joinCalls).toContain("transaction.splits");
         expect(joinCalls).toContain("splits.category");
+        expect(joinCalls).toContain("splitCategory.parent");
       });
     });
 

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -362,10 +362,12 @@ export class ReportsService {
       .createQueryBuilder("transaction")
       .leftJoinAndSelect("transaction.account", "account")
       .leftJoinAndSelect("transaction.category", "category")
+      .leftJoinAndSelect("category.parent", "categoryParent")
       .leftJoinAndSelect("transaction.payee", "payee")
       .leftJoinAndSelect("transaction.tags", "tags")
       .leftJoinAndSelect("transaction.splits", "splits")
       .leftJoinAndSelect("splits.category", "splitCategory")
+      .leftJoinAndSelect("splitCategory.parent", "splitCategoryParent")
       .leftJoinAndSelect("splits.tags", "splitTags")
       .where("transaction.userId = :userId", { userId })
       .andWhere("transaction.transactionDate >= :startDate", { startDate })
@@ -591,6 +593,14 @@ export class ReportsService {
     }
   }
 
+  private formatCategoryLabel(
+    category: Category | null | undefined,
+  ): string | undefined {
+    if (!category) return undefined;
+    if (category.parent) return `${category.parent.name}: ${category.name}`;
+    return category.name;
+  }
+
   private aggregateNoGrouping(
     transactions: Transaction[],
     metric: MetricType,
@@ -613,7 +623,7 @@ export class ReportsService {
               payee: tx.payeeName || tx.payee?.name || undefined,
               description: tx.description || undefined,
               memo: split.memo || undefined,
-              category: split.category?.name || undefined,
+              category: this.formatCategoryLabel(split.category),
               account: tx.account?.name || undefined,
             });
           }
@@ -628,7 +638,7 @@ export class ReportsService {
             payee: tx.payeeName || tx.payee?.name || undefined,
             description: tx.description || undefined,
             memo: undefined, // Transactions don't have memo, only splits do
-            category: tx.category?.name || undefined,
+            category: this.formatCategoryLabel(tx.category),
             account: tx.account?.name || undefined,
           });
         }
@@ -702,9 +712,17 @@ export class ReportsService {
     const result: AggregatedDataPoint[] = [];
     for (const [categoryId, data] of dataMap) {
       const category = categoryMap.get(categoryId);
+      const parent = category?.parentId
+        ? categoryMap.get(category.parentId)
+        : null;
+      const label = category
+        ? parent
+          ? `${parent.name}: ${category.name}`
+          : category.name
+        : "Uncategorized";
       result.push({
         id: categoryId,
-        label: category?.name || "Uncategorized",
+        label,
         value: this.calculateMetricValue(data.sum, data.count, metric),
         color: category?.color || undefined,
         percentage: totalSum > 0 ? (data.sum / totalSum) * 100 : 0,

--- a/frontend/src/components/reports/ReportChart.test.tsx
+++ b/frontend/src/components/reports/ReportChart.test.tsx
@@ -169,7 +169,7 @@ describe('ReportChart', () => {
         payee: 'Store A',
         description: 'Groceries shopping',
         memo: 'Weekly groceries',
-        category: 'Food',
+        category: 'Food: Fast Food',
         account: 'Chequing',
       },
     ];
@@ -201,6 +201,8 @@ describe('ReportChart', () => {
     expect(screen.getByText('Count')).toBeInTheDocument();
     expect(screen.getByText('Store A')).toBeInTheDocument();
     expect(screen.getByText('Weekly groceries')).toBeInTheDocument();
+    // Category column shows 'Parent: Child' format for subcategories
+    expect(screen.getByText('Food: Fast Food')).toBeInTheDocument();
   });
 
   it('renders dash for missing optional fields', () => {


### PR DESCRIPTION
## Summary
Add support for displaying subcategories in the "Parent: Child" format throughout the reports module. This improves clarity when viewing transactions and aggregated data that use category hierarchies.

## Key Changes
- **Query optimization**: Added eager loading of parent categories in the transaction query builder (`category.parent` and `splitCategory.parent` joins) to avoid N+1 queries
- **New helper method**: Introduced `formatCategoryLabel()` to consistently format category display as "Parent: Child" for subcategories, or just the category name for top-level categories
- **Individual transactions**: Updated `aggregateNoGrouping()` to use the new formatter for both regular transactions and split transactions
- **Category aggregation**: Updated `aggregateByCategoryGrouping()` to format category labels with parent prefix when grouping by category
- **Test coverage**: Added comprehensive test cases for:
  - Individual transaction rendering with subcategories
  - Split transactions with subcategories
  - Category aggregation with parent-child formatting
  - Query builder join verification

## Implementation Details
- The `formatCategoryLabel()` method checks if a category has a parent and formats accordingly, returning `undefined` for null/undefined categories
- Parent category data is loaded eagerly in the query to ensure it's available during formatting (prevents lazy-loading issues)
- Top-level categories (those without a parent) display only their name, maintaining backward compatibility
- The formatting is applied consistently across all report views (no grouping, category grouping, and split transactions)

https://claude.ai/code/session_019YUkuB5nWFNbRXwKp4McQT