### PR TITLE
Institutions page and account info widget improvements

### DIFF
--- a/backend/src/database/database.module.ts
+++ b/backend/src/database/database.module.ts
@@ -4,10 +4,16 @@ import { User } from "../users/entities/user.entity";
 import { SeedService } from "./seed.service";
 import { DemoSeedService } from "./demo-seed.service";
 import { DemoResetService } from "./demo-reset.service";
+import { InstitutionLogoService } from "../institutions/institution-logo.service";
 
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
-  providers: [SeedService, DemoSeedService, DemoResetService],
+  providers: [
+    SeedService,
+    DemoSeedService,
+    DemoResetService,
+    InstitutionLogoService,
+  ],
   exports: [SeedService, DemoSeedService],
 })
 export class DatabaseModule {}

--- a/backend/src/database/demo-reset.service.spec.ts
+++ b/backend/src/database/demo-reset.service.spec.ts
@@ -114,14 +114,19 @@ describe("DemoResetService", () => {
         .filter((call: string[]) => call[0].includes("DELETE FROM"))
         .map((call: string[]) => call[0]);
 
-      // Should delete 17 tables in FK-safe order
-      expect(deleteCalls.length).toBe(17);
+      // Should delete 18 tables in FK-safe order
+      expect(deleteCalls.length).toBe(18);
 
       // First deletes should be the leaf dependencies
       expect(deleteCalls[0]).toContain("investment_transactions");
       expect(deleteCalls[1]).toContain("holdings");
       expect(deleteCalls[2]).toContain("security_prices");
       expect(deleteCalls[3]).toContain("securities");
+
+      // Institutions are removed after accounts (FK-safe).
+      expect(deleteCalls).toContain(
+        "DELETE FROM institutions WHERE user_id = $1",
+      );
 
       // Last deletes should be the root tables
       expect(deleteCalls[deleteCalls.length - 1]).toContain("user_preferences");

--- a/backend/src/database/demo-reset.service.ts
+++ b/backend/src/database/demo-reset.service.ts
@@ -94,6 +94,11 @@ export class DemoResetService {
       await queryRunner.query("DELETE FROM accounts WHERE user_id = $1", [
         userId,
       ]);
+      // Institutions are referenced by accounts (institution_id FK); delete
+      // after accounts so the re-seed recreates them without duplicates.
+      await queryRunner.query("DELETE FROM institutions WHERE user_id = $1", [
+        userId,
+      ]);
       await queryRunner.query("DELETE FROM categories WHERE user_id = $1", [
         userId,
       ]);

--- a/backend/src/database/demo-seed-data/institutions.ts
+++ b/backend/src/database/demo-seed-data/institutions.ts
@@ -1,0 +1,19 @@
+export interface DemoInstitution {
+  /** Must match the `institution` name used on demo accounts (accounts.ts). */
+  name: string;
+  website: string;
+  country: string;
+}
+
+/**
+ * Institutions referenced by the demo accounts. Seeding these (and linking
+ * accounts via institution_id) lets the demo show institution names and brand
+ * logos, and populates the Institutions page.
+ */
+export const demoInstitutions: DemoInstitution[] = [
+  { name: "TD Canada Trust", website: "https://www.td.com", country: "CA" },
+  { name: "EQ Bank", website: "https://www.eqbank.ca", country: "CA" },
+  { name: "CIBC", website: "https://www.cibc.com", country: "CA" },
+  { name: "Scotiabank", website: "https://www.scotiabank.com", country: "CA" },
+  { name: "Questrade", website: "https://www.questrade.com", country: "CA" },
+];

--- a/backend/src/database/demo-seed.service.spec.ts
+++ b/backend/src/database/demo-seed.service.spec.ts
@@ -2,7 +2,9 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { DataSource } from "typeorm";
 import { DemoSeedService } from "./demo-seed.service";
 import { SeedService } from "./seed.service";
+import { InstitutionLogoService } from "../institutions/institution-logo.service";
 import { demoAccounts } from "./demo-seed-data/accounts";
+import { demoInstitutions } from "./demo-seed-data/institutions";
 import { demoPayees } from "./demo-seed-data/payees";
 import { demoScheduledTransactions } from "./demo-seed-data/scheduled";
 import { demoSecurities } from "./demo-seed-data/securities";
@@ -12,6 +14,7 @@ describe("DemoSeedService", () => {
   let service: DemoSeedService;
   let dataSource: Record<string, jest.Mock>;
   let seedService: Record<string, jest.Mock>;
+  let logoService: Record<string, jest.Mock>;
 
   beforeEach(async () => {
     dataSource = {
@@ -22,11 +25,16 @@ describe("DemoSeedService", () => {
       seedAll: jest.fn().mockResolvedValue(undefined),
     };
 
+    logoService = {
+      fetchFavicon: jest.fn().mockResolvedValue(null),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DemoSeedService,
         { provide: DataSource, useValue: dataSource },
         { provide: SeedService, useValue: seedService },
+        { provide: InstitutionLogoService, useValue: logoService },
       ],
     }).compile();
 
@@ -129,6 +137,48 @@ describe("DemoSeedService", () => {
           (call[0] as string).includes("true"),
       );
       expect(incomeInserts.length).toBe(4);
+    });
+
+    it("seeds an institution for each distinct demo institution", async () => {
+      await service.seedDemoData("user-123");
+
+      const institutionCalls = dataSource.query.mock.calls.filter(
+        (call: string[]) => call[0].includes("INSERT INTO institutions"),
+      );
+      expect(institutionCalls.length).toBe(demoInstitutions.length);
+    });
+
+    it("links accounts to their institution via institution_id", async () => {
+      // Return a stable id per institution insert so we can assert linkage.
+      dataSource.query.mockImplementation((sql: string, params?: unknown[]) => {
+        if (sql.includes("INSERT INTO institutions")) {
+          return Promise.resolve([{ id: `inst-${params?.[1] as string}` }]);
+        }
+        if (sql.includes("RETURNING id")) {
+          return Promise.resolve([{ id: `uuid-${Math.random()}` }]);
+        }
+        if (sql.includes("COALESCE(SUM")) {
+          return Promise.resolve([{ total: "0" }]);
+        }
+        return Promise.resolve([]);
+      });
+
+      await service.seedDemoData("user-123");
+
+      const accountInserts = dataSource.query.mock.calls.filter(
+        (call: string[]) => call[0].includes("INSERT INTO accounts"),
+      );
+      // Every INSERT INTO accounts statement carries an institution_id column.
+      for (const call of accountInserts) {
+        expect(call[0]).toContain("institution_id");
+      }
+      // At least one account is linked to a seeded institution id.
+      const linked = accountInserts.some((call: unknown[]) =>
+        (call[1] as unknown[]).some(
+          (p) => typeof p === "string" && p.startsWith("inst-"),
+        ),
+      );
+      expect(linked).toBe(true);
     });
 
     it("seeds all demo accounts", async () => {

--- a/backend/src/database/demo-seed.service.ts
+++ b/backend/src/database/demo-seed.service.ts
@@ -2,7 +2,9 @@ import { Injectable, Logger } from "@nestjs/common";
 import { DataSource } from "typeorm";
 
 import { SeedService } from "./seed.service";
+import { InstitutionLogoService } from "../institutions/institution-logo.service";
 import { demoAccounts } from "./demo-seed-data/accounts";
+import { demoInstitutions } from "./demo-seed-data/institutions";
 import { demoPayees } from "./demo-seed-data/payees";
 import { generateTransactions } from "./demo-seed-data/transactions";
 import { demoScheduledTransactions } from "./demo-seed-data/scheduled";
@@ -20,6 +22,7 @@ export class DemoSeedService {
   constructor(
     private dataSource: DataSource,
     private seedService: SeedService,
+    private logoService: InstitutionLogoService,
   ) {}
 
   /**
@@ -86,6 +89,11 @@ export class DemoSeedService {
     await this.dataSource.query("DELETE FROM accounts WHERE user_id = $1", [
       demoUser.id,
     ]);
+    // Institutions are referenced by accounts (institution_id FK); delete after
+    // accounts so the re-seed recreates them without duplicates.
+    await this.dataSource.query("DELETE FROM institutions WHERE user_id = $1", [
+      demoUser.id,
+    ]);
     await this.dataSource.query("DELETE FROM categories WHERE user_id = $1", [
       demoUser.id,
     ]);
@@ -105,7 +113,8 @@ export class DemoSeedService {
    */
   async seedDemoData(userId: string): Promise<void> {
     const categoryMap = await this.seedCategories(userId);
-    const accountMap = await this.seedAccounts(userId);
+    const institutionMap = await this.seedInstitutions(userId);
+    const accountMap = await this.seedAccounts(userId, institutionMap);
     const payeeMap = await this.seedPayees(userId, categoryMap);
     await this.seedTransactions(userId, accountMap, categoryMap, payeeMap);
     await this.seedScheduledTransactions(
@@ -225,7 +234,54 @@ export class DemoSeedService {
     return categoryMap;
   }
 
-  private async seedAccounts(userId: string): Promise<Map<string, string>> {
+  /**
+   * Seed the institutions referenced by the demo accounts and return a map of
+   * institution name -> id for linking. Brand logos are fetched best-effort:
+   * when the favicon resolver is unreachable the institution simply renders
+   * with its letter-badge fallback, exactly as a real best-effort create would.
+   */
+  private async seedInstitutions(userId: string): Promise<Map<string, string>> {
+    this.logger.log("Seeding demo institutions");
+
+    const institutionMap = new Map<string, string>();
+
+    const logos = await Promise.all(
+      demoInstitutions.map((inst) =>
+        this.logoService.fetchFavicon(inst.website).catch(() => null),
+      ),
+    );
+
+    for (let i = 0; i < demoInstitutions.length; i++) {
+      const inst = demoInstitutions[i];
+      const logo = logos[i];
+      const result = await this.dataSource.query(
+        `INSERT INTO institutions (
+          user_id, name, website, country,
+          logo_data, logo_content_type, has_logo, logo_fetched_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        RETURNING id`,
+        [
+          userId,
+          inst.name,
+          inst.website,
+          inst.country,
+          logo ? logo.data : null,
+          logo ? logo.contentType : null,
+          logo ? true : false,
+          logo ? new Date().toISOString() : null,
+        ],
+      );
+      institutionMap.set(inst.name, result[0].id);
+    }
+
+    this.logger.log(`Seeded ${institutionMap.size} institutions`);
+    return institutionMap;
+  }
+
+  private async seedAccounts(
+    userId: string,
+    institutionMap: Map<string, string>,
+  ): Promise<Map<string, string>> {
     this.logger.log("Seeding demo accounts");
 
     const accountMap = new Map<string, string>();
@@ -237,13 +293,16 @@ export class DemoSeedService {
     const createdAtStr = createdAt.toISOString();
 
     for (const acc of demoAccounts) {
+      const institutionId = acc.institution
+        ? (institutionMap.get(acc.institution) ?? null)
+        : null;
       if (acc.isInvestmentPair) {
         // Create investment account pair: cash + brokerage with bidirectional linking
         const [cashAccount] = await this.dataSource.query(
           `INSERT INTO accounts (
             user_id, account_type, account_sub_type, name, description, currency_code,
-            opening_balance, current_balance, institution, is_favourite, created_at
-          ) VALUES ($1, 'INVESTMENT', 'INVESTMENT_CASH', $2, $3, $4, $5, $6, $7, $8, $9)
+            opening_balance, current_balance, institution, institution_id, is_favourite, created_at
+          ) VALUES ($1, 'INVESTMENT', 'INVESTMENT_CASH', $2, $3, $4, $5, $6, $7, $8, $9, $10)
           RETURNING id`,
           [
             userId,
@@ -253,6 +312,7 @@ export class DemoSeedService {
             acc.openingBalance,
             acc.openingBalance,
             acc.institution || null,
+            institutionId,
             acc.isFavourite || false,
             createdAtStr,
           ],
@@ -261,9 +321,9 @@ export class DemoSeedService {
         const [brokerageAccount] = await this.dataSource.query(
           `INSERT INTO accounts (
             user_id, account_type, account_sub_type, name, description, currency_code,
-            opening_balance, current_balance, institution, is_favourite,
+            opening_balance, current_balance, institution, institution_id, is_favourite,
             linked_account_id, created_at
-          ) VALUES ($1, 'INVESTMENT', 'INVESTMENT_BROKERAGE', $2, $3, $4, 0, 0, $5, $6, $7, $8)
+          ) VALUES ($1, 'INVESTMENT', 'INVESTMENT_BROKERAGE', $2, $3, $4, 0, 0, $5, $6, $7, $8, $9)
           RETURNING id`,
           [
             userId,
@@ -271,6 +331,7 @@ export class DemoSeedService {
             acc.description,
             acc.currency,
             acc.institution || null,
+            institutionId,
             acc.isFavourite || false,
             cashAccount.id,
             createdAtStr,
@@ -292,11 +353,11 @@ export class DemoSeedService {
           `INSERT INTO accounts (
             user_id, account_type, name, description, currency_code,
             opening_balance, current_balance, credit_limit, interest_rate,
-            institution, is_favourite,
+            institution, institution_id, is_favourite,
             is_canadian_mortgage, is_variable_rate, term_months, amortization_months, original_principal,
             payment_amount, payment_frequency,
             created_at
-          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
           RETURNING id`,
           [
             userId,
@@ -309,6 +370,7 @@ export class DemoSeedService {
             acc.creditLimit || null,
             acc.interestRate || null,
             acc.institution || null,
+            institutionId,
             acc.isFavourite || false,
             acc.isCanadianMortgage || false,
             acc.isVariableRate || false,

--- a/backend/src/institutions/institutions.service.spec.ts
+++ b/backend/src/institutions/institutions.service.spec.ts
@@ -24,7 +24,10 @@ describe("InstitutionsService", () => {
     ...overrides,
   });
 
-  const chainableQb = (result: unknown, method: "getRawMany" | "getOne") => {
+  const chainableQb = (
+    result: unknown,
+    method: "getRawMany" | "getOne" | "getCount",
+  ) => {
     const qb: Record<string, jest.Mock> = {};
     for (const m of ["select", "addSelect", "where", "andWhere", "groupBy"]) {
       qb[m] = jest.fn(() => qb);
@@ -47,7 +50,9 @@ describe("InstitutionsService", () => {
       find: jest.fn().mockResolvedValue([]),
       findOne: jest.fn(),
       save: jest.fn((x) => Promise.resolve(x)),
-      createQueryBuilder: jest.fn(),
+      // Default: the logical-account count query resolves to 0. Individual
+      // tests override this to assert specific counts.
+      createQueryBuilder: jest.fn(() => chainableQb(0, "getCount")),
     };
     logoService = { fetchFavicon: jest.fn().mockResolvedValue(null) };
     actionHistory = { record: jest.fn() };
@@ -156,6 +161,24 @@ describe("InstitutionsService", () => {
       expect(result.find((i) => i.id === "inst-1")!.accountCount).toBe(2);
       expect(result.find((i) => i.id === "inst-2")!.accountCount).toBe(0);
     });
+
+    it("excludes the cash half of a linked investment pair from the counts", async () => {
+      institutionsRepo.find.mockResolvedValue([buildInstitution({ id: "inst-1" })]);
+      const qb = chainableQb(
+        [{ institution_id: "inst-1", count: "1" }],
+        "getRawMany",
+      );
+      accountsRepo.createQueryBuilder.mockReturnValue(qb);
+
+      await service.findAll(userId);
+
+      // A linked brokerage/cash pair counts once: the cash sub-account is
+      // filtered out so the pair is represented by the brokerage account alone.
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining("account_sub_type"),
+        { cashSubType: "INVESTMENT_CASH" },
+      );
+    });
   });
 
   describe("findOne()", () => {
@@ -166,11 +189,17 @@ describe("InstitutionsService", () => {
       );
     });
 
-    it("returns the institution with its account count", async () => {
+    it("returns the institution with its logical account count", async () => {
       institutionsRepo.findOne.mockResolvedValue(buildInstitution());
-      accountsRepo.count.mockResolvedValue(4);
+      const qb = chainableQb(4, "getCount");
+      accountsRepo.createQueryBuilder.mockReturnValue(qb);
       const result = await service.findOne(userId, "inst-1");
       expect(result.accountCount).toBe(4);
+      // The cash half of a linked investment pair is excluded from the count.
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining("account_sub_type"),
+        { cashSubType: "INVESTMENT_CASH" },
+      );
     });
   });
 

--- a/backend/src/institutions/institutions.service.ts
+++ b/backend/src/institutions/institutions.service.ts
@@ -8,7 +8,11 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { Repository, DataSource } from "typeorm";
 import { tr } from "../i18n/translate";
 import { Institution } from "./entities/institution.entity";
-import { Account, AccountType } from "../accounts/entities/account.entity";
+import {
+  Account,
+  AccountType,
+  AccountSubType,
+} from "../accounts/entities/account.entity";
 import { CreateInstitutionDto } from "./dto/create-institution.dto";
 import { UpdateInstitutionDto } from "./dto/update-institution.dto";
 import {
@@ -93,13 +97,29 @@ export class InstitutionsService {
     }
   }
 
+  /**
+   * Base query that counts a user's accounts treating a linked brokerage/cash
+   * investment pair as a single logical account. The cash half is a
+   * sub-account of its brokerage partner, so it is excluded from the count and
+   * the pair is represented by the brokerage (main) account alone.
+   */
+  private logicalAccountsQuery(userId: string) {
+    return this.accountsRepository
+      .createQueryBuilder("account")
+      .where("account.user_id = :userId", { userId })
+      .andWhere(
+        "NOT (account.account_sub_type = :cashSubType AND account.linked_account_id IS NOT NULL)",
+        { cashSubType: AccountSubType.INVESTMENT_CASH },
+      );
+  }
+
   private async countAccounts(
     userId: string,
     institutionId: string,
   ): Promise<number> {
-    return this.accountsRepository.count({
-      where: { userId, institutionId },
-    });
+    return this.logicalAccountsQuery(userId)
+      .andWhere("account.institution_id = :institutionId", { institutionId })
+      .getCount();
   }
 
   async create(
@@ -159,11 +179,9 @@ export class InstitutionsService {
       return [];
     }
 
-    const counts = await this.accountsRepository
-      .createQueryBuilder("account")
+    const counts = await this.logicalAccountsQuery(userId)
       .select("account.institution_id", "institution_id")
       .addSelect("COUNT(*)", "count")
-      .where("account.user_id = :userId", { userId })
       .andWhere("account.institution_id IS NOT NULL")
       .groupBy("account.institution_id")
       .getRawMany<{ institution_id: string; count: string }>();

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -20,16 +20,20 @@ export async function registerUser(
   await page.getByLabel(/confirm password/i).fill(password);
   await page.getByRole('button', { name: /create account|register|sign up/i }).click();
 
-  // After submitting we either land on the dashboard directly or hit an
-  // optional 2FA-setup step. Race the two so the happy path doesn't sit
-  // through a fixed wait, then skip the 2FA step if it appeared.
+  // After submitting we either land on the dashboard directly or pass through
+  // optional onboarding steps before it: a 2FA-setup step and a preferences
+  // step, each offering a "Skip for now" button. Race the dashboard against the
+  // skip button and skip whichever step appears until we reach the dashboard.
   const skipButton = page.getByRole('button', { name: /skip for now/i });
-  await Promise.race([
-    page.waitForURL(/\/dashboard/, { timeout: 15000 }).catch(() => {}),
-    skipButton.waitFor({ state: 'visible', timeout: 15000 }).catch(() => {}),
-  ]);
-  if (await skipButton.isVisible().catch(() => false)) {
-    await skipButton.click();
+  for (let step = 0; step < 2; step++) {
+    await Promise.race([
+      page.waitForURL(/\/dashboard/, { timeout: 15000 }).catch(() => {}),
+      skipButton.waitFor({ state: 'visible', timeout: 15000 }).catch(() => {}),
+    ]);
+    if (/\/dashboard/.test(page.url())) break;
+    if (await skipButton.isVisible().catch(() => false)) {
+      await skipButton.click();
+    }
   }
 
   await page.waitForURL(/\/dashboard/, { timeout: 15000 });

--- a/frontend/src/app/accounts/page.tsx
+++ b/frontend/src/app/accounts/page.tsx
@@ -1,16 +1,12 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import toast from 'react-hot-toast';
 import { useTranslations } from 'next-intl';
 import { useOnUndoRedo } from '@/hooks/useOnUndoRedo';
 import { Button } from '@/components/ui/Button';
-import dynamic from 'next/dynamic';
 
-const AccountForm = dynamic(() => import('@/components/accounts/AccountForm').then(m => m.AccountForm), { ssr: false });
 import { AccountList } from '@/components/accounts/AccountList';
-import { Modal } from '@/components/ui/Modal';
-import { UnsavedChangesDialog } from '@/components/ui/UnsavedChangesDialog';
+import { AccountFormModal } from '@/components/accounts/AccountFormModal';
 import { accountsApi } from '@/lib/accounts';
 import { investmentsApi } from '@/lib/investments';
 import { institutionsApi } from '@/lib/institutions';
@@ -45,7 +41,8 @@ function AccountsContent() {
   const [institutions, setInstitutions] = useState<Institution[]>([]);
   const [portfolioSummary, setPortfolioSummary] = useState<PortfolioSummary | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const { showForm, editingItem, openCreate, openEdit, close, isEditing, modalProps, setFormDirty, unsavedChangesDialog, formSubmitRef } = useFormModal<Account>();
+  const formModal = useFormModal<Account>();
+  const { openCreate, openEdit } = formModal;
   const { convertToDefault, defaultCurrency } = useExchangeRates();
   const { formatCurrency } = useNumberFormat();
 
@@ -85,51 +82,6 @@ function AccountsContent() {
     }
     return map;
   }, [portfolioSummary]);
-
-  const handleFormSubmit = async (data: any) => {
-    try {
-      const cleanedData = {
-        ...data,
-        openingBalance: data.openingBalance || data.openingBalance === 0 ? data.openingBalance : undefined,
-        creditLimit: data.creditLimit || data.creditLimit === 0 ? data.creditLimit : undefined,
-        interestRate: data.interestRate || data.interestRate === 0 ? data.interestRate : undefined,
-      };
-
-      // LOAN/MORTGAGE store openingBalance as negative. The form shows the
-      // absolute amount ("Loan Amount" / "Mortgage Amount"), so negate it when
-      // saving an update. Backend handles negation on create for these types.
-      // All other account types (including CREDIT_CARD, LINE_OF_CREDIT) let the
-      // user type the sign directly, so no auto-negation is applied.
-      const effectiveType = cleanedData.accountType || editingItem?.accountType;
-      if (
-        cleanedData.openingBalance != null &&
-        cleanedData.openingBalance > 0 &&
-        (effectiveType === 'LOAN' || effectiveType === 'MORTGAGE') &&
-        editingItem
-      ) {
-        cleanedData.openingBalance = -cleanedData.openingBalance;
-      }
-
-      Object.keys(cleanedData).forEach(key => {
-        if (cleanedData[key] === undefined || cleanedData[key] === '' || (typeof cleanedData[key] === 'number' && isNaN(cleanedData[key]))) {
-          delete cleanedData[key];
-        }
-      });
-
-      if (editingItem) {
-        await accountsApi.update(editingItem.id, cleanedData);
-        toast.success(t('toast.updateSuccess'));
-      } else {
-        await accountsApi.create(cleanedData);
-        toast.success(t('toast.createSuccess'));
-      }
-      close();
-      loadAccounts();
-    } catch (error) {
-      showErrorToast(error, `Failed to ${editingItem ? 'update' : 'create'} account`);
-      throw error;
-    }
-  };
 
   const calculateSummary = () => {
     const activeAccounts = accounts.filter((a) => !a.isClosed);
@@ -197,19 +149,7 @@ function AccountsContent() {
         </div>
 
         {/* Form Modal */}
-        <Modal isOpen={showForm} onClose={close} {...modalProps} maxWidth="2xl" className="p-6">
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">
-            {isEditing ? t('page.editAccountModal') : t('page.newAccountModal')}
-          </h2>
-          <AccountForm
-            account={editingItem}
-            onSubmit={handleFormSubmit}
-            onCancel={close}
-            onDirtyChange={setFormDirty}
-            submitRef={formSubmitRef}
-          />
-        </Modal>
-        <UnsavedChangesDialog {...unsavedChangesDialog} />
+        <AccountFormModal formModal={formModal} onSaved={loadAccounts} />
 
         {/* Accounts List */}
         <div className="bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg overflow-hidden">

--- a/frontend/src/app/institutions/page.test.tsx
+++ b/frontend/src/app/institutions/page.test.tsx
@@ -33,6 +33,13 @@ vi.mock('@/lib/constants', () => ({ PAGE_SIZE: 25 }));
 const mockGetAll = vi.fn();
 const mockCreate = vi.fn();
 const mockUpdate = vi.fn();
+const mockAccountsGetAll = vi.fn();
+
+vi.mock('@/lib/accounts', () => ({
+  accountsApi: {
+    getAll: (...a: any[]) => mockAccountsGetAll(...a),
+  },
+}));
 
 vi.mock('@/lib/institutions', () => ({
   institutionsApi: {
@@ -137,6 +144,7 @@ describe('InstitutionsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetAll.mockResolvedValue(mockInstitutions);
+    mockAccountsGetAll.mockResolvedValue([]);
   });
 
   it('renders the header, subtitle and summary cards', async () => {

--- a/frontend/src/app/institutions/page.tsx
+++ b/frontend/src/app/institutions/page.tsx
@@ -12,7 +12,9 @@ import { InstitutionForm } from '@/components/institutions/InstitutionForm';
 import { InstitutionList } from '@/components/institutions/InstitutionList';
 import { InstitutionAccountsManager } from '@/components/institutions/InstitutionAccountsManager';
 import { institutionsApi } from '@/lib/institutions';
+import { accountsApi } from '@/lib/accounts';
 import { Institution } from '@/types/institution';
+import { Account } from '@/types/account';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { SummaryCard, SummaryIcons } from '@/components/ui/SummaryCard';
@@ -38,8 +40,10 @@ export default function InstitutionsPage() {
 function InstitutionsContent() {
   const t = useTranslations('institutions');
   const [institutions, setInstitutions] = useState<Institution[]>([]);
+  const [accounts, setAccounts] = useState<Account[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
+  const [filterStatus, setFilterStatus] = useState<'active' | 'closed' | ''>('');
   const [currentPage, setCurrentPage] = useState(1);
   const [managing, setManaging] = useState<Institution | null>(null);
   const [listDensity, setListDensity] = useLocalStorage<DensityLevel>(
@@ -62,8 +66,14 @@ function InstitutionsContent() {
   const loadData = useCallback(async () => {
     setIsLoading(true);
     try {
-      const data = await institutionsApi.getAll();
+      // Accounts are loaded to derive each institution's active/closed status
+      // (an institution has no status of its own).
+      const [data, accountsData] = await Promise.all([
+        institutionsApi.getAll(),
+        accountsApi.getAll(true).catch(() => [] as Account[]),
+      ]);
       setInstitutions(data);
+      setAccounts(accountsData);
     } catch (error) {
       toast.error(getErrorMessage(error, t('page.toasts.loadFailed')));
       logger.error(error);
@@ -110,18 +120,46 @@ function InstitutionsContent() {
     }
   };
 
+  // Per-institution account status: an institution is "active" if it has any
+  // open account and "closed" if it has any closed account (mirrors the
+  // account-level filter). Institutions with no accounts have neither.
+  const statusByInstitution = useMemo(() => {
+    const map = new Map<string, { hasActive: boolean; hasClosed: boolean }>();
+    for (const account of accounts) {
+      if (!account.institutionId) continue;
+      const entry = map.get(account.institutionId) ?? {
+        hasActive: false,
+        hasClosed: false,
+      };
+      if (account.isClosed) entry.hasClosed = true;
+      else entry.hasActive = true;
+      map.set(account.institutionId, entry);
+    }
+    return map;
+  }, [accounts]);
+
   const filteredInstitutions = useMemo(() => {
-    const sorted = [...institutions].sort((a, b) =>
+    let result = [...institutions].sort((a, b) =>
       a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
     );
-    if (!searchQuery) return sorted;
-    const q = searchQuery.toLowerCase();
-    return sorted.filter(
-      (i) =>
-        i.name.toLowerCase().includes(q) ||
-        i.website.toLowerCase().includes(q),
-    );
-  }, [institutions, searchQuery]);
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter(
+        (i) =>
+          i.name.toLowerCase().includes(q) ||
+          i.website.toLowerCase().includes(q) ||
+          (i.country?.toLowerCase().includes(q) ?? false),
+      );
+    }
+    if (filterStatus) {
+      result = result.filter((i) => {
+        const status = statusByInstitution.get(i.id);
+        if (!status) return false;
+        return filterStatus === 'active' ? status.hasActive : status.hasClosed;
+      });
+    }
+    return result;
+  }, [institutions, searchQuery, filterStatus, statusByInstitution]);
 
   const totalPages = Math.ceil(filteredInstitutions.length / PAGE_SIZE);
   const paginatedInstitutions = useMemo(() => {
@@ -131,7 +169,7 @@ function InstitutionsContent() {
 
   useEffect(() => {
     setCurrentPage(1);
-  }, [searchQuery]);
+  }, [searchQuery, filterStatus]);
 
   const goToPage = (page: number) => {
     if (page >= 1 && page <= totalPages) {
@@ -173,7 +211,7 @@ function InstitutionsContent() {
           />
         </div>
 
-        <div className="mb-6">
+        <div className="mb-6 flex flex-col sm:flex-row sm:items-center gap-3">
           <input
             type="text"
             placeholder={t('page.searchPlaceholder')}
@@ -181,6 +219,41 @@ function InstitutionsContent() {
             onChange={(e) => setSearchQuery(e.target.value)}
             className="block w-full sm:max-w-md rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400"
           />
+          <div className="inline-flex rounded-md shadow-sm">
+            <button
+              type="button"
+              onClick={() => setFilterStatus('')}
+              className={`px-3 py-1.5 text-sm font-medium rounded-l-md border ${
+                filterStatus === ''
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+              }`}
+            >
+              {t('list.statusFilter.all')}
+            </button>
+            <button
+              type="button"
+              onClick={() => setFilterStatus('active')}
+              className={`px-3 py-1.5 text-sm font-medium border-t border-b ${
+                filterStatus === 'active'
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+              }`}
+            >
+              {t('list.statusFilter.active')}
+            </button>
+            <button
+              type="button"
+              onClick={() => setFilterStatus('closed')}
+              className={`px-3 py-1.5 text-sm font-medium rounded-r-md border ${
+                filterStatus === 'closed'
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+              }`}
+            >
+              {t('list.statusFilter.closed')}
+            </button>
+          </div>
         </div>
 
         <Modal isOpen={showForm} onClose={close} {...modalProps} maxWidth="lg" className="p-6">

--- a/frontend/src/app/institutions/page.tsx
+++ b/frontend/src/app/institutions/page.tsx
@@ -19,7 +19,7 @@ import { SummaryCard, SummaryIcons } from '@/components/ui/SummaryCard';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { useFormModal } from '@/hooks/useFormModal';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
-import { DensityLevel, nextDensity } from '@/hooks/useTableDensity';
+import { DensityLevel } from '@/hooks/useTableDensity';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { createLogger } from '@/lib/logger';
 import { getErrorMessage } from '@/lib/errors';
@@ -173,7 +173,7 @@ function InstitutionsContent() {
           />
         </div>
 
-        <div className="mb-6 flex items-center justify-between gap-3">
+        <div className="mb-6">
           <input
             type="text"
             placeholder={t('page.searchPlaceholder')}
@@ -181,23 +181,6 @@ function InstitutionsContent() {
             onChange={(e) => setSearchQuery(e.target.value)}
             className="block w-full sm:max-w-md rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400"
           />
-          <button
-            type="button"
-            onClick={() => setListDensity(nextDensity(listDensity))}
-            className="inline-flex items-center px-2 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 rounded flex-shrink-0"
-            title={t('list.density.title')}
-          >
-            <svg className="w-4 h-4 sm:mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
-            <span className="hidden sm:inline">
-              {listDensity === 'normal'
-                ? t('list.density.normal')
-                : listDensity === 'compact'
-                  ? t('list.density.compact')
-                  : t('list.density.dense')}
-            </span>
-          </button>
         </div>
 
         <Modal isOpen={showForm} onClose={close} {...modalProps} maxWidth="lg" className="p-6">
@@ -226,6 +209,7 @@ function InstitutionsContent() {
               }
               onManageAccounts={setManaging}
               density={listDensity}
+              onDensityChange={setListDensity}
             />
           )}
         </div>

--- a/frontend/src/app/institutions/page.tsx
+++ b/frontend/src/app/institutions/page.tsx
@@ -18,6 +18,8 @@ import { PageHeader } from '@/components/layout/PageHeader';
 import { SummaryCard, SummaryIcons } from '@/components/ui/SummaryCard';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { useFormModal } from '@/hooks/useFormModal';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { DensityLevel, nextDensity } from '@/hooks/useTableDensity';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { createLogger } from '@/lib/logger';
 import { getErrorMessage } from '@/lib/errors';
@@ -40,6 +42,10 @@ function InstitutionsContent() {
   const [searchQuery, setSearchQuery] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [managing, setManaging] = useState<Institution | null>(null);
+  const [listDensity, setListDensity] = useLocalStorage<DensityLevel>(
+    'monize-institutions-density',
+    'normal',
+  );
   const {
     showForm,
     editingItem,
@@ -167,7 +173,7 @@ function InstitutionsContent() {
           />
         </div>
 
-        <div className="mb-6">
+        <div className="mb-6 flex items-center justify-between gap-3">
           <input
             type="text"
             placeholder={t('page.searchPlaceholder')}
@@ -175,6 +181,23 @@ function InstitutionsContent() {
             onChange={(e) => setSearchQuery(e.target.value)}
             className="block w-full sm:max-w-md rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400"
           />
+          <button
+            type="button"
+            onClick={() => setListDensity(nextDensity(listDensity))}
+            className="inline-flex items-center px-2 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 rounded flex-shrink-0"
+            title={t('list.density.title')}
+          >
+            <svg className="w-4 h-4 sm:mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+            <span className="hidden sm:inline">
+              {listDensity === 'normal'
+                ? t('list.density.normal')
+                : listDensity === 'compact'
+                  ? t('list.density.compact')
+                  : t('list.density.dense')}
+            </span>
+          </button>
         </div>
 
         <Modal isOpen={showForm} onClose={close} {...modalProps} maxWidth="lg" className="p-6">
@@ -202,6 +225,7 @@ function InstitutionsContent() {
                 setInstitutions((prev) => prev.filter((i) => i.id !== deletedId))
               }
               onManageAccounts={setManaging}
+              density={listDensity}
             />
           )}
         </div>

--- a/frontend/src/app/institutions/page.tsx
+++ b/frontend/src/app/institutions/page.tsx
@@ -9,10 +9,14 @@ import { Pagination } from '@/components/ui/Pagination';
 import { Modal } from '@/components/ui/Modal';
 import { UnsavedChangesDialog } from '@/components/ui/UnsavedChangesDialog';
 import { InstitutionForm } from '@/components/institutions/InstitutionForm';
-import { InstitutionList } from '@/components/institutions/InstitutionList';
+import {
+  InstitutionList,
+  type InstitutionSortField,
+} from '@/components/institutions/InstitutionList';
 import { InstitutionAccountsManager } from '@/components/institutions/InstitutionAccountsManager';
 import { institutionsApi } from '@/lib/institutions';
 import { accountsApi } from '@/lib/accounts';
+import { countLogicalAccounts } from '@/lib/account-utils';
 import { Institution } from '@/types/institution';
 import { Account } from '@/types/account';
 import { PageLayout } from '@/components/layout/PageLayout';
@@ -44,6 +48,8 @@ function InstitutionsContent() {
   const [isLoading, setIsLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const [filterStatus, setFilterStatus] = useState<'active' | 'closed' | ''>('');
+  const [sortField, setSortField] = useState<InstitutionSortField>('name');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const [currentPage, setCurrentPage] = useState(1);
   const [managing, setManaging] = useState<Institution | null>(null);
   const [listDensity, setListDensity] = useLocalStorage<DensityLevel>(
@@ -120,28 +126,42 @@ function InstitutionsContent() {
     }
   };
 
-  // Per-institution account status: an institution is "active" if it has any
-  // open account and "closed" if it has any closed account (mirrors the
-  // account-level filter). Institutions with no accounts have neither.
-  const statusByInstitution = useMemo(() => {
-    const map = new Map<string, { hasActive: boolean; hasClosed: boolean }>();
+  // Logical (pair-aware) account counts per institution, split by status, so
+  // the Accounts column can reflect the All/Active/Closed filter without
+  // hiding any institution rows.
+  const accountCountByStatus = useMemo(() => {
+    const groups = new Map<string, Account[]>();
     for (const account of accounts) {
       if (!account.institutionId) continue;
-      const entry = map.get(account.institutionId) ?? {
-        hasActive: false,
-        hasClosed: false,
-      };
-      if (account.isClosed) entry.hasClosed = true;
-      else entry.hasActive = true;
-      map.set(account.institutionId, entry);
+      const arr = groups.get(account.institutionId) ?? [];
+      groups.set(account.institutionId, [...arr, account]);
+    }
+    const map = new Map<string, { active: number; closed: number }>();
+    for (const [id, arr] of groups) {
+      map.set(id, {
+        active: countLogicalAccounts(arr.filter((a) => !a.isClosed)),
+        closed: countLogicalAccounts(arr.filter((a) => a.isClosed)),
+      });
     }
     return map;
   }, [accounts]);
 
+  // Apply the status filter to the displayed account count (rows are kept).
+  const decoratedInstitutions = useMemo(() => {
+    if (!filterStatus) return institutions;
+    return institutions.map((i) => {
+      const counts = accountCountByStatus.get(i.id);
+      const accountCount = counts
+        ? filterStatus === 'active'
+          ? counts.active
+          : counts.closed
+        : 0;
+      return { ...i, accountCount };
+    });
+  }, [institutions, filterStatus, accountCountByStatus]);
+
   const filteredInstitutions = useMemo(() => {
-    let result = [...institutions].sort((a, b) =>
-      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
-    );
+    let result = decoratedInstitutions;
     if (searchQuery) {
       const q = searchQuery.toLowerCase();
       result = result.filter(
@@ -151,15 +171,40 @@ function InstitutionsContent() {
           (i.country?.toLowerCase().includes(q) ?? false),
       );
     }
-    if (filterStatus) {
-      result = result.filter((i) => {
-        const status = statusByInstitution.get(i.id);
-        if (!status) return false;
-        return filterStatus === 'active' ? status.hasActive : status.hasClosed;
-      });
+    const sorted = [...result].sort((a, b) => {
+      let cmp = 0;
+      switch (sortField) {
+        case 'website':
+          cmp = a.website.localeCompare(b.website, undefined, {
+            sensitivity: 'base',
+          });
+          break;
+        case 'country':
+          cmp = (a.country ?? '').localeCompare(b.country ?? '', undefined, {
+            sensitivity: 'base',
+          });
+          break;
+        case 'accounts':
+          cmp = a.accountCount - b.accountCount;
+          break;
+        default:
+          cmp = a.name.localeCompare(b.name, undefined, {
+            sensitivity: 'base',
+          });
+      }
+      return sortDirection === 'asc' ? cmp : -cmp;
+    });
+    return sorted;
+  }, [decoratedInstitutions, searchQuery, sortField, sortDirection]);
+
+  const handleSort = (field: InstitutionSortField) => {
+    if (sortField === field) {
+      setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDirection(field === 'accounts' ? 'desc' : 'asc');
     }
-    return result;
-  }, [institutions, searchQuery, filterStatus, statusByInstitution]);
+  };
 
   const totalPages = Math.ceil(filteredInstitutions.length / PAGE_SIZE);
   const paginatedInstitutions = useMemo(() => {
@@ -283,6 +328,9 @@ function InstitutionsContent() {
               onManageAccounts={setManaging}
               density={listDensity}
               onDensityChange={setListDensity}
+              sortField={sortField}
+              sortDirection={sortDirection}
+              onSort={handleSort}
             />
           )}
         </div>

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useTranslations } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import '@/lib/zodConfig';
@@ -17,6 +17,7 @@ import { useAuthStore } from '@/store/authStore';
 import { authApi, AuthMethods } from '@/lib/auth';
 import { buildPasswordSchema, buildEmailSchema } from '@/lib/zod-helpers';
 import { TwoFactorSetup } from '@/components/auth/TwoFactorSetup';
+import { OnboardingPreferences } from '@/components/auth/OnboardingPreferences';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('Register');
@@ -41,10 +42,12 @@ type RegisterFormData = z.infer<ReturnType<typeof buildRegisterSchema>>;
 export default function RegisterPage() {
   const t = useTranslations('auth.register');
   const tc = useTranslations('common');
+  const locale = useLocale();
   const router = useRouter();
   const { login } = useAuthStore();
   const [isLoading, setIsLoading] = useState(false);
   const [showTwoFactorSetup, setShowTwoFactorSetup] = useState(false);
+  const [showPreferencesSetup, setShowPreferencesSetup] = useState(false);
   const [authMethods, setAuthMethods] = useState<AuthMethods>({ local: true, oidc: false, registration: true, smtp: false, force2fa: false, demo: false });
   const [isLoadingMethods, setIsLoadingMethods] = useState(true);
 
@@ -183,9 +186,31 @@ export default function RegisterPage() {
             </p>
           </div>
           <TwoFactorSetup
-            onComplete={() => router.push('/dashboard')}
-            onSkip={authMethods.force2fa ? undefined : () => router.push('/dashboard')}
+            onComplete={() => { setShowTwoFactorSetup(false); setShowPreferencesSetup(true); }}
+            onSkip={authMethods.force2fa ? undefined : () => { setShowTwoFactorSetup(false); setShowPreferencesSetup(true); }}
             isForced={authMethods.force2fa}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (showPreferencesSetup) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 py-12 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-md w-full space-y-8">
+          <div className="text-center">
+            <Image src="/icons/monize-logo.svg" alt="Monize" width={96} height={96} className="mx-auto rounded-xl" priority />
+            <h2 className="mt-4 text-3xl font-extrabold text-gray-900 dark:text-gray-100">
+              {t('preferences.title')}
+            </h2>
+            <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+              {t('preferences.subtitle')}
+            </p>
+          </div>
+          <OnboardingPreferences
+            initialLanguage={locale}
+            onComplete={() => router.push('/dashboard')}
           />
         </div>
       </div>

--- a/frontend/src/app/transactions/page.test.tsx
+++ b/frontend/src/app/transactions/page.test.tsx
@@ -140,6 +140,11 @@ vi.mock('@/lib/accounts', () => ({
   },
 }));
 
+vi.mock('@/lib/institutions', () => ({
+  institutionsApi: { getAll: vi.fn().mockResolvedValue([]) },
+  institutionLogoUrl: (id: string) => `/api/v1/institutions/${id}/logo`,
+}));
+
 const mockGetAllCategories = vi.fn();
 vi.mock('@/lib/categories', () => ({
   categoriesApi: {

--- a/frontend/src/app/transactions/page.test.tsx
+++ b/frontend/src/app/transactions/page.test.tsx
@@ -145,6 +145,10 @@ vi.mock('@/lib/institutions', () => ({
   institutionLogoUrl: (id: string) => `/api/v1/institutions/${id}/logo`,
 }));
 
+vi.mock('@/lib/scheduled-transactions', () => ({
+  scheduledTransactionsApi: { getAll: vi.fn().mockResolvedValue([]) },
+}));
+
 const mockGetAllCategories = vi.fn();
 vi.mock('@/lib/categories', () => ({
   categoriesApi: {

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -47,6 +47,7 @@ import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useFormModal } from '@/hooks/useFormModal';
 import { AccountFormModal } from '@/components/accounts/AccountFormModal';
 import { AccountInfoWidget } from '@/components/transactions/AccountInfoWidget';
+import { ChevronDoubleRightIcon } from '@heroicons/react/24/outline';
 import { Modal } from '@/components/ui/Modal';
 import { UnsavedChangesDialog } from '@/components/ui/UnsavedChangesDialog';
 import { PageLayout } from '@/components/layout/PageLayout';
@@ -97,6 +98,7 @@ function TransactionsContent() {
   const [showPayeeForm, setShowPayeeForm] = useState(false);
   const [editingPayee, setEditingPayee] = useState<Payee | undefined>();
   const [listDensity, setListDensity] = useLocalStorage<DensityLevel>('monize-transactions-density', 'normal');
+  const [accountWidgetCollapsed, setAccountWidgetCollapsed] = useLocalStorage<boolean>('monize-transactions-account-widget-collapsed', false);
   const [showBulkUpdate, setShowBulkUpdate] = useState(false);
   const [showBulkDeleteConfirm, setShowBulkDeleteConfirm] = useState(false);
   const [bulkSelectMode, setBulkSelectMode] = useState(false);
@@ -738,8 +740,24 @@ function TransactionsContent() {
           );
 
           // Filtered to a single account: show its info widget (25%) to the
-          // left of the chart (75%). Stacks vertically on narrow screens.
+          // left of the chart (75%). Stacks vertically on narrow screens. The
+          // widget can be collapsed (persisted) so the chart uses full width.
           if (singleFilteredAccount) {
+            if (accountWidgetCollapsed) {
+              return (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => setAccountWidgetCollapsed(false)}
+                    className="mb-2 inline-flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                  >
+                    <ChevronDoubleRightIcon className="h-4 w-4" />
+                    {t('accountWidget.show')}
+                  </button>
+                  {chart}
+                </>
+              );
+            }
             return (
               <div className="flex flex-col lg:flex-row lg:gap-6">
                 <div className="lg:w-1/4 flex-shrink-0">
@@ -747,6 +765,7 @@ function TransactionsContent() {
                     account={singleFilteredAccount}
                     institution={singleFilteredInstitution}
                     onEdit={() => accountModal.openEdit(singleFilteredAccount)}
+                    onCollapse={() => setAccountWidgetCollapsed(true)}
                   />
                 </div>
                 <div className="lg:flex-1 min-w-0">{chart}</div>

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -26,6 +26,7 @@ const CategoryPayeeBarChart = dynamic(() => import('@/components/transactions/Ca
 const AccountBalancesBarChart = dynamic(() => import('@/components/transactions/AccountBalancesBarChart').then(m => m.AccountBalancesBarChart), { ssr: false, loading: ChartLoadingPlaceholder });
 import { transactionsApi } from '@/lib/transactions';
 import { accountsApi } from '@/lib/accounts';
+import { institutionsApi } from '@/lib/institutions';
 import { categoriesApi } from '@/lib/categories';
 import { payeesApi } from '@/lib/payees';
 import { tagsApi } from '@/lib/tags';
@@ -35,6 +36,7 @@ import { useTransactionSelection } from '@/hooks/useTransactionSelection';
 import { useTransactionFilters } from '@/hooks/useTransactionFilters';
 import { BulkSelectionBanner } from '@/components/transactions/BulkSelectionBanner';
 import { Account } from '@/types/account';
+import { Institution } from '@/types/institution';
 import { Category } from '@/types/category';
 import { Payee } from '@/types/payee';
 import { Tag } from '@/types/tag';
@@ -78,6 +80,7 @@ function TransactionsContent() {
   const { convertToDefault } = useExchangeRates();
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [accounts, setAccounts] = useState<Account[]>([]);
+  const [institutions, setInstitutions] = useState<Institution[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [payees, setPayees] = useState<Payee[]>([]);
   const [tags, setTags] = useState<Tag[]>([]);
@@ -118,16 +121,18 @@ function TransactionsContent() {
   const loadStaticData = useCallback(async () => {
     if (staticDataLoaded.current) return;
     try {
-      const [accountsData, categoriesData, payeesData, tagsData] = await Promise.all([
+      const [accountsData, categoriesData, payeesData, tagsData, institutionsData] = await Promise.all([
         accountsApi.getAll(true),
         categoriesApi.getAll(),
         payeesApi.getAll(),
         tagsApi.getAll(),
+        institutionsApi.getAll().catch(() => [] as Institution[]),
       ]);
       setAccounts(accountsData);
       setCategories(categoriesData);
       setPayees(payeesData);
       setTags(tagsData);
+      setInstitutions(institutionsData);
       staticDataLoaded.current = true;
     } catch (error) {
       showErrorToast(error, 'Failed to load form data');
@@ -550,6 +555,11 @@ function TransactionsContent() {
     );
   }, [filters.filterAccountIds, filters.selectedAccounts, accounts]);
 
+  const singleFilteredInstitution = useMemo(() => {
+    if (!singleFilteredAccount?.institutionId) return undefined;
+    return institutions.find((i) => i.id === singleFilteredAccount.institutionId);
+  }, [singleFilteredAccount, institutions]);
+
   const selection = useTransactionSelection(
     transactions,
     pagination?.total ?? 0,
@@ -735,6 +745,7 @@ function TransactionsContent() {
                 <div className="lg:w-1/4 flex-shrink-0">
                   <AccountInfoWidget
                     account={singleFilteredAccount}
+                    institution={singleFilteredInstitution}
                     onEdit={() => accountModal.openEdit(singleFilteredAccount)}
                   />
                 </div>

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -43,6 +43,8 @@ import { useDateFormat } from '@/hooks/useDateFormat';
 import { usePreferencesStore } from '@/store/preferencesStore';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useFormModal } from '@/hooks/useFormModal';
+import { AccountFormModal } from '@/components/accounts/AccountFormModal';
+import { AccountInfoWidget } from '@/components/transactions/AccountInfoWidget';
 import { Modal } from '@/components/ui/Modal';
 import { UnsavedChangesDialog } from '@/components/ui/UnsavedChangesDialog';
 import { PageLayout } from '@/components/layout/PageLayout';
@@ -83,6 +85,9 @@ function TransactionsContent() {
   const [monthlyTotals, setMonthlyTotals] = useState<MonthlyTotal[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const { showForm, editingItem: editingTransaction, openCreate, openEdit, close, modalProps, setFormDirty, unsavedChangesDialog, formSubmitRef } = useFormModal<Transaction>();
+  // Separate modal instance for editing the account behind a single-account
+  // filter, reusing the same form as the Accounts page.
+  const accountModal = useFormModal<Account>();
   const [duplicatingFrom, setDuplicatingFrom] = useState<Transaction | undefined>();
   const [schedulingFrom, setSchedulingFrom] = useState<Transaction | undefined>();
   const [showScheduleForm, setShowScheduleForm] = useState(false);
@@ -534,6 +539,17 @@ function TransactionsContent() {
     return undefined;
   }, [accountBalances, filters.filterAccountIds, accounts]);
 
+  // When the list is narrowed to exactly one account, surface that account so
+  // its info widget can render beside the Account Balance chart.
+  const singleFilteredAccount = useMemo(() => {
+    if (filters.filterAccountIds.length !== 1) return undefined;
+    const id = filters.filterAccountIds[0];
+    return (
+      filters.selectedAccounts.find((a) => a.id === id) ??
+      accounts.find((a) => a.id === id)
+    );
+  }, [filters.filterAccountIds, filters.selectedAccounts, accounts]);
+
   const selection = useTransactionSelection(
     transactions,
     pagination?.total ?? 0,
@@ -682,33 +698,55 @@ function TransactionsContent() {
           helpUrl="https://github.com/kenlasko/monize/wiki/Transactions"
           actions={<Button onClick={handleCreateNew}>{t('page.newButton')}</Button>}
         />
-        {filters.filterCategoryIds.length > 0 || filters.filterPayeeIds.length > 0 || filters.filterTagIds.length > 0 || filters.filterSearch.length > 0 ? (
-          <CategoryPayeeBarChart
-            data={monthlyTotals}
-            isLoading={isLoading}
-            filterLabel={monthlyTotalsFilterLabel}
-            onMonthClick={(startDate, endDate) => {
-              filters.isFilterChange.current = true;
-              filters.setFilterStartDate(startDate);
-              filters.setFilterEndDate(endDate);
-              filters.setFilterTimePeriod('custom');
-            }}
-          />
-        ) : accountBalances.length > 1 ? (
-          <AccountBalancesBarChart
-            data={accountBalances}
-            isLoading={isLoading}
-            currencyCode={chartCurrency}
-            onAccountClick={filters.handleAccountFilterClick}
-          />
-        ) : (
-          <BalanceHistoryChart
-            data={chartBalances}
-            isLoading={isLoading}
-            currencyCode={chartCurrency}
-            accountName={balanceHistoryAccountName}
-          />
-        )}
+        {(() => {
+          const chart = filters.filterCategoryIds.length > 0 || filters.filterPayeeIds.length > 0 || filters.filterTagIds.length > 0 || filters.filterSearch.length > 0 ? (
+            <CategoryPayeeBarChart
+              data={monthlyTotals}
+              isLoading={isLoading}
+              filterLabel={monthlyTotalsFilterLabel}
+              onMonthClick={(startDate, endDate) => {
+                filters.isFilterChange.current = true;
+                filters.setFilterStartDate(startDate);
+                filters.setFilterEndDate(endDate);
+                filters.setFilterTimePeriod('custom');
+              }}
+            />
+          ) : accountBalances.length > 1 ? (
+            <AccountBalancesBarChart
+              data={accountBalances}
+              isLoading={isLoading}
+              currencyCode={chartCurrency}
+              onAccountClick={filters.handleAccountFilterClick}
+            />
+          ) : (
+            <BalanceHistoryChart
+              data={chartBalances}
+              isLoading={isLoading}
+              currencyCode={chartCurrency}
+              accountName={balanceHistoryAccountName}
+            />
+          );
+
+          // Filtered to a single account: show its info widget (25%) to the
+          // left of the chart (75%). Stacks vertically on narrow screens.
+          if (singleFilteredAccount) {
+            return (
+              <div className="flex flex-col lg:flex-row lg:gap-6">
+                <div className="lg:w-1/4 flex-shrink-0">
+                  <AccountInfoWidget
+                    account={singleFilteredAccount}
+                    onEdit={() => accountModal.openEdit(singleFilteredAccount)}
+                  />
+                </div>
+                <div className="lg:flex-1 min-w-0">{chart}</div>
+              </div>
+            );
+          }
+          return chart;
+        })()}
+
+        {/* Account Edit Modal (shared with the Accounts page) */}
+        <AccountFormModal formModal={accountModal} onSaved={loadAllData} />
 
         {/* Form Modal */}
         <Modal isOpen={showForm} onClose={handleClose} {...modalProps} maxWidth="6xl" className="p-6 !max-w-[69rem]">

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -27,6 +27,7 @@ const AccountBalancesBarChart = dynamic(() => import('@/components/transactions/
 import { transactionsApi } from '@/lib/transactions';
 import { accountsApi } from '@/lib/accounts';
 import { institutionsApi } from '@/lib/institutions';
+import { scheduledTransactionsApi } from '@/lib/scheduled-transactions';
 import { categoriesApi } from '@/lib/categories';
 import { payeesApi } from '@/lib/payees';
 import { tagsApi } from '@/lib/tags';
@@ -40,6 +41,7 @@ import { Institution } from '@/types/institution';
 import { Category } from '@/types/category';
 import { Payee } from '@/types/payee';
 import { Tag } from '@/types/tag';
+import { ScheduledTransaction } from '@/types/scheduled-transaction';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useDateFormat } from '@/hooks/useDateFormat';
 import { usePreferencesStore } from '@/store/preferencesStore';
@@ -82,6 +84,7 @@ function TransactionsContent() {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [institutions, setInstitutions] = useState<Institution[]>([]);
+  const [scheduledTransactions, setScheduledTransactions] = useState<ScheduledTransaction[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [payees, setPayees] = useState<Payee[]>([]);
   const [tags, setTags] = useState<Tag[]>([]);
@@ -123,18 +126,20 @@ function TransactionsContent() {
   const loadStaticData = useCallback(async () => {
     if (staticDataLoaded.current) return;
     try {
-      const [accountsData, categoriesData, payeesData, tagsData, institutionsData] = await Promise.all([
+      const [accountsData, categoriesData, payeesData, tagsData, institutionsData, scheduledData] = await Promise.all([
         accountsApi.getAll(true),
         categoriesApi.getAll(),
         payeesApi.getAll(),
         tagsApi.getAll(),
         institutionsApi.getAll().catch(() => [] as Institution[]),
+        scheduledTransactionsApi.getAll().catch(() => [] as ScheduledTransaction[]),
       ]);
       setAccounts(accountsData);
       setCategories(categoriesData);
       setPayees(payeesData);
       setTags(tagsData);
       setInstitutions(institutionsData);
+      setScheduledTransactions(scheduledData);
       staticDataLoaded.current = true;
     } catch (error) {
       showErrorToast(error, 'Failed to load form data');
@@ -764,6 +769,7 @@ function TransactionsContent() {
                   <AccountInfoWidget
                     account={singleFilteredAccount}
                     institution={singleFilteredInstitution}
+                    scheduledTransactions={scheduledTransactions}
                     onEdit={() => accountModal.openEdit(singleFilteredAccount)}
                     onCollapse={() => setAccountWidgetCollapsed(true)}
                   />

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -764,8 +764,8 @@ function TransactionsContent() {
               );
             }
             return (
-              <div className="flex flex-col lg:flex-row lg:gap-6">
-                <div className="lg:w-1/4 flex-shrink-0">
+              <div className="flex flex-col lg:flex-row lg:gap-6 lg:items-stretch">
+                <div className="lg:w-1/4 flex-shrink-0 lg:relative">
                   <AccountInfoWidget
                     account={singleFilteredAccount}
                     institution={singleFilteredInstitution}

--- a/frontend/src/components/accounts/AccountFormModal.test.tsx
+++ b/frontend/src/components/accounts/AccountFormModal.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, waitFor } from '@/test/render';
+import { AccountFormModal } from './AccountFormModal';
+import { Account } from '@/types/account';
+
+let capturedOnSubmit: ((data: any) => Promise<void>) | null = null;
+
+// Stand-in for the dynamically loaded AccountForm: captures the onSubmit so the
+// test can drive the modal's submit logic directly.
+vi.mock('next/dynamic', () => ({
+  default: () => (props: any) => {
+    capturedOnSubmit = props.onSubmit ?? null;
+    return <div data-testid="account-form" />;
+  },
+}));
+
+vi.mock('@/components/ui/Modal', () => ({
+  Modal: ({ children, isOpen }: any) =>
+    isOpen ? <div data-testid="modal">{children}</div> : null,
+}));
+
+vi.mock('@/components/ui/UnsavedChangesDialog', () => ({
+  UnsavedChangesDialog: () => null,
+}));
+
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+vi.mock('@/lib/accounts', () => ({
+  accountsApi: {
+    create: (...args: any[]) => mockCreate(...args),
+    update: (...args: any[]) => mockUpdate(...args),
+  },
+}));
+
+vi.mock('@/lib/errors', () => ({ showErrorToast: vi.fn() }));
+
+const buildFormModal = (overrides: Partial<any> = {}) => ({
+  showForm: true,
+  editingItem: undefined as Account | undefined,
+  isEditing: false,
+  close: vi.fn(),
+  modalProps: { pushHistory: true, onBeforeClose: vi.fn() },
+  setFormDirty: vi.fn(),
+  unsavedChangesDialog: { isOpen: false, onSave: vi.fn(), onDiscard: vi.fn(), onCancel: vi.fn() },
+  formSubmitRef: { current: null },
+  ...overrides,
+});
+
+describe('AccountFormModal', () => {
+  beforeEach(() => {
+    capturedOnSubmit = null;
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when the form is closed', () => {
+    render(<AccountFormModal formModal={buildFormModal({ showForm: false })} onSaved={vi.fn()} />);
+    expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+  });
+
+  it('shows the New Account heading when creating', () => {
+    render(<AccountFormModal formModal={buildFormModal()} onSaved={vi.fn()} />);
+    expect(screen.getByText('New Account')).toBeInTheDocument();
+  });
+
+  it('shows the Edit Account heading when editing', () => {
+    render(
+      <AccountFormModal
+        formModal={buildFormModal({ editingItem: { id: 'a-1' } as Account, isEditing: true })}
+        onSaved={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Edit Account')).toBeInTheDocument();
+  });
+
+  it('creates an account and notifies the caller on submit', async () => {
+    mockCreate.mockResolvedValue({ id: 'new' });
+    const onSaved = vi.fn();
+    const close = vi.fn();
+    render(<AccountFormModal formModal={buildFormModal({ close })} onSaved={onSaved} />);
+
+    await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
+    await act(async () => {
+      await capturedOnSubmit!({ name: 'New', accountType: 'CHEQUING' });
+    });
+
+    expect(mockCreate).toHaveBeenCalled();
+    expect(close).toHaveBeenCalled();
+    expect(onSaved).toHaveBeenCalled();
+  });
+
+  it('updates an existing account on submit', async () => {
+    mockUpdate.mockResolvedValue({});
+    render(
+      <AccountFormModal
+        formModal={buildFormModal({ editingItem: { id: 'a-1', accountType: 'CHEQUING' } as Account, isEditing: true })}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
+    await act(async () => {
+      await capturedOnSubmit!({ name: 'Renamed', accountType: 'CHEQUING' });
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith('a-1', expect.any(Object));
+  });
+});

--- a/frontend/src/components/accounts/AccountFormModal.tsx
+++ b/frontend/src/components/accounts/AccountFormModal.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useTranslations } from 'next-intl';
+import toast from 'react-hot-toast';
+import { Modal } from '@/components/ui/Modal';
+import { UnsavedChangesDialog } from '@/components/ui/UnsavedChangesDialog';
+import { accountsApi } from '@/lib/accounts';
+import { Account } from '@/types/account';
+import { showErrorToast } from '@/lib/errors';
+import { UseFormModalReturn } from '@/hooks/useFormModal';
+
+const AccountForm = dynamic(
+  () => import('@/components/accounts/AccountForm').then((m) => m.AccountForm),
+  { ssr: false },
+);
+
+/** The slice of useFormModal state this modal needs to render and control itself. */
+type AccountFormModalState = Pick<
+  UseFormModalReturn<Account>,
+  | 'showForm'
+  | 'editingItem'
+  | 'isEditing'
+  | 'close'
+  | 'modalProps'
+  | 'setFormDirty'
+  | 'unsavedChangesDialog'
+  | 'formSubmitRef'
+>;
+
+interface AccountFormModalProps {
+  /** State and handlers from a `useFormModal<Account>()` instance. */
+  formModal: AccountFormModalState;
+  /** Called after a successful create/update so the caller can refresh data. */
+  onSaved: () => void;
+}
+
+/**
+ * The shared account create/edit modal. Owns the create/update submission
+ * (field cleaning, loan/mortgage sign handling, toasts) so every surface that
+ * edits an account -- the Accounts page and the Transactions account widget --
+ * reuses the exact same form and behaviour.
+ */
+export function AccountFormModal({ formModal, onSaved }: AccountFormModalProps) {
+  const t = useTranslations('accounts');
+  const {
+    showForm,
+    editingItem,
+    isEditing,
+    close,
+    modalProps,
+    setFormDirty,
+    unsavedChangesDialog,
+    formSubmitRef,
+  } = formModal;
+
+  const handleFormSubmit = async (data: any) => {
+    try {
+      const cleanedData = {
+        ...data,
+        openingBalance:
+          data.openingBalance || data.openingBalance === 0
+            ? data.openingBalance
+            : undefined,
+        creditLimit:
+          data.creditLimit || data.creditLimit === 0
+            ? data.creditLimit
+            : undefined,
+        interestRate:
+          data.interestRate || data.interestRate === 0
+            ? data.interestRate
+            : undefined,
+      };
+
+      // LOAN/MORTGAGE store openingBalance as negative. The form shows the
+      // absolute amount ("Loan Amount" / "Mortgage Amount"), so negate it when
+      // saving an update. Backend handles negation on create for these types.
+      // All other account types (including CREDIT_CARD, LINE_OF_CREDIT) let the
+      // user type the sign directly, so no auto-negation is applied.
+      const effectiveType = cleanedData.accountType || editingItem?.accountType;
+      if (
+        cleanedData.openingBalance != null &&
+        cleanedData.openingBalance > 0 &&
+        (effectiveType === 'LOAN' || effectiveType === 'MORTGAGE') &&
+        editingItem
+      ) {
+        cleanedData.openingBalance = -cleanedData.openingBalance;
+      }
+
+      Object.keys(cleanedData).forEach((key) => {
+        if (
+          cleanedData[key] === undefined ||
+          cleanedData[key] === '' ||
+          (typeof cleanedData[key] === 'number' && isNaN(cleanedData[key]))
+        ) {
+          delete cleanedData[key];
+        }
+      });
+
+      if (editingItem) {
+        await accountsApi.update(editingItem.id, cleanedData);
+        toast.success(t('toast.updateSuccess'));
+      } else {
+        await accountsApi.create(cleanedData);
+        toast.success(t('toast.createSuccess'));
+      }
+      close();
+      onSaved();
+    } catch (error) {
+      showErrorToast(
+        error,
+        `Failed to ${editingItem ? 'update' : 'create'} account`,
+      );
+      throw error;
+    }
+  };
+
+  return (
+    <>
+      <Modal
+        isOpen={showForm}
+        onClose={close}
+        {...modalProps}
+        maxWidth="2xl"
+        className="p-6"
+      >
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+          {isEditing ? t('page.editAccountModal') : t('page.newAccountModal')}
+        </h2>
+        <AccountForm
+          account={editingItem}
+          onSubmit={handleFormSubmit}
+          onCancel={close}
+          onDirtyChange={setFormDirty}
+          submitRef={formSubmitRef}
+        />
+      </Modal>
+      <UnsavedChangesDialog {...unsavedChangesDialog} />
+    </>
+  );
+}

--- a/frontend/src/components/auth/OnboardingPreferences.test.tsx
+++ b/frontend/src/components/auth/OnboardingPreferences.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@/test/render';
+import { OnboardingPreferences } from './OnboardingPreferences';
+
+const mockUpdatePreferences = vi.fn();
+const mockStoreUpdate = vi.fn();
+
+vi.mock('@/lib/exchange-rates', () => ({
+  exchangeRatesApi: {
+    getCurrencies: vi.fn().mockResolvedValue([
+      { code: 'USD', name: 'US Dollar' },
+      { code: 'CAD', name: 'Canadian Dollar' },
+    ]),
+  },
+}));
+
+vi.mock('@/lib/user-settings', () => ({
+  userSettingsApi: {
+    updatePreferences: (...args: unknown[]) => mockUpdatePreferences(...args),
+  },
+}));
+
+vi.mock('@/store/preferencesStore', () => ({
+  usePreferencesStore: (selector: (s: unknown) => unknown) =>
+    selector({ updatePreferences: mockStoreUpdate }),
+}));
+
+vi.mock('js-cookie', () => ({ default: { set: vi.fn() } }));
+
+async function renderOnboarding(onComplete = vi.fn()) {
+  await act(async () => {
+    render(<OnboardingPreferences initialLanguage="en" onComplete={onComplete} />);
+  });
+  return { onComplete };
+}
+
+describe('OnboardingPreferences', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders language and currency selectors', async () => {
+    await renderOnboarding();
+    expect(screen.getByText('Language')).toBeInTheDocument();
+    expect(screen.getByText('Default currency')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText('CAD - Canadian Dollar')).toBeInTheDocument(),
+    );
+  });
+
+  it('saves the chosen language and currency on continue', async () => {
+    mockUpdatePreferences.mockResolvedValue({ language: 'en', defaultCurrency: 'CAD' });
+    const { onComplete } = await renderOnboarding();
+
+    await waitFor(() =>
+      expect(screen.getByText('CAD - Canadian Dollar')).toBeInTheDocument(),
+    );
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Default currency'), {
+        target: { value: 'CAD' },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Continue'));
+    });
+
+    await waitFor(() =>
+      expect(mockUpdatePreferences).toHaveBeenCalledWith({
+        language: 'en',
+        defaultCurrency: 'CAD',
+      }),
+    );
+    expect(mockStoreUpdate).toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalled();
+  });
+
+  it('skips without saving', async () => {
+    const { onComplete } = await renderOnboarding();
+    await act(async () => {
+      fireEvent.click(screen.getByText('Skip for now'));
+    });
+    expect(mockUpdatePreferences).not.toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/auth/OnboardingPreferences.tsx
+++ b/frontend/src/components/auth/OnboardingPreferences.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
+import Cookies from 'js-cookie';
+import toast from 'react-hot-toast';
+import { Select } from '@/components/ui/Select';
+import { Button } from '@/components/ui/Button';
+import { userSettingsApi } from '@/lib/user-settings';
+import { exchangeRatesApi, CurrencyInfo } from '@/lib/exchange-rates';
+import { usePreferencesStore } from '@/store/preferencesStore';
+import { LOCALE_COOKIE, SUPPORTED_LOCALES } from '@/i18n/config';
+import { getErrorMessage } from '@/lib/errors';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('OnboardingPreferences');
+
+interface OnboardingPreferencesProps {
+  /** Initial language (e.g. the locale resolved for the page). */
+  initialLanguage?: string;
+  /** Called once the user saves or skips, to continue the sign-up flow. */
+  onComplete: () => void;
+}
+
+/**
+ * Post-registration step prompting the user to pick their language and default
+ * currency. Both are saved in a single preferences update; the user can skip to
+ * keep the defaults (English / USD).
+ */
+export function OnboardingPreferences({
+  initialLanguage = 'en',
+  onComplete,
+}: OnboardingPreferencesProps) {
+  const t = useTranslations('auth.register.preferences');
+  const updatePreferencesStore = usePreferencesStore((s) => s.updatePreferences);
+
+  const [language, setLanguage] = useState(initialLanguage);
+  const [defaultCurrency, setDefaultCurrency] = useState('USD');
+  const [currencies, setCurrencies] = useState<CurrencyInfo[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    exchangeRatesApi
+      .getCurrencies()
+      .then(setCurrencies)
+      .catch((error) => logger.error(error));
+  }, []);
+
+  const languageOptions = useMemo(
+    () => SUPPORTED_LOCALES.map((l) => ({ value: l.code, label: l.label })),
+    [],
+  );
+
+  const currencyOptions = useMemo(
+    () =>
+      currencies.map((c) => ({ value: c.code, label: `${c.code} - ${c.name}` })),
+    [currencies],
+  );
+
+  const handleSave = useCallback(async () => {
+    setIsSaving(true);
+    try {
+      const updated = await userSettingsApi.updatePreferences({
+        language,
+        defaultCurrency,
+      });
+      updatePreferencesStore(updated);
+      Cookies.set(LOCALE_COOKIE, language, { sameSite: 'lax', expires: 365 });
+      onComplete();
+    } catch (error) {
+      toast.error(getErrorMessage(error, t('saveFailed')));
+      logger.error(error);
+      setIsSaving(false);
+    }
+  }, [language, defaultCurrency, updatePreferencesStore, onComplete, t]);
+
+  return (
+    <div className="space-y-6">
+      <Select
+        label={t('languageLabel')}
+        options={languageOptions}
+        value={language}
+        onChange={(e) => setLanguage(e.target.value)}
+        disabled={isSaving}
+      />
+      <Select
+        label={t('currencyLabel')}
+        options={currencyOptions}
+        value={defaultCurrency}
+        onChange={(e) => setDefaultCurrency(e.target.value)}
+        disabled={isSaving || currencyOptions.length === 0}
+      />
+      <div className="flex items-center justify-between gap-3">
+        <button
+          type="button"
+          onClick={onComplete}
+          disabled={isSaving}
+          className="text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 disabled:opacity-50"
+        >
+          {t('skip')}
+        </button>
+        <Button onClick={handleSave} isLoading={isSaving}>
+          {t('continue')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/FavouriteAccounts.tsx
+++ b/frontend/src/components/dashboard/FavouriteAccounts.tsx
@@ -9,20 +9,7 @@ import { usePreferencesStore } from '@/store/preferencesStore';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { accountsApi } from '@/lib/accounts';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
-
-function getOrdinal(day: number): string {
-  const suffix =
-    day >= 11 && day <= 13
-      ? 'th'
-      : day % 10 === 1
-        ? 'st'
-        : day % 10 === 2
-          ? 'nd'
-          : day % 10 === 3
-            ? 'rd'
-            : 'th';
-  return `${day}${suffix}`;
-}
+import { getOrdinal } from '@/lib/ordinal';
 
 interface FavouriteAccountsProps {
   accounts: Account[];

--- a/frontend/src/components/institutions/InstitutionAccountsManager.test.tsx
+++ b/frontend/src/components/institutions/InstitutionAccountsManager.test.tsx
@@ -34,6 +34,21 @@ const institution: Institution = {
 const account = (id: string, name: string): Account =>
   ({ id, name, institutionId: null }) as Account;
 
+const investmentAccount = (
+  id: string,
+  name: string,
+  subType: 'INVESTMENT_CASH' | 'INVESTMENT_BROKERAGE',
+  linkedAccountId: string,
+): Account =>
+  ({
+    id,
+    name,
+    institutionId: null,
+    accountType: 'INVESTMENT',
+    accountSubType: subType,
+    linkedAccountId,
+  }) as Account;
+
 async function renderManager(onChanged = vi.fn()) {
   await act(async () => {
     render(
@@ -89,6 +104,25 @@ describe('InstitutionAccountsManager', () => {
       expect(institutionsApi.unassignAccount).toHaveBeenCalledWith('i-1', 'a-1'),
     );
     expect(onChanged).toHaveBeenCalled();
+  });
+
+  it('shows a linked investment pair as a single main account', async () => {
+    vi.mocked(institutionsApi.getAccounts).mockResolvedValue([
+      investmentAccount('a-cash', 'TFSA - Cash', 'INVESTMENT_CASH', 'a-brok'),
+      investmentAccount('a-brok', 'TFSA - Brokerage', 'INVESTMENT_BROKERAGE', 'a-cash'),
+    ]);
+    vi.mocked(accountsApi.getAll).mockResolvedValue([
+      investmentAccount('a-cash', 'TFSA - Cash', 'INVESTMENT_CASH', 'a-brok'),
+      investmentAccount('a-brok', 'TFSA - Brokerage', 'INVESTMENT_BROKERAGE', 'a-cash'),
+    ]);
+
+    await renderManager();
+
+    // The pair collapses to one row showing the main account name.
+    await waitFor(() => expect(screen.getByText('TFSA')).toBeInTheDocument());
+    expect(screen.queryByText('TFSA - Cash')).not.toBeInTheDocument();
+    expect(screen.queryByText('TFSA - Brokerage')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Remove')).toHaveLength(1);
   });
 
   it('shows the empty state when no accounts are assigned', async () => {

--- a/frontend/src/components/institutions/InstitutionAccountsManager.test.tsx
+++ b/frontend/src/components/institutions/InstitutionAccountsManager.test.tsx
@@ -107,6 +107,25 @@ describe('InstitutionAccountsManager', () => {
     expect(mockPush).toHaveBeenCalledWith('/transactions?accountId=a-1');
   });
 
+  it('forces Show Accounts to All when a closed account is clicked', async () => {
+    const closed = { id: 'a-9', name: 'Old Savings', institutionId: 'i-1', isClosed: true } as Account;
+    vi.mocked(institutionsApi.getAccounts).mockResolvedValue([closed]);
+    vi.mocked(accountsApi.getAll).mockResolvedValue([closed]);
+
+    await renderManager();
+    await waitFor(() =>
+      expect(screen.getByText('Old Savings')).toBeInTheDocument(),
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Old Savings'));
+    });
+
+    expect(mockPush).toHaveBeenCalledWith(
+      '/transactions?accountId=a-9&accountStatus=all',
+    );
+  });
+
   it('removes an assigned account', async () => {
     vi.mocked(institutionsApi.getAccounts).mockResolvedValue([
       account('a-1', 'Chequing'),

--- a/frontend/src/components/institutions/InstitutionAccountsManager.test.tsx
+++ b/frontend/src/components/institutions/InstitutionAccountsManager.test.tsx
@@ -18,6 +18,11 @@ vi.mock('@/lib/accounts', () => ({
   accountsApi: { getAll: vi.fn() },
 }));
 
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
 const institution: Institution = {
   id: 'i-1',
   userId: 'u-1',
@@ -49,18 +54,18 @@ const investmentAccount = (
     linkedAccountId,
   }) as Account;
 
-async function renderManager(onChanged = vi.fn()) {
+async function renderManager(onChanged = vi.fn(), onClose = vi.fn()) {
   await act(async () => {
     render(
       <InstitutionAccountsManager
         institution={institution}
         isOpen
-        onClose={vi.fn()}
+        onClose={onClose}
         onChanged={onChanged}
       />,
     );
   });
-  return { onChanged };
+  return { onChanged, onClose };
 }
 
 describe('InstitutionAccountsManager', () => {
@@ -80,6 +85,26 @@ describe('InstitutionAccountsManager', () => {
     await waitFor(() =>
       expect(screen.getByText('Chequing')).toBeInTheDocument(),
     );
+  });
+
+  it('navigates to the filtered Transactions page when an account is clicked', async () => {
+    vi.mocked(institutionsApi.getAccounts).mockResolvedValue([
+      account('a-1', 'Chequing'),
+    ]);
+    vi.mocked(accountsApi.getAll).mockResolvedValue([account('a-1', 'Chequing')]);
+
+    const onClose = vi.fn();
+    await renderManager(vi.fn(), onClose);
+    await waitFor(() =>
+      expect(screen.getByText('Chequing')).toBeInTheDocument(),
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Chequing'));
+    });
+
+    expect(onClose).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith('/transactions?accountId=a-1');
   });
 
   it('removes an assigned account', async () => {

--- a/frontend/src/components/institutions/InstitutionAccountsManager.test.tsx
+++ b/frontend/src/components/institutions/InstitutionAccountsManager.test.tsx
@@ -125,6 +125,54 @@ describe('InstitutionAccountsManager', () => {
     expect(screen.getAllByText('Remove')).toHaveLength(1);
   });
 
+  it('filters assigned accounts by active/closed status', async () => {
+    const open = { id: 'a-1', name: 'Open Chequing', institutionId: 'i-1', isClosed: false } as Account;
+    const closed = { id: 'a-2', name: 'Old Savings', institutionId: 'i-1', isClosed: true } as Account;
+    vi.mocked(institutionsApi.getAccounts).mockResolvedValue([open, closed]);
+    vi.mocked(accountsApi.getAll).mockResolvedValue([]);
+
+    await renderManager();
+
+    // "All" is the default, so both accounts are listed.
+    await waitFor(() =>
+      expect(screen.getByText('Open Chequing')).toBeInTheDocument(),
+    );
+    expect(screen.getByText('Old Savings')).toBeInTheDocument();
+
+    // "Active" hides closed accounts.
+    await act(async () => {
+      fireEvent.click(screen.getByText('Active'));
+    });
+    expect(screen.getByText('Open Chequing')).toBeInTheDocument();
+    expect(screen.queryByText('Old Savings')).not.toBeInTheDocument();
+
+    // "Closed" shows only closed accounts.
+    await act(async () => {
+      fireEvent.click(screen.getByText('Closed'));
+    });
+    expect(screen.getByText('Old Savings')).toBeInTheDocument();
+    expect(screen.queryByText('Open Chequing')).not.toBeInTheDocument();
+  });
+
+  it('shows a no-match message when the filter excludes every account', async () => {
+    const open = { id: 'a-1', name: 'Open Chequing', institutionId: 'i-1', isClosed: false } as Account;
+    vi.mocked(institutionsApi.getAccounts).mockResolvedValue([open]);
+    vi.mocked(accountsApi.getAll).mockResolvedValue([]);
+
+    await renderManager();
+    await waitFor(() =>
+      expect(screen.getByText('Open Chequing')).toBeInTheDocument(),
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Closed'));
+    });
+
+    expect(
+      screen.getByText('No accounts match the selected filter.'),
+    ).toBeInTheDocument();
+  });
+
   it('shows the empty state when no accounts are assigned', async () => {
     vi.mocked(institutionsApi.getAccounts).mockResolvedValue([]);
     vi.mocked(accountsApi.getAll).mockResolvedValue([account('a-2', 'Savings')]);

--- a/frontend/src/components/institutions/InstitutionAccountsManager.tsx
+++ b/frontend/src/components/institutions/InstitutionAccountsManager.tsx
@@ -135,24 +135,6 @@ export function InstitutionAccountsManager({
         </h2>
       </div>
 
-      <div className="mb-4">
-        <Combobox
-          label={t('accountsManager.addLabel')}
-          placeholder={t('accountsManager.addPlaceholder')}
-          options={availableOptions}
-          value={selectedAccountId}
-          usePortal
-          onChange={(value) => {
-            if (value) handleAdd(value);
-          }}
-        />
-        {availableOptions.length === 0 && !isLoading && (
-          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-            {t('accountsManager.noneToAdd')}
-          </p>
-        )}
-      </div>
-
       {isLoading ? (
         <LoadingSpinner text={t('accountsManager.loading')} />
       ) : assignedMain.length === 0 ? (
@@ -226,6 +208,24 @@ export function InstitutionAccountsManager({
           )}
         </>
       )}
+
+      <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700">
+        <Combobox
+          label={t('accountsManager.addLabel')}
+          placeholder={t('accountsManager.addPlaceholder')}
+          options={availableOptions}
+          value={selectedAccountId}
+          usePortal
+          onChange={(value) => {
+            if (value) handleAdd(value);
+          }}
+        />
+        {availableOptions.length === 0 && !isLoading && (
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            {t('accountsManager.noneToAdd')}
+          </p>
+        )}
+      </div>
 
       <div className="mt-6 flex justify-end">
         <Button variant="secondary" onClick={onClose}>

--- a/frontend/src/components/institutions/InstitutionAccountsManager.tsx
+++ b/frontend/src/components/institutions/InstitutionAccountsManager.tsx
@@ -133,7 +133,7 @@ export function InstitutionAccountsManager({
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} maxWidth="lg" className="p-6" pushHistory>
+    <Modal isOpen={isOpen} onClose={onClose} maxWidth="lg" className="p-6">
       <div className="flex items-center gap-3 mb-4">
         <InstitutionLogo institution={institution ?? undefined} size={32} fallbackGlyph="$" />
         <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 truncate">

--- a/frontend/src/components/institutions/InstitutionAccountsManager.tsx
+++ b/frontend/src/components/institutions/InstitutionAccountsManager.tsx
@@ -13,6 +13,7 @@ import { institutionsApi } from '@/lib/institutions';
 import { accountsApi } from '@/lib/accounts';
 import { getErrorMessage } from '@/lib/errors';
 import { createLogger } from '@/lib/logger';
+import { isInvestmentCashHalf, getMainAccountName } from '@/lib/account-utils';
 import { InstitutionLogo } from './InstitutionLogo';
 
 const logger = createLogger('InstitutionAccountsManager');
@@ -67,11 +68,19 @@ export function InstitutionAccountsManager({
     [assigned],
   );
 
+  // Collapse a linked brokerage/cash investment pair into a single entity by
+  // dropping the cash half; assigning or removing the brokerage carries its
+  // partner along, so only the main account is shown.
+  const assignedMain = useMemo(
+    () => assigned.filter((a) => !isInvestmentCashHalf(a)),
+    [assigned],
+  );
+
   const availableOptions = useMemo(
     () =>
       allAccounts
-        .filter((a) => !assignedIds.has(a.id))
-        .map((a) => ({ value: a.id, label: a.name })),
+        .filter((a) => !assignedIds.has(a.id) && !isInvestmentCashHalf(a))
+        .map((a) => ({ value: a.id, label: getMainAccountName(a.name) })),
     [allAccounts, assignedIds],
   );
 
@@ -137,19 +146,19 @@ export function InstitutionAccountsManager({
 
       {isLoading ? (
         <LoadingSpinner text={t('accountsManager.loading')} />
-      ) : assigned.length === 0 ? (
+      ) : assignedMain.length === 0 ? (
         <p className="text-sm text-gray-500 dark:text-gray-400 py-4 text-center">
           {t('accountsManager.empty')}
         </p>
       ) : (
         <ul className="divide-y divide-gray-200 dark:divide-gray-700 border border-gray-200 dark:border-gray-700 rounded-md">
-          {assigned.map((account) => (
+          {assignedMain.map((account) => (
             <li
               key={account.id}
               className="flex items-center justify-between px-3 py-2 gap-3"
             >
               <span className="text-sm text-gray-900 dark:text-gray-100 truncate">
-                {account.name}
+                {getMainAccountName(account.name)}
               </span>
               <Button
                 variant="outline"

--- a/frontend/src/components/institutions/InstitutionAccountsManager.tsx
+++ b/frontend/src/components/institutions/InstitutionAccountsManager.tsx
@@ -229,6 +229,7 @@ export function InstitutionAccountsManager({
           options={availableOptions}
           value={selectedAccountId}
           usePortal
+          openOnFocus={false}
           onChange={(value) => {
             if (value) handleAdd(value);
           }}

--- a/frontend/src/components/institutions/InstitutionAccountsManager.tsx
+++ b/frontend/src/components/institutions/InstitutionAccountsManager.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 import { Modal } from '@/components/ui/Modal';
 import { Combobox } from '@/components/ui/Combobox';
@@ -33,6 +34,7 @@ export function InstitutionAccountsManager({
   onChanged,
 }: InstitutionAccountsManagerProps) {
   const t = useTranslations('institutions');
+  const router = useRouter();
   const [assigned, setAssigned] = useState<Account[]>([]);
   const [allAccounts, setAllAccounts] = useState<Account[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -92,6 +94,12 @@ export function InstitutionAccountsManager({
         .map((a) => ({ value: a.id, label: getMainAccountName(a.name) })),
     [allAccounts, assignedIds],
   );
+
+  // Close the modal and jump to the Transactions page filtered to the account.
+  const handleViewTransactions = (accountId: string) => {
+    onClose();
+    router.push(`/transactions?accountId=${accountId}`);
+  };
 
   const handleAdd = async (accountId: string) => {
     if (!institution || !accountId) return;
@@ -191,9 +199,14 @@ export function InstitutionAccountsManager({
                   key={account.id}
                   className="flex items-center justify-between px-3 py-2 gap-3"
                 >
-                  <span className="text-sm text-gray-900 dark:text-gray-100 truncate">
+                  <button
+                    type="button"
+                    onClick={() => handleViewTransactions(account.id)}
+                    title={t('accountsManager.viewTransactions')}
+                    className="text-sm text-left text-blue-600 dark:text-blue-400 hover:underline truncate"
+                  >
                     {getMainAccountName(account.name)}
-                  </span>
+                  </button>
                   <Button
                     variant="outline"
                     size="sm"

--- a/frontend/src/components/institutions/InstitutionAccountsManager.tsx
+++ b/frontend/src/components/institutions/InstitutionAccountsManager.tsx
@@ -96,9 +96,13 @@ export function InstitutionAccountsManager({
   );
 
   // Close the modal and jump to the Transactions page filtered to the account.
-  const handleViewTransactions = (accountId: string) => {
+  // For a closed account, force the Show Accounts filter to All so its
+  // transactions aren't hidden by an Active-only filter.
+  const handleViewTransactions = (account: Account) => {
     onClose();
-    router.push(`/transactions?accountId=${accountId}`);
+    const params = new URLSearchParams({ accountId: account.id });
+    if (account.isClosed) params.set('accountStatus', 'all');
+    router.push(`/transactions?${params.toString()}`);
   };
 
   const handleAdd = async (accountId: string) => {
@@ -201,7 +205,7 @@ export function InstitutionAccountsManager({
                 >
                   <button
                     type="button"
-                    onClick={() => handleViewTransactions(account.id)}
+                    onClick={() => handleViewTransactions(account)}
                     title={t('accountsManager.viewTransactions')}
                     className="text-sm text-left text-blue-600 dark:text-blue-400 hover:underline truncate"
                   >

--- a/frontend/src/components/institutions/InstitutionAccountsManager.tsx
+++ b/frontend/src/components/institutions/InstitutionAccountsManager.tsx
@@ -38,6 +38,7 @@ export function InstitutionAccountsManager({
   const [isLoading, setIsLoading] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [selectedAccountId, setSelectedAccountId] = useState('');
+  const [filterStatus, setFilterStatus] = useState<'active' | 'closed' | ''>('');
 
   const load = useCallback(async () => {
     if (!institution) return;
@@ -75,6 +76,14 @@ export function InstitutionAccountsManager({
     () => assigned.filter((a) => !isInvestmentCashHalf(a)),
     [assigned],
   );
+
+  // Apply the active/closed status filter to the collapsed account list.
+  const visibleAccounts = useMemo(() => {
+    if (!filterStatus) return assignedMain;
+    return assignedMain.filter((a) =>
+      filterStatus === 'active' ? !a.isClosed : a.isClosed,
+    );
+  }, [assignedMain, filterStatus]);
 
   const availableOptions = useMemo(
     () =>
@@ -151,26 +160,71 @@ export function InstitutionAccountsManager({
           {t('accountsManager.empty')}
         </p>
       ) : (
-        <ul className="divide-y divide-gray-200 dark:divide-gray-700 border border-gray-200 dark:border-gray-700 rounded-md">
-          {assignedMain.map((account) => (
-            <li
-              key={account.id}
-              className="flex items-center justify-between px-3 py-2 gap-3"
+        <>
+          {/* Active/Closed status filter */}
+          <div className="mb-3 inline-flex rounded-md shadow-sm">
+            <button
+              type="button"
+              onClick={() => setFilterStatus('')}
+              className={`px-3 py-1.5 text-sm font-medium rounded-l-md border ${
+                filterStatus === ''
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+              }`}
             >
-              <span className="text-sm text-gray-900 dark:text-gray-100 truncate">
-                {getMainAccountName(account.name)}
-              </span>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={busyId === account.id}
-                onClick={() => handleRemove(account.id)}
-              >
-                {t('accountsManager.remove')}
-              </Button>
-            </li>
-          ))}
-        </ul>
+              {t('accountsManager.filter.all')}
+            </button>
+            <button
+              type="button"
+              onClick={() => setFilterStatus('active')}
+              className={`px-3 py-1.5 text-sm font-medium border-t border-b ${
+                filterStatus === 'active'
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+              }`}
+            >
+              {t('accountsManager.filter.active')}
+            </button>
+            <button
+              type="button"
+              onClick={() => setFilterStatus('closed')}
+              className={`px-3 py-1.5 text-sm font-medium rounded-r-md border ${
+                filterStatus === 'closed'
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+              }`}
+            >
+              {t('accountsManager.filter.closed')}
+            </button>
+          </div>
+
+          {visibleAccounts.length === 0 ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400 py-4 text-center">
+              {t('accountsManager.noneMatch')}
+            </p>
+          ) : (
+            <ul className="divide-y divide-gray-200 dark:divide-gray-700 border border-gray-200 dark:border-gray-700 rounded-md">
+              {visibleAccounts.map((account) => (
+                <li
+                  key={account.id}
+                  className="flex items-center justify-between px-3 py-2 gap-3"
+                >
+                  <span className="text-sm text-gray-900 dark:text-gray-100 truncate">
+                    {getMainAccountName(account.name)}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={busyId === account.id}
+                    onClick={() => handleRemove(account.id)}
+                  >
+                    {t('accountsManager.remove')}
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
       )}
 
       <div className="mt-6 flex justify-end">

--- a/frontend/src/components/institutions/InstitutionForm.test.tsx
+++ b/frontend/src/components/institutions/InstitutionForm.test.tsx
@@ -93,6 +93,15 @@ describe('InstitutionForm', () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
+  it('treats the website field as a URL on mobile (not normal text)', () => {
+    render(<InstitutionForm onSubmit={vi.fn()} onCancel={() => {}} />);
+    const website = screen.getByLabelText('Website');
+    expect(website).toHaveAttribute('inputmode', 'url');
+    expect(website).toHaveAttribute('autocapitalize', 'none');
+    expect(website).toHaveAttribute('autocorrect', 'off');
+    expect(website).toHaveAttribute('spellcheck', 'false');
+  });
+
   it('prefills the name for inline creation', () => {
     render(
       <InstitutionForm

--- a/frontend/src/components/institutions/InstitutionForm.test.tsx
+++ b/frontend/src/components/institutions/InstitutionForm.test.tsx
@@ -102,6 +102,17 @@ describe('InstitutionForm', () => {
     expect(website).toHaveAttribute('spellcheck', 'false');
   });
 
+  it('forces the country code to uppercase while typing', async () => {
+    render(<InstitutionForm onSubmit={vi.fn()} onCancel={() => {}} />);
+    const country = screen.getByLabelText('Country (optional)') as HTMLInputElement;
+
+    await act(async () => {
+      fireEvent.change(country, { target: { value: 'ca' } });
+    });
+
+    await waitFor(() => expect(country).toHaveValue('CA'));
+  });
+
   it('prefills the name for inline creation', () => {
     render(
       <InstitutionForm

--- a/frontend/src/components/institutions/InstitutionForm.tsx
+++ b/frontend/src/components/institutions/InstitutionForm.tsx
@@ -102,6 +102,10 @@ export function InstitutionForm({
       <Input
         label={t('form.websiteLabel')}
         placeholder={t('form.websitePlaceholder')}
+        inputMode="url"
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
         error={errors.website?.message}
         {...register('website')}
       />

--- a/frontend/src/components/institutions/InstitutionForm.tsx
+++ b/frontend/src/components/institutions/InstitutionForm.tsx
@@ -58,6 +58,7 @@ export function InstitutionForm({
   const {
     register,
     handleSubmit,
+    setValue,
     formState: { errors, isSubmitting, isDirty },
   } = useForm<InstitutionFormData>({
     resolver: zodResolver(buildInstitutionSchema(t)),
@@ -114,8 +115,15 @@ export function InstitutionForm({
         label={t('form.countryLabel')}
         placeholder={t('form.countryPlaceholder')}
         maxLength={2}
+        autoCapitalize="characters"
         error={errors.country?.message}
         {...register('country')}
+        onChange={(e) =>
+          setValue('country', e.target.value.toUpperCase(), {
+            shouldDirty: true,
+            shouldValidate: true,
+          })
+        }
       />
 
       <p className="text-xs text-gray-500 dark:text-gray-400">

--- a/frontend/src/components/institutions/InstitutionList.test.tsx
+++ b/frontend/src/components/institutions/InstitutionList.test.tsx
@@ -40,6 +40,21 @@ describe('InstitutionList', () => {
     expect(screen.getByText('2 accounts')).toBeInTheDocument();
   });
 
+  it('applies dense row padding when density is dense', () => {
+    render(
+      <InstitutionList
+        institutions={[makeInstitution()]}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onManageAccounts={vi.fn()}
+        density="dense"
+      />,
+    );
+    // The name cell uses the dense padding (py-1) rather than the default.
+    const nameCell = screen.getByText('TD Canada Trust').closest('td');
+    expect(nameCell?.className).toContain('py-1');
+  });
+
   it('shows the empty state', () => {
     render(
       <InstitutionList

--- a/frontend/src/components/institutions/InstitutionList.test.tsx
+++ b/frontend/src/components/institutions/InstitutionList.test.tsx
@@ -37,7 +37,10 @@ describe('InstitutionList', () => {
     );
     expect(screen.getByText('TD Canada Trust')).toBeInTheDocument();
     expect(screen.getByText('https://td.com')).toBeInTheDocument();
-    expect(screen.getByText('2 accounts')).toBeInTheDocument();
+    // Accounts column shows just the number (with an accessible label).
+    expect(
+      screen.getByRole('button', { name: '2 accounts' }),
+    ).toHaveTextContent('2');
   });
 
   it('applies dense row padding when density is dense', () => {
@@ -84,8 +87,24 @@ describe('InstitutionList', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
     expect(onEdit).toHaveBeenCalled();
-    fireEvent.click(screen.getByRole('button', { name: 'Accounts' }));
+    fireEvent.click(screen.getByRole('button', { name: '2 accounts' }));
     expect(onManageAccounts).toHaveBeenCalled();
+  });
+
+  it('renders edit/delete as icon buttons in dense view', () => {
+    render(
+      <InstitutionList
+        institutions={[makeInstitution()]}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onManageAccounts={vi.fn()}
+        density="dense"
+      />,
+    );
+    // Icon buttons expose their action via aria-label, with no text content.
+    const edit = screen.getByRole('button', { name: 'Edit' });
+    expect(edit).toHaveTextContent('');
+    expect(edit.querySelector('svg')).toBeInTheDocument();
   });
 
   it('deletes after confirmation', async () => {

--- a/frontend/src/components/institutions/InstitutionList.test.tsx
+++ b/frontend/src/components/institutions/InstitutionList.test.tsx
@@ -43,6 +43,31 @@ describe('InstitutionList', () => {
     ).toHaveTextContent('2');
   });
 
+  it('renders the website as a link only for http(s) schemes', () => {
+    const { rerender } = render(
+      <InstitutionList
+        institutions={[makeInstitution()]}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onManageAccounts={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole('link', { name: 'https://td.com' }),
+    ).toHaveAttribute('href', 'https://td.com');
+
+    rerender(
+      <InstitutionList
+        institutions={[makeInstitution({ website: 'javascript:alert(1)' })]}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onManageAccounts={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('javascript:alert(1)')).toBeInTheDocument();
+  });
+
   it('applies dense row padding when density is dense', () => {
     render(
       <InstitutionList

--- a/frontend/src/components/institutions/InstitutionList.test.tsx
+++ b/frontend/src/components/institutions/InstitutionList.test.tsx
@@ -58,6 +58,25 @@ describe('InstitutionList', () => {
     expect(nameCell?.className).toContain('py-1');
   });
 
+  it('calls onSort when a sortable column header is clicked', () => {
+    const onSort = vi.fn();
+    render(
+      <InstitutionList
+        institutions={[makeInstitution()]}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onManageAccounts={vi.fn()}
+        sortField="name"
+        sortDirection="asc"
+        onSort={onSort}
+      />,
+    );
+    fireEvent.click(screen.getByText('Name'));
+    expect(onSort).toHaveBeenCalledWith('name');
+    fireEvent.click(screen.getByText('Accounts'));
+    expect(onSort).toHaveBeenCalledWith('accounts');
+  });
+
   it('shows the empty state', () => {
     render(
       <InstitutionList

--- a/frontend/src/components/institutions/InstitutionList.tsx
+++ b/frontend/src/components/institutions/InstitutionList.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import toast from 'react-hot-toast';
+import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline';
 import { Button } from '@/components/ui/Button';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { Institution } from '@/types/institution';
@@ -112,33 +113,51 @@ export function InstitutionList({
               <td className={cellPadding}>
                 <button
                   onClick={() => onManageAccounts(institution)}
+                  aria-label={t('list.accountCount', { count: institution.accountCount })}
+                  title={t('list.actions.manageAccounts')}
                   className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
                 >
-                  {t('list.accountCount', { count: institution.accountCount })}
+                  {institution.accountCount}
                 </button>
               </td>
-              <td className={`${cellPadding} text-right whitespace-nowrap space-x-2`}>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => onManageAccounts(institution)}
-                >
-                  {t('list.actions.manageAccounts')}
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => onEdit(institution)}
-                >
-                  {tc('edit')}
-                </Button>
-                <Button
-                  variant="danger"
-                  size="sm"
-                  onClick={() => setToDelete(institution)}
-                >
-                  {tc('delete')}
-                </Button>
+              <td className={`${cellPadding} text-right whitespace-nowrap ${density === 'dense' ? 'space-x-1' : 'space-x-2'}`}>
+                {density === 'dense' ? (
+                  <>
+                    <button
+                      onClick={() => onEdit(institution)}
+                      aria-label={tc('edit')}
+                      title={tc('edit')}
+                      className="inline-flex items-center p-1.5 rounded text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+                    >
+                      <PencilSquareIcon className="h-5 w-5" />
+                    </button>
+                    <button
+                      onClick={() => setToDelete(institution)}
+                      aria-label={tc('delete')}
+                      title={tc('delete')}
+                      className="inline-flex items-center p-1.5 rounded text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+                    >
+                      <TrashIcon className="h-5 w-5" />
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onEdit(institution)}
+                    >
+                      {tc('edit')}
+                    </Button>
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      onClick={() => setToDelete(institution)}
+                    >
+                      {tc('delete')}
+                    </Button>
+                  </>
+                )}
               </td>
             </tr>
           ))}

--- a/frontend/src/components/institutions/InstitutionList.tsx
+++ b/frontend/src/components/institutions/InstitutionList.tsx
@@ -9,6 +9,7 @@ import { Institution } from '@/types/institution';
 import { institutionsApi } from '@/lib/institutions';
 import { getErrorMessage } from '@/lib/errors';
 import { createLogger } from '@/lib/logger';
+import { useTableDensity, DensityLevel } from '@/hooks/useTableDensity';
 import { InstitutionLogo } from './InstitutionLogo';
 
 const logger = createLogger('InstitutionList');
@@ -18,6 +19,7 @@ interface InstitutionListProps {
   onEdit: (institution: Institution) => void;
   onDelete: (id: string) => void;
   onManageAccounts: (institution: Institution) => void;
+  density?: DensityLevel;
 }
 
 export function InstitutionList({
@@ -25,9 +27,11 @@ export function InstitutionList({
   onEdit,
   onDelete,
   onManageAccounts,
+  density = 'normal',
 }: InstitutionListProps) {
   const t = useTranslations('institutions');
   const tc = useTranslations('common');
+  const { cellPadding, headerPadding } = useTableDensity(density);
   const [toDelete, setToDelete] = useState<Institution | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
@@ -60,19 +64,19 @@ export function InstitutionList({
       <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead className="bg-gray-50 dark:bg-gray-800">
           <tr>
-            <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+            <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>
               {t('list.columns.name')}
             </th>
-            <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden md:table-cell">
+            <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden md:table-cell`}>
               {t('list.columns.website')}
             </th>
-            <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell">
+            <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell`}>
               {t('list.columns.country')}
             </th>
-            <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+            <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>
               {t('list.columns.accounts')}
             </th>
-            <th className="px-3 sm:px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+            <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>
               {t('list.columns.actions')}
             </th>
           </tr>
@@ -83,7 +87,7 @@ export function InstitutionList({
               key={institution.id}
               className="hover:bg-gray-50 dark:hover:bg-gray-800"
             >
-              <td className="px-3 sm:px-6 py-3">
+              <td className={cellPadding}>
                 <div className="flex items-center gap-3 min-w-0">
                   <InstitutionLogo institution={institution} size={24} fallbackGlyph="$" />
                   <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
@@ -91,7 +95,7 @@ export function InstitutionList({
                   </span>
                 </div>
               </td>
-              <td className="px-3 sm:px-6 py-3 hidden md:table-cell max-w-[16rem]">
+              <td className={`${cellPadding} hidden md:table-cell max-w-[16rem]`}>
                 <a
                   href={institution.website}
                   target="_blank"
@@ -102,10 +106,10 @@ export function InstitutionList({
                   {institution.website}
                 </a>
               </td>
-              <td className="px-3 sm:px-6 py-3 hidden sm:table-cell text-sm text-gray-500 dark:text-gray-400">
+              <td className={`${cellPadding} hidden sm:table-cell text-sm text-gray-500 dark:text-gray-400`}>
                 {institution.country || '—'}
               </td>
-              <td className="px-3 sm:px-6 py-3">
+              <td className={cellPadding}>
                 <button
                   onClick={() => onManageAccounts(institution)}
                   className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
@@ -113,7 +117,7 @@ export function InstitutionList({
                   {t('list.accountCount', { count: institution.accountCount })}
                 </button>
               </td>
-              <td className="px-3 sm:px-6 py-3 text-right whitespace-nowrap space-x-2">
+              <td className={`${cellPadding} text-right whitespace-nowrap space-x-2`}>
                 <Button
                   variant="outline"
                   size="sm"

--- a/frontend/src/components/institutions/InstitutionList.tsx
+++ b/frontend/src/components/institutions/InstitutionList.tsx
@@ -10,7 +10,7 @@ import { Institution } from '@/types/institution';
 import { institutionsApi } from '@/lib/institutions';
 import { getErrorMessage } from '@/lib/errors';
 import { createLogger } from '@/lib/logger';
-import { useTableDensity, DensityLevel } from '@/hooks/useTableDensity';
+import { useTableDensity, nextDensity, DensityLevel } from '@/hooks/useTableDensity';
 import { InstitutionLogo } from './InstitutionLogo';
 
 const logger = createLogger('InstitutionList');
@@ -21,6 +21,7 @@ interface InstitutionListProps {
   onDelete: (id: string) => void;
   onManageAccounts: (institution: Institution) => void;
   density?: DensityLevel;
+  onDensityChange?: (density: DensityLevel) => void;
 }
 
 export function InstitutionList({
@@ -29,6 +30,7 @@ export function InstitutionList({
   onDelete,
   onManageAccounts,
   density = 'normal',
+  onDensityChange,
 }: InstitutionListProps) {
   const t = useTranslations('institutions');
   const tc = useTranslations('common');
@@ -61,8 +63,27 @@ export function InstitutionList({
   }
 
   return (
-    <div className="overflow-x-auto">
-      <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+    <div>
+      {onDensityChange && (
+        <div className="flex justify-end p-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
+          <button
+            onClick={() => onDensityChange(nextDensity(density))}
+            className="inline-flex items-center px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+            title={t('list.density.title')}
+          >
+            <svg className="w-4 h-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+            {density === 'normal'
+              ? t('list.density.normal')
+              : density === 'compact'
+                ? t('list.density.compact')
+                : t('list.density.dense')}
+          </button>
+        </div>
+      )}
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead className="bg-gray-50 dark:bg-gray-800">
           <tr>
             <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>
@@ -161,8 +182,9 @@ export function InstitutionList({
               </td>
             </tr>
           ))}
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </div>
 
       <ConfirmDialog
         isOpen={toDelete !== null}

--- a/frontend/src/components/institutions/InstitutionList.tsx
+++ b/frontend/src/components/institutions/InstitutionList.tsx
@@ -12,6 +12,7 @@ import { getErrorMessage } from '@/lib/errors';
 import { createLogger } from '@/lib/logger';
 import { useTableDensity, nextDensity, DensityLevel } from '@/hooks/useTableDensity';
 import { SortIcon } from '@/components/ui/SortIcon';
+import { safeHttpUrl } from '@/lib/safe-url';
 import { InstitutionLogo } from './InstitutionLogo';
 
 const logger = createLogger('InstitutionList');
@@ -143,15 +144,21 @@ export function InstitutionList({
                 </div>
               </td>
               <td className={`${cellPadding} hidden md:table-cell max-w-[16rem]`}>
-                <a
-                  href={institution.website}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={(e) => e.stopPropagation()}
-                  className="text-sm text-blue-600 dark:text-blue-400 hover:underline truncate inline-block max-w-full"
-                >
-                  {institution.website}
-                </a>
+                {safeHttpUrl(institution.website) ? (
+                  <a
+                    href={safeHttpUrl(institution.website)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    className="text-sm text-blue-600 dark:text-blue-400 hover:underline truncate inline-block max-w-full"
+                  >
+                    {institution.website}
+                  </a>
+                ) : (
+                  <span className="text-sm text-gray-500 dark:text-gray-400 truncate inline-block max-w-full">
+                    {institution.website}
+                  </span>
+                )}
               </td>
               <td className={`${cellPadding} hidden sm:table-cell text-sm text-gray-500 dark:text-gray-400`}>
                 {institution.country || '—'}

--- a/frontend/src/components/institutions/InstitutionList.tsx
+++ b/frontend/src/components/institutions/InstitutionList.tsx
@@ -11,9 +11,12 @@ import { institutionsApi } from '@/lib/institutions';
 import { getErrorMessage } from '@/lib/errors';
 import { createLogger } from '@/lib/logger';
 import { useTableDensity, nextDensity, DensityLevel } from '@/hooks/useTableDensity';
+import { SortIcon } from '@/components/ui/SortIcon';
 import { InstitutionLogo } from './InstitutionLogo';
 
 const logger = createLogger('InstitutionList');
+
+export type InstitutionSortField = 'name' | 'website' | 'country' | 'accounts';
 
 interface InstitutionListProps {
   institutions: Institution[];
@@ -22,6 +25,9 @@ interface InstitutionListProps {
   onManageAccounts: (institution: Institution) => void;
   density?: DensityLevel;
   onDensityChange?: (density: DensityLevel) => void;
+  sortField?: InstitutionSortField;
+  sortDirection?: 'asc' | 'desc';
+  onSort?: (field: InstitutionSortField) => void;
 }
 
 export function InstitutionList({
@@ -31,6 +37,9 @@ export function InstitutionList({
   onManageAccounts,
   density = 'normal',
   onDensityChange,
+  sortField = 'name',
+  sortDirection = 'asc',
+  onSort,
 }: InstitutionListProps) {
   const t = useTranslations('institutions');
   const tc = useTranslations('common');
@@ -86,17 +95,33 @@ export function InstitutionList({
         <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead className="bg-gray-50 dark:bg-gray-800">
           <tr>
-            <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>
+            <th
+              className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider ${onSort ? 'cursor-pointer hover:text-gray-700 dark:hover:text-gray-200 select-none' : ''}`}
+              onClick={onSort ? () => onSort('name') : undefined}
+            >
               {t('list.columns.name')}
+              {onSort && <SortIcon field="name" sortField={sortField} sortDirection={sortDirection} />}
             </th>
-            <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden md:table-cell`}>
+            <th
+              className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden md:table-cell ${onSort ? 'cursor-pointer hover:text-gray-700 dark:hover:text-gray-200 select-none' : ''}`}
+              onClick={onSort ? () => onSort('website') : undefined}
+            >
               {t('list.columns.website')}
+              {onSort && <SortIcon field="website" sortField={sortField} sortDirection={sortDirection} />}
             </th>
-            <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell`}>
+            <th
+              className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell ${onSort ? 'cursor-pointer hover:text-gray-700 dark:hover:text-gray-200 select-none' : ''}`}
+              onClick={onSort ? () => onSort('country') : undefined}
+            >
               {t('list.columns.country')}
+              {onSort && <SortIcon field="country" sortField={sortField} sortDirection={sortDirection} />}
             </th>
-            <th className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>
+            <th
+              className={`${headerPadding} text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider ${onSort ? 'cursor-pointer hover:text-gray-700 dark:hover:text-gray-200 select-none' : ''}`}
+              onClick={onSort ? () => onSort('accounts') : undefined}
+            >
               {t('list.columns.accounts')}
+              {onSort && <SortIcon field="accounts" sortField={sortField} sortDirection={sortDirection} />}
             </th>
             <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>
               {t('list.columns.actions')}

--- a/frontend/src/components/institutions/InstitutionLogo.tsx
+++ b/frontend/src/components/institutions/InstitutionLogo.tsx
@@ -16,8 +16,6 @@ interface InstitutionLogoProps {
   className?: string;
   /** Glyph shown when there is no institution (e.g. cashflow-only accounts). */
   fallbackGlyph?: string;
-  /** Draw the thin ring around the logo. Defaults to true. */
-  ring?: boolean;
 }
 
 /**
@@ -30,7 +28,6 @@ export function InstitutionLogo({
   size = 20,
   className = '',
   fallbackGlyph = '$',
-  ring = true,
 }: InstitutionLogoProps) {
   const [errored, setErrored] = useState(false);
 
@@ -58,9 +55,8 @@ export function InstitutionLogo({
         style={dimension}
         onError={() => setErrored(true)}
         // Circular chip with no forced backing: transparent favicons keep their
-        // transparency, opaque ones fill the circle. The optional ring keeps it
-        // defined against any background.
-        className={`shrink-0 rounded-full object-contain ${ring ? 'ring-1 ring-black/10 dark:ring-white/15' : ''} ${className}`}
+        // transparency, opaque ones fill the circle.
+        className={`shrink-0 rounded-full object-contain ${className}`}
       />
     );
   }

--- a/frontend/src/components/institutions/InstitutionLogo.tsx
+++ b/frontend/src/components/institutions/InstitutionLogo.tsx
@@ -16,6 +16,8 @@ interface InstitutionLogoProps {
   className?: string;
   /** Glyph shown when there is no institution (e.g. cashflow-only accounts). */
   fallbackGlyph?: string;
+  /** Draw the thin ring around the logo. Defaults to true. */
+  ring?: boolean;
 }
 
 /**
@@ -28,6 +30,7 @@ export function InstitutionLogo({
   size = 20,
   className = '',
   fallbackGlyph = '$',
+  ring = true,
 }: InstitutionLogoProps) {
   const [errored, setErrored] = useState(false);
 
@@ -55,9 +58,9 @@ export function InstitutionLogo({
         style={dimension}
         onError={() => setErrored(true)}
         // Circular chip with no forced backing: transparent favicons keep their
-        // transparency, opaque ones fill the circle. The ring keeps it defined
-        // against any background.
-        className={`shrink-0 rounded-full object-contain ring-1 ring-black/10 dark:ring-white/15 ${className}`}
+        // transparency, opaque ones fill the circle. The optional ring keeps it
+        // defined against any background.
+        className={`shrink-0 rounded-full object-contain ${ring ? 'ring-1 ring-black/10 dark:ring-white/15' : ''} ${className}`}
       />
     );
   }

--- a/frontend/src/components/transactions/AccountInfoWidget.test.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.test.tsx
@@ -86,10 +86,29 @@ describe('AccountInfoWidget', () => {
     expect(screen.getByText('Legacy Bank')).toBeInTheDocument();
   });
 
+  it('shows statement settlement and due days as ordinals when populated', () => {
+    render(
+      <AccountInfoWidget
+        account={makeAccount({
+          accountType: 'CREDIT_CARD',
+          statementSettlementDay: 22,
+          statementDueDay: 1,
+        })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Settlement Day')).toBeInTheDocument();
+    expect(screen.getByText('22nd')).toBeInTheDocument();
+    expect(screen.getByText('Payment Due')).toBeInTheDocument();
+    expect(screen.getByText('1st')).toBeInTheDocument();
+  });
+
   it('omits optional fields that are absent', () => {
     render(<AccountInfoWidget account={makeAccount()} onEdit={vi.fn()} />);
     expect(screen.queryByText('Account Number')).not.toBeInTheDocument();
     expect(screen.queryByText('Credit Limit')).not.toBeInTheDocument();
+    expect(screen.queryByText('Settlement Day')).not.toBeInTheDocument();
+    expect(screen.queryByText('Payment Due')).not.toBeInTheDocument();
     expect(screen.queryByText('Closed')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/transactions/AccountInfoWidget.test.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.test.tsx
@@ -103,6 +103,18 @@ describe('AccountInfoWidget', () => {
     expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
   });
 
+  it('does not render a logo link for a non-http(s) website scheme', () => {
+    render(
+      <AccountInfoWidget
+        account={makeAccount({ institutionId: 'inst-1' })}
+        institution={{ id: 'inst-1', name: 'TD', hasLogo: true, website: 'javascript:alert(1)' }}
+        onEdit={vi.fn()}
+        onCollapse={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
   it('falls back to the legacy institution string when no entity is linked', () => {
     render(
       <AccountInfoWidget

--- a/frontend/src/components/transactions/AccountInfoWidget.test.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.test.tsx
@@ -101,6 +101,10 @@ describe('AccountInfoWidget', () => {
     expect(screen.getByText('22nd')).toBeInTheDocument();
     expect(screen.getByText('Payment Due')).toBeInTheDocument();
     expect(screen.getByText('1st')).toBeInTheDocument();
+    // The settlement day carries an explanatory tooltip, as on the dashboard.
+    expect(
+      screen.getByLabelText(/last day of the billing cycle/i),
+    ).toBeInTheDocument();
   });
 
   it('omits optional fields that are absent', () => {

--- a/frontend/src/components/transactions/AccountInfoWidget.test.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@/test/render';
+import { AccountInfoWidget } from './AccountInfoWidget';
+import { Account } from '@/types/account';
+
+vi.mock('@/hooks/useNumberFormat', () => ({
+  useNumberFormat: () => ({
+    formatCurrency: (val: number, currency: string) => `${currency} ${val.toFixed(2)}`,
+    formatNumber: (val: number) => String(val),
+  }),
+}));
+
+const makeAccount = (overrides: Partial<Account> = {}): Account =>
+  ({
+    id: 'a-1',
+    name: 'Everyday Chequing',
+    accountType: 'CHEQUING',
+    accountSubType: null,
+    linkedAccountId: null,
+    description: null,
+    currencyCode: 'CAD',
+    accountNumber: null,
+    institution: null,
+    institutionId: null,
+    currentBalance: 1234.5,
+    creditLimit: null,
+    interestRate: null,
+    isClosed: false,
+    ...overrides,
+  }) as Account;
+
+describe('AccountInfoWidget', () => {
+  it('shows the account name, balance and type', () => {
+    render(<AccountInfoWidget account={makeAccount()} onEdit={vi.fn()} />);
+    expect(screen.getByText('Everyday Chequing')).toBeInTheDocument();
+    expect(screen.getByText('CAD 1234.50')).toBeInTheDocument();
+    expect(screen.getByText('Chequing')).toBeInTheDocument();
+  });
+
+  it('calls onEdit when the pencil button is clicked', () => {
+    const onEdit = vi.fn();
+    render(<AccountInfoWidget account={makeAccount()} onEdit={onEdit} />);
+    fireEvent.click(screen.getByLabelText('Edit account settings'));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders optional fields and a closed badge when present', () => {
+    render(
+      <AccountInfoWidget
+        account={makeAccount({
+          accountType: 'CREDIT_CARD',
+          institution: 'TD',
+          accountNumber: '****1234',
+          creditLimit: 5000,
+          interestRate: 19.99,
+          isClosed: true,
+        })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('TD')).toBeInTheDocument();
+    expect(screen.getByText('****1234')).toBeInTheDocument();
+    expect(screen.getByText('CAD 5000.00')).toBeInTheDocument();
+    expect(screen.getByText('19.99%')).toBeInTheDocument();
+    expect(screen.getByText('Closed')).toBeInTheDocument();
+  });
+
+  it('omits optional fields that are absent', () => {
+    render(<AccountInfoWidget account={makeAccount()} onEdit={vi.fn()} />);
+    expect(screen.queryByText('Institution')).not.toBeInTheDocument();
+    expect(screen.queryByText('Account Number')).not.toBeInTheDocument();
+    expect(screen.queryByText('Credit Limit')).not.toBeInTheDocument();
+    expect(screen.queryByText('Closed')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/transactions/AccountInfoWidget.test.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.test.tsx
@@ -49,7 +49,6 @@ describe('AccountInfoWidget', () => {
       <AccountInfoWidget
         account={makeAccount({
           accountType: 'CREDIT_CARD',
-          institution: 'TD',
           accountNumber: '****1234',
           creditLimit: 5000,
           interestRate: 19.99,
@@ -58,16 +57,37 @@ describe('AccountInfoWidget', () => {
         onEdit={vi.fn()}
       />,
     );
-    expect(screen.getByText('TD')).toBeInTheDocument();
     expect(screen.getByText('****1234')).toBeInTheDocument();
     expect(screen.getByText('CAD 5000.00')).toBeInTheDocument();
     expect(screen.getByText('19.99%')).toBeInTheDocument();
     expect(screen.getByText('Closed')).toBeInTheDocument();
   });
 
+  it('shows the institution name and logo when an institution is provided', () => {
+    render(
+      <AccountInfoWidget
+        account={makeAccount({ institutionId: 'inst-1' })}
+        institution={{ id: 'inst-1', name: 'TD Canada Trust', hasLogo: true }}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('TD Canada Trust')).toBeInTheDocument();
+    // The cached favicon is rendered with the institution name as alt text.
+    expect(screen.getByRole('img', { name: 'TD Canada Trust' })).toBeInTheDocument();
+  });
+
+  it('falls back to the legacy institution string when no entity is linked', () => {
+    render(
+      <AccountInfoWidget
+        account={makeAccount({ institution: 'Legacy Bank' })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Legacy Bank')).toBeInTheDocument();
+  });
+
   it('omits optional fields that are absent', () => {
     render(<AccountInfoWidget account={makeAccount()} onEdit={vi.fn()} />);
-    expect(screen.queryByText('Institution')).not.toBeInTheDocument();
     expect(screen.queryByText('Account Number')).not.toBeInTheDocument();
     expect(screen.queryByText('Credit Limit')).not.toBeInTheDocument();
     expect(screen.queryByText('Closed')).not.toBeInTheDocument();

--- a/frontend/src/components/transactions/AccountInfoWidget.test.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.test.tsx
@@ -88,6 +88,21 @@ describe('AccountInfoWidget', () => {
     expect(screen.getByRole('img', { name: 'TD Canada Trust' })).toBeInTheDocument();
   });
 
+  it('links the institution logo to its website in a new tab', () => {
+    render(
+      <AccountInfoWidget
+        account={makeAccount({ institutionId: 'inst-1' })}
+        institution={{ id: 'inst-1', name: 'TD', hasLogo: true, website: 'https://td.com' }}
+        onEdit={vi.fn()}
+        onCollapse={vi.fn()}
+      />,
+    );
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'https://td.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
   it('falls back to the legacy institution string when no entity is linked', () => {
     render(
       <AccountInfoWidget

--- a/frontend/src/components/transactions/AccountInfoWidget.test.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.test.tsx
@@ -31,7 +31,7 @@ const makeAccount = (overrides: Partial<Account> = {}): Account =>
 
 describe('AccountInfoWidget', () => {
   it('shows the account name, balance and type', () => {
-    render(<AccountInfoWidget account={makeAccount()} onEdit={vi.fn()} />);
+    render(<AccountInfoWidget account={makeAccount()} onEdit={vi.fn()} onCollapse={vi.fn()} />);
     expect(screen.getByText('Everyday Chequing')).toBeInTheDocument();
     expect(screen.getByText('CAD 1234.50')).toBeInTheDocument();
     expect(screen.getByText('Chequing')).toBeInTheDocument();
@@ -39,9 +39,16 @@ describe('AccountInfoWidget', () => {
 
   it('calls onEdit when the pencil button is clicked', () => {
     const onEdit = vi.fn();
-    render(<AccountInfoWidget account={makeAccount()} onEdit={onEdit} />);
+    render(<AccountInfoWidget account={makeAccount()} onEdit={onEdit} onCollapse={vi.fn()} />);
     fireEvent.click(screen.getByLabelText('Edit account settings'));
     expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCollapse when the collapse button is clicked', () => {
+    const onCollapse = vi.fn();
+    render(<AccountInfoWidget account={makeAccount()} onEdit={vi.fn()} onCollapse={onCollapse} />);
+    fireEvent.click(screen.getByLabelText('Hide account info'));
+    expect(onCollapse).toHaveBeenCalledTimes(1);
   });
 
   it('renders optional fields and a closed badge when present', () => {
@@ -54,7 +61,7 @@ describe('AccountInfoWidget', () => {
           interestRate: 19.99,
           isClosed: true,
         })}
-        onEdit={vi.fn()}
+        onEdit={vi.fn()} onCollapse={vi.fn()}
       />,
     );
     expect(screen.getByText('****1234')).toBeInTheDocument();
@@ -68,7 +75,7 @@ describe('AccountInfoWidget', () => {
       <AccountInfoWidget
         account={makeAccount({ institutionId: 'inst-1' })}
         institution={{ id: 'inst-1', name: 'TD Canada Trust', hasLogo: true }}
-        onEdit={vi.fn()}
+        onEdit={vi.fn()} onCollapse={vi.fn()}
       />,
     );
     expect(screen.getByText('TD Canada Trust')).toBeInTheDocument();
@@ -80,7 +87,7 @@ describe('AccountInfoWidget', () => {
     render(
       <AccountInfoWidget
         account={makeAccount({ institution: 'Legacy Bank' })}
-        onEdit={vi.fn()}
+        onEdit={vi.fn()} onCollapse={vi.fn()}
       />,
     );
     expect(screen.getByText('Legacy Bank')).toBeInTheDocument();
@@ -94,7 +101,7 @@ describe('AccountInfoWidget', () => {
           statementSettlementDay: 22,
           statementDueDay: 1,
         })}
-        onEdit={vi.fn()}
+        onEdit={vi.fn()} onCollapse={vi.fn()}
       />,
     );
     expect(screen.getByText('Settlement Day')).toBeInTheDocument();
@@ -108,7 +115,7 @@ describe('AccountInfoWidget', () => {
   });
 
   it('omits optional fields that are absent', () => {
-    render(<AccountInfoWidget account={makeAccount()} onEdit={vi.fn()} />);
+    render(<AccountInfoWidget account={makeAccount()} onEdit={vi.fn()} onCollapse={vi.fn()} />);
     expect(screen.queryByText('Account Number')).not.toBeInTheDocument();
     expect(screen.queryByText('Credit Limit')).not.toBeInTheDocument();
     expect(screen.queryByText('Settlement Day')).not.toBeInTheDocument();

--- a/frontend/src/components/transactions/AccountInfoWidget.test.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.test.tsx
@@ -114,10 +114,10 @@ describe('AccountInfoWidget', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows the soonest scheduled payment for the account', () => {
+  it('shows the soonest scheduled payment with payee, in red for a debit', () => {
     const scheduled = [
-      { id: 's1', accountId: 'a-1', isActive: true, nextDueDate: '2026-07-15', amount: -120.5, currencyCode: 'CAD' },
-      { id: 's2', accountId: 'a-1', isActive: true, nextDueDate: '2026-06-20', amount: -80, currencyCode: 'CAD' },
+      { id: 's1', accountId: 'a-1', isActive: true, nextDueDate: '2026-07-15', amount: -120.5, currencyCode: 'CAD', payeeName: 'Landlord' },
+      { id: 's2', accountId: 'a-1', isActive: true, nextDueDate: '2026-06-20', amount: -80, currencyCode: 'CAD', payee: { name: 'Hydro' } },
       { id: 's3', accountId: 'other', isActive: true, nextDueDate: '2026-06-01', amount: -999, currencyCode: 'CAD' },
     ] as any;
     render(
@@ -130,8 +130,30 @@ describe('AccountInfoWidget', () => {
     );
     expect(screen.getByText('Next Payment')).toBeInTheDocument();
     // The 2026-06-20 bill is sooner than 2026-07-15; the other account is ignored.
-    expect(screen.getByText('CAD 80.00')).toBeInTheDocument();
+    const amount = screen.getByText('CAD 80.00');
+    expect(amount).toBeInTheDocument();
+    expect(amount.className).toContain('text-red-600');
+    // The payee for the soonest bill is shown.
+    expect(screen.getByText('Hydro')).toBeInTheDocument();
+    expect(screen.queryByText('Landlord')).not.toBeInTheDocument();
     expect(screen.queryByText('CAD 999.00')).not.toBeInTheDocument();
+  });
+
+  it('shows an incoming scheduled deposit in green', () => {
+    const scheduled = [
+      { id: 's1', accountId: 'a-1', isActive: true, nextDueDate: '2026-06-20', amount: 2500, currencyCode: 'CAD', payeeName: 'Employer' },
+    ] as any;
+    render(
+      <AccountInfoWidget
+        account={makeAccount()}
+        scheduledTransactions={scheduled}
+        onEdit={vi.fn()}
+        onCollapse={vi.fn()}
+      />,
+    );
+    const amount = screen.getByText('CAD 2500.00');
+    expect(amount.className).toContain('text-green-600');
+    expect(screen.getByText('Employer')).toBeInTheDocument();
   });
 
   it('uses the per-occurrence override date and amount when present', () => {

--- a/frontend/src/components/transactions/AccountInfoWidget.test.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.test.tsx
@@ -114,6 +114,60 @@ describe('AccountInfoWidget', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows the soonest scheduled payment for the account', () => {
+    const scheduled = [
+      { id: 's1', accountId: 'a-1', isActive: true, nextDueDate: '2026-07-15', amount: -120.5, currencyCode: 'CAD' },
+      { id: 's2', accountId: 'a-1', isActive: true, nextDueDate: '2026-06-20', amount: -80, currencyCode: 'CAD' },
+      { id: 's3', accountId: 'other', isActive: true, nextDueDate: '2026-06-01', amount: -999, currencyCode: 'CAD' },
+    ] as any;
+    render(
+      <AccountInfoWidget
+        account={makeAccount()}
+        scheduledTransactions={scheduled}
+        onEdit={vi.fn()}
+        onCollapse={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Next Payment')).toBeInTheDocument();
+    // The 2026-06-20 bill is sooner than 2026-07-15; the other account is ignored.
+    expect(screen.getByText('CAD 80.00')).toBeInTheDocument();
+    expect(screen.queryByText('CAD 999.00')).not.toBeInTheDocument();
+  });
+
+  it('uses the per-occurrence override date and amount when present', () => {
+    const scheduled = [
+      {
+        id: 's1', accountId: 'a-1', isActive: true,
+        nextDueDate: '2026-07-15', amount: -120.5, currencyCode: 'CAD',
+        nextOverride: { overrideDate: '2026-05-01', amount: -42 },
+      },
+    ] as any;
+    render(
+      <AccountInfoWidget
+        account={makeAccount()}
+        scheduledTransactions={scheduled}
+        onEdit={vi.fn()}
+        onCollapse={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('CAD 42.00')).toBeInTheDocument();
+  });
+
+  it('ignores inactive scheduled transactions', () => {
+    const scheduled = [
+      { id: 's1', accountId: 'a-1', isActive: false, nextDueDate: '2026-06-20', amount: -80, currencyCode: 'CAD' },
+    ] as any;
+    render(
+      <AccountInfoWidget
+        account={makeAccount()}
+        scheduledTransactions={scheduled}
+        onEdit={vi.fn()}
+        onCollapse={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText('Next Payment')).not.toBeInTheDocument();
+  });
+
   it('omits optional fields that are absent', () => {
     render(<AccountInfoWidget account={makeAccount()} onEdit={vi.fn()} onCollapse={vi.fn()} />);
     expect(screen.queryByText('Account Number')).not.toBeInTheDocument();

--- a/frontend/src/components/transactions/AccountInfoWidget.test.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.test.tsx
@@ -10,6 +10,11 @@ vi.mock('@/hooks/useNumberFormat', () => ({
   }),
 }));
 
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
 const makeAccount = (overrides: Partial<Account> = {}): Account =>
   ({
     id: 'a-1',
@@ -137,6 +142,23 @@ describe('AccountInfoWidget', () => {
     expect(screen.getByText('Hydro')).toBeInTheDocument();
     expect(screen.queryByText('Landlord')).not.toBeInTheDocument();
     expect(screen.queryByText('CAD 999.00')).not.toBeInTheDocument();
+  });
+
+  it('navigates to Bills & Deposits when the next payment is clicked', () => {
+    mockPush.mockClear();
+    const scheduled = [
+      { id: 's1', accountId: 'a-1', isActive: true, nextDueDate: '2026-06-20', amount: -80, currencyCode: 'CAD', payeeName: 'Hydro' },
+    ] as any;
+    render(
+      <AccountInfoWidget
+        account={makeAccount()}
+        scheduledTransactions={scheduled}
+        onEdit={vi.fn()}
+        onCollapse={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText('Next Payment'));
+    expect(mockPush).toHaveBeenCalledWith('/bills');
   });
 
   it('shows an incoming scheduled deposit in green', () => {

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -166,19 +166,21 @@ export function AccountInfoWidget({
           title={t('accountWidget.viewBills')}
           className="mb-4 w-full text-left rounded-md bg-gray-50 dark:bg-gray-700/40 hover:bg-gray-100 dark:hover:bg-gray-700/60 transition-colors px-3 py-2"
         >
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            {t('accountWidget.nextPayment')}
-          </p>
           <div className="flex items-start justify-between gap-3">
-            <p
-              className={`text-base font-semibold ${
-                nextPayment.amount < 0
-                  ? 'text-red-600 dark:text-red-400'
-                  : 'text-green-600 dark:text-green-400'
-              }`}
-            >
-              {formatCurrency(Math.abs(nextPayment.amount), nextPayment.currencyCode)}
-            </p>
+            <div className="min-w-0">
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {t('accountWidget.nextPayment')}
+              </p>
+              <p
+                className={`text-base font-semibold ${
+                  nextPayment.amount < 0
+                    ? 'text-red-600 dark:text-red-400'
+                    : 'text-green-600 dark:text-green-400'
+                }`}
+              >
+                {formatCurrency(Math.abs(nextPayment.amount), nextPayment.currencyCode)}
+              </p>
+            </div>
             <div className="text-right min-w-0">
               {nextPayment.payeeName && (
                 <p className="text-sm text-gray-700 dark:text-gray-300 truncate">
@@ -198,7 +200,7 @@ export function AccountInfoWidget({
           <div key={detail.label} className="flex items-baseline justify-between gap-3">
             <dt className="text-gray-500 dark:text-gray-400 flex-shrink-0 flex items-center">
               {detail.label}
-              {detail.tooltip && <InfoTooltip text={detail.tooltip} />}
+              {detail.tooltip && <InfoTooltip text={detail.tooltip} usePortal />}
             </dt>
             <dd className="text-gray-900 dark:text-gray-100 text-right truncate">
               {detail.value}

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -7,6 +7,7 @@ import { formatAccountType } from '@/lib/account-utils';
 import { getOrdinal } from '@/lib/ordinal';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { InstitutionLogo, InstitutionLogoData } from '@/components/institutions/InstitutionLogo';
+import { InfoTooltip } from '@/components/ui/InfoTooltip';
 
 interface AccountInfoWidgetProps {
   account: Account;
@@ -34,7 +35,7 @@ export function AccountInfoWidget({ account, institution, onEdit }: AccountInfoW
   // free-text field stored on the account.
   const institutionName = institution?.name ?? account.institution ?? null;
 
-  const details: Array<{ label: string; value: string }> = [];
+  const details: Array<{ label: string; value: string; tooltip?: string }> = [];
   details.push({
     label: t('accountWidget.type'),
     value: formatAccountType(account.accountType, tc),
@@ -59,6 +60,7 @@ export function AccountInfoWidget({ account, institution, onEdit }: AccountInfoW
     details.push({
       label: t('accountWidget.statementSettlement'),
       value: getOrdinal(account.statementSettlementDay),
+      tooltip: t('accountWidget.statementSettlementTooltip'),
     });
   }
   if (account.statementDueDay) {
@@ -118,8 +120,9 @@ export function AccountInfoWidget({ account, institution, onEdit }: AccountInfoW
       <dl className="space-y-2 text-sm">
         {details.map((detail) => (
           <div key={detail.label} className="flex items-baseline justify-between gap-3">
-            <dt className="text-gray-500 dark:text-gray-400 flex-shrink-0">
+            <dt className="text-gray-500 dark:text-gray-400 flex-shrink-0 flex items-center">
               {detail.label}
+              {detail.tooltip && <InfoTooltip text={detail.tooltip} />}
             </dt>
             <dd className="text-gray-900 dark:text-gray-100 text-right truncate">
               {detail.value}

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -110,15 +110,19 @@ export function AccountInfoWidget({
             <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">
               {account.name}
             </h3>
-            {institutionName && (
-              <p className="text-sm text-gray-500 dark:text-gray-400 truncate">
-                {institutionName}
-              </p>
-            )}
-            {account.isClosed && (
-              <span className="inline-block mt-1 text-xs font-medium px-2 py-0.5 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
-                {t('accountWidget.closed')}
-              </span>
+            {(institutionName || account.isClosed) && (
+              <div className="flex items-center gap-2 min-w-0">
+                {institutionName && (
+                  <p className="text-sm text-gray-500 dark:text-gray-400 truncate">
+                    {institutionName}
+                  </p>
+                )}
+                {account.isClosed && (
+                  <span className="flex-shrink-0 text-xs font-medium px-2 py-0.5 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+                    {t('accountWidget.closed')}
+                  </span>
+                )}
+              </div>
             )}
           </div>
         </div>

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -5,9 +5,12 @@ import { PencilSquareIcon } from '@heroicons/react/24/outline';
 import { Account } from '@/types/account';
 import { formatAccountType } from '@/lib/account-utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { InstitutionLogo, InstitutionLogoData } from '@/components/institutions/InstitutionLogo';
 
 interface AccountInfoWidgetProps {
   account: Account;
+  /** The account's institution, when assigned, for the logo + name. */
+  institution?: InstitutionLogoData | null;
   /** Open the shared account edit modal for this account. */
   onEdit: () => void;
 }
@@ -17,7 +20,7 @@ interface AccountInfoWidgetProps {
  * Transactions list is filtered to a single account. The pencil opens the same
  * edit modal used on the Accounts page via the supplied `onEdit` callback.
  */
-export function AccountInfoWidget({ account, onEdit }: AccountInfoWidgetProps) {
+export function AccountInfoWidget({ account, institution, onEdit }: AccountInfoWidgetProps) {
   const t = useTranslations('transactions');
   const tc = useTranslations('common');
   const { formatCurrency } = useNumberFormat();
@@ -26,15 +29,15 @@ export function AccountInfoWidget({ account, onEdit }: AccountInfoWidgetProps) {
     account.accountType,
   );
   const balance = Number(account.currentBalance) || 0;
+  // Prefer the linked institution's canonical name; fall back to the legacy
+  // free-text field stored on the account.
+  const institutionName = institution?.name ?? account.institution ?? null;
 
   const details: Array<{ label: string; value: string }> = [];
   details.push({
     label: t('accountWidget.type'),
     value: formatAccountType(account.accountType, tc),
   });
-  if (account.institution) {
-    details.push({ label: t('accountWidget.institution'), value: account.institution });
-  }
   if (account.accountNumber) {
     details.push({ label: t('accountWidget.accountNumber'), value: account.accountNumber });
   }
@@ -55,15 +58,23 @@ export function AccountInfoWidget({ account, onEdit }: AccountInfoWidgetProps) {
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 sm:p-6 mb-6 min-h-[420px] h-full flex flex-col">
       <div className="flex items-start justify-between gap-2 mb-4">
-        <div className="min-w-0">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">
-            {account.name}
-          </h3>
-          {account.isClosed && (
-            <span className="inline-block mt-1 text-xs font-medium px-2 py-0.5 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
-              {t('accountWidget.closed')}
-            </span>
-          )}
+        <div className="flex items-start gap-3 min-w-0">
+          <InstitutionLogo institution={institution ?? undefined} size={32} fallbackGlyph="$" />
+          <div className="min-w-0">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">
+              {account.name}
+            </h3>
+            {institutionName && (
+              <p className="text-sm text-gray-500 dark:text-gray-400 truncate">
+                {institutionName}
+              </p>
+            )}
+            {account.isClosed && (
+              <span className="inline-block mt-1 text-xs font-medium px-2 py-0.5 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+                {t('accountWidget.closed')}
+              </span>
+            )}
+          </div>
         </div>
         <button
           type="button"

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { PencilSquareIcon } from '@heroicons/react/24/outline';
+import { PencilSquareIcon, ChevronDoubleLeftIcon } from '@heroicons/react/24/outline';
 import { Account } from '@/types/account';
 import { formatAccountType } from '@/lib/account-utils';
 import { getOrdinal } from '@/lib/ordinal';
@@ -15,6 +15,8 @@ interface AccountInfoWidgetProps {
   institution?: InstitutionLogoData | null;
   /** Open the shared account edit modal for this account. */
   onEdit: () => void;
+  /** Collapse the widget so the chart can use the full width. */
+  onCollapse: () => void;
 }
 
 /**
@@ -22,7 +24,7 @@ interface AccountInfoWidgetProps {
  * Transactions list is filtered to a single account. The pencil opens the same
  * edit modal used on the Accounts page via the supplied `onEdit` callback.
  */
-export function AccountInfoWidget({ account, institution, onEdit }: AccountInfoWidgetProps) {
+export function AccountInfoWidget({ account, institution, onEdit, onCollapse }: AccountInfoWidgetProps) {
   const t = useTranslations('transactions');
   const tc = useTranslations('common');
   const { formatCurrency } = useNumberFormat();
@@ -91,15 +93,26 @@ export function AccountInfoWidget({ account, institution, onEdit }: AccountInfoW
             )}
           </div>
         </div>
-        <button
-          type="button"
-          onClick={onEdit}
-          aria-label={t('accountWidget.editAria')}
-          title={t('accountWidget.editAria')}
-          className="flex-shrink-0 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded p-1"
-        >
-          <PencilSquareIcon className="h-5 w-5" />
-        </button>
+        <div className="flex items-center gap-0.5 flex-shrink-0">
+          <button
+            type="button"
+            onClick={onEdit}
+            aria-label={t('accountWidget.editAria')}
+            title={t('accountWidget.editAria')}
+            className="text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded p-1"
+          >
+            <PencilSquareIcon className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
+            onClick={onCollapse}
+            aria-label={t('accountWidget.collapseAria')}
+            title={t('accountWidget.collapseAria')}
+            className="text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded p-1"
+          >
+            <ChevronDoubleLeftIcon className="h-5 w-5" />
+          </button>
+        </div>
       </div>
 
       <div className="mb-4">

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl';
 import { PencilSquareIcon } from '@heroicons/react/24/outline';
 import { Account } from '@/types/account';
 import { formatAccountType } from '@/lib/account-utils';
+import { getOrdinal } from '@/lib/ordinal';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { InstitutionLogo, InstitutionLogoData } from '@/components/institutions/InstitutionLogo';
 
@@ -52,6 +53,18 @@ export function AccountInfoWidget({ account, institution, onEdit }: AccountInfoW
     details.push({
       label: t('accountWidget.interestRate'),
       value: `${Number(account.interestRate)}%`,
+    });
+  }
+  if (account.statementSettlementDay) {
+    details.push({
+      label: t('accountWidget.statementSettlement'),
+      value: getOrdinal(account.statementSettlementDay),
+    });
+  }
+  if (account.statementDueDay) {
+    details.push({
+      label: t('accountWidget.statementDue'),
+      value: getOrdinal(account.statementDueDay),
     });
   }
 

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { PencilSquareIcon } from '@heroicons/react/24/outline';
+import { Account } from '@/types/account';
+import { formatAccountType } from '@/lib/account-utils';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
+
+interface AccountInfoWidgetProps {
+  account: Account;
+  /** Open the shared account edit modal for this account. */
+  onEdit: () => void;
+}
+
+/**
+ * Compact account summary shown beside the Account Balance chart when the
+ * Transactions list is filtered to a single account. The pencil opens the same
+ * edit modal used on the Accounts page via the supplied `onEdit` callback.
+ */
+export function AccountInfoWidget({ account, onEdit }: AccountInfoWidgetProps) {
+  const t = useTranslations('transactions');
+  const tc = useTranslations('common');
+  const { formatCurrency } = useNumberFormat();
+
+  const isLiability = ['CREDIT_CARD', 'LOAN', 'MORTGAGE', 'LINE_OF_CREDIT'].includes(
+    account.accountType,
+  );
+  const balance = Number(account.currentBalance) || 0;
+
+  const details: Array<{ label: string; value: string }> = [];
+  details.push({
+    label: t('accountWidget.type'),
+    value: formatAccountType(account.accountType, tc),
+  });
+  if (account.institution) {
+    details.push({ label: t('accountWidget.institution'), value: account.institution });
+  }
+  if (account.accountNumber) {
+    details.push({ label: t('accountWidget.accountNumber'), value: account.accountNumber });
+  }
+  details.push({ label: t('accountWidget.currency'), value: account.currencyCode });
+  if (account.creditLimit != null && Number(account.creditLimit) !== 0) {
+    details.push({
+      label: t('accountWidget.creditLimit'),
+      value: formatCurrency(Number(account.creditLimit), account.currencyCode),
+    });
+  }
+  if (account.interestRate != null && Number(account.interestRate) !== 0) {
+    details.push({
+      label: t('accountWidget.interestRate'),
+      value: `${Number(account.interestRate)}%`,
+    });
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 sm:p-6 mb-6 min-h-[420px] h-full flex flex-col">
+      <div className="flex items-start justify-between gap-2 mb-4">
+        <div className="min-w-0">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">
+            {account.name}
+          </h3>
+          {account.isClosed && (
+            <span className="inline-block mt-1 text-xs font-medium px-2 py-0.5 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+              {t('accountWidget.closed')}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onEdit}
+          aria-label={t('accountWidget.editAria')}
+          title={t('accountWidget.editAria')}
+          className="flex-shrink-0 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded p-1"
+        >
+          <PencilSquareIcon className="h-5 w-5" />
+        </button>
+      </div>
+
+      <div className="mb-4">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {t('accountWidget.currentBalance')}
+        </p>
+        <p
+          className={`text-2xl font-bold ${
+            balance < 0 || isLiability
+              ? 'text-red-600 dark:text-red-400'
+              : 'text-gray-900 dark:text-gray-100'
+          }`}
+        >
+          {formatCurrency(balance, account.currencyCode)}
+        </p>
+      </div>
+
+      <dl className="space-y-2 text-sm">
+        {details.map((detail) => (
+          <div key={detail.label} className="flex items-baseline justify-between gap-3">
+            <dt className="text-gray-500 dark:text-gray-400 flex-shrink-0">
+              {detail.label}
+            </dt>
+            <dd className="text-gray-900 dark:text-gray-100 text-right truncate">
+              {detail.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      {account.description && (
+        <p className="mt-4 text-sm text-gray-500 dark:text-gray-400 break-words">
+          {account.description}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -15,8 +15,9 @@ import { InfoTooltip } from '@/components/ui/InfoTooltip';
 
 interface AccountInfoWidgetProps {
   account: Account;
-  /** The account's institution, when assigned, for the logo + name. */
-  institution?: InstitutionLogoData | null;
+  /** The account's institution, when assigned, for the logo + name. The
+   *  optional website makes the logo a link to the institution's site. */
+  institution?: (InstitutionLogoData & { website?: string }) | null;
   /** Scheduled bills/deposits; the soonest for this account is surfaced. */
   scheduledTransactions?: ScheduledTransaction[];
   /** Open the shared account edit modal for this account. */
@@ -105,7 +106,19 @@ export function AccountInfoWidget({
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 sm:p-6 mb-6 lg:mb-0 lg:absolute lg:inset-x-0 lg:top-0 lg:bottom-6 lg:overflow-y-auto flex flex-col">
       <div className="flex items-start justify-between gap-2 mb-4">
         <div className="flex items-center gap-3 min-w-0">
-          <InstitutionLogo institution={institution ?? undefined} size={40} fallbackGlyph="$" />
+          {institution?.website ? (
+            <a
+              href={institution.website}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={institution.website}
+              className="flex-shrink-0 rounded-full focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <InstitutionLogo institution={institution} size={40} fallbackGlyph="$" />
+            </a>
+          ) : (
+            <InstitutionLogo institution={institution ?? undefined} size={40} fallbackGlyph="$" />
+          )}
           <div className="min-w-0">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">
               {account.name}

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -51,6 +51,12 @@ export function AccountInfoWidget({
   // Prefer the linked institution's canonical name; fall back to the legacy
   // free-text field stored on the account.
   const institutionName = institution?.name ?? account.institution ?? null;
+  // Only treat http(s) URLs as a safe link target, to avoid javascript:/data:
+  // URIs ever reaching the href.
+  const institutionWebsite =
+    institution?.website && /^https?:\/\//i.test(institution.website)
+      ? institution.website
+      : undefined;
 
   // The soonest active scheduled bill/deposit booked against this account.
   // Honours a per-occurrence override for both the date and the amount.
@@ -106,12 +112,12 @@ export function AccountInfoWidget({
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 sm:p-6 mb-6 lg:mb-0 lg:absolute lg:inset-x-0 lg:top-0 lg:bottom-6 lg:overflow-y-auto flex flex-col">
       <div className="flex items-start justify-between gap-2 mb-4">
         <div className="flex items-center gap-3 min-w-0">
-          {institution?.website ? (
+          {institutionWebsite ? (
             <a
-              href={institution.website}
+              href={institutionWebsite}
               target="_blank"
               rel="noopener noreferrer"
-              title={institution.website}
+              title={institutionWebsite}
               className="flex-shrink-0 rounded-full focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               <InstitutionLogo institution={institution} size={40} fallbackGlyph="$" />

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react';
 import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
 import { PencilSquareIcon, ChevronDoubleLeftIcon } from '@heroicons/react/24/outline';
 import { Account } from '@/types/account';
 import { ScheduledTransaction } from '@/types/scheduled-transaction';
@@ -38,6 +39,7 @@ export function AccountInfoWidget({
 }: AccountInfoWidgetProps) {
   const t = useTranslations('transactions');
   const tc = useTranslations('common');
+  const router = useRouter();
   const { formatCurrency } = useNumberFormat();
   const { formatDate } = useDateFormat();
 
@@ -100,7 +102,7 @@ export function AccountInfoWidget({
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 sm:p-6 mb-6 lg:mb-0 lg:h-full flex flex-col overflow-hidden">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 sm:p-6 mb-6 lg:mb-0 lg:absolute lg:inset-x-0 lg:top-0 lg:bottom-6 lg:overflow-y-auto flex flex-col">
       <div className="flex items-start justify-between gap-2 mb-4">
         <div className="flex items-center gap-3 min-w-0">
           <InstitutionLogo institution={institution ?? undefined} size={40} fallbackGlyph="$" />
@@ -158,28 +160,37 @@ export function AccountInfoWidget({
       </div>
 
       {nextPayment && (
-        <div className="mb-4 rounded-md bg-gray-50 dark:bg-gray-700/40 px-3 py-2">
+        <button
+          type="button"
+          onClick={() => router.push('/bills')}
+          title={t('accountWidget.viewBills')}
+          className="mb-4 w-full text-left rounded-md bg-gray-50 dark:bg-gray-700/40 hover:bg-gray-100 dark:hover:bg-gray-700/60 transition-colors px-3 py-2"
+        >
           <p className="text-sm text-gray-500 dark:text-gray-400">
             {t('accountWidget.nextPayment')}
           </p>
-          <p
-            className={`text-base font-semibold ${
-              nextPayment.amount < 0
-                ? 'text-red-600 dark:text-red-400'
-                : 'text-green-600 dark:text-green-400'
-            }`}
-          >
-            {formatCurrency(Math.abs(nextPayment.amount), nextPayment.currencyCode)}
-          </p>
-          {nextPayment.payeeName && (
-            <p className="text-sm text-gray-700 dark:text-gray-300 truncate">
-              {nextPayment.payeeName}
+          <div className="flex items-start justify-between gap-3">
+            <p
+              className={`text-base font-semibold ${
+                nextPayment.amount < 0
+                  ? 'text-red-600 dark:text-red-400'
+                  : 'text-green-600 dark:text-green-400'
+              }`}
+            >
+              {formatCurrency(Math.abs(nextPayment.amount), nextPayment.currencyCode)}
             </p>
-          )}
-          <p className="text-xs text-gray-500 dark:text-gray-400">
-            {formatDate(nextPayment.date)}
-          </p>
-        </div>
+            <div className="text-right min-w-0">
+              {nextPayment.payeeName && (
+                <p className="text-sm text-gray-700 dark:text-gray-300 truncate">
+                  {nextPayment.payeeName}
+                </p>
+              )}
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                {formatDate(nextPayment.date)}
+              </p>
+            </div>
+          </div>
+        </button>
       )}
 
       <dl className="space-y-2 text-sm">

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -1,11 +1,14 @@
 'use client';
 
+import { useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import { PencilSquareIcon, ChevronDoubleLeftIcon } from '@heroicons/react/24/outline';
 import { Account } from '@/types/account';
+import { ScheduledTransaction } from '@/types/scheduled-transaction';
 import { formatAccountType } from '@/lib/account-utils';
 import { getOrdinal } from '@/lib/ordinal';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useDateFormat } from '@/hooks/useDateFormat';
 import { InstitutionLogo, InstitutionLogoData } from '@/components/institutions/InstitutionLogo';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
 
@@ -13,6 +16,8 @@ interface AccountInfoWidgetProps {
   account: Account;
   /** The account's institution, when assigned, for the logo + name. */
   institution?: InstitutionLogoData | null;
+  /** Scheduled bills/deposits; the soonest for this account is surfaced. */
+  scheduledTransactions?: ScheduledTransaction[];
   /** Open the shared account edit modal for this account. */
   onEdit: () => void;
   /** Collapse the widget so the chart can use the full width. */
@@ -24,10 +29,17 @@ interface AccountInfoWidgetProps {
  * Transactions list is filtered to a single account. The pencil opens the same
  * edit modal used on the Accounts page via the supplied `onEdit` callback.
  */
-export function AccountInfoWidget({ account, institution, onEdit, onCollapse }: AccountInfoWidgetProps) {
+export function AccountInfoWidget({
+  account,
+  institution,
+  scheduledTransactions = [],
+  onEdit,
+  onCollapse,
+}: AccountInfoWidgetProps) {
   const t = useTranslations('transactions');
   const tc = useTranslations('common');
   const { formatCurrency } = useNumberFormat();
+  const { formatDate } = useDateFormat();
 
   const isLiability = ['CREDIT_CARD', 'LOAN', 'MORTGAGE', 'LINE_OF_CREDIT'].includes(
     account.accountType,
@@ -36,6 +48,20 @@ export function AccountInfoWidget({ account, institution, onEdit, onCollapse }: 
   // Prefer the linked institution's canonical name; fall back to the legacy
   // free-text field stored on the account.
   const institutionName = institution?.name ?? account.institution ?? null;
+
+  // The soonest active scheduled bill/deposit booked against this account.
+  // Honours a per-occurrence override for both the date and the amount.
+  const nextPayment = useMemo(() => {
+    const candidates = scheduledTransactions
+      .filter((st) => st.isActive && st.accountId === account.id)
+      .map((st) => ({
+        date: (st.nextOverride?.overrideDate ?? st.nextDueDate).split('T')[0],
+        amount: st.nextOverride?.amount ?? st.amount,
+        currencyCode: st.currencyCode,
+      }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+    return candidates[0] ?? null;
+  }, [scheduledTransactions, account.id]);
 
   const details: Array<{ label: string; value: string; tooltip?: string }> = [];
   details.push({
@@ -129,6 +155,20 @@ export function AccountInfoWidget({ account, institution, onEdit, onCollapse }: 
           {formatCurrency(balance, account.currencyCode)}
         </p>
       </div>
+
+      {nextPayment && (
+        <div className="mb-4 rounded-md bg-gray-50 dark:bg-gray-700/40 px-3 py-2">
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {t('accountWidget.nextPayment')}
+          </p>
+          <p className="text-base font-semibold text-gray-900 dark:text-gray-100">
+            {formatCurrency(Math.abs(nextPayment.amount), nextPayment.currencyCode)}
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {formatDate(nextPayment.date)}
+          </p>
+        </div>
+      )}
 
       <dl className="space-y-2 text-sm">
         {details.map((detail) => (

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -187,7 +187,7 @@ export function AccountInfoWidget({
                   {nextPayment.payeeName}
                 </p>
               )}
-              <p className="text-xs text-gray-500 dark:text-gray-400">
+              <p className="text-base font-semibold text-gray-700 dark:text-gray-300">
                 {formatDate(nextPayment.date)}
               </p>
             </div>

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -12,6 +12,7 @@ import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useDateFormat } from '@/hooks/useDateFormat';
 import { InstitutionLogo, InstitutionLogoData } from '@/components/institutions/InstitutionLogo';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
+import { safeHttpUrl } from '@/lib/safe-url';
 
 interface AccountInfoWidgetProps {
   account: Account;
@@ -53,10 +54,7 @@ export function AccountInfoWidget({
   const institutionName = institution?.name ?? account.institution ?? null;
   // Only treat http(s) URLs as a safe link target, to avoid javascript:/data:
   // URIs ever reaching the href.
-  const institutionWebsite =
-    institution?.website && /^https?:\/\//i.test(institution.website)
-      ? institution.website
-      : undefined;
+  const institutionWebsite = safeHttpUrl(institution?.website);
 
   // The soonest active scheduled bill/deposit booked against this account.
   // Honours a per-occurrence override for both the date and the amount.

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -118,10 +118,10 @@ export function AccountInfoWidget({
               title={institutionWebsite}
               className="flex-shrink-0 rounded-full focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
-              <InstitutionLogo institution={institution} size={40} fallbackGlyph="$" ring={false} />
+              <InstitutionLogo institution={institution} size={40} fallbackGlyph="$" />
             </a>
           ) : (
-            <InstitutionLogo institution={institution ?? undefined} size={40} fallbackGlyph="$" ring={false} />
+            <InstitutionLogo institution={institution ?? undefined} size={40} fallbackGlyph="$" />
           )}
           <div className="min-w-0">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -58,6 +58,7 @@ export function AccountInfoWidget({
         date: (st.nextOverride?.overrideDate ?? st.nextDueDate).split('T')[0],
         amount: st.nextOverride?.amount ?? st.amount,
         currencyCode: st.currencyCode,
+        payeeName: st.payee?.name ?? st.payeeName ?? null,
       }))
       .sort((a, b) => a.date.localeCompare(b.date));
     return candidates[0] ?? null;
@@ -99,10 +100,10 @@ export function AccountInfoWidget({
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 sm:p-6 mb-6 min-h-[420px] h-full flex flex-col">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 sm:p-6 mb-6 lg:mb-0 lg:h-full flex flex-col overflow-hidden">
       <div className="flex items-start justify-between gap-2 mb-4">
-        <div className="flex items-start gap-3 min-w-0">
-          <InstitutionLogo institution={institution ?? undefined} size={32} fallbackGlyph="$" />
+        <div className="flex items-center gap-3 min-w-0">
+          <InstitutionLogo institution={institution ?? undefined} size={40} fallbackGlyph="$" />
           <div className="min-w-0">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">
               {account.name}
@@ -161,9 +162,20 @@ export function AccountInfoWidget({
           <p className="text-sm text-gray-500 dark:text-gray-400">
             {t('accountWidget.nextPayment')}
           </p>
-          <p className="text-base font-semibold text-gray-900 dark:text-gray-100">
+          <p
+            className={`text-base font-semibold ${
+              nextPayment.amount < 0
+                ? 'text-red-600 dark:text-red-400'
+                : 'text-green-600 dark:text-green-400'
+            }`}
+          >
             {formatCurrency(Math.abs(nextPayment.amount), nextPayment.currencyCode)}
           </p>
+          {nextPayment.payeeName && (
+            <p className="text-sm text-gray-700 dark:text-gray-300 truncate">
+              {nextPayment.payeeName}
+            </p>
+          )}
           <p className="text-xs text-gray-500 dark:text-gray-400">
             {formatDate(nextPayment.date)}
           </p>

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -118,10 +118,10 @@ export function AccountInfoWidget({
               title={institutionWebsite}
               className="flex-shrink-0 rounded-full focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
-              <InstitutionLogo institution={institution} size={40} fallbackGlyph="$" />
+              <InstitutionLogo institution={institution} size={40} fallbackGlyph="$" ring={false} />
             </a>
           ) : (
-            <InstitutionLogo institution={institution ?? undefined} size={40} fallbackGlyph="$" />
+            <InstitutionLogo institution={institution ?? undefined} size={40} fallbackGlyph="$" ring={false} />
           )}
           <div className="min-w-0">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">

--- a/frontend/src/components/ui/Combobox.test.tsx
+++ b/frontend/src/components/ui/Combobox.test.tsx
@@ -40,6 +40,19 @@ describe('Combobox', () => {
     expect(screen.getByText('Date')).toBeInTheDocument();
   });
 
+  it('does not open on focus when openOnFocus is false, but opens on click', () => {
+    render(<Combobox options={options} onChange={onChange} openOnFocus={false} />);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.focus(input);
+    // Focus alone must not reveal the options.
+    expect(screen.queryByText('Apple')).not.toBeInTheDocument();
+
+    // An explicit click still opens the dropdown.
+    fireEvent.click(input);
+    expect(screen.getByText('Apple')).toBeInTheDocument();
+  });
+
   it('filters options when typing', async () => {
     render(<Combobox options={options} onChange={onChange} />);
 

--- a/frontend/src/components/ui/Combobox.tsx
+++ b/frontend/src/components/ui/Combobox.tsx
@@ -32,6 +32,12 @@ interface ComboboxProps {
   alwaysShowSubtitle?: boolean;
   /** Values to sort to the top of the list when not filtering */
   priorityValues?: string[];
+  /**
+   * Open the dropdown when the input gains focus. Defaults to true. Set false
+   * when the field may be auto-focused (e.g. it is the first focusable element
+   * in a modal) so the list only opens on an explicit click, keypress, or type.
+   */
+  openOnFocus?: boolean;
 }
 
 export function Combobox({
@@ -49,6 +55,7 @@ export function Combobox({
   usePortal = false,
   alwaysShowSubtitle = false,
   priorityValues,
+  openOnFocus = true,
 }: ComboboxProps) {
   const t = useTranslations('common');
   const [isOpen, setIsOpen] = useState(false);
@@ -232,7 +239,10 @@ export function Combobox({
   };
 
   const handleFocus = () => {
-    openDropdown();
+    // When openOnFocus is disabled, focusing the input (e.g. a modal
+    // auto-focusing the first focusable element) must not open the dropdown;
+    // it only opens on an explicit click, keypress, or typing.
+    if (openOnFocus) openDropdown();
     // Select all text when focusing so user can easily type to filter
     if (inputRef.current && inputValue) {
       setTimeout(() => {

--- a/frontend/src/components/ui/InfoTooltip.tsx
+++ b/frontend/src/components/ui/InfoTooltip.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 
 interface InfoTooltipProps {
@@ -17,7 +19,16 @@ interface InfoTooltipProps {
   align?: 'left' | 'right';
   /** Tailwind size classes for the icon. Defaults to 'h-4 w-4'. */
   iconClassName?: string;
+  /**
+   * Render the popover in a fixed-position portal on document.body so it
+   * escapes ancestors that clip overflow (e.g. a scrollable card). The
+   * position is clamped to the viewport so it never gets cut off.
+   */
+  usePortal?: boolean;
 }
+
+const POPOVER_WIDTH = 256; // matches w-64
+const VIEWPORT_MARGIN = 8;
 
 /**
  * Inline help icon with a desktop-only hover popover. Hidden below the md
@@ -30,7 +41,58 @@ export function InfoTooltip({
   placement = 'bottom',
   align,
   iconClassName = 'h-4 w-4',
+  usePortal = false,
 }: InfoTooltipProps) {
+  const iconRef = useRef<HTMLSpanElement>(null);
+  const [portalPos, setPortalPos] = useState<{ top: number; left: number } | null>(
+    null,
+  );
+
+  const showPortal = useCallback(() => {
+    const rect = iconRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const left = Math.min(
+      Math.max(VIEWPORT_MARGIN, rect.left),
+      window.innerWidth - POPOVER_WIDTH - VIEWPORT_MARGIN,
+    );
+    const top =
+      placement === 'top' ? rect.top : rect.bottom + 4;
+    setPortalPos({ top, left });
+  }, [placement]);
+
+  const hidePortal = useCallback(() => setPortalPos(null), []);
+
+  if (usePortal) {
+    return (
+      <span
+        ref={iconRef}
+        aria-label={text}
+        onMouseEnter={showPortal}
+        onMouseLeave={hidePortal}
+        className="relative hidden md:inline-flex items-center align-middle ml-1 text-gray-400 hover:text-blue-500 transition-colors cursor-help"
+      >
+        <QuestionMarkCircleIcon className={iconClassName} />
+        {portalPos &&
+          createPortal(
+            <span
+              role="tooltip"
+              style={{
+                position: 'fixed',
+                top: portalPos.top,
+                left: portalPos.left,
+                width: POPOVER_WIDTH,
+                transform: placement === 'top' ? 'translateY(-100%)' : undefined,
+              }}
+              className="pointer-events-none z-50 whitespace-normal rounded-md bg-gray-900 dark:bg-gray-700 px-2.5 py-2 text-xs font-normal leading-snug text-white shadow-lg"
+            >
+              {text}
+            </span>,
+            document.body,
+          )}
+      </span>
+    );
+  }
+
   const vertical = placement === 'top' ? 'bottom-full mb-2' : 'top-full mt-1';
   const horizontal =
     align === 'right'

--- a/frontend/src/hooks/useFormModal.ts
+++ b/frontend/src/hooks/useFormModal.ts
@@ -7,7 +7,7 @@ interface UnsavedChangesDialogState {
   onCancel: () => void;
 }
 
-interface UseFormModalReturn<T> {
+export interface UseFormModalReturn<T> {
   /** Whether the form modal is currently open */
   showForm: boolean;
   /** The item being edited, or undefined for new item */

--- a/frontend/src/hooks/useTransactionFilters.ts
+++ b/frontend/src/hooks/useTransactionFilters.ts
@@ -303,6 +303,7 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
   useEffect(() => {
     const hasAnyUrlParams = searchParams.has('accountId') ||
       searchParams.has('accountIds') ||
+      searchParams.has('accountStatus') ||
       searchParams.has('categoryId') ||
       searchParams.has('categoryIds') ||
       searchParams.has('categoryType') ||
@@ -338,6 +339,17 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
     };
 
     setFilterAccountIds(getAccountIds());
+    // An explicit accountStatus param (e.g. when opening a closed account from
+    // the Institutions page) overrides the stored Show Accounts filter so the
+    // selected account is not pruned and its transactions are visible.
+    const accountStatusParam = searchParams.get('accountStatus');
+    if (
+      accountStatusParam === 'all' ||
+      accountStatusParam === 'active' ||
+      accountStatusParam === 'closed'
+    ) {
+      setFilterAccountStatus(accountStatusParam === 'all' ? '' : accountStatusParam);
+    }
     setFilterCategoryIds(getCategoryIds());
     setFilterPayeeIds(getPayeeIds());
     setFilterTagIds(getFilterValues(STORAGE_KEYS.tagIds, searchParams.get('tagIds'), hasAnyUrlParams));

--- a/frontend/src/i18n/messages/en/auth.json
+++ b/frontend/src/i18n/messages/en/auth.json
@@ -47,6 +47,15 @@
       "requiredSubtitle": "Two-factor authentication is required by the administrator.",
       "optionalSubtitle": "Add an extra layer of security to your account."
     },
+    "preferences": {
+      "title": "Set Your Preferences",
+      "subtitle": "Choose your language and the currency Monize should use by default. You can change these later in Settings.",
+      "languageLabel": "Language",
+      "currencyLabel": "Default currency",
+      "continue": "Continue",
+      "skip": "Skip for now",
+      "saveFailed": "Failed to save preferences"
+    },
     "toasts": {
       "created": "Account created successfully!"
     },

--- a/frontend/src/i18n/messages/en/institutions.json
+++ b/frontend/src/i18n/messages/en/institutions.json
@@ -36,6 +36,11 @@
       "compact": "Compact",
       "dense": "Dense"
     },
+    "statusFilter": {
+      "all": "All",
+      "active": "Active",
+      "closed": "Closed"
+    },
     "actions": {
       "manageAccounts": "Accounts"
     },

--- a/frontend/src/i18n/messages/en/institutions.json
+++ b/frontend/src/i18n/messages/en/institutions.json
@@ -75,6 +75,7 @@
       "closed": "Closed"
     },
     "remove": "Remove",
+    "viewTransactions": "View transactions for this account",
     "added": "Account added",
     "removed": "Account removed",
     "addFailed": "Failed to add account",

--- a/frontend/src/i18n/messages/en/institutions.json
+++ b/frontend/src/i18n/messages/en/institutions.json
@@ -30,6 +30,12 @@
       "actions": "Actions"
     },
     "accountCount": "{count, plural, =0 {No accounts} one {# account} other {# accounts}}",
+    "density": {
+      "title": "Toggle row density",
+      "normal": "Normal",
+      "compact": "Compact",
+      "dense": "Dense"
+    },
     "actions": {
       "manageAccounts": "Accounts"
     },

--- a/frontend/src/i18n/messages/en/institutions.json
+++ b/frontend/src/i18n/messages/en/institutions.json
@@ -62,6 +62,12 @@
     "noneToAdd": "All your accounts are already assigned to an institution.",
     "loading": "Loading accounts...",
     "empty": "No accounts are assigned to this institution yet.",
+    "noneMatch": "No accounts match the selected filter.",
+    "filter": {
+      "all": "All",
+      "active": "Active",
+      "closed": "Closed"
+    },
     "remove": "Remove",
     "added": "Account added",
     "removed": "Account removed",

--- a/frontend/src/i18n/messages/en/transactions.json
+++ b/frontend/src/i18n/messages/en/transactions.json
@@ -1,4 +1,15 @@
 {
+  "accountWidget": {
+    "currentBalance": "Current Balance",
+    "type": "Type",
+    "institution": "Institution",
+    "accountNumber": "Account Number",
+    "currency": "Currency",
+    "creditLimit": "Credit Limit",
+    "interestRate": "Interest Rate",
+    "closed": "Closed",
+    "editAria": "Edit account settings"
+  },
   "page": {
     "title": "Transactions",
     "subtitle": "Manage your income and expenses",

--- a/frontend/src/i18n/messages/en/transactions.json
+++ b/frontend/src/i18n/messages/en/transactions.json
@@ -6,6 +6,8 @@
     "currency": "Currency",
     "creditLimit": "Credit Limit",
     "interestRate": "Interest Rate",
+    "statementSettlement": "Settlement Day",
+    "statementDue": "Payment Due",
     "closed": "Closed",
     "editAria": "Edit account settings"
   },

--- a/frontend/src/i18n/messages/en/transactions.json
+++ b/frontend/src/i18n/messages/en/transactions.json
@@ -2,7 +2,6 @@
   "accountWidget": {
     "currentBalance": "Current Balance",
     "type": "Type",
-    "institution": "Institution",
     "accountNumber": "Account Number",
     "currency": "Currency",
     "creditLimit": "Credit Limit",

--- a/frontend/src/i18n/messages/en/transactions.json
+++ b/frontend/src/i18n/messages/en/transactions.json
@@ -7,6 +7,7 @@
     "creditLimit": "Credit Limit",
     "interestRate": "Interest Rate",
     "statementSettlement": "Settlement Day",
+    "statementSettlementTooltip": "The last day of the billing cycle. Transactions posted on or before this day appear on the current statement.",
     "statementDue": "Payment Due",
     "closed": "Closed",
     "editAria": "Edit account settings"

--- a/frontend/src/i18n/messages/en/transactions.json
+++ b/frontend/src/i18n/messages/en/transactions.json
@@ -10,7 +10,9 @@
     "statementSettlementTooltip": "The last day of the billing cycle. Transactions posted on or before this day appear on the current statement.",
     "statementDue": "Payment Due",
     "closed": "Closed",
-    "editAria": "Edit account settings"
+    "editAria": "Edit account settings",
+    "collapseAria": "Hide account info",
+    "show": "Show account info"
   },
   "page": {
     "title": "Transactions",

--- a/frontend/src/i18n/messages/en/transactions.json
+++ b/frontend/src/i18n/messages/en/transactions.json
@@ -2,6 +2,7 @@
   "accountWidget": {
     "currentBalance": "Current Balance",
     "nextPayment": "Next Payment",
+    "viewBills": "View in Bills & Deposits",
     "type": "Type",
     "accountNumber": "Account Number",
     "currency": "Currency",

--- a/frontend/src/i18n/messages/en/transactions.json
+++ b/frontend/src/i18n/messages/en/transactions.json
@@ -1,6 +1,7 @@
 {
   "accountWidget": {
     "currentBalance": "Current Balance",
+    "nextPayment": "Next Payment",
     "type": "Type",
     "accountNumber": "Account Number",
     "currency": "Currency",

--- a/frontend/src/i18n/messages/pl/auth.json
+++ b/frontend/src/i18n/messages/pl/auth.json
@@ -47,6 +47,15 @@
       "requiredSubtitle": "Uwierzytelnianie dwuskładnikowe jest wymagane przez administratora.",
       "optionalSubtitle": "Dodaj dodatkową warstwę zabezpieczeń do swojego konta."
     },
+    "preferences": {
+      "title": "Ustaw swoje preferencje",
+      "subtitle": "Wybierz język i walutę, której Monize ma używać domyślnie. Możesz to później zmienić w Ustawieniach.",
+      "languageLabel": "Język",
+      "currencyLabel": "Waluta domyślna",
+      "continue": "Kontynuuj",
+      "skip": "Pomiń na razie",
+      "saveFailed": "Nie udało się zapisać preferencji"
+    },
     "toasts": {
       "created": "Konto zostało utworzone pomyślnie!"
     },

--- a/frontend/src/i18n/messages/pl/institutions.json
+++ b/frontend/src/i18n/messages/pl/institutions.json
@@ -75,6 +75,7 @@
       "closed": "Zamknięte"
     },
     "remove": "Usuń",
+    "viewTransactions": "Wyświetl transakcje dla tego konta",
     "added": "Konto dodane",
     "removed": "Konto usunięte",
     "addFailed": "Nie udało się dodać konta",

--- a/frontend/src/i18n/messages/pl/institutions.json
+++ b/frontend/src/i18n/messages/pl/institutions.json
@@ -30,6 +30,12 @@
       "actions": "Akcje"
     },
     "accountCount": "{count, plural, =0 {Brak kont} one {# konto} few {# konta} many {# kont} other {# konta}}",
+    "density": {
+      "title": "Przełącz gęstość wierszy",
+      "normal": "Normalna",
+      "compact": "Kompaktowa",
+      "dense": "Gęsta"
+    },
     "actions": {
       "manageAccounts": "Konta"
     },

--- a/frontend/src/i18n/messages/pl/institutions.json
+++ b/frontend/src/i18n/messages/pl/institutions.json
@@ -36,6 +36,11 @@
       "compact": "Kompaktowa",
       "dense": "Gęsta"
     },
+    "statusFilter": {
+      "all": "Wszystkie",
+      "active": "Aktywne",
+      "closed": "Zamknięte"
+    },
     "actions": {
       "manageAccounts": "Konta"
     },

--- a/frontend/src/i18n/messages/pl/institutions.json
+++ b/frontend/src/i18n/messages/pl/institutions.json
@@ -62,6 +62,12 @@
     "noneToAdd": "Wszystkie Twoje konta są już przypisane do instytucji.",
     "loading": "Ładowanie kont...",
     "empty": "Do tej instytucji nie przypisano jeszcze żadnych kont.",
+    "noneMatch": "Żadne konto nie pasuje do wybranego filtra.",
+    "filter": {
+      "all": "Wszystkie",
+      "active": "Aktywny",
+      "closed": "Zamknięte"
+    },
     "remove": "Usuń",
     "added": "Konto dodane",
     "removed": "Konto usunięte",

--- a/frontend/src/i18n/messages/pl/transactions.json
+++ b/frontend/src/i18n/messages/pl/transactions.json
@@ -10,7 +10,9 @@
     "statementSettlementTooltip": "Ostatni dzień cyklu rozliczeniowego. Transakcje zaksięgowane w tym dniu lub wcześniej pojawiają się na bieżącym wyciągu.",
     "statementDue": "Termin płatności",
     "closed": "Zamknięte",
-    "editAria": "Edytuj ustawienia konta"
+    "editAria": "Edytuj ustawienia konta",
+    "collapseAria": "Ukryj informacje o koncie",
+    "show": "Pokaż informacje o koncie"
   },
   "page": {
     "title": "Transakcje",

--- a/frontend/src/i18n/messages/pl/transactions.json
+++ b/frontend/src/i18n/messages/pl/transactions.json
@@ -7,6 +7,7 @@
     "creditLimit": "Limit kredytowy",
     "interestRate": "Oprocentowanie",
     "statementSettlement": "Dzień rozliczenia",
+    "statementSettlementTooltip": "Ostatni dzień cyklu rozliczeniowego. Transakcje zaksięgowane w tym dniu lub wcześniej pojawiają się na bieżącym wyciągu.",
     "statementDue": "Termin płatności",
     "closed": "Zamknięte",
     "editAria": "Edytuj ustawienia konta"

--- a/frontend/src/i18n/messages/pl/transactions.json
+++ b/frontend/src/i18n/messages/pl/transactions.json
@@ -1,4 +1,15 @@
 {
+  "accountWidget": {
+    "currentBalance": "Bieżące saldo",
+    "type": "Typ",
+    "institution": "Instytucja",
+    "accountNumber": "Numer konta",
+    "currency": "Waluta",
+    "creditLimit": "Limit kredytowy",
+    "interestRate": "Oprocentowanie",
+    "closed": "Zamknięte",
+    "editAria": "Edytuj ustawienia konta"
+  },
   "page": {
     "title": "Transakcje",
     "subtitle": "Zarządzaj swoimi przychodami i wydatkami",

--- a/frontend/src/i18n/messages/pl/transactions.json
+++ b/frontend/src/i18n/messages/pl/transactions.json
@@ -2,7 +2,6 @@
   "accountWidget": {
     "currentBalance": "Bieżące saldo",
     "type": "Typ",
-    "institution": "Instytucja",
     "accountNumber": "Numer konta",
     "currency": "Waluta",
     "creditLimit": "Limit kredytowy",

--- a/frontend/src/i18n/messages/pl/transactions.json
+++ b/frontend/src/i18n/messages/pl/transactions.json
@@ -6,6 +6,8 @@
     "currency": "Waluta",
     "creditLimit": "Limit kredytowy",
     "interestRate": "Oprocentowanie",
+    "statementSettlement": "Dzień rozliczenia",
+    "statementDue": "Termin płatności",
     "closed": "Zamknięte",
     "editAria": "Edytuj ustawienia konta"
   },

--- a/frontend/src/i18n/messages/pl/transactions.json
+++ b/frontend/src/i18n/messages/pl/transactions.json
@@ -2,6 +2,7 @@
   "accountWidget": {
     "currentBalance": "Bieżące saldo",
     "nextPayment": "Następna płatność",
+    "viewBills": "Zobacz w Rachunki i wpłaty",
     "type": "Typ",
     "accountNumber": "Numer konta",
     "currency": "Waluta",

--- a/frontend/src/i18n/messages/pl/transactions.json
+++ b/frontend/src/i18n/messages/pl/transactions.json
@@ -1,6 +1,7 @@
 {
   "accountWidget": {
     "currentBalance": "Bieżące saldo",
+    "nextPayment": "Następna płatność",
     "type": "Typ",
     "accountNumber": "Numer konta",
     "currency": "Waluta",

--- a/frontend/src/i18n/messages/xx/auth.json
+++ b/frontend/src/i18n/messages/xx/auth.json
@@ -47,6 +47,15 @@
       "requiredSubtitle": "[XX-Two-factor authentication is required by the administrator.-XX]",
       "optionalSubtitle": "[XX-Add an extra layer of security to your account.-XX]"
     },
+    "preferences": {
+      "title": "[XX-Set Your Preferences-XX]",
+      "subtitle": "[XX-Choose your language and the currency Monize should use by default. You can change these later in Settings.-XX]",
+      "languageLabel": "[XX-Language-XX]",
+      "currencyLabel": "[XX-Default currency-XX]",
+      "continue": "[XX-Continue-XX]",
+      "skip": "[XX-Skip for now-XX]",
+      "saveFailed": "[XX-Failed to save preferences-XX]"
+    },
     "toasts": {
       "created": "[XX-Account created successfully!-XX]"
     },

--- a/frontend/src/i18n/messages/xx/institutions.json
+++ b/frontend/src/i18n/messages/xx/institutions.json
@@ -75,6 +75,7 @@
       "closed": "[XX-Closed-XX]"
     },
     "remove": "[XX-Remove-XX]",
+    "viewTransactions": "[XX-View transactions for this account-XX]",
     "added": "[XX-Account added-XX]",
     "removed": "[XX-Account removed-XX]",
     "addFailed": "[XX-Failed to add account-XX]",

--- a/frontend/src/i18n/messages/xx/institutions.json
+++ b/frontend/src/i18n/messages/xx/institutions.json
@@ -30,6 +30,12 @@
       "actions": "[XX-Actions-XX]"
     },
     "accountCount": "[XX-{count, plural, =0 {No accounts} one {# account} other {# accounts}}-XX]",
+    "density": {
+      "title": "[XX-Toggle row density-XX]",
+      "normal": "[XX-Normal-XX]",
+      "compact": "[XX-Compact-XX]",
+      "dense": "[XX-Dense-XX]"
+    },
     "actions": {
       "manageAccounts": "[XX-Accounts-XX]"
     },

--- a/frontend/src/i18n/messages/xx/institutions.json
+++ b/frontend/src/i18n/messages/xx/institutions.json
@@ -36,6 +36,11 @@
       "compact": "[XX-Compact-XX]",
       "dense": "[XX-Dense-XX]"
     },
+    "statusFilter": {
+      "all": "[XX-All-XX]",
+      "active": "[XX-Active-XX]",
+      "closed": "[XX-Closed-XX]"
+    },
     "actions": {
       "manageAccounts": "[XX-Accounts-XX]"
     },

--- a/frontend/src/i18n/messages/xx/institutions.json
+++ b/frontend/src/i18n/messages/xx/institutions.json
@@ -62,6 +62,12 @@
     "noneToAdd": "[XX-All your accounts are already assigned to an institution.-XX]",
     "loading": "[XX-Loading accounts...-XX]",
     "empty": "[XX-No accounts are assigned to this institution yet.-XX]",
+    "noneMatch": "[XX-No accounts match the selected filter.-XX]",
+    "filter": {
+      "all": "[XX-All-XX]",
+      "active": "[XX-Active-XX]",
+      "closed": "[XX-Closed-XX]"
+    },
     "remove": "[XX-Remove-XX]",
     "added": "[XX-Account added-XX]",
     "removed": "[XX-Account removed-XX]",

--- a/frontend/src/i18n/messages/xx/transactions.json
+++ b/frontend/src/i18n/messages/xx/transactions.json
@@ -7,6 +7,7 @@
     "creditLimit": "[XX-Credit Limit-XX]",
     "interestRate": "[XX-Interest Rate-XX]",
     "statementSettlement": "[XX-Settlement Day-XX]",
+    "statementSettlementTooltip": "[XX-The last day of the billing cycle. Transactions posted on or before this day appear on the current statement.-XX]",
     "statementDue": "[XX-Payment Due-XX]",
     "closed": "[XX-Closed-XX]",
     "editAria": "[XX-Edit account settings-XX]"

--- a/frontend/src/i18n/messages/xx/transactions.json
+++ b/frontend/src/i18n/messages/xx/transactions.json
@@ -2,7 +2,6 @@
   "accountWidget": {
     "currentBalance": "[XX-Current Balance-XX]",
     "type": "[XX-Type-XX]",
-    "institution": "[XX-Institution-XX]",
     "accountNumber": "[XX-Account Number-XX]",
     "currency": "[XX-Currency-XX]",
     "creditLimit": "[XX-Credit Limit-XX]",

--- a/frontend/src/i18n/messages/xx/transactions.json
+++ b/frontend/src/i18n/messages/xx/transactions.json
@@ -1,4 +1,15 @@
 {
+  "accountWidget": {
+    "currentBalance": "[XX-Current Balance-XX]",
+    "type": "[XX-Type-XX]",
+    "institution": "[XX-Institution-XX]",
+    "accountNumber": "[XX-Account Number-XX]",
+    "currency": "[XX-Currency-XX]",
+    "creditLimit": "[XX-Credit Limit-XX]",
+    "interestRate": "[XX-Interest Rate-XX]",
+    "closed": "[XX-Closed-XX]",
+    "editAria": "[XX-Edit account settings-XX]"
+  },
   "page": {
     "title": "[XX-Transactions-XX]",
     "subtitle": "[XX-Manage your income and expenses-XX]",

--- a/frontend/src/i18n/messages/xx/transactions.json
+++ b/frontend/src/i18n/messages/xx/transactions.json
@@ -10,7 +10,9 @@
     "statementSettlementTooltip": "[XX-The last day of the billing cycle. Transactions posted on or before this day appear on the current statement.-XX]",
     "statementDue": "[XX-Payment Due-XX]",
     "closed": "[XX-Closed-XX]",
-    "editAria": "[XX-Edit account settings-XX]"
+    "editAria": "[XX-Edit account settings-XX]",
+    "collapseAria": "[XX-Hide account info-XX]",
+    "show": "[XX-Show account info-XX]"
   },
   "page": {
     "title": "[XX-Transactions-XX]",

--- a/frontend/src/i18n/messages/xx/transactions.json
+++ b/frontend/src/i18n/messages/xx/transactions.json
@@ -6,6 +6,8 @@
     "currency": "[XX-Currency-XX]",
     "creditLimit": "[XX-Credit Limit-XX]",
     "interestRate": "[XX-Interest Rate-XX]",
+    "statementSettlement": "[XX-Settlement Day-XX]",
+    "statementDue": "[XX-Payment Due-XX]",
     "closed": "[XX-Closed-XX]",
     "editAria": "[XX-Edit account settings-XX]"
   },

--- a/frontend/src/i18n/messages/xx/transactions.json
+++ b/frontend/src/i18n/messages/xx/transactions.json
@@ -1,6 +1,7 @@
 {
   "accountWidget": {
     "currentBalance": "[XX-Current Balance-XX]",
+    "nextPayment": "[XX-Next Payment-XX]",
     "type": "[XX-Type-XX]",
     "accountNumber": "[XX-Account Number-XX]",
     "currency": "[XX-Currency-XX]",

--- a/frontend/src/i18n/messages/xx/transactions.json
+++ b/frontend/src/i18n/messages/xx/transactions.json
@@ -2,6 +2,7 @@
   "accountWidget": {
     "currentBalance": "[XX-Current Balance-XX]",
     "nextPayment": "[XX-Next Payment-XX]",
+    "viewBills": "[XX-View in Bills & Deposits-XX]",
     "type": "[XX-Type-XX]",
     "accountNumber": "[XX-Account Number-XX]",
     "currency": "[XX-Currency-XX]",

--- a/frontend/src/lib/account-utils.test.ts
+++ b/frontend/src/lib/account-utils.test.ts
@@ -4,6 +4,8 @@ import {
   buildAccountFilterLabel,
   formatAccountType,
   isInvestmentBrokerageAccount,
+  isInvestmentCashHalf,
+  getMainAccountName,
 } from './account-utils';
 import { Account } from '@/types/account';
 
@@ -267,5 +269,58 @@ describe('buildAccountFilterLabel', () => {
 
   it('ignores selections for accounts not in the available list', () => {
     expect(buildAccountFilterLabel(['99'], accounts)).toBe('All Accounts');
+  });
+});
+
+describe('isInvestmentCashHalf', () => {
+  it('returns true for the cash half of a linked pair', () => {
+    const cash = makeAccount({
+      id: 'c1', name: 'TFSA - Cash',
+      accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_CASH',
+      linkedAccountId: 'b1',
+    });
+    expect(isInvestmentCashHalf(cash)).toBe(true);
+  });
+
+  it('returns false for the brokerage half', () => {
+    const brokerage = makeAccount({
+      id: 'b1', name: 'TFSA - Brokerage',
+      accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_BROKERAGE',
+      linkedAccountId: 'c1',
+    });
+    expect(isInvestmentCashHalf(brokerage)).toBe(false);
+  });
+
+  it('returns false for a cash account with no linked partner', () => {
+    const cash = makeAccount({
+      id: 'c2', name: 'Standalone',
+      accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_CASH',
+      linkedAccountId: null,
+    });
+    expect(isInvestmentCashHalf(cash)).toBe(false);
+  });
+
+  it('returns false for a plain account', () => {
+    expect(isInvestmentCashHalf(makeAccount({ id: 'p', name: 'Chequing' }))).toBe(
+      false,
+    );
+  });
+});
+
+describe('getMainAccountName', () => {
+  it('strips a trailing " - Brokerage" suffix', () => {
+    expect(getMainAccountName('TFSA - Brokerage')).toBe('TFSA');
+  });
+
+  it('strips a trailing " - Cash" suffix', () => {
+    expect(getMainAccountName('TFSA - Cash')).toBe('TFSA');
+  });
+
+  it('leaves a plain account name untouched', () => {
+    expect(getMainAccountName('Chequing')).toBe('Chequing');
+  });
+
+  it('only strips the suffix at the end of the name', () => {
+    expect(getMainAccountName('Cash - Reserve')).toBe('Cash - Reserve');
   });
 });

--- a/frontend/src/lib/account-utils.ts
+++ b/frontend/src/lib/account-utils.ts
@@ -72,6 +72,23 @@ export const isInvestmentBrokerageAccount = (account: Account): boolean => {
 };
 
 /**
+ * Whether the account is the cash half of a linked investment pair. The cash
+ * half is a sub-account of its brokerage partner, so callers that present a
+ * pair as a single entity drop it in favour of the brokerage (main) account.
+ */
+export const isInvestmentCashHalf = (account: Account): boolean => {
+  return (
+    account.accountSubType === 'INVESTMENT_CASH' &&
+    account.linkedAccountId !== null
+  );
+};
+
+/** The main account name, with any " - Brokerage"/" - Cash" suffix stripped. */
+export const getMainAccountName = (name: string): string => {
+  return name.replace(/ - (Brokerage|Cash)$/, '');
+};
+
+/**
  * Count accounts treating a linked brokerage/cash investment pair as one
  * logical account. Both halves of the pair must appear in the input list
  * for the dedup to apply.

--- a/frontend/src/lib/ordinal.ts
+++ b/frontend/src/lib/ordinal.ts
@@ -1,0 +1,17 @@
+/**
+ * Format a day-of-month number as an English ordinal (1 -> "1st", 22 -> "22nd").
+ * Used for credit-card statement due/settlement days.
+ */
+export function getOrdinal(day: number): string {
+  const suffix =
+    day >= 11 && day <= 13
+      ? 'th'
+      : day % 10 === 1
+        ? 'st'
+        : day % 10 === 2
+          ? 'nd'
+          : day % 10 === 3
+            ? 'rd'
+            : 'th';
+  return `${day}${suffix}`;
+}

--- a/frontend/src/lib/safe-url.test.ts
+++ b/frontend/src/lib/safe-url.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { safeHttpUrl } from './safe-url';
+
+describe('safeHttpUrl', () => {
+  it('accepts http and https URLs', () => {
+    expect(safeHttpUrl('https://example.com')).toBe('https://example.com');
+    expect(safeHttpUrl('http://example.com')).toBe('http://example.com');
+    expect(safeHttpUrl('HTTPS://EXAMPLE.COM')).toBe('HTTPS://EXAMPLE.COM');
+  });
+
+  it('rejects dangerous or empty schemes', () => {
+    expect(safeHttpUrl('javascript:alert(1)')).toBeUndefined();
+    expect(safeHttpUrl('data:text/html,<script>')).toBeUndefined();
+    expect(safeHttpUrl('ftp://example.com')).toBeUndefined();
+    expect(safeHttpUrl('example.com')).toBeUndefined();
+    expect(safeHttpUrl('')).toBeUndefined();
+    expect(safeHttpUrl(null)).toBeUndefined();
+    expect(safeHttpUrl(undefined)).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/safe-url.ts
+++ b/frontend/src/lib/safe-url.ts
@@ -1,0 +1,8 @@
+/**
+ * Returns the given value only if it is an http(s) URL, otherwise undefined.
+ * Use before assigning a stored/user-provided value to an anchor `href` so a
+ * `javascript:`/`data:` URI can never reach the DOM.
+ */
+export function safeHttpUrl(value?: string | null): string | undefined {
+  return value && /^https?:\/\//i.test(value) ? value : undefined;
+}


### PR DESCRIPTION
Improvements to the institutions page, a new account info widget on the
single-account transactions view, plus supporting onboarding, demo, i18n,
and security changes.

## Institutions page
- Treat a linked brokerage/cash investment pair as a single logical
  account: backend account counts (list + single institution) exclude the
  cash half, and the accounts manager shows one row per logical account
  (with the " - Brokerage"/" - Cash" suffix stripped) and collapses the
  add-account dropdown the same way.
- Status filter (All/Active/Closed) that adjusts the Accounts column count
  (pair-aware) rather than hiding institution rows.
- Sortable Name/Website/Country/Accounts columns with a sort indicator.
- Broadened search across name, website, and country; country is
  uppercased.
- Normal/compact/dense row density, persisted.
- Streamlined the list and accounts manager layout.
- Website field behaves as a URL on mobile (inputMode="url",
  autocapitalize/autocorrect/spellcheck off). type="url" is deliberately
  avoided so schemeless input like "td.com" is still accepted and
  normalized server-side.
- Accounts in the manager link to the filtered Transactions page. Opening a
  closed account forces the Transactions "Show Accounts" filter to All
  (via an accountStatus URL param) so its transactions are visible instead
  of being hidden by an Active-only filter.

## Account info widget (single-account transactions view)
- New widget shown beside the chart when filtered to a single account.
- Institution logo + name; the logo links to the institution website
  (opens in a new tab).
- Statement settlement and due days, with a settlement-day tooltip.
- Next scheduled payment surfaced and linked to Bills; the date is sized to
  match the amount.
- Collapsible (persisted), with height and layout refinements.
- "Closed" badge sits inline with the institution name.
- Removed the grey ring around institution logos everywhere.

## Onboarding
- Prompt new users to set their language and default currency after
  sign-up.

## Demo
- Seed demo institutions and link demo accounts to them.

## i18n
- New/changed strings are translated for every supported locale; the xx
  pseudo-locale is regenerated.

## Security
- Validate the institution website scheme before using it as an href via a
  shared safeHttpUrl helper, so a stored javascript:/data: URI can never
  reach the DOM (defense-in-depth on top of server-side normalization).

## Tests
- Added/updated unit tests across the touched components and the new
  safe-url helper.

https://claude.ai/code/session_01Tks3AdtTQtLr5adjRTRZAE