### PR TITLE
Fix account widget collapse animation and optional field clearing on edit

### DIFF
--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -748,24 +748,20 @@ function TransactionsContent() {
           // left of the chart (75%). Stacks vertically on narrow screens. The
           // widget can be collapsed (persisted) so the chart uses full width.
           if (singleFilteredAccount) {
-            if (accountWidgetCollapsed) {
-              return (
-                <>
-                  <button
-                    type="button"
-                    onClick={() => setAccountWidgetCollapsed(false)}
-                    className="mb-2 inline-flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400 hover:underline"
-                  >
-                    <ChevronDoubleRightIcon className="h-4 w-4" />
-                    {t('accountWidget.show')}
-                  </button>
-                  {chart}
-                </>
-              );
-            }
+            // The widget animates between expanded and collapsed rather than
+            // mounting/unmounting, so the chevron toggle slides it out of view:
+            // its column collapses width (desktop) or height (mobile) and fades,
+            // while the chart flexes to fill the reclaimed space.
             return (
-              <div className="flex flex-col lg:flex-row lg:gap-6 lg:items-stretch">
-                <div className="lg:w-1/4 flex-shrink-0 lg:relative">
+              <div className="flex flex-col lg:flex-row lg:items-stretch">
+                <div
+                  aria-hidden={accountWidgetCollapsed}
+                  className={`flex-shrink-0 lg:relative overflow-hidden transition-all duration-300 ease-in-out motion-reduce:transition-none ${
+                    accountWidgetCollapsed
+                      ? 'max-h-0 lg:max-h-none lg:w-0 lg:mr-0 opacity-0 lg:-translate-x-6 pointer-events-none'
+                      : 'max-h-[1000px] lg:max-h-none lg:w-1/4 lg:mr-6 opacity-100 lg:translate-x-0'
+                  }`}
+                >
                   <AccountInfoWidget
                     account={singleFilteredAccount}
                     institution={singleFilteredInstitution}
@@ -774,7 +770,19 @@ function TransactionsContent() {
                     onCollapse={() => setAccountWidgetCollapsed(true)}
                   />
                 </div>
-                <div className="lg:flex-1 min-w-0">{chart}</div>
+                <div className="lg:flex-1 min-w-0">
+                  {accountWidgetCollapsed && (
+                    <button
+                      type="button"
+                      onClick={() => setAccountWidgetCollapsed(false)}
+                      className="mb-2 inline-flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                    >
+                      <ChevronDoubleRightIcon className="h-4 w-4" />
+                      {t('accountWidget.show')}
+                    </button>
+                  )}
+                  {chart}
+                </div>
               </div>
             );
           }

--- a/frontend/src/components/accounts/AccountFormModal.test.tsx
+++ b/frontend/src/components/accounts/AccountFormModal.test.tsx
@@ -151,6 +151,29 @@ describe('AccountFormModal', () => {
     );
   });
 
+  it('clears a previously set institution by sending null when removed on edit', async () => {
+    mockUpdate.mockResolvedValue({});
+    render(
+      <AccountFormModal
+        formModal={buildFormModal({
+          editingItem: { id: 'a-1', accountType: 'CHEQUING', institutionId: 'inst-1' } as Account,
+          isEditing: true,
+        })}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
+    await act(async () => {
+      await capturedOnSubmit!({ name: 'Renamed', accountType: 'CHEQUING', institutionId: undefined });
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      'a-1',
+      expect.objectContaining({ institutionId: null }),
+    );
+  });
+
   it('omits an empty description when the account never had one', async () => {
     mockUpdate.mockResolvedValue({});
     render(

--- a/frontend/src/components/accounts/AccountFormModal.test.tsx
+++ b/frontend/src/components/accounts/AccountFormModal.test.tsx
@@ -104,4 +104,71 @@ describe('AccountFormModal', () => {
 
     expect(mockUpdate).toHaveBeenCalledWith('a-1', expect.any(Object));
   });
+
+  it('clears a previously set description by sending null when blanked on edit', async () => {
+    mockUpdate.mockResolvedValue({});
+    render(
+      <AccountFormModal
+        formModal={buildFormModal({
+          editingItem: { id: 'a-1', accountType: 'CHEQUING', description: 'Old note' } as Account,
+          isEditing: true,
+        })}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
+    await act(async () => {
+      await capturedOnSubmit!({ name: 'Renamed', accountType: 'CHEQUING', description: '' });
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      'a-1',
+      expect.objectContaining({ description: null }),
+    );
+  });
+
+  it('clears a previously set account number by sending null when blanked on edit', async () => {
+    mockUpdate.mockResolvedValue({});
+    render(
+      <AccountFormModal
+        formModal={buildFormModal({
+          editingItem: { id: 'a-1', accountType: 'CHEQUING', accountNumber: '12345' } as Account,
+          isEditing: true,
+        })}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
+    await act(async () => {
+      await capturedOnSubmit!({ name: 'Renamed', accountType: 'CHEQUING', accountNumber: '' });
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      'a-1',
+      expect.objectContaining({ accountNumber: null }),
+    );
+  });
+
+  it('omits an empty description when the account never had one', async () => {
+    mockUpdate.mockResolvedValue({});
+    render(
+      <AccountFormModal
+        formModal={buildFormModal({
+          editingItem: { id: 'a-1', accountType: 'CHEQUING' } as Account,
+          isEditing: true,
+        })}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
+    await act(async () => {
+      await capturedOnSubmit!({ name: 'Renamed', accountType: 'CHEQUING', description: '' });
+    });
+
+    const [, payload] = mockUpdate.mock.calls[0];
+    expect(payload).not.toHaveProperty('description');
+  });
 });

--- a/frontend/src/components/accounts/AccountFormModal.tsx
+++ b/frontend/src/components/accounts/AccountFormModal.tsx
@@ -87,6 +87,21 @@ export function AccountFormModal({ formModal, onSaved }: AccountFormModalProps) 
         cleanedData.openingBalance = -cleanedData.openingBalance;
       }
 
+      // When editing, a cleared optional text field must reach the backend as
+      // null so the stored value is overwritten. Left as '' it would be stripped
+      // by the cleanup below and the field would silently keep its old value.
+      if (editingItem) {
+        const clearableTextFields = ['description', 'accountNumber'] as const;
+        for (const key of clearableTextFields) {
+          if (
+            (cleanedData[key] === '' || cleanedData[key] === undefined) &&
+            editingItem[key]
+          ) {
+            cleanedData[key] = null;
+          }
+        }
+      }
+
       Object.keys(cleanedData).forEach((key) => {
         if (
           cleanedData[key] === undefined ||

--- a/frontend/src/components/accounts/AccountFormModal.tsx
+++ b/frontend/src/components/accounts/AccountFormModal.tsx
@@ -87,12 +87,17 @@ export function AccountFormModal({ formModal, onSaved }: AccountFormModalProps) 
         cleanedData.openingBalance = -cleanedData.openingBalance;
       }
 
-      // When editing, a cleared optional text field must reach the backend as
-      // null so the stored value is overwritten. Left as '' it would be stripped
-      // by the cleanup below and the field would silently keep its old value.
+      // When editing, a cleared optional field must reach the backend as null
+      // so the stored value is overwritten. Left as '' or undefined it would be
+      // stripped by the cleanup below and the field would silently keep its old
+      // value (e.g. removing a description or institution would not save).
       if (editingItem) {
-        const clearableTextFields = ['description', 'accountNumber'] as const;
-        for (const key of clearableTextFields) {
+        const clearableFields = [
+          'description',
+          'accountNumber',
+          'institutionId',
+        ] as const;
+        for (const key of clearableFields) {
           if (
             (cleanedData[key] === '' || cleanedData[key] === undefined) &&
             editingItem[key]


### PR DESCRIPTION
## Summary
Fixes two issues in the accounts UI: (1) the account widget collapse animation now smoothly transitions instead of abruptly mounting/unmounting, and (2) optional fields (description, account number, institution) are now properly cleared when blanked during account editing.

## Key Changes

**Account Widget Animation (`transactions/page.tsx`)**
- Replaced conditional mount/unmount logic with a single animated container that transitions between expanded and collapsed states
- Added Tailwind transition classes (`transition-all duration-300 ease-in-out`) with `motion-reduce` support for accessibility
- Uses `aria-hidden` to hide the widget from screen readers when collapsed
- The widget now slides out smoothly (width on desktop, height on mobile) while the chart flexes to fill reclaimed space
- Show button moved into the chart area and only renders when widget is collapsed

**Optional Field Clearing on Edit (`AccountFormModal.tsx` + tests)**
- Added logic to convert empty strings and undefined values to `null` for clearable fields (`description`, `accountNumber`, `institutionId`) when editing an existing account
- This ensures the backend receives an explicit `null` to overwrite stored values, rather than silently keeping old values when fields are omitted
- Only applies when editing (not on create) and only for fields that previously had a value
- Includes comprehensive test coverage:
  - Clears description when blanked
  - Clears account number when blanked
  - Clears institution when removed
  - Omits empty description when account never had one (no unnecessary payload)

## Implementation Details
- The animation uses CSS transitions with proper fallbacks for users with `prefers-reduced-motion`
- The field-clearing logic runs after form validation but before the cleanup that strips undefined values, ensuring the distinction between "never set" and "cleared" is preserved
- All new test cases follow existing patterns and verify both the update call and payload shape

https://claude.ai/code/session_01JFoRoRhntdrs6FFiGbvXxW