### PR TITLE
docs: refresh CLAUDE.md files for i18n and QueryRunner changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ See `backend/CLAUDE.md`, `frontend/CLAUDE.md`, and `database/CLAUDE.md` for laye
 | Forms | react-hook-form + Zod (frontend), class-validator (backend) |
 | Auth | JWT + Passport + OIDC + TOTP 2FA |
 | AI | Anthropic SDK, OpenAI SDK, Ollama (user-configurable) |
+| i18n | next-intl (frontend), nestjs-i18n (backend) -- locales: `en`, `pl`, `xx` (pseudo) |
 | Testing | Jest (backend), Vitest (frontend), Playwright (e2e) |
 
 Everything runs in Docker: `docker compose -f docker-compose.dev.yml up`.
@@ -33,6 +34,15 @@ Everything runs in Docker: `docker compose -f docker-compose.dev.yml up`.
 - Put the shared logic on the relevant domain service (e.g., `PortfolioService.getLlmSummary`, `TransactionAnalyticsService.getTransfersByAccount`). The two tool layers become thin adapters that call it.
 - Both surfaces must return the same data shape. The AI tool executor wraps it with `{ summary, sources }`; MCP just `toolResult(data)`s it.
 - Adding a new AI tool means wiring it into both layers in the same PR -- never ship a tool to only one of the two.
+
+### Internationalization (i18n)
+Every user-facing string must be translated -- no hardcoded literals in toasts, labels, placeholders, validation messages, or emails. A new feature is not done until it is fully internationalized and translated for every supported locale in the same PR.
+- **Frontend** (`next-intl`): read strings via `useTranslations('namespace')`; catalogs live in `frontend/src/i18n/messages/{locale}/{namespace}.json` (register new namespaces in `src/i18n/messages.ts`). Use `t.rich` for embedded markup and `t.raw` for template strings.
+- **Backend** (`nestjs-i18n`): wrap exception messages in `tr(key, fallback, args)`; render emails with an `EmailT` translator (`emailTranslator(i18n, recipientLang)`) so copy matches the recipient's stored locale, not the request's. Catalogs live in `backend/src/i18n/locales/{locale}/*.json`.
+- **Supported locales** are defined in `frontend/src/i18n/config.ts` and `backend/src/i18n/config.ts` -- keep the two lists in sync. Currently `en`, `pl`, and `xx` (dev-only pseudo-locale for QA).
+- **Adding or changing a string means updating every locale**, not just `en`. Parity tests (`frontend/src/i18n/messages.parity.test.ts`, `backend/src/i18n/locales.parity.spec.ts`) fail when a locale is missing a key or references a placeholder `en` does not supply.
+- After editing any `en/*.json`, regenerate the pseudo-locale: `npm run i18n:pseudo` (CI enforces freshness via `npm run i18n:check`).
+- The user's language lives in `user_preferences.language` and is chosen in Settings -> Preferences (`LanguageSelector`). See `frontend/src/i18n/messages/README.md` and `backend/src/i18n/README.md` for the full contributor flow.
 
 ### Code Style
 - No emojis in code, comments, or documentation
@@ -87,9 +97,7 @@ async createSomething(userId: string, dto: CreateDto) {
 }
 ```
 
-Operations that already use QueryRunner correctly: `create()` and `createTransfer()` in transactions, investment transaction CRUD, transfer CRUD, holdings rebuild.
-
-Operations that still need it (see AUDIT_FINDINGS.md): `update()`, `remove()`, split operations, bulk updates.
+Operations that correctly use QueryRunner: in the transactions domain, `create()`, `update()`, `remove()`, transfers, splits, and bulk update/delete; plus investment transaction CRUD and holdings rebuild. The split, bulk, transfer, and reconciliation flows live in dedicated `transaction-*.service.ts` files, each managing its own QueryRunner. When adding a new multi-table or read-modify-write operation, follow the same pattern.
 
 ## Financial Math
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -13,6 +13,8 @@ npm run test               # All tests (unit + E2E)
 npm run test:unit          # Unit tests only (src/**/*.spec.ts)
 npm run test:cov           # Coverage report (95% lines, 94% stmts, 95% funcs, 85% branches)
 npm run test:e2e           # E2E tests (test/**/*.spec.ts, 30s timeout, sequential)
+npm run i18n:pseudo        # Regenerate the xx pseudo-locale from en
+npm run i18n:check         # Verify the pseudo-locale is up to date (CI gate)
 ```
 
 ## Module Structure
@@ -92,6 +94,10 @@ transactionDate: string;
 ## Testing Conventions
 
 Mock repositories use `Record<string, jest.Mock>`; tests use `Test.createTestingModule` with mocks injected via `getRepositoryToken()`. E2E tests live in `test/` with helpers under `test/helpers/` (`auth-helper.ts`, `test-database.ts`, `test-factories.ts`).
+
+## Internationalization (i18n)
+
+Server-rendered strings (exception messages, email copy) are localized via `nestjs-i18n`. Wrap exception messages in `tr(key, fallback, args)` (`src/i18n/translate.ts`), which resolves against the request locale and returns the English `fallback` outside an HTTP context (jobs, schedulers, tests). Render emails with an `EmailT` translator (`emailTranslator(i18n, recipientLang)` from `src/i18n/email-translator.ts`) so copy matches the recipient's stored locale rather than the request's. Catalogs live in `src/i18n/locales/{locale}/*.json` (locales `en`, `pl`, `xx`); keep the locale list in `src/i18n/config.ts` in sync with the frontend. Adding or changing a string means updating every locale -- the parity test `src/i18n/locales.parity.spec.ts` fails otherwise -- then regenerating the pseudo-locale with `npm run i18n:pseudo`. Full contributor flow: `src/i18n/README.md`.
 
 ## Cron Jobs
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -12,6 +12,8 @@ npm run type-check         # tsc --noEmit
 npm run test               # Vitest (single run)
 npm run test:watch         # Vitest (watch mode)
 npm run test:cov           # Coverage report (91% lines, 90% stmts, 87% funcs, 85% branches)
+npm run i18n:pseudo        # Regenerate the xx pseudo-locale from en
+npm run i18n:check         # Verify the pseudo-locale is up to date (CI gate)
 ```
 
 ## Layout
@@ -61,6 +63,10 @@ This is Next.js middleware (NOT the deprecated middleware pattern from this proj
 `useFormModal<T>` (`hooks/useFormModal.ts`) manages create/edit modal state with browser-history integration (back button closes), unsaved-changes detection via `UnsavedChangesDialog`, and form submit exposed via ref. Returns `showForm`, `editingItem`, `openCreate()`, `openEdit(item)`, `close()`, `modalProps`, `unsavedChangesDialog`.
 
 Supporting hooks: `useFormSubmitRef` (expose submit via ref), `useFormDirtyNotify` (track dirty state). Forms use react-hook-form + Zod.
+
+## Internationalization (i18n)
+
+All user-facing strings go through `next-intl` -- no hardcoded literals. Read them with `useTranslations('namespace')`; catalogs live in `src/i18n/messages/{locale}/{namespace}.json` (locales `en`, `pl`, `xx`; register new namespaces in `src/i18n/messages.ts`). Use `t.rich` for embedded markup and `t.raw` for template strings. Adding or changing a string means updating every locale -- the parity test `src/i18n/messages.parity.test.ts` fails otherwise -- then regenerating the pseudo-locale with `npm run i18n:pseudo`. The language is a user preference (`LanguageSelector` in Settings -> Preferences). Full contributor flow: `src/i18n/messages/README.md`.
 
 ## React Testing (act() Pattern)
 


### PR DESCRIPTION
Documentation-only update to the three `CLAUDE.md` files, reflecting recent changes (chiefly the multi-phase i18n effort) and removing stale references.

## Top-level `CLAUDE.md`
- New **Internationalization (i18n)** rule under Critical Rules: every user-facing string must be translated, and a new feature is not done until it is fully internationalized and translated for every supported locale in the same PR. Documents the frontend (`next-intl`) / backend (`nestjs-i18n`) mechanics, the two config files that must stay in sync, the parity tests, and pseudo-locale regeneration.
- Added an `i18n` row to the Tech Stack table (locales: `en`, `pl`, `xx`).
- Updated the QueryRunner section: `update()`, `remove()`, splits, and bulk operations now correctly use QueryRunner, and dropped the reference to the deleted `AUDIT_FINDINGS.md`.

## `frontend/CLAUDE.md`
- Added `i18n:pseudo` / `i18n:check` to the Commands block.
- Added a short Internationalization section (`useTranslations`, catalog paths, `t.rich`/`t.raw`, parity test, `LanguageSelector`) pointing at `src/i18n/messages/README.md`.

## `backend/CLAUDE.md`
- Added `i18n:pseudo` / `i18n:check` to the Commands block.
- Added a short Internationalization section (`tr()` for exceptions, `EmailT`/`emailTranslator` for recipient-locale emails, parity test, config sync) pointing at `src/i18n/README.md`.

Verified that `en` and `pl` catalogs are at file-level parity on both layers, and that each operation described as QueryRunner-backed actually creates one.

https://claude.ai/code/session_014g5WCzU2S92MnWitp2z39v

---
_Generated by [Claude Code](https://claude.ai/code/session_014g5WCzU2S92MnWitp2z39v)_