### PR TITLE
Route MCP requests at root to backend MCP endpoint

### DIFF
--- a/frontend/src/proxy.test.ts
+++ b/frontend/src/proxy.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { proxy } from './proxy';
+
+const BASE = 'https://monize.laskonet.com';
+
+function makeRequest(
+  path: string,
+  init: { method?: string; headers?: Record<string, string> } = {},
+): NextRequest {
+  return new NextRequest(`${BASE}${path}`, {
+    method: init.method ?? 'GET',
+    headers: init.headers,
+  });
+}
+
+describe('proxy MCP-at-root routing', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockResolvedValue(
+      new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    fetchMock.mockReset();
+  });
+
+  it('proxies POST / with MCP Accept header to the backend MCP endpoint', async () => {
+    const request = makeRequest('/', {
+      method: 'POST',
+      headers: {
+        accept: 'application/json, text/event-stream',
+        'content-type': 'application/json',
+      },
+    });
+    const response = await proxy(request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:3001/api/v1/mcp');
+    expect(response.status).toBe(200);
+  });
+
+  it('proxies GET / SSE stream requests to the backend MCP endpoint', async () => {
+    const request = makeRequest('/', {
+      headers: { accept: 'text/event-stream' },
+    });
+    await proxy(request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:3001/api/v1/mcp');
+  });
+
+  it('proxies DELETE / with an Mcp-Session-Id header to the backend MCP endpoint', async () => {
+    const request = makeRequest('/', {
+      method: 'DELETE',
+      headers: { 'mcp-session-id': 'abc123' },
+    });
+    await proxy(request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:3001/api/v1/mcp');
+  });
+
+  it('does not proxy a browser navigation to / (redirects to login instead)', async () => {
+    const request = makeRequest('/', {
+      headers: { accept: 'text/html,application/xhtml+xml' },
+    });
+    const response = await proxy(request);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(`${BASE}/login`);
+  });
+
+  it('does not proxy /login even when MCP headers are present', async () => {
+    const request = makeRequest('/login', {
+      method: 'POST',
+      headers: { accept: 'application/json, text/event-stream' },
+    });
+    const response = await proxy(request);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.headers.get('location')).toBeNull();
+  });
+
+  it('still proxies explicit /api/v1/mcp requests unchanged', async () => {
+    const request = makeRequest('/api/v1/mcp', {
+      method: 'POST',
+      headers: { accept: 'application/json, text/event-stream' },
+    });
+    await proxy(request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:3001/api/v1/mcp');
+  });
+});

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -65,6 +65,22 @@ function nextWithCsp(request: NextRequest): NextResponse {
   return response;
 }
 
+// MCP clients configured with the bare origin (https://monize.laskonet.com)
+// send their JSON-RPC traffic to "/". The Streamable HTTP transport requires
+// clients to send "Accept: application/json, text/event-stream" on POST and
+// "Accept: text/event-stream" on GET, and follow-up requests carry an
+// Mcp-Session-Id / MCP-Protocol-Version header — none of which a browser
+// navigation ever sends, so this cannot intercept normal page loads.
+function isRootMcpRequest(request: NextRequest, pathname: string): boolean {
+  if (pathname !== '/') return false;
+  const accept = request.headers.get('accept') ?? '';
+  return (
+    accept.includes('text/event-stream') ||
+    request.headers.has('mcp-session-id') ||
+    request.headers.has('mcp-protocol-version')
+  );
+}
+
 // OAuth 2.1 endpoints exposed at the application root for the MCP remote
 // connector flow. These live outside /api because OAuth issuer URLs and the
 // RFC 9728 protected-resource metadata path are fixed by the spec; clients
@@ -90,9 +106,11 @@ export async function proxy(request: NextRequest) {
   }
 
   // Handle API proxying to backend
-  if (pathname.startsWith('/api/') || isOAuthPath(pathname)) {
+  const rootMcp = isRootMcpRequest(request, pathname);
+  if (pathname.startsWith('/api/') || isOAuthPath(pathname) || rootMcp) {
     const apiUrl = process.env.INTERNAL_API_URL || 'http://localhost:3001';
-    const url = new URL(pathname + request.nextUrl.search, apiUrl);
+    const backendPath = rootMcp ? '/api/v1/mcp' : pathname;
+    const url = new URL(backendPath + request.nextUrl.search, apiUrl);
     logger.debug(`${request.method} ${pathname} -> ${apiUrl}`);
 
     const headers = new Headers(request.headers);


### PR DESCRIPTION
## Summary
- Allow the bare origin (`https://monize.laskonet.com`) to be used as a remote MCP connector URL in claude.ai / Claude Desktop
- `proxy.ts` forwards requests hitting `/` to the backend `/api/v1/mcp` when they are MCP-shaped: `Accept: text/event-stream` (required by the MCP Streamable HTTP spec on both POST and SSE GET) or an `Mcp-Session-Id` / `MCP-Protocol-Version` header
- Browser navigations never send these, so normal page loads, auth redirects, and `/login` behave exactly as before

## Background
Debugging a claude.ai connector failure showed Claude sends MCP JSON-RPC traffic to the connector URL exactly as configured. With the bare origin configured, `POST /` previously rendered the Next.js app (HTML 200) and the connector showed "not connected" despite OAuth completing.

## Testing
- 6 new tests in `frontend/src/proxy.test.ts` (MCP POST//GET-SSE//DELETE routed; browser GET / redirect intact; `/login` never intercepted even with MCP headers; explicit `/api/v1/mcp` unchanged)
- Verified live in production: MCP-shaped `POST /` returns 401 + `WWW-Authenticate` resource-metadata challenge; full claude.ai connector handshake (initialize → tools/list) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)