### PR TITLE
Add payee category filters and edit-time category backfill

### DIFF
--- a/backend/src/payees/dto/update-payee.dto.ts
+++ b/backend/src/payees/dto/update-payee.dto.ts
@@ -1,7 +1,9 @@
 import { PartialType } from "@nestjs/swagger";
-import { IsBoolean, IsOptional } from "class-validator";
+import { IsBoolean, IsIn, IsOptional } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
 import { CreatePayeeDto } from "./create-payee.dto";
+
+export type ApplyCategoryToTransactions = "none" | "uncategorized" | "all";
 
 export class UpdatePayeeDto extends PartialType(CreatePayeeDto) {
   @ApiProperty({
@@ -12,4 +14,15 @@ export class UpdatePayeeDto extends PartialType(CreatePayeeDto) {
   @IsOptional()
   @IsBoolean()
   isActive?: boolean;
+
+  @ApiProperty({
+    example: "uncategorized",
+    required: false,
+    enum: ["none", "uncategorized", "all"],
+    description:
+      "When a default category is set, optionally apply it to the payee's existing transactions: 'uncategorized' only fills transactions with no category, 'all' overwrites every transaction (transfers and split parents are never touched). Defaults to 'none'.",
+  })
+  @IsOptional()
+  @IsIn(["none", "uncategorized", "all"])
+  applyCategoryToTransactions?: ApplyCategoryToTransactions;
 }

--- a/backend/src/payees/payee-backfill.util.spec.ts
+++ b/backend/src/payees/payee-backfill.util.spec.ts
@@ -1,5 +1,6 @@
 import { IsNull } from "typeorm";
 import {
+  applyPayeeCategoryToAll,
   backfillPayeeCategory,
   countUncategorizedTransactionsByPayee,
 } from "./payee-backfill.util";
@@ -9,9 +10,10 @@ const userId = "user-1";
 
 describe("payee-backfill.util", () => {
   describe("countUncategorizedTransactionsByPayee", () => {
-    function makeManager(
-      rows: Array<{ payeeId: string; cnt: string }>,
-    ): { manager: any; qb: Record<string, jest.Mock> } {
+    function makeManager(rows: Array<{ payeeId: string; cnt: string }>): {
+      manager: any;
+      qb: Record<string, jest.Mock>;
+    } {
       const qb: Record<string, jest.Mock> = {
         select: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
@@ -100,6 +102,48 @@ describe("payee-backfill.util", () => {
       const manager = { update: jest.fn().mockResolvedValue({}) };
 
       const affected = await backfillPayeeCategory(
+        manager as any,
+        userId,
+        "p1",
+        "cat-1",
+      );
+
+      expect(affected).toBe(0);
+    });
+  });
+
+  describe("applyPayeeCategoryToAll", () => {
+    it("updates all of the payee's non-transfer, non-split rows regardless of existing category", async () => {
+      const manager = {
+        update: jest.fn().mockResolvedValue({ affected: 8 }),
+      };
+
+      const affected = await applyPayeeCategoryToAll(
+        manager as any,
+        userId,
+        "p1",
+        "cat-1",
+      );
+
+      expect(affected).toBe(8);
+      // No categoryId condition: rows that already have a category are
+      // overwritten, unlike the uncategorized-only backfill.
+      expect(manager.update).toHaveBeenCalledWith(
+        Transaction,
+        {
+          userId,
+          payeeId: "p1",
+          isTransfer: false,
+          isSplit: false,
+        },
+        { categoryId: "cat-1" },
+      );
+    });
+
+    it("returns 0 when the driver reports no affected count", async () => {
+      const manager = { update: jest.fn().mockResolvedValue({}) };
+
+      const affected = await applyPayeeCategoryToAll(
         manager as any,
         userId,
         "p1",

--- a/backend/src/payees/payee-backfill.util.ts
+++ b/backend/src/payees/payee-backfill.util.ts
@@ -64,3 +64,38 @@ export async function backfillPayeeCategory(
   );
   return result.affected ?? 0;
 }
+
+/**
+ * "Recategorizable" transactions are every one of a payee's transactions except
+ * transfers (whose categorisation is implicit) and split parents (whose
+ * categories live on the split lines). Unlike `backfillableWhere`, this includes
+ * rows that already have a category, so applying a category overwrites them.
+ */
+function recategorizableWhere(userId: string, payeeId: string) {
+  return {
+    userId,
+    payeeId,
+    isTransfer: false,
+    isSplit: false,
+  };
+}
+
+/**
+ * Assign `categoryId` to ALL of a single payee's recategorizable transactions
+ * (see `recategorizableWhere`), overwriting any existing category. Returns the
+ * number of transactions updated. Pass the EntityManager from an active
+ * QueryRunner so the update joins the caller's transaction.
+ */
+export async function applyPayeeCategoryToAll(
+  manager: EntityManager,
+  userId: string,
+  payeeId: string,
+  categoryId: string,
+): Promise<number> {
+  const result = await manager.update(
+    Transaction,
+    recategorizableWhere(userId, payeeId),
+    { categoryId },
+  );
+  return result.affected ?? 0;
+}

--- a/backend/src/payees/payees.service.spec.ts
+++ b/backend/src/payees/payees.service.spec.ts
@@ -5,7 +5,7 @@ import {
   NotFoundException,
   BadRequestException,
 } from "@nestjs/common";
-import { DataSource } from "typeorm";
+import { DataSource, IsNull } from "typeorm";
 import { PayeesService } from "./payees.service";
 import { Payee } from "./entities/payee.entity";
 import { PayeeAlias } from "./entities/payee-alias.entity";
@@ -534,6 +534,105 @@ describe("PayeesService", () => {
 
       // findOne called twice: once for ownership check, once for re-fetch; no conflict check
       expect(payeesRepository.findOne).toHaveBeenCalledTimes(2);
+    });
+
+    it("applies the new default category to uncategorized transactions when requested", async () => {
+      const existingPayee = {
+        ...mockPayee,
+        defaultCategoryId: null,
+        defaultCategory: null,
+      };
+      const refreshedPayee = { ...mockPayee, defaultCategoryId: "cat-99" };
+      payeesRepository.findOne
+        .mockResolvedValueOnce(existingPayee)
+        .mockResolvedValueOnce(refreshedPayee);
+      mockQueryRunner.manager.update.mockResolvedValue({ affected: 4 });
+
+      const result = await service.update(userId, "payee-1", {
+        defaultCategoryId: "cat-99",
+        applyCategoryToTransactions: "uncategorized",
+      });
+
+      expect(result.transactionsCategorized).toBe(4);
+      // Uncategorized-only backfill: rows with no category, excluding
+      // transfers and split parents.
+      expect(mockQueryRunner.manager.update).toHaveBeenCalledWith(
+        Transaction,
+        {
+          userId,
+          payeeId: "payee-1",
+          categoryId: IsNull(),
+          isTransfer: false,
+          isSplit: false,
+        },
+        { categoryId: "cat-99" },
+      );
+    });
+
+    it("applies the new default category to all transactions when requested", async () => {
+      const existingPayee = {
+        ...mockPayee,
+        defaultCategoryId: null,
+        defaultCategory: null,
+      };
+      const refreshedPayee = { ...mockPayee, defaultCategoryId: "cat-99" };
+      payeesRepository.findOne
+        .mockResolvedValueOnce(existingPayee)
+        .mockResolvedValueOnce(refreshedPayee);
+      mockQueryRunner.manager.update.mockResolvedValue({ affected: 9 });
+
+      const result = await service.update(userId, "payee-1", {
+        defaultCategoryId: "cat-99",
+        applyCategoryToTransactions: "all",
+      });
+
+      expect(result.transactionsCategorized).toBe(9);
+      // "all" overwrites every non-transfer, non-split row (no categoryId filter).
+      expect(mockQueryRunner.manager.update).toHaveBeenCalledWith(
+        Transaction,
+        {
+          userId,
+          payeeId: "payee-1",
+          isTransfer: false,
+          isSplit: false,
+        },
+        { categoryId: "cat-99" },
+      );
+    });
+
+    it("does not touch transactions when no apply mode is given", async () => {
+      const existingPayee = {
+        ...mockPayee,
+        defaultCategoryId: null,
+        defaultCategory: null,
+      };
+      const refreshedPayee = { ...mockPayee, defaultCategoryId: "cat-99" };
+      payeesRepository.findOne
+        .mockResolvedValueOnce(existingPayee)
+        .mockResolvedValueOnce(refreshedPayee);
+
+      const result = await service.update(userId, "payee-1", {
+        defaultCategoryId: "cat-99",
+      });
+
+      expect(result.transactionsCategorized).toBe(0);
+      expect(mockQueryRunner.manager.update).not.toHaveBeenCalled();
+    });
+
+    it("does not apply a category when the payee ends up without one", async () => {
+      const existingPayee = { ...mockPayee };
+      const refreshedPayee = { ...mockPayee, defaultCategoryId: null };
+      payeesRepository.findOne
+        .mockResolvedValueOnce(existingPayee)
+        .mockResolvedValueOnce(refreshedPayee);
+
+      const result = await service.update(userId, "payee-1", {
+        defaultCategoryId: null,
+        applyCategoryToTransactions: "all",
+      });
+
+      expect(result.transactionsCategorized).toBe(0);
+      expect(mockQueryRunner.manager.update).not.toHaveBeenCalled();
     });
 
     it("should update defaultCategoryId via explicit mapping", async () => {
@@ -1166,7 +1265,11 @@ describe("PayeesService", () => {
       mockQueryRunner.manager.update.mockResolvedValue({ affected: 3 });
 
       const result = await service.applyCategorySuggestions(userId, [
-        { payeeId: "payee-2", categoryId: "cat-new", backfillTransactions: true },
+        {
+          payeeId: "payee-2",
+          categoryId: "cat-new",
+          backfillTransactions: true,
+        },
       ]);
 
       expect(result).toEqual({ updated: 1, transactionsBackfilled: 3 });

--- a/backend/src/payees/payees.service.ts
+++ b/backend/src/payees/payees.service.ts
@@ -21,6 +21,7 @@ import { ActionHistoryService } from "../action-history/action-history.service";
 import { toCountMap } from "../common/count-map.util";
 import { matchesAliasPattern } from "./alias-match.util";
 import {
+  applyPayeeCategoryToAll,
   backfillPayeeCategory,
   countUncategorizedTransactionsByPayee,
 } from "./payee-backfill.util";
@@ -274,7 +275,13 @@ export class PayeesService {
     userId: string,
     id: string,
     updatePayeeDto: UpdatePayeeDto,
-  ): Promise<Payee & { aliasCount: number; transactionCount: number }> {
+  ): Promise<
+    Payee & {
+      aliasCount: number;
+      transactionCount: number;
+      transactionsCategorized: number;
+    }
+  > {
     const payee = await this.findOne(userId, id);
     const beforeData = {
       name: payee.name,
@@ -319,9 +326,16 @@ export class PayeesService {
     if (updatePayeeDto.isActive !== undefined)
       payee.isActive = updatePayeeDto.isActive;
 
+    // Optionally apply the (new) default category to the payee's existing
+    // transactions. Only meaningful when the payee ends up with a category.
+    const applyMode = updatePayeeDto.applyCategoryToTransactions ?? "none";
+
     // Save the payee and cascade the name change to existing transactions and
     // scheduled transactions atomically, so a partial failure cannot leave the
-    // denormalised payeeName snapshots out of sync with the payee record.
+    // denormalised payeeName snapshots out of sync with the payee record. The
+    // optional category backfill runs in the same transaction so the payee
+    // default and its transactions can never drift apart on a partial failure.
+    let transactionsCategorized = 0;
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
     await queryRunner.startTransaction();
@@ -339,6 +353,23 @@ export class PayeesService {
           { payeeId: id, userId },
           { payeeName: updatePayeeDto.name },
         );
+      }
+
+      if (applyMode !== "none" && payee.defaultCategoryId) {
+        transactionsCategorized =
+          applyMode === "all"
+            ? await applyPayeeCategoryToAll(
+                queryRunner.manager,
+                userId,
+                id,
+                payee.defaultCategoryId,
+              )
+            : await backfillPayeeCategory(
+                queryRunner.manager,
+                userId,
+                id,
+                payee.defaultCategoryId,
+              );
       }
 
       await queryRunner.commitTransaction();
@@ -372,7 +403,12 @@ export class PayeesService {
       descriptionKey: "updatedPayee",
       descriptionParams: { name: refreshed.name },
     });
-    return { ...refreshed, aliasCount, transactionCount };
+    return {
+      ...refreshed,
+      aliasCount,
+      transactionCount,
+      transactionsCategorized,
+    };
   }
 
   async remove(userId: string, id: string): Promise<void> {

--- a/frontend/src/app/payees/page.test.tsx
+++ b/frontend/src/app/payees/page.test.tsx
@@ -164,6 +164,7 @@ vi.mock('@/components/payees/PayeeForm', () => ({
       {payee && <span data-testid="editing-payee">{payee.name}</span>}
       <button data-testid="submit-form" onClick={() => Promise.resolve(onSubmit({ name: 'New Payee', defaultCategoryId: '', notes: '' })).catch(() => {})}>Submit</button>
       <button data-testid="submit-with-aliases" onClick={() => Promise.resolve(onSubmit({ name: 'WithAliases', defaultCategoryId: 'cat-1', notes: 'note', pendingAliases: ['Alias1', 'Alias2'] })).catch(() => {})}>SubmitWithAliases</button>
+      <button data-testid="submit-apply-category" onClick={() => Promise.resolve(onSubmit({ name: 'Updated', defaultCategoryId: 'cat-1', notes: '', applyCategoryToTransactions: 'all' })).catch(() => {})}>SubmitApplyCategory</button>
     </div>
   ),
 }));
@@ -595,6 +596,61 @@ describe('PayeesPage', () => {
       await waitFor(() => {
         expect(screen.queryByTestId('payee-p-1')).not.toBeInTheDocument();
         expect(screen.getByTestId('payee-p-5')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Category Filter', () => {
+    it('renders category filter buttons with counts', async () => {
+      render(<PayeesPage />);
+      await waitFor(() => {
+        expect(screen.getByText(/All Payees \(4\)/)).toBeInTheDocument();
+        expect(screen.getByText(/No Default Category \(2\)/)).toBeInTheDocument();
+        expect(screen.getByText(/Uncategorized Txns \(0\)/)).toBeInTheDocument();
+      });
+    });
+
+    it('filters to payees without a default category', async () => {
+      render(<PayeesPage />);
+      await waitFor(() => expect(screen.getByTestId('payee-list')).toBeInTheDocument());
+      await act(async () => { fireEvent.click(screen.getByText(/No Default Category \(2\)/)); });
+      await waitFor(() => {
+        expect(screen.queryByTestId('payee-p-1')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('payee-p-2')).not.toBeInTheDocument();
+        expect(screen.getByTestId('payee-p-3')).toBeInTheDocument();
+        expect(screen.getByTestId('payee-p-4')).toBeInTheDocument();
+      });
+    });
+
+    it('filters to payees that have uncategorized transactions', async () => {
+      const withUncat = [
+        { id: 'p-1', name: 'Grocery Store', defaultCategoryId: 'cat-1', defaultCategory: { name: 'Food' }, transactionCount: 50, uncategorizedCount: 5, isActive: true },
+        { id: 'p-2', name: 'Gas Station', defaultCategoryId: 'cat-2', defaultCategory: { name: 'Auto' }, transactionCount: 20, uncategorizedCount: 0, isActive: true },
+      ];
+      mockGetAllPayees.mockResolvedValue(withUncat);
+      render(<PayeesPage />);
+      await waitFor(() => expect(screen.getByTestId('payee-list')).toBeInTheDocument());
+      await act(async () => { fireEvent.click(screen.getByText(/Uncategorized Txns \(1\)/)); });
+      await waitFor(() => {
+        expect(screen.getByTestId('payee-p-1')).toBeInTheDocument();
+        expect(screen.queryByTestId('payee-p-2')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Apply category to transactions', () => {
+    it('passes the apply mode through, toasts, and reloads when transactions are categorized', async () => {
+      mockUpdatePayee.mockResolvedValue({ id: 'p-1', name: 'Updated', defaultCategoryId: 'cat-1', transactionsCategorized: 7 });
+      render(<PayeesPage />);
+      await waitFor(() => expect(screen.getByTestId('payee-list')).toBeInTheDocument());
+      await act(async () => { fireEvent.click(screen.getByTestId('edit-p-1')); });
+      await waitFor(() => expect(screen.getByTestId('submit-apply-category')).toBeInTheDocument());
+      mockGetAllPayees.mockClear();
+      await act(async () => { fireEvent.click(screen.getByTestId('submit-apply-category')); });
+      await waitFor(() => {
+        expect(mockUpdatePayee).toHaveBeenCalledWith('p-1', { name: 'Updated', defaultCategoryId: 'cat-1', notes: undefined, applyCategoryToTransactions: 'all' });
+        expect(toast.success).toHaveBeenCalledWith('Categorized 7 transactions');
+        expect(mockGetAllPayees).toHaveBeenCalled();
       });
     });
   });

--- a/frontend/src/app/payees/page.tsx
+++ b/frontend/src/app/payees/page.tsx
@@ -17,7 +17,7 @@ import { payeesApi } from '@/lib/payees';
 import { categoriesApi } from '@/lib/categories';
 import { buildCategoryColorMap, buildCategoryLabelMap } from '@/lib/categoryUtils';
 import { MergePayeeDialog } from '@/components/payees/MergePayeeDialog';
-import { Payee, PayeeStatusFilter } from '@/types/payee';
+import { Payee, PayeeStatusFilter, PayeeCategoryFilter } from '@/types/payee';
 import { Category } from '@/types/category';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { PageLayout } from '@/components/layout/PageLayout';
@@ -50,6 +50,7 @@ function PayeesContent() {
   const [showAutoMerge, setShowAutoMerge] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<PayeeStatusFilter>('active');
+  const [categoryFilter, setCategoryFilter] = useState<PayeeCategoryFilter>('all');
   const [currentPage, setCurrentPage] = useState(1);
   const [listDensity, setListDensity] = useLocalStorage<DensityLevel>('monize-payees-density', 'normal');
   const [sortField, setSortField] = useLocalStorage<SortField>('monize-payees-sort-field', 'name');
@@ -94,8 +95,18 @@ function PayeesContent() {
       if (editingItem) {
         const updated = await payeesApi.update(editingItem.id, cleanedData);
         toast.success(t('page.toasts.updated'));
+        const categorized = updated.transactionsCategorized ?? 0;
+        if (categorized > 0) {
+          toast.success(t('page.toasts.categorized', { count: categorized }));
+        }
         close();
-        setPayees(prev => prev.map(p => p.id === updated.id ? { ...p, ...updated } : p));
+        if (categorized > 0) {
+          // The backfill changed transaction categories, so derived per-payee
+          // counts (uncategorized, etc.) are stale -- reload rather than merge.
+          loadData();
+        } else {
+          setPayees(prev => prev.map(p => p.id === updated.id ? { ...p, ...updated } : p));
+        }
       } else {
         const created = await payeesApi.create(cleanedData);
 
@@ -138,12 +149,24 @@ function PayeesContent() {
     return payees.filter(p => statusFilter === 'active' ? p.isActive : !p.isActive);
   }, [payees, statusFilter]);
 
+  // Apply category filter: payees missing a default category, or payees that
+  // still have transactions with no category at all.
+  const categoryFilteredPayees = useMemo(() => {
+    if (categoryFilter === 'noDefaultCategory') {
+      return statusFilteredPayees.filter(p => !p.defaultCategoryId);
+    }
+    if (categoryFilter === 'uncategorizedTransactions') {
+      return statusFilteredPayees.filter(p => (p.uncategorizedCount ?? 0) > 0);
+    }
+    return statusFilteredPayees;
+  }, [statusFilteredPayees, categoryFilter]);
+
   const filteredPayees = useMemo(() => {
-    if (!searchQuery) return statusFilteredPayees;
-    return statusFilteredPayees.filter((p) =>
+    if (!searchQuery) return categoryFilteredPayees;
+    return categoryFilteredPayees.filter((p) =>
       p.name.toLowerCase().includes(searchQuery.toLowerCase())
     );
-  }, [statusFilteredPayees, searchQuery]);
+  }, [categoryFilteredPayees, searchQuery]);
 
   const sortedPayees = useMemo(() => {
     return [...filteredPayees].sort((a, b) => {
@@ -185,7 +208,7 @@ function PayeesContent() {
 
   useEffect(() => {
     setCurrentPage(1);
-  }, [searchQuery, statusFilter]);
+  }, [searchQuery, statusFilter, categoryFilter]);
 
   const goToPage = (page: number) => {
     if (page >= 1 && page <= totalPages) {
@@ -198,6 +221,7 @@ function PayeesContent() {
   const inactiveCount = payees.filter(p => !p.isActive).length;
   const payeesWithCategory = payees.filter((p) => p.defaultCategoryId).length;
   const payeesWithoutCategory = payees.length - payeesWithCategory;
+  const payeesWithUncategorizedTx = payees.filter((p) => (p.uncategorizedCount ?? 0) > 0).length;
 
   return (
     <PageLayout>
@@ -277,6 +301,29 @@ function PayeesContent() {
                 {status === 'active' ? t('page.statusActive', { count: activeCount }) :
                  status === 'inactive' ? t('page.statusInactive', { count: inactiveCount }) :
                  t('page.statusAll', { count: payees.length })}
+              </button>
+            ))}
+          </div>
+          <div className="flex rounded-md shadow-sm">
+            {(['all', 'noDefaultCategory', 'uncategorizedTransactions'] as PayeeCategoryFilter[]).map((filter) => (
+              <button
+                key={filter}
+                onClick={() => setCategoryFilter(filter)}
+                className={`px-4 py-2 text-sm font-medium border ${
+                  categoryFilter === filter
+                    ? 'bg-blue-600 text-white border-blue-600 dark:bg-blue-500 dark:border-blue-500'
+                    : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
+                } ${
+                  filter === 'all' ? 'rounded-l-md' : ''
+                } ${
+                  filter === 'uncategorizedTransactions' ? 'rounded-r-md' : ''
+                } ${
+                  filter !== 'all' ? '-ml-px' : ''
+                }`}
+              >
+                {filter === 'noDefaultCategory' ? t('page.categoryFilterNoCategory', { count: payeesWithoutCategory }) :
+                 filter === 'uncategorizedTransactions' ? t('page.categoryFilterUncategorized', { count: payeesWithUncategorizedTx }) :
+                 t('page.categoryFilterAll', { count: payees.length })}
               </button>
             ))}
           </div>

--- a/frontend/src/components/payees/PayeeForm.test.tsx
+++ b/frontend/src/components/payees/PayeeForm.test.tsx
@@ -112,4 +112,38 @@ describe('PayeeForm', () => {
     });
     expect(screen.getByText('Update Payee')).toBeInTheDocument();
   });
+
+  describe('apply category to existing transactions', () => {
+    it('offers the apply options when editing a payee with a category and transactions', async () => {
+      const payee = { id: 'p1', name: 'Walmart', defaultCategoryId: 'c1', notes: '', transactionCount: 10, uncategorizedCount: 3 } as any;
+      await act(async () => {
+        render(<PayeeForm payee={payee} categories={categories} onSubmit={onSubmit} onCancel={onCancel} />);
+      });
+      expect(screen.getByText('Apply this category to existing transactions')).toBeInTheDocument();
+      expect(screen.getByText("Don't change existing transactions")).toBeInTheDocument();
+      expect(screen.getByText('Only transactions without a category (3)')).toBeInTheDocument();
+      expect(screen.getByText('All transactions (10)')).toBeInTheDocument();
+    });
+
+    it('does not offer apply options when creating a payee', () => {
+      render(<PayeeForm categories={categories} onSubmit={onSubmit} onCancel={onCancel} />);
+      expect(screen.queryByText('Apply this category to existing transactions')).not.toBeInTheDocument();
+    });
+
+    it('does not offer apply options when the editing payee has no transactions', async () => {
+      const payee = { id: 'p1', name: 'Walmart', defaultCategoryId: 'c1', notes: '', transactionCount: 0, uncategorizedCount: 0 } as any;
+      await act(async () => {
+        render(<PayeeForm payee={payee} categories={categories} onSubmit={onSubmit} onCancel={onCancel} />);
+      });
+      expect(screen.queryByText('Apply this category to existing transactions')).not.toBeInTheDocument();
+    });
+
+    it('does not offer apply options when the editing payee has no default category', async () => {
+      const payee = { id: 'p1', name: 'Walmart', defaultCategoryId: null, notes: '', transactionCount: 10, uncategorizedCount: 3 } as any;
+      await act(async () => {
+        render(<PayeeForm payee={payee} categories={categories} onSubmit={onSubmit} onCancel={onCancel} />);
+      });
+      expect(screen.queryByText('Apply this category to existing transactions')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/payees/PayeeForm.tsx
+++ b/frontend/src/components/payees/PayeeForm.tsx
@@ -8,7 +8,8 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Input } from '@/components/ui/Input';
 import { Combobox } from '@/components/ui/Combobox';
-import { Payee } from '@/types/payee';
+import { Select } from '@/components/ui/Select';
+import { Payee, ApplyCategoryToTransactions } from '@/types/payee';
 import { Category } from '@/types/category';
 import { buildCategoryTree } from '@/lib/categoryUtils';
 import { useFormSubmitRef } from '@/hooks/useFormSubmitRef';
@@ -26,6 +27,7 @@ type PayeeFormData = z.infer<ReturnType<typeof buildPayeeSchema>>;
 
 export type PayeeFormSubmitData = PayeeFormData & {
   pendingAliases?: string[];
+  applyCategoryToTransactions?: ApplyCategoryToTransactions;
 };
 
 interface PayeeFormProps {
@@ -40,6 +42,7 @@ interface PayeeFormProps {
 export function PayeeForm({ payee, categories, onSubmit, onCancel, onDirtyChange, submitRef }: PayeeFormProps) {
   const t = useTranslations('payees');
   const [selectedCategoryId, setSelectedCategoryId] = useState<string>(payee?.defaultCategoryId || '');
+  const [applyMode, setApplyMode] = useState<ApplyCategoryToTransactions>('none');
   const pendingAliasesRef = useRef<string[]>([]);
 
   const {
@@ -67,8 +70,13 @@ export function PayeeForm({ payee, categories, onSubmit, onCancel, onDirtyChange
     if (!payee && pendingAliasesRef.current.length > 0) {
       submitData.pendingAliases = pendingAliasesRef.current;
     }
+    // Only carry the backfill instruction when editing an existing payee that
+    // ends up with a default category and the user opted into applying it.
+    if (payee && data.defaultCategoryId && applyMode !== 'none') {
+      submitData.applyCategoryToTransactions = applyMode;
+    }
     return onSubmit(submitData);
-  }, [payee, onSubmit]);
+  }, [payee, onSubmit, applyMode]);
 
   const onFormSubmit = useCallback((e?: React.BaseSyntheticEvent) => {
     handleSubmit(handleFormSubmit)(e);
@@ -92,7 +100,29 @@ export function PayeeForm({ payee, categories, onSubmit, onCancel, onDirtyChange
   const handleCategoryChange = (categoryId: string) => {
     setSelectedCategoryId(categoryId);
     setValue('defaultCategoryId', categoryId || '', { shouldDirty: true });
+    // Clearing the category makes the backfill choice meaningless; reset it.
+    if (!categoryId) {
+      setApplyMode('none');
+    }
   };
+
+  // Counts for the backfill option labels. Transfers and split parents are
+  // excluded by the backend, so "all" is an upper bound on what changes.
+  const uncategorizedCount = payee?.uncategorizedCount ?? 0;
+  const transactionCount = payee?.transactionCount ?? 0;
+  const showApplyCategory =
+    !!payee && !!selectedCategoryId && transactionCount > 0;
+  const applyOptions = useMemo(
+    () => [
+      { value: 'none', label: t('form.applyCategoryNone') },
+      {
+        value: 'uncategorized',
+        label: t('form.applyCategoryUncategorized', { count: uncategorizedCount }),
+      },
+      { value: 'all', label: t('form.applyCategoryAll', { count: transactionCount }) },
+    ],
+    [t, uncategorizedCount, transactionCount],
+  );
 
   // Find display name for the initial category
   const defaultCategoryId = payee?.defaultCategoryId;
@@ -121,6 +151,20 @@ export function PayeeForm({ payee, categories, onSubmit, onCancel, onDirtyChange
         onChange={handleCategoryChange}
         error={errors.defaultCategoryId?.message}
       />
+
+      {showApplyCategory && (
+        <div>
+          <Select
+            label={t('form.applyCategoryLabel')}
+            options={applyOptions}
+            value={applyMode}
+            onChange={(e) => setApplyMode(e.target.value as ApplyCategoryToTransactions)}
+          />
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            {t('form.applyCategoryHelp')}
+          </p>
+        </div>
+      )}
 
       <Input
         label={t('form.notesLabel')}

--- a/frontend/src/i18n/messages/de/payees.json
+++ b/frontend/src/i18n/messages/de/payees.json
@@ -10,6 +10,9 @@
     "statusAll": "Alle ({count})",
     "statusActive": "Aktiv ({count})",
     "statusInactive": "Inaktiv ({count})",
+    "categoryFilterAll": "Alle Zahlungsempfänger ({count})",
+    "categoryFilterNoCategory": "Ohne Standardkategorie ({count})",
+    "categoryFilterUncategorized": "Unkat. Transaktionen ({count})",
     "modalTitleEdit": "Zahlungsempfänger bearbeiten",
     "modalTitleNew": "Neuer Zahlungsempfänger",
     "loading": "Zahlungsempfänger werden geladen...",
@@ -21,7 +24,8 @@
       "reactivated": "Zahlungsempfänger \"{name}\" reaktiviert",
       "reactivateFailed": "Zahlungsempfänger konnte nicht reaktiviert werden",
       "updateFailed": "Zahlungsempfänger konnte nicht aktualisiert werden",
-      "createFailed": "Zahlungsempfänger konnte nicht erstellt werden"
+      "createFailed": "Zahlungsempfänger konnte nicht erstellt werden",
+      "categorized": "{count, plural, one {# Transaktion kategorisiert} other {# Transaktionen kategorisiert}}"
     },
     "summary": {
       "totalPayees": "Zahlungsempfänger gesamt",
@@ -86,7 +90,12 @@
     "categoryLabel": "Standardkategorie",
     "notesLabel": "Notizen (optional)",
     "submitCreate": "Zahlungsempfänger erstellen",
-    "submitUpdate": "Zahlungsempfänger aktualisieren"
+    "submitUpdate": "Zahlungsempfänger aktualisieren",
+    "applyCategoryLabel": "Diese Kategorie auf vorhandene Transaktionen anwenden",
+    "applyCategoryNone": "Vorhandene Transaktionen nicht ändern",
+    "applyCategoryUncategorized": "Nur Transaktionen ohne Kategorie ({count})",
+    "applyCategoryAll": "Alle Transaktionen ({count})",
+    "applyCategoryHelp": "Überweisungen und aufgeteilte Transaktionen werden nie geändert."
   },
   "merge": {
     "title": "Zahlungsempfänger zusammenführen",

--- a/frontend/src/i18n/messages/en/payees.json
+++ b/frontend/src/i18n/messages/en/payees.json
@@ -10,6 +10,9 @@
     "statusAll": "All ({count})",
     "statusActive": "Active ({count})",
     "statusInactive": "Inactive ({count})",
+    "categoryFilterAll": "All Payees ({count})",
+    "categoryFilterNoCategory": "No Default Category ({count})",
+    "categoryFilterUncategorized": "Uncategorized Txns ({count})",
     "modalTitleEdit": "Edit Payee",
     "modalTitleNew": "New Payee",
     "loading": "Loading payees...",
@@ -21,7 +24,8 @@
       "reactivated": "Payee \"{name}\" reactivated",
       "reactivateFailed": "Failed to reactivate payee",
       "updateFailed": "Failed to update payee",
-      "createFailed": "Failed to create payee"
+      "createFailed": "Failed to create payee",
+      "categorized": "{count, plural, one {Categorized # transaction} other {Categorized # transactions}}"
     },
     "summary": {
       "totalPayees": "Total Payees",
@@ -86,7 +90,12 @@
     "categoryLabel": "Default Category",
     "notesLabel": "Notes (optional)",
     "submitCreate": "Create Payee",
-    "submitUpdate": "Update Payee"
+    "submitUpdate": "Update Payee",
+    "applyCategoryLabel": "Apply this category to existing transactions",
+    "applyCategoryNone": "Don't change existing transactions",
+    "applyCategoryUncategorized": "Only transactions without a category ({count})",
+    "applyCategoryAll": "All transactions ({count})",
+    "applyCategoryHelp": "Transfers and split transactions are never changed."
   },
   "merge": {
     "title": "Merge Payee",

--- a/frontend/src/i18n/messages/es/payees.json
+++ b/frontend/src/i18n/messages/es/payees.json
@@ -10,6 +10,9 @@
     "statusAll": "Todos ({count})",
     "statusActive": "Activos ({count})",
     "statusInactive": "Inactivos ({count})",
+    "categoryFilterAll": "Todos los beneficiarios ({count})",
+    "categoryFilterNoCategory": "Sin categoría predeterminada ({count})",
+    "categoryFilterUncategorized": "Trans. sin categoría ({count})",
     "modalTitleEdit": "Editar beneficiario",
     "modalTitleNew": "Nuevo beneficiario",
     "loading": "Cargando beneficiarios...",
@@ -21,7 +24,8 @@
       "reactivated": "Beneficiario \"{name}\" reactivado",
       "reactivateFailed": "Error al reactivar el beneficiario",
       "updateFailed": "Error al actualizar el beneficiario",
-      "createFailed": "Error al crear el beneficiario"
+      "createFailed": "Error al crear el beneficiario",
+      "categorized": "{count, plural, one {# transacción categorizada} other {# transacciones categorizadas}}"
     },
     "summary": {
       "totalPayees": "Total de beneficiarios",
@@ -86,7 +90,12 @@
     "categoryLabel": "Categoría predeterminada",
     "notesLabel": "Notas (opcional)",
     "submitCreate": "Crear beneficiario",
-    "submitUpdate": "Actualizar beneficiario"
+    "submitUpdate": "Actualizar beneficiario",
+    "applyCategoryLabel": "Aplicar esta categoría a las transacciones existentes",
+    "applyCategoryNone": "No modificar las transacciones existentes",
+    "applyCategoryUncategorized": "Solo transacciones sin categoría ({count})",
+    "applyCategoryAll": "Todas las transacciones ({count})",
+    "applyCategoryHelp": "Las transferencias y las transacciones divididas nunca se modifican."
   },
   "merge": {
     "title": "Fusionar beneficiario",

--- a/frontend/src/i18n/messages/fr/payees.json
+++ b/frontend/src/i18n/messages/fr/payees.json
@@ -10,6 +10,9 @@
     "statusAll": "Tous ({count})",
     "statusActive": "Actifs ({count})",
     "statusInactive": "Inactifs ({count})",
+    "categoryFilterAll": "Tous les bénéficiaires ({count})",
+    "categoryFilterNoCategory": "Sans catégorie par défaut ({count})",
+    "categoryFilterUncategorized": "Trans. sans catégorie ({count})",
     "modalTitleEdit": "Modifier le bénéficiaire",
     "modalTitleNew": "Nouveau bénéficiaire",
     "loading": "Chargement des bénéficiaires...",
@@ -21,7 +24,8 @@
       "reactivated": "Bénéficiaire « {name} » réactivé",
       "reactivateFailed": "Échec de la réactivation du bénéficiaire",
       "updateFailed": "Échec de la mise à jour du bénéficiaire",
-      "createFailed": "Échec de la création du bénéficiaire"
+      "createFailed": "Échec de la création du bénéficiaire",
+      "categorized": "{count, plural, one {# transaction catégorisée} other {# transactions catégorisées}}"
     },
     "summary": {
       "totalPayees": "Total des bénéficiaires",
@@ -86,7 +90,12 @@
     "categoryLabel": "Catégorie par défaut",
     "notesLabel": "Notes (facultatif)",
     "submitCreate": "Créer le bénéficiaire",
-    "submitUpdate": "Mettre à jour le bénéficiaire"
+    "submitUpdate": "Mettre à jour le bénéficiaire",
+    "applyCategoryLabel": "Appliquer cette catégorie aux transactions existantes",
+    "applyCategoryNone": "Ne pas modifier les transactions existantes",
+    "applyCategoryUncategorized": "Uniquement les transactions sans catégorie ({count})",
+    "applyCategoryAll": "Toutes les transactions ({count})",
+    "applyCategoryHelp": "Les virements et les transactions ventilées ne sont jamais modifiés."
   },
   "merge": {
     "title": "Fusionner le bénéficiaire",

--- a/frontend/src/i18n/messages/it/payees.json
+++ b/frontend/src/i18n/messages/it/payees.json
@@ -10,6 +10,9 @@
     "statusAll": "Tutti ({count})",
     "statusActive": "Attivi ({count})",
     "statusInactive": "Inattivi ({count})",
+    "categoryFilterAll": "Tutti i beneficiari ({count})",
+    "categoryFilterNoCategory": "Senza categoria predefinita ({count})",
+    "categoryFilterUncategorized": "Trans. senza categoria ({count})",
     "modalTitleEdit": "Modifica beneficiario",
     "modalTitleNew": "Nuovo beneficiario",
     "loading": "Caricamento beneficiari...",
@@ -21,7 +24,8 @@
       "reactivated": "Beneficiario \"{name}\" riattivato",
       "reactivateFailed": "Riattivazione del beneficiario non riuscita",
       "updateFailed": "Aggiornamento del beneficiario non riuscito",
-      "createFailed": "Creazione del beneficiario non riuscita"
+      "createFailed": "Creazione del beneficiario non riuscita",
+      "categorized": "{count, plural, one {# transazione categorizzata} other {# transazioni categorizzate}}"
     },
     "summary": {
       "totalPayees": "Beneficiari totali",
@@ -86,7 +90,12 @@
     "categoryLabel": "Categoria predefinita",
     "notesLabel": "Note (opzionale)",
     "submitCreate": "Crea beneficiario",
-    "submitUpdate": "Aggiorna beneficiario"
+    "submitUpdate": "Aggiorna beneficiario",
+    "applyCategoryLabel": "Applica questa categoria alle transazioni esistenti",
+    "applyCategoryNone": "Non modificare le transazioni esistenti",
+    "applyCategoryUncategorized": "Solo transazioni senza categoria ({count})",
+    "applyCategoryAll": "Tutte le transazioni ({count})",
+    "applyCategoryHelp": "I trasferimenti e le transazioni suddivise non vengono mai modificati."
   },
   "merge": {
     "title": "Unisci beneficiario",

--- a/frontend/src/i18n/messages/nl/payees.json
+++ b/frontend/src/i18n/messages/nl/payees.json
@@ -10,6 +10,9 @@
     "statusAll": "Alle ({count})",
     "statusActive": "Actief ({count})",
     "statusInactive": "Inactief ({count})",
+    "categoryFilterAll": "Alle begunstigden ({count})",
+    "categoryFilterNoCategory": "Zonder standaardcategorie ({count})",
+    "categoryFilterUncategorized": "Ongecat. transacties ({count})",
     "modalTitleEdit": "Begunstigde bewerken",
     "modalTitleNew": "Nieuwe begunstigde",
     "loading": "Begunstigden laden...",
@@ -21,7 +24,8 @@
       "reactivated": "Begunstigde \"{name}\" geheractiveerd",
       "reactivateFailed": "Begunstigde heractiveren mislukt",
       "updateFailed": "Begunstigde bijwerken mislukt",
-      "createFailed": "Begunstigde aanmaken mislukt"
+      "createFailed": "Begunstigde aanmaken mislukt",
+      "categorized": "{count, plural, one {# transactie gecategoriseerd} other {# transacties gecategoriseerd}}"
     },
     "summary": {
       "totalPayees": "Totaal begunstigden",
@@ -86,7 +90,12 @@
     "categoryLabel": "Standaardcategorie",
     "notesLabel": "Notities (optioneel)",
     "submitCreate": "Begunstigde aanmaken",
-    "submitUpdate": "Begunstigde bijwerken"
+    "submitUpdate": "Begunstigde bijwerken",
+    "applyCategoryLabel": "Deze categorie toepassen op bestaande transacties",
+    "applyCategoryNone": "Bestaande transacties niet wijzigen",
+    "applyCategoryUncategorized": "Alleen transacties zonder categorie ({count})",
+    "applyCategoryAll": "Alle transacties ({count})",
+    "applyCategoryHelp": "Overboekingen en gesplitste transacties worden nooit gewijzigd."
   },
   "merge": {
     "title": "Begunstigde samenvoegen",

--- a/frontend/src/i18n/messages/pl/payees.json
+++ b/frontend/src/i18n/messages/pl/payees.json
@@ -10,6 +10,9 @@
     "statusAll": "Wszystkie ({count})",
     "statusActive": "Aktywne ({count})",
     "statusInactive": "Nieaktywne ({count})",
+    "categoryFilterAll": "Wszyscy odbiorcy ({count})",
+    "categoryFilterNoCategory": "Bez domyślnej kategorii ({count})",
+    "categoryFilterUncategorized": "Nieskat. transakcje ({count})",
     "modalTitleEdit": "Edytuj odbiorcę",
     "modalTitleNew": "Nowy odbiorca",
     "loading": "Wczytywanie odbiorców...",
@@ -21,7 +24,8 @@
       "reactivated": "Odbiorca \"{name}\" został przywrócony",
       "reactivateFailed": "Nie udało się przywrócić odbiorcy",
       "updateFailed": "Nie udało się zaktualizować odbiorcy",
-      "createFailed": "Nie udało się utworzyć odbiorcy"
+      "createFailed": "Nie udało się utworzyć odbiorcy",
+      "categorized": "{count, plural, one {Skategoryzowano # transakcję} few {Skategoryzowano # transakcje} many {Skategoryzowano # transakcji} other {Skategoryzowano # transakcji}}"
     },
     "summary": {
       "totalPayees": "Wszyscy odbiorcy",
@@ -86,7 +90,12 @@
     "categoryLabel": "Domyślna kategoria",
     "notesLabel": "Notatki (opcjonalnie)",
     "submitCreate": "Utwórz odbiorcę",
-    "submitUpdate": "Zapisz odbiorcę"
+    "submitUpdate": "Zapisz odbiorcę",
+    "applyCategoryLabel": "Zastosuj tę kategorię do istniejących transakcji",
+    "applyCategoryNone": "Nie zmieniaj istniejących transakcji",
+    "applyCategoryUncategorized": "Tylko transakcje bez kategorii ({count})",
+    "applyCategoryAll": "Wszystkie transakcje ({count})",
+    "applyCategoryHelp": "Przelewy i transakcje podzielone nigdy nie są zmieniane."
   },
   "merge": {
     "title": "Scal odbiorcę",

--- a/frontend/src/i18n/messages/pt-BR/payees.json
+++ b/frontend/src/i18n/messages/pt-BR/payees.json
@@ -10,6 +10,9 @@
     "statusAll": "Todos ({count})",
     "statusActive": "Ativos ({count})",
     "statusInactive": "Inativos ({count})",
+    "categoryFilterAll": "Todos os beneficiários ({count})",
+    "categoryFilterNoCategory": "Sem categoria padrão ({count})",
+    "categoryFilterUncategorized": "Trans. sem categoria ({count})",
     "modalTitleEdit": "Editar Beneficiário",
     "modalTitleNew": "Novo Beneficiário",
     "loading": "Carregando beneficiários...",
@@ -21,7 +24,8 @@
       "reactivated": "Beneficiário \"{name}\" reativado",
       "reactivateFailed": "Falha ao reativar beneficiário",
       "updateFailed": "Falha ao atualizar beneficiário",
-      "createFailed": "Falha ao criar beneficiário"
+      "createFailed": "Falha ao criar beneficiário",
+      "categorized": "{count, plural, one {# transação categorizada} other {# transações categorizadas}}"
     },
     "summary": {
       "totalPayees": "Total de Beneficiários",
@@ -86,7 +90,12 @@
     "categoryLabel": "Categoria Padrão",
     "notesLabel": "Notas (opcional)",
     "submitCreate": "Criar Beneficiário",
-    "submitUpdate": "Atualizar Beneficiário"
+    "submitUpdate": "Atualizar Beneficiário",
+    "applyCategoryLabel": "Aplicar esta categoria às transações existentes",
+    "applyCategoryNone": "Não alterar as transações existentes",
+    "applyCategoryUncategorized": "Apenas transações sem categoria ({count})",
+    "applyCategoryAll": "Todas as transações ({count})",
+    "applyCategoryHelp": "As transferências e as transações divididas nunca são alteradas."
   },
   "merge": {
     "title": "Unir Beneficiário",

--- a/frontend/src/i18n/messages/pt/payees.json
+++ b/frontend/src/i18n/messages/pt/payees.json
@@ -10,6 +10,9 @@
     "statusAll": "Todos ({count})",
     "statusActive": "Ativos ({count})",
     "statusInactive": "Inativos ({count})",
+    "categoryFilterAll": "Todos os beneficiários ({count})",
+    "categoryFilterNoCategory": "Sem categoria predefinida ({count})",
+    "categoryFilterUncategorized": "Trans. sem categoria ({count})",
     "modalTitleEdit": "Editar Beneficiário",
     "modalTitleNew": "Novo Beneficiário",
     "loading": "A carregar beneficiários...",
@@ -21,7 +24,8 @@
       "reactivated": "Beneficiário \"{name}\" reativado",
       "reactivateFailed": "Falha ao reativar beneficiário",
       "updateFailed": "Falha ao atualizar beneficiário",
-      "createFailed": "Falha ao criar beneficiário"
+      "createFailed": "Falha ao criar beneficiário",
+      "categorized": "{count, plural, one {# transação categorizada} other {# transações categorizadas}}"
     },
     "summary": {
       "totalPayees": "Total de Beneficiários",
@@ -86,7 +90,12 @@
     "categoryLabel": "Categoria Predefinida",
     "notesLabel": "Notas (opcional)",
     "submitCreate": "Criar Beneficiário",
-    "submitUpdate": "Atualizar Beneficiário"
+    "submitUpdate": "Atualizar Beneficiário",
+    "applyCategoryLabel": "Aplicar esta categoria às transações existentes",
+    "applyCategoryNone": "Não alterar as transações existentes",
+    "applyCategoryUncategorized": "Apenas transações sem categoria ({count})",
+    "applyCategoryAll": "Todas as transações ({count})",
+    "applyCategoryHelp": "As transferências e as transações divididas nunca são alteradas."
   },
   "merge": {
     "title": "Unir Beneficiário",

--- a/frontend/src/i18n/messages/xx/payees.json
+++ b/frontend/src/i18n/messages/xx/payees.json
@@ -10,6 +10,9 @@
     "statusAll": "[XX-All ({count})-XX]",
     "statusActive": "[XX-Active ({count})-XX]",
     "statusInactive": "[XX-Inactive ({count})-XX]",
+    "categoryFilterAll": "[XX-All Payees ({count})-XX]",
+    "categoryFilterNoCategory": "[XX-No Default Category ({count})-XX]",
+    "categoryFilterUncategorized": "[XX-Uncategorized Txns ({count})-XX]",
     "modalTitleEdit": "[XX-Edit Payee-XX]",
     "modalTitleNew": "[XX-New Payee-XX]",
     "loading": "[XX-Loading payees...-XX]",
@@ -21,7 +24,8 @@
       "reactivated": "[XX-Payee \"{name}\" reactivated-XX]",
       "reactivateFailed": "[XX-Failed to reactivate payee-XX]",
       "updateFailed": "[XX-Failed to update payee-XX]",
-      "createFailed": "[XX-Failed to create payee-XX]"
+      "createFailed": "[XX-Failed to create payee-XX]",
+      "categorized": "[XX-{count, plural, one {Categorized # transaction} other {Categorized # transactions}}-XX]"
     },
     "summary": {
       "totalPayees": "[XX-Total Payees-XX]",
@@ -86,7 +90,12 @@
     "categoryLabel": "[XX-Default Category-XX]",
     "notesLabel": "[XX-Notes (optional)-XX]",
     "submitCreate": "[XX-Create Payee-XX]",
-    "submitUpdate": "[XX-Update Payee-XX]"
+    "submitUpdate": "[XX-Update Payee-XX]",
+    "applyCategoryLabel": "[XX-Apply this category to existing transactions-XX]",
+    "applyCategoryNone": "[XX-Don't change existing transactions-XX]",
+    "applyCategoryUncategorized": "[XX-Only transactions without a category ({count})-XX]",
+    "applyCategoryAll": "[XX-All transactions ({count})-XX]",
+    "applyCategoryHelp": "[XX-Transfers and split transactions are never changed.-XX]"
   },
   "merge": {
     "title": "[XX-Merge Payee-XX]",

--- a/frontend/src/lib/payees.ts
+++ b/frontend/src/lib/payees.ts
@@ -52,9 +52,16 @@ export const payeesApi = {
     return response.data;
   },
 
-  // Update payee
-  update: async (id: string, data: UpdatePayeeData): Promise<Payee> => {
-    const response = await apiClient.patch<Payee>(`/payees/${id}`, data);
+  // Update payee. When the update applies the default category to existing
+  // transactions, the response also reports how many were categorized.
+  update: async (
+    id: string,
+    data: UpdatePayeeData,
+  ): Promise<Payee & { transactionsCategorized?: number }> => {
+    const response = await apiClient.patch<Payee & { transactionsCategorized?: number }>(
+      `/payees/${id}`,
+      data,
+    );
     invalidateCache('payees:');
     return response.data;
   },

--- a/frontend/src/types/payee.ts
+++ b/frontend/src/types/payee.ts
@@ -30,8 +30,11 @@ export interface CreatePayeeData {
   notes?: string;
 }
 
+export type ApplyCategoryToTransactions = 'none' | 'uncategorized' | 'all';
+
 export interface UpdatePayeeData extends Partial<CreatePayeeData> {
   isActive?: boolean;
+  applyCategoryToTransactions?: ApplyCategoryToTransactions;
 }
 
 export interface CreatePayeeAliasData {
@@ -146,3 +149,5 @@ export interface DeactivationCandidate {
 }
 
 export type PayeeStatusFilter = 'active' | 'inactive' | 'all';
+
+export type PayeeCategoryFilter = 'all' | 'noDefaultCategory' | 'uncategorizedTransactions';


### PR DESCRIPTION
Payees page:
- Add a segmented category filter (All Payees / No Default Category /
  Uncategorized Txns) alongside the existing All/Active/Inactive status
  filter, with live counts.

Edit payee:
- When a default category is set, offer applying it to existing
  transactions: none, only uncategorized, or all. Transfers and split
  parents are never touched. The backend runs the backfill inside the
  payee-update transaction and reports how many transactions changed.

Adds applyPayeeCategoryToAll backfill helper, wires applyCategoryToTransactions
through the update DTO/service/API, translates all new strings across every
locale, and covers the new behavior with backend and frontend tests.