### PR TITLE
i18n: translate MultiSelect "x items selected" trigger label

### DIFF
--- a/frontend/src/components/ui/MultiSelect.test.tsx
+++ b/frontend/src/components/ui/MultiSelect.test.tsx
@@ -54,7 +54,7 @@ describe('MultiSelect', () => {
       <MultiSelect options={flatOptions} value={['a', 'b']} onChange={onChange} />,
     );
 
-    expect(screen.getByText('2 selected')).toBeInTheDocument();
+    expect(screen.getByText('2 items selected')).toBeInTheDocument();
   });
 
   it('shows single option label when one item is selected', () => {
@@ -229,12 +229,12 @@ describe('MultiSelect', () => {
     expect(screen.getByText('Pick one')).toBeInTheDocument();
   });
 
-  it('shows "1 selected" when selected value does not match any option', () => {
+  it('shows "1 item selected" when selected value does not match any option', () => {
     render(
       <MultiSelect options={flatOptions} value={['unknown']} onChange={onChange} />,
     );
 
-    expect(screen.getByText('1 selected')).toBeInTheDocument();
+    expect(screen.getByText('1 item selected')).toBeInTheDocument();
   });
 
   it('clears search text via the clear button inside the search input', () => {

--- a/frontend/src/components/ui/MultiSelect.tsx
+++ b/frontend/src/components/ui/MultiSelect.tsx
@@ -229,10 +229,10 @@ export function MultiSelect({
     if (value.length === 0) return placeholder;
     if (value.length === 1) {
       const opt = flatOptions.find(o => o.value === value[0]);
-      return opt?.label || '1 selected';
+      return opt?.label || t('multiSelect.selectedCount', { count: 1 });
     }
-    return `${value.length} selected`;
-  }, [value, flatOptions, placeholder]);
+    return t('multiSelect.selectedCount', { count: value.length });
+  }, [value, flatOptions, placeholder, t]);
 
   return (
     <div ref={wrapperRef} className="w-full relative">

--- a/frontend/src/i18n/messages/de/common.json
+++ b/frontend/src/i18n/messages/de/common.json
@@ -102,7 +102,8 @@
     "search": "Suchen...",
     "selectAll": "Alle auswählen",
     "clear": "Löschen",
-    "noOptions": "Keine Optionen gefunden"
+    "noOptions": "Keine Optionen gefunden",
+    "selectedCount": "{count, plural, one {# Element ausgewählt} other {# Elemente ausgewählt}}"
   },
   "combobox": {
     "createOption": "\"{value}\" erstellen"

--- a/frontend/src/i18n/messages/en/common.json
+++ b/frontend/src/i18n/messages/en/common.json
@@ -102,7 +102,8 @@
     "search": "Search...",
     "selectAll": "Select All",
     "clear": "Clear",
-    "noOptions": "No options found"
+    "noOptions": "No options found",
+    "selectedCount": "{count, plural, one {# item selected} other {# items selected}}"
   },
   "combobox": {
     "createOption": "Create \"{value}\""

--- a/frontend/src/i18n/messages/es/common.json
+++ b/frontend/src/i18n/messages/es/common.json
@@ -102,7 +102,8 @@
     "search": "Buscar...",
     "selectAll": "Seleccionar todo",
     "clear": "Limpiar",
-    "noOptions": "No se encontraron opciones"
+    "noOptions": "No se encontraron opciones",
+    "selectedCount": "{count, plural, one {# elemento seleccionado} other {# elementos seleccionados}}"
   },
   "combobox": {
     "createOption": "Crear \"{value}\""

--- a/frontend/src/i18n/messages/fr/common.json
+++ b/frontend/src/i18n/messages/fr/common.json
@@ -102,7 +102,8 @@
     "search": "Rechercher...",
     "selectAll": "Tout sélectionner",
     "clear": "Effacer",
-    "noOptions": "Aucune option trouvée"
+    "noOptions": "Aucune option trouvée",
+    "selectedCount": "{count, plural, one {# élément sélectionné} other {# éléments sélectionnés}}"
   },
   "combobox": {
     "createOption": "Créer « {value} »"

--- a/frontend/src/i18n/messages/hi/common.json
+++ b/frontend/src/i18n/messages/hi/common.json
@@ -102,7 +102,8 @@
     "search": "खोजें...",
     "selectAll": "सभी चुनें",
     "clear": "साफ़ करें",
-    "noOptions": "कोई विकल्प नहीं मिला"
+    "noOptions": "कोई विकल्प नहीं मिला",
+    "selectedCount": "{count, plural, one {# आइटम चयनित} other {# आइटम चयनित}}"
   },
   "combobox": {
     "createOption": "\"{value}\" बनाएं"

--- a/frontend/src/i18n/messages/id/common.json
+++ b/frontend/src/i18n/messages/id/common.json
@@ -102,7 +102,8 @@
     "search": "Cari...",
     "selectAll": "Pilih Semua",
     "clear": "Hapus",
-    "noOptions": "Tidak ada opsi ditemukan"
+    "noOptions": "Tidak ada opsi ditemukan",
+    "selectedCount": "{count, plural, one {# item dipilih} other {# item dipilih}}"
   },
   "combobox": {
     "createOption": "Buat \"{value}\""

--- a/frontend/src/i18n/messages/it/common.json
+++ b/frontend/src/i18n/messages/it/common.json
@@ -102,7 +102,8 @@
     "search": "Cerca...",
     "selectAll": "Seleziona tutto",
     "clear": "Cancella",
-    "noOptions": "Nessuna opzione trovata"
+    "noOptions": "Nessuna opzione trovata",
+    "selectedCount": "{count, plural, one {# elemento selezionato} other {# elementi selezionati}}"
   },
   "combobox": {
     "createOption": "Crea \"{value}\""

--- a/frontend/src/i18n/messages/ja/common.json
+++ b/frontend/src/i18n/messages/ja/common.json
@@ -102,7 +102,8 @@
     "search": "検索...",
     "selectAll": "すべて選択",
     "clear": "クリア",
-    "noOptions": "オプションが見つかりません"
+    "noOptions": "オプションが見つかりません",
+    "selectedCount": "{count, plural, one {# 件選択中} other {# 件選択中}}"
   },
   "combobox": {
     "createOption": "\"{value}\" を作成"

--- a/frontend/src/i18n/messages/ko/common.json
+++ b/frontend/src/i18n/messages/ko/common.json
@@ -102,7 +102,8 @@
     "search": "검색...",
     "selectAll": "모두 선택",
     "clear": "지우기",
-    "noOptions": "옵션을 찾을 수 없습니다"
+    "noOptions": "옵션을 찾을 수 없습니다",
+    "selectedCount": "{count, plural, one {# 개 선택됨} other {# 개 선택됨}}"
   },
   "combobox": {
     "createOption": "\"{value}\" 만들기"

--- a/frontend/src/i18n/messages/nl/common.json
+++ b/frontend/src/i18n/messages/nl/common.json
@@ -102,7 +102,8 @@
     "search": "Zoeken...",
     "selectAll": "Alles selecteren",
     "clear": "Wissen",
-    "noOptions": "Geen opties gevonden"
+    "noOptions": "Geen opties gevonden",
+    "selectedCount": "{count, plural, one {# item geselecteerd} other {# items geselecteerd}}"
   },
   "combobox": {
     "createOption": "Maak \"{value}\" aan"

--- a/frontend/src/i18n/messages/pl/common.json
+++ b/frontend/src/i18n/messages/pl/common.json
@@ -102,7 +102,8 @@
     "search": "Szukaj...",
     "selectAll": "Zaznacz wszystko",
     "clear": "Wyczyść",
-    "noOptions": "Nie znaleziono opcji"
+    "noOptions": "Nie znaleziono opcji",
+    "selectedCount": "{count, plural, one {Wybrano # element} few {Wybrano # elementy} many {Wybrano # elementów} other {Wybrano # elementu}}"
   },
   "combobox": {
     "createOption": "Utwórz \"{value}\""

--- a/frontend/src/i18n/messages/pt-BR/common.json
+++ b/frontend/src/i18n/messages/pt-BR/common.json
@@ -102,7 +102,8 @@
     "search": "Pesquisar...",
     "selectAll": "Selecionar tudo",
     "clear": "Limpar",
-    "noOptions": "Sem opções disponíveis"
+    "noOptions": "Sem opções disponíveis",
+    "selectedCount": "{count, plural, one {# item selecionado} other {# itens selecionados}}"
   },
   "combobox": {
     "createOption": "Criar \"{value}\""

--- a/frontend/src/i18n/messages/pt/common.json
+++ b/frontend/src/i18n/messages/pt/common.json
@@ -102,7 +102,8 @@
     "search": "Pesquisar...",
     "selectAll": "Selecionar tudo",
     "clear": "Limpar",
-    "noOptions": "Sem opções disponíveis"
+    "noOptions": "Sem opções disponíveis",
+    "selectedCount": "{count, plural, one {# item selecionado} other {# itens selecionados}}"
   },
   "combobox": {
     "createOption": "Criar \"{value}\""

--- a/frontend/src/i18n/messages/ru/common.json
+++ b/frontend/src/i18n/messages/ru/common.json
@@ -102,7 +102,8 @@
     "search": "Поиск...",
     "selectAll": "Выбрать все",
     "clear": "Очистить",
-    "noOptions": "Варианты не найдены"
+    "noOptions": "Варианты не найдены",
+    "selectedCount": "{count, plural, one {Выбран # элемент} few {Выбрано # элемента} many {Выбрано # элементов} other {Выбрано # элемента}}"
   },
   "combobox": {
     "createOption": "Создать \"{value}\""

--- a/frontend/src/i18n/messages/tr/common.json
+++ b/frontend/src/i18n/messages/tr/common.json
@@ -102,7 +102,8 @@
     "search": "Ara...",
     "selectAll": "Tümünü Seç",
     "clear": "Temizle",
-    "noOptions": "Seçenek bulunamadı"
+    "noOptions": "Seçenek bulunamadı",
+    "selectedCount": "{count, plural, one {# öğe seçildi} other {# öğe seçildi}}"
   },
   "combobox": {
     "createOption": "\"{value}\" oluştur"

--- a/frontend/src/i18n/messages/uk/common.json
+++ b/frontend/src/i18n/messages/uk/common.json
@@ -102,7 +102,8 @@
     "search": "Пошук...",
     "selectAll": "Вибрати все",
     "clear": "Очистити",
-    "noOptions": "Варіанти не знайдено"
+    "noOptions": "Варіанти не знайдено",
+    "selectedCount": "{count, plural, one {Вибрано # елемент} few {Вибрано # елементи} many {Вибрано # елементів} other {Вибрано # елемента}}"
   },
   "combobox": {
     "createOption": "Створити \"{value}\""

--- a/frontend/src/i18n/messages/vi/common.json
+++ b/frontend/src/i18n/messages/vi/common.json
@@ -102,7 +102,8 @@
     "search": "Tìm kiếm...",
     "selectAll": "Chọn tất cả",
     "clear": "Xóa",
-    "noOptions": "Không tìm thấy tùy chọn"
+    "noOptions": "Không tìm thấy tùy chọn",
+    "selectedCount": "{count, plural, one {Đã chọn # mục} other {Đã chọn # mục}}"
   },
   "combobox": {
     "createOption": "Tạo \"{value}\""

--- a/frontend/src/i18n/messages/xx/common.json
+++ b/frontend/src/i18n/messages/xx/common.json
@@ -102,7 +102,8 @@
     "search": "[XX-Search...-XX]",
     "selectAll": "[XX-Select All-XX]",
     "clear": "[XX-Clear-XX]",
-    "noOptions": "[XX-No options found-XX]"
+    "noOptions": "[XX-No options found-XX]",
+    "selectedCount": "[XX-{count, plural, one {# item selected} other {# items selected}}-XX]"
   },
   "combobox": {
     "createOption": "[XX-Create \"{value}\"-XX]"

--- a/frontend/src/i18n/messages/zh-CN/common.json
+++ b/frontend/src/i18n/messages/zh-CN/common.json
@@ -102,7 +102,8 @@
     "search": "搜索...",
     "selectAll": "全选",
     "clear": "清除",
-    "noOptions": "未找到选项"
+    "noOptions": "未找到选项",
+    "selectedCount": "{count, plural, one {已选择 # 项} other {已选择 # 项}}"
   },
   "combobox": {
     "createOption": "创建 \"{value}\""

--- a/frontend/src/i18n/messages/zh-TW/common.json
+++ b/frontend/src/i18n/messages/zh-TW/common.json
@@ -102,7 +102,8 @@
     "search": "搜尋...",
     "selectAll": "全選",
     "clear": "清除",
-    "noOptions": "找不到選項"
+    "noOptions": "找不到選項",
+    "selectedCount": "{count, plural, one {已選擇 # 項} other {已選擇 # 項}}"
   },
   "combobox": {
     "createOption": "建立「{value}」"


### PR DESCRIPTION
The MultiSelect trigger rendered a hardcoded "${count} selected" /
"1 selected" string that never went through next-intl, so it stayed in
English for every locale. Add a pluralized common.multiSelect.selectedCount
key, use it for both the single-unknown and multi-selection cases, and
provide translations for all supported locales plus the regenerated
pseudo-locale.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SdjHCHf8qEAJ2cZwtZvW5k