### PR TITLE
feat(auth): add OIDC_REQUIRE_VERIFIED_EMAIL to merge by IdP email without verification/SMTP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,7 +94,9 @@ OIDC_CALLBACK_URL=http://localhost:3000/api/v1/auth/oidc/callback
 # confirmation step (needs SMTP). Set to 'false' to trust the IdP email even
 # without `email_verified` and merge directly into a matching account, no
 # confirmation/SMTP needed. Lowers security -- only disable if you trust your
-# IdP to verify email ownership.
+# IdP to verify email ownership. Note: with it disabled, an already-linked
+# user's stored email also follows the (unverified) IdP email on subsequent
+# logins, so a misconfigured/compromised IdP can change it.
 OIDC_REQUIRE_VERIFIED_EMAIL=true
 
 # ==============================================

--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,15 @@ OIDC_CLIENT_SECRET=
 # Callback URL must point to the backend API
 OIDC_CALLBACK_URL=http://localhost:3000/api/v1/auth/oidc/callback
 
+# OIDC_REQUIRE_VERIFIED_EMAIL (default true): require the provider to assert
+# `email_verified` before trusting the OIDC email. With it true, an OIDC login
+# only merges into an existing local (password) account after an email
+# confirmation step (needs SMTP). Set to 'false' to trust the IdP email even
+# without `email_verified` and merge directly into a matching account, no
+# confirmation/SMTP needed. Lowers security -- only disable if you trust your
+# IdP to verify email ownership.
+OIDC_REQUIRE_VERIFIED_EMAIL=true
+
 # ==============================================
 # Email Notifications (Optional)
 # ==============================================

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -774,6 +774,40 @@ describe("AuthService", () => {
       expect(existing.authProvider).toBe("oidc");
       expect(sendSpy).not.toHaveBeenCalled();
     });
+
+    it("with OIDC_REQUIRE_VERIFIED_EMAIL=false also merges directly on the duplicate-email (23505) catch path", async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === "JWT_SECRET")
+          return "test-jwt-secret-minimum-32-chars-long";
+        if (key === "OIDC_REQUIRE_VERIFIED_EMAIL") return "false";
+        return undefined;
+      });
+      const existing: any = {
+        id: "u1",
+        email: "user@example.com",
+        passwordHash: "hash",
+        authProvider: "local",
+      };
+      usersRepository.findOne
+        .mockResolvedValueOnce(null) // by oidcSubject
+        .mockResolvedValueOnce(null) // primary by-email lookup misses -> create
+        .mockResolvedValueOnce(existing); // catch path re-lookup by email
+      // Force the create INSERT to fail with a unique-violation so we exercise
+      // the duplicate-email catch path (not the primary merge path).
+      dataSource.transaction.mockRejectedValue({ code: "23505" });
+      usersRepository.save.mockImplementation(async (u: any) => u);
+      const sendSpy = jest
+        .spyOn(service as any, "sendOidcLinkEmail")
+        .mockResolvedValue(undefined);
+
+      const result = await service.findOrCreateOidcUser(oidcProfile, true);
+
+      expect(result.linkPending).toBeFalsy();
+      expect(result.user).toBe(existing);
+      expect(existing.oidcSubject).toBe("oidc-sub-123");
+      expect(existing.authProvider).toBe("oidc");
+      expect(sendSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("sanitizeUser", () => {

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -727,6 +727,55 @@ describe("AuthService", () => {
     });
   });
 
+  describe("findOrCreateOidcUser OIDC_REQUIRE_VERIFIED_EMAIL", () => {
+    const oidcProfile = {
+      sub: "oidc-sub-123",
+      email: "User@Example.com",
+      email_verified: false,
+      name: "Test User",
+    };
+
+    it("by default does not trust an unverified email (falls through to registration, which is gated)", async () => {
+      // No oidcSubject match; email not verified and verification is required,
+      // so the email-merge path is skipped and it reaches the disabled
+      // registration guard.
+      usersRepository.findOne.mockResolvedValueOnce(null);
+      await expect(
+        service.findOrCreateOidcUser(oidcProfile, false),
+      ).rejects.toThrow("New account registration is disabled.");
+    });
+
+    it("with OIDC_REQUIRE_VERIFIED_EMAIL=false merges directly into a matching password account (no confirmation email)", async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === "JWT_SECRET")
+          return "test-jwt-secret-minimum-32-chars-long";
+        if (key === "OIDC_REQUIRE_VERIFIED_EMAIL") return "false";
+        return undefined;
+      });
+      const existing: any = {
+        id: "u1",
+        email: "user@example.com",
+        passwordHash: "hash",
+        authProvider: "local",
+      };
+      usersRepository.findOne
+        .mockResolvedValueOnce(null) // by oidcSubject
+        .mockResolvedValueOnce(existing); // by email
+      usersRepository.save.mockImplementation(async (u: any) => u);
+      const sendSpy = jest
+        .spyOn(service as any, "sendOidcLinkEmail")
+        .mockResolvedValue(undefined);
+
+      const result = await service.findOrCreateOidcUser(oidcProfile, false);
+
+      expect(result.linkPending).toBeFalsy();
+      expect(result.user).toBe(existing);
+      expect(existing.oidcSubject).toBe("oidc-sub-123");
+      expect(existing.authProvider).toBe("oidc");
+      expect(sendSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe("sanitizeUser", () => {
     it("strips sensitive fields from user", async () => {
       usersRepository.findOne.mockResolvedValue(null);

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -387,9 +387,21 @@ export class AuthService {
     const rawEmail = userInfo.email as string | undefined;
     // H7: Normalize email before lookups
     const email = rawEmail?.toLowerCase().trim();
-    // SECURITY: Only trust email if verified by the OIDC provider
+    // SECURITY: Only trust the IdP email if it is verified.
+    // OIDC_REQUIRE_VERIFIED_EMAIL (default true) gates this. Set it to "false"
+    // to drop the requirement: Monize then trusts the IdP-provided email even
+    // without an `email_verified` claim and merges directly into an existing
+    // account matching that email -- including a local password account,
+    // skipping the email-confirmation step (so it works without SMTP). This
+    // lowers security; only disable it when you trust your IdP to verify email
+    // ownership.
     const emailVerified = userInfo.email_verified === true;
-    const trustedEmail = emailVerified ? email : undefined;
+    const requireVerifiedEmail =
+      this.configService
+        .get<string>("OIDC_REQUIRE_VERIFIED_EMAIL")
+        ?.toLowerCase() !== "false";
+    const trustedEmail =
+      emailVerified || !requireVerifiedEmail ? email : undefined;
 
     // Handle name claims - try specific claims first, fall back to 'name'
     const fullName = userInfo.name as string | undefined;
@@ -425,8 +437,8 @@ export class AuthService {
         });
 
         if (existingUser) {
-          if (existingUser.passwordHash) {
-            // SECURITY: Local account requires user confirmation before linking.
+          if (existingUser.passwordHash && requireVerifiedEmail) {
+            // SECURITY: Local account requires user confirmation before merging.
             const linkToken = await this.initiateOidcLink(existingUser, sub);
             this.logger.warn(
               `OIDC link pending confirmation for user ${existingUser.id}`,
@@ -434,7 +446,8 @@ export class AuthService {
             await this.sendOidcLinkEmail(existingUser, linkToken);
             return { user: existingUser, linkPending: true };
           } else {
-            // OIDC-only account -- safe to link directly
+            // OIDC-only account, or OIDC_REQUIRE_VERIFIED_EMAIL=false bypasses
+            // the confirmation step -- merge the OIDC identity in directly.
             existingUser.oidcSubject = sub;
             existingUser.authProvider = "oidc";
             await this.usersRepository.save(existingUser);
@@ -486,7 +499,7 @@ export class AuthService {
               where: { email: trustedEmail },
             });
             if (existingUser) {
-              if (existingUser.passwordHash) {
+              if (existingUser.passwordHash && requireVerifiedEmail) {
                 // SECURITY: Local account requires confirmation
                 const linkToken = await this.initiateOidcLink(
                   existingUser,
@@ -498,7 +511,8 @@ export class AuthService {
                 await this.sendOidcLinkEmail(existingUser, linkToken);
                 return { user: existingUser, linkPending: true };
               } else {
-                // OIDC-only account -- safe to link directly
+                // OIDC-only account, or OIDC_REQUIRE_VERIFIED_EMAIL=false --
+                // merge directly
                 existingUser.oidcSubject = sub;
                 existingUser.authProvider = "oidc";
                 await this.usersRepository.save(existingUser);


### PR DESCRIPTION
## Problem

Monize is stricter than typical OIDC apps in two places, which together block some self-hosted setups:

1. It only trusts the OIDC provider's email when the provider asserts `email_verified: true`.
2. Merging an OIDC identity into an existing **local (password)** account requires an email-confirmation step, which needs **SMTP**.

So if your IdP does not send `email_verified` (e.g. a default Authentik OAuth2 provider) and you have no SMTP configured, an OIDC login for a user who already has a local account fails: the email isn't trusted, it falls through to user creation, and either hits the disabled-registration guard or a duplicate-email error. There is no way to link/merge that account without standing up SMTP.

## Change

Add a single environment variable, **`OIDC_REQUIRE_VERIFIED_EMAIL`** (default `true` — **no behavior change**).

Set it to `false` to:
- trust the IdP-provided email even without an `email_verified` claim, and
- merge the OIDC identity **directly** into an existing account matching that email — including a local password account — skipping the confirmation email (so it works without SMTP).

Local password login keeps working afterwards (the merge sets `oidcSubject`/`authProvider` but preserves the password; `login()` gates only on the password, not `authProvider`).

## Security

This intentionally lowers security: with it disabled, anyone who can get the IdP to issue a token for an email owns the matching Monize account. Only disable it when you trust your IdP to verify email ownership. Documented as such in `.env.example`, and the default keeps the strict, confirmation-based behavior.

## Scope / testing

- No DB or schema changes — pure config + logic in `findOrCreateOidcUser`.
- `backend/.env.example` documents the variable.
- Added unit tests: default still requires verification; `false` merges a password account directly without sending a confirmation email.
- `tsc` clean; full `auth.service`/`auth.controller` suites pass (219 tests).

Files: `backend/src/auth/auth.service.ts`, `backend/src/auth/auth.service.spec.ts`, `.env.example`.

