### PR TITLE
Add total utilization donut chart to credit report

### DIFF
--- a/frontend/src/components/reports/CreditUtilizationReport.test.tsx
+++ b/frontend/src/components/reports/CreditUtilizationReport.test.tsx
@@ -32,6 +32,8 @@ vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
   BarChart: ({ children }: any) => <div data-testid="bar-chart">{children}</div>,
   Bar: ({ children }: any) => <div data-testid="bar">{children}</div>,
+  PieChart: ({ children }: any) => <div data-testid="pie-chart">{children}</div>,
+  Pie: ({ children }: any) => <div data-testid="pie">{children}</div>,
   Cell: () => null,
   XAxis: () => null,
   YAxis: () => null,
@@ -39,9 +41,11 @@ vi.mock('recharts', () => ({
   ReferenceLine: () => null,
   Tooltip: ({ content }: any) => {
     if (typeof content === 'function') {
+      // One payload shape serves both tooltips: the bar tooltip reads
+      // used/available/utilizationPercent, the pie tooltip reads value/percent.
       return (
         <div>
-          {content({ active: true, payload: [{ payload: { id: 'tip', name: 'TooltipAccount', used: 500, available: 4500, utilizationPercent: 10 } }] })}
+          {content({ active: true, payload: [{ payload: { id: 'tip', name: 'TooltipAccount', used: 500, available: 4500, utilizationPercent: 10, value: 500, percent: 10 } }] })}
           {content({ active: false, payload: [] })}
         </div>
       );
@@ -174,6 +178,23 @@ describe('CreditUtilizationReport', () => {
       expect(screen.getByText('Utilization by Account')).toBeInTheDocument();
     });
     expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+  });
+
+  it('renders the total utilization pie chart alongside the bar chart', async () => {
+    mockGetAll.mockResolvedValue(cadAccounts);
+    render(<CreditUtilizationReport />);
+    await waitFor(() => {
+      expect(screen.getByText('Total Utilization')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('pie-chart')).toBeInTheDocument();
+    // Donut centre repeats the overall utilization (6500 / 15000 = 43.3%),
+    // which also appears in the summary card and the table footer.
+    expect(screen.getAllByText('43.3%').length).toBeGreaterThanOrEqual(3);
+    // Legend lists used and available totals next to their slice labels.
+    expect(screen.getAllByText('Used').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText('Available').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText('CAD 6500.00').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText('CAD 8500.00').length).toBeGreaterThanOrEqual(2);
   });
 
   it('exports pdf through the export pipeline', async () => {

--- a/frontend/src/components/reports/CreditUtilizationReport.tsx
+++ b/frontend/src/components/reports/CreditUtilizationReport.tsx
@@ -240,7 +240,10 @@ export function CreditUtilizationReport() {
     );
   }
 
-  const chartHeight = Math.max(200, sortedRows.length * 52);
+  // Scales with the account count; the chart container also stretches to fill
+  // the row, so with few accounts the bars use the full height of the donut
+  // column instead of leaving empty space below.
+  const chartMinHeight = Math.max(200, sortedRows.length * 52);
 
   // The donut shows drawn credit (coloured by the same thresholds as the bars)
   // against remaining available credit (muted). Available is clamped at zero
@@ -315,54 +318,58 @@ export function CreditUtilizationReport() {
       {/* Utilization Charts */}
       <div ref={chartRef} className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="min-w-0 lg:col-span-2">
+          <div className="min-w-0 lg:col-span-2 flex flex-col">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
               {t('creditUtilization.utilizationByAccount')}
             </h3>
-            <div style={{ width: '100%', height: chartHeight }}>
-              <ResponsiveContainer minWidth={0}>
-                <BarChart data={sortedRows} layout="vertical" margin={{ left: 8, right: 24 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} horizontal={false} />
-                  <XAxis
-                    type="number"
-                    domain={[0, 100]}
-                    tickFormatter={(value: number) => `${value}%`}
-                    tick={{ fontSize: 12 }}
-                  />
-                  <YAxis
-                    type="category"
-                    dataKey="name"
-                    width={120}
-                    tick={{ fontSize: 12 }}
-                  />
-                  <Tooltip
-                    content={({ active, payload }) => {
-                      if (!active || !payload?.length) return null;
-                      const row = payload[0].payload as CreditAccountRow;
-                      return (
-                        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
-                          <p className="font-medium text-gray-900 dark:text-gray-100">{row.name}</p>
-                          <p className="text-sm text-gray-600 dark:text-gray-400">
-                            {t('creditUtilization.tooltipUtilization')}: {row.utilizationPercent.toFixed(1)}%
-                          </p>
-                          <p className="text-sm text-gray-600 dark:text-gray-400">
-                            {t('creditUtilization.tooltipUsed')}: {formatCurrency(row.used, displayCurrency)}
-                          </p>
-                          <p className="text-sm text-gray-600 dark:text-gray-400">
-                            {t('creditUtilization.tooltipAvailable')}: {formatCurrency(row.available, displayCurrency)}
-                          </p>
-                        </div>
-                      );
-                    }}
-                  />
-                  <ReferenceLine x={100} stroke={chartColors.axis} strokeDasharray="4 4" />
-                  <Bar dataKey="utilizationPercent" radius={[0, 4, 4, 0]}>
-                    {sortedRows.map((row) => (
-                      <Cell key={row.id} fill={utilizationColour(row.utilizationPercent)} />
-                    ))}
-                  </Bar>
-                </BarChart>
-              </ResponsiveContainer>
+            {/* The absolutely positioned inner div lets ResponsiveContainer
+                track the stretched flex height without a feedback loop. */}
+            <div className="relative flex-1" style={{ minHeight: chartMinHeight }}>
+              <div className="absolute inset-0">
+                <ResponsiveContainer minWidth={0}>
+                  <BarChart data={sortedRows} layout="vertical" margin={{ left: 8, right: 24 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} horizontal={false} />
+                    <XAxis
+                      type="number"
+                      domain={[0, 100]}
+                      tickFormatter={(value: number) => `${value}%`}
+                      tick={{ fontSize: 12 }}
+                    />
+                    <YAxis
+                      type="category"
+                      dataKey="name"
+                      width={120}
+                      tick={{ fontSize: 12 }}
+                    />
+                    <Tooltip
+                      content={({ active, payload }) => {
+                        if (!active || !payload?.length) return null;
+                        const row = payload[0].payload as CreditAccountRow;
+                        return (
+                          <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
+                            <p className="font-medium text-gray-900 dark:text-gray-100">{row.name}</p>
+                            <p className="text-sm text-gray-600 dark:text-gray-400">
+                              {t('creditUtilization.tooltipUtilization')}: {row.utilizationPercent.toFixed(1)}%
+                            </p>
+                            <p className="text-sm text-gray-600 dark:text-gray-400">
+                              {t('creditUtilization.tooltipUsed')}: {formatCurrency(row.used, displayCurrency)}
+                            </p>
+                            <p className="text-sm text-gray-600 dark:text-gray-400">
+                              {t('creditUtilization.tooltipAvailable')}: {formatCurrency(row.available, displayCurrency)}
+                            </p>
+                          </div>
+                        );
+                      }}
+                    />
+                    <ReferenceLine x={100} stroke={chartColors.axis} strokeDasharray="4 4" />
+                    <Bar dataKey="utilizationPercent" radius={[0, 4, 4, 0]} maxBarSize={32}>
+                      {sortedRows.map((row) => (
+                        <Cell key={row.id} fill={utilizationColour(row.utilizationPercent)} />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
             </div>
           </div>
           <div className="min-w-0">

--- a/frontend/src/components/reports/CreditUtilizationReport.tsx
+++ b/frontend/src/components/reports/CreditUtilizationReport.tsx
@@ -11,6 +11,8 @@ import {
   Tooltip,
   ResponsiveContainer,
   ReferenceLine,
+  PieChart,
+  Pie,
 } from 'recharts';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { accountsApi } from '@/lib/accounts';
@@ -60,6 +62,17 @@ interface CreditAccountRow {
   available: number;
   /** Utilization is currency-independent (a ratio of native amounts). */
   utilizationPercent: number;
+}
+
+/** One slice of the total-utilization donut: drawn vs available credit. */
+interface TotalUtilizationSlice {
+  key: 'used' | 'available';
+  name: string;
+  /** Amount in the report's display currency. */
+  value: number;
+  /** Share of the total credit limit. */
+  percent: number;
+  color: string;
 }
 
 export function CreditUtilizationReport() {
@@ -229,6 +242,27 @@ export function CreditUtilizationReport() {
 
   const chartHeight = Math.max(200, sortedRows.length * 52);
 
+  // The donut shows drawn credit (coloured by the same thresholds as the bars)
+  // against remaining available credit (muted). Available is clamped at zero
+  // so an over-limit balance still renders as a fully used pie.
+  const availableForPie = Math.max(totals.available, 0);
+  const totalPieData: TotalUtilizationSlice[] = [
+    {
+      key: 'used',
+      name: t('creditUtilization.tooltipUsed'),
+      value: totals.used,
+      percent: totals.utilizationPercent,
+      color: utilizationColour(totals.utilizationPercent),
+    },
+    {
+      key: 'available',
+      name: t('creditUtilization.tooltipAvailable'),
+      value: availableForPie,
+      percent: totals.limit > 0 ? (availableForPie / totals.limit) * 100 : 0,
+      color: chartColors.grid,
+    },
+  ];
+
   return (
     <div className="space-y-6">
       {/* Account Filter */}
@@ -278,55 +312,115 @@ export function CreditUtilizationReport() {
         </p>
       )}
 
-      {/* Utilization Chart */}
+      {/* Utilization Charts */}
       <div ref={chartRef} className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-          {t('creditUtilization.utilizationByAccount')}
-        </h3>
-        <div style={{ width: '100%', height: chartHeight }}>
-          <ResponsiveContainer minWidth={0}>
-            <BarChart data={sortedRows} layout="vertical" margin={{ left: 8, right: 24 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} horizontal={false} />
-              <XAxis
-                type="number"
-                domain={[0, 100]}
-                tickFormatter={(value: number) => `${value}%`}
-                tick={{ fontSize: 12 }}
-              />
-              <YAxis
-                type="category"
-                dataKey="name"
-                width={120}
-                tick={{ fontSize: 12 }}
-              />
-              <Tooltip
-                content={({ active, payload }) => {
-                  if (!active || !payload?.length) return null;
-                  const row = payload[0].payload as CreditAccountRow;
-                  return (
-                    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
-                      <p className="font-medium text-gray-900 dark:text-gray-100">{row.name}</p>
-                      <p className="text-sm text-gray-600 dark:text-gray-400">
-                        {t('creditUtilization.tooltipUtilization')}: {row.utilizationPercent.toFixed(1)}%
-                      </p>
-                      <p className="text-sm text-gray-600 dark:text-gray-400">
-                        {t('creditUtilization.tooltipUsed')}: {formatCurrency(row.used, displayCurrency)}
-                      </p>
-                      <p className="text-sm text-gray-600 dark:text-gray-400">
-                        {t('creditUtilization.tooltipAvailable')}: {formatCurrency(row.available, displayCurrency)}
-                      </p>
-                    </div>
-                  );
-                }}
-              />
-              <ReferenceLine x={100} stroke={chartColors.axis} strokeDasharray="4 4" />
-              <Bar dataKey="utilizationPercent" radius={[0, 4, 4, 0]}>
-                {sortedRows.map((row) => (
-                  <Cell key={row.id} fill={utilizationColour(row.utilizationPercent)} />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="min-w-0 lg:col-span-2">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+              {t('creditUtilization.utilizationByAccount')}
+            </h3>
+            <div style={{ width: '100%', height: chartHeight }}>
+              <ResponsiveContainer minWidth={0}>
+                <BarChart data={sortedRows} layout="vertical" margin={{ left: 8, right: 24 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} horizontal={false} />
+                  <XAxis
+                    type="number"
+                    domain={[0, 100]}
+                    tickFormatter={(value: number) => `${value}%`}
+                    tick={{ fontSize: 12 }}
+                  />
+                  <YAxis
+                    type="category"
+                    dataKey="name"
+                    width={120}
+                    tick={{ fontSize: 12 }}
+                  />
+                  <Tooltip
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.length) return null;
+                      const row = payload[0].payload as CreditAccountRow;
+                      return (
+                        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
+                          <p className="font-medium text-gray-900 dark:text-gray-100">{row.name}</p>
+                          <p className="text-sm text-gray-600 dark:text-gray-400">
+                            {t('creditUtilization.tooltipUtilization')}: {row.utilizationPercent.toFixed(1)}%
+                          </p>
+                          <p className="text-sm text-gray-600 dark:text-gray-400">
+                            {t('creditUtilization.tooltipUsed')}: {formatCurrency(row.used, displayCurrency)}
+                          </p>
+                          <p className="text-sm text-gray-600 dark:text-gray-400">
+                            {t('creditUtilization.tooltipAvailable')}: {formatCurrency(row.available, displayCurrency)}
+                          </p>
+                        </div>
+                      );
+                    }}
+                  />
+                  <ReferenceLine x={100} stroke={chartColors.axis} strokeDasharray="4 4" />
+                  <Bar dataKey="utilizationPercent" radius={[0, 4, 4, 0]}>
+                    {sortedRows.map((row) => (
+                      <Cell key={row.id} fill={utilizationColour(row.utilizationPercent)} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+              {t('creditUtilization.totalUtilization')}
+            </h3>
+            <div className="relative mx-auto w-full max-w-xs" style={{ height: 240 }}>
+              <ResponsiveContainer minWidth={0}>
+                <PieChart>
+                  <Pie
+                    data={totalPieData}
+                    cx="50%"
+                    cy="50%"
+                    innerRadius="62%"
+                    outerRadius="92%"
+                    startAngle={90}
+                    endAngle={-270}
+                    paddingAngle={2}
+                    dataKey="value"
+                  >
+                    {totalPieData.map((slice) => (
+                      <Cell key={slice.key} fill={slice.color} />
+                    ))}
+                  </Pie>
+                  <Tooltip
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.length) return null;
+                      const slice = payload[0].payload as TotalUtilizationSlice;
+                      return (
+                        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
+                          <p className="font-medium text-gray-900 dark:text-gray-100">{slice.name}</p>
+                          <p className="text-sm text-gray-600 dark:text-gray-400">
+                            {formatCurrency(slice.value, displayCurrency)} ({slice.percent.toFixed(1)}%)
+                          </p>
+                        </div>
+                      );
+                    }}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+              <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                <span className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                  {totals.utilizationPercent.toFixed(1)}%
+                </span>
+              </div>
+            </div>
+            <div className="mt-4 space-y-2">
+              {totalPieData.map((slice) => (
+                <div key={slice.key} className="flex items-center gap-2 text-sm">
+                  <span className="w-3 h-3 rounded-sm shrink-0" style={{ backgroundColor: slice.color }} />
+                  <span className="flex-1 text-gray-600 dark:text-gray-400">{slice.name}</span>
+                  <span className="font-medium text-gray-900 dark:text-gray-100">
+                    {formatCurrency(slice.value, displayCurrency)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       </div>
 

--- a/frontend/src/i18n/messages/de/reports.json
+++ b/frontend/src/i18n/messages/de/reports.json
@@ -303,6 +303,7 @@
     "totalAvailable": "Gesamt verfügbar",
     "overallUtilization": "Gesamtauslastung",
     "utilizationByAccount": "Auslastung nach Konto",
+    "totalUtilization": "Gesamtauslastung",
     "colAccount": "Konto",
     "colType": "Typ",
     "colCreditLimit": "Kreditlimit",

--- a/frontend/src/i18n/messages/en/reports.json
+++ b/frontend/src/i18n/messages/en/reports.json
@@ -303,6 +303,7 @@
     "totalAvailable": "Total Available",
     "overallUtilization": "Overall Utilization",
     "utilizationByAccount": "Utilization by Account",
+    "totalUtilization": "Total Utilization",
     "colAccount": "Account",
     "colType": "Type",
     "colCreditLimit": "Credit Limit",

--- a/frontend/src/i18n/messages/es/reports.json
+++ b/frontend/src/i18n/messages/es/reports.json
@@ -303,6 +303,7 @@
     "totalAvailable": "Total disponible",
     "overallUtilization": "Utilización general",
     "utilizationByAccount": "Utilización por cuenta",
+    "totalUtilization": "Utilización total",
     "colAccount": "Cuenta",
     "colType": "Tipo",
     "colCreditLimit": "Límite de crédito",

--- a/frontend/src/i18n/messages/fr/reports.json
+++ b/frontend/src/i18n/messages/fr/reports.json
@@ -303,6 +303,7 @@
     "totalAvailable": "Total disponible",
     "overallUtilization": "Utilisation globale",
     "utilizationByAccount": "Utilisation par compte",
+    "totalUtilization": "Utilisation totale",
     "colAccount": "Compte",
     "colType": "Type",
     "colCreditLimit": "Limite de crédit",

--- a/frontend/src/i18n/messages/it/reports.json
+++ b/frontend/src/i18n/messages/it/reports.json
@@ -303,6 +303,7 @@
     "totalAvailable": "Totale disponibile",
     "overallUtilization": "Utilizzo complessivo",
     "utilizationByAccount": "Utilizzo per conto",
+    "totalUtilization": "Utilizzo totale",
     "colAccount": "Conto",
     "colType": "Tipo",
     "colCreditLimit": "Limite di credito",

--- a/frontend/src/i18n/messages/nl/reports.json
+++ b/frontend/src/i18n/messages/nl/reports.json
@@ -303,6 +303,7 @@
     "totalAvailable": "Totaal beschikbaar",
     "overallUtilization": "Totale benutting",
     "utilizationByAccount": "Benutting per rekening",
+    "totalUtilization": "Totale benutting",
     "colAccount": "Rekening",
     "colType": "Type",
     "colCreditLimit": "Kredietlimiet",

--- a/frontend/src/i18n/messages/pl/reports.json
+++ b/frontend/src/i18n/messages/pl/reports.json
@@ -303,6 +303,7 @@
     "totalAvailable": "Łącznie dostępne",
     "overallUtilization": "Całkowite wykorzystanie",
     "utilizationByAccount": "Wykorzystanie według konta",
+    "totalUtilization": "Całkowite wykorzystanie",
     "colAccount": "Konto",
     "colType": "Typ",
     "colCreditLimit": "Limit kredytowy",

--- a/frontend/src/i18n/messages/pt-BR/reports.json
+++ b/frontend/src/i18n/messages/pt-BR/reports.json
@@ -303,6 +303,7 @@
     "totalAvailable": "Total Disponível",
     "overallUtilization": "Utilização Global",
     "utilizationByAccount": "Utilização por Conta",
+    "totalUtilization": "Utilização Total",
     "colAccount": "Conta",
     "colType": "Tipo",
     "colCreditLimit": "Limite de Crédito",

--- a/frontend/src/i18n/messages/pt/reports.json
+++ b/frontend/src/i18n/messages/pt/reports.json
@@ -303,6 +303,7 @@
     "totalAvailable": "Total Disponível",
     "overallUtilization": "Utilização Global",
     "utilizationByAccount": "Utilização por Conta",
+    "totalUtilization": "Utilização Total",
     "colAccount": "Conta",
     "colType": "Tipo",
     "colCreditLimit": "Limite de Crédito",

--- a/frontend/src/i18n/messages/xx/reports.json
+++ b/frontend/src/i18n/messages/xx/reports.json
@@ -303,6 +303,7 @@
     "totalAvailable": "[XX-Total Available-XX]",
     "overallUtilization": "[XX-Overall Utilization-XX]",
     "utilizationByAccount": "[XX-Utilization by Account-XX]",
+    "totalUtilization": "[XX-Total Utilization-XX]",
     "colAccount": "[XX-Account-XX]",
     "colType": "[XX-Type-XX]",
     "colCreditLimit": "[XX-Credit Limit-XX]",


### PR DESCRIPTION
## Summary
Adds a donut chart displaying total credit utilization alongside the existing per-account bar chart in the Credit Utilization Report. The donut visualizes used vs. available credit at a glance, with the center showing the overall utilization percentage.

## Changes
- **New component layout**: Restructured the chart section into a two-column grid (bar chart on left, donut on right; stacks on mobile)
- **Donut chart**: Displays total used credit (colored by utilization threshold) vs. remaining available credit (muted gray), with a legend below showing amounts
- **Center label**: Overall utilization percentage displayed in the donut center
- **Data model**: Added `TotalUtilizationSlice` interface to represent pie slices with value, percent, and color
- **Responsive sizing**: Bar chart height scales with account count; donut has fixed 240px height with max-width constraint
- **Internationalization**: Added `totalUtilization` key to all 10 supported locales (de, en, es, fr, it, nl, pl, pt, pt-BR, xx)
- **Tests**: Added test case verifying pie chart renders with correct utilization percentage and legend values

## Implementation Details
- Over-limit balances are clamped at zero for the available slice, so the pie always renders as fully used when credit limit is exceeded
- Tooltip shows both currency amount and percentage for each slice
- Bar chart now has `maxBarSize={32}` to prevent oversizing with few accounts
- Absolute positioning pattern used to let `ResponsiveContainer` track flex-stretched height without feedback loops
- Pie chart uses 62% inner radius for donut effect with 2° padding between slices

https://claude.ai/code/session_01HqVycGZRfaPShAWjarAtUV