### PR TITLE
Make Monthly Breakdown category names link to filtered transactions

### DIFF
--- a/frontend/src/components/reports/MonthlyCategoryBreakdownReport.test.tsx
+++ b/frontend/src/components/reports/MonthlyCategoryBreakdownReport.test.tsx
@@ -195,6 +195,49 @@ describe('MonthlyCategoryBreakdownReport', () => {
     expect(url).toContain('endDate=2025-01-31');
   });
 
+  it('drills down using the full report range when a category name is clicked', async () => {
+    mockGetMonthlyCategoryBreakdown.mockResolvedValue(sampleResponse);
+    render(<MonthlyCategoryBreakdownReport />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Groceries')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Groceries'));
+    });
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const url = mockPush.mock.calls[0][0] as string;
+    expect(url).toContain('/transactions?');
+    expect(url).toContain('categoryIds=cat-groceries');
+    // Full resolved report range, not a single month.
+    expect(url).toContain('startDate=2025-01-01');
+    expect(url).toContain('endDate=2025-06-30');
+  });
+
+  it('drills down into every child category when a section header is clicked', async () => {
+    mockGetMonthlyCategoryBreakdown.mockResolvedValue(sampleResponse);
+    render(<MonthlyCategoryBreakdownReport />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Groceries')).toBeInTheDocument();
+    });
+
+    // The first "Food & Dining" occurrence is the clickable section header.
+    const header = screen.getAllByText('Food & Dining')[0];
+    await act(async () => {
+      fireEvent.click(header);
+    });
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const url = mockPush.mock.calls[0][0] as string;
+    expect(url).toContain('/transactions?');
+    expect(url).toContain('categoryIds=cat-groceries');
+    expect(url).toContain('startDate=2025-01-01');
+    expect(url).toContain('endDate=2025-06-30');
+  });
+
   it('switches to percentage view when the toggle is checked', async () => {
     mockGetMonthlyCategoryBreakdown.mockResolvedValue(sampleResponse);
     render(<MonthlyCategoryBreakdownReport />);

--- a/frontend/src/components/reports/MonthlyCategoryBreakdownReport.test.tsx
+++ b/frontend/src/components/reports/MonthlyCategoryBreakdownReport.test.tsx
@@ -112,6 +112,7 @@ describe('MonthlyCategoryBreakdownReport', () => {
     vi.clearAllMocks();
     mockPush.mockClear();
     mockIsValid = true;
+    window.localStorage.clear();
   });
 
   it('shows loading state initially', async () => {
@@ -252,6 +253,30 @@ describe('MonthlyCategoryBreakdownReport', () => {
     });
 
     // Groceries is the only expense, so its monthly value is 100% of expenses.
+    await waitFor(() => {
+      expect(screen.getAllByText('-100.0%').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('persists the percentage toggle to localStorage and restores it', async () => {
+    mockGetMonthlyCategoryBreakdown.mockResolvedValue(sampleResponse);
+    const first = render(<MonthlyCategoryBreakdownReport />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Groceries')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Show percentages'));
+    });
+    await waitFor(() => {
+      expect(screen.getAllByText('-100.0%').length).toBeGreaterThan(0);
+    });
+
+    // Re-mounting the report reads the persisted toggle and stays in
+    // percentage mode without any further interaction.
+    first.unmount();
+    render(<MonthlyCategoryBreakdownReport />);
     await waitFor(() => {
       expect(screen.getAllByText('-100.0%').length).toBeGreaterThan(0);
     });

--- a/frontend/src/components/reports/MonthlyCategoryBreakdownReport.tsx
+++ b/frontend/src/components/reports/MonthlyCategoryBreakdownReport.tsx
@@ -279,17 +279,28 @@ export function MonthlyCategoryBreakdownReport() {
     return `${year}-${String(mon).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
   };
 
-  const drillDown = (month: string, categoryIds: string[]) => {
+  const navigateToTransactions = (
+    categoryIds: string[],
+    start: string | undefined,
+    end: string | undefined,
+  ) => {
     const ids = Array.from(new Set(categoryIds));
     if (ids.length === 0) return;
-    const start = `${month}-01`;
-    const end = lastDayOfMonth(month);
-    const params = new URLSearchParams({
-      categoryIds: ids.join(','),
-      startDate: start,
-      endDate: end,
-    });
+    const params = new URLSearchParams({ categoryIds: ids.join(',') });
+    if (start) params.set('startDate', start);
+    if (end) params.set('endDate', end);
     router.push(`/transactions?${params.toString()}`);
+  };
+
+  // Drill into a single month for the given categories.
+  const drillDown = (month: string, categoryIds: string[]) => {
+    navigateToTransactions(categoryIds, `${month}-01`, lastDayOfMonth(month));
+  };
+
+  // Drill into the full report date range for the given categories (used when
+  // clicking a category/subcategory name rather than a single month cell).
+  const drillDownRange = (categoryIds: string[]) => {
+    navigateToTransactions(categoryIds, rangeStart || undefined, rangeEnd || undefined);
   };
 
   // Export the breakdown as a CSV matrix: one row per category (with its parent
@@ -452,10 +463,24 @@ export function MonthlyCategoryBreakdownReport() {
                   const sectionAvg = section.isIncome ? model!.totalIncomeAvg : model!.totalExpensesAvg;
                   return (
                     <tbody key={`section-${si}`} className="contents">
-                      {/* Section header */}
+                      {/* Section header. The colored bar spans the full table
+                          width while the label is pinned to the left so it stays
+                          visible when the table is scrolled horizontally. */}
                       <tr>
-                        <td colSpan={colSpan} className={`px-2 py-1.5 font-semibold ${section.paletteClass}`}>
-                          {section.title}
+                        <td colSpan={colSpan} className={`p-0 font-semibold ${section.paletteClass}`}>
+                          <div className="sticky left-0 z-10 px-2 py-1.5 inline-block max-w-full">
+                            {section.allCategoryIds.length > 0 ? (
+                              <button
+                                type="button"
+                                onClick={() => drillDownRange(section.allCategoryIds)}
+                                className="text-left hover:underline"
+                              >
+                                {section.title}
+                              </button>
+                            ) : (
+                              section.title
+                            )}
+                          </div>
                         </td>
                       </tr>
                       {/* Category rows */}
@@ -465,7 +490,17 @@ export function MonthlyCategoryBreakdownReport() {
                             className="sticky left-0 z-10 bg-white dark:bg-gray-800 pl-5 pr-2 py-1 text-gray-900 dark:text-gray-100 truncate max-w-[220px]"
                             title={row.displayName}
                           >
-                            {row.displayName}
+                            {row.categoryId ? (
+                              <button
+                                type="button"
+                                onClick={() => drillDownRange([row.categoryId!])}
+                                className="block w-full text-left truncate hover:underline"
+                              >
+                                {row.displayName}
+                              </button>
+                            ) : (
+                              row.displayName
+                            )}
                           </td>
                           {months.map((m) => {
                             const value = row.values[m] || 0;
@@ -497,8 +532,8 @@ export function MonthlyCategoryBreakdownReport() {
                         </tr>
                       ))}
                       {/* Section subtotal */}
-                      <tr className="font-bold bg-gray-50 dark:bg-gray-900/40 border-t-2 border-gray-300 dark:border-gray-600">
-                        <td className="sticky left-0 z-10 bg-gray-50 dark:bg-gray-900/40 px-2 py-1 truncate" title={`${t('monthlyCategoryBreakdown.subtotal')}: ${section.title}`}>
+                      <tr className="font-bold bg-gray-50 dark:bg-gray-900 border-t-2 border-gray-300 dark:border-gray-600">
+                        <td className="sticky left-0 z-10 bg-gray-50 dark:bg-gray-900 px-2 py-1 truncate" title={`${t('monthlyCategoryBreakdown.subtotal')}: ${section.title}`}>
                           {t('monthlyCategoryBreakdown.subtotal')}: {section.title}
                         </td>
                         {months.map((m) => {
@@ -536,8 +571,8 @@ export function MonthlyCategoryBreakdownReport() {
                     {t('monthlyCategoryBreakdown.summary')}
                   </td>
                 </tr>
-                <tr className="font-bold bg-gray-100 dark:bg-gray-900/50 border-t-2 border-gray-400 dark:border-gray-500">
-                  <td className="sticky left-0 z-10 bg-gray-100 dark:bg-gray-900/50 px-2 py-1">
+                <tr className="font-bold bg-gray-100 dark:bg-gray-900 border-t-2 border-gray-400 dark:border-gray-500">
+                  <td className="sticky left-0 z-10 bg-gray-100 dark:bg-gray-900 px-2 py-1">
                     {t('monthlyCategoryBreakdown.totalExpenses')}
                   </td>
                   {months.map((m) => (
@@ -552,8 +587,8 @@ export function MonthlyCategoryBreakdownReport() {
                     {formatGrand(model!.totalExpensesAvg, false, formatCurrency, currency)}
                   </td>
                 </tr>
-                <tr className="font-bold bg-gray-100 dark:bg-gray-900/50">
-                  <td className="sticky left-0 z-10 bg-gray-100 dark:bg-gray-900/50 px-2 py-1">
+                <tr className="font-bold bg-gray-100 dark:bg-gray-900">
+                  <td className="sticky left-0 z-10 bg-gray-100 dark:bg-gray-900 px-2 py-1">
                     {t('monthlyCategoryBreakdown.totalIncome')}
                   </td>
                   {months.map((m) => (
@@ -568,8 +603,8 @@ export function MonthlyCategoryBreakdownReport() {
                     {formatGrand(model!.totalIncomeAvg, true, formatCurrency, currency)}
                   </td>
                 </tr>
-                <tr className="font-bold bg-gray-100 dark:bg-gray-900/50">
-                  <td className="sticky left-0 z-10 bg-gray-100 dark:bg-gray-900/50 px-2 py-1">
+                <tr className="font-bold bg-gray-100 dark:bg-gray-900">
+                  <td className="sticky left-0 z-10 bg-gray-100 dark:bg-gray-900 px-2 py-1">
                     {t('monthlyCategoryBreakdown.balance')}
                   </td>
                   {months.map((m) => {
@@ -600,8 +635,8 @@ export function MonthlyCategoryBreakdownReport() {
                   const sectionSum = section.isIncome ? model!.totalIncomeSum : model!.totalExpensesSum;
                   const sectionAvg = section.isIncome ? model!.totalIncomeAvg : model!.totalExpensesAvg;
                   return (
-                    <tr key={`recap-${si}`} className="font-bold bg-gray-50 dark:bg-gray-900/40">
-                      <td className="sticky left-0 z-10 bg-gray-50 dark:bg-gray-900/40 px-2 py-1 truncate" title={section.title}>
+                    <tr key={`recap-${si}`} className="font-bold bg-gray-50 dark:bg-gray-900">
+                      <td className="sticky left-0 z-10 bg-gray-50 dark:bg-gray-900 px-2 py-1 truncate" title={section.title}>
                         {section.title}
                       </td>
                       {months.map((m) => {

--- a/frontend/src/components/reports/MonthlyCategoryBreakdownReport.tsx
+++ b/frontend/src/components/reports/MonthlyCategoryBreakdownReport.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
@@ -9,11 +9,16 @@ import { MonthlyBreakdownCategoryRow } from '@/types/built-in-reports';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useDateFormat } from '@/hooks/useDateFormat';
 import { useDateRange } from '@/hooks/useDateRange';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useReportData } from '@/hooks/useReportData';
 import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
 import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
 import { ReportError } from '@/components/reports/ReportError';
 import { exportToCsv } from '@/lib/csv-export';
+
+const RANGE_STORAGE_KEY = 'monize-reports-monthly-category-breakdown-range';
+const PERCENTAGES_STORAGE_KEY =
+  'monize-reports-monthly-category-breakdown-percentages';
 
 // Deviation thresholds (fraction of the non-zero average) mirroring yaffa.
 const DEVIATION_LEVEL_1 = 0.05;
@@ -154,7 +159,10 @@ export function MonthlyCategoryBreakdownReport() {
   const { formatCurrency } = useNumberFormat();
   const { formatMonth } = useDateFormat();
   const otherExpensesLabel = t('monthlyCategoryBreakdown.otherExpenses');
-  const [showPercentages, setShowPercentages] = useState(false);
+  const [showPercentages, setShowPercentages] = useLocalStorage<boolean>(
+    PERCENTAGES_STORAGE_KEY,
+    false,
+  );
   const {
     dateRange,
     setDateRange,
@@ -164,7 +172,7 @@ export function MonthlyCategoryBreakdownReport() {
     setEndDate,
     resolvedRange,
     isValid,
-  } = useDateRange({ defaultRange: '6m' });
+  } = useDateRange({ defaultRange: '6m', storageKey: RANGE_STORAGE_KEY });
 
   const { start: rangeStart, end: rangeEnd } = resolvedRange;
 

--- a/frontend/src/hooks/useDateRange.test.ts
+++ b/frontend/src/hooks/useDateRange.test.ts
@@ -203,4 +203,58 @@ describe('useDateRange', () => {
     expect(result.current.resolvedRange.start).toBe('2024-08-01');
     expect(result.current.resolvedRange.end).toBe('2025-01-15');
   });
+
+  describe('storageKey persistence', () => {
+    const KEY = 'test-date-range';
+
+    beforeEach(() => {
+      window.localStorage.clear();
+    });
+
+    it('does not touch localStorage when no storageKey is given', () => {
+      const { result } = renderHook(() => useDateRange({ defaultRange: '3m' }));
+      act(() => {
+        result.current.setDateRange('1y');
+      });
+      expect(window.localStorage.getItem(KEY)).toBeNull();
+    });
+
+    it('persists the selected preset and restores it on remount', () => {
+      const { result, unmount } = renderHook(() =>
+        useDateRange({ defaultRange: '6m', storageKey: KEY }),
+      );
+      act(() => {
+        result.current.setDateRange('1y');
+      });
+      unmount();
+
+      // A fresh hook instance with a different default should still restore
+      // the previously selected preset from localStorage.
+      const { result: restored } = renderHook(() =>
+        useDateRange({ defaultRange: '3m', storageKey: KEY }),
+      );
+      expect(restored.current.dateRange).toBe('1y');
+    });
+
+    it('persists and restores custom start/end dates', () => {
+      const { result, unmount } = renderHook(() =>
+        useDateRange({ defaultRange: 'custom', storageKey: KEY }),
+      );
+      act(() => {
+        result.current.setDateRange('custom');
+        result.current.setStartDate('2024-03-01');
+        result.current.setEndDate('2024-09-30');
+      });
+      unmount();
+
+      const { result: restored } = renderHook(() =>
+        useDateRange({ defaultRange: '6m', storageKey: KEY }),
+      );
+      expect(restored.current.dateRange).toBe('custom');
+      expect(restored.current.startDate).toBe('2024-03-01');
+      expect(restored.current.endDate).toBe('2024-09-30');
+      expect(restored.current.resolvedRange.start).toBe('2024-03-01');
+      expect(restored.current.resolvedRange.end).toBe('2024-09-30');
+    });
+  });
 });

--- a/frontend/src/hooks/useDateRange.ts
+++ b/frontend/src/hooks/useDateRange.ts
@@ -1,11 +1,37 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { format, subMonths, subDays, subYears, subWeeks, startOfMonth } from 'date-fns';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('useDateRange');
 
 interface UseDateRangeOptions {
   /** Which preset is selected by default. */
   defaultRange: string;
   /** Whether date boundaries snap to start/end of month. Default: 'day'. */
   alignment?: 'day' | 'month';
+  /**
+   * When provided, the selected preset plus custom start/end dates are
+   * persisted to localStorage under this key and restored on mount, so the
+   * selection survives leaving and returning to the screen.
+   */
+  storageKey?: string;
+}
+
+interface PersistedRange {
+  dateRange?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+function readPersistedRange(storageKey?: string): PersistedRange | null {
+  if (!storageKey || typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    return raw ? (JSON.parse(raw) as PersistedRange) : null;
+  } catch (error) {
+    logger.warn(`Error reading localStorage key "${storageKey}":`, error);
+    return null;
+  }
 }
 
 interface UseDateRangeReturn {
@@ -28,10 +54,29 @@ interface UseDateRangeReturn {
 }
 
 export function useDateRange(options: UseDateRangeOptions): UseDateRangeReturn {
-  const { defaultRange, alignment = 'day' } = options;
-  const [dateRange, setDateRange] = useState<string>(defaultRange);
-  const [startDate, setStartDate] = useState('');
-  const [endDate, setEndDate] = useState('');
+  const { defaultRange, alignment = 'day', storageKey } = options;
+  const [dateRange, setDateRange] = useState<string>(
+    () => readPersistedRange(storageKey)?.dateRange ?? defaultRange,
+  );
+  const [startDate, setStartDate] = useState(
+    () => readPersistedRange(storageKey)?.startDate ?? '',
+  );
+  const [endDate, setEndDate] = useState(
+    () => readPersistedRange(storageKey)?.endDate ?? '',
+  );
+
+  // Persist the selection whenever it changes (no-op without a storageKey).
+  useEffect(() => {
+    if (!storageKey || typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(
+        storageKey,
+        JSON.stringify({ dateRange, startDate, endDate }),
+      );
+    } catch (error) {
+      logger.warn(`Error setting localStorage key "${storageKey}":`, error);
+    }
+  }, [storageKey, dateRange, startDate, endDate]);
 
   const resolveRange = useCallback(
     (range: string): { start: string; end: string } => {


### PR DESCRIPTION
Clicking a category or subcategory name in the Monthly Category
Breakdown report now navigates to the Transactions page filtered by
that category (or all child categories for a parent section header)
and the report's full date range.

Also fix mobile horizontal scrolling: pin the parent-category section
header label to the left so it stays visible, and make the subtotal,
grand summary, and recap row backgrounds opaque so values from other
columns no longer bleed under the sticky first column.