### PR TITLE
fix(investments): use a real FX rate for cross-currency transactions, never a silent 1.0

### DIFF
--- a/backend/src/ai/query/tool-definitions.ts
+++ b/backend/src/ai/query/tool-definitions.ts
@@ -769,6 +769,11 @@ export const FINANCIAL_TOOLS: AiToolDefinition[] = [
                 description:
                   "Commission or fee (up to 4 decimals). Defaults to 0.",
               },
+              exchangeRate: {
+                type: "number",
+                description:
+                  "create/update: FX rate converting the security's currency into the funding cash account's currency (e.g. for a EUR security funded from a PLN account, the EUR->PLN rate such as 4.2514). Supply this when the broker's settlement data gives the rate or the converted cash total, so the cash posting is exact. Omit for same-currency transactions, or to use the rate for the transaction date.",
+              },
               fundingAccountName: {
                 type: "string",
                 description:

--- a/backend/src/ai/query/tool-executor.service.spec.ts
+++ b/backend/src/ai/query/tool-executor.service.spec.ts
@@ -1380,6 +1380,30 @@ describe("ToolExecutorService", () => {
       expect(JSON.stringify(result.data)).not.toContain("signature-abc");
     });
 
+    it("forwards an explicit exchangeRate to the create prep (issue #744)", async () => {
+      await service.execute(userId, "manage_investment_transactions", {
+        operation: "create",
+        items: [
+          {
+            accountName: "Brokerage",
+            action: "BUY",
+            date: "2026-01-15",
+            security: "AAPL",
+            quantity: 10,
+            price: 150,
+            exchangeRate: 4.2514,
+          },
+        ],
+      });
+
+      expect(
+        investmentTransactions.prepareCreateInvestmentSingle,
+      ).toHaveBeenCalledWith(
+        userId,
+        expect.objectContaining({ exchangeRate: 4.2514 }),
+      );
+    });
+
     it("single create surfaces a 4xx preview error without a pending action", async () => {
       investmentTransactions.prepareCreateInvestmentSingle.mockRejectedValueOnce(
         new BadRequestException(

--- a/backend/src/ai/query/tool-executor.service.ts
+++ b/backend/src/ai/query/tool-executor.service.ts
@@ -1310,6 +1310,7 @@ export class ToolExecutorService {
       price: item.price as number | undefined,
       commission: item.commission as number | undefined,
       fundingAccountName: item.fundingAccountName as string | undefined,
+      exchangeRate: item.exchangeRate as number | undefined,
       description: item.description as string | undefined,
     };
   }
@@ -1325,6 +1326,7 @@ export class ToolExecutorService {
       quantity: item.quantity as number | undefined,
       price: item.price as number | undefined,
       commission: item.commission as number | undefined,
+      exchangeRate: item.exchangeRate as number | undefined,
       description: item.description as string | undefined,
     };
   }

--- a/backend/src/ai/query/tool-input-schemas.ts
+++ b/backend/src/ai/query/tool-input-schemas.ts
@@ -284,6 +284,7 @@ const manageInvestmentItemSchema = z
     quantity: nonNegativeAmountSchema.optional(),
     price: nonNegativeAmountSchema.optional(),
     commission: nonNegativeAmountSchema.optional(),
+    exchangeRate: nonNegativeAmountSchema.optional(),
     description: z.string().max(500).optional(),
     transactionId: z.string().uuid().optional(),
   })

--- a/backend/src/currencies/exchange-rate.service.spec.ts
+++ b/backend/src/currencies/exchange-rate.service.spec.ts
@@ -773,6 +773,58 @@ describe("ExchangeRateService", () => {
     });
   });
 
+  describe("getRateForDate", () => {
+    it("returns 1 for the same currency without any lookup", async () => {
+      const result = await service.getRateForDate("USD", "USD", "2026-06-08");
+
+      expect(result).toBe(1);
+      expect(exchangeRateRepository.findOne).not.toHaveBeenCalled();
+      expect(yahooFinanceService.fetchHistorical).not.toHaveBeenCalled();
+    });
+
+    it("returns the closest stored rate on or before the target date", async () => {
+      exchangeRateRepository.findOne.mockResolvedValue(mockExchangeRate);
+
+      const result = await service.getRateForDate("USD", "CAD", "2026-06-08");
+
+      expect(result).toBe(1.365);
+      // Looked up the latest stored rate not after the target date.
+      const call = exchangeRateRepository.findOne.mock.calls[0][0];
+      expect(call.where.fromCurrency).toBe("USD");
+      expect(call.where.toCurrency).toBe("CAD");
+      expect(call.order).toEqual({ rateDate: "DESC" });
+      // No Yahoo fetch needed when a stored rate exists.
+      expect(yahooFinanceService.fetchHistorical).not.toHaveBeenCalled();
+    });
+
+    it("fetches the historical rate for the date from Yahoo when none is stored", async () => {
+      exchangeRateRepository.findOne.mockResolvedValue(null);
+      exchangeRateRepository.save.mockImplementation((data) => data);
+      // Daily series straddling the target 2026-06-08 (a weekend in this set):
+      // the closest day on or before is 2026-06-05.
+      yahooFinanceService.fetchHistorical.mockResolvedValue([
+        { date: new Date("2026-06-05"), close: 4.25, open: null, high: null, low: null, volume: null },
+        { date: new Date("2026-06-09"), close: 4.3, open: null, high: null, low: null, volume: null },
+      ]);
+
+      const result = await service.getRateForDate("EUR", "PLN", "2026-06-08");
+
+      expect(result).toBe(4.25);
+      expect(yahooFinanceService.fetchHistorical).toHaveBeenCalled();
+      // The chosen point is persisted for reuse (forward + inverse via saveRate).
+      expect(exchangeRateRepository.save).toHaveBeenCalled();
+    });
+
+    it("returns null when neither a stored rate nor a Yahoo series is available", async () => {
+      exchangeRateRepository.findOne.mockResolvedValue(null);
+      yahooFinanceService.fetchHistorical.mockResolvedValue(null);
+
+      const result = await service.getRateForDate("EUR", "PLN", "2026-06-08");
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe("getLatestRates", () => {
     it("returns latest rates using distinctOn query", async () => {
       const rates = [mockExchangeRate];

--- a/backend/src/currencies/exchange-rate.service.ts
+++ b/backend/src/currencies/exchange-rate.service.ts
@@ -568,6 +568,75 @@ export class ExchangeRateService implements OnModuleInit {
   }
 
   /**
+   * Get the exchange rate for a currency pair as of a specific date.
+   *
+   * Unlike getLatestRate (the once-a-day stored snapshot), this returns the
+   * rate that applied on the transaction's date -- essential for back-dated
+   * transactions, where the latest snapshot can be far from the historical
+   * rate. Precedence:
+   *   1. The stored rate on the closest date on or before the target
+   *      (carry-forward, matching how a missing weekend/holiday is handled).
+   *   2. A historical daily series fetched from Yahoo for the pair; the value
+   *      on the closest day on or before the target is used and persisted for
+   *      reuse.
+   * Returns null when no rate can be determined (so the caller can reject or
+   * flag the operation rather than silently assuming 1.0).
+   */
+  async getRateForDate(
+    from: string,
+    to: string,
+    date: string | Date,
+  ): Promise<number | null> {
+    if (from === to) return 1;
+
+    const target =
+      typeof date === "string"
+        ? date.slice(0, 10)
+        : date.toISOString().slice(0, 10);
+    const targetDate = new Date(`${target}T00:00:00.000Z`);
+
+    // 1. Closest stored rate on or before the target date.
+    const stored = await this.exchangeRateRepository.findOne({
+      where: {
+        fromCurrency: from,
+        toCurrency: to,
+        rateDate: LessThanOrEqual(targetDate),
+      },
+      order: { rateDate: "DESC" },
+    });
+    if (stored) return Number(stored.rate);
+
+    // 2. Fetch the historical daily series from Yahoo and use the rate on the
+    //    closest day on or before the target. Persist just the chosen point
+    //    (and its inverse, via saveRate) so a repeat lookup hits the database
+    //    without re-fetching the whole series.
+    const series = await this.fetchYahooHistoricalRates(from, to);
+    if (series && series.length > 0) {
+      const targetTime = targetDate.getTime();
+      const sorted = [...series].sort(
+        (a, b) => a.date.getTime() - b.date.getTime(),
+      );
+      const onOrBefore = sorted.filter((p) => p.date.getTime() <= targetTime);
+      // Fall back to the earliest available point when the target predates the
+      // series -- a best-effort rate is still far better than a silent 1.0.
+      const chosen =
+        onOrBefore.length > 0 ? onOrBefore[onOrBefore.length - 1] : sorted[0];
+      try {
+        await this.saveRate(from, to, chosen.rate, chosen.date);
+      } catch (error) {
+        this.logger.warn(
+          `Could not persist historical rate ${from}->${to} for ${target}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+      return chosen.rate;
+    }
+
+    return null;
+  }
+
+  /**
    * Get the current spot rate for a currency pair, fetched live from the quote
    * provider. Tries the direct pair, then the reverse pair (inverted), then
    * falls back to the most recent stored daily rate when the live fetch is

--- a/backend/src/i18n/locales/de/errors.json
+++ b/backend/src/i18n/locales/de/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "Datum muss im Format YYYY-MM-DD sein"
   },
   "securities": {
+    "exchangeRateUnavailable": "Wechselkurs für {{ from }} -> {{ to }} zum Transaktionsdatum konnte nicht ermittelt werden. Geben Sie einen expliziten exchangeRate an, damit die Buchung auf dem Geldkonto korrekt ist.",
     "accountMustBeInvestment": "Konto muss vom Typ INVESTMENT sein",
     "securityIdRequired": "Wertpapier-ID ist für {{ action }}-Buchungen erforderlich",
     "splitRatioRequired": "Teilungsverhältnis (Menge) muss größer als null sein",

--- a/backend/src/i18n/locales/en/errors.json
+++ b/backend/src/i18n/locales/en/errors.json
@@ -322,6 +322,7 @@
   "securities": {
     "accountMustBeInvestment": "Account must be of type INVESTMENT",
     "securityIdRequired": "Security ID is required for {{ action }} transactions",
+    "exchangeRateUnavailable": "Could not determine an exchange rate for {{ from }} -> {{ to }} on the transaction date. Supply an explicit exchangeRate so the cash posting is correct.",
     "splitRatioRequired": "Split ratio (quantity) must be greater than zero",
     "ambiguousSecurity": "\"{{ query }}\" matches multiple securities: {{ list }}. Use the exact ticker symbol.",
     "securityNotFoundByQuery": "No security matches \"{{ query }}\". Add the security first or check the ticker symbol.",

--- a/backend/src/i18n/locales/es/errors.json
+++ b/backend/src/i18n/locales/es/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "la fecha debe estar en formato YYYY-MM-DD"
   },
   "securities": {
+    "exchangeRateUnavailable": "No se pudo determinar un tipo de cambio para {{ from }} -> {{ to }} en la fecha de la transacción. Indica un exchangeRate explícito para que el asiento en la cuenta de efectivo sea correcto.",
     "accountMustBeInvestment": "La cuenta debe ser de tipo INVESTMENT",
     "securityIdRequired": "El ID del valor es obligatorio para las transacciones de {{ action }}",
     "splitRatioRequired": "El ratio de división (cantidad) debe ser mayor que cero",

--- a/backend/src/i18n/locales/fr/errors.json
+++ b/backend/src/i18n/locales/fr/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "La date doit être au format YYYY-MM-DD"
   },
   "securities": {
+    "exchangeRateUnavailable": "Impossible de déterminer un taux de change pour {{ from }} -> {{ to }} à la date de la transaction. Fournissez un exchangeRate explicite afin que l'écriture sur le compte d'espèces soit correcte.",
     "accountMustBeInvestment": "Le compte doit être de type INVESTMENT",
     "securityIdRequired": "L'ID de titre est requis pour les transactions {{ action }}",
     "splitRatioRequired": "Le ratio de fractionnement (quantité) doit être supérieur à zéro",

--- a/backend/src/i18n/locales/hi/errors.json
+++ b/backend/src/i18n/locales/hi/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "तिथि YYYY-MM-DD प्रारूप में होनी चाहिए"
   },
   "securities": {
+    "exchangeRateUnavailable": "लेन-देन की तारीख पर {{ from }} -> {{ to }} के लिए विनिमय दर निर्धारित नहीं की जा सकी। नकद खाते में सही प्रविष्टि के लिए स्पष्ट exchangeRate दें।",
     "accountMustBeInvestment": "खाता INVESTMENT प्रकार का होना चाहिए",
     "securityIdRequired": "{{ action }} लेनदेन के लिए प्रतिभूति ID आवश्यक है",
     "splitRatioRequired": "विभाजन अनुपात (मात्रा) शून्य से अधिक होना चाहिए",

--- a/backend/src/i18n/locales/id/errors.json
+++ b/backend/src/i18n/locales/id/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "tanggal harus dalam format YYYY-MM-DD"
   },
   "securities": {
+    "exchangeRateUnavailable": "Tidak dapat menentukan nilai tukar untuk {{ from }} -> {{ to }} pada tanggal transaksi. Berikan exchangeRate eksplisit agar pencatatan ke akun kas benar.",
     "accountMustBeInvestment": "Akun harus bertipe INVESTMENT",
     "securityIdRequired": "ID sekuritas diperlukan untuk transaksi {{ action }}",
     "splitRatioRequired": "Rasio pemecahan (kuantitas) harus lebih dari nol",

--- a/backend/src/i18n/locales/it/errors.json
+++ b/backend/src/i18n/locales/it/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "la data deve essere nel formato YYYY-MM-DD"
   },
   "securities": {
+    "exchangeRateUnavailable": "Impossibile determinare un tasso di cambio per {{ from }} -> {{ to }} alla data della transazione. Fornisci un exchangeRate esplicito affinché la registrazione sul conto di liquidità sia corretta.",
     "accountMustBeInvestment": "Il conto deve essere di tipo INVESTMENT",
     "securityIdRequired": "L'ID titolo è obbligatorio per le transazioni {{ action }}",
     "splitRatioRequired": "Il rapporto di suddivisione (quantità) deve essere maggiore di zero",

--- a/backend/src/i18n/locales/ja/errors.json
+++ b/backend/src/i18n/locales/ja/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "date は YYYY-MM-DD 形式でなければなりません"
   },
   "securities": {
+    "exchangeRateUnavailable": "取引日における {{ from }} -> {{ to }} の為替レートを特定できませんでした。現金口座への計上が正しくなるよう、明示的な exchangeRate を指定してください。",
     "accountMustBeInvestment": "口座は INVESTMENT タイプでなければなりません",
     "securityIdRequired": "{{ action }} 取引には有価証券IDが必要です",
     "splitRatioRequired": "株式分割比率（数量）はゼロより大きくなければなりません",

--- a/backend/src/i18n/locales/ko/errors.json
+++ b/backend/src/i18n/locales/ko/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "date는 YYYY-MM-DD 형식이어야 합니다"
   },
   "securities": {
+    "exchangeRateUnavailable": "거래일의 {{ from }} -> {{ to }} 환율을 확인할 수 없습니다. 현금 계좌 기록이 정확하도록 명시적인 exchangeRate를 입력하세요.",
     "accountMustBeInvestment": "계정은 INVESTMENT 유형이어야 합니다",
     "securityIdRequired": "{{ action }} 거래에는 증권 ID가 필요합니다",
     "splitRatioRequired": "분할 비율(수량)은 0보다 커야 합니다",

--- a/backend/src/i18n/locales/nl/errors.json
+++ b/backend/src/i18n/locales/nl/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "datum moet in JJJJ-MM-DD-formaat zijn"
   },
   "securities": {
+    "exchangeRateUnavailable": "Kon geen wisselkoers bepalen voor {{ from }} -> {{ to }} op de transactiedatum. Geef een expliciete exchangeRate op zodat de boeking op de geldrekening correct is.",
     "accountMustBeInvestment": "Rekening moet van het type INVESTMENT zijn",
     "securityIdRequired": "Waardepapier-ID is vereist voor {{ action }}-transacties",
     "splitRatioRequired": "Splitsingsverhouding (hoeveelheid) moet groter zijn dan nul",

--- a/backend/src/i18n/locales/pl/errors.json
+++ b/backend/src/i18n/locales/pl/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "date musi być w formacie YYYY-MM-DD"
   },
   "securities": {
+    "exchangeRateUnavailable": "Nie można ustalić kursu wymiany dla {{ from }} -> {{ to }} na dzień transakcji. Podaj jawny exchangeRate, aby księgowanie na koncie gotówkowym było poprawne.",
     "accountMustBeInvestment": "Konto musi być typu INVESTMENT",
     "securityIdRequired": "Identyfikator papieru wartościowego jest wymagany dla transakcji {{ action }}",
     "splitRatioRequired": "Współczynnik splitu (ilość) musi być większy od zera",

--- a/backend/src/i18n/locales/pt-BR/errors.json
+++ b/backend/src/i18n/locales/pt-BR/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "date deve estar no formato YYYY-MM-DD"
   },
   "securities": {
+    "exchangeRateUnavailable": "Não foi possível determinar uma taxa de câmbio para {{ from }} -> {{ to }} na data da transação. Informe um exchangeRate explícito para que o lançamento na conta de caixa fique correto.",
     "accountMustBeInvestment": "A conta deve ser do tipo INVESTMENT",
     "securityIdRequired": "O ID do título é obrigatório para transações de {{ action }}",
     "splitRatioRequired": "O índice de desdobramento (quantidade) deve ser maior que zero",

--- a/backend/src/i18n/locales/pt/errors.json
+++ b/backend/src/i18n/locales/pt/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "date deve estar no formato YYYY-MM-DD"
   },
   "securities": {
+    "exchangeRateUnavailable": "Não foi possível determinar uma taxa de câmbio para {{ from }} -> {{ to }} na data da transação. Forneça um exchangeRate explícito para que o lançamento na conta de caixa fique correto.",
     "accountMustBeInvestment": "A conta deve ser do tipo INVESTMENT",
     "securityIdRequired": "O ID do título é obrigatório para transações de {{ action }}",
     "splitRatioRequired": "O rácio de desdobramento (quantidade) deve ser maior que zero",

--- a/backend/src/i18n/locales/ru/errors.json
+++ b/backend/src/i18n/locales/ru/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "дата должна быть в формате ГГГГ-ММ-ДД"
   },
   "securities": {
+    "exchangeRateUnavailable": "Не удалось определить обменный курс для {{ from }} -> {{ to }} на дату транзакции. Укажите явный exchangeRate, чтобы проводка по денежному счёту была корректной.",
     "accountMustBeInvestment": "Счёт должен быть типа INVESTMENT",
     "securityIdRequired": "ID ценной бумаги обязателен для проводок {{ action }}",
     "splitRatioRequired": "Коэффициент дробления (количество) должен быть больше нуля",

--- a/backend/src/i18n/locales/tr/errors.json
+++ b/backend/src/i18n/locales/tr/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "tarih YYYY-AA-GG biçiminde olmalıdır"
   },
   "securities": {
+    "exchangeRateUnavailable": "İşlem tarihinde {{ from }} -> {{ to }} için bir döviz kuru belirlenemedi. Nakit hesabına kaydın doğru olması için açık bir exchangeRate girin.",
     "accountMustBeInvestment": "Hesap YATIRİM türünde olmalıdır",
     "securityIdRequired": "{{ action }} işlemleri için menkul kıymet kimliği gereklidir",
     "splitRatioRequired": "Bölünme oranı (miktar) sıfırdan büyük olmalıdır",

--- a/backend/src/i18n/locales/uk/errors.json
+++ b/backend/src/i18n/locales/uk/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "Дата має бути у форматі YYYY-MM-DD"
   },
   "securities": {
+    "exchangeRateUnavailable": "Не вдалося визначити обмінний курс для {{ from }} -> {{ to }} на дату транзакції. Вкажіть явний exchangeRate, щоб проведення за грошовим рахунком було коректним.",
     "accountMustBeInvestment": "Рахунок має бути типу INVESTMENT",
     "securityIdRequired": "Ідентифікатор цінного паперу обов'язковий для операцій {{ action }}",
     "splitRatioRequired": "Коефіцієнт дроблення (кількість) має бути більше нуля",

--- a/backend/src/i18n/locales/vi/errors.json
+++ b/backend/src/i18n/locales/vi/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "date phải có định dạng YYYY-MM-DD"
   },
   "securities": {
+    "exchangeRateUnavailable": "Không thể xác định tỷ giá hối đoái cho {{ from }} -> {{ to }} vào ngày giao dịch. Hãy cung cấp exchangeRate rõ ràng để bút toán vào tài khoản tiền mặt được chính xác.",
     "accountMustBeInvestment": "Tài khoản phải là loại ĐẦU TƯ",
     "securityIdRequired": "ID chứng khoán là bắt buộc cho giao tác {{ action }}",
     "splitRatioRequired": "Tỷ lệ chia (số lượng) phải lớn hơn không",

--- a/backend/src/i18n/locales/xx/errors.json
+++ b/backend/src/i18n/locales/xx/errors.json
@@ -322,6 +322,7 @@
   "securities": {
     "accountMustBeInvestment": "[XX-Account must be of type INVESTMENT-XX]",
     "securityIdRequired": "[XX-Security ID is required for {{ action }} transactions-XX]",
+    "exchangeRateUnavailable": "[XX-Could not determine an exchange rate for {{ from }} -> {{ to }} on the transaction date. Supply an explicit exchangeRate so the cash posting is correct.-XX]",
     "splitRatioRequired": "[XX-Split ratio (quantity) must be greater than zero-XX]",
     "ambiguousSecurity": "[XX-\"{{ query }}\" matches multiple securities: {{ list }}. Use the exact ticker symbol.-XX]",
     "securityNotFoundByQuery": "[XX-No security matches \"{{ query }}\". Add the security first or check the ticker symbol.-XX]",

--- a/backend/src/i18n/locales/zh-CN/errors.json
+++ b/backend/src/i18n/locales/zh-CN/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "date 必须为 YYYY-MM-DD 格式"
   },
   "securities": {
+    "exchangeRateUnavailable": "无法确定交易日 {{ from }} -> {{ to }} 的汇率。请提供明确的 exchangeRate，以便现金账户的记账正确。",
     "accountMustBeInvestment": "账户类型必须为 INVESTMENT",
     "securityIdRequired": "{{ action }} 交易需要证券 ID",
     "splitRatioRequired": "拆股比例（数量）必须大于零",

--- a/backend/src/i18n/locales/zh-TW/errors.json
+++ b/backend/src/i18n/locales/zh-TW/errors.json
@@ -320,6 +320,7 @@
     "dateMustBeYMD": "date 必須為 YYYY-MM-DD 格式"
   },
   "securities": {
+    "exchangeRateUnavailable": "無法確定交易日 {{ from }} -> {{ to }} 的匯率。請提供明確的 exchangeRate，以便現金帳戶的記帳正確。",
     "accountMustBeInvestment": "科目類型必須為 INVESTMENT",
     "securityIdRequired": "{{ action }} 交易需要證券 ID",
     "splitRatioRequired": "分割比例（數量）必須大於零",

--- a/backend/src/mcp/tools/investments.tool.spec.ts
+++ b/backend/src/mcp/tools/investments.tool.spec.ts
@@ -1037,6 +1037,32 @@ describe("McpInvestmentsTools", () => {
       expect(parsed.count).toBe(1);
     });
 
+    it("forwards an explicit exchangeRate to the create prep (issue #744)", async () => {
+      resolve.mockReturnValue({ userId: "u1", scopes: "write" });
+      investmentTransactionsService.prepareCreateInvestmentSingle.mockResolvedValue(
+        createPreview,
+      );
+      investmentTransactionsService.create.mockResolvedValue({
+        id: "inv-1",
+        transactionDate: "2026-01-15",
+      });
+
+      await handlers["manage_investment_transactions"](
+        {
+          operation: "create",
+          items: [{ ...createArgs.items[0], exchangeRate: 4.2514 }],
+        },
+        { sessionId: "s1" },
+      );
+
+      expect(
+        investmentTransactionsService.prepareCreateInvestmentSingle,
+      ).toHaveBeenCalledWith(
+        "u1",
+        expect.objectContaining({ exchangeRate: 4.2514 }),
+      );
+    });
+
     it("surfaces an unknown-account error from the single create prep", async () => {
       resolve.mockReturnValue({ userId: "u1", scopes: "write" });
       investmentTransactionsService.prepareCreateInvestmentSingle.mockRejectedValue(

--- a/backend/src/mcp/tools/investments.tool.ts
+++ b/backend/src/mcp/tools/investments.tool.ts
@@ -64,6 +64,7 @@ interface ManageInvItem {
   quantity?: number;
   price?: number;
   commission?: number;
+  exchangeRate?: number;
   description?: string;
   // update / delete
   transactionId?: string;
@@ -548,6 +549,14 @@ export class McpInvestmentsTools {
                   .max(999999999999)
                   .optional()
                   .describe("Commission or fee (4 dp). Defaults to 0."),
+                exchangeRate: z
+                  .number()
+                  .min(0)
+                  .max(999999999999)
+                  .optional()
+                  .describe(
+                    "create/update: FX rate converting the security's currency into the funding cash account's currency (e.g. for a EUR security funded from a PLN account, the EUR->PLN rate such as 4.2514). Supply this when the broker's settlement data gives the rate or the converted cash total, so the cash posting is exact. Omit for same-currency transactions, or to use the rate for the transaction date.",
+                  ),
                 description: z
                   .string()
                   .max(500)
@@ -629,6 +638,7 @@ export class McpInvestmentsTools {
       price: item.price,
       commission: item.commission,
       fundingAccountName: item.fundingAccountName,
+      exchangeRate: item.exchangeRate,
       description: item.description,
     };
   }
@@ -642,6 +652,7 @@ export class McpInvestmentsTools {
       quantity: item.quantity,
       price: item.price,
       commission: item.commission,
+      exchangeRate: item.exchangeRate,
       description: item.description,
     };
   }

--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -274,6 +274,9 @@ describe("InvestmentTransactionsService", () => {
 
     exchangeRateService = {
       getLatestRate: jest.fn().mockResolvedValue(1),
+      // Default to "no dated rate stored" so tests exercise the getLatestRate
+      // fallback unless they opt into a dated rate explicitly.
+      getRateForDate: jest.fn().mockResolvedValue(null),
     };
 
     currenciesService = {
@@ -3798,7 +3801,11 @@ describe("InvestmentTransactionsService", () => {
       );
     });
 
-    it("falls back to rate 1 when no market rate is available", async () => {
+    it("rejects a cross-currency buy when no exchange rate can be determined (issue #744)", async () => {
+      // USD security funded from a CAD cash account, with neither a dated rate
+      // nor a latest snapshot available. Previously this silently posted at
+      // rate 1.0 and corrupted the cash balance; now it must reject so the
+      // caller can supply an explicit exchangeRate.
       const cadCashAccount = { ...mockCashAccount, currencyCode: "CAD" };
       const cadInvestmentAccount = {
         ...mockInvestmentAccount,
@@ -3811,7 +3818,41 @@ describe("InvestmentTransactionsService", () => {
           return Promise.reject(new NotFoundException("Account not found"));
         },
       );
+      exchangeRateService.getRateForDate.mockResolvedValue(null);
       exchangeRateService.getLatestRate.mockResolvedValue(null);
+
+      await expect(
+        service.create(userId, {
+          accountId,
+          securityId,
+          action: InvestmentAction.BUY,
+          transactionDate: "2025-01-15",
+          quantity: 10,
+          price: 100,
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(investmentTransactionsRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("uses the rate for the transaction date when available (issue #744)", async () => {
+      // A back-dated cross-currency buy (USD security funded from a CAD cash
+      // account) converts at the dated rate, not the latest snapshot or a
+      // silent 1.0.
+      const cadCashAccount = { ...mockCashAccount, currencyCode: "CAD" };
+      const cadInvestmentAccount = {
+        ...mockInvestmentAccount,
+        currencyCode: "CAD",
+      };
+      accountsService.findOne.mockImplementation(
+        (_uid: string, aid: string) => {
+          if (aid === accountId) return Promise.resolve(cadInvestmentAccount);
+          if (aid === cashAccountId) return Promise.resolve(cadCashAccount);
+          return Promise.reject(new NotFoundException("Account not found"));
+        },
+      );
+      exchangeRateService.getRateForDate.mockResolvedValue(1.31);
+      exchangeRateService.getLatestRate.mockResolvedValue(1.99);
 
       await service.create(userId, {
         accountId,
@@ -3822,15 +3863,15 @@ describe("InvestmentTransactionsService", () => {
         price: 100,
       });
 
-      expect(investmentTransactionsRepository.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          exchangeRate: 1,
-        }),
+      expect(exchangeRateService.getRateForDate).toHaveBeenCalledWith(
+        "USD",
+        "CAD",
+        "2025-01-15",
       );
-      expect(transactionRepository.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          amount: -1000,
-        }),
+      // The latest snapshot is not consulted once the dated rate resolves.
+      expect(exchangeRateService.getLatestRate).not.toHaveBeenCalled();
+      expect(investmentTransactionsRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ exchangeRate: 1.31 }),
       );
     });
 

--- a/backend/src/securities/investment-transactions.service.ts
+++ b/backend/src/securities/investment-transactions.service.ts
@@ -231,6 +231,8 @@ export interface InvestmentCreateRowInput {
   price?: number;
   commission?: number;
   fundingAccountName?: string;
+  /** Optional FX rate (security currency -> cash currency) to pin the cash posting. */
+  exchangeRate?: number;
   description?: string;
 }
 
@@ -243,6 +245,8 @@ export interface InvestmentUpdateRowInput {
   quantity?: number;
   price?: number;
   commission?: number;
+  /** Optional FX rate (security currency -> cash currency) to pin the cash posting. */
+  exchangeRate?: number;
   description?: string;
 }
 
@@ -381,9 +385,16 @@ export class InvestmentTransactionsService {
    * (expressed in the security's currency) into the cash account's currency.
    *
    * Precedence:
-   *  1. Explicit DTO override (the user entered a rate in the form).
-   *  2. Latest market rate between source and target currencies.
-   *  3. Fallback of 1 when no rate is available.
+   *  1. Explicit override (the user entered a rate in the form, or an MCP/AI
+   *     caller supplied one from the broker's settlement data).
+   *  2. The market rate as of the transaction's date (stored, or fetched from
+   *     Yahoo for that date), not the latest snapshot -- a back-dated buy must
+   *     convert at the historical rate.
+   *  3. The latest stored rate, as a secondary source.
+   *
+   * For a genuine cross-currency pair with no determinable rate this throws
+   * rather than silently returning 1.0: posting at 1.0 corrupts the cash
+   * balance and cost basis by the size of the FX rate (see issue #744).
    */
   private async resolveCashExchangeRate(
     userId: string,
@@ -391,6 +402,7 @@ export class InvestmentTransactionsService {
     fundingAccountId: string | null | undefined,
     securityId: string | null | undefined,
     dtoRate: number | undefined,
+    transactionDate?: string | Date,
   ): Promise<number> {
     if (dtoRate !== undefined && dtoRate !== null) {
       return Number(dtoRate);
@@ -416,19 +428,34 @@ export class InvestmentTransactionsService {
       return 1;
     }
 
-    const rate = await this.exchangeRateService.getLatestRate(
-      sourceCurrency,
-      cashAccount.currencyCode,
-    );
-
-    if (rate === null) {
-      this.logger.warn(
-        `No exchange rate found for ${sourceCurrency}->${cashAccount.currencyCode}, falling back to 1`,
+    // Prefer the rate as of the transaction date (fetching from Yahoo for that
+    // date when not already stored); fall back to the latest stored snapshot.
+    let rate: number | null = null;
+    if (transactionDate) {
+      rate = await this.exchangeRateService.getRateForDate(
+        sourceCurrency,
+        cashAccount.currencyCode,
+        transactionDate,
       );
-      return 1;
+    }
+    if (rate === null) {
+      rate = await this.exchangeRateService.getLatestRate(
+        sourceCurrency,
+        cashAccount.currencyCode,
+      );
     }
 
-    return rate;
+    if (rate === null || !(Number(rate) > 0)) {
+      throw new BadRequestException(
+        tr(
+          "errors.securities.exchangeRateUnavailable",
+          `Could not determine an exchange rate for ${sourceCurrency} -> ${cashAccount.currencyCode} on the transaction date. Supply an explicit exchangeRate so the cash posting is correct.`,
+          { from: sourceCurrency, to: cashAccount.currencyCode },
+        ),
+      );
+    }
+
+    return Number(rate);
   }
 
   private formatCashTransactionPayeeName(
@@ -644,6 +671,7 @@ export class InvestmentTransactionsService {
       createDto.fundingAccountId ?? null,
       createDto.securityId ?? null,
       createDto.exchangeRate,
+      createDto.transactionDate,
     );
 
     const queryRunner = this.dataSource.createQueryRunner();
@@ -801,6 +829,7 @@ export class InvestmentTransactionsService {
       price?: number;
       commission?: number;
       fundingAccountId?: string;
+      exchangeRate?: number;
       description?: string;
     },
   ): Promise<CreateInvestmentTransactionPreview> {
@@ -910,7 +939,8 @@ export class InvestmentTransactionsService {
       input.accountId,
       input.fundingAccountId ?? null,
       security?.id ?? null,
-      undefined,
+      input.exchangeRate,
+      input.transactionDate,
     );
 
     // Signed cash impact in the security's currency, converted to the cash
@@ -981,6 +1011,7 @@ export class InvestmentTransactionsService {
       quantity?: number;
       price?: number;
       commission?: number;
+      exchangeRate?: number;
       description?: string;
     },
   ): Promise<UpdateInvestmentTransactionPreview> {
@@ -993,6 +1024,7 @@ export class InvestmentTransactionsService {
       input.quantity !== undefined ||
       input.price !== undefined ||
       input.commission !== undefined ||
+      input.exchangeRate !== undefined ||
       input.description !== undefined;
     if (!hasChange) {
       throw new BadRequestException(
@@ -1020,6 +1052,10 @@ export class InvestmentTransactionsService {
           : undefined),
       commission: input.commission ?? Number(existing.commission ?? 0),
       fundingAccountId: existing.fundingAccountId ?? undefined,
+      // Only an explicit override pins the rate; otherwise the preview
+      // re-resolves it fresh (for the new currency pair if the security or
+      // account changed), matching update()'s re-resolution precedence.
+      exchangeRate: input.exchangeRate,
       description: input.description ?? existing.description ?? undefined,
     });
 
@@ -1158,6 +1194,7 @@ export class InvestmentTransactionsService {
       price: row.price,
       commission: row.commission,
       fundingAccountId,
+      exchangeRate: row.exchangeRate,
       description: row.description,
     });
   }
@@ -1233,6 +1270,7 @@ export class InvestmentTransactionsService {
           price: row.price,
           commission: row.commission,
           fundingAccountId,
+          exchangeRate: row.exchangeRate,
           description: row.description,
         });
         okPreviews.push(preview);
@@ -1275,6 +1313,7 @@ export class InvestmentTransactionsService {
             quantity: row.quantity,
             price: row.price,
             commission: row.commission,
+            exchangeRate: row.exchangeRate,
             description: row.description,
           },
         );
@@ -1893,6 +1932,7 @@ export class InvestmentTransactionsService {
       cashAccountId,
       dto.securityId ?? null,
       dto.exchangeRate ?? undefined,
+      parentTransactionDate,
     );
 
     const investmentTransaction = queryRunner.manager.create(
@@ -2942,6 +2982,7 @@ export class InvestmentTransactionsService {
             transaction.fundingAccountId,
             transaction.securityId,
             undefined,
+            transaction.transactionDate,
           );
         }
       }


### PR DESCRIPTION
## Linked discussion / issue

Closes #744 (labeled `approved-to-build`).

## Summary

A cross-currency investment **Buy/Sell** created via the MCP server (and the AI Assistant) silently used an exchange rate of **1.000000** when no stored daily rate was available, so the amount posted to the funding cash account was wrong by the size of the FX rate. For a EUR security funded from a PLN account this understated the PLN cash posting ~4.3x, corrupting the cash balance and the recorded cost basis with no error shown.

Resolution now follows a clear precedence and **never silently falls back to 1.0** for a genuine cross-currency pair.

## Behavior

`InvestmentTransactionsService.resolveCashExchangeRate()` resolves the rate, in order:

1. **Explicit override.** An `exchangeRate` supplied by the caller (the web form already does this; now MCP/AI can too, e.g. from the broker's settlement data).
2. **The rate as of the transaction date.** New `ExchangeRateService.getRateForDate(from, to, date)`: the closest stored rate on or before the date, otherwise a historical fetch from Yahoo for that date (the chosen point is persisted, with its inverse, for reuse). This replaces the old `getLatestRate()` snapshot, so a back-dated buy converts at the historical rate, not today's.
3. **The latest stored rate**, as a secondary source.
4. **No determinable rate for a cross-currency pair -> reject** with `errors.securities.exchangeRateUnavailable`, instead of posting at 1.0.

Same-currency transactions are unaffected (rate stays 1). The transaction date is now threaded into all four `resolveCashExchangeRate` call sites (create, preview, embedded split, update re-resolve).

## Changes

**Backend (FX resolution)**
- `currencies/exchange-rate.service.ts`: add `getRateForDate()` (dated lookup + Yahoo historical fallback, persisted).
- `securities/investment-transactions.service.ts`: `resolveCashExchangeRate()` takes the transaction date, prefers the dated rate, and throws for an undeterminable cross-currency pair; thread the date through every caller; expose `exchangeRate` on the create/update preview and row inputs.

**Backend (shared tools, both layers in sync per the shared-tool rule)**
- MCP `mcp/tools/investments.tool.ts`: optional `exchangeRate` on `manage_investment_transactions` (create + update), forwarded through `toInvCreateRow`/`toInvUpdateRow`.
- AI `ai/query/tool-input-schemas.ts`, `tool-definitions.ts`, `tool-executor.service.ts`: matching optional `exchangeRate` field and converters.

**i18n**
- New `errors.securities.exchangeRateUnavailable` key, translated for every locale (regional `en-*` variants inherit from `en`), preserving the `{{ from }}` / `{{ to }}` placeholders.

## Acceptance criteria (from the issue)

- [x] A cross-currency Buy/Sell via MCP/AI posts using the FX rate for the **transaction date** (supplied or Yahoo), not 1.
- [x] MCP and AI investment-transaction tools accept an optional rate override (both layers in sync).
- [x] No silent 1.0 for genuinely different currencies; an undeterminable rate is reported, not hidden.
- [x] Reproduction (IUSQ EUR -> PLN, 2026-06-08, 3 @ EUR 104.66) posts ~zl 1350, not zl 313.98.

## Tests

- `getRateForDate`: stored carry-forward, dated Yahoo fallback, and null when unavailable.
- `create`: rejects an undeterminable cross-currency rate; uses the dated rate when present.
- MCP and AI: forward an explicit `exchangeRate` to the create prep.
- Touched suites green (exchange-rate, investment-transactions, MCP investments, AI tool-executor, i18n parity).

## Checklist

- [x] An approved discussion or issue exists and is linked above (#744, `approved-to-build`).
- [x] This PR addresses a **single concern** (cross-currency FX rate for investment transactions).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (1 new key: `errors.securities.exchangeRateUnavailable`).
- [x] No shared/core areas were refactored without prior agreement (additive optional field on the shared tools; the FX resolution change is internal).
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Implemented with Claude Code; design, approach, and the FX precedence reviewed and owned by me. Verified the reproduction case locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
