### PR TITLE
Standardize per-row ACTIONS across all list views (#688)

### DIFF
--- a/frontend/src/components/accounts/AccountList.test.tsx
+++ b/frontend/src/components/accounts/AccountList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@/test/render';
+import { render, screen, fireEvent, waitFor, act, within } from '@/test/render';
 import * as nextNavigation from 'next/navigation';
 import { AccountList } from './AccountList';
 import { Account } from '@/types/account';
@@ -1542,7 +1542,7 @@ describe('AccountList', () => {
       fireEvent.click(densityButton);
       fireEvent.click(densityButton);
 
-      expect(screen.getByTitle('Permanently delete account (no transactions)')).toBeInTheDocument();
+      expect(screen.getByTitle('Delete')).toBeInTheDocument();
     });
 
     it('renders reopen icon button in dense mode for closed accounts', async () => {
@@ -1581,7 +1581,7 @@ describe('AccountList', () => {
       fireEvent.click(densityButton);
       fireEvent.click(densityButton);
 
-      expect(screen.getByTitle('Permanently delete account (no transactions)')).toBeInTheDocument();
+      expect(screen.getByTitle('Delete')).toBeInTheDocument();
     });
 
     it('hides Market value label in dense mode for brokerage accounts', () => {
@@ -1760,12 +1760,13 @@ describe('AccountList', () => {
       expect(mockPush).toHaveBeenCalledWith('/investments?accountId=broker-1');
     });
 
-    it('context menu shows Edit Account button for active accounts and calls onEdit', () => {
+    it('context menu shows Edit button for active accounts and calls onEdit', () => {
       const account = createAccount({ name: 'My Account' });
       openContextMenu(account);
 
-      expect(screen.getByText('Edit Account')).toBeInTheDocument();
-      fireEvent.click(screen.getByText('Edit Account'));
+      const sheet = within(screen.getByRole('dialog'));
+      expect(sheet.getByText('Edit')).toBeInTheDocument();
+      fireEvent.click(sheet.getByText('Edit'));
       expect(mockOnEdit).toHaveBeenCalledWith(account);
     });
 
@@ -1800,33 +1801,31 @@ describe('AccountList', () => {
       expect(mockPush).toHaveBeenCalledWith('/reconcile?accountId=acc-1');
     });
 
-    it('context menu shows Close Account button enabled when balance is zero', () => {
+    it('context menu shows Close button enabled when balance is zero', () => {
       const account = createAccount({ name: 'Zero Balance', currentBalance: 0 });
       openContextMenu(account);
 
-      const closeBtn = screen.getByRole('button', { name: /Close Account/ });
+      const closeBtn = within(screen.getByRole('dialog')).getByRole('button', { name: 'Close' });
       expect(closeBtn).not.toBeDisabled();
     });
 
-    it('context menu shows Close Account button disabled when balance is non-zero', () => {
+    it('context menu shows Close button disabled when balance is non-zero', () => {
       const account = createAccount({ name: 'Non Zero', currentBalance: 500 });
       openContextMenu(account);
 
-      const closeBtn = screen.getByRole('button', { name: /Close Account/ });
+      const closeBtn = within(screen.getByRole('dialog')).getByRole('button', { name: 'Close' });
       expect(closeBtn).toBeDisabled();
-      // Shows helper text
-      expect(screen.getByText('Balance must be zero')).toBeInTheDocument();
     });
 
-    it('context menu Close Account opens close dialog', () => {
+    it('context menu Close opens close dialog', () => {
       const account = createAccount({ name: 'Zero Bal', currentBalance: 0 });
       openContextMenu(account);
 
-      fireEvent.click(screen.getByRole('button', { name: /Close Account/ }));
+      fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Close' }));
       expect(screen.getByText(/Are you sure you want to close/)).toBeInTheDocument();
     });
 
-    it('context menu shows Reopen Account for closed accounts', async () => {
+    it('context menu shows Reopen for closed accounts', async () => {
       const account = createAccount({
         name: 'Closed Acct',
         isClosed: true,
@@ -1834,13 +1833,14 @@ describe('AccountList', () => {
       });
       openContextMenu(account);
 
-      expect(screen.getByText('Reopen Account')).toBeInTheDocument();
+      const sheet = within(screen.getByRole('dialog'));
+      expect(sheet.getByText('Reopen')).toBeInTheDocument();
       // Active-account-only buttons should not appear
-      expect(screen.queryByText('Edit Account')).not.toBeInTheDocument();
-      expect(screen.queryByText('Close Account')).not.toBeInTheDocument();
+      expect(sheet.queryByText('Edit')).not.toBeInTheDocument();
+      expect(sheet.queryByText('Close')).not.toBeInTheDocument();
     });
 
-    it('context menu Reopen Account calls reopen API', async () => {
+    it('context menu Reopen calls reopen API', async () => {
       const account = createAccount({
         name: 'Closed Acct',
         isClosed: true,
@@ -1848,7 +1848,7 @@ describe('AccountList', () => {
       });
       openContextMenu(account);
 
-      fireEvent.click(screen.getByText('Reopen Account'));
+      fireEvent.click(within(screen.getByRole('dialog')).getByText('Reopen'));
 
       // Switch to real timers so waitFor can work
       vi.useRealTimers();
@@ -1913,26 +1913,26 @@ describe('AccountList', () => {
       expect(invCashTexts.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('context menu shows Delete Account for deletable accounts', () => {
+    it('context menu shows Delete for deletable accounts', () => {
       const account = createAccount({ name: 'Del Acct', canDelete: true });
       openContextMenu(account);
 
-      expect(screen.getByText('Delete Account')).toBeInTheDocument();
+      expect(within(screen.getByRole('dialog')).getByText('Delete')).toBeInTheDocument();
     });
 
-    it('context menu Delete Account opens delete confirmation dialog', () => {
+    it('context menu Delete opens delete confirmation dialog', () => {
       const account = createAccount({ name: 'Del Acct', canDelete: true });
       openContextMenu(account);
 
-      fireEvent.click(screen.getByText('Delete Account'));
+      fireEvent.click(within(screen.getByRole('dialog')).getByText('Delete'));
       expect(screen.getByText(/Are you sure you want to permanently delete/)).toBeInTheDocument();
     });
 
-    it('context menu does not show Delete Account for non-deletable accounts', () => {
+    it('context menu does not show Delete for non-deletable accounts', () => {
       const account = createAccount({ name: 'No Del Acct', canDelete: false });
       openContextMenu(account);
 
-      expect(screen.queryByText('Delete Account')).not.toBeInTheDocument();
+      expect(within(screen.getByRole('dialog')).queryByText('Delete')).not.toBeInTheDocument();
     });
 
     it('closes context menu when modal onClose is triggered', () => {
@@ -2330,7 +2330,7 @@ describe('AccountList', () => {
       // No Reconcile in dense mode for brokerage
       expect(screen.queryByTitle('Reconcile')).not.toBeInTheDocument();
       // But delete button appears for deletable
-      expect(screen.getByTitle('Permanently delete account (no transactions)')).toBeInTheDocument();
+      expect(screen.getByTitle('Delete')).toBeInTheDocument();
     });
 
     it('dense mode with non-deletable closed account does not show delete button', () => {
@@ -2348,7 +2348,7 @@ describe('AccountList', () => {
       fireEvent.click(densityButton);
       fireEvent.click(densityButton); // dense
 
-      expect(screen.queryByTitle('Permanently delete account (no transactions)')).not.toBeInTheDocument();
+      expect(screen.queryByTitle('Delete')).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -1,18 +1,19 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Account, AccountType } from '@/types/account';
 import { Institution } from '@/types/institution';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
-import { Modal } from '@/components/ui/Modal';
 import { accountsApi } from '@/lib/accounts';
 import { useAuthStore } from '@/store/authStore';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import toast from 'react-hot-toast';
 import { getErrorMessage } from '@/lib/errors';
-import { AccountRow } from './AccountRow';
+import { AccountRow, buildAccountActions, type AccountActionLabels } from './AccountRow';
+import { useLongPress } from '@/hooks/useLongPress';
+import { RowActionSheet } from '@/components/ui/row-actions/RowActionSheet';
 import { useTableDensity, nextDensity, type DensityLevel } from '@/hooks/useTableDensity';
 import { SortIcon } from '@/components/ui/SortIcon';
 import { formatAccountType, countLogicalAccounts } from '@/lib/account-utils';
@@ -186,58 +187,32 @@ export function AccountList({ accounts, institutions, brokerageMarketValues, def
     );
   }, [collapsedGroups]);
 
-  // Long-press handling for context menu on mobile
-  const longPressTimer = useRef<NodeJS.Timeout | null>(null);
-  const longPressTriggered = useRef(false);
-  const touchStartPos = useRef<{ x: number; y: number } | null>(null);
-  const LONG_PRESS_MOVE_THRESHOLD = 10;
+  // Long-press opens a per-row action sheet on mobile (and via right-click).
   const [contextAccount, setContextAccount] = useState<Account | null>(null);
 
-  const handleLongPressStart = useCallback((account: Account, e?: React.TouchEvent) => {
-    if (e?.touches?.[0]) {
-      touchStartPos.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
-    } else {
-      touchStartPos.current = null;
-    }
-
-    longPressTriggered.current = false;
-    longPressTimer.current = setTimeout(() => {
-      longPressTriggered.current = true;
-      setContextAccount(account);
-    }, 750);
-  }, []);
-
-  const handleLongPressEnd = useCallback(() => {
-    if (longPressTimer.current) {
-      clearTimeout(longPressTimer.current);
-      longPressTimer.current = null;
-    }
-    touchStartPos.current = null;
-  }, []);
-
-  const handleTouchMove = useCallback((e: React.TouchEvent) => {
-    if (touchStartPos.current && longPressTimer.current && e.touches?.[0]) {
-      const deltaX = Math.abs(e.touches[0].clientX - touchStartPos.current.x);
-      const deltaY = Math.abs(e.touches[0].clientY - touchStartPos.current.y);
-      if (deltaX > LONG_PRESS_MOVE_THRESHOLD || deltaY > LONG_PRESS_MOVE_THRESHOLD) {
-        clearTimeout(longPressTimer.current);
-        longPressTimer.current = null;
-        touchStartPos.current = null;
-      }
-    }
-  }, []);
-
   const handleRowClick = useCallback((account: Account) => {
-    if (longPressTriggered.current) {
-      longPressTriggered.current = false;
-      return;
-    }
     if (account.accountSubType === 'INVESTMENT_BROKERAGE') {
       router.push(`/investments?accountId=${account.id}`);
     } else {
       router.push(`/transactions?accountId=${account.id}`);
     }
   }, [router]);
+
+  const { getRowHandlers } = useLongPress<Account>({
+    onLongPress: setContextAccount,
+    onClick: handleRowClick,
+  });
+
+  const accountActionLabels = useMemo<AccountActionLabels>(() => ({
+    viewTransactions: t('row.actions.viewTransactions'),
+    edit: tc('actions.edit'),
+    reconcile: tc('actions.reconcile'),
+    close: tc('actions.close'),
+    closeTitleDisabled: t('row.actions.closeTitleDisabled'),
+    closeTitleEnabled: t('row.actions.closeTitleEnabled'),
+    reopen: tc('actions.reopen'),
+    delete: tc('actions.delete'),
+  }), [t, tc]);
   const { cellPadding, headerPadding } = useTableDensity(density);
 
   const cycleDensity = useCallback(() => {
@@ -749,16 +724,13 @@ export function AccountList({ accounts, institutions, brokerageMarketValues, def
                   convertToDefault={convertToDefault}
                   formatAccountType={(type) => formatAccountType(type, tc)}
                   getAccountTypeColor={getAccountTypeColor}
-                  onRowClick={handleRowClick}
+                  actionLabels={accountActionLabels}
                   onEdit={onEdit}
                   onReconcile={handleReconcile}
                   onCloseClick={handleCloseClick}
                   onDeleteClick={handleDeleteClick}
                   onReopen={handleReopen}
-                  onLongPressStart={handleLongPressStart}
-                  onLongPressStartTouch={handleLongPressStart}
-                  onLongPressEnd={handleLongPressEnd}
-                  onTouchMove={handleTouchMove}
+                  getRowHandlers={getRowHandlers}
                   onToggleFavourite={handleToggleFavourite}
                 />
               ),
@@ -769,96 +741,27 @@ export function AccountList({ accounts, institutions, brokerageMarketValues, def
       </div>
       )}
 
-      {/* Long-press Context Menu */}
-      <Modal isOpen={!!contextAccount} onClose={() => setContextAccount(null)} maxWidth="sm" className="p-0">
-        {contextAccount && (
-          <div>
-            <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">{contextAccount.name}</h3>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                {contextAccount.accountSubType === 'INVESTMENT_BROKERAGE' ? t('contextMenu.subtypeBrokerage') :
-                 contextAccount.accountSubType === 'INVESTMENT_CASH' ? t('contextMenu.subtypeInvCash') :
-                 formatAccountType(contextAccount.accountType, tc)}
-                {contextAccount.isClosed ? t('contextMenu.closedSuffix') : ''}
-              </p>
-            </div>
-            <div className="py-2">
-              <button
-                onClick={() => { setContextAccount(null); handleViewTransactions(contextAccount); }}
-                className="w-full text-left px-5 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
-              >
-                <svg className="w-5 h-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                </svg>
-                {t('row.actions.viewTransactions')}
-              </button>
-              {!contextAccount.isClosed && (
-                <>
-                  <button
-                    onClick={() => { setContextAccount(null); onEdit(contextAccount); }}
-                    className="w-full text-left px-5 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
-                  >
-                    <svg className="w-5 h-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                    </svg>
-                    {t('row.actions.editAccount')}
-                  </button>
-                  {contextAccount.accountSubType !== 'INVESTMENT_BROKERAGE' && (
-                    <button
-                      onClick={() => { setContextAccount(null); handleReconcile(contextAccount); }}
-                      className="w-full text-left px-5 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
-                    >
-                      <svg className="w-5 h-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                      </svg>
-                      {t('row.actions.reconcile')}
-                    </button>
-                  )}
-                  <button
-                    onClick={() => { setContextAccount(null); handleCloseClick(contextAccount); }}
-                    disabled={Number(contextAccount.currentBalance) !== 0}
-                    className={`w-full text-left px-5 py-3 text-sm flex items-center gap-3 ${
-                      Number(contextAccount.currentBalance) !== 0
-                        ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
-                        : 'text-orange-600 dark:text-orange-400 hover:bg-gray-100 dark:hover:bg-gray-700'
-                    }`}
-                  >
-                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
-                    </svg>
-                    {t('row.actions.closeAccount')}
-                    {Number(contextAccount.currentBalance) !== 0 && (
-                      <span className="text-xs text-gray-400 dark:text-gray-500 ml-auto">{t('row.actions.balanceMustBeZero')}</span>
-                    )}
-                  </button>
-                </>
-              )}
-              {contextAccount.isClosed && (
-                <button
-                  onClick={() => { setContextAccount(null); handleReopen(contextAccount); }}
-                  className="w-full text-left px-5 py-3 text-sm text-blue-600 dark:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
-                >
-                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                  </svg>
-                  {t('row.actions.reopenAccount')}
-                </button>
-              )}
-              {deletableAccounts.has(contextAccount.id) && (
-                <button
-                  onClick={() => { setContextAccount(null); handleDeleteClick(contextAccount); }}
-                  className="w-full text-left px-5 py-3 text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
-                >
-                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                  </svg>
-                  {t('row.actions.deleteAccount')}
-                </button>
-              )}
-            </div>
-          </div>
-        )}
-      </Modal>
+      {/* Long-press action sheet */}
+      <RowActionSheet
+        isOpen={!!contextAccount}
+        title={contextAccount?.name ?? ''}
+        subtitle={contextAccount
+          ? `${contextAccount.accountSubType === 'INVESTMENT_BROKERAGE' ? t('contextMenu.subtypeBrokerage') :
+              contextAccount.accountSubType === 'INVESTMENT_CASH' ? t('contextMenu.subtypeInvCash') :
+              formatAccountType(contextAccount.accountType, tc)}${contextAccount.isClosed ? t('contextMenu.closedSuffix') : ''}`
+          : undefined}
+        actions={contextAccount
+          ? buildAccountActions(contextAccount, deletableAccounts.has(contextAccount.id), accountActionLabels, {
+              onViewTransactions: handleViewTransactions,
+              onEdit,
+              onReconcile: handleReconcile,
+              onCloseClick: handleCloseClick,
+              onReopen: handleReopen,
+              onDeleteClick: handleDeleteClick,
+            })
+          : []}
+        onClose={() => setContextAccount(null)}
+      />
 
       {/* Close Account Confirmation Dialog */}
       <ConfirmDialog

--- a/frontend/src/components/accounts/AccountRow.test.tsx
+++ b/frontend/src/components/accounts/AccountRow.test.tsx
@@ -79,16 +79,32 @@ function createDefaultProps(overrides: Partial<AccountRowProps> = {}): AccountRo
       return labels[type] || type;
     },
     getAccountTypeColor: () => 'bg-blue-100 text-blue-800',
-    onRowClick: vi.fn(),
+    actionLabels: {
+      viewTransactions: 'View Transactions',
+      edit: 'Edit',
+      reconcile: 'Reconcile',
+      close: 'Close',
+      closeTitleDisabled: 'Balance must be zero',
+      closeTitleEnabled: 'Close account',
+      reopen: 'Reopen',
+      delete: 'Delete',
+    },
     onEdit: vi.fn(),
     onReconcile: vi.fn(),
     onCloseClick: vi.fn(),
     onDeleteClick: vi.fn(),
     onReopen: vi.fn(),
-    onLongPressStart: vi.fn(),
-    onLongPressStartTouch: vi.fn(),
-    onLongPressEnd: vi.fn(),
-    onTouchMove: vi.fn(),
+    getRowHandlers: () => ({
+      onClick: vi.fn(),
+      onContextMenu: vi.fn(),
+      onMouseDown: vi.fn(),
+      onMouseUp: vi.fn(),
+      onMouseLeave: vi.fn(),
+      onTouchStart: vi.fn(),
+      onTouchMove: vi.fn(),
+      onTouchEnd: vi.fn(),
+      onTouchCancel: vi.fn(),
+    }),
     ...overrides,
   };
 }
@@ -590,8 +606,8 @@ describe('AccountRow', () => {
       // In dense mode, buttons are icon-only with title attributes
       expect(screen.getByTitle('Edit')).toBeInTheDocument();
       expect(screen.getByTitle('Reconcile')).toBeInTheDocument();
-      expect(screen.getByTitle(/Close account|Account must have zero balance/)).toBeInTheDocument();
-      expect(screen.getByTitle('Permanently delete account (no transactions)')).toBeInTheDocument();
+      expect(screen.getByTitle(/Close account|Balance must be zero/)).toBeInTheDocument();
+      expect(screen.getByTitle('Delete')).toBeInTheDocument();
     });
 
     it('renders icon-only Reopen button for closed accounts in dense mode', () => {
@@ -645,7 +661,7 @@ describe('AccountRow', () => {
       });
       renderAccountRow(props);
 
-      const closeButton = screen.getByTitle('Account must have zero balance to close');
+      const closeButton = screen.getByTitle('Balance must be zero');
       expect(closeButton).toBeDisabled();
     });
 
@@ -747,60 +763,59 @@ describe('AccountRow', () => {
   });
 
   describe('row click and interaction', () => {
-    it('calls onRowClick when row is clicked', () => {
-      const onRowClick = vi.fn();
+    // Builds a full set of long-press row handlers backed by spies so we can
+    // assert AccountRow spreads them onto the <tr>.
+    function makeRowHandlers() {
+      const spies = {
+        onClick: vi.fn(),
+        onContextMenu: vi.fn(),
+        onMouseDown: vi.fn(),
+        onMouseUp: vi.fn(),
+        onMouseLeave: vi.fn(),
+        onTouchStart: vi.fn(),
+        onTouchMove: vi.fn(),
+        onTouchEnd: vi.fn(),
+        onTouchCancel: vi.fn(),
+      };
+      return spies;
+    }
+
+    it('spreads the row click handler onto the row', () => {
+      const handlers = makeRowHandlers();
       const account = createAccount();
-      const props = createDefaultProps({ account, onRowClick });
+      const props = createDefaultProps({ account, getRowHandlers: () => handlers });
       renderAccountRow(props);
 
       fireEvent.click(screen.getByText('Main Chequing'));
-      expect(onRowClick).toHaveBeenCalledWith(account);
+      expect(handlers.onClick).toHaveBeenCalled();
     });
 
     it('does not propagate row click when action buttons are clicked', () => {
-      const onRowClick = vi.fn();
+      const handlers = makeRowHandlers();
       const onEdit = vi.fn();
       const account = createAccount({ isClosed: false });
-      const props = createDefaultProps({ account, onRowClick, onEdit });
+      const props = createDefaultProps({ account, onEdit, getRowHandlers: () => handlers });
       renderAccountRow(props);
 
-      // The actions column has stopPropagation on click
+      // The actions column has stopPropagation on click.
       fireEvent.click(screen.getByText('Edit'));
       expect(onEdit).toHaveBeenCalledWith(account);
-      // onRowClick should not be called because of stopPropagation on the actions td
+      expect(handlers.onClick).not.toHaveBeenCalled();
     });
 
-    it('calls onLongPressStart on mouse down', () => {
-      const onLongPressStart = vi.fn();
+    it('spreads the long-press handlers onto the row', () => {
+      const handlers = makeRowHandlers();
       const account = createAccount();
-      const props = createDefaultProps({ account, onLongPressStart });
+      const props = createDefaultProps({ account, getRowHandlers: () => handlers });
       renderAccountRow(props);
 
       const row = screen.getByRole('row');
       fireEvent.mouseDown(row);
-      expect(onLongPressStart).toHaveBeenCalledWith(account);
-    });
-
-    it('calls onLongPressEnd on mouse up', () => {
-      const onLongPressEnd = vi.fn();
-      const account = createAccount();
-      const props = createDefaultProps({ account, onLongPressEnd });
-      renderAccountRow(props);
-
-      const row = screen.getByRole('row');
+      expect(handlers.onMouseDown).toHaveBeenCalled();
       fireEvent.mouseUp(row);
-      expect(onLongPressEnd).toHaveBeenCalled();
-    });
-
-    it('calls onLongPressEnd on mouse leave', () => {
-      const onLongPressEnd = vi.fn();
-      const account = createAccount();
-      const props = createDefaultProps({ account, onLongPressEnd });
-      renderAccountRow(props);
-
-      const row = screen.getByRole('row');
+      expect(handlers.onMouseUp).toHaveBeenCalled();
       fireEvent.mouseLeave(row);
-      expect(onLongPressEnd).toHaveBeenCalled();
+      expect(handlers.onMouseLeave).toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/components/accounts/AccountRow.tsx
+++ b/frontend/src/components/accounts/AccountRow.tsx
@@ -4,8 +4,98 @@ import { memo } from 'react';
 import { useTranslations } from 'next-intl';
 import { gainLossColor } from '@/lib/format';
 import { Account, AccountType } from '@/types/account';
-import { Button } from '@/components/ui/Button';
 import { InstitutionLogo, InstitutionLogoData } from '@/components/institutions/InstitutionLogo';
+import { RowActions } from '@/components/ui/row-actions/RowActions';
+import type { LongPressRowHandlers } from '@/hooks/useLongPress';
+import type { RowAction } from '@/components/ui/row-actions/rowAction';
+
+export interface AccountActionLabels {
+  viewTransactions: string;
+  edit: string;
+  reconcile: string;
+  close: string;
+  closeTitleDisabled: string;
+  closeTitleEnabled: string;
+  reopen: string;
+  delete: string;
+}
+
+export interface AccountActionHandlers {
+  onViewTransactions?: (account: Account) => void;
+  onEdit: (account: Account) => void;
+  onReconcile: (account: Account) => void;
+  onCloseClick: (account: Account) => void;
+  onReopen: (account: Account) => void;
+  onDeleteClick: (account: Account) => void;
+}
+
+/**
+ * Builds the standard row actions for an account. Shared by the desktop
+ * `RowActions` cell and the mobile `RowActionSheet`. The desktop surface omits
+ * "View transactions" (a row tap already opens it) by leaving `onViewTransactions`
+ * undefined; the action sheet supplies it.
+ */
+export function buildAccountActions(
+  account: Account,
+  isDeletable: boolean,
+  labels: AccountActionLabels,
+  handlers: AccountActionHandlers,
+): RowAction[] {
+  const balanceNonZero = Number(account.currentBalance) !== 0;
+  return [
+    {
+      key: 'view',
+      label: labels.viewTransactions,
+      icon: 'transactions',
+      tone: 'neutral',
+      onClick: () => handlers.onViewTransactions?.(account),
+      hidden: !handlers.onViewTransactions,
+    },
+    {
+      key: 'edit',
+      label: labels.edit,
+      icon: 'edit',
+      tone: 'primary',
+      onClick: () => handlers.onEdit(account),
+      hidden: account.isClosed,
+    },
+    {
+      key: 'reconcile',
+      label: labels.reconcile,
+      icon: 'reconcile',
+      tone: 'success',
+      onClick: () => handlers.onReconcile(account),
+      hidden: account.isClosed || account.accountSubType === 'INVESTMENT_BROKERAGE',
+    },
+    {
+      key: 'close',
+      label: labels.close,
+      icon: 'close',
+      tone: 'warning',
+      onClick: () => handlers.onCloseClick(account),
+      hidden: account.isClosed,
+      disabled: balanceNonZero,
+      title: balanceNonZero ? labels.closeTitleDisabled : labels.closeTitleEnabled,
+    },
+    {
+      key: 'reopen',
+      label: labels.reopen,
+      icon: 'reopen',
+      tone: 'primary',
+      onClick: () => handlers.onReopen(account),
+      hidden: !account.isClosed,
+    },
+    {
+      key: 'delete',
+      label: labels.delete,
+      icon: 'delete',
+      tone: 'delete',
+      destructive: true,
+      onClick: () => handlers.onDeleteClick(account),
+      hidden: !isDeletable,
+    },
+  ];
+}
 
 export interface AccountRowProps {
   account: Account;
@@ -24,16 +114,13 @@ export interface AccountRowProps {
   convertToDefault: (value: number, fromCurrency: string) => number;
   formatAccountType: (type: AccountType) => string;
   getAccountTypeColor: (type: AccountType) => string;
-  onRowClick: (account: Account) => void;
+  actionLabels: AccountActionLabels;
   onEdit: (account: Account) => void;
   onReconcile: (account: Account) => void;
   onCloseClick: (account: Account) => void;
   onDeleteClick: (account: Account) => void;
   onReopen: (account: Account) => void;
-  onLongPressStart: (account: Account) => void;
-  onLongPressStartTouch: (account: Account, e: React.TouchEvent) => void;
-  onLongPressEnd: () => void;
-  onTouchMove: (e: React.TouchEvent) => void;
+  getRowHandlers: (account: Account) => LongPressRowHandlers;
   // Provided only in delegate (acting) view: makes the favourite star an
   // interactive toggle for the delegate's own (non-shared) favourites.
   onToggleFavourite?: (account: Account) => void;
@@ -54,30 +141,27 @@ export const AccountRow = memo(function AccountRow({
   convertToDefault,
   formatAccountType,
   getAccountTypeColor,
-  onRowClick,
+  actionLabels,
   onEdit,
   onReconcile,
   onCloseClick,
   onDeleteClick,
   onReopen,
-  onLongPressStart,
-  onLongPressStartTouch,
-  onLongPressEnd,
-  onTouchMove,
+  getRowHandlers,
   onToggleFavourite,
 }: AccountRowProps) {
   const t = useTranslations('accounts');
+  const actions = buildAccountActions(account, isDeletable, actionLabels, {
+    onEdit,
+    onReconcile,
+    onCloseClick,
+    onReopen,
+    onDeleteClick,
+  });
   return (
     <tr
       className={`group hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer select-none ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'}`}
-      onClick={() => onRowClick(account)}
-      onMouseDown={() => onLongPressStart(account)}
-      onMouseUp={onLongPressEnd}
-      onMouseLeave={onLongPressEnd}
-      onTouchStart={(e) => onLongPressStartTouch(account, e)}
-      onTouchMove={onTouchMove}
-      onTouchEnd={onLongPressEnd}
-      onTouchCancel={onLongPressEnd}
+      {...getRowHandlers(account)}
     >
       <td className={`${cellPadding} ${account.isClosed ? 'opacity-50' : ''} max-w-[50vw] sm:max-w-[180px] md:max-w-none`}>
         <div
@@ -219,107 +303,10 @@ export const AccountRow = memo(function AccountRow({
           </>
         )}
       </td>
-      <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium ${density === 'dense' ? 'space-x-1' : 'space-x-2'} hidden min-[480px]:table-cell sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`} onClick={(e) => e.stopPropagation()}>
-        {!account.isClosed ? (
-          <ActiveAccountActions
-            account={account}
-            density={density}
-            isDeletable={isDeletable}
-            onEdit={onEdit}
-            onReconcile={onReconcile}
-            onCloseClick={onCloseClick}
-            onDeleteClick={onDeleteClick}
-          />
-        ) : (
-          <ClosedAccountActions
-            account={account}
-            density={density}
-            isDeletable={isDeletable}
-            onReopen={onReopen}
-            onDeleteClick={onDeleteClick}
-          />
-        )}
+      <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium hidden min-[480px]:table-cell sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`} onClick={(e) => e.stopPropagation()}>
+        <RowActions actions={actions} density={density} />
       </td>
     </tr>
   );
 });
 
-function ActiveAccountActions({ account, density, isDeletable, onEdit, onReconcile, onCloseClick, onDeleteClick }: {
-  account: Account;
-  density: 'normal' | 'compact' | 'dense';
-  isDeletable: boolean;
-  onEdit: (account: Account) => void;
-  onReconcile: (account: Account) => void;
-  onCloseClick: (account: Account) => void;
-  onDeleteClick: (account: Account) => void;
-}) {
-  const t = useTranslations('accounts');
-  if (density === 'dense') {
-    return (
-      <>
-        <button onClick={() => onEdit(account)} className="inline-flex items-center justify-center p-1.5 text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded" title={t('row.actions.edit')}>
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
-        </button>
-        {account.accountSubType !== 'INVESTMENT_BROKERAGE' && (
-          <button onClick={() => onReconcile(account)} className="inline-flex items-center justify-center p-1.5 text-gray-600 dark:text-gray-300 hover:text-green-600 dark:hover:text-green-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded" title={t('row.actions.reconcile')}>
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-          </button>
-        )}
-        <button onClick={() => onCloseClick(account)} disabled={Number(account.currentBalance) !== 0} className={`inline-flex items-center justify-center p-1.5 rounded ${Number(account.currentBalance) !== 0 ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed' : 'text-gray-600 dark:text-gray-300 hover:text-orange-600 dark:hover:text-orange-400 hover:bg-gray-100 dark:hover:bg-gray-700'}`} title={Number(account.currentBalance) !== 0 ? t('row.actions.closeTitleDisabled') : t('row.actions.closeTitleEnabled')}>
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" /></svg>
-        </button>
-        {isDeletable && (
-          <button onClick={() => onDeleteClick(account)} className="inline-flex items-center justify-center p-1.5 text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/30 rounded" title={t('row.actions.deleteTitle')}>
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
-          </button>
-        )}
-      </>
-    );
-  }
-
-  return (
-    <>
-      <Button variant="outline" size="sm" onClick={() => onEdit(account)}>{t('row.actions.edit')}</Button>
-      {account.accountSubType !== 'INVESTMENT_BROKERAGE' && (
-        <Button variant="outline" size="sm" onClick={() => onReconcile(account)} title={t('row.actions.reconcileTitle')}>{t('row.actions.reconcile')}</Button>
-      )}
-      <Button variant="outline" size="sm" onClick={() => onCloseClick(account)} disabled={Number(account.currentBalance) !== 0} title={Number(account.currentBalance) !== 0 ? t('row.actions.closeTitleDisabled') : t('row.actions.closeTitleEnabled')}>{t('row.actions.close')}</Button>
-      {isDeletable && (
-        <Button variant="danger" size="sm" onClick={() => onDeleteClick(account)} title={t('row.actions.deleteTitle')}>{t('row.actions.delete')}</Button>
-      )}
-    </>
-  );
-}
-
-function ClosedAccountActions({ account, density, isDeletable, onReopen, onDeleteClick }: {
-  account: Account;
-  density: 'normal' | 'compact' | 'dense';
-  isDeletable: boolean;
-  onReopen: (account: Account) => void;
-  onDeleteClick: (account: Account) => void;
-}) {
-  const t = useTranslations('accounts');
-  if (density === 'dense') {
-    return (
-      <>
-        <button onClick={() => onReopen(account)} className="inline-flex items-center justify-center p-1.5 text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded" title={t('row.actions.reopen')}>
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" /></svg>
-        </button>
-        {isDeletable && (
-          <button onClick={() => onDeleteClick(account)} className="inline-flex items-center justify-center p-1.5 text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/30 rounded" title={t('row.actions.deleteTitle')}>
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
-          </button>
-        )}
-      </>
-    );
-  }
-
-  return (
-    <>
-      <Button variant="outline" size="sm" onClick={() => onReopen(account)}>{t('row.actions.reopen')}</Button>
-      {isDeletable && (
-        <Button variant="danger" size="sm" onClick={() => onDeleteClick(account)} title={t('row.actions.deleteTitle')}>{t('row.actions.delete')}</Button>
-      )}
-    </>
-  );
-}

--- a/frontend/src/components/categories/CategoryList.tsx
+++ b/frontend/src/components/categories/CategoryList.tsx
@@ -4,7 +4,6 @@ import { useState, useMemo, useCallback, memo } from 'react';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { Category } from '@/types/category';
-import { Button } from '@/components/ui/Button';
 import { DeleteCategoryDialog } from './DeleteCategoryDialog';
 import { categoriesApi } from '@/lib/categories';
 import toast from 'react-hot-toast';
@@ -12,8 +11,41 @@ import { createLogger } from '@/lib/logger';
 import { getErrorMessage } from '@/lib/errors';
 import { useTableDensity, nextDensity, type DensityLevel } from '@/hooks/useTableDensity';
 import { SortIcon } from '@/components/ui/SortIcon';
+import { useLongPress, type LongPressRowHandlers } from '@/hooks/useLongPress';
+import { RowActions } from '@/components/ui/row-actions/RowActions';
+import { RowActionSheet } from '@/components/ui/row-actions/RowActionSheet';
+import type { RowAction } from '@/components/ui/row-actions/rowAction';
 
 const logger = createLogger('CategoryList');
+
+/**
+ * Builds the standard row actions for a category. Shared by the desktop
+ * `RowActions` cell and the mobile `RowActionSheet`.
+ */
+function buildCategoryActions(
+  category: Category,
+  labels: { edit: string; delete: string },
+  handlers: { onEdit: (category: Category) => void; onDeleteClick: (category: Category) => void },
+): RowAction[] {
+  return [
+    {
+      key: 'edit',
+      label: labels.edit,
+      icon: 'edit',
+      tone: 'primary',
+      onClick: () => handlers.onEdit(category),
+    },
+    {
+      key: 'delete',
+      label: labels.delete,
+      icon: 'delete',
+      tone: 'delete',
+      destructive: true,
+      onClick: () => handlers.onDeleteClick(category),
+      hidden: category.isSystem,
+    },
+  ];
+}
 
 export type { DensityLevel } from '@/hooks/useTableDensity';
 
@@ -28,6 +60,7 @@ interface CategoryRowProps {
   onDeleteClick: (category: Category) => void;
   onViewTransactions: (category: Category) => void;
   index: number;
+  getRowHandlers: (category: Category) => LongPressRowHandlers;
 }
 
 const CategoryRow = memo(function CategoryRow({
@@ -38,24 +71,24 @@ const CategoryRow = memo(function CategoryRow({
   onDeleteClick,
   onViewTransactions,
   index,
+  getRowHandlers,
 }: CategoryRowProps) {
   const t = useTranslations('categories');
   const tc = useTranslations('common');
-  const handleEdit = useCallback(() => {
-    onEdit(category);
-  }, [onEdit, category]);
 
-  const handleDelete = useCallback(() => {
-    onDeleteClick(category);
-  }, [onDeleteClick, category]);
-
-  const handleView = useCallback(() => {
-    onViewTransactions(category);
-  }, [onViewTransactions, category]);
+  const actions = useMemo(
+    () => buildCategoryActions(
+      category,
+      { edit: tc('actions.edit'), delete: tc('actions.delete') },
+      { onEdit, onDeleteClick },
+    ),
+    [category, tc, onEdit, onDeleteClick],
+  );
 
   return (
     <tr
-      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'}`}
+      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer select-none ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'}`}
+      {...getRowHandlers(category)}
     >
       <td className={`${cellPadding} whitespace-nowrap`}>
         <div
@@ -72,7 +105,7 @@ const CategoryRow = memo(function CategoryRow({
             />
           )}
           <button
-            onClick={handleView}
+            onClick={(e) => { e.stopPropagation(); onViewTransactions(category); }}
             className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline text-left"
             title={t('list.viewTransactionsTitle')}
           >
@@ -104,25 +137,8 @@ const CategoryRow = memo(function CategoryRow({
           </div>
         </td>
       )}
-      <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`}>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={handleEdit}
-          className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300 mr-2"
-        >
-          {density === 'dense' ? '✎' : tc('edit')}
-        </Button>
-        {!category.isSystem && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleDelete}
-            className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300"
-          >
-            {density === 'dense' ? '✕' : tc('delete')}
-          </Button>
-        )}
+      <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium hidden min-[480px]:table-cell sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`}>
+        <RowActions actions={actions} density={density} />
       </td>
     </tr>
   );
@@ -152,8 +168,10 @@ export function CategoryList({
   onSort,
 }: CategoryListProps) {
   const t = useTranslations('categories');
+  const tc = useTranslations('common');
   const router = useRouter();
   const [deleteCategory, setDeleteCategory] = useState<Category | null>(null);
+  const [actionSheet, setActionSheet] = useState<{ open: boolean; category: Category | null }>({ open: false, category: null });
   const [localDensity, setLocalDensity] = useState<DensityLevel>('normal');
   const [localSortField, setLocalSortField] = useState<SortField>('name');
   const [localSortDirection, setLocalSortDirection] = useState<SortDirection>('asc');
@@ -200,6 +218,11 @@ export function CategoryList({
     }
     setDeleteCategory(category);
   }, [t]);
+
+  const { getRowHandlers } = useLongPress<Category>({
+    onLongPress: (category) => setActionSheet({ open: true, category }),
+    onClick: onEdit,
+  });
 
   const handleConfirmDelete = async (reassignToCategoryId: string | null) => {
     if (!deleteCategory) return;
@@ -319,7 +342,7 @@ export function CategoryList({
                   {t('list.colDescription')}
                 </th>
               )}
-              <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider sticky right-0 bg-gray-50 dark:bg-gray-800`}>
+              <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden min-[480px]:table-cell sticky right-0 bg-gray-50 dark:bg-gray-800`}>
                 {t('list.colActions')}
               </th>
             </tr>
@@ -335,6 +358,7 @@ export function CategoryList({
                 onDeleteClick={handleDeleteClick}
                 onViewTransactions={handleViewTransactions}
                 index={index}
+                getRowHandlers={getRowHandlers}
               />
             ))}
           </tbody>
@@ -347,6 +371,19 @@ export function CategoryList({
         categories={categories}
         onConfirm={handleConfirmDelete}
         onCancel={() => setDeleteCategory(null)}
+      />
+
+      <RowActionSheet
+        isOpen={actionSheet.open}
+        title={actionSheet.category?.name ?? ''}
+        actions={actionSheet.category
+          ? buildCategoryActions(
+              actionSheet.category,
+              { edit: tc('actions.edit'), delete: tc('actions.delete') },
+              { onEdit, onDeleteClick: handleDeleteClick },
+            )
+          : []}
+        onClose={() => setActionSheet({ open: false, category: null })}
       />
     </div>
   );

--- a/frontend/src/components/currencies/CurrencyList.test.tsx
+++ b/frontend/src/components/currencies/CurrencyList.test.tsx
@@ -632,25 +632,25 @@ describe('CurrencyList', () => {
       expect(screen.getByText('Ina')).toBeInTheDocument();
     });
 
-    it('shows dense edit symbol in dense mode', () => {
+    it('shows the edit icon button in dense mode', () => {
       const currencies = [makeCurrency({ code: 'USD' })];
 
       render(<CurrencyList currencies={currencies} {...defaultProps} density="dense" />);
-      expect(screen.getByText('✎')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
     });
 
-    it('shows dense deactivate symbol in dense mode', () => {
+    it('shows the deactivate icon button in dense mode', () => {
       const currencies = [makeCurrency({ code: 'USD', isActive: true })];
 
       render(<CurrencyList currencies={currencies} {...defaultProps} density="dense" />);
-      expect(screen.getByText('⊘')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Deactivate' })).toBeInTheDocument();
     });
 
-    it('shows dense activate symbol for inactive currency in dense mode', () => {
+    it('shows the activate icon button for inactive currency in dense mode', () => {
       const currencies = [makeCurrency({ code: 'USD', isActive: false })];
 
       render(<CurrencyList currencies={currencies} {...defaultProps} density="dense" />);
-      expect(screen.getByText('✓')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Activate' })).toBeInTheDocument();
     });
 
     it('hides Decimals column in compact mode', () => {

--- a/frontend/src/components/currencies/CurrencyList.tsx
+++ b/frontend/src/components/currencies/CurrencyList.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import { useState, useMemo, useCallback, useRef, memo } from 'react';
+import { useState, useMemo, useCallback, memo } from 'react';
 import { useTranslations } from 'next-intl';
 import { CurrencyInfo, CurrencyUsage } from '@/lib/exchange-rates';
-import { Button } from '@/components/ui/Button';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
-import { Modal } from '@/components/ui/Modal';
 import { exchangeRatesApi } from '@/lib/exchange-rates';
 import toast from 'react-hot-toast';
 import { createLogger } from '@/lib/logger';
@@ -13,11 +11,80 @@ import { getErrorMessage } from '@/lib/errors';
 
 import { DensityLevel, nextDensity } from '@/hooks/useTableDensity';
 import { SortIcon } from '@/components/ui/SortIcon';
+import { useLongPress, type LongPressRowHandlers } from '@/hooks/useLongPress';
+import { RowActions } from '@/components/ui/row-actions/RowActions';
+import { RowActionSheet } from '@/components/ui/row-actions/RowActionSheet';
+import type { RowAction } from '@/components/ui/row-actions/rowAction';
 
 export type CurrencySortField = 'code' | 'name' | 'symbol' | 'decimals' | 'rate';
 export type SortDirection = 'asc' | 'desc';
 
 const logger = createLogger('CurrencyList');
+
+interface CurrencyActionLabels {
+  edit: string;
+  activate: string;
+  deactivate: string;
+  delete: string;
+}
+
+interface CurrencyActionHandlers {
+  onEdit: (currency: CurrencyInfo) => void;
+  onToggleActive: (currency: CurrencyInfo) => void;
+  onDelete: (currency: CurrencyInfo) => void;
+}
+
+/**
+ * Builds the standard row actions for a currency. Shared by the desktop
+ * `RowActions` cell and the mobile `RowActionSheet`. Delete is desktop-omitted
+ * (only the sheet surfaces it) via `includeDelete`.
+ */
+function buildCurrencyActions(
+  currency: CurrencyInfo,
+  totalUsage: number,
+  isDefault: boolean,
+  labels: CurrencyActionLabels,
+  handlers: CurrencyActionHandlers,
+  opts: { includeDelete: boolean },
+): RowAction[] {
+  const canToggleOrDelete = !isDefault && totalUsage === 0;
+  return [
+    {
+      key: 'edit',
+      label: labels.edit,
+      icon: 'edit',
+      tone: 'primary',
+      onClick: () => handlers.onEdit(currency),
+      hidden: currency.isSystem,
+    },
+    currency.isActive
+      ? {
+          key: 'toggle',
+          label: labels.deactivate,
+          icon: 'deactivate',
+          tone: 'warning',
+          onClick: () => handlers.onToggleActive(currency),
+          hidden: !canToggleOrDelete,
+        }
+      : {
+          key: 'toggle',
+          label: labels.activate,
+          icon: 'activate',
+          tone: 'success',
+          onClick: () => handlers.onToggleActive(currency),
+          hidden: !canToggleOrDelete,
+        },
+    {
+      key: 'delete',
+      label: labels.delete,
+      icon: 'delete',
+      tone: 'delete',
+      destructive: true,
+      onClick: () => handlers.onDelete(currency),
+      hidden: !opts.includeDelete || currency.isSystem || !canToggleOrDelete,
+    },
+  ];
+}
 
 interface CurrencyListProps {
   currencies: CurrencyInfo[];
@@ -44,10 +111,7 @@ interface CurrencyRowProps {
   onEdit: (currency: CurrencyInfo) => void;
   onToggleActive: (currency: CurrencyInfo) => void;
   onDelete: (currency: CurrencyInfo) => void;
-  onLongPressStart: (currency: CurrencyInfo) => void;
-  onLongPressStartTouch: (currency: CurrencyInfo, e: React.TouchEvent) => void;
-  onLongPressEnd: () => void;
-  onTouchMove: (e: React.TouchEvent) => void;
+  getRowHandlers: (currency: CurrencyInfo) => LongPressRowHandlers;
   index: number;
 }
 
@@ -60,30 +124,29 @@ const CurrencyRow = memo(function CurrencyRow({
   cellPadding,
   onEdit,
   onToggleActive,
-  onDelete: _onDelete,
-  onLongPressStart,
-  onLongPressStartTouch,
-  onLongPressEnd,
-  onTouchMove,
+  onDelete,
+  getRowHandlers,
   index,
 }: CurrencyRowProps) {
   const t = useTranslations('currencies');
-  const handleEdit = useCallback(() => onEdit(currency), [onEdit, currency]);
-  const handleToggle = useCallback(() => onToggleActive(currency), [onToggleActive, currency]);
+  const tc = useTranslations('common');
 
   const totalUsage = (usage?.accounts || 0) + (usage?.securities || 0);
   const isDefault = currency.code === defaultCurrency;
 
+  const actions = buildCurrencyActions(
+    currency,
+    totalUsage,
+    isDefault,
+    { edit: tc('actions.edit'), activate: t('list.actions.activate'), deactivate: t('list.actions.deactivate'), delete: tc('actions.delete') },
+    { onEdit, onToggleActive, onDelete },
+    { includeDelete: false },
+  );
+
   return (
     <tr
       className={`hover:bg-gray-100 dark:hover:bg-gray-800 select-none ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'}`}
-      onMouseDown={() => onLongPressStart(currency)}
-      onMouseUp={onLongPressEnd}
-      onMouseLeave={onLongPressEnd}
-      onTouchStart={(e) => onLongPressStartTouch(currency, e)}
-      onTouchMove={onTouchMove}
-      onTouchEnd={onLongPressEnd}
-      onTouchCancel={onLongPressEnd}
+      {...getRowHandlers(currency)}
     >
       {/* Code */}
       <td className={`${cellPadding} whitespace-nowrap`}>
@@ -152,32 +215,7 @@ const CurrencyRow = memo(function CurrencyRow({
       </td>
       {/* Actions - hidden on mobile */}
       <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium hidden sm:table-cell`}>
-        {!currency.isSystem && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleEdit}
-            className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300 mr-1"
-          >
-            {density === 'dense' ? '✎' : t('list.actions.edit')}
-          </Button>
-        )}
-        {!isDefault && totalUsage === 0 && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleToggle}
-            className={`mr-1 ${
-              currency.isActive
-                ? 'text-yellow-600 dark:text-yellow-400 hover:text-yellow-900 dark:hover:text-yellow-300'
-                : 'text-green-600 dark:text-green-400 hover:text-green-900 dark:hover:text-green-300'
-            }`}
-          >
-            {density === 'dense'
-              ? currency.isActive ? '⊘' : '✓'
-              : currency.isActive ? t('list.actions.deactivate') : t('list.actions.activate')}
-          </Button>
-        )}
+        <RowActions actions={actions} density={density} />
       </td>
     </tr>
   );
@@ -222,54 +260,12 @@ export function CurrencyList({
     }
   }, [onSort, localSortField]);
 
-  // Long-press handling for context menu on mobile
-  const longPressTimer = useRef<NodeJS.Timeout | null>(null);
-  const longPressTriggered = useRef(false);
-  const touchStartPos = useRef<{ x: number; y: number } | null>(null);
-  const LONG_PRESS_MOVE_THRESHOLD = 10;
+  // Long-press opens a per-row action sheet on mobile (and via right-click).
   const [contextCurrency, setContextCurrency] = useState<CurrencyInfo | null>(null);
 
-  const handleLongPressStart = useCallback((currency: CurrencyInfo) => {
-    touchStartPos.current = null;
-    longPressTriggered.current = false;
-    longPressTimer.current = setTimeout(() => {
-      longPressTriggered.current = true;
-      setContextCurrency(currency);
-    }, 750);
-  }, []);
-
-  const handleLongPressStartTouch = useCallback((currency: CurrencyInfo, e: React.TouchEvent) => {
-    if (e?.touches?.[0]) {
-      touchStartPos.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
-    } else {
-      touchStartPos.current = null;
-    }
-    longPressTriggered.current = false;
-    longPressTimer.current = setTimeout(() => {
-      longPressTriggered.current = true;
-      setContextCurrency(currency);
-    }, 750);
-  }, []);
-
-  const handleLongPressEnd = useCallback(() => {
-    if (longPressTimer.current) {
-      clearTimeout(longPressTimer.current);
-      longPressTimer.current = null;
-    }
-    touchStartPos.current = null;
-  }, []);
-
-  const handleTouchMove = useCallback((e: React.TouchEvent) => {
-    if (touchStartPos.current && longPressTimer.current && e.touches?.[0]) {
-      const deltaX = Math.abs(e.touches[0].clientX - touchStartPos.current.x);
-      const deltaY = Math.abs(e.touches[0].clientY - touchStartPos.current.y);
-      if (deltaX > LONG_PRESS_MOVE_THRESHOLD || deltaY > LONG_PRESS_MOVE_THRESHOLD) {
-        clearTimeout(longPressTimer.current);
-        longPressTimer.current = null;
-        touchStartPos.current = null;
-      }
-    }
-  }, []);
+  const { getRowHandlers } = useLongPress<CurrencyInfo>({
+    onLongPress: setContextCurrency,
+  });
 
   const cellPadding = useMemo(() => {
     switch (density) {
@@ -407,10 +403,7 @@ export function CurrencyList({
                 onEdit={onEdit}
                 onToggleActive={onToggleActive}
                 onDelete={setDeleteCurrency}
-                onLongPressStart={handleLongPressStart}
-                onLongPressStartTouch={handleLongPressStartTouch}
-                onLongPressEnd={handleLongPressEnd}
-                onTouchMove={handleTouchMove}
+                getRowHandlers={getRowHandlers}
                 index={index}
               />
             ))}
@@ -419,67 +412,22 @@ export function CurrencyList({
       </div>
 
       {/* Long-press Context Menu */}
-      <Modal isOpen={!!contextCurrency} onClose={() => setContextCurrency(null)} maxWidth="sm" className="p-0">
-        {contextCurrency && (() => {
-          const contextUsage = usage[contextCurrency.code];
-          const contextTotalUsage = (contextUsage?.accounts || 0) + (contextUsage?.securities || 0);
-          const isContextDefault = contextCurrency.code === defaultCurrency;
-          const canDeactivateOrDelete = !isContextDefault && contextTotalUsage === 0;
-          return (
-          <div>
-            <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">{contextCurrency.code}</h3>
-              <p className="text-sm text-gray-500 dark:text-gray-400">{contextCurrency.name}</p>
-            </div>
-            <div className="py-2">
-              {!contextCurrency.isSystem && (
-                <button
-                  onClick={() => { setContextCurrency(null); onEdit(contextCurrency); }}
-                  className="w-full text-left px-5 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
-                >
-                  <svg className="w-5 h-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                  </svg>
-                  {t('list.contextMenu.editCurrency')}
-                </button>
-              )}
-              {canDeactivateOrDelete && (
-                <button
-                  onClick={() => { setContextCurrency(null); onToggleActive(contextCurrency); }}
-                  className={`w-full text-left px-5 py-3 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3 ${
-                    contextCurrency.isActive
-                      ? 'text-yellow-600 dark:text-yellow-400'
-                      : 'text-green-600 dark:text-green-400'
-                  }`}
-                >
-                  {contextCurrency.isActive ? (
-                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
-                    </svg>
-                  ) : (
-                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                    </svg>
-                  )}
-                  {contextCurrency.isActive ? t('list.contextMenu.deactivate') : t('list.contextMenu.activate')}
-                </button>
-              )}
-              {canDeactivateOrDelete && !contextCurrency.isSystem && (
-                <button
-                  onClick={() => { setContextCurrency(null); setDeleteCurrency(contextCurrency); }}
-                  className="w-full text-left px-5 py-3 text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
-                >
-                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                  </svg>
-                  {t('list.contextMenu.deleteCurrency')}
-                </button>
-              )}
-            </div>
-          </div>
-          );
-        })()}
-      </Modal>
+      <RowActionSheet
+        isOpen={!!contextCurrency}
+        title={contextCurrency?.code ?? ''}
+        subtitle={contextCurrency?.name}
+        actions={contextCurrency
+          ? buildCurrencyActions(
+              contextCurrency,
+              (usage[contextCurrency.code]?.accounts || 0) + (usage[contextCurrency.code]?.securities || 0),
+              contextCurrency.code === defaultCurrency,
+              { edit: t('list.contextMenu.editCurrency'), activate: t('list.contextMenu.activate'), deactivate: t('list.contextMenu.deactivate'), delete: t('list.contextMenu.deleteCurrency') },
+              { onEdit, onToggleActive, onDelete: setDeleteCurrency },
+              { includeDelete: true },
+            )
+          : []}
+        onClose={() => setContextCurrency(null)}
+      />
 
       <ConfirmDialog
         isOpen={deleteCurrency !== null}

--- a/frontend/src/components/institutions/InstitutionList.tsx
+++ b/frontend/src/components/institutions/InstitutionList.tsx
@@ -3,8 +3,6 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import toast from 'react-hot-toast';
-import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline';
-import { Button } from '@/components/ui/Button';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { Institution } from '@/types/institution';
 import { institutionsApi } from '@/lib/institutions';
@@ -14,8 +12,27 @@ import { useTableDensity, nextDensity, DensityLevel } from '@/hooks/useTableDens
 import { SortIcon } from '@/components/ui/SortIcon';
 import { safeHttpUrl } from '@/lib/safe-url';
 import { InstitutionLogo } from './InstitutionLogo';
+import { useLongPress } from '@/hooks/useLongPress';
+import { RowActions } from '@/components/ui/row-actions/RowActions';
+import { RowActionSheet } from '@/components/ui/row-actions/RowActionSheet';
+import type { RowAction } from '@/components/ui/row-actions/rowAction';
 
 const logger = createLogger('InstitutionList');
+
+/**
+ * Builds the standard row actions for an institution. Shared by the desktop
+ * `RowActions` cell and the mobile `RowActionSheet`.
+ */
+function buildInstitutionActions(
+  institution: Institution,
+  labels: { edit: string; delete: string },
+  handlers: { onEdit: (institution: Institution) => void; onDeleteClick: (institution: Institution) => void },
+): RowAction[] {
+  return [
+    { key: 'edit', label: labels.edit, icon: 'edit', tone: 'primary', onClick: () => handlers.onEdit(institution) },
+    { key: 'delete', label: labels.delete, icon: 'delete', tone: 'delete', destructive: true, onClick: () => handlers.onDeleteClick(institution) },
+  ];
+}
 
 export type InstitutionSortField = 'name' | 'website' | 'country' | 'accounts';
 
@@ -47,6 +64,11 @@ export function InstitutionList({
   const { cellPadding, headerPadding } = useTableDensity(density);
   const [toDelete, setToDelete] = useState<Institution | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [contextInstitution, setContextInstitution] = useState<Institution | null>(null);
+
+  const { getRowHandlers } = useLongPress<Institution>({
+    onLongPress: setContextInstitution,
+  });
 
   const handleDeleteConfirm = async () => {
     if (!toDelete) return;
@@ -124,7 +146,7 @@ export function InstitutionList({
               {t('list.columns.accounts')}
               {onSort && <SortIcon field="accounts" sortField={sortField} sortDirection={sortDirection} />}
             </th>
-            <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider`}>
+            <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden min-[480px]:table-cell`}>
               {t('list.columns.actions')}
             </th>
           </tr>
@@ -133,7 +155,8 @@ export function InstitutionList({
           {institutions.map((institution) => (
             <tr
               key={institution.id}
-              className="hover:bg-gray-50 dark:hover:bg-gray-800"
+              className="hover:bg-gray-50 dark:hover:bg-gray-800 select-none"
+              {...getRowHandlers(institution)}
             >
               <td className={cellPadding}>
                 <div className="flex items-center gap-3 min-w-0">
@@ -173,44 +196,15 @@ export function InstitutionList({
                   {institution.accountCount}
                 </button>
               </td>
-              <td className={`${cellPadding} text-right whitespace-nowrap ${density === 'dense' ? 'space-x-1' : 'space-x-2'}`}>
-                {density === 'dense' ? (
-                  <>
-                    <button
-                      onClick={() => onEdit(institution)}
-                      aria-label={tc('edit')}
-                      title={tc('edit')}
-                      className="inline-flex items-center p-1.5 rounded text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700"
-                    >
-                      <PencilSquareIcon className="h-5 w-5" />
-                    </button>
-                    <button
-                      onClick={() => setToDelete(institution)}
-                      aria-label={tc('delete')}
-                      title={tc('delete')}
-                      className="inline-flex items-center p-1.5 rounded text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700"
-                    >
-                      <TrashIcon className="h-5 w-5" />
-                    </button>
-                  </>
-                ) : (
-                  <>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => onEdit(institution)}
-                    >
-                      {tc('edit')}
-                    </Button>
-                    <Button
-                      variant="danger"
-                      size="sm"
-                      onClick={() => setToDelete(institution)}
-                    >
-                      {tc('delete')}
-                    </Button>
-                  </>
-                )}
+              <td className={`${cellPadding} text-right whitespace-nowrap hidden min-[480px]:table-cell`} onClick={(e) => e.stopPropagation()}>
+                <RowActions
+                  actions={buildInstitutionActions(
+                    institution,
+                    { edit: tc('actions.edit'), delete: tc('actions.delete') },
+                    { onEdit, onDeleteClick: setToDelete },
+                  )}
+                  density={density}
+                />
               </td>
             </tr>
           ))}
@@ -231,6 +225,20 @@ export function InstitutionList({
         variant="danger"
         onConfirm={handleDeleteConfirm}
         onCancel={() => setToDelete(null)}
+      />
+
+      <RowActionSheet
+        isOpen={contextInstitution !== null}
+        title={contextInstitution?.name ?? ''}
+        subtitle={contextInstitution?.country ?? undefined}
+        actions={contextInstitution
+          ? buildInstitutionActions(
+              contextInstitution,
+              { edit: tc('actions.edit'), delete: tc('actions.delete') },
+              { onEdit, onDeleteClick: setToDelete },
+            )
+          : []}
+        onClose={() => setContextInstitution(null)}
       />
     </div>
   );

--- a/frontend/src/components/investments/InvestmentTransactionList.test.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, act } from '@/test/render';
+import { render, screen, fireEvent, act, within } from '@/test/render';
 import { InvestmentTransactionList } from './InvestmentTransactionList';
 
 vi.mock('@/hooks/useDateFormat', () => ({
@@ -521,7 +521,7 @@ describe('InvestmentTransactionList', () => {
       expect(screen.getByText('Apple Inc.')).toBeInTheDocument();
     });
 
-    it('shows edit button label "E" (pencil) in dense mode', () => {
+    it('shows icon-only edit and delete buttons in dense mode', () => {
       const tx = makeTx({ id: 'tx-edit-dense', action: 'BUY' });
       render(
         <InvestmentTransactionList
@@ -532,9 +532,9 @@ describe('InvestmentTransactionList', () => {
           onDelete={vi.fn()}
         />
       );
-      // In dense mode edit shows pencil icon (✎) and delete shows (✕)
-      expect(screen.getByText('✎')).toBeInTheDocument();
-      expect(screen.getByText('✕')).toBeInTheDocument();
+      // In dense mode the actions are icon-only buttons exposed via their labels.
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
     });
 
     it('applies striped background class for odd rows in non-normal density', () => {
@@ -752,7 +752,7 @@ describe('InvestmentTransactionList', () => {
       // Should not throw and timer should be cleared
     });
 
-    it('initiates long-press on touch start and fires delete dialog', async () => {
+    it('opens the action sheet on long press and the delete dialog from it', async () => {
       const onDelete = vi.fn();
       const tx = makeTx();
       render(
@@ -771,6 +771,8 @@ describe('InvestmentTransactionList', () => {
         await new Promise((resolve) => setTimeout(resolve, 800));
       });
 
+      // The long-press opens the shared action sheet; its Delete opens the dialog.
+      fireEvent.click(within(screen.getByRole('dialog')).getByText('Delete'));
       expect(screen.getByText('Delete Transaction')).toBeInTheDocument();
     });
 
@@ -820,6 +822,8 @@ describe('InvestmentTransactionList', () => {
         await new Promise((resolve) => setTimeout(resolve, 800));
       });
 
+      // The action sheet opened (long-press was not cancelled); its Delete opens the dialog.
+      fireEvent.click(within(screen.getByRole('dialog')).getByText('Delete'));
       expect(screen.getByText('Delete Transaction')).toBeInTheDocument();
     });
 

--- a/frontend/src/components/investments/InvestmentTransactionList.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useCallback, useRef, memo, Fragment } from 'react';
+import { useState, useMemo, useCallback, memo, Fragment } from 'react';
 import { useTranslations } from 'next-intl';
 import { useDateFormat } from '@/hooks/useDateFormat';
 import { DateInput } from '@/components/ui/DateInput';
@@ -11,6 +11,39 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { DensityLevel, nextDensity } from '@/hooks/useTableDensity';
 import { Account } from '@/types/account';
 import { getLocalDateString } from '@/lib/utils';
+import { useLongPress, type LongPressRowHandlers } from '@/hooks/useLongPress';
+import { RowActions } from '@/components/ui/row-actions/RowActions';
+import { RowActionSheet } from '@/components/ui/row-actions/RowActionSheet';
+import type { RowAction } from '@/components/ui/row-actions/rowAction';
+
+/**
+ * Builds the standard row actions for an investment transaction. Shared by the
+ * desktop `RowActions` cell and the mobile `RowActionSheet`.
+ */
+function buildInvestmentTxActions(
+  tx: InvestmentTransaction,
+  labels: { edit: string; delete: string },
+  handlers: { onEdit?: (tx: InvestmentTransaction) => void; onDeleteClick: (tx: InvestmentTransaction) => void },
+): RowAction[] {
+  return [
+    {
+      key: 'edit',
+      label: labels.edit,
+      icon: 'edit',
+      tone: 'primary',
+      onClick: () => handlers.onEdit?.(tx),
+      hidden: !handlers.onEdit,
+    },
+    {
+      key: 'delete',
+      label: labels.delete,
+      icon: 'delete',
+      tone: 'delete',
+      destructive: true,
+      onClick: () => handlers.onDeleteClick(tx),
+    },
+  ];
+}
 
 export interface TransactionFilters {
   symbol?: string;
@@ -98,10 +131,7 @@ interface InvestmentTransactionRowProps {
   formatDate: (date: string) => string;
   formatCurrency: (amount: number, currencyCode?: string, fractionDigits?: number) => string;
   formatQuantity: (value: number) => string;
-  onRowClick: (tx: InvestmentTransaction) => void;
-  onLongPressStart: (tx: InvestmentTransaction, e?: React.TouchEvent) => void;
-  onLongPressEnd: () => void;
-  onTouchMove: (e: React.TouchEvent) => void;
+  getRowHandlers: (tx: InvestmentTransaction) => LongPressRowHandlers;
   onEdit?: (tx: InvestmentTransaction) => void;
   onDeleteClick: (tx: InvestmentTransaction) => void;
   hasActions: boolean;
@@ -117,15 +147,13 @@ const InvestmentTransactionRow = memo(function InvestmentTransactionRow({
   formatDate,
   formatCurrency,
   formatQuantity,
-  onRowClick,
-  onLongPressStart,
-  onLongPressEnd,
-  onTouchMove,
+  getRowHandlers,
   onEdit,
   onDeleteClick,
   hasActions,
 }: InvestmentTransactionRowProps) {
   const t = useTranslations('investments');
+  const tc = useTranslations('common');
   const ACTION_LABELS: Record<string, { label: string; shortLabel: string; color: string }> = {
     BUY: { label: t('transactionList.actionBuy'), shortLabel: t('transactionList.actionBuy'), color: ACTION_COLORS.BUY },
     SELL: { label: t('transactionList.actionSell'), shortLabel: t('transactionList.actionSell'), color: ACTION_COLORS.SELL },
@@ -145,17 +173,16 @@ const InvestmentTransactionRow = memo(function InvestmentTransactionRow({
     color: 'text-gray-600 dark:text-gray-400',
   };
 
+  const actions = buildInvestmentTxActions(
+    tx,
+    { edit: tc('actions.edit'), delete: tc('actions.delete') },
+    { onEdit, onDeleteClick },
+  );
+
   return (
     <tr
-      onClick={() => onRowClick(tx)}
-      onMouseDown={() => onLongPressStart(tx)}
-      onMouseUp={onLongPressEnd}
-      onMouseLeave={onLongPressEnd}
-      onTouchStart={(e) => onLongPressStart(tx, e)}
-      onTouchMove={onTouchMove}
-      onTouchEnd={onLongPressEnd}
-      onTouchCancel={onLongPressEnd}
-      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${onEdit ? 'cursor-pointer' : ''}`}
+      {...getRowHandlers(tx)}
+      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 select-none ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${onEdit ? 'cursor-pointer' : ''}`}
     >
       <td className={`${cellPadding} whitespace-nowrap text-sm text-gray-900 dark:text-gray-100`}>
         {formatDate(tx.transactionDate)}
@@ -202,21 +229,8 @@ const InvestmentTransactionRow = memo(function InvestmentTransactionRow({
         )}
       </td>
       {hasActions && (
-        <td className={`${cellPadding} whitespace-nowrap text-right text-sm space-x-3 hidden min-[480px]:table-cell sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`}>
-          {onEdit && (
-            <button
-              onClick={(e) => { e.stopPropagation(); onEdit(tx); }}
-              className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
-            >
-              {density === 'dense' ? '✎' : t('transactionList.editButton')}
-            </button>
-          )}
-          <button
-            onClick={(e) => { e.stopPropagation(); onDeleteClick(tx); }}
-            className="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300"
-          >
-            {density === 'dense' ? '✕' : t('transactionList.deleteButton')}
-          </button>
+        <td className={`${cellPadding} whitespace-nowrap text-right text-sm hidden min-[480px]:table-cell sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`} onClick={(e) => e.stopPropagation()}>
+          <RowActions actions={actions} density={density} />
         </td>
       )}
     </tr>
@@ -274,61 +288,19 @@ export function InvestmentTransactionList({
   const [showFilters, setShowFilters] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState<{ isOpen: boolean; transaction: InvestmentTransaction | null }>({ isOpen: false, transaction: null });
 
-  // Long-press handling for delete on mobile
-  const longPressTimer = useRef<NodeJS.Timeout | null>(null);
-  const longPressTriggered = useRef(false);
-  const touchStartPos = useRef<{ x: number; y: number } | null>(null);
-  const LONG_PRESS_MOVE_THRESHOLD = 10;
-
-  const handleLongPressStart = useCallback((transaction: InvestmentTransaction, e?: React.TouchEvent) => {
-    if (!onDelete) return;
-
-    if (e?.touches?.[0]) {
-      touchStartPos.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
-    } else {
-      touchStartPos.current = null;
-    }
-
-    longPressTriggered.current = false;
-    longPressTimer.current = setTimeout(() => {
-      longPressTriggered.current = true;
-      setDeleteConfirm({ isOpen: true, transaction });
-    }, 750);
-  }, [onDelete]);
-
-  const handleLongPressEnd = useCallback(() => {
-    if (longPressTimer.current) {
-      clearTimeout(longPressTimer.current);
-      longPressTimer.current = null;
-    }
-    touchStartPos.current = null;
-  }, []);
-
-  const handleTouchMove = useCallback((e: React.TouchEvent) => {
-    if (touchStartPos.current && longPressTimer.current && e.touches?.[0]) {
-      const deltaX = Math.abs(e.touches[0].clientX - touchStartPos.current.x);
-      const deltaY = Math.abs(e.touches[0].clientY - touchStartPos.current.y);
-      if (deltaX > LONG_PRESS_MOVE_THRESHOLD || deltaY > LONG_PRESS_MOVE_THRESHOLD) {
-        clearTimeout(longPressTimer.current);
-        longPressTimer.current = null;
-        touchStartPos.current = null;
-      }
-    }
-  }, []);
-
-  const handleRowClick = useCallback((transaction: InvestmentTransaction) => {
-    if (longPressTriggered.current) {
-      longPressTriggered.current = false;
-      return;
-    }
-    if (onEdit) {
-      onEdit(transaction);
-    }
-  }, [onEdit]);
+  // Long-press opens a per-row action sheet on mobile (and via right-click).
+  const tc = useTranslations('common');
+  const [contextTx, setContextTx] = useState<InvestmentTransaction | null>(null);
 
   const handleDeleteClick = useCallback((tx: InvestmentTransaction) => {
     setDeleteConfirm({ isOpen: true, transaction: tx });
   }, []);
+
+  const { getRowHandlers } = useLongPress<InvestmentTransaction>({
+    onLongPress: setContextTx,
+    onClick: (transaction) => onEdit?.(transaction),
+    enabled: !!(onDelete || onEdit),
+  });
 
   const handleDeleteConfirm = useCallback(() => {
     if (deleteConfirm.transaction && onDelete) {
@@ -650,10 +622,7 @@ export function InvestmentTransactionList({
                     formatDate={formatDate}
                     formatCurrency={formatCurrency}
                     formatQuantity={formatQuantity}
-                    onRowClick={handleRowClick}
-                    onLongPressStart={handleLongPressStart}
-                    onLongPressEnd={handleLongPressEnd}
-                    onTouchMove={handleTouchMove}
+                    getRowHandlers={getRowHandlers}
                     onEdit={onEdit}
                     onDeleteClick={handleDeleteClick}
                     hasActions={!!(onDelete || onEdit)}
@@ -680,6 +649,20 @@ export function InvestmentTransactionList({
         variant="danger"
         onConfirm={handleDeleteConfirm}
         onCancel={handleDeleteCancel}
+      />
+
+      <RowActionSheet
+        isOpen={!!contextTx}
+        title={contextTx?.security?.symbol ?? (contextTx ? ACTION_LABEL_MAP[contextTx.action] || contextTx.action : '')}
+        subtitle={contextTx ? formatDate(contextTx.transactionDate) : undefined}
+        actions={contextTx
+          ? buildInvestmentTxActions(
+              contextTx,
+              { edit: tc('actions.edit'), delete: tc('actions.delete') },
+              { onEdit, onDeleteClick: handleDeleteClick },
+            )
+          : []}
+        onClose={() => setContextTx(null)}
       />
     </div>
   );

--- a/frontend/src/components/payees/PayeeList.test.tsx
+++ b/frontend/src/components/payees/PayeeList.test.tsx
@@ -771,27 +771,27 @@ describe('PayeeList', () => {
   });
 
   // Dense mode button labels
-  it('shows abbreviated button labels in dense mode', () => {
+  it('shows icon-only action buttons in dense mode', () => {
     const onMerge = vi.fn();
-    const _onReactivate = vi.fn();
     const payees = [
       makePayee({ id: 'p1', name: 'Walmart', isActive: true }),
     ];
 
     render(<PayeeList payees={payees} onEdit={onEdit} onRefresh={onRefresh} onMerge={onMerge} density="dense" />);
-    expect(screen.getByText('M')).toBeInTheDocument();
-    expect(screen.getByText('E')).toBeInTheDocument();
-    expect(screen.getByText('X')).toBeInTheDocument();
+    // Icon-only buttons expose their label via the accessible name, not visible text.
+    expect(screen.getByRole('button', { name: 'Merge' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
   });
 
-  it('shows abbreviated Reactivate label in dense mode for inactive payee', () => {
+  it('shows the Reactivate action in dense mode for an inactive payee', () => {
     const onReactivate = vi.fn();
     const payees = [
       makePayee({ id: 'p1', name: 'Walmart', isActive: false }),
     ];
 
     render(<PayeeList payees={payees} onEdit={onEdit} onRefresh={onRefresh} onReactivate={onReactivate} density="dense" />);
-    expect(screen.getByText('Re')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reactivate' })).toBeInTheDocument();
   });
 
   // Category badge density

--- a/frontend/src/components/payees/PayeeList.tsx
+++ b/frontend/src/components/payees/PayeeList.tsx
@@ -4,7 +4,6 @@ import { useState, useMemo, useCallback, memo } from 'react';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { Payee } from '@/types/payee';
-import { Button } from '@/components/ui/Button';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { payeesApi } from '@/lib/payees';
 import toast from 'react-hot-toast';
@@ -13,8 +12,68 @@ import { getErrorMessage } from '@/lib/errors';
 import { useTableDensity, nextDensity, type DensityLevel } from '@/hooks/useTableDensity';
 import { SortIcon } from '@/components/ui/SortIcon';
 import { useDateFormat } from '@/hooks/useDateFormat';
+import { useLongPress, type LongPressRowHandlers } from '@/hooks/useLongPress';
+import { RowActions } from '@/components/ui/row-actions/RowActions';
+import { RowActionSheet } from '@/components/ui/row-actions/RowActionSheet';
+import type { RowAction } from '@/components/ui/row-actions/rowAction';
 
 const logger = createLogger('PayeeList');
+
+type PayeeActionLabels = {
+  edit: string;
+  delete: string;
+  merge: string;
+  reactivate: string;
+};
+
+/**
+ * Builds the standard row actions for a payee. Shared by the desktop `RowActions`
+ * cell and the mobile `RowActionSheet` so both surfaces stay in sync.
+ */
+function buildPayeeActions(
+  payee: Payee,
+  labels: PayeeActionLabels,
+  handlers: {
+    onEdit: (payee: Payee) => void;
+    onDelete: (payee: Payee) => void;
+    onMerge?: (payee: Payee) => void;
+    onReactivate?: (payeeId: string) => void;
+  },
+): RowAction[] {
+  return [
+    {
+      key: 'reactivate',
+      label: labels.reactivate,
+      icon: 'reactivate',
+      tone: 'success',
+      onClick: () => handlers.onReactivate?.(payee.id),
+      hidden: payee.isActive || !handlers.onReactivate,
+    },
+    {
+      key: 'merge',
+      label: labels.merge,
+      icon: 'merge',
+      tone: 'accent',
+      onClick: () => handlers.onMerge?.(payee),
+      hidden: !handlers.onMerge || !payee.isActive,
+    },
+    {
+      key: 'edit',
+      label: labels.edit,
+      icon: 'edit',
+      tone: 'primary',
+      onClick: () => handlers.onEdit(payee),
+    },
+    {
+      key: 'delete',
+      label: labels.delete,
+      icon: 'delete',
+      tone: 'delete',
+      destructive: true,
+      onClick: () => handlers.onDelete(payee),
+    },
+  ];
+}
 
 // Re-export DensityLevel from shared hook
 export type { DensityLevel };
@@ -53,6 +112,7 @@ interface PayeeRowProps {
   categoryColorMap?: Map<string, string | null>;
   categoryLabelMap?: Map<string, string>;
   formatDate: (date: string) => string;
+  getRowHandlers: (payee: Payee) => LongPressRowHandlers;
 }
 
 const PayeeRow = memo(function PayeeRow({
@@ -69,42 +129,34 @@ const PayeeRow = memo(function PayeeRow({
   categoryColorMap,
   categoryLabelMap,
   formatDate,
+  getRowHandlers,
 }: PayeeRowProps) {
   const t = useTranslations('payees');
+  const tc = useTranslations('common');
   const defaultCategoryColor = payee.defaultCategory
     ? (categoryColorMap?.get(payee.defaultCategory.id) ?? payee.defaultCategory.color)
     : null;
   const defaultCategoryLabel = payee.defaultCategory
     ? (categoryLabelMap?.get(payee.defaultCategory.id) ?? payee.defaultCategory.name)
     : null;
-  const handleEdit = useCallback(() => {
-    onEdit(payee);
-  }, [onEdit, payee]);
-
-  const handleDelete = useCallback(() => {
-    onDelete(payee);
-  }, [onDelete, payee]);
-
-  const handleViewTransactions = useCallback(() => {
-    onViewTransactions(payee);
-  }, [onViewTransactions, payee]);
-
-  const handleReactivate = useCallback(() => {
-    onReactivate?.(payee.id);
-  }, [onReactivate, payee.id]);
-
-  const handleMerge = useCallback(() => {
-    onMerge?.(payee);
-  }, [onMerge, payee]);
+  const actions = useMemo(
+    () => buildPayeeActions(
+      payee,
+      { edit: tc('actions.edit'), delete: tc('actions.delete'), merge: tc('actions.merge'), reactivate: tc('actions.reactivate') },
+      { onEdit, onDelete, onMerge, onReactivate },
+    ),
+    [payee, tc, onEdit, onDelete, onMerge, onReactivate],
+  );
 
   return (
     <tr
-      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${!payee.isActive ? 'opacity-60' : ''}`}
+      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer select-none ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${!payee.isActive ? 'opacity-60' : ''}`}
+      {...getRowHandlers(payee)}
     >
       <td className={`${cellPadding} whitespace-nowrap`}>
         <div className="flex flex-col items-start gap-0.5 sm:flex-row sm:items-center sm:gap-2">
           <button
-            onClick={handleViewTransactions}
+            onClick={(e) => { e.stopPropagation(); onViewTransactions(payee); }}
             className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline text-left"
             title={t('list.viewTransactionsTitle')}
           >
@@ -171,43 +223,8 @@ const PayeeRow = memo(function PayeeRow({
           </div>
         </td>
       )}
-      <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`}>
-        {!payee.isActive && onReactivate ? (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleReactivate}
-            className="text-green-600 dark:text-green-400 hover:text-green-900 dark:hover:text-green-300 mr-2"
-          >
-            {density === 'dense' ? t('list.actions.reactivateShort') : t('list.actions.reactivate')}
-          </Button>
-        ) : null}
-        {onMerge && payee.isActive && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleMerge}
-            className="text-purple-600 dark:text-purple-400 hover:text-purple-900 dark:hover:text-purple-300 mr-2"
-          >
-            {density === 'dense' ? t('list.actions.mergeShort') : t('list.actions.merge')}
-          </Button>
-        )}
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={handleEdit}
-          className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300 mr-2"
-        >
-          {density === 'dense' ? t('list.actions.editShort') : t('list.actions.edit')}
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={handleDelete}
-          className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300"
-        >
-          {density === 'dense' ? t('list.actions.deleteShort') : t('list.actions.delete')}
-        </Button>
+      <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium hidden min-[480px]:table-cell sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`}>
+        <RowActions actions={actions} density={density} />
       </td>
     </tr>
   );
@@ -230,9 +247,11 @@ export function PayeeList({
   categoryLabelMap,
 }: PayeeListProps) {
   const t = useTranslations('payees');
+  const tc = useTranslations('common');
   const router = useRouter();
   const { formatDate } = useDateFormat();
   const [deletePayee, setDeletePayee] = useState<Payee | null>(null);
+  const [actionSheet, setActionSheet] = useState<{ open: boolean; payee: Payee | null }>({ open: false, payee: null });
   const [localDensity, setLocalDensity] = useState<DensityLevel>('normal');
   const [localSortField, setLocalSortField] = useState<SortField>('name');
   const [localSortDirection, setLocalSortDirection] = useState<SortDirection>('asc');
@@ -296,6 +315,11 @@ export function PayeeList({
   const handleViewTransactions = useCallback((payee: Payee) => {
     router.push(`/transactions?payeeId=${payee.id}`);
   }, [router]);
+
+  const { getRowHandlers } = useLongPress<Payee>({
+    onLongPress: (payee) => setActionSheet({ open: true, payee }),
+    onClick: onEdit,
+  });
 
   const handleConfirmDelete = async () => {
     if (!deletePayee) return;
@@ -402,7 +426,7 @@ export function PayeeList({
                   {t('list.columns.notes')}
                 </th>
               )}
-              <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider sticky right-0 bg-gray-50 dark:bg-gray-800`}>
+              <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden min-[480px]:table-cell sticky right-0 bg-gray-50 dark:bg-gray-800`}>
                 {t('list.columns.actions')}
               </th>
             </tr>
@@ -424,6 +448,7 @@ export function PayeeList({
                 categoryColorMap={categoryColorMap}
                 categoryLabelMap={categoryLabelMap}
                 formatDate={formatDate}
+                getRowHandlers={getRowHandlers}
               />
             ))}
           </tbody>
@@ -439,6 +464,19 @@ export function PayeeList({
         variant="danger"
         onConfirm={handleConfirmDelete}
         onCancel={() => setDeletePayee(null)}
+      />
+
+      <RowActionSheet
+        isOpen={actionSheet.open}
+        title={actionSheet.payee?.name ?? ''}
+        actions={actionSheet.payee
+          ? buildPayeeActions(
+              actionSheet.payee,
+              { edit: tc('actions.edit'), delete: tc('actions.delete'), merge: tc('actions.merge'), reactivate: tc('actions.reactivate') },
+              { onEdit, onDelete: setDeletePayee, onMerge, onReactivate },
+            )
+          : []}
+        onClose={() => setActionSheet({ open: false, payee: null })}
       />
     </div>
   );

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionList.test.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionList.test.tsx
@@ -432,19 +432,19 @@ describe('ScheduledTransactionList', () => {
   it('shows post button for active transactions', () => {
     const transactions = [createTransaction({ isActive: true })];
     render(<ScheduledTransactionList transactions={transactions} />);
-    expect(screen.getByTitle('Post transaction')).toBeInTheDocument();
+    expect(screen.getByTitle('Post Transaction')).toBeInTheDocument();
   });
 
   it('shows skip button for active recurring transactions', () => {
     const transactions = [createTransaction({ isActive: true, frequency: 'MONTHLY' })];
     render(<ScheduledTransactionList transactions={transactions} />);
-    expect(screen.getByTitle('Skip this occurrence')).toBeInTheDocument();
+    expect(screen.getByTitle('Skip Occurrence')).toBeInTheDocument();
   });
 
   it('does not show skip button for ONCE frequency transactions', () => {
     const transactions = [createTransaction({ isActive: true, frequency: 'ONCE' })];
     render(<ScheduledTransactionList transactions={transactions} />);
-    expect(screen.queryByTitle('Skip this occurrence')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Skip Occurrence')).not.toBeInTheDocument();
   });
 
   it('shows delete button for all transactions', () => {
@@ -457,34 +457,34 @@ describe('ScheduledTransactionList', () => {
     const onEdit = vi.fn();
     const transactions = [createTransaction()];
     render(<ScheduledTransactionList transactions={transactions} onEdit={onEdit} />);
-    expect(screen.getByTitle('Edit schedule')).toBeInTheDocument();
+    expect(screen.getByTitle('Edit Schedule')).toBeInTheDocument();
   });
 
   it('does not show edit schedule button when onEdit is not provided', () => {
     const transactions = [createTransaction()];
     render(<ScheduledTransactionList transactions={transactions} />);
-    expect(screen.queryByTitle('Edit schedule')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Edit Schedule')).not.toBeInTheDocument();
   });
 
   it('shows edit occurrence button when onEditOccurrence is provided and transaction is active', () => {
     const onEditOccurrence = vi.fn();
     const transactions = [createTransaction({ isActive: true })];
     render(<ScheduledTransactionList transactions={transactions} onEditOccurrence={onEditOccurrence} />);
-    expect(screen.getByTitle('Edit occurrence')).toBeInTheDocument();
+    expect(screen.getByTitle('Edit Occurrence')).toBeInTheDocument();
   });
 
   it('does not show edit occurrence button for inactive transactions', () => {
     const onEditOccurrence = vi.fn();
     const transactions = [createTransaction({ isActive: false })];
     render(<ScheduledTransactionList transactions={transactions} onEditOccurrence={onEditOccurrence} />);
-    expect(screen.queryByTitle('Edit occurrence')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Edit Occurrence')).not.toBeInTheDocument();
   });
 
   it('does not show post and skip buttons for inactive transactions', () => {
     const transactions = [createTransaction({ isActive: false })];
     render(<ScheduledTransactionList transactions={transactions} />);
-    expect(screen.queryByTitle('Post transaction')).not.toBeInTheDocument();
-    expect(screen.queryByTitle('Skip this occurrence')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Post Transaction')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Skip Occurrence')).not.toBeInTheDocument();
   });
 
   // --- Edit button click ---
@@ -493,7 +493,7 @@ describe('ScheduledTransactionList', () => {
     const transaction = createTransaction();
     render(<ScheduledTransactionList transactions={[transaction]} onEdit={onEdit} />);
 
-    fireEvent.click(screen.getByTitle('Edit schedule'));
+    fireEvent.click(screen.getByTitle('Edit Schedule'));
     expect(onEdit).toHaveBeenCalledWith(transaction);
   });
 
@@ -512,7 +512,7 @@ describe('ScheduledTransactionList', () => {
     const transaction = createTransaction({ isActive: true });
     render(<ScheduledTransactionList transactions={[transaction]} onEditOccurrence={onEditOccurrence} />);
 
-    fireEvent.click(screen.getByTitle('Edit occurrence'));
+    fireEvent.click(screen.getByTitle('Edit Occurrence'));
     expect(onEditOccurrence).toHaveBeenCalledWith(transaction);
   });
 
@@ -585,7 +585,7 @@ describe('ScheduledTransactionList', () => {
     const transactions = [createTransaction()];
     render(<ScheduledTransactionList transactions={transactions} />);
 
-    fireEvent.click(screen.getByTitle('Post transaction'));
+    fireEvent.click(screen.getByTitle('Post Transaction'));
 
     expect(screen.getByText('Post Transaction')).toBeInTheDocument();
     expect(screen.getByText(/Post "Netflix"/)).toBeInTheDocument();
@@ -596,7 +596,7 @@ describe('ScheduledTransactionList', () => {
     const transaction = createTransaction();
     render(<ScheduledTransactionList transactions={[transaction]} onRefresh={onRefresh} />);
 
-    fireEvent.click(screen.getByTitle('Post transaction'));
+    fireEvent.click(screen.getByTitle('Post Transaction'));
     fireEvent.click(screen.getByText('Post'));
 
     await waitFor(() => {
@@ -613,7 +613,7 @@ describe('ScheduledTransactionList', () => {
     const transaction = createTransaction();
     render(<ScheduledTransactionList transactions={[transaction]} onPost={onPost} />);
 
-    fireEvent.click(screen.getByTitle('Post transaction'));
+    fireEvent.click(screen.getByTitle('Post Transaction'));
 
     // onPost should be called directly, not opening confirm dialog
     expect(onPost).toHaveBeenCalledWith(transaction);
@@ -625,7 +625,7 @@ describe('ScheduledTransactionList', () => {
     const transaction = createTransaction();
     render(<ScheduledTransactionList transactions={[transaction]} />);
 
-    fireEvent.click(screen.getByTitle('Post transaction'));
+    fireEvent.click(screen.getByTitle('Post Transaction'));
     fireEvent.click(screen.getByText('Post'));
 
     await waitFor(() => {
@@ -638,7 +638,7 @@ describe('ScheduledTransactionList', () => {
     const transactions = [createTransaction({ frequency: 'MONTHLY' })];
     render(<ScheduledTransactionList transactions={transactions} />);
 
-    fireEvent.click(screen.getByTitle('Skip this occurrence'));
+    fireEvent.click(screen.getByTitle('Skip Occurrence'));
 
     expect(screen.getByText('Skip Occurrence')).toBeInTheDocument();
     expect(screen.getByText(/Skip this occurrence of "Netflix"/)).toBeInTheDocument();
@@ -649,7 +649,7 @@ describe('ScheduledTransactionList', () => {
     const transaction = createTransaction({ frequency: 'MONTHLY' });
     render(<ScheduledTransactionList transactions={[transaction]} onRefresh={onRefresh} />);
 
-    fireEvent.click(screen.getByTitle('Skip this occurrence'));
+    fireEvent.click(screen.getByTitle('Skip Occurrence'));
     fireEvent.click(screen.getByText('Skip'));
 
     await waitFor(() => {
@@ -666,7 +666,7 @@ describe('ScheduledTransactionList', () => {
     const transaction = createTransaction({ frequency: 'MONTHLY' });
     render(<ScheduledTransactionList transactions={[transaction]} />);
 
-    fireEvent.click(screen.getByTitle('Skip this occurrence'));
+    fireEvent.click(screen.getByTitle('Skip Occurrence'));
     fireEvent.click(screen.getByText('Skip'));
 
     await waitFor(() => {

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionList.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef, memo, type JSX } from 'react';
+import { useState, memo, type JSX } from 'react';
 import { useTranslations } from 'next-intl';
 import { isPast, isToday, addDays, isBefore } from 'date-fns';
 import toast from 'react-hot-toast';
@@ -12,6 +12,82 @@ import { useDateFormat } from '@/hooks/useDateFormat';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { computeInvestmentCashImpact } from '@/lib/investmentCashImpact';
 import { InvestmentAction } from '@/types/investment';
+import { useLongPress, type LongPressRowHandlers } from '@/hooks/useLongPress';
+import { RowActions } from '@/components/ui/row-actions/RowActions';
+import { RowActionSheet } from '@/components/ui/row-actions/RowActionSheet';
+import type { RowAction } from '@/components/ui/row-actions/rowAction';
+
+interface ScheduledActionLabels {
+  post: string;
+  skip: string;
+  editOccurrence: string;
+  editSchedule: string;
+  delete: string;
+}
+
+interface ScheduledActionHandlers {
+  onPost?: (transaction: ScheduledTransaction) => void;
+  onOpenConfirm: (action: 'post' | 'skip' | 'delete', transaction: ScheduledTransaction) => void;
+  onEdit?: (transaction: ScheduledTransaction) => void;
+  onEditOccurrence?: (transaction: ScheduledTransaction) => void;
+}
+
+/**
+ * Builds the standard row actions for a scheduled transaction. Shared by the
+ * desktop `RowActions` cell and the mobile `RowActionSheet`.
+ */
+function buildScheduledActions(
+  transaction: ScheduledTransaction,
+  isProcessing: boolean,
+  labels: ScheduledActionLabels,
+  handlers: ScheduledActionHandlers,
+): RowAction[] {
+  return [
+    {
+      key: 'post',
+      label: labels.post,
+      icon: 'post',
+      tone: 'success',
+      disabled: isProcessing,
+      onClick: () => (handlers.onPost ? handlers.onPost(transaction) : handlers.onOpenConfirm('post', transaction)),
+      hidden: !transaction.isActive,
+    },
+    {
+      key: 'skip',
+      label: labels.skip,
+      icon: 'skip',
+      tone: 'warning',
+      disabled: isProcessing,
+      onClick: () => handlers.onOpenConfirm('skip', transaction),
+      hidden: !transaction.isActive || transaction.frequency === 'ONCE',
+    },
+    {
+      key: 'editOccurrence',
+      label: labels.editOccurrence,
+      icon: 'schedule',
+      tone: 'accent',
+      onClick: () => handlers.onEditOccurrence?.(transaction),
+      hidden: !handlers.onEditOccurrence || !transaction.isActive,
+    },
+    {
+      key: 'editSchedule',
+      label: labels.editSchedule,
+      icon: 'edit',
+      tone: 'primary',
+      onClick: () => handlers.onEdit?.(transaction),
+      hidden: !handlers.onEdit,
+    },
+    {
+      key: 'delete',
+      label: labels.delete,
+      icon: 'delete',
+      tone: 'delete',
+      destructive: true,
+      disabled: isProcessing,
+      onClick: () => handlers.onOpenConfirm('delete', transaction),
+    },
+  ];
+}
 
 /**
  * Cash impact of a scheduled transaction occurrence, taking nextOverride into
@@ -54,7 +130,6 @@ function scheduledOccurrenceAmount(
   return Number(transaction.amount);
 }
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
-import { Modal } from '@/components/ui/Modal';
 
 type ConfirmAction = 'post' | 'skip' | 'delete';
 
@@ -70,11 +145,7 @@ interface ScheduledTransactionRowProps {
   formatDate: (date: string) => string;
   formatAmount: (amount: number | null | undefined, currencyCode?: string) => JSX.Element;
   getDueDateStatus: (nextDueDate: string | undefined | null) => { label: string; className: string } | null;
-  onRowClick: (transaction: ScheduledTransaction) => void;
-  onLongPressStart: (transaction: ScheduledTransaction) => void;
-  onLongPressStartTouch: (transaction: ScheduledTransaction, e: React.TouchEvent) => void;
-  onLongPressEnd: () => void;
-  onTouchMove: (e: React.TouchEvent) => void;
+  getRowHandlers: (transaction: ScheduledTransaction) => LongPressRowHandlers;
   onPost?: (transaction: ScheduledTransaction) => void;
   onOpenConfirm: (action: 'post' | 'skip' | 'delete', transaction: ScheduledTransaction) => void;
   onEdit?: (transaction: ScheduledTransaction) => void;
@@ -88,11 +159,7 @@ const ScheduledTransactionRow = memo(function ScheduledTransactionRow({
   formatDate,
   formatAmount,
   getDueDateStatus,
-  onRowClick,
-  onLongPressStart,
-  onLongPressStartTouch,
-  onLongPressEnd,
-  onTouchMove,
+  getRowHandlers,
   onPost,
   onOpenConfirm,
   onEdit,
@@ -100,6 +167,18 @@ const ScheduledTransactionRow = memo(function ScheduledTransactionRow({
   categoryColorMap,
 }: ScheduledTransactionRowProps) {
   const t = useTranslations('scheduledTransactions');
+  const actions = buildScheduledActions(
+    transaction,
+    isProcessing,
+    {
+      post: t('list.contextMenu.postTransaction'),
+      skip: t('list.contextMenu.skipOccurrence'),
+      editOccurrence: t('list.contextMenu.editOccurrence'),
+      editSchedule: t('list.contextMenu.editSchedule'),
+      delete: t('list.contextMenu.delete'),
+    },
+    { onPost, onOpenConfirm, onEdit, onEditOccurrence },
+  );
   const categoryColor = transaction.category
     ? (categoryColorMap?.get(transaction.category.id) ?? transaction.category.color)
     : null;
@@ -110,14 +189,7 @@ const ScheduledTransactionRow = memo(function ScheduledTransactionRow({
   return (
     <tr
       className={`group hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer select-none ${!transaction.isActive ? 'opacity-50' : ''} ${dueDateStatus?.label === t('list.dueDateStatus.overdue') ? 'bg-red-50 dark:bg-red-900/10' : 'bg-white dark:bg-gray-900'}`}
-      onClick={() => onRowClick(transaction)}
-      onMouseDown={() => onLongPressStart(transaction)}
-      onMouseUp={onLongPressEnd}
-      onMouseLeave={onLongPressEnd}
-      onTouchStart={(e) => onLongPressStartTouch(transaction, e)}
-      onTouchMove={onTouchMove}
-      onTouchEnd={onLongPressEnd}
-      onTouchCancel={onLongPressEnd}
+      {...getRowHandlers(transaction)}
     >
       {/* Name / Payee */}
       <td className="px-4 py-3">
@@ -277,66 +349,7 @@ const ScheduledTransactionRow = memo(function ScheduledTransactionRow({
 
       {/* Actions */}
       <td className={`px-4 py-3 whitespace-nowrap text-right hidden min-[480px]:table-cell sticky right-0 ${dueDateStatus?.label === t('list.dueDateStatus.overdue') ? 'bg-red-50 dark:bg-red-900/10' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`} onClick={(e) => e.stopPropagation()}>
-        <div className="flex justify-end items-center space-x-1">
-          {transaction.isActive && (
-            <>
-              <button
-                onClick={() => onPost ? onPost(transaction) : onOpenConfirm('post', transaction)}
-                disabled={isProcessing}
-                className="p-1 text-green-600 dark:text-green-400 hover:text-green-900 dark:hover:text-green-300 hover:bg-green-50 dark:hover:bg-green-900/50 rounded disabled:opacity-50"
-                title={t('list.actionTitles.post')}
-              >
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                </svg>
-              </button>
-              {transaction.frequency !== 'ONCE' && (
-                <button
-                  onClick={() => onOpenConfirm('skip', transaction)}
-                  disabled={isProcessing}
-                  className="p-1 text-yellow-600 dark:text-yellow-400 hover:text-yellow-900 dark:hover:text-yellow-300 hover:bg-yellow-50 dark:hover:bg-yellow-900/50 rounded disabled:opacity-50"
-                  title={t('list.actionTitles.skip')}
-                >
-                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 5l7 7-7 7M5 5l7 7-7 7" />
-                  </svg>
-                </button>
-              )}
-            </>
-          )}
-          {onEditOccurrence && transaction.isActive && (
-            <button
-              onClick={() => onEditOccurrence(transaction)}
-              className="p-1 text-purple-600 dark:text-purple-400 hover:text-purple-900 dark:hover:text-purple-300 hover:bg-purple-50 dark:hover:bg-purple-900/50 rounded"
-              title={t('list.actionTitles.editOccurrence')}
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-              </svg>
-            </button>
-          )}
-          {onEdit && (
-            <button
-              onClick={() => onEdit(transaction)}
-              className="p-1 text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/50 rounded"
-              title={t('list.actionTitles.editSchedule')}
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-          )}
-          <button
-            onClick={() => onOpenConfirm('delete', transaction)}
-            disabled={isProcessing}
-            className="p-1 text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/50 rounded disabled:opacity-50"
-            title={t('list.actionTitles.delete')}
-          >
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-            </svg>
-          </button>
-        </div>
+        <RowActions actions={actions} density="compact" />
       </td>
     </tr>
   );
@@ -369,53 +382,13 @@ export function ScheduledTransactionList({
     transaction: null,
   });
 
-  // Long-press handling for context menu on mobile
-  const longPressTimer = useRef<NodeJS.Timeout | null>(null);
-  const longPressTriggered = useRef(false);
-  const touchStartPos = useRef<{ x: number; y: number } | null>(null);
-  const LONG_PRESS_MOVE_THRESHOLD = 10;
+  // Long-press opens a per-row action sheet on mobile (and via right-click).
   const [contextTransaction, setContextTransaction] = useState<ScheduledTransaction | null>(null);
 
-  const handleLongPressStart = useCallback((transaction: ScheduledTransaction, e?: React.TouchEvent) => {
-    if (e?.touches?.[0]) {
-      touchStartPos.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
-    } else {
-      touchStartPos.current = null;
-    }
-    longPressTriggered.current = false;
-    longPressTimer.current = setTimeout(() => {
-      longPressTriggered.current = true;
-      setContextTransaction(transaction);
-    }, 750);
-  }, []);
-
-  const handleLongPressEnd = useCallback(() => {
-    if (longPressTimer.current) {
-      clearTimeout(longPressTimer.current);
-      longPressTimer.current = null;
-    }
-    touchStartPos.current = null;
-  }, []);
-
-  const handleTouchMove = useCallback((e: React.TouchEvent) => {
-    if (touchStartPos.current && longPressTimer.current && e.touches?.[0]) {
-      const deltaX = Math.abs(e.touches[0].clientX - touchStartPos.current.x);
-      const deltaY = Math.abs(e.touches[0].clientY - touchStartPos.current.y);
-      if (deltaX > LONG_PRESS_MOVE_THRESHOLD || deltaY > LONG_PRESS_MOVE_THRESHOLD) {
-        clearTimeout(longPressTimer.current);
-        longPressTimer.current = null;
-        touchStartPos.current = null;
-      }
-    }
-  }, []);
-
-  const handleRowClick = useCallback((transaction: ScheduledTransaction) => {
-    if (longPressTriggered.current) {
-      longPressTriggered.current = false;
-      return;
-    }
-    onEdit?.(transaction);
-  }, [onEdit]);
+  const { getRowHandlers } = useLongPress<ScheduledTransaction>({
+    onLongPress: setContextTransaction,
+    onClick: (transaction) => onEdit?.(transaction),
+  });
 
   const openConfirm = (action: ConfirmAction, transaction: ScheduledTransaction) => {
     setConfirmState({ isOpen: true, action, transaction });
@@ -594,11 +567,7 @@ export function ScheduledTransactionList({
               formatDate={formatDate}
               formatAmount={formatAmount}
               getDueDateStatus={getDueDateStatus}
-              onRowClick={handleRowClick}
-              onLongPressStart={handleLongPressStart}
-              onLongPressStartTouch={handleLongPressStart}
-              onLongPressEnd={handleLongPressEnd}
-              onTouchMove={handleTouchMove}
+              getRowHandlers={getRowHandlers}
               onPost={onPost}
               onOpenConfirm={openConfirm}
               onEdit={onEdit}
@@ -609,77 +578,29 @@ export function ScheduledTransactionList({
         </tbody>
       </table>
 
-      {/* Long-press Context Menu */}
-      <Modal isOpen={!!contextTransaction} onClose={() => setContextTransaction(null)} maxWidth="sm" className="p-0">
-        {contextTransaction && (
-          <div>
-            <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">{contextTransaction.name}</h3>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                {t(`frequency.${contextTransaction.frequency}`)}
-                {!contextTransaction.isActive ? t('list.inactiveSuffix') : ''}
-              </p>
-            </div>
-            <div className="py-2">
-              {contextTransaction.isActive && (
-                <>
-                  <button
-                    onClick={() => { const t = contextTransaction; setContextTransaction(null); onPost ? onPost(t) : openConfirm('post', t); }}
-                    className="w-full text-left px-5 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
-                  >
-                    <svg className="w-5 h-5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
-                    {t('list.contextMenu.postTransaction')}
-                  </button>
-                  {contextTransaction.frequency !== 'ONCE' && (
-                    <button
-                      onClick={() => { const t = contextTransaction; setContextTransaction(null); openConfirm('skip', t); }}
-                      className="w-full text-left px-5 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
-                    >
-                      <svg className="w-5 h-5 text-yellow-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 5l7 7-7 7M5 5l7 7-7 7" />
-                      </svg>
-                      {t('list.contextMenu.skipOccurrence')}
-                    </button>
-                  )}
-                  {onEditOccurrence && (
-                    <button
-                      onClick={() => { const t = contextTransaction; setContextTransaction(null); onEditOccurrence(t); }}
-                      className="w-full text-left px-5 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
-                    >
-                      <svg className="w-5 h-5 text-purple-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                      </svg>
-                      {t('list.contextMenu.editOccurrence')}
-                    </button>
-                  )}
-                </>
-              )}
-              {onEdit && (
-                <button
-                  onClick={() => { const t = contextTransaction; setContextTransaction(null); onEdit(t); }}
-                  className="w-full text-left px-5 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
-                >
-                  <svg className="w-5 h-5 text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                  </svg>
-                  {t('list.contextMenu.editSchedule')}
-                </button>
-              )}
-              <button
-                onClick={() => { const t = contextTransaction; setContextTransaction(null); openConfirm('delete', t); }}
-                className="w-full text-left px-5 py-3 text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
-              >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                </svg>
-                {t('list.contextMenu.delete')}
-              </button>
-            </div>
-          </div>
-        )}
-      </Modal>
+      {/* Long-press action sheet */}
+      <RowActionSheet
+        isOpen={!!contextTransaction}
+        title={contextTransaction?.name ?? ''}
+        subtitle={contextTransaction
+          ? `${t(`frequency.${contextTransaction.frequency}`)}${!contextTransaction.isActive ? t('list.inactiveSuffix') : ''}`
+          : undefined}
+        actions={contextTransaction
+          ? buildScheduledActions(
+              contextTransaction,
+              actionInProgress === contextTransaction.id,
+              {
+                post: t('list.contextMenu.postTransaction'),
+                skip: t('list.contextMenu.skipOccurrence'),
+                editOccurrence: t('list.contextMenu.editOccurrence'),
+                editSchedule: t('list.contextMenu.editSchedule'),
+                delete: t('list.contextMenu.delete'),
+              },
+              { onPost, onOpenConfirm: openConfirm, onEdit, onEditOccurrence },
+            )
+          : []}
+        onClose={() => setContextTransaction(null)}
+      />
 
       <ConfirmDialog
         isOpen={confirmState.isOpen}

--- a/frontend/src/components/securities/SecurityList.test.tsx
+++ b/frontend/src/components/securities/SecurityList.test.tsx
@@ -673,12 +673,12 @@ describe('SecurityList', () => {
       expect(onViewPrices).toHaveBeenCalledWith(expect.objectContaining({ symbol: 'AAPL' }));
     });
 
-    it('shows $ button in dense mode when onViewPrices provided', () => {
+    it('shows the prices icon button in dense mode when onViewPrices provided', () => {
       const onViewPrices = vi.fn();
       const securities = [makeSecurity()];
 
       render(<SecurityList securities={securities} onEdit={onEdit} onToggleActive={onToggleActive} onViewPrices={onViewPrices} density="dense" />);
-      expect(screen.getByText('$')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Prices' })).toBeInTheDocument();
     });
 
     it('does not show Prices button when onViewPrices not provided', () => {

--- a/frontend/src/components/securities/SecurityList.tsx
+++ b/frontend/src/components/securities/SecurityList.tsx
@@ -1,14 +1,98 @@
 'use client';
 
-import { useState, useMemo, useCallback, useRef, memo } from 'react';
+import { useState, useMemo, useCallback, memo } from 'react';
 import { useTranslations, useMessages } from 'next-intl';
 import { Security } from '@/types/investment';
-import { Button } from '@/components/ui/Button';
-import { Modal } from '@/components/ui/Modal';
 import { DensityLevel, nextDensity } from '@/hooks/useTableDensity';
 import { SortIcon } from '@/components/ui/SortIcon';
 import { usePreferencesStore } from '@/store/preferencesStore';
 import { formatShareQuantity } from '@/lib/format';
+import { useLongPress, type LongPressRowHandlers } from '@/hooks/useLongPress';
+import { RowActions } from '@/components/ui/row-actions/RowActions';
+import { RowActionSheet } from '@/components/ui/row-actions/RowActionSheet';
+import type { RowAction } from '@/components/ui/row-actions/rowAction';
+
+interface SecurityActionLabels {
+  history: string;
+  prices: string;
+  edit: string;
+  activate: string;
+  deactivate: string;
+  delete: string;
+}
+
+interface SecurityActionHandlers {
+  onViewHistory?: (security: Security) => void;
+  onViewPrices?: (security: Security) => void;
+  onEdit: (security: Security) => void;
+  onToggleActive: (security: Security) => void;
+  onDelete?: (security: Security) => void;
+}
+
+/**
+ * Builds the standard row actions for a security. Shared by the desktop
+ * `RowActions` cell and the mobile `RowActionSheet`.
+ */
+function buildSecurityActions(
+  security: Security,
+  hasHoldings: boolean,
+  hasTransactions: boolean,
+  labels: SecurityActionLabels,
+  handlers: SecurityActionHandlers,
+): RowAction[] {
+  const canDelete = !hasHoldings && !hasTransactions;
+  return [
+    {
+      key: 'history',
+      label: labels.history,
+      icon: 'history',
+      tone: 'neutral',
+      onClick: () => handlers.onViewHistory?.(security),
+      hidden: !handlers.onViewHistory,
+    },
+    {
+      key: 'prices',
+      label: labels.prices,
+      icon: 'prices',
+      tone: 'neutral',
+      onClick: () => handlers.onViewPrices?.(security),
+      hidden: !handlers.onViewPrices,
+    },
+    {
+      key: 'edit',
+      label: labels.edit,
+      icon: 'edit',
+      tone: 'primary',
+      onClick: () => handlers.onEdit(security),
+    },
+    security.isActive
+      ? {
+          key: 'toggle',
+          label: labels.deactivate,
+          icon: 'deactivate',
+          tone: 'warning',
+          onClick: () => handlers.onToggleActive(security),
+          hidden: hasHoldings,
+        }
+      : {
+          key: 'toggle',
+          label: labels.activate,
+          icon: 'activate',
+          tone: 'success',
+          onClick: () => handlers.onToggleActive(security),
+          hidden: hasHoldings,
+        },
+    {
+      key: 'delete',
+      label: labels.delete,
+      icon: 'delete',
+      tone: 'delete',
+      destructive: true,
+      onClick: () => handlers.onDelete?.(security),
+      hidden: !canDelete || !handlers.onDelete,
+    },
+  ];
+}
 
 export type SecuritySortField = 'symbol' | 'name' | 'type' | 'shares' | 'exchange' | 'currency' | 'provider' | 'source';
 
@@ -84,10 +168,7 @@ interface SecurityRowProps {
   onDelete?: (security: Security) => void;
   onViewPrices?: (security: Security) => void;
   onViewHistory?: (security: Security) => void;
-  onLongPressStart: (security: Security) => void;
-  onLongPressStartTouch: (security: Security, e: React.TouchEvent) => void;
-  onLongPressEnd: () => void;
-  onTouchMove: (e: React.TouchEvent) => void;
+  getRowHandlers: (security: Security) => LongPressRowHandlers;
   index: number;
   defaultQuoteProvider: 'yahoo' | 'msn';
 }
@@ -105,21 +186,18 @@ const SecurityRow = memo(function SecurityRow({
   onDelete,
   onViewPrices,
   onViewHistory,
-  onLongPressStart,
-  onLongPressStartTouch,
-  onLongPressEnd,
-  onTouchMove,
+  getRowHandlers,
   index,
   defaultQuoteProvider,
 }: SecurityRowProps) {
   const t = useTranslations('securities');
+  const tc = useTranslations('common');
   const messages = useMessages();
   const typeLabelsMap = ((messages as any)?.securities?.typeLabels ?? {}) as Record<string, string>;
   const getTypeLabel = (type: string, short: boolean): string => {
     const key = short ? `${type}_short` : type;
     return typeLabelsMap[key] ?? type;
   };
-  const canDelete = !hasHoldings && !hasTransactions;
 
   const handleToggleFavourite = useCallback(
     (e: React.MouseEvent) => {
@@ -129,38 +207,27 @@ const SecurityRow = memo(function SecurityRow({
     [onToggleFavourite, security],
   );
 
-  const handleEdit = useCallback(() => {
-    onEdit(security);
-  }, [onEdit, security]);
-
-  const handleToggleActive = useCallback(() => {
-    onToggleActive(security);
-  }, [onToggleActive, security]);
-
-  const handleDelete = useCallback(() => {
-    onDelete?.(security);
-  }, [onDelete, security]);
-
-  const handleViewPrices = useCallback(() => {
-    onViewPrices?.(security);
-  }, [onViewPrices, security]);
-
-  const handleViewHistory = useCallback(() => {
-    onViewHistory?.(security);
-  }, [onViewHistory, security]);
+  const actions = buildSecurityActions(
+    security,
+    hasHoldings,
+    hasTransactions,
+    {
+      history: t('list.actions.history'),
+      prices: t('list.actions.prices'),
+      edit: tc('actions.edit'),
+      activate: t('list.actions.activate'),
+      deactivate: t('list.actions.deactivate'),
+      delete: tc('actions.delete'),
+    },
+    { onViewHistory, onViewPrices, onEdit, onToggleActive, onDelete },
+  );
 
   return (
     <tr
       className={`group hover:bg-gray-100 dark:hover:bg-gray-800 select-none ${
         !security.isActive ? 'opacity-60' : ''
       } ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'}`}
-      onMouseDown={() => onLongPressStart(security)}
-      onMouseUp={onLongPressEnd}
-      onMouseLeave={onLongPressEnd}
-      onTouchStart={(e) => onLongPressStartTouch(security, e)}
-      onTouchMove={onTouchMove}
-      onTouchEnd={onLongPressEnd}
-      onTouchCancel={onLongPressEnd}
+      {...getRowHandlers(security)}
     >
       <td className={`${cellPadding} whitespace-nowrap text-center`}>
         <button
@@ -271,60 +338,7 @@ const SecurityRow = memo(function SecurityRow({
       </td>
       {/* Actions - hidden on mobile */}
       <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium hidden sm:table-cell sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`}>
-        <div className="flex justify-end gap-2">
-          {onViewHistory && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleViewHistory}
-              className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
-            >
-              {density === 'dense' ? '☰' : t('list.actions.history')}
-            </Button>
-          )}
-          {onViewPrices && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleViewPrices}
-              className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
-            >
-              {density === 'dense' ? '$' : t('list.actions.prices')}
-            </Button>
-          )}
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleEdit}
-            className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300"
-          >
-            {density === 'dense' ? '✎' : t('list.actions.edit')}
-          </Button>
-          {!hasHoldings && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleToggleActive}
-              className={security.isActive
-                ? 'text-yellow-600 dark:text-yellow-400 hover:text-yellow-900 dark:hover:text-yellow-300'
-                : 'text-green-600 dark:text-green-400 hover:text-green-900 dark:hover:text-green-300'}
-            >
-              {density === 'dense'
-                ? (security.isActive ? '⊘' : '✓')
-                : (security.isActive ? t('list.actions.deactivate') : t('list.actions.activate'))}
-            </Button>
-          )}
-          {canDelete && onDelete && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleDelete}
-              className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300"
-            >
-              {density === 'dense' ? '\u2715' : t('list.actions.delete')}
-            </Button>
-          )}
-        </div>
+        <RowActions actions={actions} density={density} />
       </td>
     </tr>
   );
@@ -374,54 +388,12 @@ export function SecurityList({
     }
   }, [onSort, localSortField]);
 
-  // Long-press handling for context menu on mobile
-  const longPressTimer = useRef<NodeJS.Timeout | null>(null);
-  const longPressTriggered = useRef(false);
-  const touchStartPos = useRef<{ x: number; y: number } | null>(null);
-  const LONG_PRESS_MOVE_THRESHOLD = 10;
+  // Long-press opens a per-row action sheet on mobile (and via right-click).
   const [contextSecurity, setContextSecurity] = useState<Security | null>(null);
 
-  const handleLongPressStart = useCallback((security: Security) => {
-    touchStartPos.current = null;
-    longPressTriggered.current = false;
-    longPressTimer.current = setTimeout(() => {
-      longPressTriggered.current = true;
-      setContextSecurity(security);
-    }, 750);
-  }, []);
-
-  const handleLongPressStartTouch = useCallback((security: Security, e: React.TouchEvent) => {
-    if (e?.touches?.[0]) {
-      touchStartPos.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
-    } else {
-      touchStartPos.current = null;
-    }
-    longPressTriggered.current = false;
-    longPressTimer.current = setTimeout(() => {
-      longPressTriggered.current = true;
-      setContextSecurity(security);
-    }, 750);
-  }, []);
-
-  const handleLongPressEnd = useCallback(() => {
-    if (longPressTimer.current) {
-      clearTimeout(longPressTimer.current);
-      longPressTimer.current = null;
-    }
-    touchStartPos.current = null;
-  }, []);
-
-  const handleTouchMove = useCallback((e: React.TouchEvent) => {
-    if (touchStartPos.current && longPressTimer.current && e.touches?.[0]) {
-      const deltaX = Math.abs(e.touches[0].clientX - touchStartPos.current.x);
-      const deltaY = Math.abs(e.touches[0].clientY - touchStartPos.current.y);
-      if (deltaX > LONG_PRESS_MOVE_THRESHOLD || deltaY > LONG_PRESS_MOVE_THRESHOLD) {
-        clearTimeout(longPressTimer.current);
-        longPressTimer.current = null;
-        touchStartPos.current = null;
-      }
-    }
-  }, []);
+  const { getRowHandlers } = useLongPress<Security>({
+    onLongPress: setContextSecurity,
+  });
 
   // Memoize padding classes based on density
   const cellPadding = useMemo(() => {
@@ -575,10 +547,7 @@ export function SecurityList({
                 onDelete={onDelete}
                 onViewPrices={onViewPrices}
                 onViewHistory={onViewHistory}
-                onLongPressStart={handleLongPressStart}
-                onLongPressStartTouch={handleLongPressStartTouch}
-                onLongPressEnd={handleLongPressEnd}
-                onTouchMove={handleTouchMove}
+                getRowHandlers={getRowHandlers}
                 index={index}
                 defaultQuoteProvider={defaultQuoteProvider}
               />
@@ -587,87 +556,29 @@ export function SecurityList({
         </table>
       </div>
 
-      {/* Long-press Context Menu */}
-      <Modal isOpen={!!contextSecurity} onClose={() => setContextSecurity(null)} maxWidth="sm" className="p-0">
-        {contextSecurity && (() => {
-          const contextHasHoldings = (holdings[contextSecurity.id] || 0) > 0;
-          const contextHasTransactions = transactionSecurityIds.has(contextSecurity.id);
-          const contextCanDelete = !contextHasHoldings && !contextHasTransactions;
-          return (
-          <div>
-            <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">{contextSecurity.symbol}</h3>
-              <p className="text-sm text-gray-500 dark:text-gray-400">{contextSecurity.name}</p>
-            </div>
-            <div className="py-2">
-              {onViewHistory && (
-                <button
-                  onClick={() => { setContextSecurity(null); onViewHistory(contextSecurity); }}
-                  className="w-full text-left px-5 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
-                >
-                  <svg className="w-5 h-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
-                  </svg>
-                  {t('list.contextMenu.transactionHistory')}
-                </button>
-              )}
-              {onViewPrices && (
-                <button
-                  onClick={() => { setContextSecurity(null); onViewPrices(contextSecurity); }}
-                  className="w-full text-left px-5 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
-                >
-                  <svg className="w-5 h-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                  </svg>
-                  {t('list.contextMenu.viewPrices')}
-                </button>
-              )}
-              <button
-                onClick={() => { setContextSecurity(null); onEdit(contextSecurity); }}
-                className="w-full text-left px-5 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
-              >
-                <svg className="w-5 h-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                </svg>
-                {t('list.contextMenu.editSecurity')}
-              </button>
-              {!contextHasHoldings && (
-                <button
-                  onClick={() => { setContextSecurity(null); onToggleActive(contextSecurity); }}
-                  className={`w-full text-left px-5 py-3 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3 ${
-                    contextSecurity.isActive
-                      ? 'text-yellow-600 dark:text-yellow-400'
-                      : 'text-green-600 dark:text-green-400'
-                  }`}
-                >
-                  {contextSecurity.isActive ? (
-                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
-                    </svg>
-                  ) : (
-                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                    </svg>
-                  )}
-                  {contextSecurity.isActive ? t('list.contextMenu.deactivate') : t('list.contextMenu.activate')}
-                </button>
-              )}
-              {contextCanDelete && onDelete && (
-                <button
-                  onClick={() => { setContextSecurity(null); onDelete(contextSecurity); }}
-                  className="w-full text-left px-5 py-3 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 flex items-center gap-3"
-                >
-                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                  </svg>
-                  {t('list.contextMenu.delete')}
-                </button>
-              )}
-            </div>
-          </div>
-          );
-        })()}
-      </Modal>
+      {/* Long-press action sheet */}
+      <RowActionSheet
+        isOpen={!!contextSecurity}
+        title={contextSecurity?.symbol ?? ''}
+        subtitle={contextSecurity?.name}
+        actions={contextSecurity
+          ? buildSecurityActions(
+              contextSecurity,
+              (holdings[contextSecurity.id] || 0) > 0,
+              transactionSecurityIds.has(contextSecurity.id),
+              {
+                history: t('list.contextMenu.transactionHistory'),
+                prices: t('list.contextMenu.viewPrices'),
+                edit: t('list.contextMenu.editSecurity'),
+                activate: t('list.contextMenu.activate'),
+                deactivate: t('list.contextMenu.deactivate'),
+                delete: t('list.contextMenu.delete'),
+              },
+              { onViewHistory, onViewPrices, onEdit, onToggleActive, onDelete },
+            )
+          : []}
+        onClose={() => setContextSecurity(null)}
+      />
     </div>
   );
 }

--- a/frontend/src/components/tags/TagList.tsx
+++ b/frontend/src/components/tags/TagList.tsx
@@ -3,12 +3,30 @@
 import { useState, useMemo, useCallback, memo } from 'react';
 import { useTranslations } from 'next-intl';
 import { Tag } from '@/types/tag';
-import { Button } from '@/components/ui/Button';
 import { getIconComponent } from '@/components/ui/IconPicker';
 import { useTableDensity, nextDensity, type DensityLevel } from '@/hooks/useTableDensity';
 import { SortIcon } from '@/components/ui/SortIcon';
+import { useLongPress, type LongPressRowHandlers } from '@/hooks/useLongPress';
+import { RowActions } from '@/components/ui/row-actions/RowActions';
+import { RowActionSheet } from '@/components/ui/row-actions/RowActionSheet';
+import type { RowAction } from '@/components/ui/row-actions/rowAction';
 
 export type { DensityLevel } from '@/hooks/useTableDensity';
+
+/**
+ * Builds the standard row actions for a tag. Shared by the desktop `RowActions`
+ * cell and the mobile `RowActionSheet`.
+ */
+function buildTagActions(
+  tag: Tag,
+  labels: { edit: string; delete: string },
+  handlers: { onEdit: (tag: Tag) => void; onDeleteClick: (tag: Tag) => void },
+): RowAction[] {
+  return [
+    { key: 'edit', label: labels.edit, icon: 'edit', tone: 'primary', onClick: () => handlers.onEdit(tag) },
+    { key: 'delete', label: labels.delete, icon: 'delete', tone: 'delete', destructive: true, onClick: () => handlers.onDeleteClick(tag) },
+  ];
+}
 
 export type SortField = 'name' | 'createdAt';
 export type SortDirection = 'asc' | 'desc';
@@ -22,6 +40,7 @@ interface TagRowProps {
   onDeleteClick: (tag: Tag) => void;
   onTagClick?: (tag: Tag) => void;
   index: number;
+  getRowHandlers: (tag: Tag) => LongPressRowHandlers;
 }
 
 const TagRow = memo(function TagRow({
@@ -33,23 +52,23 @@ const TagRow = memo(function TagRow({
   onDeleteClick,
   onTagClick,
   index,
+  getRowHandlers,
 }: TagRowProps) {
   const tc = useTranslations('common');
-  const handleEdit = useCallback(() => {
-    onEdit(tag);
-  }, [onEdit, tag]);
-
-  const handleDelete = useCallback(() => {
-    onDeleteClick(tag);
-  }, [onDeleteClick, tag]);
 
   const handleTagClick = useCallback(() => {
     onTagClick?.(tag);
   }, [onTagClick, tag]);
 
+  const actions = useMemo(
+    () => buildTagActions(tag, { edit: tc('actions.edit'), delete: tc('actions.delete') }, { onEdit, onDeleteClick }),
+    [tag, tc, onEdit, onDeleteClick],
+  );
+
   return (
     <tr
-      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'}`}
+      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer select-none ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'}`}
+      {...getRowHandlers(tag)}
     >
       <td className={`${cellPadding} whitespace-nowrap`}>
         <div className="flex items-center">
@@ -61,7 +80,7 @@ const TagRow = memo(function TagRow({
           )}
           {onTagClick ? (
             <button
-              onClick={handleTagClick}
+              onClick={(e) => { e.stopPropagation(); handleTagClick(); }}
               className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline"
             >
               {tag.name}
@@ -85,23 +104,8 @@ const TagRow = memo(function TagRow({
       <td className={`${cellPadding} whitespace-nowrap text-right text-sm text-gray-500 dark:text-gray-400 hidden sm:table-cell`}>
         {transactionCount}
       </td>
-      <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`}>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={handleEdit}
-          className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300 mr-2"
-        >
-          {density === 'dense' ? '✎' : tc('edit')}
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={handleDelete}
-          className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300"
-        >
-          {density === 'dense' ? '✕' : tc('delete')}
-        </Button>
+      <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium hidden min-[480px]:table-cell sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`}>
+        <RowActions actions={actions} density={density} />
       </td>
     </tr>
   );
@@ -133,6 +137,8 @@ export function TagList({
   onSort,
 }: TagListProps) {
   const t = useTranslations('tags');
+  const tc = useTranslations('common');
+  const [actionSheet, setActionSheet] = useState<{ open: boolean; tag: Tag | null }>({ open: false, tag: null });
   const [localDensity, setLocalDensity] = useState<DensityLevel>('normal');
   const [localSortField, setLocalSortField] = useState<SortField>('name');
   const [localSortDirection, setLocalSortDirection] = useState<SortDirection>('asc');
@@ -168,6 +174,11 @@ export function TagList({
   const handleDeleteClick = useCallback((tag: Tag) => {
     onDelete(tag);
   }, [onDelete]);
+
+  const { getRowHandlers } = useLongPress<Tag>({
+    onLongPress: (tag) => setActionSheet({ open: true, tag }),
+    onClick: onEdit,
+  });
 
   const sortedTags = useMemo(() => {
     return [...tags].sort((a, b) => {
@@ -236,7 +247,7 @@ export function TagList({
               <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell`}>
                 {t('list.header.transactions')}
               </th>
-              <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider sticky right-0 bg-gray-50 dark:bg-gray-800`}>
+              <th className={`${headerPadding} text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden min-[480px]:table-cell sticky right-0 bg-gray-50 dark:bg-gray-800`}>
                 {t('list.header.actions')}
               </th>
             </tr>
@@ -253,11 +264,21 @@ export function TagList({
                 onDeleteClick={handleDeleteClick}
                 onTagClick={onTagClick}
                 index={index}
+                getRowHandlers={getRowHandlers}
               />
             ))}
           </tbody>
         </table>
       </div>
+
+      <RowActionSheet
+        isOpen={actionSheet.open}
+        title={actionSheet.tag?.name ?? ''}
+        actions={actionSheet.tag
+          ? buildTagActions(actionSheet.tag, { edit: tc('actions.edit'), delete: tc('actions.delete') }, { onEdit, onDeleteClick: handleDeleteClick })
+          : []}
+        onClose={() => setActionSheet({ open: false, tag: null })}
+      />
     </div>
   );
 }

--- a/frontend/src/components/ui/row-actions/ActionIcon.tsx
+++ b/frontend/src/components/ui/row-actions/ActionIcon.tsx
@@ -1,0 +1,48 @@
+import type { ActionIconKey } from './rowAction';
+
+/**
+ * Shared inline-SVG icon set for row actions. One glyph per verb so every list
+ * shows the same icon for the same action. Paths are the outline (stroke,
+ * `currentColor`, 24x24) shapes already used across the app's row components,
+ * consolidated here. Inline SVG keeps this CSP-safe (no external icon runtime).
+ */
+const ACTION_ICON_PATHS: Record<ActionIconKey, string> = {
+  edit: 'M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z',
+  view: 'M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z',
+  delete:
+    'M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16',
+  duplicate:
+    'M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z',
+  merge: 'M7 8l-4 4 4 4m-4-4h11a4 4 0 004-4V6',
+  reconcile: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z',
+  post: 'M5 13l4 4L19 7',
+  skip: 'M13 5l7 7-7 7M5 5l7 7-7 7',
+  close: 'M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4',
+  reopen:
+    'M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15',
+  reactivate: 'M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6',
+  schedule: 'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z',
+  deactivate: 'M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636',
+  activate: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z',
+  favorite:
+    'M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z',
+  prices: 'M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z',
+  history: 'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z',
+  transactions:
+    'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2',
+  filter:
+    'M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z',
+};
+
+export interface ActionIconProps {
+  name: ActionIconKey;
+  className?: string;
+}
+
+export function ActionIcon({ name, className = 'w-4 h-4' }: ActionIconProps) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={ACTION_ICON_PATHS[name]} />
+    </svg>
+  );
+}

--- a/frontend/src/components/ui/row-actions/RowActionSheet.test.tsx
+++ b/frontend/src/components/ui/row-actions/RowActionSheet.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { render } from '@/test/render';
+import { RowActionSheet } from './RowActionSheet';
+import type { RowAction } from './rowAction';
+
+describe('RowActionSheet', () => {
+  const baseActions: RowAction[] = [
+    { key: 'edit', label: 'Edit', icon: 'edit', tone: 'primary', onClick: vi.fn() },
+    { key: 'delete', label: 'Delete', icon: 'delete', tone: 'delete', onClick: vi.fn(), destructive: true },
+  ];
+
+  it('renders title and subtitle', () => {
+    render(<RowActionSheet isOpen title="Coffee Co" subtitle="2025-06-15" actions={baseActions} onClose={vi.fn()} />);
+    expect(screen.getByText('Coffee Co')).toBeInTheDocument();
+    expect(screen.getByText('2025-06-15')).toBeInTheDocument();
+  });
+
+  it('renders one button per visible action', () => {
+    render(<RowActionSheet isOpen title="X" actions={baseActions} onClose={vi.fn()} />);
+    expect(screen.getByText('Edit')).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+  });
+
+  it('closes then fires the action on click', () => {
+    const onClose = vi.fn();
+    const onClick = vi.fn();
+    const actions: RowAction[] = [{ key: 'edit', label: 'Edit', icon: 'edit', tone: 'primary', onClick }];
+    render(<RowActionSheet isOpen title="X" actions={actions} onClose={onClose} />);
+    fireEvent.click(screen.getByText('Edit'));
+    expect(onClose).toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('omits hidden actions', () => {
+    const actions: RowAction[] = [
+      { key: 'edit', label: 'Edit', icon: 'edit', tone: 'primary', onClick: vi.fn(), hidden: true },
+      { key: 'delete', label: 'Delete', icon: 'delete', tone: 'delete', onClick: vi.fn() },
+    ];
+    render(<RowActionSheet isOpen title="X" actions={actions} onClose={vi.fn()} />);
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+  });
+
+  it('applies destructive styling to destructive actions', () => {
+    render(<RowActionSheet isOpen title="X" actions={baseActions} onClose={vi.fn()} />);
+    const deleteBtn = screen.getByText('Delete').closest('button');
+    expect(deleteBtn?.className).toContain('text-red-600');
+  });
+});

--- a/frontend/src/components/ui/row-actions/RowActionSheet.tsx
+++ b/frontend/src/components/ui/row-actions/RowActionSheet.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { Modal } from '@/components/ui/Modal';
+import { ActionIcon } from './ActionIcon';
+import { TONE_SHEET_ICON_CLASS } from './actionTones';
+import { visibleActions, type RowAction } from './rowAction';
+
+export interface RowActionSheetProps {
+  isOpen: boolean;
+  /** Heading (e.g. the row's name). */
+  title: string;
+  /** Optional sub-heading (e.g. a date or type). */
+  subtitle?: string;
+  actions: RowAction[];
+  onClose: () => void;
+}
+
+/**
+ * Standard mobile action sheet shared by every list. Opened by a long-press /
+ * right-click on a row (see `useLongPress`). Generalizes the former
+ * `TransactionActionSheet`: a `Modal` with a title block and a vertical list of
+ * full-width action buttons. Destructive actions get a red row treatment.
+ */
+export function RowActionSheet({ isOpen, title, subtitle, actions, onClose }: RowActionSheetProps) {
+  const shown = visibleActions(actions);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} maxWidth="sm" className="p-0">
+      <div className="py-2">
+        <div className="px-4 py-2 border-b border-gray-200 dark:border-gray-700">
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{title}</p>
+          {subtitle && <p className="text-xs text-gray-500 dark:text-gray-400">{subtitle}</p>}
+        </div>
+        {shown.map((action) => (
+          <button
+            key={action.key}
+            type="button"
+            disabled={action.disabled}
+            onClick={() => { onClose(); action.onClick(); }}
+            className={`w-full px-4 py-3 text-left text-sm flex items-center gap-3 disabled:opacity-50 disabled:cursor-not-allowed ${
+              action.destructive
+                ? 'text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20'
+                : 'text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700'
+            }`}
+          >
+            <ActionIcon
+              name={action.icon}
+              className={`w-4 h-4 shrink-0 ${action.destructive ? '' : TONE_SHEET_ICON_CLASS[action.tone]}`}
+            />
+            {action.label}
+          </button>
+        ))}
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/ui/row-actions/RowActions.test.tsx
+++ b/frontend/src/components/ui/row-actions/RowActions.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { render } from '@/test/render';
+import { RowActions } from './RowActions';
+import type { RowAction } from './rowAction';
+
+function makeActions(overrides: Partial<RowAction>[] = []): RowAction[] {
+  const base: RowAction[] = [
+    { key: 'edit', label: 'Edit', icon: 'edit', tone: 'primary', onClick: vi.fn() },
+    { key: 'delete', label: 'Delete', icon: 'delete', tone: 'delete', onClick: vi.fn() },
+  ];
+  return base.map((a, i) => ({ ...a, ...overrides[i] }));
+}
+
+describe('RowActions', () => {
+  it('renders text labels in normal density', () => {
+    render(<RowActions actions={makeActions()} density="normal" />);
+    expect(screen.getByText('Edit')).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+  });
+
+  it('renders icon-only buttons with accessible labels in compact density', () => {
+    render(<RowActions actions={makeActions()} density="compact" />);
+    // Label text is not rendered visibly, but exposed via aria-label / title.
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('fires onClick and stops propagation', () => {
+    const onClick = vi.fn();
+    const rowClick = vi.fn();
+    const actions = makeActions([{ onClick }]);
+    render(
+      <div onClick={rowClick}>
+        <RowActions actions={actions} density="normal" />
+      </div>,
+    );
+    fireEvent.click(screen.getByText('Edit'));
+    expect(onClick).toHaveBeenCalled();
+    expect(rowClick).not.toHaveBeenCalled();
+  });
+
+  it('omits hidden actions and disables disabled ones', () => {
+    const actions = makeActions([{ hidden: true }, { disabled: true }]);
+    render(<RowActions actions={actions} density="normal" />);
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeDisabled();
+  });
+
+  it('folds surplus actions into an overflow menu past maxInline', () => {
+    const actions: RowAction[] = [
+      { key: 'a', label: 'Alpha', icon: 'edit', tone: 'primary', onClick: vi.fn() },
+      { key: 'b', label: 'Bravo', icon: 'view', tone: 'view', onClick: vi.fn() },
+      { key: 'c', label: 'Charlie', icon: 'duplicate', tone: 'neutral', onClick: vi.fn() },
+    ];
+    render(<RowActions actions={actions} density="normal" maxInline={2} />);
+    // First (maxInline - 1) inline, rest behind the kebab.
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.queryByText('Bravo')).not.toBeInTheDocument();
+    const more = screen.getByRole('button', { name: 'More actions' });
+    fireEvent.click(more);
+    expect(screen.getByText('Bravo')).toBeInTheDocument();
+    expect(screen.getByText('Charlie')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/row-actions/RowActions.tsx
+++ b/frontend/src/components/ui/row-actions/RowActions.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import type { DensityLevel } from '@/hooks/useTableDensity';
+import { ActionIcon } from './ActionIcon';
+import { RowActionsOverflow } from './RowActionsOverflow';
+import { TONE_TEXT_CLASS } from './actionTones';
+import { visibleActions, type RowAction } from './rowAction';
+
+export interface RowActionsProps {
+  actions: RowAction[];
+  density: DensityLevel;
+  /**
+   * When the number of visible actions exceeds this, the surplus folds into a
+   * "more" overflow kebab. Defaults to a large number (no folding).
+   */
+  maxInline?: number;
+  /** Extra classes for the flex container. */
+  className?: string;
+}
+
+/**
+ * Standard desktop ACTIONS renderer shared by every list. Renders the contents of
+ * the (caller-owned) sticky actions cell:
+ * - normal density: colored text-label buttons (preserves the existing look)
+ * - compact / dense: icon-only buttons with tooltips (frees horizontal space)
+ *
+ * Color comes from each action's semantic `tone`, so the same verb looks the same
+ * across every list. Callers own the `<td>` (and its striped/selected background);
+ * this only renders the buttons.
+ */
+export function RowActions({ actions, density, maxInline = Infinity, className }: RowActionsProps) {
+  const tc = useTranslations('common');
+  const shown = visibleActions(actions);
+  const iconOnly = density !== 'normal';
+  const iconClass = density === 'dense' ? 'w-3.5 h-3.5' : 'w-4 h-4';
+  const gap = density === 'dense' ? 'gap-1' : 'gap-2';
+
+  const inline = shown.length > maxInline ? shown.slice(0, maxInline - 1) : shown;
+  const overflow = shown.length > maxInline ? shown.slice(maxInline - 1) : [];
+
+  return (
+    <div className={`flex justify-end items-center ${gap} ${className ?? ''}`}>
+      {inline.map((action) => {
+        const tone = TONE_TEXT_CLASS[action.tone];
+        const title = action.title ?? action.label;
+        if (iconOnly) {
+          return (
+            <button
+              key={action.key}
+              type="button"
+              onClick={(e) => { e.stopPropagation(); action.onClick(); }}
+              disabled={action.disabled}
+              title={title}
+              aria-label={action.label}
+              className={`inline-flex items-center justify-center p-1 rounded ${tone} hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed`}
+            >
+              <ActionIcon name={action.icon} className={iconClass} />
+            </button>
+          );
+        }
+        return (
+          <button
+            key={action.key}
+            type="button"
+            onClick={(e) => { e.stopPropagation(); action.onClick(); }}
+            disabled={action.disabled}
+            title={action.title}
+            className={`text-sm font-medium ${tone} disabled:opacity-50 disabled:cursor-not-allowed`}
+          >
+            {action.label}
+          </button>
+        );
+      })}
+      {overflow.length > 0 && (
+        <RowActionsOverflow actions={overflow} label={tc('actions.more')} iconClass={iconClass} />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/row-actions/RowActionsOverflow.tsx
+++ b/frontend/src/components/ui/row-actions/RowActionsOverflow.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useClickOutside } from '@/hooks/useClickOutside';
+import { ActionIcon } from './ActionIcon';
+import { TONE_SHEET_ICON_CLASS } from './actionTones';
+import type { RowAction } from './rowAction';
+
+export interface RowActionsOverflowProps {
+  actions: RowAction[];
+  /** Accessible label / tooltip for the kebab trigger. */
+  label: string;
+  /** Icon size class for the trigger glyph. */
+  iconClass?: string;
+}
+
+/**
+ * A "more actions" overflow menu (kebab) rendered in a portal. Generalizes the
+ * former Transactions `CopyDropdown` so any list can fold extra row actions
+ * behind a single trigger. Closes on outside-click or scroll.
+ */
+export function RowActionsOverflow({ actions, label, iconClass = 'w-4 h-4' }: RowActionsOverflowProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [dropdownPos, setDropdownPos] = useState({ top: 0, left: 0 });
+
+  const updatePosition = useCallback(() => {
+    if (buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      setDropdownPos({ top: rect.bottom + 4, left: rect.right });
+    }
+  }, []);
+
+  useClickOutside([dropdownRef, buttonRef], () => setIsOpen(false), { enabled: isOpen });
+
+  useEffect(() => {
+    if (!isOpen) return;
+    updatePosition();
+    const handleScroll = () => setIsOpen(false);
+    window.addEventListener('scroll', handleScroll, true);
+    return () => window.removeEventListener('scroll', handleScroll, true);
+  }, [isOpen, updatePosition]);
+
+  if (actions.length === 0) return null;
+
+  return (
+    <div className="relative inline-block">
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={(e) => { e.stopPropagation(); setIsOpen((prev) => !prev); }}
+        className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 align-middle"
+        title={label}
+        aria-label={label}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+      >
+        <svg className={iconClass} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v.01M12 12v.01M12 19v.01" />
+        </svg>
+      </button>
+      {isOpen && createPortal(
+        <div
+          ref={dropdownRef}
+          role="menu"
+          className="fixed z-50 w-56 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black/5 dark:ring-white/10 py-1"
+          style={{ top: dropdownPos.top, left: dropdownPos.left, transform: 'translateX(-100%)' }}
+        >
+          {actions.map((action) => (
+            <button
+              key={action.key}
+              type="button"
+              role="menuitem"
+              disabled={action.disabled}
+              onClick={(e) => { e.stopPropagation(); setIsOpen(false); action.onClick(); }}
+              className="w-full px-3 py-2 text-left text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2 whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ActionIcon name={action.icon} className={`w-4 h-4 shrink-0 ${TONE_SHEET_ICON_CLASS[action.tone]}`} />
+              {action.label}
+            </button>
+          ))}
+        </div>,
+        document.body,
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/row-actions/actionTones.ts
+++ b/frontend/src/components/ui/row-actions/actionTones.ts
@@ -1,0 +1,31 @@
+import type { ActionTone } from './rowAction';
+
+/**
+ * Text/hover color for a desktop action button (normal-density text label and
+ * compact/dense icon-only). Mirrors the per-verb color conventions already used
+ * across the lists so existing rows look unchanged: edit=blue, delete=red,
+ * reconcile/post/reactivate=green, close/skip=orange, merge/schedule=purple.
+ */
+export const TONE_TEXT_CLASS: Record<ActionTone, string> = {
+  primary: 'text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300',
+  view: 'text-emerald-600 dark:text-emerald-400 hover:text-emerald-900 dark:hover:text-emerald-300',
+  delete: 'text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300',
+  success: 'text-green-600 dark:text-green-400 hover:text-green-900 dark:hover:text-green-300',
+  warning: 'text-orange-600 dark:text-orange-400 hover:text-orange-900 dark:hover:text-orange-300',
+  accent: 'text-purple-600 dark:text-purple-400 hover:text-purple-900 dark:hover:text-purple-300',
+  neutral: 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200',
+};
+
+/**
+ * Icon tint for an action-sheet (mobile) row. Destructive actions are red; every
+ * other verb is neutral gray, matching the original TransactionActionSheet.
+ */
+export const TONE_SHEET_ICON_CLASS: Record<ActionTone, string> = {
+  primary: 'text-gray-400',
+  view: 'text-gray-400',
+  delete: 'text-red-600 dark:text-red-400',
+  success: 'text-gray-400',
+  warning: 'text-gray-400',
+  accent: 'text-gray-400',
+  neutral: 'text-gray-400',
+};

--- a/frontend/src/components/ui/row-actions/index.ts
+++ b/frontend/src/components/ui/row-actions/index.ts
@@ -1,0 +1,7 @@
+export { ActionIcon } from './ActionIcon';
+export { RowActions } from './RowActions';
+export { RowActionSheet } from './RowActionSheet';
+export { RowActionsOverflow } from './RowActionsOverflow';
+export { TONE_TEXT_CLASS, TONE_SHEET_ICON_CLASS } from './actionTones';
+export { visibleActions } from './rowAction';
+export type { RowAction, ActionTone, ActionIconKey } from './rowAction';

--- a/frontend/src/components/ui/row-actions/rowAction.ts
+++ b/frontend/src/components/ui/row-actions/rowAction.ts
@@ -1,0 +1,64 @@
+/**
+ * Semantic color for a row action. The tone -- not a raw Tailwind class -- is what
+ * callers choose, so every list uses the same color for the same verb.
+ */
+export type ActionTone =
+  | 'primary' // blue   -- edit, reopen
+  | 'view' // emerald -- view/open a linked record
+  | 'delete' // red    -- destructive
+  | 'success' // green  -- reconcile, post, reactivate
+  | 'warning' // orange -- close, skip, deactivate
+  | 'accent' // purple -- merge, schedule recurring
+  | 'neutral'; // gray  -- duplicate, filters, secondary
+
+/** Key into the shared inline-SVG icon set (see ActionIcon.tsx). */
+export type ActionIconKey =
+  | 'edit'
+  | 'view'
+  | 'delete'
+  | 'duplicate'
+  | 'merge'
+  | 'reconcile'
+  | 'post'
+  | 'skip'
+  | 'close'
+  | 'reopen'
+  | 'reactivate'
+  | 'schedule'
+  | 'deactivate'
+  | 'activate'
+  | 'favorite'
+  | 'prices'
+  | 'history'
+  | 'transactions'
+  | 'filter';
+
+/**
+ * A single per-row action. Callers build these from already-translated labels and
+ * their own handlers; the shared renderers (`RowActions`, `RowActionSheet`) turn
+ * them into consistent buttons.
+ */
+export interface RowAction {
+  /** Stable identity for React keys. */
+  key: string;
+  /** Already-translated label (also the default tooltip / aria-label). */
+  label: string;
+  /** Which icon to show in icon-only (compact/dense) mode and in the action sheet. */
+  icon: ActionIconKey;
+  /** Semantic color. */
+  tone: ActionTone;
+  onClick: () => void;
+  /** When true, the action is omitted entirely. */
+  hidden?: boolean;
+  /** When true, the button renders disabled. */
+  disabled?: boolean;
+  /** Tooltip override; defaults to `label`. */
+  title?: string;
+  /** When true, the action-sheet row uses the destructive (red) hover background. */
+  destructive?: boolean;
+}
+
+/** Convenience: drop hidden actions, used by both renderers. */
+export function visibleActions(actions: RowAction[]): RowAction[] {
+  return actions.filter((a) => !a.hidden);
+}

--- a/frontend/src/hooks/useLongPress.test.ts
+++ b/frontend/src/hooks/useLongPress.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useLongPress } from './useLongPress';
+
+type Item = { id: string };
+const item: Item = { id: 'x1' };
+
+function touchEvent(x: number, y: number): React.TouchEvent {
+  return { touches: [{ clientX: x, clientY: y }] } as unknown as React.TouchEvent;
+}
+
+describe('useLongPress', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('fires onLongPress after the delay on touch and suppresses the trailing click', () => {
+    const onLongPress = vi.fn();
+    const onClick = vi.fn();
+    const { result } = renderHook(() => useLongPress<Item>({ onLongPress, onClick }));
+    const handlers = result.current.getRowHandlers(item);
+
+    handlers.onTouchStart(touchEvent(0, 0));
+    vi.advanceTimersByTime(750);
+    expect(onLongPress).toHaveBeenCalledWith(item);
+    expect(result.current.wasLongPress.current).toBe(true);
+
+    // The click that follows a long-press must be swallowed.
+    handlers.onClick({} as React.MouseEvent);
+    expect(onClick).not.toHaveBeenCalled();
+    expect(result.current.wasLongPress.current).toBe(false);
+  });
+
+  it('does not fire onLongPress when released before the delay', () => {
+    const onLongPress = vi.fn();
+    const onClick = vi.fn();
+    const { result } = renderHook(() => useLongPress<Item>({ onLongPress, onClick }));
+    const handlers = result.current.getRowHandlers(item);
+
+    handlers.onTouchStart(touchEvent(0, 0));
+    vi.advanceTimersByTime(300);
+    handlers.onTouchEnd();
+    vi.advanceTimersByTime(750);
+    expect(onLongPress).not.toHaveBeenCalled();
+
+    handlers.onClick({} as React.MouseEvent);
+    expect(onClick).toHaveBeenCalledWith(item);
+  });
+
+  it('cancels the press when the touch moves beyond the threshold', () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress<Item>({ onLongPress }));
+    const handlers = result.current.getRowHandlers(item);
+
+    handlers.onTouchStart(touchEvent(0, 0));
+    handlers.onTouchMove(touchEvent(20, 0));
+    vi.advanceTimersByTime(750);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('keeps the press alive for small moves within the threshold', () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress<Item>({ onLongPress }));
+    const handlers = result.current.getRowHandlers(item);
+
+    handlers.onTouchStart(touchEvent(0, 0));
+    handlers.onTouchMove(touchEvent(5, 5));
+    vi.advanceTimersByTime(750);
+    expect(onLongPress).toHaveBeenCalledWith(item);
+  });
+
+  it('fires immediately on context menu and suppresses the click', () => {
+    const onLongPress = vi.fn();
+    const onClick = vi.fn();
+    const preventDefault = vi.fn();
+    const { result } = renderHook(() => useLongPress<Item>({ onLongPress, onClick }));
+    const handlers = result.current.getRowHandlers(item);
+
+    handlers.onContextMenu({ preventDefault } as unknown as React.MouseEvent);
+    expect(preventDefault).toHaveBeenCalled();
+    expect(onLongPress).toHaveBeenCalledWith(item);
+
+    handlers.onClick({} as React.MouseEvent);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-left mouse buttons', () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress<Item>({ onLongPress }));
+    const handlers = result.current.getRowHandlers(item);
+
+    handlers.onMouseDown({ button: 2 } as React.MouseEvent);
+    vi.advanceTimersByTime(750);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when disabled but still forwards plain clicks', () => {
+    const onLongPress = vi.fn();
+    const onClick = vi.fn();
+    const { result } = renderHook(() => useLongPress<Item>({ onLongPress, onClick, enabled: false }));
+    const handlers = result.current.getRowHandlers(item);
+
+    handlers.onTouchStart(touchEvent(0, 0));
+    vi.advanceTimersByTime(750);
+    expect(onLongPress).not.toHaveBeenCalled();
+
+    handlers.onClick({} as React.MouseEvent);
+    expect(onClick).toHaveBeenCalledWith(item);
+  });
+});

--- a/frontend/src/hooks/useLongPress.ts
+++ b/frontend/src/hooks/useLongPress.ts
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+export interface UseLongPressOptions<T> {
+  /** Fired when a long-press (or right-click) completes -- typically opens an action sheet. */
+  onLongPress: (item: T) => void;
+  /** Fired on a normal click/tap that was not a long-press -- typically the row's primary action. */
+  onClick?: (item: T) => void;
+  /** How long the press must be held before `onLongPress` fires. Defaults to 750ms. */
+  delayMs?: number;
+  /** Cancels the press if the pointer moves more than this many pixels. Defaults to 10. */
+  moveThresholdPx?: number;
+  /** When false, the handlers become no-ops (and `onClick` still fires). Defaults to true. */
+  enabled?: boolean;
+}
+
+/** Handler props to spread directly onto a row element (e.g. a `<tr>`). */
+export interface LongPressRowHandlers {
+  onClick: (e: React.MouseEvent) => void;
+  onContextMenu: (e: React.MouseEvent) => void;
+  onMouseDown: (e: React.MouseEvent) => void;
+  onMouseUp: () => void;
+  onMouseLeave: () => void;
+  onTouchStart: (e: React.TouchEvent) => void;
+  onTouchMove: (e: React.TouchEvent) => void;
+  onTouchEnd: () => void;
+  onTouchCancel: () => void;
+}
+
+export interface UseLongPressResult<T> {
+  /** Binds the given item into a set of handlers to spread onto its row element. */
+  getRowHandlers: (item: T) => LongPressRowHandlers;
+  /**
+   * True immediately after a long-press / context-menu fired, so the trailing
+   * synthetic click can be suppressed. Reset by the click handler itself.
+   */
+  wasLongPress: React.RefObject<boolean>;
+}
+
+/**
+ * Shared press-and-hold (long-press) behavior for list rows. A 750ms press --
+ * or a right-click -- invokes `onLongPress` (used to open a mobile action sheet),
+ * while a quick tap/click invokes `onClick`. Touch moves beyond the threshold
+ * cancel the press so vertical scrolling does not trigger the menu.
+ *
+ * Extracted from the per-list duplicated logic so every list shares one
+ * implementation. The handlers only ever set a timer; consumer state (the action
+ * sheet) is set inside the supplied callbacks, never in an effect.
+ */
+export function useLongPress<T>({
+  onLongPress,
+  onClick,
+  delayMs = 750,
+  moveThresholdPx = 10,
+  enabled = true,
+}: UseLongPressOptions<T>): UseLongPressResult<T> {
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wasLongPress = useRef(false);
+  const touchStartPos = useRef<{ x: number; y: number } | null>(null);
+
+  // Latest options held in a ref so the returned handlers stay stable (callers
+  // can pass inline closures without re-binding every row each render). Updated
+  // in an effect -- never during render -- and read only inside event handlers.
+  const latest = useRef({ onLongPress, onClick, delayMs, moveThresholdPx, enabled });
+  useEffect(() => {
+    latest.current = { onLongPress, onClick, delayMs, moveThresholdPx, enabled };
+  });
+
+  const clearTimer = useCallback(() => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+  }, []);
+
+  // Cancel any pending timer if the row unmounts mid-press.
+  useEffect(() => clearTimer, [clearTimer]);
+
+  const getRowHandlers = useCallback(
+    (item: T): LongPressRowHandlers => ({
+      onClick: () => {
+        if (wasLongPress.current) {
+          wasLongPress.current = false;
+          return;
+        }
+        latest.current.onClick?.(item);
+      },
+      onContextMenu: (e: React.MouseEvent) => {
+        if (!latest.current.enabled) return;
+        e.preventDefault();
+        clearTimer();
+        wasLongPress.current = true;
+        latest.current.onLongPress(item);
+      },
+      onMouseDown: (e: React.MouseEvent) => {
+        if (!latest.current.enabled || e.button !== 0) return;
+        touchStartPos.current = null;
+        wasLongPress.current = false;
+        timer.current = setTimeout(() => {
+          wasLongPress.current = true;
+          latest.current.onLongPress(item);
+        }, latest.current.delayMs);
+      },
+      onMouseUp: clearTimer,
+      onMouseLeave: clearTimer,
+      onTouchStart: (e: React.TouchEvent) => {
+        if (!latest.current.enabled) return;
+        const touch = e.touches?.[0];
+        touchStartPos.current = touch ? { x: touch.clientX, y: touch.clientY } : null;
+        wasLongPress.current = false;
+        timer.current = setTimeout(() => {
+          wasLongPress.current = true;
+          latest.current.onLongPress(item);
+        }, latest.current.delayMs);
+      },
+      onTouchMove: (e: React.TouchEvent) => {
+        const start = touchStartPos.current;
+        const touch = e.touches?.[0];
+        if (start && timer.current && touch) {
+          const deltaX = Math.abs(touch.clientX - start.x);
+          const deltaY = Math.abs(touch.clientY - start.y);
+          if (deltaX > latest.current.moveThresholdPx || deltaY > latest.current.moveThresholdPx) {
+            clearTimer();
+            touchStartPos.current = null;
+          }
+        }
+      },
+      onTouchEnd: clearTimer,
+      onTouchCancel: clearTimer,
+    }),
+    [clearTimer],
+  );
+
+  return { getRowHandlers, wasLongPress };
+}

--- a/frontend/src/i18n/messages/de/common.json
+++ b/frontend/src/i18n/messages/de/common.json
@@ -10,6 +10,21 @@
   "delete": "Löschen",
   "edit": "Bearbeiten",
   "close": "Schließen",
+  "actions": {
+    "edit": "Bearbeiten",
+    "delete": "Löschen",
+    "view": "Anzeigen",
+    "duplicate": "Duplizieren",
+    "merge": "Zusammenführen",
+    "reactivate": "Reaktivieren",
+    "reconcile": "Abgleichen",
+    "post": "Buchen",
+    "skip": "Überspringen",
+    "close": "Schließen",
+    "reopen": "Wieder öffnen",
+    "scheduleRecurring": "Wiederkehrend machen",
+    "more": "Weitere Aktionen"
+  },
   "loading": "Wird geladen...",
   "pagination": {
     "showing": "Angezeigt",

--- a/frontend/src/i18n/messages/en/common.json
+++ b/frontend/src/i18n/messages/en/common.json
@@ -10,6 +10,21 @@
   "delete": "Delete",
   "edit": "Edit",
   "close": "Close",
+  "actions": {
+    "edit": "Edit",
+    "delete": "Delete",
+    "view": "View",
+    "duplicate": "Duplicate",
+    "merge": "Merge",
+    "reactivate": "Reactivate",
+    "reconcile": "Reconcile",
+    "post": "Post",
+    "skip": "Skip",
+    "close": "Close",
+    "reopen": "Reopen",
+    "scheduleRecurring": "Make recurring",
+    "more": "More actions"
+  },
   "loading": "Loading...",
   "pagination": {
     "showing": "Showing",

--- a/frontend/src/i18n/messages/es/common.json
+++ b/frontend/src/i18n/messages/es/common.json
@@ -10,6 +10,21 @@
   "delete": "Eliminar",
   "edit": "Editar",
   "close": "Cerrar",
+  "actions": {
+    "edit": "Editar",
+    "delete": "Eliminar",
+    "view": "Ver",
+    "duplicate": "Duplicar",
+    "merge": "Combinar",
+    "reactivate": "Reactivar",
+    "reconcile": "Conciliar",
+    "post": "Registrar",
+    "skip": "Omitir",
+    "close": "Cerrar",
+    "reopen": "Reabrir",
+    "scheduleRecurring": "Hacer recurrente",
+    "more": "Más acciones"
+  },
   "loading": "Cargando...",
   "pagination": {
     "showing": "Mostrando",

--- a/frontend/src/i18n/messages/fr/common.json
+++ b/frontend/src/i18n/messages/fr/common.json
@@ -10,6 +10,21 @@
   "delete": "Supprimer",
   "edit": "Modifier",
   "close": "Fermer",
+  "actions": {
+    "edit": "Modifier",
+    "delete": "Supprimer",
+    "view": "Afficher",
+    "duplicate": "Dupliquer",
+    "merge": "Fusionner",
+    "reactivate": "Réactiver",
+    "reconcile": "Rapprocher",
+    "post": "Comptabiliser",
+    "skip": "Ignorer",
+    "close": "Fermer",
+    "reopen": "Rouvrir",
+    "scheduleRecurring": "Rendre récurrent",
+    "more": "Plus d'actions"
+  },
   "loading": "Chargement...",
   "pagination": {
     "showing": "Affichage",

--- a/frontend/src/i18n/messages/it/common.json
+++ b/frontend/src/i18n/messages/it/common.json
@@ -10,6 +10,21 @@
   "delete": "Elimina",
   "edit": "Modifica",
   "close": "Chiudi",
+  "actions": {
+    "edit": "Modifica",
+    "delete": "Elimina",
+    "view": "Visualizza",
+    "duplicate": "Duplica",
+    "merge": "Unisci",
+    "reactivate": "Riattiva",
+    "reconcile": "Riconcilia",
+    "post": "Registra",
+    "skip": "Salta",
+    "close": "Chiudi",
+    "reopen": "Riapri",
+    "scheduleRecurring": "Rendi ricorrente",
+    "more": "Altre azioni"
+  },
   "loading": "Caricamento...",
   "pagination": {
     "showing": "Visualizzazione",

--- a/frontend/src/i18n/messages/nl/common.json
+++ b/frontend/src/i18n/messages/nl/common.json
@@ -10,6 +10,21 @@
   "delete": "Verwijderen",
   "edit": "Bewerken",
   "close": "Sluiten",
+  "actions": {
+    "edit": "Bewerken",
+    "delete": "Verwijderen",
+    "view": "Bekijken",
+    "duplicate": "Dupliceren",
+    "merge": "Samenvoegen",
+    "reactivate": "Heractiveren",
+    "reconcile": "Afstemmen",
+    "post": "Boeken",
+    "skip": "Overslaan",
+    "close": "Sluiten",
+    "reopen": "Heropenen",
+    "scheduleRecurring": "Terugkerend maken",
+    "more": "Meer acties"
+  },
   "loading": "Laden...",
   "pagination": {
     "showing": "Weergeven",

--- a/frontend/src/i18n/messages/pl/common.json
+++ b/frontend/src/i18n/messages/pl/common.json
@@ -10,6 +10,21 @@
   "delete": "Usuń",
   "edit": "Edytuj",
   "close": "Zamknij",
+  "actions": {
+    "edit": "Edytuj",
+    "delete": "Usuń",
+    "view": "Wyświetl",
+    "duplicate": "Duplikuj",
+    "merge": "Scal",
+    "reactivate": "Reaktywuj",
+    "reconcile": "Uzgodnij",
+    "post": "Zaksięguj",
+    "skip": "Pomiń",
+    "close": "Zamknij",
+    "reopen": "Otwórz ponownie",
+    "scheduleRecurring": "Ustaw jako cykliczne",
+    "more": "Więcej akcji"
+  },
   "loading": "Wczytywanie...",
   "pagination": {
     "showing": "Wyświetlanie",

--- a/frontend/src/i18n/messages/pt-BR/common.json
+++ b/frontend/src/i18n/messages/pt-BR/common.json
@@ -10,6 +10,21 @@
   "delete": "Excluir",
   "edit": "Editar",
   "close": "Fechar",
+  "actions": {
+    "edit": "Editar",
+    "delete": "Excluir",
+    "view": "Visualizar",
+    "duplicate": "Duplicar",
+    "merge": "Mesclar",
+    "reactivate": "Reativar",
+    "reconcile": "Conciliar",
+    "post": "Lançar",
+    "skip": "Pular",
+    "close": "Fechar",
+    "reopen": "Reabrir",
+    "scheduleRecurring": "Tornar recorrente",
+    "more": "Mais ações"
+  },
   "loading": "Carregando...",
   "pagination": {
     "showing": "Exibindo",

--- a/frontend/src/i18n/messages/pt/common.json
+++ b/frontend/src/i18n/messages/pt/common.json
@@ -10,6 +10,21 @@
   "delete": "Eliminar",
   "edit": "Editar",
   "close": "Fechar",
+  "actions": {
+    "edit": "Editar",
+    "delete": "Eliminar",
+    "view": "Ver",
+    "duplicate": "Duplicar",
+    "merge": "Unir",
+    "reactivate": "Reativar",
+    "reconcile": "Reconciliar",
+    "post": "Lançar",
+    "skip": "Ignorar",
+    "close": "Fechar",
+    "reopen": "Reabrir",
+    "scheduleRecurring": "Tornar recorrente",
+    "more": "Mais ações"
+  },
   "loading": "A carregar...",
   "pagination": {
     "showing": "A mostrar",

--- a/frontend/src/i18n/messages/xx/common.json
+++ b/frontend/src/i18n/messages/xx/common.json
@@ -10,6 +10,21 @@
   "delete": "[XX-Delete-XX]",
   "edit": "[XX-Edit-XX]",
   "close": "[XX-Close-XX]",
+  "actions": {
+    "edit": "[XX-Edit-XX]",
+    "delete": "[XX-Delete-XX]",
+    "view": "[XX-View-XX]",
+    "duplicate": "[XX-Duplicate-XX]",
+    "merge": "[XX-Merge-XX]",
+    "reactivate": "[XX-Reactivate-XX]",
+    "reconcile": "[XX-Reconcile-XX]",
+    "post": "[XX-Post-XX]",
+    "skip": "[XX-Skip-XX]",
+    "close": "[XX-Close-XX]",
+    "reopen": "[XX-Reopen-XX]",
+    "scheduleRecurring": "[XX-Make recurring-XX]",
+    "more": "[XX-More actions-XX]"
+  },
   "loading": "[XX-Loading...-XX]",
   "pagination": {
     "showing": "[XX-Showing-XX]",


### PR DESCRIPTION
## What & why

Closes the UX inconsistencies raised in #688. Per-row actions were implemented differently across every list (different components, icons, colors, and responsive behavior), and **Payees / Categories / Tags** showed their inline actions at every width — crowding the row and truncating the primary content on phone-width screens.

This PR introduces one shared row-actions system and adopts it across the list views, so every page now has:

1. **A standard ACTIONS view** — one shared implementation.
2. **Standardized icons** — one inline-SVG glyph per verb (edit, delete, merge, reconcile, post, skip, close, reopen, reactivate, schedule, activate/deactivate, view, prices, history, …).
3. **Consistent colors** — a semantic tone map (edit=blue, delete=red, reconcile/post/reactivate=green, close/skip=orange, merge/schedule=purple, secondary=gray).
4. **Press-and-hold on every page** — the Transactions long-press → action sheet pattern, now shared. Below 480px the inline actions hide and a long-press (or right-click) opens the sheet.

## Shared building blocks (new)

- `hooks/useLongPress.ts` — press-and-hold / right-click handling (750ms, 10px move threshold), extracted from the logic that was duplicated in 6 lists. Returns handlers to spread on a `<tr>`.
- `components/ui/row-actions/`
  - `rowAction.ts` — the `RowAction` descriptor + `ActionTone` / `ActionIconKey`.
  - `ActionIcon.tsx` — shared inline-SVG icon set (one glyph per verb).
  - `actionTones.ts` — semantic tone → Tailwind color maps.
  - `RowActions.tsx` — desktop actions cell: **text labels in normal density, icon-only (with tooltips) in compact/dense**; optional overflow kebab.
  - `RowActionsOverflow.tsx` — portal kebab menu (generalizes the old Transactions `CopyDropdown`).
  - `RowActionSheet.tsx` — shared mobile action sheet (generalizes `TransactionActionSheet`).

## Lists migrated

Payees, Categories, Tags, Accounts, Scheduled Transactions, Currencies, Securities, Investment Transactions, Institutions. Each now builds its actions from a small `build*Actions` helper shared between the desktop cell and the mobile sheet, and the bespoke per-list context menus / inline long-press were removed.

Notes:
- **Payees / Categories / Tags** were the crowding offenders — they now hide actions below 480px and expose them via long-press.
- **Investment Transactions** previously deleted directly on long-press; it now opens a standard Edit/Delete sheet.
- **Transactions** already embodies this pattern (it was the reference) and is unchanged in this PR.
- AI provider settings (`settings/ai/ProviderList`) is a card-based config screen, not a data-row list, so it's out of scope.

## i18n

Added a shared `common.actions.*` verb set (edit, delete, view, duplicate, merge, reactivate, reconcile, post, skip, close, reopen, scheduleRecurring, more) translated for every locale (`de, en, es, fr, it, nl, pl, pt, pt-BR`); the pseudo-locale was regenerated. Parity test and `i18n:check` pass.

## Verification

- `npm run type-check` — clean
- `npm run lint` — clean
- `npm run i18n:check` + i18n parity test — pass
- `npm run test` — **424 files / 8886 tests pass** (includes new tests for `useLongPress`, `RowActions`, `RowActionSheet`, and updated list tests)

https://claude.ai/code/session_016LJdgYQnQa6YjpkRAWbnss

---
_Generated by [Claude Code](https://claude.ai/code/session_016LJdgYQnQa6YjpkRAWbnss)_