### PR TITLE
Add user-selectable colour themes (beige, Classic Money, Nord, Forest, Solarized, high contrast)

### DIFF
--- a/backend/src/institutions/institutions.service.spec.ts
+++ b/backend/src/institutions/institutions.service.spec.ts
@@ -163,7 +163,9 @@ describe("InstitutionsService", () => {
     });
 
     it("excludes the cash half of a linked investment pair from the counts", async () => {
-      institutionsRepo.find.mockResolvedValue([buildInstitution({ id: "inst-1" })]);
+      institutionsRepo.find.mockResolvedValue([
+        buildInstitution({ id: "inst-1" }),
+      ]);
       const qb = chainableQb(
         [{ institution_id: "inst-1", count: "1" }],
         "getRawMany",

--- a/backend/src/users/dto/update-preferences.dto.ts
+++ b/backend/src/users/dto/update-preferences.dto.ts
@@ -48,6 +48,33 @@ export class UpdatePreferencesDto {
   theme?: string;
 
   @ApiPropertyOptional({
+    description:
+      "Colour theme (palette), separate from the light/dark mode preference",
+    example: "default",
+    enum: [
+      "default",
+      "beige",
+      "msmoney",
+      "nord",
+      "forest",
+      "solarized",
+      "highcontrast",
+    ],
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn([
+    "default",
+    "beige",
+    "msmoney",
+    "nord",
+    "forest",
+    "solarized",
+    "highcontrast",
+  ])
+  colorTheme?: string;
+
+  @ApiPropertyOptional({
     description: "Timezone (browser = use browser timezone)",
     example: "browser",
   })

--- a/backend/src/users/dto/update-preferences.dto.ts
+++ b/backend/src/users/dto/update-preferences.dto.ts
@@ -53,7 +53,7 @@ export class UpdatePreferencesDto {
     example: "default",
     enum: [
       "default",
-      "beige",
+      "latte",
       "msmoney",
       "nord",
       "forest",
@@ -65,7 +65,7 @@ export class UpdatePreferencesDto {
   @IsString()
   @IsIn([
     "default",
-    "beige",
+    "latte",
     "msmoney",
     "nord",
     "forest",

--- a/backend/src/users/dto/update-preferences.dto.ts
+++ b/backend/src/users/dto/update-preferences.dto.ts
@@ -55,10 +55,18 @@ export class UpdatePreferencesDto {
       "default",
       "latte",
       "msmoney",
+      "newspaper",
+      "burgundy",
       "nord",
       "forest",
       "solarized",
+      "gruvbox",
+      "dracula",
+      "tokyonight",
+      "rosepine",
+      "midnight",
       "highcontrast",
+      "colorblind",
     ],
   })
   @IsOptional()
@@ -67,10 +75,18 @@ export class UpdatePreferencesDto {
     "default",
     "latte",
     "msmoney",
+    "newspaper",
+    "burgundy",
     "nord",
     "forest",
     "solarized",
+    "gruvbox",
+    "dracula",
+    "tokyonight",
+    "rosepine",
+    "midnight",
     "highcontrast",
+    "colorblind",
   ])
   colorTheme?: string;
 

--- a/backend/src/users/entities/user-preference.entity.ts
+++ b/backend/src/users/entities/user-preference.entity.ts
@@ -26,6 +26,9 @@ export class UserPreference {
   @Column({ default: "light" })
   theme: string;
 
+  @Column({ name: "color_theme", length: 20, default: "default" })
+  colorTheme: string;
+
   @Column({ default: "browser" })
   timezone: string;
 

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -465,7 +465,7 @@ describe("UsersService", () => {
       ["defaultQuoteProvider", "yahoo"],
       ["recentTransactionsLimit", 25],
       ["language", "fr"],
-      ["colorTheme", "beige"],
+      ["colorTheme", "latte"],
     ])(
       "updates the %s field when provided",
       async (field: string, value: any) => {

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -465,6 +465,7 @@ describe("UsersService", () => {
       ["defaultQuoteProvider", "yahoo"],
       ["recentTransactionsLimit", 25],
       ["language", "fr"],
+      ["colorTheme", "beige"],
     ])(
       "updates the %s field when provided",
       async (field: string, value: any) => {
@@ -476,6 +477,18 @@ describe("UsersService", () => {
         expect(savedData[field]).toEqual(value);
       },
     );
+
+    it("leaves colorTheme untouched when not provided", async () => {
+      preferencesRepository.findOne.mockResolvedValue({
+        ...mockPreferences,
+        colorTheme: "nord",
+      });
+
+      await service.updatePreferences("user-1", { theme: "dark" });
+
+      const savedData = preferencesRepository.save.mock.calls[0][0];
+      expect(savedData.colorTheme).toBe("nord");
+    });
 
     it("seeds language='en' when creating default preferences", async () => {
       preferencesRepository.findOne.mockResolvedValue(null);

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -181,6 +181,9 @@ export class UsersService {
     if (dto.theme !== undefined) {
       preferences.theme = dto.theme;
     }
+    if (dto.colorTheme !== undefined) {
+      preferences.colorTheme = dto.colorTheme;
+    }
     if (dto.timezone !== undefined) {
       preferences.timezone = dto.timezone;
     }

--- a/backend/test/integration/security-cross-user-isolation.integration.spec.ts
+++ b/backend/test/integration/security-cross-user-isolation.integration.spec.ts
@@ -290,7 +290,9 @@ describe("Cross-user data isolation (integration)", () => {
         undefined,
         undefined,
       );
-      expect(result.data.find((t) => t.id === userATransaction.id)).toBeUndefined();
+      expect(
+        result.data.find((t) => t.id === userATransaction.id),
+      ).toBeUndefined();
       expect(result.data.every((t) => t.userId === userBId)).toBe(true);
     });
 
@@ -304,7 +306,9 @@ describe("Cross-user data isolation (integration)", () => {
       } as any);
 
       const result = await transactionsService.findAll(userBId);
-      expect(result.data.find((t) => t.id === userATransaction.id)).toBeUndefined();
+      expect(
+        result.data.find((t) => t.id === userATransaction.id),
+      ).toBeUndefined();
       expect(result.data.every((t) => t.userId === userBId)).toBe(true);
     });
   });
@@ -372,9 +376,7 @@ describe("Cross-user data isolation (integration)", () => {
       await createTestCategory(dataSource, userBId, { name: "userB dining" });
 
       const result = await categoriesService.findAll(userBId);
-      expect(
-        result.find((c) => c.id === userACategory.id),
-      ).toBeUndefined();
+      expect(result.find((c) => c.id === userACategory.id)).toBeUndefined();
       expect(result.every((c) => c.userId === userBId)).toBe(true);
     });
   });
@@ -422,7 +424,9 @@ describe("Cross-user data isolation (integration)", () => {
     });
 
     it("findAll(userB) does not include any of userA's payees", async () => {
-      await createTestPayee(dataSource, userBId, { name: "userB hardware store" });
+      await createTestPayee(dataSource, userBId, {
+        name: "userB hardware store",
+      });
 
       const result = await payeesService.findAll(userBId);
       expect(result.find((p) => p.id === userAPayee.id)).toBeUndefined();
@@ -443,9 +447,9 @@ describe("Cross-user data isolation (integration)", () => {
     });
 
     it("findOne(userB, userA.tag.id) throws NotFoundException", async () => {
-      await expect(
-        tagsService.findOne(userBId, userATag.id),
-      ).rejects.toThrow(NotFoundException);
+      await expect(tagsService.findOne(userBId, userATag.id)).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it("update(userB, userA.tag.id) throws NotFoundException and leaves the row untouched", async () => {
@@ -461,9 +465,9 @@ describe("Cross-user data isolation (integration)", () => {
     });
 
     it("remove(userB, userA.tag.id) throws NotFoundException and the row still exists", async () => {
-      await expect(
-        tagsService.remove(userBId, userATag.id),
-      ).rejects.toThrow(NotFoundException);
+      await expect(tagsService.remove(userBId, userATag.id)).rejects.toThrow(
+        NotFoundException,
+      );
 
       const stillThere = await dataSource.manager.findOne(Tag, {
         where: { id: userATag.id },
@@ -651,9 +655,12 @@ describe("Cross-user data isolation (integration)", () => {
         investmentTransactionsService.remove(userBId, userATx.id),
       ).rejects.toThrow(NotFoundException);
 
-      const stillThere = await dataSource.manager.findOne(InvestmentTransaction, {
-        where: { id: userATx.id },
-      });
+      const stillThere = await dataSource.manager.findOne(
+        InvestmentTransaction,
+        {
+          where: { id: userATx.id },
+        },
+      );
       expect(stillThere).not.toBeNull();
     });
 
@@ -761,9 +768,12 @@ describe("Cross-user data isolation (integration)", () => {
         } as any),
       ).rejects.toThrow(NotFoundException);
 
-      const reloaded = await dataSource.manager.findOneOrFail(InvestmentReport, {
-        where: { id: userAReport.id },
-      });
+      const reloaded = await dataSource.manager.findOneOrFail(
+        InvestmentReport,
+        {
+          where: { id: userAReport.id },
+        },
+      );
       expect(reloaded.name).toBe("userA holdings");
       expect(reloaded.userId).toBe(userAId);
     });

--- a/database/migrations/083_user_preferences_color_theme.sql
+++ b/database/migrations/083_user_preferences_color_theme.sql
@@ -1,6 +1,6 @@
 -- Per-user colour theme preference, separate from the light/dark/system mode
 -- setting (`theme`). The value is one of the palette names defined in
--- frontend/src/lib/color-themes.ts ('default', 'beige', 'msmoney', 'nord',
+-- frontend/src/lib/color-themes.ts ('default', 'latte', 'msmoney', 'nord',
 -- 'forest', 'solarized', 'highcontrast') and is validated against the same
 -- list in backend/src/users/dto/update-preferences.dto.ts. Every palette has
 -- both light and dark variants; `theme` continues to choose between them.

--- a/database/migrations/083_user_preferences_color_theme.sql
+++ b/database/migrations/083_user_preferences_color_theme.sql
@@ -1,0 +1,9 @@
+-- Per-user colour theme preference, separate from the light/dark/system mode
+-- setting (`theme`). The value is one of the palette names defined in
+-- frontend/src/lib/color-themes.ts ('default', 'beige', 'msmoney', 'nord',
+-- 'forest', 'solarized', 'highcontrast') and is validated against the same
+-- list in backend/src/users/dto/update-preferences.dto.ts. Every palette has
+-- both light and dark variants; `theme` continues to choose between them.
+
+ALTER TABLE user_preferences
+  ADD COLUMN IF NOT EXISTS color_theme VARCHAR(20) NOT NULL DEFAULT 'default';

--- a/database/migrations/083_user_preferences_color_theme.sql
+++ b/database/migrations/083_user_preferences_color_theme.sql
@@ -1,9 +1,8 @@
 -- Per-user colour theme preference, separate from the light/dark/system mode
 -- setting (`theme`). The value is one of the palette names defined in
--- frontend/src/lib/color-themes.ts ('default', 'latte', 'msmoney', 'nord',
--- 'forest', 'solarized', 'highcontrast') and is validated against the same
--- list in backend/src/users/dto/update-preferences.dto.ts. Every palette has
--- both light and dark variants; `theme` continues to choose between them.
+-- frontend/src/lib/color-themes.ts and validated against the same list in
+-- backend/src/users/dto/update-preferences.dto.ts. Every palette has both
+-- light and dark variants; `theme` continues to choose between them.
 
 ALTER TABLE user_preferences
   ADD COLUMN IF NOT EXISTS color_theme VARCHAR(20) NOT NULL DEFAULT 'default';

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -575,6 +575,7 @@ CREATE TABLE user_preferences (
     date_format VARCHAR(20) DEFAULT 'YYYY-MM-DD',
     number_format VARCHAR(20) DEFAULT 'en-US',
     theme VARCHAR(20) DEFAULT 'light',
+    color_theme VARCHAR(20) NOT NULL DEFAULT 'default',
     timezone VARCHAR(50) DEFAULT 'browser',
     notification_email BOOLEAN DEFAULT true,
     notification_browser BOOLEAN DEFAULT true,

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -109,7 +109,9 @@ Never use synchronous `act(() => {...})` for calls that trigger async side-effec
 
 ## Theme
 
-`ThemeContext` provides `theme` (light/dark/system), `resolvedTheme`, and `setTheme()`. Persisted to localStorage; applies `dark` class to `<html>` (Tailwind dark mode strategy); listens for system preference changes via `matchMedia`. Custom theme variables in `globals.css` `@theme` block; dark variant `@variant dark (&:where(.dark, .dark *))`.
+`ThemeContext` provides `theme` (light/dark/system), `resolvedTheme`, and `setTheme()`, plus `colorTheme`/`setColorTheme()` for the colour palette (`src/lib/color-themes.ts`). Both persisted to localStorage; applies `dark` class (Tailwind dark mode strategy) and a `data-theme` attribute (`default` = no attribute) to `<html>`; listens for system preference changes via `matchMedia`. Custom theme variables in `globals.css` `@theme` block; dark variant `@variant dark (&:where(.dark, .dark *))`.
+
+Colour themes are pure CSS variable overrides in `src/app/themes.css` (`html[data-theme="..."]` redefines the gray/blue ramps etc. -- Tailwind v4 utilities compile to `var(--color-*)` so no component changes are needed). Chart colours go through `src/lib/chart-colors.ts`, which exposes `var(--chart-*)` strings for Recharts props; never hardcode hex colours in charts, and never theme user-chosen entity colours (tags, categories, payees).
 
 ## Security Notes
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "./themes.css";
 
 /* Custom theme extensions */
 @theme {
@@ -78,15 +79,44 @@ body {
 
 /* Category badge colour variables for light/dark mode */
 :root {
-  --category-bg-base: #e5e7eb;
-  --category-text-base: #6b7280;
+  --category-bg-base: var(--color-gray-200);
+  --category-text-base: var(--color-gray-500);
   --category-text-mix: #000;
 }
 
 .dark {
-  --category-bg-base: #374151;
-  --category-text-base: #9ca3af;
+  --category-bg-base: var(--color-gray-700);
+  --category-text-base: var(--color-gray-400);
   --category-text-mix: #fff;
+}
+
+/* Chart colour tokens. Recharts components reference these as
+   `var(--chart-*)` strings (see src/lib/chart-colors.ts) so charts follow
+   both the colour theme and light/dark mode without any JS recomputation.
+   Grid, axis, and primary derive from the gray/blue ramps and therefore
+   re-theme automatically; the rest have per-theme overrides in themes.css. */
+:root {
+  --chart-primary: var(--color-blue-500);
+  --chart-grid: var(--color-gray-200);
+  --chart-axis: var(--color-gray-500);
+  --chart-income: #10b981;
+  --chart-expense: #ef4444;
+  --chart-warning: #f59e0b;
+  --chart-1: #3b82f6;
+  --chart-2: #10b981;
+  --chart-3: #f59e0b;
+  --chart-4: #ef4444;
+  --chart-5: #8b5cf6;
+  --chart-6: #ec4899;
+  --chart-7: #06b6d4;
+  --chart-8: #84cc16;
+  --chart-9: #f97316;
+  --chart-10: #6366f1;
+}
+
+.dark {
+  --chart-grid: var(--color-gray-700);
+  --chart-axis: var(--color-gray-400);
 }
 
 /* Form element styling (replaces @tailwindcss/forms) */
@@ -102,7 +132,7 @@ textarea,
 select {
   @apply w-full rounded-md border border-gray-300 shadow-sm px-3 py-2 text-base font-sans;
   appearance: none;
-  background-color: #fff;
+  background-color: var(--color-white);
   font-family: 'Inter', system-ui, sans-serif;
 }
 
@@ -117,17 +147,17 @@ select {
 [type='time'],
 [type='week'] {
   @apply w-full rounded-md border border-gray-300 shadow-sm px-3 py-2 text-base font-sans;
-  background-color: #fff;
+  background-color: var(--color-white);
   font-family: 'Inter', system-ui, sans-serif;
 }
 
 /* Placeholder colors */
 ::placeholder {
-  color: rgb(156 163 175); /* gray-400 */
+  color: var(--color-gray-400);
 }
 
 .dark ::placeholder {
-  color: rgb(156 163 175); /* gray-400 */
+  color: var(--color-gray-400);
 }
 
 [type='text']:focus,
@@ -164,7 +194,7 @@ select:focus {
 .dark textarea,
 .dark select {
   @apply border-gray-600 text-gray-100;
-  background-color: rgb(31 41 55); /* gray-800 to match MultiSelect */
+  background-color: var(--color-gray-800); /* matches MultiSelect */
 }
 
 /* Select dropdown arrow for dark mode */
@@ -200,12 +230,12 @@ select {
 .dark [type='checkbox'],
 .dark [type='radio'] {
   @apply border-gray-600;
-  background-color: rgb(31 41 55); /* gray-800 */
+  background-color: var(--color-gray-800);
 }
 
 /* Date input styling - empty date inputs should match placeholder color */
 .date-empty {
-  color: rgb(156 163 175) !important; /* gray-400 - matches placeholder */
+  color: var(--color-gray-400) !important; /* matches placeholder */
 }
 
 /* Select placeholder color - applied when no option is selected. The selectors
@@ -213,7 +243,7 @@ select {
    `.dark select { text-gray-100 }` rule above. */
 select.select-placeholder,
 .dark select.select-placeholder {
-  color: rgb(156 163 175); /* gray-400 - matches MultiSelect placeholder */
+  color: var(--color-gray-400); /* matches MultiSelect placeholder */
 }
 
 /* Calendar picker indicator for dark mode */

--- a/frontend/src/app/themes.css
+++ b/frontend/src/app/themes.css
@@ -20,8 +20,8 @@
  * allows.
  */
 
-/* ===== Beige -- warm cream surfaces, taupe darks, caramel accent ===== */
-html[data-theme='beige'] {
+/* ===== Latte -- warm cream surfaces, taupe darks, caramel accent ===== */
+html[data-theme='latte'] {
   --color-white: #fbf7ef;
 
   --color-gray-50: #f6f1e7;

--- a/frontend/src/app/themes.css
+++ b/frontend/src/app/themes.css
@@ -1,0 +1,330 @@
+/*
+ * Colour themes (palettes), selected in Settings -> Preferences and applied
+ * as a `data-theme` attribute on <html> by ThemeContext. The default palette
+ * has no attribute and uses the stock Tailwind colours.
+ *
+ * How it works: Tailwind v4 utilities compile to `var(--color-*)` references,
+ * so redefining those variables here re-skins every component without
+ * touching any of them. Each theme overrides:
+ *   - the gray ramp (surfaces, borders, text -- shared by light and dark
+ *     mode, which simply pick different steps of the same ramp)
+ *   - the blue ramp (the app's accent colour)
+ *   - sky-500/600 (form focus rings and checkboxes in globals.css)
+ *   - --color-white where the theme wants tinted "paper" cards
+ *   - the --chart-* tokens that don't already follow gray/blue automatically
+ *
+ * Light/dark behaviour stays with the existing mode setting: light mode uses
+ * the 50-300 end of the gray ramp for surfaces, dark mode the 800-950 end.
+ * Only highcontrast needs a dedicated html.dark block, because its border
+ * and secondary-text grays must invert more aggressively than a shared ramp
+ * allows.
+ */
+
+/* ===== Beige -- warm cream surfaces, taupe darks, caramel accent ===== */
+html[data-theme='beige'] {
+  --color-white: #fbf7ef;
+
+  --color-gray-50: #f6f1e7;
+  --color-gray-100: #efe8da;
+  --color-gray-200: #e3d8c2;
+  --color-gray-300: #d0c1a3;
+  --color-gray-400: #b09e7f;
+  --color-gray-500: #8f7d61;
+  --color-gray-600: #74634c;
+  --color-gray-700: #5c4f3e;
+  --color-gray-800: #443a2f;
+  --color-gray-900: #2f2820;
+  --color-gray-950: #1f1a14;
+
+  --color-blue-50: #faf3ea;
+  --color-blue-100: #f2e4cf;
+  --color-blue-200: #e5cba3;
+  --color-blue-300: #d4ac72;
+  --color-blue-400: #c28f4c;
+  --color-blue-500: #aa7634;
+  --color-blue-600: #8f5f29;
+  --color-blue-700: #714b22;
+  --color-blue-800: #573a1d;
+  --color-blue-900: #422c18;
+  --color-blue-950: #24170c;
+
+  --color-sky-500: #aa7634;
+  --color-sky-600: #8f5f29;
+  --color-table-stripe-dark: #383027;
+
+  --chart-income: #6f9b54;
+  --chart-expense: #c65d4a;
+  --chart-warning: #c99a3c;
+  --chart-1: #aa7634;
+  --chart-2: #6f9b54;
+  --chart-3: #c99a3c;
+  --chart-4: #c65d4a;
+  --chart-5: #8d7aa5;
+  --chart-6: #b56a8d;
+  --chart-7: #5e8e8a;
+  --chart-8: #97a04c;
+  --chart-9: #c97f3e;
+  --chart-10: #7d6b9e;
+}
+
+/* ===== Classic Money -- parchment paper, deep Money green, navy text ===== */
+html[data-theme='msmoney'] {
+  --color-white: #fdfaf1;
+
+  --color-gray-50: #f5f0dd;
+  --color-gray-100: #ece5cc;
+  --color-gray-200: #ddd3b2;
+  --color-gray-300: #c4b894;
+  --color-gray-400: #a39a80;
+  --color-gray-500: #7f7e6e;
+  --color-gray-600: #5d6a6e;
+  --color-gray-700: #44525c;
+  --color-gray-800: #243646;
+  --color-gray-900: #182838;
+  --color-gray-950: #0e1a26;
+
+  --color-blue-50: #edf5ee;
+  --color-blue-100: #d7e9da;
+  --color-blue-200: #b2d3b9;
+  --color-blue-300: #85b691;
+  --color-blue-400: #58966a;
+  --color-blue-500: #3a7d4f;
+  --color-blue-600: #2a653e;
+  --color-blue-700: #235233;
+  --color-blue-800: #1d422b;
+  --color-blue-900: #173523;
+  --color-blue-950: #0c1e13;
+
+  --color-sky-500: #3a7d4f;
+  --color-sky-600: #2a653e;
+  --color-table-stripe-dark: #1f3142;
+
+  --chart-income: #3a7d4f;
+  --chart-expense: #a23b3b;
+  --chart-warning: #b08a3e;
+  --chart-1: #3a7d4f;
+  --chart-2: #2c4a6e;
+  --chart-3: #b08a3e;
+  --chart-4: #a23b3b;
+  --chart-5: #3f7d7d;
+  --chart-6: #6e4a7d;
+  --chart-7: #a85c32;
+  --chart-8: #7d7d3b;
+  --chart-9: #5a7d9e;
+  --chart-10: #5c7d4a;
+}
+
+/* ===== Nord -- arctic blue-grey (nordtheme.com), frost accent, aurora charts ===== */
+html[data-theme='nord'] {
+  --color-gray-50: #eceff4;
+  --color-gray-100: #e5e9f0;
+  --color-gray-200: #d8dee9;
+  --color-gray-300: #c2c9d6;
+  --color-gray-400: #9aa5b8;
+  --color-gray-500: #6f7d96;
+  --color-gray-600: #55637e;
+  --color-gray-700: #4c566a;
+  --color-gray-800: #3b4252;
+  --color-gray-900: #2e3440;
+  --color-gray-950: #242933;
+
+  --color-blue-50: #f0f7f9;
+  --color-blue-100: #ddeef3;
+  --color-blue-200: #bcdde7;
+  --color-blue-300: #a3cdd8;
+  --color-blue-400: #88c0d0;
+  --color-blue-500: #81a1c1;
+  --color-blue-600: #5e81ac;
+  --color-blue-700: #4d6b91;
+  --color-blue-800: #3f5878;
+  --color-blue-900: #344860;
+  --color-blue-950: #1f2c3d;
+
+  --color-sky-500: #81a1c1;
+  --color-sky-600: #5e81ac;
+  --color-table-stripe-dark: #333a48;
+
+  --chart-income: #a3be8c;
+  --chart-expense: #bf616a;
+  --chart-warning: #ebcb8b;
+  --chart-1: #5e81ac;
+  --chart-2: #a3be8c;
+  --chart-3: #ebcb8b;
+  --chart-4: #bf616a;
+  --chart-5: #b48ead;
+  --chart-6: #88c0d0;
+  --chart-7: #d08770;
+  --chart-8: #8fbcbb;
+  --chart-9: #81a1c1;
+  --chart-10: #4c566a;
+}
+
+/* ===== Forest -- warm stone neutrals, forest-green accent ===== */
+html[data-theme='forest'] {
+  --color-gray-50: #fafaf9;
+  --color-gray-100: #f5f5f4;
+  --color-gray-200: #e7e5e4;
+  --color-gray-300: #d6d3d1;
+  --color-gray-400: #a8a29e;
+  --color-gray-500: #78716c;
+  --color-gray-600: #57534e;
+  --color-gray-700: #44403c;
+  --color-gray-800: #292524;
+  --color-gray-900: #1c1917;
+  --color-gray-950: #0c0a09;
+
+  --color-blue-50: #f0f7f2;
+  --color-blue-100: #dcefe2;
+  --color-blue-200: #b9dfc6;
+  --color-blue-300: #8cc6a2;
+  --color-blue-400: #57a578;
+  --color-blue-500: #378758;
+  --color-blue-600: #286e46;
+  --color-blue-700: #21583a;
+  --color-blue-800: #1c4630;
+  --color-blue-900: #173a28;
+  --color-blue-950: #0b2016;
+
+  --color-sky-500: #378758;
+  --color-sky-600: #286e46;
+  --color-table-stripe-dark: #221e1c;
+
+  --chart-income: #378758;
+  --chart-expense: #b5543d;
+  --chart-warning: #c9892e;
+  --chart-1: #378758;
+  --chart-2: #4f7d8c;
+  --chart-3: #c9892e;
+  --chart-4: #b5543d;
+  --chart-5: #7a5c8f;
+  --chart-6: #8f9a3d;
+  --chart-7: #57a578;
+  --chart-8: #8c6d4f;
+  --chart-9: #356b5e;
+  --chart-10: #a08a4f;
+}
+
+/* ===== Solarized -- precision colours (ethanschoonover.com/solarized) ===== */
+html[data-theme='solarized'] {
+  --color-white: #fdf6e3; /* base3 */
+
+  --color-gray-50: #eee8d5; /* base2 */
+  --color-gray-100: #e4dcc4;
+  --color-gray-200: #d4cbb2;
+  --color-gray-300: #b5ad97;
+  --color-gray-400: #93a1a1; /* base1 */
+  --color-gray-500: #657b83; /* base00 */
+  --color-gray-600: #586e75; /* base01 */
+  --color-gray-700: #355661;
+  --color-gray-800: #073642; /* base02 */
+  --color-gray-900: #002b36; /* base03 */
+  --color-gray-950: #00212b;
+
+  --color-blue-50: #eaf4fb;
+  --color-blue-100: #d2e7f6;
+  --color-blue-200: #a6cfed;
+  --color-blue-300: #74b4e2;
+  --color-blue-400: #449bd9;
+  --color-blue-500: #268bd2; /* blue */
+  --color-blue-600: #1f74b0;
+  --color-blue-700: #1b5e8e;
+  --color-blue-800: #174b71;
+  --color-blue-900: #143c5a;
+  --color-blue-950: #0b2335;
+
+  --color-sky-500: #268bd2;
+  --color-sky-600: #1f74b0;
+  --color-table-stripe-dark: #06313c;
+
+  --chart-income: #859900; /* green */
+  --chart-expense: #dc322f; /* red */
+  --chart-warning: #b58900; /* yellow */
+  --chart-1: #268bd2;
+  --chart-2: #859900;
+  --chart-3: #b58900;
+  --chart-4: #dc322f;
+  --chart-5: #6c71c4;
+  --chart-6: #2aa198;
+  --chart-7: #cb4b16;
+  --chart-8: #d33682;
+  --chart-9: #93a1a1;
+  --chart-10: #586e75;
+}
+
+/* ===== High contrast -- maximum legibility, saturated accents ===== */
+html[data-theme='highcontrast'] {
+  --color-gray-50: #ffffff;
+  --color-gray-100: #f0f0f0;
+  --color-gray-200: #c8c8c8;
+  --color-gray-300: #8f8f8f;
+  --color-gray-400: #595959;
+  --color-gray-500: #404040;
+  --color-gray-600: #2e2e2e;
+  --color-gray-700: #1a1a1a;
+  --color-gray-800: #111111;
+  --color-gray-900: #050505;
+  --color-gray-950: #000000;
+
+  --color-blue-50: #eff6ff;
+  --color-blue-100: #dbeafe;
+  --color-blue-200: #bfdbfe;
+  --color-blue-300: #93c5fd;
+  --color-blue-400: #3b82f6;
+  --color-blue-500: #1d4ed8;
+  --color-blue-600: #1a3faf;
+  --color-blue-700: #172f86;
+  --color-blue-800: #13266b;
+  --color-blue-900: #101e52;
+  --color-blue-950: #0a1233;
+
+  --color-sky-500: #1d4ed8;
+  --color-sky-600: #1a3faf;
+  --color-table-stripe-dark: #101010;
+
+  --chart-income: #15803d;
+  --chart-expense: #b91c1c;
+  --chart-warning: #b45309;
+  --chart-1: #1d4ed8;
+  --chart-2: #15803d;
+  --chart-3: #b45309;
+  --chart-4: #b91c1c;
+  --chart-5: #6d28d9;
+  --chart-6: #be185d;
+  --chart-7: #0e7490;
+  --chart-8: #4d7c0f;
+  --chart-9: #c2410c;
+  --chart-10: #4338ca;
+}
+
+/* High contrast dark: the shared-ramp trick fails here because dark borders
+   (gray-600/700) and secondary text (gray-300/400) must brighten, not darken,
+   relative to the light ramp above. Invert the middle of the ramp and lift
+   the accents so everything stays >= 4.5:1 on black. */
+html.dark[data-theme='highcontrast'] {
+  --color-gray-100: #ffffff;
+  --color-gray-200: #f2f2f2;
+  --color-gray-300: #e8e8e8;
+  --color-gray-400: #d0d0d0;
+  --color-gray-500: #b5b5b5;
+  --color-gray-600: #9e9e9e;
+  --color-gray-700: #6e6e6e;
+  --color-gray-800: #0a0a0a;
+  --color-gray-900: #000000;
+
+  --color-blue-400: #93c5fd;
+  --color-blue-500: #2563eb;
+
+  --chart-income: #4ade80;
+  --chart-expense: #f87171;
+  --chart-warning: #fbbf24;
+  --chart-1: #60a5fa;
+  --chart-2: #4ade80;
+  --chart-3: #fbbf24;
+  --chart-4: #f87171;
+  --chart-5: #a78bfa;
+  --chart-6: #f472b6;
+  --chart-7: #22d3ee;
+  --chart-8: #a3e635;
+  --chart-9: #fb923c;
+  --chart-10: #818cf8;
+}

--- a/frontend/src/app/themes.css
+++ b/frontend/src/app/themes.css
@@ -67,7 +67,7 @@ html[data-theme='latte'] {
   --chart-10: #7d6b9e;
 }
 
-/* ===== Classic Money -- parchment paper, deep Money green, navy text ===== */
+/* ===== MS Money -- parchment paper, deep Money green, navy text ===== */
 html[data-theme='msmoney'] {
   --color-white: #fdfaf1;
 

--- a/frontend/src/app/themes.css
+++ b/frontend/src/app/themes.css
@@ -328,3 +328,333 @@ html.dark[data-theme='highcontrast'] {
   --chart-9: #fb923c;
   --chart-10: #818cf8;
 }
+
+/* ===== Newspaper -- salmon paper (FT-style), claret accent, navy-slate text ===== */
+html[data-theme='newspaper'] {
+  --color-white: #fff8f0;
+
+  --color-gray-50: #fff1e5;
+  --color-gray-100: #f7e7d7;
+  --color-gray-200: #ecd9c4;
+  --color-gray-300: #d9c2a9;
+  --color-gray-400: #b3a48f;
+  --color-gray-500: #8f8270;
+  --color-gray-600: #6f6557;
+  --color-gray-700: #4d4a45;
+  --color-gray-800: #33363f;
+  --color-gray-900: #262a33;
+  --color-gray-950: #181b21;
+
+  --color-blue-50: #fcedf2;
+  --color-blue-100: #f8d8e2;
+  --color-blue-200: #f0adc3;
+  --color-blue-300: #e57d9f;
+  --color-blue-400: #d44d7a;
+  --color-blue-500: #b82a5c;
+  --color-blue-600: #990f3d;
+  --color-blue-700: #7d0c32;
+  --color-blue-800: #630a28;
+  --color-blue-900: #4d081f;
+  --color-blue-950: #2d0512;
+
+  --color-sky-500: #b82a5c;
+  --color-sky-600: #990f3d;
+  --color-table-stripe-dark: #2b2f3a;
+
+  --chart-income: #00824c;
+  --chart-expense: #cc0000;
+  --chart-warning: #cf8a00;
+  --chart-1: #0f5499;
+  --chart-2: #00824c;
+  --chart-3: #cf8a00;
+  --chart-4: #990f3d;
+  --chart-5: #593380;
+  --chart-6: #0d7680;
+  --chart-7: #cc5a2a;
+  --chart-8: #96cc28;
+  --chart-9: #c4577e;
+  --chart-10: #66605c;
+}
+
+/* ===== Burgundy -- warm gray neutrals, deep wine accent ===== */
+html[data-theme='burgundy'] {
+  --color-gray-50: #faf9f8;
+  --color-gray-100: #f4f2f0;
+  --color-gray-200: #e6e2df;
+  --color-gray-300: #d3cdc9;
+  --color-gray-400: #a39c97;
+  --color-gray-500: #7a736e;
+  --color-gray-600: #5c5651;
+  --color-gray-700: #46413d;
+  --color-gray-800: #2e2a28;
+  --color-gray-900: #201d1b;
+  --color-gray-950: #141211;
+
+  --color-blue-50: #fbeef0;
+  --color-blue-100: #f6d9de;
+  --color-blue-200: #edb3bd;
+  --color-blue-300: #e08795;
+  --color-blue-400: #cd5a6e;
+  --color-blue-500: #b03a52;
+  --color-blue-600: #93203c;
+  --color-blue-700: #771a33;
+  --color-blue-800: #5e152a;
+  --color-blue-900: #4a1122;
+  --color-blue-950: #2b0a14;
+
+  --color-sky-500: #b03a52;
+  --color-sky-600: #93203c;
+  --color-table-stripe-dark: #282422;
+
+  --chart-income: #2e7d4f;
+  --chart-expense: #c44528;
+  --chart-warning: #c9882e;
+  --chart-1: #b03a52;
+  --chart-2: #2e7d4f;
+  --chart-3: #c9882e;
+  --chart-4: #cd5a3e;
+  --chart-5: #5b6e9e;
+  --chart-6: #3f7d80;
+  --chart-7: #8a6d3b;
+  --chart-8: #7d5a8c;
+  --chart-9: #2f5d8a;
+  --chart-10: #6e6259;
+}
+
+/* ===== Gruvbox -- retro warm (github.com/morhetz/gruvbox), orange accent ===== */
+html[data-theme='gruvbox'] {
+  --color-white: #fbf1c7;
+
+  --color-gray-50: #f4e8be;
+  --color-gray-100: #ebdbb2;
+  --color-gray-200: #d5c4a1;
+  --color-gray-300: #bdae93;
+  --color-gray-400: #a89984;
+  --color-gray-500: #7c6f64;
+  --color-gray-600: #665c54;
+  --color-gray-700: #504945;
+  --color-gray-800: #3c3836;
+  --color-gray-900: #282828;
+  --color-gray-950: #1d2021;
+
+  --color-blue-50: #fdf0e3;
+  --color-blue-100: #fadfc4;
+  --color-blue-200: #f5c08c;
+  --color-blue-300: #ee9d55;
+  --color-blue-400: #e57d2a;
+  --color-blue-500: #d65d0e;
+  --color-blue-600: #af3a03;
+  --color-blue-700: #8e3000;
+  --color-blue-800: #6f2710;
+  --color-blue-900: #571f0d;
+  --color-blue-950: #331106;
+
+  --color-sky-500: #d65d0e;
+  --color-sky-600: #af3a03;
+  --color-table-stripe-dark: #32302f;
+
+  --chart-income: #98971a;
+  --chart-expense: #cc241d;
+  --chart-warning: #d79921;
+  --chart-1: #d65d0e;
+  --chart-2: #98971a;
+  --chart-3: #d79921;
+  --chart-4: #cc241d;
+  --chart-5: #b16286;
+  --chart-6: #458588;
+  --chart-7: #689d6a;
+  --chart-8: #83a598;
+  --chart-9: #d3869b;
+  --chart-10: #665c54;
+}
+
+/* ===== Dracula -- (draculatheme.com) purple accent, neon chart accents ===== */
+html[data-theme='dracula'] {
+  --color-gray-50: #f7f7fb;
+  --color-gray-100: #ededf5;
+  --color-gray-200: #dcdcea;
+  --color-gray-300: #c0c2d8;
+  --color-gray-400: #9a9cb8;
+  --color-gray-500: #6f7396;
+  --color-gray-600: #565a7c;
+  --color-gray-700: #44475a;
+  --color-gray-800: #343746;
+  --color-gray-900: #282a36;
+  --color-gray-950: #1e2029;
+
+  --color-blue-50: #f6f1fe;
+  --color-blue-100: #ece2fd;
+  --color-blue-200: #d9c5fb;
+  --color-blue-300: #c5a8fa;
+  --color-blue-400: #bd93f9;
+  --color-blue-500: #9d6ef0;
+  --color-blue-600: #8454d8;
+  --color-blue-700: #6c41b4;
+  --color-blue-800: #573490;
+  --color-blue-900: #452a72;
+  --color-blue-950: #2a1947;
+
+  --color-sky-500: #9d6ef0;
+  --color-sky-600: #8454d8;
+  --color-table-stripe-dark: #2d303e;
+
+  --chart-income: #3ac463;
+  --chart-expense: #ff5555;
+  --chart-warning: #e8a843;
+  --chart-1: #9d6ef0;
+  --chart-2: #3ac463;
+  --chart-3: #e8a843;
+  --chart-4: #ff5555;
+  --chart-5: #ff79c6;
+  --chart-6: #38b6d8;
+  --chart-7: #ffb86c;
+  --chart-8: #50fa7b;
+  --chart-9: #bd93f9;
+  --chart-10: #6272a4;
+}
+
+/* ===== Tokyo Night -- indigo darks (github.com/tokyo-night), blue accent ===== */
+html[data-theme='tokyonight'] {
+  --color-gray-50: #eceef4;
+  --color-gray-100: #e1e2e7;
+  --color-gray-200: #d0d2de;
+  --color-gray-300: #b4b8ca;
+  --color-gray-400: #8a91ad;
+  --color-gray-500: #686e8c;
+  --color-gray-600: #515872;
+  --color-gray-700: #414868;
+  --color-gray-800: #24283b;
+  --color-gray-900: #1a1b26;
+  --color-gray-950: #16161e;
+
+  --color-blue-50: #eef3fe;
+  --color-blue-100: #dde7fd;
+  --color-blue-200: #bccffb;
+  --color-blue-300: #9bb8f9;
+  --color-blue-400: #7aa2f7;
+  --color-blue-500: #3d6ae0;
+  --color-blue-600: #2f55c4;
+  --color-blue-700: #2845a3;
+  --color-blue-800: #233a82;
+  --color-blue-900: #1f3168;
+  --color-blue-950: #131c3d;
+
+  --color-sky-500: #3d6ae0;
+  --color-sky-600: #2f55c4;
+  --color-table-stripe-dark: #20243a;
+
+  --chart-income: #74a857;
+  --chart-expense: #f7768e;
+  --chart-warning: #e0af68;
+  --chart-1: #5d82ec;
+  --chart-2: #74a857;
+  --chart-3: #e0af68;
+  --chart-4: #f7768e;
+  --chart-5: #bb9af7;
+  --chart-6: #2ac3de;
+  --chart-7: #ff9e64;
+  --chart-8: #73daca;
+  --chart-9: #9d7cd8;
+  --chart-10: #565f89;
+}
+
+/* ===== Rose Pine -- muted rose/pine/gold (rosepinetheme.com); light = Dawn ===== */
+html[data-theme='rosepine'] {
+  --color-white: #fffaf3;
+
+  --color-gray-50: #faf4ed;
+  --color-gray-100: #f2e9e1;
+  --color-gray-200: #e2d9d3;
+  --color-gray-300: #c5c0ce;
+  --color-gray-400: #9893a5;
+  --color-gray-500: #797593;
+  --color-gray-600: #615d7a;
+  --color-gray-700: #524f67;
+  --color-gray-800: #1f1d2e;
+  --color-gray-900: #191724;
+  --color-gray-950: #131020;
+
+  --color-blue-50: #eef6f8;
+  --color-blue-100: #d9ecf1;
+  --color-blue-200: #b5d9e3;
+  --color-blue-300: #8ec3d3;
+  --color-blue-400: #56949f;
+  --color-blue-500: #31748f;
+  --color-blue-600: #286983;
+  --color-blue-700: #225770;
+  --color-blue-800: #1e4759;
+  --color-blue-900: #1a3a48;
+  --color-blue-950: #0f222b;
+
+  --color-sky-500: #31748f;
+  --color-sky-600: #286983;
+  --color-table-stripe-dark: #232136;
+
+  --chart-income: #56949f;
+  --chart-expense: #b4637a;
+  --chart-warning: #ea9d34;
+  --chart-1: #31748f;
+  --chart-2: #d7827e;
+  --chart-3: #ea9d34;
+  --chart-4: #b4637a;
+  --chart-5: #907aa9;
+  --chart-6: #56949f;
+  --chart-7: #eb6f92;
+  --chart-8: #f6c177;
+  --chart-9: #c4a7e7;
+  --chart-10: #797593;
+}
+
+/* ===== Midnight -- pure-black AMOLED dark mode; light mode stays neutral.
+   Only the dark end of the gray ramp changes: black page, near-black cards,
+   and a border gray that stays visible on black. Accent and charts keep the
+   stock palette, which has plenty of contrast on true black. ===== */
+html[data-theme='midnight'] {
+  --color-gray-50: #fafafa;
+  --color-gray-100: #f5f5f5;
+  --color-gray-200: #e5e5e5;
+  --color-gray-300: #d4d4d4;
+  --color-gray-400: #a3a3a3;
+  --color-gray-500: #737373;
+  --color-gray-600: #525252;
+  --color-gray-700: #262626;
+  --color-gray-800: #0c0c0c;
+  --color-gray-900: #000000;
+  --color-gray-950: #000000;
+
+  --color-table-stripe-dark: #101010;
+}
+
+/* ===== Colour-blind safe -- Okabe-Ito palette: blue/vermillion semantics
+   instead of green/red, chart series distinguishable under deuteranopia,
+   protanopia, and tritanopia. Grays stay stock. ===== */
+html[data-theme='colorblind'] {
+  --color-blue-50: #eaf3fa;
+  --color-blue-100: #d2e7f5;
+  --color-blue-200: #a5cfeb;
+  --color-blue-300: #6fb1dd;
+  --color-blue-400: #3a92cc;
+  --color-blue-500: #0072b2;
+  --color-blue-600: #005e94;
+  --color-blue-700: #004c78;
+  --color-blue-800: #003c5f;
+  --color-blue-900: #002f4b;
+  --color-blue-950: #001b2c;
+
+  --color-sky-500: #0072b2;
+  --color-sky-600: #005e94;
+
+  --chart-income: #0072b2;
+  --chart-expense: #d55e00;
+  --chart-warning: #e69f00;
+  --chart-1: #0072b2;
+  --chart-2: #009e73;
+  --chart-3: #e69f00;
+  --chart-4: #d55e00;
+  --chart-5: #cc79a7;
+  --chart-6: #56b4e9;
+  --chart-7: #f0e442;
+  --chart-8: #785ef0;
+  --chart-9: #919191;
+  --chart-10: #117733;
+}

--- a/frontend/src/components/ai/ResultChart.tsx
+++ b/frontend/src/components/ai/ResultChart.tsx
@@ -18,12 +18,8 @@ import {
   Area,
 } from 'recharts';
 import { captureSvgAsImage } from '@/lib/pdf-export-charts';
+import { chartColors, chartSeriesColor } from '@/lib/chart-colors';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
-
-const COLORS = [
-  '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6',
-  '#ec4899', '#06b6d4', '#84cc16', '#f97316', '#6366f1',
-];
 
 interface ChartData {
   label: string;
@@ -146,7 +142,7 @@ export function ResultChart({ type, title, data }: ResultChartProps) {
                 {data.map((_, index) => (
                   <Cell
                     key={`cell-${index}`}
-                    fill={COLORS[index % COLORS.length]}
+                    fill={chartSeriesColor(index)}
                   />
                 ))}
               </Pie>
@@ -161,8 +157,9 @@ export function ResultChart({ type, title, data }: ResultChartProps) {
               <Area
                 type="monotone"
                 dataKey="value"
-                stroke="#3b82f6"
-                fill="#bfdbfe"
+                stroke={chartColors.primary}
+                fill={chartColors.primary}
+                fillOpacity={0.25}
               />
             </AreaChart>
           ) : (
@@ -175,7 +172,7 @@ export function ResultChart({ type, title, data }: ResultChartProps) {
                 {data.map((_, index) => (
                   <Cell
                     key={`cell-${index}`}
-                    fill={COLORS[index % COLORS.length]}
+                    fill={chartSeriesColor(index)}
                   />
                 ))}
               </Bar>

--- a/frontend/src/components/auth/ProtectedRoute.test.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.test.tsx
@@ -145,6 +145,7 @@ describe('ProtectedRoute', () => {
         dateFormat: 'browser',
         numberFormat: 'browser',
         theme: 'system',
+        colorTheme: 'default',
         timezone: 'browser',
         notificationEmail: false,
         notificationBrowser: false,

--- a/frontend/src/components/bills/CashFlowForecastChart.test.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.test.tsx
@@ -2,17 +2,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@/test/render';
 import { CashFlowForecastChart } from './CashFlowForecastChart';
 
-// The recharts mock invokes the Line `dot` render-prop and the Tooltip
-// `content` render-prop so the SVG min-balance callout (component lines
-// ~320-368) and the tooltip transaction-overflow branch (~38-89) are
-// exercised by the data-driven tests below. The render-prop output is exposed
-// via test ids those tests opt into; existing assertions are unaffected since
-// the chart only renders when forecast data is present.
+// The recharts mock invokes the Area `dot` render-prop and the Tooltip
+// `content` render-prop so the SVG min-balance callout and the tooltip
+// transaction-overflow branch are exercised by the data-driven tests below.
+// The render-prop output is exposed via test ids those tests opt into;
+// existing assertions are unaffected since the chart only renders when
+// forecast data is present.
 vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
-  LineChart: ({ children }: any) => <div data-testid="line-chart">{children}</div>,
-  Line: ({ dot }: any) => (
-    <div data-testid="line">
+  AreaChart: ({ children }: any) => <div data-testid="area-chart">{children}</div>,
+  Area: ({ dot, fill, stroke }: any) => (
+    <div data-testid="area" data-fill={fill} data-stroke={stroke}>
       {typeof dot === 'function' && (
         <svg data-testid="line-dots">
           {dot({ cx: 50, cy: 60, index: 0 })}
@@ -21,6 +21,8 @@ vi.mock('recharts', () => ({
       )}
     </div>
   ),
+  LineChart: ({ children }: any) => <div data-testid="line-chart">{children}</div>,
+  Line: () => <div data-testid="line" />,
   XAxis: () => <div data-testid="x-axis" />,
   YAxis: ({ tickFormatter }: any) => (
     <div data-testid="y-axis">{tickFormatter ? tickFormatter(2000) : null}</div>
@@ -487,6 +489,30 @@ describe('CashFlowForecastChart', () => {
       expect(screen.getByTestId('line-dots')).toBeInTheDocument();
       // A min balance >= 1000 uses formatCurrencyAxis for the bubble label.
       expect(mockFormatCurrencyAxis).toHaveBeenCalled();
+    });
+
+    it('shades the area under the line with the zero-anchored balance gradient', () => {
+      const forecastData = [
+        { label: 'Day 1', balance: 1000, transactions: [{ amount: 0, name: 'Open' }] },
+        { label: 'Day 2', balance: -150, transactions: [{ amount: -1150, name: 'Rent' }] },
+      ];
+      mockBuildForecast.mockReturnValue(forecastData);
+      mockGetForecastSummary.mockReturnValue({
+        startingBalance: 1000,
+        endingBalance: -150,
+        minBalance: -150,
+        goesNegative: true,
+      });
+      render(
+        <CashFlowForecastChart
+          scheduledTransactions={[{} as any]}
+          accounts={[makeAccount()]}
+          isLoading={false}
+        />,
+      );
+      const area = screen.getByTestId('area');
+      expect(area.getAttribute('data-fill')).toBe('url(#forecastBalance)');
+      expect(area.getAttribute('data-stroke')).toBe('var(--chart-primary)');
     });
 
     it('renders the tooltip content with a transaction overflow indicator', () => {

--- a/frontend/src/components/bills/CashFlowForecastChart.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.tsx
@@ -5,6 +5,8 @@ import { useTranslations } from 'next-intl';
 import { gainLossColor } from '@/lib/format';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
+  AreaChart,
+  Area,
   LineChart,
   Line,
   XAxis,
@@ -14,6 +16,8 @@ import {
   ResponsiveContainer,
   ReferenceLine,
 } from 'recharts';
+import { chartColors } from '@/lib/chart-colors';
+import { computeBalanceGradient } from '@/lib/balance-history';
 import { ScheduledTransaction } from '@/types/scheduled-transaction';
 import { Account } from '@/types/account';
 import { Select } from '@/components/ui/Select';
@@ -185,6 +189,11 @@ export function CashFlowForecastChart({
     return forecastData.findIndex((dp) => dp.balance === summary.minBalance);
   }, [forecastData, summary.minBalance]);
 
+  const areaGradient = useMemo(
+    () => computeBalanceGradient(forecastData.map((point) => point.balance)),
+    [forecastData],
+  );
+
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6">
@@ -260,38 +269,42 @@ export function CashFlowForecastChart({
           </div>
           <ResponsiveContainer width="100%" height="90%" minWidth={0}>
             <LineChart data={forecastData} margin={{ left: 0, right: 8, top: 5, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" className="dark:stroke-gray-700" />
-              <XAxis dataKey="label" tick={{ fill: '#6b7280', fontSize: 12 }} tickLine={false} axisLine={{ stroke: '#e5e7eb' }} interval="preserveStartEnd" />
-              <YAxis tick={{ fill: '#6b7280', fontSize: 11 }} tickLine={false} axisLine={false} tickFormatter={formatAxis} width={45} domain={['auto', 'auto']} />
+              <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
+              <XAxis dataKey="label" tick={{ fill: chartColors.axis, fontSize: 12 }} tickLine={false} axisLine={{ stroke: chartColors.grid }} interval="preserveStartEnd" />
+              <YAxis tick={{ fill: chartColors.axis, fontSize: 11 }} tickLine={false} axisLine={false} tickFormatter={formatAxis} width={45} domain={['auto', 'auto']} />
               <Tooltip content={<CashFlowTooltip formatCurrency={formatCurrency} />} />
-              <ReferenceLine y={0} stroke="#ef4444" strokeDasharray="5 5" strokeOpacity={0.5} />
-              <Line type="monotone" dataKey="balance" stroke="#9ca3af" strokeWidth={2} dot={false} strokeDasharray="5 5" />
+              <ReferenceLine y={0} stroke={chartColors.expense} strokeDasharray="5 5" strokeOpacity={0.5} />
+              <Line type="monotone" dataKey="balance" stroke={chartColors.axis} strokeWidth={2} dot={false} strokeDasharray="5 5" />
             </LineChart>
           </ResponsiveContainer>
         </div>
       ) : (
         <div className="h-72" style={{ minHeight: 288 }}>
           <ResponsiveContainer width="100%" height="100%" minWidth={0}>
-            <LineChart data={forecastData} margin={{ left: 0, right: 8, top: 5, bottom: 0 }}>
+            <AreaChart data={forecastData} margin={{ left: 0, right: 8, top: 5, bottom: 0 }}>
               <defs>
                 <filter id="minShadow" x="-20%" y="-20%" width="140%" height="140%">
                   <feDropShadow dx="0" dy="1" stdDeviation="2" floodOpacity="0.3" />
                 </filter>
+                <linearGradient id="forecastBalance" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset={0} stopColor={chartColors.primary} stopOpacity={areaGradient.topOpacity} />
+                  <stop offset={areaGradient.zeroOffset} stopColor={chartColors.primary} stopOpacity={0} />
+                  <stop offset={1} stopColor={chartColors.primary} stopOpacity={areaGradient.bottomOpacity} />
+                </linearGradient>
               </defs>
               <CartesianGrid
                 strokeDasharray="3 3"
-                stroke="#e5e7eb"
-                className="dark:stroke-gray-700"
+                stroke={chartColors.grid}
               />
               <XAxis
                 dataKey="label"
-                tick={{ fill: '#6b7280', fontSize: 12 }}
+                tick={{ fill: chartColors.axis, fontSize: 12 }}
                 tickLine={false}
-                axisLine={{ stroke: '#e5e7eb' }}
+                axisLine={{ stroke: chartColors.grid }}
                 interval="preserveStartEnd"
               />
               <YAxis
-                tick={{ fill: '#6b7280', fontSize: 11 }}
+                tick={{ fill: chartColors.axis, fontSize: 11 }}
                 tickLine={false}
                 axisLine={false}
                 tickFormatter={formatAxis}
@@ -302,7 +315,7 @@ export function CashFlowForecastChart({
               {/* Reference line at $0 */}
               <ReferenceLine
                 y={0}
-                stroke="#ef4444"
+                stroke={chartColors.expense}
                 strokeDasharray="5 5"
                 strokeOpacity={0.5}
               />
@@ -310,20 +323,22 @@ export function CashFlowForecastChart({
               {summary.minBalance !== summary.startingBalance && (
                 <ReferenceLine
                   y={summary.minBalance}
-                  stroke={summary.minBalance < 0 ? '#ef4444' : '#f59e0b'}
+                  stroke={summary.minBalance < 0 ? chartColors.expense : chartColors.warning}
                   strokeDasharray="3 3"
                   strokeOpacity={0.4}
                 />
               )}
-              <Line
+              <Area
                 type="monotone"
                 dataKey="balance"
-                stroke="#3b82f6"
+                stroke={chartColors.primary}
                 strokeWidth={2}
+                fillOpacity={1}
+                fill="url(#forecastBalance)"
                 dot={(props: any) => {
                   const { cx, cy } = props;
                   if (props.index === minBalanceIndex) {
-                    const color = summary.minBalance < 0 ? '#ef4444' : '#f59e0b';
+                    const color = summary.minBalance < 0 ? chartColors.expense : chartColors.warning;
                     const label = Math.abs(summary.minBalance) >= 1000
                       ? formatAxis(summary.minBalance)
                       : formatCurrency(summary.minBalance);
@@ -335,7 +350,7 @@ export function CashFlowForecastChart({
                     const bubbleTop = bubbleBottom - arrowSize - labelHeight;
                     return (
                       <g key={`min-${props.index}`}>
-                        <circle cx={cx} cy={cy} r={5} fill={color} stroke="#fff" strokeWidth={2} />
+                        <circle cx={cx} cy={cy} r={5} fill={color} stroke="var(--color-white)" strokeWidth={2} />
                         {/* Connector line from dot to arrow */}
                         <line x1={cx} y1={cy - 5} x2={cx} y2={bubbleBottom} stroke={color} strokeWidth={1.5} strokeDasharray="3 2" />
                         {/* Bubble */}
@@ -358,7 +373,7 @@ export function CashFlowForecastChart({
                           y={bubbleTop + labelHeight / 2}
                           textAnchor="middle"
                           dominantBaseline="central"
-                          fill="#fff"
+                          fill="var(--color-white)"
                           fontSize={11}
                           fontWeight={600}
                         >
@@ -369,9 +384,9 @@ export function CashFlowForecastChart({
                   }
                   return <circle key={`dot-${props.index}`} cx={cx} cy={cy} r={0} fill="none" />;
                 }}
-                activeDot={{ r: 6, fill: '#3b82f6' }}
+                activeDot={{ r: 6, fill: chartColors.primary }}
               />
-            </LineChart>
+            </AreaChart>
           </ResponsiveContainer>
         </div>
       )}

--- a/frontend/src/components/budgets/BudgetCategoryTrend.test.tsx
+++ b/frontend/src/components/budgets/BudgetCategoryTrend.test.tsx
@@ -136,7 +136,7 @@ describe('BudgetCategoryTrend', () => {
     expect(toggleBtn).toHaveStyle({ backgroundColor: expect.any(String) });
     fireEvent.click(toggleBtn);
     // After deselecting, backgroundColor should be unset
-    expect(toggleBtn).not.toHaveStyle({ backgroundColor: '#3b82f6' });
+    expect(toggleBtn).not.toHaveStyle({ backgroundColor: 'var(--chart-1)' });
   });
 
   it('re-selects category when toggle clicked again', () => {

--- a/frontend/src/components/budgets/BudgetCategoryTrend.tsx
+++ b/frontend/src/components/budgets/BudgetCategoryTrend.tsx
@@ -12,25 +12,13 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
+import { chartSeriesColor } from '@/lib/chart-colors';
 import type { CategoryTrendSeries } from '@/types/budget';
 
 interface BudgetCategoryTrendProps {
   data: CategoryTrendSeries[];
   formatCurrency: (amount: number) => string;
 }
-
-const CHART_COLORS = [
-  '#3b82f6',
-  '#10b981',
-  '#f59e0b',
-  '#ef4444',
-  '#8b5cf6',
-  '#06b6d4',
-  '#f97316',
-  '#ec4899',
-  '#14b8a6',
-  '#6366f1',
-];
 
 function CategoryTrendTooltip({
   active,
@@ -138,7 +126,7 @@ export function BudgetCategoryTrend({
       {/* Category toggles */}
       <div className="flex flex-wrap gap-2 mb-4">
         {data.map((series, idx) => {
-          const color = CHART_COLORS[idx % CHART_COLORS.length];
+          const color = chartSeriesColor(idx);
           const isSelected = selectedCategories.has(series.categoryId);
           return (
             <button
@@ -181,7 +169,7 @@ export function BudgetCategoryTrend({
             <Legend />
             {data.map((series, idx) => {
               if (!selectedCategories.has(series.categoryId)) return null;
-              const color = CHART_COLORS[idx % CHART_COLORS.length];
+              const color = chartSeriesColor(idx);
               return (
                 <Line
                   key={series.categoryId}

--- a/frontend/src/components/budgets/BudgetTrendChart.test.tsx
+++ b/frontend/src/components/budgets/BudgetTrendChart.test.tsx
@@ -14,8 +14,8 @@ vi.mock('recharts', () => ({
   Tooltip: ({ content }: any) => {
     // Render the tooltip content with active payload to cover CustomTooltip branches
     const payload = [
-      { value: 5000, dataKey: 'budgeted', color: '#3b82f6' },
-      { value: 4800, dataKey: 'actual', color: '#10b981' },
+      { value: 5000, dataKey: 'budgeted', color: 'var(--chart-primary)' },
+      { value: 4800, dataKey: 'actual', color: 'var(--chart-income)' },
     ];
     if (content) {
       const ContentComponent = content.type;

--- a/frontend/src/components/budgets/BudgetTrendChart.tsx
+++ b/frontend/src/components/budgets/BudgetTrendChart.tsx
@@ -11,6 +11,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
+import { chartColors } from '@/lib/chart-colors';
 
 interface TrendDataPoint {
   month: string;
@@ -108,7 +109,7 @@ export function BudgetTrendChart({
             <Line
               type="monotone"
               dataKey="budgeted"
-              stroke="#3b82f6"
+              stroke={chartColors.primary}
               strokeWidth={2}
               strokeDasharray="5 5"
               dot={{ r: 4 }}
@@ -117,7 +118,7 @@ export function BudgetTrendChart({
             <Line
               type="monotone"
               dataKey="actual"
-              stroke="#10b981"
+              stroke={chartColors.income}
               strokeWidth={2}
               dot={{ r: 4 }}
               name={actualLabel}

--- a/frontend/src/components/dashboard/AssetsVsLiabilities.tsx
+++ b/frontend/src/components/dashboard/AssetsVsLiabilities.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
+import { chartColors } from '@/lib/chart-colors';
 import { MonthlyNetWorth } from '@/types/net-worth';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 
@@ -12,8 +13,8 @@ interface AssetsVsLiabilitiesProps {
   isLoading: boolean;
 }
 
-const ASSET_COLOUR = '#22c55e';
-const LIABILITY_COLOUR = '#ef4444';
+const ASSET_COLOUR = chartColors.income;
+const LIABILITY_COLOUR = chartColors.expense;
 
 function AssetsTooltip({
   active,

--- a/frontend/src/components/dashboard/IncomeExpensesBarChart.tsx
+++ b/frontend/src/components/dashboard/IncomeExpensesBarChart.tsx
@@ -16,6 +16,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { format, startOfWeek, endOfWeek, eachWeekOfInterval, subWeeks } from 'date-fns';
+import { chartColors } from '@/lib/chart-colors';
 import { Transaction } from '@/types/transaction';
 import { parseLocalDate } from '@/lib/utils';
 import { useDateFormat } from '@/hooks/useDateFormat';
@@ -210,21 +211,17 @@ export function IncomeExpensesBarChart({
             onClick={handleChartClick}
             style={{ cursor: 'pointer' }}
           >
-            <CartesianGrid
-              strokeDasharray="3 3"
-              stroke="#e5e7eb"
-              className="dark:stroke-gray-700"
-            />
+            <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
             <XAxis
               dataKey="name"
-              tick={{ fill: '#6b7280', fontSize: 12 }}
+              tick={{ fill: chartColors.axis, fontSize: 12 }}
               tickLine={false}
-              axisLine={{ stroke: '#e5e7eb' }}
+              axisLine={{ stroke: chartColors.grid }}
             />
             <YAxis
-              tick={{ fill: '#6b7280', fontSize: 12 }}
+              tick={{ fill: chartColors.axis, fontSize: 12 }}
               tickLine={false}
-              axisLine={{ stroke: '#e5e7eb' }}
+              axisLine={{ stroke: chartColors.grid }}
               tickFormatter={formatCurrencyAxis}
             />
             <Tooltip content={<IncomeExpensesTooltip formatCurrency={formatCurrency} weekOfLabel={(date) => t('incomeExpenses.weekOf', { date })} />} />
@@ -236,7 +233,7 @@ export function IncomeExpensesBarChart({
             />
             <Bar
               dataKey="Income"
-              fill="#22c55e"
+              fill={chartColors.income}
               radius={[4, 4, 0, 0]}
               maxBarSize={40}
               cursor="pointer"
@@ -244,7 +241,7 @@ export function IncomeExpensesBarChart({
             />
             <Bar
               dataKey="Expenses"
-              fill="#ef4444"
+              fill={chartColors.expense}
               radius={[4, 4, 0, 0]}
               maxBarSize={40}
               cursor="pointer"

--- a/frontend/src/components/dashboard/NetWorthChart.tsx
+++ b/frontend/src/components/dashboard/NetWorthChart.tsx
@@ -13,6 +13,7 @@ import {
   LabelList,
 } from 'recharts';
 import { format } from 'date-fns';
+import { chartColors } from '@/lib/chart-colors';
 import { MonthlyNetWorth } from '@/types/net-worth';
 import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
@@ -151,7 +152,7 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
             <YAxis hide domain={yAxisDomain} />
             <XAxis
               dataKey="name"
-              tick={{ fill: '#6b7280', fontSize: 11 }}
+              tick={{ fill: chartColors.axis, fontSize: 11 }}
               tickLine={false}
               axisLine={false}
               interval="preserveStartEnd"
@@ -159,9 +160,9 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
             />
             <Tooltip
               content={<NetWorthTooltip formatCurrency={formatCurrency} />}
-              cursor={{ fill: '#e5e7eb', fillOpacity: 0.35 }}
+              cursor={{ fill: chartColors.grid, fillOpacity: 0.35 }}
             />
-            <Bar dataKey="netWorth" fill="#3b82f6" radius={[4, 4, 0, 0]}>
+            <Bar dataKey="netWorth" fill={chartColors.primary} radius={[4, 4, 0, 0]}>
               <LabelList
                 dataKey="netWorth"
                 position="top"
@@ -169,7 +170,7 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
                 offset={6}
                 textAnchor="start"
                 formatter={(value: unknown) => formatCurrencyLabel(Number(value))}
-                style={{ fill: '#6b7280', fontSize: 11, fontWeight: 600, dominantBaseline: 'central' }}
+                style={{ fill: chartColors.axis, fontSize: 11, fontWeight: 600, dominantBaseline: 'central' }}
               />
             </Bar>
           </BarChart>

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -12,6 +12,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { format } from 'date-fns';
+import { chartColors } from '@/lib/chart-colors';
 import { netWorthApi } from '@/lib/net-worth';
 import { investmentsApi } from '@/lib/investments';
 import { parseLocalDate } from '@/lib/utils';
@@ -505,12 +506,12 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
             >
               <defs>
                 <linearGradient id="colorInvestments" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#10b981" stopOpacity={0.3} />
-                  <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
+                  <stop offset="5%" stopColor={chartColors.income} stopOpacity={0.3} />
+                  <stop offset="95%" stopColor={chartColors.income} stopOpacity={0} />
                 </linearGradient>
               </defs>
               <ChartFlagShadowFilter />
-              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+              <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
               <XAxis
                 dataKey="name"
                 tick={{ fontSize: 12 }}
@@ -542,13 +543,13 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
               <Area
                 type="monotone"
                 dataKey="Value"
-                stroke="#10b981"
+                stroke={chartColors.income}
                 strokeWidth={2}
                 fillOpacity={1}
                 fill="url(#colorInvestments)"
                 name="Portfolio Value"
                 isAnimationActive={false}
-                activeDot={{ r: 4, fill: '#10b981' }}
+                activeDot={{ r: 4, fill: chartColors.income }}
                 dot={(props: { cx?: number; cy?: number; index?: number }) => {
                   const { cx, cy, index } = props;
                   if (cx == null || cy == null || index == null) {
@@ -565,7 +566,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
                     cx,
                     cy,
                     index,
-                    color: isHighest ? '#10b981' : '#ef4444',
+                    color: isHighest ? chartColors.income : chartColors.expense,
                     label: fmtFlag(value),
                     side: isLeftHalf ? 'right' : 'left',
                   });

--- a/frontend/src/components/investments/portfolio-chart-utils.tsx
+++ b/frontend/src/components/investments/portfolio-chart-utils.tsx
@@ -154,7 +154,7 @@ export interface FlagDotOptions {
   cx: number;
   cy: number;
   index: number;
-  /** Color of dot/bubble (e.g. '#10b981' for highest, '#ef4444' for lowest). */
+  /** Color of dot/bubble (e.g. chartColors.income for highest, chartColors.expense for lowest). */
   color: string;
   /** Pre-formatted label text (caller chooses compact vs full). */
   label: string;

--- a/frontend/src/components/providers/PreferencesLoader.test.tsx
+++ b/frontend/src/components/providers/PreferencesLoader.test.tsx
@@ -34,7 +34,7 @@ vi.mock('@/store/authStore', () => ({
 vi.mock('@/store/preferencesStore', () => ({
   usePreferencesStore: (selector: any) => {
     const state = {
-      preferences: { theme: 'dark', colorTheme: 'beige' },
+      preferences: { theme: 'dark', colorTheme: 'latte' },
       isLoaded: false,
       _hasHydrated: true,
       loadPreferences: mockLoadPreferences,
@@ -82,6 +82,6 @@ describe('PreferencesLoader', () => {
         <div>Child</div>
       </PreferencesLoader>,
     );
-    expect(mockSetColorTheme).toHaveBeenCalledWith('beige');
+    expect(mockSetColorTheme).toHaveBeenCalledWith('latte');
   });
 });

--- a/frontend/src/components/providers/PreferencesLoader.test.tsx
+++ b/frontend/src/components/providers/PreferencesLoader.test.tsx
@@ -5,6 +5,7 @@ import { PreferencesLoader } from './PreferencesLoader';
 const mockLoadPreferences = vi.fn();
 const mockClearPreferences = vi.fn();
 const mockSetTheme = vi.fn();
+const mockSetColorTheme = vi.fn();
 
 // Mock useTheme
 vi.mock('@/contexts/ThemeContext', () => ({
@@ -13,6 +14,8 @@ vi.mock('@/contexts/ThemeContext', () => ({
     theme: 'system',
     resolvedTheme: 'light',
     setTheme: mockSetTheme,
+    colorTheme: 'default',
+    setColorTheme: mockSetColorTheme,
   }),
 }));
 
@@ -31,7 +34,7 @@ vi.mock('@/store/authStore', () => ({
 vi.mock('@/store/preferencesStore', () => ({
   usePreferencesStore: (selector: any) => {
     const state = {
-      preferences: { theme: 'dark' },
+      preferences: { theme: 'dark', colorTheme: 'beige' },
       isLoaded: false,
       _hasHydrated: true,
       loadPreferences: mockLoadPreferences,
@@ -71,5 +74,14 @@ describe('PreferencesLoader', () => {
       </PreferencesLoader>,
     );
     expect(mockSetTheme).toHaveBeenCalledWith('dark');
+  });
+
+  it('syncs colour theme when preferences have a valid colorTheme value', () => {
+    render(
+      <PreferencesLoader>
+        <div>Child</div>
+      </PreferencesLoader>,
+    );
+    expect(mockSetColorTheme).toHaveBeenCalledWith('beige');
   });
 });

--- a/frontend/src/components/providers/PreferencesLoader.tsx
+++ b/frontend/src/components/providers/PreferencesLoader.tsx
@@ -7,6 +7,7 @@ import { useAuthStore } from '@/store/authStore';
 import { usePreferencesStore } from '@/store/preferencesStore';
 import { useTheme } from '@/contexts/ThemeContext';
 import { LOCALE_COOKIE, isSupportedLocale } from '@/i18n/config';
+import { isColorTheme } from '@/lib/color-themes';
 
 /**
  * Component that loads user preferences when authenticated.
@@ -21,7 +22,7 @@ export function PreferencesLoader({ children }: { children: React.ReactNode }) {
   const preferences = usePreferencesStore((state) => state.preferences);
   const isLoaded = usePreferencesStore((state) => state.isLoaded);
   const prefsHydrated = usePreferencesStore((state) => state._hasHydrated);
-  const { setTheme } = useTheme();
+  const { setTheme, setColorTheme } = useTheme();
 
   useEffect(() => {
     // Wait for both stores to hydrate
@@ -40,6 +41,13 @@ export function PreferencesLoader({ children }: { children: React.ReactNode }) {
       setTheme(preferences.theme as 'light' | 'dark' | 'system');
     }
   }, [prefsHydrated, preferences?.theme, setTheme]);
+
+  // Sync colour theme when preferences change
+  useEffect(() => {
+    if (prefsHydrated && isColorTheme(preferences?.colorTheme)) {
+      setColorTheme(preferences.colorTheme);
+    }
+  }, [prefsHydrated, preferences?.colorTheme, setColorTheme]);
 
   // Sync language cookie from DB preference. The proxy reads NEXT_LOCALE and
   // sets the x-locale header on the next request; we refresh the router so

--- a/frontend/src/components/reports/BillPaymentHistoryReport.tsx
+++ b/frontend/src/components/reports/BillPaymentHistoryReport.tsx
@@ -26,6 +26,7 @@ import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { useTranslations } from 'next-intl';
 import { useReportData } from '@/hooks/useReportData';
 import { ReportError } from '@/components/reports/ReportError';
+import { chartColors } from '@/lib/chart-colors';
 
 type BillSortField = 'bill' | 'count' | 'average' | 'total' | 'lastPayment';
 
@@ -241,11 +242,11 @@ export function BillPaymentHistoryReport() {
           <div className="h-80">
             <ResponsiveContainer width="100%" height="100%" minWidth={0}>
               <BarChart data={billData.monthlyTotals}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                 <XAxis dataKey="label" tick={{ fontSize: 11 }} />
                 <YAxis tickFormatter={formatCurrencyAxis} />
                 <Tooltip content={<CustomTooltip />} />
-                <Bar dataKey="total" fill="#3b82f6" name={t('billPaymentHistory.totalPaid')} radius={[4, 4, 0, 0]} />
+                <Bar dataKey="total" fill={chartColors.primary} name={t('billPaymentHistory.totalPaid')} radius={[4, 4, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
           </div>

--- a/frontend/src/components/reports/BudgetSeasonalPatternsReport.tsx
+++ b/frontend/src/components/reports/BudgetSeasonalPatternsReport.tsx
@@ -20,6 +20,7 @@ import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { ReportError } from '@/components/reports/ReportError';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
+import { chartColors } from '@/lib/chart-colors';
 
 type SeasonalPatternsSortField = 'category' | 'typical' | 'highMonths';
 
@@ -238,7 +239,7 @@ export function BudgetSeasonalPatternsReport() {
                     {chartData.map((entry, index) => (
                       <Cell
                         key={index}
-                        fill={entry.isHigh ? '#ef4444' : '#3b82f6'}
+                        fill={entry.isHigh ? chartColors.expense : chartColors.primary}
                       />
                     ))}
                   </Bar>

--- a/frontend/src/components/reports/BudgetTrendReport.test.tsx
+++ b/frontend/src/components/reports/BudgetTrendReport.test.tsx
@@ -43,7 +43,7 @@ vi.mock('recharts', () => ({
     const C = content;
     if (!C) return null;
     const samples = [
-      { active: true, payload: [{ dataKey: 'budgeted', name: 'Budgeted', color: '#3b82f6', value: 1000 }, { dataKey: 'actual', name: 'Actual', color: '#10b981', value: 900 }], label: 'tip-x' },
+      { active: true, payload: [{ dataKey: 'budgeted', name: 'Budgeted', color: 'var(--chart-primary)', value: 1000 }, { dataKey: 'actual', name: 'Actual', color: 'var(--chart-income)', value: 900 }], label: 'tip-x' },
       { active: false, payload: [], label: '' },
       { active: true, payload: [], label: 'empty' },
     ];

--- a/frontend/src/components/reports/BudgetTrendReport.tsx
+++ b/frontend/src/components/reports/BudgetTrendReport.tsx
@@ -18,6 +18,9 @@ import { useTranslations } from 'next-intl';
 import { useReportData } from '@/hooks/useReportData';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { ReportError } from '@/components/reports/ReportError';
+import { chartColors } from '@/lib/chart-colors';
+import { resolvePdfColor } from '@/components/reports/resolve-pdf-color';
+
 
 export function BudgetTrendReport() {
   const t = useTranslations('reports');
@@ -77,8 +80,8 @@ export function BudgetTrendReport() {
       title: t('budgetTrend.pdfTitle'),
       chartContainer: chartRef.current,
       chartLegend: [
-        { color: '#3b82f6', label: t('budgetTrend.seriesBudgeted') },
-        { color: '#10b981', label: t('budgetTrend.seriesActual') },
+        { color: resolvePdfColor(chartColors.primary), label: t('budgetTrend.seriesBudgeted') },
+        { color: resolvePdfColor(chartColors.income), label: t('budgetTrend.seriesActual') },
       ],
       tableData: { headers, rows },
       filename: 'budget-trend',
@@ -172,7 +175,7 @@ export function BudgetTrendReport() {
                   <Line
                     type="monotone"
                     dataKey="budgeted"
-                    stroke="#3b82f6"
+                    stroke={chartColors.primary}
                     strokeWidth={2}
                     strokeDasharray="5 5"
                     dot={{ r: 4 }}
@@ -181,7 +184,7 @@ export function BudgetTrendReport() {
                   <Line
                     type="monotone"
                     dataKey="actual"
-                    stroke="#10b981"
+                    stroke={chartColors.income}
                     strokeWidth={2}
                     dot={{ r: 4 }}
                     name={t('budgetTrend.seriesActual')}

--- a/frontend/src/components/reports/BudgetVsActualReport.test.tsx
+++ b/frontend/src/components/reports/BudgetVsActualReport.test.tsx
@@ -53,7 +53,7 @@ vi.mock('recharts', () => ({
     const C = content;
     if (!C) return null;
     const samples = [
-      { active: true, payload: [{ dataKey: 'budgeted', name: 'Budgeted', color: '#3b82f6', value: 1000 }, { dataKey: 'actual', name: 'Actual', color: '#10b981', value: 1100 }], label: 'tip-1' },
+      { active: true, payload: [{ dataKey: 'budgeted', name: 'Budgeted', color: 'var(--chart-primary)', value: 1000 }, { dataKey: 'actual', name: 'Actual', color: 'var(--chart-income)', value: 1100 }], label: 'tip-1' },
       { active: true, payload: [{ value: 100 }], label: 'tip-2' },
       { active: true, payload: [{ value: -50 }], label: 'tip-3' },
       { active: false, payload: [], label: '' },

--- a/frontend/src/components/reports/BudgetVsActualReport.tsx
+++ b/frontend/src/components/reports/BudgetVsActualReport.tsx
@@ -24,6 +24,7 @@ import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { ReportError } from '@/components/reports/ReportError';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
+import { chartColors } from '@/lib/chart-colors';
 
 type BudgetTrendSortField = 'month' | 'budgeted' | 'actual' | 'variance' | 'percentUsed';
 
@@ -240,8 +241,8 @@ export function BudgetVsActualReport() {
                       }}
                     />
                     <Legend />
-                    <Bar dataKey="budgeted" name={t('budgetVsActual.seriesBudgeted')} fill="#3b82f6" radius={[2, 2, 0, 0]} />
-                    <Bar dataKey="actual" name={t('budgetVsActual.seriesActual')} fill="#10b981" radius={[2, 2, 0, 0]} />
+                    <Bar dataKey="budgeted" name={t('budgetVsActual.seriesBudgeted')} fill={chartColors.primary} radius={[2, 2, 0, 0]} />
+                    <Bar dataKey="actual" name={t('budgetVsActual.seriesActual')} fill={chartColors.income} radius={[2, 2, 0, 0]} />
                   </BarChart>
                 </ResponsiveContainer>
               </div>
@@ -272,7 +273,7 @@ export function BudgetVsActualReport() {
                       <Line
                         type="monotone"
                         dataKey="variance"
-                        stroke="#f59e0b"
+                        stroke={chartColors.warning}
                         strokeWidth={2}
                         dot={{ r: 4 }}
                         name={t('budgetVsActual.seriesVariance')}

--- a/frontend/src/components/reports/CashFlowReport.tsx
+++ b/frontend/src/components/reports/CashFlowReport.tsx
@@ -28,6 +28,7 @@ import { DateRangeSelector } from "@/components/ui/DateRangeSelector";
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { ChartTooltip } from "@/components/reports/ChartTooltip";
 import { ReportError } from "@/components/reports/ReportError";
+import { chartColors } from "@/lib/chart-colors";
 import { useTranslations } from 'next-intl';
 
 interface ChartDataItem {
@@ -299,7 +300,7 @@ export function CashFlowReport() {
               onClick={handleChartClick}
               style={{ cursor: "pointer" }}
             >
-              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+              <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
               <XAxis
                 dataKey="name"
                 tick={{ fontSize: 12 }}
@@ -313,16 +314,16 @@ export function CashFlowReport() {
               />
               <Tooltip content={<CustomTooltip />} />
               <Legend />
-              <ReferenceLine y={0} stroke="#9ca3af" />
+              <ReferenceLine y={0} stroke={chartColors.axis} />
               <Bar
                 dataKey="Income"
-                fill="#22c55e"
+                fill={chartColors.income}
                 name={t('cashFlow.seriesInflows')}
                 radius={[4, 4, 0, 0]}
               />
               <Bar
                 dataKey="Expenses"
-                fill="#ef4444"
+                fill={chartColors.expense}
                 name={t('cashFlow.seriesOutflows')}
                 radius={[4, 4, 0, 0]}
               />

--- a/frontend/src/components/reports/CreditUtilizationReport.tsx
+++ b/frontend/src/components/reports/CreditUtilizationReport.tsx
@@ -24,6 +24,7 @@ import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { ReportError } from '@/components/reports/ReportError';
 import { useTranslations } from 'next-intl';
+import { chartColors } from '@/lib/chart-colors';
 
 // Only credit cards and lines of credit with a credit limit can have a
 // meaningful utilization figure (used / available credit).
@@ -43,9 +44,9 @@ type CreditUtilizationSortField =
 // Utilization thresholds drive the bar colour: low (green), moderate (amber),
 // high (red). 30% / 75% mirror the common "keep utilization under 30%" guidance.
 function utilizationColour(percent: number): string {
-  if (percent >= 75) return '#ef4444';
-  if (percent >= 30) return '#f59e0b';
-  return '#22c55e';
+  if (percent >= 75) return chartColors.expense;
+  if (percent >= 30) return chartColors.warning;
+  return chartColors.income;
 }
 
 interface CreditAccountRow {
@@ -285,7 +286,7 @@ export function CreditUtilizationReport() {
         <div style={{ width: '100%', height: chartHeight }}>
           <ResponsiveContainer minWidth={0}>
             <BarChart data={sortedRows} layout="vertical" margin={{ left: 8, right: 24 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" horizontal={false} />
+              <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} horizontal={false} />
               <XAxis
                 type="number"
                 domain={[0, 100]}
@@ -318,7 +319,7 @@ export function CreditUtilizationReport() {
                   );
                 }}
               />
-              <ReferenceLine x={100} stroke="#9ca3af" strokeDasharray="4 4" />
+              <ReferenceLine x={100} stroke={chartColors.axis} strokeDasharray="4 4" />
               <Bar dataKey="utilizationPercent" radius={[0, 4, 4, 0]}>
                 {sortedRows.map((row) => (
                   <Cell key={row.id} fill={utilizationColour(row.utilizationPercent)} />

--- a/frontend/src/components/reports/CurrencyExposureReport.tsx
+++ b/frontend/src/components/reports/CurrencyExposureReport.tsx
@@ -22,8 +22,10 @@ import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { useReportData } from '@/hooks/useReportData';
 import { ReportError } from '@/components/reports/ReportError';
+import { CHART_SERIES } from '@/lib/chart-colors';
 import { createLogger } from '@/lib/logger';
 import { useTranslations } from 'next-intl';
+import { resolvePdfColor } from '@/components/reports/resolve-pdf-color';
 
 const logger = createLogger('CurrencyExposureReport');
 
@@ -34,17 +36,18 @@ const excludeCashAccounts = (a: Account) => a.accountSubType !== 'INVESTMENT_CAS
 type CurrencyExposureSortField = 'currency' | 'nativeValue' | 'rate' | 'convertedValue' | 'percentage' | 'count';
 
 const CURRENCY_COLOURS: Record<string, string> = {
-  CAD: '#ef4444',
-  USD: '#3b82f6',
-  EUR: '#22c55e',
-  GBP: '#8b5cf6',
-  JPY: '#f97316',
-  CHF: '#ec4899',
-  AUD: '#14b8a6',
-  HKD: '#eab308',
+  CAD: CHART_SERIES[0],
+  USD: CHART_SERIES[1],
+  EUR: CHART_SERIES[2],
+  GBP: CHART_SERIES[3],
+  JPY: CHART_SERIES[4],
+  CHF: CHART_SERIES[5],
+  AUD: CHART_SERIES[6],
+  HKD: CHART_SERIES[7],
 };
 
-const FALLBACK_COLOURS = ['#06b6d4', '#a855f7', '#f43f5e', '#84cc16', '#6b7280'];
+const FALLBACK_COLOURS = [CHART_SERIES[8], CHART_SERIES[9]];
+
 
 interface CurrencyAllocation {
   currency: string;
@@ -203,7 +206,7 @@ export function CurrencyExposureReport() {
       ? accounts.filter((a) => selectedAccountIds.includes(a.id)).map((a) => a.name).join(', ')
       : 'All Accounts';
     const legendItems = allocationData.map((item) => ({
-      color: item.color,
+      color: resolvePdfColor(item.color),
       label: `${item.currency} - ${formatCurrencyFull(item.convertedValue, defaultCurrency)} (${item.percentage.toFixed(1)}%)`,
     }));
     await exportToPdf({

--- a/frontend/src/components/reports/DebtPayoffTimelineReport.tsx
+++ b/frontend/src/components/reports/DebtPayoffTimelineReport.tsx
@@ -23,6 +23,7 @@ import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useReportData } from '@/hooks/useReportData';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { ReportError } from '@/components/reports/ReportError';
+import { chartColors } from '@/lib/chart-colors';
 import { useTranslations } from 'next-intl';
 
 interface PayoffScheduleItem {
@@ -591,7 +592,7 @@ export function DebtPayoffTimelineReport() {
               <div className="h-80">
                 <ResponsiveContainer width="100%" height="100%" minWidth={0}>
                   <AreaChart data={payoffSchedule}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                    <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                     <XAxis
                       dataKey="label"
                       tick={{ fontSize: 11 }}
@@ -605,8 +606,9 @@ export function DebtPayoffTimelineReport() {
                     <Area
                       type="monotone"
                       dataKey="historicalBalance"
-                      stroke="#ef4444"
-                      fill="#fecaca"
+                      stroke={chartColors.expense}
+                      fill={chartColors.expense}
+                      fillOpacity={0.3}
                       name={t('debtPayoff.seriesRemainingBalance')}
                       strokeWidth={2}
                       connectNulls={false}
@@ -615,25 +617,25 @@ export function DebtPayoffTimelineReport() {
                       <Area
                         type="monotone"
                         dataKey="projectedBalance"
-                        stroke="#3b82f6"
-                        fill="#dbeafe"
+                        stroke={chartColors.primary}
+                        fill={chartColors.primary}
                         name={t('debtPayoff.seriesProjectedBalance')}
                         strokeWidth={2}
                         strokeDasharray="6 3"
-                        fillOpacity={0.4}
+                        fillOpacity={0.15}
                         connectNulls={false}
                       />
                     )}
                     {projectionStartLabel && (
                       <ReferenceLine
                         x={projectionStartLabel}
-                        stroke="#6b7280"
+                        stroke={chartColors.axis}
                         strokeDasharray="4 4"
                         strokeWidth={2}
                         label={{
                           value: t('debtPayoff.today'),
                           position: 'top',
-                          fill: '#6b7280',
+                          fill: chartColors.axis,
                           fontSize: 12,
                           fontWeight: 600,
                         }}
@@ -647,7 +649,7 @@ export function DebtPayoffTimelineReport() {
               <div className="h-80">
                 <ResponsiveContainer width="100%" height="100%" minWidth={0}>
                   <BarChart data={payoffSchedule}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                    <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                     <XAxis
                       dataKey="label"
                       tick={{ fontSize: 11 }}
@@ -662,25 +664,25 @@ export function DebtPayoffTimelineReport() {
                     <Bar
                       dataKey="cumulativePrincipal"
                       stackId="a"
-                      fill="#22c55e"
+                      fill={chartColors.income}
                       name={t('debtPayoff.seriesPrincipalPaid')}
                     />
                     <Bar
                       dataKey="cumulativeInterest"
                       stackId="a"
-                      fill="#f97316"
+                      fill={chartColors.warning}
                       name={t('debtPayoff.seriesInterestPaid')}
                     />
                     {projectionStartLabel && (
                       <ReferenceLine
                         x={projectionStartLabel}
-                        stroke="#6b7280"
+                        stroke={chartColors.axis}
                         strokeDasharray="4 4"
                         strokeWidth={2}
                         label={{
                           value: t('debtPayoff.today'),
                           position: 'top',
-                          fill: '#6b7280',
+                          fill: chartColors.axis,
                           fontSize: 12,
                           fontWeight: 600,
                         }}
@@ -694,7 +696,7 @@ export function DebtPayoffTimelineReport() {
               <div className="h-80">
                 <ResponsiveContainer width="100%" height="100%" minWidth={0}>
                   <BarChart data={distributionData}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                    <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                     <XAxis
                       dataKey="label"
                       tick={{ fontSize: 11 }}
@@ -733,25 +735,25 @@ export function DebtPayoffTimelineReport() {
                     <Bar
                       dataKey="principalPercent"
                       stackId="a"
-                      fill="#22c55e"
+                      fill={chartColors.income}
                       name={t('debtPayoff.seriesPrincipal')}
                     />
                     <Bar
                       dataKey="interestPercent"
                       stackId="a"
-                      fill="#f97316"
+                      fill={chartColors.warning}
                       name={t('debtPayoff.seriesInterest')}
                     />
                     {projectionStartLabel && (
                       <ReferenceLine
                         x={projectionStartLabel}
-                        stroke="#6b7280"
+                        stroke={chartColors.axis}
                         strokeDasharray="4 4"
                         strokeWidth={2}
                         label={{
                           value: t('debtPayoff.today'),
                           position: 'top',
-                          fill: '#6b7280',
+                          fill: chartColors.axis,
                           fontSize: 12,
                           fontWeight: 600,
                         }}

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -31,6 +31,7 @@ import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { exportToCsv } from '@/lib/csv-export';
+import { chartColors, CHART_SERIES } from '@/lib/chart-colors';
 import { useTranslations } from 'next-intl';
 
 type SeriesKey = 'dividends' | 'interest' | 'capitalGains';
@@ -70,9 +71,9 @@ interface DailyIncome {
 }
 
 const SERIES_COLORS: Record<SeriesKey, { positive: string; negative: string }> = {
-  dividends: { positive: '#22c55e', negative: '#22c55e' },
-  interest: { positive: '#3b82f6', negative: '#3b82f6' },
-  capitalGains: { positive: '#8b5cf6', negative: '#ef4444' },
+  dividends: { positive: chartColors.income, negative: chartColors.income },
+  interest: { positive: chartColors.primary, negative: chartColors.primary },
+  capitalGains: { positive: CHART_SERIES[4], negative: chartColors.expense },
 };
 
 export function DividendIncomeReport() {
@@ -1210,12 +1211,12 @@ export function DividendIncomeReport() {
           <div className="h-80">
             <ResponsiveContainer width="100%" height="100%" minWidth={0}>
               <BarChart data={monthlyData}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                 <XAxis dataKey="label" tick={{ fontSize: 11 }} />
                 <YAxis tickFormatter={formatCurrencyAxis} />
                 <Tooltip content={<CustomTooltip />} />
                 <Legend />
-                <ReferenceLine y={0} stroke="#9ca3af" />
+                <ReferenceLine y={0} stroke={chartColors.axis} />
                 {visibleSeries.dividends && (
                   <Bar
                     dataKey="dividends"
@@ -1412,12 +1413,12 @@ export function DividendIncomeReport() {
             <div className="h-80">
               <ResponsiveContainer width="100%" height="100%" minWidth={0}>
                 <BarChart data={displayedDailyData}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                  <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                   <XAxis dataKey="label" tick={{ fontSize: 11 }} />
                   <YAxis tickFormatter={formatCurrencyAxis} />
                   <Tooltip content={<CustomTooltip />} />
                   <Legend />
-                  <ReferenceLine y={0} stroke="#9ca3af" />
+                  <ReferenceLine y={0} stroke={chartColors.axis} />
                   {visibleSeries.dividends && (
                     <Bar
                       dataKey="dividends"

--- a/frontend/src/components/reports/DividendYieldGrowthReport.tsx
+++ b/frontend/src/components/reports/DividendYieldGrowthReport.tsx
@@ -27,6 +27,7 @@ import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { createLogger } from '@/lib/logger';
+import { chartColors, CHART_SERIES } from '@/lib/chart-colors';
 import { useTranslations } from 'next-intl';
 
 const logger = createLogger('DividendYieldGrowthReport');
@@ -588,7 +589,7 @@ export function DividendYieldGrowthReport() {
               <div className="h-80">
                 <ResponsiveContainer width="100%" height="100%" minWidth={0}>
                   <BarChart data={annualData}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                    <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                     <XAxis dataKey="year" tick={{ fontSize: 11 }} />
                     <YAxis tickFormatter={formatCurrencyAxis} />
                     <Tooltip
@@ -610,7 +611,7 @@ export function DividendYieldGrowthReport() {
                         );
                       }}
                     />
-                    <Bar dataKey="amount" fill="#22c55e" name={t('dividendYieldGrowth.barDividends')} radius={[4, 4, 0, 0]} />
+                    <Bar dataKey="amount" fill={chartColors.income} name={t('dividendYieldGrowth.barDividends')} radius={[4, 4, 0, 0]} />
                   </BarChart>
                 </ResponsiveContainer>
               </div>
@@ -679,7 +680,7 @@ export function DividendYieldGrowthReport() {
               <div className="h-64">
                 <ResponsiveContainer width="100%" height="100%" minWidth={0}>
                   <BarChart data={frequencyData}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                    <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                     <XAxis dataKey="frequency" tick={{ fontSize: 11 }} />
                     <YAxis tickFormatter={formatCurrencyAxis} />
                     <Tooltip
@@ -695,7 +696,7 @@ export function DividendYieldGrowthReport() {
                         );
                       }}
                     />
-                    <Bar dataKey="totalDividends" fill="#8b5cf6" name={t('dividendYieldGrowth.barTotalDividends')} radius={[4, 4, 0, 0]} />
+                    <Bar dataKey="totalDividends" fill={CHART_SERIES[4]} name={t('dividendYieldGrowth.barTotalDividends')} radius={[4, 4, 0, 0]} />
                   </BarChart>
                 </ResponsiveContainer>
               </div>

--- a/frontend/src/components/reports/FlexGroupAnalysisReport.test.tsx
+++ b/frontend/src/components/reports/FlexGroupAnalysisReport.test.tsx
@@ -44,7 +44,7 @@ vi.mock('recharts', () => ({
     const C = content;
     if (!C) return null;
     const samples = [
-      { active: true, payload: [{ dataKey: 'spent', name: 'Spent', color: '#3b82f6', value: 500 }], label: 'tip-x' },
+      { active: true, payload: [{ dataKey: 'spent', name: 'Spent', color: 'var(--chart-primary)', value: 500 }], label: 'tip-x' },
       { active: false, payload: [], label: '' },
       { active: true, payload: [], label: 'empty' },
     ];

--- a/frontend/src/components/reports/FlexGroupAnalysisReport.tsx
+++ b/frontend/src/components/reports/FlexGroupAnalysisReport.tsx
@@ -23,6 +23,7 @@ import { ReportError } from '@/components/reports/ReportError';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { createLogger } from '@/lib/logger';
+import { chartColors } from '@/lib/chart-colors';
 import { useTranslations } from 'next-intl';
 
 const logger = createLogger('FlexGroupAnalysisReport');
@@ -247,15 +248,15 @@ export function FlexGroupAnalysisReport() {
                   <Bar
                     dataKey="spent"
                     name={t('flexGroupAnalysis.seriesSpent')}
-                    fill="#3b82f6"
+                    fill={chartColors.primary}
                     radius={[0, 4, 4, 0]}
                   />
                   <ReferenceLine
                     x={group.totalBudgeted}
-                    stroke="#ef4444"
+                    stroke={chartColors.expense}
                     strokeWidth={2}
                     strokeDasharray="5 5"
-                    label={{ value: t('flexGroupAnalysis.limitLabel', { amount: formatCurrency(group.totalBudgeted) }), position: 'top', fill: '#ef4444', fontSize: 11 }}
+                    label={{ value: t('flexGroupAnalysis.limitLabel', { amount: formatCurrency(group.totalBudgeted) }), position: 'top', fill: chartColors.expense, fontSize: 11 }}
                   />
                 </BarChart>
               </ResponsiveContainer>

--- a/frontend/src/components/reports/GeographicAllocationReport.tsx
+++ b/frontend/src/components/reports/GeographicAllocationReport.tsx
@@ -26,8 +26,10 @@ import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { useReportData } from '@/hooks/useReportData';
 import { ReportError } from '@/components/reports/ReportError';
+import { chartColors, CHART_SERIES } from '@/lib/chart-colors';
 import { createLogger } from '@/lib/logger';
 import { useTranslations } from 'next-intl';
+import { resolvePdfColor } from '@/components/reports/resolve-pdf-color';
 
 const logger = createLogger('GeographicAllocationReport');
 
@@ -71,16 +73,14 @@ const EXCHANGE_TO_REGION: Record<string, { country: string; region: string }> = 
 };
 
 const REGION_COLOURS: Record<string, string> = {
-  'North America': '#3b82f6',
-  'Europe': '#22c55e',
-  'Asia-Pacific': '#f97316',
-  'Other': '#8b5cf6',
+  'North America': CHART_SERIES[0],
+  'Europe': CHART_SERIES[1],
+  'Asia-Pacific': CHART_SERIES[2],
+  'Other': CHART_SERIES[3],
 };
 
-const COUNTRY_COLOURS = [
-  '#3b82f6', '#22c55e', '#f97316', '#8b5cf6', '#ec4899',
-  '#14b8a6', '#eab308', '#ef4444', '#06b6d4', '#a855f7',
-];
+const COUNTRY_COLOURS = CHART_SERIES;
+
 
 interface ExchangeAllocation {
   exchange: string;
@@ -218,7 +218,7 @@ export function GeographicAllocationReport() {
         marketValue: data.value,
         percentage: total > 0 ? (data.value / total) * 100 : 0,
         count: data.count,
-        color: REGION_COLOURS[region] || '#6b7280',
+        color: REGION_COLOURS[region] || chartColors.axis,
       }))
       .sort((a, b) => b.marketValue - a.marketValue);
 
@@ -296,11 +296,11 @@ export function GeographicAllocationReport() {
 
     const legendItems = viewType === 'region'
       ? regionData.map((item) => ({
-          color: item.color,
+          color: resolvePdfColor(item.color),
           label: `${item.region} - ${formatCurrencyFull(item.marketValue, defaultCurrency)} (${item.percentage.toFixed(1)}%)`,
         }))
       : exchangeData.map((item, idx) => ({
-          color: COUNTRY_COLOURS[idx % COUNTRY_COLOURS.length],
+          color: resolvePdfColor(COUNTRY_COLOURS[idx % COUNTRY_COLOURS.length]),
           label: `${item.exchange} - ${formatCurrencyFull(item.marketValue, defaultCurrency)} (${item.percentage.toFixed(1)}%)`,
         }));
 
@@ -468,7 +468,7 @@ export function GeographicAllocationReport() {
                   tick={{ fill: 'currentColor', fontSize: 11 }}
                 />
                 <Tooltip content={<CustomTooltip formatCurrencyFull={(v) => formatCurrencyFull(v, defaultCurrency)} holdingLabel={(count) => t('geographicAllocation.holdingCount', { count })} />} />
-                <Bar dataKey="marketValue" fill="#3b82f6" radius={[0, 4, 4, 0]}>
+                <Bar dataKey="marketValue" fill={chartColors.primary} radius={[0, 4, 4, 0]}>
                   {exchangeData.map((entry, index) => (
                     <Cell key={entry.exchange} fill={COUNTRY_COLOURS[index % COUNTRY_COLOURS.length]} />
                   ))}

--- a/frontend/src/components/reports/HealthScoreHistoryReport.tsx
+++ b/frontend/src/components/reports/HealthScoreHistoryReport.tsx
@@ -19,15 +19,16 @@ import { ReportError } from '@/components/reports/ReportError';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useReportData } from '@/hooks/useReportData';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
+import { chartColors, CHART_SERIES } from '@/lib/chart-colors';
 import { useTranslations } from 'next-intl';
 
 type HealthHistorySortField = 'month' | 'score' | 'grade' | 'change';
 
 function getScoreColor(score: number): string {
-  if (score >= 80) return '#10b981';
-  if (score >= 60) return '#f59e0b';
-  if (score >= 40) return '#f97316';
-  return '#ef4444';
+  if (score >= 80) return chartColors.income;
+  if (score >= 60) return chartColors.warning;
+  if (score >= 40) return CHART_SERIES[8];
+  return chartColors.expense;
 }
 
 export function HealthScoreHistoryReport() {
@@ -271,12 +272,12 @@ export function HealthScoreHistoryReport() {
                     );
                   }}
                 />
-                <ReferenceLine y={80} stroke="#10b981" strokeDasharray="3 3" label={{ value: t('healthScoreHistory.refLineGood'), position: 'right', fill: '#10b981', fontSize: 11 }} />
-                <ReferenceLine y={60} stroke="#f59e0b" strokeDasharray="3 3" label={{ value: t('healthScoreHistory.refLineFair'), position: 'right', fill: '#f59e0b', fontSize: 11 }} />
+                <ReferenceLine y={80} stroke={chartColors.income} strokeDasharray="3 3" label={{ value: t('healthScoreHistory.refLineGood'), position: 'right', fill: chartColors.income, fontSize: 11 }} />
+                <ReferenceLine y={60} stroke={chartColors.warning} strokeDasharray="3 3" label={{ value: t('healthScoreHistory.refLineFair'), position: 'right', fill: chartColors.warning, fontSize: 11 }} />
                 <Line
                   type="monotone"
                   dataKey="score"
-                  stroke="#6366f1"
+                  stroke={chartColors.primary}
                   strokeWidth={3}
                   dot={(props: { cx?: number; cy?: number; payload?: HealthScoreHistoryPoint }) => {
                     const { cx, cy, payload } = props;

--- a/frontend/src/components/reports/IncomeBySourceReport.tsx
+++ b/frontend/src/components/reports/IncomeBySourceReport.tsx
@@ -28,6 +28,7 @@ import { SortableHeader } from '@/components/ui/SortableHeader';
 import { ChartTooltipPanel } from '@/components/reports/ChartTooltip';
 import { ReportError } from '@/components/reports/ReportError';
 import { CHART_COLOURS_INCOME } from '@/lib/chart-colours';
+import { chartColors } from '@/lib/chart-colors';
 import { exportToCsv } from '@/lib/csv-export';
 import type { ChartDatum } from '@/types/chart';
 import { useTranslations } from 'next-intl';
@@ -310,7 +311,7 @@ export function IncomeBySourceReport() {
               <div className="h-96">
                 <ResponsiveContainer width="100%" height="100%" minWidth={0}>
                   <BarChart data={chartData} layout="vertical" margin={{ left: 10 }}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                    <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                     <XAxis type="number" tickFormatter={(value) => formatCurrency(value)} />
                     <YAxis type="category" dataKey="name" tick={{ fontSize: 12 }} width={80} />
                     <Tooltip content={<CustomTooltip />} />

--- a/frontend/src/components/reports/IncomeVsExpensesReport.tsx
+++ b/frontend/src/components/reports/IncomeVsExpensesReport.tsx
@@ -28,6 +28,7 @@ import { SortableHeader } from '@/components/ui/SortableHeader';
 import { ChartTooltip } from "@/components/reports/ChartTooltip";
 import { ReportError } from "@/components/reports/ReportError";
 import { exportToCsv } from "@/lib/csv-export";
+import { chartColors } from "@/lib/chart-colors";
 import { useTranslations } from 'next-intl';
 
 type IncomeVsExpensesSortField = 'name' | 'income' | 'expenses' | 'savings' | 'savingsRate';
@@ -389,7 +390,7 @@ export function IncomeVsExpensesReport() {
                   onClick={handleChartClick}
                   style={{ cursor: "pointer" }}
                 >
-                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                  <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                   <XAxis
                     dataKey="name"
                     tick={{ fontSize: 12 }}
@@ -403,11 +404,11 @@ export function IncomeVsExpensesReport() {
                   />
                   <Tooltip content={<CustomTooltip />} />
                   <Legend />
-                  <ReferenceLine y={0} stroke="#9ca3af" />
+                  <ReferenceLine y={0} stroke={chartColors.axis} />
                   <Bar
                     dataKey="Income"
                     name={t('incomeVsExpenses.seriesIncome')}
-                    fill="#22c55e"
+                    fill={chartColors.income}
                     radius={[4, 4, 0, 0]}
                     cursor="pointer"
                     onClick={handleBarClick('income')}
@@ -415,7 +416,7 @@ export function IncomeVsExpensesReport() {
                   <Bar
                     dataKey="Expenses"
                     name={t('incomeVsExpenses.seriesExpenses')}
-                    fill="#ef4444"
+                    fill={chartColors.expense}
                     radius={[4, 4, 0, 0]}
                     cursor="pointer"
                     onClick={handleBarClick('expense')}
@@ -423,7 +424,7 @@ export function IncomeVsExpensesReport() {
                   <Bar
                     dataKey="Savings"
                     name={t('incomeVsExpenses.seriesSavings')}
-                    fill="#3b82f6"
+                    fill={chartColors.primary}
                     radius={[4, 4, 0, 0]}
                     cursor="pointer"
                   />

--- a/frontend/src/components/reports/MonteCarloChartParts.test.tsx
+++ b/frontend/src/components/reports/MonteCarloChartParts.test.tsx
@@ -10,7 +10,7 @@ describe('CashFlowLegendSwatch', () => {
       </svg>,
     );
     const polygon = container.querySelector('polygon');
-    expect(polygon?.getAttribute('fill')).toBe('#16a34a');
+    expect(polygon?.getAttribute('fill')).toBe('var(--chart-income)');
   });
 
   it('renders expense end triangle in red', () => {
@@ -20,7 +20,7 @@ describe('CashFlowLegendSwatch', () => {
       </svg>,
     );
     const polygon = container.querySelector('polygon');
-    expect(polygon?.getAttribute('fill')).toBe('#dc2626');
+    expect(polygon?.getAttribute('fill')).toBe('var(--chart-expense)');
   });
 });
 
@@ -32,7 +32,7 @@ describe('CashFlowMarker', () => {
       </svg>,
     );
     const polygon = container.querySelector('polygon');
-    expect(polygon?.getAttribute('fill')).toBe('#16a34a');
+    expect(polygon?.getAttribute('fill')).toBe('var(--chart-income)');
   });
 
   it('renders expense end marker (down triangle, red)', () => {
@@ -42,7 +42,7 @@ describe('CashFlowMarker', () => {
       </svg>,
     );
     const polygon = container.querySelector('polygon');
-    expect(polygon?.getAttribute('fill')).toBe('#dc2626');
+    expect(polygon?.getAttribute('fill')).toBe('var(--chart-expense)');
   });
 });
 

--- a/frontend/src/components/reports/MonteCarloChartParts.tsx
+++ b/frontend/src/components/reports/MonteCarloChartParts.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { CashFlowType } from '@/lib/monte-carlo';
+import { chartColors } from '@/lib/chart-colors';
 import { useTranslations } from 'next-intl';
 
 export interface CashFlowEvent {
@@ -21,12 +22,12 @@ export function CashFlowLegendSwatch({
   role: 'start' | 'end';
   income: boolean;
 }) {
-  const fill = income ? '#16a34a' : '#dc2626';
+  const fill = income ? chartColors.income : chartColors.expense;
   const points =
     role === 'start' ? '7,1 1,11 13,11' : '7,11 1,1 13,1';
   return (
     <svg width={14} height={12} viewBox="0 0 14 12" className="shrink-0">
-      <polygon points={points} fill={fill} stroke="#ffffff" strokeWidth={1} />
+      <polygon points={points} fill={fill} stroke="var(--color-white)" strokeWidth={1} />
     </svg>
   );
 }
@@ -42,8 +43,8 @@ export function CashFlowMarker({
   role: 'start' | 'end';
   income: boolean;
 }) {
-  const fill = income ? '#16a34a' : '#dc2626';
-  const stroke = '#ffffff';
+  const fill = income ? chartColors.income : chartColors.expense;
+  const stroke = 'var(--color-white)';
   // Triangle pointing up = start, pointing down = end. Income green, expense red.
   const size = 7;
   const points =

--- a/frontend/src/components/reports/MonteCarloReport.tsx
+++ b/frontend/src/components/reports/MonteCarloReport.tsx
@@ -49,6 +49,7 @@ import { MultiSelect } from '@/components/ui/MultiSelect';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import { createLogger } from '@/lib/logger';
+import { chartColors } from '@/lib/chart-colors';
 import { useMonteCarloScenarios, MAX_COMPARE_SCENARIOS } from './useMonteCarloScenarios';
 import { useTranslations } from 'next-intl';
 
@@ -1207,7 +1208,8 @@ export function MonteCarloReport() {
                       dataKey="band10to25"
                       stackId="band"
                       stroke="none"
-                      fill="#bfdbfe"
+                      fill={chartColors.primary}
+                      fillOpacity={0.3}
                       name={t('monteCarlo.chartBand10to25')}
                     />
                     <Area
@@ -1215,7 +1217,8 @@ export function MonteCarloReport() {
                       dataKey="band25to75"
                       stackId="band"
                       stroke="none"
-                      fill="#60a5fa"
+                      fill={chartColors.primary}
+                      fillOpacity={0.6}
                       name={t('monteCarlo.chartBand25to75')}
                     />
                     <Area
@@ -1223,13 +1226,14 @@ export function MonteCarloReport() {
                       dataKey="band75to90"
                       stackId="band"
                       stroke="none"
-                      fill="#bfdbfe"
+                      fill={chartColors.primary}
+                      fillOpacity={0.3}
                       name={t('monteCarlo.chartBand75to90')}
                     />
                     <Line
                       type="monotone"
                       dataKey="p50"
-                      stroke="#1d4ed8"
+                      stroke={chartColors.primary}
                       strokeWidth={2}
                       dot={false}
                       name={t('monteCarlo.chartMedian')}
@@ -1245,7 +1249,7 @@ export function MonteCarloReport() {
                         undefined && (
                         <ReferenceLine
                           x={result.yearLabels[form.yearsToRetirement - 1]}
-                          stroke="#d97706"
+                          stroke={chartColors.warning}
                           strokeDasharray="8 4"
                           strokeWidth={2.5}
                           label={{
@@ -1274,7 +1278,7 @@ export function MonteCarloReport() {
                               0.5
                                 ? 'insideTopRight'
                                 : 'insideTopLeft',
-                            fill: '#d97706',
+                            fill: chartColors.warning,
                             fontSize: 12,
                             fontWeight: 600,
                           }}

--- a/frontend/src/components/reports/MonthlyComparisonReport.tsx
+++ b/frontend/src/components/reports/MonthlyComparisonReport.tsx
@@ -23,6 +23,7 @@ import {
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { gainLossColor } from '@/lib/format';
 import { CHART_COLOURS } from '@/lib/chart-colours';
+import { chartColors } from '@/lib/chart-colors';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
@@ -533,14 +534,14 @@ export function MonthlyComparisonReport() {
                   name: format(parseMonth(p.month), 'MMM yy'),
                   netWorth: Math.round(p.netWorth),
                 }))} margin={{ top: 10, right: 10, left: 0, bottom: 5 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                  <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                   <XAxis dataKey="name" tick={{ fontSize: 12 }} />
                   <YAxis tickFormatter={formatCurrencyAxis} tick={{ fontSize: 12 }} />
                   <Tooltip
                     formatter={(value) => [formatCurrencyCompact(Number(value), currency), t('monthlyComparison.tooltipNetWorth')]}
-                    contentStyle={{ backgroundColor: 'var(--tooltip-bg, #fff)', borderColor: 'var(--tooltip-border, #e5e7eb)' }}
+                    contentStyle={{ backgroundColor: 'var(--tooltip-bg, var(--color-white))', borderColor: 'var(--tooltip-border, var(--color-gray-200))' }}
                   />
-                  <Bar dataKey="netWorth" fill="#14b8a6" radius={[4, 4, 0, 0]} />
+                  <Bar dataKey="netWorth" fill={chartColors.primary} radius={[4, 4, 0, 0]} />
                 </BarChart>
               </ResponsiveContainer>
             </div>
@@ -579,7 +580,7 @@ export function MonthlyComparisonReport() {
                     margin={{ top: 10, right: 10, left: 0, bottom: 5 }}
                     layout="vertical"
                   >
-                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                    <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                     <XAxis type="number" tickFormatter={(v: number) => `${v}%`} tick={{ fontSize: 12 }} />
                     <YAxis type="category" dataKey="name" tick={{ fontSize: 12 }} width={90} />
                     <Tooltip formatter={(value) => [`${Number(value).toFixed(2)}%`, t('monthlyComparison.pdfAnnualizedReturn')]} />
@@ -590,7 +591,7 @@ export function MonthlyComparisonReport() {
                       {investments.accountPerformance.map((_, i) => (
                         <Cell
                           key={i}
-                          fill={investments.accountPerformance[i].annualizedReturn >= 0 ? '#22c55e' : '#ef4444'}
+                          fill={investments.accountPerformance[i].annualizedReturn >= 0 ? chartColors.income : chartColors.expense}
                         />
                       ))}
                     </Bar>

--- a/frontend/src/components/reports/MonthlySpendingTrendReport.tsx
+++ b/frontend/src/components/reports/MonthlySpendingTrendReport.tsx
@@ -29,8 +29,11 @@ import { SortableHeader } from '@/components/ui/SortableHeader';
 import { ChartTooltip } from "@/components/reports/ChartTooltip";
 import { ReportError } from "@/components/reports/ReportError";
 import { exportToCsv } from "@/lib/csv-export";
+import { chartColors } from "@/lib/chart-colors";
+import { resolvePdfColor } from '@/components/reports/resolve-pdf-color';
 
 type MonthlySpendingSortField = 'name' | 'income' | 'expenses' | 'net';
+
 
 interface ChartDataItem {
   name: string;
@@ -142,8 +145,8 @@ export function MonthlySpendingTrendReport() {
       ],
       chartContainer: chartRef.current,
       chartLegend: [
-        { color: '#ef4444', label: t('monthlySpendingTrend.seriesExpenses') },
-        { color: '#22c55e', label: t('monthlySpendingTrend.seriesIncome') },
+        { color: resolvePdfColor(chartColors.expense), label: t('monthlySpendingTrend.seriesExpenses') },
+        { color: resolvePdfColor(chartColors.income), label: t('monthlySpendingTrend.seriesIncome') },
       ],
       filename: "monthly-spending-trend",
     });
@@ -334,7 +337,7 @@ export function MonthlySpendingTrendReport() {
                   onClick={handleChartClick}
                   style={{ cursor: "pointer" }}
                 >
-                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                  <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                   <XAxis
                     dataKey="name"
                     tick={{ fontSize: 12 }}
@@ -351,17 +354,17 @@ export function MonthlySpendingTrendReport() {
                   <Line
                     type="monotone"
                     dataKey="Expenses"
-                    stroke="#ef4444"
+                    stroke={chartColors.expense}
                     strokeWidth={2}
-                    dot={{ fill: "#ef4444", strokeWidth: 2, r: 4 }}
+                    dot={{ fill: chartColors.expense, strokeWidth: 2, r: 4 }}
                     activeDot={{ r: 6 }}
                   />
                   <Line
                     type="monotone"
                     dataKey="Income"
-                    stroke="#22c55e"
+                    stroke={chartColors.income}
                     strokeWidth={2}
-                    dot={{ fill: "#22c55e", strokeWidth: 2, r: 4 }}
+                    dot={{ fill: chartColors.income, strokeWidth: 2, r: 4 }}
                     activeDot={{ r: 6 }}
                   />
                 </LineChart>

--- a/frontend/src/components/reports/NetWorthReport.tsx
+++ b/frontend/src/components/reports/NetWorthReport.tsx
@@ -19,6 +19,7 @@ import {
   LabelList,
 } from 'recharts';
 import { format } from 'date-fns';
+import { chartColors } from '@/lib/chart-colors';
 import { netWorthApi } from '@/lib/net-worth';
 import { MonthlyNetWorth } from '@/types/net-worth';
 import { parseLocalDate } from '@/lib/utils';
@@ -374,11 +375,11 @@ export function NetWorthReport() {
               <AreaChart data={chartData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
                 <defs>
                   <linearGradient id="colorNetWorth" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.3} />
-                    <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+                    <stop offset="5%" stopColor={chartColors.primary} stopOpacity={0.3} />
+                    <stop offset="95%" stopColor={chartColors.primary} stopOpacity={0} />
                   </linearGradient>
                 </defs>
-                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                 <XAxis
                   dataKey="name"
                   tick={{ fontSize: 12 }}
@@ -400,11 +401,11 @@ export function NetWorthReport() {
                 />
                 <Tooltip content={<CustomTooltip />} />
                 <Legend />
-                <ReferenceLine y={0} stroke="#9ca3af" strokeDasharray="3 3" />
+                <ReferenceLine y={0} stroke={chartColors.axis} strokeDasharray="3 3" />
                 <Area
                   type="monotone"
                   dataKey="NetWorth"
-                  stroke="#3b82f6"
+                  stroke={chartColors.primary}
                   strokeWidth={2}
                   fillOpacity={1}
                   fill="url(#colorNetWorth)"
@@ -415,10 +416,10 @@ export function NetWorthReport() {
                     x={minMax.max.name}
                     y={minMax.max.NetWorth}
                     r={6}
-                    fill="#16a34a"
+                    fill={chartColors.income}
                     stroke="#fff"
                     strokeWidth={2}
-                    label={{ value: formatCurrencyLabel(minMax.max.NetWorth), position: 'bottom', fontSize: 12, fill: '#16a34a', fontWeight: 600, offset: 8 }}
+                    label={{ value: formatCurrencyLabel(minMax.max.NetWorth), position: 'bottom', fontSize: 12, fill: chartColors.income, fontWeight: 600, offset: 8 }}
                   />
                 )}
                 {minMax && (
@@ -426,16 +427,16 @@ export function NetWorthReport() {
                     x={minMax.min.name}
                     y={minMax.min.NetWorth}
                     r={6}
-                    fill="#dc2626"
+                    fill={chartColors.expense}
                     stroke="#fff"
                     strokeWidth={2}
-                    label={{ value: formatCurrencyLabel(minMax.min.NetWorth), position: 'top', fontSize: 12, fill: '#dc2626', fontWeight: 600, offset: 8 }}
+                    label={{ value: formatCurrencyLabel(minMax.min.NetWorth), position: 'top', fontSize: 12, fill: chartColors.expense, fontWeight: 600, offset: 8 }}
                   />
                 )}
               </AreaChart>
               ) : (
               <BarChart data={chartData} margin={{ top: showBarLabels ? (barLabelsVertical ? 52 : 22) : 10, right: 10, left: 0, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" vertical={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} vertical={false} />
                 <XAxis
                   dataKey="name"
                   tick={{ fontSize: 12 }}
@@ -457,8 +458,8 @@ export function NetWorthReport() {
                 />
                 <Tooltip content={<CustomTooltip />} />
                 <Legend />
-                <ReferenceLine y={0} stroke="#9ca3af" strokeDasharray="3 3" />
-                <Bar dataKey="NetWorth" fill="#3b82f6" name={t('netWorth.seriesNetWorth')} radius={[4, 4, 0, 0]}>
+                <ReferenceLine y={0} stroke={chartColors.axis} strokeDasharray="3 3" />
+                <Bar dataKey="NetWorth" fill={chartColors.primary} name={t('netWorth.seriesNetWorth')} radius={[4, 4, 0, 0]}>
                   {showBarLabels && (
                     <LabelList
                       dataKey="NetWorth"
@@ -468,7 +469,7 @@ export function NetWorthReport() {
                       textAnchor={barLabelsVertical ? 'start' : 'middle'}
                       formatter={(value: unknown) => formatCurrencyLabel(Number(value))}
                       style={{
-                        fill: '#6b7280',
+                        fill: chartColors.axis,
                         fontSize: 11,
                         fontWeight: 600,
                         ...(barLabelsVertical && { dominantBaseline: 'central' as const }),

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -13,6 +13,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { format } from 'date-fns';
+import { chartColors } from '@/lib/chart-colors';
 import { netWorthApi } from '@/lib/net-worth';
 import { investmentsApi } from '@/lib/investments';
 import { PortfolioSummary } from '@/types/investment';
@@ -607,12 +608,12 @@ export function PortfolioValueReport() {
               <AreaChart data={chartPoints} margin={{ top: 30, right: 30, left: 0, bottom: 30 }}>
                 <defs>
                   <linearGradient id="colorPortfolioValue" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="#10b981" stopOpacity={0.3} />
-                    <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
+                    <stop offset="5%" stopColor={chartColors.income} stopOpacity={0.3} />
+                    <stop offset="95%" stopColor={chartColors.income} stopOpacity={0} />
                   </linearGradient>
                 </defs>
                 <ChartFlagShadowFilter />
-                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                 <XAxis
                   dataKey="name"
                   tick={{ fontSize: 12 }}
@@ -643,7 +644,7 @@ export function PortfolioValueReport() {
                 <Area
                   type="monotone"
                   dataKey="Value"
-                  stroke="#10b981"
+                  stroke={chartColors.income}
                   strokeWidth={2}
                   fillOpacity={1}
                   fill="url(#colorPortfolioValue)"
@@ -671,7 +672,7 @@ export function PortfolioValueReport() {
                       cx,
                       cy,
                       index,
-                      color: isHighest ? '#10b981' : '#ef4444',
+                      color: isHighest ? chartColors.income : chartColors.expense,
                       label: fmtFlag(value),
                       side: isLeftHalf ? 'right' : 'left',
                     });

--- a/frontend/src/components/reports/RealizedGainsReport.tsx
+++ b/frontend/src/components/reports/RealizedGainsReport.tsx
@@ -16,6 +16,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { format } from 'date-fns';
+import { chartColors } from '@/lib/chart-colors';
 import { investmentsApi } from '@/lib/investments';
 import { RealizedGainEntry } from '@/types/investment';
 import { Account } from '@/types/account';
@@ -392,14 +393,14 @@ export function RealizedGainsReport() {
             <div className="h-80">
               <ResponsiveContainer width="100%" height="100%" minWidth={0}>
                 <BarChart data={chartData} layout="vertical" margin={{ left: 0, right: 10 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                  <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                   <XAxis type="number" tickFormatter={formatCurrencyAxis} />
                   <YAxis type="category" dataKey="symbol" width={60} tick={{ fontSize: 12 }} />
                   <Tooltip content={<CustomTooltip fmtValue={fmtValue} />} />
                   <Bar
                     dataKey="gain"
                     name={t('realizedGains.realizedGainLoss')}
-                    fill="#22c55e"
+                    fill={chartColors.income}
                     radius={[0, 4, 4, 0]}
                   />
                 </BarChart>

--- a/frontend/src/components/reports/RecurringExpensesReport.test.tsx
+++ b/frontend/src/components/reports/RecurringExpensesReport.test.tsx
@@ -15,10 +15,6 @@ vi.mock("@/hooks/useNumberFormat", () => ({
   }),
 }));
 
-vi.mock("@/lib/chart-colours", () => ({
-  CHART_COLOURS: ["#3b82f6", "#ef4444", "#22c55e"],
-}));
-
 vi.mock("recharts", () => ({
   ResponsiveContainer: ({ children }: any) => (
     <div data-testid="responsive-container">{children}</div>

--- a/frontend/src/components/reports/RecurringExpensesReport.tsx
+++ b/frontend/src/components/reports/RecurringExpensesReport.tsx
@@ -15,7 +15,8 @@ import { format } from 'date-fns';
 import { builtInReportsApi } from '@/lib/built-in-reports';
 import { RecurringExpenseItem } from '@/types/built-in-reports';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
-import { CHART_COLOURS } from '@/lib/chart-colours';
+import { chartSeriesColor } from '@/lib/chart-colors';
+import { resolvePdfColor } from '@/components/reports/resolve-pdf-color';
 import { exportToCsv } from '@/lib/csv-export';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { SortableHeader } from '@/components/ui/SortableHeader';
@@ -77,7 +78,7 @@ export function RecurringExpensesReport() {
     if (!recurringData) return [];
     return recurringData.data.slice(0, 10).map((item, index) => ({
       ...item,
-      color: CHART_COLOURS[index % CHART_COLOURS.length],
+      color: chartSeriesColor(index),
     }));
   }, [recurringData]);
 
@@ -124,7 +125,7 @@ export function RecurringExpensesReport() {
       ],
       chartContainer: chartRef.current,
       chartLegend: chartData.map((item) => ({
-        color: item.color,
+        color: resolvePdfColor(item.color),
         label: `${item.payeeName}: ${formatCurrency(item.totalAmount)}`,
       })),
       tableData: { headers: expData.headers, rows: expData.rows },

--- a/frontend/src/components/reports/ReportChart.tsx
+++ b/frontend/src/components/reports/ReportChart.tsx
@@ -19,6 +19,7 @@ import { ReportViewType, AggregatedDataPoint, GroupByType, TableColumn } from '@
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useDateFormat } from '@/hooks/useDateFormat';
 import { CHART_COLOURS } from '@/lib/chart-colours';
+import { chartColors } from '@/lib/chart-colors';
 import { exportToCsv } from '@/lib/csv-export';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 
@@ -181,7 +182,7 @@ export function ReportChart({ viewType, data, groupBy, onDataPointClick, tableCo
           <div ref={chartContainerRef} className="h-80">
             <ResponsiveContainer width="100%" height="100%" minWidth={0}>
               <BarChart data={chartData} margin={{ top: 20, right: 10, left: 0, bottom: 60 }}>
-                <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
+                <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                 <XAxis
                   dataKey="label"
                   tick={{ fontSize: 12, fill: 'currentColor' }}
@@ -219,7 +220,7 @@ export function ReportChart({ viewType, data, groupBy, onDataPointClick, tableCo
           <div ref={chartContainerRef} className="h-80">
             <ResponsiveContainer width="100%" height="100%" minWidth={0}>
               <LineChart data={chartData} margin={{ top: 20, right: 10, left: 0, bottom: 60 }}>
-                <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
+                <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                 <XAxis
                   dataKey="label"
                   tick={{ fontSize: 12, fill: 'currentColor' }}
@@ -238,9 +239,9 @@ export function ReportChart({ viewType, data, groupBy, onDataPointClick, tableCo
                 <Line
                   type="monotone"
                   dataKey="value"
-                  stroke="#3b82f6"
+                  stroke={chartColors.primary}
                   strokeWidth={2}
-                  dot={{ fill: '#3b82f6', strokeWidth: 2 }}
+                  dot={{ fill: chartColors.primary, strokeWidth: 2 }}
                   activeDot={{ r: 6 }}
                 />
               </LineChart>

--- a/frontend/src/components/reports/SavingsRateReport.tsx
+++ b/frontend/src/components/reports/SavingsRateReport.tsx
@@ -16,6 +16,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { budgetsApi } from '@/lib/budgets';
+import { chartColors } from '@/lib/chart-colors';
 import type { Budget, SavingsRatePoint } from '@/types/budget';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
@@ -270,15 +271,15 @@ export function SavingsRateReport() {
                 <Legend />
                 <ReferenceLine
                   y={targetRate}
-                  stroke="#3b82f6"
+                  stroke={chartColors.primary}
                   strokeDasharray="3 3"
-                  label={{ value: t('savingsRate.targetPrefix', { rate: targetRate }), position: 'right', fill: '#3b82f6', fontSize: 11 }}
+                  label={{ value: t('savingsRate.targetPrefix', { rate: targetRate }), position: 'right', fill: chartColors.primary, fontSize: 11 }}
                 />
-                <ReferenceLine y={0} stroke="#9ca3af" />
+                <ReferenceLine y={0} stroke={chartColors.axis} />
                 <Line
                   type="monotone"
                   dataKey="savingsRate"
-                  stroke="#10b981"
+                  stroke={chartColors.income}
                   strokeWidth={2}
                   dot={{ r: 4 }}
                   name={t('savingsRate.seriesSavingsRate')}

--- a/frontend/src/components/reports/SectorWeightingsReport.tsx
+++ b/frontend/src/components/reports/SectorWeightingsReport.tsx
@@ -14,6 +14,7 @@ import {
   ResponsiveContainer,
   Legend,
 } from 'recharts';
+import { chartColors, chartSeriesColor } from '@/lib/chart-colors';
 import { investmentsApi } from '@/lib/investments';
 import { Security } from '@/types/investment';
 import { Account } from '@/types/account';
@@ -34,12 +35,6 @@ const logger = createLogger('SectorWeightingsReport');
 const excludeCashAccounts = (a: Account) => a.accountSubType !== 'INVESTMENT_CASH';
 
 type SectorSortField = 'sector' | 'direct' | 'etf' | 'total' | 'percentage';
-
-const SECTOR_COLOURS = [
-  '#3b82f6', '#22c55e', '#f97316', '#8b5cf6', '#ec4899',
-  '#14b8a6', '#eab308', '#ef4444', '#06b6d4', '#a855f7',
-  '#f43f5e', '#84cc16',
-];
 
 function CustomTooltip({ active, payload, formatCurrencyFull, defaultCurrency, labelDirect, labelEtf, labelTotal }: {
   active?: boolean;
@@ -200,7 +195,7 @@ export function SectorWeightingsReport() {
     etf: item.etfValue,
     total: item.totalValue,
     percentage: item.percentage,
-    color: SECTOR_COLOURS[idx % SECTOR_COLOURS.length],
+    color: chartSeriesColor(idx),
   }));
 
   return (
@@ -304,8 +299,8 @@ export function SectorWeightingsReport() {
                   value === 'direct' ? t('sectorWeightings.viewDirect') : t('sectorWeightings.viewEtf')
                 }
               />
-              <Bar dataKey="direct" stackId="a" fill="#3b82f6" name="direct" />
-              <Bar dataKey="etf" stackId="a" fill="#22c55e" name="etf" radius={[0, 4, 4, 0]} />
+              <Bar dataKey="direct" stackId="a" fill={chartColors.primary} name="direct" />
+              <Bar dataKey="etf" stackId="a" fill={chartColors.income} name="etf" radius={[0, 4, 4, 0]} />
             </BarChart>
           </ResponsiveContainer>
         </div>
@@ -377,7 +372,7 @@ export function SectorWeightingsReport() {
                     <div className="flex items-center gap-2">
                       <div
                         className="w-3 h-3 rounded-full flex-shrink-0"
-                        style={{ backgroundColor: SECTOR_COLOURS[idx % SECTOR_COLOURS.length] }}
+                        style={{ backgroundColor: chartSeriesColor(idx) }}
                       />
                       {item.sector}
                     </div>

--- a/frontend/src/components/reports/SecurityPerformanceReport.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.tsx
@@ -17,6 +17,7 @@ import {
   ReferenceLine,
 } from 'recharts';
 import { format, differenceInDays } from 'date-fns';
+import { chartColors } from '@/lib/chart-colors';
 import { investmentsApi } from '@/lib/investments';
 import { Security, SecurityPrice, InvestmentTransaction, HoldingWithMarketValue } from '@/types/investment';
 import { Account } from '@/types/account';
@@ -522,11 +523,11 @@ export function SecurityPerformanceReport() {
                     <AreaChart data={chartData}>
                       <defs>
                         <linearGradient id="priceGradient" x1="0" y1="0" x2="0" y2="1">
-                          <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.3} />
-                          <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+                          <stop offset="5%" stopColor={chartColors.primary} stopOpacity={0.3} />
+                          <stop offset="95%" stopColor={chartColors.primary} stopOpacity={0} />
                         </linearGradient>
                       </defs>
-                      <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                      <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                       <XAxis
                         dataKey="label"
                         tick={{ fontSize: 11 }}
@@ -556,7 +557,7 @@ export function SecurityPerformanceReport() {
                       <Area
                         type="monotone"
                         dataKey="close"
-                        stroke="#3b82f6"
+                        stroke={chartColors.primary}
                         fill="url(#priceGradient)"
                         strokeWidth={2}
                       />
@@ -566,7 +567,7 @@ export function SecurityPerformanceReport() {
                         dataKey="buyMarker"
                         stroke="none"
                         fill="none"
-                        dot={{ r: 6, fill: '#22c55e', stroke: '#fff', strokeWidth: 2 }}
+                        dot={{ r: 6, fill: chartColors.income, stroke: '#fff', strokeWidth: 2 }}
                         activeDot={false}
                         connectNulls={false}
                       />
@@ -576,16 +577,16 @@ export function SecurityPerformanceReport() {
                         dataKey="sellMarker"
                         stroke="none"
                         fill="none"
-                        dot={{ r: 6, fill: '#ef4444', stroke: '#fff', strokeWidth: 2 }}
+                        dot={{ r: 6, fill: chartColors.expense, stroke: '#fff', strokeWidth: 2 }}
                         activeDot={false}
                         connectNulls={false}
                       />
                       {stats && stats.averageCost > 0 && (
                         <ReferenceLine
                           y={stats.averageCost}
-                          stroke="#f97316"
+                          stroke={chartColors.warning}
                           strokeDasharray="4 4"
-                          label={{ value: t('securityPerformance.avgCostRefLine'), position: 'right', fill: '#f97316', fontSize: 11 }}
+                          label={{ value: t('securityPerformance.avgCostRefLine'), position: 'right', fill: chartColors.warning, fontSize: 11 }}
                         />
                       )}
                     </AreaChart>

--- a/frontend/src/components/reports/SecurityTypeAllocationReport.tsx
+++ b/frontend/src/components/reports/SecurityTypeAllocationReport.tsx
@@ -13,6 +13,7 @@ import {
   ResponsiveContainer,
   Legend,
 } from 'recharts';
+import { chartColors, CHART_SERIES, chartSeriesColor } from '@/lib/chart-colors';
 import { investmentsApi } from '@/lib/investments';
 import { HoldingWithMarketValue } from '@/types/investment';
 import { Account } from '@/types/account';
@@ -20,6 +21,7 @@ import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { resolvePdfColor } from '@/components/reports/resolve-pdf-color';
 import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
@@ -35,14 +37,12 @@ const excludeCashAccounts = (a: Account) => a.accountSubType !== 'INVESTMENT_CAS
 type SecurityTypeSortField = 'label' | 'totalValue' | 'percentage' | 'count';
 
 const TYPE_COLOURS: Record<string, string> = {
-  STOCK: '#3b82f6',
-  ETF: '#22c55e',
-  MUTUAL_FUND: '#f97316',
-  BOND: '#8b5cf6',
-  CASH: '#6b7280',
+  STOCK: CHART_SERIES[0],
+  ETF: CHART_SERIES[1],
+  MUTUAL_FUND: CHART_SERIES[8],
+  BOND: CHART_SERIES[4],
+  CASH: chartColors.axis,
 };
-
-const FALLBACK_COLOURS = ['#14b8a6', '#eab308', '#ef4444', '#06b6d4', '#a855f7', '#f43f5e'];
 
 const TYPE_LABELS: Record<string, string> = {
   STOCK: 'Stocks',
@@ -63,7 +63,7 @@ interface TypeAllocation {
 }
 
 function getColor(type: string, index: number): string {
-  return TYPE_COLOURS[type] || FALLBACK_COLOURS[index % FALLBACK_COLOURS.length];
+  return TYPE_COLOURS[type] || chartSeriesColor(index);
 }
 
 function CustomTooltip({ active, payload, formatCurrencyFull, getHoldingsLabel }: {
@@ -210,7 +210,7 @@ export function SecurityTypeAllocationReport() {
       ],
       chartContainer: chartRef.current,
       chartLegend: allocationData.map((item) => ({
-        color: item.color,
+        color: resolvePdfColor(item.color),
         label: `${item.label} - ${formatCurrencyFull(item.totalValue, defaultCurrency)} (${item.percentage.toFixed(1)}%)`,
       })),
       tableData: { headers, rows },

--- a/frontend/src/components/reports/SpendingByCategoryReport.tsx
+++ b/frontend/src/components/reports/SpendingByCategoryReport.tsx
@@ -23,6 +23,7 @@ import { useDateRange } from '@/hooks/useDateRange';
 import { useReportData } from '@/hooks/useReportData';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { CHART_COLOURS } from '@/lib/chart-colours';
+import { chartColors } from '@/lib/chart-colors';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
@@ -315,7 +316,7 @@ export function SpendingByCategoryReport() {
               <div className="h-96">
                 <ResponsiveContainer width="100%" height="100%" minWidth={0}>
                   <BarChart data={chartData} layout="vertical" margin={{ left: 10 }}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                    <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                     <XAxis type="number" tickFormatter={(value) => formatCurrency(value)} />
                     <YAxis type="category" dataKey="name" tick={{ fontSize: 12 }} width={80} />
                     <Tooltip content={<CustomTooltip />} />

--- a/frontend/src/components/reports/SpendingByPayeeReport.test.tsx
+++ b/frontend/src/components/reports/SpendingByPayeeReport.test.tsx
@@ -30,10 +30,6 @@ vi.mock("@/hooks/useDateRange", () => ({
   }),
 }));
 
-vi.mock("@/lib/chart-colours", () => ({
-  CHART_COLOURS: ["#3b82f6", "#ef4444", "#22c55e", "#f97316"],
-}));
-
 vi.mock("@/components/ui/DateRangeSelector", () => ({
   DateRangeSelector: () => <div data-testid="date-range-selector" />,
 }));

--- a/frontend/src/components/reports/SpendingByPayeeReport.tsx
+++ b/frontend/src/components/reports/SpendingByPayeeReport.tsx
@@ -22,7 +22,7 @@ import { useReportData } from '@/hooks/useReportData';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
-import { CHART_COLOURS } from '@/lib/chart-colours';
+import { chartColors, chartSeriesColor } from '@/lib/chart-colors';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { ChartTooltipPanel } from '@/components/reports/ChartTooltip';
@@ -239,7 +239,7 @@ export function SpendingByPayeeReport() {
                           <div className="flex items-center gap-2">
                             <div
                               className="w-3 h-3 rounded-full flex-shrink-0"
-                              style={{ backgroundColor: CHART_COLOURS[idx % CHART_COLOURS.length] }}
+                              style={{ backgroundColor: chartSeriesColor(idx) }}
                             />
                             {item.name}
                           </div>
@@ -273,7 +273,7 @@ export function SpendingByPayeeReport() {
             <div className="h-[500px]">
               <ResponsiveContainer width="100%" height="100%" minWidth={0}>
                 <BarChart data={chartData} layout="vertical" margin={{ left: 10, right: 10 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                  <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                   <XAxis
                     type="number"
                     tickFormatter={formatCurrencyAxis}
@@ -287,7 +287,7 @@ export function SpendingByPayeeReport() {
                     radius={[0, 4, 4, 0]}
                   >
                     {chartData.map((entry, index) => (
-                      <Cell key={`cell-${index}`} fill={CHART_COLOURS[index % CHART_COLOURS.length]} />
+                      <Cell key={`cell-${index}`} fill={chartSeriesColor(index)} />
                     ))}
                   </Bar>
                 </BarChart>

--- a/frontend/src/components/reports/WeekendVsWeekdayReport.tsx
+++ b/frontend/src/components/reports/WeekendVsWeekdayReport.tsx
@@ -17,12 +17,18 @@ import {
   Cell,
 } from 'recharts';
 import { builtInReportsApi } from '@/lib/built-in-reports';
+import { chartColors, CHART_SERIES } from '@/lib/chart-colors';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useDateRange } from '@/hooks/useDateRange';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { useReportData } from '@/hooks/useReportData';
 import { ReportError } from '@/components/reports/ReportError';
+import { resolvePdfColor } from '@/components/reports/resolve-pdf-color';
+
+// Weekend purple vs weekday blue, drawn from the categorical theme palette.
+const WEEKEND_COLOR = CHART_SERIES[4];
+const WEEKDAY_COLOR = CHART_SERIES[0];
 
 interface DaySpendingDisplay {
   day: string;
@@ -112,8 +118,8 @@ export function WeekendVsWeekdayReport() {
   const weekendPercent = totalSpending > 0 ? (weekendTotal / totalSpending) * 100 : 0;
 
   const pieData = [
-    { name: t('weekendVsWeekday.weekendLabel'), value: weekendTotal, color: '#8b5cf6' },
-    { name: t('weekendVsWeekday.weekdayLabel'), value: weekdayTotal, color: '#3b82f6' },
+    { name: t('weekendVsWeekday.weekendLabel'), value: weekendTotal, color: WEEKEND_COLOR },
+    { name: t('weekendVsWeekday.weekdayLabel'), value: weekdayTotal, color: WEEKDAY_COLOR },
   ];
 
   const CustomTooltip = ({ active, payload, label }: { active?: boolean; payload?: Array<{ name: string; value: number; color: string }>; label?: string }) => {
@@ -145,8 +151,8 @@ export function WeekendVsWeekdayReport() {
       ],
       chartContainer: chartRef.current,
       chartLegend: [
-        { color: '#8b5cf6', label: `${t('weekendVsWeekday.weekendLabel')} - ${formatCurrency(weekendTotal)} (${weekendPercent.toFixed(1)}%)` },
-        { color: '#3b82f6', label: `${t('weekendVsWeekday.weekdayLabel')} - ${formatCurrency(weekdayTotal)} (${weekdayPercent.toFixed(1)}%)` },
+        { color: resolvePdfColor(WEEKEND_COLOR), label: `${t('weekendVsWeekday.weekendLabel')} - ${formatCurrency(weekendTotal)} (${weekendPercent.toFixed(1)}%)` },
+        { color: resolvePdfColor(WEEKDAY_COLOR), label: `${t('weekendVsWeekday.weekdayLabel')} - ${formatCurrency(weekdayTotal)} (${weekdayPercent.toFixed(1)}%)` },
       ],
       filename: 'weekend-vs-weekday',
     });
@@ -322,7 +328,7 @@ export function WeekendVsWeekdayReport() {
           <div className="h-96">
             <ResponsiveContainer width="100%" height="100%" minWidth={0}>
               <BarChart data={dayData}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                 <XAxis dataKey="day" />
                 <YAxis tickFormatter={formatCurrencyAxis} />
                 <Tooltip content={<CustomTooltip />} />
@@ -330,7 +336,7 @@ export function WeekendVsWeekdayReport() {
                   {dayData.map((entry, index) => (
                     <Cell
                       key={`cell-${index}`}
-                      fill={entry.isWeekend ? '#8b5cf6' : '#3b82f6'}
+                      fill={entry.isWeekend ? WEEKEND_COLOR : WEEKDAY_COLOR}
                     />
                   ))}
                 </Bar>
@@ -364,13 +370,13 @@ export function WeekendVsWeekdayReport() {
           <div className="h-[480px]">
             <ResponsiveContainer width="100%" height="100%" minWidth={0}>
               <BarChart data={categoryComparison} layout="vertical" margin={{ left: 10 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                 <XAxis type="number" tickFormatter={formatCurrencyAxis} />
                 <YAxis type="category" dataKey="name" tick={{ fontSize: 12 }} width={80} />
                 <Tooltip content={<CustomTooltip />} />
                 <Legend />
-                <Bar dataKey="weekendTotal" fill="#8b5cf6" name={t('weekendVsWeekday.barWeekend')} />
-                <Bar dataKey="weekdayTotal" fill="#3b82f6" name={t('weekendVsWeekday.barWeekday')} />
+                <Bar dataKey="weekendTotal" fill={WEEKEND_COLOR} name={t('weekendVsWeekday.barWeekend')} />
+                <Bar dataKey="weekdayTotal" fill={WEEKDAY_COLOR} name={t('weekendVsWeekday.barWeekday')} />
               </BarChart>
             </ResponsiveContainer>
           </div>

--- a/frontend/src/components/reports/YearOverYearReport.test.tsx
+++ b/frontend/src/components/reports/YearOverYearReport.test.tsx
@@ -17,10 +17,6 @@ vi.mock("@/hooks/useNumberFormat", () => ({
   }),
 }));
 
-vi.mock("@/lib/chart-colours", () => ({
-  CHART_COLOURS: ["#3b82f6", "#ef4444", "#22c55e", "#f97316"],
-}));
-
 vi.mock("recharts", () => ({
   ResponsiveContainer: ({ children }: any) => (
     <div data-testid="responsive-container">{children}</div>

--- a/frontend/src/components/reports/YearOverYearReport.tsx
+++ b/frontend/src/components/reports/YearOverYearReport.tsx
@@ -19,7 +19,8 @@ import { builtInReportsApi } from "@/lib/built-in-reports";
 import { YearData } from "@/types/built-in-reports";
 import { useNumberFormat } from "@/hooks/useNumberFormat";
 import { useSortableTable, compareValues } from "@/hooks/useSortableTable";
-import { CHART_COLOURS } from "@/lib/chart-colours";
+import { chartColors, chartSeriesColor } from "@/lib/chart-colors";
+import { resolvePdfColor } from "@/components/reports/resolve-pdf-color";
 import { ChartViewToggle } from "@/components/ui/ChartViewToggle";
 import { ExportDropdown } from "@/components/ui/ExportDropdown";
 import { SortableHeader } from "@/components/ui/SortableHeader";
@@ -139,7 +140,7 @@ export function YearOverYearReport() {
     const cards = years.map((year, index) => ({
       label: String(year),
       value: formatCurrency(yearTotals[year]?.[metric] || 0),
-      color: CHART_COLOURS[index % CHART_COLOURS.length],
+      color: resolvePdfColor(chartSeriesColor(index)),
     }));
 
     // Build YoY change table
@@ -295,7 +296,7 @@ export function YearOverYearReport() {
             key={year}
             className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4"
             style={{
-              borderLeft: `4px solid ${CHART_COLOURS[index % CHART_COLOURS.length]}`,
+              borderLeft: `4px solid ${chartSeriesColor(index)}`,
             }}
           >
             <div className="text-lg font-bold text-gray-900 dark:text-gray-100">
@@ -362,7 +363,7 @@ export function YearOverYearReport() {
                       align="right"
                       className="px-4 py-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase"
                     >
-                      <span style={{ color: CHART_COLOURS[index % CHART_COLOURS.length] }}>{year}</span>
+                      <span style={{ color: chartSeriesColor(index) }}>{year}</span>
                     </SortableHeader>
                   ))}
                 </tr>
@@ -407,7 +408,7 @@ export function YearOverYearReport() {
                 data={chartData}
                 margin={{ top: 20, right: 10, left: 0, bottom: 5 }}
               >
-                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                 <XAxis dataKey="name" tick={{ fontSize: 12 }} />
                 <YAxis
                   tickFormatter={formatCurrencyAxis}
@@ -419,7 +420,7 @@ export function YearOverYearReport() {
                   <Bar
                     key={year}
                     dataKey={`${year}`}
-                    fill={CHART_COLOURS[index % CHART_COLOURS.length]}
+                    fill={chartSeriesColor(index)}
                     radius={[4, 4, 0, 0]}
                     name={`${year}`}
                     cursor="pointer"

--- a/frontend/src/components/reports/resolve-pdf-color.test.ts
+++ b/frontend/src/components/reports/resolve-pdf-color.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { resolvePdfColor } from './resolve-pdf-color';
+
+function mockComputedColor(value: string) {
+  return vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+    getPropertyValue: () => value,
+  } as unknown as CSSStyleDeclaration);
+}
+
+describe('resolvePdfColor', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns plain hex colours unchanged without consulting computed styles', () => {
+    const spy = mockComputedColor('#123456');
+    expect(resolvePdfColor('#ff0000')).toBe('#ff0000');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('resolves a CSS variable reference to its computed hex value', () => {
+    mockComputedColor(' #3b82f6 ');
+    expect(resolvePdfColor('var(--chart-1)')).toBe('#3b82f6');
+  });
+
+  it('falls back to neutral gray when the variable resolves to a non-hex colour', () => {
+    mockComputedColor('oklch(55.1% 0.027 264.364)');
+    expect(resolvePdfColor('var(--chart-axis)')).toBe('#6b7280');
+  });
+
+  it('falls back to neutral gray when the variable is undefined', () => {
+    mockComputedColor('');
+    expect(resolvePdfColor('var(--chart-missing)')).toBe('#6b7280');
+  });
+});

--- a/frontend/src/components/reports/resolve-pdf-color.ts
+++ b/frontend/src/components/reports/resolve-pdf-color.ts
@@ -1,0 +1,18 @@
+/**
+ * The PDF legend renderer draws swatches with jsPDF, which needs concrete
+ * hex values rather than CSS variable references like the chart colour
+ * tokens from `@/lib/chart-colors`. Resolve a token against the active
+ * theme at export time (the chart image itself is handled by
+ * pdf-export-charts inlining computed colours into the captured SVG).
+ *
+ * Falls back to a neutral gray when the variable resolves to a non-hex
+ * colour (e.g. an `oklch()` value from the default Tailwind ramps).
+ */
+export function resolvePdfColor(color: string): string {
+  const varName = color.match(/^var\((--[\w-]+)\)$/)?.[1];
+  if (!varName) return color;
+  const resolved = getComputedStyle(document.documentElement)
+    .getPropertyValue(varName)
+    .trim();
+  return /^#[0-9a-fA-F]{6}$/.test(resolved) ? resolved : '#6b7280';
+}

--- a/frontend/src/components/settings/ColorThemeSelector.test.tsx
+++ b/frontend/src/components/settings/ColorThemeSelector.test.tsx
@@ -21,7 +21,7 @@ vi.mock('@/contexts/ThemeContext', () => ({
 
 vi.mock('@/lib/user-settings', () => ({
   userSettingsApi: {
-    updatePreferences: vi.fn().mockResolvedValue({ colorTheme: 'beige', defaultCurrency: 'USD' }),
+    updatePreferences: vi.fn().mockResolvedValue({ colorTheme: 'latte', defaultCurrency: 'USD' }),
   },
 }));
 
@@ -53,15 +53,15 @@ describe('ColorThemeSelector', () => {
     render(<ColorThemeSelector value="default" onChange={onChange} />);
 
     await act(async () => {
-      fireEvent.change(screen.getByRole('combobox'), { target: { value: 'beige' } });
+      fireEvent.change(screen.getByRole('combobox'), { target: { value: 'latte' } });
     });
 
     // Parent state and the live colour theme update right away, no save step.
-    expect(onChange).toHaveBeenCalledWith('beige');
-    expect(mockSetAppColorTheme).toHaveBeenCalledWith('beige');
+    expect(onChange).toHaveBeenCalledWith('latte');
+    expect(mockSetAppColorTheme).toHaveBeenCalledWith('latte');
 
     await waitFor(() =>
-      expect(userSettingsApi.updatePreferences).toHaveBeenCalledWith({ colorTheme: 'beige' }),
+      expect(userSettingsApi.updatePreferences).toHaveBeenCalledWith({ colorTheme: 'latte' }),
     );
     await waitFor(() => expect(toast.success).toHaveBeenCalled());
   });

--- a/frontend/src/components/settings/ColorThemeSelector.test.tsx
+++ b/frontend/src/components/settings/ColorThemeSelector.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+import { act, fireEvent, screen, waitFor, render } from '@/test/render';
+import { ColorThemeSelector } from './ColorThemeSelector';
+import { COLOR_THEMES } from '@/lib/color-themes';
+
+const { mockSetAppColorTheme } = vi.hoisted(() => ({ mockSetAppColorTheme: vi.fn() }));
+
+// Mock the theme context so we can assert the live colour theme is updated.
+// A pass-through ThemeProvider keeps the custom test render wrapper working.
+vi.mock('@/contexts/ThemeContext', () => ({
+  ThemeProvider: ({ children }: { children: ReactNode }) => children,
+  useTheme: () => ({
+    theme: 'system',
+    resolvedTheme: 'light',
+    setTheme: vi.fn(),
+    colorTheme: 'default',
+    setColorTheme: mockSetAppColorTheme,
+  }),
+}));
+
+vi.mock('@/lib/user-settings', () => ({
+  userSettingsApi: {
+    updatePreferences: vi.fn().mockResolvedValue({ colorTheme: 'beige', defaultCurrency: 'USD' }),
+  },
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/errors', () => ({
+  getErrorMessage: vi.fn((_error: unknown, fallback: string) => fallback),
+}));
+
+import toast from 'react-hot-toast';
+import { userSettingsApi } from '@/lib/user-settings';
+
+describe('ColorThemeSelector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders every colour theme option', () => {
+    render(<ColorThemeSelector value="default" onChange={() => {}} />);
+    const select = screen.getByRole('combobox') as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    expect(optionValues).toEqual([...COLOR_THEMES]);
+  });
+
+  it('applies and persists the colour theme immediately on change', async () => {
+    const onChange = vi.fn();
+    render(<ColorThemeSelector value="default" onChange={onChange} />);
+
+    await act(async () => {
+      fireEvent.change(screen.getByRole('combobox'), { target: { value: 'beige' } });
+    });
+
+    // Parent state and the live colour theme update right away, no save step.
+    expect(onChange).toHaveBeenCalledWith('beige');
+    expect(mockSetAppColorTheme).toHaveBeenCalledWith('beige');
+
+    await waitFor(() =>
+      expect(userSettingsApi.updatePreferences).toHaveBeenCalledWith({ colorTheme: 'beige' }),
+    );
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+  });
+
+  it('still applies the colour theme locally and surfaces an error when saving fails', async () => {
+    (userSettingsApi.updatePreferences as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('network'),
+    );
+    render(<ColorThemeSelector value="default" onChange={() => {}} />);
+
+    await act(async () => {
+      fireEvent.change(screen.getByRole('combobox'), { target: { value: 'nord' } });
+    });
+
+    expect(mockSetAppColorTheme).toHaveBeenCalledWith('nord');
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Failed to save colour theme'),
+    );
+  });
+});

--- a/frontend/src/components/settings/ColorThemeSelector.tsx
+++ b/frontend/src/components/settings/ColorThemeSelector.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import toast from 'react-hot-toast';
+import { Select } from '@/components/ui/Select';
+import { userSettingsApi } from '@/lib/user-settings';
+import { usePreferencesStore } from '@/store/preferencesStore';
+import { useTheme } from '@/contexts/ThemeContext';
+import { getErrorMessage } from '@/lib/errors';
+import { COLOR_THEMES, ColorTheme } from '@/lib/color-themes';
+
+interface ColorThemeSelectorProps {
+  value: ColorTheme;
+  onChange: (colorTheme: ColorTheme) => void;
+}
+
+/**
+ * Colour theme (palette) picker that applies and persists the choice
+ * immediately, mirroring the ThemeSelector. The change is reflected in the
+ * app right away (via the theme context) and saved to the server without
+ * waiting for "Save Preferences".
+ */
+export function ColorThemeSelector({ value, onChange }: ColorThemeSelectorProps) {
+  const t = useTranslations('settings.preferences');
+  const [isSaving, startTransition] = useTransition();
+  const updatePreferencesStore = usePreferencesStore((state) => state.updatePreferences);
+  const { setColorTheme: setAppColorTheme } = useTheme();
+
+  const handleChange = (next: ColorTheme) => {
+    onChange(next);
+    setAppColorTheme(next);
+
+    startTransition(async () => {
+      try {
+        const updated = await userSettingsApi.updatePreferences({ colorTheme: next });
+        updatePreferencesStore(updated);
+        toast.success(t('toasts.saved'));
+      } catch (error) {
+        toast.error(getErrorMessage(error, 'Failed to save colour theme'));
+      }
+    });
+  };
+
+  return (
+    <Select
+      label={t('colorThemeLabel')}
+      options={COLOR_THEMES.map((name) => ({
+        value: name,
+        label: t(`colorThemeOptions.${name}`),
+      }))}
+      value={value}
+      onChange={(e) => handleChange(e.target.value as ColorTheme)}
+      disabled={isSaving}
+    />
+  );
+}

--- a/frontend/src/components/settings/NotificationsSection.test.tsx
+++ b/frontend/src/components/settings/NotificationsSection.test.tsx
@@ -27,6 +27,7 @@ const mockPreferences: UserPreferences = {
   numberFormat: 'en-US',
   timezone: 'UTC',
   theme: 'system',
+  colorTheme: 'default',
   defaultCurrency: 'CAD',
   notificationEmail: false,
   notificationBrowser: false,

--- a/frontend/src/components/settings/PreferencesSection.test.tsx
+++ b/frontend/src/components/settings/PreferencesSection.test.tsx
@@ -50,6 +50,7 @@ const mockPreferences: UserPreferences = {
   numberFormat: 'en-US',
   timezone: 'UTC',
   theme: 'system',
+  colorTheme: 'default',
   defaultCurrency: 'CAD',
   notificationEmail: false,
   notificationBrowser: false,
@@ -280,6 +281,35 @@ describe('PreferencesSection', () => {
     });
     expect(userSettingsApi.updatePreferences).toHaveBeenCalledWith(
       expect.not.objectContaining({ theme: expect.anything() }),
+    );
+  });
+
+  it('persists the colour theme immediately on change, without waiting for save', async () => {
+    (userSettingsApi.updatePreferences as ReturnType<typeof vi.fn>).mockResolvedValue(mockPreferences);
+
+    render(<PreferencesSection preferences={mockPreferences} onPreferencesUpdated={mockOnPreferencesUpdated} />);
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Colour theme'), { target: { value: 'beige' } });
+    });
+
+    await waitFor(() => {
+      expect(userSettingsApi.updatePreferences).toHaveBeenCalledWith({ colorTheme: 'beige' });
+    });
+  });
+
+  it('does not include colorTheme in the bulk Save Preferences payload', async () => {
+    (userSettingsApi.updatePreferences as ReturnType<typeof vi.fn>).mockResolvedValue(mockPreferences);
+
+    render(<PreferencesSection preferences={mockPreferences} onPreferencesUpdated={mockOnPreferencesUpdated} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Preferences' }));
+
+    await waitFor(() => {
+      expect(userSettingsApi.updatePreferences).toHaveBeenCalled();
+    });
+    expect(userSettingsApi.updatePreferences).toHaveBeenCalledWith(
+      expect.not.objectContaining({ colorTheme: expect.anything() }),
     );
   });
 

--- a/frontend/src/components/settings/PreferencesSection.test.tsx
+++ b/frontend/src/components/settings/PreferencesSection.test.tsx
@@ -290,11 +290,11 @@ describe('PreferencesSection', () => {
     render(<PreferencesSection preferences={mockPreferences} onPreferencesUpdated={mockOnPreferencesUpdated} />);
 
     await act(async () => {
-      fireEvent.change(screen.getByLabelText('Colour theme'), { target: { value: 'beige' } });
+      fireEvent.change(screen.getByLabelText('Colour theme'), { target: { value: 'latte' } });
     });
 
     await waitFor(() => {
-      expect(userSettingsApi.updatePreferences).toHaveBeenCalledWith({ colorTheme: 'beige' });
+      expect(userSettingsApi.updatePreferences).toHaveBeenCalledWith({ colorTheme: 'latte' });
     });
   });
 

--- a/frontend/src/components/settings/PreferencesSection.tsx
+++ b/frontend/src/components/settings/PreferencesSection.tsx
@@ -17,6 +17,8 @@ import { Combobox } from '@/components/ui/Combobox';
 import { getDateFormatOptions, EXCHANGE_OPTIONS } from '@/lib/constants';
 import { LanguageSelector } from '@/components/settings/LanguageSelector';
 import { ThemeSelector } from '@/components/settings/ThemeSelector';
+import { ColorThemeSelector } from '@/components/settings/ColorThemeSelector';
+import { ColorTheme } from '@/lib/color-themes';
 
 const NUMBER_FORMAT_OPTIONS = [
   { value: 'browser', labelKey: 'numberFormatOptions.browser' },
@@ -88,6 +90,7 @@ export function PreferencesSection({ preferences, onPreferencesUpdated }: Prefer
   const [numberFormat, setNumberFormat] = useState(preferences.numberFormat);
   const [timezone, setTimezone] = useState(preferences.timezone);
   const [theme, setTheme] = useState<'light' | 'dark' | 'system'>(preferences.theme);
+  const [colorTheme, setColorTheme] = useState<ColorTheme>(preferences.colorTheme ?? 'default');
   const [defaultCurrency, setDefaultCurrency] = useState(preferences.defaultCurrency);
   const [weekStartsOn, setWeekStartsOn] = useState(preferences.weekStartsOn ?? 1);
   const [showCreatedAt, setShowCreatedAt] = useState(preferences.showCreatedAt ?? false);
@@ -128,8 +131,9 @@ export function PreferencesSection({ preferences, onPreferencesUpdated }: Prefer
   const handleUpdatePreferences = async () => {
     setIsUpdatingPreferences(true);
     try {
-      // Theme is applied and persisted immediately by ThemeSelector (like
-      // language), so it is intentionally omitted from this bulk save.
+      // Theme and colour theme are applied and persisted immediately by
+      // ThemeSelector / ColorThemeSelector (like language), so they are
+      // intentionally omitted from this bulk save.
       const data: UpdatePreferencesData = {
         dateFormat,
         numberFormat,
@@ -162,6 +166,8 @@ export function PreferencesSection({ preferences, onPreferencesUpdated }: Prefer
         <LanguageSelector value={language} onChange={setLanguage} />
 
         <ThemeSelector value={theme} onChange={setTheme} />
+
+        <ColorThemeSelector value={colorTheme} onChange={setColorTheme} />
 
         <Select
           label={t('defaultCurrencyLabel')}

--- a/frontend/src/components/settings/SecuritySection.test.tsx
+++ b/frontend/src/components/settings/SecuritySection.test.tsx
@@ -71,6 +71,7 @@ const mockPreferences: UserPreferences = {
   numberFormat: 'en-US',
   timezone: 'UTC',
   theme: 'system',
+  colorTheme: 'default',
   defaultCurrency: 'CAD',
   notificationEmail: false,
   notificationBrowser: false,

--- a/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@/test/render';
-import { BalanceHistoryChart, computeBalanceGradient } from './BalanceHistoryChart';
+import { BalanceHistoryChart } from './BalanceHistoryChart';
+import { computeBalanceGradient } from '@/lib/balance-history';
 
 vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,

--- a/frontend/src/components/transactions/BalanceHistoryChart.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.tsx
@@ -15,6 +15,7 @@ import {
   ReferenceLine,
 } from 'recharts';
 import { format } from 'date-fns';
+import { chartColors } from '@/lib/chart-colors';
 import { parseLocalDate } from '@/lib/utils';
 import { computeBalanceSummary } from '@/lib/balance-history';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
@@ -191,26 +192,22 @@ export function BalanceHistoryChart({
           <AreaChart data={chartData} margin={{ left: 0, right: 8, top: 5, bottom: 0 }}>
             <defs>
               <linearGradient id="colorBalance" x1="0" y1="0" x2="0" y2="1">
-                <stop offset={0} stopColor="#3b82f6" stopOpacity={areaGradient.topOpacity} />
-                <stop offset={areaGradient.zeroOffset} stopColor="#3b82f6" stopOpacity={0} />
-                <stop offset={1} stopColor="#3b82f6" stopOpacity={areaGradient.bottomOpacity} />
+                <stop offset={0} stopColor={chartColors.primary} stopOpacity={areaGradient.topOpacity} />
+                <stop offset={areaGradient.zeroOffset} stopColor={chartColors.primary} stopOpacity={0} />
+                <stop offset={1} stopColor={chartColors.primary} stopOpacity={areaGradient.bottomOpacity} />
               </linearGradient>
             </defs>
-            <CartesianGrid
-              strokeDasharray="3 3"
-              stroke="#e5e7eb"
-              className="dark:stroke-gray-700"
-            />
+            <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
             <XAxis
               dataKey="date"
               ticks={monthTicks}
-              tick={{ fill: '#6b7280', fontSize: 12 }}
+              tick={{ fill: chartColors.axis, fontSize: 12 }}
               tickLine={false}
-              axisLine={{ stroke: '#e5e7eb' }}
+              axisLine={{ stroke: chartColors.grid }}
               tickFormatter={(value: string) => format(parseLocalDate(value), 'MMM')}
             />
             <YAxis
-              tick={{ fill: '#6b7280', fontSize: 11 }}
+              tick={{ fill: chartColors.axis, fontSize: 11 }}
               tickLine={false}
               axisLine={false}
               tickFormatter={formatAxis}
@@ -220,14 +217,14 @@ export function BalanceHistoryChart({
             <Tooltip content={<BalanceTooltip formatCurrency={formatCurrency} />} />
             <ReferenceLine
               y={0}
-              stroke="#ef4444"
+              stroke={chartColors.expense}
               strokeDasharray="5 5"
               strokeOpacity={0.5}
             />
             {summary && summary.minBalance !== summary.startBalance && (
               <ReferenceLine
                 y={summary.minBalance}
-                stroke={summary.minBalance < 0 ? '#ef4444' : '#f59e0b'}
+                stroke={summary.minBalance < 0 ? chartColors.expense : chartColors.warning}
                 strokeDasharray="3 3"
                 strokeOpacity={0.4}
               />
@@ -235,12 +232,12 @@ export function BalanceHistoryChart({
             <Area
               type="monotone"
               dataKey="balance"
-              stroke="#3b82f6"
+              stroke={chartColors.primary}
               strokeWidth={2}
               fillOpacity={1}
               fill="url(#colorBalance)"
               dot={false}
-              activeDot={{ r: 6, fill: '#3b82f6' }}
+              activeDot={{ r: 6, fill: chartColors.primary }}
             />
           </AreaChart>
         </ResponsiveContainer>

--- a/frontend/src/components/transactions/BalanceHistoryChart.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.tsx
@@ -17,7 +17,7 @@ import {
 import { format } from 'date-fns';
 import { chartColors } from '@/lib/chart-colors';
 import { parseLocalDate } from '@/lib/utils';
-import { computeBalanceSummary } from '@/lib/balance-history';
+import { computeBalanceGradient, computeBalanceSummary } from '@/lib/balance-history';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { ChartDownloadButton } from '@/components/ui/ChartDownloadButton';
 
@@ -63,40 +63,6 @@ function BalanceTooltip({
     );
   }
   return null;
-}
-
-/**
- * Opacity stops for the balance area's vertical gradient. The fill is densest
- * along the data line and fades to transparent at the zero axis, whether
- * balances are positive, negative, or cross zero. `zeroOffset` is the fraction
- * (measured from the top of the area's bounding box) at which the zero line
- * falls, clamped to [0, 1] so all-positive data keeps the original
- * top-to-bottom fade and all-negative data mirrors it (shading increasing
- * toward the bottom).
- */
-export function computeBalanceGradient(values: number[]): {
-  topOpacity: number;
-  zeroOffset: number;
-  bottomOpacity: number;
-} {
-  const SHADE = 0.3;
-  if (values.length === 0) {
-    return { topOpacity: SHADE, zeroOffset: 1, bottomOpacity: 0 };
-  }
-  let max = values[0];
-  let min = values[0];
-  for (const value of values) {
-    if (value > max) max = value;
-    if (value < min) min = value;
-  }
-  const span = max - min;
-  const zeroOffset =
-    span === 0 ? (max >= 0 ? 1 : 0) : Math.min(1, Math.max(0, max / span));
-  return {
-    topOpacity: max > 0 ? SHADE : 0,
-    zeroOffset,
-    bottomOpacity: min < 0 ? SHADE : 0,
-  };
 }
 
 export function BalanceHistoryChart({

--- a/frontend/src/contexts/ThemeContext.test.tsx
+++ b/frontend/src/contexts/ThemeContext.test.tsx
@@ -137,9 +137,9 @@ describe('ThemeContext', () => {
     const { result } = renderHook(() => useTheme(), { wrapper: ThemeProvider });
 
     act(() => {
-      result.current.setColorTheme('beige');
+      result.current.setColorTheme('latte');
     });
-    expect(document.documentElement.getAttribute('data-theme')).toBe('beige');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('latte');
 
     act(() => {
       result.current.setColorTheme('default');

--- a/frontend/src/contexts/ThemeContext.test.tsx
+++ b/frontend/src/contexts/ThemeContext.test.tsx
@@ -7,6 +7,7 @@ describe('ThemeContext', () => {
   beforeEach(() => {
     localStorage.clear();
     document.documentElement.classList.remove('dark');
+    document.documentElement.removeAttribute('data-theme');
     vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
       matches: false,
       media: query,
@@ -112,6 +113,54 @@ describe('ThemeContext', () => {
     });
     expect(result.current.theme).toBe('dark');
     expect(result.current.resolvedTheme).toBe('dark');
+  });
+
+  it('defaults to the default colour theme', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper: ThemeProvider });
+    expect(result.current.colorTheme).toBe('default');
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
+  });
+
+  it('persists colour theme to localStorage and applies data-theme when setColorTheme is called', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper: ThemeProvider });
+
+    act(() => {
+      result.current.setColorTheme('nord');
+    });
+
+    expect(localStorage.setItem).toHaveBeenCalledWith('monize-color-theme', 'nord');
+    expect(result.current.colorTheme).toBe('nord');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('nord');
+  });
+
+  it('removes the data-theme attribute when switching back to the default colour theme', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper: ThemeProvider });
+
+    act(() => {
+      result.current.setColorTheme('beige');
+    });
+    expect(document.documentElement.getAttribute('data-theme')).toBe('beige');
+
+    act(() => {
+      result.current.setColorTheme('default');
+    });
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
+  });
+
+  it('reads persisted colour theme from localStorage on mount', () => {
+    localStorage.setItem('monize-color-theme', 'solarized');
+
+    const { result } = renderHook(() => useTheme(), { wrapper: ThemeProvider });
+    expect(result.current.colorTheme).toBe('solarized');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('solarized');
+  });
+
+  it('ignores invalid stored colour theme values', () => {
+    localStorage.setItem('monize-color-theme', 'neon-disco');
+
+    const { result } = renderHook(() => useTheme(), { wrapper: ThemeProvider });
+    expect(result.current.colorTheme).toBe('default');
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
   });
 
   it('throws when useTheme is called outside ThemeProvider', () => {

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { ColorTheme, isColorTheme } from '@/lib/color-themes';
 
 type Theme = 'light' | 'dark' | 'system';
 
@@ -8,14 +9,18 @@ interface ThemeContextType {
   theme: Theme;
   resolvedTheme: 'light' | 'dark';
   setTheme: (theme: Theme) => void;
+  colorTheme: ColorTheme;
+  setColorTheme: (colorTheme: ColorTheme) => void;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 const THEME_KEY = 'monize-theme';
+const COLOR_THEME_KEY = 'monize-color-theme';
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setThemeState] = useState<Theme>('system');
+  const [colorTheme, setColorThemeState] = useState<ColorTheme>('default');
   const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('light');
   const [mounted, setMounted] = useState(false);
 
@@ -33,6 +38,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     const stored = localStorage.getItem(THEME_KEY) as Theme | null;
     if (stored && ['light', 'dark', 'system'].includes(stored)) {
       setThemeState(stored);
+    }
+    const storedColorTheme = localStorage.getItem(COLOR_THEME_KEY);
+    if (isColorTheme(storedColorTheme)) {
+      setColorThemeState(storedColorTheme);
     }
     setMounted(true);
   }, []);
@@ -74,9 +83,26 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     }
   }, [resolvedTheme, mounted]);
 
+  // Apply data-theme attribute to html element ('default' = no attribute)
+  useEffect(() => {
+    if (!mounted) return;
+
+    const root = document.documentElement;
+    if (colorTheme === 'default') {
+      root.removeAttribute('data-theme');
+    } else {
+      root.setAttribute('data-theme', colorTheme);
+    }
+  }, [colorTheme, mounted]);
+
   const setTheme = (newTheme: Theme) => {
     setThemeState(newTheme);
     localStorage.setItem(THEME_KEY, newTheme);
+  };
+
+  const setColorTheme = (newColorTheme: ColorTheme) => {
+    setColorThemeState(newColorTheme);
+    localStorage.setItem(COLOR_THEME_KEY, newColorTheme);
   };
 
   // Prevent flash of incorrect theme
@@ -85,7 +111,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>
+    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme, colorTheme, setColorTheme }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/frontend/src/i18n/messages/en/settings.json
+++ b/frontend/src/i18n/messages/en/settings.json
@@ -150,7 +150,7 @@
     "colorThemeLabel": "Colour theme",
     "colorThemeOptions": {
       "default": "Default",
-      "beige": "Beige",
+      "latte": "Latte",
       "msmoney": "Classic Money",
       "nord": "Nord",
       "forest": "Forest",

--- a/frontend/src/i18n/messages/en/settings.json
+++ b/frontend/src/i18n/messages/en/settings.json
@@ -147,6 +147,16 @@
       "light": "Light",
       "dark": "Dark"
     },
+    "colorThemeLabel": "Colour theme",
+    "colorThemeOptions": {
+      "default": "Default",
+      "beige": "Beige",
+      "msmoney": "Classic Money",
+      "nord": "Nord",
+      "forest": "Forest",
+      "solarized": "Solarized",
+      "highcontrast": "High contrast"
+    },
     "timezoneBrowserOption": "Use browser timezone (auto-detected as {tz})"
   },
   "notifications": {

--- a/frontend/src/i18n/messages/en/settings.json
+++ b/frontend/src/i18n/messages/en/settings.json
@@ -151,7 +151,7 @@
     "colorThemeOptions": {
       "default": "Default",
       "latte": "Latte",
-      "msmoney": "Classic Money",
+      "msmoney": "MS Money",
       "nord": "Nord",
       "forest": "Forest",
       "solarized": "Solarized",

--- a/frontend/src/i18n/messages/en/settings.json
+++ b/frontend/src/i18n/messages/en/settings.json
@@ -152,10 +152,18 @@
       "default": "Default",
       "latte": "Latte",
       "msmoney": "MS Money",
+      "newspaper": "Newspaper",
+      "burgundy": "Burgundy",
       "nord": "Nord",
       "forest": "Forest",
       "solarized": "Solarized",
-      "highcontrast": "High contrast"
+      "gruvbox": "Gruvbox",
+      "dracula": "Dracula",
+      "tokyonight": "Tokyo Night",
+      "rosepine": "Rosé Pine",
+      "midnight": "Midnight",
+      "highcontrast": "High contrast",
+      "colorblind": "Colour-blind safe"
     },
     "timezoneBrowserOption": "Use browser timezone (auto-detected as {tz})"
   },

--- a/frontend/src/i18n/messages/pl/settings.json
+++ b/frontend/src/i18n/messages/pl/settings.json
@@ -150,7 +150,7 @@
     "colorThemeLabel": "Motyw kolorystyczny",
     "colorThemeOptions": {
       "default": "Domyślny",
-      "beige": "Beżowy",
+      "latte": "Latte",
       "msmoney": "Klasyczny Money",
       "nord": "Nord",
       "forest": "Leśny",

--- a/frontend/src/i18n/messages/pl/settings.json
+++ b/frontend/src/i18n/messages/pl/settings.json
@@ -147,6 +147,16 @@
       "light": "Jasny",
       "dark": "Ciemny"
     },
+    "colorThemeLabel": "Motyw kolorystyczny",
+    "colorThemeOptions": {
+      "default": "Domyślny",
+      "beige": "Beżowy",
+      "msmoney": "Klasyczny Money",
+      "nord": "Nord",
+      "forest": "Leśny",
+      "solarized": "Solarized",
+      "highcontrast": "Wysoki kontrast"
+    },
     "timezoneBrowserOption": "Użyj strefy czasowej przeglądarki (wykryto {tz})"
   },
   "notifications": {

--- a/frontend/src/i18n/messages/pl/settings.json
+++ b/frontend/src/i18n/messages/pl/settings.json
@@ -151,7 +151,7 @@
     "colorThemeOptions": {
       "default": "Domyślny",
       "latte": "Latte",
-      "msmoney": "Klasyczny Money",
+      "msmoney": "MS Money",
       "nord": "Nord",
       "forest": "Leśny",
       "solarized": "Solarized",

--- a/frontend/src/i18n/messages/pl/settings.json
+++ b/frontend/src/i18n/messages/pl/settings.json
@@ -152,10 +152,18 @@
       "default": "Domyślny",
       "latte": "Latte",
       "msmoney": "MS Money",
+      "newspaper": "Gazeta",
+      "burgundy": "Burgund",
       "nord": "Nord",
       "forest": "Leśny",
       "solarized": "Solarized",
-      "highcontrast": "Wysoki kontrast"
+      "gruvbox": "Gruvbox",
+      "dracula": "Dracula",
+      "tokyonight": "Tokyo Night",
+      "rosepine": "Rosé Pine",
+      "midnight": "Północ",
+      "highcontrast": "Wysoki kontrast",
+      "colorblind": "Bezpieczny dla daltonistów"
     },
     "timezoneBrowserOption": "Użyj strefy czasowej przeglądarki (wykryto {tz})"
   },

--- a/frontend/src/i18n/messages/xx/settings.json
+++ b/frontend/src/i18n/messages/xx/settings.json
@@ -147,6 +147,16 @@
       "light": "[XX-Light-XX]",
       "dark": "[XX-Dark-XX]"
     },
+    "colorThemeLabel": "[XX-Colour theme-XX]",
+    "colorThemeOptions": {
+      "default": "[XX-Default-XX]",
+      "beige": "[XX-Beige-XX]",
+      "msmoney": "[XX-Classic Money-XX]",
+      "nord": "[XX-Nord-XX]",
+      "forest": "[XX-Forest-XX]",
+      "solarized": "[XX-Solarized-XX]",
+      "highcontrast": "[XX-High contrast-XX]"
+    },
     "timezoneBrowserOption": "[XX-Use browser timezone (auto-detected as {tz})-XX]"
   },
   "notifications": {

--- a/frontend/src/i18n/messages/xx/settings.json
+++ b/frontend/src/i18n/messages/xx/settings.json
@@ -150,7 +150,7 @@
     "colorThemeLabel": "[XX-Colour theme-XX]",
     "colorThemeOptions": {
       "default": "[XX-Default-XX]",
-      "beige": "[XX-Beige-XX]",
+      "latte": "[XX-Latte-XX]",
       "msmoney": "[XX-Classic Money-XX]",
       "nord": "[XX-Nord-XX]",
       "forest": "[XX-Forest-XX]",

--- a/frontend/src/i18n/messages/xx/settings.json
+++ b/frontend/src/i18n/messages/xx/settings.json
@@ -151,7 +151,7 @@
     "colorThemeOptions": {
       "default": "[XX-Default-XX]",
       "latte": "[XX-Latte-XX]",
-      "msmoney": "[XX-Classic Money-XX]",
+      "msmoney": "[XX-MS Money-XX]",
       "nord": "[XX-Nord-XX]",
       "forest": "[XX-Forest-XX]",
       "solarized": "[XX-Solarized-XX]",

--- a/frontend/src/i18n/messages/xx/settings.json
+++ b/frontend/src/i18n/messages/xx/settings.json
@@ -152,10 +152,18 @@
       "default": "[XX-Default-XX]",
       "latte": "[XX-Latte-XX]",
       "msmoney": "[XX-MS Money-XX]",
+      "newspaper": "[XX-Newspaper-XX]",
+      "burgundy": "[XX-Burgundy-XX]",
       "nord": "[XX-Nord-XX]",
       "forest": "[XX-Forest-XX]",
       "solarized": "[XX-Solarized-XX]",
-      "highcontrast": "[XX-High contrast-XX]"
+      "gruvbox": "[XX-Gruvbox-XX]",
+      "dracula": "[XX-Dracula-XX]",
+      "tokyonight": "[XX-Tokyo Night-XX]",
+      "rosepine": "[XX-Rosé Pine-XX]",
+      "midnight": "[XX-Midnight-XX]",
+      "highcontrast": "[XX-High contrast-XX]",
+      "colorblind": "[XX-Colour-blind safe-XX]"
     },
     "timezoneBrowserOption": "[XX-Use browser timezone (auto-detected as {tz})-XX]"
   },

--- a/frontend/src/lib/balance-history.ts
+++ b/frontend/src/lib/balance-history.ts
@@ -81,3 +81,37 @@ export function computeBalanceSummary(
     goesNegative: minBalance < 0,
   };
 }
+
+/**
+ * Opacity stops for a balance area's vertical gradient. The fill is densest
+ * along the data line and fades to transparent at the zero axis, whether
+ * balances are positive, negative, or cross zero. `zeroOffset` is the fraction
+ * (measured from the top of the area's bounding box) at which the zero line
+ * falls, clamped to [0, 1] so all-positive data keeps the original
+ * top-to-bottom fade and all-negative data mirrors it (shading increasing
+ * toward the bottom).
+ */
+export function computeBalanceGradient(values: number[]): {
+  topOpacity: number;
+  zeroOffset: number;
+  bottomOpacity: number;
+} {
+  const SHADE = 0.3;
+  if (values.length === 0) {
+    return { topOpacity: SHADE, zeroOffset: 1, bottomOpacity: 0 };
+  }
+  let max = values[0];
+  let min = values[0];
+  for (const value of values) {
+    if (value > max) max = value;
+    if (value < min) min = value;
+  }
+  const span = max - min;
+  const zeroOffset =
+    span === 0 ? (max >= 0 ? 1 : 0) : Math.min(1, Math.max(0, max / span));
+  return {
+    topOpacity: max > 0 ? SHADE : 0,
+    zeroOffset,
+    bottomOpacity: min < 0 ? SHADE : 0,
+  };
+}

--- a/frontend/src/lib/chart-colors.ts
+++ b/frontend/src/lib/chart-colors.ts
@@ -1,0 +1,46 @@
+/**
+ * Chart colour tokens for Recharts components.
+ *
+ * These are CSS variable references, not hex values: passing them straight
+ * into Recharts `fill` / `stroke` / `stopColor` props makes every chart
+ * follow the active colour theme AND light/dark mode automatically, with no
+ * JS recomputation on theme change. The variables are defined in
+ * `src/app/globals.css` (defaults) and overridden per theme in
+ * `src/app/themes.css`.
+ *
+ * Do not use these for user-chosen entity colours (tags, categories,
+ * payees) -- those come from the database and are intentionally not themed.
+ */
+export const chartColors = {
+  /** Accent-coloured series (balance lines, primary bars). Follows the theme accent. */
+  primary: 'var(--chart-primary)',
+  /** Income / gains / positive values. */
+  income: 'var(--chart-income)',
+  /** Expenses / losses / negative values. */
+  expense: 'var(--chart-expense)',
+  /** Warnings, projections, secondary highlights. */
+  warning: 'var(--chart-warning)',
+  /** CartesianGrid stroke and axis lines. */
+  grid: 'var(--chart-grid)',
+  /** Axis tick label fill. */
+  axis: 'var(--chart-axis)',
+} as const;
+
+/** Categorical palette for multi-series charts (pies, stacked bars, multi-line). */
+export const CHART_SERIES = [
+  'var(--chart-1)',
+  'var(--chart-2)',
+  'var(--chart-3)',
+  'var(--chart-4)',
+  'var(--chart-5)',
+  'var(--chart-6)',
+  'var(--chart-7)',
+  'var(--chart-8)',
+  'var(--chart-9)',
+  'var(--chart-10)',
+] as const;
+
+/** Cycle through the categorical palette for series index `i`. */
+export function chartSeriesColor(i: number): string {
+  return CHART_SERIES[i % CHART_SERIES.length];
+}

--- a/frontend/src/lib/color-themes.ts
+++ b/frontend/src/lib/color-themes.ts
@@ -8,7 +8,7 @@
  */
 export const COLOR_THEMES = [
   'default',
-  'beige',
+  'latte',
   'msmoney',
   'nord',
   'forest',

--- a/frontend/src/lib/color-themes.ts
+++ b/frontend/src/lib/color-themes.ts
@@ -1,0 +1,25 @@
+/**
+ * Colour theme (palette) identifiers, separate from the light/dark/system
+ * mode preference. Each palette has both light and dark variants; the mode
+ * setting chooses between them. Palette CSS lives in `src/app/themes.css`
+ * under `html[data-theme="..."]` selectors ('default' applies no attribute
+ * and uses the stock palette). The backend validates the same list in
+ * `backend/src/users/dto/update-preferences.dto.ts`.
+ */
+export const COLOR_THEMES = [
+  'default',
+  'beige',
+  'msmoney',
+  'nord',
+  'forest',
+  'solarized',
+  'highcontrast',
+] as const;
+
+export type ColorTheme = (typeof COLOR_THEMES)[number];
+
+export function isColorTheme(value: unknown): value is ColorTheme {
+  return (
+    typeof value === 'string' && (COLOR_THEMES as readonly string[]).includes(value)
+  );
+}

--- a/frontend/src/lib/color-themes.ts
+++ b/frontend/src/lib/color-themes.ts
@@ -10,10 +10,18 @@ export const COLOR_THEMES = [
   'default',
   'latte',
   'msmoney',
+  'newspaper',
+  'burgundy',
   'nord',
   'forest',
   'solarized',
+  'gruvbox',
+  'dracula',
+  'tokyonight',
+  'rosepine',
+  'midnight',
   'highcontrast',
+  'colorblind',
 ] as const;
 
 export type ColorTheme = (typeof COLOR_THEMES)[number];

--- a/frontend/src/lib/pdf-export-charts.ts
+++ b/frontend/src/lib/pdf-export-charts.ts
@@ -41,6 +41,33 @@ function resolveChartDimensions(
 }
 
 /**
+ * Chart colours are CSS variable references (var(--chart-*), see
+ * src/lib/chart-colors.ts) that resolve against the document's active colour
+ * theme. The serialized standalone SVG has no stylesheet context, so they
+ * would render as black. Bake the computed colours into the clone before
+ * serialization by reading them from the live elements.
+ */
+function inlineCssVariableColors(original: SVGSVGElement, clone: SVGSVGElement): void {
+  const COLOR_ATTRS = ['fill', 'stroke', 'stop-color'] as const;
+  const originalElements = [original, ...Array.from(original.querySelectorAll<SVGElement>('*'))];
+  const cloneElements = [clone, ...Array.from(clone.querySelectorAll<SVGElement>('*'))];
+  if (originalElements.length !== cloneElements.length) return;
+
+  originalElements.forEach((origEl, i) => {
+    const cloneEl = cloneElements[i];
+    for (const attr of COLOR_ATTRS) {
+      const value = origEl.getAttribute(attr);
+      if (value && value.includes('var(')) {
+        const computed = getComputedStyle(origEl).getPropertyValue(attr);
+        if (computed) {
+          cloneEl.setAttribute(attr, computed);
+        }
+      }
+    }
+  });
+}
+
+/**
  * Captures a single SVG element and converts it to a PNG data URL.
  * Forces a white background regardless of dark mode for print-friendly output.
  *
@@ -71,6 +98,10 @@ function captureSingleSvg(
   svgClone.querySelectorAll(':scope > g[style], :scope > svg[style]').forEach((el) => {
     (el as SVGElement).removeAttribute('style');
   });
+
+  // Resolve theme CSS variables to concrete colours while both trees still
+  // mirror each other (before the background rect is inserted below).
+  inlineCssVariableColors(svg, svgClone);
 
   // Set the clone to render at scaled resolution natively.
   // viewBox preserves the original coordinate system while width/height

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,3 +1,5 @@
+import type { ColorTheme } from '@/lib/color-themes';
+
 export interface User {
   id: string;
   email: string;
@@ -87,6 +89,7 @@ export interface UserPreferences {
   dateFormat: string; // 'browser' = use browser locale
   numberFormat: string; // 'browser' = use browser locale
   theme: 'light' | 'dark' | 'system';
+  colorTheme: ColorTheme;
   timezone: string; // 'browser' = use browser timezone
   notificationEmail: boolean;
   notificationBrowser: boolean;
@@ -147,6 +150,7 @@ export interface UpdatePreferencesData {
   dateFormat?: string;
   numberFormat?: string;
   theme?: 'light' | 'dark' | 'system';
+  colorTheme?: ColorTheme;
   timezone?: string;
   notificationEmail?: boolean;
   notificationBrowser?: boolean;


### PR DESCRIPTION
Colour theme is a new preference, separate from the light/dark/system
mode setting. Each palette has light and dark variants and is applied as
pure CSS variable overrides under html[data-theme=...] in themes.css --
Tailwind v4 utilities compile to var(--color-*) references, so no
component changes are needed.

- New color_theme column on user_preferences (migration 083), validated
  in UpdatePreferencesDto and persisted by users.service
- ThemeContext gains colorTheme/setColorTheme with localStorage
  persistence and data-theme application; PreferencesLoader syncs the
  server value on load
- New ColorThemeSelector in Settings -> Preferences (applies and saves
  immediately, like the mode selector), translated for en/pl/xx
- Chart colour tokens (--chart-*) defined in globals.css with per-theme
  overrides, exposed to Recharts via src/lib/chart-colors.ts
- PDF chart export resolves CSS variable colours before SVG
  serialization so exports keep the active theme's colours

https://claude.ai/code/session_019nuAkBzt7NrXxSWC7ieeaP