### PR TITLE
Support hierarchical category labels in payee display and sorting

### DIFF
--- a/backend/src/payees/payees.service.spec.ts
+++ b/backend/src/payees/payees.service.spec.ts
@@ -506,7 +506,13 @@ describe("PayeesService", () => {
     });
 
     it("should update defaultCategoryId via explicit mapping", async () => {
-      const existingPayee = { ...mockPayee };
+      // Existing payee already has a loaded relation pointing at the old
+      // category -- this is the scenario that exposed the persistence bug.
+      const existingPayee = {
+        ...mockPayee,
+        defaultCategoryId: "cat-1",
+        defaultCategory: { id: "cat-1", name: "Food" },
+      };
       const refreshedPayee = { ...mockPayee, defaultCategoryId: "cat-99" };
       payeesRepository.findOne
         .mockResolvedValueOnce(existingPayee)
@@ -517,9 +523,12 @@ describe("PayeesService", () => {
       });
 
       expect(result.defaultCategoryId).toBe("cat-99");
-      expect(
-        mockDataSource.createQueryRunner().manager.save,
-      ).toHaveBeenCalled();
+      // The stale loaded relation must be cleared so TypeORM save() persists
+      // the new scalar FK instead of re-deriving the old one from the relation.
+      const savedPayee =
+        mockDataSource.createQueryRunner().manager.save.mock.calls[0][0];
+      expect(savedPayee.defaultCategoryId).toBe("cat-99");
+      expect(savedPayee.defaultCategory).toBeNull();
     });
 
     it("should clear defaultCategoryId when set to null", async () => {

--- a/backend/src/payees/payees.service.ts
+++ b/backend/src/payees/payees.service.ts
@@ -311,11 +311,11 @@ export class PayeesService {
     if (updatePayeeDto.name !== undefined) payee.name = updatePayeeDto.name;
     if (updatePayeeDto.defaultCategoryId !== undefined) {
       payee.defaultCategoryId = updatePayeeDto.defaultCategoryId;
-      // Must also clear the loaded relation object, otherwise TypeORM's save()
-      // re-derives the FK from the stale relation entity and ignores the null.
-      if (updatePayeeDto.defaultCategoryId === null) {
-        payee.defaultCategory = null as any;
-      }
+      // Always clear the loaded relation object. Otherwise TypeORM's save()
+      // re-derives the FK from the stale relation entity and ignores the
+      // changed scalar -- so switching to a different category (or to null)
+      // would silently not persist.
+      payee.defaultCategory = null as any;
     }
     if (updatePayeeDto.notes !== undefined) payee.notes = updatePayeeDto.notes;
     if (updatePayeeDto.isActive !== undefined)

--- a/frontend/src/app/payees/page.test.tsx
+++ b/frontend/src/app/payees/page.test.tsx
@@ -89,6 +89,7 @@ vi.mock('@/lib/payees', () => ({
 
 vi.mock('@/lib/categoryUtils', () => ({
   buildCategoryColorMap: () => new Map(),
+  buildCategoryLabelMap: () => new Map(),
 }));
 
 vi.mock('@/lib/categories', () => ({

--- a/frontend/src/app/payees/page.tsx
+++ b/frontend/src/app/payees/page.tsx
@@ -13,7 +13,7 @@ import { Modal } from '@/components/ui/Modal';
 import { UnsavedChangesDialog } from '@/components/ui/UnsavedChangesDialog';
 import { payeesApi } from '@/lib/payees';
 import { categoriesApi } from '@/lib/categories';
-import { buildCategoryColorMap } from '@/lib/categoryUtils';
+import { buildCategoryColorMap, buildCategoryLabelMap } from '@/lib/categoryUtils';
 import { MergePayeeDialog } from '@/components/payees/MergePayeeDialog';
 import { Payee, PayeeStatusFilter } from '@/types/payee';
 import { Category } from '@/types/category';
@@ -126,6 +126,7 @@ function PayeesContent() {
   };
 
   const categoryColorMap = useMemo(() => buildCategoryColorMap(categories), [categories]);
+  const categoryLabelMap = useMemo(() => buildCategoryLabelMap(categories), [categories]);
 
   // Apply status filter
   const statusFilteredPayees = useMemo(() => {
@@ -309,6 +310,7 @@ function PayeesContent() {
               sortDirection={sortDirection}
               onSort={handleSort}
               categoryColorMap={categoryColorMap}
+              categoryLabelMap={categoryLabelMap}
             />
           )}
         </div>

--- a/frontend/src/app/payees/page.tsx
+++ b/frontend/src/app/payees/page.tsx
@@ -147,8 +147,8 @@ function PayeesContent() {
       if (sortField === 'name') {
         comparison = a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
       } else if (sortField === 'category') {
-        const catA = a.defaultCategory?.name || '';
-        const catB = b.defaultCategory?.name || '';
+        const catA = a.defaultCategory ? (categoryLabelMap.get(a.defaultCategory.id) ?? a.defaultCategory.name) : '';
+        const catB = b.defaultCategory ? (categoryLabelMap.get(b.defaultCategory.id) ?? b.defaultCategory.name) : '';
         comparison = catA.localeCompare(catB, undefined, { sensitivity: 'base' });
       } else if (sortField === 'count') {
         comparison = (a.transactionCount ?? 0) - (b.transactionCount ?? 0);
@@ -161,7 +161,7 @@ function PayeesContent() {
       }
       return sortDirection === 'asc' ? comparison : -comparison;
     });
-  }, [filteredPayees, sortField, sortDirection]);
+  }, [filteredPayees, sortField, sortDirection, categoryLabelMap]);
 
   const totalPages = Math.ceil(sortedPayees.length / PAGE_SIZE);
   const paginatedPayees = useMemo(() => {

--- a/frontend/src/components/payees/PayeeList.test.tsx
+++ b/frontend/src/components/payees/PayeeList.test.tsx
@@ -107,6 +107,77 @@ describe('PayeeList', () => {
     expect(screen.getByText('Groceries')).toBeInTheDocument();
   });
 
+  it('shows full "Parent: Child" label when categoryLabelMap is provided', () => {
+    const payees = [
+      makePayee({
+        id: 'p1',
+        name: 'Walmart',
+        defaultCategory: {
+          id: 'cat-1',
+          userId: 'user-1',
+          parentId: 'parent-1',
+          parent: null,
+          children: [],
+          name: 'Groceries',
+          description: null,
+          icon: null,
+          color: '#22c55e',
+          effectiveColor: '#22c55e',
+          isIncome: false,
+          isSystem: false,
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+      }),
+    ];
+    const categoryLabelMap = new Map([['cat-1', 'Food: Groceries']]);
+
+    render(
+      <PayeeList
+        payees={payees}
+        onEdit={onEdit}
+        onRefresh={onRefresh}
+        categoryLabelMap={categoryLabelMap}
+      />,
+    );
+    expect(screen.getByText('Food: Groceries')).toBeInTheDocument();
+    expect(screen.queryByText('Groceries')).not.toBeInTheDocument();
+  });
+
+  it('falls back to category name when categoryLabelMap has no entry', () => {
+    const payees = [
+      makePayee({
+        id: 'p1',
+        name: 'Walmart',
+        defaultCategory: {
+          id: 'cat-1',
+          userId: 'user-1',
+          parentId: null,
+          parent: null,
+          children: [],
+          name: 'Groceries',
+          description: null,
+          icon: null,
+          color: '#22c55e',
+          effectiveColor: '#22c55e',
+          isIncome: false,
+          isSystem: false,
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+      }),
+    ];
+    const categoryLabelMap = new Map([['cat-other', 'Food: Other']]);
+
+    render(
+      <PayeeList
+        payees={payees}
+        onEdit={onEdit}
+        onRefresh={onRefresh}
+        categoryLabelMap={categoryLabelMap}
+      />,
+    );
+    expect(screen.getByText('Groceries')).toBeInTheDocument();
+  });
+
   it('shows "None" when payee has no default category', () => {
     const payees = [
       makePayee({ id: 'p1', name: 'Walmart', defaultCategory: null }),

--- a/frontend/src/components/payees/PayeeList.test.tsx
+++ b/frontend/src/components/payees/PayeeList.test.tsx
@@ -406,6 +406,52 @@ describe('PayeeList', () => {
     expect(screen.getByText('Netflix')).toBeInTheDocument();
   });
 
+  it('sorts by full category label when categoryLabelMap is provided', () => {
+    // Leaf names would order Walmart (Apples) before Netflix (Zebra), but the
+    // full labels invert that: "Zoo: Apples" sorts after "Animals: Zebra".
+    const payees = [
+      makePayee({
+        id: 'p1',
+        name: 'Walmart',
+        defaultCategory: {
+          id: 'cat-1', userId: 'u', parentId: 'zoo', parent: null, children: [],
+          name: 'Apples', description: null, icon: null, color: null, effectiveColor: null,
+          isIncome: false, isSystem: false, createdAt: '',
+        },
+      }),
+      makePayee({
+        id: 'p2',
+        name: 'Netflix',
+        defaultCategory: {
+          id: 'cat-2', userId: 'u', parentId: 'animals', parent: null, children: [],
+          name: 'Zebra', description: null, icon: null, color: null, effectiveColor: null,
+          isIncome: false, isSystem: false, createdAt: '',
+        },
+      }),
+    ];
+    const categoryLabelMap = new Map([
+      ['cat-1', 'Zoo: Apples'],
+      ['cat-2', 'Animals: Zebra'],
+    ]);
+
+    const { container } = render(
+      <PayeeList
+        payees={payees}
+        onEdit={onEdit}
+        onRefresh={onRefresh}
+        categoryLabelMap={categoryLabelMap}
+      />,
+    );
+    fireEvent.click(screen.getByText('Default Category'));
+
+    const names = Array.from(container.querySelectorAll('tbody tr')).map(
+      (row) => row.querySelector('td')?.textContent?.trim(),
+    );
+    // Ascending by full label: "Animals: Zebra" (Netflix) < "Zoo: Apples" (Walmart)
+    expect(names[0]).toBe('Netflix');
+    expect(names[1]).toBe('Walmart');
+  });
+
   it('sorts by count when Count header is clicked', () => {
     const payees = [
       makePayee({ id: 'p1', name: 'Walmart', transactionCount: 10 }),

--- a/frontend/src/components/payees/PayeeList.tsx
+++ b/frontend/src/components/payees/PayeeList.tsx
@@ -35,6 +35,7 @@ interface PayeeListProps {
   sortDirection?: SortDirection;
   onSort?: (field: SortField) => void;
   categoryColorMap?: Map<string, string | null>;
+  categoryLabelMap?: Map<string, string>;
 }
 
 interface PayeeRowProps {
@@ -49,6 +50,7 @@ interface PayeeRowProps {
   showStatusColumn: boolean;
   index: number;
   categoryColorMap?: Map<string, string | null>;
+  categoryLabelMap?: Map<string, string>;
   formatDate: (date: string) => string;
 }
 
@@ -64,10 +66,14 @@ const PayeeRow = memo(function PayeeRow({
   showStatusColumn,
   index,
   categoryColorMap,
+  categoryLabelMap,
   formatDate,
 }: PayeeRowProps) {
   const defaultCategoryColor = payee.defaultCategory
     ? (categoryColorMap?.get(payee.defaultCategory.id) ?? payee.defaultCategory.color)
+    : null;
+  const defaultCategoryLabel = payee.defaultCategory
+    ? (categoryLabelMap?.get(payee.defaultCategory.id) ?? payee.defaultCategory.name)
     : null;
   const handleEdit = useCallback(() => {
     onEdit(payee);
@@ -115,7 +121,7 @@ const PayeeRow = memo(function PayeeRow({
                 : 'var(--category-text-base, #6b7280)',
             }}
           >
-            {payee.defaultCategory.name}
+            {defaultCategoryLabel}
           </span>
         ) : (
           <span className="text-sm text-gray-400 dark:text-gray-500">None</span>
@@ -209,6 +215,7 @@ export function PayeeList({
   sortDirection: propSortDirection,
   onSort,
   categoryColorMap,
+  categoryLabelMap,
 }: PayeeListProps) {
   const router = useRouter();
   const { formatDate } = useDateFormat();
@@ -402,6 +409,7 @@ export function PayeeList({
                 showStatusColumn={showStatusColumn}
                 index={index}
                 categoryColorMap={categoryColorMap}
+                categoryLabelMap={categoryLabelMap}
                 formatDate={formatDate}
               />
             ))}

--- a/frontend/src/components/payees/PayeeList.tsx
+++ b/frontend/src/components/payees/PayeeList.tsx
@@ -264,8 +264,8 @@ export function PayeeList({
       if (sortField === 'name') {
         comparison = a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
       } else if (sortField === 'category') {
-        const catA = a.defaultCategory?.name || '';
-        const catB = b.defaultCategory?.name || '';
+        const catA = a.defaultCategory ? (categoryLabelMap?.get(a.defaultCategory.id) ?? a.defaultCategory.name) : '';
+        const catB = b.defaultCategory ? (categoryLabelMap?.get(b.defaultCategory.id) ?? b.defaultCategory.name) : '';
         comparison = catA.localeCompare(catB, undefined, { sensitivity: 'base' });
       } else if (sortField === 'count') {
         comparison = (a.transactionCount ?? 0) - (b.transactionCount ?? 0);
@@ -278,7 +278,7 @@ export function PayeeList({
       }
       return sortDirection === 'asc' ? comparison : -comparison;
     });
-  }, [payees, sortField, sortDirection, onSort]);
+  }, [payees, sortField, sortDirection, onSort, categoryLabelMap]);
 
   const handleViewTransactions = useCallback((payee: Payee) => {
     router.push(`/transactions?payeeId=${payee.id}`);


### PR DESCRIPTION
## Summary
Add support for displaying and sorting payees by full hierarchical category labels (e.g., "Food: Groceries") instead of just leaf category names. This improves UX when categories have parent-child relationships.

## Key Changes

**Frontend:**
- Add `categoryLabelMap` prop to `PayeeList` component to accept pre-computed full category labels
- Update payee category display to use the label map when available, falling back to category name
- Update category sorting logic to use full labels from the map for consistent sort order
- Add `buildCategoryLabelMap` utility function to construct the label map from category hierarchy
- Wire the label map through the payees page and pass it to `PayeeList`
- Add comprehensive test coverage for label display and sorting behavior

**Backend:**
- Fix TypeORM persistence bug in `PayeesService.update()`: always clear the loaded `defaultCategory` relation when updating `defaultCategoryId`, not just when setting to null
  - This prevents TypeORM from re-deriving the old FK value from the stale relation entity
  - Fixes silent failures when switching a payee to a different category
- Update test to verify the relation is cleared and the new FK value persists correctly

## Implementation Details

The `categoryLabelMap` is built once per render using `useMemo` and passed down to avoid recalculating labels for every payee. The sorting logic checks the map first, then falls back to the category name if no entry exists, ensuring graceful degradation.

The backend fix addresses a critical bug where TypeORM's `save()` method would silently ignore FK changes if a loaded relation object was present. The solution clears the relation unconditionally whenever the FK is updated, ensuring the new value persists to the database.

https://claude.ai/code/session_012QXY2rKZnyugfSLSrD6Sj7