### PR TITLE
Add ISO timestamps to all frontend container logs

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -60,6 +60,11 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 
+# Console formatter preloaded before the standalone server so that every line
+# the container emits -- including Next.js's own startup banner -- carries an
+# ISO timestamp consistent with createLogger and the backend logs.
+COPY --from=builder --chown=nextjs:nodejs /app/server-log-format.cjs ./
+
 USER nextjs
 
 EXPOSE 3000
@@ -68,4 +73,4 @@ ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
 ENTRYPOINT ["dumb-init", "--"]
-CMD ["node", "server.js"]
+CMD ["node", "--require", "./server-log-format.cjs", "server.js"]

--- a/frontend/server-log-format.cjs
+++ b/frontend/server-log-format.cjs
@@ -1,0 +1,101 @@
+'use strict';
+
+/*
+ * Standalone-server console formatter.
+ *
+ * Preloaded into the Next.js standalone server (via `node --require` in the
+ * production Dockerfile) so that EVERY line the frontend container emits carries
+ * an ISO timestamp -- including Next.js's own startup banner ("▲ Next.js ...",
+ * "✓ Ready in ...") which is printed by the framework before any application
+ * code (and therefore before `createLogger`) runs.
+ *
+ * Lines that already begin with an ISO timestamp are left untouched, so output
+ * from `src/lib/logger.ts` (which timestamps its own server-side lines) is not
+ * double-prefixed.
+ *
+ * This file ships as plain CommonJS (not TypeScript) because it is referenced by
+ * the container start command, not imported by application code, so Next.js
+ * never compiles it. The pure `prefixArgs` helper is unit-tested from
+ * `src/lib/server-log-format.test.ts`.
+ */
+
+const ISO_PREFIX_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\b/;
+
+const LEVEL_LABELS = {
+  log: 'INFO',
+  info: 'INFO',
+  debug: 'DEBUG',
+  warn: 'WARN',
+  error: 'ERROR',
+};
+
+const CONSOLE_METHODS = ['log', 'info', 'debug', 'warn', 'error'];
+
+/**
+ * Flatten an Error onto a single line so a log shipper keeps one record per
+ * error instead of splitting its stack across many lines. Mirrors the
+ * flattening done server-side in src/lib/logger.ts.
+ */
+function flattenError(error) {
+  const stack = error.stack || `${error.name}: ${error.message}`;
+  return stack.replace(/\n\s*/g, ' \\n ');
+}
+
+/**
+ * Build the argument list to forward to the underlying console method.
+ *
+ * Error arguments are flattened to a single line, and the prefix is merged into
+ * a leading string argument (rather than unshifted as a separate argument) so
+ * that printf-style format specifiers in that first argument -- e.g.
+ * console.log('%s ready', name) -- keep working.
+ */
+function prefixArgs(level, args, now = new Date()) {
+  const prefix = `${now.toISOString()} [Next.js] ${LEVEL_LABELS[level] || 'INFO'}:`;
+
+  if (args.length === 0) {
+    return [prefix];
+  }
+
+  const [first] = args;
+  // Already timestamped (e.g. from createLogger, which flattens its own
+  // errors) -- pass through untouched to avoid a second timestamp.
+  if (typeof first === 'string' && ISO_PREFIX_RE.test(first)) {
+    return args;
+  }
+
+  const flat = args.map((arg) => (arg instanceof Error ? flattenError(arg) : arg));
+  const [flatFirst, ...rest] = flat;
+  if (typeof flatFirst === 'string') {
+    return [`${prefix} ${flatFirst}`, ...rest];
+  }
+
+  return [prefix, ...flat];
+}
+
+/**
+ * Patch the console methods on `target` so their output is timestamped.
+ * Idempotent: a second call on the same console is a no-op.
+ */
+function installConsoleTimestamps(target) {
+  if (target.__monizeTimestamps) {
+    return target;
+  }
+
+  for (const method of CONSOLE_METHODS) {
+    const original = target[method].bind(target);
+    target[method] = (...args) => original(...prefixArgs(method, args));
+  }
+
+  Object.defineProperty(target, '__monizeTimestamps', { value: true });
+  return target;
+}
+
+module.exports = { ISO_PREFIX_RE, LEVEL_LABELS, prefixArgs, installConsoleTimestamps };
+
+// When preloaded into the production standalone server, patch the real console
+// immediately so Next.js's banner is timestamped too. Gated on NODE_ENV so unit
+// tests (NODE_ENV=test) can import the pure helpers without mutating the global
+// console.
+if (process.env.NODE_ENV === 'production') {
+  installConsoleTimestamps(console);
+}

--- a/frontend/src/lib/logger.test.ts
+++ b/frontend/src/lib/logger.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createLogger } from './logger';
 
 describe('createLogger', () => {
@@ -43,6 +43,57 @@ describe('createLogger', () => {
     loggerB.info('world');
     expect(spy).toHaveBeenCalledWith('[ServiceA]', 'hello');
     expect(spy).toHaveBeenCalledWith('[ServiceB]', 'world');
+  });
+});
+
+describe('createLogger on the server', () => {
+  // The logger treats a missing `window` as server-side; stub it to undefined so
+  // `typeof window === 'undefined'` is true, exercising the Node/standalone path.
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.stubGlobal('window', undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('prefixes an ISO timestamp, context tag, and level', () => {
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const logger = createLogger('App');
+    logger.info('initialized');
+    const prefix = spy.mock.calls[0][0] as string;
+    expect(prefix).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z \[App\] INFO:$/);
+    expect(spy.mock.calls[0][1]).toBe('initialized');
+  });
+
+  it('uses the matching level label and console method for each level', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    createLogger('Svc').error('boom');
+    createLogger('Svc').warn('careful');
+    expect(errorSpy.mock.calls[0][0]).toContain('[Svc] ERROR:');
+    expect(warnSpy.mock.calls[0][0]).toContain('[Svc] WARN:');
+  });
+
+  it('flattens an Error onto a single line', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const error = new Error('something failed');
+    error.stack = 'Error: something failed\n    at foo (file.ts:1:1)\n    at bar (file.ts:2:2)';
+    createLogger('Module').error('Failed:', error);
+    const serialized = spy.mock.calls[0][2] as string;
+    expect(serialized).not.toContain('\n');
+    expect(serialized).toContain('Error: something failed');
+    expect(serialized).toContain('at foo (file.ts:1:1)');
+    expect(serialized).toContain('at bar (file.ts:2:2)');
+  });
+
+  it('passes non-Error arguments through untouched', () => {
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const payload = { count: 1 };
+    createLogger('App').info('initialized', payload);
+    expect(spy.mock.calls[0][1]).toBe('initialized');
+    expect(spy.mock.calls[0][2]).toBe(payload);
   });
 });
 

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -4,6 +4,16 @@
  * Log level is controlled by NEXT_PUBLIC_LOG_LEVEL (default: 'info').
  * Levels: error > warn > info > debug
  *
+ * Server-side (the Next.js standalone server / Node), each line is prefixed
+ * with an ISO timestamp, level, and context so the output lines up with the
+ * backend NestJS logs and can be correlated in aggregated/Docker logs, e.g.:
+ *   2026-06-19T11:20:00.123Z [Investments] ERROR: Failed to load data: ...
+ * Error objects are flattened onto a single line so a log shipper keeps one
+ * record per error instead of splitting the stack across many lines.
+ *
+ * Browser-side, lines keep the simpler `[context]` tag and pass arguments
+ * through untouched so the devtools console can expand Error objects.
+ *
  * Usage:
  *   const logger = createLogger('Investments');
  *   logger.error('Failed to load data:', error);  // level >= error
@@ -22,6 +32,13 @@ export interface Logger {
 const LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3 } as const;
 type LogLevel = keyof typeof LOG_LEVELS;
 
+const LEVEL_LABELS: Record<LogLevel, string> = {
+  error: 'ERROR',
+  warn: 'WARN',
+  info: 'INFO',
+  debug: 'DEBUG',
+};
+
 function getConfiguredLevel(): number {
   const raw = (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_LOG_LEVEL) || 'info';
   return LOG_LEVELS[raw as LogLevel] ?? LOG_LEVELS.info;
@@ -31,21 +48,46 @@ const configuredLevel = getConfiguredLevel();
 
 const noop = () => {};
 
+// Evaluated per call so the running environment (and tests that stub `window`)
+// are reflected; the check is cheap.
+function isServer(): boolean {
+  return typeof window === 'undefined';
+}
+
+/**
+ * Flatten an Error into a single line: message plus stack with newlines and
+ * their leading indentation collapsed to a literal ` \n ` separator. This keeps
+ * the whole error in one log record while staying grep-friendly.
+ */
+function flattenError(error: Error): string {
+  const stack = error.stack ?? `${error.name}: ${error.message}`;
+  return stack.replace(/\n\s*/g, ' \\n ');
+}
+
+function serializeServerArg(arg: unknown): unknown {
+  return arg instanceof Error ? flattenError(arg) : arg;
+}
+
 export function createLogger(context: string): Logger {
   const tag = `[${context}]`;
 
+  const make = (level: LogLevel, write: (...args: unknown[]) => void) => {
+    if (configuredLevel < LOG_LEVELS[level]) return noop;
+
+    return (...args: unknown[]) => {
+      if (isServer()) {
+        const prefix = `${new Date().toISOString()} ${tag} ${LEVEL_LABELS[level]}:`;
+        write(prefix, ...args.map(serializeServerArg));
+        return;
+      }
+      write(tag, ...args);
+    };
+  };
+
   return {
-    error: configuredLevel >= LOG_LEVELS.error
-      ? (...args: unknown[]) => { console.error(tag, ...args); }
-      : noop,
-    warn: configuredLevel >= LOG_LEVELS.warn
-      ? (...args: unknown[]) => { console.warn(tag, ...args); }
-      : noop,
-    info: configuredLevel >= LOG_LEVELS.info
-      ? (...args: unknown[]) => { console.info(tag, ...args); }
-      : noop,
-    debug: configuredLevel >= LOG_LEVELS.debug
-      ? (...args: unknown[]) => { console.debug(tag, ...args); }
-      : noop,
+    error: make('error', (...args) => console.error(...args)),
+    warn: make('warn', (...args) => console.warn(...args)),
+    info: make('info', (...args) => console.info(...args)),
+    debug: make('debug', (...args) => console.debug(...args)),
   };
 }

--- a/frontend/src/lib/server-log-format.test.ts
+++ b/frontend/src/lib/server-log-format.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+// The preloaded console formatter ships as raw CommonJS at the project root (it
+// is referenced by the container start command, not imported by app code).
+import {
+  prefixArgs,
+  installConsoleTimestamps,
+  ISO_PREFIX_RE,
+} from '../../server-log-format.cjs';
+
+const FIXED = new Date('2026-06-19T11:20:00.123Z');
+
+describe('prefixArgs', () => {
+  it('merges an ISO timestamp, context, and level into a leading string arg', () => {
+    expect(prefixArgs('log', ['▲ Next.js 16.2.6'], FIXED)).toEqual([
+      '2026-06-19T11:20:00.123Z [Next.js] INFO: ▲ Next.js 16.2.6',
+    ]);
+  });
+
+  it('maps console methods to level labels', () => {
+    expect(prefixArgs('warn', ['careful'], FIXED)[0]).toContain('[Next.js] WARN:');
+    expect(prefixArgs('error', ['boom'], FIXED)[0]).toContain('[Next.js] ERROR:');
+    expect(prefixArgs('debug', ['trace'], FIXED)[0]).toContain('[Next.js] DEBUG:');
+  });
+
+  it('leaves lines that already start with an ISO timestamp untouched', () => {
+    const fromLogger = ['2026-06-19T11:20:00.123Z [Proxy] INFO:', 'Backend connected'];
+    expect(prefixArgs('info', fromLogger, FIXED)).toBe(fromLogger);
+  });
+
+  it('keeps printf-style format specifiers in the first argument working', () => {
+    const result = prefixArgs('log', ['%s ready in %dms', 'app', 5], FIXED);
+    // The format string stays the (single) first argument so util.format can
+    // still interpolate the trailing values.
+    expect(result[0]).toBe('2026-06-19T11:20:00.123Z [Next.js] INFO: %s ready in %dms');
+    expect(result.slice(1)).toEqual(['app', 5]);
+  });
+
+  it('flattens an Error argument onto a single line', () => {
+    const error = new Error('something failed');
+    error.stack = 'Error: something failed\n    at foo (file.ts:1:1)\n    at bar (file.ts:2:2)';
+    const result = prefixArgs('error', ['Request failed:', error], FIXED);
+    expect(result[0]).toBe('2026-06-19T11:20:00.123Z [Next.js] ERROR: Request failed:');
+    const serialized = result[1] as string;
+    expect(serialized).not.toContain('\n');
+    expect(serialized).toContain('Error: something failed');
+    expect(serialized).toContain('at foo (file.ts:1:1)');
+    expect(serialized).toContain('at bar (file.ts:2:2)');
+  });
+
+  it('flattens an Error passed as the sole argument into one line', () => {
+    const error = new Error('boom');
+    error.stack = 'Error: boom\n    at x (y.ts:1:1)';
+    const result = prefixArgs('error', [error], FIXED);
+    // The flattened error becomes the leading string and merges with the prefix.
+    expect(result).toEqual([
+      '2026-06-19T11:20:00.123Z [Next.js] ERROR: Error: boom \\n at x (y.ts:1:1)',
+    ]);
+  });
+
+  it('prepends the prefix as a separate argument when the first arg is not a string', () => {
+    const obj = { ready: true };
+    expect(prefixArgs('info', [obj], FIXED)).toEqual([
+      '2026-06-19T11:20:00.123Z [Next.js] INFO:',
+      obj,
+    ]);
+  });
+
+  it('handles a call with no arguments', () => {
+    expect(prefixArgs('log', [], FIXED)).toEqual(['2026-06-19T11:20:00.123Z [Next.js] INFO:']);
+  });
+});
+
+describe('ISO_PREFIX_RE', () => {
+  it('matches createLogger output and rejects the framework banner', () => {
+    expect(ISO_PREFIX_RE.test('2026-06-19T11:20:00.123Z [Proxy] INFO:')).toBe(true);
+    expect(ISO_PREFIX_RE.test('▲ Next.js 16.2.6')).toBe(false);
+  });
+});
+
+describe('installConsoleTimestamps', () => {
+  it('timestamps output and is idempotent, without double-prefixing logger lines', () => {
+    const calls: unknown[][] = [];
+    const fakeConsole = {
+      log: (...args: unknown[]) => calls.push(args),
+      info: (...args: unknown[]) => calls.push(args),
+      debug: (...args: unknown[]) => calls.push(args),
+      warn: (...args: unknown[]) => calls.push(args),
+      error: (...args: unknown[]) => calls.push(args),
+    };
+
+    installConsoleTimestamps(fakeConsole);
+    installConsoleTimestamps(fakeConsole); // second call is a no-op
+
+    fakeConsole.log('▲ Next.js 16.2.6');
+    fakeConsole.info('2026-06-19T11:20:00.123Z [Proxy] INFO:', 'Backend connected');
+
+    expect(calls[0][0]).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z \[Next\.js\] INFO: ▲ Next\.js 16\.2\.6$/,
+    );
+    // The logger line is passed through unchanged (no second timestamp).
+    expect(calls[1]).toEqual(['2026-06-19T11:20:00.123Z [Proxy] INFO:', 'Backend connected']);
+  });
+});


### PR DESCRIPTION
## Linked discussion / issue

Closes #728 
Approved in: https://github.com/kenlasko/monize/issues/728

## Summary

Adds ISO timestamp prefixing to all console output in the Next.js standalone server, ensuring every line emitted by the frontend container (including Next.js's own startup banner) carries a timestamp consistent with `createLogger` output and backend NestJS logs. This enables proper log correlation in aggregated/Docker logs.

The solution consists of:

1. **`server-log-format.cjs`** – A CommonJS module preloaded via `node --require` that patches `console` methods to prefix each line with an ISO timestamp, log level, and context tag (`[Next.js]`). Lines already timestamped (from `createLogger`) are passed through untouched to avoid double-prefixing. Error objects are flattened to a single line so log shippers keep one record per error instead of splitting stacks across many lines.

2. **`createLogger` refactor** – Server-side logging now prefixes each call with an ISO timestamp, level label, and context tag, matching the format of the preloaded console formatter. Browser-side behavior is unchanged. Error arguments are flattened on the server to keep stacks in a single log record.

3. **Dockerfile update** – The `server-log-format.cjs` module is copied into the production image and preloaded before the standalone server starts via `node --require ./server-log-format.cjs server.js`.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). *(No user-facing strings added.)*
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

<!-- Disclose any AI tools used. Using AI is fine and expected — you remain responsible for correctness, conventions, and tests. -->

https://claude.ai/code/session_0178Ey3pdyb49aR9egaDFtP9