### PR TITLE
Enable write confirmations in web chat via relay pending actions

### DIFF
--- a/backend/src/ai/actions/ai-action-builder.module.ts
+++ b/backend/src/ai/actions/ai-action-builder.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { AiActionSigningService } from "./ai-action-signing.service";
+import { AiActionBuilderService } from "./ai-action-builder.service";
+
+/**
+ * Minimal shared module for proposing human-in-the-loop write actions. It holds
+ * only the dependency-light pieces (HMAC signing + the action builder) so both
+ * the AI Assistant (`AiModule`) and the MCP server (`McpModule`) can mint the
+ * same signed `PendingAiAction` without `McpModule` having to import the whole
+ * `AiModule`.
+ */
+@Module({
+  imports: [ConfigModule],
+  providers: [AiActionSigningService, AiActionBuilderService],
+  exports: [AiActionSigningService, AiActionBuilderService],
+})
+export class AiActionBuilderModule {}

--- a/backend/src/ai/actions/ai-action-builder.service.spec.ts
+++ b/backend/src/ai/actions/ai-action-builder.service.spec.ts
@@ -1,0 +1,149 @@
+import { AiActionBuilderService } from "./ai-action-builder.service";
+import { AiActionSigningService } from "./ai-action-signing.service";
+import {
+  CategorizeTransactionPreview,
+  CreateTransactionPreview,
+} from "../../transactions/transactions.service";
+import { CreatePayeePreview } from "../../payees/payees.service";
+import { CreateInvestmentTransactionPreview } from "../../securities/investment-transactions.service";
+import { InvestmentAction } from "../../securities/entities/investment-transaction.entity";
+
+describe("AiActionBuilderService", () => {
+  let builder: AiActionBuilderService;
+  let signing: { sign: jest.Mock };
+
+  beforeEach(() => {
+    signing = { sign: jest.fn().mockReturnValue("sig-123") };
+    builder = new AiActionBuilderService(
+      signing as unknown as AiActionSigningService,
+    );
+  });
+
+  it("builds a signed create_transaction action from a preview", () => {
+    const preview: CreateTransactionPreview = {
+      accountId: "a1",
+      accountName: "Checking",
+      amount: -50,
+      transactionDate: "2025-01-15",
+      payeeId: "p1",
+      payeeName: "Store",
+      payeeMatched: true,
+      payeeWillBeCreated: false,
+      categoryId: "c1",
+      categoryName: "Groceries",
+      description: "weekly shop",
+      currencyCode: "USD",
+    };
+
+    const action = builder.buildCreateTransaction("u1", preview);
+
+    expect(action.type).toBe("create_transaction");
+    expect(action.signature).toBe("sig-123");
+    expect(action.expiresAt).toBeGreaterThan(Date.now());
+    expect(action.descriptor).toMatchObject({
+      type: "create_transaction",
+      userId: "u1",
+      accountId: "a1",
+      amount: -50,
+      payeeId: "p1",
+      createPayee: false,
+      categoryId: "c1",
+      currencyCode: "USD",
+    });
+    // The descriptor (not the preview) is what gets signed.
+    expect(signing.sign).toHaveBeenCalledWith(action.descriptor);
+    expect(action.preview).toMatchObject({
+      accountName: "Checking",
+      amount: -50,
+      categoryName: "Groceries",
+    });
+  });
+
+  it("builds a categorize_transaction action and omits a null account name", () => {
+    const preview: CategorizeTransactionPreview = {
+      transactionId: "t1",
+      payeeName: null,
+      amount: 12,
+      transactionDate: "2025-02-01",
+      accountName: null,
+      currentCategoryName: null,
+      categoryId: "c2",
+      newCategoryName: "Dining",
+    };
+
+    const action = builder.buildCategorizeTransaction("u1", preview);
+
+    expect(action.type).toBe("categorize_transaction");
+    expect(action.descriptor).toMatchObject({
+      type: "categorize_transaction",
+      userId: "u1",
+      transactionId: "t1",
+      categoryId: "c2",
+    });
+    expect(action.preview.accountName).toBeUndefined();
+    expect(action.preview.newCategoryName).toBe("Dining");
+  });
+
+  it("builds a create_payee action", () => {
+    const preview: CreatePayeePreview = {
+      name: "Hydro",
+      defaultCategoryId: "c3",
+      defaultCategoryName: "Utilities",
+    };
+
+    const action = builder.buildCreatePayee("u1", preview);
+
+    expect(action.type).toBe("create_payee");
+    expect(action.descriptor).toMatchObject({
+      type: "create_payee",
+      userId: "u1",
+      name: "Hydro",
+      defaultCategoryId: "c3",
+    });
+    expect(action.preview).toMatchObject({
+      name: "Hydro",
+      categoryName: "Utilities",
+    });
+  });
+
+  it("builds a create_investment_transaction action", () => {
+    const preview: CreateInvestmentTransactionPreview = {
+      accountId: "acc1",
+      accountName: "Brokerage",
+      accountCurrency: "USD",
+      action: InvestmentAction.BUY,
+      transactionDate: "2025-03-03",
+      securityId: "s1",
+      symbol: "VTI",
+      securityName: "Vanguard Total",
+      securityCurrency: "USD",
+      fundingAccountId: null,
+      quantity: 10,
+      price: 200,
+      commission: 1,
+      exchangeRate: 1,
+      totalAmount: 2001,
+      cashAccountName: "Brokerage Cash",
+      cashCurrency: "USD",
+      cashAmount: -2001,
+      description: null,
+    };
+
+    const action = builder.buildCreateInvestmentTransaction("u1", preview);
+
+    expect(action.type).toBe("create_investment_transaction");
+    expect(action.descriptor).toMatchObject({
+      type: "create_investment_transaction",
+      userId: "u1",
+      accountId: "acc1",
+      action: InvestmentAction.BUY,
+      securityId: "s1",
+      exchangeRate: 1,
+    });
+    expect(action.preview).toMatchObject({
+      symbol: "VTI",
+      investmentAction: InvestmentAction.BUY,
+      totalAmount: 2001,
+    });
+  });
+});

--- a/backend/src/ai/actions/ai-action-builder.service.ts
+++ b/backend/src/ai/actions/ai-action-builder.service.ts
@@ -1,0 +1,185 @@
+import { Injectable } from "@nestjs/common";
+import { randomUUID } from "crypto";
+import {
+  AiActionSigningService,
+  AI_ACTION_TTL_MS,
+} from "./ai-action-signing.service";
+import {
+  CategorizeTransactionDescriptor,
+  CreateInvestmentTransactionDescriptor,
+  CreatePayeeDescriptor,
+  CreateTransactionDescriptor,
+  PendingAiAction,
+} from "./ai-action.types";
+import {
+  CategorizeTransactionPreview,
+  CreateTransactionPreview,
+} from "../../transactions/transactions.service";
+import { CreatePayeePreview } from "../../payees/payees.service";
+import { CreateInvestmentTransactionPreview } from "../../securities/investment-transactions.service";
+
+/**
+ * Builds the signed `PendingAiAction` envelopes for human-in-the-loop write
+ * actions from an already-resolved preview.
+ *
+ * Both surfaces that propose writes share this single source of truth: the AI
+ * Assistant tool executor (`ToolExecutorService`) and the MCP write tools
+ * (which, when serving a relayed browser prompt, emit the same card to the web
+ * chat). Keeping the descriptor/signature/preview construction here guarantees
+ * the two surfaces produce byte-identical actions that the confirm endpoint
+ * (`/ai/actions/confirm`) can verify and commit the same way.
+ */
+@Injectable()
+export class AiActionBuilderService {
+  constructor(private readonly signingService: AiActionSigningService) {}
+
+  private newEnvelope(): { actionId: string; expiresAt: number } {
+    return {
+      actionId: randomUUID(),
+      expiresAt: Date.now() + AI_ACTION_TTL_MS,
+    };
+  }
+
+  buildCreateTransaction(
+    userId: string,
+    preview: CreateTransactionPreview,
+  ): PendingAiAction {
+    const { actionId, expiresAt } = this.newEnvelope();
+    const descriptor: CreateTransactionDescriptor = {
+      type: "create_transaction",
+      userId,
+      actionId,
+      expiresAt,
+      accountId: preview.accountId,
+      amount: preview.amount,
+      transactionDate: preview.transactionDate,
+      payeeId: preview.payeeId,
+      payeeName: preview.payeeName,
+      createPayee: preview.payeeWillBeCreated,
+      categoryId: preview.categoryId,
+      description: preview.description,
+      currencyCode: preview.currencyCode,
+    };
+    return {
+      actionId,
+      type: "create_transaction",
+      expiresAt,
+      descriptor,
+      signature: this.signingService.sign(descriptor),
+      preview: {
+        accountName: preview.accountName,
+        amount: preview.amount,
+        currencyCode: preview.currencyCode,
+        transactionDate: preview.transactionDate,
+        payeeName: preview.payeeName,
+        payeeWillBeCreated: preview.payeeWillBeCreated,
+        categoryName: preview.categoryName,
+        description: preview.description,
+      },
+    };
+  }
+
+  buildCategorizeTransaction(
+    userId: string,
+    preview: CategorizeTransactionPreview,
+  ): PendingAiAction {
+    const { actionId, expiresAt } = this.newEnvelope();
+    const descriptor: CategorizeTransactionDescriptor = {
+      type: "categorize_transaction",
+      userId,
+      actionId,
+      expiresAt,
+      transactionId: preview.transactionId,
+      categoryId: preview.categoryId,
+    };
+    return {
+      actionId,
+      type: "categorize_transaction",
+      expiresAt,
+      descriptor,
+      signature: this.signingService.sign(descriptor),
+      preview: {
+        payeeName: preview.payeeName,
+        amount: preview.amount,
+        transactionDate: preview.transactionDate,
+        // AiActionPreview.accountName is non-nullable display text; a
+        // transaction without a resolvable account name omits it.
+        accountName: preview.accountName ?? undefined,
+        currentCategoryName: preview.currentCategoryName,
+        newCategoryName: preview.newCategoryName,
+      },
+    };
+  }
+
+  buildCreatePayee(
+    userId: string,
+    preview: CreatePayeePreview,
+  ): PendingAiAction {
+    const { actionId, expiresAt } = this.newEnvelope();
+    const descriptor: CreatePayeeDescriptor = {
+      type: "create_payee",
+      userId,
+      actionId,
+      expiresAt,
+      name: preview.name,
+      defaultCategoryId: preview.defaultCategoryId,
+    };
+    return {
+      actionId,
+      type: "create_payee",
+      expiresAt,
+      descriptor,
+      signature: this.signingService.sign(descriptor),
+      preview: {
+        name: preview.name,
+        categoryName: preview.defaultCategoryName,
+      },
+    };
+  }
+
+  buildCreateInvestmentTransaction(
+    userId: string,
+    preview: CreateInvestmentTransactionPreview,
+  ): PendingAiAction {
+    const { actionId, expiresAt } = this.newEnvelope();
+    const descriptor: CreateInvestmentTransactionDescriptor = {
+      type: "create_investment_transaction",
+      userId,
+      actionId,
+      expiresAt,
+      accountId: preview.accountId,
+      action: preview.action,
+      transactionDate: preview.transactionDate,
+      securityId: preview.securityId,
+      fundingAccountId: preview.fundingAccountId,
+      quantity: preview.quantity,
+      price: preview.price,
+      commission: preview.commission,
+      exchangeRate: preview.exchangeRate,
+      description: preview.description,
+    };
+    return {
+      actionId,
+      type: "create_investment_transaction",
+      expiresAt,
+      descriptor,
+      signature: this.signingService.sign(descriptor),
+      preview: {
+        accountName: preview.accountName,
+        transactionDate: preview.transactionDate,
+        investmentAction: preview.action,
+        symbol: preview.symbol,
+        securityName: preview.securityName,
+        securityCurrency: preview.securityCurrency,
+        quantity: preview.quantity,
+        price: preview.price,
+        commission: preview.commission,
+        totalAmount: preview.totalAmount,
+        cashAccountName: preview.cashAccountName,
+        cashCurrency: preview.cashCurrency,
+        cashAmount: preview.cashAmount,
+        description: preview.description,
+      },
+    };
+  }
+}

--- a/backend/src/ai/ai.module.ts
+++ b/backend/src/ai/ai.module.ts
@@ -26,7 +26,7 @@ import { AiForecastController } from "./forecast/ai-forecast.controller";
 import { ForecastAggregatorService } from "./forecast/forecast-aggregator.service";
 import { AiActionsController } from "./actions/ai-actions.controller";
 import { AiActionsService } from "./actions/ai-actions.service";
-import { AiActionSigningService } from "./actions/ai-action-signing.service";
+import { AiActionBuilderModule } from "./actions/ai-action-builder.module";
 import { AiWriteLimiter } from "./actions/ai-write-limiter";
 import { AccountsModule } from "../accounts/accounts.module";
 import { CategoriesModule } from "../categories/categories.module";
@@ -57,6 +57,7 @@ import { ScheduledTransactionsModule } from "../scheduled-transactions/scheduled
     forwardRef(() => BudgetsModule),
     SecuritiesModule,
     forwardRef(() => ScheduledTransactionsModule),
+    AiActionBuilderModule,
   ],
   providers: [
     AiService,
@@ -72,7 +73,6 @@ import { ScheduledTransactionsModule } from "../scheduled-transactions/scheduled
     AiForecastService,
     ForecastAggregatorService,
     AiActionsService,
-    AiActionSigningService,
     AiWriteLimiter,
   ],
   controllers: [

--- a/backend/src/ai/query/tool-executor.service.spec.ts
+++ b/backend/src/ai/query/tool-executor.service.spec.ts
@@ -12,6 +12,7 @@ import { ScheduledTransactionsService } from "../../scheduled-transactions/sched
 import { TransactionsService } from "../../transactions/transactions.service";
 import { PayeesService } from "../../payees/payees.service";
 import { AiActionSigningService } from "../actions/ai-action-signing.service";
+import { AiActionBuilderService } from "../actions/ai-action-builder.service";
 
 describe("ToolExecutorService", () => {
   let service: ToolExecutorService;
@@ -306,6 +307,9 @@ describe("ToolExecutorService", () => {
         { provide: TransactionsService, useValue: transactions },
         { provide: PayeesService, useValue: payees },
         { provide: AiActionSigningService, useValue: signing },
+        // Real builder wrapping the mocked signing service, so the executor's
+        // pending-action construction (and signing.sign assertions) still run.
+        AiActionBuilderService,
       ],
     }).compile();
 

--- a/backend/src/ai/query/tool-executor.service.ts
+++ b/backend/src/ai/query/tool-executor.service.ts
@@ -5,19 +5,11 @@ import {
   Logger,
   HttpException,
 } from "@nestjs/common";
-import { randomUUID } from "crypto";
 import { AccountsService } from "../../accounts/accounts.service";
 import { TransactionsService } from "../../transactions/transactions.service";
 import { PayeesService } from "../../payees/payees.service";
-import { AiActionSigningService } from "../actions/ai-action-signing.service";
-import { AI_ACTION_TTL_MS } from "../actions/ai-action-signing.service";
-import {
-  CategorizeTransactionDescriptor,
-  CreatePayeeDescriptor,
-  CreateTransactionDescriptor,
-  CreateInvestmentTransactionDescriptor,
-  PendingAiAction,
-} from "../actions/ai-action.types";
+import { AiActionBuilderService } from "../actions/ai-action-builder.service";
+import { PendingAiAction } from "../actions/ai-action.types";
 import { AccountType } from "../../accounts/entities/account.entity";
 import { CategoriesService } from "../../categories/categories.service";
 import { TransactionAnalyticsService } from "../../transactions/transaction-analytics.service";
@@ -88,7 +80,7 @@ export class ToolExecutorService {
     private readonly transactionsService: TransactionsService,
     @Inject(forwardRef(() => PayeesService))
     private readonly payeesService: PayeesService,
-    private readonly signingService: AiActionSigningService,
+    private readonly actionBuilder: AiActionBuilderService,
   ) {}
 
   async execute(
@@ -402,39 +394,10 @@ export class ToolExecutorService {
       );
     }
 
-    const { actionId, expiresAt } = this.newActionEnvelope();
-    const descriptor: CreateTransactionDescriptor = {
-      type: "create_transaction",
+    const pendingAction = this.actionBuilder.buildCreateTransaction(
       userId,
-      actionId,
-      expiresAt,
-      accountId: preview.accountId,
-      amount: preview.amount,
-      transactionDate: preview.transactionDate,
-      payeeId: preview.payeeId,
-      payeeName: preview.payeeName,
-      createPayee: preview.payeeWillBeCreated,
-      categoryId: preview.categoryId,
-      description: preview.description,
-      currencyCode: preview.currencyCode,
-    };
-    const pendingAction: PendingAiAction = {
-      actionId,
-      type: "create_transaction",
-      expiresAt,
-      descriptor,
-      signature: this.signingService.sign(descriptor),
-      preview: {
-        accountName: preview.accountName,
-        amount: preview.amount,
-        currencyCode: preview.currencyCode,
-        transactionDate: preview.transactionDate,
-        payeeName: preview.payeeName,
-        payeeWillBeCreated: preview.payeeWillBeCreated,
-        categoryName: preview.categoryName,
-        description: preview.description,
-      },
-    };
+      preview,
+    );
 
     // When the name does not match an existing payee, tell the model whether a
     // new payee will be created (default) or it will be stored as free text so
@@ -485,30 +448,10 @@ export class ToolExecutorService {
       );
     }
 
-    const { actionId, expiresAt } = this.newActionEnvelope();
-    const descriptor: CategorizeTransactionDescriptor = {
-      type: "categorize_transaction",
+    const pendingAction = this.actionBuilder.buildCategorizeTransaction(
       userId,
-      actionId,
-      expiresAt,
-      transactionId: preview.transactionId,
-      categoryId: preview.categoryId,
-    };
-    const pendingAction: PendingAiAction = {
-      actionId,
-      type: "categorize_transaction",
-      expiresAt,
-      descriptor,
-      signature: this.signingService.sign(descriptor),
-      preview: {
-        payeeName: preview.payeeName,
-        amount: preview.amount,
-        transactionDate: preview.transactionDate,
-        accountName: preview.accountName,
-        currentCategoryName: preview.currentCategoryName,
-        newCategoryName: preview.newCategoryName,
-      },
-    };
+      preview,
+    );
 
     return {
       data: PENDING_ACTION_TOOL_RESULT,
@@ -549,26 +492,7 @@ export class ToolExecutorService {
       return this.toolErrorFromException(err, "Could not prepare the payee.");
     }
 
-    const { actionId, expiresAt } = this.newActionEnvelope();
-    const descriptor: CreatePayeeDescriptor = {
-      type: "create_payee",
-      userId,
-      actionId,
-      expiresAt,
-      name: preview.name,
-      defaultCategoryId: preview.defaultCategoryId,
-    };
-    const pendingAction: PendingAiAction = {
-      actionId,
-      type: "create_payee",
-      expiresAt,
-      descriptor,
-      signature: this.signingService.sign(descriptor),
-      preview: {
-        name: preview.name,
-        categoryName: preview.defaultCategoryName,
-      },
-    };
+    const pendingAction = this.actionBuilder.buildCreatePayee(userId, preview);
 
     return {
       data: PENDING_ACTION_TOOL_RESULT,
@@ -637,46 +561,10 @@ export class ToolExecutorService {
       );
     }
 
-    const { actionId, expiresAt } = this.newActionEnvelope();
-    const descriptor: CreateInvestmentTransactionDescriptor = {
-      type: "create_investment_transaction",
+    const pendingAction = this.actionBuilder.buildCreateInvestmentTransaction(
       userId,
-      actionId,
-      expiresAt,
-      accountId: preview.accountId,
-      action: preview.action,
-      transactionDate: preview.transactionDate,
-      securityId: preview.securityId,
-      fundingAccountId: preview.fundingAccountId,
-      quantity: preview.quantity,
-      price: preview.price,
-      commission: preview.commission,
-      exchangeRate: preview.exchangeRate,
-      description: preview.description,
-    };
-    const pendingAction: PendingAiAction = {
-      actionId,
-      type: "create_investment_transaction",
-      expiresAt,
-      descriptor,
-      signature: this.signingService.sign(descriptor),
-      preview: {
-        accountName: preview.accountName,
-        transactionDate: preview.transactionDate,
-        investmentAction: preview.action,
-        symbol: preview.symbol,
-        securityName: preview.securityName,
-        securityCurrency: preview.securityCurrency,
-        quantity: preview.quantity,
-        price: preview.price,
-        commission: preview.commission,
-        totalAmount: preview.totalAmount,
-        cashAccountName: preview.cashAccountName,
-        cashCurrency: preview.cashCurrency,
-        cashAmount: preview.cashAmount,
-        description: preview.description,
-      },
-    };
+      preview,
+    );
 
     const securityLabel = preview.symbol
       ? ` of ${preview.symbol}`
@@ -688,13 +576,6 @@ export class ToolExecutorService {
       summary: `Prepared a ${preview.action} investment transaction${securityLabel} in ${preview.accountName} dated ${preview.transactionDate}. Awaiting user confirmation.`,
       sources: [],
       pendingAction,
-    };
-  }
-
-  private newActionEnvelope(): { actionId: string; expiresAt: number } {
-    return {
-      actionId: randomUUID(),
-      expiresAt: Date.now() + AI_ACTION_TTL_MS,
     };
   }
 

--- a/backend/src/ai/relay/ai-relay.controller.ts
+++ b/backend/src/ai/relay/ai-relay.controller.ts
@@ -87,6 +87,9 @@ export class AiRelayController {
         userId,
         dto.query,
         history,
+        // Lets a write tool render its confirmation card in this browser stream
+        // while the agent is still working on the prompt.
+        write,
       );
       // Emit `content` (not `assistant_text`): the chat store treats
       // assistant_text as ephemeral "thinking" text and only `content` creates

--- a/backend/src/ai/relay/ai-relay.service.spec.ts
+++ b/backend/src/ai/relay/ai-relay.service.spec.ts
@@ -125,6 +125,46 @@ describe("AiRelayService", () => {
     });
   });
 
+  describe("reportProgress", () => {
+    it("returns false when the user has no in-flight prompt", () => {
+      expect(service.reportProgress(USER, "missing", "working...")).toBe(false);
+    });
+
+    it("streams an assistant_text event on the in-flight prompt", async () => {
+      const emit = jest.fn();
+      service.enqueuePrompt(USER, "buy XBAL", [], emit);
+      const claimed = await service.waitForPrompt(USER);
+
+      expect(
+        service.reportProgress(USER, claimed!.promptId, "looking up category"),
+      ).toBe(true);
+      expect(emit).toHaveBeenCalledWith({
+        type: "assistant_text",
+        text: "looking up category\n",
+      });
+    });
+
+    it("does not target another user's prompt", async () => {
+      const emit = jest.fn();
+      service.enqueuePrompt(USER, "q", [], emit);
+      const claimed = await service.waitForPrompt(USER);
+
+      expect(service.reportProgress(OTHER, claimed!.promptId, "x")).toBe(false);
+      expect(emit).not.toHaveBeenCalled();
+    });
+
+    it("returns false once the prompt has been answered", async () => {
+      const emit = jest.fn();
+      service.enqueuePrompt(USER, "q", [], emit);
+      const claimed = await service.waitForPrompt(USER);
+      service.postResponse(USER, claimed!.promptId, "done");
+
+      expect(service.reportProgress(USER, claimed!.promptId, "late")).toBe(
+        false,
+      );
+    });
+  });
+
   describe("status", () => {
     it("is offline before any agent polls", () => {
       expect(service.getStatus(USER)).toEqual({ state: "offline", queued: 0 });

--- a/backend/src/ai/relay/ai-relay.service.spec.ts
+++ b/backend/src/ai/relay/ai-relay.service.spec.ts
@@ -86,6 +86,45 @@ describe("AiRelayService", () => {
     await expect(pending).resolves.toEqual({ text: "a" });
   });
 
+  describe("emitPendingAction", () => {
+    const action = {
+      actionId: "act-1",
+      type: "create_transaction",
+      expiresAt: Date.now() + 1000,
+      descriptor: { type: "create_transaction" },
+      signature: "sig",
+      preview: {},
+    } as any;
+
+    it("returns false when the user has no in-flight prompt", () => {
+      expect(service.emitPendingAction(USER, action)).toBe(false);
+    });
+
+    it("emits a pending_action event on the in-flight prompt's stream", async () => {
+      const emit = jest.fn();
+      service.enqueuePrompt(USER, "add a transaction", [], emit);
+      await service.waitForPrompt(USER);
+
+      expect(service.emitPendingAction(USER, action)).toBe(true);
+      expect(emit).toHaveBeenCalledWith({ type: "pending_action", action });
+    });
+
+    it("does not target another user's in-flight prompt", async () => {
+      const emit = jest.fn();
+      service.enqueuePrompt(USER, "q", [], emit);
+      await service.waitForPrompt(USER);
+
+      expect(service.emitPendingAction(OTHER, action)).toBe(false);
+      expect(emit).not.toHaveBeenCalled();
+    });
+
+    it("returns false when the in-flight prompt has no emit channel", async () => {
+      service.enqueuePrompt(USER, "q", []);
+      await service.waitForPrompt(USER);
+      expect(service.emitPendingAction(USER, action)).toBe(false);
+    });
+  });
+
   describe("status", () => {
     it("is offline before any agent polls", () => {
       expect(service.getStatus(USER)).toEqual({ state: "offline", queued: 0 });

--- a/backend/src/ai/relay/ai-relay.service.spec.ts
+++ b/backend/src/ai/relay/ai-relay.service.spec.ts
@@ -165,6 +165,34 @@ describe("AiRelayService", () => {
     });
   });
 
+  describe("reportToolActivity", () => {
+    it("streams tool_start and tool_result on the in-flight prompt", async () => {
+      const emit = jest.fn();
+      service.enqueuePrompt(USER, "q", [], emit);
+      await service.waitForPrompt(USER);
+
+      service.reportToolActivity(USER, "get_categories", "start");
+      service.reportToolActivity(USER, "get_categories", "result", false);
+
+      expect(emit).toHaveBeenNthCalledWith(1, {
+        type: "tool_start",
+        name: "get_categories",
+      });
+      expect(emit).toHaveBeenNthCalledWith(2, {
+        type: "tool_result",
+        name: "get_categories",
+        isError: false,
+      });
+    });
+
+    it("is a no-op when the user has no in-flight prompt", () => {
+      // No throw, nothing emitted (no prompt to target).
+      expect(() =>
+        service.reportToolActivity(USER, "get_categories", "start"),
+      ).not.toThrow();
+    });
+  });
+
   describe("status", () => {
     it("is offline before any agent polls", () => {
       expect(service.getStatus(USER)).toEqual({ state: "offline", queued: 0 });

--- a/backend/src/ai/relay/ai-relay.service.ts
+++ b/backend/src/ai/relay/ai-relay.service.ts
@@ -3,9 +3,11 @@ import { randomUUID } from "crypto";
 import {
   RelayClaimedPrompt,
   RelayResponse,
+  RelayServerEvent,
   RelayTunnelState,
   RelayTunnelStatus,
 } from "./ai-relay.types";
+import { PendingAiAction } from "../actions/ai-action.types";
 
 /**
  * How long the browser waits for the agent to answer before giving up. The
@@ -36,6 +38,13 @@ interface PendingPrompt {
   /** Browser-side timeout handle; cleared once the prompt settles. */
   timer: ReturnType<typeof setTimeout>;
   settled: boolean;
+  /**
+   * Pushes an intermediate SSE event to the browser stream still parked on this
+   * prompt. Used to deliver a write-confirmation card (`pending_action`) while
+   * the agent is working, so the user approves it in the web chat instead of in
+   * their MCP client. Undefined for callers that do not stream (e.g. tests).
+   */
+  emit?: (event: RelayServerEvent) => void;
 }
 
 interface Waiter {
@@ -76,6 +85,7 @@ export class AiRelayService {
     userId: string,
     prompt: string,
     history: Array<{ role: "user" | "assistant"; content: string }>,
+    emit?: (event: RelayServerEvent) => void,
   ): Promise<RelayResponse> {
     return new Promise<RelayResponse>((resolve, reject) => {
       const entry: PendingPrompt = {
@@ -85,6 +95,7 @@ export class AiRelayService {
         resolve,
         reject,
         settled: false,
+        emit,
         timer: setTimeout(() => {
           this.settleTimeout(userId, entry);
         }, BROWSER_WAIT_MS),
@@ -149,6 +160,33 @@ export class AiRelayService {
     clearTimeout(prompt.timer);
     prompt.resolve({ text });
     return true;
+  }
+
+  /**
+   * Push a write-confirmation card to the browser parked on this user's
+   * in-flight relay prompt. Called by the MCP write tools when they detect they
+   * are serving a relayed prompt: instead of an MCP-client elicitation (which
+   * the user would have to accept in their CLI), the approve/reject card is
+   * rendered in the web chat, exactly like the native AI Assistant.
+   *
+   * Returns true when a card was delivered (the caller is in relay context and
+   * must NOT perform the write -- the browser commits it via /ai/actions/confirm
+   * on approval). Returns false when the user has no in-flight relay prompt, so
+   * the caller falls back to its normal (direct MCP-client) confirmation.
+   */
+  emitPendingAction(userId: string, action: PendingAiAction): boolean {
+    for (const record of this.inFlight.values()) {
+      if (record.userId !== userId) {
+        continue;
+      }
+      const { prompt } = record;
+      if (prompt.settled || !prompt.emit) {
+        return false;
+      }
+      prompt.emit({ type: "pending_action", action });
+      return true;
+    }
+    return false;
   }
 
   /** Tunnel status for the chat indicator. */

--- a/backend/src/ai/relay/ai-relay.service.ts
+++ b/backend/src/ai/relay/ai-relay.service.ts
@@ -163,6 +163,31 @@ export class AiRelayService {
   }
 
   /**
+   * Called by the `report_progress` MCP tool. Streams an interim status line
+   * from the agent to the browser parked on this prompt as an `assistant_text`
+   * event -- the same live-narration channel the native AI Assistant uses -- so
+   * the user sees what the agent is doing ("looking up the category...",
+   * "sending the confirmation card...") instead of a static spinner. Returns
+   * false if the prompt is unknown, already settled, or has no stream.
+   */
+  reportProgress(userId: string, promptId: string, text: string): boolean {
+    this.lastPollAt.set(userId, Date.now());
+    const record = this.inFlight.get(promptId);
+    if (!record || record.userId !== userId) {
+      return false;
+    }
+    const { prompt } = record;
+    if (prompt.settled || !prompt.emit) {
+      return false;
+    }
+    // The browser accumulates assistant_text into one live-narration block
+    // (rendered whitespace-pre-wrap), so terminate each discrete update with a
+    // newline to keep sequential progress lines from running together.
+    prompt.emit({ type: "assistant_text", text: `${text}\n` });
+    return true;
+  }
+
+  /**
    * Push a write-confirmation card to the browser parked on this user's
    * in-flight relay prompt. Called by the MCP write tools when they detect they
    * are serving a relayed prompt: instead of an MCP-client elicitation (which

--- a/backend/src/ai/relay/ai-relay.service.ts
+++ b/backend/src/ai/relay/ai-relay.service.ts
@@ -188,6 +188,47 @@ export class AiRelayService {
   }
 
   /**
+   * Emit an interim SSE event to the browser parked on this user's in-flight
+   * relay prompt. Returns true if delivered, false if the user has no active
+   * prompt (or its stream is gone). Shared by the progress, tool-activity, and
+   * pending-action emitters.
+   */
+  private emitToInFlight(userId: string, event: RelayServerEvent): boolean {
+    for (const record of this.inFlight.values()) {
+      if (record.userId !== userId) {
+        continue;
+      }
+      const { prompt } = record;
+      if (prompt.settled || !prompt.emit) {
+        return false;
+      }
+      prompt.emit(event);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Stream the agent's tool activity to the browser as `tool_start` /
+   * `tool_result` events -- the same channel the native AI Assistant uses to
+   * show "Looking up ..." chips. Called by the MCP server's per-call wrapper for
+   * every Monize tool the agent invokes while handling a relayed prompt, so the
+   * user sees real-time progress without the agent having to narrate explicitly.
+   */
+  reportToolActivity(
+    userId: string,
+    toolName: string,
+    phase: "start" | "result",
+    isError = false,
+  ): void {
+    const event: RelayServerEvent =
+      phase === "start"
+        ? { type: "tool_start", name: toolName }
+        : { type: "tool_result", name: toolName, isError };
+    this.emitToInFlight(userId, event);
+  }
+
+  /**
    * Push a write-confirmation card to the browser parked on this user's
    * in-flight relay prompt. Called by the MCP write tools when they detect they
    * are serving a relayed prompt: instead of an MCP-client elicitation (which
@@ -200,18 +241,7 @@ export class AiRelayService {
    * the caller falls back to its normal (direct MCP-client) confirmation.
    */
   emitPendingAction(userId: string, action: PendingAiAction): boolean {
-    for (const record of this.inFlight.values()) {
-      if (record.userId !== userId) {
-        continue;
-      }
-      const { prompt } = record;
-      if (prompt.settled || !prompt.emit) {
-        return false;
-      }
-      prompt.emit({ type: "pending_action", action });
-      return true;
-    }
-    return false;
+    return this.emitToInFlight(userId, { type: "pending_action", action });
   }
 
   /** Tunnel status for the chat indicator. */

--- a/backend/src/ai/relay/ai-relay.types.ts
+++ b/backend/src/ai/relay/ai-relay.types.ts
@@ -22,6 +22,17 @@ export interface RelayResponse {
 }
 
 /**
+ * An intermediate SSE event pushed to the browser while its prompt is still
+ * in-flight (e.g. a `pending_action` write-confirmation card). Mirrors the SSE
+ * event shape the native AI chat stream emits, so the frontend chat store
+ * handles relay and native events identically.
+ */
+export type RelayServerEvent = {
+  type: string;
+  [key: string]: unknown;
+};
+
+/**
  * Tunnel status for the chat indicator.
  * - `offline`: no agent has polled recently.
  * - `listening`: an agent is connected and idle (a poll is parked or was very

--- a/backend/src/mcp/CLAUDE.md
+++ b/backend/src/mcp/CLAUDE.md
@@ -101,6 +101,15 @@ Checklist for a new tool:
    `toolError` without writing. `"unsupported"` means the client can't show a
    dialog -- it still gates every tool call with its own approval prompt, so
    proceeding is not a consent bypass.
+   - **Relay first.** When the call is serving a prompt the user typed in the
+     Monize web chat (reverse relay), confirm there instead of in the agent's
+     MCP client: build the signed `PendingAiAction` with `AiActionBuilderService`
+     (shared with the AI Assistant tool executor) and call
+     `AiRelayService.emitPendingAction(userId, action)`. If it returns `true`,
+     the approve/reject card is shown in the browser and committed via
+     `/ai/actions/confirm` on approval -- return `RELAY_PREVIEW_SHOWN` and do
+     NOT write or `confirmWrite`. If it returns `false` (no in-flight relay
+     prompt), fall through to `confirmWrite` as above.
 6. Update `mcp-server.service.ts` count and `mcp.module.ts` if it's a new
    provider class.
 7. Add/extend tests (below). `mcp-annotations.spec.ts` enforces that every tool

--- a/backend/src/mcp/CLAUDE.md
+++ b/backend/src/mcp/CLAUDE.md
@@ -93,8 +93,10 @@ Checklist for a new tool:
 5. If it mutates data, derive scope `"write"` and enforce the daily write limit
    via `McpWriteLimiter` (see `transactions.tool.ts`). `whitelist`-style
    sanitize user strings with `stripHtml(...)` before persisting. Gate the write
-   behind a user confirmation with `confirmWrite(server, message)` (the
-   MCP-elicitation equivalent of the AI Assistant's approve/reject card) and
+   behind a user confirmation with `confirmWrite(server, message, extra.requestId)`
+   (the MCP-elicitation equivalent of the AI Assistant's approve/reject card --
+   pass `extra.requestId` so the elicitation is delivered on the tool call's own
+   Streamable HTTP SSE stream rather than the standalone GET stream) and
    only persist on `"accepted"`/`"unsupported"`; on `"declined"` return a
    `toolError` without writing. `"unsupported"` means the client can't show a
    dialog -- it still gates every tool call with its own approval prompt, so

--- a/backend/src/mcp/mcp-annotations.spec.ts
+++ b/backend/src/mcp/mcp-annotations.spec.ts
@@ -20,7 +20,7 @@ const WRITE_TOOLS = new Set([
 // Write tools whose repeated calls converge to the same state.
 const IDEMPOTENT_WRITES = new Set(["categorize_transaction"]);
 
-const EXPECTED_TOOL_COUNT = 30;
+const EXPECTED_TOOL_COUNT = 31;
 
 interface ToolProvider {
   register: (server: unknown, resolve?: unknown) => void;

--- a/backend/src/mcp/mcp-annotations.spec.ts
+++ b/backend/src/mcp/mcp-annotations.spec.ts
@@ -31,11 +31,22 @@ function collectToolConfigs(): Array<{ name: string; config: any }> {
   // register(), so empty mocks are sufficient to capture the tool configs.
   const providers: ToolProvider[] = [
     new McpAccountsTools({} as any) as unknown as ToolProvider,
-    new McpTransactionsTools({} as any, {} as any) as unknown as ToolProvider,
+    new McpTransactionsTools(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    ) as unknown as ToolProvider,
     new McpCategoriesTools({} as any) as unknown as ToolProvider,
-    new McpPayeesTools({} as any) as unknown as ToolProvider,
+    new McpPayeesTools(
+      {} as any,
+      {} as any,
+      {} as any,
+    ) as unknown as ToolProvider,
     new McpReportsTools({} as any) as unknown as ToolProvider,
     new McpInvestmentsTools(
+      {} as any,
+      {} as any,
       {} as any,
       {} as any,
       {} as any,

--- a/backend/src/mcp/mcp-context.spec.ts
+++ b/backend/src/mcp/mcp-context.spec.ts
@@ -188,13 +188,25 @@ describe("mcp-context", () => {
     it("returns 'accepted' when the user accepts the elicitation", async () => {
       const elicit = jest.fn().mockResolvedValue({ action: "accept" });
       const server = fakeServer({ capabilities: caps, elicit });
-      await expect(confirmWrite(server, "Confirm?")).resolves.toBe("accepted");
+      await expect(confirmWrite(server, "Confirm?", "req-1")).resolves.toBe(
+        "accepted",
+      );
       expect(elicit).toHaveBeenCalledWith(
         {
           message: "Confirm?",
           requestedSchema: { type: "object", properties: {} },
         },
-        { timeout: expect.any(Number) },
+        { timeout: expect.any(Number), relatedRequestId: "req-1" },
+      );
+    });
+
+    it("threads the tool call's request id so the elicitation rides its POST SSE stream", async () => {
+      const elicit = jest.fn().mockResolvedValue({ action: "accept" });
+      const server = fakeServer({ capabilities: caps, elicit });
+      await confirmWrite(server, "Confirm?", 42);
+      expect(elicit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ relatedRequestId: 42 }),
       );
     });
 
@@ -203,23 +215,23 @@ describe("mcp-context", () => {
         capabilities: caps,
         elicit: jest.fn().mockResolvedValue({ action: "decline" }),
       });
-      await expect(confirmWrite(declineServer, "Confirm?")).resolves.toBe(
-        "declined",
-      );
+      await expect(
+        confirmWrite(declineServer, "Confirm?", "req-1"),
+      ).resolves.toBe("declined");
 
       const cancelServer = fakeServer({
         capabilities: caps,
         elicit: jest.fn().mockResolvedValue({ action: "cancel" }),
       });
-      await expect(confirmWrite(cancelServer, "Confirm?")).resolves.toBe(
-        "declined",
-      );
+      await expect(
+        confirmWrite(cancelServer, "Confirm?", "req-1"),
+      ).resolves.toBe("declined");
     });
 
     it("returns 'unsupported' without eliciting when the client lacks the capability", async () => {
       const elicit = jest.fn();
       const server = fakeServer({ capabilities: {}, elicit });
-      await expect(confirmWrite(server, "Confirm?")).resolves.toBe(
+      await expect(confirmWrite(server, "Confirm?", "req-1")).resolves.toBe(
         "unsupported",
       );
       expect(elicit).not.toHaveBeenCalled();
@@ -227,7 +239,7 @@ describe("mcp-context", () => {
 
     it("returns 'unsupported' when capabilities are undefined", async () => {
       const server = fakeServer({ capabilities: undefined });
-      await expect(confirmWrite(server, "Confirm?")).resolves.toBe(
+      await expect(confirmWrite(server, "Confirm?", "req-1")).resolves.toBe(
         "unsupported",
       );
     });
@@ -235,7 +247,9 @@ describe("mcp-context", () => {
     it("returns 'declined' (never silently proceeds) when a supported dialog errors or times out", async () => {
       const elicit = jest.fn().mockRejectedValue(new Error("timed out"));
       const server = fakeServer({ capabilities: caps, elicit });
-      await expect(confirmWrite(server, "Confirm?")).resolves.toBe("declined");
+      await expect(confirmWrite(server, "Confirm?", "req-1")).resolves.toBe(
+        "declined",
+      );
     });
   });
 });

--- a/backend/src/mcp/mcp-context.ts
+++ b/backend/src/mcp/mcp-context.ts
@@ -133,7 +133,10 @@ const CONFIRM_TIMEOUT_MS = 5 * 60 * 1000;
  *  - "unsupported": the client advertises no form-elicitation capability, so no
  *    dialog can be shown and the caller falls back to its normal behavior. The
  *    client still gates every tool call with its own approval prompt, so this
- *    is not a consent bypass.
+ *    is not a consent bypass. Claude Desktop currently lands here: it does not
+ *    advertise the elicitation capability (and returns -32601 for
+ *    elicitation/create), so writes proceed under its own per-tool approval
+ *    rather than an MCP-native confirm dialog.
  *
  * We pre-check the capability (rather than relying solely on the thrown
  * "client does not support elicitation" error) so that only a genuine lack of

--- a/backend/src/mcp/mcp-context.ts
+++ b/backend/src/mcp/mcp-context.ts
@@ -1,5 +1,6 @@
 import { sanitizeToolResultStrings } from "../common/sanitization.util";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { RequestId } from "@modelcontextprotocol/sdk/types.js";
 
 export interface McpUserContext {
   userId: string;
@@ -138,10 +139,20 @@ const CONFIRM_TIMEOUT_MS = 5 * 60 * 1000;
  * "client does not support elicitation" error) so that only a genuine lack of
  * capability falls through to the write -- a dismissed or timed-out dialog on a
  * capable client must abort.
+ *
+ * `relatedRequestId` MUST be the in-flight tool call's request id (from the
+ * handler's `extra.requestId`). Over the Streamable HTTP transport, a
+ * server-to-client request with no related request id is routed to the
+ * standalone GET SSE stream, which a tool-calling client (Claude Desktop, IDE
+ * agents) does not keep open during a `tools/call` -- so the elicitation is
+ * silently dropped and never shown, then times out as a decline. Threading the
+ * tool call's id sends the elicitation back over that call's own POST SSE
+ * stream, where the client is listening.
  */
 export async function confirmWrite(
   server: McpServer,
   message: string,
+  relatedRequestId: RequestId,
 ): Promise<WriteConfirmation> {
   const capabilities = server.server.getClientCapabilities();
   if (!capabilities?.elicitation?.form) {
@@ -154,7 +165,7 @@ export async function confirmWrite(
         // No fields to collect -- the accept/decline/cancel action is the answer.
         requestedSchema: { type: "object", properties: {} },
       },
-      { timeout: CONFIRM_TIMEOUT_MS },
+      { timeout: CONFIRM_TIMEOUT_MS, relatedRequestId },
     );
     return result.action === "accept" ? "accepted" : "declined";
   } catch {

--- a/backend/src/mcp/mcp-relay-confirm.ts
+++ b/backend/src/mcp/mcp-relay-confirm.ts
@@ -1,0 +1,13 @@
+/**
+ * LLM-facing result returned by an MCP write tool when it is serving a relayed
+ * browser prompt and has handed the confirmation off to the web chat as a
+ * `pending_action` card. It mirrors the AI Assistant's own `preview_shown`
+ * status: the write has NOT happened (the browser commits it via
+ * `/ai/actions/confirm` on approval), so the agent must not retry or claim
+ * success -- it should ask the user to review and approve the card.
+ */
+export const RELAY_PREVIEW_SHOWN = {
+  status: "preview_shown",
+  message:
+    "A confirmation card was shown to the user in the Monize web chat. The action has NOT been performed yet -- it is applied only when the user approves the card there. Do not retry or say it is done; tell the user to review and approve the card.",
+} as const;

--- a/backend/src/mcp/mcp-relay-tool-activity.spec.ts
+++ b/backend/src/mcp/mcp-relay-tool-activity.spec.ts
@@ -1,0 +1,121 @@
+import {
+  RELAY_CONTROL_TOOLS,
+  installRelayToolActivity,
+  wrapToolHandlerForRelay,
+} from "./mcp-relay-tool-activity";
+import type { AiRelayService } from "../ai/relay/ai-relay.service";
+
+describe("wrapToolHandlerForRelay", () => {
+  const relay = () =>
+    ({ reportToolActivity: jest.fn() }) as unknown as AiRelayService & {
+      reportToolActivity: jest.Mock;
+    };
+  const resolveUser = (() => ({ userId: "u1", scopes: "read" })) as any;
+
+  it("brackets a successful call with start then result (no error)", async () => {
+    const relayService = relay();
+    const handler = jest.fn().mockResolvedValue({ ok: true });
+    const wrapped = wrapToolHandlerForRelay(
+      "get_accounts",
+      handler,
+      resolveUser,
+      relayService,
+    );
+
+    const result = await wrapped({}, { sessionId: "s1" });
+
+    expect(result).toEqual({ ok: true });
+    expect((relayService as any).reportToolActivity.mock.calls).toEqual([
+      ["u1", "get_accounts", "start"],
+      ["u1", "get_accounts", "result", false],
+    ]);
+  });
+
+  it("reports isError:true when the tool result is an error", async () => {
+    const relayService = relay();
+    const wrapped = wrapToolHandlerForRelay(
+      "create_transaction",
+      jest.fn().mockResolvedValue({ isError: true }),
+      resolveUser,
+      relayService,
+    );
+
+    await wrapped({}, { sessionId: "s1" });
+
+    expect((relayService as any).reportToolActivity).toHaveBeenLastCalledWith(
+      "u1",
+      "create_transaction",
+      "result",
+      true,
+    );
+  });
+
+  it("still reports a result when the handler throws, then rethrows", async () => {
+    const relayService = relay();
+    const boom = new Error("boom");
+    const wrapped = wrapToolHandlerForRelay(
+      "get_accounts",
+      jest.fn().mockRejectedValue(boom),
+      resolveUser,
+      relayService,
+    );
+
+    await expect(wrapped({}, { sessionId: "s1" })).rejects.toThrow("boom");
+    expect((relayService as any).reportToolActivity).toHaveBeenLastCalledWith(
+      "u1",
+      "get_accounts",
+      "result",
+      true,
+    );
+  });
+
+  it("does not report activity when there is no user context", async () => {
+    const relayService = relay();
+    const wrapped = wrapToolHandlerForRelay(
+      "get_accounts",
+      jest.fn().mockResolvedValue({}),
+      (() => undefined) as any,
+      relayService,
+    );
+
+    await wrapped({}, {});
+
+    expect((relayService as any).reportToolActivity).not.toHaveBeenCalled();
+  });
+});
+
+describe("installRelayToolActivity", () => {
+  it("wraps data tools but leaves relay control tools untouched", async () => {
+    const relayService = {
+      reportToolActivity: jest.fn(),
+    } as unknown as AiRelayService;
+    const registered: Record<string, any> = {};
+    const server = {
+      registerTool: (name: string, _config: unknown, handler: any) => {
+        registered[name] = handler;
+      },
+    } as any;
+
+    installRelayToolActivity(
+      server,
+      (() => ({ userId: "u1", scopes: "read" })) as any,
+      relayService,
+    );
+
+    // Register one data tool and one control tool through the patched method.
+    server.registerTool("get_accounts", {}, jest.fn().mockResolvedValue({}));
+    server.registerTool(
+      "get_next_prompt",
+      {},
+      jest.fn().mockResolvedValue({ hasPrompt: false }),
+    );
+
+    await registered["get_accounts"]({}, { sessionId: "s1" });
+    expect((relayService as any).reportToolActivity).toHaveBeenCalled();
+
+    (relayService as any).reportToolActivity.mockClear();
+    await registered["get_next_prompt"]({}, { sessionId: "s1" });
+    expect((relayService as any).reportToolActivity).not.toHaveBeenCalled();
+    expect(RELAY_CONTROL_TOOLS.has("get_next_prompt")).toBe(true);
+  });
+});

--- a/backend/src/mcp/mcp-relay-tool-activity.ts
+++ b/backend/src/mcp/mcp-relay-tool-activity.ts
@@ -1,0 +1,84 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { UserContextResolver } from "./mcp-context";
+import type { AiRelayService } from "../ai/relay/ai-relay.service";
+
+// Relay control tools are infrastructure (the long-poll and answer channel),
+// not work the user should see as progress.
+export const RELAY_CONTROL_TOOLS = new Set([
+  "get_next_prompt",
+  "post_response",
+  "report_progress",
+]);
+
+type ToolHandler = (
+  args: unknown,
+  extra: { sessionId?: string },
+) => unknown | Promise<unknown>;
+
+/**
+ * Wrap a tool handler so that, when the call is serving a relayed browser
+ * prompt, it streams `tool_start` before and `tool_result` after to the web
+ * chat. The agent (Claude CLI/Desktop) does not reliably narrate progress via
+ * report_progress, but it always invokes the actual data tools -- and those
+ * calls reach us -- so surfacing them gives the web chat live "Looking up ..."
+ * progress automatically. Outside relay context `reportToolActivity` finds no
+ * in-flight prompt and is a no-op.
+ */
+export function wrapToolHandlerForRelay(
+  name: string,
+  handler: ToolHandler,
+  resolve: UserContextResolver,
+  relayService: AiRelayService,
+): ToolHandler {
+  return async (args, extra) => {
+    const userId = resolve(extra?.sessionId)?.userId;
+    if (userId) {
+      relayService.reportToolActivity(userId, name, "start");
+    }
+    let isError = false;
+    try {
+      const result = await handler(args, extra);
+      isError = Boolean((result as { isError?: boolean } | undefined)?.isError);
+      return result;
+    } catch (err) {
+      isError = true;
+      throw err;
+    } finally {
+      if (userId) {
+        relayService.reportToolActivity(userId, name, "result", isError);
+      }
+    }
+  };
+}
+
+/**
+ * Monkeypatch `server.registerTool` so every tool registered afterwards is
+ * wrapped with `wrapToolHandlerForRelay` (relay control tools excepted). Must
+ * run before the tool providers register their tools.
+ */
+export function installRelayToolActivity(
+  server: McpServer,
+  resolve: UserContextResolver,
+  relayService: AiRelayService,
+): void {
+  const baseRegister = server.registerTool.bind(server) as (
+    name: string,
+    config: unknown,
+    handler: ToolHandler,
+  ) => unknown;
+
+  (server as { registerTool: unknown }).registerTool = (
+    name: string,
+    config: unknown,
+    handler: ToolHandler,
+  ) => {
+    if (RELAY_CONTROL_TOOLS.has(name)) {
+      return baseRegister(name, config, handler);
+    }
+    return baseRegister(
+      name,
+      config,
+      wrapToolHandlerForRelay(name, handler, resolve, relayService),
+    );
+  };
+}

--- a/backend/src/mcp/mcp-server.service.spec.ts
+++ b/backend/src/mcp/mcp-server.service.spec.ts
@@ -19,6 +19,7 @@ import { McpFinancialReviewPrompt } from "./prompts/financial-review.prompt";
 import { McpBudgetCheckPrompt } from "./prompts/budget-check.prompt";
 import { McpTransactionLookupPrompt } from "./prompts/transaction-lookup.prompt";
 import { McpSpendingAnalysisPrompt } from "./prompts/spending-analysis.prompt";
+import { AiRelayService } from "../ai/relay/ai-relay.service";
 
 describe("McpServerService", () => {
   let service: McpServerService;
@@ -44,6 +45,10 @@ describe("McpServerService", () => {
         { provide: McpCalculateTools, useValue: mockToolProvider },
         { provide: McpBudgetsTools, useValue: mockToolProvider },
         { provide: McpRelayTools, useValue: mockToolProvider },
+        {
+          provide: AiRelayService,
+          useValue: { reportToolActivity: jest.fn() },
+        },
         { provide: McpAccountListResource, useValue: mockResourceProvider },
         { provide: McpCategoryTreeResource, useValue: mockResourceProvider },
         {

--- a/backend/src/mcp/mcp-server.service.ts
+++ b/backend/src/mcp/mcp-server.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from "@nestjs/common";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { UserContextResolver } from "./mcp-context";
+import { AiRelayService } from "../ai/relay/ai-relay.service";
+import { installRelayToolActivity } from "./mcp-relay-tool-activity";
 import { McpAccountsTools } from "./tools/accounts.tool";
 import { McpTransactionsTools } from "./tools/transactions.tool";
 import { McpCategoriesTools } from "./tools/categories.tool";
@@ -41,6 +43,7 @@ export class McpServerService {
     private readonly calculateTools: McpCalculateTools,
     private readonly budgetsTools: McpBudgetsTools,
     private readonly relayTools: McpRelayTools,
+    private readonly relayService: AiRelayService,
     private readonly accountListResource: McpAccountListResource,
     private readonly categoryTreeResource: McpCategoryTreeResource,
     private readonly recentTransactionsResource: McpRecentTransactionsResource,
@@ -97,6 +100,10 @@ export class McpServerService {
         },
       },
     );
+
+    // Stream the agent's tool calls to the web chat as live progress when this
+    // session is serving a relayed prompt. Must run before the tools register.
+    installRelayToolActivity(server, resolve, this.relayService);
 
     this.accountsTools.register(server, resolve);
     this.transactionsTools.register(server, resolve);

--- a/backend/src/mcp/mcp.module.ts
+++ b/backend/src/mcp/mcp.module.ts
@@ -11,6 +11,7 @@ import { BudgetsModule } from "../budgets/budgets.module";
 import { BuiltInReportsModule } from "../built-in-reports/built-in-reports.module";
 import { OAuthModule } from "../oauth/oauth.module";
 import { AiRelayModule } from "../ai/relay/ai-relay.module";
+import { AiActionBuilderModule } from "../ai/actions/ai-action-builder.module";
 
 import { McpServerService } from "./mcp-server.service";
 import { McpHttpController } from "./mcp-http.controller";
@@ -51,6 +52,7 @@ import { McpSpendingAnalysisPrompt } from "./prompts/spending-analysis.prompt";
     BuiltInReportsModule,
     OAuthModule,
     AiRelayModule,
+    AiActionBuilderModule,
   ],
   providers: [
     McpServerService,

--- a/backend/src/mcp/tool-output-schemas.ts
+++ b/backend/src/mcp/tool-output-schemas.ts
@@ -609,3 +609,7 @@ export const getNextPromptOutput = {
 export const postResponseOutput = {
   delivered: bool,
 };
+
+export const reportProgressOutput = {
+  delivered: bool,
+};

--- a/backend/src/mcp/tool-output-schemas.ts
+++ b/backend/src/mcp/tool-output-schemas.ts
@@ -237,9 +237,12 @@ export const createTransactionOutput = {
 };
 
 export const categorizeTransactionOutput = {
-  id: str,
-  categoryId: strNull,
-  message: str,
+  // Applied branch (direct MCP client).
+  id: str.optional(),
+  categoryId: strNull.optional(),
+  message: str.optional(),
+  // Relay branch: a confirmation card was shown in the web chat instead.
+  status: str.optional(),
 };
 
 // ---------------------------------------------------------------------------
@@ -282,9 +285,12 @@ export const getPayeesOutput = {
 };
 
 export const createPayeeOutput = {
-  id: str,
-  name: str,
-  message: str,
+  // Created branch (direct MCP client).
+  id: str.optional(),
+  name: str.optional(),
+  message: str.optional(),
+  // Relay branch: a confirmation card was shown in the web chat instead.
+  status: str.optional(),
 };
 
 // ---------------------------------------------------------------------------
@@ -481,6 +487,8 @@ export const createInvestmentTransactionOutput = {
   quantity: numNull.optional(),
   price: numNull.optional(),
   totalAmount: num.optional(),
+  // Relay branch: a confirmation card was shown in the web chat instead.
+  status: str.optional(),
 };
 
 // ---------------------------------------------------------------------------

--- a/backend/src/mcp/tools/investments.tool.spec.ts
+++ b/backend/src/mcp/tools/investments.tool.spec.ts
@@ -11,6 +11,7 @@ describe("McpInvestmentsTools", () => {
     server: { getClientCapabilities: jest.Mock; elicitInput: jest.Mock };
   };
   let elicitInput: jest.Mock;
+  let relayService: { emitPendingAction: jest.Mock };
   let resolve: jest.MockedFunction<UserContextResolver>;
   const handlers: Record<string, (...args: any[]) => any> = {};
 
@@ -31,10 +32,19 @@ describe("McpInvestmentsTools", () => {
       create: jest.fn(),
     };
 
+    // Default: not serving a relayed prompt, so the tool uses its normal
+    // (direct MCP-client) confirmation path and the existing assertions hold.
+    relayService = { emitPendingAction: jest.fn().mockReturnValue(false) };
+    const actionBuilder = {
+      buildCreateInvestmentTransaction: jest.fn().mockReturnValue({}),
+    };
+
     tool = new McpInvestmentsTools(
       portfolioService as any,
       holdingsService as any,
       investmentTransactionsService as any,
+      relayService as any,
+      actionBuilder as any,
     );
 
     elicitInput = jest.fn();
@@ -518,6 +528,28 @@ describe("McpInvestmentsTools", () => {
       expect(elicitInput).toHaveBeenCalled();
       expect(investmentTransactionsService.create).not.toHaveBeenCalled();
       expect(result.isError).toBe(true);
+    });
+
+    it("shows a web-chat card (no elicitation, no write) when serving a relayed prompt", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "write" });
+      server.server.getClientCapabilities.mockReturnValue({
+        elicitation: { form: {} },
+      });
+      relayService.emitPendingAction.mockReturnValue(true);
+      investmentTransactionsService.previewCreateInvestmentTransaction.mockResolvedValue(
+        preview,
+      );
+
+      const result = await handlers["create_investment_transaction"](args, {
+        sessionId: "s1",
+        requestId: "call-1",
+      });
+
+      expect(relayService.emitPendingAction).toHaveBeenCalled();
+      expect(elicitInput).not.toHaveBeenCalled();
+      expect(investmentTransactionsService.create).not.toHaveBeenCalled();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.status).toBe("preview_shown");
     });
 
     it("surfaces a 4xx from the shared preview", async () => {

--- a/backend/src/mcp/tools/investments.tool.ts
+++ b/backend/src/mcp/tools/investments.tool.ts
@@ -9,6 +9,9 @@ import {
   LlmInvestmentTxGroupBy,
 } from "../../securities/investment-transactions.service";
 import { InvestmentAction } from "../../securities/entities/investment-transaction.entity";
+import { AiRelayService } from "../../ai/relay/ai-relay.service";
+import { AiActionBuilderService } from "../../ai/actions/ai-action-builder.service";
+import { RELAY_PREVIEW_SHOWN } from "../mcp-relay-confirm";
 import {
   UserContextResolver,
   requireScope,
@@ -35,6 +38,8 @@ export class McpInvestmentsTools {
     private readonly portfolioService: PortfolioService,
     private readonly holdingsService: HoldingsService,
     private readonly investmentTransactionsService: InvestmentTransactionsService,
+    private readonly relayService: AiRelayService,
+    private readonly actionBuilder: AiActionBuilderService,
   ) {}
 
   register(server: McpServer, resolve: UserContextResolver) {
@@ -364,6 +369,17 @@ export class McpInvestmentsTools {
               message:
                 "This is a preview. Call again with dryRun=false to create the transaction.",
             });
+          }
+
+          // Relay path: confirm in the web chat via the approve/reject card
+          // rather than an elicitation in the agent's MCP client.
+          const pendingAction =
+            this.actionBuilder.buildCreateInvestmentTransaction(
+              ctx.userId,
+              preview,
+            );
+          if (this.relayService.emitPendingAction(ctx.userId, pendingAction)) {
+            return toolResult(RELAY_PREVIEW_SHOWN);
           }
 
           // Ask the client to confirm before persisting (AI Assistant parity).

--- a/backend/src/mcp/tools/investments.tool.ts
+++ b/backend/src/mcp/tools/investments.tool.ts
@@ -395,6 +395,7 @@ export class McpInvestmentsTools {
           const confirmation = await confirmWrite(
             server,
             confirmLines.join("\n"),
+            extra.requestId,
           );
           if (confirmation === "declined") {
             return toolError(

--- a/backend/src/mcp/tools/payees.tool.spec.ts
+++ b/backend/src/mcp/tools/payees.tool.spec.ts
@@ -9,6 +9,7 @@ describe("McpPayeesTools", () => {
     server: { getClientCapabilities: jest.Mock; elicitInput: jest.Mock };
   };
   let elicitInput: jest.Mock;
+  let relayService: { emitPendingAction: jest.Mock };
   let resolve: jest.MockedFunction<UserContextResolver>;
   const handlers: Record<string, (...args: any[]) => any> = {};
 
@@ -24,7 +25,16 @@ describe("McpPayeesTools", () => {
       }),
     };
 
-    tool = new McpPayeesTools(payeesService as any);
+    // Default: not serving a relayed prompt, so the tool uses its normal
+    // (direct MCP-client) confirmation path and the existing assertions hold.
+    relayService = { emitPendingAction: jest.fn().mockReturnValue(false) };
+    const actionBuilder = { buildCreatePayee: jest.fn().mockReturnValue({}) };
+
+    tool = new McpPayeesTools(
+      payeesService as any,
+      relayService as any,
+      actionBuilder as any,
+    );
 
     elicitInput = jest.fn();
     server = {
@@ -105,6 +115,25 @@ describe("McpPayeesTools", () => {
       expect(payeesService.create).not.toHaveBeenCalled();
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("declined");
+    });
+
+    it("shows a web-chat card (no elicitation, no write) when serving a relayed prompt", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read,write" });
+      server.server.getClientCapabilities.mockReturnValue({
+        elicitation: { form: {} },
+      });
+      relayService.emitPendingAction.mockReturnValue(true);
+
+      const result = await handlers["create_payee"](
+        { name: "New Payee" },
+        { sessionId: "s1", requestId: "call-1" },
+      );
+
+      expect(relayService.emitPendingAction).toHaveBeenCalled();
+      expect(elicitInput).not.toHaveBeenCalled();
+      expect(payeesService.create).not.toHaveBeenCalled();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.status).toBe("preview_shown");
     });
 
     it("returns error when no user context for create_payee", async () => {

--- a/backend/src/mcp/tools/payees.tool.ts
+++ b/backend/src/mcp/tools/payees.tool.ts
@@ -2,6 +2,9 @@ import { Injectable } from "@nestjs/common";
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { PayeesService } from "../../payees/payees.service";
+import { AiRelayService } from "../../ai/relay/ai-relay.service";
+import { AiActionBuilderService } from "../../ai/actions/ai-action-builder.service";
+import { RELAY_PREVIEW_SHOWN } from "../mcp-relay-confirm";
 import {
   UserContextResolver,
   requireScope,
@@ -15,7 +18,11 @@ import { READ_ONLY, CREATE } from "../mcp-annotations";
 
 @Injectable()
 export class McpPayeesTools {
-  constructor(private readonly payeesService: PayeesService) {}
+  constructor(
+    private readonly payeesService: PayeesService,
+    private readonly relayService: AiRelayService,
+    private readonly actionBuilder: AiActionBuilderService,
+  ) {}
 
   register(server: McpServer, resolve: UserContextResolver) {
     server.registerTool(
@@ -93,6 +100,16 @@ export class McpPayeesTools {
               ? `Default category: ${preview.defaultCategoryName}`
               : null,
           ].filter((line): line is string => line !== null);
+          // Relay path: confirm in the web chat via the approve/reject card
+          // rather than an elicitation in the agent's MCP client.
+          const pendingAction = this.actionBuilder.buildCreatePayee(
+            ctx.userId,
+            preview,
+          );
+          if (this.relayService.emitPendingAction(ctx.userId, pendingAction)) {
+            return toolResult(RELAY_PREVIEW_SHOWN);
+          }
+
           const confirmation = await confirmWrite(
             server,
             confirmLines.join("\n"),

--- a/backend/src/mcp/tools/payees.tool.ts
+++ b/backend/src/mcp/tools/payees.tool.ts
@@ -96,6 +96,7 @@ export class McpPayeesTools {
           const confirmation = await confirmWrite(
             server,
             confirmLines.join("\n"),
+            extra.requestId,
           );
           if (confirmation === "declined") {
             return toolError(

--- a/backend/src/mcp/tools/relay.tool.spec.ts
+++ b/backend/src/mcp/tools/relay.tool.spec.ts
@@ -86,4 +86,41 @@ describe("McpRelayTools", () => {
       expect(parse(result)).toEqual({ delivered: false });
     });
   });
+
+  describe("report_progress", () => {
+    it("streams the update and reports delivered:true", async () => {
+      const reportProgress = jest.fn().mockReturnValue(true);
+      const handlers = register({ reportProgress });
+      const result = await handlers.report_progress(
+        { promptId: "p1", text: "looking up category" },
+        { sessionId: "s" },
+      );
+      expect(parse(result)).toEqual({ delivered: true });
+      expect(reportProgress).toHaveBeenCalledWith(
+        "user-1",
+        "p1",
+        "looking up category",
+      );
+    });
+
+    it("reports delivered:false when the prompt is no longer active", async () => {
+      const handlers = register({
+        reportProgress: jest.fn().mockReturnValue(false),
+      });
+      const result = await handlers.report_progress(
+        { promptId: "p1", text: "late update" },
+        { sessionId: "s" },
+      );
+      expect(parse(result)).toEqual({ delivered: false });
+    });
+
+    it("requires read scope", async () => {
+      const handlers = register({}, "reports");
+      const result = await handlers.report_progress(
+        { promptId: "p1", text: "x" },
+        { sessionId: "s" },
+      );
+      expect(result.isError).toBe(true);
+    });
+  });
 });

--- a/backend/src/mcp/tools/relay.tool.ts
+++ b/backend/src/mcp/tools/relay.tool.ts
@@ -12,6 +12,7 @@ import {
 import {
   getNextPromptOutput,
   postResponseOutput,
+  reportProgressOutput,
 } from "../tool-output-schemas";
 import { READ_ONLY } from "../mcp-annotations";
 
@@ -24,8 +25,8 @@ import { READ_ONLY } from "../mcp-annotations";
  *
  * Usage pattern the agent is told to follow: loop forever -- call
  * `get_next_prompt`; if `hasPrompt` is false, call it again; otherwise handle
- * the request with the Monize tools, then call `post_response` with the answer,
- * then loop.
+ * the request with the Monize tools, narrating progress with `report_progress`
+ * as it goes, then call `post_response` with the final answer, then loop.
  */
 @Injectable()
 export class McpRelayTools {
@@ -38,7 +39,7 @@ export class McpRelayTools {
         title: "Wait for the next chat prompt",
         annotations: READ_ONLY,
         description:
-          "Long-poll for the next prompt a user typed in the Monize web chat. Returns { hasPrompt: false } if none arrives within the poll window -- in that case call this tool again immediately to keep listening. When hasPrompt is true, handle the request using the other Monize tools, then call post_response with promptId and your answer. 'history' is the prior conversation, oldest first.",
+          "Long-poll for the next prompt a user typed in the Monize web chat. Returns { hasPrompt: false } if none arrives within the poll window -- in that case call this tool again immediately to keep listening. When hasPrompt is true, handle the request using the other Monize tools, calling report_progress with short status updates as you work (before a lookup, or when sending a confirmation card), then call post_response with promptId and your final answer. 'history' is the prior conversation, oldest first.",
         inputSchema: {},
         outputSchema: getNextPromptOutput,
       },
@@ -92,6 +93,44 @@ export class McpRelayTools {
 
         try {
           const delivered = this.relayService.postResponse(
+            ctx.userId,
+            args.promptId,
+            args.text,
+          );
+          return toolResult({ delivered });
+        } catch (err: unknown) {
+          return safeToolError(err);
+        }
+      },
+    );
+
+    server.registerTool(
+      "report_progress",
+      {
+        title: "Stream a progress update",
+        annotations: READ_ONLY,
+        description:
+          "Stream a short, human-readable progress update to the Monize web chat while you work on a prompt from get_next_prompt. Shown live to the user as the assistant's running narration (e.g. 'Looking up the sporting goods category...' or 'Dry run looks good, sending the confirmation card.'). Call it whenever you start a lookup or make a decision, before the relevant tool call. Pass the promptId you are handling and one concise sentence. This does not answer the prompt -- still call post_response with the final answer when done. Returns { delivered: false } if the prompt is no longer active (already answered or timed out); if so, stop sending updates for it.",
+        inputSchema: {
+          promptId: z
+            .string()
+            .uuid()
+            .describe("The promptId from get_next_prompt"),
+          text: z
+            .string()
+            .max(2000)
+            .describe("A short status update to show the user"),
+        },
+        outputSchema: reportProgressOutput,
+      },
+      async (args, extra) => {
+        const ctx = resolve(extra.sessionId);
+        if (!ctx) return toolError("No user context");
+        const check = requireScope(ctx.scopes, "read");
+        if (check.error) return check.result;
+
+        try {
+          const delivered = this.relayService.reportProgress(
             ctx.userId,
             args.promptId,
             args.text,

--- a/backend/src/mcp/tools/transactions.tool.spec.ts
+++ b/backend/src/mcp/tools/transactions.tool.spec.ts
@@ -11,6 +11,7 @@ describe("McpTransactionsTools", () => {
     server: { getClientCapabilities: jest.Mock; elicitInput: jest.Mock };
   };
   let elicitInput: jest.Mock;
+  let relayService: { emitPendingAction: jest.Mock };
   let resolve: jest.MockedFunction<UserContextResolver>;
   const handlers: Record<string, (...args: any[]) => any> = {};
 
@@ -41,9 +42,19 @@ describe("McpTransactionsTools", () => {
       getLlmPeriodComparison: jest.fn(),
     };
 
+    // Default: not serving a relayed prompt, so the tool uses its normal
+    // (direct MCP-client) confirmation path and the existing assertions hold.
+    relayService = { emitPendingAction: jest.fn().mockReturnValue(false) };
+    const actionBuilder = {
+      buildCreateTransaction: jest.fn().mockReturnValue({}),
+      buildCategorizeTransaction: jest.fn().mockReturnValue({}),
+    };
+
     tool = new McpTransactionsTools(
       transactionsService as any,
       analyticsService as any,
+      relayService as any,
+      actionBuilder as any,
     );
 
     elicitInput = jest.fn();
@@ -581,6 +592,48 @@ describe("McpTransactionsTools", () => {
       expect(result.content[0].text).toContain("declined");
     });
 
+    it("shows a web-chat card (no elicitation, no write) when serving a relayed prompt", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read,write" });
+      server.server.getClientCapabilities.mockReturnValue({
+        elicitation: { form: {} },
+      });
+      // The user is driving from the Monize web chat via the reverse relay.
+      relayService.emitPendingAction.mockReturnValue(true);
+      transactionsService.previewCreate.mockResolvedValue({
+        accountId: "a1",
+        accountName: "Checking",
+        amount: -50,
+        transactionDate: "2025-01-15",
+        payeeId: "p1",
+        payeeName: "Store",
+        payeeMatched: true,
+        payeeWillBeCreated: false,
+        categoryId: null,
+        categoryName: null,
+        description: null,
+        currencyCode: "USD",
+      });
+
+      const result = await handlers["create_transaction"](
+        {
+          accountId: "a1",
+          amount: -50,
+          date: "2025-01-15",
+          payeeName: "Store",
+          dryRun: false,
+        },
+        { sessionId: "s1", requestId: "call-1" },
+      );
+
+      // Confirmation goes to the browser card, not an MCP-client dialog, and the
+      // write is deferred to /ai/actions/confirm.
+      expect(relayService.emitPendingAction).toHaveBeenCalled();
+      expect(elicitInput).not.toHaveBeenCalled();
+      expect(transactionsService.create).not.toHaveBeenCalled();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.status).toBe("preview_shown");
+    });
+
     it("does not elicit a confirmation in dry-run mode", async () => {
       resolve.mockReturnValue({ userId: "u1", scopes: "read,write" });
       server.server.getClientCapabilities.mockReturnValue({
@@ -830,6 +883,11 @@ describe("McpTransactionsTools", () => {
       const freshTool = new McpTransactionsTools(
         transactionsService as any,
         analyticsService as any,
+        relayService as any,
+        {
+          buildCreateTransaction: jest.fn(),
+          buildCategorizeTransaction: jest.fn(),
+        } as any,
       );
       const freshHandlers: Record<string, (...args: any[]) => any> = {};
       const freshServer = {
@@ -894,12 +952,36 @@ describe("McpTransactionsTools", () => {
       expect(result.content[0].text).toContain("declined");
     });
 
+    it("shows a web-chat card (no elicitation, no write) when serving a relayed prompt", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "read,write" });
+      server.server.getClientCapabilities.mockReturnValue({
+        elicitation: { form: {} },
+      });
+      relayService.emitPendingAction.mockReturnValue(true);
+
+      const result = await handlers["categorize_transaction"](
+        { transactionId: "t1", categoryId: "c1" },
+        { sessionId: "s1", requestId: "call-1" },
+      );
+
+      expect(relayService.emitPendingAction).toHaveBeenCalled();
+      expect(elicitInput).not.toHaveBeenCalled();
+      expect(transactionsService.update).not.toHaveBeenCalled();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.status).toBe("preview_shown");
+    });
+
     it("should enforce daily write rate limit for categorization", async () => {
       resolve.mockReturnValue({ userId: "u1", scopes: "read,write" });
 
       const freshTool = new McpTransactionsTools(
         transactionsService as any,
         analyticsService as any,
+        relayService as any,
+        {
+          buildCreateTransaction: jest.fn(),
+          buildCategorizeTransaction: jest.fn(),
+        } as any,
       );
       const freshHandlers: Record<string, (...args: any[]) => any> = {};
       const freshServer = {

--- a/backend/src/mcp/tools/transactions.tool.spec.ts
+++ b/backend/src/mcp/tools/transactions.tool.spec.ts
@@ -529,10 +529,16 @@ describe("McpTransactionsTools", () => {
           payeeName: "Store",
           dryRun: false,
         },
-        { sessionId: "s1" },
+        { sessionId: "s1", requestId: "call-1" },
       );
 
-      expect(elicitInput).toHaveBeenCalled();
+      // The elicitation must be related to the tool call's request id so the
+      // Streamable HTTP transport delivers it on that call's POST SSE stream
+      // rather than the (typically absent) standalone GET stream.
+      expect(elicitInput).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ relatedRequestId: "call-1" }),
+      );
       expect(transactionsService.create).toHaveBeenCalled();
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed.id).toBe("t1");

--- a/backend/src/mcp/tools/transactions.tool.ts
+++ b/backend/src/mcp/tools/transactions.tool.ts
@@ -3,6 +3,9 @@ import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { TransactionsService } from "../../transactions/transactions.service";
 import { TransactionAnalyticsService } from "../../transactions/transaction-analytics.service";
+import { AiRelayService } from "../../ai/relay/ai-relay.service";
+import { AiActionBuilderService } from "../../ai/actions/ai-action-builder.service";
+import { RELAY_PREVIEW_SHOWN } from "../mcp-relay-confirm";
 import {
   UserContextResolver,
   requireScope,
@@ -36,6 +39,8 @@ export class McpTransactionsTools {
   constructor(
     private readonly transactionsService: TransactionsService,
     private readonly analyticsService: TransactionAnalyticsService,
+    private readonly relayService: AiRelayService,
+    private readonly actionBuilder: AiActionBuilderService,
   ) {}
 
   register(server: McpServer, resolve: UserContextResolver) {
@@ -528,6 +533,19 @@ export class McpTransactionsTools {
             });
           }
 
+          // When this call is serving a prompt the user typed in the Monize web
+          // chat (reverse relay), confirm there with the same approve/reject
+          // card the native AI Assistant uses, instead of an elicitation in the
+          // agent's MCP client. The browser commits on approval; nothing is
+          // written here.
+          const pendingAction = this.actionBuilder.buildCreateTransaction(
+            ctx.userId,
+            preview,
+          );
+          if (this.relayService.emitPendingAction(ctx.userId, pendingAction)) {
+            return toolResult(RELAY_PREVIEW_SHOWN);
+          }
+
           // Ask the client to confirm before persisting (AI Assistant parity).
           // Falls through to the write only when the client cannot show a dialog.
           const confirmLines = [
@@ -631,6 +649,16 @@ export class McpTransactionsTools {
             args.transactionId,
             args.categoryId,
           );
+          // Relay path: show the approve/reject card in the web chat (see
+          // create_transaction). Nothing is written here on success.
+          const pendingAction = this.actionBuilder.buildCategorizeTransaction(
+            ctx.userId,
+            preview,
+          );
+          if (this.relayService.emitPendingAction(ctx.userId, pendingAction)) {
+            return toolResult(RELAY_PREVIEW_SHOWN);
+          }
+
           const confirmLines = [
             "Apply this category change?",
             preview.payeeName ? `Payee: ${preview.payeeName}` : null,

--- a/backend/src/mcp/tools/transactions.tool.ts
+++ b/backend/src/mcp/tools/transactions.tool.ts
@@ -550,6 +550,7 @@ export class McpTransactionsTools {
           const confirmation = await confirmWrite(
             server,
             confirmLines.join("\n"),
+            extra.requestId,
           );
           if (confirmation === "declined") {
             return toolError(
@@ -640,6 +641,7 @@ export class McpTransactionsTools {
           const confirmation = await confirmWrite(
             server,
             confirmLines.join("\n"),
+            extra.requestId,
           );
           if (confirmation === "declined") {
             return toolError(


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: <!-- discussion/issue link -->

## Summary

This PR enables the web chat to display write-confirmation cards (`pending_action`) for AI-proposed transactions, payees, and investment transactions when the user is driving the agent via the browser relay. Previously, all confirmations went through MCP-client dialogs; now they can be shown inline in the chat interface.

The change introduces:

1. **`AiActionBuilderService`** — A new shared service that builds signed `PendingAiAction` envelopes from preview data. Both the AI Assistant tool executor and MCP write tools now use this single source of truth to mint byte-identical actions, ensuring the confirm endpoint can verify and commit them the same way regardless of which surface proposed them.

2. **Relay event streaming** — Extended `AiRelayService` with three new methods:
   - `emitPendingAction()` — Sends a write-confirmation card to the browser's in-flight prompt stream
   - `reportProgress()` — Streams interim status updates (e.g., "looking up category...") as `assistant_text` events
   - `reportToolActivity()` — Emits `tool_start` and `tool_result` events so the web chat shows live tool invocation progress

3. **MCP tool wrapping** — New `installRelayToolActivity()` function that monkeypatches `server.registerTool()` to wrap all data tools (except relay control tools) with activity reporting. This gives the web chat automatic "Looking up..." progress without requiring the agent to call `report_progress`.

4. **Conditional confirmation paths** — MCP write tools (`transactions`, `payees`, `investments`) now check `relayService.emitPendingAction()` to decide whether to show a confirmation card in the web chat or fall back to the traditional MCP-client elicitation dialog. When serving a relay prompt, they return `{ status: "preview_shown" }` (mirroring the AI Assistant's own behavior) instead of writing immediately.

5. **Request ID threading** — Tool calls now carry a `requestId` that gets threaded through to elicitation requests, ensuring MCP-client dialogs ride the correct POST SSE stream in the Streamable HTTP transport.

All four write-action types (`create_transaction`, `categorize_transaction`, `create_payee`, `create_investment_transaction`) now support both surfaces equally.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [ ] This PR addresses a **single concern** (large work is split into a series).
- [ ] New behavior has tests, and the existing suite passes.
- [ ] All user-facing strings are translated for **every** locale (i18n parity).
- [ ] No shared/core areas were refactored without prior agreement.
- [ ] The branch is rebased on the latest `main`.
- [ ] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

<!-- Disclose any AI tools used. Using AI is fine and expected — you remain responsible for correctness, conventions, and tests. -->

https://claude.ai/code/session_01Bd5Bu9LuS7D4335vV7pgAe