### PR TITLE
Add Help & Support section to settings and improve page headers

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -44,9 +44,9 @@ import { ScheduledTransaction } from '@/types/scheduled-transaction';
 import { TopMover, PortfolioSummary, FavouriteSecurityQuote } from '@/types/investment';
 import { MonthlyNetWorth } from '@/types/net-worth';
 import { PageLayout } from '@/components/layout/PageLayout';
+import { PageHeader } from '@/components/layout/PageHeader';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { usePriceRefresh } from '@/hooks/usePriceRefresh';
-import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('Dashboard');
@@ -212,25 +212,11 @@ function DashboardContent() {
       <main className="px-4 sm:px-6 lg:px-12 pt-6 pb-8">
         <div className="sm:px-0">
           {/* Welcome section */}
-          <div className="mb-6">
-            <div className="flex items-center gap-2">
-              <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-                Welcome{user?.firstName ? `, ${user.firstName}` : ''}!
-              </h1>
-              <a
-                href="https://github.com/kenlasko/monize/wiki/Dashboard"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-gray-400 hover:text-blue-500 transition-colors"
-                aria-label="Help"
-              >
-                <QuestionMarkCircleIcon className="h-5 w-5" />
-              </a>
-            </div>
-            <p className="text-gray-500 dark:text-gray-400">
-              Here&apos;s your financial overview
-            </p>
-          </div>
+          <PageHeader
+            title={`Welcome${user?.firstName ? `, ${user.firstName}` : ''}!`}
+            subtitle="Here's your financial overview"
+            helpUrl="https://github.com/kenlasko/monize/wiki/Dashboard"
+          />
 
           {isDelegateView ? (
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -13,6 +13,7 @@ import { DangerZoneSection } from '@/components/settings/DangerZoneSection';
 import { BackupRestoreSection } from '@/components/settings/BackupRestoreSection';
 import { AutoBackupSection } from '@/components/settings/AutoBackupSection';
 import { ApiAccessSection } from '@/components/settings/ApiAccessSection';
+import { HelpSection } from '@/components/settings/HelpSection';
 import { SettingsNav, SettingsSection } from '@/components/settings/SettingsNav';
 import { useScrollSpy } from '@/hooks/useScrollSpy';
 import { userSettingsApi } from '@/lib/user-settings';
@@ -38,7 +39,8 @@ const ALL_SETTINGS_SECTIONS: readonly (SettingsSection & { demoVisible?: boolean
   { id: 'ai-settings', label: 'AI Settings', href: '/settings/ai' },
   { id: 'backup-restore', label: 'Backup & Restore' },
   { id: 'auto-backup', label: 'Automatic Backup' },
-  { id: 'danger-zone', label: 'Danger Zone' },
+  { id: 'help', label: 'Help & Support' },
+  { id: 'danger-zone', label: 'Danger Zone', variant: 'danger' },
 ] as const;
 
 export default function SettingsPage() {
@@ -363,6 +365,10 @@ function OwnerSettingsView() {
                 <AutoBackupSection />
               </div>
             )}
+
+            <div id="help" className="scroll-mt-32 lg:scroll-mt-22">
+              <HelpSection />
+            </div>
 
             {!isDemoMode && user && (
               <div id="danger-zone" className="scroll-mt-32 lg:scroll-mt-22">

--- a/frontend/src/components/settings/HelpSection.test.tsx
+++ b/frontend/src/components/settings/HelpSection.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@/test/render';
+import { HelpSection } from './HelpSection';
+
+// Mock heroicons so the icons render as simple svgs in tests
+vi.mock('@heroicons/react/24/outline', () => ({
+  ArrowTopRightOnSquareIcon: (props: any) => <svg data-testid="external-icon" {...props} />,
+  BookOpenIcon: (props: any) => <svg data-testid="book-icon" {...props} />,
+  ChatBubbleLeftRightIcon: (props: any) => <svg data-testid="chat-icon" {...props} />,
+  CodeBracketIcon: (props: any) => <svg data-testid="code-icon" {...props} />,
+  ExclamationTriangleIcon: (props: any) => <svg data-testid="warning-icon" {...props} />,
+}));
+
+const REPO_URL = 'https://github.com/kenlasko/monize';
+
+describe('HelpSection', () => {
+  it('renders the section heading', () => {
+    render(<HelpSection />);
+    expect(screen.getByRole('heading', { name: 'Help & Support' })).toBeInTheDocument();
+  });
+
+  it('renders a GitHub link to the repository', () => {
+    render(<HelpSection />);
+    const link = screen.getByText('GitHub').closest('a');
+    expect(link).toHaveAttribute('href', REPO_URL);
+  });
+
+  it('renders a link to open a new issue', () => {
+    render(<HelpSection />);
+    const link = screen.getByText('Open an Issue').closest('a');
+    expect(link).toHaveAttribute('href', `${REPO_URL}/issues/new`);
+  });
+
+  it('renders a link to Discussions', () => {
+    render(<HelpSection />);
+    const link = screen.getByText('Discussions').closest('a');
+    expect(link).toHaveAttribute('href', `${REPO_URL}/discussions`);
+  });
+
+  it('renders a link to the wiki', () => {
+    render(<HelpSection />);
+    const link = screen.getByText('Wiki').closest('a');
+    expect(link).toHaveAttribute('href', `${REPO_URL}/wiki`);
+  });
+
+  it('opens all links in a new tab with safe rel attributes', () => {
+    render(<HelpSection />);
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(4);
+    for (const link of links) {
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    }
+  });
+});

--- a/frontend/src/components/settings/HelpSection.tsx
+++ b/frontend/src/components/settings/HelpSection.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import {
+  ArrowTopRightOnSquareIcon,
+  BookOpenIcon,
+  ChatBubbleLeftRightIcon,
+  CodeBracketIcon,
+  ExclamationTriangleIcon,
+} from '@heroicons/react/24/outline';
+
+interface HelpLink {
+  readonly label: string;
+  readonly description: string;
+  readonly href: string;
+  readonly Icon: typeof CodeBracketIcon;
+}
+
+const REPO_URL = 'https://github.com/kenlasko/monize';
+
+const HELP_LINKS: readonly HelpLink[] = [
+  {
+    label: 'GitHub',
+    description: 'View the source code and star the project.',
+    href: REPO_URL,
+    Icon: CodeBracketIcon,
+  },
+  {
+    label: 'Open an Issue',
+    description: 'Report a bug or request a feature.',
+    href: `${REPO_URL}/issues/new`,
+    Icon: ExclamationTriangleIcon,
+  },
+  {
+    label: 'Discussions',
+    description: 'Ask questions and share ideas with the community.',
+    href: `${REPO_URL}/discussions`,
+    Icon: ChatBubbleLeftRightIcon,
+  },
+  {
+    label: 'Wiki',
+    description: 'Browse guides and documentation.',
+    href: `${REPO_URL}/wiki`,
+    Icon: BookOpenIcon,
+  },
+] as const;
+
+export function HelpSection() {
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg p-6 mb-6">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">
+        Help & Support
+      </h2>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        Find documentation, report issues, or join the conversation.
+      </p>
+      <ul className="space-y-2">
+        {HELP_LINKS.map(({ label, description, href, Icon }) => (
+          <li key={href}>
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-3 rounded-md border border-gray-200 dark:border-gray-700 px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+            >
+              <Icon className="h-6 w-6 shrink-0 text-gray-400 dark:text-gray-500" />
+              <span className="min-w-0 flex-1">
+                <span className="block text-sm font-medium text-gray-900 dark:text-gray-100">
+                  {label}
+                </span>
+                <span className="block text-sm text-gray-500 dark:text-gray-400">
+                  {description}
+                </span>
+              </span>
+              <ArrowTopRightOnSquareIcon className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/SettingsNav.test.tsx
+++ b/frontend/src/components/settings/SettingsNav.test.tsx
@@ -323,6 +323,73 @@ describe('SettingsNav', () => {
     });
   });
 
+  describe('danger variant styling', () => {
+    const dangerSections: SettingsSection[] = [
+      { id: 'profile', label: 'Profile' },
+      { id: 'danger-zone', label: 'Danger Zone', variant: 'danger' },
+    ];
+
+    it('renders a danger section in red text in the vertical sidebar', () => {
+      render(
+        <SettingsNav
+          sections={dangerSections}
+          activeSection="profile"
+          onSectionClick={onSectionClick}
+          variant="vertical"
+        />,
+      );
+
+      const dangerButton = screen.getByText('Danger Zone');
+      expect(dangerButton.className).toContain('text-red-600');
+      expect(dangerButton.className).not.toContain('text-gray-700');
+    });
+
+    it('renders an active danger section with red background in the vertical sidebar', () => {
+      render(
+        <SettingsNav
+          sections={dangerSections}
+          activeSection="danger-zone"
+          onSectionClick={onSectionClick}
+          variant="vertical"
+        />,
+      );
+
+      const dangerButton = screen.getByText('Danger Zone');
+      expect(dangerButton.className).toContain('bg-red-50');
+      expect(dangerButton.className).toContain('text-red-700');
+      expect(dangerButton.className).not.toContain('bg-blue-50');
+    });
+
+    it('renders a danger section in red text in the horizontal tabs', () => {
+      render(
+        <SettingsNav
+          sections={dangerSections}
+          activeSection="profile"
+          onSectionClick={onSectionClick}
+          variant="horizontal"
+        />,
+      );
+
+      const dangerTab = screen.getByText('Danger Zone');
+      expect(dangerTab.className).toContain('text-red-600');
+    });
+
+    it('leaves non-danger sections with their default gray styling', () => {
+      render(
+        <SettingsNav
+          sections={dangerSections}
+          activeSection="danger-zone"
+          onSectionClick={onSectionClick}
+          variant="vertical"
+        />,
+      );
+
+      const profileButton = screen.getByText('Profile');
+      expect(profileButton.className).toContain('text-gray-700');
+      expect(profileButton.className).not.toContain('text-red-600');
+    });
+  });
+
   describe('default variant', () => {
     it('defaults to vertical variant when not specified', () => {
       render(

--- a/frontend/src/components/settings/SettingsNav.tsx
+++ b/frontend/src/components/settings/SettingsNav.tsx
@@ -9,6 +9,8 @@ export interface SettingsSection {
   readonly label: string;
   /** If set, renders as a navigation link instead of a scroll-to button */
   readonly href?: string;
+  /** Visual treatment for the nav item (e.g. 'danger' renders in red) */
+  readonly variant?: 'default' | 'danger';
 }
 
 interface SettingsNavProps {
@@ -82,6 +84,8 @@ export function SettingsNav({
             );
           }
 
+          const isDanger = section.variant === 'danger';
+
           return (
             <button
               key={section.id}
@@ -90,8 +94,12 @@ export function SettingsNav({
               className={`
                 whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-medium transition-colors shrink-0
                 ${isActive
-                  ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-200'
-                  : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-gray-200'
+                  ? isDanger
+                    ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+                    : 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-200'
+                  : isDanger
+                    ? 'text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/30'
+                    : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-gray-200'
                 }
               `}
               role="tab"
@@ -138,6 +146,8 @@ export function SettingsNav({
             );
           }
 
+          const isDanger = section.variant === 'danger';
+
           return (
             <li key={section.id}>
               <button
@@ -146,8 +156,12 @@ export function SettingsNav({
                 className={`
                   w-full text-left rounded-md px-3 py-2 text-sm font-medium transition-colors
                   ${isActive
-                    ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/50 dark:text-blue-200'
-                    : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                    ? isDanger
+                      ? 'bg-red-50 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+                      : 'bg-blue-50 text-blue-700 dark:bg-blue-900/50 dark:text-blue-200'
+                    : isDanger
+                      ? 'text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30'
+                      : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
                   }
                 `}
               >


### PR DESCRIPTION
## Summary
Adds a new Help & Support section to the settings page with links to GitHub, issue tracker, discussions, and wiki. Also introduces a reusable `PageHeader` component and refactors the dashboard welcome section to use it. Updates `SettingsNav` to support a "danger" variant for visual distinction of destructive actions.

## Key Changes

- **New `HelpSection` component** (`frontend/src/components/settings/HelpSection.tsx`)
  - Displays four help links (GitHub, Open an Issue, Discussions, Wiki) with icons and descriptions
  - Opens all links in new tabs with safe `rel="noopener noreferrer"` attributes
  - Includes full test coverage

- **New `PageHeader` component** (`frontend/src/components/layout/PageHeader.tsx`)
  - Reusable header component with title, subtitle, and optional help link
  - Replaces inline header markup in dashboard

- **Enhanced `SettingsNav` component**
  - Added `variant?: 'default' | 'danger'` prop to `SettingsSection` interface
  - Danger sections render in red (both horizontal tabs and vertical sidebar)
  - Active danger sections use red background instead of blue
  - Includes comprehensive test coverage for danger variant styling

- **Updated settings page**
  - Integrated `HelpSection` before the Danger Zone section
  - Added "Help & Support" nav item with danger zone marked as `variant: 'danger'`

- **Refactored dashboard page**
  - Replaced inline welcome header with `PageHeader` component
  - Removed `QuestionMarkCircleIcon` import (now handled by PageHeader)
  - Cleaner, more maintainable code

## Testing
- Added `HelpSection.test.tsx` with 5 test cases covering all links and attributes
- Added 4 new test cases to `SettingsNav.test.tsx` for danger variant styling
- All tests verify correct styling, links, and accessibility attributes

https://claude.ai/code/session_01BSRUxkQpjB3UKmAHcs22mv