### PR TITLE
Apply security headers to middleware-generated proxy responses

### DIFF
--- a/frontend/src/proxy.test.ts
+++ b/frontend/src/proxy.test.ts
@@ -98,3 +98,59 @@ describe('proxy MCP-at-root routing', () => {
     expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:3001/api/v1/mcp');
   });
 });
+
+describe('proxy security headers', () => {
+  const originalDisable = process.env.DISABLE_HTTPS_HEADERS;
+
+  afterEach(() => {
+    if (originalDisable === undefined) delete process.env.DISABLE_HTTPS_HEADERS;
+    else process.env.DISABLE_HTTPS_HEADERS = originalDisable;
+    vi.unstubAllGlobals();
+  });
+
+  it('sets HSTS and static security headers on the unauthenticated /login redirect', async () => {
+    delete process.env.DISABLE_HTTPS_HEADERS;
+    const request = makeRequest('/dashboard', {
+      headers: { accept: 'text/html' },
+    });
+    const response = await proxy(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(`${BASE}/login`);
+    expect(response.headers.get('Strict-Transport-Security')).toBe(
+      'max-age=63072000; includeSubDomains; preload',
+    );
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+    expect(response.headers.get('Cross-Origin-Opener-Policy')).toBe('same-origin');
+  });
+
+  it('omits HSTS on the redirect when DISABLE_HTTPS_HEADERS is set', async () => {
+    process.env.DISABLE_HTTPS_HEADERS = 'true';
+    const request = makeRequest('/dashboard', {
+      headers: { accept: 'text/html' },
+    });
+    const response = await proxy(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('Strict-Transport-Security')).toBeNull();
+    expect(response.headers.get('Cross-Origin-Opener-Policy')).toBeNull();
+    // Static (non-HTTPS-gated) headers are still present.
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+  });
+
+  it('sets security headers on the 502 backend-unavailable fallback', async () => {
+    delete process.env.DISABLE_HTTPS_HEADERS;
+    const fetchMock = vi.fn().mockRejectedValue(new Error('connection refused'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const request = makeRequest('/api/v1/accounts');
+    const response = await proxy(request);
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get('Strict-Transport-Security')).toBe(
+      'max-age=63072000; includeSubDomains; preload',
+    );
+    expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+  });
+});

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -22,6 +22,40 @@ function resolveRequestLocale(request: NextRequest): { locale: string; fromCooki
   return { locale: fromAccept || DEFAULT_LOCALE, fromCookie: false };
 }
 
+// Security headers that mirror next.config.js. Next's `headers()` config is
+// only applied to responses Next renders (via NextResponse.next()); responses
+// the middleware returns directly -- the unauthenticated redirect to /login and
+// the 502 backend-unavailable fallback -- bypass it, so a scanner hitting the
+// site root sees a redirect with no HSTS. Applying the same set here keeps every
+// middleware-generated response consistent with the framework-rendered ones.
+const STATIC_SECURITY_HEADERS: Record<string, string> = {
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+  'Cross-Origin-Resource-Policy': 'same-origin',
+};
+
+// HTTPS-only headers, gated by DISABLE_HTTPS_HEADERS for plain-HTTP deployments
+// (mirrors next.config.js and the backend Helmet config).
+const HTTPS_SECURITY_HEADERS: Record<string, string> = {
+  'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
+  'Cross-Origin-Opener-Policy': 'same-origin',
+  'Cross-Origin-Embedder-Policy': 'require-corp',
+};
+
+function applySecurityHeaders(response: NextResponse): NextResponse {
+  for (const [key, value] of Object.entries(STATIC_SECURITY_HEADERS)) {
+    response.headers.set(key, value);
+  }
+  if (process.env.DISABLE_HTTPS_HEADERS !== 'true') {
+    for (const [key, value] of Object.entries(HTTPS_SECURITY_HEADERS)) {
+      response.headers.set(key, value);
+    }
+  }
+  return response;
+}
+
 function buildCspHeader(nonce: string): string {
   const isDev = process.env.NODE_ENV !== 'production';
   return [
@@ -155,7 +189,9 @@ export async function proxy(request: NextRequest) {
       });
     } catch (error) {
       logger.error('API proxy error:', error);
-      return NextResponse.json({ error: 'Backend unavailable' }, { status: 502 });
+      return applySecurityHeaders(
+        NextResponse.json({ error: 'Backend unavailable' }, { status: 502 }),
+      );
     }
   }
 
@@ -173,7 +209,7 @@ export async function proxy(request: NextRequest) {
   // Protect all other routes
   if (!token) {
     const loginUrl = new URL('/login', request.url);
-    return NextResponse.redirect(loginUrl);
+    return applySecurityHeaders(NextResponse.redirect(loginUrl));
   }
 
   return nextWithCsp(request);


### PR DESCRIPTION
next.config.js headers() (including HSTS) only apply to responses Next
renders via NextResponse.next(); responses the proxy middleware returns
directly -- the unauthenticated redirect to /login and the 502
backend-unavailable fallback -- bypass it. A security scanner hitting the
site root sees the redirect first, with no Strict-Transport-Security
header, hence the "No HSTS header" finding.

Apply the same security header set (HSTS/COOP/COEP gated by
DISABLE_HTTPS_HEADERS, plus the always-on static headers) to those
middleware-generated responses so every response is consistent with the
framework-rendered ones.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KLvhtbwF4h5e4emJT6MYwa