### PR TITLE
Report fixes: Security Performance chart + investment transaction improvements

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7538,9 +7538,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
-      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -108,6 +108,7 @@
     "path-to-regexp": "8.4.0",
     "uuid": "^14.0.0",
     "fast-uri": "^3.1.2",
+    "multer": "^2.2.0",
     "typeorm": {
       "glob": "13.0.0"
     },

--- a/backend/src/built-in-reports/monthly-category-breakdown.service.spec.ts
+++ b/backend/src/built-in-reports/monthly-category-breakdown.service.spec.ts
@@ -363,4 +363,108 @@ describe("MonthlyCategoryBreakdownService", () => {
     expect(sql).toContain("asset_category_id");
     expect(sql).toContain("parent_transaction_id IS NULL");
   });
+
+  it("counts brokerage income legs as income, not transfers, in SQL", async () => {
+    await service.getMonthlyCategoryBreakdown(
+      mockUserId,
+      "2025-01-01",
+      "2025-12-31",
+    );
+
+    const incomeSql = transactionsRepository.query.mock.calls[0][0];
+    const transferSql = transactionsRepository.query.mock.calls[1][0];
+
+    // The income query keeps a transaction whose linked investment action is an
+    // income action (interest, dividends, capital gains) even though it is
+    // flagged is_transfer = true.
+    expect(incomeSql).toContain(
+      "it.action IN ('INTEREST', 'DIVIDEND', 'CAPITAL_GAIN')",
+    );
+    expect(incomeSql).toMatch(/t\.is_transfer = false\s*\n\s*OR\s/);
+    expect(incomeSql).toMatch(/t\.is_transfer = false[\s\S]*EXISTS/);
+
+    // The income query collapses those legs into the synthetic
+    // investment-income bucket instead of their (absent) real category.
+    expect(incomeSql).toContain("'investment-income'");
+    expect(incomeSql).toContain(" as category_id");
+
+    // Investment accounts are still excluded except for income legs sitting in
+    // an INVESTMENT_CASH sub-account, where brokerage interest/dividends land.
+    expect(incomeSql).toContain("a.account_sub_type = 'INVESTMENT_CASH'");
+    expect(incomeSql).toMatch(
+      /a\.account_type != 'INVESTMENT'\s*\n\s*OR\s*\(a\.account_sub_type = 'INVESTMENT_CASH'/,
+    );
+
+    // The transfer query drops those same legs so they are not double-reported.
+    expect(transferSql).toContain("t.is_transfer = true");
+    expect(transferSql).toMatch(/NOT\s*\n\s*EXISTS/);
+    expect(transferSql).toContain(
+      "it.action IN ('INTEREST', 'DIVIDEND', 'CAPITAL_GAIN')",
+    );
+  });
+
+  it("surfaces a brokerage income leg under the Investment Income bucket", async () => {
+    // The income query tags these legs with the synthetic investment-income
+    // category id; the row must carry the 'Investment Income' label, classify as
+    // income, and stay out of the transfers section.
+    transactionsRepository.query.mockResolvedValueOnce([
+      {
+        month: "2025-03",
+        category_id: "investment-income",
+        currency_code: "USD",
+        deposits: "42.50",
+        withdrawals: "0.00",
+      },
+    ]);
+    categoriesRepository.find.mockResolvedValue([]);
+
+    const result = await service.getMonthlyCategoryBreakdown(
+      mockUserId,
+      "2025-01-01",
+      "2025-12-31",
+    );
+
+    expect(result.data).toHaveLength(1);
+    const row = result.data[0];
+    expect(row.categoryId).toBe("investment-income");
+    expect(row.categoryName).toBe("Investment Income");
+    expect(row.parentId).toBeNull();
+    expect(row.isIncome).toBe(true);
+    expect(row.valuesByMonth["2025-03"]).toBe(42.5);
+    expect(result.transfers).toEqual([]);
+  });
+
+  it("keeps the investment-income bucket separate from uncategorized rows", async () => {
+    transactionsRepository.query.mockResolvedValueOnce([
+      {
+        month: "2025-03",
+        category_id: "investment-income",
+        currency_code: "USD",
+        deposits: "42.50",
+        withdrawals: "0.00",
+      },
+      {
+        month: "2025-03",
+        category_id: null,
+        currency_code: "USD",
+        deposits: "0.00",
+        withdrawals: "10.00",
+      },
+    ]);
+    categoriesRepository.find.mockResolvedValue([]);
+
+    const result = await service.getMonthlyCategoryBreakdown(
+      mockUserId,
+      "2025-01-01",
+      "2025-12-31",
+    );
+
+    const investment = result.data.find(
+      (r) => r.categoryId === "investment-income",
+    );
+    const uncategorized = result.data.find((r) => r.categoryId === null);
+    expect(investment?.categoryName).toBe("Investment Income");
+    expect(investment?.isIncome).toBe(true);
+    expect(uncategorized?.categoryName).toBe("Uncategorized");
+  });
 });

--- a/backend/src/built-in-reports/monthly-category-breakdown.service.ts
+++ b/backend/src/built-in-reports/monthly-category-breakdown.service.ts
@@ -5,6 +5,7 @@ import { Transaction } from "../transactions/entities/transaction.entity";
 import { Category } from "../categories/entities/category.entity";
 import { ReportCurrencyService } from "./report-currency.service";
 import { roundMoney, toMoneyNumber } from "../common/round.util";
+import { INVESTMENT_INCOME_PSEUDO_CATEGORY } from "../common/query-param-utils";
 import {
   MonthlyCategoryBreakdownResponse,
   MonthlyBreakdownCategoryRow,
@@ -53,6 +54,45 @@ interface CategoryAccumulator {
 
 @Injectable()
 export class MonthlyCategoryBreakdownService {
+  /**
+   * SQL predicate (correlated on the `transactions t` alias) that matches the
+   * cash leg of a brokerage income event -- interest, dividends or capital
+   * gains paid into a linked cash account. The investment importer records both
+   * sides of such an event as `is_transfer = true` (a cash leg plus a synthetic
+   * brokerage-side offset), even though, unlike a buy or sell, this is new money
+   * entering the books rather than a movement between the user's own accounts.
+   * Either leg is recognised here -- the cash leg via its `linked_transaction_id`
+   * pointing at the brokerage leg, the brokerage leg via its own id -- so the
+   * breakdown can surface the cash leg as income and drop both legs from the
+   * transfers section. Buys and sells are genuine cash<->holdings transfers and
+   * are deliberately excluded.
+   */
+  private static readonly INVESTMENT_INCOME_LEG_PREDICATE = `
+    EXISTS (
+      SELECT 1 FROM investment_transactions it
+      WHERE it.action IN ('INTEREST', 'DIVIDEND', 'CAPITAL_GAIN')
+        AND (it.transaction_id = t.id
+             OR it.transaction_id = t.linked_transaction_id)
+    )`;
+
+  /**
+   * Category id expression for the income aggregate: a recognised brokerage
+   * income leg collapses to the synthetic INVESTMENT_INCOME_PSEUDO_CATEGORY
+   * bucket (it carries no real category), otherwise the row keeps its own
+   * category (split category first, then the transaction's). Used identically in
+   * the SELECT list and GROUP BY so the grouping key matches the projection.
+   */
+  private static readonly INVESTMENT_INCOME_CATEGORY_EXPR = `
+    COALESCE(
+      (SELECT '${INVESTMENT_INCOME_PSEUDO_CATEGORY}'
+         FROM investment_transactions it
+        WHERE it.action IN ('INTEREST', 'DIVIDEND', 'CAPITAL_GAIN')
+          AND (it.transaction_id = t.id
+               OR it.transaction_id = t.linked_transaction_id)
+        LIMIT 1),
+      ts.category_id::text, t.category_id::text
+    )`;
+
   constructor(
     @InjectRepository(Transaction)
     private transactionsRepository: Repository<Transaction>,
@@ -77,7 +117,7 @@ export class MonthlyCategoryBreakdownService {
     let query = `
       SELECT
         TO_CHAR(t.transaction_date, 'YYYY-MM') as month,
-        COALESCE(ts.category_id, t.category_id) as category_id,
+        ${MonthlyCategoryBreakdownService.INVESTMENT_INCOME_CATEGORY_EXPR} as category_id,
         t.currency_code,
         SUM(CASE WHEN COALESCE(ts.amount, t.amount) > 0
               THEN COALESCE(ts.amount, t.amount) ELSE 0 END) as deposits,
@@ -88,10 +128,13 @@ export class MonthlyCategoryBreakdownService {
       LEFT JOIN accounts a ON a.id = t.account_id
       WHERE t.user_id = $1
         AND t.transaction_date <= $2
-        AND t.is_transfer = false
+        AND (t.is_transfer = false
+             OR ${MonthlyCategoryBreakdownService.INVESTMENT_INCOME_LEG_PREDICATE})
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
-        AND a.account_type != 'INVESTMENT'
+        AND (a.account_type != 'INVESTMENT'
+             OR (a.account_sub_type = 'INVESTMENT_CASH'
+                 AND ${MonthlyCategoryBreakdownService.INVESTMENT_INCOME_LEG_PREDICATE}))
         AND (ts.transfer_account_id IS NULL OR ts.id IS NULL)
         AND NOT EXISTS (
           SELECT 1 FROM accounts ax
@@ -109,8 +152,7 @@ export class MonthlyCategoryBreakdownService {
     }
 
     query += `
-      GROUP BY TO_CHAR(t.transaction_date, 'YYYY-MM'),
-               COALESCE(ts.category_id, t.category_id), t.currency_code
+      GROUP BY 1, 2, t.currency_code
       ORDER BY month
     `;
 
@@ -142,12 +184,15 @@ export class MonthlyCategoryBreakdownService {
         rateMap,
       );
 
-      // Treat an unknown category_id (e.g. the row references a category that
+      // Keep the synthetic investment-income bucket as its own row; otherwise
+      // treat an unknown category_id (e.g. the row references a category that
       // no longer exists) the same as no category at all.
       const categoryId =
-        row.category_id && categoryMap.has(row.category_id)
-          ? row.category_id
-          : null;
+        row.category_id === INVESTMENT_INCOME_PSEUDO_CATEGORY
+          ? INVESTMENT_INCOME_PSEUDO_CATEGORY
+          : row.category_id && categoryMap.has(row.category_id)
+            ? row.category_id
+            : null;
       const key = categoryId ?? "uncategorized";
 
       let acc = accumulators.get(key);
@@ -222,6 +267,7 @@ export class MonthlyCategoryBreakdownService {
       WHERE t.user_id = $1
         AND t.transaction_date <= $2
         AND t.is_transfer = true
+        AND NOT ${MonthlyCategoryBreakdownService.INVESTMENT_INCOME_LEG_PREDICATE}
         AND (t.status IS NULL OR t.status != 'VOID')
         AND t.parent_transaction_id IS NULL
     `;
@@ -337,16 +383,24 @@ export class MonthlyCategoryBreakdownService {
     acc: CategoryAccumulator,
     categoryMap: Map<string, Category>,
   ): MonthlyBreakdownCategoryRow {
-    const category = acc.categoryId
-      ? (categoryMap.get(acc.categoryId) ?? null)
-      : null;
+    const isInvestmentIncome =
+      acc.categoryId === INVESTMENT_INCOME_PSEUDO_CATEGORY;
+    const category =
+      acc.categoryId && !isInvestmentIncome
+        ? (categoryMap.get(acc.categoryId) ?? null)
+        : null;
     const parent = category?.parentId
       ? (categoryMap.get(category.parentId) ?? null)
       : null;
 
-    const isIncome = category
-      ? category.isIncome
-      : acc.depositTotal > acc.withdrawalTotal;
+    // Brokerage interest, dividends and capital gains are always income; a real
+    // category goes by its own flag, and a bare uncategorized bucket falls back
+    // to whichever side dominates.
+    const isIncome = isInvestmentIncome
+      ? true
+      : category
+        ? category.isIncome
+        : acc.depositTotal > acc.withdrawalTotal;
 
     const valuesByMonth: Record<string, number> = {};
     const allMonths = new Set<string>([
@@ -362,7 +416,9 @@ export class MonthlyCategoryBreakdownService {
 
     return {
       categoryId: acc.categoryId,
-      categoryName: category?.name ?? "Uncategorized",
+      categoryName: isInvestmentIncome
+        ? "Investment Income"
+        : (category?.name ?? "Uncategorized"),
       parentId: parent?.id ?? null,
       parentName: parent?.name ?? null,
       parentIsIncome: parent?.isIncome ?? null,

--- a/backend/src/common/query-param-utils.spec.ts
+++ b/backend/src/common/query-param-utils.spec.ts
@@ -102,6 +102,12 @@ describe("parseCategoryIds()", () => {
     expect(parseCategoryIds("transfer")).toEqual(["transfer"]);
   });
 
+  it("accepts the special 'investment-income' value", () => {
+    expect(parseCategoryIds("investment-income")).toEqual([
+      "investment-income",
+    ]);
+  });
+
   it("accepts a mix of UUIDs and special values", () => {
     expect(parseCategoryIds(`${VALID_UUID},uncategorized`)).toEqual([
       VALID_UUID,

--- a/backend/src/common/query-param-utils.ts
+++ b/backend/src/common/query-param-utils.ts
@@ -6,6 +6,14 @@ export const UUID_REGEX =
 export const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
+ * Synthetic category id for brokerage income (interest, dividends, capital
+ * gains) paid into a linked cash account. These cash legs carry no real
+ * category and are flagged as transfers by the importer, so reports and the
+ * transactions list address them through this pseudo-value instead of a UUID.
+ */
+export const INVESTMENT_INCOME_PSEUDO_CATEGORY = "investment-income";
+
+/**
  * Parse comma-separated UUIDs from query params, with backward compatibility
  * for singular param fallback.
  */
@@ -64,7 +72,11 @@ export function parseUuids(value?: string): string[] | undefined {
  * like 'uncategorized' and 'transfer' in addition to UUIDs.
  */
 export function parseCategoryIds(value?: string): string[] | undefined {
-  const specialCategoryIds = new Set(["uncategorized", "transfer"]);
+  const specialCategoryIds = new Set([
+    "uncategorized",
+    "transfer",
+    INVESTMENT_INCOME_PSEUDO_CATEGORY,
+  ]);
   if (!value) return undefined;
   const ids = value
     .split(",")

--- a/backend/src/transactions/transactions.service.spec.ts
+++ b/backend/src/transactions/transactions.service.spec.ts
@@ -1616,6 +1616,27 @@ describe("TransactionsService", () => {
       );
     });
 
+    it("handles 'investment-income' special category filter", async () => {
+      const mockQb = createMockQueryBuilder();
+      mockQb.getManyAndCount.mockResolvedValue([[], 0]);
+      transactionsRepository.createQueryBuilder.mockReturnValue(mockQb);
+      investmentTxRepository.find.mockResolvedValue([]);
+
+      await service.findAll("user-1", undefined, undefined, undefined, [
+        "investment-income",
+      ]);
+
+      expect(mockQb.andWhere).toHaveBeenCalledWith(expect.any(Brackets));
+      expect(mockQb.where).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "it.action IN ('INTEREST', 'DIVIDEND', 'CAPITAL_GAIN')",
+        ),
+      );
+      expect(mockQb.where).toHaveBeenCalledWith(
+        expect.stringContaining("account.accountType != 'INVESTMENT'"),
+      );
+    });
+
     it("handles combined uncategorized + transfer + regular category filters", async () => {
       const mockQb = createMockQueryBuilder();
       mockQb.getManyAndCount.mockResolvedValue([[], 0]);

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -36,6 +36,7 @@ import { BulkUpdateDto, BulkDeleteDto } from "./dto/bulk-update.dto";
 import { isTransactionInFuture } from "../common/date-utils";
 import { ActionHistoryService } from "../action-history/action-history.service";
 import { getAllCategoryIdsWithChildren } from "../common/category-tree.util";
+import { INVESTMENT_INCOME_PSEUDO_CATEGORY } from "../common/query-param-utils";
 import { formatCurrency } from "../common/format-currency.util";
 import {
   buildPaginationMeta,
@@ -709,13 +710,24 @@ export class TransactionsService {
   ): Promise<void> {
     const hasUncategorized = categoryIds.includes("uncategorized");
     const hasTransfer = categoryIds.includes("transfer");
+    const hasInvestmentIncome = categoryIds.includes(
+      INVESTMENT_INCOME_PSEUDO_CATEGORY,
+    );
     const regularCategoryIds = categoryIds.filter(
-      (id) => id !== "uncategorized" && id !== "transfer",
+      (id) =>
+        id !== "uncategorized" &&
+        id !== "transfer" &&
+        id !== INVESTMENT_INCOME_PSEUDO_CATEGORY,
     );
 
     let hasCondition = false;
 
-    if (hasUncategorized || hasTransfer || regularCategoryIds.length > 0) {
+    if (
+      hasUncategorized ||
+      hasTransfer ||
+      hasInvestmentIncome ||
+      regularCategoryIds.length > 0
+    ) {
       const uniqueCategoryIds =
         regularCategoryIds.length > 0
           ? await getAllCategoryIdsWithChildren(
@@ -738,6 +750,19 @@ export class TransactionsService {
             const method = hasCondition ? "orWhere" : "where";
             hasCondition = true;
             qb[method]("transaction.isTransfer = true");
+          }
+          if (hasInvestmentIncome) {
+            const method = hasCondition ? "orWhere" : "where";
+            hasCondition = true;
+            // The cash leg of a brokerage income event, tied (directly or via its
+            // linked brokerage-side leg) to an income-type investment
+            // transaction. It lands either on a plain cash account or on an
+            // INVESTMENT_CASH sub-account; the account filter keeps both while
+            // dropping the synthetic INVESTMENT_BROKERAGE offset leg, mirroring
+            // what the monthly breakdown counts as income (any is_transfer).
+            qb[method](
+              `(account.accountType != 'INVESTMENT' OR account.accountSubType = 'INVESTMENT_CASH') AND EXISTS (SELECT 1 FROM investment_transactions it WHERE it.action IN ('INTEREST', 'DIVIDEND', 'CAPITAL_GAIN') AND (it.transaction_id = transaction.id OR it.transaction_id = transaction.linkedTransactionId))`,
+            );
           }
           if (uniqueCategoryIds.length > 0) {
             const method = hasCondition ? "orWhere" : "where";

--- a/frontend/src/components/investments/InvestmentTransactionForm.test.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@/test/render';
 import { InvestmentTransactionForm } from './InvestmentTransactionForm';
 import { investmentsApi } from '@/lib/investments';
+import { getLocalDateString } from '@/lib/utils';
 import toast from 'react-hot-toast';
 
 vi.mock('@/hooks/useNumberFormat', () => ({
@@ -471,6 +472,119 @@ describe('InvestmentTransactionForm', () => {
     expect(payload.fundingAccountId).toBe('a2');
   });
 
+  describe('Remembering the last entered date', () => {
+    const INVESTMENT_DATE_KEY = 'monize-last-investment-transaction-date';
+    const REGULAR_DATE_KEY = 'monize-last-transaction-date';
+
+    beforeEach(() => {
+      sessionStorage.clear();
+    });
+
+    async function createBuy() {
+      await waitFor(() => {
+        expect(screen.getByText('Brokerage Account')).toBeInTheDocument();
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('Brokerage Account'), {
+          target: { value: 'a1' },
+        });
+      });
+      await waitFor(() => {
+        expect(screen.getByLabelText('Security')).toBeInTheDocument();
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('Security'), {
+          target: { value: 'sec-1' },
+        });
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText('Create Transaction'));
+      });
+      await waitFor(() => {
+        expect(investmentsApi.createTransaction).toHaveBeenCalled();
+      });
+    }
+
+    it('pre-fills the date from a recently saved value', async () => {
+      sessionStorage.setItem(
+        INVESTMENT_DATE_KEY,
+        JSON.stringify({ date: '2026-02-20', savedAt: Date.now() - 10 * 60 * 1000 }),
+      );
+      render(<InvestmentTransactionForm accounts={accounts} />);
+      await waitFor(() => {
+        expect(screen.getByLabelText('Date')).toHaveValue('2026-02-20');
+      });
+    });
+
+    it('ignores and clears a saved date older than one hour', async () => {
+      sessionStorage.setItem(
+        INVESTMENT_DATE_KEY,
+        JSON.stringify({ date: '2026-02-20', savedAt: Date.now() - 61 * 60 * 1000 }),
+      );
+      render(<InvestmentTransactionForm accounts={accounts} />);
+      await waitFor(() => {
+        expect(screen.getByLabelText('Date')).toHaveValue(getLocalDateString());
+      });
+      expect(sessionStorage.getItem(INVESTMENT_DATE_KEY)).toBeNull();
+    });
+
+    it('saves the entered date after creating a transaction', async () => {
+      render(<InvestmentTransactionForm accounts={accounts} />);
+      await waitFor(() => {
+        expect(screen.getByText('Brokerage Account')).toBeInTheDocument();
+      });
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('Date'), {
+          target: { value: '2026-09-09' },
+        });
+      });
+      await createBuy();
+
+      const payload = vi.mocked(investmentsApi.createTransaction).mock
+        .calls[0][0] as any;
+      expect(payload.transactionDate).toBe('2026-09-09');
+      const stored = JSON.parse(
+        sessionStorage.getItem(INVESTMENT_DATE_KEY) as string,
+      );
+      expect(stored.date).toBe('2026-09-09');
+    });
+
+    it('does not write to the regular-transaction date key', async () => {
+      render(<InvestmentTransactionForm accounts={accounts} />);
+      await createBuy();
+      expect(sessionStorage.getItem(REGULAR_DATE_KEY)).toBeNull();
+      expect(sessionStorage.getItem(INVESTMENT_DATE_KEY)).not.toBeNull();
+    });
+
+    it('does not remember the date when editing an existing transaction', async () => {
+      const transaction = {
+        id: 't1',
+        accountId: 'a1',
+        action: 'BUY' as const,
+        transactionDate: '2024-01-01',
+        securityId: 'sec-1',
+        quantity: 10,
+        price: 50,
+        commission: 5,
+        totalAmount: 505,
+        description: '',
+      } as any;
+      render(
+        <InvestmentTransactionForm accounts={accounts} transaction={transaction} />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Update Transaction')).toBeInTheDocument();
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText('Update Transaction'));
+      });
+      await waitFor(() => {
+        expect(investmentsApi.updateTransaction).toHaveBeenCalled();
+      });
+      expect(sessionStorage.getItem(INVESTMENT_DATE_KEY)).toBeNull();
+    });
+  });
+
   describe('Transfer between accounts', () => {
     const brokerageB = {
       id: 'b1',
@@ -796,6 +910,49 @@ describe('InvestmentTransactionForm', () => {
       );
       await waitFor(() => {
         expect(investmentsApi.getTransaction).toHaveBeenCalledWith('leg-in');
+      });
+      await waitFor(() => {
+        expect(screen.getByLabelText('From Account')).toHaveValue('a1');
+        expect(screen.getByLabelText('To Account')).toHaveValue('b1');
+      });
+    });
+
+    it('shows the destination account when the opened leg is the TRANSFER_IN side', async () => {
+      // Opening the IN leg (dest b1) must still resolve and display the source
+      // (a1) and destination (b1). The destination option only enters the list
+      // once the source is resolved, so an uncontrolled select would leave
+      // "To Account" blank -- the bug this guards against.
+      const transferInLeg = {
+        id: 'leg-in',
+        accountId: 'b1',
+        action: 'TRANSFER_IN' as const,
+        transactionDate: '2026-02-01',
+        securityId: 'sec-1',
+        quantity: 100,
+        price: 1.67,
+        commission: 0,
+        totalAmount: 0,
+        description: '',
+        linkedTransactionId: 'leg-out',
+      } as any;
+      vi.mocked(investmentsApi.getTransaction).mockResolvedValue({
+        id: 'leg-out',
+        accountId: 'a1',
+        action: 'TRANSFER_OUT',
+        securityId: 'sec-1',
+        quantity: 100,
+        price: 1.67,
+        linkedTransactionId: 'leg-in',
+      } as any);
+
+      render(
+        <InvestmentTransactionForm
+          accounts={editAccounts}
+          transaction={transferInLeg}
+        />,
+      );
+      await waitFor(() => {
+        expect(investmentsApi.getTransaction).toHaveBeenCalledWith('leg-out');
       });
       await waitFor(() => {
         expect(screen.getByLabelText('From Account')).toHaveValue('a1');

--- a/frontend/src/components/investments/InvestmentTransactionForm.tsx
+++ b/frontend/src/components/investments/InvestmentTransactionForm.tsx
@@ -15,7 +15,11 @@ import { Select } from '@/components/ui/Select';
 import { Modal } from '@/components/ui/Modal';
 import { SecurityForm } from '@/components/securities/SecurityForm';
 import { investmentsApi } from '@/lib/investments';
-import { getLocalDateString } from '@/lib/utils';
+import {
+  LAST_INVESTMENT_TRANSACTION_DATE_KEY,
+  getRememberedTransactionDate,
+  rememberTransactionDate,
+} from '@/lib/lastTransactionDate';
 import { Account } from '@/types/account';
 import {
   InvestmentAction,
@@ -226,6 +230,10 @@ export function InvestmentTransactionForm({
           transactionDate: transaction.transactionDate,
           securityId: transaction.securityId || transaction.security?.id || '',
           fundingAccountId: transaction.fundingAccountId || '',
+          // The destination account for a transfer leg is resolved from the
+          // paired (linked) leg once it loads; start empty so the field is
+          // known to react-hook-form from the first render.
+          destinationAccountId: '',
           quantity: transaction.quantity ?? 0,
           // For amount-only actions, use totalAmount as the price field value
           price: amountOnlyActions.includes(transaction.action)
@@ -253,7 +261,9 @@ export function InvestmentTransactionForm({
       : {
           accountId: defaultAccountId || '',
           action: 'BUY',
-          transactionDate: getLocalDateString(),
+          transactionDate: getRememberedTransactionDate(
+            LAST_INVESTMENT_TRANSACTION_DATE_KEY,
+          ),
           fundingAccountId: '',
           destinationAccountId: '',
           quantity: undefined,
@@ -673,6 +683,10 @@ export function InvestmentTransactionForm({
           description: data.description,
         });
         toast.success(t('transactionForm.toastTransferred'));
+        rememberTransactionDate(
+          LAST_INVESTMENT_TRANSACTION_DATE_KEY,
+          data.transactionDate,
+        );
         onSuccess?.();
         return;
       }
@@ -808,6 +822,10 @@ export function InvestmentTransactionForm({
       } else {
         await investmentsApi.createTransaction(payload);
         toast.success(t('transactionForm.toastCreated'));
+        rememberTransactionDate(
+          LAST_INVESTMENT_TRANSACTION_DATE_KEY,
+          data.transactionDate,
+        );
       }
       onSuccess?.();
     } catch (error) {
@@ -937,11 +955,23 @@ export function InvestmentTransactionForm({
         />
       )}
 
-      {/* Destination account - for a transfer between accounts */}
+      {/* Destination account - for a transfer between accounts.
+          Controlled (rather than registered) so it reflects the value set
+          asynchronously when editing a transfer leg: the destination option
+          only enters the list once the source account is resolved, and an
+          uncontrolled select would silently drop a value not yet in its
+          options (the cause of the blank "To Account" on TRANSFER_IN). */}
       {transferMode && (
         <Select
           label={t('transactionForm.toAccount')}
           error={errors.destinationAccountId?.message}
+          value={watchedDestinationAccountId || ''}
+          onChange={(e) =>
+            setValue('destinationAccountId', e.target.value, {
+              shouldDirty: true,
+              shouldValidate: true,
+            })
+          }
           options={[
             { value: '', label: t('transactionForm.selectAccount') },
             ...destinationAccounts.map((a) => ({
@@ -949,7 +979,6 @@ export function InvestmentTransactionForm({
               label: `${a.name} (${a.currencyCode})`,
             })),
           ]}
-          {...register('destinationAccountId')}
         />
       )}
 

--- a/frontend/src/components/investments/portfolio-chart-utils.tsx
+++ b/frontend/src/components/investments/portfolio-chart-utils.tsx
@@ -177,6 +177,18 @@ export interface FlagDotOptions {
   onDismiss?: () => void;
   /** Localized title/aria label for the dismiss control. */
   dismissLabel?: string;
+  /**
+   * When false, omit the pin dot, dashed connector, and arrow -- rendering just
+   * the labelled box. Useful for anchoring the box to a reference line rather
+   * than a single datapoint. Default true.
+   */
+  showDot?: boolean;
+  /**
+   * Vertical placement of the box for the horizontal sides ('left' / 'right'):
+   * 'middle' centers it on cy (default); 'top' puts the box's top edge at cy so
+   * it hangs below the anchor (e.g. flush under a reference line).
+   */
+  boxVerticalAlign?: 'middle' | 'top';
 }
 
 export function renderChartFlagDot({
@@ -189,13 +201,16 @@ export function renderChartFlagDot({
   gap = 24,
   onDismiss,
   dismissLabel,
+  showDot = true,
+  boxVerticalAlign = 'middle',
 }: FlagDotOptions): ReactElement {
   // Reserve room on the right of the bubble for the dismiss "x" when present.
   const hasClose = typeof onDismiss === 'function';
   const closeZone = hasClose ? 16 : 0;
   const labelWidth = label.length * 7 + 14 + closeZone;
   const labelHeight = 22;
-  const arrowSize = 5;
+  // No arrow when the pin dot is suppressed -- the box anchors directly.
+  const arrowSize = showDot ? 5 : 0;
 
   // Bubble centroid + arrow tip geometry. Vertical sides ('above'/'below')
   // anchor the arrow on the top/bottom edge of the bubble; horizontal sides
@@ -226,7 +241,7 @@ export function renderChartFlagDot({
     arrowPoints = `${cx - arrowSize},${arrowTipY + arrowSize} ${cx + arrowSize},${arrowTipY + arrowSize} ${cx},${arrowTipY}`;
   } else if (side === 'right') {
     bubbleX = cx + gap + arrowSize;
-    bubbleY = cy - labelHeight / 2;
+    bubbleY = boxVerticalAlign === 'top' ? cy : cy - labelHeight / 2;
     arrowTipX = cx + gap;
     arrowTipY = cy;
     connectorX1 = cx + 5;
@@ -235,7 +250,7 @@ export function renderChartFlagDot({
   } else {
     // 'left'
     bubbleX = cx - gap - arrowSize - labelWidth;
-    bubbleY = cy - labelHeight / 2;
+    bubbleY = boxVerticalAlign === 'top' ? cy : cy - labelHeight / 2;
     arrowTipX = cx - gap;
     arrowTipY = cy;
     connectorX1 = cx - 5;
@@ -254,26 +269,30 @@ export function renderChartFlagDot({
       strokeOpacity={1}
       opacity={1}
     >
-      <circle
-        cx={cx}
-        cy={cy}
-        r={5}
-        fill={color}
-        fillOpacity={1}
-        stroke="#fff"
-        strokeWidth={2}
-        strokeOpacity={1}
-      />
-      <line
-        x1={connectorX1}
-        y1={connectorY1}
-        x2={arrowTipX}
-        y2={arrowTipY}
-        stroke={color}
-        strokeWidth={1.5}
-        strokeDasharray="3 2"
-        strokeOpacity={1}
-      />
+      {showDot && (
+        <>
+          <circle
+            cx={cx}
+            cy={cy}
+            r={5}
+            fill={color}
+            fillOpacity={1}
+            stroke="#fff"
+            strokeWidth={2}
+            strokeOpacity={1}
+          />
+          <line
+            x1={connectorX1}
+            y1={connectorY1}
+            x2={arrowTipX}
+            y2={arrowTipY}
+            stroke={color}
+            strokeWidth={1.5}
+            strokeDasharray="3 2"
+            strokeOpacity={1}
+          />
+        </>
+      )}
       <rect
         x={bubbleX}
         y={bubbleY}
@@ -284,7 +303,7 @@ export function renderChartFlagDot({
         fillOpacity={1}
         filter="url(#chartFlagShadow)"
       />
-      <polygon points={arrowPoints} fill={color} fillOpacity={1} />
+      {showDot && <polygon points={arrowPoints} fill={color} fillOpacity={1} />}
       <text
         x={bubbleX + (labelWidth - closeZone) / 2}
         y={bubbleY + labelHeight / 2}

--- a/frontend/src/components/reports/MonthlyCategoryBreakdownReport.test.tsx
+++ b/frontend/src/components/reports/MonthlyCategoryBreakdownReport.test.tsx
@@ -261,6 +261,43 @@ describe('MonthlyCategoryBreakdownReport', () => {
     expect(url).toContain('categoryIds=uncategorized');
   });
 
+  it('renders the synthetic investment-income bucket and drills into it', async () => {
+    mockGetMonthlyCategoryBreakdown.mockResolvedValue({
+      currency: 'USD',
+      months: ['2025-01', '2025-02', '2025-03'],
+      data: [
+        {
+          categoryId: 'investment-income',
+          // Backend ships an English fallback; the component localizes it.
+          categoryName: 'Investment Income',
+          parentId: null,
+          parentName: null,
+          parentIsIncome: null,
+          isIncome: true,
+          valuesByMonth: { '2025-01': 42.5, '2025-02': 0, '2025-03': 10 },
+          depositTotal: 52.5,
+          withdrawalTotal: 0,
+        },
+      ],
+      transfers: [],
+    });
+    render(<MonthlyCategoryBreakdownReport />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Investment Income')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Investment Income'));
+    });
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const url = mockPush.mock.calls[0][0] as string;
+    expect(url).toContain('/transactions?');
+    // Drills through the dedicated pseudo-filter, not a UUID.
+    expect(url).toContain('categoryIds=investment-income');
+  });
+
   it('drills down into every child category when a section header is clicked', async () => {
     mockGetMonthlyCategoryBreakdown.mockResolvedValue(sampleResponse);
     render(<MonthlyCategoryBreakdownReport />);
@@ -372,6 +409,65 @@ describe('MonthlyCategoryBreakdownReport', () => {
     const redCells = container.querySelectorAll('[class*="bg-red-"]');
     expect(greenCells.length).toBeGreaterThan(0);
     expect(redCells.length).toBeGreaterThan(0);
+  });
+
+  it('hides deviation highlighting when the toggle is switched off', async () => {
+    mockGetMonthlyCategoryBreakdown.mockResolvedValue(sampleResponse);
+    const { container } = render(<MonthlyCategoryBreakdownReport />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Groceries')).toBeInTheDocument();
+    });
+
+    // Level-3 deviation cells (bg-{red,green}-200) are unique to the highlight
+    // logic -- group headers use the -100 ramp, palettes the -50 ramp -- so they
+    // isolate the deviation styling from the rest of the table.
+    expect(
+      container.querySelectorAll('[class*="bg-green-200"]').length,
+    ).toBeGreaterThan(0);
+    expect(
+      container.querySelectorAll('[class*="bg-red-200"]').length,
+    ).toBeGreaterThan(0);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Highlight deviations'));
+    });
+
+    await waitFor(() => {
+      expect(
+        container.querySelectorAll('[class*="bg-green-200"]').length,
+      ).toBe(0);
+    });
+    expect(container.querySelectorAll('[class*="bg-red-200"]').length).toBe(0);
+  });
+
+  it('persists the deviation toggle to localStorage and restores it', async () => {
+    mockGetMonthlyCategoryBreakdown.mockResolvedValue(sampleResponse);
+    const first = render(<MonthlyCategoryBreakdownReport />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Groceries')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Highlight deviations'));
+    });
+    await waitFor(() => {
+      expect(
+        first.container.querySelectorAll('[class*="bg-red-200"]').length,
+      ).toBe(0);
+    });
+
+    // Re-mounting reads the persisted toggle and stays muted without any
+    // further interaction.
+    first.unmount();
+    const second = render(<MonthlyCategoryBreakdownReport />);
+    await waitFor(() => {
+      expect(screen.getByText('Groceries')).toBeInTheDocument();
+    });
+    expect(
+      second.container.querySelectorAll('[class*="bg-red-200"]').length,
+    ).toBe(0);
   });
 
   // Two expense subcategories under one parent: a normal spend and a

--- a/frontend/src/components/reports/MonthlyCategoryBreakdownReport.tsx
+++ b/frontend/src/components/reports/MonthlyCategoryBreakdownReport.tsx
@@ -23,6 +23,8 @@ import { exportToCsv } from '@/lib/csv-export';
 const RANGE_STORAGE_KEY = 'monize-reports-monthly-category-breakdown-range';
 const PERCENTAGES_STORAGE_KEY =
   'monize-reports-monthly-category-breakdown-percentages';
+const DEVIATIONS_STORAGE_KEY =
+  'monize-reports-monthly-category-breakdown-deviations';
 const SORT_COLUMN_STORAGE_KEY =
   'monize-reports-monthly-category-breakdown-sort-column';
 const SORT_DIR_STORAGE_KEY =
@@ -69,6 +71,12 @@ const TRANSFER_GROUP_CLASS =
 
 const OTHER_INCOME_KEY = '__other_income__';
 const OTHER_EXPENSE_KEY = '__other_expense__';
+
+// Synthetic category id the backend assigns to brokerage income (interest,
+// dividends, capital gains) cash legs; kept in sync with the backend's
+// INVESTMENT_INCOME_PSEUDO_CATEGORY. The label is localized here rather than
+// server-side, mirroring how the report translates its other synthetic buckets.
+const INVESTMENT_INCOME_CATEGORY_ID = 'investment-income';
 const isOtherKey = (key: string): boolean =>
   key === OTHER_INCOME_KEY || key === OTHER_EXPENSE_KEY;
 
@@ -308,9 +316,16 @@ export function MonthlyCategoryBreakdownReport() {
   const { formatMonth } = useDateFormat();
   const otherExpensesLabel = t('monthlyCategoryBreakdown.otherExpenses');
   const otherIncomeLabel = t('monthlyCategoryBreakdown.otherIncome');
+  const investmentIncomeLabel = t('monthlyCategoryBreakdown.investmentIncome');
   const [showPercentages, setShowPercentages] = useLocalStorage<boolean>(
     PERCENTAGES_STORAGE_KEY,
     false,
+  );
+  // Deviation highlighting (coloured cells flagging above/below-average months)
+  // is on by default; the toggle lets users mute it for a plain table.
+  const [showDeviations, setShowDeviations] = useLocalStorage<boolean>(
+    DEVIATIONS_STORAGE_KEY,
+    true,
   );
   const [sortColumn, setSortColumn] = useLocalStorage<string>(
     SORT_COLUMN_STORAGE_KEY,
@@ -374,7 +389,13 @@ export function MonthlyCategoryBreakdownReport() {
       ? data.months
       : data.months.filter((m) => m !== currentMonth);
     const monthCount = months.length || 1;
-    const rows = data.data;
+    // Localize the synthetic investment-income bucket's label; the backend ships
+    // a stable English fallback that we replace with the translated string.
+    const rows = data.data.map((row) =>
+      row.categoryId === INVESTMENT_INCOME_CATEGORY_ID
+        ? { ...row, categoryName: investmentIncomeLabel }
+        : row,
+    );
 
     // Group categories by parent. A category with a parent forms (or joins) a
     // section keyed by that parent; parentless categories collect into the
@@ -546,6 +567,7 @@ export function MonthlyCategoryBreakdownReport() {
     data,
     otherExpensesLabel,
     otherIncomeLabel,
+    investmentIncomeLabel,
     sortColumn,
     sortDir,
     includeCurrentMonth,
@@ -790,7 +812,9 @@ export function MonthlyCategoryBreakdownReport() {
             </td>
             {months.map((m) => {
               const value = row.values[m] || 0;
-              const cls = deviationClass(value, row.nonZeroAvg, row.nonZeroCount, row.isIncome);
+              const cls = showDeviations
+                ? deviationClass(value, row.nonZeroAvg, row.nonZeroCount, row.isIncome)
+                : '';
               return (
                 <td key={m} className={`px-2 py-1 text-right ${cls}`}>
                   {value !== 0 ? (
@@ -1115,6 +1139,15 @@ export function MonthlyCategoryBreakdownReport() {
                 size="sm"
               />
               <span>{t('monthlyCategoryBreakdown.showPercentages')}</span>
+            </div>
+            <div className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+              <ToggleSwitch
+                checked={showDeviations}
+                onChange={setShowDeviations}
+                label={t('monthlyCategoryBreakdown.showDeviations')}
+                size="sm"
+              />
+              <span>{t('monthlyCategoryBreakdown.showDeviations')}</span>
             </div>
             <button
               type="button"

--- a/frontend/src/components/reports/SecurityPerformanceReport.test.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.test.tsx
@@ -58,7 +58,10 @@ vi.mock('recharts', () => ({
     }
     return null;
   },
-  ReferenceLine: () => null,
+  ReferenceLine: ({ label }: any) =>
+    typeof label === 'function'
+      ? label({ viewBox: { x: 0, y: 50, width: 600 } })
+      : null,
 }));
 
 const mockGetSecurities = vi.fn();

--- a/frontend/src/components/reports/SecurityPerformanceReport.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.tsx
@@ -16,7 +16,7 @@ import {
   ResponsiveContainer,
   ReferenceLine,
 } from 'recharts';
-import { format, differenceInDays } from 'date-fns';
+import { format, differenceInDays, startOfYear, startOfMonth, addMonths } from 'date-fns';
 import { chartColors } from '@/lib/chart-colors';
 import { investmentsApi } from '@/lib/investments';
 import { Security, SecurityPrice, InvestmentTransaction, HoldingWithMarketValue } from '@/types/investment';
@@ -29,14 +29,47 @@ import { RefreshPricesButton } from '@/components/reports/RefreshPricesButton';
 import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { aggregateHoldingsBySecurity } from '@/lib/aggregate-holdings';
+import { renderChartFlagDot, ChartFlagShadowFilter } from '@/components/investments/portfolio-chart-utils';
 
 const MAX_PAGES = 50;
+
+// Candidate spacings (in months) for the price chart's time axis, smallest first.
+const TICK_STEP_MONTHS = [1, 2, 3, 6, 12, 24, 60, 120];
+
+// Build evenly-spaced, calendar-aligned tick timestamps for the time axis.
+// Picks the smallest step that keeps the tick count at or below `target`, then
+// anchors ticks to year/month boundaries. This keeps spacing uniform across the
+// whole timeline regardless of how densely the underlying prices are sampled
+// (e.g. sparse early history vs. daily recent prices), so old and new periods
+// get the same horizontal scale.
+function buildTimeAxisTicks(
+  minTs: number,
+  maxTs: number,
+  target = 10,
+): { ticks: number[]; stepMonths: number } {
+  if (!(maxTs > minTs)) return { ticks: [minTs], stepMonths: 1 };
+  const minDate = new Date(minTs);
+  const maxDate = new Date(maxTs);
+  const spanMonths =
+    (maxDate.getFullYear() - minDate.getFullYear()) * 12 +
+    (maxDate.getMonth() - minDate.getMonth());
+  const stepMonths =
+    TICK_STEP_MONTHS.find((s) => spanMonths / s <= target) ??
+    TICK_STEP_MONTHS[TICK_STEP_MONTHS.length - 1];
+  const anchor = stepMonths >= 12 ? startOfYear(minDate) : startOfMonth(minDate);
+  const ticks: number[] = [];
+  for (let cur = anchor; cur.getTime() <= maxTs; cur = addMonths(cur, stepMonths)) {
+    if (cur.getTime() >= minTs) ticks.push(cur.getTime());
+  }
+  return { ticks: ticks.length > 0 ? ticks : [minTs, maxTs], stepMonths };
+}
 
 type TradeSortField = 'date' | 'account' | 'action' | 'shares' | 'price' | 'total';
 type DividendSortField = 'date' | 'account' | 'type' | 'amount';
 
 interface PriceChartPoint {
   date: string;
+  ts: number;
   label: string;
   close: number;
   buyMarker?: number;
@@ -45,11 +78,16 @@ interface PriceChartPoint {
 
 export function SecurityPerformanceReport() {
   const t = useTranslations('reports');
+  const tc = useTranslations('common');
   const { formatCurrency: formatCurrencyFull, formatCurrencyAxis, formatSignedPercent } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
   const chartRef = useRef<HTMLDivElement>(null);
   const [selectedSecurityId, setSelectedSecurityId] = useState<string>('');
   const [viewType, setViewType] = useState<'chart' | 'transactions' | 'dividends'>('chart');
+  // Avg-cost bubble the user has temporarily dismissed, keyed by value (mirrors
+  // the high/low flag bubbles) so it re-shows when a different security's avg
+  // cost differs.
+  const [dismissedAvgCost, setDismissedAvgCost] = useState<number | null>(null);
   const tradeSort = useSortableTable<TradeSortField>(
     'reports.security-performance.trades.sort',
     { field: 'date', direction: 'desc' },
@@ -203,15 +241,39 @@ export function SecurityPerformanceReport() {
       .sort((a, b) => a.priceDate.localeCompare(b.priceDate))
       .map((p) => {
         const txInfo = txByDate.get(p.priceDate);
+        const parsed = parseLocalDate(p.priceDate);
         return {
           date: p.priceDate,
-          label: format(parseLocalDate(p.priceDate), 'MMM d, yyyy'),
+          ts: parsed.getTime(),
+          label: format(parsed, 'MMM d, yyyy'),
           close: Number(p.closePrice),
           buyMarker: txInfo?.buys ? Number(p.closePrice) : undefined,
           sellMarker: txInfo?.sells ? Number(p.closePrice) : undefined,
         };
       });
   }, [prices, transactions]);
+
+  // Time-axis ticks: evenly spaced in real time (not by data index), so the
+  // horizontal scale is consistent across the whole timeline. Without this the
+  // categorical axis gives every price point equal width, stretching out
+  // densely-sampled recent dates relative to sparse early history.
+  const xAxis = useMemo(() => {
+    if (chartData.length === 0) {
+      return {
+        ticks: [] as number[],
+        domain: ['dataMin', 'dataMax'] as [string, string],
+        tickFormat: 'MMM yyyy',
+      };
+    }
+    const minTs = chartData[0].ts;
+    const maxTs = chartData[chartData.length - 1].ts;
+    const { ticks, stepMonths } = buildTimeAxisTicks(minTs, maxTs);
+    return {
+      ticks,
+      domain: [minTs, maxTs] as [number, number],
+      tickFormat: stepMonths >= 12 ? 'yyyy' : 'MMM yyyy',
+    };
+  }, [chartData]);
 
   // Dividend history
   const dividendTx = useMemo(() => {
@@ -527,12 +589,16 @@ export function SecurityPerformanceReport() {
                           <stop offset="95%" stopColor={chartColors.primary} stopOpacity={0} />
                         </linearGradient>
                       </defs>
+                      <ChartFlagShadowFilter />
                       <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                       <XAxis
-                        dataKey="label"
+                        dataKey="ts"
+                        type="number"
+                        scale="time"
+                        domain={xAxis.domain}
+                        ticks={xAxis.ticks}
+                        tickFormatter={(ts: number) => format(ts, xAxis.tickFormat)}
                         tick={{ fontSize: 11 }}
-                        interval="preserveStartEnd"
-                        tickCount={8}
                       />
                       <YAxis
                         tickFormatter={(v: number) => formatCurrencyAxis(v, displayCurrency)}
@@ -586,7 +652,41 @@ export function SecurityPerformanceReport() {
                           y={stats.averageCost}
                           stroke={chartColors.warning}
                           strokeDasharray="4 4"
-                          label={{ value: t('securityPerformance.avgCostRefLine'), position: 'right', fill: chartColors.warning, fontSize: 11 }}
+                          // extendDomain widens the y-axis so the avg-cost line is
+                          // always visible, even when the cost basis sits outside the
+                          // displayed price range. zIndex 700 lifts the line and its
+                          // flag label above the buy/sell marker dots (zIndex 600).
+                          ifOverflow="extendDomain"
+                          zIndex={700}
+                          {...(stats.averageCost === dismissedAvgCost
+                            ? {}
+                            : {
+                                // The flag box hangs flush under the line (its top
+                                // edge at the line). Positioned from the label's
+                                // viewBox, which Recharts derives from the real axis
+                                // scale -- so it stays attached to the line exactly.
+                                label: (labelProps: {
+                                  viewBox?: { x?: number; y?: number; width?: number };
+                                }) => {
+                                  const vb = labelProps.viewBox ?? {};
+                                  const x = vb.x ?? 0;
+                                  const y = vb.y ?? 0;
+                                  const width = vb.width ?? 0;
+                                  return renderChartFlagDot({
+                                    cx: x + width,
+                                    cy: y,
+                                    index: 0,
+                                    color: chartColors.warning,
+                                    label: `${t('securityPerformance.avgCostRefLine')}: ${formatCurrencyFull(stats.averageCost, displayCurrency)}`,
+                                    side: 'left',
+                                    gap: 6,
+                                    showDot: false,
+                                    boxVerticalAlign: 'top',
+                                    onDismiss: () => setDismissedAvgCost(stats.averageCost),
+                                    dismissLabel: tc('chartFlag.dismiss'),
+                                  });
+                                },
+                              })}
                         />
                       )}
                     </AreaChart>

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -17,6 +17,11 @@ import { Modal } from '@/components/ui/Modal';
 import { TagForm } from '@/components/tags/TagForm';
 import { transactionsApi } from '@/lib/transactions';
 import { getLocalDateString, resolveTimezone, isoToDatetimeLocal, datetimeLocalToIso, formatDatetimeLocal, parseDatetimeFromFormat } from '@/lib/utils';
+import {
+  LAST_TRANSACTION_DATE_KEY,
+  getRememberedTransactionDate,
+  rememberTransactionDate,
+} from '@/lib/lastTransactionDate';
 import { payeesApi } from '@/lib/payees';
 import { categoriesApi } from '@/lib/categories';
 import { accountsApi } from '@/lib/accounts';
@@ -200,21 +205,7 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
       : {
           accountId: defaultAccountId || '',
           categoryId: defaultCategoryId || '',
-          transactionDate: (() => {
-            const stored = sessionStorage.getItem('monize-last-transaction-date');
-            if (stored) {
-              try {
-                const { date, savedAt } = JSON.parse(stored);
-                if (Date.now() - savedAt < 60 * 60 * 1000) {
-                  return date;
-                }
-              } catch {
-                // Legacy non-JSON value, ignore
-              }
-              sessionStorage.removeItem('monize-last-transaction-date');
-            }
-            return getLocalDateString();
-          })(),
+          transactionDate: getRememberedTransactionDate(LAST_TRANSACTION_DATE_KEY),
           currencyCode: defaultCurrency,
           status: TransactionStatus.UNRECONCILED,
         },
@@ -784,7 +775,7 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
         } else {
           await transactionsApi.createTransfer(transferData);
           toast.success(t('form.toasts.transferCreated'));
-          sessionStorage.setItem('monize-last-transaction-date', JSON.stringify({ date: data.transactionDate, savedAt: Date.now() }));
+          rememberTransactionDate(LAST_TRANSACTION_DATE_KEY, data.transactionDate);
         }
         onSuccess?.();
         return;
@@ -846,7 +837,7 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
       } else {
         await transactionsApi.create(payload);
         toast.success(t('form.toasts.transactionCreated'));
-        sessionStorage.setItem('monize-last-transaction-date', JSON.stringify({ date: data.transactionDate, savedAt: Date.now() }));
+        rememberTransactionDate(LAST_TRANSACTION_DATE_KEY, data.transactionDate);
       }
       onSuccess?.();
     } catch (error) {

--- a/frontend/src/i18n/messages/de/reports.json
+++ b/frontend/src/i18n/messages/de/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "Prozente anzeigen",
+    "showDeviations": "Abweichungen hervorheben",
+    "investmentIncome": "Kapitalerträge",
     "noData": "Keine Daten für diesen Zeitraum.",
     "category": "Kategorie",
     "total": "Gesamt",

--- a/frontend/src/i18n/messages/en/reports.json
+++ b/frontend/src/i18n/messages/en/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "Show percentages",
+    "showDeviations": "Highlight deviations",
+    "investmentIncome": "Investment Income",
     "noData": "No data for this period.",
     "category": "Category",
     "total": "Total",

--- a/frontend/src/i18n/messages/es/reports.json
+++ b/frontend/src/i18n/messages/es/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "Mostrar porcentajes",
+    "showDeviations": "Resaltar desviaciones",
+    "investmentIncome": "Ingresos por inversiones",
     "noData": "No hay datos para este período.",
     "category": "Categoría",
     "total": "Total",

--- a/frontend/src/i18n/messages/fr/reports.json
+++ b/frontend/src/i18n/messages/fr/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "Afficher les pourcentages",
+    "showDeviations": "Surligner les écarts",
+    "investmentIncome": "Revenus de placements",
     "noData": "Aucune donnée pour cette période.",
     "category": "Catégorie",
     "total": "Total",

--- a/frontend/src/i18n/messages/hi/reports.json
+++ b/frontend/src/i18n/messages/hi/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "प्रतिशत दिखाएँ",
+    "showDeviations": "विचलन हाइलाइट करें",
+    "investmentIncome": "निवेश आय",
     "noData": "इस अवधि के लिए कोई डेटा नहीं।",
     "category": "श्रेणी",
     "total": "कुल",

--- a/frontend/src/i18n/messages/id/reports.json
+++ b/frontend/src/i18n/messages/id/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "Tampilkan persentase",
+    "showDeviations": "Sorot deviasi",
+    "investmentIncome": "Pendapatan Investasi",
     "noData": "Tidak ada data untuk periode ini.",
     "category": "Kategori",
     "total": "Total",

--- a/frontend/src/i18n/messages/it/reports.json
+++ b/frontend/src/i18n/messages/it/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "Mostra percentuali",
+    "showDeviations": "Evidenzia scostamenti",
+    "investmentIncome": "Redditi da investimenti",
     "noData": "Nessun dato per questo periodo.",
     "category": "Categoria",
     "total": "Totale",

--- a/frontend/src/i18n/messages/ja/reports.json
+++ b/frontend/src/i18n/messages/ja/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "パーセンテージを表示",
+    "showDeviations": "偏差を強調表示",
+    "investmentIncome": "投資収益",
     "noData": "この期間のデータがありません。",
     "category": "カテゴリ",
     "total": "合計",

--- a/frontend/src/i18n/messages/ko/reports.json
+++ b/frontend/src/i18n/messages/ko/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "백분율 표시",
+    "showDeviations": "편차 강조 표시",
+    "investmentIncome": "투자 수익",
     "noData": "이 기간에 데이터가 없습니다.",
     "category": "카테고리",
     "total": "합계",

--- a/frontend/src/i18n/messages/nl/reports.json
+++ b/frontend/src/i18n/messages/nl/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "Percentages tonen",
+    "showDeviations": "Afwijkingen markeren",
+    "investmentIncome": "Beleggingsinkomsten",
     "noData": "Geen gegevens voor deze periode.",
     "category": "Categorie",
     "total": "Totaal",

--- a/frontend/src/i18n/messages/pl/reports.json
+++ b/frontend/src/i18n/messages/pl/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "Pokaż procenty",
+    "showDeviations": "Wyróżnij odchylenia",
+    "investmentIncome": "Dochody z inwestycji",
     "noData": "Brak danych dla tego okresu.",
     "category": "Kategoria",
     "total": "Suma",

--- a/frontend/src/i18n/messages/pt-BR/reports.json
+++ b/frontend/src/i18n/messages/pt-BR/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "Mostrar porcentagens",
+    "showDeviations": "Destacar desvios",
+    "investmentIncome": "Rendimentos de investimentos",
     "noData": "Sem dados para este período.",
     "category": "Categoria",
     "total": "Total",

--- a/frontend/src/i18n/messages/pt/reports.json
+++ b/frontend/src/i18n/messages/pt/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "Mostrar percentagens",
+    "showDeviations": "Realçar desvios",
+    "investmentIncome": "Rendimentos de investimentos",
     "noData": "Sem dados para este período.",
     "category": "Categoria",
     "total": "Total",

--- a/frontend/src/i18n/messages/ru/reports.json
+++ b/frontend/src/i18n/messages/ru/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "Показать проценты",
+    "showDeviations": "Выделять отклонения",
+    "investmentIncome": "Инвестиционный доход",
     "noData": "Нет данных за этот период.",
     "category": "Категория",
     "total": "Итого",

--- a/frontend/src/i18n/messages/tr/reports.json
+++ b/frontend/src/i18n/messages/tr/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "Yüzdeleri göster",
+    "showDeviations": "Sapmaları vurgula",
+    "investmentIncome": "Yatırım Geliri",
     "noData": "Bu dönem için veri yok.",
     "category": "Kategori",
     "total": "Toplam",

--- a/frontend/src/i18n/messages/uk/reports.json
+++ b/frontend/src/i18n/messages/uk/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "Показати відсотки",
+    "showDeviations": "Виділяти відхилення",
+    "investmentIncome": "Інвестиційний дохід",
     "noData": "Даних за цей період немає.",
     "category": "Категорія",
     "total": "Разом",

--- a/frontend/src/i18n/messages/vi/reports.json
+++ b/frontend/src/i18n/messages/vi/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "Hiển thị phần trăm",
+    "showDeviations": "Đánh dấu chênh lệch",
+    "investmentIncome": "Thu nhập đầu tư",
     "noData": "Không có dữ liệu trong kỳ này.",
     "category": "Danh mục",
     "total": "Tổng",

--- a/frontend/src/i18n/messages/xx/reports.json
+++ b/frontend/src/i18n/messages/xx/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "[XX-Show percentages-XX]",
+    "showDeviations": "[XX-Highlight deviations-XX]",
+    "investmentIncome": "[XX-Investment Income-XX]",
     "noData": "[XX-No data for this period.-XX]",
     "category": "[XX-Category-XX]",
     "total": "[XX-Total-XX]",

--- a/frontend/src/i18n/messages/zh-CN/reports.json
+++ b/frontend/src/i18n/messages/zh-CN/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "显示百分比",
+    "showDeviations": "突出显示偏差",
+    "investmentIncome": "投资收益",
     "noData": "此期间无数据。",
     "category": "分类",
     "total": "合计",

--- a/frontend/src/i18n/messages/zh-TW/reports.json
+++ b/frontend/src/i18n/messages/zh-TW/reports.json
@@ -996,6 +996,8 @@
   },
   "monthlyCategoryBreakdown": {
     "showPercentages": "顯示百分比",
+    "showDeviations": "醒目顯示偏差",
+    "investmentIncome": "投資收益",
     "noData": "此期間無資料。",
     "category": "類別",
     "total": "總計",

--- a/frontend/src/lib/lastTransactionDate.test.ts
+++ b/frontend/src/lib/lastTransactionDate.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  LAST_TRANSACTION_DATE_KEY,
+  LAST_INVESTMENT_TRANSACTION_DATE_KEY,
+  getRememberedTransactionDate,
+  rememberTransactionDate,
+} from './lastTransactionDate';
+import { getLocalDateString } from './utils';
+
+describe('lastTransactionDate', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    sessionStorage.clear();
+  });
+
+  it('uses separate keys for regular and investment transactions', () => {
+    expect(LAST_TRANSACTION_DATE_KEY).not.toBe(LAST_INVESTMENT_TRANSACTION_DATE_KEY);
+  });
+
+  describe('rememberTransactionDate', () => {
+    it('stores the date with a timestamp under the given key', () => {
+      rememberTransactionDate(LAST_TRANSACTION_DATE_KEY, '2026-03-15');
+      const raw = sessionStorage.getItem(LAST_TRANSACTION_DATE_KEY);
+      expect(raw).not.toBeNull();
+      const { date, savedAt } = JSON.parse(raw as string);
+      expect(date).toBe('2026-03-15');
+      expect(typeof savedAt).toBe('number');
+    });
+
+    it('keeps each key independent', () => {
+      rememberTransactionDate(LAST_TRANSACTION_DATE_KEY, '2026-01-01');
+      rememberTransactionDate(LAST_INVESTMENT_TRANSACTION_DATE_KEY, '2026-12-31');
+      expect(getRememberedTransactionDate(LAST_TRANSACTION_DATE_KEY)).toBe('2026-01-01');
+      expect(getRememberedTransactionDate(LAST_INVESTMENT_TRANSACTION_DATE_KEY)).toBe(
+        '2026-12-31',
+      );
+    });
+  });
+
+  describe('getRememberedTransactionDate', () => {
+    it('returns today when nothing is stored', () => {
+      expect(getRememberedTransactionDate(LAST_TRANSACTION_DATE_KEY)).toBe(
+        getLocalDateString(),
+      );
+    });
+
+    it('returns a stored date saved within the last hour', () => {
+      sessionStorage.setItem(
+        LAST_INVESTMENT_TRANSACTION_DATE_KEY,
+        JSON.stringify({ date: '2026-02-20', savedAt: Date.now() - 30 * 60 * 1000 }),
+      );
+      expect(getRememberedTransactionDate(LAST_INVESTMENT_TRANSACTION_DATE_KEY)).toBe(
+        '2026-02-20',
+      );
+    });
+
+    it('ignores and clears a stored date older than one hour', () => {
+      sessionStorage.setItem(
+        LAST_INVESTMENT_TRANSACTION_DATE_KEY,
+        JSON.stringify({ date: '2026-02-20', savedAt: Date.now() - 61 * 60 * 1000 }),
+      );
+      expect(getRememberedTransactionDate(LAST_INVESTMENT_TRANSACTION_DATE_KEY)).toBe(
+        getLocalDateString(),
+      );
+      expect(sessionStorage.getItem(LAST_INVESTMENT_TRANSACTION_DATE_KEY)).toBeNull();
+    });
+
+    it('falls back to today and clears a legacy non-JSON value', () => {
+      sessionStorage.setItem(LAST_TRANSACTION_DATE_KEY, '2026-02-20');
+      expect(getRememberedTransactionDate(LAST_TRANSACTION_DATE_KEY)).toBe(
+        getLocalDateString(),
+      );
+      expect(sessionStorage.getItem(LAST_TRANSACTION_DATE_KEY)).toBeNull();
+    });
+
+    it('round-trips a remembered date just under the one-hour boundary', () => {
+      rememberTransactionDate(LAST_TRANSACTION_DATE_KEY, '2026-05-05');
+      expect(getRememberedTransactionDate(LAST_TRANSACTION_DATE_KEY)).toBe('2026-05-05');
+    });
+  });
+});

--- a/frontend/src/lib/lastTransactionDate.ts
+++ b/frontend/src/lib/lastTransactionDate.ts
@@ -1,0 +1,49 @@
+import { getLocalDateString } from './utils';
+
+/**
+ * Remembers the date a user last entered when creating a transaction, so the
+ * next new-transaction form pre-fills the same date instead of resetting to
+ * today. Useful when entering a batch of transactions dated in the past or
+ * future. The value is held in sessionStorage and expires after one hour.
+ *
+ * Regular and investment transactions each keep their own remembered date
+ * under a distinct key, so entering one kind doesn't change the default for the
+ * other.
+ */
+export const LAST_TRANSACTION_DATE_KEY = 'monize-last-transaction-date';
+export const LAST_INVESTMENT_TRANSACTION_DATE_KEY =
+  'monize-last-investment-transaction-date';
+
+// How long a remembered date stays valid before falling back to today.
+const REMEMBER_DURATION_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Return the remembered transaction date for the given key if it was saved
+ * within the last hour; otherwise today's local date. Expired or unparseable
+ * entries are cleaned up as a side effect.
+ */
+export function getRememberedTransactionDate(key: string): string {
+  if (typeof window === 'undefined') return getLocalDateString();
+  const stored = sessionStorage.getItem(key);
+  if (stored) {
+    try {
+      const { date, savedAt } = JSON.parse(stored);
+      if (Date.now() - savedAt < REMEMBER_DURATION_MS) {
+        return date;
+      }
+    } catch {
+      // Legacy non-JSON value, ignore
+    }
+    sessionStorage.removeItem(key);
+  }
+  return getLocalDateString();
+}
+
+/**
+ * Remember `date` under `key` so the next new-transaction form pre-fills it.
+ * Call this only after successfully creating a transaction (not when editing).
+ */
+export function rememberTransactionDate(key: string, date: string): void {
+  if (typeof window === 'undefined') return;
+  sessionStorage.setItem(key, JSON.stringify({ date, savedAt: Date.now() }));
+}


### PR DESCRIPTION
## Summary

Bundles two sets of changes on this branch.

### Security Performance report chart (`199df3d8`)
- **Consistent x-axis spacing**: switched the price chart from a categorical axis (which stretched densely-sampled recent dates) to a true time scale with evenly-spaced, calendar-aligned tick marks, so spacing is uniform across the whole holding period.
- **Average-cost label**: rendered as an opaque flag bubble with a dismiss control (matching the high/low price bubbles) instead of plain text. It hangs flush under the line and renders **above** the buy/sell marker dots via the `ReferenceLine` `zIndex`.
- **Always visible**: `ifOverflow="extendDomain"` keeps the avg-cost line on-chart even when the cost basis sits outside the displayed price range.
- Added backward-compatible `showDot` / `boxVerticalAlign` options to the shared `renderChartFlagDot` helper.

### Investment & report improvements (`55243956`, pre-existing on this branch)
- Remember the last entered date in the investment transaction form.
- Fix the Transfer In account handling in `InvestmentTransactionForm`.
- Monthly Category Breakdown report changes + supporting `query-param-utils` / transactions service updates and `lastTransactionDate` helper.
- i18n: `reports.json` updated across all locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)