### PR TITLE
Add force-update endpoint for historical security prices

### DIFF
--- a/backend/src/securities/securities.controller.spec.ts
+++ b/backend/src/securities/securities.controller.spec.ts
@@ -49,6 +49,7 @@ describe("SecuritiesController", () => {
       refreshAllPrices: jest.fn(),
       refreshPricesForSecurities: jest.fn(),
       backfillHistoricalPrices: jest.fn(),
+      backfillSecurityHoldingPeriod: jest.fn(),
       backfillTransactionPrices: jest.fn(),
       getLastUpdateTime: jest.fn(),
       getPriceHistory: jest.fn(),
@@ -491,6 +492,74 @@ describe("SecuritiesController", () => {
 
       expect(securityPriceService.backfillHistoricalPrices).toHaveBeenCalled();
       expect(result).toEqual(summary);
+    });
+  });
+
+  describe("backfillSecurityPrices", () => {
+    it("delegates to backfillSecurityHoldingPeriod and recalculates accounts when prices loaded", async () => {
+      const result = {
+        symbol: "AAPL",
+        success: true,
+        pricesLoaded: 250,
+        provider: "yahoo" as const,
+      };
+      securityPriceService.backfillSecurityHoldingPeriod.mockResolvedValue(
+        result,
+      );
+
+      const response = await controller.backfillSecurityPrices(req, "sec-1");
+
+      expect(
+        securityPriceService.backfillSecurityHoldingPeriod,
+      ).toHaveBeenCalledWith("user-1", "sec-1");
+      expect(response).toEqual(result);
+      // Fire-and-forget recalc runs in the background.
+      await Promise.resolve();
+      expect(netWorthService.recalculateAllAccounts).toHaveBeenCalledWith(
+        "user-1",
+      );
+    });
+
+    it("does not recalculate when no prices were loaded", async () => {
+      securityPriceService.backfillSecurityHoldingPeriod.mockResolvedValue({
+        symbol: "AAPL",
+        success: true,
+        pricesLoaded: 0,
+        provider: "yahoo",
+      });
+
+      await controller.backfillSecurityPrices(req, "sec-1");
+
+      expect(netWorthService.recalculateAllAccounts).not.toHaveBeenCalled();
+    });
+
+    it("does not recalculate when the backfill failed", async () => {
+      securityPriceService.backfillSecurityHoldingPeriod.mockResolvedValue({
+        symbol: "AAPL",
+        success: false,
+        error: "No historical data available",
+      });
+
+      const response = await controller.backfillSecurityPrices(req, "sec-1");
+
+      expect(response.success).toBe(false);
+      expect(netWorthService.recalculateAllAccounts).not.toHaveBeenCalled();
+    });
+
+    it("swallows background recalculation errors", async () => {
+      securityPriceService.backfillSecurityHoldingPeriod.mockResolvedValue({
+        symbol: "AAPL",
+        success: true,
+        pricesLoaded: 10,
+        provider: "yahoo",
+      });
+      netWorthService.recalculateAllAccounts.mockRejectedValue(
+        new Error("recalc failed"),
+      );
+
+      await expect(
+        controller.backfillSecurityPrices(req, "sec-1"),
+      ).resolves.toBeDefined();
     });
   });
 

--- a/backend/src/securities/securities.controller.ts
+++ b/backend/src/securities/securities.controller.ts
@@ -33,6 +33,7 @@ import {
   SecurityPriceService,
   PriceRefreshSummary,
   HistoricalBackfillSummary,
+  HistoricalBackfillResult,
   SecurityLookupResult,
 } from "./security-price.service";
 import { MsnFinanceService } from "./msn-finance.service";
@@ -482,6 +483,37 @@ export class SecuritiesController {
       undefined,
       limit,
     );
+  }
+
+  @Post(":id/prices/backfill")
+  @ApiOperation({
+    summary: "Force-update historical prices for a single security",
+    description:
+      "Re-fetches historical prices across the full period the user has held this security and overwrites existing rows. Useful after correcting an imported security's symbol.",
+  })
+  @ApiResponse({ status: 200, description: "Historical backfill completed" })
+  @ApiResponse({ status: 404, description: "Security not found" })
+  async backfillSecurityPrices(
+    @Request() req,
+    @Param("id", ParseUUIDPipe) id: string,
+  ): Promise<HistoricalBackfillResult> {
+    const result =
+      await this.securityPriceService.backfillSecurityHoldingPeriod(
+        req.user.id,
+        id,
+      );
+    if (result.success && (result.pricesLoaded ?? 0) > 0) {
+      // Fire-and-forget: recalculate this user's accounts so holdings and
+      // charts reflect the refreshed history.
+      this.netWorthService
+        .recalculateAllAccounts(req.user.id)
+        .catch((err) =>
+          this.logger.warn(
+            `Background account recalculation failed: ${err.message}`,
+          ),
+        );
+    }
+    return result;
   }
 
   @Post(":id/prices")

--- a/backend/src/securities/security-price.service.spec.ts
+++ b/backend/src/securities/security-price.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException } from "@nestjs/common";
 import { getRepositoryToken } from "@nestjs/typeorm";
 import { DataSource } from "typeorm";
 import { SecurityPriceService } from "./security-price.service";
@@ -19,6 +20,7 @@ describe("SecurityPriceService", () => {
   let userPreferenceRepository: Record<string, jest.Mock>;
   let dataSourceMock: Record<string, jest.Mock>;
   let netWorthService: Record<string, jest.Mock>;
+  let msnFinanceService: Record<string, jest.Mock>;
   let originalFetch: typeof global.fetch;
 
   const mockSecurity: Security = {
@@ -162,7 +164,29 @@ describe("SecurityPriceService", () => {
 
     netWorthService = {
       recalculateAllInvestmentSnapshots: jest.fn().mockResolvedValue(undefined),
+      recalculateAllAccounts: jest.fn().mockResolvedValue(undefined),
     };
+
+    // Mock MSN to always return null by default so most tests stay
+    // Yahoo-focused. Individual tests override these to exercise the MSN path.
+    msnFinanceService = {
+      fetchQuote: jest.fn().mockResolvedValue(null),
+      fetchHistorical: jest.fn().mockResolvedValue(null),
+      lookupSecurity: jest.fn().mockResolvedValue(null),
+      fetchStockSectorInfo: jest.fn().mockResolvedValue(null),
+      fetchEtfSectorWeightings: jest.fn().mockResolvedValue(null),
+      resolveInstrumentId: jest.fn().mockResolvedValue(null),
+      getTradingDate: jest.fn((q: { regularMarketTime?: number }) => {
+        if (q.regularMarketTime) {
+          const d = new Date(q.regularMarketTime * 1000);
+          d.setUTCHours(0, 0, 0, 0);
+          return d;
+        }
+        return new Date();
+      }),
+    };
+    // The registry reads provider.name to order/resolve providers.
+    (msnFinanceService as Record<string, unknown>).name = "msn";
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -189,26 +213,8 @@ describe("SecurityPriceService", () => {
         },
         YahooFinanceService,
         {
-          // Mock MSN to always return null so these tests stay Yahoo-focused.
-          // The registry fallback still calls these methods, but they're no-ops.
           provide: MsnFinanceService,
-          useValue: {
-            name: "msn",
-            fetchQuote: jest.fn().mockResolvedValue(null),
-            fetchHistorical: jest.fn().mockResolvedValue(null),
-            lookupSecurity: jest.fn().mockResolvedValue(null),
-            fetchStockSectorInfo: jest.fn().mockResolvedValue(null),
-            fetchEtfSectorWeightings: jest.fn().mockResolvedValue(null),
-            resolveInstrumentId: jest.fn().mockResolvedValue(null),
-            getTradingDate: jest.fn((q: { regularMarketTime?: number }) => {
-              if (q.regularMarketTime) {
-                const d = new Date(q.regularMarketTime * 1000);
-                d.setUTCHours(0, 0, 0, 0);
-                return d;
-              }
-              return new Date();
-            }),
-          },
+          useValue: msnFinanceService,
         },
         QuoteProviderRegistry,
       ],
@@ -1349,6 +1355,256 @@ describe("SecurityPriceService", () => {
       await expect(
         service.backfillSecurity(mockSecurity),
       ).resolves.not.toThrow();
+    });
+  });
+
+  describe("backfillSecurityHoldingPeriod", () => {
+    const daySeconds = 24 * 60 * 60;
+    const nowSeconds = Math.floor(Date.now() / 1000);
+
+    it("throws NotFoundException when the security is not owned by the user", async () => {
+      securitiesRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.backfillSecurityHoldingPeriod(TEST_USER_ID, "missing"),
+      ).rejects.toThrow(NotFoundException);
+      expect(securitiesRepository.findOne).toHaveBeenCalledWith({
+        where: { id: "missing", userId: TEST_USER_ID },
+      });
+    });
+
+    it("backfills only 1Y when the earliest transaction is within the last year", async () => {
+      securitiesRepository.findOne.mockResolvedValue(mockSecurity);
+      const recent = new Date();
+      recent.setMonth(recent.getMonth() - 1);
+      const recentStr = recent.toISOString().substring(0, 10);
+      dataSourceMock.query.mockResolvedValueOnce([{ earliest: recentStr }]);
+
+      const historicalData = makeYahooHistoricalResponse({
+        timestamps: [nowSeconds - 2 * daySeconds, nowSeconds - daySeconds],
+        closes: [193.0, 194.0],
+      });
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(
+          createMockFetchResponse(historicalData),
+        ) as jest.Mock;
+      dataSourceMock.query.mockResolvedValue(undefined);
+
+      const result = await service.backfillSecurityHoldingPeriod(
+        TEST_USER_ID,
+        "sec-1",
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.symbol).toBe("AAPL");
+      expect(result.pricesLoaded).toBeGreaterThan(0);
+      // Only the 1Y range is fetched -- no "max" call -- since the holding
+      // period is under a year.
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain(
+        "range=1y",
+      );
+    });
+
+    it("fetches max history when the earliest transaction predates one year", async () => {
+      securitiesRepository.findOne.mockResolvedValue(mockSecurity);
+      dataSourceMock.query.mockResolvedValueOnce([{ earliest: "2018-01-01" }]);
+
+      const historicalData = makeYahooHistoricalResponse({
+        timestamps: [nowSeconds - 2 * daySeconds, nowSeconds - daySeconds],
+        closes: [193.0, 194.0],
+      });
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(
+          createMockFetchResponse(historicalData),
+        ) as jest.Mock;
+      dataSourceMock.query.mockResolvedValue(undefined);
+
+      const result = await service.backfillSecurityHoldingPeriod(
+        TEST_USER_ID,
+        "sec-1",
+      );
+
+      expect(result.success).toBe(true);
+      // Both 1Y and max ranges are fetched and merged for deep history.
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      const ranges = (global.fetch as jest.Mock).mock.calls.map((c) => c[0]);
+      expect(ranges.some((u: string) => u.includes("range=1y"))).toBe(true);
+      expect(ranges.some((u: string) => u.includes("range=max"))).toBe(true);
+    });
+
+    it("falls back to 1Y when the security has no transactions", async () => {
+      securitiesRepository.findOne.mockResolvedValue(mockSecurity);
+      dataSourceMock.query.mockResolvedValueOnce([{ earliest: null }]);
+
+      const historicalData = makeYahooHistoricalResponse({
+        timestamps: [nowSeconds - 2 * daySeconds, nowSeconds - daySeconds],
+        closes: [193.0, 194.0],
+      });
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(
+          createMockFetchResponse(historicalData),
+        ) as jest.Mock;
+      dataSourceMock.query.mockResolvedValue(undefined);
+
+      const result = await service.backfillSecurityHoldingPeriod(
+        TEST_USER_ID,
+        "sec-1",
+      );
+
+      expect(result.success).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain(
+        "range=1y",
+      );
+    });
+
+    it("bypasses the skipPriceUpdates flag (force update)", async () => {
+      const skipSec = { ...mockSecurity, skipPriceUpdates: true } as Security;
+      securitiesRepository.findOne.mockResolvedValue(skipSec);
+      dataSourceMock.query.mockResolvedValueOnce([{ earliest: null }]);
+
+      const historicalData = makeYahooHistoricalResponse({
+        timestamps: [nowSeconds - daySeconds],
+        opens: [191.0],
+        highs: [196.0],
+        lows: [190.0],
+        closes: [194.0],
+        volumes: [51000000],
+      });
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(
+          createMockFetchResponse(historicalData),
+        ) as jest.Mock;
+      dataSourceMock.query.mockResolvedValue(undefined);
+
+      const result = await service.backfillSecurityHoldingPeriod(
+        TEST_USER_ID,
+        "sec-1",
+      );
+
+      expect(result.success).toBe(true);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    it("returns failure when no historical data is available", async () => {
+      securitiesRepository.findOne.mockResolvedValue(mockSecurity);
+      dataSourceMock.query.mockResolvedValueOnce([{ earliest: null }]);
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(
+          createMockFetchResponse({ chart: { result: [] } }),
+        ) as jest.Mock;
+
+      const result = await service.backfillSecurityHoldingPeriod(
+        TEST_USER_ID,
+        "sec-1",
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("No historical data available");
+    });
+
+    it("returns failure when the upsert throws", async () => {
+      securitiesRepository.findOne.mockResolvedValue(mockSecurity);
+      dataSourceMock.query
+        .mockResolvedValueOnce([{ earliest: null }])
+        .mockRejectedValueOnce(new Error("INSERT failed"));
+
+      const historicalData = makeYahooHistoricalResponse({
+        timestamps: [nowSeconds - daySeconds],
+        closes: [194.0],
+      });
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(
+          createMockFetchResponse(historicalData),
+        ) as jest.Mock;
+
+      const result = await service.backfillSecurityHoldingPeriod(
+        TEST_USER_ID,
+        "sec-1",
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("INSERT failed");
+    });
+
+    it("returns success with zero prices loaded when all data predates the cutoff", async () => {
+      securitiesRepository.findOne.mockResolvedValue(mockSecurity);
+      // No transactions -> cutoff falls back to one year ago.
+      dataSourceMock.query.mockResolvedValueOnce([{ earliest: null }]);
+
+      // Prices two years old are entirely clipped by the 1y fallback cutoff.
+      const twoYearsAgo = nowSeconds - 2 * 365 * daySeconds;
+      const historicalData = makeYahooHistoricalResponse({
+        timestamps: [twoYearsAgo, twoYearsAgo + daySeconds],
+        closes: [100.0, 101.0],
+      });
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(
+          createMockFetchResponse(historicalData),
+        ) as jest.Mock;
+
+      const result = await service.backfillSecurityHoldingPeriod(
+        TEST_USER_ID,
+        "sec-1",
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.pricesLoaded).toBe(0);
+      // No INSERT is issued when there is nothing within the window.
+      expect(dataSourceMock.query).toHaveBeenCalledTimes(1);
+    });
+
+    it("persists the MSN instrument id when MSN wins the backfill", async () => {
+      const msnSec = {
+        ...mockSecurity,
+        quoteProvider: "msn",
+        msnInstrumentId: null,
+      } as Security;
+      securitiesRepository.findOne.mockResolvedValue(msnSec);
+      dataSourceMock.query.mockResolvedValueOnce([{ earliest: null }]);
+      dataSourceMock.query.mockResolvedValue(undefined);
+
+      const recent = new Date(Date.now() - daySeconds * 1000);
+      recent.setHours(0, 0, 0, 0);
+      msnFinanceService.fetchHistorical.mockResolvedValue([
+        {
+          date: recent,
+          open: 10,
+          high: 11,
+          low: 9,
+          close: 10.5,
+          adjClose: 10.5,
+          volume: 1000,
+        },
+      ]);
+      msnFinanceService.resolveInstrumentId.mockResolvedValue("MSN-123");
+      // Yahoo should never be reached, but guard against accidental calls.
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(
+          createMockFetchResponse({ chart: { result: [] } }),
+        ) as jest.Mock;
+
+      const result = await service.backfillSecurityHoldingPeriod(
+        TEST_USER_ID,
+        "sec-1",
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.provider).toBe("msn");
+      expect(result.pricesLoaded).toBe(1);
+      expect(msnFinanceService.fetchHistorical).toHaveBeenCalled();
+      expect(securitiesRepository.update).toHaveBeenCalledWith("sec-1", {
+        msnInstrumentId: "MSN-123",
+      });
     });
   });
 

--- a/backend/src/securities/security-price.service.ts
+++ b/backend/src/securities/security-price.service.ts
@@ -1056,6 +1056,122 @@ export class SecurityPriceService {
   }
 
   /**
+   * Force-refresh historical prices for a single security across the full
+   * period the user has held it (earliest investment transaction through the
+   * latest available price), overwriting any existing rows. Unlike the
+   * scheduled backfill this bypasses the skipPriceUpdates eligibility check:
+   * the user has explicitly requested the update, and imports flag securities
+   * with skipPriceUpdates=true, so this is how a user opts a single corrected
+   * symbol back in. Scoped by userId for multi-tenancy.
+   */
+  async backfillSecurityHoldingPeriod(
+    userId: string,
+    securityId: string,
+  ): Promise<HistoricalBackfillResult> {
+    const security = await this.securitiesRepository.findOne({
+      where: { id: securityId, userId },
+    });
+    if (!security) {
+      throw new NotFoundException(`Security ${securityId} not found`);
+    }
+
+    const ctx = (await this.loadUserContexts([userId])).get(userId) ?? {
+      defaultQuoteProvider: DEFAULT_QUOTE_PROVIDER,
+      preferredExchanges: [],
+    };
+
+    // Earliest date the user has held the security. Null when there are no
+    // transactions yet (e.g. a watchlist-only security) -- fall back to 1y.
+    const earliestRows: Array<{ earliest: string | null }> =
+      await this.dataSource.query(
+        `SELECT MIN(transaction_date)::TEXT as earliest
+         FROM investment_transactions
+         WHERE security_id = $1`,
+        [securityId],
+      );
+    const earliestTx = earliestRows[0]?.earliest ?? null;
+
+    const oneYearAgo = new Date();
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+    oneYearAgo.setHours(0, 0, 0, 0);
+    const oneYearAgoStr = oneYearAgo.toISOString().substring(0, 10);
+
+    const needsOlderData = !!earliestTx && earliestTx < oneYearAgoStr;
+
+    const daily = await this.fetchHistoricalWithFallback(security, "1y", ctx);
+    const maxBundle = needsOlderData
+      ? await this.fetchHistoricalWithFallback(security, "max", ctx)
+      : null;
+
+    if (!daily && !maxBundle) {
+      return {
+        symbol: security.symbol,
+        success: false,
+        error: "No historical data available",
+      };
+    }
+
+    const winner = daily || maxBundle!;
+    if (winner.provider === "msn") {
+      await this.persistMsnInstrumentIdIfResolved(security, "msn", ctx);
+    }
+
+    let allPrices =
+      maxBundle && daily
+        ? this.mergePrices(maxBundle.prices, daily.prices, oneYearAgo)
+        : (daily?.prices ?? maxBundle!.prices);
+
+    const seen = new Set<string>();
+    allPrices = allPrices.filter((p) => {
+      const key = p.date.toISOString().substring(0, 10);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+    // Clip to the holding period: from the first transaction date (or 1y ago
+    // when the security has never been transacted) through the latest price.
+    const cutoffStr = earliestTx ?? oneYearAgoStr;
+    const cutoff = new Date(cutoffStr);
+    cutoff.setHours(0, 0, 0, 0);
+    const prices = allPrices.filter((p) => p.date >= cutoff);
+
+    if (prices.length === 0) {
+      return {
+        symbol: security.symbol,
+        success: true,
+        pricesLoaded: 0,
+        provider: winner.provider,
+      };
+    }
+
+    const source = sourceFor(winner.provider);
+    try {
+      await this.bulkUpsertPrices(security.id, prices, source);
+    } catch (error) {
+      this.logger.error(
+        `Failed to force-backfill prices for ${security.symbol}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return {
+        symbol: security.symbol,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+
+    this.logger.log(
+      `Force-backfilled ${prices.length} prices for ${security.symbol} via ${winner.provider} (from ${cutoffStr})`,
+    );
+
+    return {
+      symbol: security.symbol,
+      success: true,
+      pricesLoaded: prices.length,
+      provider: winner.provider,
+    };
+  }
+
+  /**
    * Upsert a transaction-derived price for a security on a given date.
    * Computes average price from all price-relevant transactions on that date.
    * Never overwrites provider-sourced (yahoo_finance, msn_finance) or manual

--- a/frontend/src/components/securities/SecurityPriceHistory.test.tsx
+++ b/frontend/src/components/securities/SecurityPriceHistory.test.tsx
@@ -8,6 +8,7 @@ vi.mock('@/lib/investments', () => ({
     createSecurityPrice: vi.fn(),
     updateSecurityPrice: vi.fn(),
     deleteSecurityPrice: vi.fn(),
+    backfillSecurityPrices: vi.fn(),
   },
 }));
 
@@ -369,5 +370,109 @@ describe('SecurityPriceHistory', () => {
 
     expect(toast.error).toHaveBeenCalledWith('Failed to delete price');
     expect(screen.getAllByText('Edit')).toHaveLength(3);
+  });
+
+  describe('Force Update Prices', () => {
+    it('force-updates prices, shows a success toast with the count, and reloads', async () => {
+      const toast = (await import('react-hot-toast')).default;
+      (investmentsApi.backfillSecurityPrices as ReturnType<typeof vi.fn>).mockResolvedValue({
+        symbol: 'AAPL',
+        success: true,
+        pricesLoaded: 252,
+        provider: 'yahoo',
+      });
+      await renderComponent();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Force Update Prices' }));
+      });
+
+      expect(investmentsApi.backfillSecurityPrices).toHaveBeenCalledWith('sec-1');
+      expect(toast.success).toHaveBeenCalledWith('Updated 252 prices for AAPL');
+      // Reloaded after the update (initial mount + post-update).
+      expect(investmentsApi.getSecurityPrices).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses singular wording when exactly one price is loaded', async () => {
+      const toast = (await import('react-hot-toast')).default;
+      (investmentsApi.backfillSecurityPrices as ReturnType<typeof vi.fn>).mockResolvedValue({
+        symbol: 'AAPL',
+        success: true,
+        pricesLoaded: 1,
+        provider: 'yahoo',
+      });
+      await renderComponent();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Force Update Prices' }));
+      });
+
+      expect(toast.success).toHaveBeenCalledWith('Updated 1 price for AAPL');
+    });
+
+    it('shows a "no prices found" toast when zero prices are loaded', async () => {
+      const toast = (await import('react-hot-toast')).default;
+      (investmentsApi.backfillSecurityPrices as ReturnType<typeof vi.fn>).mockResolvedValue({
+        symbol: 'AAPL',
+        success: true,
+        pricesLoaded: 0,
+        provider: 'yahoo',
+      });
+      await renderComponent();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Force Update Prices' }));
+      });
+
+      expect(toast.success).toHaveBeenCalledWith('No prices found for AAPL');
+    });
+
+    it('shows the backend error message when the update reports failure', async () => {
+      const toast = (await import('react-hot-toast')).default;
+      (investmentsApi.backfillSecurityPrices as ReturnType<typeof vi.fn>).mockResolvedValue({
+        symbol: 'AAPL',
+        success: false,
+        error: 'No historical data available',
+      });
+      await renderComponent();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Force Update Prices' }));
+      });
+
+      expect(toast.error).toHaveBeenCalledWith('No historical data available');
+      // No reload on failure (only the initial mount load).
+      expect(investmentsApi.getSecurityPrices).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to a generic message when failure has no error string', async () => {
+      const toast = (await import('react-hot-toast')).default;
+      (investmentsApi.backfillSecurityPrices as ReturnType<typeof vi.fn>).mockResolvedValue({
+        symbol: 'AAPL',
+        success: false,
+      });
+      await renderComponent();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Force Update Prices' }));
+      });
+
+      expect(toast.error).toHaveBeenCalledWith('Failed to update prices for AAPL');
+    });
+
+    it('shows an error toast when the request throws', async () => {
+      const toast = (await import('react-hot-toast')).default;
+      (investmentsApi.backfillSecurityPrices as ReturnType<typeof vi.fn>).mockRejectedValue(
+        'boom',
+      );
+      await renderComponent();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Force Update Prices' }));
+      });
+      await act(async () => {});
+
+      expect(toast.error).toHaveBeenCalledWith('Failed to update prices');
+    });
   });
 });

--- a/frontend/src/components/securities/SecurityPriceHistory.tsx
+++ b/frontend/src/components/securities/SecurityPriceHistory.tsx
@@ -60,6 +60,7 @@ export function SecurityPriceHistory({ security, onClose }: SecurityPriceHistory
   const [showAddForm, setShowAddForm] = useState(false);
   const [editingPrice, setEditingPrice] = useState<SecurityPrice | undefined>();
   const [deletingPrice, setDeletingPrice] = useState<SecurityPrice | undefined>();
+  const [isUpdating, setIsUpdating] = useState(false);
 
   const loadPrices = useCallback(async () => {
     setIsLoading(true);
@@ -114,6 +115,27 @@ export function SecurityPriceHistory({ security, onClose }: SecurityPriceHistory
     }
   }, [security.id, deletingPrice, loadPrices]);
 
+  const handleForceUpdate = useCallback(async () => {
+    setIsUpdating(true);
+    try {
+      const result = await investmentsApi.backfillSecurityPrices(security.id);
+      if (result.success) {
+        toast.success(
+          result.pricesLoaded
+            ? `Updated ${result.pricesLoaded} price${result.pricesLoaded !== 1 ? 's' : ''} for ${result.symbol}`
+            : `No prices found for ${result.symbol}`,
+        );
+        await loadPrices();
+      } else {
+        toast.error(result.error || `Failed to update prices for ${result.symbol}`);
+      }
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Failed to update prices'));
+    } finally {
+      setIsUpdating(false);
+    }
+  }, [security.id, loadPrices]);
+
   const isFormOpen = showAddForm || !!editingPrice;
 
   return (
@@ -124,9 +146,20 @@ export function SecurityPriceHistory({ security, onClose }: SecurityPriceHistory
         </h2>
         <div className="flex gap-2">
           {!isFormOpen && (
-            <Button onClick={() => setShowAddForm(true)} size="sm">
-              + Add Price
-            </Button>
+            <>
+              <Button
+                variant="outline"
+                onClick={handleForceUpdate}
+                size="sm"
+                isLoading={isUpdating}
+                title="Re-fetch historical prices for the entire period you've held this security"
+              >
+                Force Update Prices
+              </Button>
+              <Button onClick={() => setShowAddForm(true)} size="sm" disabled={isUpdating}>
+                + Add Price
+              </Button>
+            </>
           )}
           <Button variant="outline" onClick={onClose} size="sm">
             Close

--- a/frontend/src/lib/investments.test.ts
+++ b/frontend/src/lib/investments.test.ts
@@ -197,6 +197,20 @@ describe('investmentsApi', () => {
     );
   });
 
+  it('backfillSecurityPrices posts to the per-security backfill endpoint', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({
+      data: { symbol: 'AAPL', success: true, pricesLoaded: 100 },
+    });
+    const result = await investmentsApi.backfillSecurityPrices('s-1');
+    // Generous timeout: fetches the security's full provider history.
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/securities/s-1/prices/backfill',
+      undefined,
+      { timeout: 120_000 },
+    );
+    expect(result.pricesLoaded).toBe(100);
+  });
+
   it('getPriceStatus fetches /securities/prices/status', async () => {
     vi.mocked(apiClient.get).mockResolvedValue({ data: { lastUpdated: '2025-01-01' } });
     const result = await investmentsApi.getPriceStatus();

--- a/frontend/src/lib/investments.ts
+++ b/frontend/src/lib/investments.ts
@@ -425,6 +425,28 @@ export const investmentsApi = {
     return response.data;
   },
 
+  // Force-refresh historical prices for a single security across the full
+  // period the user has held it, overwriting existing rows.
+  backfillSecurityPrices: async (
+    securityId: string,
+  ): Promise<{
+    symbol: string;
+    success: boolean;
+    pricesLoaded?: number;
+    error?: string;
+    provider?: string;
+  }> => {
+    // Hits the quote provider for the security's full history, so give it the
+    // same generous timeout as the bulk refresh endpoints.
+    const response = await apiClient.post(
+      `/securities/${securityId}/prices/backfill`,
+      undefined,
+      { timeout: 120_000 },
+    );
+    invalidateCache('investments:');
+    return response.data;
+  },
+
   // Get price update status
   getPriceStatus: async (): Promise<{ lastUpdated: string | null }> => {
     const response = await apiClient.get('/securities/prices/status');


### PR DESCRIPTION
## Summary
Adds a new "Force Update Prices" feature that allows users to manually trigger a full historical price refresh for a single security across the entire holding period, overwriting existing data. This is useful after correcting an imported security's symbol or when price data needs to be refreshed.

## Key Changes

**Backend**
- Added `backfillSecurityHoldingPeriod()` service method that:
  - Fetches the earliest transaction date for a security to determine the holding period
  - Intelligently requests 1-year history for recent holdings, or both 1-year + max history for older holdings
  - Merges and deduplicates prices, clipping to the actual holding period
  - Bypasses the `skipPriceUpdates` flag (unlike scheduled backfills) since this is an explicit user action
  - Persists MSN instrument IDs when MSN is the winning provider
  - Returns detailed result metadata (symbol, success, pricesLoaded, provider, error)
- Added `POST /securities/:id/prices/backfill` controller endpoint that:
  - Delegates to the service method
  - Triggers background account recalculation when prices are successfully loaded
  - Swallows background recalculation errors to avoid blocking the response
- Updated test mocks to extract `msnFinanceService` to module scope for reuse across test cases

**Frontend**
- Added "Force Update Prices" button to the SecurityPriceHistory modal
- Implemented `handleForceUpdate()` handler that:
  - Shows loading state during the request (120s timeout for full history fetch)
  - Displays success toast with price count (singular/plural handling)
  - Shows "No prices found" message when zero prices are loaded
  - Displays backend error messages on failure
  - Reloads the price table on success
  - Disables the "Add Price" button during update
- Added `backfillSecurityPrices()` API client method with generous timeout

## Implementation Details

- The holding period cutoff logic: uses the earliest transaction date if available, otherwise falls back to 1 year ago
- Price merging strategy: when both 1-year and max ranges are fetched, max data is used for older dates and 1-year data for recent dates to ensure freshness
- Deduplication: filters duplicate dates (keeping first occurrence) after merging
- Multi-tenancy: scoped by userId in both service and controller
- Error handling: returns structured result objects rather than throwing, allowing the UI to display specific error messages

https://claude.ai/code/session_016Upm3nowkTtMxx9Cbw47Zc