### PR TITLE
Add post-reconciliation liability payment prompt and deep links

### DIFF
--- a/frontend/src/app/bills/page.test.tsx
+++ b/frontend/src/app/bills/page.test.tsx
@@ -1253,4 +1253,39 @@ describe('BillsPage', () => {
       await waitFor(() => expect(nav.replace).toHaveBeenCalledWith('/bills'));
     });
   });
+
+  describe('Reconcile deep links', () => {
+    it('opens the override editor for the next instance from reconcileEditId', async () => {
+      mockGetOverrideByDate.mockResolvedValue(null);
+      nav.searchParams = new URLSearchParams('reconcileEditId=st-3&reconcileAmount=500');
+      render(<BillsPage />);
+      await waitFor(() => expect(screen.getByTestId('override-editor')).toBeInTheDocument());
+      // Looks up an override on the schedule's next due date.
+      expect(mockGetOverrideByDate).toHaveBeenCalledWith('st-3', '2026-03-01');
+    });
+
+    it('clears the reconcile params when the override editor closes', async () => {
+      mockGetOverrideByDate.mockResolvedValue(null);
+      nav.searchParams = new URLSearchParams('reconcileEditId=st-3&reconcileAmount=500');
+      render(<BillsPage />);
+      await waitFor(() => expect(screen.getByTestId('override-editor')).toBeInTheDocument());
+      fireEvent.click(screen.getByTestId('override-close'));
+      await waitFor(() => expect(nav.replace).toHaveBeenCalledWith('/bills'));
+    });
+
+    it('opens the create form for reconcileCreate', async () => {
+      nav.searchParams = new URLSearchParams(
+        'reconcileCreate=1&reconcileTransferAccountId=acc-2&reconcileAmount=500',
+      );
+      render(<BillsPage />);
+      await waitFor(() => expect(mockOpenCreate).toHaveBeenCalled());
+    });
+
+    it('does nothing for an unknown reconcileEditId', async () => {
+      nav.searchParams = new URLSearchParams('reconcileEditId=missing&reconcileAmount=500');
+      render(<BillsPage />);
+      await waitFor(() => expect(screen.getByTestId('scheduled-transaction-list')).toBeInTheDocument());
+      expect(screen.queryByTestId('override-editor')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/app/bills/page.tsx
+++ b/frontend/src/app/bills/page.tsx
@@ -63,6 +63,8 @@ interface OverrideEditorState {
   transaction: ScheduledTransaction | null;
   date: string;
   existingOverride: ScheduledTransactionOverride | null;
+  // When set (post-reconciliation flow), seeds the Amount field with this value.
+  prefillAmount: number | null;
 }
 
 export default function BillsPage() {
@@ -77,6 +79,11 @@ function BillsContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const postBillId = searchParams.get('postBillId');
+  // Post-reconciliation deep links (from the Reconcile completion screen).
+  const reconcileEditId = searchParams.get('reconcileEditId');
+  const reconcileCreate = searchParams.get('reconcileCreate');
+  const reconcileTransferAccountId = searchParams.get('reconcileTransferAccountId');
+  const reconcileAmount = searchParams.get('reconcileAmount');
   const { formatCurrency } = useNumberFormat();
   const [scheduledTransactions, setScheduledTransactions] = useState<ScheduledTransaction[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
@@ -93,7 +100,14 @@ function BillsContent() {
     transaction: null,
     date: '',
     existingOverride: null,
+    prefillAmount: null,
   });
+  // Prefill state for a new transfer schedule created from the reconcile flow.
+  const [createPrefill, setCreatePrefill] = useState<{
+    transferAccountId: string;
+    amount: number;
+  } | null>(null);
+  const [reconcileHandled, setReconcileHandled] = useState(false);
   const [overrideConfirm, setOverrideConfirm] = useState<{
     isOpen: boolean;
     transaction: ScheduledTransaction | null;
@@ -152,6 +166,8 @@ function BillsContent() {
   useOnUndoRedo(loadData);
 
   const handleCreateNew = () => {
+    // Clear any stale reconcile prefill so a manual create starts blank.
+    setCreatePrefill(null);
     openCreate();
   };
 
@@ -204,11 +220,57 @@ function BillsContent() {
     setOverrideConfirm({ isOpen: false, transaction: null, overrideCount: 0 });
   };
 
+  // Clear any reconcile deep-link query params once the relevant dialog is done.
+  const clearReconcileParams = () => {
+    if (reconcileEditId || reconcileCreate || reconcileTransferAccountId || reconcileAmount) {
+      router.replace('/bills');
+    }
+  };
+
+  const handleFormClose = () => {
+    close();
+    if (createPrefill) {
+      setCreatePrefill(null);
+      clearReconcileParams();
+    }
+  };
+
   const handleFormSuccess = () => {
     close();
+    if (createPrefill) {
+      setCreatePrefill(null);
+      clearReconcileParams();
+    }
     loadData();
   };
 
+  // Open the override editor directly on a schedule's next instance, optionally
+  // prefilling the amount. Used by the post-reconciliation "update next payment"
+  // deep link to skip the occurrence date picker.
+  const openNextOccurrenceEditor = async (
+    transaction: ScheduledTransaction,
+    prefillAmount?: number,
+  ) => {
+    const date = (transaction.nextDueDate || '').split('T')[0];
+    let existingOverride: ScheduledTransactionOverride | null = null;
+    if (date) {
+      try {
+        existingOverride = await scheduledTransactionsApi.getOverrideByDate(
+          transaction.id,
+          date,
+        );
+      } catch (error) {
+        logger.error('Failed to fetch override for next occurrence:', error);
+      }
+    }
+    setOverrideEditor({
+      isOpen: true,
+      transaction,
+      date,
+      existingOverride,
+      prefillAmount: prefillAmount ?? null,
+    });
+  };
 
   const handleEditOccurrence = async (transaction: ScheduledTransaction) => {
     // Fetch existing overrides to show which dates are modified (and what changed)
@@ -261,6 +323,7 @@ function BillsContent() {
         transaction,
         date: overrideByOverrideDate?.originalDate || date, // Use original date if this was an override
         existingOverride,
+        prefillAmount: null,
       });
     } catch (error) {
       logger.error('Failed to check for existing override:', error);
@@ -270,6 +333,7 @@ function BillsContent() {
         transaction,
         date,
         existingOverride: null,
+        prefillAmount: null,
       });
     }
   };
@@ -279,12 +343,17 @@ function BillsContent() {
   };
 
   const handleOverrideEditorClose = () => {
+    const wasReconcileDeepLink = overrideEditor.prefillAmount != null;
     setOverrideEditor({
       isOpen: false,
       transaction: null,
       date: '',
       existingOverride: null,
+      prefillAmount: null,
     });
+    if (wasReconcileDeepLink) {
+      clearReconcileParams();
+    }
   };
 
   const handleOverrideEditorSave = () => {
@@ -319,6 +388,25 @@ function BillsContent() {
     setAutoOpenedPostId(postBillId);
     if (target) {
       setPostDialog({ isOpen: true, transaction: target });
+    }
+  }
+
+  // Handle post-reconciliation deep links. Adjust state during render (gated so
+  // it runs once) to comply with the no-setState-in-effect rule. URL cleanup
+  // happens when the opened dialog/modal closes.
+  if (!reconcileHandled && !isLoading && (reconcileEditId || reconcileCreate)) {
+    setReconcileHandled(true);
+    const amount = reconcileAmount ? Number(reconcileAmount) : undefined;
+    if (reconcileCreate && reconcileTransferAccountId) {
+      setCreatePrefill({ transferAccountId: reconcileTransferAccountId, amount: amount ?? 0 });
+      openCreate();
+    } else if (reconcileEditId) {
+      const target = scheduledTransactions.find((st) => st.id === reconcileEditId);
+      if (target) {
+        void openNextOccurrenceEditor(target, amount);
+      } else {
+        toast.error('Scheduled payment not found');
+      }
     }
   }
 
@@ -523,15 +611,18 @@ function BillsContent() {
         </ErrorBoundary>
 
         {/* Form Modal */}
-        <Modal isOpen={showForm} onClose={close} {...modalProps} maxWidth="6xl" className="p-6 !max-w-[69rem]">
+        <Modal isOpen={showForm} onClose={handleFormClose} {...modalProps} maxWidth="6xl" className="p-6 !max-w-[69rem]">
           <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">
             {isEditing ? 'Edit Scheduled Transaction' : 'New Scheduled Transaction'}
           </h2>
           <ScheduledTransactionForm
-            key={editingTransaction?.id || 'new'}
+            key={editingTransaction?.id || (createPrefill ? 'new-prefill' : 'new')}
             scheduledTransaction={editingTransaction}
+            initialMode={createPrefill ? 'transfer' : undefined}
+            initialAmount={createPrefill?.amount}
+            initialTransferAccountId={createPrefill?.transferAccountId}
             onSuccess={handleFormSuccess}
-            onCancel={close}
+            onCancel={handleFormClose}
             onDirtyChange={setFormDirty}
             submitRef={formSubmitRef}
           />
@@ -736,6 +827,7 @@ function BillsContent() {
           categories={categories}
           accounts={accounts}
           existingOverride={overrideEditor.existingOverride}
+          prefillAmount={overrideEditor.prefillAmount}
           onClose={handleOverrideEditorClose}
           onSave={handleOverrideEditorSave}
         />

--- a/frontend/src/app/reconcile/page.test.tsx
+++ b/frontend/src/app/reconcile/page.test.tsx
@@ -66,10 +66,17 @@ vi.mock('@/lib/auth', () => ({
 const mockGetAll = vi.fn();
 const mockGetReconciliationData = vi.fn();
 const mockBulkReconcile = vi.fn();
+const mockScheduledGetAll = vi.fn();
 
 vi.mock('@/lib/accounts', () => ({
   accountsApi: {
     getAll: (...args: any[]) => mockGetAll(...args),
+  },
+}));
+
+vi.mock('@/lib/scheduled-transactions', () => ({
+  scheduledTransactionsApi: {
+    getAll: (...args: any[]) => mockScheduledGetAll(...args),
   },
 }));
 
@@ -194,6 +201,7 @@ describe('ReconcilePage', () => {
     mockGetAll.mockResolvedValue(mockAccounts);
     mockGetReconciliationData.mockResolvedValue(mockReconciliationData);
     mockBulkReconcile.mockResolvedValue({ reconciled: 2 });
+    mockScheduledGetAll.mockResolvedValue([]);
   });
 
   describe('Setup Step', () => {
@@ -528,6 +536,82 @@ describe('ReconcilePage', () => {
       await waitFor(() => {
         expect(toast.default.error).toHaveBeenCalledWith('Failed to reconcile transactions');
       }, { timeout: 3000 });
+    });
+  });
+
+  describe('Liability Payment Prompt', () => {
+    // Reconcile a liability account (Visa) to a -500 statement balance: a single
+    // cleared -500 transaction against a reconciledBalance of 0 yields a $0
+    // difference so the Finish button is enabled.
+    async function finishLiabilityReconciliation() {
+      mockGetReconciliationData.mockResolvedValue({
+        transactions: [{
+          id: 'tx-a', transactionDate: '2026-02-01', payee: { name: 'Test' },
+          payeeName: null, category: null, amount: -500, status: TransactionStatus.CLEARED,
+        }],
+        reconciledBalance: 0, clearedBalance: -500, difference: 0,
+      });
+      render(<ReconcilePage />);
+      await waitFor(() => expect(screen.getByText(/Visa/)).toBeInTheDocument(), { timeout: 3000 });
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-2' } });
+      fireEvent.change(screen.getByLabelText('Statement Ending Balance'), { target: { value: '500' } });
+      fireEvent.click(screen.getAllByText('Start Reconciliation').find(el => el.tagName === 'BUTTON')!);
+      await waitFor(() => expect(screen.getByText('Finish Reconciliation')).toBeInTheDocument(), { timeout: 3000 });
+      fireEvent.click(screen.getByText('Finish Reconciliation'));
+      await waitFor(() => expect(screen.getByText('Reconciliation Complete')).toBeInTheDocument(), { timeout: 3000 });
+    }
+
+    it('offers to update an existing scheduled payment for the account', async () => {
+      mockScheduledGetAll.mockResolvedValue([
+        { id: 'bill-1', name: 'Visa Payment', isTransfer: true, transferAccountId: 'acc-2', splits: [] },
+      ]);
+      await finishLiabilityReconciliation();
+      expect(screen.getByText(/Visa Payment/)).toBeInTheDocument();
+      fireEvent.click(screen.getByText('Update Next Payment'));
+      expect(mockRouterPush).toHaveBeenCalledWith('/bills?reconcileEditId=bill-1&reconcileAmount=500');
+    });
+
+    it('matches a scheduled payment linked via a split transfer', async () => {
+      mockScheduledGetAll.mockResolvedValue([
+        { id: 'bill-2', name: 'Paycheck Split', isTransfer: false, transferAccountId: null,
+          splits: [{ transferAccountId: 'acc-2' }] },
+      ]);
+      await finishLiabilityReconciliation();
+      fireEvent.click(screen.getByText('Update Next Payment'));
+      expect(mockRouterPush).toHaveBeenCalledWith('/bills?reconcileEditId=bill-2&reconcileAmount=500');
+    });
+
+    it('offers to create a scheduled payment when none exists', async () => {
+      mockScheduledGetAll.mockResolvedValue([
+        { id: 'other', name: 'Unrelated', isTransfer: true, transferAccountId: 'acc-1', splits: [] },
+      ]);
+      await finishLiabilityReconciliation();
+      expect(screen.getByText('Create Scheduled Payment')).toBeInTheDocument();
+      fireEvent.click(screen.getByText('Create Scheduled Payment'));
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        '/bills?reconcileCreate=1&reconcileTransferAccountId=acc-2&reconcileAmount=500'
+      );
+    });
+
+    it('does not show the payment prompt for a non-liability account', async () => {
+      mockGetReconciliationData.mockResolvedValue({
+        transactions: [{
+          id: 'tx-a', transactionDate: '2026-02-01', payee: { name: 'Test' },
+          payeeName: null, category: null, amount: 500, status: TransactionStatus.CLEARED,
+        }],
+        reconciledBalance: 1000, clearedBalance: 1500, difference: 0,
+      });
+      render(<ReconcilePage />);
+      await waitFor(() => expect(screen.getByText(/Checking/)).toBeInTheDocument(), { timeout: 3000 });
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-1' } });
+      fireEvent.change(screen.getByLabelText('Statement Ending Balance'), { target: { value: '1500' } });
+      fireEvent.click(screen.getAllByText('Start Reconciliation').find(el => el.tagName === 'BUTTON')!);
+      await waitFor(() => expect(screen.getByText('Finish Reconciliation')).toBeInTheDocument(), { timeout: 3000 });
+      fireEvent.click(screen.getByText('Finish Reconciliation'));
+      await waitFor(() => expect(screen.getByText('Reconciliation Complete')).toBeInTheDocument(), { timeout: 3000 });
+      expect(screen.queryByText('Update Next Payment')).not.toBeInTheDocument();
+      expect(screen.queryByText('Create Scheduled Payment')).not.toBeInTheDocument();
+      expect(mockScheduledGetAll).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/app/reconcile/page.test.tsx
+++ b/frontend/src/app/reconcile/page.test.tsx
@@ -180,6 +180,7 @@ const mockAccounts = [
   { id: 'acc-2', name: 'Visa', accountType: 'CREDIT_CARD', accountSubType: null, currencyCode: 'USD', currentBalance: -500, isClosed: false },
   { id: 'acc-3', name: 'Brokerage', accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_BROKERAGE', currencyCode: 'USD', currentBalance: 10000, isClosed: false },
   { id: 'acc-4', name: 'Old Savings', accountType: 'SAVINGS', accountSubType: null, currencyCode: 'USD', currentBalance: 0, isClosed: true },
+  { id: 'acc-5', name: 'Car Loan', accountType: 'LOAN', accountSubType: null, currencyCode: 'USD', currentBalance: -8000, isClosed: false },
 ];
 
 const mockTransactions = [
@@ -591,6 +592,27 @@ describe('ReconcilePage', () => {
       expect(mockRouterPush).toHaveBeenCalledWith(
         '/bills?reconcileCreate=1&reconcileTransferAccountId=acc-2&reconcileAmount=500'
       );
+    });
+
+    it('does not show the payment prompt for a loan account', async () => {
+      mockGetReconciliationData.mockResolvedValue({
+        transactions: [{
+          id: 'tx-a', transactionDate: '2026-02-01', payee: { name: 'Test' },
+          payeeName: null, category: null, amount: -8000, status: TransactionStatus.CLEARED,
+        }],
+        reconciledBalance: 0, clearedBalance: -8000, difference: 0,
+      });
+      render(<ReconcilePage />);
+      await waitFor(() => expect(screen.getByText(/Car Loan/)).toBeInTheDocument(), { timeout: 3000 });
+      fireEvent.change(screen.getByLabelText('Account'), { target: { value: 'acc-5' } });
+      fireEvent.change(screen.getByLabelText('Statement Ending Balance'), { target: { value: '8000' } });
+      fireEvent.click(screen.getAllByText('Start Reconciliation').find(el => el.tagName === 'BUTTON')!);
+      await waitFor(() => expect(screen.getByText('Finish Reconciliation')).toBeInTheDocument(), { timeout: 3000 });
+      fireEvent.click(screen.getByText('Finish Reconciliation'));
+      await waitFor(() => expect(screen.getByText('Reconciliation Complete')).toBeInTheDocument(), { timeout: 3000 });
+      expect(screen.queryByText('Update Next Payment')).not.toBeInTheDocument();
+      expect(screen.queryByText('Create Scheduled Payment')).not.toBeInTheDocument();
+      expect(mockScheduledGetAll).not.toHaveBeenCalled();
     });
 
     it('does not show the payment prompt for a non-liability account', async () => {

--- a/frontend/src/app/reconcile/page.tsx
+++ b/frontend/src/app/reconcile/page.tsx
@@ -521,7 +521,7 @@ function ReconcileContent() {
                   </span>
                   ?
                 </p>
-                <div className="mt-3">
+                <div className="mt-3 flex justify-center">
                   <Button onClick={handleUpdatePayment}>
                     Update Next Payment
                   </Button>
@@ -537,7 +537,7 @@ function ReconcileContent() {
                   </span>
                   ?
                 </p>
-                <div className="mt-3">
+                <div className="mt-3 flex justify-center">
                   <Button onClick={handleCreatePayment}>
                     Create Scheduled Payment
                   </Button>

--- a/frontend/src/app/reconcile/page.tsx
+++ b/frontend/src/app/reconcile/page.tsx
@@ -12,9 +12,11 @@ import { DateInput } from '@/components/ui/DateInput';
 import { CurrencyInput } from '@/components/ui/CurrencyInput';
 import { Select } from '@/components/ui/Select';
 import { transactionsApi } from '@/lib/transactions';
+import { scheduledTransactionsApi } from '@/lib/scheduled-transactions';
 import { getLocalDateString } from '@/lib/utils';
 import { accountsApi } from '@/lib/accounts';
 import { Account } from '@/types/account';
+import { ScheduledTransaction } from '@/types/scheduled-transaction';
 import { ReconciliationData, TransactionStatus } from '@/types/transaction';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { getCurrencySymbol } from '@/lib/format';
@@ -49,6 +51,9 @@ function ReconcileContent() {
   const [selectedTransactionIds, setSelectedTransactionIds] = useState<Set<string>>(new Set());
   const [isLoading, setIsLoading] = useState(false);
   const [isReconciling, setIsReconciling] = useState(false);
+  // Post-reconciliation liability-payment prompt: the scheduled bill (if any)
+  // that pays down the reconciled liability account.
+  const [paymentBill, setPaymentBill] = useState<ScheduledTransaction | null>(null);
 
   // Load accounts
   useEffect(() => {
@@ -180,6 +185,23 @@ function ReconcileContent() {
         statementDate
       );
       toast.success(`Successfully reconciled ${result.reconciled} transactions`);
+
+      // For liability accounts, look for an existing scheduled bill that pays
+      // down this account so we can offer to update its next instance.
+      if (isLiability) {
+        try {
+          const scheduled = await scheduledTransactionsApi.getAll();
+          const match = scheduled.find(
+            (st) =>
+              (st.isTransfer && st.transferAccountId === selectedAccountId) ||
+              (st.splits?.some((s) => s.transferAccountId === selectedAccountId) ?? false)
+          );
+          setPaymentBill(match ?? null);
+        } catch {
+          setPaymentBill(null);
+        }
+      }
+
       setStep('complete');
     } catch (error) {
       toast.error(getErrorMessage(error, 'Failed to reconcile transactions'));
@@ -192,6 +214,24 @@ function ReconcileContent() {
     setStep('setup');
     setReconciliationData(null);
     setSelectedTransactionIds(new Set());
+  };
+
+  // The amount to apply to the liability payment: the reconciled balance owed,
+  // as a positive figure (liability balances are stored negative).
+  const reconciledPaymentAmount = Math.round(Math.abs(statementBalance ?? 0) * 100) / 100;
+
+  const handleUpdatePayment = () => {
+    if (!paymentBill) return;
+    router.push(
+      `/bills?reconcileEditId=${paymentBill.id}&reconcileAmount=${reconciledPaymentAmount}`
+    );
+  };
+
+  const handleCreatePayment = () => {
+    router.push(
+      `/bills?reconcileCreate=1&reconcileTransferAccountId=${selectedAccountId}` +
+        `&reconcileAmount=${reconciledPaymentAmount}`
+    );
   };
 
   const formatCurrency = (amount: number | string | null | undefined) => {
@@ -453,6 +493,49 @@ function ReconcileContent() {
           Your account has been successfully reconciled as of{' '}
           {format(new Date(statementDate), 'MMMM d, yyyy')}.
         </p>
+
+        {/* Liability payment prompt: offer to update or create the scheduled
+            bill that pays down this account, using the reconciled balance. */}
+        {isLiability && (
+          <div className="mb-6 rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 p-4 text-left">
+            {paymentBill ? (
+              <>
+                <p className="text-sm text-gray-700 dark:text-gray-300">
+                  This account has a scheduled payment,{' '}
+                  <span className="font-medium">{paymentBill.name}</span>. Would
+                  you like to update its next instance to the reconciled balance
+                  of{' '}
+                  <span className="font-medium">
+                    {formatCurrency(reconciledPaymentAmount)}
+                  </span>
+                  ?
+                </p>
+                <div className="mt-3">
+                  <Button onClick={handleUpdatePayment}>
+                    Update Next Payment
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <>
+                <p className="text-sm text-gray-700 dark:text-gray-300">
+                  No scheduled payment was found for this account. Would you like
+                  to create one for the reconciled balance of{' '}
+                  <span className="font-medium">
+                    {formatCurrency(reconciledPaymentAmount)}
+                  </span>
+                  ?
+                </p>
+                <div className="mt-3">
+                  <Button onClick={handleCreatePayment}>
+                    Create Scheduled Payment
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
         <div className="flex justify-center space-x-4">
           <Button variant="outline" onClick={() => router.push('/accounts')}>
             Back to Accounts
@@ -463,6 +546,7 @@ function ReconcileContent() {
               setReconciliationData(null);
               setSelectedTransactionIds(new Set());
               setStatementBalance(undefined);
+              setPaymentBill(null);
             }}
           >
             Reconcile Another Account

--- a/frontend/src/app/reconcile/page.tsx
+++ b/frontend/src/app/reconcile/page.tsx
@@ -24,6 +24,11 @@ import { getErrorMessage } from '@/lib/errors';
 
 const LIABILITY_TYPES = new Set(['CREDIT_CARD', 'LOAN', 'MORTGAGE', 'LINE_OF_CREDIT']);
 
+// Revolving-credit accounts whose balance changes each statement, so the
+// payment that pays them off should track the reconciled balance. Loans and
+// mortgages have fixed payments and are intentionally excluded.
+const PAYMENT_PROMPT_TYPES = new Set(['CREDIT_CARD', 'LINE_OF_CREDIT']);
+
 type ReconcileStep = 'setup' | 'reconcile' | 'complete';
 
 export default function ReconcilePage() {
@@ -78,6 +83,11 @@ function ReconcileContent() {
   );
 
   const isLiability = selectedAccount ? LIABILITY_TYPES.has(selectedAccount.accountType) : false;
+
+  // Only revolving-credit accounts get the post-reconciliation payment prompt.
+  const offersPaymentPrompt = selectedAccount
+    ? PAYMENT_PROMPT_TYPES.has(selectedAccount.accountType)
+    : false;
 
   // For liability accounts, auto-negate positive entries. If the user explicitly
   // flips the sign (same absolute value), respect their choice -- mirrors the
@@ -186,9 +196,9 @@ function ReconcileContent() {
       );
       toast.success(`Successfully reconciled ${result.reconciled} transactions`);
 
-      // For liability accounts, look for an existing scheduled bill that pays
-      // down this account so we can offer to update its next instance.
-      if (isLiability) {
+      // For revolving-credit accounts, look for an existing scheduled bill that
+      // pays down this account so we can offer to update its next instance.
+      if (offersPaymentPrompt) {
         try {
           const scheduled = await scheduledTransactionsApi.getAll();
           const match = scheduled.find(
@@ -494,9 +504,10 @@ function ReconcileContent() {
           {format(new Date(statementDate), 'MMMM d, yyyy')}.
         </p>
 
-        {/* Liability payment prompt: offer to update or create the scheduled
-            bill that pays down this account, using the reconciled balance. */}
-        {isLiability && (
+        {/* Revolving-credit payment prompt: offer to update or create the
+            scheduled bill that pays down this account, using the reconciled
+            balance. */}
+        {offersPaymentPrompt && (
           <div className="mb-6 rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 p-4 text-left">
             {paymentBill ? (
               <>

--- a/frontend/src/components/scheduled-transactions/OverrideEditorDialog.test.tsx
+++ b/frontend/src/components/scheduled-transactions/OverrideEditorDialog.test.tsx
@@ -842,6 +842,33 @@ describe('OverrideEditorDialog', () => {
     });
   });
 
+  // --- prefillAmount (post-reconciliation flow) ---
+  describe('prefillAmount', () => {
+    it('seeds the Amount field from prefillAmount', () => {
+      render(<OverrideEditorDialog {...defaultProps} prefillAmount={999.5} />);
+      const amountInput = screen.getByLabelText('Amount') as HTMLInputElement;
+      expect(Number(amountInput.value)).toBe(999.5);
+    });
+
+    it('seeds and negates prefillAmount on save for a transfer', async () => {
+      render(
+        <OverrideEditorDialog
+          {...defaultProps}
+          scheduledTransaction={transferTransaction}
+          prefillAmount={123.45}
+        />,
+      );
+      // Save without touching the field: the seeded prefill amount is used,
+      // negated for the transfer.
+      fireEvent.click(screen.getByText('Save Override'));
+      await waitFor(() => {
+        expect(mockCreateOverride).toHaveBeenCalledWith('s2', expect.objectContaining({
+          amount: -123.45,
+        }));
+      });
+    });
+  });
+
   // --- Split override save sends serialized splits ---
   describe('split override save', () => {
     it('sends split data with null categoryId when split is enabled', async () => {

--- a/frontend/src/components/scheduled-transactions/OverrideEditorDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/OverrideEditorDialog.tsx
@@ -29,6 +29,11 @@ interface OverrideEditorDialogProps {
   categories: Category[];
   accounts: Account[];
   existingOverride?: ScheduledTransactionOverride | null;
+  // When provided, seeds the Amount field with this value (absolute, sign is
+  // applied on save for transfers) instead of the base/override amount. Used by
+  // the post-reconciliation flow to prefill a liability payment with the
+  // reconciled balance.
+  prefillAmount?: number | null;
   onClose: () => void;
   onSave: () => void;
 }
@@ -40,6 +45,7 @@ export function OverrideEditorDialog({
   categories,
   accounts,
   existingOverride,
+  prefillAmount,
   onClose,
   onSave,
 }: OverrideEditorDialogProps) {
@@ -94,7 +100,7 @@ export function OverrideEditorDialog({
         // Use override values (absolute value for transfers - sign is applied on save)
         const rawAmt = roundToCents(existingOverride.amount ?? scheduledTransaction.amount);
         const amt = scheduledTransaction.isTransfer ? Math.abs(rawAmt) : rawAmt;
-        setAmount(amt);
+        setAmount(prefillAmount != null ? roundToCents(prefillAmount) : amt);
         setCategoryId(existingOverride.categoryId ?? scheduledTransaction.categoryId ?? '');
         setDescription(existingOverride.description ?? scheduledTransaction.description ?? '');
         setIsSplit(existingOverride.isSplit ?? scheduledTransaction.isSplit);
@@ -112,7 +118,7 @@ export function OverrideEditorDialog({
         // Use base transaction values (absolute value for transfers - sign is applied on save)
         const rawAmt = roundToCents(scheduledTransaction.amount);
         const amt = scheduledTransaction.isTransfer ? Math.abs(rawAmt) : rawAmt;
-        setAmount(amt);
+        setAmount(prefillAmount != null ? roundToCents(prefillAmount) : amt);
         setCategoryId(scheduledTransaction.categoryId ?? '');
         setDescription(scheduledTransaction.description ?? '');
         setIsSplit(scheduledTransaction.isSplit);
@@ -161,7 +167,7 @@ export function OverrideEditorDialog({
       }
       setMarketPrice(null);
     }
-  }, [isOpen, existingOverride, scheduledTransaction, overrideDate]);
+  }, [isOpen, existingOverride, scheduledTransaction, overrideDate, prefillAmount]);
 
   // Fetch the most recent close price for the security so we can auto-fill
   // the Price field (matching the new-scheduled-transaction form behaviour).

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.test.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.test.tsx
@@ -534,6 +534,23 @@ describe('ScheduledTransactionForm', () => {
     expect(screen.getByText('To Account')).toBeInTheDocument();
   });
 
+  it('opens in transfer mode prefilled from initial props (reconcile flow)', async () => {
+    render(
+      <ScheduledTransactionForm
+        initialMode="transfer"
+        initialAmount={250}
+        initialTransferAccountId="acc-2"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('From Account')).toBeInTheDocument();
+    });
+    const toAccountSelect = screen.getByLabelText('To Account') as HTMLSelectElement;
+    expect(toAccountSelect.value).toBe('acc-2');
+    const amountInput = screen.getByLabelText('Transfer Amount') as HTMLInputElement;
+    expect(Number(amountInput.value)).toBe(250);
+  });
+
   // --- Form submission for new scheduled transaction ---
   it('submits form for new scheduled transaction via submit button', async () => {
     const { container } = render(<ScheduledTransactionForm />);

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx
@@ -44,7 +44,7 @@ import { FormActions } from '@/components/ui/FormActions';
 
 const logger = createLogger('ScheduledTxForm');
 
-type ScheduledTransactionMode = 'transaction' | 'split' | 'transfer' | 'investment';
+export type ScheduledTransactionMode = 'transaction' | 'split' | 'transfer' | 'investment';
 
 const INVESTMENT_ACTION_LABELS: Record<InvestmentAction, string> = {
   BUY: 'Buy',
@@ -97,6 +97,12 @@ type ScheduledTransactionFormData = z.infer<typeof scheduledTransactionSchema>;
 interface ScheduledTransactionFormProps {
   scheduledTransaction?: ScheduledTransaction;
   templateTransaction?: Transaction;
+  // Prefill hints for a brand-new schedule (ignored when editing an existing
+  // schedule or building from a template). Used by the post-reconciliation
+  // flow to seed a liability payment transfer.
+  initialMode?: ScheduledTransactionMode;
+  initialAmount?: number;
+  initialTransferAccountId?: string;
   onSuccess?: () => void;
   onCancel?: () => void;
   onDirtyChange?: (isDirty: boolean) => void;
@@ -117,6 +123,9 @@ function getTransferAccountId(st?: ScheduledTransaction): string {
 export function ScheduledTransactionForm({
   scheduledTransaction,
   templateTransaction,
+  initialMode,
+  initialAmount,
+  initialTransferAccountId,
   onSuccess,
   onCancel,
   onDirtyChange,
@@ -141,6 +150,8 @@ export function ScheduledTransactionForm({
     if (templateTransaction?.isTransfer) return 'transfer';
     if (scheduledTransaction?.isSplit && !isScheduledTransfer(scheduledTransaction)) return 'split';
     if (templateTransaction?.isSplit) return 'split';
+    // Prefill hint only applies when building a brand-new schedule
+    if (!scheduledTransaction && !templateTransaction && initialMode) return initialMode;
     return 'transaction';
   };
 
@@ -186,6 +197,7 @@ export function ScheduledTransactionForm({
   const [transferToAccountId, setTransferToAccountId] = useState<string>(
     getTransferAccountId(scheduledTransaction)
     || (templateTransaction?.isTransfer ? templateTransaction.linkedTransaction?.accountId ?? '' : '')
+    || (!scheduledTransaction && !templateTransaction ? initialTransferAccountId ?? '' : '')
   );
 
   const [selectedPayeeId, setSelectedPayeeId] = useState<string>(
@@ -256,6 +268,7 @@ export function ScheduledTransactionForm({
             reminderDaysBefore: 3,
           }
         : {
+            amount: initialAmount,
             currencyCode: defaultCurrency,
             frequency: 'MONTHLY' as FrequencyType,
             nextDueDate: getLocalDateString(),


### PR DESCRIPTION
## Summary
Adds a post-reconciliation workflow that prompts users to update or create a scheduled payment for revolving-credit accounts (credit cards and lines of credit) after reconciliation completes. The feature uses deep links to seamlessly transition from the Reconcile page to the Bills page with pre-filled payment details.

## Key Changes

**Reconcile Page (`reconcile/page.tsx`)**
- Added `PAYMENT_PROMPT_TYPES` constant to identify revolving-credit accounts (CREDIT_CARD, LINE_OF_CREDIT) that warrant payment prompts
- After successful reconciliation, queries scheduled transactions to find any bill that transfers to the reconciled account (via direct transfer or split)
- Displays a blue info box on the completion screen offering to update an existing scheduled payment or create a new one
- Passes the reconciled balance (as a positive amount) via query parameters to the Bills page

**Bills Page (`bills/page.tsx`)**
- Added support for post-reconciliation deep-link query parameters: `reconcileEditId`, `reconcileCreate`, `reconcileTransferAccountId`, `reconcileAmount`
- Implements `openNextOccurrenceEditor()` to open the override editor directly on a schedule's next due date, skipping the date picker
- Prefills the Amount field with the reconciled balance when opening from a reconciliation deep link
- For create flows, prefills the transfer account and amount in the form
- Clears reconciliation query parameters when the opened dialog/modal closes
- Added `createPrefill` state to track prefill values for new transfer schedules

**Override Editor Dialog (`OverrideEditorDialog.tsx`)**
- Added `prefillAmount` prop to seed the Amount field with the reconciled balance
- When prefillAmount is provided, it takes precedence over the base/override amount on initial load

**Scheduled Transaction Form (`ScheduledTransactionForm.tsx`)**
- Exported `ScheduledTransactionMode` type for use in Bills page
- Added `initialMode`, `initialAmount`, and `initialTransferAccountId` props to prefill a brand-new transfer schedule
- These props only apply when creating a new schedule (ignored when editing or using a template)

**Tests**
- Added comprehensive test suite for the liability payment prompt covering:
  - Updating an existing scheduled payment linked directly to the account
  - Matching a scheduled payment linked via a split transfer
  - Creating a new scheduled payment when none exists
  - Excluding loan and mortgage accounts from the prompt
  - Excluding non-liability accounts from the prompt
- Added tests for Bills page deep-link handling (edit, create, unknown ID scenarios)
- Added tests for OverrideEditorDialog and ScheduledTransactionForm prefill behavior

## Implementation Details

- Liability accounts (CREDIT_CARD, LOAN, MORTGAGE, LINE_OF_CREDIT) are identified by account type
- Only revolving-credit accounts (CREDIT_CARD, LINE_OF_CREDIT) trigger the payment prompt; loans and mortgages are excluded because they have fixed payments
- The reconciled payment amount is calculated as the absolute value of the statement balance (liability balances are stored negative)
- Deep-link query parameters are cleaned up when the user closes the opened dialog/modal, preventing stale state
- The override editor can now be opened directly on a schedule's next occurrence without requiring the user to select a date

https://claude.ai/code/session_01BGYENG1kHBSFRQkf7SGVG4