### PR TITLE
Add flexible version bumping and release notes to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,27 @@ on:
   # build-and-push only fires on workflow_dispatch so merging to main doesn't
   # publish a new image set on every PR. Trigger from the Actions tab (or
   # `gh workflow run "CI Pipeline" --ref main`) when you actually want a
-  # release: it will bump the patch version, build/sign/scan/push the
-  # images, and cut a GitHub release.
+  # release: it bumps the version, builds/signs/scans/pushes the images, and
+  # cuts a GitHub release. The inputs below choose the version bump and let you
+  # supply your own release notes (see docs/release-notes/README.md).
   workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Version bump (ignored when an explicit "version" is given)'
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+      version:
+        description: 'Explicit version, e.g. 1.11.0 (overrides "release_type"; blank = bump)'
+        type: string
+        default: ''
+      release_notes:
+        description: 'Release notes (Markdown). Blank = use docs/release-notes/<version>.md, else GitHub auto-notes'
+        type: string
+        default: ''
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -380,16 +398,35 @@ jobs:
           # version`, so it never needs the cache anyway.
           package-manager-cache: false
 
-      - name: Bump patch version
+      # Decide the new version from the workflow inputs. An explicit `version`
+      # wins; otherwise bump major/minor/patch off backend/package.json. Inputs
+      # are read via env (never interpolated into the script) to avoid template
+      # injection. Both package.json files are kept in lockstep.
+      - name: Bump version
         id: version
+        env:
+          RELEASE_TYPE: ${{ inputs.release_type }}
+          EXPLICIT_VERSION: ${{ inputs.version }}
         run: |
           CURRENT=$(node -p "require('./backend/package.json').version")
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
-          NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+          if [ -n "$EXPLICIT_VERSION" ]; then
+            if ! printf '%s' "$EXPLICIT_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "::error::Invalid version '$EXPLICIT_VERSION' (expected MAJOR.MINOR.PATCH, e.g. 1.11.0)"
+              exit 1
+            fi
+            NEW_VERSION="$EXPLICIT_VERSION"
+          else
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+            case "${RELEASE_TYPE:-patch}" in
+              major) NEW_VERSION="$((MAJOR + 1)).0.0" ;;
+              minor) NEW_VERSION="$MAJOR.$((MINOR + 1)).0" ;;
+              *)     NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))" ;;
+            esac
+          fi
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Bumping version: $CURRENT -> $NEW_VERSION"
-          cd backend  && npm version "$NEW_VERSION" --no-git-tag-version && cd ..
-          cd frontend && npm version "$NEW_VERSION" --no-git-tag-version && cd ..
+          echo "Bumping version: $CURRENT -> $NEW_VERSION (type=${RELEASE_TYPE:-patch}, explicit=${EXPLICIT_VERSION:-none})"
+          cd backend  && npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version && cd ..
+          cd frontend && npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version && cd ..
 
       - name: Log in to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -601,14 +638,44 @@ jobs:
           git pull --rebase
           git push
 
+      # Resolve the release notes body. Precedence: the `release_notes` input,
+      # then a committed docs/release-notes/<version>.md, then GitHub's
+      # auto-generated notes. The input is read via env to avoid injection.
+      - name: Resolve release notes
+        id: notes
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_NOTES_INPUT: ${{ inputs.release_notes }}
+        run: |
+          NOTES_FILE="docs/release-notes/${VERSION}.md"
+          if [ -n "$RELEASE_NOTES_INPUT" ]; then
+            printf '%s\n' "$RELEASE_NOTES_INPUT" > "$RUNNER_TEMP/release-notes.md"
+            echo "path=$RUNNER_TEMP/release-notes.md" >> "$GITHUB_OUTPUT"
+            echo "Release notes: workflow input"
+          elif [ -f "$NOTES_FILE" ]; then
+            cp "$NOTES_FILE" "$RUNNER_TEMP/release-notes.md"
+            echo "path=$RUNNER_TEMP/release-notes.md" >> "$GITHUB_OUTPUT"
+            echo "Release notes: $NOTES_FILE"
+          else
+            echo "path=" >> "$GITHUB_OUTPUT"
+            echo "Release notes: GitHub auto-generated (no input or notes file found)"
+          fi
+
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
+          NOTES_PATH: ${{ steps.notes.outputs.path }}
         run: |
-          gh release create "v${VERSION}" \
-            --title "v${VERSION}" \
-            --generate-notes
+          if [ -n "$NOTES_PATH" ]; then
+            gh release create "v${VERSION}" \
+              --title "v${VERSION}" \
+              --notes-file "$NOTES_PATH"
+          else
+            gh release create "v${VERSION}" \
+              --title "v${VERSION}" \
+              --generate-notes
+          fi
 
   # Pre-download and cache the Playwright browsers ONCE, before the sharded
   # test jobs run. The shards then restore from this cache (guaranteed hit) and

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -1,0 +1,75 @@
+# Releases and release notes
+
+Releases are cut by manually running the **CI Pipeline** workflow
+(`.github/workflows/ci.yml`) against `main`. The `build-and-push` job only runs
+on `workflow_dispatch` and only after the full CI suite (lint, unit,
+integration, e2e, audits, scans) passes. When it runs it:
+
+1. Bumps the version in `backend/package.json` and `frontend/package.json`
+   (kept in lockstep).
+2. Builds, signs, and pushes the multi-arch backend/frontend images to GHCR,
+   with SBOM and provenance attestations, and Trivy-scans them.
+3. Commits the version bump back to `main`.
+4. Creates the `v<version>` GitHub Release using the notes you provide (see
+   below), falling back to GitHub's auto-generated notes when you provide none.
+
+## Cutting a release
+
+From the Actions tab: **Actions -> CI Pipeline -> Run workflow**, pick the
+branch `main`, and fill in the inputs. Or from the CLI:
+
+```sh
+# Patch bump (default): 1.10.5 -> 1.10.6
+gh workflow run "CI Pipeline" --ref main
+
+# Minor bump: 1.10.5 -> 1.11.0
+gh workflow run "CI Pipeline" --ref main -f release_type=minor
+
+# Major bump: 1.10.5 -> 2.0.0
+gh workflow run "CI Pipeline" --ref main -f release_type=major
+
+# Explicit version (overrides release_type)
+gh workflow run "CI Pipeline" --ref main -f version=1.11.0
+```
+
+### Version inputs
+
+| Input          | Effect                                                                 |
+| -------------- | --------------------------------------------------------------------- |
+| `release_type` | `patch` (default), `minor`, or `major`. Bumps the current version.    |
+| `version`      | An explicit `MAJOR.MINOR.PATCH` string. Overrides `release_type`.     |
+
+A minor bump of the current `1.10.x` line lands on `1.11.0`; passing
+`version=1.11.0` does the same thing explicitly.
+
+## Release notes
+
+The notes are authored by hand (for example, drafted in Claude Desktop) and
+fed into the release. The workflow resolves the release body in this order:
+
+1. **`release_notes` input** - Markdown passed when you trigger the run. Best
+   when triggering from the CLI so multi-line Markdown is preserved:
+
+   ```sh
+   gh workflow run "CI Pipeline" --ref main -f release_type=minor \
+     -f release_notes="$(cat my-notes.md)"
+   ```
+
+2. **`docs/release-notes/<version>.md`** - a committed file named for the exact
+   version being released (for example, `docs/release-notes/1.11.0.md`). Commit
+   it to `main` before triggering the run. Use this when you prefer the notes to
+   live in the repo and go through review.
+
+3. **GitHub auto-generated notes** - used only when neither of the above is
+   provided, so a release never fails for lack of notes.
+
+Whichever source wins becomes the full body of the GitHub Release.
+
+### Suggested authoring flow
+
+1. Draft user-friendly notes in Claude Desktop from the commits/PRs since the
+   last release. Group them into something readable, for example
+   **New features**, **Improvements**, and **Bug fixes**, in plain language.
+2. Either pass them via `-f release_notes=...` at trigger time, or commit them
+   to `docs/release-notes/<version>.md`.
+3. Run the workflow with the matching `release_type` / `version`.


### PR DESCRIPTION
## Summary

Enhanced the CI Pipeline workflow to support flexible version bumping strategies and customizable release notes, replacing the hardcoded patch-only approach with user-controlled major/minor/patch bumps and multiple sources for release notes authoring.

## Key Changes

- **Workflow inputs** – Added three new `workflow_dispatch` inputs:
  - `release_type`: choice of `patch` (default), `minor`, or `major`
  - `version`: explicit `MAJOR.MINOR.PATCH` string (overrides `release_type`)
  - `release_notes`: Markdown text for the GitHub Release body

- **Version bumping logic** – Replaced hardcoded patch increment with:
  - Explicit version takes precedence if provided (with validation)
  - Falls back to semantic bump (major/minor/patch) off current `backend/package.json`
  - Both `backend/package.json` and `frontend/package.json` kept in lockstep
  - Added `--allow-same-version` flag to `npm version` for idempotency

- **Release notes resolution** – Three-tier precedence:
  1. `release_notes` workflow input (if provided)
  2. Committed `docs/release-notes/<version>.md` file (if exists)
  3. GitHub auto-generated notes (fallback)

- **Documentation** – Added `docs/release-notes/README.md` with:
  - Release cutting instructions (Actions UI and CLI examples)
  - Version input reference table
  - Release notes authoring flow and best practices
  - Suggested workflow for drafting and committing notes

## Implementation Details

- Version inputs read via environment variables (never interpolated into scripts) to prevent template injection
- Version validation enforces strict `MAJOR.MINOR.PATCH` format with helpful error messages
- Release notes file path resolved in a dedicated step before GitHub Release creation
- Conditional logic in release creation: uses `--notes-file` when notes are available, `--generate-notes` otherwise
- All changes maintain backward compatibility (defaults preserve existing patch-bump behavior)

https://claude.ai/code/session_01Pd47Jk48hXEtLCsG5p9oLJ