### PR TITLE
feat(reports): drill into uncategorized transactions from monthly breakdown

### DIFF
--- a/frontend/src/components/reports/MonthlyCategoryBreakdownReport.test.tsx
+++ b/frontend/src/components/reports/MonthlyCategoryBreakdownReport.test.tsx
@@ -224,6 +224,43 @@ describe('MonthlyCategoryBreakdownReport', () => {
     expect(url).toContain('endDate=2025-06-30');
   });
 
+  it('drills down to uncategorized transactions when the Uncategorized row is clicked', async () => {
+    mockGetMonthlyCategoryBreakdown.mockResolvedValue({
+      currency: 'USD',
+      months: ['2025-01', '2025-02', '2025-03'],
+      data: [
+        {
+          categoryId: null,
+          categoryName: 'Uncategorized',
+          parentId: null,
+          parentName: null,
+          parentIsIncome: null,
+          isIncome: false,
+          valuesByMonth: { '2025-01': 50, '2025-02': 0, '2025-03': 70 },
+          depositTotal: 0,
+          withdrawalTotal: 120,
+        },
+      ],
+      transfers: [],
+    });
+    render(<MonthlyCategoryBreakdownReport />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Uncategorized')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Uncategorized'));
+    });
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const url = mockPush.mock.calls[0][0] as string;
+    expect(url).toContain('/transactions?');
+    // Reuses the existing "uncategorized" pseudo-filter (categoryId IS NULL);
+    // no real category id and no extra backend query.
+    expect(url).toContain('categoryIds=uncategorized');
+  });
+
   it('drills down into every child category when a section header is clicked', async () => {
     mockGetMonthlyCategoryBreakdown.mockResolvedValue(sampleResponse);
     render(<MonthlyCategoryBreakdownReport />);

--- a/frontend/src/components/reports/MonthlyCategoryBreakdownReport.tsx
+++ b/frontend/src/components/reports/MonthlyCategoryBreakdownReport.tsx
@@ -599,6 +599,13 @@ export function MonthlyCategoryBreakdownReport() {
     navigateToTransactions(categoryIds, rangeStart || undefined, rangeEnd || undefined);
   };
 
+  // Drill-down ids for a category row: its real category id, or the
+  // "uncategorized" pseudo-filter (categoryId IS NULL) the transactions list
+  // already understands -- mirroring the transfer-section drilldown. No extra
+  // backend/DB work: the report already aggregates the uncategorized bucket.
+  const rowDrillIds = (row: ProcessedRow): string[] =>
+    row.categoryId ? [row.categoryId] : ['uncategorized'];
+
   // Drill into transfers (optionally for specific accounts) over the full
   // report range or a single month.
   const drillTransfersRange = (accountIds: string[]) => {
@@ -773,33 +780,27 @@ export function MonthlyCategoryBreakdownReport() {
               className="sticky left-0 z-10 bg-white dark:bg-gray-800 pl-5 pr-2 py-1 text-gray-900 dark:text-gray-100 truncate max-w-[220px]"
               title={row.displayName}
             >
-              {row.categoryId ? (
-                <button
-                  type="button"
-                  onClick={() => drillDownRange([row.categoryId!])}
-                  className="block w-full text-left truncate hover:underline"
-                >
-                  {row.displayName}
-                </button>
-              ) : (
-                row.displayName
-              )}
+              <button
+                type="button"
+                onClick={() => drillDownRange(rowDrillIds(row))}
+                className="block w-full text-left truncate hover:underline"
+              >
+                {row.displayName}
+              </button>
             </td>
             {months.map((m) => {
               const value = row.values[m] || 0;
               const cls = deviationClass(value, row.nonZeroAvg, row.nonZeroCount, row.isIncome);
               return (
                 <td key={m} className={`px-2 py-1 text-right ${cls}`}>
-                  {value !== 0 && row.categoryId ? (
+                  {value !== 0 ? (
                     <button
                       type="button"
-                      onClick={() => drillDown(m, [row.categoryId!])}
+                      onClick={() => drillDown(m, rowDrillIds(row))}
                       className="hover:underline"
                     >
                       {formatCell(value, sectionMonthTotal(m), row.isIncome)}
                     </button>
-                  ) : value !== 0 ? (
-                    formatCell(value, sectionMonthTotal(m), row.isIncome)
                   ) : (
                     <span className="text-gray-300 dark:text-gray-600">—</span>
                   )}
@@ -807,17 +808,13 @@ export function MonthlyCategoryBreakdownReport() {
               );
             })}
             <td className="px-2 py-1 text-right font-semibold text-gray-900 dark:text-gray-100">
-              {row.categoryId ? (
-                <button
-                  type="button"
-                  onClick={() => drillDownRange([row.categoryId!])}
-                  className="hover:underline"
-                >
-                  {formatCell(row.total, sectionSum, row.isIncome)}
-                </button>
-              ) : (
-                formatCell(row.total, sectionSum, row.isIncome)
-              )}
+              <button
+                type="button"
+                onClick={() => drillDownRange(rowDrillIds(row))}
+                className="hover:underline"
+              >
+                {formatCell(row.total, sectionSum, row.isIncome)}
+              </button>
             </td>
             <td className="px-2 py-1 text-right text-gray-700 dark:text-gray-300">
               {formatCell(row.avg, sectionAvg, row.isIncome)}


### PR DESCRIPTION

The monthly category breakdown already aggregates an "Uncategorized" bucket (transactions with no category), but its row, month cells, and total were rendered as plain text -- you could not click through to the underlying transactions like every other category row.

Make the Uncategorized row drillable using the existing "uncategorized" pseudo-filter the transactions list already supports (categoryId IS NULL, excluding splits and transfers) -- the same pattern the report's transfer section already uses with the "transfer" token. No backend, query, or schema changes: the report already computes the bucket and the transactions endpoint already understands the filter.