### PR TITLE
Remove h-full from refresh button className

### DIFF
--- a/frontend/src/app/investments/page.tsx
+++ b/frontend/src/app/investments/page.tsx
@@ -189,7 +189,7 @@ function InvestmentsContent() {
                     variant="outline"
                     onClick={handleRefreshClick}
                     disabled={data.isRefreshingPrices}
-                    className="whitespace-nowrap h-full"
+                    className="whitespace-nowrap"
                     title={data.lastPriceUpdate ? `Last updated: ${formatRelativeTime(data.lastPriceUpdate)}` : 'Never updated'}
                   >
                     {data.isRefreshingPrices ? (


### PR DESCRIPTION
## Summary
Removed the `h-full` Tailwind CSS class from the refresh prices button in the investments page, keeping only the `whitespace-nowrap` class.

## Changes
- Removed `h-full` from the refresh button's className on the investments page
- This allows the button to size naturally based on its content rather than stretching to fill the full height of its container

## Details
The `h-full` class was causing the button to stretch vertically to match its container's height. Removing it allows for more natural button sizing while maintaining the `whitespace-nowrap` class to prevent text wrapping.

https://claude.ai/code/session_01Sbz3ywKD2uUn2CygUfTUZi