### PR TITLE
Fix MCP daily write cap to be a single shared per-user limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,6 +131,13 @@ DEMO_MODE=false
 # code, refresh_token, access_token, code_verifier) are redacted.
 # OAUTH_DEBUG_LOG=false
 
+# Maximum write operations (create/update/delete) a single user can perform
+# per day through MCP tools, shared across all MCP write tools. A soft
+# guardrail that bounds how much an external AI tool can mutate financial data
+# per day. Must be a positive integer; falls back to the default if unset or
+# invalid. (default: 50)
+# MCP_DAILY_WRITE_LIMIT=50
+
 # ==============================================
 # AI Integration (Optional)
 # ==============================================
@@ -148,6 +155,12 @@ DEMO_MODE=false
 
 # Maximum AI provider configurations per user (default: 10)
 # AI_MAX_PROVIDERS_PER_USER=10
+
+# Maximum write operations (create/update/delete) a single user can perform
+# per day via the AI Assistant action-confirmation endpoint. Mirrors
+# MCP_DAILY_WRITE_LIMIT. Must be a positive integer; falls back to the default
+# if unset or invalid. (default: 50)
+# AI_DAILY_WRITE_LIMIT=50
 
 # ==============================================
 # Quote Providers

--- a/backend/src/ai/actions/ai-write-limiter.ts
+++ b/backend/src/ai/actions/ai-write-limiter.ts
@@ -1,20 +1,31 @@
-import { Injectable } from "@nestjs/common";
-import { DailyWriteLimiter } from "../../common/daily-write-limiter";
+import { Injectable, Optional } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import {
+  DailyWriteLimiter,
+  resolveDailyWriteLimit,
+} from "../../common/daily-write-limiter";
 
 /**
- * Maximum number of AI-Assistant-confirmed write operations per user per day.
- * Mirrors the MCP daily cap so the two LLM write surfaces are bounded the same
- * way.
+ * Default maximum number of AI-Assistant-confirmed write operations per user
+ * per day. Mirrors the MCP daily cap so the two LLM write surfaces are bounded
+ * the same way. Override at deploy time with the `AI_DAILY_WRITE_LIMIT`
+ * environment variable (a positive integer).
  */
 export const AI_DAILY_WRITE_LIMIT = 50;
 
 /**
  * Injectable per-user daily write limiter for the AI Assistant action
- * confirmation endpoint.
+ * confirmation endpoint. The effective limit comes from the
+ * `AI_DAILY_WRITE_LIMIT` env var when set, otherwise the default above.
  */
 @Injectable()
 export class AiWriteLimiter extends DailyWriteLimiter {
-  constructor() {
-    super(AI_DAILY_WRITE_LIMIT);
+  constructor(@Optional() configService?: ConfigService) {
+    super(
+      resolveDailyWriteLimit(
+        configService?.get("AI_DAILY_WRITE_LIMIT"),
+        AI_DAILY_WRITE_LIMIT,
+      ),
+    );
   }
 }

--- a/backend/src/common/daily-write-limiter.ts
+++ b/backend/src/common/daily-write-limiter.ts
@@ -16,6 +16,17 @@ export interface WriteOperation {
   timestamp: number;
 }
 
+/**
+ * Resolve a daily write limit from a (possibly string) environment value,
+ * falling back to `fallback` when the value is missing or not a positive
+ * integer. Env vars arrive as strings, so coerce explicitly rather than
+ * relying on the value already being numeric.
+ */
+export function resolveDailyWriteLimit(raw: unknown, fallback: number): number {
+  const parsed = typeof raw === "number" ? raw : Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 export class DailyWriteLimiter {
   private readonly operations: WriteOperation[] = [];
 

--- a/backend/src/mcp/mcp-annotations.spec.ts
+++ b/backend/src/mcp/mcp-annotations.spec.ts
@@ -48,6 +48,7 @@ function collectToolConfigs(): Array<{ name: string; config: any }> {
       {} as any,
       {} as any,
       {} as any,
+      {} as any,
     ) as unknown as ToolProvider,
     new McpCategoriesTools({} as any) as unknown as ToolProvider,
     new McpPayeesTools(
@@ -55,9 +56,11 @@ function collectToolConfigs(): Array<{ name: string; config: any }> {
       {} as any,
       {} as any,
       {} as any,
+      {} as any,
     ) as unknown as ToolProvider,
     new McpReportsTools({} as any) as unknown as ToolProvider,
     new McpInvestmentsTools(
+      {} as any,
       {} as any,
       {} as any,
       {} as any,

--- a/backend/src/mcp/mcp-write-limiter.spec.ts
+++ b/backend/src/mcp/mcp-write-limiter.spec.ts
@@ -108,9 +108,82 @@ describe("McpWriteLimiter", () => {
     });
   });
 
+  describe("reserve()", () => {
+    it("allows a reservation under the limit", () => {
+      expect(limiter.reserve("user-1", 5)).toBeUndefined();
+    });
+
+    it("allows a reservation that exactly reaches the limit", () => {
+      expect(limiter.reserve("user-1", MCP_DAILY_WRITE_LIMIT)).toBeUndefined();
+    });
+
+    it("blocks a reservation that would exceed the limit", () => {
+      const result = limiter.reserve("user-1", MCP_DAILY_WRITE_LIMIT + 1);
+      expect(result).toBeDefined();
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain("Daily write limit reached");
+    });
+
+    it("accounts for already-recorded writes when reserving", () => {
+      for (let i = 0; i < MCP_DAILY_WRITE_LIMIT - 2; i++) {
+        limiter.record("user-1", "create_transaction");
+      }
+
+      // Two slots remain: reserving two is allowed, three is not.
+      expect(limiter.reserve("user-1", 2)).toBeUndefined();
+      expect(limiter.reserve("user-1", 3)).toBeDefined();
+    });
+
+    it("shares the budget across operations regardless of tool name", () => {
+      for (let i = 0; i < MCP_DAILY_WRITE_LIMIT; i++) {
+        limiter.record(
+          "user-1",
+          i % 2 === 0 ? "create_transaction" : "create_payee",
+        );
+      }
+
+      // A single shared cap: once exhausted, any further write is blocked no
+      // matter which domain/tool it belongs to.
+      expect(limiter.reserve("user-1", 1)).toBeDefined();
+    });
+  });
+
   describe("MCP_DAILY_WRITE_LIMIT constant", () => {
     it("is set to 50", () => {
       expect(MCP_DAILY_WRITE_LIMIT).toBe(50);
+    });
+  });
+
+  describe("configurable limit via MCP_DAILY_WRITE_LIMIT env var", () => {
+    const stubConfig = (value: unknown) =>
+      ({ get: jest.fn().mockReturnValue(value) }) as any;
+
+    it("uses the env value when set to a positive integer", () => {
+      const configured = new McpWriteLimiter(stubConfig(5));
+      for (let i = 0; i < 5; i++) {
+        configured.record("user-1", "create_transaction");
+      }
+      const result = configured.checkLimit("user-1");
+      expect(result.limit).toBe(5);
+      expect(result.allowed).toBe(false);
+    });
+
+    it("accepts the env value as a string (env vars are strings)", () => {
+      const configured = new McpWriteLimiter(stubConfig("3"));
+      expect(configured.checkLimit("user-1").limit).toBe(3);
+    });
+
+    it("falls back to the default when the env value is missing", () => {
+      const configured = new McpWriteLimiter(stubConfig(undefined));
+      expect(configured.checkLimit("user-1").limit).toBe(MCP_DAILY_WRITE_LIMIT);
+    });
+
+    it("falls back to the default for invalid or non-positive values", () => {
+      for (const bad of ["abc", "0", "-5", "2.5", ""]) {
+        expect(new McpWriteLimiter(stubConfig(bad)).checkLimit("u").limit).toBe(
+          MCP_DAILY_WRITE_LIMIT,
+        );
+      }
     });
   });
 });

--- a/backend/src/mcp/mcp-write-limiter.ts
+++ b/backend/src/mcp/mcp-write-limiter.ts
@@ -9,20 +9,58 @@
  * action-confirmation endpoint enforces the same kind of cap.
  */
 
+import { Injectable, Optional } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import {
   DailyWriteLimiter,
   WriteOperation,
+  resolveDailyWriteLimit,
 } from "../common/daily-write-limiter";
+import { toolError } from "./mcp-context";
 
 export type { WriteOperation };
 
 /**
- * Maximum number of write operations per user per day via MCP.
+ * Default maximum number of write operations per user per day via MCP. Override
+ * at deploy time with the `MCP_DAILY_WRITE_LIMIT` environment variable (a
+ * positive integer). The cap exists to bound how much an external AI tool can
+ * mutate a user's financial data per day -- a soft guardrail against a
+ * misbehaving model or a runaway loop, not a hard security boundary.
  */
 export const MCP_DAILY_WRITE_LIMIT = 50;
 
+/**
+ * Single per-user daily write cap shared across every MCP write tool. It is an
+ * `@Injectable()` singleton (provided once in `mcp.module.ts`) so the cap spans
+ * all write domains -- transactions, payees, securities, and investment
+ * transactions -- rather than each tool class enforcing its own separate budget.
+ *
+ * The effective limit comes from the `MCP_DAILY_WRITE_LIMIT` env var when set,
+ * otherwise the default above.
+ */
+@Injectable()
 export class McpWriteLimiter extends DailyWriteLimiter {
-  constructor() {
-    super(MCP_DAILY_WRITE_LIMIT);
+  constructor(@Optional() configService?: ConfigService) {
+    super(
+      resolveDailyWriteLimit(
+        configService?.get("MCP_DAILY_WRITE_LIMIT"),
+        MCP_DAILY_WRITE_LIMIT,
+      ),
+    );
+  }
+
+  /**
+   * Reserve `count` writes against the daily cap. Returns a `toolError` result
+   * when the reservation would exceed the limit, or `undefined` when allowed.
+   * Built on top of `checkLimit` so callers can record the writes afterwards.
+   */
+  reserve(userId: string, count: number) {
+    const limitCheck = this.checkLimit(userId);
+    if (limitCheck.currentCount + count > limitCheck.limit) {
+      return toolError(
+        `Daily write limit reached (${limitCheck.limit} operations per day). Try again tomorrow.`,
+      );
+    }
+    return undefined;
   }
 }

--- a/backend/src/mcp/mcp.module.ts
+++ b/backend/src/mcp/mcp.module.ts
@@ -15,6 +15,7 @@ import { AiActionBuilderModule } from "../ai/actions/ai-action-builder.module";
 
 import { McpServerService } from "./mcp-server.service";
 import { McpHttpController } from "./mcp-http.controller";
+import { McpWriteLimiter } from "./mcp-write-limiter";
 
 import { McpAccountsTools } from "./tools/accounts.tool";
 import { McpTransactionsTools } from "./tools/transactions.tool";
@@ -56,6 +57,7 @@ import { McpSpendingAnalysisPrompt } from "./prompts/spending-analysis.prompt";
   ],
   providers: [
     McpServerService,
+    McpWriteLimiter,
     McpRelayTools,
     McpAccountsTools,
     McpTransactionsTools,

--- a/backend/src/mcp/tools/investments.tool.spec.ts
+++ b/backend/src/mcp/tools/investments.tool.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException } from "@nestjs/common";
 import { McpInvestmentsTools } from "./investments.tool";
+import { McpWriteLimiter } from "../mcp-write-limiter";
 import { UserContextResolver } from "../mcp-context";
 
 describe("McpInvestmentsTools", () => {
@@ -132,6 +133,7 @@ describe("McpInvestmentsTools", () => {
       relayService as any,
       actionBuilder as any,
       accountsService as any,
+      new McpWriteLimiter(),
     );
 
     elicitInput = jest.fn();

--- a/backend/src/mcp/tools/investments.tool.ts
+++ b/backend/src/mcp/tools/investments.tool.ts
@@ -85,8 +85,6 @@ interface ManageSecItem {
 
 @Injectable()
 export class McpInvestmentsTools {
-  private readonly writeLimiter = new McpWriteLimiter();
-
   constructor(
     private readonly portfolioService: PortfolioService,
     private readonly holdingsService: HoldingsService,
@@ -96,6 +94,7 @@ export class McpInvestmentsTools {
     private readonly relayService: AiRelayService,
     private readonly actionBuilder: AiActionBuilderService,
     private readonly accountsService: AccountsService,
+    private readonly writeLimiter: McpWriteLimiter,
   ) {}
 
   register(server: McpServer, resolve: UserContextResolver) {
@@ -685,20 +684,6 @@ export class McpInvestmentsTools {
     };
   }
 
-  /**
-   * Reserve N writes against the daily cap or return an error result. Returns
-   * undefined when allowed.
-   */
-  private checkWriteBudget(userId: string, count: number) {
-    const limitCheck = this.writeLimiter.checkLimit(userId);
-    if (limitCheck.currentCount + count > limitCheck.limit) {
-      return toolError(
-        `Daily write limit reached (${limitCheck.limit} operations per day). Try again tomorrow.`,
-      );
-    }
-    return undefined;
-  }
-
   private async manageInvCreate(
     server: McpServer,
     userId: string,
@@ -714,7 +699,7 @@ export class McpInvestmentsTools {
           userId,
           this.toInvCreateRow(items[0]),
         );
-      const budget = this.checkWriteBudget(userId, 1);
+      const budget = this.writeLimiter.reserve(userId, 1);
       if (budget) return budget;
       const action = this.actionBuilder.buildCreateInvestmentTransaction(
         userId,
@@ -759,7 +744,7 @@ export class McpInvestmentsTools {
         "None of the investment transactions could be prepared. Check the account, security, action, and date for each row.",
       );
     }
-    const budget = this.checkWriteBudget(userId, bulk.okPreviews.length);
+    const budget = this.writeLimiter.reserve(userId, bulk.okPreviews.length);
     if (budget) return budget;
 
     if (approvalMode === "individual") {
@@ -839,7 +824,7 @@ export class McpInvestmentsTools {
           items[0].transactionId as string,
           this.toInvUpdateRow(items[0]),
         );
-      const budget = this.checkWriteBudget(userId, 1);
+      const budget = this.writeLimiter.reserve(userId, 1);
       if (budget) return budget;
       const action = this.actionBuilder.buildUpdateInvestmentTransaction(
         userId,
@@ -905,7 +890,7 @@ export class McpInvestmentsTools {
         return toolError(
           "None of the investment transaction edits could be prepared.",
         );
-      const budget = this.checkWriteBudget(userId, cards.length);
+      const budget = this.writeLimiter.reserve(userId, cards.length);
       if (budget) return budget;
       return this.runInvIndividual(server, userId, cards, requestId, skipped);
     }
@@ -919,7 +904,7 @@ export class McpInvestmentsTools {
       return toolError(
         "None of the investment transaction edits could be prepared.",
       );
-    const budget = this.checkWriteBudget(userId, bulk.okRows.length);
+    const budget = this.writeLimiter.reserve(userId, bulk.okRows.length);
     if (budget) return budget;
     const action = this.actionBuilder.buildBatchUpdateInvestmentTransactions(
       userId,
@@ -976,7 +961,7 @@ export class McpInvestmentsTools {
           userId,
           items[0].transactionId as string,
         );
-      const budget = this.checkWriteBudget(userId, 1);
+      const budget = this.writeLimiter.reserve(userId, 1);
       if (budget) return budget;
       const action = this.actionBuilder.buildDeleteInvestmentTransaction(
         userId,
@@ -1032,7 +1017,7 @@ export class McpInvestmentsTools {
         return toolError(
           "None of the investment transactions could be prepared.",
         );
-      const budget = this.checkWriteBudget(userId, cards.length);
+      const budget = this.writeLimiter.reserve(userId, cards.length);
       if (budget) return budget;
       return this.runInvIndividual(server, userId, cards, requestId, skipped);
     }
@@ -1046,7 +1031,7 @@ export class McpInvestmentsTools {
       return toolError(
         "None of the investment transactions could be prepared.",
       );
-    const budget = this.checkWriteBudget(userId, bulk.okRows.length);
+    const budget = this.writeLimiter.reserve(userId, bulk.okRows.length);
     if (budget) return budget;
     const action = this.actionBuilder.buildBatchDeleteInvestmentTransactions(
       userId,
@@ -1329,7 +1314,7 @@ export class McpInvestmentsTools {
           userId,
           this.toSecCreateRow(items[0]),
         );
-      const budget = this.checkWriteBudget(userId, 1);
+      const budget = this.writeLimiter.reserve(userId, 1);
       if (budget) return budget;
       const action = this.actionBuilder.buildCreateSecurity(userId, preview);
       const outcome = await this.emitOrConfirmSec(
@@ -1362,7 +1347,7 @@ export class McpInvestmentsTools {
         "None of the securities could be prepared. Check the ticker/name for each row.",
       );
     }
-    const budget = this.checkWriteBudget(userId, prep.okPreviews.length);
+    const budget = this.writeLimiter.reserve(userId, prep.okPreviews.length);
     if (budget) return budget;
 
     if (approvalMode === "individual") {
@@ -1417,7 +1402,7 @@ export class McpInvestmentsTools {
           userId,
           this.toSecUpdateRow(items[0]),
         );
-      const budget = this.checkWriteBudget(userId, 1);
+      const budget = this.writeLimiter.reserve(userId, 1);
       if (budget) return budget;
       const action = this.actionBuilder.buildUpdateSecurity(userId, preview);
       const outcome = await this.emitOrConfirmSec(
@@ -1448,7 +1433,7 @@ export class McpInvestmentsTools {
     if (prep.okPreviews.length === 0) {
       return toolError("None of the security edits could be prepared.");
     }
-    const budget = this.checkWriteBudget(userId, prep.okPreviews.length);
+    const budget = this.writeLimiter.reserve(userId, prep.okPreviews.length);
     if (budget) return budget;
 
     if (approvalMode === "individual") {
@@ -1503,7 +1488,7 @@ export class McpInvestmentsTools {
           userId,
           this.toSecDeleteRow(items[0]),
         );
-      const budget = this.checkWriteBudget(userId, 1);
+      const budget = this.writeLimiter.reserve(userId, 1);
       if (budget) return budget;
       const action = this.actionBuilder.buildDeleteSecurity(userId, preview);
       const outcome = await this.emitOrConfirmSec(
@@ -1530,7 +1515,7 @@ export class McpInvestmentsTools {
     if (prep.okPreviews.length === 0) {
       return toolError("None of the securities could be prepared.");
     }
-    const budget = this.checkWriteBudget(userId, prep.okPreviews.length);
+    const budget = this.writeLimiter.reserve(userId, prep.okPreviews.length);
     if (budget) return budget;
 
     if (approvalMode === "individual") {

--- a/backend/src/mcp/tools/payees.tool.spec.ts
+++ b/backend/src/mcp/tools/payees.tool.spec.ts
@@ -1,4 +1,5 @@
 import { McpPayeesTools } from "./payees.tool";
+import { McpWriteLimiter } from "../mcp-write-limiter";
 import { UserContextResolver } from "../mcp-context";
 
 describe("McpPayeesTools", () => {
@@ -80,6 +81,7 @@ describe("McpPayeesTools", () => {
       prepService as any,
       relayService as any,
       actionBuilder as any,
+      new McpWriteLimiter(),
     );
 
     elicitInput = jest.fn().mockResolvedValue({ action: "accept" });

--- a/backend/src/mcp/tools/payees.tool.ts
+++ b/backend/src/mcp/tools/payees.tool.ts
@@ -40,13 +40,12 @@ interface ManagePayeeItem {
 
 @Injectable()
 export class McpPayeesTools {
-  private readonly writeLimiter = new McpWriteLimiter();
-
   constructor(
     private readonly payeesService: PayeesService,
     private readonly prepService: PayeeToolPrepService,
     private readonly relayService: AiRelayService,
     private readonly actionBuilder: AiActionBuilderService,
+    private readonly writeLimiter: McpWriteLimiter,
   ) {}
 
   register(server: McpServer, resolve: UserContextResolver) {
@@ -211,16 +210,6 @@ export class McpPayeesTools {
     return { name: item.name as string };
   }
 
-  private checkWriteBudget(userId: string, count: number) {
-    const limitCheck = this.writeLimiter.checkLimit(userId);
-    if (limitCheck.currentCount + count > limitCheck.limit) {
-      return toolError(
-        `Daily write limit reached (${limitCheck.limit} operations per day). Try again tomorrow.`,
-      );
-    }
-    return undefined;
-  }
-
   private async manageDryRun(
     userId: string,
     operation: ManagePayeeOperation,
@@ -281,7 +270,7 @@ export class McpPayeesTools {
         userId,
         this.toCreateRow(items[0]),
       );
-      const budget = this.checkWriteBudget(userId, 1);
+      const budget = this.writeLimiter.reserve(userId, 1);
       if (budget) return budget;
       const action = this.actionBuilder.buildCreatePayee(userId, preview);
       const outcome = await this.emitOrConfirm(
@@ -313,7 +302,7 @@ export class McpPayeesTools {
         "None of the payees could be prepared. Check the name and category for each row.",
       );
     }
-    const budget = this.checkWriteBudget(userId, prep.okPreviews.length);
+    const budget = this.writeLimiter.reserve(userId, prep.okPreviews.length);
     if (budget) return budget;
 
     if (approvalMode === "individual") {
@@ -365,7 +354,7 @@ export class McpPayeesTools {
         userId,
         this.toUpdateRow(items[0]),
       );
-      const budget = this.checkWriteBudget(userId, 1);
+      const budget = this.writeLimiter.reserve(userId, 1);
       if (budget) return budget;
       const action = this.actionBuilder.buildUpdatePayee(userId, preview);
       const outcome = await this.emitOrConfirm(
@@ -395,7 +384,7 @@ export class McpPayeesTools {
     if (prep.okPreviews.length === 0) {
       return toolError("None of the payee edits could be prepared.");
     }
-    const budget = this.checkWriteBudget(userId, prep.okPreviews.length);
+    const budget = this.writeLimiter.reserve(userId, prep.okPreviews.length);
     if (budget) return budget;
 
     if (approvalMode === "individual") {
@@ -447,7 +436,7 @@ export class McpPayeesTools {
         userId,
         this.toDeleteRow(items[0]),
       );
-      const budget = this.checkWriteBudget(userId, 1);
+      const budget = this.writeLimiter.reserve(userId, 1);
       if (budget) return budget;
       const action = this.actionBuilder.buildDeletePayee(userId, preview);
       const outcome = await this.emitOrConfirm(
@@ -474,7 +463,7 @@ export class McpPayeesTools {
     if (prep.okPreviews.length === 0) {
       return toolError("None of the payees could be prepared.");
     }
-    const budget = this.checkWriteBudget(userId, prep.okPreviews.length);
+    const budget = this.writeLimiter.reserve(userId, prep.okPreviews.length);
     if (budget) return budget;
 
     if (approvalMode === "individual") {

--- a/backend/src/mcp/tools/transactions.tool.spec.ts
+++ b/backend/src/mcp/tools/transactions.tool.spec.ts
@@ -1,4 +1,5 @@
 import { McpTransactionsTools } from "./transactions.tool";
+import { McpWriteLimiter } from "../mcp-write-limiter";
 import { UserContextResolver } from "../mcp-context";
 
 describe("McpTransactionsTools", () => {
@@ -117,6 +118,7 @@ describe("McpTransactionsTools", () => {
       actionBuilder as any,
       prepService as any,
       accountsService as any,
+      new McpWriteLimiter(),
     );
 
     elicitInput = jest.fn();
@@ -777,9 +779,7 @@ describe("McpTransactionsTools", () => {
       await handlers["manage_transactions"](
         {
           operation: "update",
-          items: [
-            { transactionId: "t1", categoryName: "Investments: IKE" },
-          ],
+          items: [{ transactionId: "t1", categoryName: "Investments: IKE" }],
         },
         { sessionId: "s1" },
       );

--- a/backend/src/mcp/tools/transactions.tool.ts
+++ b/backend/src/mcp/tools/transactions.tool.ts
@@ -65,8 +65,6 @@ interface ManageItem {
 
 @Injectable()
 export class McpTransactionsTools {
-  private readonly writeLimiter = new McpWriteLimiter();
-
   constructor(
     private readonly transactionsService: TransactionsService,
     private readonly payeesService: PayeesService,
@@ -75,6 +73,7 @@ export class McpTransactionsTools {
     private readonly actionBuilder: AiActionBuilderService,
     private readonly prepService: TransactionToolPrepService,
     private readonly accountsService: AccountsService,
+    private readonly writeLimiter: McpWriteLimiter,
   ) {}
 
   register(server: McpServer, resolve: UserContextResolver) {
@@ -694,20 +693,6 @@ export class McpTransactionsTools {
     };
   }
 
-  /**
-   * Reserve N writes against the daily cap or return an error result. Returns
-   * undefined when allowed.
-   */
-  private checkWriteBudget(userId: string, count: number) {
-    const limitCheck = this.writeLimiter.checkLimit(userId);
-    if (limitCheck.currentCount + count > limitCheck.limit) {
-      return toolError(
-        `Daily write limit reached (${limitCheck.limit} operations per day). Try again tomorrow.`,
-      );
-    }
-    return undefined;
-  }
-
   /** Dry-run preview for a single category-split create/update item. */
   private async manageDryRunSplit(
     userId: string,
@@ -871,7 +856,7 @@ export class McpTransactionsTools {
     item: ManageItem,
     requestId: unknown,
   ) {
-    const budget = this.checkWriteBudget(userId, 1);
+    const budget = this.writeLimiter.reserve(userId, 1);
     if (budget) return budget;
     const { preview, createPayee, splits } =
       await this.prepService.prepareCreateSingle(
@@ -951,7 +936,7 @@ export class McpTransactionsTools {
       );
     }
 
-    const budget = this.checkWriteBudget(userId, okCount);
+    const budget = this.writeLimiter.reserve(userId, okCount);
     if (budget) return budget;
 
     if (single) {
@@ -1134,7 +1119,7 @@ export class McpTransactionsTools {
         userId,
         this.toUpdateRow(items[0]),
       );
-      const budget = this.checkWriteBudget(userId, 1);
+      const budget = this.writeLimiter.reserve(userId, 1);
       if (budget) return budget;
       if (result.kind === "transfer") {
         const preview = result.preview;
@@ -1244,7 +1229,7 @@ export class McpTransactionsTools {
       }
       if (cards.length === 0)
         return toolError("None of the transaction edits could be prepared.");
-      const budget = this.checkWriteBudget(userId, cards.length);
+      const budget = this.writeLimiter.reserve(userId, cards.length);
       if (budget) return budget;
       return this.runIndividual(server, userId, cards, requestId, skipped);
     }
@@ -1256,7 +1241,7 @@ export class McpTransactionsTools {
     );
     if (bulk.okRows.length === 0)
       return toolError("None of the transaction edits could be prepared.");
-    const budget = this.checkWriteBudget(userId, bulk.okRows.length);
+    const budget = this.writeLimiter.reserve(userId, bulk.okRows.length);
     if (budget) return budget;
     const action = this.actionBuilder.buildBatchActions(
       userId,
@@ -1312,7 +1297,7 @@ export class McpTransactionsTools {
         userId,
         items[0].transactionId as string,
       );
-      const budget = this.checkWriteBudget(userId, 1);
+      const budget = this.writeLimiter.reserve(userId, 1);
       if (budget) return budget;
       const action = this.actionBuilder.buildDeleteTransaction(userId, preview);
       const outcome = await this.emitOrConfirm(
@@ -1350,7 +1335,7 @@ export class McpTransactionsTools {
       }
       if (cards.length === 0)
         return toolError("None of the transactions could be prepared.");
-      const budget = this.checkWriteBudget(userId, cards.length);
+      const budget = this.writeLimiter.reserve(userId, cards.length);
       if (budget) return budget;
       return this.runIndividual(server, userId, cards, requestId, skipped);
     }
@@ -1361,7 +1346,7 @@ export class McpTransactionsTools {
     );
     if (bulk.okRows.length === 0)
       return toolError("None of the transactions could be prepared.");
-    const budget = this.checkWriteBudget(userId, bulk.okRows.length);
+    const budget = this.writeLimiter.reserve(userId, bulk.okRows.length);
     if (budget) return budget;
     const action = this.actionBuilder.buildBatchActions(
       userId,


### PR DESCRIPTION
The MCP write limiter was instantiated independently in each write-tool
class (transactions, payees, investments), so the documented "per-user
daily write limit" was actually enforced per tool domain. A single user
could perform up to 3x the intended writes per day (one full budget for
transactions, payees, and securities/investment transactions each).

Make McpWriteLimiter an @Injectable() singleton provided once in
mcp.module.ts and inject it into all three write-tool classes, so the cap
spans every MCP write tool -- mirroring how the AI Assistant's
AiWriteLimiter is already a shared singleton. Consolidate the three
duplicated checkWriteBudget helpers into a single reserve() method on the
limiter.

Also make the cap configurable at deploy time: McpWriteLimiter reads
MCP_DAILY_WRITE_LIMIT and AiWriteLimiter reads AI_DAILY_WRITE_LIMIT
(positive integer, falling back to the default of 50). Document both in
.env.example.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015WyyK6n1hdg6sA2PMfvgbv