### PR TITLE
Capture browser-detected UI language at account creation

### DIFF
--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -18,7 +18,7 @@ import { TokenService } from "./token.service";
 import { TwoFactorService } from "./two-factor.service";
 import { AuthEmailService } from "./auth-email.service";
 import { DelegationService } from "../delegation/delegation.service";
-import { I18nService } from "nestjs-i18n";
+import { I18nService, I18nContext } from "nestjs-i18n";
 import { User } from "../users/entities/user.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { TrustedDevice } from "../users/entities/trusted-device.entity";
@@ -257,6 +257,38 @@ describe("AuthService", () => {
 
       const createdUser = txManager.save.mock.calls[0][0];
       expect(createdUser.role).toBe("admin");
+    });
+
+    it("creates default preferences for the new user", async () => {
+      usersRepository.findOne.mockResolvedValue(null);
+      const txManager = setupRegisterTransactionMock(1);
+
+      await service.register({
+        email: "new@example.com",
+        password: "StrongPass123!",
+      });
+
+      // First save is the user, second is the preferences row.
+      const savedPrefs = txManager.save.mock.calls[1][0];
+      expect(savedPrefs.userId).toBe("new-user");
+      expect(savedPrefs.language).toBe("en");
+    });
+
+    it("seeds the new user's language from the request locale", async () => {
+      usersRepository.findOne.mockResolvedValue(null);
+      const txManager = setupRegisterTransactionMock(1);
+      const spy = jest
+        .spyOn(I18nContext, "current")
+        .mockReturnValue({ lang: "pl" } as never);
+
+      await service.register({
+        email: "polish@example.com",
+        password: "StrongPass123!",
+      });
+
+      const savedPrefs = txManager.save.mock.calls[1][0];
+      expect(savedPrefs.language).toBe("pl");
+      spy.mockRestore();
     });
 
     it("throws for duplicate email", async () => {
@@ -1286,6 +1318,36 @@ describe("AuthService", () => {
       expect(result.user.authProvider).toBe("oidc");
       expect(result.user.firstName).toBe("OIDC");
       expect(result.user.lastName).toBe("User");
+    });
+
+    it("seeds preferences with the request locale for a new OIDC user", async () => {
+      usersRepository.findOne
+        .mockResolvedValueOnce(null) // no existing by oidcSubject
+        .mockResolvedValueOnce(null); // no existing by email
+      const txManager = setupOidcTransactionMock(1);
+      txManager.create.mockImplementation((_entity, data) => ({
+        ...data,
+        id: "oidc-user-1",
+      }));
+      usersRepository.save.mockImplementation((u) => u);
+      const spy = jest
+        .spyOn(I18nContext, "current")
+        .mockReturnValue({ lang: "fr" } as never);
+
+      await service.findOrCreateOidcUser({
+        sub: "oidc-sub-fr",
+        email: "fr@example.com",
+        email_verified: true,
+      });
+
+      const savedPrefs = txManager.save.mock.calls.find(
+        (call: unknown[]) =>
+          (call[0] as { language?: string })?.language !== undefined,
+      )?.[0];
+      expect(savedPrefs).toBeDefined();
+      expect(savedPrefs.userId).toBe("oidc-user-1");
+      expect(savedPrefs.language).toBe("fr");
+      spy.mockRestore();
     });
 
     it("creates new user with unverified email (email stored but not linked)", async () => {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -15,6 +15,7 @@ import * as crypto from "crypto";
 
 import { User } from "../users/entities/user.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
+import { buildDefaultPreferences } from "../users/user-preference.factory";
 import { TrustedDevice } from "../users/entities/trusted-device.entity";
 import { RefreshToken } from "./entities/refresh-token.entity";
 import { RegisterDto } from "./dto/register.dto";
@@ -31,6 +32,7 @@ import { TwoFactorService } from "./two-factor.service";
 import { AuthEmailService } from "./auth-email.service";
 import { DelegationService } from "../delegation/delegation.service";
 import { tr } from "../i18n/translate";
+import { currentRequestLocale } from "../i18n/request-locale";
 import { I18nService } from "nestjs-i18n";
 import { emailTranslator } from "../i18n/email-translator";
 import { DEFAULT_LOCALE } from "../i18n/config";
@@ -194,6 +196,11 @@ export class AuthService {
     const saltRounds = 12;
     const passwordHash = await bcrypt.hash(password, saltRounds);
 
+    // Capture the browser-detected UI language (resolved by the proxy and
+    // forwarded as x-locale) so it is persisted at account creation and the
+    // user keeps it on subsequent logins instead of reverting to English.
+    const language = currentRequestLocale();
+
     // C9: Use serializable transaction to prevent race condition on first-user admin
     const user = await this.dataSource.transaction(
       "SERIALIZABLE",
@@ -207,7 +214,9 @@ export class AuthService {
           authProvider: "local",
           role: userCount === 0 ? "admin" : "user",
         });
-        return manager.save(newUser);
+        const savedUser = await manager.save(newUser);
+        await manager.save(buildDefaultPreferences(savedUser.id, language));
+        return savedUser;
       },
     );
 
@@ -443,6 +452,11 @@ export class AuthService {
             ),
           );
         }
+        // Persist the browser-detected UI language at account creation (same
+        // rationale as local registration) so SSO users also keep their
+        // language across logins.
+        const language = currentRequestLocale();
+
         // C9: Use serializable transaction for first-user admin race prevention
         try {
           user = await this.dataSource.transaction(
@@ -458,7 +472,11 @@ export class AuthService {
                 role: userCount === 0 ? "admin" : "user",
               };
               const newUser = manager.create(User, userData);
-              return manager.save(newUser);
+              const savedUser = await manager.save(newUser);
+              await manager.save(
+                buildDefaultPreferences(savedUser.id, language),
+              );
+              return savedUser;
             },
           );
         } catch (err: any) {

--- a/backend/src/i18n/request-locale.spec.ts
+++ b/backend/src/i18n/request-locale.spec.ts
@@ -1,0 +1,36 @@
+import { I18nContext } from "nestjs-i18n";
+import { currentRequestLocale } from "./request-locale";
+import { DEFAULT_LOCALE } from "./config";
+
+describe("currentRequestLocale", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns DEFAULT_LOCALE outside a request context", () => {
+    jest.spyOn(I18nContext, "current").mockReturnValue(undefined as never);
+    expect(currentRequestLocale()).toBe(DEFAULT_LOCALE);
+  });
+
+  it("returns the resolved locale when it is a supported language", () => {
+    jest.spyOn(I18nContext, "current").mockReturnValue({ lang: "pl" } as never);
+    expect(currentRequestLocale()).toBe("pl");
+  });
+
+  it("preserves a supported region-tagged locale", () => {
+    jest
+      .spyOn(I18nContext, "current")
+      .mockReturnValue({ lang: "pt-BR" } as never);
+    expect(currentRequestLocale()).toBe("pt-BR");
+  });
+
+  it("never persists the xx pseudo-locale", () => {
+    jest.spyOn(I18nContext, "current").mockReturnValue({ lang: "xx" } as never);
+    expect(currentRequestLocale()).toBe(DEFAULT_LOCALE);
+  });
+
+  it("falls back to DEFAULT_LOCALE for an unsupported locale", () => {
+    jest.spyOn(I18nContext, "current").mockReturnValue({ lang: "zz" } as never);
+    expect(currentRequestLocale()).toBe(DEFAULT_LOCALE);
+  });
+});

--- a/backend/src/i18n/request-locale.ts
+++ b/backend/src/i18n/request-locale.ts
@@ -1,0 +1,25 @@
+import { I18nContext } from "nestjs-i18n";
+import { DEFAULT_LOCALE, isSupportedLocale } from "./config";
+
+/**
+ * Resolve the locale nestjs-i18n picked for the active request, suitable for
+ * persisting as a new user's `language` preference.
+ *
+ * The locale comes from the same resolver chain used for translations: the
+ * `x-locale` header set by the frontend proxy (which derives it from the
+ * `NEXT_LOCALE` cookie, itself seeded from `Accept-Language` on first visit),
+ * the `NEXT_LOCALE` cookie directly, or `Accept-Language`. This is how a brand
+ * new account captures the browser-detected UI language at creation time so it
+ * survives later logins instead of reverting to English.
+ *
+ * Returns `DEFAULT_LOCALE` outside an HTTP context (background jobs, schedulers,
+ * unit tests) and never returns the `xx` pseudo-locale -- that is a translation
+ * QA tool, not a language a real user should be permanently stored into.
+ */
+export function currentRequestLocale(): string {
+  const lang = I18nContext.current()?.lang;
+  if (lang && lang !== "xx" && isSupportedLocale(lang)) {
+    return lang;
+  }
+  return DEFAULT_LOCALE;
+}

--- a/backend/src/updates/updates.service.ts
+++ b/backend/src/updates/updates.service.ts
@@ -4,6 +4,8 @@ import { Cron, CronExpression } from "@nestjs/schedule";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { UserPreference } from "../users/entities/user-preference.entity";
+import { buildDefaultPreferences } from "../users/user-preference.factory";
+import { currentRequestLocale } from "../i18n/request-locale";
 
 // Version comes from the backend package.json at build/run time. Using require
 // keeps the read synchronous and avoids ESM import-assertion issues.
@@ -250,8 +252,10 @@ export class UpdatesService implements OnModuleInit {
       prefs.dismissedUpdateVersion = latestVersion;
       await this.preferencesRepository.save(prefs);
     } else {
-      const created = new UserPreference();
-      created.userId = userId;
+      // No row yet: materialize one from the shared defaults (seeding the
+      // request locale) so this fallback doesn't create a preferences row with
+      // a different baseline than every other creation path.
+      const created = buildDefaultPreferences(userId, currentRequestLocale());
       created.dismissedUpdateVersion = latestVersion;
       await this.preferencesRepository.save(created);
     }

--- a/backend/src/users/user-preference.factory.spec.ts
+++ b/backend/src/users/user-preference.factory.spec.ts
@@ -1,0 +1,33 @@
+import { buildDefaultPreferences } from "./user-preference.factory";
+import { DEFAULT_LOCALE } from "../i18n/config";
+
+describe("buildDefaultPreferences", () => {
+  it("sets the userId and the provided language", () => {
+    const prefs = buildDefaultPreferences("user-1", "pl");
+    expect(prefs.userId).toBe("user-1");
+    expect(prefs.language).toBe("pl");
+  });
+
+  it("defaults language to DEFAULT_LOCALE when omitted", () => {
+    const prefs = buildDefaultPreferences("user-1");
+    expect(prefs.language).toBe(DEFAULT_LOCALE);
+  });
+
+  it("uses browser/system sentinels for locale-dependent display settings", () => {
+    const prefs = buildDefaultPreferences("user-1", "en");
+    expect(prefs.dateFormat).toBe("browser");
+    expect(prefs.numberFormat).toBe("browser");
+    expect(prefs.timezone).toBe("browser");
+    expect(prefs.theme).toBe("system");
+  });
+
+  it("applies the standard non-locale defaults", () => {
+    const prefs = buildDefaultPreferences("user-1");
+    expect(prefs.defaultCurrency).toBe("USD");
+    expect(prefs.notificationEmail).toBe(true);
+    expect(prefs.notificationBrowser).toBe(true);
+    expect(prefs.twoFactorEnabled).toBe(false);
+    expect(prefs.gettingStartedDismissed).toBe(false);
+    expect(prefs.favouriteReportIds).toEqual([]);
+  });
+});

--- a/backend/src/users/user-preference.factory.ts
+++ b/backend/src/users/user-preference.factory.ts
@@ -1,0 +1,39 @@
+import { DEFAULT_LOCALE } from "../i18n/config";
+import { UserPreference } from "./entities/user-preference.entity";
+
+/**
+ * Build a new user's default preferences.
+ *
+ * Locale-dependent display settings (date/number format, timezone, theme) use
+ * the `browser` / `system` sentinels so the frontend resolves them from the
+ * client environment on every render. `language`, by contrast, is stored as a
+ * concrete locale: the UI language is an explicit, account-level choice that
+ * must follow the user across devices and sessions rather than being
+ * re-detected each time.
+ *
+ * Shared by every path that first materializes a preferences row -- eager
+ * creation at account registration / first OIDC login (`AuthService`), lazy
+ * creation on first access (`UsersService.getPreferences`), and the
+ * update-dismissal fallback (`UpdatesService`) -- so all new accounts start
+ * from one consistent baseline. Columns not set here fall back to the entity's
+ * own database defaults.
+ */
+export function buildDefaultPreferences(
+  userId: string,
+  language: string = DEFAULT_LOCALE,
+): UserPreference {
+  const preferences = new UserPreference();
+  preferences.userId = userId;
+  preferences.defaultCurrency = "USD";
+  preferences.dateFormat = "browser";
+  preferences.numberFormat = "browser";
+  preferences.theme = "system";
+  preferences.timezone = "browser";
+  preferences.notificationEmail = true;
+  preferences.notificationBrowser = true;
+  preferences.twoFactorEnabled = false;
+  preferences.gettingStartedDismissed = false;
+  preferences.favouriteReportIds = [];
+  preferences.language = language;
+  return preferences;
+}

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -16,6 +16,7 @@ import { RefreshToken } from "../auth/entities/refresh-token.entity";
 import { PersonalAccessToken } from "../auth/entities/personal-access-token.entity";
 import { PasswordBreachService } from "../auth/password-breach.service";
 import { ModuleRef } from "@nestjs/core";
+import { I18nContext } from "nestjs-i18n";
 import { ExchangeRateService } from "../currencies/exchange-rate.service";
 import { BackupEncryptionService } from "../backup/backup-encryption.service";
 
@@ -497,6 +498,19 @@ describe("UsersService", () => {
       const result = await service.getPreferences("user-1");
 
       expect(result.language).toBe("en");
+    });
+
+    it("seeds language from the request locale when creating default preferences", async () => {
+      preferencesRepository.findOne.mockResolvedValue(null);
+      preferencesRepository.save.mockImplementation((data) => data);
+      const spy = jest
+        .spyOn(I18nContext, "current")
+        .mockReturnValue({ lang: "pl" } as never);
+
+      const result = await service.getPreferences("user-1");
+
+      expect(result.language).toBe("pl");
+      spy.mockRestore();
     });
   });
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -11,8 +11,10 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { Repository, DataSource, QueryRunner } from "typeorm";
 import * as bcrypt from "bcryptjs";
 import { tr } from "../i18n/translate";
+import { currentRequestLocale } from "../i18n/request-locale";
 import { User } from "./entities/user.entity";
 import { UserPreference } from "./entities/user-preference.entity";
+import { buildDefaultPreferences } from "./user-preference.factory";
 import { TrustedDevice } from "./entities/trusted-device.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
 import { PersonalAccessToken } from "../auth/entities/personal-access-token.entity";
@@ -130,23 +132,12 @@ export class UsersService {
       where: { userId },
     });
 
-    // Create default preferences if they don't exist
-    // Default to 'browser' for locale-dependent settings
+    // Create default preferences if they don't exist. Seed `language` from the
+    // request locale (browser-detected on first visit, forwarded by the proxy)
+    // so a row first materialized here still captures the user's UI language
+    // rather than defaulting everyone to English.
     if (!preferences) {
-      // Use direct instantiation to ensure primary key is set
-      preferences = new UserPreference();
-      preferences.userId = userId;
-      preferences.defaultCurrency = "USD";
-      preferences.dateFormat = "browser";
-      preferences.numberFormat = "browser";
-      preferences.theme = "system";
-      preferences.timezone = "browser";
-      preferences.notificationEmail = true;
-      preferences.notificationBrowser = true;
-      preferences.twoFactorEnabled = false;
-      preferences.gettingStartedDismissed = false;
-      preferences.favouriteReportIds = [];
-      preferences.language = "en";
+      preferences = buildDefaultPreferences(userId, currentRequestLocale());
       await this.preferencesRepository.save(preferences);
     }
 


### PR DESCRIPTION
## Summary
Ensures that new user accounts preserve the browser-detected UI language (forwarded by the proxy via `x-locale` header) at creation time, so users keep their language preference across logins instead of reverting to English.

## Changes
- **New utility functions**:
  - `currentRequestLocale()` in `backend/src/i18n/request-locale.ts` — resolves the active request's locale from nestjs-i18n context, falling back to `DEFAULT_LOCALE` outside HTTP contexts and filtering out the `xx` pseudo-locale
  - `buildDefaultPreferences()` in `backend/src/users/user-preference.factory.ts` — centralizes user preference initialization with consistent defaults across all creation paths (registration, OIDC, lazy creation, update dismissal)

- **AuthService** (`backend/src/auth/auth.service.ts`):
  - `register()` now captures `currentRequestLocale()` and passes it to `buildDefaultPreferences()` when creating the initial preferences row in the transaction
  - `findOrCreateOidcUser()` applies the same logic for SSO users, ensuring OIDC accounts also preserve browser language at first login

- **UsersService** (`backend/src/users/users.service.ts`):
  - `getPreferences()` lazy-creation path now uses `buildDefaultPreferences(userId, currentRequestLocale())` instead of inline instantiation, so preferences materialized on first access still capture the request locale

- **UpdatesService** (`backend/src/updates/updates.service.ts`):
  - Update dismissal fallback now uses `buildDefaultPreferences()` for consistency, preventing a different baseline when this path creates a preferences row

- **Tests**:
  - Added `request-locale.spec.ts` covering context detection, locale validation, and `xx` pseudo-locale filtering
  - Added `user-preference.factory.spec.ts` validating default values and language seeding
  - Updated `auth.service.spec.ts` with tests for language capture in both registration and OIDC flows
  - Updated `users.service.spec.ts` with test for lazy preference creation with request locale

## Implementation Details
- The `buildDefaultPreferences()` factory uses `browser`/`system` sentinels for locale-dependent display settings (date/number format, timezone, theme) so the frontend resolves them from client environment on every render, while `language` is stored as a concrete locale (an explicit account-level choice that must survive across devices)
- `currentRequestLocale()` returns `DEFAULT_LOCALE` outside HTTP contexts (background jobs, tests) and never returns `xx` (QA pseudo-locale)
- All three user creation paths (registration, OIDC, lazy preference materialization) now share the same baseline, ensuring consistent behavior across the application

https://claude.ai/code/session_01R2gJUXSs1ifsGApZtcePRf