### PR TITLE
Add MCP tool output schemas and annotations

### DIFF
--- a/backend/src/mcp/CLAUDE.md
+++ b/backend/src/mcp/CLAUDE.md
@@ -1,0 +1,197 @@
+# MCP Server
+
+Monize exposes its financial data over the **Model Context Protocol** so MCP
+clients (Claude Desktop's "Add Connector", IDE agents, etc.) can query and act
+on a user's finances. This directory is the whole server: transport, the
+per-session `McpServer` factory, and the tool/resource/prompt definitions.
+
+Built on `@modelcontextprotocol/sdk` (`McpServer` + `StreamableHTTPServerTransport`).
+
+## Architecture
+
+- **Transport** (`mcp-http.controller.ts`): Streamable HTTP at `POST/GET/DELETE /mcp`.
+  Manages one transport + one `McpServer` per session, keyed by the
+  `Mcp-Session-Id` header. Sessions have a 1h TTL, a per-user cap, and periodic
+  cleanup. `@SkipCsrf()` + bearer auth only (no cookies).
+- **Auth** (`validatePat`): `Authorization: Bearer <token>`. `pat_*` tokens go
+  through `PatService`; everything else is treated as an OAuth 2.1 access token
+  (`OAuthProviderService`). A 401 returns `WWW-Authenticate` with
+  `resource_metadata` (RFC 9728) pointing at `/.well-known/oauth-protected-resource`.
+- **Server factory** (`mcp-server.service.ts`): `createServer(resolve)` builds a
+  fresh `McpServer`, sets `instructions` + capabilities (logging, tools,
+  resources, prompts), and registers every tool/resource/prompt. The server
+  `version` is read from `backend/package.json` so it tracks the released image
+  automatically -- never hardcode it.
+- **Per-request user context** (`mcp-context.ts`): the controller passes a
+  `resolve(sessionId)` that returns `{ userId, scopes }`. Handlers call
+  `resolve(extra.sessionId)` to get the caller; `userId` always comes from the
+  session, never from tool arguments.
+
+## Directory layout
+
+```
+mcp/
+  mcp-http.controller.ts     # Streamable HTTP transport + sessions + auth
+  mcp-server.service.ts      # createServer(): wires everything onto an McpServer
+  mcp-context.ts             # resolve, requireScope, toolResult/toolError, sanitization
+  mcp-annotations.ts         # shared tool annotation presets (READ_ONLY/CREATE/UPDATE)
+  mcp-write-limiter.ts       # per-user daily write cap for mutating tools
+  tool-output-schemas.ts     # one Zod output schema (raw shape) per tool
+  tools/<domain>.tool.ts     # tool definitions, grouped by domain
+  resources/<name>.resource.ts
+  prompts/<name>.prompt.ts
+  mcp.module.ts              # NestJS providers/imports
+```
+
+Each tool/resource/prompt is an `@Injectable()` class with a `register(server, resolve)`
+method, listed in both `mcp.module.ts` (providers) and `mcp-server.service.ts`
+(wired into `createServer`).
+
+## Adding a tool (required format)
+
+Every tool MUST declare **`title`**, **`description`**, **`inputSchema`**,
+**`outputSchema`**, and **`annotations`**. The handler MUST resolve context,
+check scope, run inside try/catch, and return via `toolResult` / `safeToolError`.
+
+```typescript
+server.registerTool(
+  "get_thing",
+  {
+    title: "Get thing",                 // human-readable display name
+    annotations: READ_ONLY,             // from mcp-annotations.ts
+    description: "What it does and when to use it (guide the model).",
+    inputSchema: {                      // Zod raw shape; {} if no args
+      id: z.string().uuid().describe("Thing ID"),
+    },
+    outputSchema: getThingOutput,       // from tool-output-schemas.ts
+  },
+  async (args, extra) => {
+    const ctx = resolve(extra.sessionId);
+    if (!ctx) return toolError("No user context");
+    const check = requireScope(ctx.scopes, "read");
+    if (check.error) return check.result;
+    try {
+      const data = await this.thingService.getLlmThing(ctx.userId, args.id);
+      return toolResult(data);
+    } catch (err: unknown) {
+      return safeToolError(err);        // never leak 5xx internals
+    }
+  },
+);
+```
+
+Checklist for a new tool:
+
+1. Put the data logic on the **domain service** (e.g. `getLlm*`), not in the
+   tool. The tool is a thin adapter. Per the repo rule, the same logic is shared
+   with the AI Assistant tool executor and both must return the same shape -- wire
+   both surfaces in the same PR.
+2. Add the tool to its domain `tools/*.tool.ts` with the five config fields above.
+3. Add its output schema to `tool-output-schemas.ts` (see conventions below) and
+   import it.
+4. Pick the right annotation preset (below) and import it.
+5. If it mutates data, derive scope `"write"` and enforce the daily write limit
+   via `McpWriteLimiter` (see `transactions.tool.ts`). `whitelist`-style
+   sanitize user strings with `stripHtml(...)` before persisting.
+6. Update `mcp-server.service.ts` count and `mcp.module.ts` if it's a new
+   provider class.
+7. Add/extend tests (below). `mcp-annotations.spec.ts` enforces that every tool
+   has title + input/output schema + annotations and the right read/write hints,
+   so bump `EXPECTED_TOOL_COUNT` and `WRITE_TOOLS`/`IDEMPOTENT_WRITES` there.
+
+## `toolResult` and structured content
+
+`toolResult(data)` (in `mcp-context.ts`) is the only success path. It:
+
+- sanitizes every string in the payload (`sanitizeToolResultStrings`),
+- emits a text `content` block with the pretty-printed JSON (the raw data shape,
+  which the AI Assistant relies on -- do not change it), and
+- emits `structuredContent`: objects pass through; **bare arrays are wrapped
+  under `items`**; primitives under `value`.
+
+Because every tool declares `outputSchema`, the SDK **requires** `structuredContent`
+and validates it against the schema on each call (errors via `toolError`/`safeToolError`
+set `isError` and bypass validation). So a tool's output schema must accept what
+`toolResult` produces for that tool.
+
+## Output schema conventions (`tool-output-schemas.ts`)
+
+Each export is a **Zod raw shape** (same form as `inputSchema`), not a `z.object`.
+Schemas are deliberately **tolerant** so they document shape without rejecting
+real runtime data:
+
+- Zod strips undeclared keys by default -- only model the fields you expose;
+  entity relations/timestamps are ignored automatically.
+- Money/decimals are numbers at runtime (entity `numericTransformer`). Use the
+  shared `num = z.number().or(z.nan())` so a divide-by-zero percentage (which
+  JSON-serializes to `null`) never fails validation.
+- Use `.nullable()` for documented-null fields and `.optional()` for fields that
+  may be absent (including alternate result branches, e.g. dry-run vs created,
+  or success vs not-found error payloads -- make all branch fields optional).
+- Array-returning tools must wrap under `items`: `{ items: z.array(itemSchema) }`,
+  matching `toolResult`'s array wrapping.
+
+## Annotation presets (`mcp-annotations.ts`)
+
+All tools operate on the user's own closed dataset, so `openWorldHint` is always
+`false`. Pick by effect:
+
+| Preset | Use for | Hints |
+|--------|---------|-------|
+| `READ_ONLY` | queries/aggregations/`calculate` | `readOnlyHint: true` |
+| `CREATE` | adds a new record | `readOnlyHint:false, destructiveHint:false, idempotentHint:false` |
+| `UPDATE` | sets fields to given values | `readOnlyHint:false, destructiveHint:false, idempotentHint:true` |
+
+There is no destructive preset -- no tool deletes data. Add one only if a
+delete/overwrite tool is introduced.
+
+## Scopes
+
+`requireScope(ctx.scopes, ...)` gates each handler. Scopes in use: `read`
+(queries), `reports` (report/anomaly tools), `write` (mutations). Resources gate
+with `hasScope(ctx.scopes, "read")`.
+
+## Resources & prompts
+
+- **Resources** (`registerResource`): give a `title` + `description`, return
+  `contents[]` with `mimeType: "application/json"` and the JSON `text`. Same
+  context-resolve + `hasScope` check; on error return a `contents` entry with an
+  `Error: ...` text rather than throwing.
+- **Prompts** (`registerPrompt`): give a `title` + `description` + `argsSchema`
+  (Zod raw shape of optional args), and return `messages[]`. Prompts are
+  templates only -- no data access, no scope check.
+
+## Security (do not regress)
+
+- `userId` is always from the session context, never from tool args.
+- Sanitize user-controlled strings written back: `stripHtml()` before persist,
+  and `toolResult` runs `sanitizeToolResultStrings` on all outgoing strings.
+- `safeToolError` passes through 4xx messages but returns a generic message for
+  5xx/unknown errors -- never leak internals.
+- Transport is bearer-only and `@SkipCsrf()`; do not add cookie auth here.
+
+## Testing
+
+Tools/resources/prompts unit tests mock `registerTool`/`registerResource`/
+`registerPrompt` to capture the handler, then drive it with a mocked service and
+assert on `result.content[0].text` (parsed JSON) and `result.isError`. Plus:
+
+- `mcp-annotations.spec.ts` -- every tool has title + input/output schema +
+  annotations with correct read/write hints (update its constants when adding a tool).
+- `tool-output-schemas.spec.ts` -- each output schema accepts a representative
+  `toolResult` payload (incl. NaN, null, and alternate branches), and an
+  end-to-end round-trip through the real SDK via `InMemoryTransport`.
+- `mcp-server.service.spec.ts` -- registration counts and that the advertised
+  version tracks `package.json`.
+
+## Spec compliance notes
+
+Implemented: Streamable HTTP transport, session management, OAuth 2.1 + RFC 9728
+protected-resource metadata, tools (title/description/input+output schema/
+annotations), resources (title/description/mimeType), prompts
+(title/description/arguments), logging/tools/resources/prompts capabilities.
+
+Intentionally not implemented: `completions` (argument autocompletion) and
+resource `subscribe`/`listChanged`. DNS-rebinding protection on the transport is
+omitted because auth is bearer-only (no ambient browser credentials to steal).
+Add these if a client need arises.

--- a/backend/src/mcp/mcp-annotations.spec.ts
+++ b/backend/src/mcp/mcp-annotations.spec.ts
@@ -1,0 +1,104 @@
+import { McpAccountsTools } from "./tools/accounts.tool";
+import { McpTransactionsTools } from "./tools/transactions.tool";
+import { McpCategoriesTools } from "./tools/categories.tool";
+import { McpPayeesTools } from "./tools/payees.tool";
+import { McpReportsTools } from "./tools/reports.tool";
+import { McpInvestmentsTools } from "./tools/investments.tool";
+import { McpNetWorthTools } from "./tools/net-worth.tool";
+import { McpScheduledTools } from "./tools/scheduled.tool";
+import { McpCalculateTools } from "./tools/calculate.tool";
+import { McpBudgetsTools } from "./tools/budgets.tool";
+
+// Tools that mutate state; everything else must be read-only.
+const WRITE_TOOLS = new Set([
+  "create_transaction",
+  "create_payee",
+  "categorize_transaction",
+]);
+// Write tools whose repeated calls converge to the same state.
+const IDEMPOTENT_WRITES = new Set(["categorize_transaction"]);
+
+const EXPECTED_TOOL_COUNT = 27;
+
+interface ToolProvider {
+  register: (server: unknown, resolve?: unknown) => void;
+}
+
+function collectToolConfigs(): Array<{ name: string; config: any }> {
+  // Providers only read their service deps inside handlers, never during
+  // register(), so empty mocks are sufficient to capture the tool configs.
+  const providers: ToolProvider[] = [
+    new McpAccountsTools({} as any) as unknown as ToolProvider,
+    new McpTransactionsTools(
+      {} as any,
+      {} as any,
+      {} as any,
+    ) as unknown as ToolProvider,
+    new McpCategoriesTools({} as any) as unknown as ToolProvider,
+    new McpPayeesTools({} as any) as unknown as ToolProvider,
+    new McpReportsTools({} as any) as unknown as ToolProvider,
+    new McpInvestmentsTools(
+      {} as any,
+      {} as any,
+      {} as any,
+    ) as unknown as ToolProvider,
+    new McpNetWorthTools({} as any, {} as any) as unknown as ToolProvider,
+    new McpScheduledTools({} as any) as unknown as ToolProvider,
+    new McpCalculateTools() as unknown as ToolProvider,
+    new McpBudgetsTools({} as any) as unknown as ToolProvider,
+  ];
+
+  const configs: Array<{ name: string; config: any }> = [];
+  const fakeServer = {
+    registerTool: (name: string, config: any) => {
+      configs.push({ name, config });
+    },
+  };
+  const resolve = () => undefined;
+  for (const provider of providers) {
+    provider.register(fakeServer, resolve);
+  }
+  return configs;
+}
+
+describe("MCP tool spec compliance", () => {
+  const configs = collectToolConfigs();
+
+  it("registers the expected number of tools", () => {
+    expect(configs).toHaveLength(EXPECTED_TOOL_COUNT);
+  });
+
+  it("gives every tool a unique name", () => {
+    const names = configs.map((c) => c.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  describe.each(collectToolConfigs())("$name", ({ name, config }) => {
+    it("declares a human-readable title", () => {
+      expect(typeof config.title).toBe("string");
+      expect(config.title.length).toBeGreaterThan(0);
+    });
+
+    it("declares both an input and output schema", () => {
+      expect(config.inputSchema).toBeDefined();
+      expect(config.outputSchema).toBeDefined();
+    });
+
+    it("declares annotations over a closed (non-open-world) dataset", () => {
+      expect(config.annotations).toBeDefined();
+      expect(config.annotations.openWorldHint).toBe(false);
+    });
+
+    it("sets read/write hints matching the tool's effect", () => {
+      if (WRITE_TOOLS.has(name)) {
+        expect(config.annotations.readOnlyHint).toBe(false);
+        expect(config.annotations.destructiveHint).toBe(false);
+        expect(config.annotations.idempotentHint).toBe(
+          IDEMPOTENT_WRITES.has(name),
+        );
+      } else {
+        expect(config.annotations.readOnlyHint).toBe(true);
+      }
+    });
+  });
+});

--- a/backend/src/mcp/mcp-annotations.ts
+++ b/backend/src/mcp/mcp-annotations.ts
@@ -1,0 +1,37 @@
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Shared MCP tool annotations.
+ *
+ * Annotations are optional hints (per the MCP spec) that help clients reason
+ * about a tool before calling it. Every Monize tool operates over the
+ * authenticated user's own closed financial dataset, so `openWorldHint` is
+ * always `false` (no external/open-world interaction).
+ *
+ * Pick the constant that matches the tool's effect:
+ * - `READ_ONLY`  -- queries/aggregations that never mutate state.
+ * - `CREATE`     -- adds a new record (non-idempotent, non-destructive).
+ * - `UPDATE`     -- sets fields to given values (idempotent, non-destructive).
+ *
+ * There is deliberately no "destructive" preset: no MCP tool deletes data. Add
+ * one (`destructiveHint: true`) only if a delete/overwrite tool is introduced.
+ */
+
+export const READ_ONLY: ToolAnnotations = {
+  readOnlyHint: true,
+  openWorldHint: false,
+};
+
+export const CREATE: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: false,
+  openWorldHint: false,
+};
+
+export const UPDATE: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+};

--- a/backend/src/mcp/mcp-context.spec.ts
+++ b/backend/src/mcp/mcp-context.spec.ts
@@ -150,5 +150,25 @@ describe("mcp-context", () => {
       expect(JSON.parse(toolResult(42).content[0].text)).toBe(42);
       expect(JSON.parse(toolResult("hello").content[0].text)).toBe("hello");
     });
+
+    describe("structuredContent", () => {
+      it("passes an object payload through unchanged", () => {
+        const data = { netWorth: 1000, totalAccounts: 2 };
+        const result = toolResult(data);
+        expect(result.structuredContent).toEqual(data);
+      });
+
+      it("wraps a bare array under 'items' (structured content must be an object)", () => {
+        const result = toolResult([{ id: "a1" }, { id: "a2" }]);
+        expect(result.structuredContent).toEqual({
+          items: [{ id: "a1" }, { id: "a2" }],
+        });
+      });
+
+      it("wraps a primitive payload under 'value'", () => {
+        expect(toolResult(42).structuredContent).toEqual({ value: 42 });
+        expect(toolResult(null).structuredContent).toEqual({ value: null });
+      });
+    });
   });
 });

--- a/backend/src/mcp/mcp-context.ts
+++ b/backend/src/mcp/mcp-context.ts
@@ -73,11 +73,27 @@ export function safeToolError(err: unknown) {
   return toolError("An error occurred while processing your request");
 }
 
+/**
+ * Wrap a sanitized payload into the object form required for an MCP tool's
+ * `structuredContent`. Bare arrays are nested under `items` (structured content
+ * must be a JSON object); primitives under `value`; objects pass through.
+ */
+function toStructuredContent(data: unknown): Record<string, unknown> {
+  if (Array.isArray(data)) {
+    return { items: data };
+  }
+  if (data !== null && typeof data === "object") {
+    return data as Record<string, unknown>;
+  }
+  return { value: data };
+}
+
 export function toolResult(data: unknown) {
   const sanitized = sanitizeToolResultStrings(data);
   return {
     content: [
       { type: "text" as const, text: JSON.stringify(sanitized, null, 2) },
     ],
+    structuredContent: toStructuredContent(sanitized),
   };
 }

--- a/backend/src/mcp/mcp-server.service.spec.ts
+++ b/backend/src/mcp/mcp-server.service.spec.ts
@@ -75,6 +75,20 @@ describe("McpServerService", () => {
     expect(server).toBeDefined();
   });
 
+  it("advertises the backend package.json version (auto-updates with releases)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { version } = require("../../package.json") as { version: string };
+    const resolver = jest.fn();
+    const server = service.createServer(resolver);
+    const serverInfo = (server.server as any)._serverInfo as {
+      name: string;
+      version: string;
+    };
+    expect(serverInfo.name).toBe("monize");
+    expect(serverInfo.version).toBe(version);
+    expect(serverInfo.version).not.toBe("1.0.0");
+  });
+
   it("should register all tools", () => {
     const resolver = jest.fn();
     service.createServer(resolver);

--- a/backend/src/mcp/mcp-server.service.ts
+++ b/backend/src/mcp/mcp-server.service.ts
@@ -20,6 +20,12 @@ import { McpBudgetCheckPrompt } from "./prompts/budget-check.prompt";
 import { McpTransactionLookupPrompt } from "./prompts/transaction-lookup.prompt";
 import { McpSpendingAnalysisPrompt } from "./prompts/spending-analysis.prompt";
 
+// Version comes from the backend package.json at build/run time so the MCP
+// server advertises the same version as the published image. Using require
+// keeps the read synchronous and avoids ESM import-assertion issues.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const backendPkg = require("../../package.json") as { version: string };
+
 @Injectable()
 export class McpServerService {
   constructor(
@@ -45,7 +51,7 @@ export class McpServerService {
 
   createServer(resolve: UserContextResolver): McpServer {
     const server = new McpServer(
-      { name: "monize", version: "1.0.0" },
+      { name: "monize", version: backendPkg.version },
       {
         instructions: [
           "Monize is a personal finance management service. You can query accounts, transactions, investments, and generate financial reports.",

--- a/backend/src/mcp/prompts/budget-check.prompt.ts
+++ b/backend/src/mcp/prompts/budget-check.prompt.ts
@@ -8,6 +8,7 @@ export class McpBudgetCheckPrompt {
     server.registerPrompt(
       "budget-check",
       {
+        title: "Budget check",
         description: "Check spending patterns against typical monthly expenses",
         argsSchema: {
           month: z

--- a/backend/src/mcp/prompts/financial-review.prompt.ts
+++ b/backend/src/mcp/prompts/financial-review.prompt.ts
@@ -8,6 +8,7 @@ export class McpFinancialReviewPrompt {
     server.registerPrompt(
       "financial-review",
       {
+        title: "Financial review",
         description: "Review finances for a period and provide insights",
         argsSchema: {
           period: z

--- a/backend/src/mcp/prompts/spending-analysis.prompt.ts
+++ b/backend/src/mcp/prompts/spending-analysis.prompt.ts
@@ -8,6 +8,7 @@ export class McpSpendingAnalysisPrompt {
     server.registerPrompt(
       "spending-analysis",
       {
+        title: "Spending analysis",
         description: "Analyze spending patterns in a category or overall",
         argsSchema: {
           category: z

--- a/backend/src/mcp/prompts/transaction-lookup.prompt.ts
+++ b/backend/src/mcp/prompts/transaction-lookup.prompt.ts
@@ -8,6 +8,7 @@ export class McpTransactionLookupPrompt {
     server.registerPrompt(
       "transaction-lookup",
       {
+        title: "Transaction lookup",
         description: "Help find specific transactions",
         argsSchema: {
           query: z

--- a/backend/src/mcp/resources/account-list.resource.ts
+++ b/backend/src/mcp/resources/account-list.resource.ts
@@ -12,6 +12,7 @@ export class McpAccountListResource {
       "accounts",
       "monize://accounts",
       {
+        title: "Accounts",
         description: "Current account list with types and balances",
       },
       async (_uri, extra) => {

--- a/backend/src/mcp/resources/category-tree.resource.ts
+++ b/backend/src/mcp/resources/category-tree.resource.ts
@@ -12,6 +12,7 @@ export class McpCategoryTreeResource {
       "categories",
       "monize://categories",
       {
+        title: "Category tree",
         description: "Full category hierarchy",
       },
       async (_uri, extra) => {

--- a/backend/src/mcp/resources/financial-summary.resource.ts
+++ b/backend/src/mcp/resources/financial-summary.resource.ts
@@ -17,6 +17,7 @@ export class McpFinancialSummaryResource {
       "financial-summary",
       "monize://financial-summary",
       {
+        title: "Financial summary",
         description:
           "High-level financial snapshot: income, expenses, net worth",
       },

--- a/backend/src/mcp/resources/recent-transactions.resource.ts
+++ b/backend/src/mcp/resources/recent-transactions.resource.ts
@@ -16,7 +16,10 @@ export class McpRecentTransactionsResource {
     server.registerResource(
       "recent-transactions",
       "monize://recent-transactions",
-      { description: "Last 30 days of transactions (summarized)" },
+      {
+        title: "Recent transactions",
+        description: "Last 30 days of transactions (summarized)",
+      },
       async (_uri, extra) => {
         const ctx = resolve(extra.sessionId);
         if (!ctx) {

--- a/backend/src/mcp/tool-output-schemas.spec.ts
+++ b/backend/src/mcp/tool-output-schemas.spec.ts
@@ -1,0 +1,579 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { toolResult } from "./mcp-context";
+import * as schemas from "./tool-output-schemas";
+
+type RawShape = Record<string, z.ZodTypeAny>;
+
+const scheduledItemSample = {
+  id: "sc1",
+  name: "Rent",
+  accountId: "a1",
+  accountName: "Checking",
+  payeeName: null,
+  categoryName: null,
+  amount: -50,
+  currency: "USD",
+  frequency: "MONTHLY",
+  nextDueDate: "2026-02-01",
+  daysUntilDue: 5,
+  isActive: true,
+  autoPost: false,
+  kind: "bill",
+  description: null,
+};
+
+// Each case pairs an output schema with a representative payload, in the raw
+// (pre-toolResult) form a tool handler would pass to toolResult. The payloads
+// mirror the documented service return shapes, including null fields and
+// undeclared entity fields (timestamps, relations) that must be tolerated.
+const cases: Array<{ name: string; schema: RawShape; raw: unknown }> = [
+  {
+    name: "getAccountsOutput",
+    schema: schemas.getAccountsOutput,
+    raw: [
+      {
+        id: "a1",
+        name: "Checking",
+        accountType: "CHEQUING",
+        currencyCode: "USD",
+        currentBalance: 100.5,
+        creditLimit: null,
+        isClosed: false,
+        futureTransactionsSum: 0,
+        // Undeclared fields present on the real entity must be tolerated.
+        transactions: [],
+        userId: "u1",
+      },
+    ],
+  },
+  {
+    name: "getAccountBalanceOutput",
+    schema: schemas.getAccountBalanceOutput,
+    raw: {
+      id: "a1",
+      name: "Checking",
+      type: "CHEQUING",
+      currentBalance: 100,
+      creditLimit: null,
+      currencyCode: "USD",
+    },
+  },
+  {
+    name: "getAccountBalancesOutput",
+    schema: schemas.getAccountBalancesOutput,
+    raw: {
+      accounts: [
+        {
+          name: "Checking",
+          type: "CHEQUING",
+          balance: 1,
+          currency: "USD",
+          isClosed: false,
+        },
+      ],
+      totalAssets: 1,
+      totalLiabilities: 0,
+      netWorth: 1,
+      totalAccounts: 1,
+    },
+  },
+  {
+    name: "getNetWorthOutput",
+    schema: schemas.getNetWorthOutput,
+    raw: {
+      totalAccounts: 1,
+      totalBalance: 1,
+      totalAssets: 1,
+      totalLiabilities: 0,
+      netWorth: 1,
+    },
+  },
+  {
+    name: "getNetWorthHistoryOutput",
+    schema: schemas.getNetWorthHistoryOutput,
+    raw: [{ month: "2026-01-01", assets: 1, liabilities: 0, netWorth: 1 }],
+  },
+  {
+    name: "searchTransactionsOutput",
+    schema: schemas.searchTransactionsOutput,
+    raw: {
+      transactions: [
+        {
+          id: "t1",
+          date: "2026-01-01",
+          payeeName: null,
+          amount: -5,
+          description: null,
+          status: "CLEARED",
+        },
+      ],
+      total: 1,
+      hasMore: false,
+    },
+  },
+  {
+    name: "queryTransactionsOutput",
+    schema: schemas.queryTransactionsOutput,
+    raw: {
+      totalIncome: 0,
+      totalExpenses: 5,
+      netCashFlow: -5,
+      transactionCount: 1,
+      byCurrency: {
+        USD: {
+          totalIncome: 0,
+          totalExpenses: 5,
+          netCashFlow: -5,
+          transactionCount: 1,
+        },
+      },
+      breakdown: { groupedBy: "category", groups: [] },
+    },
+  },
+  {
+    name: "getSpendingByCategoryOutput",
+    schema: schemas.getSpendingByCategoryOutput,
+    raw: {
+      categories: [
+        { category: "Food", amount: 5, percentage: 100, transactionCount: 1 },
+      ],
+      totalSpending: 5,
+    },
+  },
+  {
+    name: "getIncomeSummaryOutput",
+    schema: schemas.getIncomeSummaryOutput,
+    raw: {
+      items: [{ label: "Salary", amount: 100, count: 1 }],
+      totalIncome: 100,
+      groupedBy: "category",
+    },
+  },
+  {
+    name: "comparePeriodsOutput (tolerates NaN percentage from divide-by-zero)",
+    schema: schemas.comparePeriodsOutput,
+    raw: {
+      period1: { start: "2025-12-01", end: "2025-12-31", total: 0 },
+      period2: { start: "2026-01-01", end: "2026-01-31", total: 5 },
+      totalChange: 5,
+      totalChangePercent: NaN,
+      comparison: [
+        {
+          label: "Food",
+          period1Amount: 0,
+          period2Amount: 5,
+          change: 5,
+          changePercent: NaN,
+        },
+      ],
+    },
+  },
+  {
+    name: "getTransfersOutput",
+    schema: schemas.getTransfersOutput,
+    raw: {
+      accounts: [
+        {
+          accountName: "Checking",
+          currency: "USD",
+          inbound: 5,
+          outbound: 0,
+          net: 5,
+          transferCount: 1,
+        },
+      ],
+      totalInbound: 5,
+      totalOutbound: 0,
+      transferCount: 1,
+    },
+  },
+  {
+    name: "createTransactionOutput (created branch)",
+    schema: schemas.createTransactionOutput,
+    raw: {
+      id: "t1",
+      date: "2026-01-01",
+      amount: -5,
+      payeeName: null,
+      status: "UNRECONCILED",
+    },
+  },
+  {
+    name: "createTransactionOutput (dry-run branch)",
+    schema: schemas.createTransactionOutput,
+    raw: {
+      dryRun: true,
+      preview: {
+        accountId: "a1",
+        accountName: "Checking",
+        amount: -5,
+        date: "2026-01-01",
+        payeeName: null,
+        categoryId: null,
+        description: null,
+        currencyCode: "USD",
+      },
+      message: "preview only",
+    },
+  },
+  {
+    name: "categorizeTransactionOutput",
+    schema: schemas.categorizeTransactionOutput,
+    raw: {
+      id: "t1",
+      categoryId: "c1",
+      message: "Transaction categorized successfully",
+    },
+  },
+  {
+    name: "getCategoriesOutput",
+    schema: schemas.getCategoriesOutput,
+    raw: {
+      categories: [
+        {
+          id: "c1",
+          name: "Food",
+          parentName: null,
+          isIncome: false,
+          transactionCount: 3,
+        },
+      ],
+      totalCount: 1,
+    },
+  },
+  {
+    name: "getPayeesOutput",
+    schema: schemas.getPayeesOutput,
+    raw: [
+      {
+        id: "p1",
+        name: "Amazon",
+        defaultCategoryId: null,
+        notes: "",
+        isActive: true,
+        transactionCount: 2,
+        lastUsedDate: null,
+        aliasCount: 0,
+        uncategorizedCount: 0,
+      },
+    ],
+  },
+  {
+    name: "createPayeeOutput",
+    schema: schemas.createPayeeOutput,
+    raw: { id: "p1", name: "Amazon", message: "Payee created successfully" },
+  },
+  {
+    name: "generateReportOutput",
+    schema: schemas.generateReportOutput,
+    raw: {
+      data: [{ categoryId: "c1", categoryName: "Food", color: null, total: 5 }],
+      totalSpending: 5,
+    },
+  },
+  {
+    name: "monthlyComparisonOutput",
+    schema: schemas.monthlyComparisonOutput,
+    raw: {
+      currentMonth: "2026-01",
+      previousMonth: "2025-12",
+      currentMonthLabel: "January 2026",
+      previousMonthLabel: "December 2025",
+      currency: "USD",
+      incomeExpenses: { currentIncome: 100, savingsChangePercent: NaN },
+      notes: { savingsNote: "x", incomeNote: "y" },
+      expenses: { currentTotal: 5, previousTotal: 4, comparison: [] },
+      topCategories: { currentMonth: [], previousMonth: [] },
+      netWorth: { currentNetWorth: 1000, monthlyHistory: [] },
+      investments: { accountPerformance: [], topMovers: [] },
+    },
+  },
+  {
+    name: "getAnomaliesOutput",
+    schema: schemas.getAnomaliesOutput,
+    raw: {
+      statistics: { mean: 5, stdDev: 1 },
+      anomalies: [
+        {
+          type: "large_transaction",
+          severity: "high",
+          title: "Large purchase",
+          description: "Unusually large",
+          amount: 500,
+          transactionId: "t9",
+          transactionDate: "2026-01-15",
+          payeeName: null,
+          categoryId: null,
+          categoryName: null,
+        },
+      ],
+      counts: { high: 1, medium: 0, low: 0 },
+    },
+  },
+  {
+    name: "getPortfolioSummaryOutput",
+    schema: schemas.getPortfolioSummaryOutput,
+    raw: {
+      holdingCount: 1,
+      totalCashValue: 0,
+      totalHoldingsValue: 100,
+      totalCostBasis: 80,
+      totalPortfolioValue: 100,
+      totalGainLoss: 20,
+      totalGainLossPercent: 25,
+      timeWeightedReturn: null,
+      cagr: null,
+      holdings: [
+        {
+          symbol: "AAPL",
+          name: "Apple",
+          securityType: "stock",
+          currency: "USD",
+          quantity: 1,
+          averageCost: 80,
+          costBasis: 80,
+          marketValue: 100,
+          gainLoss: 20,
+          gainLossPercent: 25,
+        },
+      ],
+      allocation: [
+        {
+          name: "Apple",
+          symbol: "AAPL",
+          type: "security",
+          value: 100,
+          percentage: 100,
+        },
+      ],
+    },
+  },
+  {
+    name: "queryInvestmentTransactionsOutput",
+    schema: schemas.queryInvestmentTransactionsOutput,
+    raw: {
+      transactionCount: 1,
+      totalAmount: 100,
+      totalCommission: 0,
+      totalQuantity: 1,
+      actionCounts: { BUY: 1 },
+      groupedBy: null,
+      groups: null,
+      transactions: [
+        {
+          transactionDate: "2026-01-01",
+          action: "BUY",
+          accountName: null,
+          symbol: "AAPL",
+          securityName: null,
+          quantity: 1,
+          price: 100,
+          commission: 0,
+          totalAmount: 100,
+          currency: "USD",
+          description: null,
+        },
+      ],
+      truncatedTransactionList: false,
+    },
+  },
+  {
+    name: "getCapitalGainsOutput",
+    schema: schemas.getCapitalGainsOutput,
+    raw: {
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      totals: { realizedGain: 0, unrealizedGain: 20, totalCapitalGain: 20 },
+      groupedBy: "month",
+      entries: [
+        {
+          month: "2026-01",
+          accountName: null,
+          symbol: null,
+          securityName: null,
+          currency: null,
+          startValue: 80,
+          endValue: 100,
+          realizedGain: 0,
+          unrealizedGain: 20,
+          totalCapitalGain: 20,
+        },
+      ],
+      entryCount: 1,
+      truncatedEntryList: false,
+    },
+  },
+  {
+    name: "getHoldingDetailsOutput",
+    schema: schemas.getHoldingDetailsOutput,
+    raw: [
+      {
+        id: "h1",
+        accountId: "a1",
+        securityId: "s1",
+        quantity: 1,
+        averageCost: 80,
+      },
+    ],
+  },
+  {
+    name: "getUpcomingBillsOutput",
+    schema: schemas.getUpcomingBillsOutput,
+    raw: {
+      daysWindow: 30,
+      itemCount: 1,
+      overdueCount: 0,
+      totalUpcomingBills: 50,
+      totalUpcomingDeposits: 0,
+      items: [scheduledItemSample],
+    },
+  },
+  {
+    name: "getScheduledTransactionsOutput",
+    schema: schemas.getScheduledTransactionsOutput,
+    raw: {
+      totalCount: 1,
+      activeCount: 1,
+      autoPostCount: 0,
+      billCount: 1,
+      depositCount: 0,
+      items: [scheduledItemSample],
+    },
+  },
+  {
+    name: "calculateOutput",
+    schema: schemas.calculateOutput,
+    raw: {
+      result: 50,
+      formattedResult: "50%",
+      operation: "percentage",
+      label: "savings rate",
+    },
+  },
+  {
+    name: "getBudgetStatusOutput (success branch)",
+    schema: schemas.getBudgetStatusOutput,
+    raw: {
+      budgetName: "Main",
+      strategy: "envelope",
+      period: { start: "2026-01-01", end: "2026-01-31" },
+      totalBudgeted: 100,
+      totalSpent: 50,
+      totalIncome: 200,
+      remaining: 50,
+      percentUsed: 50,
+      overBudgetCategories: [],
+      nearLimitCategories: [],
+      categoryCount: 3,
+      velocity: {
+        dailyBurnRate: 1,
+        safeDailySpend: 2,
+        projectedTotal: 80,
+        projectedVariance: -20,
+        daysRemaining: 10,
+        paceStatus: "under",
+      },
+      healthScore: { score: 90, label: "Good" },
+    },
+  },
+  {
+    name: "getBudgetStatusOutput (not-found error branch)",
+    schema: schemas.getBudgetStatusOutput,
+    raw: { error: "No budget found", availableBudgets: ["Main", "Vacation"] },
+  },
+];
+
+describe("tool-output-schemas", () => {
+  // Validate exactly what the MCP SDK's server-side validateToolOutput receives:
+  // toolResult sanitizes + builds structuredContent, then the tool's outputSchema
+  // (wrapped as a Zod object) must accept it.
+  describe("structuredContent acceptance", () => {
+    it.each(cases)(
+      "$name validates against its output schema",
+      ({ schema, raw }) => {
+        const result = toolResult(raw);
+        const parsed = z.object(schema).safeParse(result.structuredContent);
+        if (!parsed.success) {
+          throw new Error(JSON.stringify(parsed.error.issues, null, 2));
+        }
+        expect(parsed.success).toBe(true);
+      },
+    );
+  });
+
+  // End-to-end through the real SDK request path: a tool declaring outputSchema
+  // and returning toolResult(...) must round-trip without an output-validation
+  // error and surface structuredContent to the client.
+  describe("end-to-end via InMemoryTransport", () => {
+    const rawFor = (schema: RawShape): unknown => {
+      const found = cases.find((c) => c.schema === schema);
+      if (!found) throw new Error("no sample for schema");
+      return found.raw;
+    };
+
+    const e2eTools: Array<{ name: string; schema: RawShape; raw: unknown }> = [
+      {
+        name: "get_accounts",
+        schema: schemas.getAccountsOutput,
+        raw: rawFor(schemas.getAccountsOutput),
+      },
+      {
+        name: "get_net_worth",
+        schema: schemas.getNetWorthOutput,
+        raw: rawFor(schemas.getNetWorthOutput),
+      },
+      {
+        name: "calculate",
+        schema: schemas.calculateOutput,
+        raw: rawFor(schemas.calculateOutput),
+      },
+      {
+        name: "get_budget_status",
+        schema: schemas.getBudgetStatusOutput,
+        raw: rawFor(schemas.getBudgetStatusOutput),
+      },
+    ];
+
+    it("returns validated structured content for tools that declare an output schema", async () => {
+      const server = new McpServer(
+        { name: "monize-test", version: "0.0.0" },
+        { capabilities: { tools: {} } },
+      );
+
+      for (const tool of e2eTools) {
+        server.registerTool(
+          tool.name,
+          {
+            description: tool.name,
+            inputSchema: {},
+            outputSchema: tool.schema,
+          },
+          () => toolResult(tool.raw),
+        );
+      }
+
+      const client = new Client(
+        { name: "test-client", version: "0.0.0" },
+        { capabilities: {} },
+      );
+      const [clientTransport, serverTransport] =
+        InMemoryTransport.createLinkedPair();
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+
+      try {
+        for (const tool of e2eTools) {
+          const res = await client.callTool({ name: tool.name, arguments: {} });
+          expect(res.isError).toBeFalsy();
+          expect(res.structuredContent).toBeDefined();
+        }
+      } finally {
+        await client.close();
+        await server.close();
+      }
+    });
+  });
+});

--- a/backend/src/mcp/tool-output-schemas.ts
+++ b/backend/src/mcp/tool-output-schemas.ts
@@ -1,0 +1,528 @@
+import { z } from "zod";
+
+/**
+ * Output schemas for every MCP tool.
+ *
+ * Each export is a Zod raw shape (the same form accepted by `inputSchema` in
+ * `registerTool`). When a tool declares an `outputSchema`, the MCP SDK requires
+ * the tool to return `structuredContent` and validates it against the schema,
+ * so these shapes describe the structured payload produced by `toolResult`.
+ *
+ * Schemas are intentionally tolerant: Zod strips undeclared keys by default, so
+ * extra/relation/timestamp fields on entity payloads never fail validation, and
+ * we only model the fields the tools meaningfully expose. Tools that return a
+ * bare array have their payload wrapped under `items` by `toStructuredContent`.
+ */
+
+// Monetary and other decimal values arrive as JS numbers at runtime (the
+// entity `numericTransformer` converts PostgreSQL decimals). NaN is allowed so
+// a divide-by-zero percentage (which serializes to JSON null) never fails
+// structured-output validation.
+const num = z.number().or(z.nan());
+const numNull = num.nullable();
+const str = z.string();
+const strNull = z.string().nullable();
+const bool = z.boolean();
+
+// ---------------------------------------------------------------------------
+// accounts.tool.ts
+// ---------------------------------------------------------------------------
+
+export const getAccountsOutput = {
+  items: z.array(
+    z.object({
+      id: str,
+      name: str,
+      accountType: str.optional(),
+      currencyCode: str.optional(),
+      currentBalance: numNull.optional(),
+      openingBalance: numNull.optional(),
+      creditLimit: numNull.optional(),
+      isClosed: bool.optional(),
+      futureTransactionsSum: numNull.optional(),
+    }),
+  ),
+};
+
+export const getAccountBalanceOutput = {
+  id: str,
+  name: str,
+  type: str,
+  currentBalance: numNull,
+  creditLimit: numNull,
+  currencyCode: str,
+};
+
+export const getAccountBalancesOutput = {
+  accounts: z.array(
+    z.object({
+      name: str,
+      type: str,
+      balance: num,
+      currency: str,
+      isClosed: bool,
+    }),
+  ),
+  totalAssets: num,
+  totalLiabilities: num,
+  netWorth: num,
+  totalAccounts: num,
+};
+
+// ---------------------------------------------------------------------------
+// net-worth.tool.ts
+// ---------------------------------------------------------------------------
+
+export const getNetWorthOutput = {
+  totalAccounts: num,
+  totalBalance: num,
+  totalAssets: num,
+  totalLiabilities: num,
+  netWorth: num,
+};
+
+export const getNetWorthHistoryOutput = {
+  items: z.array(
+    z.object({
+      month: str,
+      assets: num,
+      liabilities: num,
+      netWorth: num,
+    }),
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// transactions.tool.ts
+// ---------------------------------------------------------------------------
+
+export const searchTransactionsOutput = {
+  transactions: z.array(
+    z.object({
+      id: str,
+      splitId: str.optional(),
+      date: str,
+      payeeName: strNull,
+      categoryName: str.optional(),
+      amount: num,
+      accountName: str.optional(),
+      description: strNull,
+      status: str,
+      isSplit: bool.optional(),
+    }),
+  ),
+  total: num,
+  hasMore: bool,
+};
+
+export const queryTransactionsOutput = {
+  totalIncome: num,
+  totalExpenses: num,
+  netCashFlow: num,
+  transactionCount: num,
+  byCurrency: z
+    .record(
+      z.string(),
+      z.object({
+        totalIncome: num,
+        totalExpenses: num,
+        netCashFlow: num,
+        transactionCount: num,
+      }),
+    )
+    .optional(),
+  breakdown: z.unknown().optional(),
+};
+
+export const getSpendingByCategoryOutput = {
+  categories: z.array(
+    z.object({
+      category: str,
+      amount: num,
+      percentage: num,
+      transactionCount: num,
+    }),
+  ),
+  totalSpending: num,
+};
+
+export const getIncomeSummaryOutput = {
+  items: z.array(
+    z.object({
+      label: str,
+      amount: num,
+      count: num,
+    }),
+  ),
+  totalIncome: num,
+  groupedBy: str,
+};
+
+export const comparePeriodsOutput = {
+  period1: z.object({ start: str, end: str, total: num }),
+  period2: z.object({ start: str, end: str, total: num }),
+  totalChange: num,
+  totalChangePercent: num,
+  comparison: z.array(
+    z.object({
+      label: str,
+      period1Amount: num,
+      period2Amount: num,
+      change: num,
+      changePercent: num,
+    }),
+  ),
+};
+
+export const getTransfersOutput = {
+  accounts: z.array(
+    z.object({
+      accountName: str,
+      currency: str,
+      inbound: num,
+      outbound: num,
+      net: num,
+      transferCount: num,
+    }),
+  ),
+  totalInbound: num,
+  totalOutbound: num,
+  transferCount: num,
+};
+
+export const createTransactionOutput = {
+  // Dry-run preview branch.
+  dryRun: bool.optional(),
+  preview: z
+    .object({
+      accountId: str.optional(),
+      accountName: str.optional(),
+      amount: num.optional(),
+      date: str.optional(),
+      payeeName: strNull.optional(),
+      categoryId: strNull.optional(),
+      description: strNull.optional(),
+      currencyCode: str.optional(),
+    })
+    .optional(),
+  message: str.optional(),
+  // Created-transaction branch.
+  id: str.optional(),
+  date: str.optional(),
+  amount: num.optional(),
+  payeeName: strNull.optional(),
+  status: str.optional(),
+};
+
+export const categorizeTransactionOutput = {
+  id: str,
+  categoryId: strNull,
+  message: str,
+};
+
+// ---------------------------------------------------------------------------
+// categories.tool.ts
+// ---------------------------------------------------------------------------
+
+export const getCategoriesOutput = {
+  categories: z.array(
+    z.object({
+      id: str,
+      name: str,
+      parentName: strNull,
+      isIncome: bool,
+      transactionCount: num,
+    }),
+  ),
+  totalCount: num,
+};
+
+// ---------------------------------------------------------------------------
+// payees.tool.ts
+// ---------------------------------------------------------------------------
+
+export const getPayeesOutput = {
+  items: z.array(
+    z.object({
+      id: str,
+      name: str,
+      defaultCategoryId: strNull.optional(),
+      notes: str.optional(),
+      isActive: bool.optional(),
+      transactionCount: num.optional(),
+      lastUsedDate: strNull.optional(),
+      aliasCount: num.optional(),
+      uncategorizedCount: num.optional(),
+    }),
+  ),
+};
+
+export const createPayeeOutput = {
+  id: str,
+  name: str,
+  message: str,
+};
+
+// ---------------------------------------------------------------------------
+// reports.tool.ts
+// ---------------------------------------------------------------------------
+
+export const generateReportOutput = {
+  data: z.array(z.unknown()).optional(),
+  totals: z.unknown().optional(),
+  totalSpending: num.optional(),
+  totalIncome: num.optional(),
+};
+
+export const monthlyComparisonOutput = {
+  currentMonth: str.optional(),
+  previousMonth: str.optional(),
+  currentMonthLabel: str.optional(),
+  previousMonthLabel: str.optional(),
+  currency: str.optional(),
+  incomeExpenses: z.record(z.string(), z.unknown()).optional(),
+  notes: z.record(z.string(), z.unknown()).optional(),
+  expenses: z.record(z.string(), z.unknown()).optional(),
+  topCategories: z.record(z.string(), z.unknown()).optional(),
+  netWorth: z.record(z.string(), z.unknown()).optional(),
+  investments: z.record(z.string(), z.unknown()).optional(),
+};
+
+export const getAnomaliesOutput = {
+  statistics: z.object({ mean: num, stdDev: num }),
+  anomalies: z.array(
+    z.object({
+      type: str,
+      severity: str,
+      title: str,
+      description: str,
+      amount: num.optional(),
+      transactionId: str.optional(),
+      transactionDate: str.optional(),
+      payeeName: strNull.optional(),
+      categoryId: strNull.optional(),
+      categoryName: strNull.optional(),
+      currentPeriodAmount: num.optional(),
+      previousPeriodAmount: num.optional(),
+      percentChange: num.optional(),
+    }),
+  ),
+  counts: z.object({ high: num, medium: num, low: num }),
+};
+
+// ---------------------------------------------------------------------------
+// investments.tool.ts
+// ---------------------------------------------------------------------------
+
+export const getPortfolioSummaryOutput = {
+  holdingCount: num,
+  totalCashValue: num,
+  totalHoldingsValue: num,
+  totalCostBasis: num,
+  totalPortfolioValue: num,
+  totalGainLoss: num,
+  totalGainLossPercent: numNull,
+  timeWeightedReturn: numNull,
+  cagr: numNull,
+  holdings: z.array(
+    z.object({
+      symbol: str,
+      name: str,
+      securityType: str,
+      currency: str,
+      quantity: num,
+      averageCost: numNull,
+      costBasis: num,
+      marketValue: numNull,
+      gainLoss: numNull,
+      gainLossPercent: numNull,
+    }),
+  ),
+  allocation: z.array(
+    z.object({
+      name: str,
+      symbol: strNull,
+      type: str,
+      value: num,
+      percentage: num,
+    }),
+  ),
+};
+
+export const queryInvestmentTransactionsOutput = {
+  transactionCount: num,
+  totalAmount: num,
+  totalCommission: num,
+  totalQuantity: num,
+  actionCounts: z.record(z.string(), num),
+  groupedBy: strNull,
+  groups: z
+    .array(
+      z.object({
+        key: str,
+        transactionCount: num,
+        totalQuantity: num,
+        totalAmount: num,
+        totalCommission: num,
+      }),
+    )
+    .nullable(),
+  transactions: z.array(
+    z.object({
+      transactionDate: str,
+      action: str,
+      accountName: strNull,
+      symbol: strNull,
+      securityName: strNull,
+      quantity: numNull,
+      price: numNull,
+      commission: num,
+      totalAmount: num,
+      currency: strNull,
+      description: strNull,
+    }),
+  ),
+  truncatedTransactionList: bool,
+};
+
+export const getCapitalGainsOutput = {
+  startDate: str,
+  endDate: str,
+  totals: z.object({
+    realizedGain: num,
+    unrealizedGain: num,
+    totalCapitalGain: num,
+  }),
+  groupedBy: str,
+  entries: z.array(
+    z.object({
+      month: strNull,
+      accountName: strNull,
+      symbol: strNull,
+      securityName: strNull,
+      currency: strNull,
+      startValue: num,
+      endValue: num,
+      realizedGain: num,
+      unrealizedGain: num,
+      totalCapitalGain: num,
+    }),
+  ),
+  entryCount: num,
+  truncatedEntryList: bool,
+};
+
+export const getHoldingDetailsOutput = {
+  items: z.array(
+    z.object({
+      id: str,
+      accountId: str,
+      securityId: str,
+      quantity: num,
+      averageCost: numNull,
+    }),
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// scheduled.tool.ts
+// ---------------------------------------------------------------------------
+
+const scheduledItem = z.object({
+  id: str,
+  name: str,
+  accountId: str,
+  accountName: str,
+  payeeName: strNull,
+  categoryName: strNull,
+  amount: num,
+  currency: str,
+  frequency: str,
+  nextDueDate: str,
+  daysUntilDue: num,
+  isActive: bool,
+  autoPost: bool,
+  kind: str,
+  description: strNull,
+});
+
+export const getUpcomingBillsOutput = {
+  daysWindow: num,
+  itemCount: num,
+  overdueCount: num,
+  totalUpcomingBills: num,
+  totalUpcomingDeposits: num,
+  items: z.array(scheduledItem),
+};
+
+export const getScheduledTransactionsOutput = {
+  totalCount: num,
+  activeCount: num,
+  autoPostCount: num,
+  billCount: num,
+  depositCount: num,
+  items: z.array(scheduledItem),
+};
+
+// ---------------------------------------------------------------------------
+// calculate.tool.ts
+// ---------------------------------------------------------------------------
+
+export const calculateOutput = {
+  result: num,
+  formattedResult: str,
+  operation: str,
+  label: str.optional(),
+};
+
+// ---------------------------------------------------------------------------
+// budgets.tool.ts
+// ---------------------------------------------------------------------------
+
+export const getBudgetStatusOutput = {
+  // Success branch (all optional so the not-found error branch validates too).
+  budgetName: str.optional(),
+  strategy: str.optional(),
+  period: z.object({ start: str, end: str }).optional(),
+  totalBudgeted: num.optional(),
+  totalSpent: num.optional(),
+  totalIncome: num.optional(),
+  remaining: num.optional(),
+  percentUsed: num.optional(),
+  overBudgetCategories: z
+    .array(
+      z.object({
+        category: str,
+        budgeted: num,
+        spent: num,
+        percentUsed: num,
+      }),
+    )
+    .optional(),
+  nearLimitCategories: z
+    .array(
+      z.object({
+        category: str,
+        budgeted: num,
+        spent: num,
+        remaining: num,
+        percentUsed: num,
+      }),
+    )
+    .optional(),
+  categoryCount: num.optional(),
+  velocity: z
+    .object({
+      dailyBurnRate: num,
+      safeDailySpend: num,
+      projectedTotal: num,
+      projectedVariance: num,
+      daysRemaining: num,
+      paceStatus: str,
+    })
+    .optional(),
+  healthScore: z.object({ score: num, label: str }).optional(),
+  // Not-found error branch.
+  error: str.optional(),
+  availableBudgets: z.array(str).optional(),
+};

--- a/backend/src/mcp/tools/accounts.tool.ts
+++ b/backend/src/mcp/tools/accounts.tool.ts
@@ -15,6 +15,7 @@ import {
   getAccountBalanceOutput,
   getAccountBalancesOutput,
 } from "../tool-output-schemas";
+import { READ_ONLY } from "../mcp-annotations";
 
 @Injectable()
 export class McpAccountsTools {
@@ -24,6 +25,8 @@ export class McpAccountsTools {
     server.registerTool(
       "get_accounts",
       {
+        title: "List accounts",
+        annotations: READ_ONLY,
         description: "List all accounts with balances",
         inputSchema: {
           includeInactive: z
@@ -54,6 +57,8 @@ export class McpAccountsTools {
     server.registerTool(
       "get_account_balance",
       {
+        title: "Get account balance",
+        annotations: READ_ONLY,
         description: "Get detailed balance for a specific account",
         inputSchema: {
           accountId: z.string().uuid().describe("Account ID"),
@@ -88,6 +93,8 @@ export class McpAccountsTools {
     server.registerTool(
       "get_account_balances",
       {
+        title: "Get account balances",
+        annotations: READ_ONLY,
         description:
           "Get current account balances with per-account type and currency, plus total assets, total liabilities, and net worth. Returns the same shape as the AI Assistant's get_account_balances tool. Brokerage accounts show market value; every other account shows currentBalance + futureTransactionsSum. Totals match the dashboard Net Worth widget.",
         inputSchema: {

--- a/backend/src/mcp/tools/accounts.tool.ts
+++ b/backend/src/mcp/tools/accounts.tool.ts
@@ -10,6 +10,11 @@ import {
   toolError,
   safeToolError,
 } from "../mcp-context";
+import {
+  getAccountsOutput,
+  getAccountBalanceOutput,
+  getAccountBalancesOutput,
+} from "../tool-output-schemas";
 
 @Injectable()
 export class McpAccountsTools {
@@ -26,6 +31,7 @@ export class McpAccountsTools {
             .optional()
             .describe("Include closed accounts"),
         },
+        outputSchema: getAccountsOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -52,6 +58,7 @@ export class McpAccountsTools {
         inputSchema: {
           accountId: z.string().uuid().describe("Account ID"),
         },
+        outputSchema: getAccountBalanceOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -105,6 +112,7 @@ export class McpAccountsTools {
               "Optional: filter to specific account types (CHEQUING, SAVINGS, CREDIT_CARD, LOAN, MORTGAGE, INVESTMENT, CASH, LINE_OF_CREDIT, ASSET, OTHER). Omit to include all types.",
             ),
         },
+        outputSchema: getAccountBalancesOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);

--- a/backend/src/mcp/tools/budgets.tool.ts
+++ b/backend/src/mcp/tools/budgets.tool.ts
@@ -9,6 +9,7 @@ import {
   toolError,
   safeToolError,
 } from "../mcp-context";
+import { getBudgetStatusOutput } from "../tool-output-schemas";
 
 @Injectable()
 export class McpBudgetsTools {
@@ -36,6 +37,7 @@ export class McpBudgetsTools {
               "Optional: filter to a specific budget by name. If omitted, uses the first active budget.",
             ),
         },
+        outputSchema: getBudgetStatusOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);

--- a/backend/src/mcp/tools/budgets.tool.ts
+++ b/backend/src/mcp/tools/budgets.tool.ts
@@ -10,6 +10,7 @@ import {
   safeToolError,
 } from "../mcp-context";
 import { getBudgetStatusOutput } from "../tool-output-schemas";
+import { READ_ONLY } from "../mcp-annotations";
 
 @Injectable()
 export class McpBudgetsTools {
@@ -19,6 +20,8 @@ export class McpBudgetsTools {
     server.registerTool(
       "get_budget_status",
       {
+        title: "Budget status",
+        annotations: READ_ONLY,
         description:
           "Get budget status for a specific period. Returns total budgeted vs actual spending, per-category breakdowns, spending velocity, safe daily spend, and health score. Returns the same shape as the AI Assistant's get_budget_status tool.",
         inputSchema: {

--- a/backend/src/mcp/tools/calculate.tool.ts
+++ b/backend/src/mcp/tools/calculate.tool.ts
@@ -4,6 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toolResult, toolError } from "../mcp-context";
 import { executeCalculation } from "../../ai/query/calculate-tool";
 import { calculateOutput } from "../tool-output-schemas";
+import { READ_ONLY } from "../mcp-annotations";
 
 @Injectable()
 export class McpCalculateTools {
@@ -11,6 +12,8 @@ export class McpCalculateTools {
     server.registerTool(
       "calculate",
       {
+        title: "Calculate",
+        annotations: READ_ONLY,
         description:
           "Perform accurate server-side arithmetic on numbers from previous tool results. " +
           "Use this instead of doing math yourself. Supports: percentage (part/whole*100), " +

--- a/backend/src/mcp/tools/calculate.tool.ts
+++ b/backend/src/mcp/tools/calculate.tool.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toolResult, toolError } from "../mcp-context";
 import { executeCalculation } from "../../ai/query/calculate-tool";
+import { calculateOutput } from "../tool-output-schemas";
 
 @Injectable()
 export class McpCalculateTools {
@@ -33,6 +34,7 @@ export class McpCalculateTools {
             .optional()
             .describe("Optional label (e.g., 'savings rate')"),
         },
+        outputSchema: calculateOutput,
       },
       async (args) => {
         const result = executeCalculation({

--- a/backend/src/mcp/tools/categories.tool.ts
+++ b/backend/src/mcp/tools/categories.tool.ts
@@ -10,6 +10,7 @@ import {
   safeToolError,
 } from "../mcp-context";
 import { getCategoriesOutput } from "../tool-output-schemas";
+import { READ_ONLY } from "../mcp-annotations";
 
 @Injectable()
 export class McpCategoriesTools {
@@ -19,6 +20,8 @@ export class McpCategoriesTools {
     server.registerTool(
       "get_categories",
       {
+        title: "List categories",
+        annotations: READ_ONLY,
         description:
           "List the user's categories with their hierarchy (parent names) and transaction counts. Optionally filter by type or search by name. Returns the same shape as the AI Assistant's get_categories tool.",
         inputSchema: {

--- a/backend/src/mcp/tools/categories.tool.ts
+++ b/backend/src/mcp/tools/categories.tool.ts
@@ -9,6 +9,7 @@ import {
   toolError,
   safeToolError,
 } from "../mcp-context";
+import { getCategoriesOutput } from "../tool-output-schemas";
 
 @Injectable()
 export class McpCategoriesTools {
@@ -35,6 +36,7 @@ export class McpCategoriesTools {
               "Optional case-insensitive substring match on category name. Matched subcategories' parents are included so hierarchy stays visible.",
             ),
         },
+        outputSchema: getCategoriesOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);

--- a/backend/src/mcp/tools/investments.tool.ts
+++ b/backend/src/mcp/tools/investments.tool.ts
@@ -22,6 +22,7 @@ import {
   getCapitalGainsOutput,
   getHoldingDetailsOutput,
 } from "../tool-output-schemas";
+import { READ_ONLY } from "../mcp-annotations";
 
 @Injectable()
 export class McpInvestmentsTools {
@@ -35,6 +36,8 @@ export class McpInvestmentsTools {
     server.registerTool(
       "get_portfolio_summary",
       {
+        title: "Portfolio summary",
+        annotations: READ_ONLY,
         description:
           "Get investment portfolio overview with holdings, gains/losses, and allocation. Returns the same compact, LLM-friendly shape as the AI Assistant's tool.",
         inputSchema: {
@@ -69,6 +72,8 @@ export class McpInvestmentsTools {
     server.registerTool(
       "query_investment_transactions",
       {
+        title: "Query investment transactions",
+        annotations: READ_ONLY,
         description:
           "Query brokerage investment-account transactions (buys, sells, dividends, interest, capital gains, splits, transfers, reinvestments, share adjustments). Filter by account, security symbol, action, and date; optionally group by account, date, security, or action. Returns the same compact, LLM-friendly shape as the AI Assistant's tool.",
         inputSchema: {
@@ -139,6 +144,8 @@ export class McpInvestmentsTools {
     server.registerTool(
       "get_capital_gains",
       {
+        title: "Capital gains",
+        annotations: READ_ONLY,
         description:
           "Per-period capital gains (realized + unrealized) for the user's investment accounts. Replays transaction history and snapshots positions against historical close prices, so the output includes mark-to-market movement on currently-held positions in addition to realized SELL gains. Requires startDate and endDate. Returns the same compact, LLM-friendly shape as the AI Assistant's tool.",
         inputSchema: {
@@ -199,6 +206,8 @@ export class McpInvestmentsTools {
     server.registerTool(
       "get_holding_details",
       {
+        title: "Holding details",
+        annotations: READ_ONLY,
         description: "Get details for holdings in a specific account",
         inputSchema: {
           accountId: z

--- a/backend/src/mcp/tools/investments.tool.ts
+++ b/backend/src/mcp/tools/investments.tool.ts
@@ -16,6 +16,12 @@ import {
   toolError,
   safeToolError,
 } from "../mcp-context";
+import {
+  getPortfolioSummaryOutput,
+  queryInvestmentTransactionsOutput,
+  getCapitalGainsOutput,
+  getHoldingDetailsOutput,
+} from "../tool-output-schemas";
 
 @Injectable()
 export class McpInvestmentsTools {
@@ -40,6 +46,7 @@ export class McpInvestmentsTools {
               "Optional investment account IDs to filter to. Omit to cover all investment accounts.",
             ),
         },
+        outputSchema: getPortfolioSummaryOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -99,6 +106,7 @@ export class McpInvestmentsTools {
               "Grouping: by account name, transaction date, security symbol, or action type. Defaults to 'security' when omitted.",
             ),
         },
+        outputSchema: queryInvestmentTransactionsOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -159,6 +167,7 @@ export class McpInvestmentsTools {
               "Bucket the breakdown by month, security, or account. Defaults to 'month' when omitted.",
             ),
         },
+        outputSchema: getCapitalGainsOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -198,6 +207,7 @@ export class McpInvestmentsTools {
             .optional()
             .describe("Account ID to filter holdings"),
         },
+        outputSchema: getHoldingDetailsOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);

--- a/backend/src/mcp/tools/net-worth.tool.ts
+++ b/backend/src/mcp/tools/net-worth.tool.ts
@@ -15,6 +15,7 @@ import {
   getNetWorthOutput,
   getNetWorthHistoryOutput,
 } from "../tool-output-schemas";
+import { READ_ONLY } from "../mcp-annotations";
 
 @Injectable()
 export class McpNetWorthTools {
@@ -27,6 +28,8 @@ export class McpNetWorthTools {
     server.registerTool(
       "get_net_worth",
       {
+        title: "Get net worth",
+        annotations: READ_ONLY,
         description: "Get current net worth breakdown by account",
         inputSchema: {},
         outputSchema: getNetWorthOutput,
@@ -49,6 +52,8 @@ export class McpNetWorthTools {
     server.registerTool(
       "get_net_worth_history",
       {
+        title: "Get net worth history",
+        annotations: READ_ONLY,
         description:
           "Get net worth over time (monthly snapshots). Returns the same shape as the AI Assistant's get_net_worth_history tool. Default range is the last 12 months when both dates are omitted.",
         inputSchema: {

--- a/backend/src/mcp/tools/net-worth.tool.ts
+++ b/backend/src/mcp/tools/net-worth.tool.ts
@@ -11,6 +11,10 @@ import {
   safeToolError,
 } from "../mcp-context";
 import { formatDateYMD } from "../../common/date-utils";
+import {
+  getNetWorthOutput,
+  getNetWorthHistoryOutput,
+} from "../tool-output-schemas";
 
 @Injectable()
 export class McpNetWorthTools {
@@ -25,6 +29,7 @@ export class McpNetWorthTools {
       {
         description: "Get current net worth breakdown by account",
         inputSchema: {},
+        outputSchema: getNetWorthOutput,
       },
       async (_args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -66,6 +71,7 @@ export class McpNetWorthTools {
               "Number of months of history. Only applied when startDate/endDate are omitted.",
             ),
         },
+        outputSchema: getNetWorthHistoryOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);

--- a/backend/src/mcp/tools/payees.tool.ts
+++ b/backend/src/mcp/tools/payees.tool.ts
@@ -10,6 +10,7 @@ import {
   safeToolError,
 } from "../mcp-context";
 import { getPayeesOutput, createPayeeOutput } from "../tool-output-schemas";
+import { READ_ONLY, CREATE } from "../mcp-annotations";
 
 @Injectable()
 export class McpPayeesTools {
@@ -19,6 +20,8 @@ export class McpPayeesTools {
     server.registerTool(
       "get_payees",
       {
+        title: "List payees",
+        annotations: READ_ONLY,
         description: "List payees, optionally filtered by search query",
         inputSchema: {
           search: z
@@ -55,6 +58,8 @@ export class McpPayeesTools {
     server.registerTool(
       "create_payee",
       {
+        title: "Create payee",
+        annotations: CREATE,
         description: "Create a new payee",
         inputSchema: {
           name: z.string().max(100).describe("Payee name"),

--- a/backend/src/mcp/tools/payees.tool.ts
+++ b/backend/src/mcp/tools/payees.tool.ts
@@ -9,6 +9,7 @@ import {
   toolError,
   safeToolError,
 } from "../mcp-context";
+import { getPayeesOutput, createPayeeOutput } from "../tool-output-schemas";
 
 @Injectable()
 export class McpPayeesTools {
@@ -26,6 +27,7 @@ export class McpPayeesTools {
             .optional()
             .describe("Search query to filter payees"),
         },
+        outputSchema: getPayeesOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -62,6 +64,7 @@ export class McpPayeesTools {
             .optional()
             .describe("Default category ID for this payee"),
         },
+        outputSchema: createPayeeOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);

--- a/backend/src/mcp/tools/reports.tool.ts
+++ b/backend/src/mcp/tools/reports.tool.ts
@@ -18,6 +18,7 @@ import {
   monthlyComparisonOutput,
   getAnomaliesOutput,
 } from "../tool-output-schemas";
+import { READ_ONLY } from "../mcp-annotations";
 
 @Injectable()
 export class McpReportsTools {
@@ -27,6 +28,8 @@ export class McpReportsTools {
     server.registerTool(
       "generate_report",
       {
+        title: "Generate report",
+        annotations: READ_ONLY,
         description: "Run a financial report",
         inputSchema: {
           type: z
@@ -109,6 +112,8 @@ export class McpReportsTools {
     server.registerTool(
       "monthly_comparison",
       {
+        title: "Monthly comparison",
+        annotations: READ_ONLY,
         description:
           "Generate a monthly comparison report comparing one month to the previous month. Includes income vs expenses, category spending breakdown, net worth, and investment performance.",
         inputSchema: {
@@ -143,6 +148,8 @@ export class McpReportsTools {
     server.registerTool(
       "get_anomalies",
       {
+        title: "Detect spending anomalies",
+        annotations: READ_ONLY,
         description: "Find unusual transactions or spending patterns",
         inputSchema: {
           months: z

--- a/backend/src/mcp/tools/reports.tool.ts
+++ b/backend/src/mcp/tools/reports.tool.ts
@@ -13,6 +13,11 @@ import {
   getDefaultDateRange,
   getDefaultPreviousMonth,
 } from "../../common/tool-schemas";
+import {
+  generateReportOutput,
+  monthlyComparisonOutput,
+  getAnomaliesOutput,
+} from "../tool-output-schemas";
 
 @Injectable()
 export class McpReportsTools {
@@ -44,6 +49,7 @@ export class McpReportsTools {
             .optional()
             .describe("End date (YYYY-MM-DD). Defaults to today."),
         },
+        outputSchema: generateReportOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -114,6 +120,7 @@ export class McpReportsTools {
               "Month to compare in YYYY-MM format (e.g., 2026-01). Defaults to the previous complete month.",
             ),
         },
+        outputSchema: monthlyComparisonOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -146,6 +153,7 @@ export class McpReportsTools {
             .default(3)
             .describe("Number of months to analyze (default 3)"),
         },
+        outputSchema: getAnomaliesOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);

--- a/backend/src/mcp/tools/scheduled.tool.ts
+++ b/backend/src/mcp/tools/scheduled.tool.ts
@@ -9,6 +9,10 @@ import {
   toolError,
   safeToolError,
 } from "../mcp-context";
+import {
+  getUpcomingBillsOutput,
+  getScheduledTransactionsOutput,
+} from "../tool-output-schemas";
 
 const SCHEDULED_KIND_VALUES = [
   "bill",
@@ -50,6 +54,7 @@ export class McpScheduledTools {
             .optional()
             .describe("Optional account IDs to filter to."),
         },
+        outputSchema: getUpcomingBillsOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -98,6 +103,7 @@ export class McpScheduledTools {
               "Filter by active status. Omit to include both active and paused schedules.",
             ),
         },
+        outputSchema: getScheduledTransactionsOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);

--- a/backend/src/mcp/tools/scheduled.tool.ts
+++ b/backend/src/mcp/tools/scheduled.tool.ts
@@ -13,6 +13,7 @@ import {
   getUpcomingBillsOutput,
   getScheduledTransactionsOutput,
 } from "../tool-output-schemas";
+import { READ_ONLY } from "../mcp-annotations";
 
 const SCHEDULED_KIND_VALUES = [
   "bill",
@@ -32,6 +33,8 @@ export class McpScheduledTools {
     server.registerTool(
       "get_upcoming_bills",
       {
+        title: "Upcoming bills and deposits",
+        annotations: READ_ONLY,
         description:
           "Get upcoming scheduled bills and deposits due within a date window. Each item is classified as bill / deposit / transfer / investment and includes a daysUntilDue value (negative when overdue). Returns the same shape as the AI Assistant's get_upcoming_bills tool.",
         inputSchema: {
@@ -82,6 +85,8 @@ export class McpScheduledTools {
     server.registerTool(
       "get_scheduled_transactions",
       {
+        title: "List scheduled transactions",
+        annotations: READ_ONLY,
         description:
           "List all scheduled/recurring transactions (bills, deposits, transfers, investments). Returns rollup counts plus a curated per-item payload. Returns the same shape as the AI Assistant's get_scheduled_transactions tool.",
         inputSchema: {

--- a/backend/src/mcp/tools/transactions.tool.ts
+++ b/backend/src/mcp/tools/transactions.tool.ts
@@ -28,6 +28,7 @@ import {
   createTransactionOutput,
   categorizeTransactionOutput,
 } from "../tool-output-schemas";
+import { READ_ONLY, CREATE, UPDATE } from "../mcp-annotations";
 
 @Injectable()
 export class McpTransactionsTools {
@@ -43,6 +44,8 @@ export class McpTransactionsTools {
     server.registerTool(
       "search_transactions",
       {
+        title: "Search transactions",
+        annotations: READ_ONLY,
         description: "Search and filter transactions",
         inputSchema: {
           query: z.string().max(200).optional().describe("Search text"),
@@ -123,6 +126,8 @@ export class McpTransactionsTools {
     server.registerTool(
       "query_transactions",
       {
+        title: "Query transaction totals",
+        annotations: READ_ONLY,
         description:
           "Search and aggregate transaction data. Returns totals, counts, and optional grouped breakdowns (category, payee, year, month, week) - never individual transaction details. Returns the same shape as the AI Assistant's query_transactions tool.",
         inputSchema: {
@@ -192,6 +197,8 @@ export class McpTransactionsTools {
     server.registerTool(
       "get_spending_by_category",
       {
+        title: "Spending by category",
+        annotations: READ_ONLY,
         description:
           "Spending breakdown by category for a date range. Returns each category with total amount, percentage of total spending, and transaction count. Sorted by amount descending. Returns the same shape as the AI Assistant's get_spending_by_category tool.",
         inputSchema: {
@@ -241,6 +248,8 @@ export class McpTransactionsTools {
     server.registerTool(
       "get_income_summary",
       {
+        title: "Income summary",
+        annotations: READ_ONLY,
         description:
           "Income summary for a date range, grouped by category, payee, or month. Returns the same shape as the AI Assistant's get_income_summary tool.",
         inputSchema: {
@@ -285,6 +294,8 @@ export class McpTransactionsTools {
     server.registerTool(
       "compare_periods",
       {
+        title: "Compare periods",
+        annotations: READ_ONLY,
         description:
           "Compare spending or income between two time periods. Returns side-by-side comparison showing absolute and percentage changes per group. If any of the four period dates are omitted, defaults to the previous full month (period1) vs the current month-to-date (period2). Returns the same shape as the AI Assistant's compare_periods tool.",
         inputSchema: {
@@ -359,6 +370,8 @@ export class McpTransactionsTools {
     server.registerTool(
       "get_transfers",
       {
+        title: "Get transfers",
+        annotations: READ_ONLY,
         description:
           "Get transfer activity between the user's own accounts for a date range. Returns per-account inbound, outbound, net, and count. Transfers are deliberately excluded from other transaction queries because they net to zero across accounts. Returns the same shape as the AI Assistant's get_transfers tool.",
         inputSchema: {
@@ -406,6 +419,8 @@ export class McpTransactionsTools {
     server.registerTool(
       "create_transaction",
       {
+        title: "Create transaction",
+        annotations: CREATE,
         description:
           "Create a new transaction. Set dryRun=true to preview without saving.",
         inputSchema: {
@@ -504,6 +519,8 @@ export class McpTransactionsTools {
     server.registerTool(
       "categorize_transaction",
       {
+        title: "Categorize transaction",
+        annotations: UPDATE,
         description: "Assign a category to a transaction",
         inputSchema: {
           transactionId: z.string().uuid().describe("Transaction ID"),

--- a/backend/src/mcp/tools/transactions.tool.ts
+++ b/backend/src/mcp/tools/transactions.tool.ts
@@ -18,6 +18,16 @@ import {
   getDefaultDateRange,
   resolveComparePeriods,
 } from "../../common/tool-schemas";
+import {
+  searchTransactionsOutput,
+  queryTransactionsOutput,
+  getSpendingByCategoryOutput,
+  getIncomeSummaryOutput,
+  comparePeriodsOutput,
+  getTransfersOutput,
+  createTransactionOutput,
+  categorizeTransactionOutput,
+} from "../tool-output-schemas";
 
 @Injectable()
 export class McpTransactionsTools {
@@ -77,6 +87,7 @@ export class McpTransactionsTools {
             .default(50)
             .describe("Max results (default 50, max 100)"),
         },
+        outputSchema: searchTransactionsOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -149,6 +160,7 @@ export class McpTransactionsTools {
             .optional()
             .describe("Filter by direction"),
         },
+        outputSchema: queryTransactionsOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -203,6 +215,7 @@ export class McpTransactionsTools {
               `Limit to top N categories by amount. Defaults to ${DEFAULT_TOP_N}.`,
             ),
         },
+        outputSchema: getSpendingByCategoryOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -246,6 +259,7 @@ export class McpTransactionsTools {
             .optional()
             .describe("How to group income (default: category)"),
         },
+        outputSchema: getIncomeSummaryOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -309,6 +323,7 @@ export class McpTransactionsTools {
             .optional()
             .describe("Filter by direction (default: expenses)"),
         },
+        outputSchema: comparePeriodsOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -365,6 +380,7 @@ export class McpTransactionsTools {
               "Optional account IDs to filter to. Omit to cover all accounts.",
             ),
         },
+        outputSchema: getTransfersOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -415,6 +431,7 @@ export class McpTransactionsTools {
               "If true, validate and return a preview without creating the transaction",
             ),
         },
+        outputSchema: createTransactionOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);
@@ -492,6 +509,7 @@ export class McpTransactionsTools {
           transactionId: z.string().uuid().describe("Transaction ID"),
           categoryId: z.string().uuid().describe("Category ID"),
         },
+        outputSchema: categorizeTransactionOutput,
       },
       async (args, extra) => {
         const ctx = resolve(extra.sessionId);


### PR DESCRIPTION
## Summary

Establishes the MCP server's tool output validation layer by introducing Zod schemas for all 27 tools and shared annotation presets. This enables the MCP SDK to validate `structuredContent` returned by tools and ensures consistent, documented tool metadata across the server.

## Key Changes

- **`tool-output-schemas.ts`** (new): Defines a Zod raw shape for every MCP tool's output, covering all domains (accounts, transactions, investments, budgets, etc.). Schemas are intentionally tolerant—they strip undeclared keys and allow `NaN` for divide-by-zero percentages—so real service payloads with extra fields or null values never fail validation.

- **`mcp-annotations.ts`** (new): Introduces three shared annotation presets (`READ_ONLY`, `CREATE`, `UPDATE`) that every tool must declare. These hint to MCP clients whether a tool mutates state and whether repeated calls are idempotent.

- **`tool-output-schemas.spec.ts`** (new): Comprehensive test suite with 27 test cases pairing each schema to a representative payload (mirroring real service return shapes, including null fields and undeclared entity fields). Tests both direct schema validation and end-to-end validation via `InMemoryTransport` to ensure tools round-trip without output-validation errors.

- **`mcp-context.ts`** (modified): Added `toStructuredContent()` helper that wraps sanitized payloads into the object form required by MCP's `structuredContent`. Bare arrays nest under `items`; primitives under `value`; objects pass through unchanged.

- **All tool files** (modified): Imported and applied output schemas and annotations to every tool's `registerTool()` call. Each tool now declares `title`, `annotations`, `inputSchema`, and `outputSchema`.

- **All resource and prompt files** (modified): Added `title` field to resource and prompt registrations for consistency with MCP spec.

- **`mcp-server.service.spec.ts`** (modified): Added test verifying the server advertises the backend's `package.json` version, ensuring it auto-updates with releases.

- **`mcp-annotations.spec.ts`** (new): Enforces that every tool has title, input/output schema, and annotations; validates read/write hints match tool intent; and checks tool count against expected total.

- **`CLAUDE.md`** (new): Comprehensive MCP server documentation covering architecture, directory layout, tool registration format, output schema conventions, and the `toolResult` / `structuredContent` contract.

## Notable Implementation Details

- Schemas use helper constants (`num`, `numNull`, `str`, `strNull`, `bool`) for consistency and to centralize the `NaN` tolerance rule.
- The `toStructuredContent()` function ensures the MCP SDK always receives a JSON object, even when tools return bare arrays or primitives.
- Test payloads include real-world edge cases: null fields, undeclared entity relations, and NaN percentages from divide-by-zero, ensuring schemas accept what the service actually returns.
- Every tool now has a human-readable `title` for client display, matching MCP spec requirements.

https://claude.ai/code/session_011VfF4dXBv65vgXSJM1LLGA