### PR TITLE
fix(securities): read security currency from live quote, not exchange

### DIFF
--- a/backend/src/securities/providers/quote-provider.interface.ts
+++ b/backend/src/securities/providers/quote-provider.interface.ts
@@ -10,6 +10,14 @@ export interface QuoteResult {
   regularMarketTime?: number;
   provider?: QuoteProviderName;
   /**
+   * The instrument's actual trading currency as reported by the provider
+   * (GBX/GBp normalized to GBP). Authoritative — unlike a currency guessed from
+   * the exchange, this is correct for non-local-currency listings (e.g. a
+   * USD-denominated ETF on the LSE). May be absent if the provider doesn't
+   * report it.
+   */
+  currencyCode?: string | null;
+  /**
    * For MSN, the SecId actually used to fetch this quote. May differ from
    * the security's stored msnInstrumentId when the stored value was in the
    * legacy FullInstrument form and we re-resolved on the fly. Lets the

--- a/backend/src/securities/securities.service.spec.ts
+++ b/backend/src/securities/securities.service.spec.ts
@@ -75,6 +75,10 @@ describe("SecuritiesService", () => {
     mockSecurityPriceService = {
       backfillSecurity: jest.fn().mockResolvedValue(undefined),
       lookupSecurityCandidates: jest.fn().mockResolvedValue([]),
+      // Default: provider reports no currency, so previewCreateSecurity keeps
+      // the lookup's exchange-derived currency. Tests that exercise the
+      // authoritative-currency override set their own resolved value.
+      fetchAuthoritativeCurrency: jest.fn().mockResolvedValue(null),
     };
 
     mockActionHistoryService = {
@@ -144,6 +148,52 @@ describe("SecuritiesService", () => {
         quoteProvider: "yahoo",
         msnInstrumentId: null,
       });
+    });
+
+    it("prefers the live-quote currency over the exchange-guessed one (USD ETF on LSE)", async () => {
+      // Lookup guesses GBP from the LSE exchange, but the instrument trades in
+      // USD -- the live quote is authoritative.
+      mockSecurityPriceService.lookupSecurityCandidates.mockResolvedValue([
+        {
+          symbol: "AGGG.L",
+          name: "iShares Core Global Aggregate Bond UCITS ETF USD (Dist)",
+          exchange: "LSE",
+          securityType: "ETF",
+          currencyCode: "GBP",
+          provider: "yahoo" as const,
+          msnInstrumentId: null,
+        },
+      ]);
+      mockSecurityPriceService.fetchAuthoritativeCurrency.mockResolvedValue(
+        "USD",
+      );
+      securitiesRepository.findOne.mockResolvedValue(null);
+
+      const preview = await service.previewCreateSecurity("user-1", {
+        query: "AGGG.L",
+        exchange: "LSE",
+      });
+
+      expect(preview.currencyCode).toBe("USD");
+      expect(
+        mockSecurityPriceService.fetchAuthoritativeCurrency,
+      ).toHaveBeenCalledWith("user-1", "AGGG.L", "LSE");
+    });
+
+    it("keeps the lookup currency when no live-quote currency is available", async () => {
+      mockSecurityPriceService.lookupSecurityCandidates.mockResolvedValue([
+        lookupResult,
+      ]);
+      mockSecurityPriceService.fetchAuthoritativeCurrency.mockResolvedValue(
+        null,
+      );
+      securitiesRepository.findOne.mockResolvedValue(null);
+
+      const preview = await service.previewCreateSecurity("user-1", {
+        query: "AAPL",
+      });
+
+      expect(preview.currencyCode).toBe("USD");
     });
 
     it("lets the caller override exchange/type and pin as favourite", async () => {
@@ -244,6 +294,23 @@ describe("SecuritiesService", () => {
       });
 
       expect(preview.currencyCode).toBe("EUR");
+    });
+
+    it("prefers the authoritative live-quote currency over an explicit override", async () => {
+      mockSecurityPriceService.lookupSecurityCandidates.mockResolvedValue([
+        { ...lookupResult, currencyCode: "GBP" },
+      ]);
+      mockSecurityPriceService.fetchAuthoritativeCurrency.mockResolvedValue(
+        "USD",
+      );
+      securitiesRepository.findOne.mockResolvedValue(null);
+
+      const preview = await service.previewCreateSecurity("user-1", {
+        query: "AGGG.L",
+        currencyCode: "EUR",
+      });
+
+      expect(preview.currencyCode).toBe("USD");
     });
   });
 

--- a/backend/src/securities/securities.service.ts
+++ b/backend/src/securities/securities.service.ts
@@ -619,10 +619,22 @@ export class SecuritiesService {
 
     const lookup = candidates[0];
 
-    // An explicit currency override wins over the provider's value and also
-    // rescues the case where the lookup couldn't determine one.
-    const currencyCode =
+    // Currency precedence: the instrument's live-quote currency is
+    // authoritative (the lookup guesses from the exchange, which is wrong for
+    // non-local-currency listings such as a USD/EUR ETF on the LSE); an
+    // explicit override is the fallback that also rescues a lookup the provider
+    // can't price; the exchange-derived guess is the last resort.
+    let currencyCode =
       input.currencyCode?.trim() || lookup.currencyCode?.trim();
+    const authoritativeCurrency =
+      await this.securityPriceService.fetchAuthoritativeCurrency(
+        userId,
+        lookup.symbol,
+        lookup.exchange,
+      );
+    if (authoritativeCurrency) {
+      currencyCode = authoritativeCurrency;
+    }
     if (!currencyCode) {
       throw new BadRequestException(
         tr(

--- a/backend/src/securities/security-price.service.spec.ts
+++ b/backend/src/securities/security-price.service.spec.ts
@@ -2295,4 +2295,40 @@ describe("SecurityPriceService", () => {
       expect(result.created).toBe(0);
     });
   });
+
+  describe("fetchAuthoritativeCurrency", () => {
+    it("returns the instrument's currency from a live quote", async () => {
+      const spy = jest
+        .spyOn(YahooFinanceService.prototype, "fetchQuote")
+        .mockResolvedValue({
+          symbol: "AGGG.L",
+          currencyCode: "USD",
+        } as never);
+
+      const currency = await service.fetchAuthoritativeCurrency(
+        "user-1",
+        "AGGG.L",
+        "LSE",
+      );
+
+      expect(currency).toBe("USD");
+      spy.mockRestore();
+    });
+
+    it("returns null when no provider reports a currency", async () => {
+      // Yahoo returns a quote without a currency; MSN is mocked to null.
+      const spy = jest
+        .spyOn(YahooFinanceService.prototype, "fetchQuote")
+        .mockResolvedValue({ symbol: "X" } as never);
+
+      const currency = await service.fetchAuthoritativeCurrency(
+        "user-1",
+        "X",
+        null,
+      );
+
+      expect(currency).toBeNull();
+      spy.mockRestore();
+    });
+  });
 });

--- a/backend/src/securities/security-price.service.ts
+++ b/backend/src/securities/security-price.service.ts
@@ -725,6 +725,41 @@ export class SecurityPriceService {
     return [];
   }
 
+  /**
+   * Fetch the instrument's authoritative trading currency from a live quote
+   * (provider `meta.currency`, GBX-normalized to GBP). Used at security-create
+   * time to correct the exchange-guessed currency from the lookup, which is
+   * wrong for non-local-currency listings (e.g. a USD ETF on the LSE). Returns
+   * null if no provider reports a currency, so callers keep their fallback.
+   */
+  async fetchAuthoritativeCurrency(
+    userId: string,
+    symbol: string,
+    exchange: string | null,
+  ): Promise<string | null> {
+    const contexts = await this.loadUserContexts([userId]);
+    const ctx = contexts.get(userId) || {
+      defaultQuoteProvider: DEFAULT_QUOTE_PROVIDER,
+      preferredExchanges: [],
+    };
+    const ordered = this.providers.resolveForSecurity(
+      { quoteProvider: null },
+      ctx.defaultQuoteProvider,
+    );
+    for (const p of ordered) {
+      try {
+        const quote = await p.fetchQuote(symbol, exchange);
+        const currency = quote?.currencyCode?.trim();
+        if (currency) return currency;
+      } catch (err) {
+        this.logger.warn(
+          `${p.name} currency lookup failed for ${symbol}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    return null;
+  }
+
   async getLastUpdateTime(): Promise<Date | null> {
     const latest = await this.securityPriceRepository.findOne({
       where: {},

--- a/backend/src/securities/yahoo-finance.service.spec.ts
+++ b/backend/src/securities/yahoo-finance.service.spec.ts
@@ -323,6 +323,46 @@ describe("YahooFinanceService", () => {
 
       expect(result!.regularMarketPrice).toBe(185.5);
     });
+
+    it("reports the instrument currency (USD passthrough)", async () => {
+      mockFetchResponse({
+        chart: {
+          result: [
+            {
+              meta: {
+                symbol: "AGGG.L",
+                currency: "USD",
+                regularMarketPrice: 4.37,
+              },
+            },
+          ],
+        },
+      });
+
+      const result = await service.fetchQuote("AGGG.L", "LSE");
+
+      expect(result!.currencyCode).toBe("USD");
+    });
+
+    it("normalizes a GBp (pence) currency to GBP", async () => {
+      mockFetchResponse({
+        chart: {
+          result: [
+            {
+              meta: {
+                symbol: "VOD.L",
+                currency: "GBp",
+                regularMarketPrice: 7000,
+              },
+            },
+          ],
+        },
+      });
+
+      const result = await service.fetchQuote("VOD.L", "LSE");
+
+      expect(result!.currencyCode).toBe("GBP");
+    });
   });
 
   describe("fetchQuotes", () => {

--- a/backend/src/securities/yahoo-finance.service.ts
+++ b/backend/src/securities/yahoo-finance.service.ts
@@ -357,6 +357,11 @@ export class YahooFinanceService implements QuoteProvider {
           regularMarketDayLow: convert(meta.regularMarketDayLow),
           regularMarketVolume: meta.regularMarketVolume,
           regularMarketTime: meta.regularMarketTime,
+          // Authoritative currency from the instrument itself. GBX/GBp (pence,
+          // the LSE quote unit) maps to GBP since prices above are converted to
+          // pounds; otherwise pass the reported currency (e.g. USD for a
+          // USD-denominated LSE ETF, where guessing from the exchange is wrong).
+          currencyCode: meta.currency ? (gbx ? "GBP" : meta.currency) : null,
           provider: "yahoo",
         };
       }


### PR DESCRIPTION
## Linked discussion / issue

Bug fix for `create_security` (added in #734).

## Summary

`create_security` (and the security lookup it shares with the AI Assistant) stored the **wrong currency for non-local-currency listings** — e.g. `AGGG.L` (iShares Core Global Aggregate Bond UCITS ETF, USD) was saved as **GBP** instead of USD.

**Root cause:** the Yahoo lookup derives currency from the *exchange* via `getCurrencyFromExchange()` (`LSE → GBP`), because the Yahoo *search* endpoint doesn't return a per-instrument currency. But the London Stock Exchange lists many USD- and EUR-denominated ETFs, so the exchange→currency guess is wrong for them. This isn't cosmetic: `security.currencyCode` drives the FX conversion for investment transactions (security currency → cash-account currency), so a mislabelled GBP corrupts cost/valuation math, not just the label.

**Fix:** take the instrument's currency from the live quote's `meta.currency` (which the code already reads for prices), not from the exchange.
- `QuoteResult` gains `currencyCode` (GBX/`GBp` normalized to GBP).
- `YahooFinanceService.fetchQuoteRaw` populates it from `meta.currency`.
- New `SecurityPriceService.fetchAuthoritativeCurrency()` resolves it for a symbol via the user's provider.
- `previewCreateSecurity` now resolves currency by precedence: **live-quote currency (authoritative) → explicit `currencyCode` override → exchange-guess fallback**. This composes with the `currencyCode` override added in #737 — the live quote wins, and the explicit override remains the fallback that also rescues a lookup the provider can't price (per the maintainer's note on #736). No regression: a failed/absent quote keeps the prior behavior.

Rebased on `main` after #737 merged.

Lookups for autocomplete are unchanged (no extra network calls); the authoritative fetch happens only at create time, for the one security being saved.

Verified: `AGGG.L` now resolves to USD; a normal LSE share (`GBp`) resolves to GBP. (MSN-primary users fall back to the exchange guess until MSN also reports currency — a small follow-up.)

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (correct security currency at create).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). _(No new strings.)_
- [x] No shared/core areas were refactored without prior agreement (additive `QuoteResult` field + one new service method; no behavior change for existing callers).
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Diagnosed and fixed with Claude Code (traced the exchange→currency guess to `yahoo-finance.service.ts`); reviewed and tested locally. For this fix in particular I read through the logic myself and understand it — I reproduced the same resolution logic in a standalone script and verified it against live Yahoo data (`AGGG.L` reports USD, a normal LSE share reports `GBp`→GBP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
