### PR TITLE
Reduce Portfolio Value chart margins on mobile

### DIFF
--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -12,14 +12,30 @@ const dateRangeState = { dateRange: '1y', resolvedRange: { start: '2023-01-01', 
 
 vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
-  AreaChart: ({ children }: any) => <div data-testid="area-chart">{children}</div>,
+  AreaChart: ({ children, margin }: any) => (
+    <div data-testid="area-chart" data-margin={JSON.stringify(margin)}>{children}</div>
+  ),
   Area: () => null,
   XAxis: () => null,
-  YAxis: () => null,
+  YAxis: ({ width }: any) => <div data-testid="y-axis" data-width={width ?? ''} />,
   CartesianGrid: () => null,
   Tooltip: () => null,
   ReferenceDot: () => null,
 }));
+
+/** Toggle the useIsMobile media query for a single test. */
+function setViewport(isMobile: boolean) {
+  vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+    matches: query.includes('max-width') ? isMobile : false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }) as unknown as MediaQueryList);
+}
 
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
@@ -131,6 +147,30 @@ describe('InvestmentValueChart', () => {
     render(<InvestmentValueChart />);
     await screen.findByText('Portfolio Value Over Time');
     expect(screen.getByTestId('area-chart')).toBeInTheDocument();
+  });
+
+  it('uses generous chart margins on desktop', async () => {
+    setViewport(false);
+    render(<InvestmentValueChart />);
+    await screen.findByText('Portfolio Value Over Time');
+    const margin = JSON.parse(
+      screen.getByTestId('area-chart').getAttribute('data-margin') || '{}',
+    );
+    expect(margin).toEqual({ top: 30, right: 30, left: 0, bottom: 30 });
+    // Default YAxis width (no explicit override) on desktop.
+    expect(screen.getByTestId('y-axis').getAttribute('data-width')).toBe('');
+  });
+
+  it('reclaims wasted space with tighter margins on mobile', async () => {
+    setViewport(true);
+    render(<InvestmentValueChart />);
+    await screen.findByText('Portfolio Value Over Time');
+    const margin = JSON.parse(
+      screen.getByTestId('area-chart').getAttribute('data-margin') || '{}',
+    );
+    expect(margin).toEqual({ top: 16, right: 8, left: 0, bottom: 8 });
+    // Narrower YAxis gutter on mobile.
+    expect(screen.getByTestId('y-axis').getAttribute('data-width')).toBe('44');
   });
 
   it('displays computed summary values', async () => {

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -19,6 +19,7 @@ import { gainLossColor } from '@/lib/format';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useDateRange } from '@/hooks/useDateRange';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { createLogger } from '@/lib/logger';
 import {
@@ -53,6 +54,7 @@ interface InvestmentValueChartProps {
 export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix }: InvestmentValueChartProps) {
   const { formatCurrency, formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag, formatSignedPercent } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
+  const isMobile = useIsMobile();
   const [chartPoints, setChartPoints] = useState<Array<{ name: string; Value: number }>>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [intradayUnavailable, setIntradayUnavailable] = useState<{
@@ -490,7 +492,17 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
           }`}
         >
           <ResponsiveContainer width="100%" height="100%" minWidth={0}>
-            <AreaChart data={chartPoints} margin={{ top: 30, right: 30, left: 0, bottom: 30 }}>
+            {/* Tighter margins on mobile to reclaim wasted space. The desktop
+                margins leave generous room around the high/low flag bubbles;
+                on a narrow screen those gutters dwarf the plot, so trim them. */}
+            <AreaChart
+              data={chartPoints}
+              margin={
+                isMobile
+                  ? { top: 16, right: 8, left: 0, bottom: 8 }
+                  : { top: 30, right: 30, left: 0, bottom: 30 }
+              }
+            >
               <defs>
                 <linearGradient id="colorInvestments" x1="0" y1="0" x2="0" y2="1">
                   <stop offset="5%" stopColor="#10b981" stopOpacity={0.3} />
@@ -524,6 +536,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
                 domain={yAxisDomain}
                 tickFormatter={fmtAxis}
                 tick={{ fontSize: 12 }}
+                width={isMobile ? 44 : undefined}
               />
               <Tooltip content={<CustomTooltip />} />
               <Area


### PR DESCRIPTION
The Portfolio Value Over Time chart used fixed margins (top/bottom/right
30px) sized for the desktop high/low flag bubbles. On a narrow screen
those gutters dwarfed the plot, wasting space. Apply tighter margins and
a narrower y-axis gutter on mobile via the existing useIsMobile hook,
keeping the generous desktop layout unchanged.