### PR TITLE
Add Financial Institution concept for accounts

### DIFF
--- a/backend/src/accounts/accounts.module.ts
+++ b/backend/src/accounts/accounts.module.ts
@@ -1,6 +1,7 @@
 import { Module, forwardRef } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { Account } from "./entities/account.entity";
+import { Institution } from "../institutions/entities/institution.entity";
 import { Transaction } from "../transactions/entities/transaction.entity";
 import { InvestmentTransaction } from "../securities/entities/investment-transaction.entity";
 import { Category } from "../categories/entities/category.entity";
@@ -25,6 +26,7 @@ import { DelegationModule } from "../delegation/delegation.module";
   imports: [
     TypeOrmModule.forFeature([
       Account,
+      Institution,
       Transaction,
       InvestmentTransaction,
       Category,

--- a/backend/src/accounts/accounts.service.spec.ts
+++ b/backend/src/accounts/accounts.service.spec.ts
@@ -9,6 +9,7 @@ import {
 } from "./entities/account.entity";
 import { Transaction } from "../transactions/entities/transaction.entity";
 import { InvestmentTransaction } from "../securities/entities/investment-transaction.entity";
+import { Institution } from "../institutions/entities/institution.entity";
 import { CategoriesService } from "../categories/categories.service";
 import { ScheduledTransactionsService } from "../scheduled-transactions/scheduled-transactions.service";
 import { NetWorthService } from "../net-worth/net-worth.service";
@@ -22,6 +23,7 @@ describe("AccountsService", () => {
   let accountsRepository: Record<string, jest.Mock>;
   let transactionRepository: Record<string, jest.Mock>;
   let investmentTxRepository: Record<string, jest.Mock>;
+  let institutionsRepository: Record<string, jest.Mock>;
   let scheduledTransactionsService: Record<string, jest.Mock>;
   let categoriesService: Record<string, jest.Mock>;
   let netWorthService: Record<string, jest.Mock>;
@@ -132,6 +134,10 @@ describe("AccountsService", () => {
       },
     };
 
+    institutionsRepository = {
+      findOne: jest.fn().mockResolvedValue({ id: "inst-1" }),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AccountsService,
@@ -144,6 +150,10 @@ describe("AccountsService", () => {
         {
           provide: getRepositoryToken(InvestmentTransaction),
           useValue: investmentTxRepository,
+        },
+        {
+          provide: getRepositoryToken(Institution),
+          useValue: institutionsRepository,
         },
         { provide: CategoriesService, useValue: categoriesService },
         {
@@ -214,6 +224,36 @@ describe("AccountsService", () => {
       expect(createCall.currentBalance).toBe(500);
       expect(createCall.userId).toBe("user-1");
       expect(accountsRepository.save).toHaveBeenCalled();
+    });
+
+    it("assigns a valid owned institution", async () => {
+      await service.create("user-1", {
+        name: "Bank Account",
+        accountType: AccountType.CHEQUING,
+        currencyCode: "USD",
+        institutionId: "inst-1",
+      } as any);
+
+      expect(institutionsRepository.findOne).toHaveBeenCalledWith({
+        where: { id: "inst-1", userId: "user-1" },
+        select: { id: true },
+      });
+      const createCall = accountsRepository.create.mock.calls[0][0];
+      expect(createCall.institutionId).toBe("inst-1");
+    });
+
+    it("rejects an institution that does not belong to the user", async () => {
+      institutionsRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.create("user-1", {
+          name: "Bank Account",
+          accountType: AccountType.CHEQUING,
+          currencyCode: "USD",
+          institutionId: "someone-elses",
+        } as any),
+      ).rejects.toThrow(BadRequestException);
+      expect(accountsRepository.save).not.toHaveBeenCalled();
     });
 
     it("defaults opening balance to 0", async () => {
@@ -434,6 +474,26 @@ describe("AccountsService", () => {
       expect(result.name).toBe("Updated Name");
       expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
       expect(mockQueryRunner.release).toHaveBeenCalled();
+    });
+
+    it("assigns an owned institution on update", async () => {
+      mockQueryRunner.manager.findOne.mockResolvedValue({ ...mockAccount });
+
+      await service.update("user-1", "account-1", { institutionId: "inst-1" });
+
+      const saved = mockQueryRunner.manager.save.mock.calls[0][0];
+      expect(saved.institutionId).toBe("inst-1");
+      expect(institutionsRepository.findOne).toHaveBeenCalled();
+    });
+
+    it("rejects an unowned institution on update", async () => {
+      mockQueryRunner.manager.findOne.mockResolvedValue({ ...mockAccount });
+      institutionsRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.update("user-1", "account-1", { institutionId: "x" }),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
     });
 
     it("throws BadRequestException for closed account", async () => {

--- a/backend/src/accounts/accounts.service.spec.ts
+++ b/backend/src/accounts/accounts.service.spec.ts
@@ -2472,6 +2472,26 @@ describe("AccountsService", () => {
       expect(mockQueryRunner.manager.save).toHaveBeenCalledTimes(1);
     });
 
+    it("syncs institution to the linked investment account when changed", async () => {
+      mockQueryRunner.manager.findOne
+        .mockResolvedValueOnce({
+          ...mockAccount,
+          accountType: AccountType.INVESTMENT,
+          linkedAccountId: "linked-1",
+          institutionId: null,
+        })
+        .mockResolvedValueOnce({
+          id: "linked-1",
+          userId: "user-1",
+          institutionId: null,
+        });
+      await service.update("user-1", "account-1", { institutionId: "inst-1" });
+      // 2 saves: original account + linked partner
+      expect(mockQueryRunner.manager.save).toHaveBeenCalledTimes(2);
+      const linkedSave = mockQueryRunner.manager.save.mock.calls[1][0];
+      expect(linkedSave.institutionId).toBe("inst-1");
+    });
+
     it("triggers net-worth recalc when openingBalance changes", async () => {
       mockQueryRunner.manager.findOne.mockResolvedValue({
         ...mockAccount,

--- a/backend/src/accounts/accounts.service.ts
+++ b/backend/src/accounts/accounts.service.ts
@@ -625,9 +625,13 @@ export class AccountsService {
 
       const savedAccount = await queryRunner.manager.save(account);
 
-      // If currency changed on an investment account, update the linked account too
+      // Keep a linked investment pair (cash <-> brokerage) in sync. Both halves
+      // represent one real-world account, so shared attributes -- currency and
+      // institution -- propagate to the partner automatically.
+      const currencyChanged = updateAccountDto.currencyCode !== undefined;
+      const institutionChanged = updateAccountDto.institutionId !== undefined;
       if (
-        updateAccountDto.currencyCode !== undefined &&
+        (currencyChanged || institutionChanged) &&
         account.linkedAccountId &&
         account.accountType === AccountType.INVESTMENT
       ) {
@@ -635,7 +639,12 @@ export class AccountsService {
           where: { id: account.linkedAccountId, userId },
         });
         if (linkedAccount) {
-          linkedAccount.currencyCode = updateAccountDto.currencyCode;
+          if (updateAccountDto.currencyCode !== undefined) {
+            linkedAccount.currencyCode = updateAccountDto.currencyCode;
+          }
+          if (updateAccountDto.institutionId !== undefined) {
+            linkedAccount.institutionId = updateAccountDto.institutionId;
+          }
           await queryRunner.manager.save(linkedAccount);
         }
       }

--- a/backend/src/accounts/accounts.service.ts
+++ b/backend/src/accounts/accounts.service.ts
@@ -15,6 +15,7 @@ import {
 } from "./entities/account.entity";
 import { Transaction } from "../transactions/entities/transaction.entity";
 import { InvestmentTransaction } from "../securities/entities/investment-transaction.entity";
+import { Institution } from "../institutions/entities/institution.entity";
 import { CreateAccountDto } from "./dto/create-account.dto";
 import { UpdateAccountDto } from "./dto/update-account.dto";
 import { CategoriesService } from "../categories/categories.service";
@@ -45,6 +46,8 @@ export class AccountsService {
     private transactionRepository: Repository<Transaction>,
     @InjectRepository(InvestmentTransaction)
     private investmentTransactionRepository: Repository<InvestmentTransaction>,
+    @InjectRepository(Institution)
+    private institutionsRepository: Repository<Institution>,
     @Inject(forwardRef(() => CategoriesService))
     private categoriesService: CategoriesService,
     @Inject(forwardRef(() => ScheduledTransactionsService))
@@ -59,6 +62,28 @@ export class AccountsService {
   ) {}
 
   /**
+   * Verify that an institution id (if provided) exists and belongs to the user.
+   * Prevents assigning an account to another user's institution.
+   */
+  private async assertInstitutionOwned(
+    userId: string,
+    institutionId: string | null | undefined,
+  ): Promise<void> {
+    if (!institutionId) return;
+    const institution = await this.institutionsRepository.findOne({
+      where: { id: institutionId, userId },
+      select: { id: true },
+    });
+    if (!institution) {
+      throw new BadRequestException(
+        tr("errors.accounts.institutionNotFound", "Institution not found", {
+          id: institutionId,
+        }),
+      );
+    }
+  }
+
+  /**
    * Create a new account for a user
    */
   async create(
@@ -70,6 +95,8 @@ export class AccountsService {
       createInvestmentPair,
       ...accountData
     } = createAccountDto;
+
+    await this.assertInstitutionOwned(userId, accountData.institutionId);
 
     // If creating an investment account pair, delegate to the pair creation method
     if (
@@ -522,6 +549,16 @@ export class AccountsService {
         account.accountNumber = updateAccountDto.accountNumber;
       if (updateAccountDto.institution !== undefined)
         account.institution = updateAccountDto.institution;
+      if (updateAccountDto.institutionId !== undefined) {
+        await this.assertInstitutionOwned(
+          userId,
+          updateAccountDto.institutionId,
+        );
+        account.institutionId = updateAccountDto.institutionId;
+        // Clear the loaded relation so TypeORM persists the scalar FK change
+        // rather than re-deriving it from a stale relation object.
+        account.institutionRef = null;
+      }
       if (updateAccountDto.creditLimit !== undefined)
         account.creditLimit = updateAccountDto.creditLimit;
       if (updateAccountDto.interestRate !== undefined)

--- a/backend/src/accounts/dto/create-account.dto.ts
+++ b/backend/src/accounts/dto/create-account.dto.ts
@@ -87,13 +87,20 @@ export class CreateAccountDto {
 
   @ApiPropertyOptional({
     example: "TD Canada Trust",
-    description: "Financial institution name",
+    description: "Legacy free-text financial institution name (deprecated)",
   })
   @IsOptional()
   @IsString()
   @MaxLength(100)
   @SanitizeHtml()
   institution?: string;
+
+  @ApiPropertyOptional({
+    description: "ID of the financial institution this account belongs to",
+  })
+  @IsOptional()
+  @IsUUID()
+  institutionId?: string;
 
   @ApiPropertyOptional({
     example: 1000.0,

--- a/backend/src/accounts/dto/update-account.dto.ts
+++ b/backend/src/accounts/dto/update-account.dto.ts
@@ -11,6 +11,7 @@ import {
   IsUUID,
   IsDateString,
   IsIn,
+  ValidateIf,
 } from "class-validator";
 import { ApiPropertyOptional } from "@nestjs/swagger";
 import { AccountType } from "../entities/account.entity";
@@ -79,13 +80,22 @@ export class UpdateAccountDto {
 
   @ApiPropertyOptional({
     example: "BMO Bank of Montreal",
-    description: "Financial institution name",
+    description: "Legacy free-text financial institution name (deprecated)",
   })
   @IsOptional()
   @IsString()
   @MaxLength(100)
   @SanitizeHtml()
   institution?: string;
+
+  @ApiPropertyOptional({
+    description:
+      "ID of the financial institution this account belongs to. Pass null to clear.",
+  })
+  @IsOptional()
+  @ValidateIf((o) => o.institutionId !== null)
+  @IsUUID()
+  institutionId?: string | null;
 
   @ApiPropertyOptional({
     example: 10000.0,

--- a/backend/src/accounts/entities/account.entity.ts
+++ b/backend/src/accounts/entities/account.entity.ts
@@ -12,6 +12,7 @@ import { Transaction } from "../../transactions/entities/transaction.entity";
 import { Category } from "../../categories/entities/category.entity";
 import { ScheduledTransaction } from "../../scheduled-transactions/entities/scheduled-transaction.entity";
 import { User } from "../../users/entities/user.entity";
+import { Institution } from "../../institutions/entities/institution.entity";
 
 export enum AccountType {
   CHEQUING = "CHEQUING",
@@ -66,8 +67,17 @@ export class Account {
   })
   accountNumber: string | null;
 
+  // Legacy free-text institution name. Superseded by the structured
+  // institution relation below; retained so historical values are not lost.
   @Column({ type: "varchar", length: 255, nullable: true })
   institution: string | null;
+
+  @Column({ type: "uuid", name: "institution_id", nullable: true })
+  institutionId: string | null;
+
+  @ManyToOne(() => Institution, { nullable: true })
+  @JoinColumn({ name: "institution_id" })
+  institutionRef: Institution | null;
 
   @Column({
     type: "decimal",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -30,6 +30,7 @@ import { CategoriesModule } from "./categories/categories.module";
 import { CurrenciesModule } from "./currencies/currencies.module";
 import { SecuritiesModule } from "./securities/securities.module";
 import { PayeesModule } from "./payees/payees.module";
+import { InstitutionsModule } from "./institutions/institutions.module";
 import { ScheduledTransactionsModule } from "./scheduled-transactions/scheduled-transactions.module";
 import { ReportsModule } from "./reports/reports.module";
 import { InvestmentReportsModule } from "./investment-reports/investment-reports.module";
@@ -117,6 +118,7 @@ import { I18nModule } from "./i18n/i18n.module";
     TransactionsModule,
     CategoriesModule,
     PayeesModule,
+    InstitutionsModule,
     CurrenciesModule,
     SecuritiesModule,
     ScheduledTransactionsModule,

--- a/backend/src/i18n/locales/en/errors.json
+++ b/backend/src/i18n/locales/en/errors.json
@@ -4,6 +4,7 @@
     "notInvestmentPair": "This account is not part of an investment account pair",
     "noLinkedInvestmentAccount": "This investment account does not have a linked account",
     "notFound": "Account not found",
+    "institutionNotFound": "Institution not found",
     "updateClosed": "Cannot update a closed account",
     "changeCurrencyWithTransactions": "Cannot change the currency of an account that has transactions.",
     "alreadyClosed": "Account is already closed",
@@ -265,6 +266,12 @@
   "notifications": {
     "smtpNotConfigured": "SMTP is not configured. Set SMTP environment variables.",
     "noEmailOnFile": "No email address on file for this user."
+  },
+  "institutions": {
+    "nameConflict": "Institution with name \"{{ name }}\" already exists",
+    "notFound": "Institution with ID {{ id }} not found",
+    "logoNotFound": "No logo available for this institution",
+    "accountNotFound": "Account with ID {{ id }} not found"
   },
   "payees": {
     "nameConflict": "Payee with name \"{{ name }}\" already exists",

--- a/backend/src/i18n/locales/pl/errors.json
+++ b/backend/src/i18n/locales/pl/errors.json
@@ -4,6 +4,7 @@
     "notInvestmentPair": "To konto nie jest częścią pary kont inwestycyjnych",
     "noLinkedInvestmentAccount": "To konto inwestycyjne nie ma powiązanego konta",
     "notFound": "Nie znaleziono konta",
+    "institutionNotFound": "Nie znaleziono instytucji",
     "updateClosed": "Nie można zaktualizować zamkniętego konta",
     "changeCurrencyWithTransactions": "Nie można zmienić waluty konta, które ma transakcje.",
     "alreadyClosed": "Konto jest już zamknięte",
@@ -265,6 +266,12 @@
   "notifications": {
     "smtpNotConfigured": "SMTP nie jest skonfigurowany. Ustaw zmienne środowiskowe SMTP.",
     "noEmailOnFile": "Brak zapisanego adresu e-mail dla tego użytkownika."
+  },
+  "institutions": {
+    "nameConflict": "Instytucja o nazwie \"{{ name }}\" już istnieje",
+    "notFound": "Nie znaleziono instytucji o ID {{ id }}",
+    "logoNotFound": "Brak dostępnego logo dla tej instytucji",
+    "accountNotFound": "Nie znaleziono konta o ID {{ id }}"
   },
   "payees": {
     "nameConflict": "Odbiorca o nazwie \"{{ name }}\" już istnieje",

--- a/backend/src/i18n/locales/xx/errors.json
+++ b/backend/src/i18n/locales/xx/errors.json
@@ -4,6 +4,7 @@
     "notInvestmentPair": "[XX-This account is not part of an investment account pair-XX]",
     "noLinkedInvestmentAccount": "[XX-This investment account does not have a linked account-XX]",
     "notFound": "[XX-Account not found-XX]",
+    "institutionNotFound": "[XX-Institution not found-XX]",
     "updateClosed": "[XX-Cannot update a closed account-XX]",
     "changeCurrencyWithTransactions": "[XX-Cannot change the currency of an account that has transactions.-XX]",
     "alreadyClosed": "[XX-Account is already closed-XX]",
@@ -265,6 +266,12 @@
   "notifications": {
     "smtpNotConfigured": "[XX-SMTP is not configured. Set SMTP environment variables.-XX]",
     "noEmailOnFile": "[XX-No email address on file for this user.-XX]"
+  },
+  "institutions": {
+    "nameConflict": "[XX-Institution with name \"{{ name }}\" already exists-XX]",
+    "notFound": "[XX-Institution with ID {{ id }} not found-XX]",
+    "logoNotFound": "[XX-No logo available for this institution-XX]",
+    "accountNotFound": "[XX-Account with ID {{ id }} not found-XX]"
   },
   "payees": {
     "nameConflict": "[XX-Payee with name \"{{ name }}\" already exists-XX]",

--- a/backend/src/institutions/dto/assign-account.dto.ts
+++ b/backend/src/institutions/dto/assign-account.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsUUID } from "class-validator";
+
+export class AssignAccountDto {
+  @ApiProperty({
+    example: "account-uuid",
+    description: "ID of the account to assign to this institution",
+  })
+  @IsUUID()
+  accountId: string;
+}

--- a/backend/src/institutions/dto/create-institution.dto.ts
+++ b/backend/src/institutions/dto/create-institution.dto.ts
@@ -1,0 +1,41 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import {
+  IsString,
+  IsOptional,
+  MaxLength,
+  IsUrl,
+  Matches,
+} from "class-validator";
+import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
+
+export class CreateInstitutionDto {
+  @ApiProperty({
+    example: "TD Canada Trust",
+    description: "Name of the financial institution",
+  })
+  @IsString()
+  @MaxLength(255)
+  @SanitizeHtml()
+  name: string;
+
+  @ApiProperty({
+    example: "https://www.td.com",
+    description:
+      "Institution website. Used to resolve the brand favicon. The protocol is optional (https is assumed).",
+  })
+  @IsString()
+  @MaxLength(2048)
+  @IsUrl({ require_protocol: false, require_tld: true })
+  website: string;
+
+  @ApiPropertyOptional({
+    example: "CA",
+    description: "Optional ISO 3166-1 alpha-2 country code",
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[A-Za-z]{2}$/, {
+    message: "country must be a 2-letter ISO country code",
+  })
+  country?: string;
+}

--- a/backend/src/institutions/dto/update-institution.dto.ts
+++ b/backend/src/institutions/dto/update-institution.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from "@nestjs/swagger";
+import { CreateInstitutionDto } from "./create-institution.dto";
+
+export class UpdateInstitutionDto extends PartialType(CreateInstitutionDto) {}

--- a/backend/src/institutions/entities/institution.entity.ts
+++ b/backend/src/institutions/entities/institution.entity.ts
@@ -1,0 +1,82 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Unique,
+} from "typeorm";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { Exclude } from "class-transformer";
+import { User } from "../../users/entities/user.entity";
+
+@Entity("institutions")
+@Unique(["userId", "name"])
+export class Institution {
+  @ApiProperty({ example: "c5f5d5f0-1234-4567-890a-123456789abc" })
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @ApiProperty({ example: "user-uuid" })
+  @Column({ type: "uuid", name: "user_id" })
+  userId: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: "user_id" })
+  user?: User;
+
+  @ApiProperty({ example: "TD Canada Trust", description: "Institution name" })
+  @Column({ type: "varchar", length: 255 })
+  name: string;
+
+  @ApiProperty({
+    example: "https://www.td.com",
+    description: "Institution website (used to resolve the brand favicon)",
+  })
+  @Column({ type: "text" })
+  website: string;
+
+  @ApiPropertyOptional({
+    example: "CA",
+    description: "ISO 3166-1 alpha-2 country code",
+  })
+  @Column({ type: "varchar", length: 2, nullable: true })
+  country: string | null;
+
+  // Cached favicon bytes. Never selected by default and never serialized to the
+  // client -- the bytes are served only through GET /institutions/:id/logo.
+  @Exclude()
+  @Column({ type: "bytea", name: "logo_data", nullable: true, select: false })
+  logoData: Buffer | null;
+
+  @Exclude()
+  @Column({
+    type: "varchar",
+    name: "logo_content_type",
+    length: 100,
+    nullable: true,
+    select: false,
+  })
+  logoContentType: string | null;
+
+  @ApiProperty({
+    example: true,
+    description: "Whether a cached brand logo is available",
+  })
+  @Column({ type: "boolean", name: "has_logo", default: false })
+  hasLogo: boolean;
+
+  @ApiPropertyOptional()
+  @Column({ type: "timestamp", name: "logo_fetched_at", nullable: true })
+  logoFetchedAt: Date | null;
+
+  @ApiProperty()
+  @CreateDateColumn({ name: "created_at" })
+  createdAt: Date;
+
+  @ApiProperty()
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt: Date;
+}

--- a/backend/src/institutions/institution-logo.service.spec.ts
+++ b/backend/src/institutions/institution-logo.service.spec.ts
@@ -1,0 +1,99 @@
+import { InstitutionLogoService } from "./institution-logo.service";
+
+describe("InstitutionLogoService", () => {
+  let service: InstitutionLogoService;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    service = new InstitutionLogoService();
+    jest.spyOn(service["logger"], "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  const mockResponse = (opts: {
+    ok?: boolean;
+    status?: number;
+    contentType?: string | null;
+    body?: Uint8Array;
+  }) => ({
+    ok: opts.ok ?? true,
+    status: opts.status ?? 200,
+    headers: { get: (_k: string) => opts.contentType ?? null },
+    arrayBuffer: async () => (opts.body ?? new Uint8Array([1, 2, 3])).buffer,
+  });
+
+  describe("buildFaviconUrl()", () => {
+    it("builds a gstatic faviconV2 URL with the encoded website at 256px", () => {
+      const url = service.buildFaviconUrl("https://www.td.com");
+      expect(url).toContain("https://t2.gstatic.com/faviconV2");
+      expect(url).toContain("size=256");
+      expect(url).toContain(`url=${encodeURIComponent("https://www.td.com")}`);
+    });
+  });
+
+  describe("fetchFavicon()", () => {
+    it("returns image bytes and normalised content-type on success", async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(
+          mockResponse({ contentType: "image/png; charset=binary" }),
+        ) as any;
+
+      const result = await service.fetchFavicon("https://td.com");
+
+      expect(result).not.toBeNull();
+      expect(result!.contentType).toBe("image/png");
+      expect(Buffer.isBuffer(result!.data)).toBe(true);
+      expect(result!.data.length).toBe(3);
+    });
+
+    it("returns null when the response is not ok", async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(mockResponse({ ok: false, status: 404 })) as any;
+
+      expect(await service.fetchFavicon("https://td.com")).toBeNull();
+    });
+
+    it("returns null when the content-type is not an image", async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(mockResponse({ contentType: "text/html" })) as any;
+
+      expect(await service.fetchFavicon("https://td.com")).toBeNull();
+    });
+
+    it("returns null when the payload is empty", async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(
+          mockResponse({ contentType: "image/png", body: new Uint8Array([]) }),
+        ) as any;
+
+      expect(await service.fetchFavicon("https://td.com")).toBeNull();
+    });
+
+    it("returns null when the payload exceeds the size cap", async () => {
+      const huge = new Uint8Array(513 * 1024);
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(
+          mockResponse({ contentType: "image/png", body: huge }),
+        ) as any;
+
+      expect(await service.fetchFavicon("https://td.com")).toBeNull();
+    });
+
+    it("returns null when fetch throws (network error / abort)", async () => {
+      global.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error("network down")) as any;
+
+      expect(await service.fetchFavicon("https://td.com")).toBeNull();
+    });
+  });
+});

--- a/backend/src/institutions/institution-logo.service.ts
+++ b/backend/src/institutions/institution-logo.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+export interface FetchedLogo {
+  data: Buffer;
+  contentType: string;
+}
+
+/**
+ * Resolves a financial institution's brand icon by fetching the website's
+ * favicon from Google's faviconV2 (gstatic) endpoint -- the same resolver
+ * Chrome uses -- entirely server-side. The bytes are cached in the database so
+ * the user's browser never has to contact a third party to render the logo.
+ */
+@Injectable()
+export class InstitutionLogoService {
+  private readonly logger = new Logger(InstitutionLogoService.name);
+
+  private static readonly TIMEOUT_MS = 6000;
+  // Favicons at 256px are a few KB; cap generously to guard against a
+  // misbehaving upstream returning something huge.
+  private static readonly MAX_BYTES = 512 * 1024;
+
+  /**
+   * Build the gstatic faviconV2 URL for a website, requested at 256px.
+   */
+  buildFaviconUrl(website: string): string {
+    return (
+      "https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON" +
+      "&fallback_opts=TYPE,SIZE,URL" +
+      `&url=${encodeURIComponent(website)}&size=256`
+    );
+  }
+
+  /**
+   * Fetch the favicon for a website. Returns null on any failure (network
+   * error, timeout, non-image response, empty or oversized payload) so callers
+   * can treat the logo as best-effort and never fail the surrounding operation.
+   */
+  async fetchFavicon(website: string): Promise<FetchedLogo | null> {
+    const url = this.buildFaviconUrl(website);
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(),
+      InstitutionLogoService.TIMEOUT_MS,
+    );
+
+    try {
+      const response = await fetch(url, {
+        signal: controller.signal,
+        redirect: "follow",
+      });
+
+      if (!response.ok) {
+        this.logger.warn(
+          `Favicon fetch for ${website} returned HTTP ${response.status}`,
+        );
+        return null;
+      }
+
+      const rawContentType = response.headers.get("content-type") || "";
+      const contentType = rawContentType.split(";")[0].trim().toLowerCase();
+      if (!contentType.startsWith("image/")) {
+        this.logger.warn(
+          `Favicon fetch for ${website} returned non-image content-type "${rawContentType}"`,
+        );
+        return null;
+      }
+
+      const data = Buffer.from(await response.arrayBuffer());
+      if (data.length === 0 || data.length > InstitutionLogoService.MAX_BYTES) {
+        this.logger.warn(
+          `Favicon fetch for ${website} returned ${data.length} bytes (rejected)`,
+        );
+        return null;
+      }
+
+      return { data, contentType };
+    } catch (error) {
+      this.logger.warn(
+        `Failed to fetch favicon for ${website}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/backend/src/institutions/institutions.controller.spec.ts
+++ b/backend/src/institutions/institutions.controller.spec.ts
@@ -1,0 +1,114 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { InstitutionsController } from "./institutions.controller";
+import { InstitutionsService } from "./institutions.service";
+
+describe("InstitutionsController", () => {
+  let controller: InstitutionsController;
+  let mockService: Record<string, jest.Mock>;
+  const mockReq = { user: { id: "user-1" } };
+
+  beforeEach(async () => {
+    mockService = {
+      create: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      getLogo: jest.fn(),
+      refreshLogo: jest.fn(),
+      getAccounts: jest.fn(),
+      assignAccount: jest.fn(),
+      unassignAccount: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InstitutionsController],
+      providers: [{ provide: InstitutionsService, useValue: mockService }],
+    }).compile();
+
+    controller = module.get<InstitutionsController>(InstitutionsController);
+  });
+
+  it("create() delegates with userId and dto", async () => {
+    const dto = { name: "TD", website: "td.com" };
+    mockService.create.mockResolvedValue({ id: "inst-1" });
+    const result = await controller.create(mockReq, dto as any);
+    expect(result).toEqual({ id: "inst-1" });
+    expect(mockService.create).toHaveBeenCalledWith("user-1", dto);
+  });
+
+  it("findAll() delegates with userId", async () => {
+    mockService.findAll.mockResolvedValue([]);
+    await controller.findAll(mockReq);
+    expect(mockService.findAll).toHaveBeenCalledWith("user-1");
+  });
+
+  it("findOne() delegates with userId and id", async () => {
+    mockService.findOne.mockResolvedValue({ id: "inst-1" });
+    await controller.findOne(mockReq, "inst-1");
+    expect(mockService.findOne).toHaveBeenCalledWith("user-1", "inst-1");
+  });
+
+  it("getLogo() streams the bytes with content-type and cache headers", async () => {
+    const data = Buffer.from([1, 2, 3]);
+    mockService.getLogo.mockResolvedValue({ data, contentType: "image/png" });
+    const res = { set: jest.fn(), end: jest.fn() };
+
+    await controller.getLogo(mockReq, "inst-1", res as any);
+
+    expect(mockService.getLogo).toHaveBeenCalledWith("user-1", "inst-1");
+    expect(res.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "Content-Type": "image/png",
+        "Content-Length": "3",
+        "Cache-Control": "private, max-age=86400",
+      }),
+    );
+    expect(res.end).toHaveBeenCalledWith(data);
+  });
+
+  it("refreshLogo() delegates with userId and id", async () => {
+    mockService.refreshLogo.mockResolvedValue({ id: "inst-1" });
+    await controller.refreshLogo(mockReq, "inst-1");
+    expect(mockService.refreshLogo).toHaveBeenCalledWith("user-1", "inst-1");
+  });
+
+  it("getAccounts() delegates with userId and id", async () => {
+    mockService.getAccounts.mockResolvedValue([]);
+    await controller.getAccounts(mockReq, "inst-1");
+    expect(mockService.getAccounts).toHaveBeenCalledWith("user-1", "inst-1");
+  });
+
+  it("assignAccount() delegates with userId, id and accountId", async () => {
+    mockService.assignAccount.mockResolvedValue({ id: "acc-1" });
+    await controller.assignAccount(mockReq, "inst-1", { accountId: "acc-1" });
+    expect(mockService.assignAccount).toHaveBeenCalledWith(
+      "user-1",
+      "inst-1",
+      "acc-1",
+    );
+  });
+
+  it("unassignAccount() delegates with userId, id and accountId", async () => {
+    mockService.unassignAccount.mockResolvedValue({ id: "acc-1" });
+    await controller.unassignAccount(mockReq, "inst-1", "acc-1");
+    expect(mockService.unassignAccount).toHaveBeenCalledWith(
+      "user-1",
+      "inst-1",
+      "acc-1",
+    );
+  });
+
+  it("update() delegates with userId, id and dto", async () => {
+    const dto = { name: "New Name" };
+    mockService.update.mockResolvedValue({ id: "inst-1" });
+    await controller.update(mockReq, "inst-1", dto as any);
+    expect(mockService.update).toHaveBeenCalledWith("user-1", "inst-1", dto);
+  });
+
+  it("remove() delegates with userId and id", async () => {
+    mockService.remove.mockResolvedValue(undefined);
+    await controller.remove(mockReq, "inst-1");
+    expect(mockService.remove).toHaveBeenCalledWith("user-1", "inst-1");
+  });
+});

--- a/backend/src/institutions/institutions.controller.ts
+++ b/backend/src/institutions/institutions.controller.ts
@@ -1,0 +1,155 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+  Request,
+  Res,
+  ParseUUIDPipe,
+} from "@nestjs/common";
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+} from "@nestjs/swagger";
+import { AuthGuard } from "@nestjs/passport";
+import { Response } from "express";
+import { InstitutionsService } from "./institutions.service";
+import { CreateInstitutionDto } from "./dto/create-institution.dto";
+import { UpdateInstitutionDto } from "./dto/update-institution.dto";
+import { AssignAccountDto } from "./dto/assign-account.dto";
+import { Institution } from "./entities/institution.entity";
+import { Account } from "../accounts/entities/account.entity";
+
+@ApiTags("Institutions")
+@ApiBearerAuth()
+@UseGuards(AuthGuard("jwt"))
+@Controller("institutions")
+export class InstitutionsController {
+  constructor(private readonly institutionsService: InstitutionsService) {}
+
+  @Post()
+  @ApiOperation({ summary: "Create a new financial institution" })
+  @ApiResponse({
+    status: 201,
+    description: "Institution created",
+    type: Institution,
+  })
+  @ApiResponse({ status: 409, description: "Institution name already exists" })
+  create(@Request() req, @Body() dto: CreateInstitutionDto) {
+    return this.institutionsService.create(req.user.id, dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: "Get all institutions for the authenticated user" })
+  @ApiResponse({ status: 200, description: "List of institutions" })
+  findAll(@Request() req) {
+    return this.institutionsService.findAll(req.user.id);
+  }
+
+  @Get(":id")
+  @ApiOperation({ summary: "Get a single institution by ID" })
+  @ApiResponse({ status: 200, description: "Institution details" })
+  @ApiResponse({ status: 404, description: "Institution not found" })
+  findOne(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
+    return this.institutionsService.findOne(req.user.id, id);
+  }
+
+  @Get(":id/logo")
+  @ApiOperation({
+    summary: "Stream the cached brand favicon for an institution",
+  })
+  @ApiResponse({ status: 200, description: "Logo image bytes" })
+  @ApiResponse({ status: 404, description: "Institution or logo not found" })
+  async getLogo(
+    @Request() req,
+    @Param("id", ParseUUIDPipe) id: string,
+    @Res() res: Response,
+  ): Promise<void> {
+    const { data, contentType } = await this.institutionsService.getLogo(
+      req.user.id,
+      id,
+    );
+    res.set({
+      "Content-Type": contentType,
+      "Content-Length": String(data.length),
+      // Per-user cached image; safe to cache in the browser for a day.
+      "Cache-Control": "private, max-age=86400",
+    });
+    res.end(data);
+  }
+
+  @Post(":id/refresh-logo")
+  @ApiOperation({ summary: "Re-fetch the brand favicon for an institution" })
+  @ApiResponse({ status: 200, description: "Institution with refreshed logo" })
+  @ApiResponse({ status: 404, description: "Institution not found" })
+  refreshLogo(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
+    return this.institutionsService.refreshLogo(req.user.id, id);
+  }
+
+  @Get(":id/accounts")
+  @ApiOperation({ summary: "List accounts assigned to an institution" })
+  @ApiResponse({ status: 200, description: "Accounts", type: [Account] })
+  @ApiResponse({ status: 404, description: "Institution not found" })
+  getAccounts(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
+    return this.institutionsService.getAccounts(req.user.id, id);
+  }
+
+  @Post(":id/accounts")
+  @ApiOperation({ summary: "Assign an account to an institution" })
+  @ApiResponse({ status: 201, description: "Account assigned", type: Account })
+  @ApiResponse({ status: 404, description: "Institution or account not found" })
+  assignAccount(
+    @Request() req,
+    @Param("id", ParseUUIDPipe) id: string,
+    @Body() dto: AssignAccountDto,
+  ) {
+    return this.institutionsService.assignAccount(
+      req.user.id,
+      id,
+      dto.accountId,
+    );
+  }
+
+  @Delete(":id/accounts/:accountId")
+  @ApiOperation({ summary: "Remove an account from an institution" })
+  @ApiResponse({
+    status: 200,
+    description: "Account unassigned",
+    type: Account,
+  })
+  @ApiResponse({ status: 404, description: "Institution or account not found" })
+  unassignAccount(
+    @Request() req,
+    @Param("id", ParseUUIDPipe) id: string,
+    @Param("accountId", ParseUUIDPipe) accountId: string,
+  ) {
+    return this.institutionsService.unassignAccount(req.user.id, id, accountId);
+  }
+
+  @Patch(":id")
+  @ApiOperation({ summary: "Update an institution" })
+  @ApiResponse({ status: 200, description: "Institution updated" })
+  @ApiResponse({ status: 404, description: "Institution not found" })
+  @ApiResponse({ status: 409, description: "Institution name already exists" })
+  update(
+    @Request() req,
+    @Param("id", ParseUUIDPipe) id: string,
+    @Body() dto: UpdateInstitutionDto,
+  ) {
+    return this.institutionsService.update(req.user.id, id, dto);
+  }
+
+  @Delete(":id")
+  @ApiOperation({ summary: "Delete an institution" })
+  @ApiResponse({ status: 200, description: "Institution deleted" })
+  @ApiResponse({ status: 404, description: "Institution not found" })
+  remove(@Request() req, @Param("id", ParseUUIDPipe) id: string) {
+    return this.institutionsService.remove(req.user.id, id);
+  }
+}

--- a/backend/src/institutions/institutions.module.ts
+++ b/backend/src/institutions/institutions.module.ts
@@ -1,0 +1,19 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { Institution } from "./entities/institution.entity";
+import { Account } from "../accounts/entities/account.entity";
+import { InstitutionsService } from "./institutions.service";
+import { InstitutionLogoService } from "./institution-logo.service";
+import { InstitutionsController } from "./institutions.controller";
+import { ActionHistoryModule } from "../action-history/action-history.module";
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Institution, Account]),
+    ActionHistoryModule,
+  ],
+  providers: [InstitutionsService, InstitutionLogoService],
+  controllers: [InstitutionsController],
+  exports: [InstitutionsService],
+})
+export class InstitutionsModule {}

--- a/backend/src/institutions/institutions.service.spec.ts
+++ b/backend/src/institutions/institutions.service.spec.ts
@@ -5,6 +5,7 @@ describe("InstitutionsService", () => {
   let service: InstitutionsService;
   let institutionsRepo: Record<string, jest.Mock>;
   let accountsRepo: Record<string, jest.Mock>;
+  let qrManager: Record<string, jest.Mock>;
   let logoService: { fetchFavicon: jest.Mock };
   let actionHistory: { record: jest.Mock };
 
@@ -51,9 +52,24 @@ describe("InstitutionsService", () => {
     logoService = { fetchFavicon: jest.fn().mockResolvedValue(null) };
     actionHistory = { record: jest.fn() };
 
+    qrManager = {
+      findOne: jest.fn(),
+      save: jest.fn((x) => Promise.resolve(x)),
+    };
+    const queryRunner = {
+      connect: jest.fn(),
+      startTransaction: jest.fn(),
+      commitTransaction: jest.fn(),
+      rollbackTransaction: jest.fn(),
+      release: jest.fn(),
+      manager: qrManager,
+    };
+    const dataSource = { createQueryRunner: jest.fn(() => queryRunner) };
+
     service = new InstitutionsService(
       institutionsRepo as any,
       accountsRepo as any,
+      dataSource as any,
       logoService as any,
       actionHistory as any,
     );
@@ -299,18 +315,44 @@ describe("InstitutionsService", () => {
   describe("assignAccount()", () => {
     it("assigns an owned account to the institution", async () => {
       institutionsRepo.findOne.mockResolvedValue(buildInstitution());
-      accountsRepo.findOne.mockResolvedValue({
+      qrManager.findOne.mockResolvedValue({
         id: "acc-1",
         institutionId: null,
+        accountType: "CHEQUING",
+        linkedAccountId: null,
       });
       await service.assignAccount(userId, "inst-1", "acc-1");
-      const saved = accountsRepo.save.mock.calls[0][0];
+      const saved = qrManager.save.mock.calls[0][0];
       expect(saved.institutionId).toBe("inst-1");
+    });
+
+    it("syncs the linked investment partner when assigning", async () => {
+      institutionsRepo.findOne.mockResolvedValue(buildInstitution());
+      qrManager.findOne
+        .mockResolvedValueOnce({
+          id: "acc-1",
+          institutionId: null,
+          accountType: "INVESTMENT",
+          linkedAccountId: "acc-2",
+        })
+        .mockResolvedValueOnce({
+          id: "acc-2",
+          institutionId: null,
+          accountType: "INVESTMENT",
+          linkedAccountId: "acc-1",
+        });
+      await service.assignAccount(userId, "inst-1", "acc-1");
+      const saved = qrManager.save.mock.calls.map((c) => [
+        c[0].id,
+        c[0].institutionId,
+      ]);
+      expect(saved).toContainEqual(["acc-1", "inst-1"]);
+      expect(saved).toContainEqual(["acc-2", "inst-1"]);
     });
 
     it("throws NotFoundException when the account does not belong to the user", async () => {
       institutionsRepo.findOne.mockResolvedValue(buildInstitution());
-      accountsRepo.findOne.mockResolvedValue(null);
+      qrManager.findOne.mockResolvedValue(null);
       await expect(
         service.assignAccount(userId, "inst-1", "acc-1"),
       ).rejects.toThrow(NotFoundException);
@@ -320,28 +362,56 @@ describe("InstitutionsService", () => {
   describe("unassignAccount()", () => {
     it("clears the institution when the account is currently assigned to it", async () => {
       institutionsRepo.findOne.mockResolvedValue(buildInstitution());
-      accountsRepo.findOne.mockResolvedValue({
+      qrManager.findOne.mockResolvedValue({
         id: "acc-1",
         institutionId: "inst-1",
+        accountType: "CHEQUING",
+        linkedAccountId: null,
       });
       await service.unassignAccount(userId, "inst-1", "acc-1");
-      const saved = accountsRepo.save.mock.calls[0][0];
+      const saved = qrManager.save.mock.calls[0][0];
       expect(saved.institutionId).toBeNull();
+    });
+
+    it("clears the linked investment partner too", async () => {
+      institutionsRepo.findOne.mockResolvedValue(buildInstitution());
+      qrManager.findOne
+        .mockResolvedValueOnce({
+          id: "acc-1",
+          institutionId: "inst-1",
+          accountType: "INVESTMENT",
+          linkedAccountId: "acc-2",
+        })
+        .mockResolvedValueOnce({
+          id: "acc-2",
+          institutionId: "inst-1",
+          accountType: "INVESTMENT",
+          linkedAccountId: "acc-1",
+        });
+      await service.unassignAccount(userId, "inst-1", "acc-1");
+      const saved = qrManager.save.mock.calls.map((c) => [
+        c[0].id,
+        c[0].institutionId,
+      ]);
+      expect(saved).toContainEqual(["acc-1", null]);
+      expect(saved).toContainEqual(["acc-2", null]);
     });
 
     it("leaves the account untouched when assigned to a different institution", async () => {
       institutionsRepo.findOne.mockResolvedValue(buildInstitution());
-      accountsRepo.findOne.mockResolvedValue({
+      qrManager.findOne.mockResolvedValue({
         id: "acc-1",
         institutionId: "other",
+        accountType: "CHEQUING",
+        linkedAccountId: null,
       });
       await service.unassignAccount(userId, "inst-1", "acc-1");
-      expect(accountsRepo.save).not.toHaveBeenCalled();
+      expect(qrManager.save).not.toHaveBeenCalled();
     });
 
     it("throws NotFoundException when the account is missing", async () => {
       institutionsRepo.findOne.mockResolvedValue(buildInstitution());
-      accountsRepo.findOne.mockResolvedValue(null);
+      qrManager.findOne.mockResolvedValue(null);
       await expect(
         service.unassignAccount(userId, "inst-1", "acc-1"),
       ).rejects.toThrow(NotFoundException);

--- a/backend/src/institutions/institutions.service.spec.ts
+++ b/backend/src/institutions/institutions.service.spec.ts
@@ -1,0 +1,350 @@
+import { ConflictException, NotFoundException } from "@nestjs/common";
+import { InstitutionsService } from "./institutions.service";
+
+describe("InstitutionsService", () => {
+  let service: InstitutionsService;
+  let institutionsRepo: Record<string, jest.Mock>;
+  let accountsRepo: Record<string, jest.Mock>;
+  let logoService: { fetchFavicon: jest.Mock };
+  let actionHistory: { record: jest.Mock };
+
+  const userId = "user-1";
+
+  const buildInstitution = (overrides: Record<string, unknown> = {}) => ({
+    id: "inst-1",
+    userId,
+    name: "TD Canada Trust",
+    website: "https://td.com",
+    country: "CA",
+    hasLogo: true,
+    logoFetchedAt: new Date("2024-01-01"),
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+    ...overrides,
+  });
+
+  const chainableQb = (result: unknown, method: "getRawMany" | "getOne") => {
+    const qb: Record<string, jest.Mock> = {};
+    for (const m of ["select", "addSelect", "where", "andWhere", "groupBy"]) {
+      qb[m] = jest.fn(() => qb);
+    }
+    qb[method] = jest.fn().mockResolvedValue(result);
+    return qb;
+  };
+
+  beforeEach(() => {
+    institutionsRepo = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+      create: jest.fn((x) => x),
+      save: jest.fn((x) => Promise.resolve({ id: "inst-1", ...x })),
+      remove: jest.fn().mockResolvedValue(undefined),
+      createQueryBuilder: jest.fn(),
+    };
+    accountsRepo = {
+      count: jest.fn().mockResolvedValue(0),
+      find: jest.fn().mockResolvedValue([]),
+      findOne: jest.fn(),
+      save: jest.fn((x) => Promise.resolve(x)),
+      createQueryBuilder: jest.fn(),
+    };
+    logoService = { fetchFavicon: jest.fn().mockResolvedValue(null) };
+    actionHistory = { record: jest.fn() };
+
+    service = new InstitutionsService(
+      institutionsRepo as any,
+      accountsRepo as any,
+      logoService as any,
+      actionHistory as any,
+    );
+  });
+
+  describe("create()", () => {
+    it("creates an institution, normalises the website, and caches the favicon", async () => {
+      institutionsRepo.findOne.mockResolvedValue(null);
+      logoService.fetchFavicon.mockResolvedValue({
+        data: Buffer.from([1, 2, 3]),
+        contentType: "image/png",
+      });
+
+      const result = await service.create(userId, {
+        name: "TD Canada Trust",
+        website: "td.com",
+      });
+
+      // Website normalised to absolute https URL before storage + favicon fetch.
+      expect(institutionsRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ website: "https://td.com", userId }),
+      );
+      expect(logoService.fetchFavicon).toHaveBeenCalledWith("https://td.com");
+      const savedArg = institutionsRepo.save.mock.calls[0][0];
+      expect(savedArg.hasLogo).toBe(true);
+      expect(savedArg.logoData).toEqual(Buffer.from([1, 2, 3]));
+      expect(result.hasLogo).toBe(true);
+      expect(result.accountCount).toBe(0);
+      // Cached bytes are never part of the client-facing view.
+      expect((result as any).logoData).toBeUndefined();
+      expect(actionHistory.record).toHaveBeenCalled();
+    });
+
+    it("uppercases the country code", async () => {
+      institutionsRepo.findOne.mockResolvedValue(null);
+      await service.create(userId, {
+        name: "Acme",
+        website: "https://acme.com",
+        country: "ca",
+      });
+      expect(institutionsRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ country: "CA" }),
+      );
+    });
+
+    it("succeeds with no logo when the favicon cannot be fetched", async () => {
+      institutionsRepo.findOne.mockResolvedValue(null);
+      logoService.fetchFavicon.mockResolvedValue(null);
+
+      const result = await service.create(userId, {
+        name: "Acme",
+        website: "https://acme.com",
+      });
+
+      expect(result.hasLogo).toBe(false);
+    });
+
+    it("throws ConflictException when the name already exists", async () => {
+      institutionsRepo.findOne.mockResolvedValue(buildInstitution());
+      await expect(
+        service.create(userId, { name: "TD Canada Trust", website: "td.com" }),
+      ).rejects.toThrow(ConflictException);
+      expect(institutionsRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("findAll()", () => {
+    it("returns [] when the user has no institutions", async () => {
+      institutionsRepo.find.mockResolvedValue([]);
+      expect(await service.findAll(userId)).toEqual([]);
+    });
+
+    it("attaches per-institution account counts", async () => {
+      institutionsRepo.find.mockResolvedValue([
+        buildInstitution({ id: "inst-1" }),
+        buildInstitution({ id: "inst-2", name: "Other" }),
+      ]);
+      accountsRepo.createQueryBuilder.mockReturnValue(
+        chainableQb([{ institution_id: "inst-1", count: "2" }], "getRawMany"),
+      );
+
+      const result = await service.findAll(userId);
+
+      expect(result.find((i) => i.id === "inst-1")!.accountCount).toBe(2);
+      expect(result.find((i) => i.id === "inst-2")!.accountCount).toBe(0);
+    });
+  });
+
+  describe("findOne()", () => {
+    it("throws NotFoundException when missing", async () => {
+      institutionsRepo.findOne.mockResolvedValue(null);
+      await expect(service.findOne(userId, "inst-1")).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it("returns the institution with its account count", async () => {
+      institutionsRepo.findOne.mockResolvedValue(buildInstitution());
+      accountsRepo.count.mockResolvedValue(4);
+      const result = await service.findOne(userId, "inst-1");
+      expect(result.accountCount).toBe(4);
+    });
+  });
+
+  describe("update()", () => {
+    it("throws ConflictException on a name clash with a different institution", async () => {
+      institutionsRepo.findOne
+        .mockResolvedValueOnce(buildInstitution())
+        .mockResolvedValueOnce(buildInstitution({ id: "inst-2" }));
+      await expect(
+        service.update(userId, "inst-1", { name: "Other" }),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it("re-fetches the favicon when the website changes", async () => {
+      institutionsRepo.findOne.mockResolvedValue(buildInstitution());
+      logoService.fetchFavicon.mockResolvedValue({
+        data: Buffer.from([9]),
+        contentType: "image/x-icon",
+      });
+
+      await service.update(userId, "inst-1", { website: "newbank.com" });
+
+      expect(logoService.fetchFavicon).toHaveBeenCalledWith(
+        "https://newbank.com",
+      );
+      const saved = institutionsRepo.save.mock.calls[0][0];
+      expect(saved.website).toBe("https://newbank.com");
+      expect(saved.hasLogo).toBe(true);
+    });
+
+    it("does not re-fetch the favicon when the website is unchanged", async () => {
+      institutionsRepo.findOne.mockResolvedValue(buildInstitution());
+      await service.update(userId, "inst-1", { website: "https://td.com" });
+      expect(logoService.fetchFavicon).not.toHaveBeenCalled();
+    });
+
+    it("updates the country code", async () => {
+      institutionsRepo.findOne.mockResolvedValue(buildInstitution());
+      await service.update(userId, "inst-1", { country: "us" });
+      const saved = institutionsRepo.save.mock.calls[0][0];
+      expect(saved.country).toBe("US");
+    });
+  });
+
+  describe("remove()", () => {
+    it("removes the institution and records the action", async () => {
+      const inst = buildInstitution();
+      institutionsRepo.findOne.mockResolvedValue(inst);
+      await service.remove(userId, "inst-1");
+      expect(institutionsRepo.remove).toHaveBeenCalledWith(inst);
+      expect(actionHistory.record).toHaveBeenCalled();
+    });
+
+    it("throws NotFoundException when missing", async () => {
+      institutionsRepo.findOne.mockResolvedValue(null);
+      await expect(service.remove(userId, "inst-1")).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe("refreshLogo()", () => {
+    it("re-fetches and persists the favicon for the current website", async () => {
+      institutionsRepo.findOne.mockResolvedValue(buildInstitution());
+      logoService.fetchFavicon.mockResolvedValue({
+        data: Buffer.from([7]),
+        contentType: "image/png",
+      });
+      const result = await service.refreshLogo(userId, "inst-1");
+      expect(logoService.fetchFavicon).toHaveBeenCalledWith("https://td.com");
+      expect(result.hasLogo).toBe(true);
+    });
+  });
+
+  describe("getLogo()", () => {
+    it("throws NotFoundException when the institution is missing", async () => {
+      institutionsRepo.createQueryBuilder.mockReturnValue(
+        chainableQb(null, "getOne"),
+      );
+      await expect(service.getLogo(userId, "inst-1")).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it("throws NotFoundException when there is no cached logo", async () => {
+      institutionsRepo.createQueryBuilder.mockReturnValue(
+        chainableQb(
+          buildInstitution({ hasLogo: false, logoData: null }),
+          "getOne",
+        ),
+      );
+      await expect(service.getLogo(userId, "inst-1")).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it("returns the cached bytes and content type", async () => {
+      institutionsRepo.createQueryBuilder.mockReturnValue(
+        chainableQb(
+          buildInstitution({
+            hasLogo: true,
+            logoData: Buffer.from([5, 6]),
+            logoContentType: "image/png",
+          }),
+          "getOne",
+        ),
+      );
+      const result = await service.getLogo(userId, "inst-1");
+      expect(result.data).toEqual(Buffer.from([5, 6]));
+      expect(result.contentType).toBe("image/png");
+    });
+
+    it("falls back to image/png when content type is missing", async () => {
+      institutionsRepo.createQueryBuilder.mockReturnValue(
+        chainableQb(
+          buildInstitution({
+            hasLogo: true,
+            logoData: Buffer.from([5]),
+            logoContentType: null,
+          }),
+          "getOne",
+        ),
+      );
+      const result = await service.getLogo(userId, "inst-1");
+      expect(result.contentType).toBe("image/png");
+    });
+  });
+
+  describe("getAccounts()", () => {
+    it("lists accounts assigned to the institution", async () => {
+      institutionsRepo.findOne.mockResolvedValue(buildInstitution());
+      accountsRepo.find.mockResolvedValue([{ id: "acc-1" }]);
+      const result = await service.getAccounts(userId, "inst-1");
+      expect(accountsRepo.find).toHaveBeenCalledWith({
+        where: { userId, institutionId: "inst-1" },
+        order: { name: "ASC" },
+      });
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("assignAccount()", () => {
+    it("assigns an owned account to the institution", async () => {
+      institutionsRepo.findOne.mockResolvedValue(buildInstitution());
+      accountsRepo.findOne.mockResolvedValue({
+        id: "acc-1",
+        institutionId: null,
+      });
+      await service.assignAccount(userId, "inst-1", "acc-1");
+      const saved = accountsRepo.save.mock.calls[0][0];
+      expect(saved.institutionId).toBe("inst-1");
+    });
+
+    it("throws NotFoundException when the account does not belong to the user", async () => {
+      institutionsRepo.findOne.mockResolvedValue(buildInstitution());
+      accountsRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.assignAccount(userId, "inst-1", "acc-1"),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("unassignAccount()", () => {
+    it("clears the institution when the account is currently assigned to it", async () => {
+      institutionsRepo.findOne.mockResolvedValue(buildInstitution());
+      accountsRepo.findOne.mockResolvedValue({
+        id: "acc-1",
+        institutionId: "inst-1",
+      });
+      await service.unassignAccount(userId, "inst-1", "acc-1");
+      const saved = accountsRepo.save.mock.calls[0][0];
+      expect(saved.institutionId).toBeNull();
+    });
+
+    it("leaves the account untouched when assigned to a different institution", async () => {
+      institutionsRepo.findOne.mockResolvedValue(buildInstitution());
+      accountsRepo.findOne.mockResolvedValue({
+        id: "acc-1",
+        institutionId: "other",
+      });
+      await service.unassignAccount(userId, "inst-1", "acc-1");
+      expect(accountsRepo.save).not.toHaveBeenCalled();
+    });
+
+    it("throws NotFoundException when the account is missing", async () => {
+      institutionsRepo.findOne.mockResolvedValue(buildInstitution());
+      accountsRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.unassignAccount(userId, "inst-1", "acc-1"),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/backend/src/institutions/institutions.service.ts
+++ b/backend/src/institutions/institutions.service.ts
@@ -1,0 +1,395 @@
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+  Logger,
+} from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { tr } from "../i18n/translate";
+import { Institution } from "./entities/institution.entity";
+import { Account } from "../accounts/entities/account.entity";
+import { CreateInstitutionDto } from "./dto/create-institution.dto";
+import { UpdateInstitutionDto } from "./dto/update-institution.dto";
+import {
+  InstitutionLogoService,
+  FetchedLogo,
+} from "./institution-logo.service";
+import { ActionHistoryService } from "../action-history/action-history.service";
+
+/**
+ * Client-facing institution shape. The cached favicon bytes
+ * (logoData/logoContentType) are deliberately omitted -- they are served only
+ * through GET /institutions/:id/logo.
+ */
+export interface InstitutionView {
+  id: string;
+  userId: string;
+  name: string;
+  website: string;
+  country: string | null;
+  hasLogo: boolean;
+  logoFetchedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  accountCount: number;
+}
+
+@Injectable()
+export class InstitutionsService {
+  private readonly logger = new Logger(InstitutionsService.name);
+
+  constructor(
+    @InjectRepository(Institution)
+    private institutionsRepository: Repository<Institution>,
+    @InjectRepository(Account)
+    private accountsRepository: Repository<Account>,
+    private logoService: InstitutionLogoService,
+    private actionHistoryService: ActionHistoryService,
+  ) {}
+
+  /**
+   * Normalise a user-entered website to an absolute https URL so it works both
+   * as a stored link and as input to the favicon resolver.
+   */
+  private normalizeWebsite(website: string): string {
+    const trimmed = website.trim();
+    if (!/^https?:\/\//i.test(trimmed)) {
+      return `https://${trimmed}`;
+    }
+    return trimmed;
+  }
+
+  private toView(
+    institution: Institution,
+    accountCount: number,
+  ): InstitutionView {
+    return {
+      id: institution.id,
+      userId: institution.userId,
+      name: institution.name,
+      website: institution.website,
+      country: institution.country,
+      hasLogo: institution.hasLogo,
+      logoFetchedAt: institution.logoFetchedAt,
+      createdAt: institution.createdAt,
+      updatedAt: institution.updatedAt,
+      accountCount,
+    };
+  }
+
+  private applyLogo(institution: Institution, logo: FetchedLogo | null): void {
+    if (logo) {
+      institution.logoData = logo.data;
+      institution.logoContentType = logo.contentType;
+      institution.hasLogo = true;
+      institution.logoFetchedAt = new Date();
+    } else {
+      institution.logoData = null;
+      institution.logoContentType = null;
+      institution.hasLogo = false;
+      institution.logoFetchedAt = new Date();
+    }
+  }
+
+  private async countAccounts(
+    userId: string,
+    institutionId: string,
+  ): Promise<number> {
+    return this.accountsRepository.count({
+      where: { userId, institutionId },
+    });
+  }
+
+  async create(
+    userId: string,
+    dto: CreateInstitutionDto,
+  ): Promise<InstitutionView> {
+    const existing = await this.institutionsRepository.findOne({
+      where: { userId, name: dto.name },
+    });
+    if (existing) {
+      throw new ConflictException(
+        tr(
+          "errors.institutions.nameConflict",
+          `Institution with name "${dto.name}" already exists`,
+          { name: dto.name },
+        ),
+      );
+    }
+
+    const website = this.normalizeWebsite(dto.website);
+    const institution = this.institutionsRepository.create({
+      userId,
+      name: dto.name,
+      website,
+      country: dto.country ? dto.country.toUpperCase() : null,
+    });
+
+    // Best-effort: never fail creation because the favicon could not be fetched.
+    const logo = await this.logoService.fetchFavicon(website);
+    this.applyLogo(institution, logo);
+
+    const saved = await this.institutionsRepository.save(institution);
+
+    this.actionHistoryService.record(userId, {
+      entityType: "institution",
+      entityId: saved.id,
+      action: "create",
+      afterData: {
+        id: saved.id,
+        name: saved.name,
+        website: saved.website,
+        country: saved.country,
+      },
+      description: `Created institution "${saved.name}"`,
+    });
+
+    return this.toView(saved, 0);
+  }
+
+  async findAll(userId: string): Promise<InstitutionView[]> {
+    const institutions = await this.institutionsRepository.find({
+      where: { userId },
+      order: { name: "ASC" },
+    });
+
+    if (institutions.length === 0) {
+      return [];
+    }
+
+    const counts = await this.accountsRepository
+      .createQueryBuilder("account")
+      .select("account.institution_id", "institution_id")
+      .addSelect("COUNT(*)", "count")
+      .where("account.user_id = :userId", { userId })
+      .andWhere("account.institution_id IS NOT NULL")
+      .groupBy("account.institution_id")
+      .getRawMany<{ institution_id: string; count: string }>();
+
+    const countMap = new Map<string, number>();
+    for (const row of counts) {
+      countMap.set(row.institution_id, parseInt(row.count, 10) || 0);
+    }
+
+    return institutions.map((institution) =>
+      this.toView(institution, countMap.get(institution.id) ?? 0),
+    );
+  }
+
+  /**
+   * Load the institution entity (without the cached logo bytes), scoped to the
+   * owner. Throws NotFound if it does not exist or belongs to another user.
+   */
+  private async getOwnedEntity(
+    userId: string,
+    id: string,
+  ): Promise<Institution> {
+    const institution = await this.institutionsRepository.findOne({
+      where: { id, userId },
+    });
+    if (!institution) {
+      throw new NotFoundException(
+        tr(
+          "errors.institutions.notFound",
+          `Institution with ID ${id} not found`,
+          { id },
+        ),
+      );
+    }
+    return institution;
+  }
+
+  async findOne(userId: string, id: string): Promise<InstitutionView> {
+    const institution = await this.getOwnedEntity(userId, id);
+    const accountCount = await this.countAccounts(userId, id);
+    return this.toView(institution, accountCount);
+  }
+
+  async update(
+    userId: string,
+    id: string,
+    dto: UpdateInstitutionDto,
+  ): Promise<InstitutionView> {
+    const institution = await this.getOwnedEntity(userId, id);
+
+    if (dto.name !== undefined && dto.name !== institution.name) {
+      const existing = await this.institutionsRepository.findOne({
+        where: { userId, name: dto.name },
+      });
+      if (existing && existing.id !== id) {
+        throw new ConflictException(
+          tr(
+            "errors.institutions.nameConflict",
+            `Institution with name "${dto.name}" already exists`,
+            { name: dto.name },
+          ),
+        );
+      }
+      institution.name = dto.name;
+    }
+
+    if (dto.country !== undefined) {
+      institution.country = dto.country ? dto.country.toUpperCase() : null;
+    }
+
+    // Re-resolve the favicon whenever the website changes.
+    if (dto.website !== undefined) {
+      const website = this.normalizeWebsite(dto.website);
+      if (website !== institution.website) {
+        institution.website = website;
+        const logo = await this.logoService.fetchFavicon(website);
+        this.applyLogo(institution, logo);
+      }
+    }
+
+    const saved = await this.institutionsRepository.save(institution);
+
+    this.actionHistoryService.record(userId, {
+      entityType: "institution",
+      entityId: saved.id,
+      action: "update",
+      afterData: {
+        id: saved.id,
+        name: saved.name,
+        website: saved.website,
+        country: saved.country,
+      },
+      description: `Updated institution "${saved.name}"`,
+    });
+
+    const accountCount = await this.countAccounts(userId, id);
+    return this.toView(saved, accountCount);
+  }
+
+  async remove(userId: string, id: string): Promise<void> {
+    const institution = await this.getOwnedEntity(userId, id);
+    await this.institutionsRepository.remove(institution);
+
+    this.actionHistoryService.record(userId, {
+      entityType: "institution",
+      entityId: id,
+      action: "delete",
+      beforeData: {
+        id,
+        name: institution.name,
+        website: institution.website,
+        country: institution.country,
+      },
+      description: `Deleted institution "${institution.name}"`,
+    });
+  }
+
+  /**
+   * Re-fetch the favicon for the institution's current website.
+   */
+  async refreshLogo(userId: string, id: string): Promise<InstitutionView> {
+    const institution = await this.getOwnedEntity(userId, id);
+    const logo = await this.logoService.fetchFavicon(institution.website);
+    this.applyLogo(institution, logo);
+    const saved = await this.institutionsRepository.save(institution);
+    const accountCount = await this.countAccounts(userId, id);
+    return this.toView(saved, accountCount);
+  }
+
+  /**
+   * Load the cached favicon bytes for streaming. Throws NotFound when the
+   * institution is missing or has no cached logo.
+   */
+  async getLogo(userId: string, id: string): Promise<FetchedLogo> {
+    const institution = await this.institutionsRepository
+      .createQueryBuilder("institution")
+      .addSelect(["institution.logoData", "institution.logoContentType"])
+      .where("institution.id = :id", { id })
+      .andWhere("institution.user_id = :userId", { userId })
+      .getOne();
+
+    if (!institution) {
+      throw new NotFoundException(
+        tr(
+          "errors.institutions.notFound",
+          `Institution with ID ${id} not found`,
+          { id },
+        ),
+      );
+    }
+
+    if (!institution.hasLogo || !institution.logoData) {
+      throw new NotFoundException(
+        tr(
+          "errors.institutions.logoNotFound",
+          "No logo available for this institution",
+        ),
+      );
+    }
+
+    return {
+      data: institution.logoData,
+      contentType: institution.logoContentType || "image/png",
+    };
+  }
+
+  /**
+   * List the accounts assigned to an institution.
+   */
+  async getAccounts(userId: string, id: string): Promise<Account[]> {
+    await this.getOwnedEntity(userId, id);
+    return this.accountsRepository.find({
+      where: { userId, institutionId: id },
+      order: { name: "ASC" },
+    });
+  }
+
+  /**
+   * Assign an account to this institution.
+   */
+  async assignAccount(
+    userId: string,
+    id: string,
+    accountId: string,
+  ): Promise<Account> {
+    await this.getOwnedEntity(userId, id);
+    const account = await this.accountsRepository.findOne({
+      where: { id: accountId, userId },
+    });
+    if (!account) {
+      throw new NotFoundException(
+        tr(
+          "errors.institutions.accountNotFound",
+          `Account with ID ${accountId} not found`,
+          { id: accountId },
+        ),
+      );
+    }
+    account.institutionId = id;
+    return this.accountsRepository.save(account);
+  }
+
+  /**
+   * Remove an account from this institution.
+   */
+  async unassignAccount(
+    userId: string,
+    id: string,
+    accountId: string,
+  ): Promise<Account> {
+    await this.getOwnedEntity(userId, id);
+    const account = await this.accountsRepository.findOne({
+      where: { id: accountId, userId },
+    });
+    if (!account) {
+      throw new NotFoundException(
+        tr(
+          "errors.institutions.accountNotFound",
+          `Account with ID ${accountId} not found`,
+          { id: accountId },
+        ),
+      );
+    }
+    if (account.institutionId === id) {
+      account.institutionId = null;
+      return this.accountsRepository.save(account);
+    }
+    return account;
+  }
+}

--- a/backend/src/institutions/institutions.service.ts
+++ b/backend/src/institutions/institutions.service.ts
@@ -5,10 +5,10 @@ import {
   Logger,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
+import { Repository, DataSource } from "typeorm";
 import { tr } from "../i18n/translate";
 import { Institution } from "./entities/institution.entity";
-import { Account } from "../accounts/entities/account.entity";
+import { Account, AccountType } from "../accounts/entities/account.entity";
 import { CreateInstitutionDto } from "./dto/create-institution.dto";
 import { UpdateInstitutionDto } from "./dto/update-institution.dto";
 import {
@@ -44,6 +44,7 @@ export class InstitutionsService {
     private institutionsRepository: Repository<Institution>,
     @InjectRepository(Account)
     private accountsRepository: Repository<Account>,
+    private dataSource: DataSource,
     private logoService: InstitutionLogoService,
     private actionHistoryService: ActionHistoryService,
   ) {}
@@ -341,7 +342,74 @@ export class InstitutionsService {
   }
 
   /**
-   * Assign an account to this institution.
+   * Set an account's institution and keep a linked investment pair (cash <->
+   * brokerage) in sync, atomically. The two halves represent one real-world
+   * account, so the institution always applies to both.
+   *
+   * @param expectedInstitutionId when provided (unassign), only clears accounts
+   *        currently pointing at this institution.
+   */
+  private async setAccountInstitution(
+    userId: string,
+    accountId: string,
+    institutionId: string | null,
+    expectedInstitutionId?: string,
+  ): Promise<Account> {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    try {
+      const account = await queryRunner.manager.findOne(Account, {
+        where: { id: accountId, userId },
+      });
+      if (!account) {
+        throw new NotFoundException(
+          tr(
+            "errors.institutions.accountNotFound",
+            `Account with ID ${accountId} not found`,
+            { id: accountId },
+          ),
+        );
+      }
+
+      // Unassign is a no-op unless the account points at this institution.
+      if (
+        expectedInstitutionId !== undefined &&
+        account.institutionId !== expectedInstitutionId
+      ) {
+        await queryRunner.commitTransaction();
+        return account;
+      }
+
+      account.institutionId = institutionId;
+      await queryRunner.manager.save(account);
+
+      // Mirror the change onto the linked investment partner.
+      if (
+        account.linkedAccountId &&
+        account.accountType === AccountType.INVESTMENT
+      ) {
+        const partner = await queryRunner.manager.findOne(Account, {
+          where: { id: account.linkedAccountId, userId },
+        });
+        if (partner && partner.institutionId !== institutionId) {
+          partner.institutionId = institutionId;
+          await queryRunner.manager.save(partner);
+        }
+      }
+
+      await queryRunner.commitTransaction();
+      return account;
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  /**
+   * Assign an account (and its linked investment partner) to this institution.
    */
   async assignAccount(
     userId: string,
@@ -349,24 +417,11 @@ export class InstitutionsService {
     accountId: string,
   ): Promise<Account> {
     await this.getOwnedEntity(userId, id);
-    const account = await this.accountsRepository.findOne({
-      where: { id: accountId, userId },
-    });
-    if (!account) {
-      throw new NotFoundException(
-        tr(
-          "errors.institutions.accountNotFound",
-          `Account with ID ${accountId} not found`,
-          { id: accountId },
-        ),
-      );
-    }
-    account.institutionId = id;
-    return this.accountsRepository.save(account);
+    return this.setAccountInstitution(userId, accountId, id);
   }
 
   /**
-   * Remove an account from this institution.
+   * Remove an account (and its linked investment partner) from this institution.
    */
   async unassignAccount(
     userId: string,
@@ -374,22 +429,6 @@ export class InstitutionsService {
     accountId: string,
   ): Promise<Account> {
     await this.getOwnedEntity(userId, id);
-    const account = await this.accountsRepository.findOne({
-      where: { id: accountId, userId },
-    });
-    if (!account) {
-      throw new NotFoundException(
-        tr(
-          "errors.institutions.accountNotFound",
-          `Account with ID ${accountId} not found`,
-          { id: accountId },
-        ),
-      );
-    }
-    if (account.institutionId === id) {
-      account.institutionId = null;
-      return this.accountsRepository.save(account);
-    }
-    return account;
+    return this.setAccountInstitution(userId, accountId, null, id);
   }
 }

--- a/backend/src/net-worth/net-worth.service.spec.ts
+++ b/backend/src/net-worth/net-worth.service.spec.ts
@@ -53,6 +53,8 @@ describe("NetWorthService", () => {
     description: null,
     accountNumber: null,
     institution: null,
+    institutionId: null,
+    institutionRef: null,
     creditLimit: null,
     interestRate: null,
     isFavourite: false,

--- a/database/migrations/082_institutions.sql
+++ b/database/migrations/082_institutions.sql
@@ -1,0 +1,29 @@
+-- Financial Institutions: a per-user registry of banks and brokerages.
+-- Accounts can be assigned to an institution. The institution's brand icon is
+-- the bank's favicon, fetched server-side from Google's faviconV2 endpoint and
+-- cached in the database (logo_data) so the user's browser never has to contact
+-- a third party to render it.
+
+CREATE TABLE IF NOT EXISTS institutions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    website TEXT NOT NULL,
+    country VARCHAR(2),
+    logo_data BYTEA,
+    logo_content_type VARCHAR(100),
+    has_logo BOOLEAN NOT NULL DEFAULT false,
+    logo_fetched_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_institutions_user ON institutions(user_id);
+
+-- Link accounts to an institution. ON DELETE SET NULL so removing an
+-- institution simply unassigns its accounts rather than deleting them.
+ALTER TABLE accounts
+    ADD COLUMN IF NOT EXISTS institution_id UUID REFERENCES institutions(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_accounts_institution ON accounts(institution_id);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -111,7 +111,8 @@ CREATE TABLE accounts (
     description TEXT,
     currency_code VARCHAR(3) NOT NULL REFERENCES currencies(code),
     account_number VARCHAR(100), -- masked/encrypted
-    institution VARCHAR(255),
+    institution VARCHAR(255), -- legacy free-text institution name (superseded by institution_id)
+    institution_id UUID, -- structured financial institution (FK added after institutions table)
     opening_balance NUMERIC(20, 4) DEFAULT 0,
     current_balance NUMERIC(20, 4) DEFAULT 0,
     credit_limit NUMERIC(20, 4), -- for credit cards
@@ -165,6 +166,7 @@ CREATE INDEX idx_accounts_interest_category ON accounts(interest_category_id);
 CREATE INDEX idx_accounts_principal_category ON accounts(principal_category_id);
 CREATE INDEX idx_accounts_scheduled_transaction ON accounts(scheduled_transaction_id);
 CREATE INDEX idx_accounts_source_account ON accounts(source_account_id);
+CREATE INDEX idx_accounts_institution ON accounts(institution_id);
 
 -- Categories for transactions
 CREATE TABLE categories (
@@ -213,6 +215,26 @@ CREATE TABLE payee_aliases (
 CREATE INDEX idx_payee_aliases_payee ON payee_aliases(payee_id);
 CREATE INDEX idx_payee_aliases_user ON payee_aliases(user_id);
 CREATE UNIQUE INDEX idx_payee_aliases_user_alias ON payee_aliases(user_id, LOWER(alias));
+
+-- Financial Institutions (per-user registry of banks/brokerages). The brand
+-- icon is the website's favicon, fetched server-side and cached in logo_data so
+-- the browser never contacts a third party to render it.
+CREATE TABLE institutions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    website TEXT NOT NULL,
+    country VARCHAR(2),
+    logo_data BYTEA,
+    logo_content_type VARCHAR(100),
+    has_logo BOOLEAN NOT NULL DEFAULT false,
+    logo_fetched_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, name)
+);
+
+CREATE INDEX idx_institutions_user ON institutions(user_id);
 
 -- Transactions
 CREATE TABLE transactions (
@@ -441,6 +463,8 @@ ALTER TABLE accounts ADD CONSTRAINT fk_accounts_scheduled_transaction
     FOREIGN KEY (scheduled_transaction_id) REFERENCES scheduled_transactions(id) ON DELETE SET NULL;
 ALTER TABLE accounts ADD CONSTRAINT fk_accounts_asset_category
     FOREIGN KEY (asset_category_id) REFERENCES categories(id) ON DELETE SET NULL;
+ALTER TABLE accounts ADD CONSTRAINT fk_accounts_institution
+    FOREIGN KEY (institution_id) REFERENCES institutions(id) ON DELETE SET NULL;
 
 -- Scheduled Transaction Overrides (for modifying individual occurrences)
 CREATE TABLE scheduled_transaction_overrides (

--- a/frontend/src/app/accounts/page.tsx
+++ b/frontend/src/app/accounts/page.tsx
@@ -13,8 +13,10 @@ import { Modal } from '@/components/ui/Modal';
 import { UnsavedChangesDialog } from '@/components/ui/UnsavedChangesDialog';
 import { accountsApi } from '@/lib/accounts';
 import { investmentsApi } from '@/lib/investments';
+import { institutionsApi } from '@/lib/institutions';
 import { countLogicalAccounts } from '@/lib/account-utils';
 import { Account } from '@/types/account';
+import { Institution } from '@/types/institution';
 import { PortfolioSummary } from '@/types/investment';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { PageHeader } from '@/components/layout/PageHeader';
@@ -40,6 +42,7 @@ export default function AccountsPage() {
 function AccountsContent() {
   const t = useTranslations('accounts');
   const [accounts, setAccounts] = useState<Account[]>([]);
+  const [institutions, setInstitutions] = useState<Institution[]>([]);
   const [portfolioSummary, setPortfolioSummary] = useState<PortfolioSummary | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const { showForm, editingItem, openCreate, openEdit, close, isEditing, modalProps, setFormDirty, unsavedChangesDialog, formSubmitRef } = useFormModal<Account>();
@@ -49,12 +52,14 @@ function AccountsContent() {
   const loadAccounts = useCallback(async () => {
     setIsLoading(true);
     try {
-      const [data, portfolio] = await Promise.all([
+      const [data, portfolio, insts] = await Promise.all([
         accountsApi.getAll(true),
         investmentsApi.getPortfolioSummary().catch(() => null),
+        institutionsApi.getAll().catch(() => [] as Institution[]),
       ]);
       setAccounts(data);
       setPortfolioSummary(portfolio);
+      setInstitutions(insts);
     } catch (error) {
       showErrorToast(error, 'Failed to load accounts');
       logger.error(error);
@@ -211,7 +216,7 @@ function AccountsContent() {
           {isLoading ? (
             <LoadingSpinner text={t('page.loadingAccounts')} />
           ) : (
-            <AccountList accounts={accounts} brokerageMarketValues={brokerageMarketValues} defaultCurrency={defaultCurrency} convertToDefault={convertToDefault} onEdit={openEdit} onRefresh={loadAccounts} />
+            <AccountList accounts={accounts} institutions={institutions} brokerageMarketValues={brokerageMarketValues} defaultCurrency={defaultCurrency} convertToDefault={convertToDefault} onEdit={openEdit} onRefresh={loadAccounts} />
           )}
         </div>
       </main>

--- a/frontend/src/app/import/import-matching.test.ts
+++ b/frontend/src/app/import/import-matching.test.ts
@@ -35,7 +35,7 @@ function makeAccount(overrides: Partial<Account> = {}): Account {
     accountType: 'CHEQUING',
     accountSubType: null,
     currencyCode: 'USD',
-    institution: null,
+    institution: null, institutionId: null,
     accountNumber: null,
     notes: null,
     currentBalance: 0,

--- a/frontend/src/app/import/import-utils.test.ts
+++ b/frontend/src/app/import/import-utils.test.ts
@@ -23,7 +23,7 @@ function createAccount(overrides: Partial<Account> = {}): Account {
     description: null,
     currencyCode: 'CAD',
     accountNumber: null,
-    institution: null,
+    institution: null, institutionId: null,
     openingBalance: 0,
     currentBalance: 0,
     creditLimit: null,

--- a/frontend/src/app/institutions/loading.tsx
+++ b/frontend/src/app/institutions/loading.tsx
@@ -1,0 +1,12 @@
+import { PageHeaderSkeleton, TableSkeleton } from '@/components/ui/LoadingSkeleton';
+
+export default function InstitutionsLoading() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="px-4 sm:px-6 lg:px-12 pt-6 pb-8">
+        <PageHeaderSkeleton />
+        <TableSkeleton rows={10} columns={5} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/institutions/page.test.tsx
+++ b/frontend/src/app/institutions/page.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useState } from 'react';
+import { render, screen, waitFor, fireEvent, act } from '@/test/render';
+import InstitutionsPage from './page';
+import toast from 'react-hot-toast';
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: Object.assign(
+    (selector?: any) => {
+      const state = {
+        user: { id: 'u-1', email: 't@e.com', role: 'user' },
+        isAuthenticated: true,
+        isLoading: false,
+        _hasHydrated: true,
+        logout: vi.fn(),
+      };
+      return selector ? selector(state) : state;
+    },
+    { getState: vi.fn(() => ({ user: { id: 'u-1' }, isAuthenticated: true, _hasHydrated: true })) },
+  ),
+}));
+
+vi.mock('@/lib/errors', () => ({
+  getErrorMessage: (_error: any, fallback: string) => fallback,
+}));
+
+vi.mock('@/lib/constants', () => ({ PAGE_SIZE: 25 }));
+
+const mockGetAll = vi.fn();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+
+vi.mock('@/lib/institutions', () => ({
+  institutionsApi: {
+    getAll: (...a: any[]) => mockGetAll(...a),
+    create: (...a: any[]) => mockCreate(...a),
+    update: (...a: any[]) => mockUpdate(...a),
+  },
+  institutionLogoUrl: (id: string) => `/api/v1/institutions/${id}/logo`,
+}));
+
+vi.mock('@/hooks/useFormModal', () => ({
+  useFormModal: () => {
+    const [showForm, setShowForm] = useState(false);
+    const [editingItem, setEditingItem] = useState<any>(null);
+    return {
+      showForm,
+      editingItem,
+      openCreate: () => { setEditingItem(null); setShowForm(true); },
+      openEdit: (item: any) => { setEditingItem(item); setShowForm(true); },
+      close: () => { setEditingItem(null); setShowForm(false); },
+      isEditing: !!editingItem,
+      modalProps: {},
+      setFormDirty: vi.fn(),
+      unsavedChangesDialog: { isOpen: false, onConfirm: vi.fn(), onCancel: vi.fn() },
+      formSubmitRef: { current: null },
+    };
+  },
+}));
+
+vi.mock('@/components/layout/PageLayout', () => ({
+  PageLayout: ({ children }: any) => <div data-testid="page-layout">{children}</div>,
+}));
+vi.mock('@/components/layout/PageHeader', () => ({
+  PageHeader: ({ title, subtitle, actions }: any) => (
+    <div><h1>{title}</h1>{subtitle && <p>{subtitle}</p>}{actions}</div>
+  ),
+}));
+vi.mock('@/components/ui/Button', () => ({
+  Button: ({ children, onClick, ...rest }: any) => <button onClick={onClick} {...rest}>{children}</button>,
+}));
+vi.mock('@/components/ui/Modal', () => ({
+  Modal: ({ children, isOpen }: any) => (isOpen ? <div data-testid="modal">{children}</div> : null),
+}));
+vi.mock('@/components/ui/UnsavedChangesDialog', () => ({ UnsavedChangesDialog: () => null }));
+vi.mock('@/components/ui/LoadingSpinner', () => ({
+  LoadingSpinner: ({ text }: any) => <div data-testid="loading-spinner">{text}</div>,
+}));
+vi.mock('@/components/ui/SummaryCard', () => ({
+  SummaryCard: ({ label, value }: any) => <div data-testid={`summary-${label}`}>{value}</div>,
+  SummaryIcons: { accounts: null, checkCircle: null, money: null },
+}));
+vi.mock('@/components/ui/Pagination', () => ({
+  Pagination: ({ currentPage, totalPages }: any) => (
+    <div data-testid="pagination">Page {currentPage} of {totalPages}</div>
+  ),
+}));
+
+vi.mock('@/components/institutions/InstitutionForm', () => ({
+  InstitutionForm: ({ onSubmit, institution }: any) => (
+    <div data-testid="institution-form">
+      {institution && <span data-testid="editing">{institution.name}</span>}
+      <button
+        data-testid="submit-form"
+        onClick={() =>
+          Promise.resolve(
+            onSubmit({ name: 'New Bank', website: 'newbank.com' }),
+          ).catch(() => {})
+        }
+      >
+        Submit
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/institutions/InstitutionList', () => ({
+  InstitutionList: ({ institutions, onEdit, onDelete, onManageAccounts }: any) => (
+    <div data-testid="institution-list">
+      {institutions.map((i: any) => (
+        <div key={i.id} data-testid={`institution-${i.id}`}>
+          {i.name}
+          <button data-testid={`edit-${i.id}`} onClick={() => onEdit(i)}>Edit</button>
+          <button data-testid={`delete-${i.id}`} onClick={() => onDelete(i.id)}>Delete</button>
+          <button data-testid={`manage-${i.id}`} onClick={() => onManageAccounts(i)}>Manage</button>
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/institutions/InstitutionAccountsManager', () => ({
+  InstitutionAccountsManager: ({ isOpen }: any) =>
+    isOpen ? <div data-testid="accounts-manager">Manager</div> : null,
+}));
+
+const mockInstitutions = [
+  { id: 'i-1', name: 'TD', website: 'https://td.com', country: 'CA', hasLogo: true, accountCount: 2 },
+  { id: 'i-2', name: 'RBC', website: 'https://rbc.com', country: 'CA', hasLogo: false, accountCount: 0 },
+];
+
+describe('InstitutionsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAll.mockResolvedValue(mockInstitutions);
+  });
+
+  it('renders the header, subtitle and summary cards', async () => {
+    render(<InstitutionsPage />);
+    await waitFor(() => expect(screen.getByText('Financial Institutions')).toBeInTheDocument());
+    expect(screen.getByText('Banks and brokerages your accounts belong to')).toBeInTheDocument();
+    expect(screen.getByTestId('summary-Total Institutions')).toHaveTextContent('2');
+    expect(screen.getByTestId('summary-With Logo')).toHaveTextContent('1');
+    expect(screen.getByTestId('summary-Linked Accounts')).toHaveTextContent('2');
+  });
+
+  it('filters by search query', async () => {
+    render(<InstitutionsPage />);
+    await waitFor(() => expect(screen.getByText('TD')).toBeInTheDocument());
+    fireEvent.change(screen.getByPlaceholderText('Search institutions...'), {
+      target: { value: 'rbc' },
+    });
+    expect(screen.getByText('RBC')).toBeInTheDocument();
+    expect(screen.queryByText('TD')).not.toBeInTheDocument();
+  });
+
+  it('shows a loading spinner while loading', async () => {
+    mockGetAll.mockReturnValue(new Promise(() => {}));
+    render(<InstitutionsPage />);
+    await waitFor(() => expect(screen.getByTestId('loading-spinner')).toBeInTheDocument());
+  });
+
+  it('shows an error toast when loading fails', async () => {
+    mockGetAll.mockRejectedValue(new Error('boom'));
+    render(<InstitutionsPage />);
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Failed to load institutions'),
+    );
+  });
+
+  it('creates an institution on submit', async () => {
+    mockCreate.mockResolvedValue({ id: 'i-new', name: 'New Bank', accountCount: 0 });
+    render(<InstitutionsPage />);
+    await waitFor(() => expect(screen.getByText('New Institution')).toBeInTheDocument());
+    await act(async () => { fireEvent.click(screen.getByText('New Institution')); });
+    await waitFor(() => expect(screen.getByTestId('submit-form')).toBeInTheDocument());
+    await act(async () => { fireEvent.click(screen.getByTestId('submit-form')); });
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith({ name: 'New Bank', website: 'newbank.com' });
+      expect(toast.success).toHaveBeenCalledWith('Institution created');
+    });
+  });
+
+  it('opens the edit modal with the institution name', async () => {
+    render(<InstitutionsPage />);
+    await waitFor(() => expect(screen.getByTestId('institution-list')).toBeInTheDocument());
+    await act(async () => { fireEvent.click(screen.getByTestId('edit-i-1')); });
+    await waitFor(() => {
+      expect(screen.getByText('Edit Institution')).toBeInTheDocument();
+      expect(screen.getByTestId('editing')).toHaveTextContent('TD');
+    });
+  });
+
+  it('removes a deleted institution from the list', async () => {
+    render(<InstitutionsPage />);
+    await waitFor(() => expect(screen.getByTestId('institution-i-1')).toBeInTheDocument());
+    await act(async () => { fireEvent.click(screen.getByTestId('delete-i-1')); });
+    await waitFor(() =>
+      expect(screen.queryByTestId('institution-i-1')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('opens the accounts manager', async () => {
+    render(<InstitutionsPage />);
+    await waitFor(() => expect(screen.getByTestId('institution-list')).toBeInTheDocument());
+    await act(async () => { fireEvent.click(screen.getByTestId('manage-i-1')); });
+    await waitFor(() => expect(screen.getByTestId('accounts-manager')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/app/institutions/page.tsx
+++ b/frontend/src/app/institutions/page.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
+import toast from 'react-hot-toast';
+import { useOnUndoRedo } from '@/hooks/useOnUndoRedo';
+import { Button } from '@/components/ui/Button';
+import { Pagination } from '@/components/ui/Pagination';
+import { Modal } from '@/components/ui/Modal';
+import { UnsavedChangesDialog } from '@/components/ui/UnsavedChangesDialog';
+import { InstitutionForm } from '@/components/institutions/InstitutionForm';
+import { InstitutionList } from '@/components/institutions/InstitutionList';
+import { InstitutionAccountsManager } from '@/components/institutions/InstitutionAccountsManager';
+import { institutionsApi } from '@/lib/institutions';
+import { Institution } from '@/types/institution';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { PageHeader } from '@/components/layout/PageHeader';
+import { SummaryCard, SummaryIcons } from '@/components/ui/SummaryCard';
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import { useFormModal } from '@/hooks/useFormModal';
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+import { createLogger } from '@/lib/logger';
+import { getErrorMessage } from '@/lib/errors';
+import { PAGE_SIZE } from '@/lib/constants';
+
+const logger = createLogger('Institutions');
+
+export default function InstitutionsPage() {
+  return (
+    <ProtectedRoute>
+      <InstitutionsContent />
+    </ProtectedRoute>
+  );
+}
+
+function InstitutionsContent() {
+  const t = useTranslations('institutions');
+  const [institutions, setInstitutions] = useState<Institution[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [managing, setManaging] = useState<Institution | null>(null);
+  const {
+    showForm,
+    editingItem,
+    openCreate,
+    openEdit,
+    close,
+    isEditing,
+    modalProps,
+    setFormDirty,
+    unsavedChangesDialog,
+    formSubmitRef,
+  } = useFormModal<Institution>();
+
+  const loadData = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const data = await institutionsApi.getAll();
+      setInstitutions(data);
+    } catch (error) {
+      toast.error(getErrorMessage(error, t('page.toasts.loadFailed')));
+      logger.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  useOnUndoRedo(loadData);
+
+  const handleFormSubmit = async (data: {
+    name: string;
+    website: string;
+    country?: string;
+  }) => {
+    try {
+      if (editingItem) {
+        const updated = await institutionsApi.update(editingItem.id, data);
+        toast.success(t('page.toasts.updated'));
+        close();
+        setInstitutions((prev) =>
+          prev.map((i) => (i.id === updated.id ? { ...i, ...updated } : i)),
+        );
+      } else {
+        const created = await institutionsApi.create(data);
+        toast.success(t('page.toasts.created'));
+        close();
+        setInstitutions((prev) => [created, ...prev]);
+      }
+    } catch (error) {
+      toast.error(
+        getErrorMessage(
+          error,
+          editingItem
+            ? t('page.toasts.updateFailed')
+            : t('page.toasts.createFailed'),
+        ),
+      );
+      throw error;
+    }
+  };
+
+  const filteredInstitutions = useMemo(() => {
+    const sorted = [...institutions].sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+    );
+    if (!searchQuery) return sorted;
+    const q = searchQuery.toLowerCase();
+    return sorted.filter(
+      (i) =>
+        i.name.toLowerCase().includes(q) ||
+        i.website.toLowerCase().includes(q),
+    );
+  }, [institutions, searchQuery]);
+
+  const totalPages = Math.ceil(filteredInstitutions.length / PAGE_SIZE);
+  const paginatedInstitutions = useMemo(() => {
+    const start = (currentPage - 1) * PAGE_SIZE;
+    return filteredInstitutions.slice(start, start + PAGE_SIZE);
+  }, [filteredInstitutions, currentPage]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery]);
+
+  const goToPage = (page: number) => {
+    if (page >= 1 && page <= totalPages) {
+      setCurrentPage(page);
+    }
+  };
+
+  const withLogoCount = institutions.filter((i) => i.hasLogo).length;
+  const linkedAccountsCount = institutions.reduce(
+    (sum, i) => sum + (i.accountCount || 0),
+    0,
+  );
+
+  return (
+    <PageLayout>
+      <main className="px-4 sm:px-6 lg:px-12 pt-6 pb-8">
+        <PageHeader
+          title={t('page.title')}
+          subtitle={t('page.subtitle')}
+          actions={<Button onClick={openCreate}>{t('page.newInstitution')}</Button>}
+        />
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+          <SummaryCard
+            label={t('page.summary.total')}
+            value={institutions.length}
+            icon={SummaryIcons.accounts}
+          />
+          <SummaryCard
+            label={t('page.summary.withLogo')}
+            value={withLogoCount}
+            icon={SummaryIcons.checkCircle}
+            valueColor="green"
+          />
+          <SummaryCard
+            label={t('page.summary.linkedAccounts')}
+            value={linkedAccountsCount}
+            icon={SummaryIcons.money}
+          />
+        </div>
+
+        <div className="mb-6">
+          <input
+            type="text"
+            placeholder={t('page.searchPlaceholder')}
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="block w-full sm:max-w-md rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400"
+          />
+        </div>
+
+        <Modal isOpen={showForm} onClose={close} {...modalProps} maxWidth="lg" className="p-6">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            {isEditing ? t('page.modalTitleEdit') : t('page.modalTitleNew')}
+          </h2>
+          <InstitutionForm
+            institution={editingItem}
+            onSubmit={handleFormSubmit}
+            onCancel={close}
+            onDirtyChange={setFormDirty}
+            submitRef={formSubmitRef}
+          />
+        </Modal>
+        <UnsavedChangesDialog {...unsavedChangesDialog} />
+
+        <div className="bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg overflow-hidden">
+          {isLoading ? (
+            <LoadingSpinner text={t('page.loading')} />
+          ) : (
+            <InstitutionList
+              institutions={paginatedInstitutions}
+              onEdit={openEdit}
+              onDelete={(deletedId) =>
+                setInstitutions((prev) => prev.filter((i) => i.id !== deletedId))
+              }
+              onManageAccounts={setManaging}
+            />
+          )}
+        </div>
+
+        {totalPages > 1 && (
+          <div className="mt-4">
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              totalItems={filteredInstitutions.length}
+              pageSize={PAGE_SIZE}
+              onPageChange={goToPage}
+              itemName="institutions"
+            />
+          </div>
+        )}
+      </main>
+
+      <InstitutionAccountsManager
+        institution={managing}
+        isOpen={managing !== null}
+        onClose={() => setManaging(null)}
+        onChanged={loadData}
+      />
+    </PageLayout>
+  );
+}

--- a/frontend/src/components/accounts/AccountForm.test.tsx
+++ b/frontend/src/components/accounts/AccountForm.test.tsx
@@ -27,6 +27,14 @@ vi.mock('@/lib/categories', () => ({
   },
 }));
 
+vi.mock('@/lib/institutions', () => ({
+  institutionsApi: {
+    getAll: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+  },
+  institutionLogoUrl: (id: string) => `/api/v1/institutions/${id}/logo`,
+}));
+
 vi.mock('@/lib/exchange-rates', () => ({
   exchangeRatesApi: {
     getCurrencies: vi.fn().mockResolvedValue([
@@ -186,7 +194,7 @@ function createExistingAccount(overrides: Partial<Account> = {}): Account {
     description: null,
     currencyCode: 'CAD',
     accountNumber: null,
-    institution: null,
+    institution: null, institutionId: null,
     openingBalance: 1000,
     currentBalance: 1500,
     creditLimit: null,
@@ -449,7 +457,6 @@ describe('AccountForm', () => {
       expect(screen.getByDisplayValue('My Savings')).toBeInTheDocument();
     });
     expect(screen.getByDisplayValue('Test description')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('RBC')).toBeInTheDocument();
     expect(screen.getByDisplayValue('1234567')).toBeInTheDocument();
   });
 
@@ -552,7 +559,7 @@ describe('AccountForm', () => {
     });
   });
 
-  it('shows "Lender/Institution (required)" label for LOAN type', async () => {
+  it('shows the institution selector for LOAN type', async () => {
     render(
       <AccountForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
     );
@@ -561,11 +568,11 @@ describe('AccountForm', () => {
     fireEvent.change(typeSelect, { target: { value: 'LOAN' } });
 
     await waitFor(() => {
-      expect(screen.getByText('Lender/Institution (required)')).toBeInTheDocument();
+      expect(screen.getByText('Institution (optional)')).toBeInTheDocument();
     });
   });
 
-  it('shows "Lender/Institution (required)" label for MORTGAGE type', async () => {
+  it('shows the institution selector for MORTGAGE type', async () => {
     render(
       <AccountForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
     );
@@ -574,7 +581,7 @@ describe('AccountForm', () => {
     fireEvent.change(typeSelect, { target: { value: 'MORTGAGE' } });
 
     await waitFor(() => {
-      expect(screen.getByText('Lender/Institution (required)')).toBeInTheDocument();
+      expect(screen.getByText('Institution (optional)')).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/accounts/AccountForm.tsx
+++ b/frontend/src/components/accounts/AccountForm.tsx
@@ -8,9 +8,14 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useState, useEffect, useMemo, MutableRefObject } from 'react';
 import { Input } from '@/components/ui/Input';
+import { Combobox } from '@/components/ui/Combobox';
+import { Modal } from '@/components/ui/Modal';
 import { CurrencyInput } from '@/components/ui/CurrencyInput';
 import { Select } from '@/components/ui/Select';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
+import { InstitutionForm } from '@/components/institutions/InstitutionForm';
+import { institutionsApi } from '@/lib/institutions';
+import { Institution } from '@/types/institution';
 import { useAuthStore } from '@/store/authStore';
 import toast from 'react-hot-toast';
 import { Account, PaymentFrequency } from '@/types/account';
@@ -71,7 +76,7 @@ const buildAccountSchema = (t: (key: string) => string) => z.object({
   interestRate: optionalNumberWithRange(0, 100),
   description: z.string().optional(),
   accountNumber: z.string().optional(),
-  institution: z.string().optional(),
+  institutionId: z.string().optional(),
   isFavourite: z.boolean().optional(),
   excludeFromNetWorth: z.boolean().optional(),
   createInvestmentPair: z.boolean().optional(),
@@ -138,6 +143,11 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
   // Currency becomes locked once the account has any transactions so existing
   // balances are not silently re-denominated. Stays unlocked while loading.
   const [isCurrencyLocked, setIsCurrencyLocked] = useState(false);
+  // Financial institution selection + inline create.
+  const [institutions, setInstitutions] = useState<Institution[]>([]);
+  const [selectedInstitutionId, setSelectedInstitutionId] = useState<string>(account?.institutionId || '');
+  const [showInstitutionModal, setShowInstitutionModal] = useState(false);
+  const [pendingInstitutionName, setPendingInstitutionName] = useState('');
 
   const {
     register,
@@ -164,7 +174,7 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
           interestRate: account.interestRate || undefined,
           description: account.description || undefined,
           accountNumber: account.accountNumber || undefined,
-          institution: account.institution || undefined,
+          institutionId: account.institutionId || undefined,
           isFavourite: account.isFavourite || false,
           excludeFromNetWorth: account.excludeFromNetWorth || false,
           statementDueDay: account.statementDueDay || undefined,
@@ -238,6 +248,50 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
   useEffect(() => {
     exchangeRatesApi.getCurrencies().then(setCurrencies).catch(() => {});
   }, []);
+
+  // Load financial institutions for the selector
+  useEffect(() => {
+    institutionsApi.getAll().then(setInstitutions).catch(() => {});
+  }, []);
+
+  const institutionOptions = useMemo(
+    () => institutions.map((i) => ({ value: i.id, label: i.name, subtitle: i.website })),
+    [institutions],
+  );
+
+  const accountInstitutionId = account?.institutionId;
+  const initialInstitutionName = useMemo(() => {
+    if (!accountInstitutionId) return '';
+    return institutions.find((i) => i.id === accountInstitutionId)?.name || '';
+  }, [accountInstitutionId, institutions]);
+
+  const handleInstitutionChange = (value: string) => {
+    setSelectedInstitutionId(value);
+    setValue('institutionId', value || undefined, { shouldDirty: true });
+  };
+
+  const handleInstitutionCreate = (name: string) => {
+    setPendingInstitutionName(name);
+    setShowInstitutionModal(true);
+  };
+
+  const handleInstitutionCreated = async (data: {
+    name: string;
+    website: string;
+    country?: string;
+  }) => {
+    try {
+      const created = await institutionsApi.create(data);
+      setInstitutions((prev) => [created, ...prev]);
+      setSelectedInstitutionId(created.id);
+      setValue('institutionId', created.id, { shouldDirty: true });
+      setShowInstitutionModal(false);
+      toast.success(t('toasts.institutionCreated', { name: created.name }));
+    } catch (error) {
+      toast.error(getErrorMessage(error, t('toasts.institutionCreateFailed')));
+      throw error;
+    }
+  };
 
   // For existing accounts, check whether any transactions exist. The backend
   // rejects currency changes once transactions are present; mirror that in the
@@ -518,10 +572,18 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
           {...register('accountNumber')}
         />
 
-        <Input
-          label={isLoanAccount || isMortgageAccount ? t('form.institutionRequired') : t('form.institution')}
-          error={errors.institution?.message}
-          {...register('institution')}
+        <Combobox
+          label={t('form.institution')}
+          placeholder={t('form.institutionPlaceholder')}
+          options={institutionOptions}
+          value={selectedInstitutionId}
+          initialDisplayValue={initialInstitutionName}
+          onChange={handleInstitutionChange}
+          onCreateNew={handleInstitutionCreate}
+          allowCustomValue
+          usePortal
+          alwaysShowSubtitle
+          error={errors.institutionId?.message}
         />
       </div>
 
@@ -799,6 +861,24 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
           accountName={account.name}
         />
       )}
+
+      {/* Inline create-institution modal (stacked on top of the account form) */}
+      <Modal
+        isOpen={showInstitutionModal}
+        onClose={() => setShowInstitutionModal(false)}
+        maxWidth="lg"
+        className="p-6"
+        pushHistory
+      >
+        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+          {t('form.newInstitutionTitle')}
+        </h2>
+        <InstitutionForm
+          initialName={pendingInstitutionName}
+          onSubmit={handleInstitutionCreated}
+          onCancel={() => setShowInstitutionModal(false)}
+        />
+      </Modal>
     </form>
   );
 }

--- a/frontend/src/components/accounts/AccountList.test.tsx
+++ b/frontend/src/components/accounts/AccountList.test.tsx
@@ -52,7 +52,7 @@ function createAccount(overrides: Partial<Account> = {}): Account {
     description: 'Primary account',
     currencyCode: 'CAD',
     accountNumber: null,
-    institution: null,
+    institution: null, institutionId: null,
     openingBalance: 1000,
     currentBalance: 1500,
     creditLimit: null,

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Account, AccountType } from '@/types/account';
+import { Institution } from '@/types/institution';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { Modal } from '@/components/ui/Modal';
 import { accountsApi } from '@/lib/accounts';
@@ -83,6 +84,7 @@ const getAccountTypeColor = (type: AccountType) => {
 
 interface AccountListProps {
   accounts: Account[];
+  institutions?: Institution[];
   brokerageMarketValues?: Map<string, number>;
   defaultCurrency: string;
   convertToDefault: (value: number, fromCurrency: string) => number;
@@ -90,7 +92,7 @@ interface AccountListProps {
   onRefresh: () => void;
 }
 
-export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, convertToDefault, onEdit, onRefresh }: AccountListProps) {
+export function AccountList({ accounts, institutions, brokerageMarketValues, defaultCurrency, convertToDefault, onEdit, onRefresh }: AccountListProps) {
   const t = useTranslations('accounts');
   const tc = useTranslations('common');
   const router = useRouter();
@@ -292,6 +294,13 @@ export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, 
     accounts.forEach((a) => map.set(a.id, a.name));
     return map;
   }, [accounts]);
+
+  // Map institution id -> institution for the per-row brand icon.
+  const institutionsById = useMemo(() => {
+    const map = new Map<string, Institution>();
+    (institutions || []).forEach((i) => map.set(i.id, i));
+    return map;
+  }, [institutions]);
 
   // Group accounts by account type. Within the INVESTMENT group, ensure linked
   // brokerage/cash pairs are rendered adjacently (brokerage first).
@@ -732,6 +741,7 @@ export function AccountList({ accounts, brokerageMarketValues, defaultCurrency, 
                   cellPadding={cellPadding}
                   isDeletable={deletableAccounts.has(item.account.id)}
                   accountNameMap={accountNameMap}
+                  institution={item.account.institutionId ? institutionsById.get(item.account.institutionId) : undefined}
                   brokerageMarketValue={brokerageMarketValues?.get(item.account.id)}
                   defaultCurrency={defaultCurrency}
                   formatCurrency={formatCurrency}

--- a/frontend/src/components/accounts/AccountRow.test.tsx
+++ b/frontend/src/components/accounts/AccountRow.test.tsx
@@ -14,7 +14,7 @@ function createAccount(overrides: Partial<Account> = {}): Account {
     description: 'Primary account',
     currencyCode: 'CAD',
     accountNumber: null,
-    institution: null,
+    institution: null, institutionId: null,
     openingBalance: 1000,
     currentBalance: 1500,
     creditLimit: null,
@@ -920,6 +920,36 @@ describe('AccountRow', () => {
 
       const nameCell = screen.getByText('Main Chequing').closest('td');
       expect(nameCell?.className).toContain('px-3 py-1');
+    });
+  });
+
+  describe('institution brand icon', () => {
+    it('renders the institution logo at normal density', () => {
+      const props = createDefaultProps({
+        institution: { id: 'i-1', name: 'TD', hasLogo: true },
+      });
+      renderAccountRow(props);
+      expect(screen.getByRole('img')).toHaveAttribute(
+        'src',
+        '/api/v1/institutions/i-1/logo',
+      );
+    });
+
+    it('renders a neutral fallback badge when there is no institution', () => {
+      const props = createDefaultProps({ institution: undefined });
+      renderAccountRow(props);
+      expect(screen.queryByRole('img')).toBeNull();
+      expect(screen.getByText('$')).toBeInTheDocument();
+    });
+
+    it('hides the brand icon at dense density', () => {
+      const props = createDefaultProps({
+        density: 'dense',
+        institution: { id: 'i-1', name: 'TD', hasLogo: true },
+      });
+      renderAccountRow(props);
+      expect(screen.queryByRole('img')).toBeNull();
+      expect(screen.queryByText('$')).toBeNull();
     });
   });
 });

--- a/frontend/src/components/accounts/AccountRow.tsx
+++ b/frontend/src/components/accounts/AccountRow.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import { gainLossColor } from '@/lib/format';
 import { Account, AccountType } from '@/types/account';
 import { Button } from '@/components/ui/Button';
+import { InstitutionLogo, InstitutionLogoData } from '@/components/institutions/InstitutionLogo';
 
 export interface AccountRowProps {
   account: Account;
@@ -13,6 +14,9 @@ export interface AccountRowProps {
   cellPadding: string;
   isDeletable: boolean;
   accountNameMap: Map<string, string>;
+  // Institution the account belongs to (for the brand icon). Undefined for
+  // cashflow-only accounts, which render a neutral fallback badge.
+  institution?: InstitutionLogoData;
   brokerageMarketValue: number | undefined;
   defaultCurrency: string;
   formatCurrency: (amount: number | string | null | undefined, currency: string) => string;
@@ -42,6 +46,7 @@ export const AccountRow = memo(function AccountRow({
   cellPadding,
   isDeletable,
   accountNameMap,
+  institution,
   brokerageMarketValue,
   defaultCurrency,
   formatCurrency,
@@ -82,6 +87,9 @@ export const AccountRow = memo(function AccountRow({
             : account.name}
         >
           <div className="flex items-center text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300">
+            {density !== 'dense' && (
+              <InstitutionLogo institution={institution} size={20} className="mr-2" fallbackGlyph="$" />
+            )}
             {onToggleFavourite ? (
               <button
                 type="button"

--- a/frontend/src/components/accounts/LoanFields.test.tsx
+++ b/frontend/src/components/accounts/LoanFields.test.tsx
@@ -59,7 +59,7 @@ const mockAccounts: Account[] = [
   {
     id: 'acc-1', userId: 'user-1', accountType: 'CHEQUING', accountSubType: null,
     linkedAccountId: null, name: 'Main Chequing', description: null, currencyCode: 'CAD',
-    accountNumber: null, institution: null, openingBalance: 5000, currentBalance: 5000,
+    accountNumber: null, institution: null, institutionId: null, openingBalance: 5000, currentBalance: 5000,
     creditLimit: null, interestRate: null, isClosed: false, closedDate: null,
     isFavourite: false, favouriteSortOrder: 0, excludeFromNetWorth: false, paymentAmount: null, paymentFrequency: null, paymentStartDate: null,
     sourceAccountId: null, principalCategoryId: null, interestCategoryId: null,

--- a/frontend/src/components/accounts/LoanPaymentSetupDialog.test.tsx
+++ b/frontend/src/components/accounts/LoanPaymentSetupDialog.test.tsx
@@ -70,7 +70,7 @@ function createAccount(overrides: Partial<Account> = {}): Account {
   return {
     id: 'acc-1', userId: 'user-1', accountType: 'CHEQUING', accountSubType: null,
     linkedAccountId: null, name: 'My Chequing', description: null, currencyCode: 'CAD',
-    accountNumber: null, institution: null, openingBalance: 0, currentBalance: 1000,
+    accountNumber: null, institution: null, institutionId: null, openingBalance: 0, currentBalance: 1000,
     creditLimit: null, interestRate: null, isClosed: false, closedDate: null,
     isFavourite: false, favouriteSortOrder: 0, excludeFromNetWorth: false, paymentAmount: null, paymentFrequency: null, paymentStartDate: null,
     sourceAccountId: null, principalCategoryId: null, interestCategoryId: null,

--- a/frontend/src/components/accounts/MortgageFields.test.tsx
+++ b/frontend/src/components/accounts/MortgageFields.test.tsx
@@ -59,7 +59,7 @@ const mockAccounts: Account[] = [
   {
     id: 'acc-1', userId: 'user-1', accountType: 'CHEQUING', accountSubType: null,
     linkedAccountId: null, name: 'Main Chequing', description: null, currencyCode: 'CAD',
-    accountNumber: null, institution: null, openingBalance: 5000, currentBalance: 5000,
+    accountNumber: null, institution: null, institutionId: null, openingBalance: 5000, currentBalance: 5000,
     creditLimit: null, interestRate: null, isClosed: false, closedDate: null,
     isFavourite: false, favouriteSortOrder: 0, excludeFromNetWorth: false, paymentAmount: null, paymentFrequency: null, paymentStartDate: null,
     sourceAccountId: null, principalCategoryId: null, interestCategoryId: null,
@@ -72,7 +72,7 @@ const mockAccounts: Account[] = [
   {
     id: 'acc-2', userId: 'user-1', accountType: 'SAVINGS', accountSubType: null,
     linkedAccountId: null, name: 'Savings', description: null, currencyCode: 'CAD',
-    accountNumber: null, institution: null, openingBalance: 10000, currentBalance: 10000,
+    accountNumber: null, institution: null, institutionId: null, openingBalance: 10000, currentBalance: 10000,
     creditLimit: null, interestRate: null, isClosed: false, closedDate: null,
     isFavourite: false, favouriteSortOrder: 0, excludeFromNetWorth: false, paymentAmount: null, paymentFrequency: null, paymentStartDate: null,
     sourceAccountId: null, principalCategoryId: null, interestCategoryId: null,

--- a/frontend/src/components/budgets/BudgetWizardStrategy.test.tsx
+++ b/frontend/src/components/budgets/BudgetWizardStrategy.test.tsx
@@ -945,7 +945,7 @@ describe('BudgetWizardStrategy', () => {
         ...mockAccounts[0],
         id: 'acc-no-inst',
         name: 'Solo Account',
-        institution: null,
+        institution: null, institutionId: null,
       } as unknown as Account,
     ];
     render(

--- a/frontend/src/components/import/CompleteStep.test.tsx
+++ b/frontend/src/components/import/CompleteStep.test.tsx
@@ -34,7 +34,7 @@ function createAccount(overrides: Partial<Account> = {}): Account {
   return {
     id: 'acc-1', userId: 'user-1', accountType: 'CHEQUING', accountSubType: null,
     linkedAccountId: null, name: 'My Chequing', description: null, currencyCode: 'CAD',
-    accountNumber: null, institution: null, openingBalance: 0, currentBalance: 1000,
+    accountNumber: null, institution: null, institutionId: null, openingBalance: 0, currentBalance: 1000,
     creditLimit: null, interestRate: null, isClosed: false, closedDate: null,
     isFavourite: false, favouriteSortOrder: 0, excludeFromNetWorth: false, paymentAmount: null, paymentFrequency: null, paymentStartDate: null,
     sourceAccountId: null, principalCategoryId: null, interestCategoryId: null,

--- a/frontend/src/components/import/CsvTransferRules.test.tsx
+++ b/frontend/src/components/import/CsvTransferRules.test.tsx
@@ -9,7 +9,7 @@ function makeAccount(overrides: Partial<Account> & { id: string; name: string })
   return {
     userId: 'u1', accountType: 'CHEQUING', accountSubType: null,
     linkedAccountId: null, description: null, currencyCode: 'CAD',
-    accountNumber: null, institution: null, openingBalance: 0, currentBalance: 0,
+    accountNumber: null, institution: null, institutionId: null, openingBalance: 0, currentBalance: 0,
     creditLimit: null, interestRate: null, isClosed: false, closedDate: null,
     isFavourite: false, favouriteSortOrder: 0, excludeFromNetWorth: false, statementDueDay: null, statementSettlementDay: null,
     paymentAmount: null, paymentFrequency: null, paymentStartDate: null,

--- a/frontend/src/components/import/ReviewStep.test.tsx
+++ b/frontend/src/components/import/ReviewStep.test.tsx
@@ -7,7 +7,7 @@ function createAccount(overrides: Partial<Account> = {}): Account {
   return {
     id: 'acc-1', userId: 'user-1', accountType: 'CHEQUING', accountSubType: null,
     linkedAccountId: null, name: 'My Chequing', description: null, currencyCode: 'CAD',
-    accountNumber: null, institution: null, openingBalance: 0, currentBalance: 1000,
+    accountNumber: null, institution: null, institutionId: null, openingBalance: 0, currentBalance: 1000,
     creditLimit: null, interestRate: null, isClosed: false, closedDate: null,
     isFavourite: false, favouriteSortOrder: 0, excludeFromNetWorth: false, paymentAmount: null, paymentFrequency: null, paymentStartDate: null,
     sourceAccountId: null, principalCategoryId: null, interestCategoryId: null,

--- a/frontend/src/components/import/UploadStep.test.tsx
+++ b/frontend/src/components/import/UploadStep.test.tsx
@@ -15,7 +15,7 @@ function createAccount(overrides: Partial<Account> = {}): Account {
     description: null,
     currencyCode: 'CAD',
     accountNumber: null,
-    institution: null,
+    institution: null, institutionId: null,
     openingBalance: 0,
     currentBalance: 1000,
     creditLimit: null,

--- a/frontend/src/components/institutions/InstitutionAccountsManager.test.tsx
+++ b/frontend/src/components/institutions/InstitutionAccountsManager.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@/test/render';
+import { InstitutionAccountsManager } from './InstitutionAccountsManager';
+import { Institution } from '@/types/institution';
+import { Account } from '@/types/account';
+import { institutionsApi } from '@/lib/institutions';
+import { accountsApi } from '@/lib/accounts';
+
+vi.mock('@/lib/institutions', () => ({
+  institutionsApi: {
+    getAccounts: vi.fn(),
+    assignAccount: vi.fn(),
+    unassignAccount: vi.fn(),
+  },
+  institutionLogoUrl: (id: string) => `/api/v1/institutions/${id}/logo`,
+}));
+vi.mock('@/lib/accounts', () => ({
+  accountsApi: { getAll: vi.fn() },
+}));
+
+const institution: Institution = {
+  id: 'i-1',
+  userId: 'u-1',
+  name: 'TD',
+  website: 'https://td.com',
+  country: 'CA',
+  hasLogo: false,
+  logoFetchedAt: null,
+  createdAt: '',
+  updatedAt: '',
+  accountCount: 1,
+};
+
+const account = (id: string, name: string): Account =>
+  ({ id, name, institutionId: null }) as Account;
+
+async function renderManager(onChanged = vi.fn()) {
+  await act(async () => {
+    render(
+      <InstitutionAccountsManager
+        institution={institution}
+        isOpen
+        onClose={vi.fn()}
+        onChanged={onChanged}
+      />,
+    );
+  });
+  return { onChanged };
+}
+
+describe('InstitutionAccountsManager', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('lists the accounts assigned to the institution', async () => {
+    vi.mocked(institutionsApi.getAccounts).mockResolvedValue([
+      account('a-1', 'Chequing'),
+    ]);
+    vi.mocked(accountsApi.getAll).mockResolvedValue([
+      account('a-1', 'Chequing'),
+      account('a-2', 'Savings'),
+    ]);
+
+    await renderManager();
+
+    await waitFor(() =>
+      expect(screen.getByText('Chequing')).toBeInTheDocument(),
+    );
+  });
+
+  it('removes an assigned account', async () => {
+    vi.mocked(institutionsApi.getAccounts).mockResolvedValue([
+      account('a-1', 'Chequing'),
+    ]);
+    vi.mocked(accountsApi.getAll).mockResolvedValue([account('a-1', 'Chequing')]);
+    vi.mocked(institutionsApi.unassignAccount).mockResolvedValue(
+      account('a-1', 'Chequing'),
+    );
+
+    const { onChanged } = await renderManager();
+    await waitFor(() =>
+      expect(screen.getByText('Chequing')).toBeInTheDocument(),
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Remove'));
+    });
+
+    await waitFor(() =>
+      expect(institutionsApi.unassignAccount).toHaveBeenCalledWith('i-1', 'a-1'),
+    );
+    expect(onChanged).toHaveBeenCalled();
+  });
+
+  it('shows the empty state when no accounts are assigned', async () => {
+    vi.mocked(institutionsApi.getAccounts).mockResolvedValue([]);
+    vi.mocked(accountsApi.getAll).mockResolvedValue([account('a-2', 'Savings')]);
+
+    await renderManager();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('No accounts are assigned to this institution yet.'),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/components/institutions/InstitutionAccountsManager.tsx
+++ b/frontend/src/components/institutions/InstitutionAccountsManager.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useTranslations } from 'next-intl';
+import toast from 'react-hot-toast';
+import { Modal } from '@/components/ui/Modal';
+import { Combobox } from '@/components/ui/Combobox';
+import { Button } from '@/components/ui/Button';
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import { Institution } from '@/types/institution';
+import { Account } from '@/types/account';
+import { institutionsApi } from '@/lib/institutions';
+import { accountsApi } from '@/lib/accounts';
+import { getErrorMessage } from '@/lib/errors';
+import { createLogger } from '@/lib/logger';
+import { InstitutionLogo } from './InstitutionLogo';
+
+const logger = createLogger('InstitutionAccountsManager');
+
+interface InstitutionAccountsManagerProps {
+  institution: Institution | null;
+  isOpen: boolean;
+  onClose: () => void;
+  /** Notified after an account is added or removed so counts can refresh. */
+  onChanged?: () => void;
+}
+
+export function InstitutionAccountsManager({
+  institution,
+  isOpen,
+  onClose,
+  onChanged,
+}: InstitutionAccountsManagerProps) {
+  const t = useTranslations('institutions');
+  const [assigned, setAssigned] = useState<Account[]>([]);
+  const [allAccounts, setAllAccounts] = useState<Account[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [selectedAccountId, setSelectedAccountId] = useState('');
+
+  const load = useCallback(async () => {
+    if (!institution) return;
+    setIsLoading(true);
+    try {
+      const [assignedData, all] = await Promise.all([
+        institutionsApi.getAccounts(institution.id),
+        accountsApi.getAll(true),
+      ]);
+      setAssigned(assignedData);
+      setAllAccounts(all);
+    } catch (error) {
+      toast.error(getErrorMessage(error, t('accountsManager.loadFailed')));
+      logger.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [institution, t]);
+
+  useEffect(() => {
+    if (isOpen && institution) {
+      load();
+    }
+  }, [isOpen, institution, load]);
+
+  const assignedIds = useMemo(
+    () => new Set(assigned.map((a) => a.id)),
+    [assigned],
+  );
+
+  const availableOptions = useMemo(
+    () =>
+      allAccounts
+        .filter((a) => !assignedIds.has(a.id))
+        .map((a) => ({ value: a.id, label: a.name })),
+    [allAccounts, assignedIds],
+  );
+
+  const handleAdd = async (accountId: string) => {
+    if (!institution || !accountId) return;
+    setBusyId(accountId);
+    try {
+      await institutionsApi.assignAccount(institution.id, accountId);
+      setSelectedAccountId('');
+      await load();
+      onChanged?.();
+      toast.success(t('accountsManager.added'));
+    } catch (error) {
+      toast.error(getErrorMessage(error, t('accountsManager.addFailed')));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleRemove = async (accountId: string) => {
+    if (!institution) return;
+    setBusyId(accountId);
+    try {
+      await institutionsApi.unassignAccount(institution.id, accountId);
+      await load();
+      onChanged?.();
+      toast.success(t('accountsManager.removed'));
+    } catch (error) {
+      toast.error(getErrorMessage(error, t('accountsManager.removeFailed')));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} maxWidth="lg" className="p-6" pushHistory>
+      <div className="flex items-center gap-3 mb-4">
+        <InstitutionLogo institution={institution ?? undefined} size={32} fallbackGlyph="$" />
+        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 truncate">
+          {institution
+            ? t('accountsManager.title', { name: institution.name })
+            : ''}
+        </h2>
+      </div>
+
+      <div className="mb-4">
+        <Combobox
+          label={t('accountsManager.addLabel')}
+          placeholder={t('accountsManager.addPlaceholder')}
+          options={availableOptions}
+          value={selectedAccountId}
+          usePortal
+          onChange={(value) => {
+            if (value) handleAdd(value);
+          }}
+        />
+        {availableOptions.length === 0 && !isLoading && (
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            {t('accountsManager.noneToAdd')}
+          </p>
+        )}
+      </div>
+
+      {isLoading ? (
+        <LoadingSpinner text={t('accountsManager.loading')} />
+      ) : assigned.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400 py-4 text-center">
+          {t('accountsManager.empty')}
+        </p>
+      ) : (
+        <ul className="divide-y divide-gray-200 dark:divide-gray-700 border border-gray-200 dark:border-gray-700 rounded-md">
+          {assigned.map((account) => (
+            <li
+              key={account.id}
+              className="flex items-center justify-between px-3 py-2 gap-3"
+            >
+              <span className="text-sm text-gray-900 dark:text-gray-100 truncate">
+                {account.name}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={busyId === account.id}
+                onClick={() => handleRemove(account.id)}
+              >
+                {t('accountsManager.remove')}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="mt-6 flex justify-end">
+        <Button variant="secondary" onClick={onClose}>
+          {t('accountsManager.done')}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/institutions/InstitutionForm.test.tsx
+++ b/frontend/src/components/institutions/InstitutionForm.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@/test/render';
+import { InstitutionForm } from './InstitutionForm';
+
+describe('InstitutionForm', () => {
+  it('submits normalised data (country upper-cased)', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<InstitutionForm onSubmit={onSubmit} onCancel={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'TD Bank' },
+    });
+    fireEvent.change(screen.getByLabelText('Website'), {
+      target: { value: 'td.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Country (optional)'), {
+      target: { value: 'ca' },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Create Institution'));
+    });
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({
+        name: 'TD Bank',
+        website: 'td.com',
+        country: 'CA',
+      }),
+    );
+  });
+
+  it('omits an empty country', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<InstitutionForm onSubmit={onSubmit} onCancel={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'Acme' },
+    });
+    fireEvent.change(screen.getByLabelText('Website'), {
+      target: { value: 'acme.com' },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Create Institution'));
+    });
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({
+        name: 'Acme',
+        website: 'acme.com',
+        country: undefined,
+      }),
+    );
+  });
+
+  it('shows a validation error for an empty name', async () => {
+    const onSubmit = vi.fn();
+    render(<InstitutionForm onSubmit={onSubmit} onCancel={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText('Website'), {
+      target: { value: 'td.com' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Create Institution'));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText('Name is required')).toBeInTheDocument(),
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid website', async () => {
+    const onSubmit = vi.fn();
+    render(<InstitutionForm onSubmit={onSubmit} onCancel={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'X' },
+    });
+    fireEvent.change(screen.getByLabelText('Website'), {
+      target: { value: 'notaurl' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Create Institution'));
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Enter a valid website (e.g. td.com)'),
+      ).toBeInTheDocument(),
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('prefills the name for inline creation', () => {
+    render(
+      <InstitutionForm
+        initialName="Acme Bank"
+        onSubmit={vi.fn()}
+        onCancel={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText('Name')).toHaveValue('Acme Bank');
+  });
+
+  it('edits an existing institution', () => {
+    render(
+      <InstitutionForm
+        institution={
+          {
+            id: 'i-1',
+            name: 'Existing',
+            website: 'https://existing.com',
+            country: 'US',
+          } as never
+        }
+        onSubmit={vi.fn()}
+        onCancel={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText('Name')).toHaveValue('Existing');
+    expect(screen.getByText('Save Changes')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/institutions/InstitutionForm.tsx
+++ b/frontend/src/components/institutions/InstitutionForm.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { MutableRefObject, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
+import { useForm } from 'react-hook-form';
+import '@/lib/zodConfig';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Input } from '@/components/ui/Input';
+import { Institution } from '@/types/institution';
+import { useFormSubmitRef } from '@/hooks/useFormSubmitRef';
+import { useFormDirtyNotify } from '@/hooks/useFormDirtyNotify';
+import { FormActions } from '@/components/ui/FormActions';
+
+const buildInstitutionSchema = (t: (key: string) => string) =>
+  z.object({
+    name: z.string().min(1, t('validation.nameRequired')).max(255),
+    website: z
+      .string()
+      .min(1, t('validation.websiteRequired'))
+      .max(2048)
+      .refine((value) => {
+        const trimmed = value.trim();
+        return !/\s/.test(trimmed) && /\.[a-z]{2,}/i.test(trimmed);
+      }, t('validation.websiteInvalid')),
+    country: z
+      .union([
+        z.literal(''),
+        z.string().regex(/^[A-Za-z]{2}$/, t('validation.countryInvalid')),
+      ])
+      .optional(),
+  });
+
+export type InstitutionFormData = z.infer<
+  ReturnType<typeof buildInstitutionSchema>
+>;
+
+interface InstitutionFormProps {
+  institution?: Institution;
+  /** Pre-fill the name field (used when creating from the account form). */
+  initialName?: string;
+  onSubmit: (data: InstitutionFormData) => Promise<void>;
+  onCancel: () => void;
+  onDirtyChange?: (isDirty: boolean) => void;
+  submitRef?: MutableRefObject<(() => void) | null>;
+}
+
+export function InstitutionForm({
+  institution,
+  initialName,
+  onSubmit,
+  onCancel,
+  onDirtyChange,
+  submitRef,
+}: InstitutionFormProps) {
+  const t = useTranslations('institutions');
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting, isDirty },
+  } = useForm<InstitutionFormData>({
+    resolver: zodResolver(buildInstitutionSchema(t)),
+    defaultValues: institution
+      ? {
+          name: institution.name,
+          website: institution.website,
+          country: institution.country || '',
+        }
+      : { name: initialName || '', website: '', country: '' },
+  });
+
+  // Normalise the optional country (empty string -> undefined, upper-cased)
+  // before handing the data to the caller so it satisfies the backend's
+  // optional 2-letter validation.
+  const handleValid = useCallback(
+    (data: InstitutionFormData) =>
+      onSubmit({
+        ...data,
+        country: data.country?.trim()
+          ? data.country.trim().toUpperCase()
+          : undefined,
+      }),
+    [onSubmit],
+  );
+
+  useFormDirtyNotify(isDirty, onDirtyChange);
+  useFormSubmitRef(submitRef, handleSubmit, handleValid);
+
+  const onFormSubmit = (e?: React.BaseSyntheticEvent) => {
+    handleSubmit(handleValid)(e);
+  };
+
+  return (
+    <form onSubmit={onFormSubmit} className="space-y-4">
+      <Input
+        label={t('form.nameLabel')}
+        error={errors.name?.message}
+        {...register('name')}
+      />
+
+      <Input
+        label={t('form.websiteLabel')}
+        placeholder={t('form.websitePlaceholder')}
+        error={errors.website?.message}
+        {...register('website')}
+      />
+
+      <Input
+        label={t('form.countryLabel')}
+        placeholder={t('form.countryPlaceholder')}
+        maxLength={2}
+        error={errors.country?.message}
+        {...register('country')}
+      />
+
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        {t('form.logoHint')}
+      </p>
+
+      <FormActions
+        onCancel={onCancel}
+        submitLabel={
+          institution ? t('form.submitUpdate') : t('form.submitCreate')
+        }
+        isSubmitting={isSubmitting}
+      />
+    </form>
+  );
+}

--- a/frontend/src/components/institutions/InstitutionList.test.tsx
+++ b/frontend/src/components/institutions/InstitutionList.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@/test/render';
+import { InstitutionList } from './InstitutionList';
+import { Institution } from '@/types/institution';
+import { institutionsApi } from '@/lib/institutions';
+
+vi.mock('@/lib/institutions', () => ({
+  institutionsApi: { delete: vi.fn() },
+  institutionLogoUrl: (id: string) => `/api/v1/institutions/${id}/logo`,
+}));
+
+const makeInstitution = (overrides: Partial<Institution> = {}): Institution => ({
+  id: 'i-1',
+  userId: 'u-1',
+  name: 'TD Canada Trust',
+  website: 'https://td.com',
+  country: 'CA',
+  hasLogo: true,
+  logoFetchedAt: null,
+  createdAt: '',
+  updatedAt: '',
+  accountCount: 2,
+  ...overrides,
+});
+
+describe('InstitutionList', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders institution details', () => {
+    render(
+      <InstitutionList
+        institutions={[makeInstitution()]}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onManageAccounts={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('TD Canada Trust')).toBeInTheDocument();
+    expect(screen.getByText('https://td.com')).toBeInTheDocument();
+    expect(screen.getByText('2 accounts')).toBeInTheDocument();
+  });
+
+  it('shows the empty state', () => {
+    render(
+      <InstitutionList
+        institutions={[]}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onManageAccounts={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(
+        'No institutions yet. Create one to start grouping your accounts.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('invokes onEdit and onManageAccounts', () => {
+    const onEdit = vi.fn();
+    const onManageAccounts = vi.fn();
+    render(
+      <InstitutionList
+        institutions={[makeInstitution()]}
+        onEdit={onEdit}
+        onDelete={vi.fn()}
+        onManageAccounts={onManageAccounts}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(onEdit).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Accounts' }));
+    expect(onManageAccounts).toHaveBeenCalled();
+  });
+
+  it('deletes after confirmation', async () => {
+    vi.mocked(institutionsApi.delete).mockResolvedValue(undefined);
+    const onDelete = vi.fn();
+    render(
+      <InstitutionList
+        institutions={[makeInstitution()]}
+        onEdit={vi.fn()}
+        onDelete={onDelete}
+        onManageAccounts={vi.fn()}
+      />,
+    );
+
+    // Row delete button opens the confirmation dialog.
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Accounts assigned to it will be unassigned/),
+      ).toBeInTheDocument(),
+    );
+
+    // Confirm in the dialog (two "Delete" buttons now exist; click the last).
+    const deleteButtons = screen.getAllByRole('button', { name: 'Delete' });
+    await act(async () => {
+      fireEvent.click(deleteButtons[deleteButtons.length - 1]);
+    });
+
+    await waitFor(() => expect(institutionsApi.delete).toHaveBeenCalledWith('i-1'));
+    expect(onDelete).toHaveBeenCalledWith('i-1');
+  });
+});

--- a/frontend/src/components/institutions/InstitutionList.tsx
+++ b/frontend/src/components/institutions/InstitutionList.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import toast from 'react-hot-toast';
+import { Button } from '@/components/ui/Button';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import { Institution } from '@/types/institution';
+import { institutionsApi } from '@/lib/institutions';
+import { getErrorMessage } from '@/lib/errors';
+import { createLogger } from '@/lib/logger';
+import { InstitutionLogo } from './InstitutionLogo';
+
+const logger = createLogger('InstitutionList');
+
+interface InstitutionListProps {
+  institutions: Institution[];
+  onEdit: (institution: Institution) => void;
+  onDelete: (id: string) => void;
+  onManageAccounts: (institution: Institution) => void;
+}
+
+export function InstitutionList({
+  institutions,
+  onEdit,
+  onDelete,
+  onManageAccounts,
+}: InstitutionListProps) {
+  const t = useTranslations('institutions');
+  const tc = useTranslations('common');
+  const [toDelete, setToDelete] = useState<Institution | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDeleteConfirm = async () => {
+    if (!toDelete) return;
+    setIsDeleting(true);
+    try {
+      await institutionsApi.delete(toDelete.id);
+      toast.success(t('list.deleted', { name: toDelete.name }));
+      onDelete(toDelete.id);
+      setToDelete(null);
+    } catch (error) {
+      toast.error(getErrorMessage(error, t('list.deleteFailed')));
+      logger.error(error);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  if (institutions.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-gray-500 dark:text-gray-400">{t('list.empty')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <thead className="bg-gray-50 dark:bg-gray-800">
+          <tr>
+            <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+              {t('list.columns.name')}
+            </th>
+            <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden md:table-cell">
+              {t('list.columns.website')}
+            </th>
+            <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell">
+              {t('list.columns.country')}
+            </th>
+            <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+              {t('list.columns.accounts')}
+            </th>
+            <th className="px-3 sm:px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+              {t('list.columns.actions')}
+            </th>
+          </tr>
+        </thead>
+        <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+          {institutions.map((institution) => (
+            <tr
+              key={institution.id}
+              className="hover:bg-gray-50 dark:hover:bg-gray-800"
+            >
+              <td className="px-3 sm:px-6 py-3">
+                <div className="flex items-center gap-3 min-w-0">
+                  <InstitutionLogo institution={institution} size={24} fallbackGlyph="$" />
+                  <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                    {institution.name}
+                  </span>
+                </div>
+              </td>
+              <td className="px-3 sm:px-6 py-3 hidden md:table-cell max-w-[16rem]">
+                <a
+                  href={institution.website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={(e) => e.stopPropagation()}
+                  className="text-sm text-blue-600 dark:text-blue-400 hover:underline truncate inline-block max-w-full"
+                >
+                  {institution.website}
+                </a>
+              </td>
+              <td className="px-3 sm:px-6 py-3 hidden sm:table-cell text-sm text-gray-500 dark:text-gray-400">
+                {institution.country || '—'}
+              </td>
+              <td className="px-3 sm:px-6 py-3">
+                <button
+                  onClick={() => onManageAccounts(institution)}
+                  className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  {t('list.accountCount', { count: institution.accountCount })}
+                </button>
+              </td>
+              <td className="px-3 sm:px-6 py-3 text-right whitespace-nowrap space-x-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onManageAccounts(institution)}
+                >
+                  {t('list.actions.manageAccounts')}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onEdit(institution)}
+                >
+                  {tc('edit')}
+                </Button>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  onClick={() => setToDelete(institution)}
+                >
+                  {tc('delete')}
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <ConfirmDialog
+        isOpen={toDelete !== null}
+        title={t('list.deleteTitle')}
+        message={
+          toDelete ? t('list.deleteMessage', { name: toDelete.name }) : ''
+        }
+        confirmLabel={
+          isDeleting ? t('list.deleting') : tc('delete')
+        }
+        cancelLabel={tc('cancel')}
+        variant="danger"
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setToDelete(null)}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/institutions/InstitutionLogo.test.tsx
+++ b/frontend/src/components/institutions/InstitutionLogo.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@/test/render';
+import { InstitutionLogo } from './InstitutionLogo';
+
+describe('InstitutionLogo', () => {
+  it('renders the favicon image when a logo is available', () => {
+    render(
+      <InstitutionLogo institution={{ id: 'i-1', name: 'TD', hasLogo: true }} />,
+    );
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('src', '/api/v1/institutions/i-1/logo');
+    expect(img).toHaveAttribute('alt', 'TD');
+    expect(img).toHaveAttribute('loading', 'lazy');
+  });
+
+  it('renders a letter badge when there is no cached logo', () => {
+    render(
+      <InstitutionLogo institution={{ id: 'i-1', name: 'TD', hasLogo: false }} />,
+    );
+    expect(screen.queryByRole('img')).toBeNull();
+    expect(screen.getByText('T')).toBeInTheDocument();
+  });
+
+  it('renders the fallback glyph when there is no institution', () => {
+    render(<InstitutionLogo institution={undefined} fallbackGlyph="$" />);
+    expect(screen.getByText('$')).toBeInTheDocument();
+  });
+
+  it('falls back to the badge when the image fails to load', () => {
+    render(
+      <InstitutionLogo
+        institution={{ id: 'i-1', name: 'Acme', hasLogo: true }}
+      />,
+    );
+    fireEvent.error(screen.getByRole('img'));
+    expect(screen.queryByRole('img')).toBeNull();
+    expect(screen.getByText('A')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/institutions/InstitutionLogo.tsx
+++ b/frontend/src/components/institutions/InstitutionLogo.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState } from 'react';
+import { institutionLogoUrl } from '@/lib/institutions';
+
+export interface InstitutionLogoData {
+  id: string;
+  name: string;
+  hasLogo: boolean;
+}
+
+interface InstitutionLogoProps {
+  institution?: InstitutionLogoData | null;
+  /** Rendered square size in pixels. */
+  size?: number;
+  className?: string;
+  /** Glyph shown when there is no institution (e.g. cashflow-only accounts). */
+  fallbackGlyph?: string;
+}
+
+/**
+ * Renders an institution's brand favicon (served from our own backend, never a
+ * third party) with a neutral letter/glyph badge fallback when no logo is
+ * cached or the image fails to load.
+ */
+export function InstitutionLogo({
+  institution,
+  size = 20,
+  className = '',
+  fallbackGlyph = '$',
+}: InstitutionLogoProps) {
+  const [errored, setErrored] = useState(false);
+
+  // Reset the error flag when the institution changes, using the
+  // "info from previous render" pattern (no setState in an effect).
+  const [prevId, setPrevId] = useState(institution?.id);
+  if (institution?.id !== prevId) {
+    setPrevId(institution?.id);
+    setErrored(false);
+  }
+
+  const dimension = { width: size, height: size };
+  const letter =
+    institution?.name?.trim()?.charAt(0)?.toUpperCase() || fallbackGlyph;
+
+  if (institution?.hasLogo && !errored) {
+    return (
+      // Favicons are tiny, dynamic, and served from our own backend; next/image
+      // optimization adds no value and cannot follow the onError fallback.
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={institutionLogoUrl(institution.id)}
+        alt={institution.name}
+        loading="lazy"
+        style={dimension}
+        onError={() => setErrored(true)}
+        className={`shrink-0 rounded object-contain bg-white ${className}`}
+      />
+    );
+  }
+
+  return (
+    <span
+      style={dimension}
+      aria-hidden="true"
+      className={`shrink-0 inline-flex items-center justify-center rounded bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 text-xs font-semibold ${className}`}
+    >
+      {letter}
+    </span>
+  );
+}

--- a/frontend/src/components/institutions/InstitutionLogo.tsx
+++ b/frontend/src/components/institutions/InstitutionLogo.tsx
@@ -54,7 +54,10 @@ export function InstitutionLogo({
         loading="lazy"
         style={dimension}
         onError={() => setErrored(true)}
-        className={`shrink-0 rounded object-contain bg-white ${className}`}
+        // Circular chip with no forced backing: transparent favicons keep their
+        // transparency, opaque ones fill the circle. The ring keeps it defined
+        // against any background.
+        className={`shrink-0 rounded-full object-contain ring-1 ring-black/10 dark:ring-white/15 ${className}`}
       />
     );
   }
@@ -63,7 +66,7 @@ export function InstitutionLogo({
     <span
       style={dimension}
       aria-hidden="true"
-      className={`shrink-0 inline-flex items-center justify-center rounded bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 text-xs font-semibold ${className}`}
+      className={`shrink-0 inline-flex items-center justify-center rounded-full bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 text-xs font-semibold ${className}`}
     >
       {letter}
     </span>

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -33,6 +33,7 @@ const navLinks = [
 const toolsLinks: { href: string; labelKey: string; badge?: string }[] = [
   { href: '/categories', labelKey: 'categories' },
   { href: '/payees', labelKey: 'payees' },
+  { href: '/institutions', labelKey: 'institutions' },
   { href: '/tags', labelKey: 'tags' },
   { href: '/securities', labelKey: 'securities' },
   { href: '/currencies', labelKey: 'currencies' },

--- a/frontend/src/components/transactions/NormalTransactionFields.test.tsx
+++ b/frontend/src/components/transactions/NormalTransactionFields.test.tsx
@@ -68,7 +68,7 @@ function createAccount(overrides: Partial<Account> = {}): Account {
     description: null,
     currencyCode: 'CAD',
     accountNumber: null,
-    institution: null,
+    institution: null, institutionId: null,
     openingBalance: 0,
     currentBalance: 1000,
     creditLimit: null,

--- a/frontend/src/components/transactions/SplitTransactionFields.test.tsx
+++ b/frontend/src/components/transactions/SplitTransactionFields.test.tsx
@@ -68,7 +68,7 @@ function createAccount(overrides: Partial<Account> = {}): Account {
     description: null,
     currencyCode: 'CAD',
     accountNumber: null,
-    institution: null,
+    institution: null, institutionId: null,
     openingBalance: 0,
     currentBalance: 1000,
     creditLimit: null,

--- a/frontend/src/components/transactions/TransactionFilterPanel.test.tsx
+++ b/frontend/src/components/transactions/TransactionFilterPanel.test.tsx
@@ -9,7 +9,7 @@ function createAccount(overrides: Partial<Account> = {}): Account {
   return {
     id: 'acc-1', userId: 'user-1', accountType: 'CHEQUING', accountSubType: null,
     linkedAccountId: null, name: 'Chequing', description: null, currencyCode: 'CAD',
-    accountNumber: null, institution: null, openingBalance: 0, currentBalance: 1000,
+    accountNumber: null, institution: null, institutionId: null, openingBalance: 0, currentBalance: 1000,
     creditLimit: null, interestRate: null, isClosed: false, closedDate: null,
     isFavourite: false, favouriteSortOrder: 0, excludeFromNetWorth: false, paymentAmount: null, paymentFrequency: null, paymentStartDate: null,
     sourceAccountId: null, principalCategoryId: null, interestCategoryId: null,

--- a/frontend/src/components/transactions/TransactionForm.test.tsx
+++ b/frontend/src/components/transactions/TransactionForm.test.tsx
@@ -19,7 +19,7 @@ const mockAccounts = [
     linkedAccountId: null,
     description: null,
     accountNumber: null,
-    institution: null,
+    institution: null, institutionId: null,
     openingBalance: 0,
     currentBalance: 1000,
     creditLimit: null,

--- a/frontend/src/components/transactions/TransferTransactionFields.test.tsx
+++ b/frontend/src/components/transactions/TransferTransactionFields.test.tsx
@@ -62,7 +62,7 @@ function createAccount(overrides: Partial<Account> = {}): Account {
     description: null,
     currencyCode: 'CAD',
     accountNumber: null,
-    institution: null,
+    institution: null, institutionId: null,
     openingBalance: 0,
     currentBalance: 1000,
     creditLimit: null,

--- a/frontend/src/i18n/messages.ts
+++ b/frontend/src/i18n/messages.ts
@@ -25,6 +25,7 @@ const NAMESPACES = [
   "emergencyAccess",
   "import",
   "insights",
+  "institutions",
   "investments",
   "layout",
   "payees",

--- a/frontend/src/i18n/messages/en/accounts.json
+++ b/frontend/src/i18n/messages/en/accounts.json
@@ -105,6 +105,8 @@
     "accountNumber": "Account Number (optional)",
     "institution": "Institution (optional)",
     "institutionRequired": "Lender/Institution (required)",
+    "institutionPlaceholder": "Select or create an institution...",
+    "newInstitutionTitle": "New Institution",
     "creditLimit": "Credit Limit (optional)",
     "interestRateOptional": "Interest Rate % (optional)",
     "interestRateRequired": "Interest Rate % (required)",
@@ -281,7 +283,9 @@
     "categoryCreatedNested": "Category \"{parent}: {name}\" created",
     "categoryCreated": "Category \"{name}\" created",
     "payeeCreated": "Payee \"{name}\" created",
-    "payeeCreateFailed": "Failed to create payee"
+    "payeeCreateFailed": "Failed to create payee",
+    "institutionCreated": "Institution \"{name}\" created",
+    "institutionCreateFailed": "Failed to create institution"
   },
   "validation": {
     "nameRequired": "Account name is required",

--- a/frontend/src/i18n/messages/en/institutions.json
+++ b/frontend/src/i18n/messages/en/institutions.json
@@ -1,0 +1,73 @@
+{
+  "page": {
+    "title": "Financial Institutions",
+    "subtitle": "Banks and brokerages your accounts belong to",
+    "newInstitution": "New Institution",
+    "loading": "Loading institutions...",
+    "searchPlaceholder": "Search institutions...",
+    "modalTitleNew": "New Institution",
+    "modalTitleEdit": "Edit Institution",
+    "summary": {
+      "total": "Total Institutions",
+      "withLogo": "With Logo",
+      "linkedAccounts": "Linked Accounts"
+    },
+    "toasts": {
+      "loadFailed": "Failed to load institutions",
+      "created": "Institution created",
+      "updated": "Institution updated",
+      "createFailed": "Failed to create institution",
+      "updateFailed": "Failed to update institution"
+    }
+  },
+  "list": {
+    "empty": "No institutions yet. Create one to start grouping your accounts.",
+    "columns": {
+      "name": "Name",
+      "website": "Website",
+      "country": "Country",
+      "accounts": "Accounts",
+      "actions": "Actions"
+    },
+    "accountCount": "{count, plural, =0 {No accounts} one {# account} other {# accounts}}",
+    "actions": {
+      "manageAccounts": "Accounts"
+    },
+    "deleteTitle": "Delete Institution",
+    "deleteMessage": "Delete \"{name}\"? Accounts assigned to it will be unassigned but not deleted.",
+    "deleting": "Deleting...",
+    "deleted": "Deleted \"{name}\"",
+    "deleteFailed": "Failed to delete institution"
+  },
+  "form": {
+    "nameLabel": "Name",
+    "websiteLabel": "Website",
+    "websitePlaceholder": "e.g. td.com",
+    "countryLabel": "Country (optional)",
+    "countryPlaceholder": "2-letter code, e.g. CA",
+    "logoHint": "The brand logo is fetched automatically from the website.",
+    "submitCreate": "Create Institution",
+    "submitUpdate": "Save Changes"
+  },
+  "validation": {
+    "nameRequired": "Name is required",
+    "websiteRequired": "Website is required",
+    "websiteInvalid": "Enter a valid website (e.g. td.com)",
+    "countryInvalid": "Use a 2-letter country code"
+  },
+  "accountsManager": {
+    "title": "Accounts at {name}",
+    "addLabel": "Add an account",
+    "addPlaceholder": "Select an account to add...",
+    "noneToAdd": "All your accounts are already assigned to an institution.",
+    "loading": "Loading accounts...",
+    "empty": "No accounts are assigned to this institution yet.",
+    "remove": "Remove",
+    "added": "Account added",
+    "removed": "Account removed",
+    "addFailed": "Failed to add account",
+    "removeFailed": "Failed to remove account",
+    "loadFailed": "Failed to load accounts",
+    "done": "Done"
+  }
+}

--- a/frontend/src/i18n/messages/en/navigation.json
+++ b/frontend/src/i18n/messages/en/navigation.json
@@ -8,6 +8,7 @@
   "reports": "Reports",
   "categories": "Categories",
   "payees": "Payees",
+  "institutions": "Institutions",
   "tags": "Tags",
   "securities": "Securities",
   "currencies": "Currencies",

--- a/frontend/src/i18n/messages/pl/accounts.json
+++ b/frontend/src/i18n/messages/pl/accounts.json
@@ -105,6 +105,8 @@
     "accountNumber": "Numer konta (opcjonalnie)",
     "institution": "Instytucja (opcjonalnie)",
     "institutionRequired": "Pożyczkodawca/Instytucja (wymagane)",
+    "institutionPlaceholder": "Wybierz lub utwórz instytucję...",
+    "newInstitutionTitle": "Nowa instytucja",
     "creditLimit": "Limit kredytowy (opcjonalnie)",
     "interestRateOptional": "Oprocentowanie % (opcjonalnie)",
     "interestRateRequired": "Oprocentowanie % (wymagane)",
@@ -281,7 +283,9 @@
     "categoryCreatedNested": "Utworzono kategorię \"{parent}: {name}\"",
     "categoryCreated": "Utworzono kategorię \"{name}\"",
     "payeeCreated": "Utworzono odbiorcę \"{name}\"",
-    "payeeCreateFailed": "Nie udało się utworzyć odbiorcy"
+    "payeeCreateFailed": "Nie udało się utworzyć odbiorcy",
+    "institutionCreated": "Instytucja „{name}” utworzona",
+    "institutionCreateFailed": "Nie udało się utworzyć instytucji"
   },
   "validation": {
     "nameRequired": "Nazwa konta jest wymagana",

--- a/frontend/src/i18n/messages/pl/institutions.json
+++ b/frontend/src/i18n/messages/pl/institutions.json
@@ -1,0 +1,73 @@
+{
+  "page": {
+    "title": "Instytucje finansowe",
+    "subtitle": "Banki i biura maklerskie, do których należą Twoje konta",
+    "newInstitution": "Nowa instytucja",
+    "loading": "Ładowanie instytucji...",
+    "searchPlaceholder": "Szukaj instytucji...",
+    "modalTitleNew": "Nowa instytucja",
+    "modalTitleEdit": "Edytuj instytucję",
+    "summary": {
+      "total": "Łącznie instytucji",
+      "withLogo": "Z logo",
+      "linkedAccounts": "Powiązane konta"
+    },
+    "toasts": {
+      "loadFailed": "Nie udało się załadować instytucji",
+      "created": "Instytucja utworzona",
+      "updated": "Instytucja zaktualizowana",
+      "createFailed": "Nie udało się utworzyć instytucji",
+      "updateFailed": "Nie udało się zaktualizować instytucji"
+    }
+  },
+  "list": {
+    "empty": "Brak instytucji. Utwórz jedną, aby grupować konta.",
+    "columns": {
+      "name": "Nazwa",
+      "website": "Strona internetowa",
+      "country": "Kraj",
+      "accounts": "Konta",
+      "actions": "Akcje"
+    },
+    "accountCount": "{count, plural, =0 {Brak kont} one {# konto} few {# konta} many {# kont} other {# konta}}",
+    "actions": {
+      "manageAccounts": "Konta"
+    },
+    "deleteTitle": "Usuń instytucję",
+    "deleteMessage": "Usunąć „{name}”? Przypisane konta zostaną odłączone, ale nie usunięte.",
+    "deleting": "Usuwanie...",
+    "deleted": "Usunięto „{name}”",
+    "deleteFailed": "Nie udało się usunąć instytucji"
+  },
+  "form": {
+    "nameLabel": "Nazwa",
+    "websiteLabel": "Strona internetowa",
+    "websitePlaceholder": "np. td.com",
+    "countryLabel": "Kraj (opcjonalnie)",
+    "countryPlaceholder": "Dwuliterowy kod, np. CA",
+    "logoHint": "Logo marki jest pobierane automatycznie ze strony internetowej.",
+    "submitCreate": "Utwórz instytucję",
+    "submitUpdate": "Zapisz zmiany"
+  },
+  "validation": {
+    "nameRequired": "Nazwa jest wymagana",
+    "websiteRequired": "Strona internetowa jest wymagana",
+    "websiteInvalid": "Podaj prawidłowy adres strony (np. td.com)",
+    "countryInvalid": "Użyj dwuliterowego kodu kraju"
+  },
+  "accountsManager": {
+    "title": "Konta w {name}",
+    "addLabel": "Dodaj konto",
+    "addPlaceholder": "Wybierz konto do dodania...",
+    "noneToAdd": "Wszystkie Twoje konta są już przypisane do instytucji.",
+    "loading": "Ładowanie kont...",
+    "empty": "Do tej instytucji nie przypisano jeszcze żadnych kont.",
+    "remove": "Usuń",
+    "added": "Konto dodane",
+    "removed": "Konto usunięte",
+    "addFailed": "Nie udało się dodać konta",
+    "removeFailed": "Nie udało się usunąć konta",
+    "loadFailed": "Nie udało się załadować kont",
+    "done": "Gotowe"
+  }
+}

--- a/frontend/src/i18n/messages/pl/navigation.json
+++ b/frontend/src/i18n/messages/pl/navigation.json
@@ -8,6 +8,7 @@
   "reports": "Raporty",
   "categories": "Kategorie",
   "payees": "Odbiorcy",
+  "institutions": "Instytucje",
   "tags": "Tagi",
   "securities": "Papiery wartościowe",
   "currencies": "Waluty",

--- a/frontend/src/i18n/messages/xx/accounts.json
+++ b/frontend/src/i18n/messages/xx/accounts.json
@@ -105,6 +105,8 @@
     "accountNumber": "[XX-Account Number (optional)-XX]",
     "institution": "[XX-Institution (optional)-XX]",
     "institutionRequired": "[XX-Lender/Institution (required)-XX]",
+    "institutionPlaceholder": "[XX-Select or create an institution...-XX]",
+    "newInstitutionTitle": "[XX-New Institution-XX]",
     "creditLimit": "[XX-Credit Limit (optional)-XX]",
     "interestRateOptional": "[XX-Interest Rate % (optional)-XX]",
     "interestRateRequired": "[XX-Interest Rate % (required)-XX]",
@@ -281,7 +283,9 @@
     "categoryCreatedNested": "[XX-Category \"{parent}: {name}\" created-XX]",
     "categoryCreated": "[XX-Category \"{name}\" created-XX]",
     "payeeCreated": "[XX-Payee \"{name}\" created-XX]",
-    "payeeCreateFailed": "[XX-Failed to create payee-XX]"
+    "payeeCreateFailed": "[XX-Failed to create payee-XX]",
+    "institutionCreated": "[XX-Institution \"{name}\" created-XX]",
+    "institutionCreateFailed": "[XX-Failed to create institution-XX]"
   },
   "validation": {
     "nameRequired": "[XX-Account name is required-XX]",

--- a/frontend/src/i18n/messages/xx/institutions.json
+++ b/frontend/src/i18n/messages/xx/institutions.json
@@ -1,0 +1,73 @@
+{
+  "page": {
+    "title": "[XX-Financial Institutions-XX]",
+    "subtitle": "[XX-Banks and brokerages your accounts belong to-XX]",
+    "newInstitution": "[XX-New Institution-XX]",
+    "loading": "[XX-Loading institutions...-XX]",
+    "searchPlaceholder": "[XX-Search institutions...-XX]",
+    "modalTitleNew": "[XX-New Institution-XX]",
+    "modalTitleEdit": "[XX-Edit Institution-XX]",
+    "summary": {
+      "total": "[XX-Total Institutions-XX]",
+      "withLogo": "[XX-With Logo-XX]",
+      "linkedAccounts": "[XX-Linked Accounts-XX]"
+    },
+    "toasts": {
+      "loadFailed": "[XX-Failed to load institutions-XX]",
+      "created": "[XX-Institution created-XX]",
+      "updated": "[XX-Institution updated-XX]",
+      "createFailed": "[XX-Failed to create institution-XX]",
+      "updateFailed": "[XX-Failed to update institution-XX]"
+    }
+  },
+  "list": {
+    "empty": "[XX-No institutions yet. Create one to start grouping your accounts.-XX]",
+    "columns": {
+      "name": "[XX-Name-XX]",
+      "website": "[XX-Website-XX]",
+      "country": "[XX-Country-XX]",
+      "accounts": "[XX-Accounts-XX]",
+      "actions": "[XX-Actions-XX]"
+    },
+    "accountCount": "[XX-{count, plural, =0 {No accounts} one {# account} other {# accounts}}-XX]",
+    "actions": {
+      "manageAccounts": "[XX-Accounts-XX]"
+    },
+    "deleteTitle": "[XX-Delete Institution-XX]",
+    "deleteMessage": "[XX-Delete \"{name}\"? Accounts assigned to it will be unassigned but not deleted.-XX]",
+    "deleting": "[XX-Deleting...-XX]",
+    "deleted": "[XX-Deleted \"{name}\"-XX]",
+    "deleteFailed": "[XX-Failed to delete institution-XX]"
+  },
+  "form": {
+    "nameLabel": "[XX-Name-XX]",
+    "websiteLabel": "[XX-Website-XX]",
+    "websitePlaceholder": "[XX-e.g. td.com-XX]",
+    "countryLabel": "[XX-Country (optional)-XX]",
+    "countryPlaceholder": "[XX-2-letter code, e.g. CA-XX]",
+    "logoHint": "[XX-The brand logo is fetched automatically from the website.-XX]",
+    "submitCreate": "[XX-Create Institution-XX]",
+    "submitUpdate": "[XX-Save Changes-XX]"
+  },
+  "validation": {
+    "nameRequired": "[XX-Name is required-XX]",
+    "websiteRequired": "[XX-Website is required-XX]",
+    "websiteInvalid": "[XX-Enter a valid website (e.g. td.com)-XX]",
+    "countryInvalid": "[XX-Use a 2-letter country code-XX]"
+  },
+  "accountsManager": {
+    "title": "[XX-Accounts at {name}-XX]",
+    "addLabel": "[XX-Add an account-XX]",
+    "addPlaceholder": "[XX-Select an account to add...-XX]",
+    "noneToAdd": "[XX-All your accounts are already assigned to an institution.-XX]",
+    "loading": "[XX-Loading accounts...-XX]",
+    "empty": "[XX-No accounts are assigned to this institution yet.-XX]",
+    "remove": "[XX-Remove-XX]",
+    "added": "[XX-Account added-XX]",
+    "removed": "[XX-Account removed-XX]",
+    "addFailed": "[XX-Failed to add account-XX]",
+    "removeFailed": "[XX-Failed to remove account-XX]",
+    "loadFailed": "[XX-Failed to load accounts-XX]",
+    "done": "[XX-Done-XX]"
+  }
+}

--- a/frontend/src/i18n/messages/xx/navigation.json
+++ b/frontend/src/i18n/messages/xx/navigation.json
@@ -8,6 +8,7 @@
   "reports": "[XX-Reports-XX]",
   "categories": "[XX-Categories-XX]",
   "payees": "[XX-Payees-XX]",
+  "institutions": "[XX-Institutions-XX]",
   "tags": "[XX-Tags-XX]",
   "securities": "[XX-Securities-XX]",
   "currencies": "[XX-Currencies-XX]",

--- a/frontend/src/lib/account-utils.test.ts
+++ b/frontend/src/lib/account-utils.test.ts
@@ -11,7 +11,7 @@ function makeAccount(overrides: Partial<Account> & { id: string; name: string })
   return {
     userId: 'u1', accountType: 'CHEQUING', accountSubType: null,
     linkedAccountId: null, description: null, currencyCode: 'CAD',
-    accountNumber: null, institution: null, openingBalance: 0, currentBalance: 0,
+    accountNumber: null, institution: null, institutionId: null, openingBalance: 0, currentBalance: 0,
     creditLimit: null, interestRate: null, isClosed: false, closedDate: null,
     isFavourite: false, favouriteSortOrder: 0, excludeFromNetWorth: false,
     statementDueDay: null, statementSettlementDay: null,

--- a/frontend/src/lib/institutions.test.ts
+++ b/frontend/src/lib/institutions.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import apiClient from './api';
+import { institutionsApi, institutionLogoUrl } from './institutions';
+
+vi.mock('./api', () => ({
+  default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('./apiCache', () => ({
+  dedupe: (_key: string, fn: () => unknown) => fn(),
+  invalidateCache: vi.fn(),
+}));
+
+describe('institutionsApi', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('institutionLogoUrl builds the same-origin logo path', () => {
+    expect(institutionLogoUrl('abc')).toBe('/api/v1/institutions/abc/logo');
+  });
+
+  it('getAll fetches /institutions', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: [{ id: 'i-1' }] });
+    const result = await institutionsApi.getAll();
+    expect(apiClient.get).toHaveBeenCalledWith('/institutions');
+    expect(result).toHaveLength(1);
+  });
+
+  it('getById fetches /institutions/:id', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { id: 'i-1' } });
+    await institutionsApi.getById('i-1');
+    expect(apiClient.get).toHaveBeenCalledWith('/institutions/i-1');
+  });
+
+  it('create posts to /institutions', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { id: 'i-1' } });
+    await institutionsApi.create({ name: 'TD', website: 'td.com' });
+    expect(apiClient.post).toHaveBeenCalledWith('/institutions', {
+      name: 'TD',
+      website: 'td.com',
+    });
+  });
+
+  it('update patches /institutions/:id', async () => {
+    vi.mocked(apiClient.patch).mockResolvedValue({ data: { id: 'i-1' } });
+    await institutionsApi.update('i-1', { name: 'New' });
+    expect(apiClient.patch).toHaveBeenCalledWith('/institutions/i-1', {
+      name: 'New',
+    });
+  });
+
+  it('delete removes /institutions/:id', async () => {
+    vi.mocked(apiClient.delete).mockResolvedValue({ data: {} });
+    await institutionsApi.delete('i-1');
+    expect(apiClient.delete).toHaveBeenCalledWith('/institutions/i-1');
+  });
+
+  it('refreshLogo posts to /institutions/:id/refresh-logo', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { id: 'i-1' } });
+    await institutionsApi.refreshLogo('i-1');
+    expect(apiClient.post).toHaveBeenCalledWith('/institutions/i-1/refresh-logo');
+  });
+
+  it('getAccounts fetches /institutions/:id/accounts', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: [] });
+    await institutionsApi.getAccounts('i-1');
+    expect(apiClient.get).toHaveBeenCalledWith('/institutions/i-1/accounts');
+  });
+
+  it('assignAccount posts the account id', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { id: 'a-1' } });
+    await institutionsApi.assignAccount('i-1', 'a-1');
+    expect(apiClient.post).toHaveBeenCalledWith('/institutions/i-1/accounts', {
+      accountId: 'a-1',
+    });
+  });
+
+  it('unassignAccount deletes the account link', async () => {
+    vi.mocked(apiClient.delete).mockResolvedValue({ data: { id: 'a-1' } });
+    await institutionsApi.unassignAccount('i-1', 'a-1');
+    expect(apiClient.delete).toHaveBeenCalledWith(
+      '/institutions/i-1/accounts/a-1',
+    );
+  });
+});

--- a/frontend/src/lib/institutions.ts
+++ b/frontend/src/lib/institutions.ts
@@ -1,0 +1,95 @@
+import apiClient from './api';
+import {
+  Institution,
+  CreateInstitutionData,
+  UpdateInstitutionData,
+} from '@/types/institution';
+import { Account } from '@/types/account';
+import { dedupe, invalidateCache } from './apiCache';
+
+/**
+ * Same-origin URL for an institution's cached brand favicon. Rendered directly
+ * in an <img>; the request carries the auth cookie and never contacts a third
+ * party. Returns 404 when no logo is cached, so callers should provide a
+ * fallback (handled by the InstitutionLogo component's onError).
+ */
+export function institutionLogoUrl(id: string): string {
+  return `/api/v1/institutions/${id}/logo`;
+}
+
+export const institutionsApi = {
+  getAll: async (): Promise<Institution[]> => {
+    return dedupe(
+      'institutions:all',
+      async () => {
+        const response = await apiClient.get<Institution[]>('/institutions');
+        return response.data;
+      },
+      300_000, // 5 min
+    );
+  },
+
+  getById: async (id: string): Promise<Institution> => {
+    const response = await apiClient.get<Institution>(`/institutions/${id}`);
+    return response.data;
+  },
+
+  create: async (data: CreateInstitutionData): Promise<Institution> => {
+    const response = await apiClient.post<Institution>('/institutions', data);
+    invalidateCache('institutions:');
+    return response.data;
+  },
+
+  update: async (
+    id: string,
+    data: UpdateInstitutionData,
+  ): Promise<Institution> => {
+    const response = await apiClient.patch<Institution>(
+      `/institutions/${id}`,
+      data,
+    );
+    invalidateCache('institutions:');
+    invalidateCache('accounts:');
+    return response.data;
+  },
+
+  delete: async (id: string): Promise<void> => {
+    await apiClient.delete(`/institutions/${id}`);
+    invalidateCache('institutions:');
+    invalidateCache('accounts:');
+  },
+
+  refreshLogo: async (id: string): Promise<Institution> => {
+    const response = await apiClient.post<Institution>(
+      `/institutions/${id}/refresh-logo`,
+    );
+    invalidateCache('institutions:');
+    return response.data;
+  },
+
+  getAccounts: async (id: string): Promise<Account[]> => {
+    const response = await apiClient.get<Account[]>(
+      `/institutions/${id}/accounts`,
+    );
+    return response.data;
+  },
+
+  assignAccount: async (id: string, accountId: string): Promise<Account> => {
+    const response = await apiClient.post<Account>(
+      `/institutions/${id}/accounts`,
+      { accountId },
+    );
+    invalidateCache('institutions:');
+    invalidateCache('accounts:');
+    return response.data;
+  },
+
+  unassignAccount: async (id: string, accountId: string): Promise<Account> => {
+    const response = await apiClient.delete<Account>(
+      `/institutions/${id}/accounts/${accountId}`,
+    );
+    invalidateCache('institutions:');
+    invalidateCache('accounts:');
+    return response.data;
+  },
+};

--- a/frontend/src/types/account.ts
+++ b/frontend/src/types/account.ts
@@ -33,6 +33,7 @@ export interface Account {
   currencyCode: string;
   accountNumber: string | null;
   institution: string | null;
+  institutionId: string | null;
   openingBalance: number;
   currentBalance: number;
   creditLimit: number | null;
@@ -76,6 +77,7 @@ export interface CreateAccountData {
   currencyCode: string;
   accountNumber?: string;
   institution?: string;
+  institutionId?: string | null;
   openingBalance?: number;
   creditLimit?: number;
   interestRate?: number;

--- a/frontend/src/types/institution.ts
+++ b/frontend/src/types/institution.ts
@@ -1,0 +1,20 @@
+export interface Institution {
+  id: string;
+  userId: string;
+  name: string;
+  website: string;
+  country: string | null;
+  hasLogo: boolean;
+  logoFetchedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  accountCount: number;
+}
+
+export interface CreateInstitutionData {
+  name: string;
+  website: string;
+  country?: string;
+}
+
+export type UpdateInstitutionData = Partial<CreateInstitutionData>;


### PR DESCRIPTION
Introduce a per-user registry of banks/brokerages (Institutions), modelled
on the existing Payee feature. Accounts can be assigned to an institution
from the account form or from the new Tools > Institutions page.

Backend:
- Institution entity (name, required website, optional country) with the
  brand favicon cached in the database (logo_data bytea + content type).
- The favicon is fetched server-side from Google's gstatic faviconV2
  endpoint (InstitutionLogoService), so the user's browser never contacts a
  third party. Best-effort: creation never fails if the fetch does.
- CRUD controller plus GET /institutions/:id/logo (streams the cached bytes,
  cookie-authenticated) and GET/POST/DELETE /institutions/:id/accounts to
  view and add/remove an institution's accounts.
- New institution_id FK on accounts (ON DELETE SET NULL) with ownership
  validation on account create/update. Migration 082 + schema.sql.

Frontend:
- /institutions Tools page: list, create/edit modal, and an accounts manager
  to add/remove accounts. Account form replaces the free-text institution
  box with an institution selector that can create one inline.
- The institution brand icon renders in the account list at Normal and
  Compact density and is hidden at Dense density, with a neutral fallback
  badge served from our own backend.

Fully internationalized (en/pl/xx) with backend + frontend tests.

https://claude.ai/code/session_01JDX2DJBUTR4661X3G7RYqM