### PR TITLE
docs(release-notes): backfill notes for v1.9.4 through v1.10.5

### DIFF
--- a/docs/release-notes/1.10.1.md
+++ b/docs/release-notes/1.10.1.md
@@ -1,0 +1,53 @@
+# v1.10.1
+
+## New: Shared Access (Delegates)
+
+This release introduces **Shared Access**, a brand new way to let other people into your Monize data without handing over your account. Invite a spouse, a parent, an accountant, or anyone else, and give them exactly the access you want them to have.
+
+### How it works
+From Settings, open the new **Shared Access** screen and add a delegate by email. You can either send them an email invite or set a temporary password for them directly. Once they sign in, they can switch into your context from their own account and see only what you've shared.
+
+### Granular, per-section permissions
+Every delegate's access is fine-tuned section by section. For each delegate you choose whether they can see:
+
+- **Accounts & Transactions** - including which specific accounts they can see
+- **Investments** - scoped to the investment accounts you share
+- **Bills & Deposits** - with optional Upcoming Bills on their dashboard
+- **Budgets, Reports, Insights, and the AI Assistant**
+- **Tools** sections that match the capabilities you grant
+- **Payees, Categories, and Tags** - with separate toggles for create, edit, and delete
+
+Delegates always get basic read access to payees, categories, and tags so the data they see makes sense in context.
+
+### Designed to feel native
+- A compact, scannable list of delegates with a dedicated modal per delegate
+- Account lists are grouped and alphabetized in the Edit Access modal
+- A clear "viewing as" banner so you always know whose data you're looking at
+- Switching context reloads in place instead of bouncing back to the dashboard
+- Mobile swipe navigation is scoped to only the sections a delegate can access
+- Delegates get their own account favourites - your stars don't leak into theirs, and vice versa
+- Scheduled transfers show up for delegates who hold either leg of the transfer
+- "Hidden account" is shown in transfer edit forms when a delegate can't see the other side
+
+### Delegates own their identity
+- Delegates can set their own password and enable 2FA from Settings
+- A delegate can "claim" their account using their temp password and convert into a full self-registered user with their own data
+- Self-registered users keep their account when their last delegation is revoked
+
+## Other Improvements
+
+- **Bills**: Click an upcoming bill on the dashboard to open the Post modal directly
+- **UI**: Select placeholder color now matches MultiSelect
+
+## Bug Fixes
+
+- Fixed user deletion being blocked by category foreign keys
+- Fixed transfer splits not cascade-deleting when their target account was removed
+- Fixed imported transaction splits missing their split kind
+- Fixed `roundToDecimals` returning NaN for near-zero residual values
+- Fixed register/login 401 responses being incorrectly routed through the session-refresh fallback
+- Fixed the dashboard loading before auth hydration completed
+- Fixed delegation context not being hydrated before the app marked itself ready
+- Fixed a flaky `authStore` rehydration test
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.9.18...v1.10.1

--- a/docs/release-notes/1.10.2.md
+++ b/docs/release-notes/1.10.2.md
@@ -1,0 +1,53 @@
+# v1.10.2
+
+## New Features
+
+### Emergency Access for dormant accounts
+You can now name one or more trusted **emergency contacts** who can get into your account if you're ever unable to. If your account goes untouched for a set period (default 14 days), each contact is emailed a secure one-time link that lets them set a new password and sign in. You'll get daily reminder emails beforehand (starting at 7 days by default), so you can simply log in to reset the clock. Any activity in the app — not just signing in — resets the timer.
+
+- Leave a private message for your contacts that's **encrypted** and stays hidden until you re-confirm your identity to view or edit it.
+- Find it in **Settings → Emergency Access** (just below Shared Access). Requires email to be configured on your server.
+
+### Password-protected (encrypted) backups
+Your backups — both manual exports and the automatic scheduled ones — can now be **encrypted with a password**, so a backup file is useless to anyone without it. Turn it on in **Settings → Backup & Restore**.
+
+- Local-login users: your account password is used automatically.
+- OIDC/single-sign-on users: set a dedicated backup password under Security.
+- Restoring an encrypted backup now gives you a clearly labeled field to enter the password the backup was made with.
+
+### Custom Investment Reports
+A brand-new report builder for your portfolio, modeled on the classic MS Money investment reports:
+
+- Pick from **40 columns** (each with a description), and **drag to reorder** them.
+- Choose which investment accounts to include, **group by account, security, or currency**, and sort by any column.
+- Run the report **as of any date** (defaults to the latest market day).
+- **View values in each holding's own currency or converted to your base currency** with a single toggle.
+- **Combine a security held across several accounts** into one row, or list each account separately.
+- **Export to CSV**, save reports, and mark favourites.
+
+Create one from the Reports page via the new **New Report** dropdown (Standard Report / Investment Report).
+
+## Improvements
+
+- **Net Worth Over Time** now shows as a **bar chart with value labels** by default (on both the report and the dashboard widget), making trends easier to read at a glance.
+- **Investments page → New Transaction** is now a dropdown, so you can add either an **investment trade or a cash transaction**.
+- **Split transactions:** the right-click / long-press menu now lets you **filter by any individual category** within a split.
+- The transaction menu now shows the **full "Parent: Subcategory" category name** instead of just the subcategory.
+- **Cash Flow Forecast** account picker now lists your **favourite accounts first**.
+- **Exclude from Net Worth** on an account is now a simple on/off toggle.
+- Backups now correctly include a few previously-missed items — most notably **tags on scheduled split transactions**, Monte Carlo scenarios, and AI provider settings — so nothing is lost on restore.
+- Added a help tooltip explaining the **Show Create Date** preference.
+
+### For administrators
+- Admins can now **create user accounts** directly from User Management, using an emailed invite link, an admin-set password, or a one-time auto-generated password.
+
+## Fixes
+
+- Restoring a backup that contains **scheduled investment transactions** no longer fails with a database error.
+- Fixed dropdowns (such as a transaction's **Status** field) showing their real value in faded "placeholder" grey.
+- Date pickers now **flip upward** when there isn't room below, so the calendar is no longer cut off at the bottom of the page.
+- Sold/closed securities no longer appear incorrectly in investment reports.
+- Fixed a duplicate tooltip appearing on help icons.
+- Minor visual fix to the highlighted "current user" row in the admin user table.
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.10.1...v1.10.2

--- a/docs/release-notes/1.10.3.md
+++ b/docs/release-notes/1.10.3.md
@@ -1,0 +1,50 @@
+# v1.10.3
+
+## What's New in 1.10.3
+
+### Highlights
+
+#### Transfer securities between accounts (without losing cost basis)
+You can now move shares from one brokerage account to another directly. Pick the source and destination accounts, the security, the quantity, and a cost-per-share (pre-filled from the source holding's average cost), and Monize moves the position across — carrying the cost basis with it so your gain and profit reports stay accurate. Previously a transfer dropped the cost basis on the destination side, breaking those reports.
+- A single **Transfer** action in the investment transaction modal handles both sides of the move; no phantom cash transaction is created.
+- The security list only shows holdings you actually own in the source account.
+- Transfers can be **edited and deleted as a unit** — change the security, quantity, cost, date, or either account, and both sides update together. Deleting one side removes the other.
+- Full **undo/redo** support, so a transfer can never leave your holdings half-moved.
+
+#### Per-security transaction history
+The Securities page has a new **Transaction History** action that shows every transaction for a security with a **running share balance over time** — the tool for hunting down stray residual share counts that linger in reports.
+- Works across all accounts (including closed ones) and for inactive securities.
+- Pick any account to see its running total, or view the cross-account balance.
+- Correct errant balances inline with an add/remove-shares adjustment, or **edit any transaction directly from the history view**.
+- A new **Shares** column on the Securities page shows your exact current quantity at full precision, and is sortable.
+
+#### New dashboard widgets
+- **Favourite Securities** — star the securities you care about and see them on the dashboard with current price and daily change. Toggle a favourite right from the Securities table or the add/edit form.
+- **Assets vs Liabilities** — a donut chart beside Net Worth breaking down where you stand.
+- Both the Top Movers and Favourite Securities widgets stay hidden until you have securities.
+
+#### Top Movers filter
+The dashboard Top Movers widget gains an **All / Gainers / Losers** filter, and your choice is remembered the next time you visit.
+
+### Improvements
+
+- **Consistent investment report filters** — every investment report now uses the same multi-select account picker, so filtering behaves identically everywhere (Investment Performance, Realized Gains, Portfolio Value, Transaction History, Dividend Yield & Growth, Sector Weightings, Geographic Allocation, Security Type Allocation, Currency Exposure).
+- **Refresh Prices on every report** — a standardized Refresh button (next to Export) reloads report data once prices are updated.
+- **Custom reports** — change the accounts a saved report covers at view time without overwriting the saved configuration.
+- **Clearer Net Worth chart on desktop** — the optimized, non-zero-anchored y-axis (previously mobile-only) now applies on desktop too, so month-to-month changes are no longer flattened.
+
+### Bug Fixes
+
+- **Emergency Access reliability** — a grant now only completes once a contact has actually been emailed, so a temporary mail-server hiccup can no longer silently disable the safeguard. When you become active again, any outstanding access links are voided, monitoring is re-armed, and you're notified by email.
+- **Investment report settings stick** — editing a report no longer silently resets its account filter, sort order, or as-of date.
+- Fixed an **as-of date being off by a day** near midnight in your local timezone.
+- Share quantities no longer render as **"-0"** when a holding is zeroed out.
+- The dashboard no longer crashes in browsers where site storage is blocked (e.g. sandboxed/strict-privacy contexts).
+
+### Under the Hood
+
+- Greatly expanded end-to-end test coverage — 2FA, password reset, shared/delegated access, admin tools, custom report building, and backup export/restore round-trips.
+- CI now runs the end-to-end suite across parallel shards for faster, more reliable builds.
+
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.10.2...v1.10.3

--- a/docs/release-notes/1.10.4.md
+++ b/docs/release-notes/1.10.4.md
@@ -1,0 +1,65 @@
+# v1.10.4
+
+This is mostly a bug-fix round with minor improvements to sub-penny stock handling.
+
+## Investments & Reporting
+
+### Smoother account filtering in investment reports
+The account filter dropdown used to close after each checkbox, and the page reloaded every time you picked an account — so selecting several accounts meant re-opening the dropdown over and over. Now the dropdown **stays open while you select**, and the report updates quietly in place once you're done choosing. This applies across all investment reports (Portfolio Value, Realized Gains, Performance, Sector Weightings, Geographic Allocation, and more).
+
+### Accurate prices for sub‑penny securities
+Some securities — particularly London-listed "penny" stocks quoted in pence (GBX) — have share prices smaller than a cent (e.g. **0.000318 GBP**). These were previously rounded down, which could make a real price or daily change show as **0.00** and even drop the security out of charts and movers. Prices are now stored and displayed with the precision they deserve:
+
+- **Top Movers**, the **holdings list**, and the **security detail** views now show extra decimal places automatically **only when a value would otherwise read as 0.00**. Normal prices are unchanged — no extra clutter.
+- A holding that genuinely gained, say, **+11.4%** now appears correctly instead of being shown as **+0.00%**.
+
+### Top Movers no longer "stuck" on GICs and other rarely-priced holdings
+A GIC (or any holding whose price is only recorded occasionally) could show up as the same large gain/loss **every single day**, because the app was comparing two price points that were actually months apart and treating them as a one-day move. Top Movers now only counts a change as a "daily" move when the two most recent prices are within about a week of each other, so these holdings no longer dominate the list with a stale number.
+
+## Dashboard
+
+### Assets vs Liabilities chart now shows on mobile
+The Assets vs Liabilities pie chart was invisible on phones (it collapsed to zero height) while looking fine on desktop. It now displays correctly on all screen sizes.
+
+### Income vs Expenses card layout
+Fixed an awkward empty gap on desktop between the chart legend and the Income / Expenses / Net totals. The chart now fills the space cleanly.
+
+---
+
+## Optional: refresh prices to pick up the new precision
+
+The precision fix applies to **newly fetched** prices. Prices already stored for your sub‑penny securities will keep their old rounded values until they're re-fetched. If you'd like to correct the existing history right away, you can trigger a full price re-fetch from your browser.
+
+> **Before you start:** you must be **signed in as an admin**, and you should run this **on a Monize browser tab** (so it uses your logged-in session). This re-fetches full price history for all your securities and may take a minute or two.
+
+1. Open Monize and sign in.
+2. Open your browser's developer tools:
+   - **Windows/Linux:** `F12` or `Ctrl` + `Shift` + `I`
+   - **Mac:** `Cmd` + `Option` + `I`
+3. Click the **Console** tab.
+4. Paste the following and press **Enter**:
+
+```js
+const csrf = decodeURIComponent(
+  document.cookie.split('; ').find(c => c.startsWith('csrf_token='))?.split('=')[1] ?? ''
+);
+
+const res = await fetch('/api/v1/securities/prices/backfill', {
+  method: 'POST',
+  credentials: 'include',
+  headers: { 'X-CSRF-Token': csrf },
+});
+
+console.log('HTTP', res.status);
+console.log(await res.json()); // summary of how many prices were refreshed
+```
+
+5. Wait for it to finish — you'll see an `HTTP 200` and a summary printed in the console. Reload the dashboard and your sub‑penny securities will reflect the corrected, more precise prices.
+
+**If you see an `HTTP 403` about CSRF**, your security token just needs refreshing — run this once, then paste the snippet above again:
+
+```js
+await fetch('/api/v1/auth/csrf-refresh', { credentials: 'include' });
+```
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.10.3...v1.10.4

--- a/docs/release-notes/1.10.5.md
+++ b/docs/release-notes/1.10.5.md
@@ -1,0 +1,115 @@
+# v1.10.5
+
+This release adds AI awareness of your upcoming bills, powerful filtering on the Bills & Deposits page, a header that gets out of your way as you scroll, and a big round of reliability work — most importantly a fix for backup restores that could collide between users on a shared server.
+
+## AI Assistant
+
+### Ask about your upcoming bills and scheduled transactions
+
+The AI Assistant (and the MCP server) can now see your **Bills & Deposits**. Ask things like "what bills are due in the next two weeks?" or "what scheduled transactions hit my chequing account?" and get a real answer. Each item comes back with how many days until it's due, the amount, account, and category, and correctly distinguishes bills, deposits, transfers, and investment schedules.
+
+## Bills & Deposits
+
+### Filter your bills and deposits
+
+The Bills & Deposits list now has a collapsible filter panel — the same style as the Transactions page — so you can narrow the list by **name, payee, account, or category**, plus a **type tab** to switch between bills, deposits, and the rest.
+
+- Your filter choices (and whether the panel is expanded) are **remembered across reloads**.
+- The Category filter behaves exactly like the Transactions one, including hierarchical parent/child categories and the special "Uncategorized" and "Transfers" options.
+- The Accounts and Payees dropdowns only list accounts and payees actually used in your scheduled transactions, so there's no irrelevant clutter.
+
+### Cleaner scheduled-transaction form
+
+The "End by date", "Number of occurrences", "Active", and "Auto-post on due date" checkboxes in the scheduled-transaction form are now the same toggle switches used elsewhere in Monize.
+
+## Settings
+
+### New Help & Support section
+
+Settings now has a **Help & Support** section (just above the Danger Zone) with quick links to the project's GitHub, a place to open an issue, Discussions, and the wiki. The Danger Zone entry in the settings menu is now styled in red so it stands out.
+
+## Navigation & Layout
+
+### The header now gets out of your way
+
+The top app header is now **sticky** and slides up out of view as you scroll down, then slides back in the moment you scroll up — moving in lockstep with your scroll so it feels natural. It stays put whenever a menu or the search box is open, so nothing you've opened scrolls away. The Settings sub-menu tracks the header so it always sits flush against the top.
+
+### Land at the top when you switch pages
+
+Switching tabs or swiping between pages while scrolled down now takes you to the **top of the new page**, so the page title and action buttons are always in view. Using the browser's Back/Forward still restores your previous scroll position.
+
+## Reports & Investments
+
+### Full category names in custom reports
+
+Custom reports now show the full **"Parent: Child"** category name (e.g. "Food: Fast Food") in the Category column, matching the rest of the app, instead of just the subcategory.
+
+### Sub-penny prices in Favourite Securities
+
+The **Favourite Securities** dashboard widget now reveals the real figures for sub-penny securities (e.g. a 0.000318 GBP price) instead of collapsing them to 0.00 — the same adaptive precision already used in Top Movers. Normal balances are unaffected.
+
+### Reports recover gracefully from errors
+
+If a report fails to load (a dropped connection, a server hiccup), it now shows a clear, **retryable error message** instead of a silently empty report.
+
+## Accounts
+
+### Account currency is locked once it has transactions
+
+Changing an account's currency after transactions exist would silently re-denominate every balance. Monize now **prevents currency changes on accounts that already have transactions**, dims the currency field, and explains why with a tooltip — so the restriction is clear before you submit.
+
+## Bug Fixes
+
+### Backup & restore reliability (important)
+
+- **Restores no longer collide between users on a shared server.** Previously, if one user restored another user's backup on the same system, the restore could silently fail and even corrupt the original user's data. Restores now remap every record to fresh identifiers, so a backup always restores cleanly as if it came from a completely separate system.
+- **Custom investment reports are now included in backups.** Your saved MS Money-style portfolio reports were being silently dropped on restore — they're now backed up and restored along with everything else.
+- Fixed restore errors involving sequence-backed and bigint IDs (such as security price history).
+
+### Top Movers
+
+- GICs and other holdings **without a regular price feed** no longer show up in Top Movers with a bogus daily move (e.g. a buy-then-sell appearing as a -37.5% "day"). They're now correctly excluded.
+
+### Other fixes
+
+- Fixed a **500 error when editing or deleting a category**.
+- Fixed the **Refresh Prices button** being a different height than the account dropdown on mobile.
+- The dashboard net worth and balance figures now come from a single canonical source, so the AI Assistant, dashboard widget, and reports always agree.
+- Tiny negative values no longer render as a malformed "+-0.00%".
+
+## Under the Hood
+
+A large reliability and performance pass, with no change to how things look:
+
+- **Faster AI** — the Anthropic provider now uses prompt caching, so multi-turn conversations reuse the cached context instead of paying full cost each turn.
+- **Faster transaction search** — added trigram indexes so text searches across payees, descriptions, and categories no longer scan the whole table.
+- **Fewer, faster database queries** — eliminated N+1 query loops in net worth, transactions, accounts, and tags; balance recalculations now apply in a single bulk update; external price/FX fetches now run with bounded concurrency.
+- **Safer money math** — all monetary rounding and summation is consolidated on shared, drift-free 4-decimal helpers.
+- **Stronger data integrity** — reconciliation status changes and other multi-table writes are now wrapped in database transactions so a mid-operation failure can't leave balances out of sync.
+- Greatly expanded and de-flaked the test suite (frontend coverage held above 90%).
+
+## All Changes
+* Add Bills & Deposits filtering by name, payee, account, and category by @kenlasko in https://github.com/kenlasko/monize/pull/582
+* Top Movers GIC fix + Bills & Deposits filter persistence and toggle sliders by @kenlasko in https://github.com/kenlasko/monize/pull/583
+* Remap backup primary keys to prevent multi-user restore collisions by @kenlasko in https://github.com/kenlasko/monize/pull/584
+* Add code efficiency and consistency audit report by @kenlasko in https://github.com/kenlasko/monize/pull/585
+* Standardize money rounding/summation on shared 4dp helpers by @kenlasko in https://github.com/kenlasko/monize/pull/586
+* Fix backup restore to handle sequence-backed IDs correctly by @kenlasko in https://github.com/kenlasko/monize/pull/587
+* Extract shared utilities and add comprehensive test coverage by @kenlasko in https://github.com/kenlasko/monize/pull/588
+* Lock currency field when account has transactions by @kenlasko in https://github.com/kenlasko/monize/pull/591
+* feat: show adaptive precision for sub-penny prices in Favourite Securities by @kenlasko in https://github.com/kenlasko/monize/pull/592
+* docs: add code efficiency/consistency audit findings by @kenlasko in https://github.com/kenlasko/monize/pull/593
+* Code audit P2: efficiency & consistency fixes (follow-up to #593) by @kenlasko in https://github.com/kenlasko/monize/pull/594
+* Fix code-review findings: LLM tx pagination, net-worth perf, report error states by @kenlasko in https://github.com/kenlasko/monize/pull/595
+* Add investment_reports to backup/restore functionality by @kenlasko in https://github.com/kenlasko/monize/pull/596
+* build(deps-dev): bump vitest from 4.0.18 to 4.1.8 in /frontend in the npm_and_yarn group across 1 directory by @dependabot[bot] in https://github.com/kenlasko/monize/pull/597
+* Scroll to top on forward navigation, fix sticky header positioning by @kenlasko in https://github.com/kenlasko/monize/pull/598
+* feat(ai): add bills & deposits tools to AI Assistant and MCP by @kenlasko in https://github.com/kenlasko/monize/pull/599
+* Display subcategories with parent prefix in reports by @kenlasko in https://github.com/kenlasko/monize/pull/600
+* Add useHideOnScroll hook to collapse header on scroll by @kenlasko in https://github.com/kenlasko/monize/pull/601
+* Add Help & Support section to settings and improve page headers by @kenlasko in https://github.com/kenlasko/monize/pull/602
+* Remove h-full from refresh button className by @kenlasko in https://github.com/kenlasko/monize/pull/603
+* fix(settings): anchor settings menu to disappearing header by @kenlasko in https://github.com/kenlasko/monize/pull/604
+
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.10.4...v1.10.5

--- a/docs/release-notes/1.9.10.md
+++ b/docs/release-notes/1.9.10.md
@@ -1,0 +1,68 @@
+# v1.9.10
+
+### Investments and portfolio charts
+
+- Fall back to daily snapshots when intraday fetch fails, with a full interval ladder (1m → 5m → 15m → 30m → 60m) before giving up.
+- Use latest close as fallback for individual intraday symbol failures so partial outages no longer blank the chart.
+- Throttle Yahoo Finance fetches and retry on 429/503; drop `Math.random()` jitter in retry backoff for deterministic behaviour.
+- Extend the price-refresh axios timeout to 120s and update investment API tests for the new per-request timeout.
+- Include cash balance in intraday portfolio value calculations.
+- Fix a 1D undercount that occurred when partial intraday fetches failed.
+- Fix a stuck intraday-fallback chart and banner; drop the banner on the 1D fallback path and surface high/low instead.
+- Add highest/lowest flag callouts to portfolio value charts (mirrored in `PortfolioValueReport`); show two decimal places in flag bubbles, place bubbles to the side of their dot, point both bubbles upward, and shorten the highest flag's connector to avoid top-edge clipping.
+- Make flag bubbles solid and render on top of axis labels.
+- Show high/low bubbles on 1D / 1W / 1M ranges (#499).
+- Make the 2y range a true rolling 730 days and end charts at today even on long-range month-aligned presets.
+- Keep investment sections on screen during refreshes to reduce flicker.
+- Tie-break investment transaction list by `createdAt` for stable ordering when timestamps collide (#503).
+
+### Reports
+
+- Add a Daily view to the Gains, Dividends & Interest report, including daily capital gains.
+- Guard the daily report against malformed capital-gain month keys.
+- Add a hide-inactive-days toggle to the daily report view and move the toggle to the right side; fix the filter behaviour (#496).
+- Rename and update the `getCapitalGains` controller spec to match.
+
+### Performance
+
+- Apply performance review fixes for `/transactions`, `/investments`, and shared API caching (#495).
+- Reduce dashboard CLS by reserving card heights and stabilizing chart containers (#494).
+- Add performance review documentation (`monize-performance-review.md`, `monize-performance-review-pages.md`).
+
+### Database / migrations
+
+- Guard trigger creation in migration 056 against duplicate execution to prevent crashes on re-run (#501).
+
+### Tests, lint, and coverage
+
+- Resolve all frontend lint errors, warnings, and type errors.
+- Eliminate `act()` warnings across the frontend test suite and wrap `chart-view` `fireEvent.click`s in `act()`.
+- Silence expected logger output in tests and fix two real React key warnings (#500).
+- Fix Node 24 `vi.mock` hoisting issue and add `portfolio-chart-utils` coverage.
+- Broad test-coverage push across 47 frontend/backend files, including `MonteCarloReport`, `ScheduledTransactionForm`, `SplitEditor`, `BudgetWizard`, `CompleteStep` loan dialog, `InsightCard`, `useDateRange`, `LoadingSpinner`, `renderChartFlagDot`, and `apiCache` dedupe paths (#497, #502).
+- Raise backend and frontend coverage thresholds to match current measurements.
+- Fix CSV export tests by removing unused spy assignments to satisfy lint (#491).
+
+### Dependencies
+
+- Bump `hono` (#499 dependabot).
+- Bump `ip-address` (#492 dependabot).
+- Bump backend npm dependency (#498 dependabot).
+
+## All Changes
+* Clean up unused test spy variables and parameters by @kenlasko in https://github.com/kenlasko/monize/pull/491
+* chore(deps): bump ip-address from 10.1.0 to 10.2.0 in /backend in the npm_and_yarn group across 1 directory by @dependabot[bot] in https://github.com/kenlasko/monize/pull/492
+* Add intraday chart fallback chain and cash balance inclusion by @kenlasko in https://github.com/kenlasko/monize/pull/493
+* fix(dashboard): reduce CLS by reserving card heights and stabilizing charts by @kenlasko in https://github.com/kenlasko/monize/pull/494
+* fix(perf): apply review fixes for /transactions, /investments, and shared API caching by @kenlasko in https://github.com/kenlasko/monize/pull/495
+* Add daily view to Dividend Income Report by @kenlasko in https://github.com/kenlasko/monize/pull/496
+* test: extend SplitEditor tests for branch coverage by @kenlasko in https://github.com/kenlasko/monize/pull/497
+* Refactor chart flag rendering to use dot renderer instead of ReferenceDot by @kenlasko in https://github.com/kenlasko/monize/pull/499
+* chore(deps): bump hono from 4.12.14 to 4.12.18 in /backend in the npm_and_yarn group across 1 directory by @dependabot[bot] in https://github.com/kenlasko/monize/pull/498
+* Suppress logger output and fix console warnings in tests by @kenlasko in https://github.com/kenlasko/monize/pull/500
+* Make monte_carlo_scenarios trigger creation idempotent by @kenlasko in https://github.com/kenlasko/monize/pull/501
+* Add comprehensive test coverage for budget, auth, and admin features by @kenlasko in https://github.com/kenlasko/monize/pull/502
+* Add secondary sort by creation date for investment transactions by @kenlasko in https://github.com/kenlasko/monize/pull/503
+
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.9.9...v1.9.10

--- a/docs/release-notes/1.9.11.md
+++ b/docs/release-notes/1.9.11.md
@@ -1,0 +1,30 @@
+# v1.9.11
+
+### Transactions search
+
+- Add a **global header search box** for transactions: clicking the magnifier in the app header slides open a text input; submitting wipes every persisted transaction filter, navigates to `/transactions?search=<term>`, and collapses the filter panel so the new filter chip is the only one visible (#507).
+- Match the Transactions search term against **category name, parent/subcategory name, the transaction or split amount (cast to text), and tag names** on the transaction or any of its splits, in addition to the existing description / payee / reference number / split memo fields. Relational fields use `EXISTS` subqueries so summary aggregations don't get inflated by extra joins; the new clause is shared by the list, target-page lookup, starting-balance subquery, summary, monthly totals, bulk-update filter, and LLM grouped breakdown so all six surfaces stay consistent (#507).
+- Include `referenceNumber` in transaction search across the main list and budget-forecast queries; update the placeholder to read "Search descriptions, payees, reference #..." (#505).
+- Fix `clearFilters()` so pending debounced search operations are cancelled and the search input is reset, preventing stale search values from being re-applied after a clear (#505).
+
+### Investments and portfolio charts
+
+- Add a **Month-to-date (MTD)** date range option to the investment value chart, alongside `1d`, `1w`, `1m`, `3m`, `ytd`, `1y`, `2y`, `5y`, and `all`. MTD reuses the existing 1-month intraday endpoint and trims the response to points from the start of the current month onward, so it follows the same intraday-first granularity as `1m` without needing a new backend endpoint (#508).
+- Filter both cached data and fresh API responses to the MTD window, and add `resolvedRange` to the data-fetching effect's dependency array so the chart reacts correctly to range changes.
+
+### UI
+
+- Hide the Monize logo on mobile so the title bar isn't squeezed next to the new header search icon and hamburger menu. The logo still appears on desktop where the wordmark gives it context.
+
+### Repo cleanup
+
+- Remove the now-stale `monize-performance-review.md` and `monize-performance-review-pages.md` documents, and drop an empty `backend/schema.sql` placeholder.
+
+## All Changes
+
+* Fix Transactions search clear and include reference number in search by @kenlasko in https://github.com/kenlasko/monize/pull/505
+* Match transactions search against category, amount, and tag (plus global header search box and mobile logo hide) by @kenlasko in https://github.com/kenlasko/monize/pull/507
+* Add month-to-date (MTD) date range option to investment charts by @kenlasko in https://github.com/kenlasko/monize/pull/508
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.9.10...v1.9.11
+

--- a/docs/release-notes/1.9.12.md
+++ b/docs/release-notes/1.9.12.md
@@ -1,0 +1,89 @@
+# v1.9.12
+
+### Reports
+
+- **Sortable columns on every report table** (excluding Transactions and Monte Carlo). A shared `useSortableTable` hook and `SortableHeader` component let you click any column header to sort, with the choice persisted to localStorage per report/table (#510).
+- **Table view toggle** added to chart-based reports — Net Worth Over Time, Spending by Category, Spending by Payee, Monthly Spending Trend, Income vs Expenses, Income by Source, Year Over Year Comparison, and Portfolio Value Over Time. Each table is sortable with persisted state, and the export dropdown now offers **CSV** alongside PDF (#510).
+- Net Worth table sorts by month chronologically (using the underlying ISO `YYYY-MM`) instead of alphabetically by the formatted display string (e.g. "Apr 2021") (#510).
+
+### Accounts
+
+- **Negative opening balances** are now permitted for credit cards, lines of credit, and other non-loan accounts. You can enter the actual signed value (e.g. `-500` for an outstanding card balance) rather than relying on auto-negation in the submit handler. `LOAN`/`MORTGAGE` keeps the existing "enter absolute amount" UX since the backend negates those on create. The edit form now displays the real stored sign for non-loan/mortgage accounts instead of `Math.abs()` (#512).
+
+### Investments
+
+- **Daily opening price fix**: the Yahoo `chart` endpoint's `meta` block omits `regularMarketOpen`, which was causing every refreshed daily price to be stored with `open_price = NULL`. Fall back to the first non-null value in `result.indicators.quote[0].open` (the same series `fetchHistoricalRaw` already reads) so today's open is captured correctly on `range=1d&interval=1d` refreshes (#509).
+
+#### Backfilling missing opening price data
+
+This release fixes the daily price refresh so `open_price` is captured going forward, but historical rows that were saved with `open_price = NULL` while the bug was live need a one-shot backfill. There's no UI button — the existing admin endpoint `POST /api/v1/securities/prices/backfill` re-fetches a full historical window from each security's quote provider and `UPSERT`s rows (`open_price = EXCLUDED.open_price`), which fills in the missing opens.
+
+**Prerequisites**
+
+- You must be logged in as an **admin** user (the route is gated by `RolesGuard` + `@Roles("admin")`).
+- Run this from a tab that is **already authenticated** to your Monize instance, so the JWT and `csrf_token` cookies are present.
+- The job iterates every active security and hits the upstream provider (Yahoo Finance, etc.). Expect it to take a while and to be subject to the same rate limiting as a normal price refresh.
+
+**Steps**
+
+1. Open Monize in your browser and confirm you're signed in as an admin.
+2. Open DevTools (`F12` or `Ctrl+Shift+I` / `Cmd+Opt+I`) and switch to the **Console** tab.
+3. Make sure the Console's execution context is set to your Monize origin (top-left dropdown — not an iframe / extension).
+4. Paste and run:
+
+   ```js
+   await fetch('/api/v1/securities/prices/backfill', {
+     method: 'POST',
+     credentials: 'include',
+     headers: {
+       'x-csrf-token': decodeURIComponent(
+         document.cookie.match(/csrf_token=([^;]+)/)[1]
+       ),
+     },
+   }).then(r => r.json());
+   ```
+
+5. Wait for the promise to resolve. The response is a `HistoricalBackfillSummary` showing how many securities were processed and how many price rows were upserted.
+
+**Verifying**
+
+After the job finishes, check that `open_price` is populated for recent days:
+
+```sql
+SELECT price_date, open_price, close_price
+FROM security_prices
+WHERE security_id = '<your-security-id>'
+ORDER BY price_date DESC
+LIMIT 10;
+```
+
+You should see non-NULL `open_price` values where there were previously NULLs.
+
+**Troubleshooting**
+
+- **`401 Unauthorized`** — your session expired. Refresh the page, sign back in, and re-run.
+- **`403 Forbidden`** — the user isn't an admin. Promote the user (or sign in as one) and retry.
+- **`Cannot read properties of null (reading '1')`** on the `match()` call — the `csrf_token` cookie isn't visible to JS. That usually means you're on the wrong origin in DevTools, or the cookie was cleared. Reload the app and try again.
+- **`429` / provider errors** — Yahoo throttled the backfill. Wait a few minutes and re-run; the upsert is idempotent so partial progress is preserved.
+
+### Community
+
+- New Discussions **announcement template** and an updated welcome header with a wiki link and issues guidance (#513).
+
+### Dependencies and security
+
+- Override `fast-uri` to `^3.1.2` (transitive via `@modelcontextprotocol/sdk → ajv`) to clear the path-traversal advisory **GHSA-q3j6-qgpj-74h6** so the CI npm-audit gate passes.
+
+### Tests
+
+- Restored frontend coverage thresholds after the sortable-tables work by adding focused tests that click each sortable column header on every new table view (both asc/desc), exercise per-field switch arms in comparators, and cover edge cases (`totalIncome`/`totalExpenses === 0`, missing `payeeId`). Branch threshold tuned from 85% → 84% to leave headroom for the new switch-case branches; lines (91.6%), statements (90.46%), and functions (87.91%) all still meet or exceed thresholds.
+- Added coverage for the new account-form behaviour: parity tests across `CREDIT_CARD`, `LINE_OF_CREDIT`, and `CHEQUING` (positive, negative, and zero inputs) on both create and update, plus confirmation that `MORTGAGE` on update still negates like `LOAN`.
+
+## All Changes
+
+* fix(securities): pull opening_price from Yahoo chart indicators by @kenlasko in https://github.com/kenlasko/monize/pull/509
+* feat(reports): sortable columns and table view toggle with CSV export by @kenlasko in https://github.com/kenlasko/monize/pull/510
+* Fix opening balance handling for credit cards and loans by @kenlasko in https://github.com/kenlasko/monize/pull/512
+* Add discussion template for announcements by @kenlasko in https://github.com/kenlasko/monize/pull/513
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.9.11...v1.9.12

--- a/docs/release-notes/1.9.13.md
+++ b/docs/release-notes/1.9.13.md
@@ -1,0 +1,51 @@
+# v1.9.13
+
+The headline this release is **scheduled investment transactions** — recurring buys, dividends, DRIPs, and more, with all the per-occurrence editing you'd expect.
+
+### Scheduled investments
+
+- **Recurring investment transactions** (#525). Schedule a regular BUY, SELL, REINVEST/DRIP, DIVIDEND, INTEREST, CAPITAL_GAIN, ADD_SHARES, REMOVE_SHARES, or stock SPLIT. Each occurrence posts as a real investment transaction so your holdings, cash side, and exchange rates all stay in sync. There's a new Investment tab in the scheduled-transaction dialog right next to Transaction / Split / Transfer.
+- **Editable total when posting** (#528). Posting a BUY / SELL / REINVEST shows a Total Price field alongside quantity and price. Edit any one and the others update — set the dollars you want to spend and quantity adjusts automatically. The price prefills from the security's most recent close.
+- **Per-occurrence overrides for investments**. Editing a single upcoming occurrence now exposes the investment-specific fields (quantity, price, total) instead of the generic amount/category fields that don't apply.
+- **Smarter Post dialog**. If you've already tweaked an upcoming occurrence, the Post dialog opens with your modified values, and the projected before/after balance updates live as you change quantity, price, or total.
+- **Modified amounts visible at a glance**. On Bills & Deposits, a modified investment occurrence shows the original amount struck through with the new amount below — the same indicator non-investment overrides have always had.
+
+### Investment splits
+
+- **Investment actions inside split transactions** (#515). A single split row can now be a BUY / SELL / DIVIDEND / INTEREST / CAPITAL_GAIN / REINVEST instead of just a category or transfer, and these splits are also allowed inside scheduled transactions.
+- DIVIDEND and CAPITAL_GAIN splits now require you to pick a security, and the Post / Edit Occurrence dialogs no longer accidentally drop investment splits when you save.
+
+### Transactions
+
+- **Right-click context menu** on transaction rows (#523) — opens the same menu as press-and-hold on touch.
+- **Reference # column** in the transaction list (#526). Visible on wider screens, with a tooltip for long values.
+- **Filter by reconciliation status** on the Transactions page (#527) — Unreconciled, Cleared, Reconciled, or Void. Your selection is remembered between visits.
+- **Calculator expressions evaluate on Enter** (#529). Type something like `44*1.13` in any amount field and press Enter to see the result, without accidentally submitting the form.
+
+### Bug fixes
+
+- **Auto-post no longer fires a day early** for users in timezones west of UTC. Anyone using the default "browser" timezone preference would see scheduled transactions due tomorrow auto-post around 11pm tonight; that's fixed.
+- **"Monthly on the 31st" no longer skips months** with fewer days — it now correctly clamps to the last day (e.g. February 28).
+- **Clearing a transfer's payee** (#524) now works — it had been silently failing and reverting on save.
+- The "Latest: <price>" hint on the Price field uses your number-format preference instead of a raw number, and a tooltip on the page header help icon no longer shows twice.
+
+### Under the hood
+
+- New AI / MCP tool `get_scheduled_investments` exposes the new resource to AI assistants and MCP clients.
+- Database migrations 064–067 add the scheduled-investment-transaction tables, per-occurrence investment override columns, and a cached browser-timezone column used by the auto-post fix.
+- Lots of new test coverage and a few flaky-test cleanups.
+
+## All Changes
+
+* Add investment split support to transaction splits by @kenlasko in https://github.com/kenlasko/monize/pull/515
+* Add transactionId to realized gains test data by @kenlasko in https://github.com/kenlasko/monize/pull/516
+* Extract SplitKind enum to separate file by @kenlasko in https://github.com/kenlasko/monize/pull/517
+* Add right-click context menu support to Transactions by @kenlasko in https://github.com/kenlasko/monize/pull/523
+* Fix: clearing a transfer's payee now reverts to the default name by @kenlasko in https://github.com/kenlasko/monize/pull/524
+* Add scheduled investment transactions with timezone-safe cron by @kenlasko in https://github.com/kenlasko/monize/pull/525
+* Add reference number column to transaction list by @kenlasko in https://github.com/kenlasko/monize/pull/526
+* Add transaction reconciliation status filtering by @kenlasko in https://github.com/kenlasko/monize/pull/527
+* feat(scheduled-tx): show editable total price when posting investment transactions by @kenlasko in https://github.com/kenlasko/monize/pull/528
+* Evaluate calculator expressions on Enter without form submission by @kenlasko in https://github.com/kenlasko/monize/pull/529
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.9.12...v1.9.13

--- a/docs/release-notes/1.9.14.md
+++ b/docs/release-notes/1.9.14.md
@@ -1,0 +1,26 @@
+# v1.9.14
+
+## Release Notes
+
+### Bug Fixes
+
+#### Investments: Editing a split's investment leg no longer corrupts the parent split
+**PR [#532](https://github.com/kenlasko/monize/pull/532)**
+
+Editing an investment row that was embedded inside a split transaction (e.g. changing the price of a buy that shares a split with a dividend) would reverse-apply the row and then re-apply it via the standalone cash path. The result: a brand-new cash transaction would appear in the linked cash account, and the parent split's amount would go stale — leaving the split unsavable because its total no longer matched the sum of its children.
+
+**What changed:**
+- Embedded investment rows (those with `transactionSplitId` set) now suppress the standalone cash side on re-apply.
+- The new cash impact propagates back into the parent split's `amount`, the parent transaction's `amount`, and the cash account balance delta.
+- The brokerage account, funding account, and date are now pinned to the parent split — attempts to change them on an embedded row are rejected with a clear `BadRequestException`.
+- Switching to an investment action that isn't allowed inside a split is also rejected.
+
+**Impact:** Users can now edit quantity, price, commission, exchange rate, action, security, or description on a split's investment leg and have the parent split + cash account stay consistent. No more orphan cash transactions.
+
+### Chores
+- Bumped `next` from `16.2.3` → `16.2.6` (patch updates).
+
+---
+
+**Diff:** +386 / −48 across 3 files
+**Tests:** 5 new unit tests covering price changes, parent amount/split sync, cash balance delta, and rejection of disallowed field changes.

--- a/docs/release-notes/1.9.15.md
+++ b/docs/release-notes/1.9.15.md
@@ -1,0 +1,9 @@
+# v1.9.15
+
+A maintenance release with no user-facing changes.
+
+## Changes
+
+- Updated the container build script for the new DNS domain.
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.9.14...v1.9.15

--- a/docs/release-notes/1.9.16.md
+++ b/docs/release-notes/1.9.16.md
@@ -1,0 +1,25 @@
+# v1.9.16
+
+This release is a focused round of bug fixes for investments and transfers. No new features, no database changes — just things working the way you expect.
+
+## Investments
+
+- **Editing the funding account on an investment transaction now sticks.** Previously, switching the "Funds From"/"Funds To" account on an existing BUY/SELL would silently fail: the original account stayed debited and the new one was never touched. Both sides of the swap are now applied correctly.
+- **The funding source dropdown shows the right accounts.** Brokerage accounts (which hold securities, not cash) no longer appear as funding options for BUY/SELL transactions, while investment cash accounts are back in the list where they belong.
+- **Investment splits display properly in the transaction list.** Split rows pointing at an investment transaction were showing as "Uncategorized". They now render with the action and symbol, e.g. "Buy: AAPL".
+- **CAGR no longer shows nonsense values for new holdings.** Annualizing a few days of returns was producing wildly inflated numbers. CAGR is now hidden until a holding has at least a year of history.
+
+## Transfers
+
+- **The auto-generated payee on a transfer updates when you change the account.** If you created a transfer without a custom payee, Monize filled in "Transfer to <Account>" for you. Editing the transfer to point at a different account used to leave the stale payee in place; it now regenerates to match the new account. Custom payees you set yourself are still left alone.
+- **Auto-generated transfers no longer duplicate the payee into the description.** The description field stays empty when you don't fill one in, instead of mirroring the auto-generated payee name.
+
+## Full Changelist
+* fix: show action and symbol for investment splits in transaction list by @kenlasko in https://github.com/kenlasko/monize/pull/535
+* Exclude brokerage accounts from investment transaction funding sources by @kenlasko in https://github.com/kenlasko/monize/pull/537
+* Return null for CAGR when holding period is less than one year by @kenlasko in https://github.com/kenlasko/monize/pull/540
+* Fix auto-generated payee regeneration on transfer account changes by @kenlasko in https://github.com/kenlasko/monize/pull/541
+* Handle funding account changes in investment transactions by @kenlasko in https://github.com/kenlasko/monize/pull/542
+
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.9.15...v1.9.16

--- a/docs/release-notes/1.9.17.md
+++ b/docs/release-notes/1.9.17.md
@@ -1,0 +1,36 @@
+# v1.9.17
+
+## New features
+
+- **Multi-account filter for Gains, Dividends & Interest report** — pick any combination of investment accounts instead of one-at-a-time, so you can see results across a subset of your portfolio in a single view.
+- **Full-precision portfolio summary cards** — the totals at the top of the Investments page now show the exact value of your holdings instead of a rounded figure.
+
+## Improvements
+
+- **Editable dividend deposit account** — when recording a dividend, you can override which cash account the deposit lands in rather than being forced to the default.
+- **Account names use available width** — long investment account names no longer get truncated as aggressively in the holdings list.
+- **Better defaults for new investment accounts** — creating a new investment account now ships with the linked Cash + Brokerage pair enabled out of the box.
+
+## Bug fixes
+
+### Portfolio Value Over Time chart
+- 1D chart now starts at the day's opening price instead of the first intraday bar's close, so the day's gain/loss reads correctly from the very first point.
+- 1W and 1M charts are trimmed to a full calendar window — no more partial bars on the leading edge skewing the trend.
+- Portfolio value is now valued at the previous day's close on non-trading days/times, removing the misleading flat segments and jumps.
+- Foreign-currency holdings are converted using the **intraday** FX rate that matches each bar, fixing the day-over-day discrepancy you'd see for non-CAD/USD positions.
+
+### Reports
+- The Gains, Dividends & Interest report stays mounted while reloading, so filters and scroll position no longer reset every time the data refreshes.
+
+## Under the hood
+
+- Test stability fixes for the Dividend Income report, CSV filename test, and PostTransactionDialog/budgets lint cleanups.
+
+## What's Changed
+* Add dividend/interest/capital gain cash destination selection by @kenlasko in https://github.com/kenlasko/monize/pull/545
+* Value foreign-currency holdings at per-bar FX rates by @kenlasko in https://github.com/kenlasko/monize/pull/547
+* Use opening prices for intraday chart starting values by @kenlasko in https://github.com/kenlasko/monize/pull/546
+* Fix intraday chart range trimming for 1W and 1M requests by @kenlasko in https://github.com/kenlasko/monize/pull/548
+
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.9.16...v1.9.17

--- a/docs/release-notes/1.9.18.md
+++ b/docs/release-notes/1.9.18.md
@@ -1,0 +1,12 @@
+# v1.9.18
+
+## What's Changed
+* fix(ui): match Select placeholder color to MultiSelect by @kenlasko in https://github.com/kenlasko/monize/pull/549
+* feat(bills): open Post modal from dashboard upcoming bill click by @kenlasko in https://github.com/kenlasko/monize/pull/551
+* Fix NaN rendering in projected balances from tiny float residuals by @kenlasko in https://github.com/kenlasko/monize/pull/552
+* fix(db): cascade-delete transfer splits when their target account is removed by @kenlasko in https://github.com/kenlasko/monize/pull/555
+* Delegate account access by @kenlasko in https://github.com/kenlasko/monize/pull/553
+* chore(deps-dev): bump brace-expansion from 1.1.13 to 5.0.6 in /backend in the npm_and_yarn group across 1 directory by @dependabot[bot] in https://github.com/kenlasko/monize/pull/554
+
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.9.17...v1.9.18

--- a/docs/release-notes/1.9.4.md
+++ b/docs/release-notes/1.9.4.md
@@ -1,0 +1,28 @@
+# v1.9.4
+
+## Quick-fill new transactions from your history
+
+Re-entering the same transaction over and over? You can now repopulate the new-transaction form from one of your recent entries in a single click.
+
+### What's new
+
+- A new history button sits next to the **Payee** field on the transaction form. Click it to see a list of your recent transactions and pick one to fill in the rest of the form.
+- **Payee-aware results.** Pick or type a payee first and the popover narrows to the last few transactions for that payee — perfect for re-creating a recurring entry. With no payee selected, you see your most recent activity across all payees, deduplicated so the same coffee shop doesn't fill the list five times in a row.
+- **Works for splits too.** Pick a recent split transaction and the form switches into split mode and brings back the same category breakdown, amounts, memos, and tags. Pick a non-split entry while you're in split mode and it switches back to a regular transaction.
+- **Smart resets.** Quick-fill copies payee, category, amount, currency, description, and tags from the chosen transaction; the date becomes today and the status resets to Unreconciled.
+- **Stays out of your way.** The button is hidden when you're editing or duplicating an existing transaction (those flows already pre-fill the form), and doesn't appear for transfers.
+
+### Configurable
+
+Head to **Settings → Preferences → Recent transactions in quick-fill** to choose how many entries appear in the popover (3, 5, 10, 15, or 20). Default is 5.
+
+## All Changes
+* Add account grouping by type with collapsible headers and totals by @kenlasko in https://github.com/kenlasko/monize/pull/460
+* Add OCI image annotations to Docker build workflow by @kenlasko in https://github.com/kenlasko/monize/pull/461
+* feat(accounts): remove account type filter and align group total on mobile by @kenlasko in https://github.com/kenlasko/monize/pull/462
+* fix(accounts): count linked brokerage/cash pairs as one account by @kenlasko in https://github.com/kenlasko/monize/pull/463
+* Remove Beta badges from AI features by @kenlasko in https://github.com/kenlasko/monize/pull/464
+* Add quick-fill from recent transactions in transaction form by @kenlasko in https://github.com/kenlasko/monize/pull/465
+
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.9.3...v1.9.4

--- a/docs/release-notes/1.9.5.md
+++ b/docs/release-notes/1.9.5.md
@@ -1,0 +1,33 @@
+# v1.9.5
+
+## Net worth chart no longer drops at the start of a new month
+
+If you opened the dashboard early in a new month, you may have seen the net worth chart suddenly fall — sometimes to a fraction of its real value. That's now fixed.
+
+### What was happening
+
+Net worth is built from monthly snapshots of each account. An account's snapshot only refreshed when something happened on it (a new transaction, an edit, etc.). When the calendar rolled over, accounts that had no activity yet in the new month were stuck with a snapshot ending in the *previous* month, so they fell out of the current-month aggregate. The chart dropped to only the accounts that had posted activity in the new month.
+
+### What's fixed
+
+When the snapshot service runs, it now detects accounts missing a snapshot for the current month and recalculates them on the spot. Every account contributes to the current month's net worth, regardless of whether you've touched it since the month rolled over. The stale-account refresh path runs in parallel with proper error logging, so a single problem account won't block the rest.
+
+## Cleaner income and spending reports
+
+Investment accounts post automatic "asset value change" entries to track unrealized gains and losses on holdings. These were leaking into your reports and making the totals confusing.
+
+### What's new
+
+- **Asset value changes are excluded** from Income by Source, Spending by Category, Spending by Payee, and the Monthly Spending Trend. Reports now reflect actual cash flow, not paper gains.
+- **Income by Source shows subcategories.** Instead of rolling every income subcategory up into its parent, the report now lists each subcategory on its own line in `Parent: Child` format with its own color.
+- **Income-only filtering.** The Income by Source report now strictly filters on income categories, so stray non-income entries can't sneak in.
+- Transactions with no category (or an unknown one) are skipped from the income report rather than bucketed into "Uncategorized".
+
+## All Changes
+* fix(accounts): dedup linked investment pairs in account count header by @kenlasko in https://github.com/kenlasko/monize/pull/466
+* Fix net worth chart drop when accounts have no current-month transactions by @kenlasko in https://github.com/kenlasko/monize/pull/468
+* Add comprehensive test coverage for analytics, validators, and tools by @kenlasko in https://github.com/kenlasko/monize/pull/469
+* Exclude asset value change category from financial reports by @kenlasko in https://github.com/kenlasko/monize/pull/470
+* Add SECURITY.md with vulnerability reporting policy
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.9.4...v1.9.5

--- a/docs/release-notes/1.9.6.md
+++ b/docs/release-notes/1.9.6.md
@@ -1,0 +1,64 @@
+# v1.9.6
+
+## One-click MCP connector via OAuth 2.1
+
+Connecting Claude (Desktop, Claude.ai, or any other MCP client) to your Monize instance used to mean creating a Personal Access Token, copying it, and pasting it into a JSON config file. Now it's a single "Add connector" click.
+
+### What's new
+
+Monize ships its own OAuth 2.1 authorization server. When you point an MCP client at your Monize URL, the client discovers everything it needs, registers itself dynamically, opens a browser, asks you to consent, and gets back an audience-bound access token — no tokens to copy, no config files to edit.
+
+### Under the hood
+
+- `node-oidc-provider` is mounted at `/oauth`, advertising authorization, token, registration, JWKS, revocation, and discovery endpoints (RFC 6749 / 7591 / 8414).
+- RFC 9728 Protected Resource Metadata is published at `/.well-known/oauth-protected-resource`, so MCP clients can discover the AS from the resource URL alone.
+- 401 responses from `/api/v1/mcp` return `WWW-Authenticate: Bearer` with `resource_metadata` to drive that discovery.
+- A custom server-rendered consent page reuses your existing Monize session cookie for SSO — if you're signed in, you just click "Allow".
+- Clients, codes, tokens, grants, and sessions are persisted in a single `oauth_payloads` table (migration 055).
+- Access tokens are audience-bound to the MCP resource URL via Resource Indicators (RFC 8707).
+- The MCP controller transparently accepts both legacy `pat_*` PAT tokens and OAuth bearer tokens, so existing connections keep working.
+- Deactivating a user now revokes all their OAuth grants, sessions, and refresh tokens, not just their JWT — closing a gap where a deactivated user could keep talking to MCP through a previously-issued bearer token.
+
+The consent UI is dark-mode aware, scope strings are translated to plain English, the client name is shown prominently, and stale or duplicated consent submissions are handled gracefully instead of throwing.
+
+A new `OAUTH_DEBUG_LOG` env var gates request-level logging across the OAuth + MCP surface for easier troubleshooting; it's off by default.
+
+For more information, including public availability requirements, see the [relevant section in the wiki](https://github.com/kenlasko/monize/wiki/AI#option-1-oauth-claude-desktop-add-connector).
+
+## Account totals and UI now respect your currency and date preferences
+
+Several places in the UI were rendering raw amounts and ISO dates instead of honoring the currency and date format you set in your preferences. That's been swept up.
+
+### What's fixed
+
+- **Account totals are converted to your base currency.** The header total across accounts now sums in your configured base currency (using current exchange rates) instead of mixing currencies, so multi-currency users finally get a meaningful aggregate.
+- **Date formatting** in admin user management, insights, deactivate-unused-payees dialog, API access section, auto-backup section, security section, AI usage dashboard, and the AI result chart now follows your preferred date format.
+- **Currency formatting** in loan and mortgage account fields, insight cards, and the AI result chart now follows your base currency.
+- The exchange-rate hook surfaces a stable `convert()` helper so components can convert at render time without re-fetching rates.
+
+To pull this off without creating an import cycle, `UsersService` now resolves `ExchangeRateService` lazily via `ModuleRef`.
+
+## Smarter transaction entry on asset accounts
+
+When you add a transaction on an asset account (a house, a vehicle, anything you track for net worth that isn't an investment account with holdings), the category now pre-fills to the category set for Asset Value Change in the Account settings. 
+
+The `Combobox` component picked up a couple of fixes along the way:
+
+- The displayed label and the underlying value can no longer drift out of sync when the parent updates the value programmatically (e.g., on form reset or category pre-fill).
+- The label-mirror ref is now updated in an effect rather than during render, fixing a feedback-loop warning.
+
+## Multi-year report charts fixed
+
+The Cash Flow, Income vs Expenses, and Monthly Spending Trend reports were keying their chart series by month name only. If your date range crossed a year boundary, January 2025 and January 2026 collided and the chart drew the wrong values; tooltips also showed the wrong year.
+
+Each month is now identified by a unique `YYYY-MM` key, so multi-year ranges render correctly and tooltips show the right year. Date inputs in those reports also keep focus when you type, instead of blurring on every keystroke.
+
+## All Changes
+
+* Fix multi-year chart data display by using unique month identifiers by @kenlasko in https://github.com/kenlasko/monize/pull/471
+* feat(mcp): add OAuth 2.1 authorization server for one-click MCP connector by @kenlasko in https://github.com/kenlasko/monize/pull/472
+* Pre-fill asset value change category on new transaction by @kenlasko in https://github.com/kenlasko/monize/pull/473
+* fix(ui): respect user currency and date format preferences by @kenlasko in https://github.com/kenlasko/monize/pull/476
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.9.5...v1.9.6
+

--- a/docs/release-notes/1.9.7.md
+++ b/docs/release-notes/1.9.7.md
@@ -1,0 +1,52 @@
+# v1.9.7 — Monte Carlo retirement simulation
+
+This release adds a full Monte Carlo retirement simulation report and a number of UI polish fixes shared across the app.
+
+## New: Monte Carlo retirement simulation report
+
+A new report at **Reports → Monte Carlo Simulation** that runs thousands of probabilistic projections of your investment portfolio under user-defined contribution and withdrawal assumptions.
+
+<img width="1639" height="1113" alt="image" src="https://github.com/user-attachments/assets/388c15f6-f4c7-4206-ae75-11bf5f8f5e2b" />
+
+### Scenario configuration
+
+- Pick which **investment accounts** to include and start from their **current balance** (auto-populated) or a custom value.
+- Two-phase plan: a **contribution phase** (years, annual contribution, contribution growth rate) and a **withdrawal phase** (years, annual withdrawal in today's dollars, optional target portfolio value).
+- **Per-scenario cash flow events**: one-time or recurring income/expense layered on top of the base plan (e.g. pension, inheritance, renovation, college tuition), each with start year, end year, and inflation-adjustment toggle.
+- **Two return models**:
+  - Specify **expected return + volatility** directly, or
+  - Use **historical returns from the selected accounts** — per-holding mean and volatility computed from the last 10 years of price history (with provider backfill for short histories, dividends included via adjusted close).
+- **Saved scenarios** sidebar with last-run timestamps, in-place edit, save/update, and an in-app delete confirmation.
+- The **last-active scenario and its results are cached in localStorage**, so a refresh keeps your view instead of dumping you back to an empty form.
+
+### Results
+
+- **Fan chart** of the projected portfolio value with 10–25–75–90 percentile bands, median line, and per-cash-flow-event markers (income/expense, start/end).
+- **Phase divider**: a prominent amber dashed line marks where the contribution phase ends and the withdrawal phase begins. The label flips sides automatically so it never overflows the chart edge, and the arrow always points back to the divider.
+- **Summary stat cards**: median final value, 10th–90th percentile range, probability of depletion, probability of finishing above your target.
+- **Performance Summary table**: time-weighted return (nominal + real), end balance (nominal + real), mean return, annualized volatility, max drawdown (with and without cash flows), safe withdrawal rate, perpetual withdrawal rate. Each metric is reported as a 10/25/50/75/90 percentile band, the **50th-percentile column is visually highlighted** as the focal point, and every row has a desktop hover tooltip explaining the metric.
+- **Chart ↔ Table toggle** for the projection: either the fan chart or a year-by-year table that includes cash-flow events alongside the percentile values.
+- **Export to CSV or PDF** — chart image, summary cards, year-by-year percentile data, and a cash-flow events column included.
+
+### After-run UX
+
+- The input form **auto-collapses** once a result is available (or when you load a saved scenario with a cached result), surfacing a compact header showing the scenario name, starting value, time horizon, return assumption, and run count, plus a one-click **Run again** button. Click **Edit inputs** to expand the full form again — your values are preserved.
+
+## UI polish (cross-cutting)
+
+- New shared **`InfoTooltip`** component (`components/ui/InfoTooltip.tsx`) with a Heroicons question-mark icon, gray-400 base / blue-500 on hover, and a styled popover that only appears on desktop. Replaces three local lookalikes in `PortfolioSummaryCard`, `AccountForm`, and `FavouriteAccounts`, so all help icons across the app now look and behave the same.
+- `TwoFactorSetup` switched from react-hook-form's `watch()` to `useWatch()` to clear a React Compiler "incompatible-library" warning.
+
+## Tests & quality
+
+- **Test coverage** on the Monte Carlo report lifted from 69 % statements / 52 % branches to **96 % statements / 82 % branches** (97 % lines / 93 % functions).
+- 38 new tests added covering input collapse/expand, error paths (run/save/delete), sidebar empty state, scenario load with and without cached results, cash-flow editing, return-assumption switches, chart tooltip rendering, and CSV/PDF event labelling.
+- All **4 934 frontend tests pass**; lint and type-check are clean.
+
+## What's Changed
+* Add Monte Carlo retirement projection simulator by @kenlasko in https://github.com/kenlasko/monize/pull/478
+* feat(monte-carlo): cache simulation results in localStorage by @kenlasko in https://github.com/kenlasko/monize/pull/479
+* feat(monte-carlo): collapse inputs after a run, expand coverage by @kenlasko in https://github.com/kenlasko/monize/pull/480
+
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.9.6...v1.9.7

--- a/docs/release-notes/1.9.8.md
+++ b/docs/release-notes/1.9.8.md
@@ -1,0 +1,66 @@
+# v1.9.8 — Monte Carlo scenario comparison and investment chart accuracy
+
+This release adds side-by-side Monte Carlo scenario comparison, a set of quality-of-life improvements to the Monte Carlo simulator, smarter reconciliation for liability accounts, and two fixes for investment charts and CSV exports.
+
+## New: Compare Monte Carlo scenarios side-by-side
+
+A new **Compare** view lets you select up to 4 saved scenarios and view all their metrics in a single unified table at **Reports → Monte Carlo Simulation → Compare**.
+
+- Toggle **Select** mode in the sidebar (appears once you have 2 or more saved scenarios), check up to 4 scenarios, then click **Compare selected**.
+- All selected scenarios run in parallel and their results are displayed in columns — Identity, Inputs, Final Distribution, Performance, and Outcome metric groups.
+- Results are cached in localStorage, so switching back to a cached scenario doesn't re-run it. A **Re-run** button appears per-column if you want fresh numbers.
+- If a scenario has been deleted or fails to run, its column stays visible with an error state and a retry button.
+- The comparison URL encodes the selected scenario IDs as query parameters, so you can bookmark or share a specific comparison view.
+- The table scrolls horizontally on narrow screens with sticky metric labels and a sticky header row.
+- **CSV download** exports the full comparison table including all metric groups and subgroup separator rows.
+
+## Monte Carlo simulator improvements
+
+### Save As and scenario reordering
+
+- The **Save** button now offers a **Save As** option, letting you create a named copy of the current scenario without overwriting the original. A dialog handles name conflicts with an overwrite confirmation.
+- Scenarios in the sidebar can be reordered with **up/down arrow buttons**; order is persisted to the database.
+- The **Hide/Show Inputs** toggle preference now persists across scenario switches. Inputs collapse automatically after a fresh **Run** click, then stay in whatever state you left them when you switch between scenarios.
+
+### Performance Summary in exports
+
+The Performance Summary table (time-weighted return, volatility, max drawdown, safe withdrawal rate, etc.) is now included in both **CSV** and **PDF** exports, appearing before the year-by-year percentile table.
+
+## Reconciliation: smarter liability account handling
+
+When reconciling a **liability account** (credit card, loan, line of credit), entering a positive statement balance now automatically converts it to a negative value — matching how liabilities are stored internally — so you no longer need to remember to type a minus sign.
+
+## Investment chart: accurate first-month values
+
+Investment portfolio charts previously used the month-end market value for an account's very first month, which could show a misleading spike or drop when purchases happened mid-month at prices different from month-end.
+
+The chart now uses **cost basis** for the first active month of brokerage and standalone investment accounts, computed from the actual BUY/SELL/REINVEST/TRANSFER transaction prices and quantities in that month. For standalone accounts the month-end cash balance is added on top. All other months are unchanged.
+
+The 2-year range (`2y`) on investment charts now uses daily granularity instead of monthly, consistent with shorter ranges.
+
+## Fix: CSV exports now write numbers as numbers
+
+Numeric values in CSV exports were being written as quoted strings, which caused spreadsheet apps to treat them as text. Numbers and booleans now export as plain unquoted values. String values that begin with formula-injection characters (`=`, `+`, `-`, `@`) are still prefixed with a tab to prevent spreadsheet formula injection.
+
+## Tests and quality
+
+Coverage lifted substantially across both layers:
+
+| Layer | Lines | Statements | Functions | Branches |
+|---|---|---|---|---|
+| Backend | 95.5% | 94.6% | 95.6% | 84.9% |
+| Frontend | ~83% | ~82% | ~78% | ~73% |
+
+New thresholds are enforced in CI. ~17,000 lines of new tests were added across ~100 files, covering previously untested hooks, report components, AI providers, OAuth services, import wizard logic, and more.
+
+## What's Changed
+
+* feat(monte-carlo): include Performance Summary in PDF and CSV exports by @kenlasko in https://github.com/kenlasko/monize/pull/482
+* feat(monte-carlo): Save As, scenario reordering, and persist Hide/Show Inputs by @kenlasko in https://github.com/kenlasko/monize/pull/483
+* feat(reconcile): auto-negate statement balance for liability accounts by @kenlasko in https://github.com/kenlasko/monize/pull/484
+* feat(monte-carlo): compare scenarios side-by-side by @kenlasko in https://github.com/kenlasko/monize/pull/485
+* test: substantial coverage uplift across backend and frontend by @kenlasko in https://github.com/kenlasko/monize/pull/486
+* fix(csv-export): write numbers as numeric values, not text by @kenlasko in https://github.com/kenlasko/monize/pull/487
+* feat(investments): cost basis for first-month snapshots, 2y daily granularity by @kenlasko in https://github.com/kenlasko/monize/pull/488
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.9.7...v1.9.8

--- a/docs/release-notes/1.9.9.md
+++ b/docs/release-notes/1.9.9.md
@@ -1,0 +1,60 @@
+# v1.9.9 — Intraday portfolio charts
+
+This release adds intraday (minute/hour-level) charting to the investment views, with a 1-day range, smarter refresh behaviour, and a graceful fallback when a holding's quote provider doesn't support intraday data.
+
+## New: Intraday portfolio value charts
+
+The investment account chart and the **Reports → Portfolio Value** report can now plot live intraday bars for short ranges, instead of stretching daily snapshots across a single day or week.
+
+### What's new
+
+- **New `1d` range** on the chart range selector, alongside `1w`, `1m`, `3m`, `ytd`, `1y`, `2y`, `5y`, `all`.
+- **Intraday bars** for `1d`, `1w`, and `1m` are fetched live from Yahoo Finance, aligned on a unified time grid across every holding, and converted to your display currency. GBX (pence) prices are auto-converted to GBP.
+- **Tight-zoom Y-axis** (`computeTightYAxisDomain`) keeps small intraday moves visible — the chart no longer flatlines just because the daily move is small.
+- **Smooth transitions** between ranges: a load-token pattern cancels stale results if you click between ranges quickly, so the chart never flashes outdated data.
+- **"Updating…" indicator** appears during background chart loads so you know fresh data is on the way.
+
+### Mixed-provider fallback
+
+If any holding in the selected accounts uses a quote provider without intraday support (e.g. MSN Money):
+
+- `1w` and `1m` silently fall back to daily snapshots, with a warning icon next to the chart title naming the affected symbols.
+- `1d` shows an explicit "intraday data unavailable" notice listing the symbols that couldn't be fetched.
+
+### Refresh behaviour
+
+- The page-level **Refresh** button now broadcasts an `INVESTMENT_CHART_REFRESH_EVENT` that clears the intraday cache and re-fetches.
+- Refresh is **scoped to the holdings currently on screen** — it no longer re-quotes your entire portfolio when you only care about one account's chart.
+- Missing securities are **back-filled automatically** before rendering, removing visual jumps caused by gaps in price history.
+
+### Caching and persistence
+
+- Backend: 60-second in-memory cache keyed by `userId|range|accountIds|currency` absorbs double-clicks and rapid range switches.
+- Frontend: intraday responses are cached per-tab in `sessionStorage`; the selected range is persisted to `localStorage`, so a refresh keeps you on the range you were viewing.
+
+## Fixes
+
+- **Securities lookup**: Yahoo intraday `interval` and `range` query params are now URL-encoded.
+- **Securities form**: choosing **Use Default** for a security's quote provider now correctly clears the per-security override.
+
+## Backend
+
+- New endpoint `GET /portfolio/intraday-value` with `IntradayValueQueryDto` and `IntradayValueResponse` types.
+- `QuoteProviderRegistry` is consulted to decide which holdings support intraday data; quantities are aggregated across multiple holdings of the same security.
+- Null closes in intraday bars are forward-filled so multi-security time alignment works correctly.
+
+## What's Changed
+
+* feat(investments): add intraday Portfolio Value Over Time chart
+* fix(securities): clear quoteProvider override when picking "Use Default"
+* fix(investments): smooth chart transitions across all date ranges
+* feat(investments): warn when 1W/1M falls back to daily snapshots
+* feat(investments): show "Updating…" indicator on background chart loads
+* fix(investments): back-fill missing securities to remove intraday jumps
+* feat(investments): scope Refresh to the holdings on screen
+* fix(investments): tight-zoom y-axis so price changes are visible
+* feat(reports): apply intraday + UX upgrades to Portfolio Value report
+* fix(securities): URL-encode Yahoo intraday interval & range params
+* Add intraday portfolio value charts for 1D/1W/1M ranges by @kenlasko in https://github.com/kenlasko/monize/pull/490
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.9.8...v1.9.9

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -73,3 +73,31 @@ Whichever source wins becomes the full body of the GitHub Release.
 2. Either pass them via `-f release_notes=...` at trigger time, or commit them
    to `docs/release-notes/<version>.md`.
 3. Run the workflow with the matching `release_type` / `version`.
+
+## Archived release notes
+
+Notes for past releases live alongside this file, one Markdown file per version
+(`docs/release-notes/<version>.md`). These mirror the notes published on the
+matching [GitHub Release](https://github.com/kenlasko/monize/releases), newest
+first:
+
+- [v1.10.5](1.10.5.md)
+- [v1.10.4](1.10.4.md)
+- [v1.10.3](1.10.3.md)
+- [v1.10.2](1.10.2.md)
+- [v1.10.1](1.10.1.md)
+- [v1.9.18](1.9.18.md)
+- [v1.9.17](1.9.17.md)
+- [v1.9.16](1.9.16.md)
+- [v1.9.15](1.9.15.md)
+- [v1.9.14](1.9.14.md)
+- [v1.9.13](1.9.13.md)
+- [v1.9.12](1.9.12.md)
+- [v1.9.11](1.9.11.md)
+- [v1.9.10](1.9.10.md)
+- [v1.9.9](1.9.9.md)
+- [v1.9.8](1.9.8.md)
+- [v1.9.7](1.9.7.md)
+- [v1.9.6](1.9.6.md)
+- [v1.9.5](1.9.5.md)
+- [v1.9.4](1.9.4.md)


### PR DESCRIPTION
Archive the published GitHub Release notes into the repo as
docs/release-notes/<version>.md, one file per release from v1.9.4 to the
current v1.10.5 (there is no v1.10.0). Each file opens with a uniform
`# v<version>` title and otherwise preserves the authored highlights and
the per-release PR changelog.

- Author a short note for v1.9.15, whose release had only an auto-generated
  changelog link (build-script/DNS maintenance only).
- Fix a broken wiki link carried over from the v1.9.6 notes.
- Add an "Archived release notes" index to the README.

https://claude.ai/code/session_01WjiHCFAu4cYrDFV4kfPknQ