### PR TITLE
Add 100% stacked bar chart view for net worth composition

### DIFF
--- a/frontend/src/components/dashboard/NetWorthChart.test.tsx
+++ b/frontend/src/components/dashboard/NetWorthChart.test.tsx
@@ -18,7 +18,18 @@ vi.mock('recharts', () => ({
   YAxis: ({ domain }: any) => (
     <div data-testid="y-axis" data-domain={JSON.stringify(domain)} />
   ),
-  Tooltip: () => null,
+  Tooltip: ({ content }: any) => {
+    // `content` is a React element; invoke its function component so the
+    // tooltip's render branches are exercised.
+    const fn = content?.type;
+    if (typeof fn === 'function') {
+      try {
+        fn({ active: true, payload: [{ payload: { name: 'Jan 2024', netWorth: 100, assets: 200, liabilities: 100 } }] });
+        fn({ active: false, payload: [] });
+      } catch {}
+    }
+    return null;
+  },
 }));
 
 function setMobile(isMobile: boolean) {
@@ -43,11 +54,13 @@ vi.mock('@/hooks/useNumberFormat', () => ({
 
 vi.mock('@/lib/utils', () => ({
   parseLocalDate: (d: string) => new Date(d + 'T00:00:00'),
+  cn: (...args: any[]) => args.filter(Boolean).join(' '),
 }));
 
 describe('NetWorthChart', () => {
   beforeEach(() => {
     mockPush.mockClear();
+    window.localStorage.clear();
     setMobile(false);
   });
 
@@ -75,6 +88,30 @@ describe('NetWorthChart', () => {
     expect(screen.getByText('Past 12 months')).toBeInTheDocument();
     expect(screen.getByText('View full report')).toBeInTheDocument();
     expect(screen.getByText('$15000')).toBeInTheDocument();
+  });
+
+  it('toggles to the 100% stacked composition chart and persists the choice', () => {
+    const data = [
+      { month: '2024-01-01', assets: 50000, liabilities: 10000, netWorth: 40000 },
+      { month: '2024-06-01', assets: 55000, liabilities: 9000, netWorth: 46000 },
+    ] as any[];
+
+    render(<NetWorthChart data={data} isLoading={false} />);
+    fireEvent.click(screen.getByTitle('100% Stacked Bar'));
+    // The stacked view renders two series (assets + liabilities).
+    expect(screen.getAllByTestId('bar')).toHaveLength(2);
+    expect(window.localStorage.getItem('dashboard.net-worth.chartType')).toBe('"stacked"');
+  });
+
+  it('restores the stacked composition view from localStorage', () => {
+    window.localStorage.setItem('dashboard.net-worth.chartType', '"stacked"');
+    const data = [
+      { month: '2024-01-01', assets: 50000, liabilities: 10000, netWorth: 40000 },
+      { month: '2024-06-01', assets: 55000, liabilities: 9000, netWorth: 46000 },
+    ] as any[];
+
+    render(<NetWorthChart data={data} isLoading={false} />);
+    expect(screen.getAllByTestId('bar')).toHaveLength(2);
   });
 
   it('renders abbreviated value labels above the bars', () => {

--- a/frontend/src/components/dashboard/NetWorthChart.tsx
+++ b/frontend/src/components/dashboard/NetWorthChart.tsx
@@ -17,6 +17,8 @@ import { chartColors } from '@/lib/chart-colors';
 import { MonthlyNetWorth } from '@/types/net-worth';
 import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
 
 type YDomain = [number | ((dataMin: number) => number), number | 'auto'];
 
@@ -43,6 +45,39 @@ function NetWorthTooltip({
   return null;
 }
 
+function NetWorthCompositionTooltip({
+  active,
+  payload,
+  formatCurrency,
+  labels,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload: { name: string; assets: number; liabilities: number } }>;
+  formatCurrency: (v: number) => string;
+  labels: { assets: string; liabilities: string; netWorth: string };
+}) {
+  if (active && payload && payload.length) {
+    const d = payload[0].payload;
+    const total = d.assets + d.liabilities;
+    const pct = (v: number) => (total > 0 ? `${((v / total) * 100).toFixed(1)}%` : '0%');
+    return (
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
+        <p className="font-medium text-gray-900 dark:text-gray-100">{d.name}</p>
+        <p className="text-sm" style={{ color: chartColors.income }}>
+          {labels.assets}: {formatCurrency(d.assets)} ({pct(d.assets)})
+        </p>
+        <p className="text-sm" style={{ color: chartColors.expense }}>
+          {labels.liabilities}: {formatCurrency(d.liabilities)} ({pct(d.liabilities)})
+        </p>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 pt-1 border-t border-gray-100 dark:border-gray-700">
+          {labels.netWorth}: {formatCurrency(d.assets - d.liabilities)}
+        </p>
+      </div>
+    );
+  }
+  return null;
+}
+
 interface NetWorthChartProps {
   data: MonthlyNetWorth[];
   isLoading: boolean;
@@ -52,12 +87,23 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
   const t = useTranslations('dashboard');
   const router = useRouter();
   const { formatCurrencyCompact: formatCurrency, formatCurrencyLabel } = useNumberFormat();
+  const [chartType, setChartType] = useLocalStorage<'bar' | 'stacked'>(
+    'dashboard.net-worth.chartType',
+    'bar',
+  );
+  const compositionLabels = {
+    assets: t('assetsVsLiabilities.assets'),
+    liabilities: t('assetsVsLiabilities.liabilities'),
+    netWorth: t('assetsVsLiabilities.netWorthLabel'),
+  };
 
   const chartData = useMemo(() =>
     data.map((d) => ({
       name: format(parseLocalDate(d.month), 'MMM yyyy'),
       shortName: format(parseLocalDate(d.month), 'MMM'),
       netWorth: Math.round(d.netWorth),
+      assets: Math.round(d.assets),
+      liabilities: Math.round(d.liabilities),
     })),
   [data]);
 
@@ -132,7 +178,14 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
         >
           {t('netWorth.title')}
         </button>
-        <span className="text-sm text-gray-500 dark:text-gray-400">{t('netWorth.past12Months')}</span>
+        <div className="flex items-center gap-2">
+          <span className="hidden sm:inline text-sm text-gray-500 dark:text-gray-400">{t('netWorth.past12Months')}</span>
+          <ChartViewToggle
+            value={chartType}
+            onChange={(v) => setChartType(v as 'bar' | 'stacked')}
+            options={['bar', 'stacked']}
+          />
+        </div>
       </div>
       <div className="mb-3">
         <div className={`text-2xl font-bold ${
@@ -148,32 +201,52 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
       </div>
       <div className="h-80">
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
-          <BarChart data={chartData} margin={{ top: 52, right: 12, left: 12, bottom: 0 }}>
-            <YAxis hide domain={yAxisDomain} />
-            <XAxis
-              dataKey="name"
-              tick={{ fill: chartColors.axis, fontSize: 11 }}
-              tickLine={false}
-              axisLine={false}
-              interval="preserveStartEnd"
-              tickFormatter={(value: string) => value.split(' ')[0]}
-            />
-            <Tooltip
-              content={<NetWorthTooltip formatCurrency={formatCurrency} />}
-              cursor={{ fill: chartColors.grid, fillOpacity: 0.35 }}
-            />
-            <Bar dataKey="netWorth" fill={chartColors.primary} radius={[4, 4, 0, 0]}>
-              <LabelList
-                dataKey="netWorth"
-                position="top"
-                angle={-90}
-                offset={6}
-                textAnchor="start"
-                formatter={(value: unknown) => formatCurrencyLabel(Number(value))}
-                style={{ fill: chartColors.axis, fontSize: 11, fontWeight: 600, dominantBaseline: 'central' }}
+          {chartType === 'stacked' ? (
+            <BarChart data={chartData} stackOffset="expand" margin={{ top: 12, right: 12, left: 12, bottom: 0 }}>
+              <YAxis hide domain={[0, 1]} />
+              <XAxis
+                dataKey="name"
+                tick={{ fill: chartColors.axis, fontSize: 11 }}
+                tickLine={false}
+                axisLine={false}
+                interval="preserveStartEnd"
+                tickFormatter={(value: string) => value.split(' ')[0]}
               />
-            </Bar>
-          </BarChart>
+              <Tooltip
+                content={<NetWorthCompositionTooltip formatCurrency={formatCurrency} labels={compositionLabels} />}
+                cursor={{ fill: chartColors.grid, fillOpacity: 0.35 }}
+              />
+              <Bar dataKey="assets" stackId="nw" fill={chartColors.income} />
+              <Bar dataKey="liabilities" stackId="nw" fill={chartColors.expense} radius={[4, 4, 0, 0]} />
+            </BarChart>
+          ) : (
+            <BarChart data={chartData} margin={{ top: 52, right: 12, left: 12, bottom: 0 }}>
+              <YAxis hide domain={yAxisDomain} />
+              <XAxis
+                dataKey="name"
+                tick={{ fill: chartColors.axis, fontSize: 11 }}
+                tickLine={false}
+                axisLine={false}
+                interval="preserveStartEnd"
+                tickFormatter={(value: string) => value.split(' ')[0]}
+              />
+              <Tooltip
+                content={<NetWorthTooltip formatCurrency={formatCurrency} />}
+                cursor={{ fill: chartColors.grid, fillOpacity: 0.35 }}
+              />
+              <Bar dataKey="netWorth" fill={chartColors.primary} radius={[4, 4, 0, 0]}>
+                <LabelList
+                  dataKey="netWorth"
+                  position="top"
+                  angle={-90}
+                  offset={6}
+                  textAnchor="start"
+                  formatter={(value: unknown) => formatCurrencyLabel(Number(value))}
+                  style={{ fill: chartColors.axis, fontSize: 11, fontWeight: 600, dominantBaseline: 'central' }}
+                />
+              </Bar>
+            </BarChart>
+          )}
         </ResponsiveContainer>
       </div>
       <button

--- a/frontend/src/components/reports/NetWorthReport.test.tsx
+++ b/frontend/src/components/reports/NetWorthReport.test.tsx
@@ -11,6 +11,7 @@ vi.mock('@/components/ui/ChartViewToggle', () => ({
     <div data-testid="chart-view-toggle">
       <button onClick={() => onChange('line')}>line</button>
       <button onClick={() => onChange('bar')}>bar</button>
+      <button onClick={() => onChange('stacked')}>stacked</button>
       <button onClick={() => onChange('table')}>table</button>
       <span>val:{value}</span>
     </div>
@@ -70,8 +71,11 @@ vi.mock('recharts', () => ({
   YAxis: ({ tickFormatter }: any) => <div>{tickFormatter ? tickFormatter(1000) : ''}</div>,
   CartesianGrid: () => null,
   Tooltip: ({ content, formatter }: any) => {
-    if (typeof content === 'function') {
-      try { content({ active: true, payload: [{ value: 100, name: 'NetWorth', color: '#000', payload: { name: 'Jan', NetWorth: 100, Assets: 200, Liabilities: 100 } }] }); content({ active: false, payload: [] }); } catch {}
+    // `content` is a React element (e.g. <CustomTooltip />); invoke its function
+    // component so the tooltip's render branches are exercised in tests.
+    const fn = typeof content === 'function' ? content : content?.type;
+    if (typeof fn === 'function') {
+      try { fn({ active: true, payload: [{ value: 100, name: 'NetWorth', color: '#000', payload: { name: 'Jan', NetWorth: 100, Assets: 200, Liabilities: 100 } }] }); fn({ active: false, payload: [] }); } catch {}
     }
     if (formatter) {
       try { formatter(100, 'NetWorth'); } catch {}
@@ -118,6 +122,7 @@ vi.mock('@/lib/logger', () => ({
 describe('NetWorthReport', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
     dateRangeMock.value = '1y';
     setMobile(false);
   });
@@ -238,6 +243,38 @@ describe('NetWorthReport', () => {
       expect(screen.getByText('Current Net Worth')).toBeInTheDocument();
     });
     expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+    expect(screen.queryByTestId('area-chart')).not.toBeInTheDocument();
+  });
+
+  it('switches to the 100% stacked composition view and persists the choice', async () => {
+    mockGetMonthly.mockResolvedValue([
+      { month: '2024-01-01', assets: 50000, liabilities: 10000, netWorth: 40000 },
+      { month: '2024-06-01', assets: 55000, liabilities: 9000, netWorth: 46000 },
+    ]);
+    render(<NetWorthReport />);
+    await waitFor(() => {
+      expect(screen.getByText('Current Net Worth')).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('stacked'));
+    });
+    // The stacked view renders two series (Assets + Liabilities) rather than one.
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+    expect(screen.getAllByTestId('bar')).toHaveLength(2);
+    expect(window.localStorage.getItem('reports.net-worth.chartType')).toBe('"stacked"');
+  });
+
+  it('restores the stacked composition view from localStorage', async () => {
+    window.localStorage.setItem('reports.net-worth.chartType', '"stacked"');
+    mockGetMonthly.mockResolvedValue([
+      { month: '2024-01-01', assets: 50000, liabilities: 10000, netWorth: 40000 },
+      { month: '2024-06-01', assets: 55000, liabilities: 9000, netWorth: 46000 },
+    ]);
+    render(<NetWorthReport />);
+    await waitFor(() => {
+      expect(screen.getByText('Current Net Worth')).toBeInTheDocument();
+    });
+    expect(screen.getAllByTestId('bar')).toHaveLength(2);
     expect(screen.queryByTestId('area-chart')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/reports/NetWorthReport.tsx
+++ b/frontend/src/components/reports/NetWorthReport.tsx
@@ -35,6 +35,7 @@ import { SortableHeader } from '@/components/ui/SortableHeader';
 import { exportToCsv } from '@/lib/csv-export';
 import { useReportData } from '@/hooks/useReportData';
 import { ReportError } from '@/components/reports/ReportError';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('NetWorthReport');
@@ -46,7 +47,10 @@ export function NetWorthReport() {
   const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis, formatCurrencyLabel, formatSignedPercent } = useNumberFormat();
   const isMobile = useIsMobile();
   const [isRecalculating, setIsRecalculating] = useState(false);
-  const [chartType, setChartType] = useState<'line' | 'bar' | 'table'>('bar');
+  const [chartType, setChartType] = useLocalStorage<'line' | 'bar' | 'stacked' | 'table'>(
+    'reports.net-worth.chartType',
+    'bar',
+  );
   const chartRef = useRef<HTMLDivElement>(null);
   const { dateRange, setDateRange, startDate, setStartDate, endDate, setEndDate, resolvedRange, isValid } = useDateRange({ defaultRange: '1y', alignment: 'month' });
   const { sortField, sortDirection, handleSort } = useSortableTable<NetWorthSortField>(
@@ -207,6 +211,22 @@ export function NetWorthReport() {
   const showBarLabels = dateRange === '1y' || dateRange === '2y';
   const barLabelsVertical = showBarLabels && (chartData.length > 14 || isMobile);
 
+  // Shared between the area, bar and stacked charts so the month labels stay
+  // consistent as the range widens.
+  const formatXAxisTick = (value: string) => {
+    if (chartData.length > 36) {
+      return value.split(' ')[1] || value;
+    } else if (chartData.length > 18) {
+      const parts = value.split(' ');
+      return parts.length === 2 ? `${parts[0]} '${parts[1].slice(2)}` : value;
+    }
+    return value.split(' ')[0];
+  };
+
+  // The 100% stacked view normalises each bar to its assets/liabilities split,
+  // so the Y axis reads as a percentage rather than a currency amount.
+  const formatPercentAxis = (value: number) => `${Math.round(value * 100)}%`;
+
   const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: Array<{ name: string; value: number; color: string; payload: { name: string } }> }) => {
     if (active && payload && payload.length) {
       const data = payload[0]?.payload;
@@ -218,6 +238,31 @@ export function NetWorthReport() {
               {entry.name}: {formatCurrency(entry.value)}
             </p>
           ))}
+        </div>
+      );
+    }
+    return null;
+  };
+
+  const CompositionTooltip = ({ active, payload }: { active?: boolean; payload?: Array<{ payload: { name: string; Assets: number; Liabilities: number } }> }) => {
+    if (active && payload && payload.length) {
+      const data = payload[0]?.payload;
+      const assets = data?.Assets ?? 0;
+      const liabilities = data?.Liabilities ?? 0;
+      const total = assets + liabilities;
+      const pct = (value: number) => (total > 0 ? `${((value / total) * 100).toFixed(1)}%` : '0%');
+      return (
+        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
+          <p className="font-medium text-gray-900 dark:text-gray-100 mb-1">{data?.name}</p>
+          <p className="text-sm" style={{ color: chartColors.income }}>
+            {t('netWorth.colAssets')}: {formatCurrency(assets)} ({pct(assets)})
+          </p>
+          <p className="text-sm" style={{ color: chartColors.expense }}>
+            {t('netWorth.colLiabilities')}: {formatCurrency(liabilities)} ({pct(liabilities)})
+          </p>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 pt-1 border-t border-gray-100 dark:border-gray-700">
+            {t('netWorth.seriesNetWorth')}: {formatCurrency(assets - liabilities)}
+          </p>
         </div>
       );
     }
@@ -281,8 +326,8 @@ export function NetWorthReport() {
           <div className="flex items-center gap-3">
             <ChartViewToggle
               value={chartType}
-              onChange={(v) => setChartType(v as 'line' | 'bar' | 'table')}
-              options={['bar', 'line', 'table']}
+              onChange={(v) => setChartType(v as 'line' | 'bar' | 'stacked' | 'table')}
+              options={['bar', 'stacked', 'line', 'table']}
             />
             <button
               onClick={handleRecalculate}
@@ -384,15 +429,7 @@ export function NetWorthReport() {
                   dataKey="name"
                   tick={{ fontSize: 12 }}
                   {...(xAxisTicks ? { ticks: xAxisTicks } : {})}
-                  tickFormatter={(value: string) => {
-                    if (chartData.length > 36) {
-                      return value.split(' ')[1] || value;
-                    } else if (chartData.length > 18) {
-                      const parts = value.split(' ');
-                      return parts.length === 2 ? `${parts[0]} '${parts[1].slice(2)}` : value;
-                    }
-                    return value.split(' ')[0];
-                  }}
+                  tickFormatter={formatXAxisTick}
                 />
                 <YAxis
                   domain={yAxisDomain}
@@ -434,6 +471,25 @@ export function NetWorthReport() {
                   />
                 )}
               </AreaChart>
+              ) : chartType === 'stacked' ? (
+              <BarChart data={chartData} stackOffset="expand" margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} vertical={false} />
+                <XAxis
+                  dataKey="name"
+                  tick={{ fontSize: 12 }}
+                  {...(xAxisTicks ? { ticks: xAxisTicks } : {})}
+                  tickFormatter={formatXAxisTick}
+                />
+                <YAxis
+                  domain={[0, 1]}
+                  tickFormatter={formatPercentAxis}
+                  tick={{ fontSize: 12 }}
+                />
+                <Tooltip content={<CompositionTooltip />} />
+                <Legend />
+                <Bar dataKey="Assets" stackId="networth" fill={chartColors.income} name={t('netWorth.colAssets')} />
+                <Bar dataKey="Liabilities" stackId="networth" fill={chartColors.expense} name={t('netWorth.colLiabilities')} radius={[4, 4, 0, 0]} />
+              </BarChart>
               ) : (
               <BarChart data={chartData} margin={{ top: showBarLabels ? (barLabelsVertical ? 52 : 22) : 10, right: 10, left: 0, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} vertical={false} />
@@ -441,15 +497,7 @@ export function NetWorthReport() {
                   dataKey="name"
                   tick={{ fontSize: 12 }}
                   {...(xAxisTicks ? { ticks: xAxisTicks } : {})}
-                  tickFormatter={(value: string) => {
-                    if (chartData.length > 36) {
-                      return value.split(' ')[1] || value;
-                    } else if (chartData.length > 18) {
-                      const parts = value.split(' ');
-                      return parts.length === 2 ? `${parts[0]} '${parts[1].slice(2)}` : value;
-                    }
-                    return value.split(' ')[0];
-                  }}
+                  tickFormatter={formatXAxisTick}
                 />
                 <YAxis
                   domain={yAxisDomain}

--- a/frontend/src/components/ui/ChartViewToggle.tsx
+++ b/frontend/src/components/ui/ChartViewToggle.tsx
@@ -3,7 +3,7 @@
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 
-type ChartView = 'pie' | 'bar' | 'line' | 'area' | 'table';
+type ChartView = 'pie' | 'bar' | 'stacked' | 'line' | 'area' | 'table';
 
 interface ChartViewToggleProps {
   value: ChartView;
@@ -16,6 +16,7 @@ interface ChartViewToggleProps {
 const CHART_ICON_PATHS: Record<ChartView, string> = {
   pie: 'M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z',
   bar: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z',
+  stacked: 'M5 4 H10 V20 H5 Z M5 12 H10 M14 4 H19 V20 H14 Z M14 9 H19',
   line: 'M3 17l4-4 4 4 4-8 4 4',
   area: 'M3 17l4-4 4 4 4-8 4 4V21H3z',
   table: 'M3 10h18M3 14h18M3 6h18M3 18h18',
@@ -34,6 +35,7 @@ export function ChartViewToggle({
   const chartTitles: Record<ChartView, string> = {
     pie: t('chartViewToggle.pieChart'),
     bar: t('chartViewToggle.barChart'),
+    stacked: t('chartViewToggle.stackedChart'),
     line: t('chartViewToggle.lineChart'),
     area: t('chartViewToggle.areaChart'),
     table: t('chartViewToggle.table'),

--- a/frontend/src/i18n/messages/de/common.json
+++ b/frontend/src/i18n/messages/de/common.json
@@ -54,6 +54,7 @@
   "chartViewToggle": {
     "pieChart": "Kreisdiagramm",
     "barChart": "Balkendiagramm",
+    "stackedChart": "100 % gestapeltes Balkendiagramm",
     "lineChart": "Liniendiagramm",
     "areaChart": "Flächendiagramm",
     "table": "Tabelle"

--- a/frontend/src/i18n/messages/en/common.json
+++ b/frontend/src/i18n/messages/en/common.json
@@ -54,6 +54,7 @@
   "chartViewToggle": {
     "pieChart": "Pie Chart",
     "barChart": "Bar Chart",
+    "stackedChart": "100% Stacked Bar",
     "lineChart": "Line Chart",
     "areaChart": "Area Chart",
     "table": "Table"

--- a/frontend/src/i18n/messages/es/common.json
+++ b/frontend/src/i18n/messages/es/common.json
@@ -54,6 +54,7 @@
   "chartViewToggle": {
     "pieChart": "Gráfico circular",
     "barChart": "Gráfico de barras",
+    "stackedChart": "Gráfico de barras apiladas 100%",
     "lineChart": "Gráfico de líneas",
     "areaChart": "Gráfico de área",
     "table": "Tabla"

--- a/frontend/src/i18n/messages/fr/common.json
+++ b/frontend/src/i18n/messages/fr/common.json
@@ -54,6 +54,7 @@
   "chartViewToggle": {
     "pieChart": "Graphique circulaire",
     "barChart": "Graphique à barres",
+    "stackedChart": "Graphique à barres empilées 100 %",
     "lineChart": "Graphique en courbes",
     "areaChart": "Graphique en aires",
     "table": "Tableau"

--- a/frontend/src/i18n/messages/it/common.json
+++ b/frontend/src/i18n/messages/it/common.json
@@ -54,6 +54,7 @@
   "chartViewToggle": {
     "pieChart": "Grafico a torta",
     "barChart": "Grafico a barre",
+    "stackedChart": "Grafico a barre impilate 100%",
     "lineChart": "Grafico a linee",
     "areaChart": "Grafico ad area",
     "table": "Tabella"

--- a/frontend/src/i18n/messages/nl/common.json
+++ b/frontend/src/i18n/messages/nl/common.json
@@ -54,6 +54,7 @@
   "chartViewToggle": {
     "pieChart": "Cirkeldiagram",
     "barChart": "Staafdiagram",
+    "stackedChart": "100% gestapeld staafdiagram",
     "lineChart": "Lijndiagram",
     "areaChart": "Vlakdiagram",
     "table": "Tabel"

--- a/frontend/src/i18n/messages/pl/common.json
+++ b/frontend/src/i18n/messages/pl/common.json
@@ -54,6 +54,7 @@
   "chartViewToggle": {
     "pieChart": "Wykres kołowy",
     "barChart": "Wykres słupkowy",
+    "stackedChart": "Skumulowany wykres słupkowy 100%",
     "lineChart": "Wykres liniowy",
     "areaChart": "Wykres warstwowy",
     "table": "Tabela"

--- a/frontend/src/i18n/messages/pt-BR/common.json
+++ b/frontend/src/i18n/messages/pt-BR/common.json
@@ -54,6 +54,7 @@
   "chartViewToggle": {
     "pieChart": "Gráfico de pizza",
     "barChart": "Gráfico de barras",
+    "stackedChart": "Gráfico de barras empilhadas 100%",
     "lineChart": "Gráfico de linhas",
     "areaChart": "Gráfico de área",
     "table": "Tabela"

--- a/frontend/src/i18n/messages/pt/common.json
+++ b/frontend/src/i18n/messages/pt/common.json
@@ -54,6 +54,7 @@
   "chartViewToggle": {
     "pieChart": "Gráfico circular",
     "barChart": "Gráfico de barras",
+    "stackedChart": "Gráfico de barras empilhadas 100%",
     "lineChart": "Gráfico de linhas",
     "areaChart": "Gráfico de área",
     "table": "Tabela"

--- a/frontend/src/i18n/messages/xx/common.json
+++ b/frontend/src/i18n/messages/xx/common.json
@@ -54,6 +54,7 @@
   "chartViewToggle": {
     "pieChart": "[XX-Pie Chart-XX]",
     "barChart": "[XX-Bar Chart-XX]",
+    "stackedChart": "[XX-100% Stacked Bar-XX]",
     "lineChart": "[XX-Line Chart-XX]",
     "areaChart": "[XX-Area Chart-XX]",
     "table": "[XX-Table-XX]"


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: <!-- discussion/issue link -->

## Summary

Adds a new "100% Stacked Bar" chart view option to both the dashboard Net Worth Chart and the Net Worth Report. This view displays the composition of net worth as a percentage breakdown of assets vs. liabilities, allowing users to see how the ratio between assets and liabilities changes over time rather than absolute values.

### Changes

**Dashboard (`NetWorthChart`)**
- Added `chartType` state using `useLocalStorage` to persist user preference between sessions
- Implemented conditional rendering: toggle between traditional bar chart (net worth) and 100% stacked bar chart (assets/liabilities composition)
- Added `NetWorthCompositionTooltip` component to display asset/liability breakdown with percentages
- Extended chart data to include `assets` and `liabilities` fields
- Added `ChartViewToggle` UI control with 'bar' and 'stacked' options

**Reports (`NetWorthReport`)**
- Migrated `chartType` state from `useState` to `useLocalStorage` for persistence
- Added 'stacked' option to chart type toggle alongside existing 'bar', 'line', and 'table' views
- Implemented `CompositionTooltip` for the stacked view with asset/liability percentages
- Extracted repeated X-axis tick formatting logic into `formatXAxisTick` helper function
- Added `formatPercentAxis` helper for Y-axis percentage formatting in stacked view
- Updated chart rendering to conditionally render stacked bar chart when selected

**UI Component (`ChartViewToggle`)**
- Extended `ChartView` type to include 'stacked'
- Added SVG icon path for stacked bar chart view

**Internationalization**
- Added `stackedChart` translation key to all 10 supported locales (en, de, es, fr, it, nl, pl, pt, pt-BR, xx)
- Translations: "100% Stacked Bar" (en), "100 % gestapeltes Balkendiagramm" (de), "Gráfico de barras apiladas 100%" (es), etc.

**Tests**
- Updated `NetWorthReport.test.tsx` to test stacked view toggle and localStorage persistence
- Updated `NetWorthChart.test.tsx` to test stacked view toggle and localStorage restoration
- Fixed tooltip mocking in both test files to properly invoke React component functions

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (new chart view for net worth composition).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement.
- [ ] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

<!-- Disclose any AI tools used. Using AI is fine and expected — you remain responsible for correctness, conventions, and tests. -->

Implemented with AI assistance (Claude Code — https://claude.ai/code). Claude researched the existing net-worth report and dashboard widget, designed the toggle and 100% stacked assets-vs-liabilities composition view, and wrote the component, test, and i18n changes. Local checks were run and pass: `npm run type-check`, `npm run lint`, the affected Vitest suites, and the i18n parity test. The maintainer has reviewed and owns the result.

https://claude.ai/code/session_019Ksbce4MK1VHV5oP7DCAhP