### PR TITLE
Keep Account Info Widget mounted during filter changes

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -26,6 +26,22 @@
 
   /* Font family */
   --font-sans: 'Inter', system-ui, sans-serif;
+
+  /* Fade/slide-in for an incoming chart card, used when a page swaps between
+     chart types (e.g. Balance History -> Account Balances) so the change
+     doesn't pop abruptly. Pair with motion-reduce:animate-none. */
+  --animate-chart-in: chart-in 300ms ease-out;
+
+  @keyframes chart-in {
+    from {
+      opacity: 0;
+      transform: translateY(0.5rem);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
 }
 
 /* Dark mode variant */

--- a/frontend/src/app/transactions/page.test.tsx
+++ b/frontend/src/app/transactions/page.test.tsx
@@ -1182,6 +1182,52 @@ describe('TransactionsPage', () => {
     });
   });
 
+  describe('Account Info Widget', () => {
+    beforeEach(() => {
+      window.localStorage.clear();
+    });
+
+    it('shows the chart-derived current balance, not the stale account balance', async () => {
+      mockGetAllAccounts.mockResolvedValue(mockAccounts);
+      // acc-1's stored currentBalance is 5000 (stale); the daily-balance
+      // series — refetched whenever transactions change — ends at 1500.
+      mockGetDailyBalances.mockResolvedValue([
+        { date: '2026-02-01', balance: 1000, accountId: 'acc-1', currencyCode: 'USD' },
+        { date: '2026-02-15', balance: 1500, accountId: 'acc-1', currencyCode: 'USD' },
+      ]);
+
+      render(<TransactionsPage />);
+      await waitFor(() => {
+        expect(screen.getByTestId('filter-panel')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('set-account-filter'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Current Balance')).toBeInTheDocument();
+      });
+      expect(screen.getByText('$1500.00')).toBeInTheDocument();
+      expect(screen.queryByText('$5000.00')).not.toBeInTheDocument();
+    });
+
+    it('falls back to the stored account balance when no daily-balance rows exist', async () => {
+      mockGetAllAccounts.mockResolvedValue(mockAccounts);
+      mockGetDailyBalances.mockResolvedValue([]);
+
+      render(<TransactionsPage />);
+      await waitFor(() => {
+        expect(screen.getByTestId('filter-panel')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('set-account-filter'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Current Balance')).toBeInTheDocument();
+      });
+      expect(screen.getByText('$5000.00')).toBeInTheDocument();
+    });
+  });
+
   describe('Transaction Editing', () => {
     it('opens edit form when a regular transaction is clicked', async () => {
       mockGetAll.mockResolvedValue({

--- a/frontend/src/app/transactions/page.test.tsx
+++ b/frontend/src/app/transactions/page.test.tsx
@@ -238,6 +238,9 @@ vi.mock('@/components/transactions/TransactionFilterPanel', () => ({
       <button data-testid="set-account-filter" onClick={() => {
         props.handleArrayFilterChange(props.setFilterAccountIds, ['acc-1']);
       }}>Set Account Filter</button>
+      <button data-testid="set-two-account-filter" onClick={() => {
+        props.handleArrayFilterChange(props.setFilterAccountIds, ['acc-1', 'acc-2']);
+      }}>Set Two Account Filter</button>
       <button data-testid="set-account-status-active" onClick={() => {
         props.setFilterAccountStatus('active');
       }}>Show Active Accounts</button>
@@ -1208,6 +1211,54 @@ describe('TransactionsPage', () => {
       });
       expect(screen.getByText('$1500.00')).toBeInTheDocument();
       expect(screen.queryByText('$5000.00')).not.toBeInTheDocument();
+    });
+
+    it('keeps the widget mounted and slides it out when the filter widens to two accounts', async () => {
+      mockGetAllAccounts.mockResolvedValue(mockAccounts);
+      const rows = [
+        { date: '2026-02-01', balance: 1000, accountId: 'acc-1', currencyCode: 'USD' },
+        { date: '2026-02-15', balance: 1500, accountId: 'acc-1', currencyCode: 'USD' },
+        { date: '2026-02-01', balance: 5000, accountId: 'acc-2', currencyCode: 'USD' },
+        { date: '2026-02-15', balance: 5200, accountId: 'acc-2', currencyCode: 'USD' },
+      ];
+      // Respect the accountIds chart param like the backend does, so the
+      // single-account phase yields one account's series and the two-account
+      // phase yields both.
+      mockGetDailyBalances.mockImplementation((params?: { accountIds?: string }) => {
+        const ids = params?.accountIds?.split(',');
+        return Promise.resolve(ids ? rows.filter((r) => ids.includes(r.accountId)) : rows);
+      });
+
+      render(<TransactionsPage />);
+      await waitFor(() => {
+        expect(screen.getByTestId('filter-panel')).toBeInTheDocument();
+      });
+
+      // Narrow to one account: the widget is shown next to the history chart.
+      fireEvent.click(screen.getByTestId('set-account-filter'));
+      await waitFor(() => {
+        expect(screen.getByText('Current Balance')).toBeInTheDocument();
+      });
+      const widgetColumn = screen.getByText('Current Balance').closest('[aria-hidden]');
+      expect(widgetColumn).toHaveAttribute('aria-hidden', 'false');
+
+      // Widen to two accounts: the bar chart takes over and the widget stays
+      // mounted but hidden, so its column can animate out of view.
+      fireEvent.click(screen.getByTestId('set-two-account-filter'));
+      await waitFor(() => {
+        expect(screen.getByTestId('chart-account-balances')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Current Balance')).toBeInTheDocument();
+      expect(widgetColumn).toHaveAttribute('aria-hidden', 'true');
+      expect(widgetColumn?.className).toContain('opacity-0');
+      expect(widgetColumn?.className).toContain('pointer-events-none');
+
+      // Narrow back down to one account: the same column slides back in.
+      fireEvent.click(screen.getByTestId('set-account-filter'));
+      await waitFor(() => {
+        expect(widgetColumn).toHaveAttribute('aria-hidden', 'false');
+      });
+      expect(widgetColumn?.className).toContain('opacity-100');
     });
 
     it('falls back to the stored account balance when no daily-balance rows exist', async () => {

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -49,6 +49,7 @@ import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useFormModal } from '@/hooks/useFormModal';
 import { AccountFormModal } from '@/components/accounts/AccountFormModal';
 import { AccountInfoWidget } from '@/components/transactions/AccountInfoWidget';
+import { computeBalanceSummary } from '@/lib/balance-history';
 import { ChevronDoubleRightIcon } from '@heroicons/react/24/outline';
 import { Modal } from '@/components/ui/Modal';
 import { UnsavedChangesDialog } from '@/components/ui/UnsavedChangesDialog';
@@ -567,6 +568,15 @@ function TransactionsContent() {
     return institutions.find((i) => i.id === singleFilteredAccount.institutionId);
   }, [singleFilteredAccount, institutions]);
 
+  // The accounts list is fetched once per page load, so account.currentBalance
+  // goes stale as transactions are added or edited. The daily-balance series is
+  // refetched alongside the transactions, so the widget's balance is derived
+  // from it — the exact figure the Balance History chart shows as "Current".
+  const singleAccountCurrentBalance = useMemo(
+    () => computeBalanceSummary(chartBalances)?.currentBalance,
+    [chartBalances],
+  );
+
   const selection = useTransactionSelection(
     transactions,
     pagination?.total ?? 0,
@@ -764,6 +774,7 @@ function TransactionsContent() {
                 >
                   <AccountInfoWidget
                     account={singleFilteredAccount}
+                    currentBalance={singleAccountCurrentBalance}
                     institution={singleFilteredInstitution}
                     scheduledTransactions={scheduledTransactions}
                     onEdit={() => accountModal.openEdit(singleFilteredAccount)}

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -563,11 +563,6 @@ function TransactionsContent() {
     );
   }, [filters.filterAccountIds, filters.selectedAccounts, accounts]);
 
-  const singleFilteredInstitution = useMemo(() => {
-    if (!singleFilteredAccount?.institutionId) return undefined;
-    return institutions.find((i) => i.id === singleFilteredAccount.institutionId);
-  }, [singleFilteredAccount, institutions]);
-
   // The accounts list is fetched once per page load, so account.currentBalance
   // goes stale as transactions are added or edited. The daily-balance series is
   // refetched alongside the transactions, so the widget's balance is derived
@@ -576,6 +571,31 @@ function TransactionsContent() {
     () => computeBalanceSummary(chartBalances)?.currentBalance,
     [chartBalances],
   );
+
+  // Retain the last single-filtered account (and its live balance) across the
+  // moment the filter widens to multiple accounts, so the widget can stay
+  // mounted and play the same slide-out animation as the manual collapse
+  // instead of vanishing abruptly. Synced with the "info from previous render"
+  // pattern (no setState in an effect).
+  const [retainedWidget, setRetainedWidget] = useState<
+    { account: Account; currentBalance?: number } | undefined
+  >();
+  if (
+    singleFilteredAccount &&
+    (retainedWidget?.account !== singleFilteredAccount ||
+      retainedWidget?.currentBalance !== singleAccountCurrentBalance)
+  ) {
+    setRetainedWidget({
+      account: singleFilteredAccount,
+      currentBalance: singleAccountCurrentBalance,
+    });
+  }
+  const widgetAccount = retainedWidget?.account;
+
+  const widgetInstitution = useMemo(() => {
+    if (!widgetAccount?.institutionId) return undefined;
+    return institutions.find((i) => i.id === widgetAccount.institutionId);
+  }, [widgetAccount, institutions]);
 
   const selection = useTransactionSelection(
     transactions,
@@ -726,63 +746,78 @@ function TransactionsContent() {
           actions={<Button onClick={handleCreateNew}>{t('page.newButton')}</Button>}
         />
         {(() => {
-          const chart = filters.filterCategoryIds.length > 0 || filters.filterPayeeIds.length > 0 || filters.filterTagIds.length > 0 || filters.filterSearch.length > 0 ? (
-            <CategoryPayeeBarChart
-              data={monthlyTotals}
-              isLoading={isLoading}
-              filterLabel={monthlyTotalsFilterLabel}
-              onMonthClick={(startDate, endDate) => {
-                filters.isFilterChange.current = true;
-                filters.setFilterStartDate(startDate);
-                filters.setFilterEndDate(endDate);
-                filters.setFilterTimePeriod('custom');
-              }}
-            />
-          ) : accountBalances.length > 1 ? (
-            <AccountBalancesBarChart
-              data={accountBalances}
-              isLoading={isLoading}
-              currencyCode={chartCurrency}
-              onAccountClick={filters.handleAccountFilterClick}
-            />
-          ) : (
-            <BalanceHistoryChart
-              data={chartBalances}
-              isLoading={isLoading}
-              currencyCode={chartCurrency}
-              accountName={balanceHistoryAccountName}
-            />
+          const chartKind =
+            filters.filterCategoryIds.length > 0 || filters.filterPayeeIds.length > 0 || filters.filterTagIds.length > 0 || filters.filterSearch.length > 0
+              ? 'monthlyTotals'
+              : accountBalances.length > 1
+                ? 'accountBalances'
+                : 'balanceHistory';
+          // Keyed by kind so swapping chart types remounts the card and plays
+          // the fade-in, instead of one chart popping into the other.
+          const chart = (
+            <div key={chartKind} className="animate-chart-in motion-reduce:animate-none">
+              {chartKind === 'monthlyTotals' ? (
+                <CategoryPayeeBarChart
+                  data={monthlyTotals}
+                  isLoading={isLoading}
+                  filterLabel={monthlyTotalsFilterLabel}
+                  onMonthClick={(startDate, endDate) => {
+                    filters.isFilterChange.current = true;
+                    filters.setFilterStartDate(startDate);
+                    filters.setFilterEndDate(endDate);
+                    filters.setFilterTimePeriod('custom');
+                  }}
+                />
+              ) : chartKind === 'accountBalances' ? (
+                <AccountBalancesBarChart
+                  data={accountBalances}
+                  isLoading={isLoading}
+                  currencyCode={chartCurrency}
+                  onAccountClick={filters.handleAccountFilterClick}
+                />
+              ) : (
+                <BalanceHistoryChart
+                  data={chartBalances}
+                  isLoading={isLoading}
+                  currencyCode={chartCurrency}
+                  accountName={balanceHistoryAccountName}
+                />
+              )}
+            </div>
           );
 
           // Filtered to a single account: show its info widget (25%) to the
           // left of the chart (75%). Stacks vertically on narrow screens. The
           // widget can be collapsed (persisted) so the chart uses full width.
-          if (singleFilteredAccount) {
+          if (widgetAccount) {
             // The widget animates between expanded and collapsed rather than
-            // mounting/unmounting, so the chevron toggle slides it out of view:
-            // its column collapses width (desktop) or height (mobile) and fades,
-            // while the chart flexes to fill the reclaimed space.
+            // mounting/unmounting, so both the chevron toggle and widening the
+            // filter past one account slide it out of view: its column
+            // collapses width (desktop) or height (mobile) and fades, while
+            // the chart flexes to fill the reclaimed space.
+            const widgetVisible = Boolean(singleFilteredAccount) && !accountWidgetCollapsed;
             return (
               <div className="flex flex-col lg:flex-row lg:items-stretch">
                 <div
-                  aria-hidden={accountWidgetCollapsed}
+                  aria-hidden={!widgetVisible}
+                  inert={!widgetVisible}
                   className={`flex-shrink-0 lg:relative overflow-hidden transition-all duration-300 ease-in-out motion-reduce:transition-none ${
-                    accountWidgetCollapsed
-                      ? 'max-h-0 lg:max-h-none lg:w-0 lg:mr-0 opacity-0 lg:-translate-x-6 pointer-events-none'
-                      : 'max-h-[1000px] lg:max-h-none lg:w-1/4 lg:mr-6 opacity-100 lg:translate-x-0'
+                    widgetVisible
+                      ? 'max-h-[1000px] lg:max-h-none lg:w-1/4 lg:mr-6 opacity-100 lg:translate-x-0'
+                      : 'max-h-0 lg:max-h-none lg:w-0 lg:mr-0 opacity-0 lg:-translate-x-6 pointer-events-none'
                   }`}
                 >
                   <AccountInfoWidget
-                    account={singleFilteredAccount}
-                    currentBalance={singleAccountCurrentBalance}
-                    institution={singleFilteredInstitution}
+                    account={widgetAccount}
+                    currentBalance={retainedWidget?.currentBalance}
+                    institution={widgetInstitution}
                     scheduledTransactions={scheduledTransactions}
-                    onEdit={() => accountModal.openEdit(singleFilteredAccount)}
+                    onEdit={() => accountModal.openEdit(widgetAccount)}
                     onCollapse={() => setAccountWidgetCollapsed(true)}
                   />
                 </div>
                 <div className="lg:flex-1 min-w-0">
-                  {accountWidgetCollapsed && (
+                  {accountWidgetCollapsed && singleFilteredAccount && (
                     <button
                       type="button"
                       onClick={() => setAccountWidgetCollapsed(false)}

--- a/frontend/src/components/transactions/AccountBalancesBarChart.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.tsx
@@ -237,9 +237,12 @@ export function AccountBalancesBarChart({
         </div>
       </div>
 
+      {/* overflow-hidden: while the account-widget column animates the card's
+          width, the recharts SVG keeps its last measured size until it
+          re-measures, so clip it to the card instead of painting outside. */}
       <div
         ref={chartRef}
-        className="h-72"
+        className="h-72 overflow-hidden"
         style={{ minHeight: 288 }}
       >
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>

--- a/frontend/src/components/transactions/AccountInfoWidget.test.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.test.tsx
@@ -42,6 +42,44 @@ describe('AccountInfoWidget', () => {
     expect(screen.getByText('Chequing')).toBeInTheDocument();
   });
 
+  it('prefers the live chart-derived balance over the stale account balance', () => {
+    render(
+      <AccountInfoWidget
+        account={makeAccount({ currentBalance: 1234.5 })}
+        currentBalance={1500.25}
+        onEdit={vi.fn()}
+        onCollapse={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('CAD 1500.25')).toBeInTheDocument();
+    expect(screen.queryByText('CAD 1234.50')).not.toBeInTheDocument();
+  });
+
+  it('shows a live balance of zero rather than falling back to the account balance', () => {
+    render(
+      <AccountInfoWidget
+        account={makeAccount({ currentBalance: 1234.5 })}
+        currentBalance={0}
+        onEdit={vi.fn()}
+        onCollapse={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('CAD 0.00')).toBeInTheDocument();
+  });
+
+  it('styles a negative live balance in red', () => {
+    render(
+      <AccountInfoWidget
+        account={makeAccount({ currentBalance: 1234.5 })}
+        currentBalance={-42}
+        onEdit={vi.fn()}
+        onCollapse={vi.fn()}
+      />,
+    );
+    const amount = screen.getByText('CAD -42.00');
+    expect(amount.className).toContain('text-red-600');
+  });
+
   it('calls onEdit when the pencil button is clicked', () => {
     const onEdit = vi.fn();
     render(<AccountInfoWidget account={makeAccount()} onEdit={onEdit} onCollapse={vi.fn()} />);

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -16,6 +16,11 @@ import { safeHttpUrl } from '@/lib/safe-url';
 
 interface AccountInfoWidgetProps {
   account: Account;
+  /** Live balance derived from the same daily-balance series the Balance
+   *  History chart summarises ("Current"), so the widget stays in sync as
+   *  transactions change. Falls back to `account.currentBalance` when the
+   *  series is unavailable (e.g. category/payee filters active). */
+  currentBalance?: number;
   /** The account's institution, when assigned, for the logo + name. The
    *  optional website makes the logo a link to the institution's site. */
   institution?: (InstitutionLogoData & { website?: string }) | null;
@@ -34,6 +39,7 @@ interface AccountInfoWidgetProps {
  */
 export function AccountInfoWidget({
   account,
+  currentBalance,
   institution,
   scheduledTransactions = [],
   onEdit,
@@ -48,7 +54,7 @@ export function AccountInfoWidget({
   const isLiability = ['CREDIT_CARD', 'LOAN', 'MORTGAGE', 'LINE_OF_CREDIT'].includes(
     account.accountType,
   );
-  const balance = Number(account.currentBalance) || 0;
+  const balance = currentBalance ?? (Number(account.currentBalance) || 0);
   // Prefer the linked institution's canonical name; fall back to the legacy
   // free-text field stored on the account.
   const institutionName = institution?.name ?? account.institution ?? null;

--- a/frontend/src/components/transactions/BalanceHistoryChart.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.tsx
@@ -16,6 +16,7 @@ import {
 } from 'recharts';
 import { format } from 'date-fns';
 import { parseLocalDate } from '@/lib/utils';
+import { computeBalanceSummary } from '@/lib/balance-history';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { ChartDownloadButton } from '@/components/ui/ChartDownloadButton';
 
@@ -140,47 +141,7 @@ export function BalanceHistoryChart({
     return { chartData: points, monthTicks: ticks };
   }, [data]);
 
-  const summary = useMemo(() => {
-    if (chartData.length === 0) return null;
-    const startBalance = chartData[0].balance;
-    const endBalance = chartData[chartData.length - 1].balance;
-
-    // Find balance as of today (last data point on or before today)
-    const today = new Date();
-    const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-    let currentBalance = endBalance;
-    let todayAnchorIdx = -1;
-    for (let i = chartData.length - 1; i >= 0; i--) {
-      if (chartData[i].date <= todayStr) {
-        currentBalance = chartData[i].balance;
-        todayAnchorIdx = i;
-        break;
-      }
-    }
-    if (todayAnchorIdx === -1) {
-      // All data points are in the future
-      currentBalance = startBalance;
-    }
-
-    // The backend returns one data point per day in the filtered range, so
-    // chart points strictly after today do NOT necessarily mean future
-    // transactions exist — the balance simply carries forward on days with
-    // no activity. Only consider the range as having future data when at
-    // least one post-today point differs from the current balance.
-    let hasFutureData = false;
-    for (let i = todayAnchorIdx + 1; i < chartData.length; i++) {
-      if (chartData[i].balance !== currentBalance) {
-        hasFutureData = true;
-        break;
-      }
-    }
-
-    let minBalance = startBalance;
-    for (const point of chartData) {
-      if (point.balance < minBalance) minBalance = point.balance;
-    }
-    return { startBalance, currentBalance, endBalance, hasFutureData, minBalance, goesNegative: minBalance < 0 };
-  }, [chartData]);
+  const summary = useMemo(() => computeBalanceSummary(chartData), [chartData]);
 
   const areaGradient = useMemo(
     () => computeBalanceGradient(chartData.map((point) => point.balance)),

--- a/frontend/src/components/transactions/BalanceHistoryChart.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.tsx
@@ -183,7 +183,10 @@ export function BalanceHistoryChart({
         <ChartDownloadButton chartRef={chartRef} filename={downloadFilename} />
       </div>
 
-      <div ref={chartRef} className="h-72" style={{ minHeight: 288 }}>
+      {/* overflow-hidden: while the account-widget column animates the card's
+          width, the recharts SVG keeps its last measured size until it
+          re-measures, so clip it to the card instead of painting outside. */}
+      <div ref={chartRef} className="h-72 overflow-hidden" style={{ minHeight: 288 }}>
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           <AreaChart data={chartData} margin={{ left: 0, right: 8, top: 5, bottom: 0 }}>
             <defs>

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
@@ -146,9 +146,12 @@ export function CategoryPayeeBarChart({
         <ChartDownloadButton chartRef={chartRef} filename={downloadFilename} />
       </div>
 
+      {/* overflow-hidden: while the account-widget column animates the card's
+          width, the recharts SVG keeps its last measured size until it
+          re-measures, so clip it to the card instead of painting outside. */}
       <div
         ref={chartRef}
-        className="h-72"
+        className="h-72 overflow-hidden"
         style={{ minHeight: 288 }}
       >
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>

--- a/frontend/src/lib/balance-history.test.ts
+++ b/frontend/src/lib/balance-history.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { computeBalanceSummary } from './balance-history';
+
+describe('computeBalanceSummary', () => {
+  beforeEach(() => {
+    // Lock "today" so tests are not date-dependent.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-04-10T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns null for an empty series', () => {
+    expect(computeBalanceSummary([])).toBeNull();
+  });
+
+  it('summarises a fully past series with current = last point', () => {
+    const summary = computeBalanceSummary([
+      { date: '2026-01-01', balance: 1000 },
+      { date: '2026-01-02', balance: 750 },
+      { date: '2026-01-03', balance: 900 },
+    ]);
+    expect(summary).toEqual({
+      startBalance: 1000,
+      currentBalance: 900,
+      endBalance: 900,
+      hasFutureData: false,
+      minBalance: 750,
+      goesNegative: false,
+    });
+  });
+
+  it('anchors current at the last point on or before today when the series extends into the future', () => {
+    const summary = computeBalanceSummary([
+      { date: '2026-03-01', balance: 2000 },
+      { date: '2026-03-10', balance: 1500 },
+      { date: '2026-04-01', balance: 1800 },
+      { date: '2026-04-15', balance: 1900 },
+    ]);
+    expect(summary?.currentBalance).toBe(1800);
+    expect(summary?.endBalance).toBe(1900);
+    expect(summary?.hasFutureData).toBe(true);
+  });
+
+  it('does not flag future data when post-today points only carry the balance forward', () => {
+    const summary = computeBalanceSummary([
+      { date: '2026-01-01', balance: 1000 },
+      { date: '2026-03-01', balance: 1500 },
+      { date: '2026-06-01', balance: 1500 },
+      { date: '2026-12-31', balance: 1500 },
+    ]);
+    expect(summary?.currentBalance).toBe(1500);
+    expect(summary?.hasFutureData).toBe(false);
+  });
+
+  it('falls back to the starting balance when all points are in the future', () => {
+    const summary = computeBalanceSummary([
+      { date: '2026-05-01', balance: 300 },
+      { date: '2026-06-01', balance: 400 },
+    ]);
+    expect(summary?.currentBalance).toBe(300);
+    expect(summary?.hasFutureData).toBe(true);
+  });
+
+  it('flags a series that dips negative', () => {
+    const summary = computeBalanceSummary([
+      { date: '2026-01-01', balance: 100 },
+      { date: '2026-01-02', balance: -50 },
+    ]);
+    expect(summary?.minBalance).toBe(-50);
+    expect(summary?.goesNegative).toBe(true);
+  });
+
+  it('rounds balances to 2 decimals to match the plotted chart points', () => {
+    const summary = computeBalanceSummary([
+      { date: '2026-01-01', balance: 1000.005 },
+      { date: '2026-01-02', balance: 899.996 },
+    ]);
+    expect(summary?.startBalance).toBe(1000.01);
+    expect(summary?.currentBalance).toBe(900);
+  });
+});

--- a/frontend/src/lib/balance-history.ts
+++ b/frontend/src/lib/balance-history.ts
@@ -1,0 +1,83 @@
+/**
+ * A single day's balance in a Balance History series. `date` must be an ISO
+ * `yyyy-MM-dd` string so points can be ordered by plain string comparison.
+ */
+export interface DailyBalancePoint {
+  date: string;
+  balance: number;
+}
+
+export interface BalanceSummary {
+  startBalance: number;
+  /** Balance at the most recent data point on or before today. */
+  currentBalance: number;
+  endBalance: number;
+  /** True when at least one post-today point differs from the current balance. */
+  hasFutureData: boolean;
+  minBalance: number;
+  goesNegative: boolean;
+}
+
+/**
+ * Summarises a daily balance series the way the Balance History chart's
+ * footer does, so other surfaces (e.g. the Account Info widget) show the
+ * exact same "Current" figure. Balances are rounded to 2 decimals up front
+ * to match the chart's plotted points.
+ */
+export function computeBalanceSummary(
+  data: ReadonlyArray<DailyBalancePoint>,
+): BalanceSummary | null {
+  if (data.length === 0) return null;
+
+  const points = data.map((d) => ({
+    date: d.date,
+    balance: Math.round(d.balance * 100) / 100,
+  }));
+
+  const startBalance = points[0].balance;
+  const endBalance = points[points.length - 1].balance;
+
+  // Find balance as of today (last data point on or before today)
+  const today = new Date();
+  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+  let currentBalance = endBalance;
+  let todayAnchorIdx = -1;
+  for (let i = points.length - 1; i >= 0; i--) {
+    if (points[i].date <= todayStr) {
+      currentBalance = points[i].balance;
+      todayAnchorIdx = i;
+      break;
+    }
+  }
+  if (todayAnchorIdx === -1) {
+    // All data points are in the future
+    currentBalance = startBalance;
+  }
+
+  // The backend returns one data point per day in the filtered range, so
+  // chart points strictly after today do NOT necessarily mean future
+  // transactions exist — the balance simply carries forward on days with
+  // no activity. Only consider the range as having future data when at
+  // least one post-today point differs from the current balance.
+  let hasFutureData = false;
+  for (let i = todayAnchorIdx + 1; i < points.length; i++) {
+    if (points[i].balance !== currentBalance) {
+      hasFutureData = true;
+      break;
+    }
+  }
+
+  let minBalance = startBalance;
+  for (const point of points) {
+    if (point.balance < minBalance) minBalance = point.balance;
+  }
+
+  return {
+    startBalance,
+    currentBalance,
+    endBalance,
+    hasFutureData,
+    minBalance,
+    goesNegative: minBalance < 0,
+  };
+}


### PR DESCRIPTION
## Summary
Refactors the Account Info Widget to remain mounted (but hidden) when the transaction filter widens from a single account to multiple accounts, enabling a smooth slide-out animation instead of an abrupt unmount. Also extracts balance summary logic into a reusable utility so the widget displays the live chart-derived balance instead of the stale account balance.

## Key Changes

- **Extract `computeBalanceSummary()` utility** (`lib/balance-history.ts`): Moves balance summary calculation from `BalanceHistoryChart` into a shared function that computes `currentBalance` (last point on or before today), `hasFutureData`, and other metrics. This allows the Account Info Widget to show the exact same "Current" figure as the chart, staying in sync as transactions change.

- **Retain widget state across filter changes** (`app/transactions/page.tsx`): Introduces `retainedWidget` state that persists the single-filtered account and its live balance even after the filter widens to multiple accounts. The widget column animates out of view (via `aria-hidden`, `inert`, and opacity/width transitions) rather than unmounting, matching the manual collapse animation.

- **Pass live balance to widget** (`components/transactions/AccountInfoWidget.tsx`): Adds optional `currentBalance` prop that takes precedence over the stale `account.currentBalance`. Falls back to the account balance when the daily-balance series is unavailable (e.g., during category/payee filters).

- **Add chart fade-in animation** (`app/globals.css`): Introduces `animate-chart-in` keyframe so swapping between chart types (Balance History ↔ Account Balances) fades in the new chart instead of popping abruptly.

- **Fix chart overflow during resize** (`components/transactions/*.tsx`): Adds `overflow-hidden` to chart containers so the recharts SVG doesn't paint outside the card while the widget column animates its width.

- **Comprehensive test coverage** (`app/transactions/page.test.tsx`, `components/transactions/AccountInfoWidget.test.tsx`, `lib/balance-history.test.ts`): Tests the widget's live balance display, smooth slide-out animation when filter widens, fallback to stored balance when no daily-balance data exists, and balance summary computation edge cases (future data, negative balances, rounding).

## Implementation Details

- The widget's visibility is controlled by a `widgetVisible` boolean that combines `singleFilteredAccount` (current filter state) and `accountWidgetCollapsed` (user toggle), ensuring the animation plays in both directions.
- `computeBalanceSummary()` rounds balances to 2 decimals up front to match the chart's plotted points, and correctly distinguishes between "future data exists" (post-today points differ from current) vs. "balance carries forward" (post-today points are identical).
- The `inert` attribute prevents keyboard/pointer interaction with the hidden widget column, improving accessibility.

https://claude.ai/code/session_01UTtQT1zMvUhcUCdhCkT5U7