### PR TITLE
Wipe action_history during data restore to prevent undo to prior state

### DIFF
--- a/backend/src/backup/backup.service.spec.ts
+++ b/backend/src/backup/backup.service.spec.ts
@@ -788,6 +788,21 @@ describe("BackupService", () => {
       expect(deleteCalls[0][1]).toEqual([userId]);
     });
 
+    it("should delete existing action_history during restore wipe", async () => {
+      mockUserRepo.findOne.mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await service.restoreData(userId, makeInput({ password: "test" }));
+
+      const deleteCalls = mockQueryRunner.query.mock.calls.filter(
+        (call: unknown[]) =>
+          typeof call[0] === "string" &&
+          call[0].includes("DELETE FROM action_history"),
+      );
+      expect(deleteCalls).toHaveLength(1);
+      expect(deleteCalls[0][1]).toEqual([userId]);
+    });
+
     it("should rollback transaction on error", async () => {
       mockUserRepo.findOne.mockResolvedValue(mockUser);
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);

--- a/backend/src/backup/backup.service.ts
+++ b/backend/src/backup/backup.service.ts
@@ -809,6 +809,12 @@ export class BackupService {
   ): Promise<void> {
     // Delete in FK-safe order (reverse of insert order)
 
+    // Action history (undo/redo log) -- not included in backups, so wipe it
+    // outright; restored data should not be undoable to the prior state.
+    await queryRunner.query("DELETE FROM action_history WHERE user_id = $1", [
+      userId,
+    ]);
+
     // Monte Carlo scenarios (cash flows cascade on scenario delete)
     await queryRunner.query(
       `DELETE FROM monte_carlo_cash_flows WHERE scenario_id IN


### PR DESCRIPTION
## Summary
When restoring backup data, the action_history table (undo/redo log) is now explicitly deleted for the user. This ensures that restored data cannot be undone back to the previous state, maintaining data integrity after a restore operation.

## Changes
- **backup.service.ts**: Added `DELETE FROM action_history WHERE user_id = $1` query at the start of the `wipeDataForRestore()` method, executed before other table deletions in FK-safe order
- **backup.service.spec.ts**: Added test case verifying that action_history is deleted during restore wipe with correct user_id parameter

## Implementation Details
- The deletion is placed first in the wipe sequence since action_history has no foreign key dependencies
- Uses parameterized query (`$1` placeholder) to safely pass userId, following security conventions
- Test confirms exactly one DELETE query targets action_history with the correct userId parameter

https://claude.ai/code/session_017BisMS2mvv4b8Eemrp2uHv