### PR TITLE
fix(settings): anchor settings menu to disappearing header

### DIFF
--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -235,7 +235,7 @@ function OwnerSettingsView() {
         )}
 
         {/* Mobile horizontal tabs */}
-        <div className="lg:hidden sticky top-16 z-10 -mx-4 px-4 py-2 bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 mb-6">
+        <div className="lg:hidden sticky top-[calc(4rem-var(--app-header-offset,0px))] z-10 -mx-4 px-4 py-2 bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 mb-6">
           <SettingsNav
             sections={visibleSections}
             activeSection={activeSection}
@@ -247,7 +247,7 @@ function OwnerSettingsView() {
         <div className="lg:flex lg:gap-10">
           {/* Desktop sidebar */}
           <aside className="hidden lg:block lg:w-52 shrink-0">
-            <div className="sticky top-22">
+            <div className="sticky top-[calc(5.5rem-var(--app-header-offset,0px))]">
               <SettingsNav
                 sections={visibleSections}
                 activeSection={activeSection}

--- a/frontend/src/components/layout/AppHeader.test.tsx
+++ b/frontend/src/components/layout/AppHeader.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@/test/render';
 import { AppHeader } from './AppHeader';
 
@@ -517,5 +517,30 @@ describe('AppHeader', () => {
     expect(screen.queryByText('test@example.com')).not.toBeInTheDocument();
     // Admin link should not appear
     expect(screen.queryByText('Admin')).not.toBeInTheDocument();
+  });
+
+  describe('header offset CSS variable', () => {
+    afterEach(() => {
+      document.documentElement.style.removeProperty('--app-header-offset');
+    });
+
+    it('publishes the current header offset so sticky sub-navs can anchor to it', () => {
+      render(<AppHeader />);
+      // Header starts fully visible: offset is 0 until the user scrolls.
+      expect(
+        document.documentElement.style.getPropertyValue('--app-header-offset'),
+      ).toBe('0px');
+    });
+
+    it('clears the offset variable when the header unmounts', () => {
+      const { unmount } = render(<AppHeader />);
+      expect(
+        document.documentElement.style.getPropertyValue('--app-header-offset'),
+      ).toBe('0px');
+      unmount();
+      expect(
+        document.documentElement.style.getPropertyValue('--app-header-offset'),
+      ).toBe('');
+    });
   });
 });

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -156,6 +156,17 @@ export function AppHeader() {
   const anyMenuOpen = mobileMenuOpen || searchOpen || toolsOpen || aiOpen;
   const headerOffset = anyMenuOpen ? 0 : scrollOffset;
 
+  // Publish how far the header is currently slid up so sticky sub-navigation
+  // (e.g. the Settings menu) can anchor to the header instead of floating where
+  // the header used to be once it slides out of view.
+  useEffect(() => {
+    const root = document.documentElement;
+    root.style.setProperty('--app-header-offset', `${headerOffset}px`);
+    return () => {
+      root.style.removeProperty('--app-header-offset');
+    };
+  }, [headerOffset]);
+
   const handleLogout = async () => {
     try {
       await authApi.logout();


### PR DESCRIPTION
The Settings sub-navigation used fixed sticky offsets (top-16 mobile,
top-22 desktop) that assumed the main header was always present. After
the header was made to slide out of view on scroll, the settings menu
stayed pinned where the header's bottom edge used to be, leaving it
floating in mid air.

AppHeader now publishes its live slide-up distance as a
--app-header-offset CSS variable on the document root. The settings nav
subtracts that offset from its sticky top, so it tracks the header in
lockstep and sits flush against the top of the viewport once the header
is fully hidden.

https://claude.ai/code/session_012YpfTxJTWqbznun5AShnBR