### PR TITLE
perf(currencies): fetch a bounded Yahoo window for a dated FX rate, not the full history

### DIFF
--- a/backend/src/currencies/exchange-rate.service.spec.ts
+++ b/backend/src/currencies/exchange-rate.service.spec.ts
@@ -79,6 +79,7 @@ describe("ExchangeRateService", () => {
     yahooFinanceService = {
       fetchQuote: jest.fn(),
       fetchHistorical: jest.fn(),
+      fetchHistoricalWindow: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -779,7 +780,7 @@ describe("ExchangeRateService", () => {
 
       expect(result).toBe(1);
       expect(exchangeRateRepository.findOne).not.toHaveBeenCalled();
-      expect(yahooFinanceService.fetchHistorical).not.toHaveBeenCalled();
+      expect(yahooFinanceService.fetchHistoricalWindow).not.toHaveBeenCalled();
     });
 
     it("returns the closest stored rate on or before the target date", async () => {
@@ -794,15 +795,15 @@ describe("ExchangeRateService", () => {
       expect(call.where.toCurrency).toBe("CAD");
       expect(call.order).toEqual({ rateDate: "DESC" });
       // No Yahoo fetch needed when a stored rate exists.
-      expect(yahooFinanceService.fetchHistorical).not.toHaveBeenCalled();
+      expect(yahooFinanceService.fetchHistoricalWindow).not.toHaveBeenCalled();
     });
 
-    it("fetches the historical rate for the date from Yahoo when none is stored", async () => {
+    it("fetches a bounded Yahoo window around the date when none is stored", async () => {
       exchangeRateRepository.findOne.mockResolvedValue(null);
       exchangeRateRepository.save.mockImplementation((data) => data);
       // Daily series straddling the target 2026-06-08 (a weekend in this set):
       // the closest day on or before is 2026-06-05.
-      yahooFinanceService.fetchHistorical.mockResolvedValue([
+      yahooFinanceService.fetchHistoricalWindow.mockResolvedValue([
         { date: new Date("2026-06-05"), close: 4.25, open: null, high: null, low: null, volume: null },
         { date: new Date("2026-06-09"), close: 4.3, open: null, high: null, low: null, volume: null },
       ]);
@@ -810,14 +811,23 @@ describe("ExchangeRateService", () => {
       const result = await service.getRateForDate("EUR", "PLN", "2026-06-08");
 
       expect(result).toBe(4.25);
-      expect(yahooFinanceService.fetchHistorical).toHaveBeenCalled();
+      // A bounded window is fetched (not the full "max" history).
+      expect(yahooFinanceService.fetchHistorical).not.toHaveBeenCalled();
+      expect(yahooFinanceService.fetchHistoricalWindow).toHaveBeenCalledTimes(1);
+      const [sym, fromDate, toDate] =
+        yahooFinanceService.fetchHistoricalWindow.mock.calls[0];
+      expect(sym).toBe("EURPLN=X");
+      // Window brackets the target date (~2 weeks before, ~2 days after).
+      const target = new Date("2026-06-08T00:00:00.000Z").getTime();
+      expect((fromDate as Date).getTime()).toBeLessThan(target);
+      expect((toDate as Date).getTime()).toBeGreaterThanOrEqual(target);
       // The chosen point is persisted for reuse (forward + inverse via saveRate).
       expect(exchangeRateRepository.save).toHaveBeenCalled();
     });
 
-    it("returns null when neither a stored rate nor a Yahoo series is available", async () => {
+    it("returns null when neither a stored rate nor a Yahoo window is available", async () => {
       exchangeRateRepository.findOne.mockResolvedValue(null);
-      yahooFinanceService.fetchHistorical.mockResolvedValue(null);
+      yahooFinanceService.fetchHistoricalWindow.mockResolvedValue(null);
 
       const result = await service.getRateForDate("EUR", "PLN", "2026-06-08");
 

--- a/backend/src/currencies/exchange-rate.service.ts
+++ b/backend/src/currencies/exchange-rate.service.ts
@@ -171,6 +171,29 @@ export class ExchangeRateService implements OnModuleInit {
   }
 
   /**
+   * Like fetchYahooHistoricalRates, but bounded to a [from, to] date window so a
+   * single-date lookup fetches a handful of bars instead of the entire history.
+   */
+  private async fetchYahooHistoricalRatesWindow(
+    from: string,
+    to: string,
+    fromDate: Date,
+    toDate: Date,
+  ): Promise<Array<{ date: Date; rate: number }> | null> {
+    if (from === to) return [];
+
+    const symbol = `${from}${to}=X`;
+    const prices = await this.yahooFinanceService.fetchHistoricalWindow(
+      symbol,
+      fromDate,
+      toDate,
+    );
+    if (!prices) return null;
+
+    return prices.map((p) => ({ date: p.date, rate: p.close }));
+  }
+
+  /**
    * Save or update an exchange rate for a given date,
    * and also save the inverse rate for the reverse pair.
    */
@@ -576,9 +599,10 @@ export class ExchangeRateService implements OnModuleInit {
    * rate. Precedence:
    *   1. The stored rate on the closest date on or before the target
    *      (carry-forward, matching how a missing weekend/holiday is handled).
-   *   2. A historical daily series fetched from Yahoo for the pair; the value
-   *      on the closest day on or before the target is used and persisted for
-   *      reuse.
+   *   2. A short historical daily window fetched from Yahoo around the target
+   *      date; the value on the closest day on or before the target is used and
+   *      persisted for reuse. The window (not the full "max" history) keeps the
+   *      request small and fast.
    * Returns null when no rate can be determined (so the caller can reject or
    * flag the operation rather than silently assuming 1.0).
    */
@@ -606,11 +630,20 @@ export class ExchangeRateService implements OnModuleInit {
     });
     if (stored) return Number(stored.rate);
 
-    // 2. Fetch the historical daily series from Yahoo and use the rate on the
-    //    closest day on or before the target. Persist just the chosen point
-    //    (and its inverse, via saveRate) so a repeat lookup hits the database
-    //    without re-fetching the whole series.
-    const series = await this.fetchYahooHistoricalRates(from, to);
+    // 2. Fetch a short Yahoo window around the target (not the full "max"
+    //    history) and use the rate on the closest day on or before the target.
+    //    The lower bound reaches back two weeks so weekends/holidays before the
+    //    target still resolve; the upper bound adds two days to cover the target
+    //    itself (and minor timezone slack). Persist just the chosen point (and
+    //    its inverse, via saveRate) so a repeat lookup hits the database.
+    const windowStart = new Date(targetDate.getTime() - 14 * 86_400_000);
+    const windowEnd = new Date(targetDate.getTime() + 2 * 86_400_000);
+    const series = await this.fetchYahooHistoricalRatesWindow(
+      from,
+      to,
+      windowStart,
+      windowEnd,
+    );
     if (series && series.length > 0) {
       const targetTime = targetDate.getTime();
       const sorted = [...series].sort(

--- a/backend/src/securities/yahoo-finance.service.ts
+++ b/backend/src/securities/yahoo-finance.service.ts
@@ -395,13 +395,53 @@ export class YahooFinanceService implements QuoteProvider {
     range: string = "max",
     _opts?: QuoteProviderOptions,
   ): Promise<HistoricalPrice[] | null> {
+    return this.fetchHistoricalQuery(
+      symbol,
+      exchange,
+      `interval=1d&range=${encodeURIComponent(range)}`,
+    );
+  }
+
+  /**
+   * Fetch the daily series bounded to an explicit [from, to] date window using
+   * Yahoo's period1/period2 parameters, instead of a `range` like "max". Use
+   * this when you only need a few days around a specific date (e.g. the FX rate
+   * for one transaction's date): it returns ~a handful of bars rather than the
+   * entire multi-year history, which keeps the request fast and the parsed
+   * payload small (the "max" range can be thousands of bars / several MB).
+   */
+  async fetchHistoricalWindow(
+    symbol: string,
+    fromDate: Date,
+    toDate: Date,
+    exchange: string | null = null,
+  ): Promise<HistoricalPrice[] | null> {
+    const period1 = Math.floor(fromDate.getTime() / 1000);
+    const period2 = Math.floor(toDate.getTime() / 1000);
+    return this.fetchHistoricalQuery(
+      symbol,
+      exchange,
+      `period1=${period1}&period2=${period2}&interval=1d`,
+    );
+  }
+
+  /**
+   * Shared primary-then-alternate-symbol resolution for the v8 chart history
+   * API. `query` is the URL query fragment (either a `range=...` or a
+   * `period1=...&period2=...` window).
+   */
+  private async fetchHistoricalQuery(
+    symbol: string,
+    exchange: string | null,
+    query: string,
+  ): Promise<HistoricalPrice[] | null> {
     const primary = this.getYahooSymbol(symbol, exchange);
-    const prices = await this.fetchHistoricalRaw(primary, range);
+    const prices = await this.fetchHistoricalRaw(primary, query);
     if (prices) return prices;
 
     if (primary === symbol) {
       for (const altSymbol of this.getAlternateSymbols(symbol)) {
-        const alt = await this.fetchHistoricalRaw(altSymbol, range);
+        const alt = await this.fetchHistoricalRaw(altSymbol, query);
         if (alt) return alt;
       }
     }
@@ -410,10 +450,10 @@ export class YahooFinanceService implements QuoteProvider {
 
   private async fetchHistoricalRaw(
     yahooSymbol: string,
-    range: string,
+    query: string,
   ): Promise<HistoricalPrice[] | null> {
     try {
-      const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(yahooSymbol)}?interval=1d&range=${encodeURIComponent(range)}`;
+      const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(yahooSymbol)}?${query}`;
 
       const response = await this.throttledFetch(
         url,


### PR DESCRIPTION
## Summary

Follow-up to #744. `ExchangeRateService.getRateForDate()` (added there) fetched Yahoo's **entire `max` daily series** -- thousands of bars / several MB, parsed synchronously -- just to read the rate for one date, on every cross-currency investment transaction that lacked a stored rate. For a back-dated foreign-currency buy this is a needless multi-MB fetch (and up to a 60s request) per create.

## Change

- `YahooFinanceService.fetchHistoricalWindow(symbol, fromDate, toDate)`: a date-bounded history fetch using Yahoo's `period1`/`period2` params. The `range` and window paths now share a private `fetchHistoricalQuery()`, so primary/alternate-symbol resolution and the response parsing are unchanged.
- `getRateForDate()` requests a short window around the target date (`target - 14d .. target + 2d`, so weekends/holidays before the target still resolve) instead of `max`. Same precedence as before: closest stored rate on/before the date, else the windowed Yahoo lookup (closest day on/before, persisted), else `null`.

Net effect: a single-date lookup fetches a handful of bars instead of the full history -- removing the per-create latency spike and memory churn -- with identical results.

## Tests

- `getRateForDate` tests updated to the windowed fetch: asserts a bounded window bracketing the target date is requested and that the full `max` history is no longer used; stored-rate and null paths unchanged.
- exchange-rate, yahoo-finance, and investment-transactions suites green; type-check clean.

## Checklist

- [x] Single concern (dated FX lookup efficiency; follow-up to #744).
- [x] New behavior has tests, existing suite passes.
- [x] No user-facing strings added.
- [x] No shared/core refactor beyond the additive `fetchHistoricalWindow` + an internal extraction.
- [x] Rebased on latest `main`.

## AI assistance disclosure

Implemented with Claude Code; reviewed and owned by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)