### PR TITLE
fix(frontend): make mobile side menu navigation work

### DIFF
--- a/frontend/src/components/layout/AppHeader.test.tsx
+++ b/frontend/src/components/layout/AppHeader.test.tsx
@@ -407,6 +407,31 @@ describe('AppHeader', () => {
     expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
   });
 
+  it('closes the mobile menu when a link is selected', () => {
+    // Regression: selecting a link must dismiss the drawer (and navigate)
+    // even when the destination equals the current route, where the
+    // route-change effect never fires.
+    render(<AppHeader />);
+    fireEvent.click(screen.getByLabelText('Toggle menu'));
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Settings'));
+    expect(mockPush).toHaveBeenCalledWith('/settings');
+    // Drawer is gone (its Close button no longer rendered).
+    expect(screen.queryByLabelText('Close menu')).not.toBeInTheDocument();
+  });
+
+  it('does not push a browser history entry when the drawer opens', () => {
+    // Regression: the drawer must NOT use Modal's pushHistory. A pushed entry
+    // is popped via history.back() on close, which would revert the
+    // router.push that closes the drawer and leave the user on the old page.
+    render(<AppHeader />);
+    const lengthBeforeOpen = window.history.length;
+    fireEvent.click(screen.getByLabelText('Toggle menu'));
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(window.history.length).toBe(lengthBeforeOpen);
+  });
+
   it('closes Tools dropdown when clicking outside', () => {
     render(<AppHeader />);
     const toolsButtons = screen.getAllByText('Tools');

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -216,7 +216,13 @@ export function AppHeader() {
                 isOpen={mobileMenuOpen}
                 onClose={() => setMobileMenuOpen(false)}
                 pathname={pathname}
-                onNavigate={(href) => router.push(href)}
+                onNavigate={(href) => {
+                  // Close the drawer up front so navigating to the current
+                  // route (no pathname change, so the route-change effect
+                  // below never fires) still dismisses it.
+                  setMobileMenuOpen(false);
+                  router.push(href);
+                }}
                 navLinks={visibleNavLinks}
                 aiLinks={aiLinks}
                 showAiMenu={showAiMenu}

--- a/frontend/src/components/layout/MobileNavDrawer.tsx
+++ b/frontend/src/components/layout/MobileNavDrawer.tsx
@@ -33,8 +33,15 @@ const SECTION_HEADER_CLASS =
 /**
  * Mobile navigation drawer: a full-height panel that slides in from the left
  * over a dimmed backdrop. Reuses the shared `Modal` primitive for the portal,
- * body-scroll lock, focus trap, Escape handling, and back-button-to-close
- * (`pushHistory`). Links are a flat list grouped under section headers.
+ * body-scroll lock, focus trap, and Escape handling. Links are a flat list
+ * grouped under section headers.
+ *
+ * Note: the drawer deliberately does NOT use the Modal's `pushHistory`
+ * (back-button-to-close). That option pushes a history entry on open and pops
+ * it with `history.back()` on close; closing the drawer in response to an
+ * in-drawer navigation would then revert the `router.push` that triggered the
+ * close, leaving the user on the original page. The drawer instead closes via
+ * the caller's route-change effect (and the explicit close in `onNavigate`).
  */
 export function MobileNavDrawer({
   isOpen,
@@ -70,7 +77,7 @@ export function MobileNavDrawer({
   );
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} variant="drawer-left" pushHistory>
+    <Modal isOpen={isOpen} onClose={onClose} variant="drawer-left">
       <nav aria-label="Main menu" className="flex flex-col">
         {/* Drawer header: brand + close button */}
         <div className="flex items-center justify-between px-4 h-16 border-b border-gray-200 dark:border-gray-700">


### PR DESCRIPTION
Selecting any link in the new slide-in mobile drawer never changed the
page. The drawer wrapped its menu in the shared Modal with `pushHistory`,
which pushes a browser history entry on open and pops it via
`history.back()` on close. Navigating from a link did `router.push`, which
stacked a new entry on top of the drawer's; closing the drawer in response
to the route change then ran `history.back()` and reverted straight back to
the original page.

Drop `pushHistory` for the drawer (matching the previous dropdown, which
pushed no entry) so navigation is no longer undone. Also close the drawer
explicitly in `onNavigate` so selecting the current route still dismisses
it, where the route-change effect never fires.

Add regression tests: selecting a link closes the drawer, and opening the
drawer pushes no browser history entry.