### PR TITLE
Fix chart text rendering in PDF exports by pinning sans-serif font

### DIFF
--- a/frontend/src/lib/pdf-export-charts.test.ts
+++ b/frontend/src/lib/pdf-export-charts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { captureSvgAsImage, captureAllChartsAsImages } from './pdf-export-charts';
+import { captureSvgAsImage, captureAllChartsAsImages, CHART_FONT_FAMILY } from './pdf-export-charts';
 
 /**
  * Creates a realistic Recharts DOM structure: .recharts-wrapper > svg.recharts-surface
@@ -149,6 +149,45 @@ describe('captureSingleSvg via captureSvgAsImage (with mocked Image)', () => {
     expect(result?.width).toBe(800);
     expect(result?.height).toBe(400);
     expect(result?.dataUrl).toBe('data:image/png;base64,test');
+  });
+
+  it('pins a sans-serif font-family on the captured SVG so chart text matches the report', async () => {
+    // Capture the element handed to the serializer to inspect the clone that
+    // gets rasterized, without depending on the base64 data-URI encoding.
+    const originalSerialize = XMLSerializer.prototype.serializeToString;
+    let serialized: Element | null = null;
+    const spy = vi
+      .spyOn(XMLSerializer.prototype, 'serializeToString')
+      .mockImplementation(function (this: XMLSerializer, node: Node) {
+        serialized = node as Element;
+        return originalSerialize.call(this, node);
+      });
+
+    try {
+      const container = document.createElement('div');
+      const wrapper = document.createElement('div');
+      wrapper.classList.add('recharts-wrapper');
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.classList.add('recharts-surface');
+      svg.setAttribute('width', '800');
+      svg.setAttribute('height', '400');
+      const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      text.textContent = 'Axis label';
+      svg.appendChild(text);
+      wrapper.appendChild(svg);
+      container.appendChild(wrapper);
+
+      const result = await captureSvgAsImage(container);
+
+      expect(result).not.toBeNull();
+      expect(serialized).not.toBeNull();
+      expect(serialized!.getAttribute('font-family')).toBe(CHART_FONT_FAMILY);
+      // The stack must resolve to sans-serif and never the serif default.
+      expect(CHART_FONT_FAMILY.toLowerCase()).toContain('sans-serif');
+      expect(CHART_FONT_FAMILY.toLowerCase()).not.toContain('times');
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('captureAllChartsAsImages returns multiple captured charts', async () => {

--- a/frontend/src/lib/pdf-export-charts.ts
+++ b/frontend/src/lib/pdf-export-charts.ts
@@ -10,6 +10,18 @@ export interface CapturedChart {
 }
 
 /**
+ * Font applied to chart text in the rasterized output.
+ *
+ * On screen, Recharts text (axis ticks, labels, in-chart legends) inherits
+ * `font-family: Inter` from the page stylesheet. The clone we serialize here is
+ * detached from the document, so it has no stylesheet context and the browser's
+ * SVG renderer falls back to its default serif face (Times New Roman). Setting an
+ * explicit sans-serif family on the root SVG (inherited by all text/tspan) keeps
+ * chart text consistent with the Helvetica used by the rest of the PDF report.
+ */
+export const CHART_FONT_FAMILY = 'Helvetica, Arial, sans-serif';
+
+/**
  * Resolves chart dimensions from multiple sources for reliability.
  * Recharts sets width/height attributes on the SVG element, which are the most
  * reliable source. Falls back to getBoundingClientRect and container dimensions.
@@ -110,6 +122,11 @@ function captureSingleSvg(
   svgClone.setAttribute('viewBox', `0 0 ${width} ${height}`);
   svgClone.setAttribute('width', String(scaledWidth));
   svgClone.setAttribute('height', String(scaledHeight));
+
+  // Pin the font so text renders in sans-serif instead of the renderer's default
+  // serif face once the SVG is detached from the page stylesheet. Inherited by
+  // every text/tspan descendant.
+  svgClone.setAttribute('font-family', CHART_FONT_FAMILY);
 
   // Add white background rect as the first child
   const bgRect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');


### PR DESCRIPTION
## Summary
Charts in PDF exports were rendering with serif fonts (Times New Roman) instead of the sans-serif fonts used in the web UI, causing visual inconsistency in reports. This fix explicitly sets a sans-serif font family on the SVG root element before rasterization, ensuring chart text matches the rest of the PDF.

## Changes
- **Export constant `CHART_FONT_FAMILY`** (`'Helvetica, Arial, sans-serif'`) from `pdf-export-charts.ts` with detailed documentation explaining why the font must be pinned (detached SVG clones lose stylesheet context)
- **Apply font-family attribute** to the cloned SVG in `captureSingleSvg()` before serialization, inherited by all text/tspan descendants
- **Add comprehensive test** verifying the font-family attribute is correctly set on the captured SVG element, with assertions that the stack resolves to sans-serif (not serif defaults)

## Implementation Details
When SVG elements are cloned and detached from the document for rasterization, they lose access to the page stylesheet where `font-family: Inter` is defined. The browser's SVG renderer then falls back to its default serif face. By explicitly setting `font-family` on the root SVG element, all text inherits the sans-serif stack and renders consistently with the Helvetica used elsewhere in the PDF report.

https://claude.ai/code/session_017Qof1WyJrQHkmNyuco1Br9