### PR TITLE
ci: bump trivy-action to v0.36.0 to fix release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,7 +577,7 @@ jobs:
       # only - HIGH issues surface in the Security tab but do not block
       # releases, matching the npm-audit policy.
       - name: Scan backend image (Trivy)
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ghcr.io/kenlasko/monize-backend@${{ steps.build-backend.outputs.digest }}
           format: sarif
@@ -594,7 +594,7 @@ jobs:
           category: trivy-backend
 
       - name: Scan frontend image (Trivy)
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ghcr.io/kenlasko/monize-frontend@${{ steps.build-frontend.outputs.digest }}
           format: sarif
@@ -611,7 +611,7 @@ jobs:
           category: trivy-frontend
 
       - name: Fail on critical CVEs (backend)
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ghcr.io/kenlasko/monize-backend@${{ steps.build-backend.outputs.digest }}
           format: table
@@ -620,7 +620,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Fail on critical CVEs (frontend)
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ghcr.io/kenlasko/monize-frontend@${{ steps.build-frontend.outputs.digest }}
           format: table


### PR DESCRIPTION
## Problem

The release job (`build-and-push` in `ci.yml`) pinned `aquasecurity/trivy-action@…915b19b # v0.28.0`. That version's composite action internally references `aquasecurity/setup-trivy@v0.2.1` — a tag the upstream maintainers have since deleted. GitHub Actions can't resolve the nested reference, so the release run (CI Pipeline #1537) fails during action setup, before any build, scan, or publish can run:

```
Error: Unable to resolve action `aquasecurity/setup-trivy@v0.2.1`, unable to find version `v0.2.1`
```

This blocks cutting the v1.11.0 release. The failure is purely in action resolution — nothing was partially published.

## Fix

Bump all four `trivy-action` pins (the two SARIF scans and the two critical-CVE gates) to **v0.36.0** (`ed142fd0673e97e23eac54620cfb913e5ce36c25`). That release internally pins `setup-trivy@…3fb12ec # v0.2.6`, a valid tag, so the action resolves and the image vulnerability scan runs again.

- SHA-pinned with a version comment, matching the repo's existing action-pinning convention.
- Verified the SHA resolves to the genuine v0.36.0 `action.yaml` (Aqua Security Trivy) and that its internal `setup-trivy` reference is the valid v0.2.6 tag.

## Scope

Single file, `.github/workflows/ci.yml` (4 lines). No application or release-notes changes.

## After merge

Re-trigger the release against `main`:

```sh
gh workflow run "CI Pipeline" --ref main -f version=1.11.0
```

https://claude.ai/code/session_01QeXPDW9JKMpq5Pi8WWiWWJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeXPDW9JKMpq5Pi8WWiWWJ)_