### PR TITLE
Extract mobile navigation into MobileNavDrawer component

### DIFF
--- a/frontend/src/components/layout/AppHeader.test.tsx
+++ b/frontend/src/components/layout/AppHeader.test.tsx
@@ -374,17 +374,36 @@ describe('AppHeader', () => {
     expect(dashboardButton.closest('button')?.className).toContain('bg-blue-50');
   });
 
-  it('closes mobile menu when clicking outside', () => {
+  it('closes mobile menu when the backdrop is clicked', () => {
     render(<AppHeader />);
     const menuToggle = screen.getByLabelText('Toggle menu');
     fireEvent.click(menuToggle);
 
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
 
-    // Click outside (mousedown on document)
-    fireEvent.mouseDown(document);
+    // The drawer renders inside the shared Modal; clicking its backdrop
+    // (the parent of the dialog) dismisses it.
+    const backdrop = screen.getByRole('dialog').parentElement!;
+    fireEvent.click(backdrop);
 
-    // Mobile menu should close
+    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
+  });
+
+  it('closes mobile menu when the close button is clicked', () => {
+    render(<AppHeader />);
+    fireEvent.click(screen.getByLabelText('Toggle menu'));
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Close menu'));
+    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
+  });
+
+  it('closes mobile menu on Escape', () => {
+    render(<AppHeader />);
+    fireEvent.click(screen.getByLabelText('Toggle menu'));
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
     expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -10,6 +10,7 @@ import Image from 'next/image';
 import { Button } from '@/components/ui/Button';
 import { BudgetAlertBadge } from '@/components/budgets/BudgetAlertBadge';
 import { ActionHistoryPanel } from '@/components/layout/ActionHistoryPanel';
+import { MobileNavDrawer } from '@/components/layout/MobileNavDrawer';
 import {
   HEADER_SEARCH_EVENT,
   clearTransactionFilterStorage,
@@ -97,14 +98,12 @@ export function AppHeader() {
   const [searchTerm, setSearchTerm] = useState('');
   const toolsRef = useRef<HTMLDivElement>(null);
   const aiRef = useRef<HTMLDivElement>(null);
-  const mobileMenuRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   // Close dropdowns when clicking outside
   useClickOutside(toolsRef, () => setToolsOpen(false));
   useClickOutside(aiRef, () => setAiOpen(false));
-  useClickOutside(mobileMenuRef, () => setMobileMenuOpen(false));
   useClickOutside(searchRef, () => setSearchOpen(false));
 
   // Focus the search input as it slides open.
@@ -193,7 +192,7 @@ export function AppHeader() {
         <div className="flex justify-between h-16">
           <div className="flex items-center">
             {/* Mobile hamburger menu button */}
-            <div className="relative lg:hidden" ref={mobileMenuRef}>
+            <div className="lg:hidden">
               <button
                 onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
                 className="p-2 mr-2 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md"
@@ -210,134 +209,20 @@ export function AppHeader() {
                 )}
               </button>
 
-              {/* Mobile menu dropdown */}
-              {mobileMenuOpen && (
-                <div className="absolute left-0 top-full mt-1 w-56 bg-white dark:bg-gray-800 rounded-md shadow-lg dark:shadow-gray-700/50 border border-gray-200 dark:border-gray-700 z-50">
-                  <div className="py-1">
-                    {/* Dashboard link */}
-                    <button
-                      onClick={() => router.push('/dashboard')}
-                      className={`block w-full text-left px-4 py-2 text-sm transition-colors ${
-                        pathname === '/dashboard'
-                          ? 'bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-200'
-                          : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                      }`}
-                    >
-                      Dashboard
-                    </button>
-
-                    {/* Main nav links */}
-                    {visibleNavLinks.map((link) => (
-                      <button
-                        key={link.href}
-                        onClick={() => router.push(link.href)}
-                        className={`block w-full text-left px-4 py-2 text-sm transition-colors ${
-                          pathname === link.href
-                            ? 'bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-200'
-                            : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                        }`}
-                      >
-                        {link.label}
-                      </button>
-                    ))}
-
-                    {showAiMenu && (
-                    <>
-                    {/* Divider */}
-                    <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
-
-                    {/* AI section header */}
-                    <div className="px-4 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                      AI
-                    </div>
-
-                    {/* AI links */}
-                    {aiLinks.map((link) => (
-                      <button
-                        key={link.href}
-                        onClick={() => router.push(link.href)}
-                        className={`block w-full text-left px-4 py-2 text-sm transition-colors ${
-                          pathname === link.href
-                            ? 'bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-200'
-                            : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                        }`}
-                      >
-                        {link.label}
-                      </button>
-                    ))}
-                    </>
-                    )}
-
-                    {visibleToolsLinks.length > 0 && (
-                    <>
-                    {/* Divider */}
-                    <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
-
-                    {/* Tools section header */}
-                    <div className="px-4 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                      Tools
-                    </div>
-
-                    {/* Tools links */}
-                    {visibleToolsLinks.map((link) => (
-                      <button
-                        key={link.href}
-                        onClick={() => router.push(link.href)}
-                        className={`block w-full text-left px-4 py-2 text-sm transition-colors ${
-                          pathname === link.href
-                            ? 'bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-200'
-                            : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                        }`}
-                      >
-                        {link.label}
-                        {link.badge && (
-                          <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
-                            {link.badge}
-                          </span>
-                        )}
-                      </button>
-                    ))}
-                    </>
-                    )}
-
-                    {/* Admin section - only for admins */}
-                    {!isDelegateView && user?.role === 'admin' && (
-                      <>
-                        <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
-                        <div className="px-4 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                          Admin
-                        </div>
-                        <button
-                          onClick={() => router.push('/admin/users')}
-                          className={`block w-full text-left px-4 py-2 text-sm transition-colors ${
-                            pathname.startsWith('/admin')
-                              ? 'bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-200'
-                              : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                          }`}
-                        >
-                          User Management
-                        </button>
-                      </>
-                    )}
-
-                    {/* Divider */}
-                    <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
-
-                    {/* Settings link -- delegates land on a Security-only
-                        view that manages their OWN credentials. */}
-                    <button
-                      onClick={() => router.push('/settings')}
-                      className={`block w-full text-left px-4 py-2 text-sm transition-colors ${
-                        pathname === '/settings'
-                          ? 'bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-200'
-                          : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                      }`}
-                    >
-                      Settings
-                    </button>
-                  </div>
-                </div>
-              )}
+              {/* Mobile navigation drawer (slides in from the left).
+                  Delegates land on a Security-only Settings view that manages
+                  their OWN credentials. */}
+              <MobileNavDrawer
+                isOpen={mobileMenuOpen}
+                onClose={() => setMobileMenuOpen(false)}
+                pathname={pathname}
+                onNavigate={(href) => router.push(href)}
+                navLinks={visibleNavLinks}
+                aiLinks={aiLinks}
+                showAiMenu={showAiMenu}
+                toolsLinks={visibleToolsLinks}
+                showAdmin={!isDelegateView && user?.role === 'admin'}
+              />
             </div>
 
             <button

--- a/frontend/src/components/layout/MobileNavDrawer.test.tsx
+++ b/frontend/src/components/layout/MobileNavDrawer.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@/test/render';
+import { MobileNavDrawer } from './MobileNavDrawer';
+
+vi.mock('next/image', () => ({
+  default: ({ priority, fill, ...props }: any) => <img {...props} />,
+}));
+
+const navLinks = [
+  { href: '/transactions', label: 'Transactions' },
+  { href: '/accounts', label: 'Accounts' },
+];
+const aiLinks = [
+  { href: '/insights', label: 'Insights' },
+  { href: '/ai', label: 'AI Assistant' },
+];
+const toolsLinks = [
+  { href: '/categories', label: 'Categories' },
+  { href: '/import', label: 'Import Transactions', badge: 'Beta' },
+];
+
+function renderDrawer(overrides: Partial<React.ComponentProps<typeof MobileNavDrawer>> = {}) {
+  const onClose = vi.fn();
+  const onNavigate = vi.fn();
+  const props: React.ComponentProps<typeof MobileNavDrawer> = {
+    isOpen: true,
+    onClose,
+    pathname: '/dashboard',
+    onNavigate,
+    navLinks,
+    aiLinks,
+    showAiMenu: true,
+    toolsLinks,
+    showAdmin: false,
+    ...overrides,
+  };
+  render(<MobileNavDrawer {...props} />);
+  return { onClose, onNavigate };
+}
+
+describe('MobileNavDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when closed', () => {
+    renderDrawer({ isOpen: false });
+    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
+  });
+
+  it('renders the brand, Dashboard, nav, AI, Tools and Settings entries', () => {
+    renderDrawer();
+    expect(screen.getByText('Monize')).toBeInTheDocument();
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Transactions')).toBeInTheDocument();
+    expect(screen.getByText('Accounts')).toBeInTheDocument();
+    expect(screen.getByText('AI')).toBeInTheDocument();
+    expect(screen.getByText('Insights')).toBeInTheDocument();
+    expect(screen.getByText('AI Assistant')).toBeInTheDocument();
+    expect(screen.getByText('Categories')).toBeInTheDocument();
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+  });
+
+  it('renders a badge on a tools link when present', () => {
+    renderDrawer();
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+  });
+
+  it('hides the AI section when showAiMenu is false', () => {
+    renderDrawer({ showAiMenu: false });
+    expect(screen.queryByText('Insights')).not.toBeInTheDocument();
+    // "AI" section header should be gone too (AI Assistant lives under it)
+    expect(screen.queryByText('AI Assistant')).not.toBeInTheDocument();
+  });
+
+  it('omits the Tools section when there are no tools links', () => {
+    renderDrawer({ toolsLinks: [] });
+    expect(screen.queryByText('Tools')).not.toBeInTheDocument();
+    expect(screen.queryByText('Categories')).not.toBeInTheDocument();
+  });
+
+  it('shows the Admin section only when showAdmin is true', () => {
+    renderDrawer({ showAdmin: true });
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+    expect(screen.getByText('User Management')).toBeInTheDocument();
+  });
+
+  it('navigates when a link is clicked', () => {
+    const { onNavigate } = renderDrawer();
+    fireEvent.click(screen.getByText('Transactions'));
+    expect(onNavigate).toHaveBeenCalledWith('/transactions');
+  });
+
+  it('navigates to the dashboard from the brand button', () => {
+    const { onNavigate } = renderDrawer();
+    fireEvent.click(screen.getByText('Monize'));
+    expect(onNavigate).toHaveBeenCalledWith('/dashboard');
+  });
+
+  it('closes when the close button is clicked', () => {
+    const { onClose } = renderDrawer();
+    fireEvent.click(screen.getByLabelText('Close menu'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('highlights the active route', () => {
+    renderDrawer({ pathname: '/transactions' });
+    const active = screen.getByText('Transactions').closest('button');
+    expect(active?.className).toContain('bg-blue-50');
+  });
+
+  it('highlights the Admin entry when on an admin route', () => {
+    renderDrawer({ showAdmin: true, pathname: '/admin/users' });
+    const active = screen.getByText('User Management').closest('button');
+    expect(active?.className).toContain('bg-blue-50');
+  });
+});

--- a/frontend/src/components/layout/MobileNavDrawer.tsx
+++ b/frontend/src/components/layout/MobileNavDrawer.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import Image from 'next/image';
+import { Modal } from '@/components/ui/Modal';
+
+interface NavLink {
+  href: string;
+  label: string;
+  badge?: string;
+}
+
+interface MobileNavDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Current route, used to highlight the active entry. */
+  pathname: string;
+  /** Navigate to a route. The caller closes the drawer on route change. */
+  onNavigate: (href: string) => void;
+  /** Main section links the current user is allowed to see. */
+  navLinks: NavLink[];
+  /** AI links; only rendered when `showAiMenu` is true. */
+  aiLinks: NavLink[];
+  showAiMenu: boolean;
+  /** Tools links the current user is allowed to see. */
+  toolsLinks: NavLink[];
+  /** Whether to render the Admin section. */
+  showAdmin: boolean;
+}
+
+const SECTION_HEADER_CLASS =
+  'px-4 pt-3 pb-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider';
+
+/**
+ * Mobile navigation drawer: a full-height panel that slides in from the left
+ * over a dimmed backdrop. Reuses the shared `Modal` primitive for the portal,
+ * body-scroll lock, focus trap, Escape handling, and back-button-to-close
+ * (`pushHistory`). Links are a flat list grouped under section headers.
+ */
+export function MobileNavDrawer({
+  isOpen,
+  onClose,
+  pathname,
+  onNavigate,
+  navLinks,
+  aiLinks,
+  showAiMenu,
+  toolsLinks,
+  showAdmin,
+}: MobileNavDrawerProps) {
+  const itemClass = (active: boolean) =>
+    `flex w-full items-center text-left px-4 py-3 text-base transition-colors ${
+      active
+        ? 'bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-200'
+        : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+    }`;
+
+  const renderLink = (link: NavLink, active: boolean) => (
+    <button
+      key={link.href}
+      onClick={() => onNavigate(link.href)}
+      className={itemClass(active)}
+    >
+      {link.label}
+      {link.badge && (
+        <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
+          {link.badge}
+        </span>
+      )}
+    </button>
+  );
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} variant="drawer-left" pushHistory>
+      <nav aria-label="Main menu" className="flex flex-col">
+        {/* Drawer header: brand + close button */}
+        <div className="flex items-center justify-between px-4 h-16 border-b border-gray-200 dark:border-gray-700">
+          <button
+            onClick={() => onNavigate('/dashboard')}
+            className="flex items-center gap-2 text-xl font-bold text-blue-600 dark:text-blue-400"
+          >
+            <Image
+              src="/icons/monize-logo.svg"
+              alt="Monize"
+              width={28}
+              height={28}
+              className="rounded"
+              priority
+            />
+            <span>Monize</span>
+          </button>
+          <button
+            onClick={onClose}
+            aria-label="Close menu"
+            className="p-2 -mr-2 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md"
+          >
+            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="py-2">
+          {renderLink({ href: '/dashboard', label: 'Dashboard' }, pathname === '/dashboard')}
+          {navLinks.map((link) => renderLink(link, pathname === link.href))}
+
+          {showAiMenu && (
+            <>
+              <div className="border-t border-gray-200 dark:border-gray-700 mt-2" />
+              <div className={SECTION_HEADER_CLASS}>AI</div>
+              {aiLinks.map((link) => renderLink(link, pathname === link.href))}
+            </>
+          )}
+
+          {toolsLinks.length > 0 && (
+            <>
+              <div className="border-t border-gray-200 dark:border-gray-700 mt-2" />
+              <div className={SECTION_HEADER_CLASS}>Tools</div>
+              {toolsLinks.map((link) => renderLink(link, pathname === link.href))}
+            </>
+          )}
+
+          {showAdmin && (
+            <>
+              <div className="border-t border-gray-200 dark:border-gray-700 mt-2" />
+              <div className={SECTION_HEADER_CLASS}>Admin</div>
+              {renderLink(
+                { href: '/admin/users', label: 'User Management' },
+                pathname.startsWith('/admin'),
+              )}
+            </>
+          )}
+
+          <div className="border-t border-gray-200 dark:border-gray-700 mt-2" />
+          {renderLink({ href: '/settings', label: 'Settings' }, pathname === '/settings')}
+        </div>
+      </nav>
+    </Modal>
+  );
+}

--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -113,6 +113,38 @@ describe('Modal', () => {
     expect(dialog.className).toContain('p-6');
   });
 
+  describe('drawer-left variant', () => {
+    it('renders a full-height left sheet pinned to the left edge', () => {
+      render(<Modal isOpen={true} variant="drawer-left">Content</Modal>);
+      const dialog = screen.getByRole('dialog');
+      // Panel is a full-height sheet, not a centered rounded card.
+      expect(dialog.className).toContain('h-full');
+      expect(dialog.className).not.toContain('rounded-lg');
+      expect(dialog.className).not.toContain('max-w-lg');
+      // Backdrop pins the panel to the left.
+      const backdrop = dialog.parentElement!;
+      expect(backdrop.className).toContain('justify-start');
+      expect(backdrop.className).not.toContain('justify-center');
+    });
+
+    it('animates in from off-screen via the starting-style variant', () => {
+      render(<Modal isOpen={true} variant="drawer-left">Content</Modal>);
+      const dialog = screen.getByRole('dialog');
+      expect(dialog.className).toContain('transition-transform');
+      expect(dialog.className).toContain('translate-x-0');
+      expect(dialog.className).toContain('starting:-translate-x-full');
+    });
+
+    it('still closes on backdrop click in drawer mode', () => {
+      const onClose = vi.fn();
+      render(
+        <Modal isOpen={true} onClose={onClose} variant="drawer-left">Content</Modal>,
+      );
+      fireEvent.click(screen.getByRole('dialog').parentElement!);
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
   describe('body overflow ref counting', () => {
     it('keeps body hidden when stacked modal closes but parent remains open', () => {
       const { rerender } = render(

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -56,6 +56,11 @@ interface ModalProps {
   /** When true, uses overflow-visible instead of overflow-y-auto on the modal container.
    *  Useful when the modal contains dropdowns that need to expand beyond modal bounds. */
   allowOverflow?: boolean;
+  /** Layout variant.
+   *  - 'center' (default): centered rounded card, honours `maxWidth`.
+   *  - 'drawer-left': full-height panel pinned to the left edge that slides in.
+   *    Intended for mobile navigation. `maxWidth` is ignored in this variant. */
+  variant?: 'center' | 'drawer-left';
 }
 
 const maxWidthClasses = {
@@ -79,6 +84,7 @@ export function Modal({
   pushHistory = false,
   onBeforeClose,
   allowOverflow = false,
+  variant = 'center',
 }: ModalProps) {
   // Track whether we have a history entry pushed
   const historyPushedRef = useRef(false);
@@ -286,9 +292,25 @@ export function Modal({
 
   if (!isOpen) return null;
 
+  const isDrawer = variant === 'drawer-left';
+
+  // Backdrop alignment: drawer pins its panel to the left edge; the default
+  // centers the card with padding.
+  const backdropClassName = `fixed inset-0 bg-black/40 dark:bg-black/60 backdrop-blur-sm z-50 flex ${
+    isDrawer ? 'justify-start' : 'items-center justify-center p-4'
+  }`;
+
+  // Panel shape. The drawer is a full-height left sheet that slides in from
+  // off-screen via the CSS @starting-style (`starting:`) variant -- no extra
+  // React state needed. The default keeps the centered rounded card.
+  const overflowClass = allowOverflow ? 'overflow-visible' : 'overflow-y-auto';
+  const panelClassName = isDrawer
+    ? `bg-white dark:bg-gray-800 shadow-xl dark:shadow-gray-700/50 h-full w-[85%] max-w-sm ${overflowClass} outline-none transition-transform duration-200 ease-out translate-x-0 starting:-translate-x-full ${className}`
+    : `bg-white dark:bg-gray-800 rounded-lg shadow-xl dark:shadow-gray-700/50 ${maxWidthClasses[maxWidth]} w-full max-h-[90vh] ${overflowClass} outline-none ${className}`;
+
   return createPortal(
     <div
-      className="fixed inset-0 bg-black/40 dark:bg-black/60 backdrop-blur-sm flex items-center justify-center p-4 z-50"
+      className={backdropClassName}
       onClick={() => attemptClose('backdrop')}
     >
       <div
@@ -296,7 +318,7 @@ export function Modal({
         role="dialog"
         aria-modal="true"
         tabIndex={-1}
-        className={`bg-white dark:bg-gray-800 rounded-lg shadow-xl dark:shadow-gray-700/50 ${maxWidthClasses[maxWidth]} w-full max-h-[90vh] ${allowOverflow ? 'overflow-visible' : 'overflow-y-auto'} outline-none ${className}`}
+        className={panelClassName}
         onClick={(e) => e.stopPropagation()}
         onSubmit={(e) => e.stopPropagation()}
       >


### PR DESCRIPTION
## Summary
Refactors the mobile navigation menu from an inline dropdown in `AppHeader` into a dedicated `MobileNavDrawer` component that uses the shared `Modal` primitive with a new `drawer-left` variant. This improves code organization, reusability, and testability while maintaining the same user experience.

## Key Changes

- **New `MobileNavDrawer` component** (`frontend/src/components/layout/MobileNavDrawer.tsx`):
  - Encapsulates all mobile navigation UI and logic
  - Accepts props for nav links, AI links, tools links, admin visibility, and route state
  - Renders a full-height left-sliding drawer using the `Modal` component with `variant="drawer-left"`
  - Includes a branded header with close button and dashboard shortcut
  - Organizes links into sections (Main, AI, Tools, Admin, Settings) with dividers and headers

- **Updated `Modal` component** (`frontend/src/components/ui/Modal.tsx`):
  - Added `variant` prop supporting `'center'` (default) and `'drawer-left'`
  - `drawer-left` variant renders a full-height panel pinned to the left edge
  - Uses CSS `@starting-style` for slide-in animation (no additional React state needed)
  - Backdrop alignment differs by variant: drawer uses `justify-start`, center uses `justify-center`

- **Refactored `AppHeader`** (`frontend/src/components/layout/AppHeader.tsx`):
  - Removed 125 lines of inline mobile menu markup and logic
  - Removed `mobileMenuRef` and associated `useClickOutside` hook (now handled by `Modal`)
  - Replaced with a single `<MobileNavDrawer>` component call, passing all necessary props
  - Simplified mobile menu toggle to just manage `mobileMenuOpen` state

- **Added comprehensive tests**:
  - `MobileNavDrawer.test.tsx`: 11 test cases covering rendering, visibility, navigation, active states, and conditional sections
  - Updated `AppHeader.test.tsx`: Adjusted mobile menu tests to reflect new drawer behavior (backdrop click, close button, Escape key)
  - Updated `Modal.test.tsx`: Added 3 test cases for `drawer-left` variant (layout, animation, backdrop interaction)

## Implementation Details

- The drawer reuses the `Modal` component's portal, body-scroll lock, focus trap, Escape handling, and `pushHistory` support — no duplication of modal infrastructure
- Links are rendered as a flat list with section headers and dividers, matching the original design
- Active route highlighting works the same way, with special handling for admin routes (`pathname.startsWith('/admin')`)
- The component is fully responsive and dark-mode compatible
- All navigation closes the drawer via the `onNavigate` callback (caller responsibility to close)

https://claude.ai/code/session_01D8qnHjMdpEFB2CUFyBPtV3