### PR TITLE
Refactor OAuth consent flow to grant all missing scopes automatically

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -8,6 +8,7 @@ import * as pg from "pg";
 import { AppModule } from "./app.module";
 import { OAuthProviderService } from "./oauth/oauth-provider.service";
 import { oauthDebugLogger } from "./oauth/oauth-debug-logger.middleware";
+import { isOidcProviderPath } from "./oauth/oidc-provider-paths";
 
 // Configure pg to return DATE types as strings instead of Date objects
 // This prevents timezone-related date shifting issues
@@ -108,6 +109,7 @@ async function bootstrap() {
     "/.well-known/oauth-authorization-server",
     oauthDebugLogger("as-meta"),
   );
+  app.use("/.well-known/openid-configuration", oauthDebugLogger("oidc-meta"));
   app.use("/oauth", oauthDebugLogger("provider"));
   app.use("/api/v1/oauth-consent", oauthDebugLogger("consent"));
 
@@ -161,7 +163,8 @@ async function bootstrap() {
       path.startsWith("/api/v1/oauth-consent/") ||
       path === "/.well-known/oauth-protected-resource" ||
       path === "/.well-known/oauth-authorization-server" ||
-      path.startsWith("/.well-known/oauth-authorization-server/");
+      path.startsWith("/.well-known/oauth-authorization-server/") ||
+      path === "/.well-known/openid-configuration";
 
     if (isOpenSurface) {
       callback(null, {
@@ -230,22 +233,41 @@ async function bootstrap() {
     ],
   });
 
-  // Mount node-oidc-provider as Express middleware at /oauth. This serves the
-  // authorization, token, registration, JWKS, revocation, and discovery
-  // endpoints. Helmet's restrictive CSP doesn't apply here because the
-  // provider sets its own headers and renders no HTML of its own (we render
-  // the consent page in the interaction controller).
+  // Mount node-oidc-provider. Its issuer is the bare origin, so the discovery
+  // documents are published at the root well-known URLs
+  // (`/.well-known/openid-configuration` and
+  // `/.well-known/oauth-authorization-server`), while its endpoints are pinned
+  // under `/oauth/*` via the provider's `routes` map. Because discovery lives
+  // at the root and endpoints under `/oauth`, the provider can't be mounted on
+  // a single path prefix; it is mounted at the application root behind a
+  // routing gate (`isOidcProviderPath`) that delegates only the provider's own
+  // paths and lets every other request fall through to the Nest router.
+  // Helmet's restrictive CSP doesn't matter here because the provider sets its
+  // own headers and renders no HTML (the consent page is rendered by the
+  // interaction controller).
   //
   // ensureInitialized() is awaited because Nest's onModuleInit hook may not
   // have run yet at this point (it fires inside app.listen() / app.init()).
   const oauthProviderService = app.get(OAuthProviderService);
   const oauthProvider = await oauthProviderService.ensureInitialized();
+  const oidcHandler = oauthProvider.callback();
   // The debug-logger and permissive-CORS middlewares for /oauth/* etc. are
   // mounted earlier (before the global cookie/helmet/CORS chain) so that
-  // requests from MCP clients with an off-allowlist Origin still appear in
-  // the log. The provider middleware itself stays here because the OAuth
-  // provider mounts its own interaction handlers.
-  app.use("/oauth", oauthProvider.callback());
+  // requests from MCP clients with an off-allowlist Origin still appear in the
+  // log and bypass the strict app-wide CORS layer.
+  app.use(
+    (
+      req: express.Request,
+      res: express.Response,
+      next: express.NextFunction,
+    ) => {
+      if (isOidcProviderPath(req.path)) {
+        oidcHandler(req, res);
+        return;
+      }
+      next();
+    },
+  );
 
   // Swagger documentation (disabled in production)
   if (process.env.NODE_ENV !== "production") {

--- a/backend/src/oauth/consent-template.spec.ts
+++ b/backend/src/oauth/consent-template.spec.ts
@@ -1,7 +1,7 @@
 import { renderConsentPage } from "./consent-template";
 
 describe("renderConsentPage", () => {
-  it("renders the form with the requested scopes pre-checked", () => {
+  it("renders the requested scopes as a read-only list", () => {
     const html = renderConsentPage({
       uid: "abc-123",
       clientName: "Claude Desktop",
@@ -15,8 +15,12 @@ describe("renderConsentPage", () => {
     expect(html).toContain("Claude Desktop");
     expect(html).toContain("https://claude.ai");
     expect(html).toContain("user@example.com");
-    expect(html).toContain('value="monize:read"');
-    expect(html).toContain('value="monize:write"');
+    // Human-readable scope labels are shown...
+    expect(html).toContain("Read your financial data");
+    expect(html).toContain("Modify your financial data");
+    // ...but there are no per-scope toggles (granular consent is not offered).
+    expect(html).not.toContain("<input");
+    expect(html).not.toContain('name="scopes"');
     expect(html).toContain('action="/api/v1/oauth-consent/abc-123/confirm"');
     expect(html).toContain('formaction="/api/v1/oauth-consent/abc-123/abort"');
   });

--- a/backend/src/oauth/consent-template.ts
+++ b/backend/src/oauth/consent-template.ts
@@ -25,6 +25,10 @@ const SCOPE_LABELS: Record<string, { title: string; description: string }> = {
 export function renderConsentPage(params: ConsentParams): string {
   const { uid, clientName, clientUri, userEmail, scopes, resource } = params;
 
+  // Scopes are shown as a read-only list, not toggles: the OAuth client fixes
+  // the requested scope set, and node-oidc-provider re-prompts indefinitely if
+  // any requested scope is withheld. The user's choice is Allow (grant all) or
+  // Deny.
   const scopeRows = scopes
     .map((scope) => {
       const meta = SCOPE_LABELS[scope] ?? {
@@ -33,13 +37,10 @@ export function renderConsentPage(params: ConsentParams): string {
       };
       return `
         <li class="scope">
-          <label>
-            <input type="checkbox" name="scopes" value="${escapeHtml(scope)}" checked />
-            <div>
-              <strong>${escapeHtml(meta.title)}</strong>
-              <p>${escapeHtml(meta.description)}</p>
-            </div>
-          </label>
+          <div>
+            <strong>${escapeHtml(meta.title)}</strong>
+            <p>${escapeHtml(meta.description)}</p>
+          </div>
         </li>`;
     })
     .join("\n");
@@ -117,8 +118,6 @@ export function renderConsentPage(params: ConsentParams): string {
     padding: 12px 14px;
     margin-bottom: 8px;
   }
-  li.scope label { display: flex; gap: 12px; align-items: flex-start; cursor: pointer; }
-  li.scope input { margin-top: 4px; }
   li.scope strong { display: block; font-size: 14px; }
   li.scope p { margin: 4px 0 0; color: var(--muted); font-size: 13px; }
   .meta {

--- a/backend/src/oauth/oauth-interaction.controller.spec.ts
+++ b/backend/src/oauth/oauth-interaction.controller.spec.ts
@@ -41,6 +41,7 @@ describe("OAuthInteractionController", () => {
           addOIDCScope(s: string) {
             this.oidcScopes.push(s);
           }
+          addOIDCClaims(_c: string[]) {}
           addResourceScope(r: string, s: string) {
             this.resourceScopes.push({ resource: r, scope: s });
           }
@@ -170,7 +171,7 @@ describe("OAuthInteractionController", () => {
         expect.stringContaining("Claude Desktop"),
       );
       expect(res.send).toHaveBeenCalledWith(
-        expect.stringContaining('value="monize:read"'),
+        expect.stringContaining("Read your financial data"),
       );
     });
 
@@ -211,6 +212,13 @@ describe("OAuthInteractionController", () => {
   });
 
   describe("POST /oauth-consent/:uid/confirm", () => {
+    const consentDetails = {
+      missingOIDCScope: ["openid", "profile", "monize:read", "monize:write"],
+      missingResourceScopes: {
+        "https://app.monize.test/api/v1/mcp": ["monize:read", "monize:write"],
+      },
+    };
+
     it("renders a friendly completed page when the interaction is already consumed", async () => {
       const { controller } = makeController({
         interactionDetails: jest.fn().mockRejectedValue(
@@ -222,7 +230,7 @@ describe("OAuthInteractionController", () => {
       const req = { cookies: { auth_token: "v" }, body: {} } as any;
       const res = makeRes();
 
-      await controller.confirm(req, res, { scopes: ["monize:read"] });
+      await controller.confirm(req, res);
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.send).toHaveBeenCalledWith(
@@ -234,15 +242,15 @@ describe("OAuthInteractionController", () => {
       const { controller } = makeController({
         interactionDetails: jest.fn().mockResolvedValue({
           uid: "u",
-          prompt: { name: "consent" },
-          params: { client_id: "c", scope: "monize:read" },
+          prompt: { name: "consent", details: consentDetails },
+          params: { client_id: "c" },
         }),
         jwtVerify: jest.fn().mockRejectedValue(new Error("invalid")),
       });
-      const req = { cookies: {}, body: { scopes: ["monize:read"] } } as any;
+      const req = { cookies: {}, body: {} } as any;
       const res = makeRes();
 
-      await controller.confirm(req, res, { scopes: ["monize:read"] });
+      await controller.confirm(req, res);
 
       expect(res.status).toHaveBeenCalledWith(401);
     });
@@ -258,45 +266,58 @@ describe("OAuthInteractionController", () => {
       const req = { cookies: { auth_token: "v" }, body: {} } as any;
       const res = makeRes();
 
-      await controller.confirm(req, res, {});
+      await controller.confirm(req, res);
 
       expect(res.status).toHaveBeenCalledWith(400);
     });
 
-    it("rejects when no requested scope is granted", async () => {
-      const { controller } = makeController({
-        interactionDetails: jest.fn().mockResolvedValue({
-          uid: "u",
-          prompt: { name: "consent" },
-          params: { client_id: "c", scope: "monize:read" },
-        }),
-      });
-      const req = { cookies: { auth_token: "v" }, body: {} } as any;
-      const res = makeRes();
-
-      await controller.confirm(req, res, { scopes: [] });
-
-      expect(res.status).toHaveBeenCalledWith(400);
-    });
-
-    it("creates a grant and finishes the interaction with the granted scopes", async () => {
+    it("grants every missing OIDC and resource scope, then finishes the interaction", async () => {
+      const grant = {
+        addOIDCScope: jest.fn(),
+        addOIDCClaims: jest.fn(),
+        addResourceScope: jest.fn(),
+        save: jest.fn().mockResolvedValue("grant-id-1"),
+      };
+      class GrantMock {
+        constructor() {
+          return grant;
+        }
+        static find = jest.fn().mockResolvedValue(null);
+      }
       const { controller, interactionFinished } = makeController({
         interactionDetails: jest.fn().mockResolvedValue({
           uid: "u",
-          prompt: { name: "consent" },
-          params: {
-            client_id: "claude-desktop",
-            scope: "monize:read monize:write",
-            resource: "https://app.monize.test/api/v1/mcp",
+          prompt: {
+            name: "consent",
+            details: {
+              missingOIDCScope: ["openid", "profile", "monize:read"],
+              missingOIDCClaims: ["sub", "email"],
+              missingResourceScopes: {
+                "https://app.monize.test/api/v1/mcp": ["monize:read"],
+              },
+            },
           },
+          params: { client_id: "claude-desktop" },
           session: { accountId: "user-1" },
         }),
+        Grant: GrantMock as any,
       });
       const req = { cookies: { auth_token: "v" }, body: {} } as any;
       const res = makeRes();
 
-      await controller.confirm(req, res, { scopes: ["monize:read"] });
+      await controller.confirm(req, res);
 
+      // OIDC identity scopes (openid, profile) AND the resource scope are all
+      // granted -- not just the monize:* subset -- so the consent check clears
+      // and the provider stops re-prompting with a new uid.
+      expect(grant.addOIDCScope).toHaveBeenCalledWith(
+        "openid profile monize:read",
+      );
+      expect(grant.addOIDCClaims).toHaveBeenCalledWith(["sub", "email"]);
+      expect(grant.addResourceScope).toHaveBeenCalledWith(
+        "https://app.monize.test/api/v1/mcp",
+        "monize:read",
+      );
       expect(interactionFinished).toHaveBeenCalledWith(
         req,
         res,
@@ -309,15 +330,15 @@ describe("OAuthInteractionController", () => {
       const { controller } = makeController({
         interactionDetails: jest.fn().mockResolvedValue({
           uid: "u",
-          prompt: { name: "consent" },
-          params: { client_id: "c", scope: "monize:read" },
+          prompt: { name: "consent", details: consentDetails },
+          params: { client_id: "c" },
           session: { accountId: "other-user" },
         }),
       });
       const req = { cookies: { auth_token: "v" }, body: {} } as any;
       const res = makeRes();
 
-      await controller.confirm(req, res, { scopes: ["monize:read"] });
+      await controller.confirm(req, res);
 
       expect(res.status).toHaveBeenCalledWith(403);
     });
@@ -565,101 +586,68 @@ describe("OAuthInteractionController", () => {
   });
 
   describe("confirm branches", () => {
-    it("uses MCP resource URL when params.resource is missing", async () => {
-      const { controller } = makeController({
-        interactionDetails: jest.fn().mockResolvedValue({
-          uid: "u1",
-          prompt: { name: "consent" },
-          params: { client_id: "claude-desktop", scope: "monize:read" },
-          session: { accountId: "user-1" },
-        }),
-      });
-      const req = { cookies: { auth_token: "tok" } } as any;
-      const res = makeRes();
-      await controller.confirm(req, res, { scopes: ["monize:read"] });
-      expect(res.redirect || res.send || res.status).toBeDefined();
-    });
+    const consentDetails = {
+      missingOIDCScope: ["openid", "monize:read"],
+      missingResourceScopes: {
+        "https://app.monize.test/api/v1/mcp": ["monize:read"],
+      },
+    };
 
-    it("scopes string form is normalized to array", async () => {
-      const { controller } = makeController({
-        interactionDetails: jest.fn().mockResolvedValue({
-          uid: "u1",
-          prompt: { name: "consent" },
-          params: {
-            client_id: "claude-desktop",
-            scope: "monize:read",
-            resource: "https://app.monize.test/api/v1/mcp",
-          },
-          session: { accountId: "user-1" },
-        }),
-      });
-      const req = { cookies: { auth_token: "tok" } } as any;
-      const res = makeRes();
-      await controller.confirm(req, res, { scopes: "monize:read" });
-    });
-
-    it("uses existing grant when grantId is set on interaction", async () => {
+    it("reuses the existing grant when the interaction already has a grantId", async () => {
       const existing = {
-        accountId: "user-1",
-        clientId: "claude-desktop",
         addOIDCScope: jest.fn(),
+        addOIDCClaims: jest.fn(),
         addResourceScope: jest.fn(),
         save: jest.fn().mockResolvedValue("grant-existing"),
       };
       class GrantMock {
-        accountId: string;
-        clientId: string;
-        constructor(args: { accountId: string; clientId: string }) {
-          this.accountId = args.accountId;
-          this.clientId = args.clientId;
-        }
         static find = jest.fn().mockResolvedValue(existing);
-        addOIDCScope = jest.fn();
-        addResourceScope = jest.fn();
-        save = jest.fn().mockResolvedValue("grant-new");
       }
       const { controller } = makeController({
         interactionDetails: jest.fn().mockResolvedValue({
           uid: "u1",
-          prompt: { name: "consent" },
-          params: { client_id: "claude-desktop", scope: "monize:read" },
+          prompt: { name: "consent", details: consentDetails },
+          params: { client_id: "claude-desktop" },
           session: { accountId: "user-1" },
           grantId: "g1",
         }),
-        Grant: GrantMock,
+        Grant: GrantMock as any,
       });
       const req = { cookies: { auth_token: "tok" } } as any;
       const res = makeRes();
-      await controller.confirm(req, res, { scopes: ["monize:read"] });
+      await controller.confirm(req, res);
+      expect(GrantMock.find).toHaveBeenCalledWith("g1");
+      expect(existing.addOIDCScope).toHaveBeenCalledWith("openid monize:read");
       expect(existing.save).toHaveBeenCalled();
     });
 
-    it("creates new grant when grantId set but find returns null", async () => {
+    it("creates a new grant when grantId is set but find returns null", async () => {
+      const created = {
+        addOIDCScope: jest.fn(),
+        addOIDCClaims: jest.fn(),
+        addResourceScope: jest.fn(),
+        save: jest.fn().mockResolvedValue("grant-new"),
+      };
       class GrantMock {
-        accountId: string;
-        clientId: string;
-        constructor(args: { accountId: string; clientId: string }) {
-          this.accountId = args.accountId;
-          this.clientId = args.clientId;
+        constructor() {
+          return created;
         }
         static find = jest.fn().mockResolvedValue(null);
-        addOIDCScope = jest.fn();
-        addResourceScope = jest.fn();
-        save = jest.fn().mockResolvedValue("grant-new");
       }
       const { controller } = makeController({
         interactionDetails: jest.fn().mockResolvedValue({
           uid: "u1",
-          prompt: { name: "consent" },
-          params: { client_id: "claude-desktop", scope: "monize:read" },
+          prompt: { name: "consent", details: consentDetails },
+          params: { client_id: "claude-desktop" },
           session: { accountId: "user-1" },
           grantId: "g1",
         }),
-        Grant: GrantMock,
+        Grant: GrantMock as any,
       });
       const req = { cookies: { auth_token: "tok" } } as any;
       const res = makeRes();
-      await controller.confirm(req, res, { scopes: ["monize:read"] });
+      await controller.confirm(req, res);
+      expect(created.save).toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/oauth/oauth-interaction.controller.ts
+++ b/backend/src/oauth/oauth-interaction.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Req, Res, Body, Logger } from "@nestjs/common";
+import { Controller, Get, Post, Req, Res, Logger } from "@nestjs/common";
 import { ApiExcludeController } from "@nestjs/swagger";
 import { ConfigService } from "@nestjs/config";
 import { JwtService } from "@nestjs/jwt";
@@ -11,10 +11,6 @@ import {
 } from "./oauth-provider.service";
 import { renderConsentPage } from "./consent-template";
 import { AuthService } from "../auth/auth.service";
-
-interface InteractionFormBody {
-  scopes?: string | string[];
-}
 
 /**
  * Hosts the user-facing OAuth interaction routes (login + consent) for the
@@ -129,11 +125,7 @@ export class OAuthInteractionController {
 
   @Post(":uid/confirm")
   @Throttle({ default: { ttl: 60_000, limit: 10 } })
-  async confirm(
-    @Req() req: Request,
-    @Res() res: Response,
-    @Body() body: InteractionFormBody,
-  ) {
+  async confirm(@Req() req: Request, @Res() res: Response) {
     const provider = this.providerService.getProvider();
     let interaction;
     try {
@@ -167,38 +159,45 @@ export class OAuthInteractionController {
       return;
     }
 
-    const requestedScopes =
-      (params.scope as string | undefined)?.split(" ") ?? [];
-    const submittedScopes = this.normalizeScopes(body?.scopes);
-    const grantedScopes = requestedScopes.filter(
-      (s) =>
-        (MCP_RESOURCE_SCOPES as readonly string[]).includes(s) &&
-        submittedScopes.includes(s),
-    );
-    if (grantedScopes.length === 0) {
-      res.status(400).send("At least one scope must be granted");
-      return;
-    }
-
     const clientId = params.client_id as string;
-    const resource =
-      (params.resource as string | undefined) ??
-      this.providerService.getMcpResourceUrl();
+
+    // node-oidc-provider's consent Check requires the saved Grant to cover
+    // EVERY scope and claim the authorization request asked for. If anything
+    // stays missing the provider re-prompts, minting a fresh consent
+    // interaction on each submit (the "consent uid keeps changing" loop).
+    // Claude requests OIDC scopes (openid, profile) alongside the MCP resource
+    // scopes (monize:read/write), so grant exactly what the prompt reports as
+    // missing rather than only the monize:* subset. Granular per-scope consent
+    // is intentionally not offered: the client fixes the requested scope set,
+    // and withholding any of it would just loop the prompt — the user's choice
+    // is Allow (grant all) or Deny.
+    const details = prompt.details as {
+      missingOIDCScope?: string[];
+      missingOIDCClaims?: string[];
+      missingResourceScopes?: Record<string, string[]>;
+    };
 
     const Grant = provider.Grant;
-    let grant: InstanceType<typeof Grant>;
-    if (interaction.grantId) {
-      const existing = await Grant.find(interaction.grantId);
-      grant = existing ?? new Grant({ accountId: user.id, clientId });
-    } else {
-      grant = new Grant({ accountId: user.id, clientId });
+    const existing = interaction.grantId
+      ? await Grant.find(interaction.grantId)
+      : undefined;
+    const grant = existing ?? new Grant({ accountId: user.id, clientId });
+
+    if (details.missingOIDCScope?.length) {
+      grant.addOIDCScope(details.missingOIDCScope.join(" "));
+    }
+    if (details.missingOIDCClaims?.length) {
+      grant.addOIDCClaims(details.missingOIDCClaims);
+    }
+    for (const [indicator, scopes] of Object.entries(
+      details.missingResourceScopes ?? {},
+    )) {
+      grant.addResourceScope(indicator, scopes.join(" "));
     }
 
-    grant.addOIDCScope(grantedScopes.join(" "));
-    grant.addResourceScope(resource, grantedScopes.join(" "));
     const grantId = await grant.save();
     this.logger.log(
-      `interaction.confirm grant saved id=${grantId} account=${user.id} client=${clientId} scopes=${grantedScopes.join(",")}`,
+      `interaction.confirm grant saved id=${grantId} account=${user.id} client=${clientId} oidcScopes=${(details.missingOIDCScope ?? []).join(",")} resources=${Object.keys(details.missingResourceScopes ?? {}).join(",")}`,
     );
 
     await provider.interactionFinished(
@@ -327,10 +326,5 @@ export class OAuthInteractionController {
       );
       return { name: clientId, uri: null };
     }
-  }
-
-  private normalizeScopes(input: string | string[] | undefined): string[] {
-    if (!input) return [];
-    return Array.isArray(input) ? input : [input];
   }
 }

--- a/backend/src/oauth/oauth-metadata.controller.spec.ts
+++ b/backend/src/oauth/oauth-metadata.controller.spec.ts
@@ -10,7 +10,7 @@ describe("OAuthMetadataController", () => {
       getMcpResourceUrl: jest
         .fn()
         .mockReturnValue("https://app.monize.test/api/v1/mcp"),
-      getIssuerUrl: jest.fn().mockReturnValue("https://app.monize.test/oauth"),
+      getIssuerUrl: jest.fn().mockReturnValue("https://app.monize.test"),
     } as unknown as jest.Mocked<OAuthProviderService>;
 
     controller = new OAuthMetadataController(providerService);
@@ -20,9 +20,7 @@ describe("OAuthMetadataController", () => {
     const meta = controller.protectedResource();
 
     expect(meta.resource).toBe("https://app.monize.test/api/v1/mcp");
-    expect(meta.authorization_servers).toEqual([
-      "https://app.monize.test/oauth",
-    ]);
+    expect(meta.authorization_servers).toEqual(["https://app.monize.test"]);
     expect(meta.bearer_methods_supported).toEqual(["header"]);
     expect(meta.scopes_supported).toEqual(
       expect.arrayContaining(["monize:read", "monize:write"]),

--- a/backend/src/oauth/oauth-provider.service.spec.ts
+++ b/backend/src/oauth/oauth-provider.service.spec.ts
@@ -142,7 +142,8 @@ describe("OAuthProviderService", () => {
       );
       // The public-URL helpers do not require initialization.
       expect(svc.getMcpResourceUrl()).toBe("https://app.test/api/v1/mcp");
-      expect(svc.getIssuerUrl()).toBe("https://app.test/oauth");
+      // Issuer is the bare origin so discovery is published at the root.
+      expect(svc.getIssuerUrl()).toBe("https://app.test");
     });
   });
 
@@ -166,7 +167,18 @@ describe("OAuthProviderService", () => {
 
       expect(p1).toBe(p2);
       expect(providerConstructorCalls).toHaveLength(1);
-      expect(providerConstructorCalls[0].issuer).toBe("https://app.test/oauth");
+      // Issuer is the bare origin (discovery served at the root well-known
+      // URLs); endpoints are pinned under /oauth/* via the routes map.
+      expect(providerConstructorCalls[0].issuer).toBe("https://app.test");
+      expect(providerConstructorCalls[0].config.routes).toEqual({
+        authorization: "/oauth/auth",
+        token: "/oauth/token",
+        jwks: "/oauth/jwks",
+        registration: "/oauth/reg",
+        revocation: "/oauth/token/revocation",
+        userinfo: "/oauth/me",
+        end_session: "/oauth/session/end",
+      });
       expect(providerConstructorCalls[0].config.scopes).toEqual([
         ...MCP_RESOURCE_SCOPES,
       ]);

--- a/backend/src/oauth/oauth-provider.service.ts
+++ b/backend/src/oauth/oauth-provider.service.ts
@@ -56,7 +56,16 @@ export class OAuthProviderService implements OnModuleInit {
 
   private async initialize(): Promise<ProviderType> {
     const publicUrl = this.requirePublicUrl();
-    const issuer = `${publicUrl}/oauth`;
+    // The OAuth issuer is the bare application origin so the RFC 8414 / OIDC
+    // discovery documents are published at the conventional root well-known
+    // URLs (`/.well-known/oauth-authorization-server` and
+    // `/.well-known/openid-configuration`). The provider's actual endpoints are
+    // kept under `/oauth/*` via the `routes` map below — node-oidc-provider
+    // builds endpoint URLs as issuer + routePath, so a root issuer plus a
+    // `/oauth/...` routePath still yields `https://<host>/oauth/<route>`. This
+    // keeps the existing frontend proxy (which forwards `/oauth/*`) working and
+    // avoids colliding with frontend routes such as `/auth/callback`.
+    const issuer = publicUrl;
     const mcpResource = `${publicUrl}/api/v1/mcp`;
     const jwtSecret = this.configService.get<string>("JWT_SECRET");
     if (!jwtSecret || jwtSecret.length < 32) {
@@ -73,6 +82,19 @@ export class OAuthProviderService implements OnModuleInit {
 
     const provider = new Provider(issuer, {
       adapter: adapterFactory,
+      // Pin every provider endpoint under /oauth/* (see issuer comment above).
+      // Discovery (`/.well-known/openid-configuration` and
+      // `/.well-known/oauth-authorization-server`) is NOT in this map — it is
+      // served by the provider at the root because the issuer has no path.
+      routes: {
+        authorization: "/oauth/auth",
+        token: "/oauth/token",
+        jwks: "/oauth/jwks",
+        registration: "/oauth/reg",
+        revocation: "/oauth/token/revocation",
+        userinfo: "/oauth/me",
+        end_session: "/oauth/session/end",
+      },
       cookies: {
         keys: [cookieKey],
         // Pin path: '/' so the interaction/session cookies follow the
@@ -279,7 +301,10 @@ export class OAuthProviderService implements OnModuleInit {
   }
 
   getIssuerUrl(): string {
-    return `${this.requirePublicUrl()}/oauth`;
+    // Bare origin: the OAuth issuer identifier (see initialize()). Advertised
+    // to MCP clients in the protected-resource metadata as the authorization
+    // server, so clients fetch discovery from the root well-known URLs.
+    return this.requirePublicUrl();
   }
 
   /**

--- a/backend/src/oauth/oidc-provider-paths.spec.ts
+++ b/backend/src/oauth/oidc-provider-paths.spec.ts
@@ -1,0 +1,40 @@
+import { isOidcProviderPath } from "./oidc-provider-paths";
+
+describe("isOidcProviderPath", () => {
+  it("matches the root discovery documents", () => {
+    expect(isOidcProviderPath("/.well-known/openid-configuration")).toBe(true);
+    expect(isOidcProviderPath("/.well-known/oauth-authorization-server")).toBe(
+      true,
+    );
+  });
+
+  it("matches the provider endpoints under /oauth", () => {
+    expect(isOidcProviderPath("/oauth")).toBe(true);
+    expect(isOidcProviderPath("/oauth/auth")).toBe(true);
+    expect(isOidcProviderPath("/oauth/auth/some-interaction-uid")).toBe(true);
+    expect(isOidcProviderPath("/oauth/token")).toBe(true);
+    expect(isOidcProviderPath("/oauth/token/revocation")).toBe(true);
+    expect(isOidcProviderPath("/oauth/reg")).toBe(true);
+    expect(isOidcProviderPath("/oauth/jwks")).toBe(true);
+  });
+
+  it("does not match the protected-resource metadata (served by Nest)", () => {
+    // RFC 9728 metadata is a Nest controller, not a provider route.
+    expect(isOidcProviderPath("/.well-known/oauth-protected-resource")).toBe(
+      false,
+    );
+  });
+
+  it("does not match the consent interaction routes (Nest controller)", () => {
+    expect(isOidcProviderPath("/api/v1/oauth-consent/abc")).toBe(false);
+    expect(isOidcProviderPath("/api/v1/oauth-consent/abc/confirm")).toBe(false);
+  });
+
+  it("does not match unrelated application or frontend paths", () => {
+    expect(isOidcProviderPath("/")).toBe(false);
+    expect(isOidcProviderPath("/api/v1/mcp")).toBe(false);
+    expect(isOidcProviderPath("/auth/callback")).toBe(false);
+    expect(isOidcProviderPath("/oauthx")).toBe(false);
+    expect(isOidcProviderPath("/.well-known/other")).toBe(false);
+  });
+});

--- a/backend/src/oauth/oidc-provider-paths.ts
+++ b/backend/src/oauth/oidc-provider-paths.ts
@@ -1,0 +1,29 @@
+/**
+ * Decides which request paths are handled by node-oidc-provider.
+ *
+ * The provider is mounted at the application root (not under `/oauth`) because
+ * its issuer is the bare origin, so the discovery documents live at the root
+ * well-known URLs. Its actual endpoints are kept under `/oauth/*` via the
+ * provider's `routes` map (see `OAuthProviderService.initialize`). This
+ * predicate is the routing gate for the root mount in `main.ts`: a request is
+ * delegated to the provider only when it targets one of those paths, and every
+ * other request falls through to the normal Nest router.
+ *
+ * Kept in its own module so the routing rule is unit-testable (main.ts is
+ * excluded from coverage).
+ *
+ * NOTE: the frontend proxy (`frontend/src/proxy.ts` -> `isOAuthPath`) must
+ * forward the same set of paths to the backend; keep the two lists in sync.
+ */
+export function isOidcProviderPath(path: string): boolean {
+  return (
+    // Discovery documents, served by the provider at the root because the
+    // issuer has no path component.
+    path === "/.well-known/openid-configuration" ||
+    path === "/.well-known/oauth-authorization-server" ||
+    // All provider endpoints (authorization + resume, token, revocation,
+    // registration, jwks, ...) are pinned under /oauth/* by the routes map.
+    path === "/oauth" ||
+    path.startsWith("/oauth/")
+  );
+}

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -76,7 +76,8 @@ function isOAuthPath(pathname: string): boolean {
     pathname.startsWith('/oauth-consent/') ||
     pathname === '/.well-known/oauth-protected-resource' ||
     pathname === '/.well-known/oauth-authorization-server' ||
-    pathname.startsWith('/.well-known/oauth-authorization-server/')
+    pathname.startsWith('/.well-known/oauth-authorization-server/') ||
+    pathname === '/.well-known/openid-configuration'
   );
 }
 
@@ -173,6 +174,7 @@ export const config = {
     '/.well-known/oauth-protected-resource',
     '/.well-known/oauth-authorization-server',
     '/.well-known/oauth-authorization-server/:path*',
+    '/.well-known/openid-configuration',
     // Match all other paths except static files
     '/((?!_next/static|_next/image|favicon.ico|.*\\..*|public).*)',
   ],


### PR DESCRIPTION
## Summary
Refactors the OAuth consent interaction to automatically grant all missing OIDC scopes and resource scopes reported by node-oidc-provider, rather than requiring per-scope user selection. This fixes an infinite consent loop where the provider would re-prompt with a new interaction UID if any requested scope was withheld.

## Key Changes

- **Consent form simplification**: Removed per-scope checkboxes from the consent page. Scopes are now displayed as a read-only list with human-readable labels. The user's choice is binary: Allow (grant all) or Deny.

- **Automatic scope granting**: The `confirm` endpoint now reads `prompt.details.missingOIDCScope`, `prompt.details.missingOIDCClaims`, and `prompt.details.missingResourceScopes` from the interaction and grants all of them to the Grant object. This ensures the saved Grant covers every scope the authorization request asked for, preventing the provider from re-prompting.

- **Removed form body parameter**: The `confirm` endpoint no longer accepts a `@Body() body: InteractionFormBody` parameter. Scope selection is no longer user-driven; it is determined entirely by what the provider reports as missing.

- **OAuth issuer restructuring**: Changed the OAuth issuer from `{publicUrl}/oauth` to the bare `publicUrl`. This allows discovery documents (`/.well-known/openid-configuration` and `/.well-known/oauth-authorization-server`) to be published at the conventional root well-known URLs, while provider endpoints remain under `/oauth/*` via an explicit `routes` map in the Provider configuration.

- **Root-level provider routing**: Added `isOidcProviderPath()` utility to gate which requests are delegated to node-oidc-provider at the application root. The provider is now mounted at the root (not under `/oauth`) with a routing predicate, allowing discovery to live at the root while endpoints stay under `/oauth/*`.

- **Updated issuer URL**: `OAuthProviderService.getIssuerUrl()` now returns the bare origin instead of `{origin}/oauth`, matching the new issuer configuration.

## Implementation Details

- The consent page now calls `grant.addOIDCScope()` with all missing OIDC scopes joined as a space-separated string, `grant.addOIDCClaims()` with the missing claims array, and `grant.addResourceScope()` for each resource indicator and its missing scopes.

- The provider's `routes` map explicitly pins all endpoints (`/oauth/auth`, `/oauth/token`, `/oauth/jwks`, `/oauth/reg`, `/oauth/token/revocation`, `/oauth/me`, `/oauth/session/end`) so they remain under `/oauth/*` even though the issuer is now the bare origin.

- Frontend proxy (`frontend/src/proxy.ts`) updated to forward `/.well-known/openid-configuration` to the backend, keeping the proxy routing in sync with the backend's `isOidcProviderPath()` predicate.

- Test suite updated to reflect the new consent flow: removed tests for per-scope selection, added tests for automatic granting of all missing scopes, and updated mock interaction details to use the new `prompt.details` structure.

https://claude.ai/code/session_01UeWTRhBzaXt2X69u5S6fcU