### PR TITLE
Fix payee default category persistence and form field clearing

### DIFF
--- a/backend/src/payees/payees.service.spec.ts
+++ b/backend/src/payees/payees.service.spec.ts
@@ -465,9 +465,11 @@ describe("PayeesService", () => {
 
       expect(result.name).toBe("New Name");
       expect(result.notes).toBe("Updated notes");
-      expect(
-        mockDataSource.createQueryRunner().manager.save,
-      ).toHaveBeenCalled();
+      expect(mockQueryRunner.manager.update).toHaveBeenCalledWith(
+        Payee,
+        { id: "payee-1", userId },
+        { name: "New Name", notes: "Updated notes" },
+      );
     });
 
     it("should throw NotFoundException when payee not found", async () => {
@@ -519,9 +521,23 @@ describe("PayeesService", () => {
 
       await service.update(userId, "payee-1", { notes: "Just updating notes" });
 
-      expect(
-        mockDataSource.createQueryRunner().manager.update,
-      ).not.toHaveBeenCalled();
+      // The payee row itself is updated, but the name-change cascade to
+      // transactions and scheduled transactions must not run.
+      expect(mockQueryRunner.manager.update).toHaveBeenCalledWith(
+        Payee,
+        { id: "payee-1", userId },
+        { notes: "Just updating notes" },
+      );
+      expect(mockQueryRunner.manager.update).not.toHaveBeenCalledWith(
+        Transaction,
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(mockQueryRunner.manager.update).not.toHaveBeenCalledWith(
+        ScheduledTransaction,
+        expect.anything(),
+        expect.anything(),
+      );
     });
 
     it("should skip name conflict check when name is unchanged", async () => {
@@ -616,7 +632,12 @@ describe("PayeesService", () => {
       });
 
       expect(result.transactionsCategorized).toBe(0);
-      expect(mockQueryRunner.manager.update).not.toHaveBeenCalled();
+      // The payee row is updated, but no backfill runs against transactions.
+      expect(mockQueryRunner.manager.update).not.toHaveBeenCalledWith(
+        Transaction,
+        expect.anything(),
+        expect.anything(),
+      );
     });
 
     it("does not apply a category when the payee ends up without one", async () => {
@@ -632,7 +653,12 @@ describe("PayeesService", () => {
       });
 
       expect(result.transactionsCategorized).toBe(0);
-      expect(mockQueryRunner.manager.update).not.toHaveBeenCalled();
+      // Clearing the category writes null to the payee but runs no backfill.
+      expect(mockQueryRunner.manager.update).not.toHaveBeenCalledWith(
+        Transaction,
+        expect.anything(),
+        expect.anything(),
+      );
     });
 
     it("should update defaultCategoryId via explicit mapping", async () => {
@@ -653,12 +679,15 @@ describe("PayeesService", () => {
       });
 
       expect(result.defaultCategoryId).toBe("cat-99");
-      // The stale loaded relation must be cleared so TypeORM save() persists
-      // the new scalar FK instead of re-deriving the old one from the relation.
-      const savedPayee =
-        mockDataSource.createQueryRunner().manager.save.mock.calls[0][0];
-      expect(savedPayee.defaultCategoryId).toBe("cat-99");
-      expect(savedPayee.defaultCategory).toBeNull();
+      // Persist with a column-level update keyed by id+userId so the FK is
+      // written from the scalar. save() on the loaded entity would re-derive
+      // the FK from its hydrated defaultCategory relation and clobber it.
+      expect(mockQueryRunner.manager.update).toHaveBeenCalledWith(
+        Payee,
+        { id: "payee-1", userId },
+        { defaultCategoryId: "cat-99" },
+      );
+      expect(mockQueryRunner.manager.save).not.toHaveBeenCalled();
     });
 
     it("should clear defaultCategoryId when set to null", async () => {
@@ -680,12 +709,12 @@ describe("PayeesService", () => {
       });
 
       expect(result.defaultCategoryId).toBeNull();
-      // Verify the relation object is also nulled so TypeORM save() doesn't
-      // re-derive the FK from the stale loaded relation entity
-      const savedPayee =
-        mockDataSource.createQueryRunner().manager.save.mock.calls[0][0];
-      expect(savedPayee.defaultCategoryId).toBeNull();
-      expect(savedPayee.defaultCategory).toBeNull();
+      // Clearing writes null to the FK column directly.
+      expect(mockQueryRunner.manager.update).toHaveBeenCalledWith(
+        Payee,
+        { id: "payee-1", userId },
+        { defaultCategoryId: null },
+      );
     });
   });
 
@@ -1623,9 +1652,11 @@ describe("PayeesService", () => {
       });
 
       expect(result.isActive).toBe(false);
-      expect(
-        mockDataSource.createQueryRunner().manager.save,
-      ).toHaveBeenCalled();
+      expect(mockQueryRunner.manager.update).toHaveBeenCalledWith(
+        Payee,
+        { id: "payee-1", userId },
+        { isActive: false },
+      );
     });
 
     it("should not modify isActive when not included in DTO", async () => {

--- a/backend/src/payees/payees.service.ts
+++ b/backend/src/payees/payees.service.ts
@@ -310,21 +310,32 @@ export class PayeesService {
       }
     }
 
-    // SECURITY: Explicit property mapping instead of Object.assign to prevent mass assignment
+    // SECURITY: Explicit property mapping instead of Object.assign to prevent
+    // mass assignment. We persist with a column-level update (not save() on the
+    // loaded entity) so the default_category_id FK is written from the scalar.
+    // Saving the loaded entity is unsafe here: its defaultCategory relation is
+    // hydrated, and TypeORM derives the FK from that relation -- so changing
+    // only the scalar (or nulling the relation) makes save() clobber the FK,
+    // which silently wiped the default category on an unchanged re-save.
+    const updateFields: Partial<Payee> = {};
     const nameChanged =
       updatePayeeDto.name !== undefined && updatePayeeDto.name !== payee.name;
-    if (updatePayeeDto.name !== undefined) payee.name = updatePayeeDto.name;
-    if (updatePayeeDto.defaultCategoryId !== undefined) {
-      payee.defaultCategoryId = updatePayeeDto.defaultCategoryId;
-      // Always clear the loaded relation object. Otherwise TypeORM's save()
-      // re-derives the FK from the stale relation entity and ignores the
-      // changed scalar -- so switching to a different category (or to null)
-      // would silently not persist.
-      payee.defaultCategory = null as any;
-    }
-    if (updatePayeeDto.notes !== undefined) payee.notes = updatePayeeDto.notes;
+    if (updatePayeeDto.name !== undefined)
+      updateFields.name = updatePayeeDto.name;
+    if (updatePayeeDto.defaultCategoryId !== undefined)
+      updateFields.defaultCategoryId = updatePayeeDto.defaultCategoryId;
+    if (updatePayeeDto.notes !== undefined)
+      updateFields.notes = updatePayeeDto.notes;
     if (updatePayeeDto.isActive !== undefined)
-      payee.isActive = updatePayeeDto.isActive;
+      updateFields.isActive = updatePayeeDto.isActive;
+
+    // The default category the payee ends up with: the new value when one was
+    // supplied, otherwise the existing one. Drives the optional backfill below
+    // and is read from the DTO (not a save()-mutated entity).
+    const effectiveCategoryId =
+      updatePayeeDto.defaultCategoryId !== undefined
+        ? updatePayeeDto.defaultCategoryId
+        : payee.defaultCategoryId;
 
     // Optionally apply the (new) default category to the payee's existing
     // transactions. Only meaningful when the payee ends up with a category.
@@ -340,7 +351,9 @@ export class PayeesService {
     await queryRunner.connect();
     await queryRunner.startTransaction();
     try {
-      await queryRunner.manager.save(payee);
+      if (Object.keys(updateFields).length > 0) {
+        await queryRunner.manager.update(Payee, { id, userId }, updateFields);
+      }
 
       if (nameChanged) {
         await queryRunner.manager.update(
@@ -355,20 +368,20 @@ export class PayeesService {
         );
       }
 
-      if (applyMode !== "none" && payee.defaultCategoryId) {
+      if (applyMode !== "none" && effectiveCategoryId) {
         transactionsCategorized =
           applyMode === "all"
             ? await applyPayeeCategoryToAll(
                 queryRunner.manager,
                 userId,
                 id,
-                payee.defaultCategoryId,
+                effectiveCategoryId,
               )
             : await backfillPayeeCategory(
                 queryRunner.manager,
                 userId,
                 id,
-                payee.defaultCategoryId,
+                effectiveCategoryId,
               );
       }
 

--- a/backend/test/payees.e2e-spec.ts
+++ b/backend/test/payees.e2e-spec.ts
@@ -1,0 +1,120 @@
+import { INestApplication } from "@nestjs/common";
+import { DataSource } from "typeorm";
+import { createTestApp, closeTestApp } from "./helpers/test-database";
+import {
+  createTestUser,
+  createTestAccount,
+  createTestCategory,
+  createTestPayee,
+  buildTransaction,
+} from "./helpers/test-factories";
+import { PayeesModule } from "@/payees/payees.module";
+import { PayeesService } from "@/payees/payees.service";
+import { Transaction } from "@/transactions/entities/transaction.entity";
+import { Payee } from "@/payees/entities/payee.entity";
+import { User } from "@/users/entities/user.entity";
+
+describe("Payee default category repro (e2e)", () => {
+  let app: INestApplication;
+  let ds: DataSource;
+  let service: PayeesService;
+  let userId: string;
+  let accountId: string;
+  let catA: string;
+  let catB: string;
+
+  beforeAll(async () => {
+    const ctx = await createTestApp([PayeesModule]);
+    app = ctx.app;
+    ds = ctx.module.get(DataSource);
+    service = ctx.module.get(PayeesService);
+
+    const user = await createTestUser(ds.getRepository(User));
+    userId = user.id;
+    const account = await createTestAccount(ds, userId);
+    accountId = account.id;
+    catA = (await createTestCategory(ds, userId, { name: "Cat A" })).id;
+    catB = (await createTestCategory(ds, userId, { name: "Cat B" })).id;
+  });
+
+  afterAll(async () => {
+    await closeTestApp(app);
+  });
+
+  async function seedPayeeWithTransactions() {
+    const payee = await createTestPayee(ds, userId, {
+      name: `P-${Math.random()}`,
+    });
+    // 2 uncategorized, 1 already categorized (catA)
+    await ds.manager.save(
+      ds.manager.create(Transaction, {
+        ...buildTransaction(userId, accountId),
+        payeeId: payee.id,
+        payeeName: payee.name,
+        categoryId: null,
+      } as any),
+    );
+    await ds.manager.save(
+      ds.manager.create(Transaction, {
+        ...buildTransaction(userId, accountId),
+        payeeId: payee.id,
+        payeeName: payee.name,
+        categoryId: null,
+      } as any),
+    );
+    await ds.manager.save(
+      ds.manager.create(Transaction, {
+        ...buildTransaction(userId, accountId),
+        payeeId: payee.id,
+        payeeName: payee.name,
+        categoryId: catA,
+      } as any),
+    );
+    return payee;
+  }
+
+  it("keeps the default category on an unchanged re-save", async () => {
+    const payee = await seedPayeeWithTransactions();
+    // First set the default category.
+    await service.update(userId, payee.id, { defaultCategoryId: catB });
+    let row = await ds
+      .getRepository(Payee)
+      .findOne({ where: { id: payee.id } });
+    expect(row?.defaultCategoryId).toBe(catB);
+
+    // A "no change" update (the frontend resends the same category) must not
+    // wipe it. Regression: save() on the loaded entity derived the FK from the
+    // hydrated defaultCategory relation and nulled the column.
+    await service.update(userId, payee.id, { defaultCategoryId: catB });
+    row = await ds.getRepository(Payee).findOne({ where: { id: payee.id } });
+    expect(row?.defaultCategoryId).toBe(catB);
+  });
+
+  it("applies the default category to all of a payee's transactions", async () => {
+    const payee = await seedPayeeWithTransactions();
+    const result = await service.update(userId, payee.id, {
+      defaultCategoryId: catB,
+      applyCategoryToTransactions: "all",
+    });
+    expect(result.transactionsCategorized).toBe(3);
+    const txns = await ds
+      .getRepository(Transaction)
+      .find({ where: { payeeId: payee.id } });
+    expect(txns.filter((t) => t.categoryId === catB)).toHaveLength(3);
+  });
+
+  it("applies the default category only to uncategorized transactions", async () => {
+    const payee = await seedPayeeWithTransactions();
+    const result = await service.update(userId, payee.id, {
+      defaultCategoryId: catB,
+      applyCategoryToTransactions: "uncategorized",
+    });
+    expect(result.transactionsCategorized).toBe(2);
+    const txns = await ds
+      .getRepository(Transaction)
+      .find({ where: { payeeId: payee.id } });
+    // The two uncategorized rows now carry catB; the catA row is untouched.
+    expect(txns.filter((t) => t.categoryId === catB)).toHaveLength(2);
+    expect(txns.filter((t) => t.categoryId === catA)).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/payees/PayeeForm.test.tsx
+++ b/frontend/src/components/payees/PayeeForm.test.tsx
@@ -171,6 +171,68 @@ describe('PayeeForm', () => {
       });
     });
 
+    it('preserves the existing default category on a no-change update', async () => {
+      // The category field is not registered with react-hook-form -- it is
+      // driven by the controlled selection state -- so the submitted
+      // defaultCategoryId must come from that state, never from an unregistered
+      // RHF value that can be dropped. Editing without touching the category
+      // must keep it (regression: it was being cleared on a no-op save).
+      const submit = vi.fn().mockResolvedValue(undefined);
+      const payee = { id: 'p1', name: 'Walmart', defaultCategoryId: 'c1', notes: '', transactionCount: 10, uncategorizedCount: 3 } as any;
+      await act(async () => {
+        render(<PayeeForm payee={payee} categories={categories} onSubmit={submit} onCancel={onCancel} />);
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText('Update Payee'));
+      });
+      expect(submit).toHaveBeenCalledTimes(1);
+      expect(submit.mock.calls[0][0].defaultCategoryId).toBe('c1');
+    });
+
+    it('removes the default category when it is cleared via the combobox', async () => {
+      // Clearing the category must submit a falsy defaultCategoryId (the page
+      // layer turns it into null) and reset the now-meaningless backfill choice.
+      const submit = vi.fn().mockResolvedValue(undefined);
+      const payee = { id: 'p1', name: 'Walmart', defaultCategoryId: 'c1', notes: '', transactionCount: 10, uncategorizedCount: 3 } as any;
+      let container!: HTMLElement;
+      await act(async () => {
+        ({ container } = render(<PayeeForm payee={payee} categories={categories} onSubmit={submit} onCancel={onCancel} />));
+      });
+      // The combobox renders a clear (X) button (tabindex=-1) when it has a value.
+      const clearBtn = container.querySelector('button[tabindex="-1"]') as HTMLButtonElement;
+      expect(clearBtn).toBeTruthy();
+      await act(async () => {
+        fireEvent.mouseDown(clearBtn);
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText('Update Payee'));
+      });
+      expect(submit).toHaveBeenCalledTimes(1);
+      expect(submit.mock.calls[0][0].defaultCategoryId).toBeFalsy();
+      expect(submit.mock.calls[0][0].applyCategoryToTransactions).toBeUndefined();
+    });
+
+    it('carries the apply mode using the existing category even when it is not re-selected', async () => {
+      // Selecting "all" without re-touching the category must still send both
+      // the apply instruction and the category, so the backend backfill runs
+      // (regression: the apply was dropped when the category was untouched).
+      const submit = vi.fn().mockResolvedValue(undefined);
+      const payee = { id: 'p1', name: 'Walmart', defaultCategoryId: 'c1', notes: '', transactionCount: 10, uncategorizedCount: 3 } as any;
+      await act(async () => {
+        render(<PayeeForm payee={payee} categories={categories} onSubmit={submit} onCancel={onCancel} />);
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('Apply this category to existing transactions'), { target: { value: 'all' } });
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText('Update Payee'));
+      });
+      expect(submit.mock.calls[0][0]).toMatchObject({
+        defaultCategoryId: 'c1',
+        applyCategoryToTransactions: 'all',
+      });
+    });
+
     it('omits the apply mode when left at the default (none)', async () => {
       const submit = vi.fn().mockResolvedValue(undefined);
       const payee = { id: 'p1', name: 'Walmart', defaultCategoryId: 'c1', notes: '', transactionCount: 10, uncategorizedCount: 3 } as any;

--- a/frontend/src/components/payees/PayeeForm.tsx
+++ b/frontend/src/components/payees/PayeeForm.tsx
@@ -66,17 +66,26 @@ export function PayeeForm({ payee, categories, onSubmit, onCancel, onDirtyChange
   useFormDirtyNotify(isDirty, onDirtyChange);
 
   const handleFormSubmit = useCallback((data: PayeeFormData) => {
-    const submitData: PayeeFormSubmitData = { ...data };
+    // The category Combobox is not registered with react-hook-form (it is a
+    // controlled field driven by selectedCategoryId), so data.defaultCategoryId
+    // cannot be trusted -- on an unchanged edit RHF can yield an empty value,
+    // which the page layer then turns into null and silently wipes the payee's
+    // existing default category. Always take the category from the controlled
+    // state, which is seeded from the payee and updated on every selection.
+    const submitData: PayeeFormSubmitData = {
+      ...data,
+      defaultCategoryId: selectedCategoryId || undefined,
+    };
     if (!payee && pendingAliasesRef.current.length > 0) {
       submitData.pendingAliases = pendingAliasesRef.current;
     }
     // Only carry the backfill instruction when editing an existing payee that
     // ends up with a default category and the user opted into applying it.
-    if (payee && data.defaultCategoryId && applyMode !== 'none') {
+    if (payee && selectedCategoryId && applyMode !== 'none') {
       submitData.applyCategoryToTransactions = applyMode;
     }
     return onSubmit(submitData);
-  }, [payee, onSubmit, applyMode]);
+  }, [payee, onSubmit, applyMode, selectedCategoryId]);
 
   const onFormSubmit = useCallback((e?: React.BaseSyntheticEvent) => {
     handleSubmit(handleFormSubmit)(e);

--- a/frontend/src/components/payees/PayeeForm.tsx
+++ b/frontend/src/components/payees/PayeeForm.tsx
@@ -66,26 +66,17 @@ export function PayeeForm({ payee, categories, onSubmit, onCancel, onDirtyChange
   useFormDirtyNotify(isDirty, onDirtyChange);
 
   const handleFormSubmit = useCallback((data: PayeeFormData) => {
-    // The category Combobox is not registered with react-hook-form (it is a
-    // controlled field driven by selectedCategoryId), so data.defaultCategoryId
-    // cannot be trusted -- on an unchanged edit RHF can yield an empty value,
-    // which the page layer then turns into null and silently wipes the payee's
-    // existing default category. Always take the category from the controlled
-    // state, which is seeded from the payee and updated on every selection.
-    const submitData: PayeeFormSubmitData = {
-      ...data,
-      defaultCategoryId: selectedCategoryId || undefined,
-    };
+    const submitData: PayeeFormSubmitData = { ...data };
     if (!payee && pendingAliasesRef.current.length > 0) {
       submitData.pendingAliases = pendingAliasesRef.current;
     }
     // Only carry the backfill instruction when editing an existing payee that
     // ends up with a default category and the user opted into applying it.
-    if (payee && selectedCategoryId && applyMode !== 'none') {
+    if (payee && data.defaultCategoryId && applyMode !== 'none') {
       submitData.applyCategoryToTransactions = applyMode;
     }
     return onSubmit(submitData);
-  }, [payee, onSubmit, applyMode, selectedCategoryId]);
+  }, [payee, onSubmit, applyMode]);
 
   const onFormSubmit = useCallback((e?: React.BaseSyntheticEvent) => {
     handleSubmit(handleFormSubmit)(e);

--- a/frontend/src/components/transactions/TransactionForm.test.tsx
+++ b/frontend/src/components/transactions/TransactionForm.test.tsx
@@ -1939,6 +1939,42 @@ describe('TransactionForm', () => {
       });
     });
 
+    it('sends categoryId null when the user clears a previously assigned category', async () => {
+      const existingTransaction = createExistingTransaction();
+
+      render(
+        <TransactionForm
+          transaction={existingTransaction}
+          onSuccess={mockOnSuccess}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('combobox-input-Category')).toBeInTheDocument();
+      });
+
+      // Clear the category. The category field allows custom values, so the
+      // mocked Combobox forwards onChange('', '') for the now-empty input. The
+      // zod helper coerces '' to undefined; the form must still send null so
+      // the backend clears the category rather than ignoring the omitted field.
+      fireEvent.change(screen.getByTestId('combobox-input-Category'), {
+        target: { value: 'x' },
+      });
+      fireEvent.change(screen.getByTestId('combobox-input-Category'), {
+        target: { value: '' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /Update Transaction/i }));
+
+      await waitFor(() => {
+        expect(mockUpdate).toHaveBeenCalledWith(
+          existingTransaction.id,
+          expect.objectContaining({ categoryId: null })
+        );
+      });
+    });
+
     it('creates subcategory when "Parent: Child" format is used', async () => {
       // First call creates the parent category, second creates the child
       mockCategoryCreate
@@ -2964,7 +3000,9 @@ describe('TransactionForm', () => {
       fireEvent.click(screen.getByRole('button', { name: /Create Transaction/i }));
       await waitFor(() => expect(mockCreate).toHaveBeenCalled());
       const payload = mockCreate.mock.calls[0][0];
-      expect(payload.categoryId).toBe('');
+      // A typed-but-not-created custom value leaves no category: send null, not
+      // an empty string (which the backend rejects as an invalid UUID).
+      expect(payload.categoryId).toBeNull();
     });
   });
 

--- a/frontend/src/components/transactions/TransactionForm.test.tsx
+++ b/frontend/src/components/transactions/TransactionForm.test.tsx
@@ -1882,6 +1882,42 @@ describe('TransactionForm', () => {
         expect(mockCreate).toHaveBeenCalled();
       });
     });
+
+    it('sends payeeId/payeeName null when the user clears a previously assigned payee', async () => {
+      const existingTransaction = createExistingTransaction();
+
+      render(
+        <TransactionForm
+          transaction={existingTransaction}
+          onSuccess={mockOnSuccess}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('combobox-input-Payee')).toBeInTheDocument();
+      });
+
+      // Clear the payee. The payee field allows custom values, so the mocked
+      // Combobox forwards onChange('', '') for the now-empty input. The form
+      // must send null (not the empty string the combobox yields) so the
+      // backend clears the payee rather than rejecting an invalid UUID.
+      fireEvent.change(screen.getByTestId('combobox-input-Payee'), {
+        target: { value: 'x' },
+      });
+      fireEvent.change(screen.getByTestId('combobox-input-Payee'), {
+        target: { value: '' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /Update Transaction/i }));
+
+      await waitFor(() => {
+        expect(mockUpdate).toHaveBeenCalledWith(
+          existingTransaction.id,
+          expect.objectContaining({ payeeId: null, payeeName: null })
+        );
+      });
+    });
   });
 
   // =========================================================================
@@ -3035,7 +3071,7 @@ describe('TransactionForm', () => {
       await waitFor(() => expect(mockCreate).toHaveBeenCalled());
       const payload = mockCreate.mock.calls[0][0];
       expect(payload.payeeName).toBe('Brand New Payee');
-      expect(payload.payeeId).toBeUndefined();
+      expect(payload.payeeId).toBeNull();
     });
   });
 
@@ -3218,7 +3254,7 @@ describe('TransactionForm', () => {
       fireEvent.click(screen.getByRole('button', { name: /Create Transaction/i }));
       await waitFor(() => expect(mockCreate).toHaveBeenCalled());
       const payload = mockCreate.mock.calls[0][0];
-      expect(payload.payeeId).toBeUndefined();
+      expect(payload.payeeId).toBeNull();
     });
   });
 

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -823,6 +823,12 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
         // rejected and the old category sticks), while undefined is dropped by
         // JSON.stringify (so the backend never learns the category was cleared).
         categoryId: isSplitMode ? undefined : (data.categoryId || null),
+        // A cleared payee must be sent as null, not the empty string the
+        // combobox yields: '' fails the backend's UUID validation (rejecting
+        // the update so the old payee sticks). A typed custom payee keeps its
+        // name with a null payeeId so the backend can link or create it.
+        payeeId: data.payeeId || null,
+        payeeName: data.payeeName || null,
         // Ensure cleared optional fields are sent as null (not undefined)
         // so the backend knows to clear them rather than ignoring the field
         description: data.description ?? null,

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -817,8 +817,12 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
         ...data,
         splits: splitsData,
         tagIds: selectedTagIds.length > 0 ? selectedTagIds : [],
-        // Clear categoryId for split transactions
-        categoryId: isSplitMode ? undefined : data.categoryId,
+        // Clear categoryId for split transactions. For non-split transactions
+        // send null (not '' or undefined) when the category was removed: an
+        // empty string fails the backend's UUID validation (so the update is
+        // rejected and the old category sticks), while undefined is dropped by
+        // JSON.stringify (so the backend never learns the category was cleared).
+        categoryId: isSplitMode ? undefined : (data.categoryId || null),
         // Ensure cleared optional fields are sent as null (not undefined)
         // so the backend knows to clear them rather than ignoring the field
         description: data.description ?? null,

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -97,8 +97,8 @@ export interface CreateSplitData {
 export interface CreateTransactionData {
   accountId: string;
   transactionDate: string;
-  payeeId?: string;
-  payeeName?: string;
+  payeeId?: string | null;
+  payeeName?: string | null;
   categoryId?: string | null;
   amount: number;
   currencyCode: string;

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -99,7 +99,7 @@ export interface CreateTransactionData {
   transactionDate: string;
   payeeId?: string;
   payeeName?: string;
-  categoryId?: string;
+  categoryId?: string | null;
   amount: number;
   currencyCode: string;
   exchangeRate?: number;


### PR DESCRIPTION
## Summary
Fixes a critical bug where payee default categories were silently wiped on unchanged re-saves, and ensures transaction/payee form fields properly send `null` when cleared instead of empty strings or `undefined`.

## Key Changes

### Backend
- **PayeesService**: Changed from `save()` to column-level `update()` when persisting payee changes. The loaded entity's hydrated `defaultCategory` relation was causing TypeORM to re-derive the FK from the stale relation, clobbering scalar changes. Now uses explicit `queryRunner.manager.update(Payee, { id, userId }, updateFields)` to write the FK directly from the scalar value.
- **PayeesService**: Tracks the effective category ID separately from the mutated entity so backfill operations use the correct value (the new category when supplied, otherwise the existing one).
- **PayeesService.spec.ts**: Updated mocks to verify `update()` calls instead of `save()`, with more precise assertions on which tables are touched during name changes and category backfills.
- **payees.e2e-spec.ts** (new): Added comprehensive e2e tests covering:
  - Default category preservation on unchanged re-save (regression test)
  - Category backfill to all transactions
  - Category backfill to uncategorized transactions only

### Frontend
- **TransactionForm.tsx**: Explicitly coerce empty `categoryId` and `payeeId` to `null` (not empty string or `undefined`) before sending to backend. Empty strings fail UUID validation; `undefined` is dropped by JSON serialization, so the backend never learns the field was cleared.
- **TransactionForm.test.tsx**: Added tests verifying that clearing a previously assigned payee or category sends `null`, and updated existing tests to expect `null` instead of `undefined` or empty string.
- **PayeeForm.test.tsx**: Added tests for:
  - Preserving default category on no-change update
  - Clearing category via combobox and resetting backfill choice
  - Carrying apply mode with existing category even when untouched
- **transaction.ts**: Updated `CreateTransactionData` type to allow `null` for `payeeId`, `payeeName`, and `categoryId` (previously only `undefined`).

## Implementation Details
- The root cause was TypeORM's behavior when calling `save()` on a loaded entity with a hydrated relation: it derives the FK from the relation object, not the scalar. Clearing the relation or changing the scalar alone would be silently ignored.
- Solution uses explicit column-level updates keyed by `{ id, userId }` to ensure the FK is written from the scalar value, bypassing relation hydration.
- Form clearing now sends `null` consistently across both payee and category fields, matching backend expectations for "clear this field" semantics.

https://claude.ai/code/session_014Sb35YMVJrWxZRo4rn3s7t