### PR TITLE
Make build-and-push a manual-only release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install zizmor
         run: uv tool install zizmor
       - name: Run zizmor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  # build-and-push only fires on workflow_dispatch so merging to main doesn't
+  # publish a new image set on every PR. Trigger from the Actions tab (or
+  # `gh workflow run "CI Pipeline" --ref main`) when you actually want a
+  # release: it will bump the patch version, build/sign/scan/push the
+  # images, and cut a GitHub release.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -323,7 +329,10 @@ jobs:
   build-and-push:
     name: Build & Push Containers
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # Manual-only: this is the release step (version bump, tag, signed images,
+    # SBOM/provenance attestations, Trivy scan). Triggered from the Actions tab
+    # rather than on every push, so merges to main don't auto-publish.
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     needs:
       [
         backend-lint,

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -9,7 +9,7 @@ rules:
     # caching is intentional for build speed). This is a low-confidence false
     # positive in our setup; revisit if we ever add `cache: 'npm'` here.
     ignore:
-      - ci.yml:358:9
+      - ci.yml:367:9
 
   artipacked:
     # The build-and-push job intentionally keeps the GITHUB_TOKEN persisted on
@@ -17,4 +17,4 @@ rules:
     # the version bump and `gh release create` the tag. Every other checkout
     # in this repo sets persist-credentials: false.
     ignore:
-      - ci.yml:353:9
+      - ci.yml:362:9


### PR DESCRIPTION
## Summary
Changes the `build-and-push` CI job from automatically triggering on every push to `main` to a manual-only workflow that must be explicitly triggered via the Actions tab or `gh workflow run` command. This prevents unintended image releases on every PR merge while keeping the release process available on demand.

## Changes
- Added `workflow_dispatch` trigger to the CI workflow, enabling manual triggering from the GitHub Actions UI
- Updated the `build-and-push` job condition from `github.ref == 'refs/heads/main' && github.event_name == 'push'` to `github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'`
- Added clarifying comments explaining that this is the release step (version bump, tag, signed images, SBOM/provenance attestations, Trivy scan) and must be triggered manually
- Updated zizmor security linter ignore line numbers to reflect the new workflow structure

## Implementation Details
The release workflow now requires explicit user action to:
1. Bump the patch version
2. Build, sign, and scan container images
3. Push images to registry
4. Cut a GitHub release

This prevents accidental releases while maintaining the ability to trigger releases on demand from the `main` branch.

https://claude.ai/code/session_01SSKyaasWyT3SjLTYp3z1tn