### PR TITLE
Refine payee Auto-Merge modal, fix diacritic split, toggles + category context

### DIFF
--- a/backend/src/payees/dto/apply-auto-merge.dto.ts
+++ b/backend/src/payees/dto/apply-auto-merge.dto.ts
@@ -53,6 +53,15 @@ export class AutoMergeGroupDto {
   @MaxLength(255)
   @SanitizeHtml()
   alias?: string;
+
+  @ApiProperty({
+    required: false,
+    example: "category-uuid",
+    description: "Optional default category to set on the canonical payee",
+  })
+  @IsOptional()
+  @IsUUID()
+  defaultCategoryId?: string;
 }
 
 export class ApplyAutoMergeDto {

--- a/backend/src/payees/payee-auto-merge.service.spec.ts
+++ b/backend/src/payees/payee-auto-merge.service.spec.ts
@@ -129,6 +129,38 @@ describe("PayeeAutoMergeService", () => {
       expect(canonical?.payeeId).toBe("p1");
     });
 
+    it("suggests the group's most-used transaction category", async () => {
+      mockPayeesService.findAll.mockResolvedValue([
+        makePayee("p1", "Lidl", 10),
+        makePayee("p2", "LIDL sp. z o.o.", 2),
+        makePayee("p3", "LIDL WARSZAWA 0421", 5),
+      ]);
+      // Aggregated across the group: groceries 10, dining 5 -> groceries wins.
+      dominantRows = [
+        { payeeId: "p1", categoryId: "cat-groceries", cnt: "8" },
+        { payeeId: "p2", categoryId: "cat-groceries", cnt: "2" },
+        { payeeId: "p3", categoryId: "cat-dining", cnt: "5" },
+      ];
+
+      const { groups } = await service.previewAutoMerge(userId, opts);
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].suggestedCategoryId).toBe("cat-groceries");
+    });
+
+    it("suggests no category when no member has categorized transactions", async () => {
+      mockPayeesService.findAll.mockResolvedValue([
+        makePayee("p1", "Lidl", 10),
+        makePayee("p2", "LIDL sp. z o.o.", 2),
+      ]);
+      dominantRows = [];
+
+      const { groups } = await service.previewAutoMerge(userId, opts);
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].suggestedCategoryId).toBeNull();
+    });
+
     it("requests active-only payees by default", async () => {
       mockPayeesService.findAll.mockResolvedValue([]);
       await service.previewAutoMerge(userId, opts);
@@ -516,6 +548,41 @@ describe("PayeeAutoMergeService", () => {
       });
       expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
       expect(mockQueryRunner.manager.save).toHaveBeenCalled();
+    });
+
+    it("sets the chosen default category on the canonical", async () => {
+      mockCategoriesRepository.find.mockResolvedValue([{ id: "cat-1" }]);
+
+      await service.applyAutoMerge(userId, [
+        {
+          canonicalPayeeId: "p1",
+          sourcePayeeIds: ["p2"],
+          alias: "*LIDL*",
+          defaultCategoryId: "cat-1",
+        },
+      ]);
+
+      expect(mockQueryRunner.manager.update).toHaveBeenCalledWith(
+        Payee,
+        { id: "p1", userId },
+        { defaultCategoryId: "cat-1" },
+      );
+    });
+
+    it("rejects a default category not owned by the user", async () => {
+      mockCategoriesRepository.find.mockResolvedValue([]); // none owned
+
+      await expect(
+        service.applyAutoMerge(userId, [
+          {
+            canonicalPayeeId: "p1",
+            sourcePayeeIds: ["p2"],
+            defaultCategoryId: "cat-not-owned",
+          },
+        ]),
+      ).rejects.toThrow(BadRequestException);
+      // Fails fast, before opening a transaction.
+      expect(mockQueryRunner.startTransaction).not.toHaveBeenCalled();
     });
 
     it("renames the canonical and cascades the name", async () => {

--- a/backend/src/payees/payee-auto-merge.service.ts
+++ b/backend/src/payees/payee-auto-merge.service.ts
@@ -5,7 +5,7 @@ import {
   Logger,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { DataSource, QueryRunner, Repository } from "typeorm";
+import { DataSource, In, QueryRunner, Repository } from "typeorm";
 import { tr } from "../i18n/translate";
 import { Payee } from "./entities/payee.entity";
 import { PayeeAlias } from "./entities/payee-alias.entity";
@@ -52,6 +52,10 @@ export interface AutoMergeGroupPreview {
   suggestedCanonicalPayeeId: string;
   suggestedName: string;
   suggestedAlias: string;
+  // The group's most-used transaction category (across all members), offered as
+  // a default category for the merged payee; null when no member has any
+  // categorized transactions.
+  suggestedCategoryId: string | null;
   members: AutoMergeMember[];
   totalTransactions: number;
 }
@@ -61,6 +65,8 @@ export interface ApplyAutoMergeGroup {
   canonicalName?: string;
   sourcePayeeIds: string[];
   alias?: string;
+  // Optional default category to set on the canonical payee after merging.
+  defaultCategoryId?: string;
 }
 
 export interface ApplyAutoMergeResult {
@@ -117,6 +123,11 @@ export class PayeeAutoMergeService {
       opts.includeInactive ? "all" : "active",
     );
 
+    // Per-payee transaction-category counts drive both the optional category
+    // filter (dominant category fallback) and the suggested default category
+    // returned for each group, so build it once up front.
+    const categoryCounts = await this.buildCategoryCountsMap(userId);
+
     // Resolve each payee's effective category when the filter is on: prefer the
     // explicit default category, else fall back to the payee's dominant
     // transaction category. A null key means "category unknown" - such payees
@@ -127,7 +138,7 @@ export class PayeeAutoMergeService {
         ? await this.buildRootCategoryMap(userId)
         : null;
     const dominantByPayee = categoryFilterOn
-      ? await this.buildDominantCategoryMap(userId)
+      ? this.dominantFromCounts(categoryCounts)
       : null;
     const categoryKeyOf = (payee: PayeeWithStats): string | null => {
       if (!categoryFilterOn) return null;
@@ -163,7 +174,9 @@ export class PayeeAutoMergeService {
 
     const groups: AutoMergeGroupPreview[] = clusters
       .filter((members) => members.length >= opts.minGroupSize)
-      .map((members) => this.toGroupPreview(members, opts.minTokenLength))
+      .map((members) =>
+        this.toGroupPreview(members, opts.minTokenLength, categoryCounts),
+      )
       .sort((a, b) => {
         if (b.totalTransactions !== a.totalTransactions) {
           return b.totalTransactions - a.totalTransactions;
@@ -338,13 +351,14 @@ export class PayeeAutoMergeService {
   }
 
   /**
-   * Build a map from payee id to its dominant (most-used) transaction category,
-   * used as the payee's category when no explicit default category is set.
-   * Transfers and uncategorized transactions are ignored.
+   * Build a map from payee id to its per-category transaction counts
+   * (payeeId -> categoryId -> count). Transfers and uncategorized transactions
+   * are ignored. Drives both the dominant-category fallback used by the category
+   * filter and the suggested default category surfaced per merge group.
    */
-  private async buildDominantCategoryMap(
+  private async buildCategoryCountsMap(
     userId: string,
-  ): Promise<Map<string, string>> {
+  ): Promise<Map<string, Map<string, number>>> {
     const rows = await this.transactionsRepository
       .createQueryBuilder("t")
       .select("t.payee_id", "payeeId")
@@ -358,15 +372,72 @@ export class PayeeAutoMergeService {
       .addGroupBy("t.category_id")
       .getRawMany<{ payeeId: string; categoryId: string; cnt: string }>();
 
-    const best = new Map<string, { categoryId: string; count: number }>();
+    const map = new Map<string, Map<string, number>>();
     for (const row of rows) {
       const count = parseInt(row.cnt, 10);
-      const current = best.get(row.payeeId);
-      if (!current || count > current.count) {
-        best.set(row.payeeId, { categoryId: row.categoryId, count });
+      const inner = map.get(row.payeeId);
+      if (inner) {
+        inner.set(row.categoryId, count);
+      } else {
+        map.set(row.payeeId, new Map([[row.categoryId, count]]));
       }
     }
-    return new Map([...best].map(([payeeId, v]) => [payeeId, v.categoryId]));
+    return map;
+  }
+
+  /**
+   * Reduce per-category counts to each payee's single dominant (most-used)
+   * category, used as the payee's category when no explicit default is set.
+   */
+  private dominantFromCounts(
+    categoryCounts: Map<string, Map<string, number>>,
+  ): Map<string, string> {
+    const result = new Map<string, string>();
+    for (const [payeeId, counts] of categoryCounts) {
+      let bestCategory: string | null = null;
+      let bestCount = -1;
+      for (const [categoryId, count] of counts) {
+        if (count > bestCount) {
+          bestCategory = categoryId;
+          bestCount = count;
+        }
+      }
+      if (bestCategory !== null) {
+        result.set(payeeId, bestCategory);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * The group's most-used transaction category: sum each member's per-category
+   * counts and pick the highest total (ties broken by category id for
+   * determinism). Returns null when no member has any categorized transactions.
+   */
+  private suggestedCategoryForGroup(
+    payeeList: PayeeWithStats[],
+    categoryCounts: Map<string, Map<string, number>>,
+  ): string | null {
+    const totals = new Map<string, number>();
+    for (const payee of payeeList) {
+      const counts = categoryCounts.get(payee.id);
+      if (!counts) continue;
+      for (const [categoryId, count] of counts) {
+        totals.set(categoryId, (totals.get(categoryId) ?? 0) + count);
+      }
+    }
+    let best: string | null = null;
+    let bestCount = 0;
+    for (const [categoryId, count] of totals) {
+      if (
+        count > bestCount ||
+        (count === bestCount && best !== null && categoryId < best)
+      ) {
+        best = categoryId;
+        bestCount = count;
+      }
+    }
+    return best;
   }
 
   /**
@@ -384,6 +455,7 @@ export class PayeeAutoMergeService {
   private toGroupPreview(
     payeeList: PayeeWithStats[],
     minTokenLength: number,
+    categoryCounts: Map<string, Map<string, number>>,
   ): AutoMergeGroupPreview {
     // Canonical = most transactions, tie-break on shortest then alphabetical.
     const canonical = [...payeeList].sort((a, b) => {
@@ -429,6 +501,10 @@ export class PayeeAutoMergeService {
       suggestedCanonicalPayeeId: canonical.id,
       suggestedName: canonical.name,
       suggestedAlias: aliasBase ? `*${aliasBase}*` : "",
+      suggestedCategoryId: this.suggestedCategoryForGroup(
+        payeeList,
+        categoryCounts,
+      ),
       members,
       totalTransactions,
     };
@@ -464,6 +540,33 @@ export class PayeeAutoMergeService {
       if (group.sourcePayeeIds.includes(group.canonicalPayeeId)) {
         throw new BadRequestException(
           tr("errors.payees.mergeSelf", "Cannot merge a payee into itself"),
+        );
+      }
+    }
+
+    // Batch-verify any chosen default categories belong to the user before
+    // touching the database, so an invalid id fails fast rather than mid-merge.
+    const categoryIds = [
+      ...new Set(
+        groups
+          .map((g) => g.defaultCategoryId)
+          .filter((id): id is string => !!id),
+      ),
+    ];
+    if (categoryIds.length > 0) {
+      const owned = await this.categoriesRepository.find({
+        where: { id: In(categoryIds), userId },
+        select: ["id"],
+      });
+      const ownedIds = new Set(owned.map((c) => c.id));
+      const invalidIds = categoryIds.filter((id) => !ownedIds.has(id));
+      if (invalidIds.length > 0) {
+        throw new BadRequestException(
+          tr(
+            "errors.payees.categoryIdsNotOwned",
+            `Category IDs not found or not owned by user: ${invalidIds.join(", ")}`,
+            { ids: invalidIds.join(", ") },
+          ),
         );
       }
     }
@@ -534,6 +637,16 @@ export class PayeeAutoMergeService {
         canonical,
         group,
       );
+
+      // Optionally set the chosen default category on the canonical. Ownership
+      // was validated up front in applyAutoMerge.
+      if (group.defaultCategoryId) {
+        await queryRunner.manager.update(
+          Payee,
+          { id: canonical.id, userId },
+          { defaultCategoryId: group.defaultCategoryId },
+        );
+      }
 
       // Reassign each source's data to the canonical, then delete the source.
       let transactionsMigrated = 0;

--- a/backend/src/payees/payee-normalize.util.spec.ts
+++ b/backend/src/payees/payee-normalize.util.spec.ts
@@ -17,6 +17,25 @@ describe("payee-normalize.util", () => {
       expect(normalizePayeeName("Café Münchën")).toBe("CAFE MUNCHEN");
     });
 
+    it("transliterates stroke/ligature letters that NFD does not decompose", () => {
+      // The L-stroke must become a plain L, not a word break -- otherwise
+      // "MALGORZATA" would split into "MA" + "GORZATA" and cluster on "GORZATA".
+      expect(normalizePayeeName("MAŁGORZATA")).toBe("MALGORZATA");
+      expect(normalizePayeeName("Małgorzata")).toBe("MALGORZATA");
+      expect(normalizePayeeName("Łódź")).toBe("LODZ");
+      expect(normalizePayeeName("Smørrebrød")).toBe("SMORREBROD");
+      expect(normalizePayeeName("Æro")).toBe("AERO");
+      expect(normalizePayeeName("Œuvre")).toBe("OEUVRE");
+    });
+
+    it("keeps a stroke-letter name as a single significant token", () => {
+      // Regression: the leading significant token of "MAŁGORZATA SKLEP" must be
+      // the full name, not the fragment after the stroke.
+      expect(
+        leadingSignificantToken(normalizePayeeName("MAŁGORZATA SKLEP"), 3),
+      ).toBe("MALGORZATA");
+    });
+
     it("drops store numbers and punctuation", () => {
       expect(normalizePayeeName("STARBUCKS #1234")).toBe("STARBUCKS");
       expect(normalizePayeeName("Tesco-Express, 99")).toBe("TESCO EXPRESS");

--- a/backend/src/payees/payee-normalize.util.ts
+++ b/backend/src/payees/payee-normalize.util.ts
@@ -49,6 +49,57 @@ const BUSINESS_SUFFIXES: ReadonlySet<string> = new Set([
   "MBH",
 ]);
 
+// Latin letters whose diacritic is an integral stroke or ligature that Unicode
+// NFD does NOT split into a base letter + combining mark. Without an explicit
+// transliteration the diacritic-stripping pass in normalizePayeeName leaves them
+// untouched, and the later [^A-Z0-9] replacement turns them into a word break --
+// so e.g. Polish "MALGORZATA" (with an L-stroke) would wrongly split into "MA"
+// and "GORZATA" and cluster on "GORZATA". Mapped to upper-case ASCII bases since
+// names are upper-cased during normalization.
+const NON_DECOMPOSING_LETTERS: ReadonlyMap<string, string> = new Map([
+  ["Ł", "L"],
+  ["ł", "L"],
+  ["Ø", "O"],
+  ["ø", "O"],
+  ["Đ", "D"],
+  ["đ", "D"],
+  ["Ð", "D"],
+  ["ð", "D"],
+  ["Þ", "TH"],
+  ["þ", "TH"],
+  ["ẞ", "SS"],
+  ["ß", "SS"],
+  ["Æ", "AE"],
+  ["æ", "AE"],
+  ["Œ", "OE"],
+  ["œ", "OE"],
+  ["Ĳ", "IJ"],
+  ["ĳ", "IJ"],
+  ["Ħ", "H"],
+  ["ħ", "H"],
+  ["Ŧ", "T"],
+  ["ŧ", "T"],
+  ["Ŀ", "L"],
+  ["ŀ", "L"],
+  ["Ŋ", "NG"],
+  ["ŋ", "NG"],
+]);
+
+const NON_DECOMPOSING_RE = /[ŁłØøĐđÐðÞþẞßÆæŒœĲĳĦħŦŧĿŀŊŋ]/g;
+
+/**
+ * Replace Latin letters with an integral stroke/ligature (which NFD does not
+ * decompose) with an ASCII equivalent, so the diacritic strip in
+ * normalizePayeeName does not turn them into word breaks. Pure: `replace`
+ * returns a new string.
+ */
+function transliterateNonDecomposing(name: string): string {
+  return name.replace(
+    NON_DECOMPOSING_RE,
+    (ch) => NON_DECOMPOSING_LETTERS.get(ch) ?? ch,
+  );
+}
+
 // Payment-rail / generic noise tokens that never identify a payee. Filtered
 // out when picking the "significant" tokens used for grouping.
 const NOISE_TOKENS: ReadonlySet<string> = new Set([
@@ -84,7 +135,7 @@ const NOISE_TOKENS: ReadonlySet<string> = new Set([
  */
 export function normalizePayeeName(name: string): string {
   if (!name) return "";
-  const tokens = name
+  const tokens = transliterateNonDecomposing(name)
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
     .toUpperCase()

--- a/frontend/src/app/payees/page.test.tsx
+++ b/frontend/src/app/payees/page.test.tsx
@@ -90,6 +90,7 @@ vi.mock('@/lib/payees', () => ({
 vi.mock('@/lib/categoryUtils', () => ({
   buildCategoryColorMap: () => new Map(),
   buildCategoryLabelMap: () => new Map(),
+  buildCategoryTree: () => [],
 }));
 
 vi.mock('@/lib/categories', () => ({

--- a/frontend/src/app/payees/page.tsx
+++ b/frontend/src/app/payees/page.tsx
@@ -349,6 +349,7 @@ function PayeesContent() {
         isOpen={showAutoAssign}
         onClose={() => setShowAutoAssign(false)}
         onSuccess={loadData}
+        categories={categories}
       />
 
       {/* Merge Payee Dialog */}
@@ -372,6 +373,7 @@ function PayeesContent() {
         isOpen={showAutoMerge}
         onClose={() => setShowAutoMerge(false)}
         onSuccess={loadData}
+        categories={categories}
       />
     </PageLayout>
   );

--- a/frontend/src/components/payees/AutoMergePayeesDialog.test.tsx
+++ b/frontend/src/components/payees/AutoMergePayeesDialog.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor, act } from '@/test/render';
 import { AutoMergePayeesDialog } from './AutoMergePayeesDialog';
 import { payeesApi } from '@/lib/payees';
 import { AutoMergeGroup } from '@/types/payee';
+import { Category } from '@/types/category';
 
 vi.mock('@/lib/payees', () => ({
   payeesApi: {
@@ -33,6 +34,7 @@ const lidlGroup: AutoMergeGroup = {
   suggestedCanonicalPayeeId: 'p1',
   suggestedName: 'Lidl',
   suggestedAlias: '*LIDL*',
+  suggestedCategoryId: null,
   totalTransactions: 17,
   members: [
     { payeeId: 'p1', name: 'Lidl', transactionCount: 10, isCanonical: true },
@@ -40,6 +42,32 @@ const lidlGroup: AutoMergeGroup = {
     { payeeId: 'p3', name: 'LIDL WARSZAWA 0421', transactionCount: 5, isCanonical: false },
   ],
 };
+
+// A two-level category tree so the picker shows the "Parent: Child" label.
+const categories = [
+  { id: 'cat-food', name: 'Food', parentId: null },
+  { id: 'cat-groceries', name: 'Groceries', parentId: 'cat-food' },
+] as unknown as Category[];
+
+const groceryGroup: AutoMergeGroup = {
+  groupKey: 'LIDL',
+  suggestedCanonicalPayeeId: 'p1',
+  suggestedName: 'Lidl',
+  suggestedAlias: '*LIDL*',
+  suggestedCategoryId: 'cat-groceries',
+  totalTransactions: 12,
+  members: [
+    { payeeId: 'p1', name: 'Lidl', transactionCount: 10, isCanonical: true },
+    { payeeId: 'p2', name: 'LIDL sp. z o.o.', transactionCount: 2, isCanonical: false },
+  ],
+};
+
+// Selecting (including) every previewed group; groups start de-selected.
+async function selectAllGroups() {
+  await act(async () => {
+    fireEvent.click(screen.getByText('Select all'));
+  });
+}
 
 describe('AutoMergePayeesDialog', () => {
   const onClose = vi.fn();
@@ -145,7 +173,7 @@ describe('AutoMergePayeesDialog', () => {
     );
   });
 
-  it('deselects every group with Deselect all', async () => {
+  it('starts with every group de-selected', async () => {
     mockPreview.mockResolvedValue([lidlGroup]);
     render(<AutoMergePayeesDialog isOpen onClose={onClose} onSuccess={onSuccess} />);
 
@@ -153,6 +181,26 @@ describe('AutoMergePayeesDialog', () => {
       fireEvent.click(screen.getByText('Preview Groups'));
     });
     await waitFor(() => expect(screen.getByDisplayValue('Lidl')).toBeInTheDocument());
+
+    // Nothing is selected until the user opts in, so the apply button is
+    // disabled and no footer count is shown.
+    expect(
+      screen.getByRole('button', { name: /Merge 0 Groups/ }),
+    ).toBeDisabled();
+    expect(screen.queryByText(/group selected/)).not.toBeInTheDocument();
+  });
+
+  it('selects then deselects every group with the bulk actions', async () => {
+    mockPreview.mockResolvedValue([lidlGroup]);
+    render(<AutoMergePayeesDialog isOpen onClose={onClose} onSuccess={onSuccess} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Preview Groups'));
+    });
+    await waitFor(() => expect(screen.getByDisplayValue('Lidl')).toBeInTheDocument());
+
+    await selectAllGroups();
+    expect(screen.getByRole('button', { name: /Merge 1 Group/ })).toBeEnabled();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Deselect all'));
@@ -180,6 +228,7 @@ describe('AutoMergePayeesDialog', () => {
     });
     await waitFor(() => expect(screen.getByDisplayValue('Lidl')).toBeInTheDocument());
 
+    await selectAllGroups();
     await act(async () => {
       fireEvent.click(screen.getByText(/Merge 1 Group/));
     });
@@ -228,11 +277,14 @@ describe('AutoMergePayeesDialog', () => {
     });
     await waitFor(() => expect(screen.getByDisplayValue('Lidl')).toBeInTheDocument());
 
-    // Uncheck the "include in merge" checkbox for p2 (LIDL sp. z o.o.).
+    // The member toggles are only enabled once the group is included.
+    await selectAllGroups();
+
+    // Uncheck the "include in merge" toggle for p2 (LIDL sp. z o.o.).
     // Index 0 is the canonical (p1, disabled); index 1 is p2.
-    const includeCheckboxes = screen.getAllByLabelText('Include in merge');
+    const includeToggles = screen.getAllByLabelText('Include in merge');
     await act(async () => {
-      fireEvent.click(includeCheckboxes[1]);
+      fireEvent.click(includeToggles[1]);
     });
 
     await act(async () => {
@@ -258,6 +310,7 @@ describe('AutoMergePayeesDialog', () => {
       suggestedCanonicalPayeeId: 'a1',
       suggestedName: 'Royal Electric',
       suggestedAlias: '*ROYAL ELECTRIC*',
+      suggestedCategoryId: null,
       totalTransactions: 25,
       members: [
         { payeeId: 'a1', name: 'Royal Electric', transactionCount: 23, isCanonical: true },
@@ -269,6 +322,7 @@ describe('AutoMergePayeesDialog', () => {
       suggestedCanonicalPayeeId: 'b1',
       suggestedName: 'Royal City Nursery',
       suggestedAlias: '*ROYAL CITY NURSERY*',
+      suggestedCategoryId: null,
       totalTransactions: 11,
       members: [
         { payeeId: 'b1', name: 'Royal City Nursery', transactionCount: 9, isCanonical: true },
@@ -290,11 +344,12 @@ describe('AutoMergePayeesDialog', () => {
     });
     await waitFor(() => expect(screen.getByDisplayValue('Royal Electric')).toBeInTheDocument());
 
-    // De-select only the first group.
-    const groupCheckboxes = screen.getAllByLabelText('Include this group');
-    expect(groupCheckboxes).toHaveLength(2);
+    // Include both groups, then de-select only the first.
+    await selectAllGroups();
+    const groupToggles = screen.getAllByLabelText('Include this group');
+    expect(groupToggles).toHaveLength(2);
     await act(async () => {
-      fireEvent.click(groupCheckboxes[0]);
+      fireEvent.click(groupToggles[0]);
     });
 
     // Footer should now offer to merge exactly one group.
@@ -310,6 +365,80 @@ describe('AutoMergePayeesDialog', () => {
         sourcePayeeIds: ['b2'],
         alias: '*ROYAL CITY NURSERY*',
       },
+    ]);
+  });
+
+  it('labels the Keep/Merge columns and explains the radio choice', async () => {
+    mockPreview.mockResolvedValue([lidlGroup]);
+    render(<AutoMergePayeesDialog isOpen onClose={onClose} onSuccess={onSuccess} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Preview Groups'));
+    });
+    await waitFor(() => expect(screen.getByDisplayValue('Lidl')).toBeInTheDocument());
+
+    expect(
+      screen.getByText('Select the payee to keep. The others are merged into it.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Merge')).toBeInTheDocument();
+    // "Keep" labels both the column header and the canonical badge.
+    expect(screen.getAllByText('Keep').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('shows how many payees will be merged next to the group count', async () => {
+    mockPreview.mockResolvedValue([lidlGroup]);
+    render(<AutoMergePayeesDialog isOpen onClose={onClose} onSuccess={onSuccess} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Preview Groups'));
+    });
+    await waitFor(() => expect(screen.getByDisplayValue('Lidl')).toBeInTheDocument());
+
+    await selectAllGroups();
+
+    // One group, two non-canonical members folded into the canonical.
+    expect(screen.getByText('1 group selected')).toBeInTheDocument();
+    expect(screen.getByText('2 payees to merge')).toBeInTheDocument();
+  });
+
+  it('prefills the suggested default category and applies it', async () => {
+    mockPreview.mockResolvedValue([groceryGroup]);
+    mockApply.mockResolvedValue({
+      groupsMerged: 1,
+      payeesMerged: 1,
+      transactionsMigrated: 2,
+      aliasesCreated: 1,
+      skippedAliases: 0,
+    });
+    render(
+      <AutoMergePayeesDialog
+        isOpen
+        onClose={onClose}
+        onSuccess={onSuccess}
+        categories={categories}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Preview Groups'));
+    });
+    await waitFor(() => expect(screen.getByDisplayValue('Lidl')).toBeInTheDocument());
+
+    // The category picker is prefilled with the group's most-used category,
+    // shown with its parent ("Food: Groceries").
+    expect(screen.getByDisplayValue('Food: Groceries')).toBeInTheDocument();
+
+    await selectAllGroups();
+    await act(async () => {
+      fireEvent.click(screen.getByText(/Merge 1 Group/));
+    });
+
+    await waitFor(() => expect(mockApply).toHaveBeenCalled());
+    expect(mockApply).toHaveBeenCalledWith([
+      expect.objectContaining({
+        canonicalPayeeId: 'p1',
+        defaultCategoryId: 'cat-groceries',
+      }),
     ]);
   });
 });

--- a/frontend/src/components/payees/AutoMergePayeesDialog.tsx
+++ b/frontend/src/components/payees/AutoMergePayeesDialog.tsx
@@ -1,12 +1,15 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/Button';
 import { Modal } from '@/components/ui/Modal';
 import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
+import { Combobox } from '@/components/ui/Combobox';
 import { payeesApi } from '@/lib/payees';
 import { AutoMergeGroup } from '@/types/payee';
+import { Category } from '@/types/category';
+import { buildCategoryTree, buildCategoryLabelMap } from '@/lib/categoryUtils';
 import toast from 'react-hot-toast';
 import { createLogger } from '@/lib/logger';
 import { getErrorMessage } from '@/lib/errors';
@@ -19,6 +22,7 @@ interface AutoMergePayeesDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onSuccess: () => void;
+  categories?: Category[];
 }
 
 interface EditableGroup {
@@ -28,6 +32,7 @@ interface EditableGroup {
   canonicalPayeeId: string;
   canonicalName: string;
   alias: string;
+  defaultCategoryId: string;
   members: AutoMergeGroup['members'];
   selectedMemberIds: Set<string>;
 }
@@ -39,10 +44,13 @@ function toEditableGroups(groups: AutoMergeGroup[]): EditableGroup[] {
     // key on it.
     id: `group-${index}`,
     groupKey: g.groupKey,
-    included: true,
+    // Groups start de-selected so the user opts in to each merge deliberately.
+    included: false,
     canonicalPayeeId: g.suggestedCanonicalPayeeId,
     canonicalName: g.suggestedName,
     alias: g.suggestedAlias,
+    // Prefill with the group's most-used category, but leave it freely editable.
+    defaultCategoryId: g.suggestedCategoryId ?? '',
     members: g.members,
     selectedMemberIds: new Set(g.members.map((m) => m.payeeId)),
   }));
@@ -52,6 +60,7 @@ export function AutoMergePayeesDialog({
   isOpen,
   onClose,
   onSuccess,
+  categories = [],
 }: AutoMergePayeesDialogProps) {
   const t = useTranslations('payees');
   const tc = useTranslations('common');
@@ -70,6 +79,26 @@ export function AutoMergePayeesDialog({
   const [hasPreviewLoaded, setHasPreviewLoaded] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isApplying, setIsApplying] = useState(false);
+
+  // Hierarchical "Parent: Child" options for the per-group default category,
+  // mirroring the payee edit form so the picker behaves identically.
+  const categoryOptions = useMemo(
+    () =>
+      buildCategoryTree(categories).map(({ category }) => {
+        const parent = category.parentId
+          ? categories.find((c) => c.id === category.parentId)
+          : null;
+        return {
+          value: category.id,
+          label: parent ? `${parent.name}: ${category.name}` : category.name,
+        };
+      }),
+    [categories],
+  );
+  const categoryLabelMap = useMemo(
+    () => buildCategoryLabelMap(categories),
+    [categories],
+  );
 
   // Reset state when the dialog opens (info-from-previous-render pattern to
   // avoid setState in an effect).
@@ -143,6 +172,13 @@ export function AutoMergePayeesDialog({
     (g) => g.included && g.selectedMemberIds.size >= 2,
   );
 
+  // Total payees that will be folded into a canonical and removed (every
+  // selected member except the canonical of each applicable group).
+  const payeesToMerge = applicableGroups.reduce(
+    (sum, g) => sum + (g.selectedMemberIds.size - 1),
+    0,
+  );
+
   const handleApply = async () => {
     if (applicableGroups.length === 0) {
       toast.error(t('autoMerge.toasts.selectAtLeastOne'));
@@ -158,6 +194,7 @@ export function AutoMergePayeesDialog({
           (id) => id !== g.canonicalPayeeId,
         ),
         alias: g.alias.trim() || undefined,
+        defaultCategoryId: g.defaultCategoryId || undefined,
       }));
 
       const result = await payeesApi.applyAutoMerge(payload);
@@ -410,7 +447,7 @@ export function AutoMergePayeesDialog({
                         : 'border-gray-200 dark:border-gray-700 opacity-50'
                     }`}
                   >
-                    {/* Group header: include toggle + editable canonical name + alias */}
+                    {/* Group header: include toggle + editable canonical name, alias, category */}
                     <div className="flex items-start gap-3 mb-3">
                       <div className="mt-1">
                         <ToggleSwitch
@@ -421,41 +458,73 @@ export function AutoMergePayeesDialog({
                           label={t('autoMerge.includeGroupLabel')}
                         />
                       </div>
-                      <div className="flex-1 grid grid-cols-1 sm:grid-cols-2 gap-3">
-                        <div>
-                          <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
-                            {t('autoMerge.canonicalNameLabel')}
-                          </label>
-                          <input
-                            type="text"
-                            value={group.canonicalName}
-                            onChange={(e) =>
-                              updateGroup(group.id, {
-                                canonicalName: e.target.value,
-                              })
-                            }
-                            className="block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm text-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-800 dark:text-gray-100"
-                          />
+                      <div className="flex-1 space-y-3">
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                          <div>
+                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+                              {t('autoMerge.canonicalNameLabel')}
+                            </label>
+                            <input
+                              type="text"
+                              value={group.canonicalName}
+                              onChange={(e) =>
+                                updateGroup(group.id, {
+                                  canonicalName: e.target.value,
+                                })
+                              }
+                              className="block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm text-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-800 dark:text-gray-100"
+                            />
+                          </div>
+                          <div>
+                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+                              {t('autoMerge.aliasLabel')}
+                            </label>
+                            <input
+                              type="text"
+                              value={group.alias}
+                              onChange={(e) =>
+                                updateGroup(group.id, { alias: e.target.value })
+                              }
+                              placeholder={t('autoMerge.aliasPlaceholder')}
+                              className="block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm text-sm font-mono focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-800 dark:text-gray-100"
+                            />
+                          </div>
                         </div>
                         <div>
                           <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
-                            {t('autoMerge.aliasLabel')}
+                            {t('autoMerge.defaultCategoryLabel')}
                           </label>
-                          <input
-                            type="text"
-                            value={group.alias}
-                            onChange={(e) =>
-                              updateGroup(group.id, { alias: e.target.value })
+                          <Combobox
+                            placeholder={t('selectCategoryPlaceholder')}
+                            options={categoryOptions}
+                            value={group.defaultCategoryId}
+                            initialDisplayValue={
+                              categoryLabelMap.get(group.defaultCategoryId) ?? ''
                             }
-                            placeholder={t('autoMerge.aliasPlaceholder')}
-                            className="block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm text-sm font-mono focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-800 dark:text-gray-100"
+                            onChange={(value) =>
+                              updateGroup(group.id, { defaultCategoryId: value })
+                            }
+                            disabled={!group.included}
+                            usePortal
                           />
                         </div>
                       </div>
                     </div>
 
-                    {/* Members */}
+                    {/* Members: choose which payee to keep; the rest merge into it */}
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+                      {t('autoMerge.membersHelp')}
+                    </p>
                     <ul className="divide-y divide-gray-100 dark:divide-gray-700 border-t border-gray-100 dark:border-gray-700">
+                      <li className="flex items-center gap-3 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                        <span className="w-10 text-center">
+                          {t('autoMerge.keepColumn')}
+                        </span>
+                        <span className="w-10 text-center">
+                          {t('autoMerge.mergeColumn')}
+                        </span>
+                        <span className="flex-1" />
+                      </li>
                       {group.members.map((member) => {
                         const isCanonical = member.payeeId === group.canonicalPayeeId;
                         return (
@@ -463,22 +532,26 @@ export function AutoMergePayeesDialog({
                             key={member.payeeId}
                             className="flex items-center gap-3 py-2 text-sm"
                           >
-                            <input
-                              type="radio"
-                              name={`canonical-${group.id}`}
-                              checked={isCanonical}
-                              onChange={() => setCanonical(group, member.payeeId)}
-                              disabled={!group.included}
-                              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-gray-600"
-                              aria-label={t('autoMerge.keepLabel')}
-                            />
-                            <ToggleSwitch
-                              size="sm"
-                              checked={group.selectedMemberIds.has(member.payeeId)}
-                              onChange={() => toggleMember(group, member.payeeId)}
-                              disabled={isCanonical || !group.included}
-                              label={t('autoMerge.includeMemberLabel')}
-                            />
+                            <span className="flex w-10 justify-center">
+                              <input
+                                type="radio"
+                                name={`canonical-${group.id}`}
+                                checked={isCanonical}
+                                onChange={() => setCanonical(group, member.payeeId)}
+                                disabled={!group.included}
+                                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-gray-600"
+                                aria-label={t('autoMerge.keepLabel')}
+                              />
+                            </span>
+                            <span className="flex w-10 justify-center">
+                              <ToggleSwitch
+                                size="sm"
+                                checked={group.selectedMemberIds.has(member.payeeId)}
+                                onChange={() => toggleMember(group, member.payeeId)}
+                                disabled={isCanonical || !group.included}
+                                label={t('autoMerge.includeMemberLabel')}
+                              />
+                            </span>
                             <span className="flex-1 text-gray-900 dark:text-gray-100">
                               {member.name}
                               {isCanonical && (
@@ -506,11 +579,19 @@ export function AutoMergePayeesDialog({
 
       {/* Footer */}
       <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex justify-between items-center">
-        <div className="text-sm text-gray-500 dark:text-gray-400">
+        <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
           {applicableGroups.length > 0 && (
-            <span>
-              {t('autoMerge.selectedCount', { count: applicableGroups.length })}
-            </span>
+            <>
+              <span>
+                {t('autoMerge.selectedCount', { count: applicableGroups.length })}
+              </span>
+              <span aria-hidden="true" className="text-gray-300 dark:text-gray-600">
+                &middot;
+              </span>
+              <span>
+                {t('autoMerge.payeesMergedCount', { count: payeesToMerge })}
+              </span>
+            </>
           )}
         </div>
         <div className="flex gap-3">

--- a/frontend/src/components/payees/CategoryAutoAssignDialog.test.tsx
+++ b/frontend/src/components/payees/CategoryAutoAssignDialog.test.tsx
@@ -4,6 +4,7 @@ import { CategoryAutoAssignDialog } from './CategoryAutoAssignDialog';
 import { payeesApi } from '@/lib/payees';
 import toast from 'react-hot-toast';
 import { CategorySuggestion } from '@/types/payee';
+import { Category } from '@/types/category';
 
 vi.mock('@/lib/payees', () => ({
   payeesApi: {
@@ -316,18 +317,54 @@ describe('CategoryAutoAssignDialog', () => {
       fireEvent.click(screen.getByText('Preview Suggestions'));
 
       await waitFor(() => {
-        const checkboxes = screen.getAllByRole('checkbox').filter(
+        const toggles = screen.getAllByRole('switch').filter(
           (el) => el.closest('table')
         );
         // All should be checked
-        checkboxes.forEach((cb) => {
+        toggles.forEach((cb) => {
           expect(cb).toBeChecked();
         });
       });
     });
   });
 
-  describe('individual suggestion checkbox toggle', () => {
+  describe('suggested category label', () => {
+    it('shows the full "Parent: Child" path when categories are provided', async () => {
+      const categories = [
+        { id: 'cat-food', name: 'Food', parentId: null },
+        { id: 'cat-1', name: 'Groceries', parentId: 'cat-food' },
+      ] as unknown as Category[];
+      mockGetCategorySuggestions.mockResolvedValue([sampleSuggestions[0]]);
+      render(
+        <CategoryAutoAssignDialog
+          isOpen={true}
+          onClose={onClose}
+          onSuccess={onSuccess}
+          categories={categories}
+        />,
+      );
+
+      fireEvent.click(screen.getByText('Preview Suggestions'));
+
+      await waitFor(() => {
+        // "Groceries" (cat-1) is shown in context of its parent "Food".
+        expect(screen.getByText('Food: Groceries')).toBeInTheDocument();
+      });
+    });
+
+    it('falls back to the bare category name when no categories are provided', async () => {
+      mockGetCategorySuggestions.mockResolvedValue([sampleSuggestions[0]]);
+      render(<CategoryAutoAssignDialog isOpen={true} onClose={onClose} onSuccess={onSuccess} />);
+
+      fireEvent.click(screen.getByText('Preview Suggestions'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Groceries')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('individual suggestion toggle', () => {
     it('unchecks a suggestion when clicked', async () => {
       mockGetCategorySuggestions.mockResolvedValue(sampleSuggestions);
       render(<CategoryAutoAssignDialog isOpen={true} onClose={onClose} onSuccess={onSuccess} />);
@@ -338,13 +375,13 @@ describe('CategoryAutoAssignDialog', () => {
         expect(screen.getByText('Grocery Store')).toBeInTheDocument();
       });
 
-      // Find the checkbox in the Grocery Store row
+      // Find the toggle in the Grocery Store row
       const groceryRow = screen.getByText('Grocery Store').closest('tr')!;
-      const checkbox = groceryRow.querySelector('input[type="checkbox"]') as HTMLInputElement;
-      expect(checkbox).toBeChecked();
+      const toggle = groceryRow.querySelector('[role="switch"]') as HTMLElement;
+      expect(toggle).toBeChecked();
 
-      fireEvent.click(checkbox);
-      expect(checkbox).not.toBeChecked();
+      fireEvent.click(toggle);
+      expect(toggle).not.toBeChecked();
     });
 
     it('re-checks a suggestion when clicked again', async () => {
@@ -358,11 +395,11 @@ describe('CategoryAutoAssignDialog', () => {
       });
 
       const groceryRow = screen.getByText('Grocery Store').closest('tr')!;
-      const checkbox = groceryRow.querySelector('input[type="checkbox"]') as HTMLInputElement;
+      const toggle = groceryRow.querySelector('[role="switch"]') as HTMLElement;
 
-      fireEvent.click(checkbox); // uncheck
-      fireEvent.click(checkbox); // re-check
-      expect(checkbox).toBeChecked();
+      fireEvent.click(toggle); // uncheck
+      fireEvent.click(toggle); // re-check
+      expect(toggle).toBeChecked();
     });
 
     it('toggles suggestion when row is clicked', async () => {
@@ -376,12 +413,12 @@ describe('CategoryAutoAssignDialog', () => {
       });
 
       const gasRow = screen.getByText('Gas Station').closest('tr')!;
-      const checkbox = gasRow.querySelector('input[type="checkbox"]') as HTMLInputElement;
-      expect(checkbox).toBeChecked();
+      const toggle = gasRow.querySelector('[role="switch"]') as HTMLElement;
+      expect(toggle).toBeChecked();
 
-      // Click the row (not the checkbox)
+      // Click the row (not the toggle)
       fireEvent.click(gasRow);
-      expect(checkbox).not.toBeChecked();
+      expect(toggle).not.toBeChecked();
     });
 
     it('updates selected count in footer when toggling', async () => {
@@ -396,8 +433,8 @@ describe('CategoryAutoAssignDialog', () => {
 
       // Uncheck one
       const groceryRow = screen.getByText('Grocery Store').closest('tr')!;
-      const checkbox = groceryRow.querySelector('input[type="checkbox"]') as HTMLInputElement;
-      fireEvent.click(checkbox);
+      const toggle = groceryRow.querySelector('[role="switch"]') as HTMLElement;
+      fireEvent.click(toggle);
 
       expect(screen.getByText('2 payees selected')).toBeInTheDocument();
     });
@@ -416,18 +453,18 @@ describe('CategoryAutoAssignDialog', () => {
 
       // First uncheck one
       const groceryRow = screen.getByText('Grocery Store').closest('tr')!;
-      const checkbox = groceryRow.querySelector('input[type="checkbox"]') as HTMLInputElement;
-      fireEvent.click(checkbox);
-      expect(checkbox).not.toBeChecked();
+      const toggle = groceryRow.querySelector('[role="switch"]') as HTMLElement;
+      fireEvent.click(toggle);
+      expect(toggle).not.toBeChecked();
 
       // Click "Select all"
       fireEvent.click(screen.getByText('Select all'));
 
       // All should be checked now
-      const checkboxes = screen.getAllByRole('checkbox').filter(
+      const toggles = screen.getAllByRole('switch').filter(
         (el) => el.closest('table')
       );
-      checkboxes.forEach((cb) => {
+      toggles.forEach((cb) => {
         expect(cb).toBeChecked();
       });
     });
@@ -447,10 +484,10 @@ describe('CategoryAutoAssignDialog', () => {
       // Click "Select none"
       fireEvent.click(screen.getByText('Select none'));
 
-      const checkboxes = screen.getAllByRole('checkbox').filter(
+      const toggles = screen.getAllByRole('switch').filter(
         (el) => el.closest('table')
       );
-      checkboxes.forEach((cb) => {
+      toggles.forEach((cb) => {
         expect(cb).not.toBeChecked();
       });
     });
@@ -547,8 +584,8 @@ describe('CategoryAutoAssignDialog', () => {
       // Deselect all then select only Grocery Store
       fireEvent.click(screen.getByText('Select none'));
       const groceryRow = screen.getByText('Grocery Store').closest('tr')!;
-      const checkbox = groceryRow.querySelector('input[type="checkbox"]') as HTMLInputElement;
-      fireEvent.click(checkbox);
+      const toggle = groceryRow.querySelector('[role="switch"]') as HTMLElement;
+      fireEvent.click(toggle);
 
       fireEvent.click(screen.getByText('Apply to 1 Payee'));
 

--- a/frontend/src/components/payees/CategoryAutoAssignDialog.tsx
+++ b/frontend/src/components/payees/CategoryAutoAssignDialog.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/Button';
 import { Modal } from '@/components/ui/Modal';
+import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
 import { payeesApi } from '@/lib/payees';
 import { CategorySuggestion } from '@/types/payee';
+import { Category } from '@/types/category';
+import { buildCategoryLabelMap } from '@/lib/categoryUtils';
 import toast from 'react-hot-toast';
 import { createLogger } from '@/lib/logger';
 import { getErrorMessage } from '@/lib/errors';
@@ -16,12 +19,14 @@ interface CategoryAutoAssignDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onSuccess: () => void;
+  categories?: Category[];
 }
 
 export function CategoryAutoAssignDialog({
   isOpen,
   onClose,
   onSuccess,
+  categories = [],
 }: CategoryAutoAssignDialogProps) {
   const [minTransactions, setMinTransactions] = useState(10);
   const [minPercentage, setMinPercentage] = useState(75);
@@ -32,6 +37,13 @@ export function CategoryAutoAssignDialog({
   const [isApplying, setIsApplying] = useState(false);
   const [hasPreviewLoaded, setHasPreviewLoaded] = useState(false);
   const t = useTranslations('payees');
+
+  // Map a suggested category id to its full "Parent: Child" label so the
+  // suggestion shows the subcategory in context; fall back to the bare name.
+  const categoryLabelMap = useMemo(
+    () => buildCategoryLabelMap(categories),
+    [categories],
+  );
 
   // Load preview when parameters change
   const loadPreview = useCallback(async () => {
@@ -181,21 +193,16 @@ export function CategoryAutoAssignDialog({
             </div>
 
             {/* Only Without Category */}
-            <div className="flex items-center">
-              <input
-                type="checkbox"
-                id="onlyWithoutCategory"
+            <label className="flex items-center gap-3 cursor-pointer">
+              <ToggleSwitch
                 checked={onlyWithoutCategory}
-                onChange={(e) => setOnlyWithoutCategory(e.target.checked)}
-                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-gray-600 rounded"
+                onChange={setOnlyWithoutCategory}
+                label={t('categoryAutoAssign.onlyWithoutCategoryLabel')}
               />
-              <label
-                htmlFor="onlyWithoutCategory"
-                className="ml-2 block text-sm text-gray-700 dark:text-gray-300"
-              >
+              <span className="text-sm text-gray-700 dark:text-gray-300">
                 {t('categoryAutoAssign.onlyWithoutCategoryLabel')}
-              </label>
-            </div>
+              </span>
+            </label>
           </div>
 
           {/* Preview Button */}
@@ -265,13 +272,14 @@ export function CategoryAutoAssignDialog({
                           className="hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer"
                           onClick={() => togglePayee(suggestion.payeeId)}
                         >
-                          <td className="px-3 py-2">
-                            <input
-                              type="checkbox"
+                          <td className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
+                            <ToggleSwitch
+                              size="sm"
                               checked={selectedIds.has(suggestion.payeeId)}
                               onChange={() => togglePayee(suggestion.payeeId)}
-                              onClick={(e) => e.stopPropagation()}
-                              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-gray-600 rounded"
+                              label={t('categoryAutoAssign.selectPayeeLabel', {
+                                name: suggestion.payeeName,
+                              })}
                             />
                           </td>
                           <td className="px-3 py-2">
@@ -284,7 +292,8 @@ export function CategoryAutoAssignDialog({
                           </td>
                           <td className="px-3 py-2">
                             <span className="inline-flex text-xs font-medium rounded-full px-2 py-0.5 bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-                              {suggestion.suggestedCategoryName}
+                              {categoryLabelMap.get(suggestion.suggestedCategoryId) ??
+                                suggestion.suggestedCategoryName}
                             </span>
                           </td>
                           <td className="px-3 py-2 text-right">

--- a/frontend/src/components/payees/DeactivateUnusedPayeesDialog.test.tsx
+++ b/frontend/src/components/payees/DeactivateUnusedPayeesDialog.test.tsx
@@ -159,9 +159,9 @@ describe('DeactivateUnusedPayeesDialog', () => {
     it('allows deselecting individual candidates', async () => {
       const { getAllByRole, getByText } = await renderWithPreview();
 
-      const checkboxes = getAllByRole('checkbox');
+      const toggles = getAllByRole('switch');
       await act(async () => {
-        fireEvent.click(checkboxes[0]);
+        fireEvent.click(toggles[0]);
       });
 
       expect(getByText('1 payee selected')).toBeInTheDocument();

--- a/frontend/src/components/payees/DeactivateUnusedPayeesDialog.tsx
+++ b/frontend/src/components/payees/DeactivateUnusedPayeesDialog.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/Button';
 import { Modal } from '@/components/ui/Modal';
+import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
 import { payeesApi } from '@/lib/payees';
 import { DeactivationCandidate } from '@/types/payee';
 import toast from 'react-hot-toast';
@@ -257,13 +258,14 @@ export function DeactivateUnusedPayeesDialog({
                         className="hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer"
                         onClick={() => togglePayee(candidate.payeeId)}
                       >
-                        <td className="px-3 py-2">
-                          <input
-                            type="checkbox"
+                        <td className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
+                          <ToggleSwitch
+                            size="sm"
                             checked={selectedIds.has(candidate.payeeId)}
                             onChange={() => togglePayee(candidate.payeeId)}
-                            onClick={(e) => e.stopPropagation()}
-                            className="h-4 w-4 text-amber-600 focus:ring-amber-500 border-gray-300 dark:border-gray-600 rounded"
+                            label={t('deactivateUnused.selectPayeeLabel', {
+                              name: candidate.payeeName,
+                            })}
                           />
                         </td>
                         <td className="px-3 py-2">

--- a/frontend/src/i18n/messages/de/payees.json
+++ b/frontend/src/i18n/messages/de/payees.json
@@ -120,6 +120,7 @@
     "suggestionsHeader": "Vorschläge ({count} gefunden)",
     "selectAll": "Alle auswählen",
     "selectNone": "Keine auswählen",
+    "selectPayeeLabel": "{name} auswählen",
     "empty": {
       "line1": "Keine Zahlungsempfänger entsprechen den aktuellen Kriterien.",
       "line2": "Bitte die Einstellungen oben anpassen."
@@ -160,12 +161,17 @@
     "includeGroupLabel": "Diese Gruppe einbeziehen",
     "canonicalNameLabel": "Als Zahlungsempfänger behalten",
     "aliasLabel": "Alias für künftige Importe",
+    "defaultCategoryLabel": "Standardkategorie (optional)",
     "aliasPlaceholder": "z. B. *LIDL*",
     "keepLabel": "Diesen Zahlungsempfänger behalten",
     "includeMemberLabel": "In Zusammenführung einbeziehen",
     "keepBadge": "Behalten",
+    "keepColumn": "Behalten",
+    "mergeColumn": "Zusammenführen",
+    "membersHelp": "Wählen Sie den Zahlungsempfänger, den Sie behalten möchten. Die anderen werden in ihn zusammengeführt.",
     "memberTransactions": "{count, plural, one {# Transaktion} other {# Transaktionen}}",
     "selectedCount": "{count, plural, one {# Gruppe ausgewählt} other {# Gruppen ausgewählt}}",
+    "payeesMergedCount": "{count, plural, one {# Zahlungsempfänger zum Zusammenführen} other {# Zahlungsempfänger zum Zusammenführen}}",
     "applyButton": "{count, plural, one {# Gruppe zusammenführen} other {# Gruppen zusammenführen}}",
     "applying": "Wird zusammengeführt...",
     "toasts": {
@@ -202,6 +208,7 @@
     "candidatesHeader": "Kandidaten ({count} gefunden)",
     "selectAll": "Alle auswählen",
     "selectNone": "Keine auswählen",
+    "selectPayeeLabel": "{name} auswählen",
     "neverUsed": "Nie verwendet",
     "empty": {
       "line1": "Keine Zahlungsempfänger entsprechen den aktuellen Kriterien.",

--- a/frontend/src/i18n/messages/en/payees.json
+++ b/frontend/src/i18n/messages/en/payees.json
@@ -120,6 +120,7 @@
     "suggestionsHeader": "Suggestions ({count} found)",
     "selectAll": "Select all",
     "selectNone": "Select none",
+    "selectPayeeLabel": "Select {name}",
     "empty": {
       "line1": "No payees match the current criteria.",
       "line2": "Try adjusting the settings above."
@@ -160,12 +161,17 @@
     "includeGroupLabel": "Include this group",
     "canonicalNameLabel": "Keep as payee",
     "aliasLabel": "Alias for future imports",
+    "defaultCategoryLabel": "Default category (optional)",
     "aliasPlaceholder": "e.g., *LIDL*",
     "keepLabel": "Keep this payee",
     "includeMemberLabel": "Include in merge",
     "keepBadge": "Keep",
+    "keepColumn": "Keep",
+    "mergeColumn": "Merge",
+    "membersHelp": "Select the payee to keep. The others are merged into it.",
     "memberTransactions": "{count, plural, one {# transaction} other {# transactions}}",
     "selectedCount": "{count, plural, one {# group selected} other {# groups selected}}",
+    "payeesMergedCount": "{count, plural, one {# payee to merge} other {# payees to merge}}",
     "applyButton": "Merge {count, plural, one {# Group} other {# Groups}}",
     "applying": "Merging...",
     "toasts": {
@@ -202,6 +208,7 @@
     "candidatesHeader": "Candidates ({count} found)",
     "selectAll": "Select all",
     "selectNone": "Select none",
+    "selectPayeeLabel": "Select {name}",
     "neverUsed": "Never used",
     "empty": {
       "line1": "No payees match the current criteria.",

--- a/frontend/src/i18n/messages/es/payees.json
+++ b/frontend/src/i18n/messages/es/payees.json
@@ -120,6 +120,7 @@
     "suggestionsHeader": "Sugerencias ({count} encontradas)",
     "selectAll": "Seleccionar todos",
     "selectNone": "Deseleccionar todos",
+    "selectPayeeLabel": "Seleccionar {name}",
     "empty": {
       "line1": "Ningún beneficiario coincide con los criterios actuales.",
       "line2": "Intenta ajustar la configuración anterior."
@@ -160,12 +161,17 @@
     "includeGroupLabel": "Incluir este grupo",
     "canonicalNameLabel": "Conservar como beneficiario",
     "aliasLabel": "Alias para futuras importaciones",
+    "defaultCategoryLabel": "Categoría predeterminada (opcional)",
     "aliasPlaceholder": "p. ej., *LIDL*",
     "keepLabel": "Conservar este beneficiario",
     "includeMemberLabel": "Incluir en la combinación",
     "keepBadge": "Conservar",
+    "keepColumn": "Conservar",
+    "mergeColumn": "Combinar",
+    "membersHelp": "Seleccione el beneficiario que desea conservar. Los demás se combinarán con él.",
     "memberTransactions": "{count, plural, one {# transacción} other {# transacciones}}",
     "selectedCount": "{count, plural, one {# grupo seleccionado} other {# grupos seleccionados}}",
+    "payeesMergedCount": "{count, plural, one {# beneficiario a combinar} other {# beneficiarios a combinar}}",
     "applyButton": "Combinar {count, plural, one {# grupo} other {# grupos}}",
     "applying": "Combinando...",
     "toasts": {
@@ -202,6 +208,7 @@
     "candidatesHeader": "Candidatos ({count} encontrados)",
     "selectAll": "Seleccionar todos",
     "selectNone": "Deseleccionar todos",
+    "selectPayeeLabel": "Seleccionar {name}",
     "neverUsed": "Nunca usado",
     "empty": {
       "line1": "Ningún beneficiario coincide con los criterios actuales.",

--- a/frontend/src/i18n/messages/fr/payees.json
+++ b/frontend/src/i18n/messages/fr/payees.json
@@ -120,6 +120,7 @@
     "suggestionsHeader": "Suggestions ({count} trouvée(s))",
     "selectAll": "Tout sélectionner",
     "selectNone": "Tout désélectionner",
+    "selectPayeeLabel": "Sélectionner {name}",
     "empty": {
       "line1": "Aucun bénéficiaire ne correspond aux critères actuels.",
       "line2": "Essayez de modifier les paramètres ci-dessus."
@@ -160,12 +161,17 @@
     "includeGroupLabel": "Inclure ce groupe",
     "canonicalNameLabel": "Conserver comme bénéficiaire",
     "aliasLabel": "Alias pour les futurs imports",
+    "defaultCategoryLabel": "Catégorie par défaut (facultatif)",
     "aliasPlaceholder": "ex. : *LIDL*",
     "keepLabel": "Conserver ce bénéficiaire",
     "includeMemberLabel": "Inclure dans la fusion",
     "keepBadge": "Conserver",
+    "keepColumn": "Conserver",
+    "mergeColumn": "Fusionner",
+    "membersHelp": "Sélectionnez le bénéficiaire à conserver. Les autres y seront fusionnés.",
     "memberTransactions": "{count, plural, one {# transaction} other {# transactions}}",
     "selectedCount": "{count, plural, one {# groupe sélectionné} other {# groupes sélectionnés}}",
+    "payeesMergedCount": "{count, plural, one {# bénéficiaire à fusionner} other {# bénéficiaires à fusionner}}",
     "applyButton": "Fusionner {count, plural, one {# groupe} other {# groupes}}",
     "applying": "Fusion...",
     "toasts": {
@@ -202,6 +208,7 @@
     "candidatesHeader": "Candidats ({count} trouvé(s))",
     "selectAll": "Tout sélectionner",
     "selectNone": "Tout désélectionner",
+    "selectPayeeLabel": "Sélectionner {name}",
     "neverUsed": "Jamais utilisé",
     "empty": {
       "line1": "Aucun bénéficiaire ne correspond aux critères actuels.",

--- a/frontend/src/i18n/messages/it/payees.json
+++ b/frontend/src/i18n/messages/it/payees.json
@@ -120,6 +120,7 @@
     "suggestionsHeader": "Suggerimenti ({count} trovati)",
     "selectAll": "Seleziona tutti",
     "selectNone": "Deseleziona tutti",
+    "selectPayeeLabel": "Seleziona {name}",
     "empty": {
       "line1": "Nessun beneficiario corrisponde ai criteri attuali.",
       "line2": "Prova a modificare le impostazioni."
@@ -160,12 +161,17 @@
     "includeGroupLabel": "Includi questo gruppo",
     "canonicalNameLabel": "Mantieni come beneficiario",
     "aliasLabel": "Alias per importazioni future",
+    "defaultCategoryLabel": "Categoria predefinita (facoltativa)",
     "aliasPlaceholder": "es. *LIDL*",
     "keepLabel": "Mantieni questo beneficiario",
     "includeMemberLabel": "Includi nell'unione",
     "keepBadge": "Mantieni",
+    "keepColumn": "Mantieni",
+    "mergeColumn": "Unisci",
+    "membersHelp": "Seleziona il beneficiario da mantenere. Gli altri verranno uniti a esso.",
     "memberTransactions": "{count, plural, one {# transazione} other {# transazioni}}",
     "selectedCount": "{count, plural, one {# gruppo selezionato} other {# gruppi selezionati}}",
+    "payeesMergedCount": "{count, plural, one {# beneficiario da unire} other {# beneficiari da unire}}",
     "applyButton": "Unisci {count, plural, one {# gruppo} other {# gruppi}}",
     "applying": "Unione in corso...",
     "toasts": {
@@ -202,6 +208,7 @@
     "candidatesHeader": "Candidati ({count} trovati)",
     "selectAll": "Seleziona tutti",
     "selectNone": "Deseleziona tutti",
+    "selectPayeeLabel": "Seleziona {name}",
     "neverUsed": "Mai utilizzato",
     "empty": {
       "line1": "Nessun beneficiario corrisponde ai criteri attuali.",

--- a/frontend/src/i18n/messages/nl/payees.json
+++ b/frontend/src/i18n/messages/nl/payees.json
@@ -120,6 +120,7 @@
     "suggestionsHeader": "Suggesties ({count} gevonden)",
     "selectAll": "Alles selecteren",
     "selectNone": "Niets selecteren",
+    "selectPayeeLabel": "{name} selecteren",
     "empty": {
       "line1": "Geen begunstigden voldoen aan de huidige criteria.",
       "line2": "Pas de instellingen hierboven aan."
@@ -160,12 +161,17 @@
     "includeGroupLabel": "Deze groep opnemen",
     "canonicalNameLabel": "Behouden als begunstigde",
     "aliasLabel": "Alias voor toekomstige imports",
+    "defaultCategoryLabel": "Standaardcategorie (optioneel)",
     "aliasPlaceholder": "bijv. *LIDL*",
     "keepLabel": "Deze begunstigde behouden",
     "includeMemberLabel": "Opnemen in samenvoeging",
     "keepBadge": "Behouden",
+    "keepColumn": "Behouden",
+    "mergeColumn": "Samenvoegen",
+    "membersHelp": "Selecteer de begunstigde die u wilt behouden. De andere worden hierin samengevoegd.",
     "memberTransactions": "{count, plural, one {# transactie} other {# transacties}}",
     "selectedCount": "{count, plural, one {# groep geselecteerd} other {# groepen geselecteerd}}",
+    "payeesMergedCount": "{count, plural, one {# begunstigde om samen te voegen} other {# begunstigden om samen te voegen}}",
     "applyButton": "{count, plural, one {# groep samenvoegen} other {# groepen samenvoegen}}",
     "applying": "Samenvoegen...",
     "toasts": {
@@ -202,6 +208,7 @@
     "candidatesHeader": "Kandidaten ({count} gevonden)",
     "selectAll": "Alles selecteren",
     "selectNone": "Niets selecteren",
+    "selectPayeeLabel": "{name} selecteren",
     "neverUsed": "Nooit gebruikt",
     "empty": {
       "line1": "Geen begunstigden voldoen aan de huidige criteria.",

--- a/frontend/src/i18n/messages/pl/payees.json
+++ b/frontend/src/i18n/messages/pl/payees.json
@@ -120,6 +120,7 @@
     "suggestionsHeader": "Sugestie (znaleziono: {count})",
     "selectAll": "Zaznacz wszystkie",
     "selectNone": "Odznacz wszystkie",
+    "selectPayeeLabel": "Zaznacz {name}",
     "empty": {
       "line1": "Żaden odbiorca nie spełnia bieżących kryteriów.",
       "line2": "Spróbuj dostosować ustawienia powyżej."
@@ -160,12 +161,17 @@
     "includeGroupLabel": "Uwzględnij tę grupę",
     "canonicalNameLabel": "Zachowaj jako odbiorcę",
     "aliasLabel": "Alias dla przyszłych importów",
+    "defaultCategoryLabel": "Domyślna kategoria (opcjonalnie)",
     "aliasPlaceholder": "np. *LIDL*",
     "keepLabel": "Zachowaj tego odbiorcę",
     "includeMemberLabel": "Uwzględnij w scalaniu",
     "keepBadge": "Zachowaj",
+    "keepColumn": "Zachowaj",
+    "mergeColumn": "Scal",
+    "membersHelp": "Wybierz odbiorcę, którego chcesz zachować. Pozostali zostaną z nim scaleni.",
     "memberTransactions": "{count, plural, one {# transakcja} few {# transakcje} many {# transakcji} other {# transakcji}}",
     "selectedCount": "{count, plural, one {# grupa wybrana} few {# grupy wybrane} many {# grup wybranych} other {# grup wybranych}}",
+    "payeesMergedCount": "{count, plural, one {# odbiorca do scalenia} few {# odbiorcy do scalenia} many {# odbiorców do scalenia} other {# odbiorców do scalenia}}",
     "applyButton": "Scal {count, plural, one {# grupę} few {# grupy} many {# grup} other {# grup}}",
     "applying": "Scalanie...",
     "toasts": {
@@ -202,6 +208,7 @@
     "candidatesHeader": "Kandydaci (znaleziono: {count})",
     "selectAll": "Zaznacz wszystkie",
     "selectNone": "Odznacz wszystkie",
+    "selectPayeeLabel": "Zaznacz {name}",
     "neverUsed": "Nigdy nieużywany",
     "empty": {
       "line1": "Żaden odbiorca nie spełnia bieżących kryteriów.",

--- a/frontend/src/i18n/messages/pt-BR/payees.json
+++ b/frontend/src/i18n/messages/pt-BR/payees.json
@@ -120,6 +120,7 @@
     "suggestionsHeader": "Sugestões ({count} encontradas)",
     "selectAll": "Selecionar tudo",
     "selectNone": "Desselecionar tudo",
+    "selectPayeeLabel": "Selecionar {name}",
     "empty": {
       "line1": "Nenhum beneficiário corresponde aos critérios atuais.",
       "line2": "Tente ajustar as configurações acima."
@@ -160,12 +161,17 @@
     "includeGroupLabel": "Incluir este grupo",
     "canonicalNameLabel": "Manter como beneficiário",
     "aliasLabel": "Alias para importações futuras",
+    "defaultCategoryLabel": "Categoria padrão (opcional)",
     "aliasPlaceholder": "ex.: *LIDL*",
     "keepLabel": "Manter este beneficiário",
     "includeMemberLabel": "Incluir na mesclagem",
     "keepBadge": "Manter",
+    "keepColumn": "Manter",
+    "mergeColumn": "Mesclar",
+    "membersHelp": "Selecione o beneficiário que deseja manter. Os outros serão mesclados nele.",
     "memberTransactions": "{count, plural, one {# transação} other {# transações}}",
     "selectedCount": "{count, plural, one {# grupo selecionado} other {# grupos selecionados}}",
+    "payeesMergedCount": "{count, plural, one {# beneficiário para mesclar} other {# beneficiários para mesclar}}",
     "applyButton": "Mesclar {count, plural, one {# grupo} other {# grupos}}",
     "applying": "Mesclando...",
     "toasts": {
@@ -202,6 +208,7 @@
     "candidatesHeader": "Candidatos ({count} encontrados)",
     "selectAll": "Selecionar tudo",
     "selectNone": "Desselecionar tudo",
+    "selectPayeeLabel": "Selecionar {name}",
     "neverUsed": "Nunca utilizado",
     "empty": {
       "line1": "Nenhum beneficiário corresponde aos critérios atuais.",

--- a/frontend/src/i18n/messages/pt/payees.json
+++ b/frontend/src/i18n/messages/pt/payees.json
@@ -120,6 +120,7 @@
     "suggestionsHeader": "Sugestões ({count} encontradas)",
     "selectAll": "Selecionar tudo",
     "selectNone": "Desselecionar tudo",
+    "selectPayeeLabel": "Selecionar {name}",
     "empty": {
       "line1": "Nenhum beneficiário corresponde aos critérios atuais.",
       "line2": "Tente ajustar as definições acima."
@@ -160,12 +161,17 @@
     "includeGroupLabel": "Incluir este grupo",
     "canonicalNameLabel": "Manter como beneficiário",
     "aliasLabel": "Alias para importações futuras",
+    "defaultCategoryLabel": "Categoria predefinida (opcional)",
     "aliasPlaceholder": "por ex., *LIDL*",
     "keepLabel": "Manter este beneficiário",
     "includeMemberLabel": "Incluir na combinação",
     "keepBadge": "Manter",
+    "keepColumn": "Manter",
+    "mergeColumn": "Combinar",
+    "membersHelp": "Selecione o beneficiário que pretende manter. Os restantes serão combinados nele.",
     "memberTransactions": "{count, plural, one {# transação} other {# transações}}",
     "selectedCount": "{count, plural, one {# grupo selecionado} other {# grupos selecionados}}",
+    "payeesMergedCount": "{count, plural, one {# beneficiário a combinar} other {# beneficiários a combinar}}",
     "applyButton": "Combinar {count, plural, one {# grupo} other {# grupos}}",
     "applying": "A combinar...",
     "toasts": {
@@ -202,6 +208,7 @@
     "candidatesHeader": "Candidatos ({count} encontrados)",
     "selectAll": "Selecionar tudo",
     "selectNone": "Desselecionar tudo",
+    "selectPayeeLabel": "Selecionar {name}",
     "neverUsed": "Nunca utilizado",
     "empty": {
       "line1": "Nenhum beneficiário corresponde aos critérios atuais.",

--- a/frontend/src/i18n/messages/xx/payees.json
+++ b/frontend/src/i18n/messages/xx/payees.json
@@ -120,6 +120,7 @@
     "suggestionsHeader": "[XX-Suggestions ({count} found)-XX]",
     "selectAll": "[XX-Select all-XX]",
     "selectNone": "[XX-Select none-XX]",
+    "selectPayeeLabel": "[XX-Select {name}-XX]",
     "empty": {
       "line1": "[XX-No payees match the current criteria.-XX]",
       "line2": "[XX-Try adjusting the settings above.-XX]"
@@ -160,12 +161,17 @@
     "includeGroupLabel": "[XX-Include this group-XX]",
     "canonicalNameLabel": "[XX-Keep as payee-XX]",
     "aliasLabel": "[XX-Alias for future imports-XX]",
+    "defaultCategoryLabel": "[XX-Default category (optional)-XX]",
     "aliasPlaceholder": "[XX-e.g., *LIDL*-XX]",
     "keepLabel": "[XX-Keep this payee-XX]",
     "includeMemberLabel": "[XX-Include in merge-XX]",
     "keepBadge": "[XX-Keep-XX]",
+    "keepColumn": "[XX-Keep-XX]",
+    "mergeColumn": "[XX-Merge-XX]",
+    "membersHelp": "[XX-Select the payee to keep. The others are merged into it.-XX]",
     "memberTransactions": "[XX-{count, plural, one {# transaction} other {# transactions}}-XX]",
     "selectedCount": "[XX-{count, plural, one {# group selected} other {# groups selected}}-XX]",
+    "payeesMergedCount": "[XX-{count, plural, one {# payee to merge} other {# payees to merge}}-XX]",
     "applyButton": "[XX-Merge {count, plural, one {# Group} other {# Groups}}-XX]",
     "applying": "[XX-Merging...-XX]",
     "toasts": {
@@ -202,6 +208,7 @@
     "candidatesHeader": "[XX-Candidates ({count} found)-XX]",
     "selectAll": "[XX-Select all-XX]",
     "selectNone": "[XX-Select none-XX]",
+    "selectPayeeLabel": "[XX-Select {name}-XX]",
     "neverUsed": "[XX-Never used-XX]",
     "empty": {
       "line1": "[XX-No payees match the current criteria.-XX]",

--- a/frontend/src/types/payee.ts
+++ b/frontend/src/types/payee.ts
@@ -74,6 +74,7 @@ export interface AutoMergeGroup {
   suggestedCanonicalPayeeId: string;
   suggestedName: string;
   suggestedAlias: string;
+  suggestedCategoryId: string | null;
   members: AutoMergeMember[];
   totalTransactions: number;
 }
@@ -83,6 +84,7 @@ export interface ApplyAutoMergeGroup {
   canonicalName?: string;
   sourcePayeeIds: string[];
   alias?: string;
+  defaultCategoryId?: string;
 }
 
 export interface ApplyAutoMergeResult {


### PR DESCRIPTION
Auto-Merge Payees modal:
- Make the "Keep as payee" choice obvious: add Keep/Merge column headers and
  an instruction above each group's member list so the radio's purpose is clear.
- Start every group de-selected so merges are opt-in.
- Show a running count of payees that will actually be merged next to the
  "N groups selected" footer text.
- Let users set a default category per group, using the same picker as the
  payee edit form, prefilled with the group's most-used category (not forced).

Fix Polish (and other) diacritic clustering: letters whose stroke/ligature
NFD does not decompose (e.g. the L-stroke in "MALGORZATA") were turned into a
word break, so the name clustered on the fragment after the stroke. Transliterate
them to an ASCII base before normalization.

Auto-Assign Default Categories modal:
- Show the suggested category as its full "Parent: Child" path.
- Convert the row selection and "only without category" checkboxes to toggles.

Deactivate Unused Payees modal:
- Convert the row selection checkboxes to toggles.

All strings are translated across every locale and the pseudo-locale regenerated.

https://claude.ai/code/session_0187ZGohiC3m2WsZvEkUKvnr