### PR TITLE
fix(ai): deep-link the chat "View ..." links to the created/edited record

### DIFF
--- a/frontend/src/app/categories/page.tsx
+++ b/frontend/src/app/categories/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import toast from 'react-hot-toast';
 import { useOnUndoRedo } from '@/hooks/useOnUndoRedo';
+import { useHighlightParam } from '@/hooks/useHighlightTarget';
 import dynamic from 'next/dynamic';
 import { Button } from '@/components/ui/Button';
 const CategoryForm = dynamic(() => import('@/components/categories/CategoryForm').then(m => m.CategoryForm), { ssr: false });
@@ -34,6 +35,9 @@ export default function CategoriesPage() {
 
 function CategoriesContent() {
   const t = useTranslations('categories');
+  // Deep link to a specific category (e.g. a "View categories" link). The tree
+  // renders all rows, so no page jump is needed -- the row flashes in place.
+  const highlightId = useHighlightParam();
   const [categories, setCategories] = useState<Category[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isImporting, setIsImporting] = useState(false);
@@ -296,6 +300,7 @@ function CategoriesContent() {
               sortField={sortField}
               sortDirection={sortDirection}
               onSort={handleSort}
+              highlightId={highlightId}
             />
           )}
         </div>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -49,10 +49,14 @@
      ring out to transparent so the highlight gently disappears instead of
      blinking off. Colours come from the theme vars below so it adapts to dark
      mode; pair the utility with motion-reduce:animate-none. */
-  --animate-highlight-flash: highlight-flash 2.5s ease-out;
+  --animate-highlight-flash: highlight-flash 4.5s ease-out;
 
   @keyframes highlight-flash {
-    0% {
+    /* Hold the full highlight for the first ~55% (~2.5s) so it is still solid
+       once the page has rendered and scrolled the row into view, then fade the
+       background and inset ring out over the remainder. */
+    0%,
+    55% {
       background-color: var(--highlight-flash-bg);
       box-shadow: inset 0 0 0 2px var(--highlight-flash-ring);
     }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -43,10 +43,39 @@
       transform: none;
     }
   }
+
+  /* One-shot amber flash for a deep-linked list row (e.g. the AI chat "View
+     transaction / payees / ..." link). Fades the row background and an inset
+     ring out to transparent so the highlight gently disappears instead of
+     blinking off. Colours come from the theme vars below so it adapts to dark
+     mode; pair the utility with motion-reduce:animate-none. */
+  --animate-highlight-flash: highlight-flash 2.5s ease-out;
+
+  @keyframes highlight-flash {
+    0% {
+      background-color: var(--highlight-flash-bg);
+      box-shadow: inset 0 0 0 2px var(--highlight-flash-ring);
+    }
+    100% {
+      background-color: transparent;
+      box-shadow: inset 0 0 0 2px transparent;
+    }
+  }
 }
 
 /* Dark mode variant */
 @variant dark (&:where(.dark, .dark *));
+
+/* Flash colours (amber-50 / amber-400 in light, amber-900@30% / amber-500 in
+   dark) for the highlight-flash animation above. */
+:root {
+  --highlight-flash-bg: #fffbeb;
+  --highlight-flash-ring: #fbbf24;
+}
+.dark {
+  --highlight-flash-bg: rgb(120 53 15 / 0.3);
+  --highlight-flash-ring: #f59e0b;
+}
 
 /* Base styles -- extend background behind display cutouts */
 html {

--- a/frontend/src/app/payees/page.tsx
+++ b/frontend/src/app/payees/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useTranslations } from 'next-intl';
 import toast from 'react-hot-toast';
 import { useOnUndoRedo } from '@/hooks/useOnUndoRedo';
@@ -30,6 +30,7 @@ import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { createLogger } from '@/lib/logger';
 import { getErrorMessage } from '@/lib/errors';
 import { PAGE_SIZE } from '@/lib/constants';
+import { useHighlightParam } from '@/hooks/useHighlightTarget';
 
 const logger = createLogger('Payees');
 
@@ -256,6 +257,22 @@ function PayeesContent() {
     }
   };
 
+  // Deep link to a specific payee (e.g. the AI chat "View payees" link): once
+  // the list has loaded, jump to the client-side page that contains it so the
+  // row can flash and scroll into view. Runs once per arrival.
+  const highlightId = useHighlightParam();
+  const highlightJumpedRef = useRef(false);
+  useEffect(() => {
+    if (!highlightId || highlightJumpedRef.current || sortedPayees.length === 0) {
+      return;
+    }
+    const index = sortedPayees.findIndex((p) => p.id === highlightId);
+    if (index >= 0) {
+      highlightJumpedRef.current = true;
+      setCurrentPage(Math.floor(index / PAGE_SIZE) + 1);
+    }
+  }, [highlightId, sortedPayees]);
+
   // Summary counts
   const activeCount = payees.filter(p => p.isActive).length;
   const inactiveCount = payees.filter(p => !p.isActive).length;
@@ -408,6 +425,7 @@ function PayeesContent() {
               onSort={handleSort}
               categoryColorMap={categoryColorMap}
               categoryLabelMap={categoryLabelMap}
+              highlightId={highlightId}
             />
           )}
         </div>

--- a/frontend/src/app/securities/page.tsx
+++ b/frontend/src/app/securities/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useTranslations } from 'next-intl';
 import toast from 'react-hot-toast';
 import { Button } from '@/components/ui/Button';
@@ -27,6 +27,7 @@ import { getErrorMessage } from '@/lib/errors';
 import { useFormModal } from '@/hooks/useFormModal';
 import { useOnUndoRedo } from '@/hooks/useOnUndoRedo';
 import { PAGE_SIZE } from '@/lib/constants';
+import { useHighlightParam } from '@/hooks/useHighlightTarget';
 
 const logger = createLogger('Securities');
 
@@ -248,6 +249,22 @@ function SecuritiesContent() {
     }
   };
 
+  // Deep link to a specific security (e.g. the AI chat "View securities" link):
+  // jump to the client-side page that contains it once the list has loaded, so
+  // the row can flash and scroll into view. Runs once per arrival.
+  const highlightId = useHighlightParam();
+  const highlightJumpedRef = useRef(false);
+  useEffect(() => {
+    if (!highlightId || highlightJumpedRef.current || sortedSecurities.length === 0) {
+      return;
+    }
+    const index = sortedSecurities.findIndex((s) => s.id === highlightId);
+    if (index >= 0) {
+      highlightJumpedRef.current = true;
+      setCurrentPage(Math.floor(index / PAGE_SIZE) + 1);
+    }
+  }, [highlightId, sortedSecurities]);
+
   const activeCount = allSecurities.filter((s) => s.isActive).length;
   const inactiveCount = allSecurities.filter((s) => !s.isActive).length;
 
@@ -362,6 +379,7 @@ function SecuritiesContent() {
               sortField={sortField}
               sortDirection={sortDirection}
               onSort={handleSort}
+              highlightId={highlightId}
             />
           )}
         </div>

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -320,7 +320,7 @@ function TransactionsContent() {
   useEffect(() => {
     const id = filters.highlightTransactionId;
     if (!id || !transactions.some((tx) => tx.id === id)) return;
-    const timer = setTimeout(() => filters.setHighlightTransactionId(null), 3500);
+    const timer = setTimeout(() => filters.setHighlightTransactionId(null), 5000);
     return () => clearTimeout(timer);
   }, [transactions, filters.highlightTransactionId]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -314,6 +314,16 @@ function TransactionsContent() {
     }
   }, [filters.currentPage, filters.filterAccountIds, filters.filterCategoryIds, filters.filterPayeeIds, filters.filterTagIds, filters.filterStartDate, filters.filterEndDate, filters.filterSearch, filters.filterAmountFrom, filters.filterAmountTo, filters.filterStatuses, filters.updateUrl, loadTransactions, filters.filtersInitialized, undoRedoTick]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Once the deep-linked transaction is actually on the page, let the flash
+  // linger briefly then clear it, so the highlight does not stick around on
+  // later interactions.
+  useEffect(() => {
+    const id = filters.highlightTransactionId;
+    if (!id || !transactions.some((tx) => tx.id === id)) return;
+    const timer = setTimeout(() => filters.setHighlightTransactionId(null), 3500);
+    return () => clearTimeout(timer);
+  }, [transactions, filters.highlightTransactionId]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Patch popstate handler to skip when modals open
   useEffect(() => {
     const origHandler = (_e: PopStateEvent) => {
@@ -1016,6 +1026,7 @@ function TransactionsContent() {
               categoryColorMap={filters.categoryColorMap}
               categoryLabelMap={filters.categoryLabelMap}
               budgetStatusMap={budgetStatusMap}
+              highlightTransactionId={filters.highlightTransactionId}
             />
           )}
         </div>

--- a/frontend/src/components/ai/TransactionConfirmationCard.test.tsx
+++ b/frontend/src/components/ai/TransactionConfirmationCard.test.tsx
@@ -339,7 +339,7 @@ describe('TransactionConfirmationCard', () => {
     expect(screen.getByText('Pinned to dashboard')).toBeInTheDocument();
   });
 
-  it('shows a view-securities link once a security is created', () => {
+  it('deep-links the view-securities link to the created security', () => {
     render(
       <TransactionConfirmationCard
         action={makeSecurityAction({}, { status: 'confirmed', resultId: 'sec-1' })}
@@ -348,6 +348,19 @@ describe('TransactionConfirmationCard', () => {
       />,
     );
     expect(screen.getByText('Security created')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'View securities' }),
+    ).toHaveAttribute('href', '/securities?highlight=sec-1');
+  });
+
+  it('falls back to the plain securities list when no result id is present', () => {
+    render(
+      <TransactionConfirmationCard
+        action={makeSecurityAction({}, { status: 'confirmed' })}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
     expect(
       screen.getByRole('link', { name: 'View securities' }),
     ).toHaveAttribute('href', '/securities');
@@ -522,6 +535,25 @@ describe('TransactionConfirmationCard', () => {
       expect(screen.getByText('Create this payee?')).toBeInTheDocument();
       expect(screen.getByText('Hydro One')).toBeInTheDocument();
       expect(screen.getByText('Utilities')).toBeInTheDocument();
+    });
+
+    it('deep-links the view-payees link to the created payee', () => {
+      render(
+        <TransactionConfirmationCard
+          action={makeAction({
+            type: 'create_payee',
+            descriptor: { type: 'create_payee' },
+            status: 'confirmed',
+            resultId: 'payee-1',
+            preview: { name: 'Hydro One', categoryName: 'Utilities' },
+          })}
+          onConfirm={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+      );
+      expect(
+        screen.getByRole('link', { name: 'View payees' }),
+      ).toHaveAttribute('href', '/payees?highlight=payee-1');
     });
 
     it('renders an update_payee card and success message', () => {

--- a/frontend/src/components/ai/TransactionConfirmationCard.test.tsx
+++ b/frontend/src/components/ai/TransactionConfirmationCard.test.tsx
@@ -137,10 +137,24 @@ describe('TransactionConfirmationCard', () => {
       />,
     );
     expect(screen.getByText('Transaction created')).toBeInTheDocument();
+    // The link deep-links to the created transaction so the list flashes it.
+    expect(
+      screen.getByRole('link', { name: 'View transaction' }),
+    ).toHaveAttribute('href', '/transactions?targetTransactionId=tx-1');
+    expect(screen.queryByRole('button', { name: 'Approve' })).toBeNull();
+  });
+
+  it('falls back to the unfiltered list when no result id is present', () => {
+    render(
+      <TransactionConfirmationCard
+        action={makeAction({ status: 'confirmed' })}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
     expect(
       screen.getByRole('link', { name: 'View transaction' }),
     ).toHaveAttribute('href', '/transactions');
-    expect(screen.queryByRole('button', { name: 'Approve' })).toBeNull();
   });
 
   it('shows an error message and a retry button on error', () => {
@@ -417,7 +431,7 @@ describe('TransactionConfirmationCard', () => {
       expect(screen.getByText('Transaction updated')).toBeInTheDocument();
       expect(
         screen.getByRole('link', { name: 'View transaction' }),
-      ).toHaveAttribute('href', '/transactions');
+      ).toHaveAttribute('href', '/transactions?targetTransactionId=tx-1');
     });
 
     it('renders a delete_transaction card and offers no view link on success', () => {
@@ -698,7 +712,7 @@ describe('TransactionConfirmationCard', () => {
       expect(screen.getByText('Transfer updated')).toBeInTheDocument();
       expect(
         screen.getByRole('link', { name: 'View transaction' }),
-      ).toHaveAttribute('href', '/transactions');
+      ).toHaveAttribute('href', '/transactions?targetTransactionId=tx-1');
     });
   });
 });

--- a/frontend/src/components/ai/TransactionConfirmationCard.tsx
+++ b/frontend/src/components/ai/TransactionConfirmationCard.tsx
@@ -296,15 +296,20 @@ export function TransactionConfirmationCard({
     type === 'delete_investment_transaction' ||
     type === 'delete_payee' ||
     type === 'delete_security';
-  // The affected record's home, surfaced as a "view" link on success.
+  // The affected record's home, surfaced as a "view" link on success. For
+  // list-backed destinations we deep-link to the created/edited record
+  // (?highlight=<id>) so the list flashes and scrolls to it; without a result
+  // id we fall back to the plain list.
+  const highlightHref = (base: string) =>
+    action.resultId ? `${base}?highlight=${action.resultId}` : base;
   const viewLink = isDeletion
     ? null
     : isInvestmentTxType
       ? { href: '/investments', label: t('confirmAction.viewInvestments') }
       : isSecurityResult
-        ? { href: '/securities', label: t('confirmAction.viewSecurities') }
+        ? { href: highlightHref('/securities'), label: t('confirmAction.viewSecurities') }
         : isPayeeWriteType
-          ? { href: '/payees', label: t('confirmAction.viewPayees') }
+          ? { href: highlightHref('/payees'), label: t('confirmAction.viewPayees') }
           : isCashTxType || isTransferType || type === 'categorize_transaction'
             ? {
                 // Deep-link to the affected transaction so the list jumps to and

--- a/frontend/src/components/ai/TransactionConfirmationCard.tsx
+++ b/frontend/src/components/ai/TransactionConfirmationCard.tsx
@@ -306,7 +306,15 @@ export function TransactionConfirmationCard({
         : isPayeeWriteType
           ? { href: '/payees', label: t('confirmAction.viewPayees') }
           : isCashTxType || isTransferType || type === 'categorize_transaction'
-            ? { href: '/transactions', label: t('confirmAction.viewTransaction') }
+            ? {
+                // Deep-link to the affected transaction so the list jumps to and
+                // flashes that row; fall back to the unfiltered list if the id
+                // is missing (e.g. an older pending action without a result).
+                href: action.resultId
+                  ? `/transactions?targetTransactionId=${action.resultId}`
+                  : '/transactions',
+                label: t('confirmAction.viewTransaction'),
+              }
             : null;
   const successByType: Partial<Record<typeof type, string>> = {
     create_transaction: t('confirmAction.createdTransaction'),

--- a/frontend/src/components/categories/CategoryList.tsx
+++ b/frontend/src/components/categories/CategoryList.tsx
@@ -10,6 +10,7 @@ import toast from 'react-hot-toast';
 import { createLogger } from '@/lib/logger';
 import { getErrorMessage } from '@/lib/errors';
 import { useTableDensity, nextDensity, type DensityLevel } from '@/hooks/useTableDensity';
+import { HIGHLIGHT_RING, useScrollIntoViewWhen } from '@/hooks/useHighlightTarget';
 import { SortIcon } from '@/components/ui/SortIcon';
 import { useLongPress, type LongPressRowHandlers } from '@/hooks/useLongPress';
 import { RowActions } from '@/components/ui/row-actions/RowActions';
@@ -61,6 +62,7 @@ interface CategoryRowProps {
   onViewTransactions: (category: Category) => void;
   index: number;
   getRowHandlers: (category: Category) => LongPressRowHandlers;
+  isHighlighted?: boolean;
 }
 
 const CategoryRow = memo(function CategoryRow({
@@ -72,9 +74,11 @@ const CategoryRow = memo(function CategoryRow({
   onViewTransactions,
   index,
   getRowHandlers,
+  isHighlighted,
 }: CategoryRowProps) {
   const t = useTranslations('categories');
   const tc = useTranslations('common');
+  const rowRef = useScrollIntoViewWhen<HTMLTableRowElement>(!!isHighlighted);
 
   const actions = useMemo(
     () => buildCategoryActions(
@@ -87,7 +91,8 @@ const CategoryRow = memo(function CategoryRow({
 
   return (
     <tr
-      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer select-none ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'}`}
+      ref={rowRef}
+      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer select-none ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${isHighlighted ? HIGHLIGHT_RING : ''}`}
       {...getRowHandlers(category)}
     >
       <td className={`${cellPadding} whitespace-nowrap`}>
@@ -154,6 +159,8 @@ interface CategoryListProps {
   sortField?: SortField;
   sortDirection?: SortDirection;
   onSort?: (field: SortField) => void;
+  /** Category id to flash/scroll to (e.g. arriving from a deep link). */
+  highlightId?: string | null;
 }
 
 export function CategoryList({
@@ -166,6 +173,7 @@ export function CategoryList({
   sortField: propSortField,
   sortDirection: propSortDirection,
   onSort,
+  highlightId,
 }: CategoryListProps) {
   const t = useTranslations('categories');
   const tc = useTranslations('common');
@@ -359,6 +367,7 @@ export function CategoryList({
                 onViewTransactions={handleViewTransactions}
                 index={index}
                 getRowHandlers={getRowHandlers}
+                isHighlighted={!!highlightId && category.id === highlightId}
               />
             ))}
           </tbody>

--- a/frontend/src/components/categories/CategoryList.tsx
+++ b/frontend/src/components/categories/CategoryList.tsx
@@ -10,7 +10,7 @@ import toast from 'react-hot-toast';
 import { createLogger } from '@/lib/logger';
 import { getErrorMessage } from '@/lib/errors';
 import { useTableDensity, nextDensity, type DensityLevel } from '@/hooks/useTableDensity';
-import { HIGHLIGHT_RING, useScrollIntoViewWhen } from '@/hooks/useHighlightTarget';
+import { HIGHLIGHT_FLASH, HIGHLIGHT_FLASH_CELL, useScrollIntoViewWhen } from '@/hooks/useHighlightTarget';
 import { SortIcon } from '@/components/ui/SortIcon';
 import { useLongPress, type LongPressRowHandlers } from '@/hooks/useLongPress';
 import { RowActions } from '@/components/ui/row-actions/RowActions';
@@ -92,7 +92,7 @@ const CategoryRow = memo(function CategoryRow({
   return (
     <tr
       ref={rowRef}
-      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer select-none ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${isHighlighted ? HIGHLIGHT_RING : ''}`}
+      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer select-none ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${isHighlighted ? HIGHLIGHT_FLASH : ''}`}
       {...getRowHandlers(category)}
     >
       <td className={`${cellPadding} whitespace-nowrap`}>
@@ -142,7 +142,7 @@ const CategoryRow = memo(function CategoryRow({
           </div>
         </td>
       )}
-      <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium hidden min-[480px]:table-cell sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`}>
+      <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium hidden min-[480px]:table-cell sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800 ${isHighlighted ? HIGHLIGHT_FLASH_CELL : ''}`}>
         <RowActions actions={actions} density={density} />
       </td>
     </tr>

--- a/frontend/src/components/payees/PayeeList.test.tsx
+++ b/frontend/src/components/payees/PayeeList.test.tsx
@@ -68,6 +68,24 @@ describe('PayeeList', () => {
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 
+  it('flashes the highlighted payee row and scrolls to it', () => {
+    // jsdom doesn't implement scrollIntoView.
+    const scroll = vi.fn();
+    Element.prototype.scrollIntoView = scroll;
+    const payees = [
+      makePayee({ id: 'p1', name: 'Walmart' }),
+      makePayee({ id: 'p2', name: 'Netflix' }),
+    ];
+    render(
+      <PayeeList payees={payees} onEdit={onEdit} onRefresh={onRefresh} highlightId="p2" />,
+    );
+    const highlighted = screen.getByText('Netflix').closest('tr')!;
+    const other = screen.getByText('Walmart').closest('tr')!;
+    expect(highlighted.className).toContain('ring-amber-400');
+    expect(other.className).not.toContain('ring-amber-400');
+    expect(scroll).toHaveBeenCalled();
+  });
+
   // Rendering payees
   it('renders payees table with data', () => {
     const payees = [

--- a/frontend/src/components/payees/PayeeList.test.tsx
+++ b/frontend/src/components/payees/PayeeList.test.tsx
@@ -81,8 +81,8 @@ describe('PayeeList', () => {
     );
     const highlighted = screen.getByText('Netflix').closest('tr')!;
     const other = screen.getByText('Walmart').closest('tr')!;
-    expect(highlighted.className).toContain('ring-amber-400');
-    expect(other.className).not.toContain('ring-amber-400');
+    expect(highlighted.className).toContain('animate-highlight-flash');
+    expect(other.className).not.toContain('animate-highlight-flash');
     expect(scroll).toHaveBeenCalled();
   });
 

--- a/frontend/src/components/payees/PayeeList.tsx
+++ b/frontend/src/components/payees/PayeeList.tsx
@@ -10,7 +10,7 @@ import toast from 'react-hot-toast';
 import { createLogger } from '@/lib/logger';
 import { getErrorMessage } from '@/lib/errors';
 import { useTableDensity, nextDensity, type DensityLevel } from '@/hooks/useTableDensity';
-import { HIGHLIGHT_RING, useScrollIntoViewWhen } from '@/hooks/useHighlightTarget';
+import { HIGHLIGHT_FLASH, HIGHLIGHT_FLASH_CELL, useScrollIntoViewWhen } from '@/hooks/useHighlightTarget';
 import { SortIcon } from '@/components/ui/SortIcon';
 import { useDateFormat } from '@/hooks/useDateFormat';
 import { useLongPress, type LongPressRowHandlers } from '@/hooks/useLongPress';
@@ -157,7 +157,7 @@ const PayeeRow = memo(function PayeeRow({
   return (
     <tr
       ref={rowRef}
-      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer select-none ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${!payee.isActive ? 'opacity-60' : ''} ${isHighlighted ? HIGHLIGHT_RING : ''}`}
+      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer select-none ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${!payee.isActive ? 'opacity-60' : ''} ${isHighlighted ? HIGHLIGHT_FLASH : ''}`}
       {...getRowHandlers(payee)}
     >
       <td className={`${cellPadding} whitespace-nowrap`}>
@@ -230,7 +230,7 @@ const PayeeRow = memo(function PayeeRow({
           </div>
         </td>
       )}
-      <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium hidden min-[480px]:table-cell sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`}>
+      <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium hidden min-[480px]:table-cell sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800 ${isHighlighted ? HIGHLIGHT_FLASH_CELL : ''}`}>
         <RowActions actions={actions} density={density} />
       </td>
     </tr>

--- a/frontend/src/components/payees/PayeeList.tsx
+++ b/frontend/src/components/payees/PayeeList.tsx
@@ -10,6 +10,7 @@ import toast from 'react-hot-toast';
 import { createLogger } from '@/lib/logger';
 import { getErrorMessage } from '@/lib/errors';
 import { useTableDensity, nextDensity, type DensityLevel } from '@/hooks/useTableDensity';
+import { HIGHLIGHT_RING, useScrollIntoViewWhen } from '@/hooks/useHighlightTarget';
 import { SortIcon } from '@/components/ui/SortIcon';
 import { useDateFormat } from '@/hooks/useDateFormat';
 import { useLongPress, type LongPressRowHandlers } from '@/hooks/useLongPress';
@@ -96,6 +97,8 @@ interface PayeeListProps {
   onSort?: (field: SortField) => void;
   categoryColorMap?: Map<string, string | null>;
   categoryLabelMap?: Map<string, string>;
+  /** Payee id to flash/scroll to (e.g. arriving from a deep link). */
+  highlightId?: string | null;
 }
 
 interface PayeeRowProps {
@@ -113,6 +116,7 @@ interface PayeeRowProps {
   categoryLabelMap?: Map<string, string>;
   formatDate: (date: string) => string;
   getRowHandlers: (payee: Payee) => LongPressRowHandlers;
+  isHighlighted?: boolean;
 }
 
 const PayeeRow = memo(function PayeeRow({
@@ -130,9 +134,11 @@ const PayeeRow = memo(function PayeeRow({
   categoryLabelMap,
   formatDate,
   getRowHandlers,
+  isHighlighted,
 }: PayeeRowProps) {
   const t = useTranslations('payees');
   const tc = useTranslations('common');
+  const rowRef = useScrollIntoViewWhen<HTMLTableRowElement>(!!isHighlighted);
   const defaultCategoryColor = payee.defaultCategory
     ? (categoryColorMap?.get(payee.defaultCategory.id) ?? payee.defaultCategory.color)
     : null;
@@ -150,7 +156,8 @@ const PayeeRow = memo(function PayeeRow({
 
   return (
     <tr
-      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer select-none ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${!payee.isActive ? 'opacity-60' : ''}`}
+      ref={rowRef}
+      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer select-none ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${!payee.isActive ? 'opacity-60' : ''} ${isHighlighted ? HIGHLIGHT_RING : ''}`}
       {...getRowHandlers(payee)}
     >
       <td className={`${cellPadding} whitespace-nowrap`}>
@@ -245,6 +252,7 @@ export function PayeeList({
   onSort,
   categoryColorMap,
   categoryLabelMap,
+  highlightId,
 }: PayeeListProps) {
   const t = useTranslations('payees');
   const tc = useTranslations('common');
@@ -449,6 +457,7 @@ export function PayeeList({
                 categoryLabelMap={categoryLabelMap}
                 formatDate={formatDate}
                 getRowHandlers={getRowHandlers}
+                isHighlighted={!!highlightId && payee.id === highlightId}
               />
             ))}
           </tbody>

--- a/frontend/src/components/securities/SecurityList.tsx
+++ b/frontend/src/components/securities/SecurityList.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useCallback, memo } from 'react';
 import { useTranslations, useMessages } from 'next-intl';
 import { Security } from '@/types/investment';
 import { DensityLevel, nextDensity } from '@/hooks/useTableDensity';
-import { HIGHLIGHT_RING, useScrollIntoViewWhen } from '@/hooks/useHighlightTarget';
+import { HIGHLIGHT_FLASH, HIGHLIGHT_FLASH_CELL, useScrollIntoViewWhen } from '@/hooks/useHighlightTarget';
 import { SortIcon } from '@/components/ui/SortIcon';
 import { usePreferencesStore } from '@/store/preferencesStore';
 import { formatShareQuantity } from '@/lib/format';
@@ -233,7 +233,7 @@ const SecurityRow = memo(function SecurityRow({
       ref={rowRef}
       className={`group hover:bg-gray-100 dark:hover:bg-gray-800 select-none ${
         !security.isActive ? 'opacity-60' : ''
-      } ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${isHighlighted ? HIGHLIGHT_RING : ''}`}
+      } ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${isHighlighted ? HIGHLIGHT_FLASH : ''}`}
       {...getRowHandlers(security)}
     >
       <td className={`${cellPadding} whitespace-nowrap text-center`}>
@@ -368,7 +368,7 @@ const SecurityRow = memo(function SecurityRow({
         )}
       </td>
       {/* Actions - hidden on mobile */}
-      <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium hidden sm:table-cell sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`}>
+      <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium hidden sm:table-cell sticky right-0 ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800 ${isHighlighted ? HIGHLIGHT_FLASH_CELL : ''}`}>
         <RowActions actions={actions} density={density} />
       </td>
     </tr>

--- a/frontend/src/components/securities/SecurityList.tsx
+++ b/frontend/src/components/securities/SecurityList.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useCallback, memo } from 'react';
 import { useTranslations, useMessages } from 'next-intl';
 import { Security } from '@/types/investment';
 import { DensityLevel, nextDensity } from '@/hooks/useTableDensity';
+import { HIGHLIGHT_RING, useScrollIntoViewWhen } from '@/hooks/useHighlightTarget';
 import { SortIcon } from '@/components/ui/SortIcon';
 import { usePreferencesStore } from '@/store/preferencesStore';
 import { formatShareQuantity } from '@/lib/format';
@@ -153,6 +154,8 @@ interface SecurityListProps {
   sortField?: SecuritySortField;
   sortDirection?: SortDirection;
   onSort?: (field: SecuritySortField) => void;
+  /** Security id to flash/scroll to (e.g. arriving from a deep link). */
+  highlightId?: string | null;
 }
 
 interface SecurityRowProps {
@@ -171,6 +174,7 @@ interface SecurityRowProps {
   getRowHandlers: (security: Security) => LongPressRowHandlers;
   index: number;
   defaultQuoteProvider: 'yahoo' | 'msn';
+  isHighlighted?: boolean;
 }
 
 const SecurityRow = memo(function SecurityRow({
@@ -189,7 +193,9 @@ const SecurityRow = memo(function SecurityRow({
   getRowHandlers,
   index,
   defaultQuoteProvider,
+  isHighlighted,
 }: SecurityRowProps) {
+  const rowRef = useScrollIntoViewWhen<HTMLTableRowElement>(!!isHighlighted);
   const t = useTranslations('securities');
   const tc = useTranslations('common');
   const messages = useMessages();
@@ -224,9 +230,10 @@ const SecurityRow = memo(function SecurityRow({
 
   return (
     <tr
+      ref={rowRef}
       className={`group hover:bg-gray-100 dark:hover:bg-gray-800 select-none ${
         !security.isActive ? 'opacity-60' : ''
-      } ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'}`}
+      } ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${isHighlighted ? HIGHLIGHT_RING : ''}`}
       {...getRowHandlers(security)}
     >
       <td className={`${cellPadding} whitespace-nowrap text-center`}>
@@ -383,6 +390,7 @@ export function SecurityList({
   sortField: propSortField,
   sortDirection: propSortDirection,
   onSort,
+  highlightId,
 }: SecurityListProps) {
   const t = useTranslations('securities');
   const [localDensity, setLocalDensity] = useState<DensityLevel>('normal');
@@ -574,6 +582,7 @@ export function SecurityList({
                 getRowHandlers={getRowHandlers}
                 index={index}
                 defaultQuoteProvider={defaultQuoteProvider}
+                isHighlighted={!!highlightId && security.id === highlightId}
               />
             ))}
           </tbody>

--- a/frontend/src/components/transactions/TransactionList.tsx
+++ b/frontend/src/components/transactions/TransactionList.tsx
@@ -53,6 +53,8 @@ interface TransactionListProps {
   categoryLabelMap?: Map<string, string>;
   budgetStatusMap?: Record<string, CategoryBudgetStatus>;
   showToolbar?: boolean;
+  /** Transaction id to flash and scroll to (e.g. arriving from a deep link). */
+  highlightTransactionId?: string | null;
 }
 
 export function TransactionList({
@@ -92,6 +94,7 @@ export function TransactionList({
   categoryLabelMap,
   budgetStatusMap,
   showToolbar = true,
+  highlightTransactionId,
 }: TransactionListProps) {
   const t = useTranslations('transactions');
   const tc = useTranslations('common');
@@ -519,6 +522,7 @@ export function TransactionList({
                     categoryColorMap={categoryColorMap}
                     budgetStatusMap={budgetStatusMap}
                     isFuture={isFuture}
+                    isHighlighted={!!highlightTransactionId && transaction.id === highlightTransactionId}
                   />
                 </React.Fragment>
               );

--- a/frontend/src/components/transactions/TransactionRow.test.tsx
+++ b/frontend/src/components/transactions/TransactionRow.test.tsx
@@ -90,7 +90,7 @@ describe('TransactionRow', () => {
       .mockImplementation(() => {});
     renderRow({ isHighlighted: true });
     const row = screen.getByText('Coffee Co').closest('tr')!;
-    expect(row.className).toContain('ring-amber-400');
+    expect(row.className).toContain('animate-highlight-flash');
     expect(scrollSpy).toHaveBeenCalled();
     scrollSpy.mockRestore();
   });
@@ -101,7 +101,7 @@ describe('TransactionRow', () => {
       .mockImplementation(() => {});
     renderRow();
     const row = screen.getByText('Coffee Co').closest('tr')!;
-    expect(row.className).not.toContain('ring-amber-400');
+    expect(row.className).not.toContain('animate-highlight-flash');
     expect(scrollSpy).not.toHaveBeenCalled();
     scrollSpy.mockRestore();
   });

--- a/frontend/src/components/transactions/TransactionRow.test.tsx
+++ b/frontend/src/components/transactions/TransactionRow.test.tsx
@@ -84,6 +84,28 @@ describe('TransactionRow', () => {
     expect(onRowClick).toHaveBeenCalled();
   });
 
+  it('flashes and scrolls to the row when highlighted', () => {
+    const scrollSpy = vi
+      .spyOn(Element.prototype, 'scrollIntoView')
+      .mockImplementation(() => {});
+    renderRow({ isHighlighted: true });
+    const row = screen.getByText('Coffee Co').closest('tr')!;
+    expect(row.className).toContain('ring-amber-400');
+    expect(scrollSpy).toHaveBeenCalled();
+    scrollSpy.mockRestore();
+  });
+
+  it('does not highlight or scroll by default', () => {
+    const scrollSpy = vi
+      .spyOn(Element.prototype, 'scrollIntoView')
+      .mockImplementation(() => {});
+    renderRow();
+    const row = screen.getByText('Coffee Co').closest('tr')!;
+    expect(row.className).not.toContain('ring-amber-400');
+    expect(scrollSpy).not.toHaveBeenCalled();
+    scrollSpy.mockRestore();
+  });
+
   it('renders payee as button when onPayeeClick provided', () => {
     const onPayeeClick = vi.fn();
     renderRow({ onPayeeClick });

--- a/frontend/src/components/transactions/TransactionRow.tsx
+++ b/frontend/src/components/transactions/TransactionRow.tsx
@@ -8,6 +8,7 @@ import { getIconComponent } from '@/components/ui/IconPicker';
 import { Transaction, TransactionSplit, TransactionStatus } from '@/types/transaction';
 import { CategoryBudgetStatus } from '@/types/budget';
 import { DensityLevel } from '@/hooks/useTableDensity';
+import { HIGHLIGHT_FLASH, HIGHLIGHT_FLASH_CELL } from '@/hooks/useHighlightTarget';
 import { formatAmountWithCommas, getDecimalPlacesForCurrency } from '@/lib/format';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 
@@ -239,7 +240,7 @@ export const TransactionRow = memo(function TransactionRow({
       onTouchMove={onTouchMove}
       onTouchEnd={onLongPressEnd}
       onTouchCancel={onLongPressEnd}
-      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 select-none touch-manipulation ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${isVoid ? 'opacity-50' : ''} ${isFuture && !isVoid ? 'opacity-60' : ''} ${onEdit ? 'cursor-pointer' : ''} ${isSelected ? 'bg-blue-50 dark:bg-blue-900/20' : ''} ${isHighlighted ? 'ring-2 ring-inset ring-amber-400 dark:ring-amber-500 !bg-amber-50 dark:!bg-amber-900/30' : ''}`}
+      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 select-none touch-manipulation ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${isVoid ? 'opacity-50' : ''} ${isFuture && !isVoid ? 'opacity-60' : ''} ${onEdit ? 'cursor-pointer' : ''} ${isSelected ? 'bg-blue-50 dark:bg-blue-900/20' : ''} ${isHighlighted ? HIGHLIGHT_FLASH : ''}`}
     >
       {selectionMode && (
         <td className={`${cellPadding} whitespace-nowrap w-10`} onClick={e => e.stopPropagation()}>
@@ -551,7 +552,7 @@ export const TransactionRow = memo(function TransactionRow({
           )}
         </button>
       </td>
-      <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium space-x-2 hidden min-[480px]:table-cell sticky right-0 ${isSelected ? 'bg-blue-50 dark:bg-blue-900/20' : density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800`}>
+      <td className={`${cellPadding} whitespace-nowrap text-right text-sm font-medium space-x-2 hidden min-[480px]:table-cell sticky right-0 ${isSelected ? 'bg-blue-50 dark:bg-blue-900/20' : density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} group-hover:bg-gray-100 dark:group-hover:bg-gray-800 ${isHighlighted ? HIGHLIGHT_FLASH_CELL : ''}`}>
         {onEdit && (
           <button
             onClick={(e) => { e.stopPropagation(); onEdit(transaction); }}

--- a/frontend/src/components/transactions/TransactionRow.tsx
+++ b/frontend/src/components/transactions/TransactionRow.tsx
@@ -166,6 +166,8 @@ export interface TransactionRowProps {
   categoryColorMap?: Map<string, string | null>;
   budgetStatusMap?: Record<string, CategoryBudgetStatus>;
   isFuture?: boolean;
+  /** Flash and scroll to this row (e.g. when arriving from a deep link). */
+  isHighlighted?: boolean;
 }
 
 export const TransactionRow = memo(function TransactionRow({
@@ -202,11 +204,21 @@ export const TransactionRow = memo(function TransactionRow({
   categoryColorMap,
   budgetStatusMap,
   isFuture,
+  isHighlighted,
 }: TransactionRowProps) {
   const t = useTranslations('transactions');
   const tc = useTranslations('common');
   const { formatCurrency } = useNumberFormat();
   const isVoid = transaction.status === TransactionStatus.VOID;
+
+  // When this row is the deep-link target, scroll it into view once it mounts
+  // so the user lands on it rather than hunting through the page.
+  const rowRef = useRef<HTMLTableRowElement>(null);
+  useEffect(() => {
+    if (isHighlighted) {
+      rowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [isHighlighted]);
   // Prefer the denormalized payeeName, but fall back to the linked payee's name
   // so a transaction that has only payeeId set (e.g. created via the REST API
   // without payeeName) still shows the payee instead of a dash.
@@ -217,6 +229,7 @@ export const TransactionRow = memo(function TransactionRow({
 
   return (
     <tr
+      ref={rowRef}
       onClick={() => onRowClick(transaction)}
       onContextMenu={(e) => onContextMenu(transaction, e)}
       onMouseDown={(e) => onLongPressStart(transaction, e)}
@@ -226,7 +239,7 @@ export const TransactionRow = memo(function TransactionRow({
       onTouchMove={onTouchMove}
       onTouchEnd={onLongPressEnd}
       onTouchCancel={onLongPressEnd}
-      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 select-none touch-manipulation ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${isVoid ? 'opacity-50' : ''} ${isFuture && !isVoid ? 'opacity-60' : ''} ${onEdit ? 'cursor-pointer' : ''} ${isSelected ? 'bg-blue-50 dark:bg-blue-900/20' : ''}`}
+      className={`group hover:bg-gray-100 dark:hover:bg-gray-800 select-none touch-manipulation ${density !== 'normal' && index % 2 === 1 ? 'bg-gray-50 dark:bg-table-stripe-dark' : 'bg-white dark:bg-gray-900'} ${isVoid ? 'opacity-50' : ''} ${isFuture && !isVoid ? 'opacity-60' : ''} ${onEdit ? 'cursor-pointer' : ''} ${isSelected ? 'bg-blue-50 dark:bg-blue-900/20' : ''} ${isHighlighted ? 'ring-2 ring-inset ring-amber-400 dark:ring-amber-500 !bg-amber-50 dark:!bg-amber-900/30' : ''}`}
     >
       {selectionMode && (
         <td className={`${cellPadding} whitespace-nowrap w-10`} onClick={e => e.stopPropagation()}>

--- a/frontend/src/hooks/useHighlightTarget.test.ts
+++ b/frontend/src/hooks/useHighlightTarget.test.ts
@@ -27,7 +27,7 @@ describe('useHighlightParam', () => {
     expect(result.current).toBe('abc-123');
 
     act(() => {
-      vi.advanceTimersByTime(4000);
+      vi.advanceTimersByTime(6000);
     });
     expect(result.current).toBeNull();
   });

--- a/frontend/src/hooks/useHighlightTarget.test.ts
+++ b/frontend/src/hooks/useHighlightTarget.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useHighlightParam, useScrollIntoViewWhen } from './useHighlightTarget';
+
+let mockSearchParams = new URLSearchParams();
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+}));
+
+describe('useHighlightParam', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockSearchParams = new URLSearchParams();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns null when no highlight param is present', () => {
+    const { result } = renderHook(() => useHighlightParam());
+    expect(result.current).toBeNull();
+  });
+
+  it('reads the id from ?highlight and clears it after the delay', () => {
+    mockSearchParams = new URLSearchParams('highlight=abc-123');
+    const { result } = renderHook(() => useHighlightParam());
+    expect(result.current).toBe('abc-123');
+
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(result.current).toBeNull();
+  });
+
+  it('supports a custom param name', () => {
+    mockSearchParams = new URLSearchParams('focus=xyz');
+    const { result } = renderHook(() => useHighlightParam('focus'));
+    expect(result.current).toBe('xyz');
+  });
+});
+
+describe('useScrollIntoViewWhen', () => {
+  it('scrolls the element into view only when active', () => {
+    const scroll = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ active }: { active: boolean }) => useScrollIntoViewWhen<HTMLDivElement>(active),
+      { initialProps: { active: false } },
+    );
+    // Attach a fake element to the returned ref.
+    result.current.current = { scrollIntoView: scroll } as unknown as HTMLDivElement;
+
+    expect(scroll).not.toHaveBeenCalled();
+    rerender({ active: true });
+    expect(scroll).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+  });
+});

--- a/frontend/src/hooks/useHighlightTarget.ts
+++ b/frontend/src/hooks/useHighlightTarget.ts
@@ -29,7 +29,9 @@ export const HIGHLIGHT_FLASH = 'animate-highlight-flash motion-reduce:animate-no
 export const HIGHLIGHT_FLASH_CELL = '!bg-transparent';
 
 // How long the flash lingers before it clears itself.
-const HIGHLIGHT_DURATION_MS = 3500;
+// Slightly longer than the highlight-flash animation (4.5s) so the row keeps
+// the highlight class until the flash finishes, then clears.
+const HIGHLIGHT_DURATION_MS = 5000;
 
 /**
  * Read a one-shot highlight id from the URL (`?highlight=<id>` by default).

--- a/frontend/src/hooks/useHighlightTarget.ts
+++ b/frontend/src/hooks/useHighlightTarget.ts
@@ -1,0 +1,63 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+/**
+ * Shared deep-link "flash this row" helpers, used by list pages to draw
+ * attention to the item a link points at -- e.g. the AI chat confirmation
+ * card's "View payees / View securities / ..." links after creating or
+ * editing an entity. A list page reads the id from the URL with
+ * {@link useHighlightParam} and an item scrolls itself into view with
+ * {@link useScrollIntoViewWhen}, painted with {@link HIGHLIGHT_RING}.
+ *
+ * The transactions list uses its own `targetTransactionId` mechanism instead,
+ * because it is server-paginated and the backend has to resolve which page
+ * contains the row; these helpers cover the client-loaded lists (payees,
+ * securities, categories, ...).
+ */
+
+// Amber flash applied to the targeted row. `!bg-` overrides the row's own
+// striping/hover background while the flash is showing.
+export const HIGHLIGHT_RING =
+  'ring-2 ring-inset ring-amber-400 dark:ring-amber-500 !bg-amber-50 dark:!bg-amber-900/30';
+
+// How long the flash lingers before it clears itself.
+const HIGHLIGHT_DURATION_MS = 3500;
+
+/**
+ * Read a one-shot highlight id from the URL (`?highlight=<id>` by default).
+ * Returns the id, then clears it after a short delay so the flash does not
+ * stick on later interactions. The value is captured once on mount, so
+ * navigating within the page (which rewrites the query string) does not
+ * re-trigger it.
+ */
+export function useHighlightParam(param = 'highlight'): string | null {
+  const searchParams = useSearchParams();
+  const [highlightId, setHighlightId] = useState<string | null>(
+    () => searchParams.get(param),
+  );
+
+  useEffect(() => {
+    if (!highlightId) return;
+    const timer = setTimeout(() => setHighlightId(null), HIGHLIGHT_DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [highlightId]);
+
+  return highlightId;
+}
+
+/**
+ * Returns a ref to attach to a row element; when `active` flips to true the
+ * row smoothly scrolls itself into view (centered). Pair it with
+ * {@link HIGHLIGHT_RING} on the same element for the visual flash.
+ */
+export function useScrollIntoViewWhen<T extends HTMLElement>(active: boolean) {
+  const ref = useRef<T>(null);
+  useEffect(() => {
+    if (active) {
+      ref.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [active]);
+  return ref;
+}

--- a/frontend/src/hooks/useHighlightTarget.ts
+++ b/frontend/src/hooks/useHighlightTarget.ts
@@ -17,10 +17,16 @@ import { useSearchParams } from 'next/navigation';
  * securities, categories, ...).
  */
 
-// Amber flash applied to the targeted row. `!bg-` overrides the row's own
-// striping/hover background while the flash is showing.
-export const HIGHLIGHT_RING =
-  'ring-2 ring-inset ring-amber-400 dark:ring-amber-500 !bg-amber-50 dark:!bg-amber-900/30';
+// One-shot amber flash for the targeted row: a fading background + inset ring
+// (see the `highlight-flash` keyframe in globals.css) that gently fades out
+// instead of blinking off. Sticky cells (e.g. a `sticky right-0` actions
+// column) must drop their opaque background while highlighted so the flash
+// and its ring wrap the whole row -- see HIGHLIGHT_FLASH_CELL.
+export const HIGHLIGHT_FLASH = 'animate-highlight-flash motion-reduce:animate-none';
+
+// Apply to a sticky/opaque cell so the row flash shows through it (otherwise
+// the cell's own background paints over the flash and the ring stops short).
+export const HIGHLIGHT_FLASH_CELL = '!bg-transparent';
 
 // How long the flash lingers before it clears itself.
 const HIGHLIGHT_DURATION_MS = 3500;

--- a/frontend/src/hooks/useTransactionFilters.test.ts
+++ b/frontend/src/hooks/useTransactionFilters.test.ts
@@ -142,6 +142,21 @@ describe('useTransactionFilters - URL/localStorage initialization', () => {
     expect(result.current.filterAmountTo).toBe('50');
   });
 
+  it('initializes the deep-link target from a valid targetTransactionId param', () => {
+    const id = '11111111-1111-4111-8111-111111111111';
+    mockSearchParams = new URLSearchParams(`targetTransactionId=${id}`);
+    const { result } = renderHook(() => useTransactionFilters(defaultOptions));
+    expect(result.current.highlightTransactionId).toBe(id);
+    expect(result.current.targetTransactionIdRef.current).toBe(id);
+  });
+
+  it('ignores a malformed targetTransactionId param', () => {
+    mockSearchParams = new URLSearchParams('targetTransactionId=not-a-uuid');
+    const { result } = renderHook(() => useTransactionFilters(defaultOptions));
+    expect(result.current.highlightTransactionId).toBeNull();
+    expect(result.current.targetTransactionIdRef.current).toBeNull();
+  });
+
   it('reads tagIds from URL params', () => {
     mockSearchParams = new URLSearchParams('tagIds=t1,t2');
     const { result } = renderHook(() => useTransactionFilters(defaultOptions));

--- a/frontend/src/hooks/useTransactionFilters.ts
+++ b/frontend/src/hooks/useTransactionFilters.ts
@@ -31,6 +31,11 @@ const STORAGE_KEYS = {
   statuses: 'transactions.filter.statuses',
 };
 
+// Mirrors the backend's targetTransactionId validation so a malformed deep-link
+// value is ignored rather than sent on to a 4xx.
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 const VALID_TRANSACTION_STATUSES = new Set<string>(Object.values(TransactionStatus));
 
 function sanitizeStatuses(values: string[]): TransactionStatus[] {
@@ -135,6 +140,9 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
   const searchDebounceRef = useRef<NodeJS.Timeout | null>(null);
   const [filtersInitialized, setFiltersInitialized] = useState(false);
   const [filtersExpanded, setFiltersExpanded] = useState(true);
+  // Transaction id to flash/scroll to after a deep link (e.g. the AI chat's
+  // "View transaction" link). Initialized from the URL once on mount.
+  const [highlightTransactionId, setHighlightTransactionId] = useState<string | null>(null);
 
   // Track when we're syncing state from browser back/forward navigation
   const syncingFromPopstateRef = useRef(false);
@@ -315,7 +323,8 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
       searchParams.has('amountFrom') ||
       searchParams.has('amountTo') ||
       searchParams.has('tagIds') ||
-      searchParams.has('statuses');
+      searchParams.has('statuses') ||
+      searchParams.has('targetTransactionId');
 
     const getAccountIds = () => {
       const ids = searchParams.get('accountIds');
@@ -367,6 +376,14 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
       setFilterTimePeriod((initialStartDate || initialEndDate) ? 'custom' : '');
     } else {
       setFilterTimePeriod(getFilterValue(STORAGE_KEYS.timePeriod, null, false));
+    }
+    // Deep link to a specific transaction (e.g. the AI chat "View transaction"
+    // link). The backend resolves which page contains it; we flash/scroll to it
+    // once it renders. A bogus value is ignored so the list still loads.
+    const targetId = searchParams.get('targetTransactionId');
+    if (targetId && UUID_REGEX.test(targetId)) {
+      targetTransactionIdRef.current = targetId;
+      setHighlightTransactionId(targetId);
     }
     setFiltersInitialized(true);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -579,6 +596,7 @@ export function useTransactionFilters({ accounts, categories, payees, tags, week
     filtersInitialized,
     filtersExpanded, setFiltersExpanded,
     activeFilterCount,
+    highlightTransactionId, setHighlightTransactionId,
 
     // Derived filter data
     filteredAccounts,

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -89,6 +89,9 @@ Object.defineProperty(window, 'localStorage', { value: localStorageMock });
 // Mock scrollTo (not implemented in jsdom)
 window.scrollTo = vi.fn() as any;
 
+// Mock scrollIntoView (not implemented in jsdom)
+Element.prototype.scrollIntoView = vi.fn();
+
 // Mock matchMedia
 Object.defineProperty(window, 'matchMedia', {
   writable: true,


### PR DESCRIPTION
## Summary

Makes the AI chat's **"View …"** link land on the record it just created/edited and flash it, instead of dumping the user on an unfiltered list.

Today the confirmation card's success link is a bare list route (`/transactions`, `/payees`, `/securities`), so after approving an action you have to hunt for the affected row yourself. The card already has the result id (`action.resultId`); this wires it into a deep link and flashes the row on arrival.

Two commits:
1. **Transactions** — reuses the existing `targetTransactionId` machinery (the backend resolves which page contains the row, used today for transfer-leg navigation).
2. **Payees / securities / categories** — a small shared `useHighlightTarget` hook (`?highlight=<id>` URL param + scroll-into-view + flash style) for the client-loaded lists.

## Behavior

- After a confirmed create / update / categorize:
  - **transaction / transfer** → `/transactions?targetTransactionId=<id>`
  - **payee** → `/payees?highlight=<id>`
  - **security** → `/securities?highlight=<id>`
- The destination list opens on the page that contains the record, and the row briefly flashes (amber ring) and scrolls into view; the flash clears a few seconds after it appears.
- **Categories** get the same `?highlight=<id>` support (the tree flashes in place) even though no AI action links there yet — ready for other entry points.
- Falls back to the plain list when no result id is present. Delete actions still have no link.

## Not included

**Investments** are deferred: the card's investment result is a *transaction* id, but `/investments` lists holdings (by security), so there's no matching row there. Highlighting it needs the transaction-list path on that page plus server-side page resolution for investment transactions — a separate change.

## Changes

**Shared**
- `hooks/useHighlightTarget.ts`: `useHighlightParam` (reads `?highlight`, auto-clears), `useScrollIntoViewWhen` (scrolls a row in), `HIGHLIGHT_RING` (shared flash style).

**Transactions**
- `TransactionConfirmationCard.tsx`: build the transaction link from `action.resultId`.
- `useTransactionFilters.ts`: read `targetTransactionId` from the URL (UUID-validated), feed the existing `targetTransactionIdRef`, expose `highlightTransactionId`.
- `TransactionList.tsx` / `TransactionRow.tsx`: `highlightTransactionId` prop → ring + scroll.
- `transactions/page.tsx`: clear the flash a few seconds after the row renders.
- `test/setup.ts`: mock `Element.prototype.scrollIntoView` (absent in jsdom).

**Payees / securities / categories**
- `PayeeList` / `SecurityList` / `CategoryList`: `isHighlighted` row prop (ring + scroll via the shared hook).
- `payees` + `securities` pages: jump to the client-side page holding the target. `categories` renders a full tree, so it flashes in place.
- `TransactionConfirmationCard.tsx`: payee/security links use `?highlight=<resultId>`.

## Why minimal backend impact

Transactions reuse the existing `targetTransactionId` query param + "find the page" logic; the other lists are fully client-loaded. No controller, service, or schema changes.

## Tests

- `useHighlightTarget`: param read + auto-clear, custom param name, scroll only when active.
- `TransactionConfirmationCard`: each link deep-links with its id and falls back without one (transactions, payees, securities).
- `useTransactionFilters`: valid/invalid `targetTransactionId` init.
- `TransactionRow` / `PayeeList`: the targeted row gets the ring and scrolls; others don't.
- Touched component + page suites green; ESLint + `tsc --noEmit` clean.

## Checklist

- [x] Single concern (deep-link + flash the AI card's "View" links).
- [x] New behavior has tests, and the existing suite passes.
- [x] No new user-facing strings (reuses existing `ai.confirmAction.view*` keys) — no i18n impact.
- [x] No shared/core refactor beyond an additive `highlight`/`isHighlighted` prop and a small shared hook.
- [x] The branch is based on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Implemented with Claude Code; design and approach reviewed and owned by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
