### PR TITLE
Add daily FX rate history fallback for intraday chart bars

### DIFF
--- a/backend/src/securities/portfolio-calculation.service.spec.ts
+++ b/backend/src/securities/portfolio-calculation.service.spec.ts
@@ -816,3 +816,162 @@ describe("PortfolioCalculationService.primeLiveRates", () => {
     expect(rateCache.get("USD->CAD")).toBe(1.37);
   });
 });
+
+describe("PortfolioCalculationService daily rate index", () => {
+  let service: PortfolioCalculationService;
+  let exchangeRateService: { getRateHistory: jest.Mock };
+
+  const rate = (
+    fromCurrency: string,
+    toCurrency: string,
+    r: number,
+    rateDate: string,
+  ) => ({ fromCurrency, toCurrency, rate: r, rateDate });
+
+  beforeEach(async () => {
+    exchangeRateService = { getRateHistory: jest.fn().mockResolvedValue([]) };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PortfolioCalculationService,
+        { provide: getRepositoryToken(Holding), useValue: {} },
+        { provide: getRepositoryToken(SecurityPrice), useValue: {} },
+        { provide: getRepositoryToken(InvestmentTransaction), useValue: {} },
+        { provide: getRepositoryToken(Account), useValue: {} },
+        { provide: ExchangeRateService, useValue: exchangeRateService },
+      ],
+    }).compile();
+    service = module.get(PortfolioCalculationService);
+  });
+
+  describe("buildDailyRateIndex", () => {
+    it("returns an empty index and skips the query when no foreign currencies", async () => {
+      const index = await service.buildDailyRateIndex(
+        ["CAD"],
+        "CAD",
+        "2026-05-01",
+        "2026-06-04",
+      );
+
+      expect(index.size).toBe(0);
+      expect(exchangeRateService.getRateHistory).not.toHaveBeenCalled();
+    });
+
+    it("keeps only pairs involving the default and a requested currency", async () => {
+      exchangeRateService.getRateHistory.mockResolvedValue([
+        rate("USD", "CAD", 1.3, "2026-06-02"),
+        rate("CAD", "USD", 0.74, "2026-06-02"), // reverse direction kept
+        rate("EUR", "GBP", 0.85, "2026-06-02"), // unrelated pair dropped
+        rate("USD", "EUR", 0.92, "2026-06-02"), // not involving default dropped
+      ]);
+
+      const index = await service.buildDailyRateIndex(
+        ["USD"],
+        "CAD",
+        "2026-05-20",
+        "2026-06-04",
+      );
+
+      expect([...index.keys()].sort()).toEqual(["CAD->USD", "USD->CAD"]);
+      expect(exchangeRateService.getRateHistory).toHaveBeenCalledWith(
+        "2026-05-20",
+        "2026-06-04",
+      );
+    });
+
+    it("normalizes Date and numeric-string rate values and sorts by date", async () => {
+      exchangeRateService.getRateHistory.mockResolvedValue([
+        rate("USD", "CAD", "1.50" as unknown as number, "2026-06-03"),
+        rate("USD", "CAD", "1.40" as unknown as number, "2026-06-01"),
+        {
+          fromCurrency: "USD",
+          toCurrency: "CAD",
+          rate: 1.45,
+          rateDate: new Date("2026-06-02T00:00:00.000Z"),
+        },
+      ]);
+
+      const index = await service.buildDailyRateIndex(
+        ["USD"],
+        "CAD",
+        "2026-05-20",
+        "2026-06-04",
+      );
+
+      expect(index.get("USD->CAD")).toEqual([
+        { date: "2026-06-01", rate: 1.4 },
+        { date: "2026-06-02", rate: 1.45 },
+        { date: "2026-06-03", rate: 1.5 },
+      ]);
+    });
+  });
+
+  describe("resolveDailyRate", () => {
+    it("returns the most recent direct rate at or before the date", async () => {
+      exchangeRateService.getRateHistory.mockResolvedValue([
+        rate("USD", "CAD", 1.4, "2026-06-01"),
+        rate("USD", "CAD", 1.5, "2026-06-03"),
+      ]);
+      const index = await service.buildDailyRateIndex(
+        ["USD"],
+        "CAD",
+        "2026-05-20",
+        "2026-06-04",
+      );
+
+      // On 2026-06-02 the most recent rate at or before is the 06-01 close.
+      expect(service.resolveDailyRate(index, "USD", "CAD", "2026-06-02")).toBe(
+        1.4,
+      );
+      // On 2026-06-03 the same-day close applies.
+      expect(service.resolveDailyRate(index, "USD", "CAD", "2026-06-03")).toBe(
+        1.5,
+      );
+    });
+
+    it("falls back to the earliest known rate when the date precedes all history", async () => {
+      exchangeRateService.getRateHistory.mockResolvedValue([
+        rate("USD", "CAD", 1.4, "2026-06-01"),
+      ]);
+      const index = await service.buildDailyRateIndex(
+        ["USD"],
+        "CAD",
+        "2026-05-20",
+        "2026-06-04",
+      );
+
+      expect(service.resolveDailyRate(index, "USD", "CAD", "2026-05-15")).toBe(
+        1.4,
+      );
+    });
+
+    it("inverts the reverse pair when only that direction is stored", async () => {
+      exchangeRateService.getRateHistory.mockResolvedValue([
+        rate("CAD", "USD", 0.5, "2026-06-01"),
+      ]);
+      const index = await service.buildDailyRateIndex(
+        ["USD"],
+        "CAD",
+        "2026-05-20",
+        "2026-06-04",
+      );
+
+      // 1 USD -> CAD via the reciprocal of the stored CAD->USD rate.
+      expect(service.resolveDailyRate(index, "USD", "CAD", "2026-06-02")).toBe(
+        2,
+      );
+    });
+
+    it("returns undefined when the pair is absent in both directions", async () => {
+      const index = await service.buildDailyRateIndex(
+        ["USD"],
+        "CAD",
+        "2026-05-20",
+        "2026-06-04",
+      );
+
+      expect(
+        service.resolveDailyRate(index, "USD", "CAD", "2026-06-02"),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/backend/src/securities/portfolio-calculation.service.ts
+++ b/backend/src/securities/portfolio-calculation.service.ts
@@ -15,13 +15,25 @@ import {
   AllocationItem,
 } from "./portfolio.service";
 import { roundMoney } from "../common/round.util";
-import { formatDateYMDLocal } from "../common/date-utils";
+import { formatDateYMD, formatDateYMDLocal } from "../common/date-utils";
 import { mapWithConcurrency } from "../common/concurrency.util";
+import { convertWithRateLookup } from "../common/currency-conversion.util";
 
 // "As of now" portfolio valuations fetch a live spot rate per foreign
 // currency. Cap concurrent quote-provider fetches so a portfolio spanning
 // many currencies does not burst the provider on an interactive request.
 const LIVE_FX_FETCH_CONCURRENCY = 6;
+
+/**
+ * Date-indexed history of stored daily exchange rates, keyed by the raw
+ * "{from}->{to}" pair as stored in the exchange_rates table. Each entry's
+ * rates are sorted ascending by date so an "as of" lookup can walk to the
+ * most recent rate at or before a target date. Used to value intraday chart
+ * bars that fall outside the live intraday FX series (pre-market, weekend and
+ * holiday gaps, or a failed FX fetch) at the rate that actually prevailed on
+ * that bar's own date rather than a single near-current rate.
+ */
+export type DailyRateIndex = Map<string, Array<{ date: string; rate: number }>>;
 
 /**
  * Categorised investment accounts: brokerage, standalone, and cash accounts
@@ -313,6 +325,98 @@ export class PortfolioCalculationService {
         }
       },
     );
+  }
+
+  /**
+   * Build a date-indexed history of stored daily rates for converting each of
+   * `currencies` to `defaultCurrency`, covering [startDate, endDate]. Only the
+   * pairs that involve the default currency and a requested currency are kept,
+   * in either direction, so `resolveDailyRate` can apply the same direct-then-
+   * inverse decision used everywhere else.
+   *
+   * Used by the intraday Portfolio Value Over Time chart to value bars that the
+   * live intraday FX series does not cover at the daily close that prevailed on
+   * that bar's own date, instead of the first/latest intraday rate.
+   */
+  async buildDailyRateIndex(
+    currencies: Iterable<string>,
+    defaultCurrency: string,
+    startDate: string,
+    endDate: string,
+  ): Promise<DailyRateIndex> {
+    const needed = new Set<string>();
+    for (const c of currencies) {
+      if (c && c !== defaultCurrency) needed.add(c);
+    }
+    const index: DailyRateIndex = new Map();
+    if (needed.size === 0) return index;
+
+    const rows = await this.exchangeRateService.getRateHistory(
+      startDate,
+      endDate,
+    );
+    for (const row of rows) {
+      const from = row.fromCurrency;
+      const to = row.toCurrency;
+      const involvesPair =
+        (needed.has(from) && to === defaultCurrency) ||
+        (from === defaultCurrency && needed.has(to));
+      if (!involvesPair) continue;
+      const key = `${from}->${to}`;
+      const arr = index.get(key);
+      // rate_date is normally returned as a "YYYY-MM-DD" string (DATE columns
+      // are parsed as strings, see main.ts) but tolerate a Date instance too.
+      const rawDate: string | Date = row.rateDate;
+      const date =
+        rawDate instanceof Date
+          ? formatDateYMD(rawDate)
+          : String(rawDate).substring(0, 10);
+      const entry = { date, rate: Number(row.rate) };
+      if (arr) {
+        index.set(key, [...arr, entry]);
+      } else {
+        index.set(key, [entry]);
+      }
+    }
+
+    // getRateHistory already orders by rate_date ASC, but sort defensively so
+    // the as-of walk in resolveDailyRate never depends on query ordering.
+    for (const [key, arr] of index) {
+      index.set(
+        key,
+        [...arr].sort((a, b) =>
+          a.date < b.date ? -1 : a.date > b.date ? 1 : 0,
+        ),
+      );
+    }
+
+    return index;
+  }
+
+  /**
+   * Resolve the stored daily rate for converting 1 unit of `from` to `to` as of
+   * `dateStr` (YYYY-MM-DD) from a `DailyRateIndex`. Picks the most recent rate
+   * at or before the date; if none exists yet it uses the earliest known rate.
+   * Returns undefined when the pair is absent in either direction so callers can
+   * apply their own fallback.
+   */
+  resolveDailyRate(
+    index: DailyRateIndex,
+    from: string,
+    to: string,
+    dateStr: string,
+  ): number | undefined {
+    const result = convertWithRateLookup(1, from, to, (f, t) => {
+      const rates = index.get(`${f}->${t}`);
+      if (!rates || rates.length === 0) return undefined;
+      let best: number | undefined;
+      for (const r of rates) {
+        if (r.date <= dateStr) best = r.rate;
+        else break;
+      }
+      return best ?? rates[0].rate;
+    });
+    return result == null ? undefined : result;
   }
 
   // ---------------------------------------------------------------------------

--- a/backend/src/securities/portfolio.service.spec.ts
+++ b/backend/src/securities/portfolio.service.spec.ts
@@ -169,6 +169,10 @@ describe("PortfolioService", () => {
       // unset and conversions fall back to the stored getLatestRate path that
       // these tests configure. Tests for the live-rate path override this.
       getLiveRate: jest.fn().mockResolvedValue(null),
+      // Default: no stored daily history, so the intraday chart's date-aware
+      // FX fallback resolves nothing and drops through to the latest spot.
+      // Tests for the historical-fallback path override this.
+      getRateHistory: jest.fn().mockResolvedValue([]),
     };
 
     yahooFinanceService = {
@@ -3514,6 +3518,59 @@ describe("PortfolioService", () => {
       // ts1: 10 * 100 * 1.4 = 1400; ts2 keeps the same price but FX moved.
       expect(result.points[0].value).toBeCloseTo(1400, 4);
       expect(result.points[1].value).toBeCloseTo(10 * 100 * 1.5, 4);
+    });
+
+    it("values bars before the first intraday FX bar at the prior daily close, not the first intraday rate", async () => {
+      // Yahoo's intraday FX series often starts later than the price series
+      // (sparse leading data). Bars before the first FX bar must use the stored
+      // daily close for that date -- the rate that actually prevailed -- rather
+      // than backfilling the first intraday bar, which is a later, near-current
+      // rate. Regression test for the chart's start-of-day / earlier points
+      // drifting while only the latest point stayed correct.
+      accountsRepository.find.mockResolvedValue([mockBrokerageAccount]);
+      holdingsRepository.find.mockResolvedValue([mockHoldingAAPL]);
+
+      const ts0 = new Date("2026-06-04T13:30:00.000Z");
+      const ts1 = new Date("2026-06-04T13:31:00.000Z");
+      const ts2 = new Date("2026-06-04T13:32:00.000Z");
+
+      yahooFinanceService.fetchIntradaySeries.mockResolvedValue([
+        { timestamp: ts0, close: 100 },
+        { timestamp: ts1, close: 100 },
+        { timestamp: ts2, close: 100 },
+      ]);
+      // FX series only covers ts1 and ts2 -- nothing at or before ts0.
+      yahooFinanceService.fetchIntradayFxSeries.mockImplementation(
+        async (from: string, to: string) => {
+          if (from === "USD" && to === "CAD") {
+            return [
+              { timestamp: ts1, close: 1.4 },
+              { timestamp: ts2, close: 1.5 },
+            ];
+          }
+          return null;
+        },
+      );
+      // Prior day's stored daily close used for the uncovered ts0 bar.
+      exchangeRateService.getRateHistory.mockResolvedValue([
+        {
+          fromCurrency: "USD",
+          toCurrency: "CAD",
+          rate: 1.3,
+          rateDate: "2026-06-03",
+        },
+      ]);
+      exchangeRateService.getLatestRate.mockResolvedValue(1.3);
+
+      const result = await service.getIntradayValueSeries(userId, {
+        range: "1d",
+      });
+
+      // ts0: no intraday FX yet -> prior daily close 1.3 (NOT the first
+      // intraday bar 1.4). ts1/ts2: per-bar intraday FX.
+      expect(result.points[0].value).toBeCloseTo(10 * 100 * 1.3, 4);
+      expect(result.points[1].value).toBeCloseTo(10 * 100 * 1.4, 4);
+      expect(result.points[2].value).toBeCloseTo(10 * 100 * 1.5, 4);
     });
 
     it("applies per-bar FX to cash held in a foreign currency", async () => {

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -5,11 +5,15 @@ import { Holding } from "./entities/holding.entity";
 import { SecurityPrice } from "./entities/security-price.entity";
 import { Account, AccountType } from "../accounts/entities/account.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
-import { PortfolioCalculationService } from "./portfolio-calculation.service";
+import {
+  PortfolioCalculationService,
+  DailyRateIndex,
+} from "./portfolio-calculation.service";
 import { YahooFinanceService } from "./yahoo-finance.service";
 import { QuoteProviderRegistry } from "./providers/quote-provider.registry";
 import { roundMoney } from "../common/round.util";
 import { mapWithConcurrency } from "../common/concurrency.util";
+import { formatDateYMD } from "../common/date-utils";
 import {
   IntradayInterval,
   IntradayPoint,
@@ -1092,19 +1096,27 @@ export class PortfolioService {
           displayCurrency,
           rateCache,
         );
+        // Mirror the per-holding price fetch: try the primary interval, then
+        // any range-specific coarser fallbacks. Yahoo's narrowest FX intervals
+        // are the most rate-limited and most likely to return a short or empty
+        // series, which would otherwise leave the whole currency on a flat
+        // fallback rate. Walk up the ladder until one returns bars.
         let series: IntradayPoint[] | null = null;
-        try {
-          series = await this.yahooFinanceService.fetchIntradayFxSeries(
-            currency,
-            displayCurrency,
-            yahooParams,
-          );
-        } catch (error) {
-          this.logger.warn(
-            `Failed to fetch intraday FX ${currency}->${displayCurrency}: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-          );
+        for (const params of intervalCandidates) {
+          try {
+            series = await this.yahooFinanceService.fetchIntradayFxSeries(
+              currency,
+              displayCurrency,
+              params,
+            );
+            if (series && series.length > 0) break;
+          } catch (error) {
+            this.logger.warn(
+              `Failed to fetch intraday FX ${currency}->${displayCurrency} at ${params.interval}: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
+          }
         }
         fxByCurrency.set(currency, {
           times: series?.map((p) => p.timestamp.getTime()) ?? [],
@@ -1115,19 +1127,65 @@ export class PortfolioService {
       },
     );
 
-    // Walk each FX cursor monotonically as the grid advances; if no
-    // intraday FX series is available (failed fetch or same-currency),
-    // use the latest spot. Backfill the earliest known rate when the
-    // first FX bar arrives after the current grid timestamp.
+    // Stored daily-close FX history, used to value any grid bar the live
+    // intraday FX series does not cover (pre-market before the first bar of the
+    // day, weekend/holiday gaps on 1W/1M, or a currency whose intraday fetch
+    // failed). Without this such bars fall back to a single near-current rate,
+    // which makes the start of the day and earlier multi-day points drift while
+    // only the latest point -- backed by a live intraday bar -- stays correct.
+    // Over-fetch a couple of weeks before the grid so an at-or-before rate
+    // exists even for the first day.
+    const indexStart = formatDateYMD(
+      new Date(timestamps[0] - 14 * 24 * 60 * 60 * 1000),
+    );
+    const indexEnd = formatDateYMD(new Date(now));
+    const dailyRateIndex =
+      fxCurrencies.size > 0
+        ? await this.calculationService.buildDailyRateIndex(
+            fxCurrencies,
+            displayCurrency,
+            indexStart,
+            indexEnd,
+          )
+        : (new Map() as DailyRateIndex);
+    // Memoise the per-currency, per-date daily lookup -- fxAt is called once per
+    // currency per grid bar and the daily rate only changes by date.
+    const dailyRateCache = new Map<string, number | undefined>();
+    const dailyFxAt = (currency: string, ts: number): number | undefined => {
+      const dateStr = formatDateYMD(new Date(ts));
+      const memoKey = `${currency}|${dateStr}`;
+      if (dailyRateCache.has(memoKey)) return dailyRateCache.get(memoKey);
+      const rate = this.calculationService.resolveDailyRate(
+        dailyRateIndex,
+        currency,
+        displayCurrency,
+        dateStr,
+      );
+      dailyRateCache.set(memoKey, rate);
+      return rate;
+    };
+
+    // Walk each FX cursor monotonically as the grid advances. When an intraday
+    // FX bar exists at or before the current timestamp, value the bar at that
+    // live rate. Otherwise (before the first intraday bar, or no intraday series
+    // at all) fall back to the stored daily close for that bar's own date so
+    // historical points are valued at the rate that prevailed then -- not the
+    // first/latest intraday rate -- with the stored latest spot as a last
+    // resort when no daily history exists for the pair.
     const fxAt = (currency: string, ts: number): number => {
       if (currency === displayCurrency) return 1;
       const fx = fxByCurrency.get(currency);
       if (!fx) return rateCache.get(`${currency}->${displayCurrency}`) ?? 1;
-      if (fx.times.length === 0) return fx.latest;
-      while (fx.cursor + 1 < fx.times.length && fx.times[fx.cursor + 1] <= ts) {
-        fx.cursor++;
+      if (fx.times.length > 0) {
+        while (
+          fx.cursor + 1 < fx.times.length &&
+          fx.times[fx.cursor + 1] <= ts
+        ) {
+          fx.cursor++;
+        }
+        if (fx.cursor >= 0) return fx.rates[fx.cursor];
       }
-      return fx.cursor < 0 ? fx.rates[0] : fx.rates[fx.cursor];
+      return dailyFxAt(currency, ts) ?? fx.latest;
     };
 
     // Build per-security ordered timestamp/close arrays and a cursor-based


### PR DESCRIPTION
## Summary

Adds support for valuing intraday portfolio chart bars at historical daily exchange rates when live intraday FX data is unavailable. This ensures bars before the first intraday FX bar, or those in gaps (weekends, holidays, failed fetches), are valued at the rate that actually prevailed on that date rather than backfilling with the first/latest intraday rate.

## Key Changes

- **New `DailyRateIndex` type and methods in `PortfolioCalculationService`:**
  - `buildDailyRateIndex()` — fetches stored daily FX history for a date range and currencies, filters to pairs involving the default currency, normalizes dates/rates, and sorts by date for efficient lookups
  - `resolveDailyRate()` — resolves the most recent rate at or before a given date from the index, with fallback to earliest known rate and support for inverted pairs

- **Enhanced intraday FX fetching in `PortfolioService`:**
  - Implements fallback ladder through coarser intervals (1m → 5m → 1h, etc.) when the primary interval returns empty or fails, reducing reliance on a single rate-limited endpoint
  - Builds a daily rate index covering the grid period (with 2-week lookback buffer) to fill gaps in live intraday data
  - Memoizes daily rate lookups per currency/date to avoid redundant index walks

- **Improved FX resolution logic:**
  - `fxAt()` now prefers live intraday bars when available, falls back to stored daily close for that bar's date, then uses latest spot as last resort
  - Ensures historical points are valued at rates that actually prevailed, not near-current rates

- **Comprehensive test coverage:**
  - Tests for `buildDailyRateIndex`: empty index when no foreign currencies, pair filtering, date/rate normalization and sorting
  - Tests for `resolveDailyRate`: direct rate lookup, fallback to earliest, inverted pair handling, undefined when pair absent
  - Integration test confirming bars before first intraday FX bar use prior daily close (regression test for start-of-day drift)

## Implementation Details

- Daily rates are stored in a `Map<string, Array<{ date: string; rate: number }>>` keyed by `"{from}->{to}"` pairs, with entries sorted by date for binary-search-friendly lookups
- The `convertWithRateLookup` utility handles both direct and inverted pair resolution
- Date normalization tolerates both string (DATE column) and Date instance formats from the database
- The daily rate cache is memoized per currency/date to avoid repeated index walks during grid iteration

https://claude.ai/code/session_01UHrRJGHNtoB7XHr4pdxfKL