### PR TITLE
feat(payees): backfill uncategorized transactions from default category

### DIFF
--- a/frontend/src/app/payees/page.test.tsx
+++ b/frontend/src/app/payees/page.test.tsx
@@ -9,6 +9,18 @@ vi.mock('next/image', () => ({
   default: ({ priority, fill, ...props }: any) => <img alt="" {...props} />,
 }));
 
+// Callable toast mock: the bulk backfill uses the bare toast() for the
+// "nothing to do" notice, so the default export must be a function (the
+// global setup mock only exposes toast.success/.error).
+vi.mock('react-hot-toast', () => {
+  const fn: any = vi.fn();
+  fn.success = vi.fn();
+  fn.error = vi.fn();
+  fn.loading = vi.fn();
+  fn.dismiss = vi.fn();
+  return { default: fn, Toaster: () => null };
+});
+
 // Mock logger
 vi.mock('@/lib/logger', () => ({
   createLogger: () => ({
@@ -76,6 +88,7 @@ const mockCreatePayee = vi.fn();
 const mockUpdatePayee = vi.fn();
 const mockReactivatePayee = vi.fn();
 const mockCreateAlias = vi.fn();
+const mockApplyCategorySuggestions = vi.fn();
 
 vi.mock('@/lib/payees', () => ({
   payeesApi: {
@@ -84,6 +97,7 @@ vi.mock('@/lib/payees', () => ({
     update: (...args: any[]) => mockUpdatePayee(...args),
     reactivatePayee: (...args: any[]) => mockReactivatePayee(...args),
     createAlias: (...args: any[]) => mockCreateAlias(...args),
+    applyCategorySuggestions: (...args: any[]) => mockApplyCategorySuggestions(...args),
   },
 }));
 
@@ -379,6 +393,73 @@ describe('PayeesPage', () => {
       await waitFor(() => expect(screen.getByText('Auto-Assign Categories')).toBeInTheDocument());
       fireEvent.click(screen.getByText('Auto-Assign Categories'));
       await waitFor(() => expect(screen.getByTestId('auto-assign-dialog')).toBeInTheDocument());
+    });
+  });
+
+  describe('Apply Default Categories', () => {
+    it('renders the Apply Default Categories button', async () => {
+      render(<PayeesPage />);
+      await waitFor(() => expect(screen.getByText('Apply Default Categories')).toBeInTheDocument());
+    });
+
+    it('backfills each payee default category into its uncategorized transactions', async () => {
+      mockGetAllPayees.mockResolvedValue([
+        { id: 'p-1', name: 'Grocery Store', defaultCategoryId: 'cat-1', defaultCategory: { id: 'cat-1', name: 'Food' }, transactionCount: 50, uncategorizedCount: 5, isActive: true },
+        { id: 'p-3', name: 'Amazon', defaultCategoryId: null, defaultCategory: null, transactionCount: 35, uncategorizedCount: 3, isActive: true },
+      ]);
+      mockApplyCategorySuggestions.mockResolvedValue({ updated: 1, transactionsBackfilled: 5 });
+      render(<PayeesPage />);
+      await waitFor(() => expect(screen.getByText('Apply Default Categories')).toBeInTheDocument());
+      await act(async () => { fireEvent.click(screen.getByText('Apply Default Categories')); });
+      await act(async () => { fireEvent.click(screen.getByText('Apply', { exact: true })); });
+      await waitFor(() =>
+        expect(mockApplyCategorySuggestions).toHaveBeenCalledWith([
+          { payeeId: 'p-1', categoryId: 'cat-1', backfillTransactions: true },
+        ]),
+      );
+    });
+
+    it('only targets payees that have a default category AND uncategorized transactions', async () => {
+      mockGetAllPayees.mockResolvedValue([
+        // has default + uncategorized -> included
+        { id: 'p-1', name: 'Grocery Store', defaultCategoryId: 'cat-1', defaultCategory: { id: 'cat-1', name: 'Food' }, transactionCount: 50, uncategorizedCount: 5, isActive: true },
+        // has default but nothing uncategorized -> excluded
+        { id: 'p-2', name: 'Gas Station', defaultCategoryId: 'cat-2', defaultCategory: { id: 'cat-2', name: 'Auto' }, transactionCount: 20, uncategorizedCount: 0, isActive: true },
+        // uncategorized but no default category -> excluded
+        { id: 'p-3', name: 'Amazon', defaultCategoryId: null, defaultCategory: null, transactionCount: 35, uncategorizedCount: 3, isActive: true },
+      ]);
+      mockApplyCategorySuggestions.mockResolvedValue({ updated: 1, transactionsBackfilled: 5 });
+      render(<PayeesPage />);
+      await waitFor(() => expect(screen.getByText('Apply Default Categories')).toBeInTheDocument());
+      await act(async () => { fireEvent.click(screen.getByText('Apply Default Categories')); });
+      await act(async () => { fireEvent.click(screen.getByText('Apply', { exact: true })); });
+      await waitFor(() =>
+        expect(mockApplyCategorySuggestions).toHaveBeenCalledWith([
+          { payeeId: 'p-1', categoryId: 'cat-1', backfillTransactions: true },
+        ]),
+      );
+    });
+
+    it('does nothing and does not call the API when there is nothing to backfill', async () => {
+      mockGetAllPayees.mockResolvedValue([
+        { id: 'p-2', name: 'Gas Station', defaultCategoryId: 'cat-2', defaultCategory: { id: 'cat-2', name: 'Auto' }, transactionCount: 20, uncategorizedCount: 0, isActive: true },
+      ]);
+      render(<PayeesPage />);
+      await waitFor(() => expect(screen.getByText('Apply Default Categories')).toBeInTheDocument());
+      await act(async () => { fireEvent.click(screen.getByText('Apply Default Categories')); });
+      await act(async () => { fireEvent.click(screen.getByText('Apply', { exact: true })); });
+      expect(mockApplyCategorySuggestions).not.toHaveBeenCalled();
+    });
+
+    it('does not call the API when the confirmation is cancelled', async () => {
+      mockGetAllPayees.mockResolvedValue([
+        { id: 'p-1', name: 'Grocery Store', defaultCategoryId: 'cat-1', defaultCategory: { id: 'cat-1', name: 'Food' }, transactionCount: 50, uncategorizedCount: 5, isActive: true },
+      ]);
+      render(<PayeesPage />);
+      await waitFor(() => expect(screen.getByText('Apply Default Categories')).toBeInTheDocument());
+      await act(async () => { fireEvent.click(screen.getByText('Apply Default Categories')); });
+      await act(async () => { fireEvent.click(screen.getByText('Cancel', { exact: true })); });
+      expect(mockApplyCategorySuggestions).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/app/payees/page.tsx
+++ b/frontend/src/app/payees/page.tsx
@@ -13,6 +13,7 @@ import { DeactivateUnusedPayeesDialog } from '@/components/payees/DeactivateUnus
 import { AutoMergePayeesDialog } from '@/components/payees/AutoMergePayeesDialog';
 import { Modal } from '@/components/ui/Modal';
 import { UnsavedChangesDialog } from '@/components/ui/UnsavedChangesDialog';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { payeesApi } from '@/lib/payees';
 import { categoriesApi } from '@/lib/categories';
 import { buildCategoryColorMap, buildCategoryLabelMap } from '@/lib/categoryUtils';
@@ -48,6 +49,7 @@ function PayeesContent() {
   const [showAutoAssign, setShowAutoAssign] = useState(false);
   const [showDeactivate, setShowDeactivate] = useState(false);
   const [showAutoMerge, setShowAutoMerge] = useState(false);
+  const [showApplyDefaults, setShowApplyDefaults] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<PayeeStatusFilter>('active');
   const [categoryFilter, setCategoryFilter] = useState<PayeeCategoryFilter>('all');
@@ -142,6 +144,44 @@ function PayeesContent() {
 
   const categoryColorMap = useMemo(() => buildCategoryColorMap(categories), [categories]);
   const categoryLabelMap = useMemo(() => buildCategoryLabelMap(categories), [categories]);
+
+  // Payees that have a default category set but still have uncategorized
+  // transactions -- the scope of the bulk "apply default categories" action.
+  const backfillTargets = useMemo(
+    () => payees.filter((p) => p.defaultCategoryId && (p.uncategorizedCount ?? 0) > 0),
+    [payees],
+  );
+  const backfillTotals = useMemo(
+    () => ({
+      payees: backfillTargets.length,
+      transactions: backfillTargets.reduce((sum, p) => sum + (p.uncategorizedCount ?? 0), 0),
+    }),
+    [backfillTargets],
+  );
+
+  // Apply each payee's existing default category to its uncategorized
+  // transactions, reusing the category-suggestions apply endpoint (which sets
+  // the default category -- a no-op here -- and backfills when asked).
+  const handleApplyDefaultCategories = async () => {
+    setShowApplyDefaults(false);
+    if (backfillTargets.length === 0) {
+      toast(t('defaultCategoryBackfill.toasts.nothingToDo'));
+      return;
+    }
+    try {
+      const assignments = backfillTargets.map((p) => ({
+        payeeId: p.id,
+        categoryId: p.defaultCategoryId as string,
+        backfillTransactions: true,
+      }));
+      const result = await payeesApi.applyCategorySuggestions(assignments);
+      toast.success(t('defaultCategoryBackfill.toasts.applied', { count: result.transactionsBackfilled }));
+      loadData();
+    } catch (error) {
+      toast.error(getErrorMessage(error, t('defaultCategoryBackfill.toasts.failed')));
+      logger.error(error);
+    }
+  };
 
   // Apply status filter
   const statusFilteredPayees = useMemo(() => {
@@ -240,6 +280,9 @@ function PayeesContent() {
               </Button>
               <Button variant="secondary" onClick={() => setShowAutoAssign(true)}>
                 {t('page.autoAssignCategories')}
+              </Button>
+              <Button variant="secondary" onClick={() => setShowApplyDefaults(true)}>
+                {t('page.applyDefaultCategories')}
               </Button>
               <Button onClick={openCreate}>{t('page.newPayee')}</Button>
             </>
@@ -421,6 +464,20 @@ function PayeesContent() {
         onClose={() => setShowAutoMerge(false)}
         onSuccess={loadData}
         categories={categories}
+      />
+
+      {/* Apply default categories to all payees with uncategorized transactions */}
+      <ConfirmDialog
+        isOpen={showApplyDefaults}
+        variant="info"
+        title={t('defaultCategoryBackfill.allConfirmTitle')}
+        message={t('defaultCategoryBackfill.allConfirmMessage', {
+          transactions: backfillTotals.transactions,
+          payees: backfillTotals.payees,
+        })}
+        confirmLabel={t('defaultCategoryBackfill.confirmButton')}
+        onConfirm={handleApplyDefaultCategories}
+        onCancel={() => setShowApplyDefaults(false)}
       />
     </PageLayout>
   );

--- a/frontend/src/i18n/messages/de/payees.json
+++ b/frontend/src/i18n/messages/de/payees.json
@@ -32,7 +32,8 @@
       "active": "Aktiv",
       "inactive": "Inaktiv",
       "withoutCategory": "Ohne Kategorie"
-    }
+    },
+    "applyDefaultCategories": "Standardkategorien zuweisen"
   },
   "list": {
     "columns": {
@@ -277,5 +278,15 @@
   "selectCategoryPlaceholder": "Kategorie auswählen...",
   "validation": {
     "nameRequired": "Name des Zahlungsempfängers ist erforderlich"
+  },
+  "defaultCategoryBackfill": {
+    "allConfirmTitle": "Standardkategorien zuweisen?",
+    "allConfirmMessage": "Dadurch werden {transactions, plural, one {# nicht kategorisierte Transaktion} other {# nicht kategorisierte Transaktionen}} bei {payees, plural, one {# Zahlungsempfänger} other {# Zahlungsempfängern}} mit der jeweiligen Standardkategorie kategorisiert. Manuell kategorisierte Transaktionen, Überweisungen und Splitbuchungen bleiben unverändert.",
+    "confirmButton": "Anwenden",
+    "toasts": {
+      "nothingToDo": "Keine nicht kategorisierten Transaktionen zum Kategorisieren",
+      "applied": "{count, plural, one {# Transaktion kategorisiert} other {# Transaktionen kategorisiert}}",
+      "failed": "Transaktionen konnten nicht kategorisiert werden"
+    }
   }
 }

--- a/frontend/src/i18n/messages/en/payees.json
+++ b/frontend/src/i18n/messages/en/payees.json
@@ -32,7 +32,8 @@
       "active": "Active",
       "inactive": "Inactive",
       "withoutCategory": "Without Category"
-    }
+    },
+    "applyDefaultCategories": "Apply Default Categories"
   },
   "list": {
     "columns": {
@@ -277,5 +278,15 @@
   "selectCategoryPlaceholder": "Select category...",
   "validation": {
     "nameRequired": "Payee name is required"
+  },
+  "defaultCategoryBackfill": {
+    "allConfirmTitle": "Apply default categories?",
+    "allConfirmMessage": "This will categorize {transactions, plural, one {# uncategorized transaction} other {# uncategorized transactions}} across {payees, plural, one {# payee} other {# payees}} using each payee's default category. Manually categorized transactions, transfers, and split transactions are left unchanged.",
+    "confirmButton": "Apply",
+    "toasts": {
+      "nothingToDo": "No uncategorized transactions to categorize",
+      "applied": "{count, plural, one {Categorized # transaction} other {Categorized # transactions}}",
+      "failed": "Failed to categorize transactions"
+    }
   }
 }

--- a/frontend/src/i18n/messages/es/payees.json
+++ b/frontend/src/i18n/messages/es/payees.json
@@ -32,7 +32,8 @@
       "active": "Activos",
       "inactive": "Inactivos",
       "withoutCategory": "Sin categoría"
-    }
+    },
+    "applyDefaultCategories": "Aplicar categorías predeterminadas"
   },
   "list": {
     "columns": {
@@ -277,5 +278,15 @@
   "selectCategoryPlaceholder": "Seleccionar categoría...",
   "validation": {
     "nameRequired": "El nombre del beneficiario es obligatorio"
+  },
+  "defaultCategoryBackfill": {
+    "allConfirmTitle": "¿Aplicar categorías predeterminadas?",
+    "allConfirmMessage": "Esto categorizará {transactions, plural, one {# transacción sin categoría} other {# transacciones sin categoría}} en {payees, plural, one {# beneficiario} other {# beneficiarios}} usando la categoría predeterminada de cada beneficiario. Las transacciones categorizadas manualmente, las transferencias y las transacciones divididas no se modifican.",
+    "confirmButton": "Aplicar",
+    "toasts": {
+      "nothingToDo": "No hay transacciones sin categoría para categorizar",
+      "applied": "{count, plural, one {# transacción categorizada} other {# transacciones categorizadas}}",
+      "failed": "No se pudieron categorizar las transacciones"
+    }
   }
 }

--- a/frontend/src/i18n/messages/fr/payees.json
+++ b/frontend/src/i18n/messages/fr/payees.json
@@ -32,7 +32,8 @@
       "active": "Actifs",
       "inactive": "Inactifs",
       "withoutCategory": "Sans catégorie"
-    }
+    },
+    "applyDefaultCategories": "Appliquer les catégories par défaut"
   },
   "list": {
     "columns": {
@@ -277,5 +278,15 @@
   "selectCategoryPlaceholder": "Sélectionner une catégorie...",
   "validation": {
     "nameRequired": "Le nom du bénéficiaire est requis"
+  },
+  "defaultCategoryBackfill": {
+    "allConfirmTitle": "Appliquer les catégories par défaut ?",
+    "allConfirmMessage": "Cela catégorisera {transactions, plural, one {# transaction sans catégorie} other {# transactions sans catégorie}} pour {payees, plural, one {# bénéficiaire} other {# bénéficiaires}} en utilisant la catégorie par défaut de chaque bénéficiaire. Les transactions catégorisées manuellement, les virements et les transactions ventilées restent inchangés.",
+    "confirmButton": "Appliquer",
+    "toasts": {
+      "nothingToDo": "Aucune transaction sans catégorie à catégoriser",
+      "applied": "{count, plural, one {# transaction catégorisée} other {# transactions catégorisées}}",
+      "failed": "Échec de la catégorisation des transactions"
+    }
   }
 }

--- a/frontend/src/i18n/messages/it/payees.json
+++ b/frontend/src/i18n/messages/it/payees.json
@@ -32,7 +32,8 @@
       "active": "Attivi",
       "inactive": "Inattivi",
       "withoutCategory": "Senza categoria"
-    }
+    },
+    "applyDefaultCategories": "Applica categorie predefinite"
   },
   "list": {
     "columns": {
@@ -277,5 +278,15 @@
   "selectCategoryPlaceholder": "Seleziona categoria...",
   "validation": {
     "nameRequired": "Il nome del beneficiario è obbligatorio"
+  },
+  "defaultCategoryBackfill": {
+    "allConfirmTitle": "Applicare le categorie predefinite?",
+    "allConfirmMessage": "Verranno categorizzate {transactions, plural, one {# transazione senza categoria} other {# transazioni senza categoria}} per {payees, plural, one {# beneficiario} other {# beneficiari}} usando la categoria predefinita di ciascun beneficiario. Le transazioni categorizzate manualmente, i trasferimenti e le transazioni suddivise restano invariati.",
+    "confirmButton": "Applica",
+    "toasts": {
+      "nothingToDo": "Nessuna transazione senza categoria da categorizzare",
+      "applied": "{count, plural, one {# transazione categorizzata} other {# transazioni categorizzate}}",
+      "failed": "Impossibile categorizzare le transazioni"
+    }
   }
 }

--- a/frontend/src/i18n/messages/nl/payees.json
+++ b/frontend/src/i18n/messages/nl/payees.json
@@ -32,7 +32,8 @@
       "active": "Actief",
       "inactive": "Inactief",
       "withoutCategory": "Zonder categorie"
-    }
+    },
+    "applyDefaultCategories": "Standaardcategorieën toepassen"
   },
   "list": {
     "columns": {
@@ -277,5 +278,15 @@
   "selectCategoryPlaceholder": "Selecteer categorie...",
   "validation": {
     "nameRequired": "Naam begunstigde is verplicht"
+  },
+  "defaultCategoryBackfill": {
+    "allConfirmTitle": "Standaardcategorieën toepassen?",
+    "allConfirmMessage": "Hiermee worden {transactions, plural, one {# niet-gecategoriseerde transactie} other {# niet-gecategoriseerde transacties}} bij {payees, plural, one {# begunstigde} other {# begunstigden}} gecategoriseerd met de standaardcategorie van elke begunstigde. Handmatig gecategoriseerde transacties, overboekingen en gesplitste transacties blijven ongewijzigd.",
+    "confirmButton": "Toepassen",
+    "toasts": {
+      "nothingToDo": "Geen niet-gecategoriseerde transacties om te categoriseren",
+      "applied": "{count, plural, one {# transactie gecategoriseerd} other {# transacties gecategoriseerd}}",
+      "failed": "Kan transacties niet categoriseren"
+    }
   }
 }

--- a/frontend/src/i18n/messages/pl/payees.json
+++ b/frontend/src/i18n/messages/pl/payees.json
@@ -32,7 +32,8 @@
       "active": "Aktywny",
       "inactive": "Nieaktywny",
       "withoutCategory": "Bez kategorii"
-    }
+    },
+    "applyDefaultCategories": "Przypisz domyślne kategorie"
   },
   "list": {
     "columns": {
@@ -277,5 +278,15 @@
   "selectCategoryPlaceholder": "Wybierz kategorię...",
   "validation": {
     "nameRequired": "Nazwa odbiorcy jest wymagana"
+  },
+  "defaultCategoryBackfill": {
+    "allConfirmTitle": "Przypisać domyślne kategorie?",
+    "allConfirmMessage": "Spowoduje to skategoryzowanie {transactions, plural, one {# nieskategoryzowanej transakcji} few {# nieskategoryzowanych transakcji} many {# nieskategoryzowanych transakcji} other {# nieskategoryzowanych transakcji}} dla {payees, plural, one {# odbiorcy} few {# odbiorców} many {# odbiorców} other {# odbiorców}} przy użyciu domyślnej kategorii każdego odbiorcy. Ręcznie skategoryzowane transakcje, przelewy i transakcje podzielone pozostają bez zmian.",
+    "confirmButton": "Zastosuj",
+    "toasts": {
+      "nothingToDo": "Brak nieskategoryzowanych transakcji do skategoryzowania",
+      "applied": "{count, plural, one {Skategoryzowano # transakcję} few {Skategoryzowano # transakcje} many {Skategoryzowano # transakcji} other {Skategoryzowano # transakcji}}",
+      "failed": "Nie udało się skategoryzować transakcji"
+    }
   }
 }

--- a/frontend/src/i18n/messages/pt-BR/payees.json
+++ b/frontend/src/i18n/messages/pt-BR/payees.json
@@ -32,7 +32,8 @@
       "active": "Ativos",
       "inactive": "Inativos",
       "withoutCategory": "Sem Categoria"
-    }
+    },
+    "applyDefaultCategories": "Aplicar categorias padrão"
   },
   "list": {
     "columns": {
@@ -277,5 +278,15 @@
   "selectCategoryPlaceholder": "Selecionar categoria...",
   "validation": {
     "nameRequired": "O nome do beneficiário é obrigatório"
+  },
+  "defaultCategoryBackfill": {
+    "allConfirmTitle": "Aplicar categorias padrão?",
+    "allConfirmMessage": "Isso irá categorizar {transactions, plural, one {# transação sem categoria} other {# transações sem categoria}} em {payees, plural, one {# beneficiário} other {# beneficiários}} usando a categoria padrão de cada beneficiário. As transações categorizadas manualmente, as transferências e as transações divididas permanecem inalteradas.",
+    "confirmButton": "Aplicar",
+    "toasts": {
+      "nothingToDo": "Não há transações sem categoria para categorizar",
+      "applied": "{count, plural, one {# transação categorizada} other {# transações categorizadas}}",
+      "failed": "Falha ao categorizar as transações"
+    }
   }
 }

--- a/frontend/src/i18n/messages/pt/payees.json
+++ b/frontend/src/i18n/messages/pt/payees.json
@@ -32,7 +32,8 @@
       "active": "Ativos",
       "inactive": "Inativos",
       "withoutCategory": "Sem Categoria"
-    }
+    },
+    "applyDefaultCategories": "Aplicar categorias predefinidas"
   },
   "list": {
     "columns": {
@@ -277,5 +278,15 @@
   "selectCategoryPlaceholder": "Selecionar categoria...",
   "validation": {
     "nameRequired": "O nome do beneficiário é obrigatório"
+  },
+  "defaultCategoryBackfill": {
+    "allConfirmTitle": "Aplicar categorias predefinidas?",
+    "allConfirmMessage": "Isto irá categorizar {transactions, plural, one {# transação sem categoria} other {# transações sem categoria}} em {payees, plural, one {# beneficiário} other {# beneficiários}} usando a categoria predefinida de cada beneficiário. As transações categorizadas manualmente, as transferências e as transações divididas permanecem inalteradas.",
+    "confirmButton": "Aplicar",
+    "toasts": {
+      "nothingToDo": "Não há transações sem categoria para categorizar",
+      "applied": "{count, plural, one {# transação categorizada} other {# transações categorizadas}}",
+      "failed": "Falha ao categorizar as transações"
+    }
   }
 }

--- a/frontend/src/i18n/messages/xx/payees.json
+++ b/frontend/src/i18n/messages/xx/payees.json
@@ -32,7 +32,8 @@
       "active": "[XX-Active-XX]",
       "inactive": "[XX-Inactive-XX]",
       "withoutCategory": "[XX-Without Category-XX]"
-    }
+    },
+    "applyDefaultCategories": "[XX-Apply Default Categories-XX]"
   },
   "list": {
     "columns": {
@@ -277,5 +278,15 @@
   "selectCategoryPlaceholder": "[XX-Select category...-XX]",
   "validation": {
     "nameRequired": "[XX-Payee name is required-XX]"
+  },
+  "defaultCategoryBackfill": {
+    "allConfirmTitle": "[XX-Apply default categories?-XX]",
+    "allConfirmMessage": "[XX-This will categorize {transactions, plural, one {# uncategorized transaction} other {# uncategorized transactions}} across {payees, plural, one {# payee} other {# payees}} using each payee's default category. Manually categorized transactions, transfers, and split transactions are left unchanged.-XX]",
+    "confirmButton": "[XX-Apply-XX]",
+    "toasts": {
+      "nothingToDo": "[XX-No uncategorized transactions to categorize-XX]",
+      "applied": "[XX-{count, plural, one {Categorized # transaction} other {Categorized # transactions}}-XX]",
+      "failed": "[XX-Failed to categorize transactions-XX]"
+    }
   }
 }


### PR DESCRIPTION
Setting a payee's default category only affects future transactions, so payees imported with a default category often keep large numbers of uncategorized historical transactions. The existing Auto-Assign dialog only surfaces payees whose category can be inferred from already categorized transactions, so these payees have no one-click fix.

Add three entry points on the Payees page that apply a payee's existing default category to its backfillable (uncategorized, non-transfer, non-split) transactions:

- A "No Category" status filter to find payees missing a default category.
- A clickable "N uncategorized" badge that backfills a single payee (only when it already has a default category).
- An "Apply Default Categories" toolbar button that backfills every payee that has a default category, with a confirmation showing the totals.

All three reuse the existing POST /payees/category-suggestions/apply endpoint (with backfillTransactions), so there are no backend changes. Fully internationalized across all locales with added tests.