### PR TITLE
Consolidate tabular-nums to global CSS rule

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -52,6 +52,13 @@ body {
   @apply bg-gray-900 text-gray-100;
 }
 
+/* Tabular figures for all tables so numeric columns (balances, amounts,
+   prices, quantities, percentages) align with fixed-width digits. This is
+   purely a glyph-width change; non-numeric text is unaffected. */
+table {
+  font-variant-numeric: tabular-nums;
+}
+
 /* Category badge colour variables for light/dark mode */
 :root {
   --category-bg-base: #e5e7eb;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -52,10 +52,11 @@ body {
   @apply bg-gray-900 text-gray-100;
 }
 
-/* Tabular figures for all tables so numeric columns (balances, amounts,
-   prices, quantities, percentages) align with fixed-width digits. This is
-   purely a glyph-width change; non-numeric text is unaffected. */
-table {
+/* Tabular figures across the whole app so numeric values (balances, amounts,
+   prices, quantities, percentages) align with fixed-width digits wherever they
+   appear -- tables, cards, grid/flex widgets, inputs. This is purely a
+   glyph-width change for digits; non-numeric text is unaffected. */
+body {
   font-variant-numeric: tabular-nums;
 }
 

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -706,7 +706,7 @@ export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, 
                   <td className="hidden md:table-cell" aria-hidden="true" />
                   <td className={`${cellPadding} text-right whitespace-nowrap`}>
                     <span
-                      className={`text-sm font-medium tabular-nums ${
+                      className={`text-sm font-medium ${
                         item.total >= 0
                           ? 'text-gray-700 dark:text-gray-200'
                           : 'text-red-600 dark:text-red-400'

--- a/frontend/src/components/accounts/AccountRow.tsx
+++ b/frontend/src/components/accounts/AccountRow.tsx
@@ -166,7 +166,7 @@ export const AccountRow = memo(function AccountRow({
       <td className={`${cellPadding} whitespace-nowrap text-right ${account.isClosed ? 'opacity-50' : ''}`}>
         {account.accountSubType === 'INVESTMENT_BROKERAGE' && brokerageMarketValue !== undefined ? (
           <>
-            <div className="text-sm font-medium tabular-nums text-green-600 dark:text-green-400">
+            <div className="text-sm font-medium text-green-600 dark:text-green-400">
               {formatCurrency(brokerageMarketValue, account.currencyCode)}
             </div>
             {density === 'normal' && (
@@ -175,7 +175,7 @@ export const AccountRow = memo(function AccountRow({
               </div>
             )}
             {density !== 'dense' && account.currencyCode !== defaultCurrency && (
-              <div className="text-xs tabular-nums text-gray-400 dark:text-gray-500">
+              <div className="text-xs text-gray-400 dark:text-gray-500">
                 {'\u2248 '}{formatCurrencyBase(convertToDefault(brokerageMarketValue, account.currencyCode), defaultCurrency)}
               </div>
             )}
@@ -187,14 +187,14 @@ export const AccountRow = memo(function AccountRow({
               return (
                 <>
                   <div
-                    className={`text-sm font-medium tabular-nums ${
+                    className={`text-sm font-medium ${
                       gainLossColor(totalBalance)
                     }`}
                   >
                     {formatCurrency(totalBalance, account.currencyCode)}
                   </div>
                   {density !== 'dense' && account.currencyCode !== defaultCurrency && (
-                    <div className="text-xs tabular-nums text-gray-400 dark:text-gray-500">
+                    <div className="text-xs text-gray-400 dark:text-gray-500">
                       {'\u2248 '}{formatCurrencyBase(convertToDefault(totalBalance, account.currencyCode), defaultCurrency)}
                     </div>
                   )}
@@ -202,7 +202,7 @@ export const AccountRow = memo(function AccountRow({
               );
             })()}
             {density !== 'dense' && account.creditLimit && (
-              <div className="text-xs tabular-nums text-gray-500 dark:text-gray-400">
+              <div className="text-xs text-gray-500 dark:text-gray-400">
                 Limit: {formatCurrency(account.creditLimit, account.currencyCode)}
               </div>
             )}

--- a/frontend/src/components/accounts/AccountRow.tsx
+++ b/frontend/src/components/accounts/AccountRow.tsx
@@ -166,7 +166,7 @@ export const AccountRow = memo(function AccountRow({
       <td className={`${cellPadding} whitespace-nowrap text-right ${account.isClosed ? 'opacity-50' : ''}`}>
         {account.accountSubType === 'INVESTMENT_BROKERAGE' && brokerageMarketValue !== undefined ? (
           <>
-            <div className="text-sm font-medium text-green-600 dark:text-green-400">
+            <div className="text-sm font-medium tabular-nums text-green-600 dark:text-green-400">
               {formatCurrency(brokerageMarketValue, account.currencyCode)}
             </div>
             {density === 'normal' && (
@@ -175,7 +175,7 @@ export const AccountRow = memo(function AccountRow({
               </div>
             )}
             {density !== 'dense' && account.currencyCode !== defaultCurrency && (
-              <div className="text-xs text-gray-400 dark:text-gray-500">
+              <div className="text-xs tabular-nums text-gray-400 dark:text-gray-500">
                 {'\u2248 '}{formatCurrencyBase(convertToDefault(brokerageMarketValue, account.currencyCode), defaultCurrency)}
               </div>
             )}
@@ -187,14 +187,14 @@ export const AccountRow = memo(function AccountRow({
               return (
                 <>
                   <div
-                    className={`text-sm font-medium ${
+                    className={`text-sm font-medium tabular-nums ${
                       gainLossColor(totalBalance)
                     }`}
                   >
                     {formatCurrency(totalBalance, account.currencyCode)}
                   </div>
                   {density !== 'dense' && account.currencyCode !== defaultCurrency && (
-                    <div className="text-xs text-gray-400 dark:text-gray-500">
+                    <div className="text-xs tabular-nums text-gray-400 dark:text-gray-500">
                       {'\u2248 '}{formatCurrencyBase(convertToDefault(totalBalance, account.currencyCode), defaultCurrency)}
                     </div>
                   )}
@@ -202,7 +202,7 @@ export const AccountRow = memo(function AccountRow({
               );
             })()}
             {density !== 'dense' && account.creditLimit && (
-              <div className="text-xs text-gray-500 dark:text-gray-400">
+              <div className="text-xs tabular-nums text-gray-500 dark:text-gray-400">
                 Limit: {formatCurrency(account.creditLimit, account.currencyCode)}
               </div>
             )}

--- a/frontend/src/components/reports/InvestmentReportViewer.tsx
+++ b/frontend/src/components/reports/InvestmentReportViewer.tsx
@@ -413,7 +413,7 @@ export function InvestmentReportViewer({ reportId }: InvestmentReportViewerProps
                               key={key}
                               className={`px-3 py-2 text-sm whitespace-nowrap ${
                                 numeric
-                                  ? 'text-right tabular-nums text-gray-900 dark:text-gray-100'
+                                  ? 'text-right text-gray-900 dark:text-gray-100'
                                   : 'text-gray-700 dark:text-gray-300'
                               }`}
                             >

--- a/frontend/src/components/reports/MonteCarloPerformanceSummary.tsx
+++ b/frontend/src/components/reports/MonteCarloPerformanceSummary.tsx
@@ -140,19 +140,19 @@ export function PerformanceSummaryTable({
                 {row.label}
                 <InfoTooltip text={row.description} />
               </td>
-              <td className="px-3 py-1.5 text-right tabular-nums">
+              <td className="px-3 py-1.5 text-right">
                 {formatValue(row.band.p10, row.format)}
               </td>
-              <td className="px-3 py-1.5 text-right tabular-nums">
+              <td className="px-3 py-1.5 text-right">
                 {formatValue(row.band.p25, row.format)}
               </td>
-              <td className="px-3 py-1.5 text-right tabular-nums font-semibold text-gray-900 dark:text-gray-100 bg-blue-50 dark:bg-blue-900/30">
+              <td className="px-3 py-1.5 text-right font-semibold text-gray-900 dark:text-gray-100 bg-blue-50 dark:bg-blue-900/30">
                 {formatValue(row.band.p50, row.format)}
               </td>
-              <td className="px-3 py-1.5 text-right tabular-nums">
+              <td className="px-3 py-1.5 text-right">
                 {formatValue(row.band.p75, row.format)}
               </td>
-              <td className="px-3 py-1.5 text-right tabular-nums">
+              <td className="px-3 py-1.5 text-right">
                 {formatValue(row.band.p90, row.format)}
               </td>
             </tr>

--- a/frontend/src/components/reports/monte-carlo/CompareMetricTable.tsx
+++ b/frontend/src/components/reports/monte-carlo/CompareMetricTable.tsx
@@ -226,7 +226,7 @@ function GroupBlock({
             return (
               <td
                 key={col.id}
-                className="px-3 py-1.5 text-gray-900 dark:text-gray-100 tabular-nums"
+                className="px-3 py-1.5 text-gray-900 dark:text-gray-100"
               >
                 {formatCellValue(value, row.format, formatCurrency)}
               </td>

--- a/frontend/src/components/securities/SecurityPriceHistory.tsx
+++ b/frontend/src/components/securities/SecurityPriceHistory.tsx
@@ -217,19 +217,19 @@ export function SecurityPriceHistory({ security, onClose }: SecurityPriceHistory
                   <td className="px-3 py-2 text-sm text-gray-900 dark:text-gray-100 whitespace-nowrap">
                     {formatDate(price.priceDate)}
                   </td>
-                  <td className="px-3 py-2 text-sm text-gray-900 dark:text-gray-100 text-right tabular-nums">
+                  <td className="px-3 py-2 text-sm text-gray-900 dark:text-gray-100 text-right">
                     {formatPrice(price.closePrice)}
                   </td>
-                  <td className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400 text-right tabular-nums hidden sm:table-cell">
+                  <td className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400 text-right hidden sm:table-cell">
                     {formatPrice(price.openPrice)}
                   </td>
-                  <td className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400 text-right tabular-nums hidden sm:table-cell">
+                  <td className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400 text-right hidden sm:table-cell">
                     {formatPrice(price.highPrice)}
                   </td>
-                  <td className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400 text-right tabular-nums hidden sm:table-cell">
+                  <td className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400 text-right hidden sm:table-cell">
                     {formatPrice(price.lowPrice)}
                   </td>
-                  <td className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400 text-right tabular-nums hidden md:table-cell">
+                  <td className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400 text-right hidden md:table-cell">
                     {price.volume !== null ? Number(price.volume).toLocaleString() : '-'}
                   </td>
                   <td className="px-3 py-2 whitespace-nowrap">


### PR DESCRIPTION
## Summary
Moves the `tabular-nums` font variant from individual Tailwind class applications to a global CSS rule in `globals.css`. This ensures numeric values (balances, amounts, prices, quantities, percentages) align with fixed-width digits consistently across the entire application.

## Changes
- Added global `font-variant-numeric: tabular-nums` rule to `body` in `globals.css` with explanatory comment
- Removed `tabular-nums` Tailwind class from 7 table cell elements across 5 components:
  - `MonteCarloPerformanceSummary.tsx` (5 cells in percentile columns)
  - `SecurityPriceHistory.tsx` (5 cells in price/volume columns)
  - `AccountList.tsx` (1 cell in balance display)
  - `InvestmentReportViewer.tsx` (1 cell in numeric table data)
  - `CompareMetricTable.tsx` (1 cell in metric values)

## Implementation Details
- The global rule applies `font-variant-numeric: tabular-nums` to all text in the document, affecting only digit glyph widths
- Non-numeric text remains unaffected by this purely typographic change
- This eliminates the need to manually add the class to every numeric display, reducing code duplication and ensuring consistency
- The change is purely visual and does not affect functionality or data handling

https://claude.ai/code/session_01FZzYNW9ZmfjGzgKWBZZ7Hz