### PR TITLE
Fix brokerage close button, merge icon, and action sheet colors

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9078,6 +9078,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -758,7 +758,7 @@ export function AccountList({ accounts, institutions, brokerageMarketValues, def
               onCloseClick: handleCloseClick,
               onReopen: handleReopen,
               onDeleteClick: handleDeleteClick,
-            })
+            }, brokerageMarketValues?.get(contextAccount.id))
           : []}
         onClose={() => setContextAccount(null)}
       />

--- a/frontend/src/components/accounts/AccountRow.test.tsx
+++ b/frontend/src/components/accounts/AccountRow.test.tsx
@@ -495,6 +495,38 @@ describe('AccountRow', () => {
       expect(closeButton).not.toBeDisabled();
     });
 
+    it('disables Close button for brokerage accounts with non-zero market value', () => {
+      const props = createDefaultProps({
+        density: 'normal',
+        account: createAccount({
+          isClosed: false,
+          currentBalance: 0,
+          accountSubType: 'INVESTMENT_BROKERAGE',
+        }),
+        brokerageMarketValue: 25000,
+      });
+      renderAccountRow(props);
+
+      const closeButton = screen.getByText('Close');
+      expect(closeButton).toBeDisabled();
+    });
+
+    it('enables Close button for brokerage accounts with zero market value', () => {
+      const props = createDefaultProps({
+        density: 'normal',
+        account: createAccount({
+          isClosed: false,
+          currentBalance: 0,
+          accountSubType: 'INVESTMENT_BROKERAGE',
+        }),
+        brokerageMarketValue: 0,
+      });
+      renderAccountRow(props);
+
+      const closeButton = screen.getByText('Close');
+      expect(closeButton).not.toBeDisabled();
+    });
+
     it('calls onCloseClick when Close button is clicked', () => {
       const onCloseClick = vi.fn();
       const account = createAccount({ isClosed: false, currentBalance: 0 });

--- a/frontend/src/components/accounts/AccountRow.tsx
+++ b/frontend/src/components/accounts/AccountRow.tsx
@@ -40,8 +40,15 @@ export function buildAccountActions(
   isDeletable: boolean,
   labels: AccountActionLabels,
   handlers: AccountActionHandlers,
+  brokerageMarketValue?: number,
 ): RowAction[] {
-  const balanceNonZero = Number(account.currentBalance) !== 0;
+  // Brokerage accounts display their holdings' market value rather than the
+  // cash `currentBalance` (which is usually zero), so a brokerage with
+  // securities must block closure based on that market value instead.
+  const balanceNonZero =
+    account.accountSubType === 'INVESTMENT_BROKERAGE' && brokerageMarketValue !== undefined
+      ? Math.round(brokerageMarketValue * 10000) !== 0
+      : Number(account.currentBalance) !== 0;
   return [
     {
       key: 'view',
@@ -157,7 +164,7 @@ export const AccountRow = memo(function AccountRow({
     onCloseClick,
     onReopen,
     onDeleteClick,
-  });
+  }, brokerageMarketValue);
   return (
     <tr
       className={`group hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer select-none ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'}`}

--- a/frontend/src/components/ui/row-actions/ActionIcon.tsx
+++ b/frontend/src/components/ui/row-actions/ActionIcon.tsx
@@ -13,7 +13,7 @@ const ACTION_ICON_PATHS: Record<ActionIconKey, string> = {
     'M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16',
   duplicate:
     'M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z',
-  merge: 'M7 8l-4 4 4 4m-4-4h11a4 4 0 004-4V6',
+  merge: 'M4 7h4c4 0 4 5 8 5h4M4 17h4c4 0 4-5 8-5M16 8l4 4-4 4',
   reconcile: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z',
   post: 'M5 13l4 4L19 7',
   skip: 'M13 5l7 7-7 7M5 5l7 7-7 7',

--- a/frontend/src/components/ui/row-actions/RowActionSheet.test.tsx
+++ b/frontend/src/components/ui/row-actions/RowActionSheet.test.tsx
@@ -47,4 +47,16 @@ describe('RowActionSheet', () => {
     const deleteBtn = screen.getByText('Delete').closest('button');
     expect(deleteBtn?.className).toContain('text-red-600');
   });
+
+  it('tints non-destructive icons with the action tone color (matching the ACTIONS column)', () => {
+    const actions: RowAction[] = [
+      { key: 'edit', label: 'Edit', icon: 'edit', tone: 'primary', onClick: vi.fn() },
+      { key: 'merge', label: 'Merge', icon: 'merge', tone: 'accent', onClick: vi.fn() },
+    ];
+    render(<RowActionSheet isOpen title="X" actions={actions} onClose={vi.fn()} />);
+    const editIcon = screen.getByText('Edit').closest('button')?.querySelector('svg');
+    const mergeIcon = screen.getByText('Merge').closest('button')?.querySelector('svg');
+    expect(editIcon?.getAttribute('class')).toContain('text-blue-600');
+    expect(mergeIcon?.getAttribute('class')).toContain('text-purple-600');
+  });
 });

--- a/frontend/src/components/ui/row-actions/actionTones.ts
+++ b/frontend/src/components/ui/row-actions/actionTones.ts
@@ -17,15 +17,17 @@ export const TONE_TEXT_CLASS: Record<ActionTone, string> = {
 };
 
 /**
- * Icon tint for an action-sheet (mobile) row. Destructive actions are red; every
- * other verb is neutral gray, matching the original TransactionActionSheet.
+ * Icon tint for an action-sheet (popup modal) row. Mirrors the per-verb colors
+ * of the desktop ACTIONS column (`TONE_TEXT_CLASS`) so the same verb shows the
+ * same color in the table and the popup. Hover variants are omitted because the
+ * sheet's hover state is a row background change, not a text-color change.
  */
 export const TONE_SHEET_ICON_CLASS: Record<ActionTone, string> = {
-  primary: 'text-gray-400',
-  view: 'text-gray-400',
+  primary: 'text-blue-600 dark:text-blue-400',
+  view: 'text-emerald-600 dark:text-emerald-400',
   delete: 'text-red-600 dark:text-red-400',
-  success: 'text-gray-400',
-  warning: 'text-gray-400',
-  accent: 'text-gray-400',
-  neutral: 'text-gray-400',
+  success: 'text-green-600 dark:text-green-400',
+  warning: 'text-orange-600 dark:text-orange-400',
+  accent: 'text-purple-600 dark:text-purple-400',
+  neutral: 'text-gray-500 dark:text-gray-400',
 };


### PR DESCRIPTION
- Disable the Close account button for brokerage accounts whose holdings
  have a non-zero market value (previously only the cash currentBalance,
  usually zero, was checked, so brokerages with securities stayed closable).
- Redesign the merge row-action icon as two arrows converging into one.
- Color action-sheet (popup modal) icons by their verb tone to match the
  desktop ACTIONS column instead of flattening them to gray.