### PR TITLE
fix: show linked payee name in transaction list when payeeName is null

### DIFF
--- a/docs/bugs/transaction-list-missing-payee-name.md
+++ b/docs/bugs/transaction-list-missing-payee-name.md
@@ -1,0 +1,54 @@
+# Bug: transaction list shows "-" for payee when only `payeeId` is set
+
+## Symptom
+In the transaction list, the payee column shows `-` (empty) for transactions
+that have a `payeeId` (foreign key to the payee) but a `null` `payeeName`. Opening
+the transaction detail shows the payee correctly.
+
+Example API response:
+```json
+{ "payeeName": null, "payeeId": "04b2701c-1e0a-43c5-9c12-e9526aff13ed" }
+```
+Reported after bulk-importing ~8,400 transactions via the REST API using only
+`payeeId` (no `payeeName`).
+
+## Root cause
+`payeeName` is a **denormalized** column on `transactions`, kept alongside the
+`payeeId` FK and the `payee` relation (`backend/.../transaction.entity.ts`).
+Create/update store whatever `payeeName` the client sends and do **not** derive
+it from `payeeId` (`transactions.service.ts`), so `payeeName` can legitimately be
+`null` while `payeeId` is set.
+
+The list **does** load the payee relation — `findAll` uses
+`leftJoinAndSelect("transaction.payee", "payee")` — and the frontend `Transaction`
+type includes `payee`. The actual defect is in the renderer:
+`frontend/src/components/transactions/TransactionRow.tsx` rendered
+`{transaction.payeeName || '-'}` with **no fallback** to `transaction.payee?.name`.
+
+This made `TransactionRow` inconsistent with the rest of the app, which already
+falls back to the linked payee name:
+- `app/transactions/page.tsx` (CSV export): `tx.payee?.name ?? tx.payeeName`
+- `components/transactions/RecentTransactionsPopover.tsx`: `t.payeeName || t.payee?.name`
+- `components/dashboard/UpcomingBills.tsx`: `item.payeeName || item.payee?.name`
+
+## Fix
+`TransactionRow.tsx` now derives a single `payeeLabel`:
+```ts
+const payeeLabel = transaction.payeeName || transaction.payee?.name || null;
+```
+and uses it for the payee text and the title attributes in both the
+clickable-button and plain-text branches. The payee data is already fetched, so
+this is a display-only fix — no schema, write-path, or migration changes.
+
+## Notes / not done here
+The original report also proposed auto-populating `payeeName` from `payeeId` on
+`POST`/`PATCH` plus a backfill migration for the ~8,400 existing rows. That is a
+reasonable API-contract / data-hygiene improvement but is **separate** from this
+display fix and not required to resolve the symptom. If pursued, it should keep
+the write paths transactional (QueryRunner) and would not change `schema.sql`
+(data backfill only).
+
+## Verification
+- New `TransactionRow` tests: payee name still renders from `payeeName`, and now
+  also falls back to `payee.name` when `payeeName` is null (button + text branches).
+- `tsc --noEmit` clean.

--- a/frontend/src/components/transactions/TransactionRow.test.tsx
+++ b/frontend/src/components/transactions/TransactionRow.test.tsx
@@ -98,6 +98,32 @@ describe('TransactionRow', () => {
     expect(dashes.length).toBeGreaterThan(0);
   });
 
+  it('falls back to the linked payee name when payeeName is null (button branch)', () => {
+    const onPayeeClick = vi.fn();
+    renderRow(
+      { onPayeeClick },
+      {
+        payeeId: 'p1',
+        payeeName: null,
+        payee: { id: 'p1', name: 'Linked Payee' } as Transaction['payee'],
+      },
+    );
+    fireEvent.click(screen.getByText('Linked Payee'));
+    expect(onPayeeClick).toHaveBeenCalledWith('p1');
+  });
+
+  it('falls back to the linked payee name when payeeName is null (text branch)', () => {
+    renderRow(
+      {},
+      {
+        payeeId: 'p1',
+        payeeName: null,
+        payee: { id: 'p1', name: 'Linked Payee' } as Transaction['payee'],
+      },
+    );
+    expect(screen.getByText('Linked Payee')).toBeInTheDocument();
+  });
+
   it('renders category as clickable when onCategoryClick provided', () => {
     const onCategoryClick = vi.fn();
     renderRow({ onCategoryClick });

--- a/frontend/src/components/transactions/TransactionRow.tsx
+++ b/frontend/src/components/transactions/TransactionRow.tsx
@@ -203,6 +203,10 @@ export const TransactionRow = memo(function TransactionRow({
 }: TransactionRowProps) {
   const { formatCurrency } = useNumberFormat();
   const isVoid = transaction.status === TransactionStatus.VOID;
+  // Prefer the denormalized payeeName, but fall back to the linked payee's name
+  // so a transaction that has only payeeId set (e.g. created via the REST API
+  // without payeeName) still shows the payee instead of a dash.
+  const payeeLabel = transaction.payeeName || transaction.payee?.name || null;
   const categoryColor = transaction.category
     ? (categoryColorMap?.get(transaction.category.id) ?? transaction.category.color)
     : null;
@@ -241,16 +245,16 @@ export const TransactionRow = memo(function TransactionRow({
           <button
             onClick={(e) => { e.stopPropagation(); onPayeeClick(transaction.payeeId!); }}
             className={`text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline block truncate sm:max-w-[280px] text-left ${isVoid ? 'line-through' : ''}`}
-            title={`Edit payee: ${transaction.payeeName}`}
+            title={`Edit payee: ${payeeLabel ?? ''}`}
           >
-            {transaction.payeeName || '-'}
+            {payeeLabel || '-'}
           </button>
         ) : (
           <div
             className={`text-sm font-medium text-gray-900 dark:text-gray-100 truncate sm:max-w-[280px] ${isVoid ? 'line-through' : ''}`}
-            title={transaction.payeeName || undefined}
+            title={payeeLabel || undefined}
           >
-            {transaction.payeeName || '-'}
+            {payeeLabel || '-'}
           </div>
         )}
         {density === 'normal' && transaction.referenceNumber && (


### PR DESCRIPTION
# Bug: transaction list shows "-" for payee when only `payeeId` is set

## Symptom
In the transaction list, the payee column shows `-` (empty) for transactions
that have a `payeeId` (foreign key to the payee) but a `null` `payeeName`. Opening
the transaction detail shows the payee correctly.

Example API response:
```json
{ "payeeName": null, "payeeId": "04b2701c-1e0a-43c5-9c12-e9526aff13ed" }
```
Reported after bulk-importing ~8,400 transactions via the REST API using only
`payeeId` (no `payeeName`).

## Root cause
`payeeName` is a **denormalized** column on `transactions`, kept alongside the
`payeeId` FK and the `payee` relation (`backend/.../transaction.entity.ts`).
Create/update store whatever `payeeName` the client sends and do **not** derive
it from `payeeId` (`transactions.service.ts`), so `payeeName` can legitimately be
`null` while `payeeId` is set.

The list **does** load the payee relation — `findAll` uses
`leftJoinAndSelect("transaction.payee", "payee")` — and the frontend `Transaction`
type includes `payee`. The actual defect is in the renderer:
`frontend/src/components/transactions/TransactionRow.tsx` rendered
`{transaction.payeeName || '-'}` with **no fallback** to `transaction.payee?.name`.

This made `TransactionRow` inconsistent with the rest of the app, which already
falls back to the linked payee name:
- `app/transactions/page.tsx` (CSV export): `tx.payee?.name ?? tx.payeeName`
- `components/transactions/RecentTransactionsPopover.tsx`: `t.payeeName || t.payee?.name`
- `components/dashboard/UpcomingBills.tsx`: `item.payeeName || item.payee?.name`

## Fix
`TransactionRow.tsx` now derives a single `payeeLabel`:
```ts
const payeeLabel = transaction.payeeName || transaction.payee?.name || null;
```
and uses it for the payee text and the title attributes in both the
clickable-button and plain-text branches. The payee data is already fetched, so
this is a display-only fix — no schema, write-path, or migration changes.

## Notes / not done here
The original report also proposed auto-populating `payeeName` from `payeeId` on
`POST`/`PATCH` plus a backfill migration for the ~8,400 existing rows. That is a
reasonable API-contract / data-hygiene improvement but is **separate** from this
display fix and not required to resolve the symptom. If pursued, it should keep
the write paths transactional (QueryRunner) and would not change `schema.sql`
(data backfill only).

## Verification
- New `TransactionRow` tests: payee name still renders from `payeeName`, and now
  also falls back to `payee.name` when `payeeName` is null (button + text branches).
- `tsc --noEmit` clean.
