### PR TITLE
Upgrade anchore/sbom-action from v0.15.0 to v0.24.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,7 +543,7 @@ jobs:
       # OCI manifest; these attestations make them discoverable via
       # `gh attestation verify` for downstream consumers.
       - name: Generate backend SBOM
-        uses: anchore/sbom-action@fd74a6fb98a204a1ad35bbfae0122c1a302ff88b # v0.15.0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ghcr.io/kenlasko/monize-backend@${{ steps.build-backend.outputs.digest }}
           format: spdx-json
@@ -558,7 +558,7 @@ jobs:
           push-to-registry: true
 
       - name: Generate frontend SBOM
-        uses: anchore/sbom-action@fd74a6fb98a204a1ad35bbfae0122c1a302ff88b # v0.15.0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ghcr.io/kenlasko/monize-frontend@${{ steps.build-frontend.outputs.digest }}
           format: spdx-json


### PR DESCRIPTION
## Summary
Updates the `anchore/sbom-action` GitHub Action to the latest version (v0.24.0) for both backend and frontend SBOM generation in the CI workflow.

## Changes
- Updated `anchore/sbom-action` from v0.15.0 (commit `fd74a6f`) to v0.24.0 (commit `e22c389`) in the "Generate backend SBOM" step
- Updated `anchore/sbom-action` from v0.15.0 (commit `fd74a6f`) to v0.24.0 (commit `e22c389`) in the "Generate frontend SBOM" step

## Details
This upgrade brings the SBOM generation action to a more recent version, which may include bug fixes, performance improvements, and enhanced compatibility with current container image formats and OCI manifest standards used for attestation verification.

https://claude.ai/code/session_01BhMedgwcRRZyskCyNtfRAX