### PR TITLE
Use live FX rates for portfolio summary valuations

### DIFF
--- a/backend/src/currencies/exchange-rate.service.spec.ts
+++ b/backend/src/currencies/exchange-rate.service.spec.ts
@@ -849,6 +849,86 @@ describe("ExchangeRateService", () => {
     });
   });
 
+  describe("getLiveRate", () => {
+    it("returns 1 when from and to are the same currency", async () => {
+      const result = await service.getLiveRate("USD", "USD");
+
+      expect(result).toBe(1);
+      expect(yahooFinanceService.fetchQuote).not.toHaveBeenCalled();
+      expect(exchangeRateRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it("returns the live direct quote when available", async () => {
+      yahooFinanceService.fetchQuote.mockResolvedValue({
+        regularMarketPrice: 1.372,
+      });
+
+      const result = await service.getLiveRate("USD", "CAD");
+
+      expect(result).toBe(1.372);
+      expect(yahooFinanceService.fetchQuote).toHaveBeenCalledWith("USDCAD=X");
+      // Does not touch the stored daily snapshot when a live quote exists
+      expect(exchangeRateRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it("inverts the reverse live quote when the direct pair is unavailable", async () => {
+      yahooFinanceService.fetchQuote
+        .mockResolvedValueOnce({ regularMarketPrice: null }) // direct USDCAD=X
+        .mockResolvedValueOnce({ regularMarketPrice: 0.5 }); // reverse CADUSD=X
+
+      const result = await service.getLiveRate("USD", "CAD");
+
+      expect(result).toBe(2);
+      expect(yahooFinanceService.fetchQuote).toHaveBeenNthCalledWith(
+        1,
+        "USDCAD=X",
+      );
+      expect(yahooFinanceService.fetchQuote).toHaveBeenNthCalledWith(
+        2,
+        "CADUSD=X",
+      );
+      expect(exchangeRateRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the stored daily rate when no live quote is available", async () => {
+      yahooFinanceService.fetchQuote.mockResolvedValue({
+        regularMarketPrice: null,
+      });
+      exchangeRateRepository.findOne.mockResolvedValue(mockExchangeRate);
+
+      const result = await service.getLiveRate("USD", "CAD");
+
+      expect(result).toBe(1.365);
+      expect(exchangeRateRepository.findOne).toHaveBeenCalledWith({
+        where: { fromCurrency: "USD", toCurrency: "CAD" },
+        order: { rateDate: "DESC" },
+      });
+    });
+
+    it("falls back to the stored daily rate when the live fetch throws", async () => {
+      yahooFinanceService.fetchQuote.mockRejectedValue(
+        new Error("rate limited"),
+      );
+      exchangeRateRepository.findOne.mockResolvedValue(mockExchangeRate);
+
+      const result = await service.getLiveRate("USD", "CAD");
+
+      expect(result).toBe(1.365);
+      expect(exchangeRateRepository.findOne).toHaveBeenCalled();
+    });
+
+    it("returns null when neither a live quote nor a stored rate exists", async () => {
+      yahooFinanceService.fetchQuote.mockResolvedValue({
+        regularMarketPrice: null,
+      });
+      exchangeRateRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.getLiveRate("USD", "XYZ");
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe("getRateHistory", () => {
     it("returns all rates when no date filters are provided", async () => {
       const rates = [mockExchangeRate];

--- a/backend/src/currencies/exchange-rate.service.ts
+++ b/backend/src/currencies/exchange-rate.service.ts
@@ -568,6 +568,36 @@ export class ExchangeRateService implements OnModuleInit {
   }
 
   /**
+   * Get the current spot rate for a currency pair, fetched live from the quote
+   * provider. Tries the direct pair, then the reverse pair (inverted), then
+   * falls back to the most recent stored daily rate when the live fetch is
+   * unavailable (rate limited, unsupported pair, offline).
+   *
+   * Use this for "as of now" valuations such as the Investments portfolio
+   * summary so they line up with the live intraday Portfolio Value Over Time
+   * chart, which fetches live FX directly from the quote provider, rather than
+   * the once-a-day stored snapshot returned by getLatestRate. Returns null when
+   * neither a live quote nor a stored rate is available, letting callers apply
+   * their own fallback (e.g. reverse lookup or treating the rate as 1).
+   */
+  async getLiveRate(from: string, to: string): Promise<number | null> {
+    if (from === to) return 1;
+    try {
+      const direct = await this.fetchYahooRate(from, to);
+      if (direct !== null && direct > 0) return direct;
+      const reverse = await this.fetchYahooRate(to, from);
+      if (reverse !== null && reverse > 0) return 1 / reverse;
+    } catch (error) {
+      this.logger.warn(
+        `Live FX fetch ${from}->${to} failed, falling back to stored rate: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    return this.getLatestRate(from, to);
+  }
+
+  /**
    * Get exchange rates within a date range (for historical net worth)
    */
   async getRateHistory(

--- a/backend/src/securities/portfolio-calculation.service.spec.ts
+++ b/backend/src/securities/portfolio-calculation.service.spec.ts
@@ -722,3 +722,97 @@ describe("PortfolioCalculationService.calculateCapitalGainsByDay", () => {
     expect(result).toEqual([]);
   });
 });
+
+describe("PortfolioCalculationService.primeLiveRates", () => {
+  let service: PortfolioCalculationService;
+  let holdingsRepo: { createQueryBuilder: jest.Mock };
+  let exchangeRateService: { getLiveRate: jest.Mock };
+  let rawCurrencies: Array<{ currency: string | null }>;
+
+  const makeQueryBuilder = () => ({
+    innerJoin: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn().mockResolvedValue(rawCurrencies),
+  });
+
+  beforeEach(async () => {
+    rawCurrencies = [];
+    holdingsRepo = {
+      createQueryBuilder: jest.fn(() => makeQueryBuilder()),
+    };
+    exchangeRateService = { getLiveRate: jest.fn() };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PortfolioCalculationService,
+        { provide: getRepositoryToken(Holding), useValue: holdingsRepo },
+        { provide: getRepositoryToken(SecurityPrice), useValue: {} },
+        { provide: getRepositoryToken(InvestmentTransaction), useValue: {} },
+        { provide: getRepositoryToken(Account), useValue: {} },
+        { provide: ExchangeRateService, useValue: exchangeRateService },
+      ],
+    }).compile();
+    service = module.get(PortfolioCalculationService);
+  });
+
+  const account = (currencyCode: string) =>
+    ({ id: "a", currencyCode }) as Account;
+
+  it("primes the cache with live rates for account and holding currencies", async () => {
+    rawCurrencies = [{ currency: "EUR" }, { currency: "GBP" }];
+    exchangeRateService.getLiveRate.mockImplementation(
+      async (from: string) =>
+        ({ USD: 1.37, EUR: 1.48, GBP: 1.72 })[from] ?? null,
+    );
+    const rateCache = new Map<string, number>();
+
+    await service.primeLiveRates(
+      rateCache,
+      [account("USD")],
+      ["acct-1"],
+      "CAD",
+    );
+
+    expect(rateCache.get("USD->CAD")).toBe(1.37);
+    expect(rateCache.get("EUR->CAD")).toBe(1.48);
+    expect(rateCache.get("GBP->CAD")).toBe(1.72);
+  });
+
+  it("skips the default currency and de-duplicates currencies", async () => {
+    rawCurrencies = [{ currency: "USD" }, { currency: "CAD" }];
+    exchangeRateService.getLiveRate.mockResolvedValue(1.37);
+    const rateCache = new Map<string, number>();
+
+    await service.primeLiveRates(
+      rateCache,
+      [account("USD"), account("CAD")],
+      ["acct-1"],
+      "CAD",
+    );
+
+    // CAD is the default currency, so it is never fetched or cached
+    expect(rateCache.has("CAD->CAD")).toBe(false);
+    expect(exchangeRateService.getLiveRate).toHaveBeenCalledTimes(1);
+    expect(exchangeRateService.getLiveRate).toHaveBeenCalledWith("USD", "CAD");
+  });
+
+  it("leaves the cache unset for a currency when no live rate is available", async () => {
+    rawCurrencies = [];
+    exchangeRateService.getLiveRate.mockResolvedValue(null);
+    const rateCache = new Map<string, number>();
+
+    await service.primeLiveRates(rateCache, [account("USD")], [], "CAD");
+
+    expect(rateCache.has("USD->CAD")).toBe(false);
+  });
+
+  it("does not query holdings when there are no holdings accounts", async () => {
+    exchangeRateService.getLiveRate.mockResolvedValue(1.37);
+    const rateCache = new Map<string, number>();
+
+    await service.primeLiveRates(rateCache, [account("USD")], [], "CAD");
+
+    expect(holdingsRepo.createQueryBuilder).not.toHaveBeenCalled();
+    expect(rateCache.get("USD->CAD")).toBe(1.37);
+  });
+});

--- a/backend/src/securities/portfolio-calculation.service.ts
+++ b/backend/src/securities/portfolio-calculation.service.ts
@@ -16,6 +16,12 @@ import {
 } from "./portfolio.service";
 import { roundMoney } from "../common/round.util";
 import { formatDateYMDLocal } from "../common/date-utils";
+import { mapWithConcurrency } from "../common/concurrency.util";
+
+// "As of now" portfolio valuations fetch a live spot rate per foreign
+// currency. Cap concurrent quote-provider fetches so a portfolio spanning
+// many currencies does not burst the provider on an interactive request.
+const LIVE_FX_FETCH_CONCURRENCY = 6;
 
 /**
  * Categorised investment accounts: brokerage, standalone, and cash accounts
@@ -254,6 +260,59 @@ export class PortfolioCalculationService {
       rateCache.set(cacheKey, rate);
     }
     return amount * rate;
+  }
+
+  /**
+   * Pre-populate the rate cache with live spot FX rates for every non-default
+   * currency held across the given accounts and their holdings. The portfolio
+   * summary's "as of now" valuations (holdings value, cash, allocation, net
+   * invested) then convert at the current rate -- matching the live Portfolio
+   * Value Over Time chart -- instead of the once-a-day stored snapshot used by
+   * getLatestRate.
+   *
+   * Best effort: when a live quote is unavailable for a currency the cache is
+   * left unset for that pair, so the downstream convertToDefault falls back to
+   * the stored daily rate (its existing behaviour).
+   */
+  async primeLiveRates(
+    rateCache: Map<string, number>,
+    accounts: Account[],
+    holdingsAccountIds: string[],
+    defaultCurrency: string,
+  ): Promise<void> {
+    const currencies = new Set<string>();
+    for (const account of accounts) {
+      if (account.currencyCode) currencies.add(account.currencyCode);
+    }
+
+    if (holdingsAccountIds.length > 0) {
+      const rows: Array<{ currency: string | null }> =
+        await this.holdingsRepository
+          .createQueryBuilder("h")
+          .innerJoin("h.security", "s")
+          .where("h.account_id IN (:...ids)", { ids: holdingsAccountIds })
+          .select("DISTINCT s.currency_code", "currency")
+          .getRawMany();
+      for (const row of rows) {
+        if (row.currency) currencies.add(row.currency);
+      }
+    }
+
+    currencies.delete(defaultCurrency);
+
+    await mapWithConcurrency(
+      [...currencies],
+      LIVE_FX_FETCH_CONCURRENCY,
+      async (currency) => {
+        const rate = await this.exchangeRateService.getLiveRate(
+          currency,
+          defaultCurrency,
+        );
+        if (rate !== null && rate > 0) {
+          rateCache.set(`${currency}->${defaultCurrency}`, rate);
+        }
+      },
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -136,6 +136,14 @@ describe("PortfolioService", () => {
   beforeEach(async () => {
     holdingsRepository = {
       find: jest.fn(),
+      // primeLiveRates queries distinct holding currencies via the query
+      // builder. Default: no rows, so only account currencies are considered.
+      createQueryBuilder: jest.fn(() => ({
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      })),
     };
 
     securityPriceRepository = {
@@ -157,6 +165,10 @@ describe("PortfolioService", () => {
 
     exchangeRateService = {
       getLatestRate: jest.fn(),
+      // Default: no live quote available, so primeLiveRates leaves the cache
+      // unset and conversions fall back to the stored getLatestRate path that
+      // these tests configure. Tests for the live-rate path override this.
+      getLiveRate: jest.fn().mockResolvedValue(null),
     };
 
     yahooFinanceService = {

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -308,6 +308,18 @@ export class PortfolioService {
     // Categorise into cash / brokerage / standalone
     const categorised = this.calculationService.categoriseAccounts(accounts);
 
+    // Prime the rate cache with live spot FX so every "as of now" valuation
+    // below (holdings value, cash, net invested, allocation) converts at the
+    // current rate and matches the live Portfolio Value Over Time chart rather
+    // than the once-a-day stored snapshot. Best effort -- per currency, falls
+    // back to the stored daily rate when no live quote is available.
+    await this.calculationService.primeLiveRates(
+      rateCache,
+      accounts,
+      categorised.holdingsAccountIds,
+      defaultCurrency,
+    );
+
     // Compute effective cash balances excluding future-dated transactions
     const cashAndStandaloneIds = [
       ...categorised.cashAccounts,

--- a/frontend/src/components/investments/PortfolioSummaryCard.test.tsx
+++ b/frontend/src/components/investments/PortfolioSummaryCard.test.tsx
@@ -184,6 +184,37 @@ describe('PortfolioSummaryCard', () => {
     expect(screen.getByText('Portfolio Summary (My Account)')).toBeInTheDocument();
   });
 
+  it('uses backend totals (live FX) in the default-currency view, not the stale frontend rate', () => {
+    // Simulate useExchangeRates returning a stale/different rate (x2). The
+    // default-currency view must show the backend's already-converted totals
+    // so it stays in sync with the Portfolio Value Over Time chart, rather
+    // than re-converting per account with this stale rate.
+    mockConvertToDefault.mockImplementation((n: number) => n * 2);
+    const summary = makeSummary({
+      totalHoldingsValue: 45000,
+      totalCashValue: 5000,
+      holdingsByAccount: [
+        {
+          accountId: 'a1',
+          currencyCode: 'USD',
+          totalMarketValue: 45000,
+          totalCostBasis: 40000,
+          cashBalance: 5000,
+          totalGainLoss: 5000,
+          totalGainLossPercent: 12.5,
+          netInvested: 35000,
+          holdings: [],
+        },
+      ],
+    });
+    render(<PortfolioSummaryCard summary={summary} isLoading={false} />);
+    // Backend total is shown ($45000.00), not the re-converted 45000 * 2.
+    expect(screen.getByText('$45000.00')).toBeInTheDocument();
+    expect(screen.queryByText('$90000.00')).not.toBeInTheDocument();
+    // The default-currency view must not re-convert through the rate hook.
+    expect(mockConvertToDefault).not.toHaveBeenCalled();
+  });
+
   it('renders titleSuffix in populated state', () => {
     render(<PortfolioSummaryCard summary={makeSummary()} isLoading={false} titleSuffix="My Account" />);
     expect(screen.getByText('Portfolio Summary (My Account)')).toBeInTheDocument();

--- a/frontend/src/components/investments/PortfolioSummaryCard.tsx
+++ b/frontend/src/components/investments/PortfolioSummaryCard.tsx
@@ -49,21 +49,15 @@ export function PortfolioSummaryCard({
       return { cash, holdings, costBasis, netInvested, portfolio, gainLoss, gainLossPercent };
     }
 
-    let cash = 0;
-    let holdings = 0;
-    let costBasis = 0;
-    let netInvested = 0;
-    for (const acct of summary.holdingsByAccount) {
-      cash += convertToDefault(acct.cashBalance, acct.currencyCode);
-      holdings += convertToDefault(acct.totalMarketValue, acct.currencyCode);
-      costBasis += convertToDefault(acct.totalCostBasis, acct.currencyCode);
-      netInvested += convertToDefault(acct.netInvested, acct.currencyCode);
-    }
-    const portfolio = cash + holdings;
-    const gainLoss = holdings - costBasis;
-    const gainLossPercent = costBasis > 0 ? (gainLoss / costBasis) * 100 : 0;
-    return { cash, holdings, costBasis, netInvested, portfolio, gainLoss, gainLossPercent };
-  }, [summary, convertToDefault, foreignCurrency]);
+    // Default-currency view: use the backend totals as-is. They are already
+    // converted to the default currency using live spot FX -- the same rate
+    // source the Portfolio Value Over Time chart uses -- so the two stay in
+    // sync. Re-converting per account here with the cached daily-snapshot
+    // rates from useExchangeRates drifted from the chart (and triangulated
+    // through each account's currency); returning null makes every field below
+    // fall back to summary.total* directly.
+    return null;
+  }, [summary, foreignCurrency]);
 
   // Compute default-currency total when showing foreign, for the "approx" line
   const defaultTotal = useMemo(() => {


### PR DESCRIPTION
## Summary
Portfolio summary valuations ("as of now" holdings value, cash, allocation, net invested) now convert to the default currency using live spot FX rates instead of once-a-day stored snapshots. This ensures the summary stays in sync with the live Portfolio Value Over Time chart, which already fetches live FX directly from the quote provider.

## Key Changes

**Backend:**
- Added `ExchangeRateService.getLiveRate()` to fetch current spot rates from the quote provider with fallback to stored daily rates when live quotes are unavailable (rate limited, unsupported pair, offline)
- Added `PortfolioCalculationService.primeLiveRates()` to pre-populate the rate cache with live FX for all non-default currencies across accounts and their holdings, with concurrency limiting (6 concurrent fetches) to avoid bursting the quote provider
- Updated `PortfolioService.getPortfolioSummary()` to call `primeLiveRates()` before computing valuations, so all conversions use live rates
- Added comprehensive test coverage for both new methods

**Frontend:**
- Updated `PortfolioSummaryCard` to use backend totals directly in the default-currency view instead of re-converting per account with potentially stale cached daily rates
- This prevents drift between the summary display and the Portfolio Value Over Time chart

## Implementation Details

- Live rate fetching tries the direct pair first (e.g., `USDCAD=X`), then the reverse pair inverted (e.g., `CADUSD=X`), then falls back to the most recent stored daily rate
- Returns `null` when neither live quote nor stored rate is available, allowing callers to apply their own fallback
- The rate cache is pre-populated before valuations are computed, so all conversions use the same live rates
- Best effort: when a live quote is unavailable for a currency, the cache is left unset and downstream conversions fall back to the stored daily rate (existing behavior)
- Concurrency is capped at 6 simultaneous quote-provider fetches to prevent bursting on interactive requests spanning many currencies

https://claude.ai/code/session_012Bi1X53BJfJC6vhAPoBuwL