### PR TITLE
Fix email/i18n placeholder interpolation

### DIFF
--- a/backend/src/i18n/i18n-formatter.spec.ts
+++ b/backend/src/i18n/i18n-formatter.spec.ts
@@ -1,0 +1,67 @@
+import { i18nFormatter } from "./i18n-formatter";
+
+describe("i18nFormatter", () => {
+  it("substitutes a single {{ placeholder }} from the args object", () => {
+    expect(i18nFormatter("Hi {{ name }},", { name: "Ken" })).toBe("Hi Ken,");
+  });
+
+  it("substitutes numeric values via String coercion", () => {
+    expect(
+      i18nFormatter("Monize: {{ count }} alerts need attention", { count: 3 }),
+    ).toBe("Monize: 3 alerts need attention");
+  });
+
+  it("substitutes multiple placeholders in one template", () => {
+    expect(
+      i18nFormatter("{{ greeting }} {{ name }}!", {
+        greeting: "Hello",
+        name: "Ken",
+      }),
+    ).toBe("Hello Ken!");
+  });
+
+  it("tolerates placeholders with no surrounding whitespace", () => {
+    expect(i18nFormatter("Hi {{name}},", { name: "Ken" })).toBe("Hi Ken,");
+  });
+
+  it("resolves dotted argument paths", () => {
+    expect(
+      i18nFormatter("Account {{ account.name }}", {
+        account: { name: "Chequing" },
+      }),
+    ).toBe("Account Chequing");
+  });
+
+  it("leaves a placeholder untouched when the arg is missing", () => {
+    expect(i18nFormatter("Hi {{ name }},", { count: 1 })).toBe(
+      "Hi {{ name }},",
+    );
+  });
+
+  it("leaves a placeholder untouched when the value is null or undefined", () => {
+    expect(i18nFormatter("Hi {{ name }},", { name: null })).toBe(
+      "Hi {{ name }},",
+    );
+    expect(i18nFormatter("Hi {{ name }},", { name: undefined })).toBe(
+      "Hi {{ name }},",
+    );
+  });
+
+  it("returns the template unchanged when it has no placeholders", () => {
+    expect(i18nFormatter("Your budget needs attention:", { name: "Ken" })).toBe(
+      "Your budget needs attention:",
+    );
+  });
+
+  it("merges multiple object args (nestjs-i18n passes a merged object)", () => {
+    expect(i18nFormatter("{{ a }}-{{ b }}", { a: "1" }, { b: "2" })).toBe(
+      "1-2",
+    );
+  });
+
+  it("ignores non-object formatter args", () => {
+    expect(i18nFormatter("Hi {{ name }},", undefined as unknown)).toBe(
+      "Hi {{ name }},",
+    );
+  });
+});

--- a/backend/src/i18n/i18n-formatter.ts
+++ b/backend/src/i18n/i18n-formatter.ts
@@ -1,0 +1,41 @@
+/**
+ * Custom value formatter for nestjs-i18n.
+ *
+ * nestjs-i18n ships with `string-format` as its default formatter, which uses
+ * single-brace `{key}` placeholders and treats `{{ key }}` as an escaped pair of
+ * literal braces. Every catalogue in this project uses the `{{ placeholder }}`
+ * convention (see `translate.ts` / `email-translator.ts`), so the stock
+ * formatter emitted those placeholders verbatim -- e.g. `"Hi {{ name }},"` was
+ * rendered as `"Hi { name },"` with the argument never substituted. The bug only
+ * surfaced once copy moved out of inline fallbacks and into the catalogues
+ * (e.g. `en/emails.json`), at which point the catalogue value started being
+ * returned instead of the already-interpolated English fallback.
+ *
+ * nestjs-i18n only resolves `{{ ... }}` itself when a transform pipe is present
+ * (`{{ name | uppercase }}`); plain placeholders fall through to this formatter.
+ * This implementation substitutes `{{ key }}` and dotted `{{ a.b }}` paths from
+ * the args object, leaving any unmatched placeholder untouched so a missing arg
+ * degrades gracefully rather than throwing.
+ */
+export function i18nFormatter(template: string, ...args: unknown[]): string {
+  const data = Object.assign(
+    {},
+    ...args.filter(
+      (arg): arg is Record<string, unknown> =>
+        typeof arg === "object" && arg !== null && !Array.isArray(arg),
+    ),
+  ) as Record<string, unknown>;
+
+  return template.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (match, path: string) => {
+    const value = path
+      .split(".")
+      .reduce<unknown>(
+        (acc, key) =>
+          acc !== null && acc !== undefined && typeof acc === "object"
+            ? (acc as Record<string, unknown>)[key]
+            : undefined,
+        data,
+      );
+    return value === undefined || value === null ? match : String(value);
+  });
+}

--- a/backend/src/i18n/i18n-interpolation.integration.spec.ts
+++ b/backend/src/i18n/i18n-interpolation.integration.spec.ts
@@ -1,0 +1,45 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { I18nService } from "nestjs-i18n";
+import { I18nModule } from "./i18n.module";
+import { emailTranslator } from "./email-translator";
+
+/**
+ * Regression guard for the email/exception placeholder bug: the catalogues use
+ * the `{{ name }}` convention, and nestjs-i18n's stock `string-format` formatter
+ * rendered those verbatim as `{ name }`. This boots the real I18nModule (with our
+ * custom formatter wired in) and asserts a catalogue value is actually
+ * interpolated rather than emitted with literal braces.
+ */
+describe("i18n interpolation (real catalogue)", () => {
+  let i18n: I18nService;
+
+  beforeAll(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [I18nModule],
+    }).compile();
+    i18n = moduleRef.get<I18nService>(I18nService);
+  });
+
+  it("interpolates a {{ name }} placeholder from a catalogue string", () => {
+    const t = emailTranslator(i18n, "en");
+    const greeting = t(
+      "emails.budgetAlertImmediate.greeting",
+      "Hi {{ name }},",
+      {
+        name: "Ken",
+      },
+    );
+    expect(greeting).toBe("Hi Ken,");
+    expect(greeting).not.toContain("{");
+  });
+
+  it("interpolates a {{ count }} placeholder in an email subject", () => {
+    const t = emailTranslator(i18n, "en");
+    const subject = t(
+      "emails.budgetAlertImmediate.subjectPlural",
+      "Monize: {{ count }} alerts need attention",
+      { count: 4 },
+    );
+    expect(subject).toBe("Monize: 4 alerts need attention");
+  });
+});

--- a/backend/src/i18n/i18n.module.ts
+++ b/backend/src/i18n/i18n.module.ts
@@ -8,6 +8,7 @@ import {
   QueryResolver,
 } from "nestjs-i18n";
 import { DEFAULT_LOCALE } from "./config";
+import { i18nFormatter } from "./i18n-formatter";
 
 /**
  * Centralised translation catalogues for backend strings (exception messages,
@@ -28,6 +29,9 @@ import { DEFAULT_LOCALE } from "./config";
   imports: [
     NestjsI18nModule.forRoot({
       fallbackLanguage: DEFAULT_LOCALE,
+      // The stock `string-format` formatter treats our `{{ key }}` placeholder
+      // convention as escaped literal braces; this one interpolates them.
+      formatter: i18nFormatter,
       loaderOptions: {
         path: path.join(__dirname, "locales"),
         watch: process.env.NODE_ENV !== "production",


### PR DESCRIPTION
Catalogue strings use the documented `{{ name }}` placeholder convention,
but nestjs-i18n's default formatter (string-format) only substitutes
single-brace `{name}` and treats `{{ name }}` as escaped literal braces --
so emails rendered "Hi { name }," and "Monize: { count } alerts need
attention" with the values never filled in. nestjs-i18n only resolves
`{{ ... }}` itself when a transform pipe is present; plain placeholders
fall through to the formatter untouched.

This regressed when email copy moved from inline fallbacks into the
catalogues (en/emails.json): the catalogue value started being returned
instead of the already-interpolated English fallback, exposing the
mismatch. All 1490 `{{ }}` placeholders across the locales were affected,
not just emails.

Register a custom formatter that substitutes the `{{ key }}` (and dotted
`{{ a.b }}`) convention from the args object, leaving unmatched
placeholders intact. Add unit tests for the formatter and an integration
test that boots the real I18nModule and asserts a catalogue string is
interpolated.

https://claude.ai/code/session_018N8VNXUgFuvVyPuEmVUVXe