### PR TITLE
fix(ai): stop the AI chat page overflowing the viewport by the header height

### DIFF
--- a/frontend/src/app/ai/page.tsx
+++ b/frontend/src/app/ai/page.tsx
@@ -2,7 +2,6 @@
 
 import { useTranslations } from 'next-intl';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
-import { PageLayout } from '@/components/layout/PageLayout';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { ChatInterface } from '@/components/ai/ChatInterface';
 
@@ -10,18 +9,26 @@ export default function AiPage() {
   const t = useTranslations('ai');
   return (
     <ProtectedRoute>
-      <PageLayout>
-        <main className="px-4 sm:px-6 lg:px-12 pt-6 pb-8">
+      {/*
+        The chat is meant to fit the viewport, so this page is bounded to the
+        space below the sticky AppHeader (h-16 = 4rem) and lays its content out
+        as a flex column -- not PageLayout's `min-h-screen`, which would force
+        the content to >=100vh under the 4rem header and overflow the viewport
+        by exactly the header height (the stray page scrollbar this fixes).
+        100dvh keeps it correct on mobile where the address bar collapses.
+      */}
+      <div className="flex flex-col h-[calc(100dvh-4rem)] bg-gray-50 dark:bg-gray-900">
+        <main className="flex flex-1 min-h-0 flex-col px-4 sm:px-6 lg:px-12 pt-6 pb-8">
           <PageHeader
             title={t('page.title')}
             subtitle={t('page.subtitle')}
             helpUrl="https://github.com/kenlasko/monize/wiki/AI"
           />
-          <div className="max-w-4xl mx-auto">
+          <div className="flex min-h-0 flex-1 flex-col w-full max-w-4xl mx-auto">
             <ChatInterface />
           </div>
         </main>
-      </PageLayout>
+      </div>
     </ProtectedRoute>
   );
 }

--- a/frontend/src/components/ai/ChatInterface.tsx
+++ b/frontend/src/components/ai/ChatInterface.tsx
@@ -109,7 +109,7 @@ export function ChatInterface() {
     !statusLoading && aiStatus && !aiStatus.configured;
 
   return (
-    <div className="flex flex-col h-[calc(100vh-12rem)]">
+    <div className="flex flex-col h-full min-h-0">
       {/* AI not configured banner */}
       {aiNotConfigured && (
         <div className="mb-4 p-4 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800 rounded-lg">


### PR DESCRIPTION
## Linked discussion / issue

Bug fix: stray page scrollbar on the AI chat page.

## Summary

The AI chat page (`/ai`) had a stray vertical page scrollbar: the page was taller than the viewport and could be scrolled down by exactly the height of the app header, even though the chat has its own internal scroll area.

**Root cause:** `AppHeader` is `sticky top-0` and `h-16` (4rem), and `PageLayout` wraps page content in `min-h-screen` (>=100vh). On a page meant to fit the viewport, that guarantees `4rem (header) + 100vh (content) = 100vh + header`, so the page overflows by exactly the header height. The chat's own `h-[calc(100vh-12rem)]` magic offset never affected this — the overflow came entirely from `min-h-screen` sitting under the sticky header.

**Fix (scoped to `/ai`):**
- The page is now bounded to `h-[calc(100dvh-4rem)]` (the space below the sticky `h-16` header) and lays out as a flex column, instead of `PageLayout`'s `min-h-screen`.
- `ChatInterface` fills that bounded parent with `h-full min-h-0` instead of the hardcoded `h-[calc(100vh-12rem)]`, so its size no longer depends on guessing the combined height of the header, page padding, page title, and (relay users only) the status bar.
- `100dvh` (not `100vh`) so the mobile address-bar collapse doesn't reintroduce the same off-by-a-bit overflow.

No other page uses `PageLayout` differently and no shared component changed, so this is contained to the chat page. No user-facing strings added.

## Checklist

- [x] This PR addresses a **single concern** (chat page viewport sizing).
- [x] Existing tests pass (`page.test.tsx`, `ChatInterface.test.tsx`); no layout-class assertions to update.
- [x] All user-facing strings are translated for every locale. _(No new strings.)_
- [x] No shared/core areas were refactored without prior agreement (change is confined to `app/ai/page.tsx` and the chat container class).
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Diagnosed and fixed with Claude Code (traced the overflow to `min-h-screen` under the sticky `h-16` header). Reviewed and tested locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
