### PR TITLE
ci: move build actions to Node 24 and harden flaky e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,11 @@ jobs:
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          # This job only runs `uv tool install zizmor` -- there are no Python
+          # dependency manifests to key a cache on, so leaving caching enabled
+          # only produces setup-uv's "cache will never get invalidated" warning.
+          enable-cache: false
       - name: Install zizmor
         run: uv tool install zizmor
       - name: Run zizmor
@@ -491,21 +496,21 @@ jobs:
         run: cd "$WORKDIR" && npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build and push image
         id: build
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
@@ -563,7 +568,10 @@ jobs:
           output-file: ${{ matrix.name }}-sbom.spdx.json
 
       - name: Attest SBOM
-        uses: actions/attest-sbom@cbfd0027ae731a5892db25ecd226930d7ffd19eb # v2.1.0
+        # Pinned to v3.0.0: the last release before attest-sbom was deprecated
+        # in favor of actions/attest (v4.0.0+), and the first to run on Node 24.
+        # Inputs are unchanged from v2.
+        uses: actions/attest-sbom@4651f806c01d8637787e274ac3bdf724ef169f34 # v3.0.0
         with:
           subject-name: ${{ matrix.image }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/e2e/helpers/nav.ts
+++ b/e2e/helpers/nav.ts
@@ -1,0 +1,32 @@
+import { Page } from '@playwright/test';
+
+// A goto that tolerates an in-flight navigation being aborted by a competing
+// client-side navigation. The most common source is a full-page reload kicked
+// off by app code right after auth state settles -- e.g. the DelegationBanner
+// auto-switching a single-owner delegate calls window.location.reload(), which
+// aborts a concurrent page.goto() with net::ERR_ABORTED. The competing
+// navigation settles quickly, so we wait for it to finish and re-issue the
+// goto; after that the app no longer reloads and the navigation lands.
+export async function gotoStable(
+  page: Page,
+  url: string,
+  opts: { timeout?: number } = {},
+): Promise<void> {
+  const timeout = opts.timeout ?? 15000;
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      await page.goto(url, { timeout });
+      return;
+    } catch (err) {
+      lastErr = err;
+      if (err instanceof Error && err.message.includes('net::ERR_ABORTED')) {
+        // Let the competing navigation (the reload) finish before retrying.
+        await page.waitForLoadState('load').catch(() => {});
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastErr;
+}

--- a/e2e/tests/delegation.spec.ts
+++ b/e2e/tests/delegation.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../fixtures';
 import { loginUser } from '../helpers/auth';
+import { gotoStable } from '../helpers/nav';
 import { createApiClient, uniqueId } from '../helpers/api';
 import {
   createAccount,
@@ -52,13 +53,16 @@ test.describe('Delegation (shared access)', () => {
       const delegatePage = await delegateContext.newPage();
       await loginUser(delegatePage, email, password);
 
-      // Switch into the owner's context explicitly (deterministic -- avoids
-      // racing the DelegationBanner's auto-switch), then view the shared
-      // account. GET /accounts is @AllowDelegate and returns granted accounts.
+      // Switch into the owner's context explicitly so the server-side context
+      // is deterministic. The DelegationBanner in the browser page also
+      // auto-switches this single-owner delegate, and that path ends in a
+      // window.location.reload() which can abort a concurrent goto with
+      // net::ERR_ABORTED -- gotoStable retries past that transient reload.
+      // GET /accounts is @AllowDelegate and returns granted accounts.
       const delegateApi = createApiClient(delegatePage.request);
       await delegateApi.post('/auth/switch-context', { targetUserId: owner.id });
 
-      await delegatePage.goto('/accounts');
+      await gotoStable(delegatePage, '/accounts');
       await expect(
         delegatePage.locator('tr', { hasText: account.name }),
       ).toBeVisible({ timeout: 15000 });

--- a/e2e/tests/transactions.spec.ts
+++ b/e2e/tests/transactions.spec.ts
@@ -47,16 +47,23 @@ test.describe('Transactions', () => {
     await createTransaction(api, { accountId: account.id, amount: 73.19, payeeName });
 
     await page.goto('/transactions');
+
+    const dialog = page.getByRole('dialog');
     // Clicking the row opens the edit modal; the amount cell doesn't stop
     // propagation (unlike the payee/category/action cells). first() since the
     // running-balance cell shows the same value for a single transaction.
-    await page
-      .locator('tr', { hasText: payeeName })
-      .getByText(/73\.19/)
-      .first()
-      .click();
+    // The list is client-rendered, so a click that lands before the row's
+    // handler hydrates is a no-op -- retry the click until the dialog opens
+    // rather than clicking once into the void.
+    await expect(async () => {
+      await page
+        .locator('tr', { hasText: payeeName })
+        .getByText(/73\.19/)
+        .first()
+        .click();
+      await expect(dialog).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 30000 });
 
-    const dialog = page.getByRole('dialog');
     await dialog.getByLabel(/amount/i).first().fill('88.88');
     await dialog.getByRole('button', { name: /update transaction/i }).click();
 


### PR DESCRIPTION
Upgrade the Build & Push job's actions to Node 24 releases ahead of
GitHub forcing the switch on 2026-06-16:
- docker/login-action v3.7.0 -> v4.2.0
- docker/setup-qemu-action v3.7.0 -> v4.1.0
- docker/setup-buildx-action v3.12.0 -> v4.1.0
- docker/build-push-action v6.19.2 -> v7.2.0
- actions/attest-sbom v2.1.0 -> v3.0.0 (last non-deprecated release,
  first on Node 24; inputs unchanged)

Disable setup-uv caching in the zizmor job to silence the
"cache will never get invalidated" warning (no Python manifests exist).

Fix two flaky e2e tests:
- delegation: the DelegationBanner auto-switches a single-owner delegate
  and reloads the page, aborting a concurrent goto with ERR_ABORTED. Add
  a gotoStable helper that retries past the transient reload.
- transactions edit: retry the row click until the edit dialog opens, so
  a click landing before the client-rendered row hydrates is not a no-op.

https://claude.ai/code/session_01CWyX8xwjT3kJEXfYrGf45y