### PR TITLE
Fix async test and escape backslashes in markdown tables

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -41,7 +41,7 @@
         "qrcode": "^1.5.4",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
-        "typeorm": "^0.3.28",
+        "typeorm": "^0.3.30",
         "ua-parser-js": "^2.0.10",
         "undici": "^8.5.0",
         "zod": "^4.3.6"
@@ -4585,7 +4585,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.19",
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -4613,7 +4615,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.7.1",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -9806,23 +9810,25 @@
       "license": "MIT"
     },
     "node_modules/typeorm": {
-      "version": "0.3.28",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
+      "integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
         "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "dayjs": "^1.11.19",
+        "dayjs": "^1.11.20",
         "debug": "^4.4.3",
-        "dedent": "^1.7.0",
+        "dedent": "^1.7.2",
         "dotenv": "^16.6.1",
         "glob": "^10.5.0",
         "reflect-metadata": "^0.2.2",
         "sha.js": "^2.4.12",
         "sql-highlight": "^6.1.0",
         "tslib": "^2.8.1",
-        "uuid": "^11.1.0",
+        "uuid": "^11.1.1",
         "yargs": "^17.7.2"
       },
       "bin": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -64,7 +64,7 @@
     "qrcode": "^1.5.4",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
-    "typeorm": "^0.3.28",
+    "typeorm": "^0.3.30",
     "ua-parser-js": "^2.0.10",
     "undici": "^8.5.0",
     "zod": "^4.3.6"

--- a/frontend/src/components/insights/InsightCard.tsx
+++ b/frontend/src/components/insights/InsightCard.tsx
@@ -45,6 +45,8 @@ export function InsightCard({ insight, onDismiss, isDismissing }: InsightCardPro
   const { formatDate } = useDateFormat();
   const style = severityStyles[insight.severity] || severityStyles.info;
   const typeStyle = typeStyles[insight.type] || typeStyles.anomaly;
+  const typeKey = `insightTypes.${insight.type}`;
+  const typeLabel = t.has(typeKey) ? t(typeKey) : t('insightTypes.anomaly');
 
   return (
     <div
@@ -66,7 +68,7 @@ export function InsightCard({ insight, onDismiss, isDismissing }: InsightCardPro
             <span
               className={`px-1.5 py-0.5 text-xs font-medium rounded ${typeStyle}`}
             >
-              {t(`insightTypes.${insight.type}`)}
+              {typeLabel}
             </span>
           </div>
           <p className="text-sm text-gray-700 dark:text-gray-300 mb-2">

--- a/frontend/src/components/reports/GeographicAllocationReport.test.tsx
+++ b/frontend/src/components/reports/GeographicAllocationReport.test.tsx
@@ -133,11 +133,16 @@ describe('GeographicAllocationReport', () => {
     mockGetCountryWeightings.mockResolvedValue(emptyCountryWeightings);
   });
 
-  it('shows loading state initially', () => {
+  it('shows loading state initially', async () => {
     mockGetPortfolioSummary.mockReturnValue(new Promise(() => {}));
     mockGetInvestmentAccounts.mockReturnValue(new Promise(() => {}));
     mockGetSecurities.mockReturnValue(new Promise(() => {}));
-    render(<GeographicAllocationReport />);
+    // Country look-through resolves on mount, so wrap the render in act() to
+    // flush that state update (the portfolio summary stays pending, keeping the
+    // skeleton on screen).
+    await act(async () => {
+      render(<GeographicAllocationReport />);
+    });
     expect(document.querySelector('.animate-pulse')).toBeTruthy();
   });
 

--- a/frontend/src/lib/html-table-to-markdown.test.ts
+++ b/frontend/src/lib/html-table-to-markdown.test.ts
@@ -26,6 +26,13 @@ describe('htmlTablesToMarkdown', () => {
     );
   });
 
+  it('escapes backslashes before pipes so input is preserved unambiguously', () => {
+    const html = '<table><tr><td>a\\</td><td>b\\|c</td></tr></table>';
+    expect(htmlTablesToMarkdown(html)).toBe(
+      ['| a\\\\ | b\\\\\\|c |', '| --- | --- |'].join('\n'),
+    );
+  });
+
   it('pads short rows to the widest row', () => {
     const html =
       '<table><tr><th>A</th><th>B</th><th>C</th></tr><tr><td>1</td></tr></table>';

--- a/frontend/src/lib/html-table-to-markdown.ts
+++ b/frontend/src/lib/html-table-to-markdown.ts
@@ -23,10 +23,13 @@ export function htmlTablesToMarkdown(html: string): string | null {
 }
 
 function cellText(cell: Element): string {
-  // Collapse whitespace and escape pipes so the cell can't break the table.
+  // Collapse whitespace and escape so the cell can't break the table.
+  // Backslashes are escaped first so an input backslash can't combine with the
+  // pipe-escaping below to alter the rendered text.
   return (cell.textContent || '')
     .replace(/\s+/g, ' ')
     .trim()
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|');
 }
 


### PR DESCRIPTION
## Summary

This PR addresses three small fixes:

1. **GeographicAllocationReport test**: Wrap the initial render in `act()` to flush the country weightings state update that resolves on mount, ensuring the loading skeleton is properly displayed while portfolio data remains pending.

2. **Markdown table escaping**: Escape backslashes before pipes in table cells so that input backslashes are preserved unambiguously in the rendered markdown. Without this, a backslash followed by a pipe could be misinterpreted.

3. **InsightCard i18n fallback**: Add a fallback to `insightTypes.anomaly` when the insight type key is missing from translations, preventing potential runtime errors if an unexpected type is encountered.

4. **TypeORM dependency**: Bump TypeORM from 0.3.28 to 0.3.30 (transitive lockfile update).

## Checklist

- [x] New behavior has tests (markdown escaping and async test fixes)
- [x] Existing test suite passes
- [x] No user-facing strings added (i18n fallback uses existing keys)
- [x] No shared/core areas refactored

https://claude.ai/code/session_018TXAXcjwmXmHAzUDQMn2Jo