### PR TITLE
fix(deps): bump hono to 4.12.25 to clear high-severity npm audit advisory

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5954,9 +5954,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Why

The CI **NPM Audit** job (`npm audit --audit-level=high`) is failing on `main` and on open PRs. The trigger is a single **high**-severity advisory:

- **`hono <= 4.12.24`** — [GHSA-wwfh-h76j-fc44](https://github.com/advisories/GHSA-wwfh-h76j-fc44), path traversal in `serve-static` on Windows via encoded backslash (plus several related moderate `hono` advisories).

`hono` is a **transitive** dependency of `@modelcontextprotocol/sdk` (the MCP server SDK), pulled in both directly and via `@hono/node-server`.

## The fix

Bump `hono` `4.12.23 → 4.12.25` (the patched release) **via the lockfile only** — `backend/package-lock.json` is the only file changed; no `package.json` edit. Both consumers already accept it (`@modelcontextprotocol/sdk` wants `^4.11.4`, `@hono/node-server` wants `^4`), so this is a safe patch bump with no API surface change.

After this change:
- `cd backend && npm audit --audit-level=high` → **exit 0**
- `cd frontend && npm audit --audit-level=high` → **exit 0**

## Triage of the remaining advisories (intentionally not changed here)

These are all **below** the `--audit-level=high` gate, so they do not fail CI, and remediating them requires breaking major bumps that don't belong in a security-patch PR:

| Advisory | Severity | Where | Why deferred |
|---|---|---|---|
| `js-yaml <= 4.1.1` (GHSA-h67p-54hq-rp68) | moderate | backend, via `@nestjs/swagger` and the `jest`/`ts-jest`/`@istanbuljs` toolchain | npm's only fix is `npm audit fix --force`, which **downgrades `@nestjs/swagger` to 5.2.1** (breaking). Largely dev/build-time (jest) plus dev-time API docs (swagger). |
| `@babel/core <= 7.29.0` (GHSA-4x5r-pxfx-6jf8) | low | frontend (dev/build toolchain) | Below gate; dev-only. Can be swept in a routine dependency bump. |

Suggest handling those in a dedicated dependency-maintenance PR (or via Dependabot) rather than coupling a breaking `@nestjs/swagger` change to this patch.

## Scope

Independent of the `create_transaction` payee work in #702 — branched from `main`, touches only `backend/package-lock.json`.

https://claude.ai/code/session_016TBCpxo69HE49E8oqy9ffE

---
_Generated by [Claude Code](https://claude.ai/code/session_016TBCpxo69HE49E8oqy9ffE)_