### PR TITLE
Add dismissible high/low value bubbles to charts and mask account numbers

### DIFF
--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -359,11 +359,15 @@ describe('LoginPage', () => {
     expect(authApi.initiateOidc).toHaveBeenCalled();
   });
 
-  it('renders version number', async () => {
+  it('renders the version number linked to its GitHub release notes', async () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_VERSION', '1.11.0');
     render(<LoginPage />);
-    await waitFor(() => {
-      expect(screen.getByText(/^v/)).toBeInTheDocument();
-    });
+    const link = await screen.findByRole('link', { name: 'v1.11.0' });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://github.com/kenlasko/monize/releases/tag/v1.11.0',
+    );
+    vi.unstubAllEnvs();
   });
 
   it('shows loading indicator while fetching auth methods', async () => {

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -17,6 +17,7 @@ import { useDemoStore } from '@/store/demoStore';
 import { authApi, AuthMethods } from '@/lib/auth';
 import { TwoFactorVerify } from '@/components/auth/TwoFactorVerify';
 import { AuthLanguageSwitcher } from '@/components/auth/AuthLanguageSwitcher';
+import { AppVersion } from '@/components/ui/AppVersion';
 import { User } from '@/types/auth';
 import { createLogger } from '@/lib/logger';
 import { buildEmailSchema } from '@/lib/zod-helpers';
@@ -204,9 +205,7 @@ export default function LoginPage() {
 
           <AuthLanguageSwitcher />
 
-          <p className="text-xs text-gray-400 dark:text-gray-500 mt-6">
-            v{process.env.NEXT_PUBLIC_APP_VERSION}
-          </p>
+          <AppVersion className="text-xs text-gray-400 dark:text-gray-500 mt-6" />
         </div>
       </div>
     );
@@ -365,9 +364,7 @@ export default function LoginPage() {
 
         <AuthLanguageSwitcher />
 
-        <p className="text-center text-xs text-gray-400 dark:text-gray-500 mt-6">
-          v{process.env.NEXT_PUBLIC_APP_VERSION}
-        </p>
+        <AppVersion className="text-center text-xs text-gray-400 dark:text-gray-500 mt-6" />
       </div>
     </div>
   );

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import { AppVersion } from '@/components/ui/AppVersion';
 import { ProfileSection } from '@/components/settings/ProfileSection';
 import { PreferencesSection } from '@/components/settings/PreferencesSection';
 import { NotificationsSection } from '@/components/settings/NotificationsSection';
@@ -391,9 +392,7 @@ function OwnerSettingsView() {
               </div>
             )}
 
-            <p className="text-center text-xs text-gray-400 dark:text-gray-500 mt-8 mb-4">
-              v{process.env.NEXT_PUBLIC_APP_VERSION}
-            </p>
+            <AppVersion className="text-center text-xs text-gray-400 dark:text-gray-500 mt-8 mb-4" />
           </div>
         </div>
       </main>

--- a/frontend/src/components/bills/CashFlowForecastChart.test.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.test.tsx
@@ -63,11 +63,13 @@ vi.mock('recharts', () => ({
 
 const mockFormatCurrency = vi.fn((n: number, _code?: string) => `$${n.toFixed(2)}`);
 const mockFormatCurrencyAxis = vi.fn((n: number, _code?: string) => `$${n}`);
+const mockFormatCurrencyFlag = vi.fn((n: number, _code?: string) => `$${n}`);
 
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
     formatCurrency: mockFormatCurrency,
     formatCurrencyAxis: mockFormatCurrencyAxis,
+    formatCurrencyFlag: mockFormatCurrencyFlag,
   }),
 }));
 
@@ -442,7 +444,7 @@ describe('CashFlowForecastChart', () => {
   });
 
   describe('chart render-prop and tooltip branches', () => {
-    it('renders the negative (red) min-balance callout bubble', () => {
+    it('marks the highest and lowest forecast points with value bubbles', () => {
       const forecastData = [
         { label: 'Day 1', balance: 1000, transactions: [{ amount: 0, name: 'Open' }] },
         { label: 'Day 2', balance: -150, transactions: [{ amount: -1150, name: 'Rent' }] },
@@ -461,13 +463,16 @@ describe('CashFlowForecastChart', () => {
           isLoading={false}
         />,
       );
-      // The mocked Line invokes the dot render-prop; the min-balance point
-      // (index 1) draws the callout group containing the formatted label text.
+      // The mocked Area invokes the dot render-prop for both points: the high
+      // (1000) and low (-150) each draw a callout group with the formatted
+      // label text.
       const dots = screen.getByTestId('line-dots');
-      expect(dots.querySelector('text')).not.toBeNull();
+      const labels = Array.from(dots.querySelectorAll('text')).map((node) => node.textContent);
+      expect(labels).toContain('$1000');
+      expect(labels).toContain('$-150');
     });
 
-    it('renders the positive (amber) min-balance callout using the axis formatter for large values', () => {
+    it('formats the bubble labels with the compact flag formatter', () => {
       const forecastData = [
         { label: 'Day 1', balance: 60000, transactions: [{ amount: 0, name: 'Open' }] },
         { label: 'Day 2', balance: 5000, transactions: [{ amount: -55000, name: 'Bill' }] },
@@ -479,6 +484,7 @@ describe('CashFlowForecastChart', () => {
         minBalance: 5000,
         goesNegative: false,
       });
+      mockFormatCurrencyFlag.mockClear();
       render(
         <CashFlowForecastChart
           scheduledTransactions={[{} as any]}
@@ -487,8 +493,8 @@ describe('CashFlowForecastChart', () => {
         />,
       );
       expect(screen.getByTestId('line-dots')).toBeInTheDocument();
-      // A min balance >= 1000 uses formatCurrencyAxis for the bubble label.
-      expect(mockFormatCurrencyAxis).toHaveBeenCalled();
+      // The high/low bubbles are labelled via the compact flag formatter.
+      expect(mockFormatCurrencyFlag).toHaveBeenCalled();
     });
 
     it('shades the area under the line with the zero-anchored balance gradient', () => {

--- a/frontend/src/components/bills/CashFlowForecastChart.test.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.test.tsx
@@ -472,6 +472,41 @@ describe('CashFlowForecastChart', () => {
       expect(labels).toContain('$-150');
     });
 
+    it('temporarily hides a value bubble when its dismiss control is clicked', () => {
+      const forecastData = [
+        { label: 'Day 1', balance: 1000, transactions: [{ amount: 0, name: 'Open' }] },
+        { label: 'Day 2', balance: -150, transactions: [{ amount: -1150, name: 'Rent' }] },
+      ];
+      mockBuildForecast.mockReturnValue(forecastData);
+      mockGetForecastSummary.mockReturnValue({
+        startingBalance: 1000,
+        endingBalance: -150,
+        minBalance: -150,
+        goesNegative: true,
+      });
+      const { container } = render(
+        <CashFlowForecastChart
+          scheduledTransactions={[{} as any]}
+          accounts={[makeAccount()]}
+          isLoading={false}
+        />,
+      );
+      const labels = () =>
+        Array.from(
+          container.querySelectorAll('[data-testid="line-dots"] text'),
+        ).map((node) => node.textContent);
+      expect(labels()).toEqual(expect.arrayContaining(['$1000', '$-150']));
+
+      // The dot mock renders index 0 (high, $1000) first, so the first dismiss
+      // control belongs to the high bubble.
+      const closeControls = container.querySelectorAll('.chart-flag-dismiss');
+      expect(closeControls).toHaveLength(2);
+      fireEvent.click(closeControls[0]);
+
+      expect(labels()).toContain('$-150');
+      expect(labels()).not.toContain('$1000');
+    });
+
     it('formats the bubble labels with the compact flag formatter', () => {
       const forecastData = [
         { label: 'Day 1', balance: 60000, transactions: [{ amount: 0, name: 'Open' }] },

--- a/frontend/src/components/bills/CashFlowForecastChart.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.tsx
@@ -124,11 +124,17 @@ export function CashFlowForecastChart({
   isLoading,
 }: CashFlowForecastChartProps) {
   const t = useTranslations('bills');
+  const tc = useTranslations('common');
   const { formatCurrency: formatCurrencyFull, formatCurrencyAxis, formatCurrencyFlag } =
     useNumberFormat();
   const { convertToDefault, defaultCurrency } = useExchangeRates();
   const [selectedPeriod, setSelectedPeriod] = useState<ForecastPeriod>(() => getStoredPeriod());
   const [selectedAccountId, setSelectedAccountId] = useState<string>(() => getStoredAccountId());
+  // High/low value bubbles the user has temporarily dismissed, keyed by the
+  // value they marked so a forecast change with a new extreme shows its bubble
+  // again. Component-local (not persisted), so it resets on navigation.
+  const [dismissedHigh, setDismissedHigh] = useState<number | null>(null);
+  const [dismissedLow, setDismissedLow] = useState<number | null>(null);
 
   // Persist period changes
   useEffect(() => {
@@ -201,8 +207,12 @@ export function CashFlowForecastChart({
     () => computeMinMaxFlagIndices(forecastData.map((dp) => dp.balance)),
     [forecastData],
   );
-  const highLabel = flags.show ? formatFlag(forecastData[flags.maxIndex].balance) : '';
-  const lowLabel = flags.show ? formatFlag(forecastData[flags.minIndex].balance) : '';
+  const highValue = flags.show ? forecastData[flags.maxIndex].balance : null;
+  const lowValue = flags.show ? forecastData[flags.minIndex].balance : null;
+  const highLabel = highValue !== null ? formatFlag(highValue) : '';
+  const lowLabel = lowValue !== null ? formatFlag(lowValue) : '';
+  const highDismissed = highValue !== null && highValue === dismissedHigh;
+  const lowDismissed = lowValue !== null && lowValue === dismissedLow;
 
   const areaGradient = useMemo(
     () => computeBalanceGradient(forecastData.map((point) => point.balance)),
@@ -360,6 +370,11 @@ export function CashFlowForecastChart({
                     lowColor: chartColors.expense,
                     highLabel,
                     lowLabel,
+                    highDismissed,
+                    lowDismissed,
+                    onDismissHigh: () => setDismissedHigh(highValue),
+                    onDismissLow: () => setDismissedLow(lowValue),
+                    dismissLabel: tc('chartFlag.dismiss'),
                   })
                 }
                 activeDot={{ r: 6, fill: chartColors.primary }}

--- a/frontend/src/components/bills/CashFlowForecastChart.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.tsx
@@ -18,6 +18,11 @@ import {
 } from 'recharts';
 import { chartColors } from '@/lib/chart-colors';
 import { computeBalanceGradient } from '@/lib/balance-history';
+import {
+  ChartFlagShadowFilter,
+  computeMinMaxFlagIndices,
+  renderMinMaxFlagDots,
+} from '@/components/investments/portfolio-chart-utils';
 import { ScheduledTransaction } from '@/types/scheduled-transaction';
 import { Account } from '@/types/account';
 import { Select } from '@/components/ui/Select';
@@ -119,7 +124,8 @@ export function CashFlowForecastChart({
   isLoading,
 }: CashFlowForecastChartProps) {
   const t = useTranslations('bills');
-  const { formatCurrency: formatCurrencyFull, formatCurrencyAxis } = useNumberFormat();
+  const { formatCurrency: formatCurrencyFull, formatCurrencyAxis, formatCurrencyFlag } =
+    useNumberFormat();
   const { convertToDefault, defaultCurrency } = useExchangeRates();
   const [selectedPeriod, setSelectedPeriod] = useState<ForecastPeriod>(() => getStoredPeriod());
   const [selectedAccountId, setSelectedAccountId] = useState<string>(() => getStoredAccountId());
@@ -167,6 +173,11 @@ export function CashFlowForecastChart({
     [formatCurrencyAxis, chartCurrency],
   );
 
+  const formatFlag = useCallback(
+    (value: number) => formatCurrencyFlag(value, chartCurrency),
+    [formatCurrencyFlag, chartCurrency],
+  );
+
   const forecastData = useMemo(() => {
     return buildForecast(
       accounts, scheduledTransactions, selectedPeriod, selectedAccountId, futureTransactions,
@@ -183,11 +194,15 @@ export function CashFlowForecastChart({
     return forecastData.reduce((sum, dp) => sum + dp.transactions.length, 0);
   }, [forecastData]);
 
-  // Index of the first data point at the minimum balance (for single callout)
-  const minBalanceIndex = useMemo(() => {
-    if (forecastData.length === 0) return -1;
-    return forecastData.findIndex((dp) => dp.balance === summary.minBalance);
-  }, [forecastData, summary.minBalance]);
+  // Highest/lowest forecast points get green/red value bubbles, each placed to
+  // the inside of whichever chart half it falls on so the callouts stay clear
+  // of the plot edges and the dot marker.
+  const flags = useMemo(
+    () => computeMinMaxFlagIndices(forecastData.map((dp) => dp.balance)),
+    [forecastData],
+  );
+  const highLabel = flags.show ? formatFlag(forecastData[flags.maxIndex].balance) : '';
+  const lowLabel = flags.show ? formatFlag(forecastData[flags.minIndex].balance) : '';
 
   const areaGradient = useMemo(
     () => computeBalanceGradient(forecastData.map((point) => point.balance)),
@@ -281,17 +296,16 @@ export function CashFlowForecastChart({
       ) : (
         <div className="h-72" style={{ minHeight: 288 }}>
           <ResponsiveContainer width="100%" height="100%" minWidth={0}>
-            <AreaChart data={forecastData} margin={{ left: 0, right: 8, top: 5, bottom: 0 }}>
+            {/* top margin leaves headroom for the high-value bubble callout */}
+            <AreaChart data={forecastData} margin={{ left: 0, right: 8, top: 20, bottom: 0 }}>
               <defs>
-                <filter id="minShadow" x="-20%" y="-20%" width="140%" height="140%">
-                  <feDropShadow dx="0" dy="1" stdDeviation="2" floodOpacity="0.3" />
-                </filter>
                 <linearGradient id="forecastBalance" x1="0" y1="0" x2="0" y2="1">
                   <stop offset={0} stopColor={chartColors.primary} stopOpacity={areaGradient.topOpacity} />
                   <stop offset={areaGradient.zeroOffset} stopColor={chartColors.primary} stopOpacity={0} />
                   <stop offset={1} stopColor={chartColors.primary} stopOpacity={areaGradient.bottomOpacity} />
                 </linearGradient>
               </defs>
+              <ChartFlagShadowFilter />
               <CartesianGrid
                 strokeDasharray="3 3"
                 stroke={chartColors.grid}
@@ -335,55 +349,19 @@ export function CashFlowForecastChart({
                 strokeWidth={2}
                 fillOpacity={1}
                 fill="url(#forecastBalance)"
-                dot={(props: any) => {
-                  const { cx, cy } = props;
-                  if (props.index === minBalanceIndex) {
-                    const color = summary.minBalance < 0 ? chartColors.expense : chartColors.warning;
-                    const label = Math.abs(summary.minBalance) >= 1000
-                      ? formatAxis(summary.minBalance)
-                      : formatCurrency(summary.minBalance);
-                    const labelWidth = label.length * 7 + 14;
-                    const labelHeight = 22;
-                    const arrowSize = 5;
-                    const gap = 24;
-                    const bubbleBottom = cy - gap;
-                    const bubbleTop = bubbleBottom - arrowSize - labelHeight;
-                    return (
-                      <g key={`min-${props.index}`}>
-                        <circle cx={cx} cy={cy} r={5} fill={color} stroke="var(--color-white)" strokeWidth={2} />
-                        {/* Connector line from dot to arrow */}
-                        <line x1={cx} y1={cy - 5} x2={cx} y2={bubbleBottom} stroke={color} strokeWidth={1.5} strokeDasharray="3 2" />
-                        {/* Bubble */}
-                        <rect
-                          x={cx - labelWidth / 2}
-                          y={bubbleTop}
-                          width={labelWidth}
-                          height={labelHeight}
-                          rx={5}
-                          fill={color}
-                          filter="url(#minShadow)"
-                        />
-                        {/* Arrow */}
-                        <polygon
-                          points={`${cx - arrowSize},${bubbleTop + labelHeight} ${cx + arrowSize},${bubbleTop + labelHeight} ${cx},${bubbleBottom}`}
-                          fill={color}
-                        />
-                        <text
-                          x={cx}
-                          y={bubbleTop + labelHeight / 2}
-                          textAnchor="middle"
-                          dominantBaseline="central"
-                          fill="var(--color-white)"
-                          fontSize={11}
-                          fontWeight={600}
-                        >
-                          {label}
-                        </text>
-                      </g>
-                    );
-                  }
-                  return <circle key={`dot-${props.index}`} cx={cx} cy={cy} r={0} fill="none" />;
-                }}
+                dot={(props: { cx?: number; cy?: number; index?: number }) =>
+                  renderMinMaxFlagDots({
+                    cx: props.cx,
+                    cy: props.cy,
+                    index: props.index,
+                    flags,
+                    pointCount: forecastData.length,
+                    highColor: chartColors.income,
+                    lowColor: chartColors.expense,
+                    highLabel,
+                    lowLabel,
+                  })
+                }
                 activeDot={{ r: 6, fill: chartColors.primary }}
               />
             </AreaChart>

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act } from 'react';
-import { render, screen, waitFor } from '@/test/render';
+import { render, screen, waitFor, fireEvent } from '@/test/render';
 import {
   InvestmentValueChart,
   INVESTMENT_CHART_REFRESH_EVENT,
@@ -15,7 +15,18 @@ vi.mock('recharts', () => ({
   AreaChart: ({ children, margin }: any) => (
     <div data-testid="area-chart" data-margin={JSON.stringify(margin)}>{children}</div>
   ),
-  Area: () => null,
+  // Invoke the dot render-prop so the high/low value bubbles (and their dismiss
+  // controls) are exercised; indices 0..2 cover both extremes of the test
+  // series. Existing tests are unaffected -- the bubble labels use the compact
+  // flag formatter (no decimals), distinct from the ".00" summary figures.
+  Area: ({ dot }: any) =>
+    typeof dot === 'function' ? (
+      <div data-testid="line-dots">
+        {dot({ cx: 10, cy: 20, index: 0 })}
+        {dot({ cx: 30, cy: 40, index: 1 })}
+        {dot({ cx: 50, cy: 60, index: 2 })}
+      </div>
+    ) : null,
   XAxis: () => null,
   YAxis: ({ width }: any) => <div data-testid="y-axis" data-width={width ?? ''} />,
   CartesianGrid: () => null,
@@ -43,6 +54,7 @@ vi.mock('@/hooks/useNumberFormat', () => ({
     formatCurrency: (n: number) => `$${n.toFixed(2)}`,
     formatCurrencyCompact: (n: number) => `$${n.toFixed(0)}`,
     formatCurrencyAxis: (n: number) => `$${n}`,
+    formatCurrencyFlag: (n: number, _currency?: string) => `$${n}`,
   }),
 }));
 
@@ -147,6 +159,29 @@ describe('InvestmentValueChart', () => {
     render(<InvestmentValueChart />);
     await screen.findByText('Portfolio Value Over Time');
     expect(screen.getByTestId('area-chart')).toBeInTheDocument();
+  });
+
+  it('temporarily hides a value bubble when its dismiss control is clicked', async () => {
+    const { container } = render(<InvestmentValueChart />);
+    await screen.findByText('Portfolio Value Over Time');
+    const labels = () =>
+      Array.from(
+        container.querySelectorAll('[data-testid="line-dots"] text'),
+      ).map((node) => node.textContent);
+    // highest=15000 (index 1), lowest=10000 (index 0) -> a bubble each.
+    await waitFor(() => {
+      expect(labels()).toEqual(expect.arrayContaining(['$10000', '$15000']));
+    });
+
+    const closeControls = container.querySelectorAll('.chart-flag-dismiss');
+    expect(closeControls).toHaveLength(2);
+    // The second control belongs to the high bubble (dot index 1).
+    await act(async () => {
+      fireEvent.click(closeControls[1]);
+    });
+
+    expect(labels()).toContain('$10000');
+    expect(labels()).not.toContain('$15000');
   });
 
   it('uses generous chart margins on desktop', async () => {

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -55,11 +55,17 @@ interface InvestmentValueChartProps {
 
 export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix }: InvestmentValueChartProps) {
   const t = useTranslations('investments');
+  const tc = useTranslations('common');
   const { formatCurrency, formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag, formatSignedPercent } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
   const isMobile = useIsMobile();
   const [chartPoints, setChartPoints] = useState<Array<{ name: string; Value: number }>>([]);
   const [isLoading, setIsLoading] = useState(true);
+  // High/low value bubbles the user has temporarily dismissed, keyed by the
+  // value they marked so a later data change with a new extreme shows the
+  // bubble again. Component-local (not persisted), so it resets on navigation.
+  const [dismissedHigh, setDismissedHigh] = useState<number | null>(null);
+  const [dismissedLow, setDismissedLow] = useState<number | null>(null);
   const [intradayUnavailable, setIntradayUnavailable] = useState<{
     skipped: string[];
   } | null>(null);
@@ -555,8 +561,8 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
                   if (cx == null || cy == null || index == null) {
                     return <circle cx={0} cy={0} r={0} fill="none" />;
                   }
-                  const isHighest = showFlags && index === highestIndex;
-                  const isLowest = showFlags && index === lowestIndex;
+                  const isHighest = showFlags && index === highestIndex && summary.highest !== dismissedHigh;
+                  const isLowest = showFlags && index === lowestIndex && summary.lowest !== dismissedLow;
                   if (!isHighest && !isLowest) {
                     return <circle key={`dot-${index}`} cx={cx} cy={cy} r={0} fill="none" />;
                   }
@@ -569,6 +575,10 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
                     color: isHighest ? chartColors.income : chartColors.expense,
                     label: fmtFlag(value),
                     side: isLeftHalf ? 'right' : 'left',
+                    onDismiss: isHighest
+                      ? () => setDismissedHigh(summary.highest)
+                      : () => setDismissedLow(summary.lowest),
+                    dismissLabel: tc('chartFlag.dismiss'),
                   });
                 }}
               />

--- a/frontend/src/components/investments/portfolio-chart-utils.test.ts
+++ b/frontend/src/components/investments/portfolio-chart-utils.test.ts
@@ -244,6 +244,24 @@ describe('renderChartFlagDot', () => {
     const el = renderChartFlagDot({ ...baseOpts, side: 'above', gap: 12 });
     expect(el).toBeTruthy();
   });
+
+  it('adds a dismiss control wired to onDismiss when provided', () => {
+    const onDismiss = vi.fn();
+    const el = renderChartFlagDot({ ...baseOpts, side: 'right', onDismiss, dismissLabel: 'Hide' });
+    const children = (el.props as any).children as any[];
+    const closeButton = children.find((c: any) => c && c.props && c.props.role === 'button');
+    expect(closeButton).toBeTruthy();
+    expect(closeButton.props['aria-label']).toBe('Hide');
+    closeButton.props.onClick({ stopPropagation: () => {} });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the dismiss control when onDismiss is absent', () => {
+    const el = renderChartFlagDot({ ...baseOpts, side: 'right' });
+    const children = (el.props as any).children as any[];
+    const closeButton = children.find((c: any) => c && c.props && c.props.role === 'button');
+    expect(closeButton).toBeFalsy();
+  });
 });
 
 describe('ChartFlagShadowFilter', () => {
@@ -316,5 +334,32 @@ describe('renderMinMaxFlagDots', () => {
       index: 0,
     });
     expect(el.type).toBe('circle');
+  });
+
+  it('hides the high bubble when highDismissed is set', () => {
+    const el = renderMinMaxFlagDots({ ...base, cx: 10, cy: 20, index: 1, highDismissed: true });
+    expect(el.type).toBe('circle');
+  });
+
+  it('hides the low bubble when lowDismissed is set', () => {
+    const el = renderMinMaxFlagDots({ ...base, cx: 10, cy: 20, index: 4, lowDismissed: true });
+    expect(el.type).toBe('circle');
+  });
+
+  it('wires the high bubble dismiss control to onDismissHigh', () => {
+    const onDismissHigh = vi.fn();
+    const el = renderMinMaxFlagDots({
+      ...base,
+      cx: 10,
+      cy: 20,
+      index: 1,
+      onDismissHigh,
+      dismissLabel: 'Hide',
+    });
+    const children = (el.props as any).children as any[];
+    const closeButton = children.find((c: any) => c && c.props && c.props.role === 'button');
+    expect(closeButton).toBeTruthy();
+    closeButton.props.onClick({ stopPropagation: () => {} });
+    expect(onDismissHigh).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/investments/portfolio-chart-utils.test.ts
+++ b/frontend/src/components/investments/portfolio-chart-utils.test.ts
@@ -3,11 +3,13 @@ import {
   buildIntradayCacheKey,
   ChartFlagShadowFilter,
   clearAllIntradayCache,
+  computeMinMaxFlagIndices,
   computeTightYAxisDomain,
   INTRADAY_CACHE_PREFIX,
   niceAxisStep,
   readIntradayCache,
   renderChartFlagDot,
+  renderMinMaxFlagDots,
   writeIntradayCache,
 } from './portfolio-chart-utils';
 
@@ -249,5 +251,70 @@ describe('ChartFlagShadowFilter', () => {
     const el = ChartFlagShadowFilter();
     expect(el).toBeTruthy();
     expect(typeof el).toBe('object');
+  });
+});
+
+describe('computeMinMaxFlagIndices', () => {
+  it('returns no flags for an empty series', () => {
+    expect(computeMinMaxFlagIndices([])).toEqual({ maxIndex: -1, minIndex: -1, show: false });
+  });
+
+  it('suppresses the flags for a flat series', () => {
+    expect(computeMinMaxFlagIndices([5, 5, 5])).toEqual({ maxIndex: 0, minIndex: 0, show: false });
+  });
+
+  it('finds the max and min indices', () => {
+    expect(computeMinMaxFlagIndices([3, 9, 1, 7])).toEqual({ maxIndex: 1, minIndex: 2, show: true });
+  });
+
+  it('resolves ties to the first occurrence', () => {
+    expect(computeMinMaxFlagIndices([4, 9, 9, 1, 1])).toEqual({ maxIndex: 1, minIndex: 3, show: true });
+  });
+
+  it('handles all-negative values', () => {
+    expect(computeMinMaxFlagIndices([-2, -8, -1])).toEqual({ maxIndex: 2, minIndex: 1, show: true });
+  });
+});
+
+describe('renderMinMaxFlagDots', () => {
+  const flags = { maxIndex: 1, minIndex: 4, show: true };
+  const base = {
+    flags,
+    pointCount: 6,
+    highColor: '#10b981',
+    lowColor: '#ef4444',
+    highLabel: '$9',
+    lowLabel: '$1',
+  };
+
+  it('renders an invisible dot for a non-extreme point', () => {
+    const el = renderMinMaxFlagDots({ ...base, cx: 10, cy: 20, index: 2 });
+    expect(el.type).toBe('circle');
+  });
+
+  it('renders a bubble group for the max point', () => {
+    const el = renderMinMaxFlagDots({ ...base, cx: 10, cy: 20, index: 1 });
+    expect(el.type).toBe('g');
+  });
+
+  it('renders a bubble group for the min point', () => {
+    const el = renderMinMaxFlagDots({ ...base, cx: 10, cy: 20, index: 4 });
+    expect(el.type).toBe('g');
+  });
+
+  it('renders an invisible dot when coordinates are missing', () => {
+    const el = renderMinMaxFlagDots({ ...base, index: 1 });
+    expect(el.type).toBe('circle');
+  });
+
+  it('renders an invisible dot when the flags are suppressed', () => {
+    const el = renderMinMaxFlagDots({
+      ...base,
+      flags: { maxIndex: 0, minIndex: 0, show: false },
+      cx: 10,
+      cy: 20,
+      index: 0,
+    });
+    expect(el.type).toBe('circle');
   });
 });

--- a/frontend/src/components/investments/portfolio-chart-utils.tsx
+++ b/frontend/src/components/investments/portfolio-chart-utils.tsx
@@ -169,6 +169,14 @@ export interface FlagDotOptions {
    * edge that would clip it.
    */
   gap?: number;
+  /**
+   * When provided, the bubble grows a small "x" control on its right edge
+   * that calls this on click, letting the user temporarily hide the bubble to
+   * see the chart behind it. The dismissal is the caller's state to track.
+   */
+  onDismiss?: () => void;
+  /** Localized title/aria label for the dismiss control. */
+  dismissLabel?: string;
 }
 
 export function renderChartFlagDot({
@@ -179,8 +187,13 @@ export function renderChartFlagDot({
   label,
   side,
   gap = 24,
+  onDismiss,
+  dismissLabel,
 }: FlagDotOptions): ReactElement {
-  const labelWidth = label.length * 7 + 14;
+  // Reserve room on the right of the bubble for the dismiss "x" when present.
+  const hasClose = typeof onDismiss === 'function';
+  const closeZone = hasClose ? 16 : 0;
+  const labelWidth = label.length * 7 + 14 + closeZone;
   const labelHeight = 22;
   const arrowSize = 5;
 
@@ -273,7 +286,7 @@ export function renderChartFlagDot({
       />
       <polygon points={arrowPoints} fill={color} fillOpacity={1} />
       <text
-        x={bubbleX + labelWidth / 2}
+        x={bubbleX + (labelWidth - closeZone) / 2}
         y={bubbleY + labelHeight / 2}
         textAnchor="middle"
         dominantBaseline="central"
@@ -284,6 +297,58 @@ export function renderChartFlagDot({
       >
         {label}
       </text>
+      {hasClose && (
+        <g
+          role="button"
+          aria-label={dismissLabel}
+          className="chart-flag-dismiss"
+          style={{ cursor: 'pointer', pointerEvents: 'all' }}
+          onClick={(event) => {
+            event.stopPropagation();
+            onDismiss!();
+          }}
+        >
+          {dismissLabel ? <title>{dismissLabel}</title> : null}
+          {/* Faint divider separating the value from the dismiss control. */}
+          <line
+            x1={bubbleX + labelWidth - closeZone}
+            y1={bubbleY + 5}
+            x2={bubbleX + labelWidth - closeZone}
+            y2={bubbleY + labelHeight - 5}
+            stroke="#fff"
+            strokeOpacity={0.4}
+            strokeWidth={1}
+          />
+          {/* Transparent hit area so the whole close zone is clickable. */}
+          <rect
+            x={bubbleX + labelWidth - closeZone}
+            y={bubbleY}
+            width={closeZone}
+            height={labelHeight}
+            fill="transparent"
+          />
+          <line
+            x1={bubbleX + labelWidth - closeZone / 2 - 3}
+            y1={bubbleY + labelHeight / 2 - 3}
+            x2={bubbleX + labelWidth - closeZone / 2 + 3}
+            y2={bubbleY + labelHeight / 2 + 3}
+            stroke="#fff"
+            strokeWidth={1.3}
+            strokeLinecap="round"
+            strokeOpacity={1}
+          />
+          <line
+            x1={bubbleX + labelWidth - closeZone / 2 - 3}
+            y1={bubbleY + labelHeight / 2 + 3}
+            x2={bubbleX + labelWidth - closeZone / 2 + 3}
+            y2={bubbleY + labelHeight / 2 - 3}
+            stroke="#fff"
+            strokeWidth={1.3}
+            strokeLinecap="round"
+            strokeOpacity={1}
+          />
+        </g>
+      )}
     </g>
   );
 }
@@ -348,6 +413,14 @@ export interface MinMaxFlagDotOptions {
   highLabel: string;
   /** Pre-formatted label for the minimum point. */
   lowLabel: string;
+  /** When true, the high/low bubble is hidden (the user dismissed it). */
+  highDismissed?: boolean;
+  lowDismissed?: boolean;
+  /** Called when the user clicks the high/low bubble's dismiss control. */
+  onDismissHigh?: () => void;
+  onDismissLow?: () => void;
+  /** Localized title/aria label for the dismiss control. */
+  dismissLabel?: string;
 }
 
 /**
@@ -368,12 +441,18 @@ export function renderMinMaxFlagDots({
   lowColor,
   highLabel,
   lowLabel,
+  highDismissed,
+  lowDismissed,
+  onDismissHigh,
+  onDismissLow,
+  dismissLabel,
 }: MinMaxFlagDotOptions): ReactElement {
   if (cx == null || cy == null || index == null) {
     return <circle cx={0} cy={0} r={0} fill="none" />;
   }
-  const isMax = flags.show && index === flags.maxIndex;
-  const isMin = flags.show && index === flags.minIndex;
+  // A dismissed extreme renders like any other point: an invisible dot.
+  const isMax = flags.show && index === flags.maxIndex && !highDismissed;
+  const isMin = flags.show && index === flags.minIndex && !lowDismissed;
   if (!isMax && !isMin) {
     return <circle key={`dot-${index}`} cx={cx} cy={cy} r={0} fill="none" />;
   }
@@ -385,5 +464,7 @@ export function renderMinMaxFlagDots({
     color: isMax ? highColor : lowColor,
     label: isMax ? highLabel : lowLabel,
     side: isLeftHalf ? 'right' : 'left',
+    onDismiss: isMax ? onDismissHigh : onDismissLow,
+    dismissLabel,
   });
 }

--- a/frontend/src/components/investments/portfolio-chart-utils.tsx
+++ b/frontend/src/components/investments/portfolio-chart-utils.tsx
@@ -298,3 +298,92 @@ export function ChartFlagShadowFilter(): ReactElement {
     </defs>
   );
 }
+
+export interface MinMaxFlagIndices {
+  /** Index of the first datapoint at the series maximum, or -1 when empty. */
+  maxIndex: number;
+  /** Index of the first datapoint at the series minimum, or -1 when empty. */
+  minIndex: number;
+  /**
+   * Whether to draw the high/low bubbles. False for an empty or flat series,
+   * where the two flags would coincide and convey nothing.
+   */
+  show: boolean;
+}
+
+/**
+ * Locate the highest and lowest points of a chart series so the high/low
+ * bubbles (see {@link renderMinMaxFlagDots}) can be pinned to them. Ties
+ * resolve to the first occurrence, matching the Portfolio Value chart.
+ */
+export function computeMinMaxFlagIndices(
+  values: readonly number[],
+): MinMaxFlagIndices {
+  if (values.length === 0) return { maxIndex: -1, minIndex: -1, show: false };
+  let maxIndex = 0;
+  let minIndex = 0;
+  for (let i = 1; i < values.length; i++) {
+    if (values[i] > values[maxIndex]) maxIndex = i;
+    if (values[i] < values[minIndex]) minIndex = i;
+  }
+  return { maxIndex, minIndex, show: values[maxIndex] !== values[minIndex] };
+}
+
+export interface MinMaxFlagDotOptions {
+  /** Recharts dot x coordinate. */
+  cx?: number;
+  /** Recharts dot y coordinate. */
+  cy?: number;
+  /** Recharts datapoint index. */
+  index?: number;
+  /** High/low indices for the series (see {@link computeMinMaxFlagIndices}). */
+  flags: MinMaxFlagIndices;
+  /** Number of points in the series, used to choose each bubble's side. */
+  pointCount: number;
+  /** Bubble color for the maximum (e.g. chartColors.income, green). */
+  highColor: string;
+  /** Bubble color for the minimum (e.g. chartColors.expense, red). */
+  lowColor: string;
+  /** Pre-formatted label for the maximum point. */
+  highLabel: string;
+  /** Pre-formatted label for the minimum point. */
+  lowLabel: string;
+}
+
+/**
+ * Recharts `dot` renderer that pins a high (max, green) and low (min, red)
+ * bubble to a balance/value series. A point on the chart's left half places
+ * its bubble to the right and vice versa, so the callouts stay clear of the
+ * plot's left/right edges and the marker -- the same scheme used by the
+ * Portfolio Value chart. Every other point renders an invisible zero-radius
+ * dot.
+ */
+export function renderMinMaxFlagDots({
+  cx,
+  cy,
+  index,
+  flags,
+  pointCount,
+  highColor,
+  lowColor,
+  highLabel,
+  lowLabel,
+}: MinMaxFlagDotOptions): ReactElement {
+  if (cx == null || cy == null || index == null) {
+    return <circle cx={0} cy={0} r={0} fill="none" />;
+  }
+  const isMax = flags.show && index === flags.maxIndex;
+  const isMin = flags.show && index === flags.minIndex;
+  if (!isMax && !isMin) {
+    return <circle key={`dot-${index}`} cx={cx} cy={cy} r={0} fill="none" />;
+  }
+  const isLeftHalf = index < pointCount / 2;
+  return renderChartFlagDot({
+    cx,
+    cy,
+    index,
+    color: isMax ? highColor : lowColor,
+    label: isMax ? highLabel : lowLabel,
+    side: isLeftHalf ? 'right' : 'left',
+  });
+}

--- a/frontend/src/components/reports/PortfolioValueReport.test.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent, act } from '@/test/render';
 import { PortfolioValueReport } from './PortfolioValueReport';
+import { renderChartFlagDot } from '@/components/investments/portfolio-chart-utils';
+import { chartColors } from '@/lib/chart-colors';
 
 vi.mock('@/lib/pdf-export', () => ({
   exportToPdf: vi.fn().mockResolvedValue(undefined),
@@ -12,6 +14,7 @@ vi.mock('@/hooks/useNumberFormat', () => ({
     formatCurrencyCompact: (n: number, _currency?: string) => `$${n.toFixed(0)}`,
     formatCurrency: (n: number, _currency?: string) => `$${n.toFixed(2)}`,
     formatCurrencyAxis: (n: number) => `$${n}`,
+    formatCurrencyFlag: (n: number, _currency?: string) => `$${n}`,
     defaultCurrency: 'CAD',
   }),
 }));
@@ -72,7 +75,17 @@ vi.mock('@/components/ui/ExportDropdown', () => ({
 vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
   AreaChart: ({ children }: any) => <div data-testid="area-chart">{children}</div>,
-  Area: () => null,
+  // Invoke the dot render-prop so the high/low bubble wiring (and its dismiss
+  // control) is exercised. Indices 0..2 cover both extremes of the 3-point
+  // series the dismiss test renders.
+  Area: ({ dot }: any) =>
+    typeof dot === 'function' ? (
+      <>
+        {dot({ cx: 10, cy: 20, index: 0 })}
+        {dot({ cx: 30, cy: 40, index: 1 })}
+        {dot({ cx: 50, cy: 60, index: 2 })}
+      </>
+    ) : null,
   XAxis: ({ tickFormatter }: any) => (
     <div>
       {tickFormatter ? tickFormatter('Jan 2024') : ''}
@@ -206,6 +219,36 @@ describe('PortfolioValueReport', () => {
     expect(screen.getByText('Lowest Value')).toBeInTheDocument();
     expect(screen.getByText('Period Change')).toBeInTheDocument();
     expect(screen.getByText('Period Return')).toBeInTheDocument();
+  });
+
+  it('lets the user dismiss a high or low value bubble without persisting it', async () => {
+    mockGetInvestmentsMonthly.mockResolvedValue([
+      { month: '2024-06-01', value: 50000 },
+      { month: '2024-07-01', value: 52000 },
+      { month: '2024-08-01', value: 55000 },
+    ]);
+    mockGetPortfolioSummary.mockResolvedValue(emptyPortfolio);
+    mockGetInvestmentAccounts.mockResolvedValue([]);
+    render(<PortfolioValueReport />);
+
+    const flagMock = vi.mocked(renderChartFlagDot);
+    await waitFor(() => {
+      expect(flagMock.mock.calls.some(([o]: any) => o.color === chartColors.income)).toBe(true);
+    });
+
+    // Both bubbles are wired with a dismiss control and the localized label.
+    const highCall = flagMock.mock.calls.find(([o]: any) => o.color === chartColors.income)!;
+    expect(typeof highCall[0].onDismiss).toBe('function');
+    expect(highCall[0].dismissLabel).toBe('Hide this value');
+    expect(flagMock.mock.calls.some(([o]: any) => o.color === chartColors.expense)).toBe(true);
+
+    // Dismissing the high bubble hides it on the next render; the low remains.
+    flagMock.mockClear();
+    await act(async () => {
+      highCall[0].onDismiss!();
+    });
+    expect(flagMock.mock.calls.some(([o]: any) => o.color === chartColors.income)).toBe(false);
+    expect(flagMock.mock.calls.some(([o]: any) => o.color === chartColors.expense)).toBe(true);
   });
 
   it('renders the area chart', async () => {

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -71,6 +71,7 @@ function CustomTooltip({ active, payload, fmtFull, portfolioLabel }: {
 
 export function PortfolioValueReport() {
   const t = useTranslations('reports');
+  const tc = useTranslations('common');
   const { formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag, formatCurrency: formatCurrencyFull, formatSignedPercent } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
   const chartRef = useRef<HTMLDivElement>(null);
@@ -81,6 +82,11 @@ export function PortfolioValueReport() {
   const [reloadKey, setReloadKey] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [chartViewType, setChartViewType] = useState<'area' | 'table'>('area');
+  // High/low value bubbles the user has temporarily dismissed, keyed by the
+  // value they marked so a later data change with a new extreme shows the
+  // bubble again. Component-local (not persisted), so it resets on navigation.
+  const [dismissedHigh, setDismissedHigh] = useState<number | null>(null);
+  const [dismissedLow, setDismissedLow] = useState<number | null>(null);
   const isSingleAccount = selectedAccountIds.length === 1;
   const { sortField, sortDirection, handleSort } = useSortableTable<PortfolioBreakdownSortField>(
     'reports.portfolio-value.breakdown.sort',
@@ -655,8 +661,8 @@ export function PortfolioValueReport() {
                     if (cx == null || cy == null || index == null) {
                       return <circle cx={0} cy={0} r={0} fill="none" />;
                     }
-                    const isHighest = showFlags && index === highestIndex;
-                    const isLowest = showFlags && index === lowestIndex;
+                    const isHighest = showFlags && index === highestIndex && summary.highest !== dismissedHigh;
+                    const isLowest = showFlags && index === lowestIndex && summary.lowest !== dismissedLow;
                     if (!isHighest && !isLowest) {
                       return <circle key={`dot-${index}`} cx={cx} cy={cy} r={0} fill="none" />;
                     }
@@ -675,6 +681,10 @@ export function PortfolioValueReport() {
                       color: isHighest ? chartColors.income : chartColors.expense,
                       label: fmtFlag(value),
                       side: isLeftHalf ? 'right' : 'left',
+                      onDismiss: isHighest
+                        ? () => setDismissedHigh(summary.highest)
+                        : () => setDismissedLow(summary.lowest),
+                      dismissLabel: tc('chartFlag.dismiss'),
                     });
                   }}
                 />

--- a/frontend/src/components/transactions/AccountInfoWidget.test.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.test.tsx
@@ -99,7 +99,7 @@ describe('AccountInfoWidget', () => {
       <AccountInfoWidget
         account={makeAccount({
           accountType: 'CREDIT_CARD',
-          accountNumber: '****1234',
+          accountNumber: '4111111111111234',
           creditLimit: 5000,
           interestRate: 19.99,
           isClosed: true,
@@ -107,10 +107,66 @@ describe('AccountInfoWidget', () => {
         onEdit={vi.fn()} onCollapse={vi.fn()}
       />,
     );
-    expect(screen.getByText('****1234')).toBeInTheDocument();
+    // The credit-card number is masked to its first and last four digits.
+    expect(screen.getByText('4111••••••••1234')).toBeInTheDocument();
+    expect(screen.queryByText('4111111111111234')).not.toBeInTheDocument();
     expect(screen.getByText('CAD 5000.00')).toBeInTheDocument();
     expect(screen.getByText('19.99%')).toBeInTheDocument();
     expect(screen.getByText('Closed')).toBeInTheDocument();
+  });
+
+  it('masks a non-credit-card account number to its last four digits', () => {
+    render(
+      <AccountInfoWidget
+        account={makeAccount({ accountType: 'CHEQUING', accountNumber: '12345678' })}
+        onEdit={vi.fn()}
+        onCollapse={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('••••5678')).toBeInTheDocument();
+    expect(screen.queryByText('12345678')).not.toBeInTheDocument();
+  });
+
+  it('reveals and re-masks the account number via the eye toggle', () => {
+    render(
+      <AccountInfoWidget
+        account={makeAccount({ accountType: 'CREDIT_CARD', accountNumber: '4111111111111234' })}
+        onEdit={vi.fn()}
+        onCollapse={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('4111••••••••1234')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Show account number'));
+    expect(screen.getByText('4111111111111234')).toBeInTheDocument();
+    expect(screen.queryByText('4111••••••••1234')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Hide account number'));
+    expect(screen.getByText('4111••••••••1234')).toBeInTheDocument();
+    expect(screen.queryByText('4111111111111234')).not.toBeInTheDocument();
+  });
+
+  it('re-masks the number when switching to another account', () => {
+    const { rerender } = render(
+      <AccountInfoWidget
+        account={makeAccount({ id: 'a-1', accountNumber: '12345678' })}
+        onEdit={vi.fn()}
+        onCollapse={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('Show account number'));
+    expect(screen.getByText('12345678')).toBeInTheDocument();
+
+    // Switching accounts must not leak the previous account's revealed number.
+    rerender(
+      <AccountInfoWidget
+        account={makeAccount({ id: 'a-2', accountNumber: '87654321' })}
+        onEdit={vi.fn()}
+        onCollapse={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('••••4321')).toBeInTheDocument();
+    expect(screen.queryByText('87654321')).not.toBeInTheDocument();
   });
 
   it('shows the institution name and logo when an institution is provided', () => {

--- a/frontend/src/components/transactions/AccountInfoWidget.tsx
+++ b/frontend/src/components/transactions/AccountInfoWidget.tsx
@@ -1,12 +1,17 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
-import { PencilSquareIcon, ChevronDoubleLeftIcon } from '@heroicons/react/24/outline';
+import {
+  PencilSquareIcon,
+  ChevronDoubleLeftIcon,
+  EyeIcon,
+  EyeSlashIcon,
+} from '@heroicons/react/24/outline';
 import { Account } from '@/types/account';
 import { ScheduledTransaction } from '@/types/scheduled-transaction';
-import { formatAccountType } from '@/lib/account-utils';
+import { formatAccountType, maskAccountNumber } from '@/lib/account-utils';
 import { getOrdinal } from '@/lib/ordinal';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useDateFormat } from '@/hooks/useDateFormat';
@@ -51,6 +56,19 @@ export function AccountInfoWidget({
   const { formatCurrency } = useNumberFormat();
   const { formatDate } = useDateFormat();
 
+  // The account number is masked by default and only unmasked while the user
+  // holds it open via the eye toggle. The state is intentionally not persisted,
+  // so it re-masks on remount, and resets when switching to another account so
+  // one account's number never leaks onto another. We follow the project's
+  // "info from previous render" pattern rather than resetting in an effect.
+  const [accountNumberVisible, setAccountNumberVisible] = useState(false);
+  const [shownAccountId, setShownAccountId] = useState(account.id);
+  if (shownAccountId !== account.id) {
+    setShownAccountId(account.id);
+    setAccountNumberVisible(false);
+  }
+
+  const isCreditCard = account.accountType === 'CREDIT_CARD';
   const isLiability = ['CREDIT_CARD', 'LOAN', 'MORTGAGE', 'LINE_OF_CREDIT'].includes(
     account.accountType,
   );
@@ -77,13 +95,22 @@ export function AccountInfoWidget({
     return candidates[0] ?? null;
   }, [scheduledTransactions, account.id]);
 
-  const details: Array<{ label: string; value: string; tooltip?: string }> = [];
+  const details: Array<{
+    label: string;
+    value: string;
+    tooltip?: string;
+    maskable?: boolean;
+  }> = [];
   details.push({
     label: t('accountWidget.type'),
     value: formatAccountType(account.accountType, tc),
   });
   if (account.accountNumber) {
-    details.push({ label: t('accountWidget.accountNumber'), value: account.accountNumber });
+    details.push({
+      label: t('accountWidget.accountNumber'),
+      value: account.accountNumber,
+      maskable: true,
+    });
   }
   details.push({ label: t('accountWidget.currency'), value: account.currencyCode });
   if (account.creditLimit != null && Number(account.creditLimit) !== 0) {
@@ -229,9 +256,40 @@ export function AccountInfoWidget({
               {detail.label}
               {detail.tooltip && <InfoTooltip text={detail.tooltip} usePortal />}
             </dt>
-            <dd className="text-gray-900 dark:text-gray-100 text-right truncate">
-              {detail.value}
-            </dd>
+            {detail.maskable ? (
+              <dd className="text-gray-900 dark:text-gray-100 min-w-0 flex items-center justify-end gap-1.5">
+                <span className="truncate tracking-wider">
+                  {accountNumberVisible
+                    ? detail.value
+                    : maskAccountNumber(detail.value, isCreditCard)}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setAccountNumberVisible((v) => !v)}
+                  aria-label={
+                    accountNumberVisible
+                      ? t('accountWidget.hideAccountNumber')
+                      : t('accountWidget.showAccountNumber')
+                  }
+                  title={
+                    accountNumberVisible
+                      ? t('accountWidget.hideAccountNumber')
+                      : t('accountWidget.showAccountNumber')
+                  }
+                  className="flex-shrink-0 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
+                >
+                  {accountNumberVisible ? (
+                    <EyeSlashIcon className="h-4 w-4" />
+                  ) : (
+                    <EyeIcon className="h-4 w-4" />
+                  )}
+                </button>
+              </dd>
+            ) : (
+              <dd className="text-gray-900 dark:text-gray-100 text-right truncate">
+                {detail.value}
+              </dd>
+            )}
           </div>
         ))}
       </dl>

--- a/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
@@ -3,10 +3,22 @@ import { render, screen } from '@/test/render';
 import { BalanceHistoryChart } from './BalanceHistoryChart';
 import { computeBalanceGradient } from '@/lib/balance-history';
 
+// The Area mock invokes the `dot` render-prop so the high/low value bubbles
+// are exercised by the data-driven tests below; their output is exposed via
+// the "line-dots" test id. Existing assertions are unaffected.
 vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
   AreaChart: ({ children }: any) => <div data-testid="area-chart">{children}</div>,
-  Area: () => <div data-testid="area" />,
+  Area: ({ dot }: any) => (
+    <div data-testid="area">
+      {typeof dot === 'function' && (
+        <svg data-testid="line-dots">
+          {dot({ cx: 50, cy: 60, index: 0 })}
+          {dot({ cx: 70, cy: 80, index: 1 })}
+        </svg>
+      )}
+    </div>
+  ),
   XAxis: () => <div data-testid="x-axis" />,
   YAxis: () => <div data-testid="y-axis" />,
   CartesianGrid: () => <div data-testid="cartesian-grid" />,
@@ -16,11 +28,13 @@ vi.mock('recharts', () => ({
 
 const mockFormatCurrency = vi.fn((n: number, _code?: string) => `$${n.toFixed(2)}`);
 const mockFormatCurrencyAxis = vi.fn((n: number, _code?: string) => `$${n}`);
+const mockFormatCurrencyFlag = vi.fn((n: number, _code?: string) => `$${n}`);
 
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
     formatCurrency: mockFormatCurrency,
     formatCurrencyAxis: mockFormatCurrencyAxis,
+    formatCurrencyFlag: mockFormatCurrencyFlag,
   }),
 }));
 
@@ -228,6 +242,28 @@ describe('BalanceHistoryChart', () => {
       ([, code]) => code === 'EUR',
     );
     expect(eurCalls.length).toBeGreaterThan(0);
+  });
+
+  it('marks the highest and lowest points with value bubbles', () => {
+    mockFormatCurrencyFlag.mockClear();
+    render(
+      <BalanceHistoryChart
+        data={[
+          { date: '2025-01-01', balance: 500 },
+          { date: '2025-01-02', balance: 600 },
+        ]}
+        isLoading={false}
+        currencyCode="EUR"
+      />
+    );
+    // The lowest (500) and highest (600) points each render a labelled bubble,
+    // formatted through the compact "flag" formatter with the chart currency.
+    const dots = screen.getByTestId('line-dots');
+    const labels = Array.from(dots.querySelectorAll('text')).map((node) => node.textContent);
+    expect(labels).toContain('$500');
+    expect(labels).toContain('$600');
+    const eurFlagCalls = mockFormatCurrencyFlag.mock.calls.filter(([, code]) => code === 'EUR');
+    expect(eurFlagCalls.length).toBeGreaterThan(0);
   });
 });
 

--- a/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@/test/render';
+import { render, screen, fireEvent } from '@/test/render';
 import { BalanceHistoryChart } from './BalanceHistoryChart';
 import { computeBalanceGradient } from '@/lib/balance-history';
 
@@ -264,6 +264,33 @@ describe('BalanceHistoryChart', () => {
     expect(labels).toContain('$600');
     const eurFlagCalls = mockFormatCurrencyFlag.mock.calls.filter(([, code]) => code === 'EUR');
     expect(eurFlagCalls.length).toBeGreaterThan(0);
+  });
+
+  it('temporarily hides a value bubble when its dismiss control is clicked', () => {
+    const { container } = render(
+      <BalanceHistoryChart
+        data={[
+          { date: '2025-01-01', balance: 500 },
+          { date: '2025-01-02', balance: 600 },
+        ]}
+        isLoading={false}
+        currencyCode="EUR"
+      />
+    );
+    const labels = () =>
+      Array.from(
+        container.querySelectorAll('[data-testid="line-dots"] text'),
+      ).map((node) => node.textContent);
+    expect(labels()).toEqual(expect.arrayContaining(['$500', '$600']));
+
+    // The dot mock renders index 0 (low, $500) then index 1 (high, $600), so
+    // the second dismiss control belongs to the high bubble.
+    const closeControls = container.querySelectorAll('.chart-flag-dismiss');
+    expect(closeControls).toHaveLength(2);
+    fireEvent.click(closeControls[1]);
+
+    expect(labels()).toContain('$500');
+    expect(labels()).not.toContain('$600');
   });
 });
 

--- a/frontend/src/components/transactions/BalanceHistoryChart.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.tsx
@@ -20,6 +20,11 @@ import { parseLocalDate } from '@/lib/utils';
 import { computeBalanceGradient, computeBalanceSummary } from '@/lib/balance-history';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { ChartDownloadButton } from '@/components/ui/ChartDownloadButton';
+import {
+  ChartFlagShadowFilter,
+  computeMinMaxFlagIndices,
+  renderMinMaxFlagDots,
+} from '@/components/investments/portfolio-chart-utils';
 
 
 interface BalanceHistoryChartProps {
@@ -73,7 +78,8 @@ export function BalanceHistoryChart({
 }: BalanceHistoryChartProps) {
   const t = useTranslations('transactions');
   const chartTitle = t('charts.balanceHistory.title');
-  const { formatCurrency: formatCurrencyFull, formatCurrencyAxis } = useNumberFormat();
+  const { formatCurrency: formatCurrencyFull, formatCurrencyAxis, formatCurrencyFlag } =
+    useNumberFormat();
   const chartRef = useRef<HTMLDivElement>(null);
   const downloadFilename = accountName ? `${chartTitle} - ${accountName}` : chartTitle;
 
@@ -85,6 +91,11 @@ export function BalanceHistoryChart({
   const formatAxis = useCallback(
     (value: number) => formatCurrencyAxis(value, currencyCode),
     [formatCurrencyAxis, currencyCode],
+  );
+
+  const formatFlag = useCallback(
+    (value: number) => formatCurrencyFlag(value, currencyCode),
+    [formatCurrencyFlag, currencyCode],
   );
 
   const { chartData, monthTicks } = useMemo(() => {
@@ -115,6 +126,14 @@ export function BalanceHistoryChart({
     [chartData],
   );
 
+  // Highest/lowest points get green/red value bubbles, positioned to the
+  // inside of whichever chart half they fall on so they never overlap the
+  // plot edges.
+  const flags = useMemo(
+    () => computeMinMaxFlagIndices(chartData.map((point) => point.balance)),
+    [chartData],
+  );
+
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6 min-h-[420px]">
@@ -141,6 +160,9 @@ export function BalanceHistoryChart({
     );
   }
 
+  const highLabel = flags.show ? formatFlag(chartData[flags.maxIndex].balance) : '';
+  const lowLabel = flags.show ? formatFlag(chartData[flags.minIndex].balance) : '';
+
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6 min-h-[420px]">
       <div className="flex items-center justify-between mb-4">
@@ -155,7 +177,8 @@ export function BalanceHistoryChart({
           re-measures, so clip it to the card instead of painting outside. */}
       <div ref={chartRef} className="h-72 overflow-hidden" style={{ minHeight: 288 }}>
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
-          <AreaChart data={chartData} margin={{ left: 0, right: 8, top: 5, bottom: 0 }}>
+          {/* top margin leaves headroom for the high-value bubble callout */}
+          <AreaChart data={chartData} margin={{ left: 0, right: 8, top: 20, bottom: 0 }}>
             <defs>
               <linearGradient id="colorBalance" x1="0" y1="0" x2="0" y2="1">
                 <stop offset={0} stopColor={chartColors.primary} stopOpacity={areaGradient.topOpacity} />
@@ -163,6 +186,7 @@ export function BalanceHistoryChart({
                 <stop offset={1} stopColor={chartColors.primary} stopOpacity={areaGradient.bottomOpacity} />
               </linearGradient>
             </defs>
+            <ChartFlagShadowFilter />
             <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
             <XAxis
               dataKey="date"
@@ -202,7 +226,19 @@ export function BalanceHistoryChart({
               strokeWidth={2}
               fillOpacity={1}
               fill="url(#colorBalance)"
-              dot={false}
+              dot={(props: { cx?: number; cy?: number; index?: number }) =>
+                renderMinMaxFlagDots({
+                  cx: props.cx,
+                  cy: props.cy,
+                  index: props.index,
+                  flags,
+                  pointCount: chartData.length,
+                  highColor: chartColors.income,
+                  lowColor: chartColors.expense,
+                  highLabel,
+                  lowLabel,
+                })
+              }
               activeDot={{ r: 6, fill: chartColors.primary }}
             />
           </AreaChart>

--- a/frontend/src/components/transactions/BalanceHistoryChart.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { gainLossColor } from '@/lib/format';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
@@ -77,10 +77,17 @@ export function BalanceHistoryChart({
   accountName,
 }: BalanceHistoryChartProps) {
   const t = useTranslations('transactions');
+  const tc = useTranslations('common');
   const chartTitle = t('charts.balanceHistory.title');
   const { formatCurrency: formatCurrencyFull, formatCurrencyAxis, formatCurrencyFlag } =
     useNumberFormat();
   const chartRef = useRef<HTMLDivElement>(null);
+  // High/low value bubbles a user has temporarily dismissed, keyed by the value
+  // they marked so a later data change with a new extreme shows its bubble
+  // again. Intentionally component-local (not persisted), so it resets on
+  // navigation.
+  const [dismissedHigh, setDismissedHigh] = useState<number | null>(null);
+  const [dismissedLow, setDismissedLow] = useState<number | null>(null);
   const downloadFilename = accountName ? `${chartTitle} - ${accountName}` : chartTitle;
 
   const formatCurrency = useCallback(
@@ -160,8 +167,12 @@ export function BalanceHistoryChart({
     );
   }
 
-  const highLabel = flags.show ? formatFlag(chartData[flags.maxIndex].balance) : '';
-  const lowLabel = flags.show ? formatFlag(chartData[flags.minIndex].balance) : '';
+  const highValue = flags.show ? chartData[flags.maxIndex].balance : null;
+  const lowValue = flags.show ? chartData[flags.minIndex].balance : null;
+  const highLabel = highValue !== null ? formatFlag(highValue) : '';
+  const lowLabel = lowValue !== null ? formatFlag(lowValue) : '';
+  const highDismissed = highValue !== null && highValue === dismissedHigh;
+  const lowDismissed = lowValue !== null && lowValue === dismissedLow;
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6 min-h-[420px]">
@@ -237,6 +248,11 @@ export function BalanceHistoryChart({
                   lowColor: chartColors.expense,
                   highLabel,
                   lowLabel,
+                  highDismissed,
+                  lowDismissed,
+                  onDismissHigh: () => setDismissedHigh(highValue),
+                  onDismissLow: () => setDismissedLow(lowValue),
+                  dismissLabel: tc('chartFlag.dismiss'),
                 })
               }
               activeDot={{ r: 6, fill: chartColors.primary }}

--- a/frontend/src/components/ui/AppVersion.test.tsx
+++ b/frontend/src/components/ui/AppVersion.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen } from '@/test/render';
+import { AppVersion } from './AppVersion';
+
+describe('AppVersion', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('links the version to its GitHub release notes', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_VERSION', '1.11.0');
+    render(<AppVersion className="footer" />);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveTextContent('v1.11.0');
+    expect(link).toHaveAttribute(
+      'href',
+      'https://github.com/kenlasko/monize/releases/tag/v1.11.0',
+    );
+    expect(link).toHaveAttribute('title', 'View release notes for v1.11.0');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
+  it('uses the provided version in the release URL and applies the wrapper class', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_VERSION', '2.0.0');
+    const { container } = render(<AppVersion className="text-center mt-6" />);
+
+    expect(container.querySelector('p')).toHaveClass('text-center', 'mt-6');
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      'https://github.com/kenlasko/monize/releases/tag/v2.0.0',
+    );
+  });
+
+  it('renders nothing when the version is unavailable', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_VERSION', '');
+    const { container } = render(<AppVersion />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/ui/AppVersion.tsx
+++ b/frontend/src/components/ui/AppVersion.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+/** Repository whose GitHub releases hold the per-version notes. */
+const RELEASE_NOTES_BASE_URL = 'https://github.com/kenlasko/monize/releases/tag/v';
+
+interface AppVersionProps {
+  /** Classes for the wrapping paragraph (margins, text size/colour). */
+  className?: string;
+}
+
+/**
+ * Footer label showing the running app version, linked to that version's
+ * GitHub release notes (e.g. v1.11.0 ->
+ * github.com/kenlasko/monize/releases/tag/v1.11.0). The version is injected at
+ * build time from package.json via NEXT_PUBLIC_APP_VERSION; if it is somehow
+ * absent the component renders nothing rather than a link to a missing
+ * release. Shown in the Settings and login footers.
+ */
+export function AppVersion({ className }: AppVersionProps) {
+  const t = useTranslations('common');
+  const version = process.env.NEXT_PUBLIC_APP_VERSION;
+  if (!version) return null;
+
+  return (
+    <p className={className}>
+      <a
+        href={`${RELEASE_NOTES_BASE_URL}${version}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={t('appVersion.releaseNotes', { version })}
+        className="hover:text-gray-600 dark:hover:text-gray-300 hover:underline focus:outline-none focus:underline"
+      >
+        v{version}
+      </a>
+    </p>
+  );
+}

--- a/frontend/src/i18n/messages/de/common.json
+++ b/frontend/src/i18n/messages/de/common.json
@@ -1,4 +1,7 @@
 {
+  "appVersion": {
+    "releaseNotes": "Versionshinweise für v{version} anzeigen"
+  },
   "save": "Speichern",
   "cancel": "Abbrechen",
   "delete": "Löschen",

--- a/frontend/src/i18n/messages/de/common.json
+++ b/frontend/src/i18n/messages/de/common.json
@@ -1,4 +1,7 @@
 {
+  "chartFlag": {
+    "dismiss": "Diesen Wert ausblenden"
+  },
   "appVersion": {
     "releaseNotes": "Versionshinweise für v{version} anzeigen"
   },

--- a/frontend/src/i18n/messages/de/transactions.json
+++ b/frontend/src/i18n/messages/de/transactions.json
@@ -14,6 +14,8 @@
     "closed": "Geschlossen",
     "editAria": "Kontoeinstellungen bearbeiten",
     "collapseAria": "Kontoinformationen ausblenden",
+    "showAccountNumber": "Kontonummer anzeigen",
+    "hideAccountNumber": "Kontonummer ausblenden",
     "show": "Kontoinformationen anzeigen"
   },
   "page": {

--- a/frontend/src/i18n/messages/en/common.json
+++ b/frontend/src/i18n/messages/en/common.json
@@ -1,4 +1,7 @@
 {
+  "appVersion": {
+    "releaseNotes": "View release notes for v{version}"
+  },
   "save": "Save",
   "cancel": "Cancel",
   "delete": "Delete",

--- a/frontend/src/i18n/messages/en/common.json
+++ b/frontend/src/i18n/messages/en/common.json
@@ -1,4 +1,7 @@
 {
+  "chartFlag": {
+    "dismiss": "Hide this value"
+  },
   "appVersion": {
     "releaseNotes": "View release notes for v{version}"
   },

--- a/frontend/src/i18n/messages/en/transactions.json
+++ b/frontend/src/i18n/messages/en/transactions.json
@@ -14,6 +14,8 @@
     "closed": "Closed",
     "editAria": "Edit account settings",
     "collapseAria": "Hide account info",
+    "showAccountNumber": "Show account number",
+    "hideAccountNumber": "Hide account number",
     "show": "Show account info"
   },
   "page": {

--- a/frontend/src/i18n/messages/es/common.json
+++ b/frontend/src/i18n/messages/es/common.json
@@ -1,4 +1,7 @@
 {
+  "appVersion": {
+    "releaseNotes": "Ver las notas de la versión v{version}"
+  },
   "save": "Guardar",
   "cancel": "Cancelar",
   "delete": "Eliminar",

--- a/frontend/src/i18n/messages/es/common.json
+++ b/frontend/src/i18n/messages/es/common.json
@@ -1,4 +1,7 @@
 {
+  "chartFlag": {
+    "dismiss": "Ocultar este valor"
+  },
   "appVersion": {
     "releaseNotes": "Ver las notas de la versión v{version}"
   },

--- a/frontend/src/i18n/messages/es/transactions.json
+++ b/frontend/src/i18n/messages/es/transactions.json
@@ -14,6 +14,8 @@
     "closed": "Cerrada",
     "editAria": "Editar configuración de cuenta",
     "collapseAria": "Ocultar información de cuenta",
+    "showAccountNumber": "Mostrar número de cuenta",
+    "hideAccountNumber": "Ocultar número de cuenta",
     "show": "Mostrar información de cuenta"
   },
   "page": {

--- a/frontend/src/i18n/messages/fr/common.json
+++ b/frontend/src/i18n/messages/fr/common.json
@@ -1,4 +1,7 @@
 {
+  "appVersion": {
+    "releaseNotes": "Voir les notes de version de la v{version}"
+  },
   "save": "Enregistrer",
   "cancel": "Annuler",
   "delete": "Supprimer",

--- a/frontend/src/i18n/messages/fr/common.json
+++ b/frontend/src/i18n/messages/fr/common.json
@@ -1,4 +1,7 @@
 {
+  "chartFlag": {
+    "dismiss": "Masquer cette valeur"
+  },
   "appVersion": {
     "releaseNotes": "Voir les notes de version de la v{version}"
   },

--- a/frontend/src/i18n/messages/fr/transactions.json
+++ b/frontend/src/i18n/messages/fr/transactions.json
@@ -14,6 +14,8 @@
     "closed": "Fermé",
     "editAria": "Modifier les paramètres du compte",
     "collapseAria": "Masquer les informations du compte",
+    "showAccountNumber": "Afficher le numéro de compte",
+    "hideAccountNumber": "Masquer le numéro de compte",
     "show": "Afficher les informations du compte"
   },
   "page": {

--- a/frontend/src/i18n/messages/it/common.json
+++ b/frontend/src/i18n/messages/it/common.json
@@ -1,4 +1,7 @@
 {
+  "appVersion": {
+    "releaseNotes": "Visualizza le note di rilascio della v{version}"
+  },
   "save": "Salva",
   "cancel": "Annulla",
   "delete": "Elimina",

--- a/frontend/src/i18n/messages/it/common.json
+++ b/frontend/src/i18n/messages/it/common.json
@@ -1,4 +1,7 @@
 {
+  "chartFlag": {
+    "dismiss": "Nascondi questo valore"
+  },
   "appVersion": {
     "releaseNotes": "Visualizza le note di rilascio della v{version}"
   },

--- a/frontend/src/i18n/messages/it/transactions.json
+++ b/frontend/src/i18n/messages/it/transactions.json
@@ -14,6 +14,8 @@
     "closed": "Chiuso",
     "editAria": "Modifica impostazioni conto",
     "collapseAria": "Nascondi info conto",
+    "showAccountNumber": "Mostra numero di conto",
+    "hideAccountNumber": "Nascondi numero di conto",
     "show": "Mostra info conto"
   },
   "page": {

--- a/frontend/src/i18n/messages/nl/common.json
+++ b/frontend/src/i18n/messages/nl/common.json
@@ -1,4 +1,7 @@
 {
+  "appVersion": {
+    "releaseNotes": "Release-opmerkingen voor v{version} bekijken"
+  },
   "save": "Opslaan",
   "cancel": "Annuleren",
   "delete": "Verwijderen",

--- a/frontend/src/i18n/messages/nl/common.json
+++ b/frontend/src/i18n/messages/nl/common.json
@@ -1,4 +1,7 @@
 {
+  "chartFlag": {
+    "dismiss": "Deze waarde verbergen"
+  },
   "appVersion": {
     "releaseNotes": "Release-opmerkingen voor v{version} bekijken"
   },

--- a/frontend/src/i18n/messages/nl/transactions.json
+++ b/frontend/src/i18n/messages/nl/transactions.json
@@ -14,6 +14,8 @@
     "closed": "Gesloten",
     "editAria": "Rekeninginstellingen bewerken",
     "collapseAria": "Rekeninginfo verbergen",
+    "showAccountNumber": "Rekeningnummer tonen",
+    "hideAccountNumber": "Rekeningnummer verbergen",
     "show": "Rekeninginfo tonen"
   },
   "page": {

--- a/frontend/src/i18n/messages/pl/common.json
+++ b/frontend/src/i18n/messages/pl/common.json
@@ -1,4 +1,7 @@
 {
+  "appVersion": {
+    "releaseNotes": "Zobacz informacje o wydaniu v{version}"
+  },
   "save": "Zapisz",
   "cancel": "Anuluj",
   "delete": "Usuń",

--- a/frontend/src/i18n/messages/pl/common.json
+++ b/frontend/src/i18n/messages/pl/common.json
@@ -1,4 +1,7 @@
 {
+  "chartFlag": {
+    "dismiss": "Ukryj tę wartość"
+  },
   "appVersion": {
     "releaseNotes": "Zobacz informacje o wydaniu v{version}"
   },

--- a/frontend/src/i18n/messages/pl/transactions.json
+++ b/frontend/src/i18n/messages/pl/transactions.json
@@ -14,6 +14,8 @@
     "closed": "Zamknięte",
     "editAria": "Edytuj ustawienia konta",
     "collapseAria": "Ukryj informacje o koncie",
+    "showAccountNumber": "Pokaż numer konta",
+    "hideAccountNumber": "Ukryj numer konta",
     "show": "Pokaż informacje o koncie"
   },
   "page": {

--- a/frontend/src/i18n/messages/pt-BR/common.json
+++ b/frontend/src/i18n/messages/pt-BR/common.json
@@ -1,4 +1,7 @@
 {
+  "appVersion": {
+    "releaseNotes": "Ver as notas de versão da v{version}"
+  },
   "save": "Salvar",
   "cancel": "Cancelar",
   "delete": "Excluir",

--- a/frontend/src/i18n/messages/pt-BR/common.json
+++ b/frontend/src/i18n/messages/pt-BR/common.json
@@ -1,4 +1,7 @@
 {
+  "chartFlag": {
+    "dismiss": "Ocultar este valor"
+  },
   "appVersion": {
     "releaseNotes": "Ver as notas de versão da v{version}"
   },

--- a/frontend/src/i18n/messages/pt-BR/transactions.json
+++ b/frontend/src/i18n/messages/pt-BR/transactions.json
@@ -14,6 +14,8 @@
     "closed": "Fechada",
     "editAria": "Editar configurações da conta",
     "collapseAria": "Ocultar informações da conta",
+    "showAccountNumber": "Mostrar número da conta",
+    "hideAccountNumber": "Ocultar número da conta",
     "show": "Mostrar informações da conta"
   },
   "page": {

--- a/frontend/src/i18n/messages/pt/common.json
+++ b/frontend/src/i18n/messages/pt/common.json
@@ -1,4 +1,7 @@
 {
+  "appVersion": {
+    "releaseNotes": "Ver as notas de versão da v{version}"
+  },
   "save": "Guardar",
   "cancel": "Cancelar",
   "delete": "Eliminar",

--- a/frontend/src/i18n/messages/pt/common.json
+++ b/frontend/src/i18n/messages/pt/common.json
@@ -1,4 +1,7 @@
 {
+  "chartFlag": {
+    "dismiss": "Ocultar este valor"
+  },
   "appVersion": {
     "releaseNotes": "Ver as notas de versão da v{version}"
   },

--- a/frontend/src/i18n/messages/pt/transactions.json
+++ b/frontend/src/i18n/messages/pt/transactions.json
@@ -14,6 +14,8 @@
     "closed": "Fechada",
     "editAria": "Editar definições da conta",
     "collapseAria": "Ocultar informações da conta",
+    "showAccountNumber": "Mostrar número da conta",
+    "hideAccountNumber": "Ocultar número da conta",
     "show": "Mostrar informações da conta"
   },
   "page": {

--- a/frontend/src/i18n/messages/xx/common.json
+++ b/frontend/src/i18n/messages/xx/common.json
@@ -1,4 +1,7 @@
 {
+  "appVersion": {
+    "releaseNotes": "[XX-View release notes for v{version}-XX]"
+  },
   "save": "[XX-Save-XX]",
   "cancel": "[XX-Cancel-XX]",
   "delete": "[XX-Delete-XX]",

--- a/frontend/src/i18n/messages/xx/common.json
+++ b/frontend/src/i18n/messages/xx/common.json
@@ -1,4 +1,7 @@
 {
+  "chartFlag": {
+    "dismiss": "[XX-Hide this value-XX]"
+  },
   "appVersion": {
     "releaseNotes": "[XX-View release notes for v{version}-XX]"
   },

--- a/frontend/src/i18n/messages/xx/transactions.json
+++ b/frontend/src/i18n/messages/xx/transactions.json
@@ -14,6 +14,8 @@
     "closed": "[XX-Closed-XX]",
     "editAria": "[XX-Edit account settings-XX]",
     "collapseAria": "[XX-Hide account info-XX]",
+    "showAccountNumber": "[XX-Show account number-XX]",
+    "hideAccountNumber": "[XX-Hide account number-XX]",
     "show": "[XX-Show account info-XX]"
   },
   "page": {

--- a/frontend/src/lib/account-utils.test.ts
+++ b/frontend/src/lib/account-utils.test.ts
@@ -6,6 +6,7 @@ import {
   isInvestmentBrokerageAccount,
   isInvestmentCashHalf,
   getMainAccountName,
+  maskAccountNumber,
 } from './account-utils';
 import { Account } from '@/types/account';
 
@@ -322,5 +323,35 @@ describe('getMainAccountName', () => {
 
   it('only strips the suffix at the end of the name', () => {
     expect(getMainAccountName('Cash - Reserve')).toBe('Cash - Reserve');
+  });
+});
+
+describe('maskAccountNumber', () => {
+  it('keeps the first and last four digits of a credit-card number', () => {
+    expect(maskAccountNumber('4111111111111234', true)).toBe('4111••••••••1234');
+  });
+
+  it('keeps only the last four digits of a non-credit-card number', () => {
+    expect(maskAccountNumber('12345678', false)).toBe('••••5678');
+  });
+
+  it('preserves separators while masking the digits between the windows', () => {
+    expect(maskAccountNumber('4111 1111 1111 1234', true)).toBe('4111 •••• •••• 1234');
+    expect(maskAccountNumber('1234-5678-9012', false)).toBe('••••-••••-9012');
+  });
+
+  it('masks every digit when the number is too short to reveal a window', () => {
+    // Non-credit-card: revealing the last four would expose all four.
+    expect(maskAccountNumber('1234', false)).toBe('••••');
+    // Credit-card: revealing first and last four would expose all eight.
+    expect(maskAccountNumber('12345678', true)).toBe('••••••••');
+  });
+
+  it('ignores surrounding whitespace', () => {
+    expect(maskAccountNumber('  987654321  ', false)).toBe('•••••4321');
+  });
+
+  it('returns an empty string for an empty value', () => {
+    expect(maskAccountNumber('', false)).toBe('');
   });
 });

--- a/frontend/src/lib/account-utils.ts
+++ b/frontend/src/lib/account-utils.ts
@@ -66,6 +66,40 @@ export const formatAccountType = (type: AccountType, t?: (key: string) => string
   return labels[type] || type;
 };
 
+/** Character used to mask the hidden portion of an account number. */
+const ACCOUNT_MASK_CHAR = '•'; // bullet (•)
+
+/**
+ * Mask an account number for display so only an identifying window stays
+ * visible. Credit cards keep their first four and last four digits (the
+ * standard PAN-truncation pattern, e.g. "4111 •••• •••• 1234"); every other
+ * account type keeps only the last four. Separators such as spaces and dashes
+ * are preserved for readability and are not counted toward the revealed
+ * window. When the number is too short to reveal that window without exposing
+ * all of it, every digit is masked.
+ */
+export function maskAccountNumber(value: string, isCreditCard: boolean): string {
+  const chars = [...value.trim()];
+  const isSignificant = (c: string) => /[a-z0-9]/i.test(c);
+  const length = chars.filter(isSignificant).length;
+
+  const lead = isCreditCard ? 4 : 0;
+  const tail = 4;
+  // Only reveal the lead/tail windows when at least one significant character
+  // stays masked; otherwise the whole number would be exposed.
+  const revealWindows = length > lead + tail;
+
+  return chars
+    .map((char, index) => {
+      if (!isSignificant(char)) return char;
+      // Position of this character among the significant (alphanumeric) ones.
+      const order = chars.slice(0, index).filter(isSignificant).length;
+      const visible = revealWindows && (order < lead || order >= length - tail);
+      return visible ? char : ACCOUNT_MASK_CHAR;
+    })
+    .join('');
+}
+
 /** Check if an account is an investment brokerage sub-type. */
 export const isInvestmentBrokerageAccount = (account: Account): boolean => {
   return account.accountSubType === 'INVESTMENT_BROKERAGE';


### PR DESCRIPTION
## Summary
This PR adds two user-facing features: (1) dismissible high/low value bubbles on balance and forecast charts that let users temporarily hide extremes to see the chart behind them, and (2) account number masking in the account info widget with a toggle to reveal/hide. It also introduces a new `AppVersion` footer component that links to GitHub release notes.

## Key Changes

### Chart High/Low Value Bubbles
- **New utility functions** in `portfolio-chart-utils.tsx`:
  - `computeMinMaxFlagIndices()` — locates the highest and lowest points in a series (ties resolve to first occurrence)
  - `renderMinMaxFlagDots()` — Recharts dot renderer that pins green (high) and red (low) bubbles to extremes, positioned to the inside of whichever chart half they fall on to avoid plot edges
  - Extended `renderChartFlagDot()` with `onDismiss` and `dismissLabel` props to render a clickable "×" control on the bubble's right edge
- **Applied to three charts**:
  - `BalanceHistoryChart` — marks highest/lowest account balances
  - `CashFlowForecastChart` — marks highest/lowest forecast balances
  - `InvestmentValueChart` — marks highest/lowest portfolio values
  - `PortfolioValueReport` — marks highest/lowest portfolio values
- **Dismissal state** is component-local (not persisted), keyed by the value so a data change with a new extreme shows its bubble again; resets on navigation
- **Accessibility**: bubbles are keyboard-accessible via `role="button"` and `aria-label`; dismiss control includes a `<title>` element for SVG tooltips

### Account Number Masking
- **New utility** `maskAccountNumber()` in `account-utils.ts`:
  - Credit cards: reveals first 4 and last 4 digits (e.g., `4111••••••••1234`)
  - Other accounts: reveals only last 4 digits (e.g., `••••5678`)
  - Preserves separators (spaces, dashes) for readability
  - Masks entirely if the number is too short to reveal the window without exposing all digits
- **UI in `AccountInfoWidget`**:
  - Account number is masked by default
  - Eye icon toggle to reveal/hide (only for credit cards and accounts with numbers)
  - State resets when switching accounts so one account's number never leaks onto another
  - Uses "info from previous render" pattern to avoid effect-based resets

### App Version Footer
- **New component** `AppVersion` in `ui/AppVersion.tsx`:
  - Displays version from `NEXT_PUBLIC_APP_VERSION` env var
  - Links to GitHub release notes (e.g., `v1.11.0` → `github.com/kenlasko/monize/releases/tag/v1.11.0`)
  - Renders nothing if version is unavailable
  - Integrated into login page and settings footer

### Internationalization
- Added `chartFlag.dismiss` and `appVersion.releaseNotes` keys to all 10 supported locales (en, de, es, fr, it, nl, pl, pt, pt-BR, xx)
- Added `accountWidget.showAccountNumber` and `accountWidget.hideAccountNumber` keys to all locales
- Pseudo-locale (`xx`) regenerated

### Testing
- Comprehensive test coverage for all new utilities and components:
  - `computeMinMaxFlagIndices()` — empty series, flat series, ties, negative values
  - `renderMinMaxFlagDots()` — extremes, non-extremes, dismissed states, dismiss control wiring
  - `maskAccountNumber()` — credit cards, other accounts, separators, short numbers
  - `AppVersion` — version linking, missing version, class application
  - Chart integration tests verify bubbles render and dismiss controls work end-to-end
- Updated existing chart tests to exercise the new dot render-prop via mocked Recharts components

## Notable Implementation Details
- Bubble positioning uses the same "left/right half" scheme as the Portfolio Value chart to

https://claude.ai/code/session_01TenqSuPrWcrpWPD1mXjeYt