### PR TITLE
test: add branch-coverage tests for import parsers and recurring-charge detection

### DIFF
--- a/backend/src/import/csv-parser.spec.ts
+++ b/backend/src/import/csv-parser.spec.ts
@@ -107,6 +107,21 @@ describe("CSV Parser", () => {
       expect(result.sampleRows).toEqual([]);
       expect(result.rowCount).toBe(0);
     });
+
+    it("auto-detects a delimiter with inconsistent column counts", () => {
+      // Comma appears in every line but with differing counts, so detection
+      // falls through the "consistent" check to the most-present candidate.
+      const csv = "A,B,C\nd,e\nf,g,h,i\n";
+      const result = parseCsvHeaders(csv);
+      expect(result.headers).toEqual(["A", "B", "C"]);
+    });
+
+    it("ignores delimiters inside quoted fields during auto-detection", () => {
+      const csv = '"Name","Amount"\n"Smith, John",100\n';
+      const result = parseCsvHeaders(csv);
+      expect(result.headers).toEqual(["Name", "Amount"]);
+      expect(result.sampleRows[0]).toEqual(["Smith, John", "100"]);
+    });
   });
 
   describe("parseCsv", () => {
@@ -263,6 +278,32 @@ describe("CSV Parser", () => {
         // reverseSign only applies to single amount mode
         expect(result.transactions[0].amount).toBe(-50);
         expect(result.transactions[1].amount).toBe(100);
+      });
+
+      it("uses a debit-only column (no credit mapping)", () => {
+        const csv = "Date,Debit,Payee\n01/15/2026,50.00,Store\n";
+        const config = baseConfig({
+          amount: undefined,
+          debit: 1,
+          credit: undefined,
+          payee: 2,
+        });
+        const result = parseCsv(csv, config);
+
+        expect(result.transactions[0].amount).toBe(-50);
+      });
+
+      it("uses a credit-only column (no debit mapping)", () => {
+        const csv = "Date,Credit,Payee\n01/15/2026,100.00,Deposit\n";
+        const config = baseConfig({
+          amount: undefined,
+          debit: undefined,
+          credit: 1,
+          payee: 2,
+        });
+        const result = parseCsv(csv, config);
+
+        expect(result.transactions[0].amount).toBe(100);
       });
     });
 
@@ -635,6 +676,56 @@ describe("CSV Parser", () => {
         expect(result.transactions).toHaveLength(1);
         expect(result.transactions[0].payee).toBe("Shop");
       });
+
+      it("skips a non-ISO date when the format expects YYYY-MM-DD", () => {
+        const csv =
+          "Date,Amount,Payee\n01/15/2026,-50.00,Store\n2026-01-16,-30.00,Shop\n";
+        const result = parseCsv(csv, baseConfig({ dateFormat: "YYYY-MM-DD" }));
+
+        // First row does not match the ISO regex and is skipped
+        expect(result.transactions).toHaveLength(1);
+        expect(result.transactions[0].payee).toBe("Shop");
+      });
+    });
+
+    describe("custom date format patterns", () => {
+      it("parses a dotted DD.MM.YYYY custom pattern", () => {
+        const csv = "Date,Amount,Payee\n15.01.2026,-50.00,Store\n";
+        const result = parseCsv(csv, baseConfig({ dateFormat: "DD.MM.YYYY" }));
+
+        expect(result.transactions[0].date).toBe("2026-01-15");
+      });
+
+      it("resolves a 2-digit year in a custom YY/MM/DD pattern (20xx)", () => {
+        const csv = "Date,Amount,Payee\n26/01/15,-50.00,Store\n";
+        const result = parseCsv(csv, baseConfig({ dateFormat: "YY/MM/DD" }));
+
+        expect(result.transactions[0].date).toBe("2026-01-15");
+      });
+
+      it("resolves a 2-digit year above 50 to the 1900s", () => {
+        const csv = "Date,Amount,Payee\n75/01/15,-50.00,Store\n";
+        const result = parseCsv(csv, baseConfig({ dateFormat: "YY/MM/DD" }));
+
+        expect(result.transactions[0].date).toBe("1975-01-15");
+      });
+
+      it("skips a row when a custom pattern does not match", () => {
+        const csv =
+          "Date,Amount,Payee\nnot-a-date,-50.00,Store\n15.01.2026,-30.00,Shop\n";
+        const result = parseCsv(csv, baseConfig({ dateFormat: "DD.MM.YYYY" }));
+
+        expect(result.transactions).toHaveLength(1);
+        expect(result.transactions[0].payee).toBe("Shop");
+      });
+
+      it("skips a row when a custom pattern lacks a required component", () => {
+        // Pattern has no year token, so year stays empty and the date is null
+        const csv = "Date,Amount,Payee\n01/15,-50.00,Store\n";
+        const result = parseCsv(csv, baseConfig({ dateFormat: "MM/DD" }));
+
+        expect(result.transactions).toHaveLength(0);
+      });
     });
 
     describe("amount formatting", () => {
@@ -852,6 +943,17 @@ describe("CSV Parser", () => {
           "Transport:Bus Fare",
         ]);
       });
+
+      it("truncates an over-long combined category to the column limit", () => {
+        const cat = "C".repeat(200);
+        const sub = "S".repeat(200);
+        const csv = `Date,Amount,Payee,Category,Subcategory\n01/15/2026,-50.00,Store,${cat},${sub}\n`;
+        const config = baseConfig({ category: 3, subcategory: 4 });
+        const result = parseCsv(csv, config);
+
+        // CATEGORY limit is 255
+        expect(result.transactions[0].category).toHaveLength(255);
+      });
     });
 
     describe("amount type column", () => {
@@ -898,6 +1000,17 @@ describe("CSV Parser", () => {
 
       it("leaves amount unchanged for unrecognized values (not in any list)", () => {
         const csv = "Date,Amount,Type\n01/15/2026,650.23,Unknown\n";
+        const config = baseConfig({
+          amountTypeColumn: 2,
+          expenseValues: ["Expense"],
+        });
+        const result = parseCsv(csv, config);
+
+        expect(result.transactions[0].amount).toBe(650.23);
+      });
+
+      it("leaves amount unchanged when the type column is empty", () => {
+        const csv = "Date,Amount,Type\n01/15/2026,650.23,\n";
         const config = baseConfig({
           amountTypeColumn: 2,
           expenseValues: ["Expense"],
@@ -1562,6 +1675,35 @@ describe("CSV Parser", () => {
       expect(normalizeReconciliationStatus("anything weird")).toBe(
         "UNRECONCILED",
       );
+    });
+
+    it("falls back to substring matches inside longer status sentences", () => {
+      expect(normalizeReconciliationStatus("order cancellation pending")).toBe(
+        "VOID",
+      );
+      expect(
+        normalizeReconciliationStatus("Payment reconciled on 2026-01-15"),
+      ).toBe("RECONCILED");
+      expect(normalizeReconciliationStatus("Transaction posted today")).toBe(
+        "CLEARED",
+      );
+      expect(normalizeReconciliationStatus("still pending review")).toBe(
+        "UNRECONCILED",
+      );
+    });
+
+    it("de-duplicates tags case-insensitively and truncates long names", () => {
+      expect(splitTagValue("Food, food, FOOD", ",")).toEqual(["Food"]);
+      const longTag = "T".repeat(120);
+      const [name] = splitTagValue(longTag, ",");
+      // TAG limit is 100
+      expect(name).toHaveLength(100);
+    });
+
+    it("ignores null entries when detecting a tag separator", () => {
+      expect(
+        detectTagSeparator([null as unknown as string, "a;b", "c;d"]),
+      ).toBe(";");
     });
   });
 });

--- a/backend/src/import/qif-parser.spec.ts
+++ b/backend/src/import/qif-parser.spec.ts
@@ -2124,3 +2124,196 @@ T-50.00
     });
   });
 });
+
+describe("parseQif - field edge cases", () => {
+  it("truncates over-long field values to the column limit", () => {
+    const longPayee = "A".repeat(300);
+    const qif = `!Type:Bank\nD01/15/2026\nT-50.00\nP${longPayee}\n^\n`;
+    const result = parseQif(qif, "MM/DD/YYYY");
+    // PAYEE limit is 255
+    expect(result.transactions[0].payee).toHaveLength(255);
+  });
+
+  it("keeps the !Type account type when the !Account T type is unknown", () => {
+    const qif = `!Account\nNMy Account\nTWeirdType\n^\n!Type:Bank\nD01/15/2026\nT-50.00\nPStore\n^\n`;
+    const result = parseQif(qif, "MM/DD/YYYY");
+    expect(result.accountType).toBe("CHEQUING");
+  });
+
+  it("falls back to zero for an unparseable amount", () => {
+    const qif = `!Type:Bank\nD01/15/2026\nTnot-a-number\nPStore\n^\n`;
+    const result = parseQif(qif, "MM/DD/YYYY");
+    expect(result.transactions[0].amount).toBe(0);
+  });
+
+  it("leaves cleared and reconciled false for an unrecognised C value", () => {
+    const qif = `!Type:Bank\nD01/15/2026\nT-50.00\nPStore\nC?\n^\n`;
+    const result = parseQif(qif, "MM/DD/YYYY");
+    expect(result.transactions[0].cleared).toBe(false);
+    expect(result.transactions[0].reconciled).toBe(false);
+  });
+
+  it("ignores split memo (E) and split amount ($) with no active split", () => {
+    const qif = `!Type:Bank\nD01/15/2026\nT-50.00\nPStore\nEorphan memo\n$-10.00\n^\n`;
+    const result = parseQif(qif, "MM/DD/YYYY");
+    const tx = result.transactions[0];
+    expect(tx.splits).toHaveLength(0);
+    expect(tx.amount).toBe(-50);
+  });
+
+  it("does not register an empty security symbol", () => {
+    const qif = `!Type:Invst\nD01/15/2026\nNBuy\nY\nI10.00\nQ5\nT-50.00\n^\n`;
+    const result = parseQif(qif, "MM/DD/YYYY");
+    expect(result.transactions[0].security).toBe("");
+    expect(result.securities).toHaveLength(0);
+  });
+
+  it("treats a StkSplit ratio with a zero denominator as zero quantity", () => {
+    const qif = `!Type:Invst\nD01/15/2026\nNStkSplit\nQ2:0\n^\n`;
+    const result = parseQif(qif, "MM/DD/YYYY");
+    expect(result.transactions[0].quantity).toBe(0);
+  });
+
+  it("treats a non-numeric StkSplit quantity as zero", () => {
+    const qif = `!Type:Invst\nD01/15/2026\nNStkSplit\nQabc\n^\n`;
+    const result = parseQif(qif, "MM/DD/YYYY");
+    expect(result.transactions[0].quantity).toBe(0);
+  });
+
+  it("disambiguates an ISO date format using a later unambiguous day-first date", () => {
+    // First date is ambiguous; a later YYYY-DD-MM date (day 15 > 12) resolves it.
+    const qif = `!Type:Bank\nD2026-05-06\nT-10.00\n^\nD2026-15-03\nT-20.00\n^\n`;
+    const result = parseQif(qif);
+    expect(result.detectedDateFormat).toBe("YYYY-DD-MM");
+  });
+
+  it("disambiguates an ISO date format using a later unambiguous month-first date", () => {
+    const qif = `!Type:Bank\nD2026-05-06\nT-10.00\n^\nD2026-03-15\nT-20.00\n^\n`;
+    const result = parseQif(qif);
+    expect(result.detectedDateFormat).toBe("YYYY-MM-DD");
+  });
+
+  it("decodes a StkSplit quantity when the file ends without a separator", () => {
+    const qif = `!Type:Invst\nD01/15/2026\nNStkSplit\nYAAPL\nQ20\n`;
+    const result = parseQif(qif, "MM/DD/YYYY");
+    expect(result.transactions[0].quantity).toBe(2);
+  });
+});
+
+describe("parseQifFull - field edge cases", () => {
+  it("parses account description, credit limit, and an unknown account type", () => {
+    const qif = `!Account
+NMy Asset Account
+Toth a
+DAsset description
+L5000.00
+^
+!Type:Foo
+D01/15/2026
+T-50.00
+PStore
+^
+`;
+    const result = parseQifFull(qif, "MM/DD/YYYY");
+    const block = result.accountBlocks[0];
+    // Unknown !Type falls back to the pending account type from the !Account section
+    expect(block.accountType).toBe("ASSET");
+    expect(block.description).toBe("Asset description");
+    expect(block.creditLimit).toBe(5000);
+  });
+
+  it("uppercases an unknown !Account T type as the pending type", () => {
+    const qif = `!Account
+NMystery
+TGizmo
+^
+!Type:Foo
+D01/15/2026
+T-50.00
+^
+`;
+    const result = parseQifFull(qif, "MM/DD/YYYY");
+    expect(result.accountBlocks[0].accountType).toBe("GIZMO");
+  });
+
+  it("skips !Type:Security/Prices/Budget sections", () => {
+    const qif = `!Type:Security
+NApple Inc
+SAAPL
+^
+!Type:Prices
+"AAPL",150.00,"01/15/2026"
+^
+!Type:Budget
+NMonthly
+^
+!Account
+NChecking
+TBank
+^
+!Type:Bank
+D01/15/2026
+T-50.00
+PStore
+^
+`;
+    const result = parseQifFull(qif, "MM/DD/YYYY");
+    expect(result.accountBlocks).toHaveLength(1);
+    expect(result.accountBlocks[0].transactions).toHaveLength(1);
+  });
+
+  it("records lowercase reconciled status (Cx)", () => {
+    const qif = `!Account\nNChecking\nTBank\n^\n!Type:Bank\nD01/15/2026\nT-50.00\nPStore\nCx\n^\n`;
+    const result = parseQifFull(qif, "MM/DD/YYYY");
+    expect(result.accountBlocks[0].transactions[0].reconciled).toBe(true);
+  });
+
+  it("ignores split memo (E) and amount ($) with no active split", () => {
+    const qif = `!Account\nNChecking\nTBank\n^\n!Type:Bank\nD01/15/2026\nT-50.00\nPStore\nEorphan\n$-10.00\n^\n`;
+    const result = parseQifFull(qif, "MM/DD/YYYY");
+    expect(result.accountBlocks[0].transactions[0].splits).toHaveLength(0);
+  });
+
+  it("does not register an empty security symbol", () => {
+    const qif = `!Account\nNBrokerage\nTInvst\n^\n!Type:Invst\nD01/15/2026\nNBuy\nY\nI10.00\nQ5\nT-50.00\n^\n`;
+    const result = parseQifFull(qif, "MM/DD/YYYY");
+    expect(result.accountBlocks[0].securities).toHaveLength(0);
+  });
+
+  it("decodes a StkSplit quantity at the record separator", () => {
+    // Q20 with StkSplit action decodes to ratio 2.0
+    const qif = `!Account\nNBrokerage\nTInvst\n^\n!Type:Invst\nD01/15/2026\nNStkSplit\nYAAPL\nQ20\n^\n`;
+    const result = parseQifFull(qif, "MM/DD/YYYY");
+    expect(result.accountBlocks[0].transactions[0].quantity).toBe(2);
+  });
+
+  it("decodes a StkSplit quantity when the block ends without a separator", () => {
+    // No trailing ^ -- finalizeBlock must re-interpret the StkSplit Q field
+    const qif = `!Account\nNBrokerage\nTInvst\n^\n!Type:Invst\nD01/15/2026\nNStkSplit\nYAAPL\nQ20\n`;
+    const result = parseQifFull(qif, "MM/DD/YYYY");
+    expect(result.accountBlocks[0].transactions[0].quantity).toBe(2);
+  });
+
+  it("pushes a pending split when the block ends without a separator", () => {
+    const qif = `!Account\nNChecking\nTBank\n^\n!Type:Bank\nD01/15/2026\nT-100.00\nPStore\nSFood\n$-100.00\n`;
+    const result = parseQifFull(qif, "MM/DD/YYYY");
+    const tx = result.accountBlocks[0].transactions[0];
+    expect(tx.splits).toHaveLength(1);
+    expect(tx.splits[0].category).toBe("Food");
+  });
+
+  it("saves the previous category when a new N arrives without a separator", () => {
+    const qif = `!Type:Cat\nNFood\nE\nNUtilities\nE\n^\n!Account\nNChecking\nTBank\n^\n!Type:Bank\nD01/15/2026\nT-50.00\n^\n`;
+    const result = parseQifFull(qif, "MM/DD/YYYY");
+    expect(result.categoryDefs.map((c) => c.name)).toEqual([
+      "Food",
+      "Utilities",
+    ]);
+  });
+
+  it("saves the previous tag when a new N arrives without a separator", () => {
+    const qif = `!Type:Tag\nNVacation\nDTravel\nNBusiness\n^\n!Account\nNChecking\nTBank\n^\n!Type:Bank\nD01/15/2026\nT-50.00\n^\n`;
+    const result = parseQifFull(qif, "MM/DD/YYYY");
+    expect(result.tagDefs.map((t) => t.name)).toEqual(["Vacation", "Business"]);
+  });
+});

--- a/backend/src/transactions/recurring-charges.util.spec.ts
+++ b/backend/src/transactions/recurring-charges.util.spec.ts
@@ -1,0 +1,68 @@
+import { detectFrequency } from "./recurring-charges.util";
+
+/**
+ * Build an ascending list of ISO date strings starting at `start`, with each
+ * consecutive date separated by `gapDays`. An optional `jitter` array offsets
+ * individual gaps so we can exercise the variance / std-dev branch.
+ */
+function buildDates(
+  start: string,
+  gapDays: number,
+  count: number,
+  jitter: number[] = [],
+): string[] {
+  const dates: string[] = [];
+  let current = new Date(start).getTime();
+  dates.push(new Date(current).toISOString().slice(0, 10));
+  for (let i = 1; i < count; i++) {
+    const offset = jitter[i - 1] ?? 0;
+    current += (gapDays + offset) * 24 * 60 * 60 * 1000;
+    dates.push(new Date(current).toISOString().slice(0, 10));
+  }
+  return dates;
+}
+
+describe("detectFrequency", () => {
+  it("returns irregular when there are fewer than three dates", () => {
+    expect(detectFrequency([])).toBe("irregular");
+    expect(detectFrequency(["2026-01-01"])).toBe("irregular");
+    expect(detectFrequency(["2026-01-01", "2026-01-08"])).toBe("irregular");
+  });
+
+  it("classifies a weekly cadence (avg gap 5-10 days)", () => {
+    expect(detectFrequency(buildDates("2026-01-01", 7, 5))).toBe("weekly");
+  });
+
+  it("classifies a biweekly cadence (avg gap 12-18 days)", () => {
+    expect(detectFrequency(buildDates("2026-01-01", 14, 5))).toBe("biweekly");
+  });
+
+  it("classifies a monthly cadence (avg gap 25-35 days)", () => {
+    expect(detectFrequency(buildDates("2026-01-01", 30, 6))).toBe("monthly");
+  });
+
+  it("classifies a quarterly cadence (avg gap 80-100 days)", () => {
+    expect(detectFrequency(buildDates("2026-01-01", 91, 5))).toBe("quarterly");
+  });
+
+  it("classifies a yearly cadence (avg gap 350-380 days)", () => {
+    expect(detectFrequency(buildDates("2020-01-01", 365, 4))).toBe("yearly");
+  });
+
+  it("returns irregular when gaps are too noisy relative to the average", () => {
+    // Average gap ~30 days but with large swings, pushing std-dev above the
+    // 40% threshold.
+    const noisy = buildDates("2026-01-01", 30, 5, [20, -20, 25, -22]);
+    expect(detectFrequency(noisy)).toBe("irregular");
+  });
+
+  it("returns irregular when the steady gap falls between recognised bands", () => {
+    // ~21-day cadence is consistent (low variance) but matches none of the
+    // named frequency windows, so it falls through to irregular.
+    expect(detectFrequency(buildDates("2026-01-01", 21, 5))).toBe("irregular");
+  });
+
+  it("returns irregular for sub-weekly daily charges", () => {
+    expect(detectFrequency(buildDates("2026-01-01", 2, 5))).toBe("irregular");
+  });
+});


### PR DESCRIPTION
Branch coverage was sitting exactly on the 85% threshold. Add focused tests
that exercise previously-uncovered branches:

- recurring-charges.util: new spec covering every cadence band (weekly,
  biweekly, monthly, quarterly, yearly) plus irregular/noisy/too-few-points
  cases (file was entirely untested).
- qif-parser: field truncation, unknown account types, unparseable amounts,
  orphan split fields, empty securities, StkSplit ratio edge cases, deep ISO
  date disambiguation, EOF finalization, and consecutive cat/tag defs without
  separators (82% -> 92% branches).
- csv-parser: reconciliation-status substring fallbacks, tag dedup/truncation,
  debit-only/credit-only columns, combined-category truncation, empty
  amount-type values, and the custom date-format parser (84% -> 96% branches).

Global branch coverage 85.00% -> 85.49%.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012PBYKPQM6JDbokjFf4FDjH