### PR TITLE
Localize chart month markers to the user's language

### DIFF
--- a/frontend/src/components/bills/CashFlowForecastChart.test.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.test.tsx
@@ -38,7 +38,7 @@ vi.mock('recharts', () => ({
       payload: [
         {
           payload: {
-            label: 'Tooltip Day',
+            date: '2025-01-15',
             balance: -150,
             transactions: [
               { name: 'Rent', amount: -1000 },
@@ -578,7 +578,9 @@ describe('CashFlowForecastChart', () => {
       // The mocked Tooltip renders content with 6 transactions, so the
       // "+1 more" overflow line (component lines ~78-83) renders.
       expect(screen.getByText(/\+1 more/)).toBeInTheDocument();
-      expect(screen.getByText('Tooltip Day')).toBeInTheDocument();
+      // The tooltip date is localized from the data point's `date` via
+      // useChartDateFormat; '2025-01-15' renders as "Jan 15" in the default locale.
+      expect(screen.getByText('Jan 15')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/bills/CashFlowForecastChart.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.tsx
@@ -36,6 +36,7 @@ import {
   FORECAST_PERIOD_LABELS,
 } from '@/lib/forecast';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 
 interface CashFlowForecastChartProps {
@@ -49,10 +50,12 @@ function CashFlowTooltip({
   active,
   payload,
   formatCurrency,
+  formatChartDate,
 }: {
   active?: boolean;
   payload?: Array<{ payload: ForecastDataPoint }>;
   formatCurrency: (v: number) => string;
+  formatChartDate: (date: Date | string, pattern: 'MMM d') => string;
 }) {
   const t = useTranslations('bills');
   if (active && payload?.[0]) {
@@ -60,7 +63,7 @@ function CashFlowTooltip({
     return (
       <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3 max-w-xs">
         <p className="font-medium text-gray-900 dark:text-gray-100 mb-1">
-          {data.label}
+          {formatChartDate(data.date, 'MMM d')}
         </p>
         <p
           className={`text-lg font-semibold ${
@@ -127,6 +130,7 @@ export function CashFlowForecastChart({
   const tc = useTranslations('common');
   const { formatCurrency: formatCurrencyFull, formatCurrencyAxis, formatCurrencyFlag } =
     useNumberFormat();
+  const formatChartDate = useChartDateFormat();
   const { convertToDefault, defaultCurrency } = useExchangeRates();
   const [selectedPeriod, setSelectedPeriod] = useState<ForecastPeriod>(() => getStoredPeriod());
   const [selectedAccountId, setSelectedAccountId] = useState<string>(() => getStoredAccountId());
@@ -295,9 +299,9 @@ export function CashFlowForecastChart({
           <ResponsiveContainer width="100%" height="90%" minWidth={0}>
             <LineChart data={forecastData} margin={{ left: 0, right: 8, top: 5, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
-              <XAxis dataKey="label" tick={{ fill: chartColors.axis, fontSize: 12 }} tickLine={false} axisLine={{ stroke: chartColors.grid }} interval="preserveStartEnd" />
+              <XAxis dataKey="date" tickFormatter={(value: string) => formatChartDate(value, 'MMM d')} tick={{ fill: chartColors.axis, fontSize: 12 }} tickLine={false} axisLine={{ stroke: chartColors.grid }} interval="preserveStartEnd" />
               <YAxis tick={{ fill: chartColors.axis, fontSize: 11 }} tickLine={false} axisLine={false} tickFormatter={formatAxis} width={45} domain={['auto', 'auto']} />
-              <Tooltip content={<CashFlowTooltip formatCurrency={formatCurrency} />} />
+              <Tooltip content={<CashFlowTooltip formatCurrency={formatCurrency} formatChartDate={formatChartDate} />} />
               <ReferenceLine y={0} stroke={chartColors.expense} strokeDasharray="5 5" strokeOpacity={0.5} />
               <Line type="monotone" dataKey="balance" stroke={chartColors.axis} strokeWidth={2} dot={false} strokeDasharray="5 5" />
             </LineChart>
@@ -321,7 +325,8 @@ export function CashFlowForecastChart({
                 stroke={chartColors.grid}
               />
               <XAxis
-                dataKey="label"
+                dataKey="date"
+                tickFormatter={(value: string) => formatChartDate(value, 'MMM d')}
                 tick={{ fill: chartColors.axis, fontSize: 12 }}
                 tickLine={false}
                 axisLine={{ stroke: chartColors.grid }}
@@ -335,7 +340,7 @@ export function CashFlowForecastChart({
                 width={45}
                 domain={['auto', 'auto']}
               />
-              <Tooltip content={<CashFlowTooltip formatCurrency={formatCurrency} />} />
+              <Tooltip content={<CashFlowTooltip formatCurrency={formatCurrency} formatChartDate={formatChartDate} />} />
               {/* Reference line at $0 */}
               <ReferenceLine
                 y={0}

--- a/frontend/src/components/bills/CashFlowForecastChart.tsx
+++ b/frontend/src/components/bills/CashFlowForecastChart.tsx
@@ -300,7 +300,7 @@ export function CashFlowForecastChart({
             <LineChart data={forecastData} margin={{ left: 0, right: 8, top: 5, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
               <XAxis dataKey="date" tickFormatter={(value: string) => formatChartDate(value, 'MMM d')} tick={{ fill: chartColors.axis, fontSize: 12 }} tickLine={false} axisLine={{ stroke: chartColors.grid }} interval="preserveStartEnd" />
-              <YAxis tick={{ fill: chartColors.axis, fontSize: 11 }} tickLine={false} axisLine={false} tickFormatter={formatAxis} width={45} domain={['auto', 'auto']} />
+              <YAxis tick={{ fill: chartColors.axis, fontSize: 11 }} tickLine={false} axisLine={false} tickFormatter={formatAxis} width="auto" domain={['auto', 'auto']} />
               <Tooltip content={<CashFlowTooltip formatCurrency={formatCurrency} formatChartDate={formatChartDate} />} />
               <ReferenceLine y={0} stroke={chartColors.expense} strokeDasharray="5 5" strokeOpacity={0.5} />
               <Line type="monotone" dataKey="balance" stroke={chartColors.axis} strokeWidth={2} dot={false} strokeDasharray="5 5" />
@@ -337,7 +337,7 @@ export function CashFlowForecastChart({
                 tickLine={false}
                 axisLine={false}
                 tickFormatter={formatAxis}
-                width={45}
+                width="auto"
                 domain={['auto', 'auto']}
               />
               <Tooltip content={<CashFlowTooltip formatCurrency={formatCurrency} formatChartDate={formatChartDate} />} />

--- a/frontend/src/components/dashboard/NetWorthChart.test.tsx
+++ b/frontend/src/components/dashboard/NetWorthChart.test.tsx
@@ -52,7 +52,8 @@ vi.mock('@/hooks/useNumberFormat', () => ({
   }),
 }));
 
-vi.mock('@/lib/utils', () => ({
+vi.mock('@/lib/utils', async (importActual) => ({
+  ...(await importActual<typeof import('@/lib/utils')>()),
   parseLocalDate: (d: string) => new Date(d + 'T00:00:00'),
   cn: (...args: any[]) => args.filter(Boolean).join(' '),
 }));

--- a/frontend/src/components/dashboard/NetWorthChart.tsx
+++ b/frontend/src/components/dashboard/NetWorthChart.tsx
@@ -12,11 +12,10 @@ import {
   ResponsiveContainer,
   LabelList,
 } from 'recharts';
-import { format } from 'date-fns';
 import { chartColors } from '@/lib/chart-colors';
 import { MonthlyNetWorth } from '@/types/net-worth';
-import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
 
@@ -87,6 +86,7 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
   const t = useTranslations('dashboard');
   const router = useRouter();
   const { formatCurrencyCompact: formatCurrency, formatCurrencyLabel } = useNumberFormat();
+  const formatChartDate = useChartDateFormat();
   const [chartType, setChartType] = useLocalStorage<'bar' | 'stacked'>(
     'dashboard.net-worth.chartType',
     'bar',
@@ -99,13 +99,15 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
 
   const chartData = useMemo(() =>
     data.map((d) => ({
-      name: format(parseLocalDate(d.month), 'MMM yyyy'),
-      shortName: format(parseLocalDate(d.month), 'MMM'),
+      // Raw YYYY-MM keeps the X-axis category stable and locale-independent;
+      // the tick formatter localizes it to a short month for display.
+      month: d.month,
+      name: formatChartDate(`${d.month}-01`, 'MMM yyyy'),
       netWorth: Math.round(d.netWorth),
       assets: Math.round(d.assets),
       liabilities: Math.round(d.liabilities),
     })),
-  [data]);
+  [data, formatChartDate]);
 
   const summary = useMemo(() => {
     if (chartData.length === 0) return null;
@@ -205,12 +207,12 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
             <BarChart data={chartData} stackOffset="expand" margin={{ top: 12, right: 12, left: 12, bottom: 0 }}>
               <YAxis hide domain={[0, 1]} />
               <XAxis
-                dataKey="name"
+                dataKey="month"
                 tick={{ fill: chartColors.axis, fontSize: 11 }}
                 tickLine={false}
                 axisLine={false}
                 interval="preserveStartEnd"
-                tickFormatter={(value: string) => value.split(' ')[0]}
+                tickFormatter={(value: string) => formatChartDate(`${value}-01`, 'MMM')}
               />
               <Tooltip
                 content={<NetWorthCompositionTooltip formatCurrency={formatCurrency} labels={compositionLabels} />}
@@ -223,12 +225,12 @@ export function NetWorthChart({ data, isLoading }: NetWorthChartProps) {
             <BarChart data={chartData} margin={{ top: 52, right: 12, left: 12, bottom: 0 }}>
               <YAxis hide domain={yAxisDomain} />
               <XAxis
-                dataKey="name"
+                dataKey="month"
                 tick={{ fill: chartColors.axis, fontSize: 11 }}
                 tickLine={false}
                 axisLine={false}
                 interval="preserveStartEnd"
-                tickFormatter={(value: string) => value.split(' ')[0]}
+                tickFormatter={(value: string) => formatChartDate(`${value}-01`, 'MMM')}
               />
               <Tooltip
                 content={<NetWorthTooltip formatCurrency={formatCurrency} />}

--- a/frontend/src/components/investments/InvestmentValueChart.test.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.test.tsx
@@ -104,7 +104,8 @@ vi.mock('@/hooks/useLocalStorage', () => ({
   useLocalStorage: (_key: string, initial: any) => [initial, vi.fn()],
 }));
 
-vi.mock('@/lib/utils', () => ({
+vi.mock('@/lib/utils', async (importActual) => ({
+  ...(await importActual<typeof import('@/lib/utils')>()),
   parseLocalDate: (d: string) => new Date(d + 'T00:00:00'),
   cn: (...args: any[]) => args.filter(Boolean).join(' '),
 }));

--- a/frontend/src/components/investments/InvestmentValueChart.tsx
+++ b/frontend/src/components/investments/InvestmentValueChart.tsx
@@ -11,12 +11,11 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
-import { format } from 'date-fns';
 import { chartColors } from '@/lib/chart-colors';
 import { netWorthApi } from '@/lib/net-worth';
 import { investmentsApi } from '@/lib/investments';
-import { parseLocalDate } from '@/lib/utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { gainLossColor } from '@/lib/format';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useDateRange } from '@/hooks/useDateRange';
@@ -57,6 +56,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
   const t = useTranslations('investments');
   const tc = useTranslations('common');
   const { formatCurrency, formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag, formatSignedPercent } = useNumberFormat();
+  const formatChartDate = useChartDateFormat();
   const { defaultCurrency } = useExchangeRates();
   const isMobile = useIsMobile();
   const [chartPoints, setChartPoints] = useState<Array<{ name: string; Value: number }>>([]);
@@ -136,10 +136,10 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
     (iso: string, range: string) => {
       const d = new Date(iso);
       return range === '1d'
-        ? format(d, 'HH:mm')
-        : format(d, 'MMM d HH:mm');
+        ? formatChartDate(d, 'HH:mm')
+        : formatChartDate(d, 'MMM d HH:mm');
     },
-    [],
+    [formatChartDate],
   );
 
   const loadDailyOrMonthly = useCallback(
@@ -157,7 +157,7 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
         if (loadSeqRef.current !== seq) return;
         setChartPoints(
           data.map((d) => ({
-            name: format(parseLocalDate(d.date), 'MMM d, yyyy'),
+            name: formatChartDate(d.date, 'MMM d, yyyy'),
             Value: d.value,
           })),
         );
@@ -166,13 +166,13 @@ export function InvestmentValueChart({ accountIds, displayCurrency, titleSuffix 
         if (loadSeqRef.current !== seq) return;
         setChartPoints(
           data.map((d) => ({
-            name: format(parseLocalDate(d.month), 'MMM yyyy'),
+            name: formatChartDate(d.month, 'MMM yyyy'),
             Value: d.value,
           })),
         );
       }
     },
-    [resolvedRange, accountIds, foreignCurrency, useDaily, isIntraday],
+    [resolvedRange, accountIds, foreignCurrency, useDaily, isIntraday, formatChartDate],
   );
 
   const loadData = useCallback(

--- a/frontend/src/components/reports/CashFlowReport.tsx
+++ b/frontend/src/components/reports/CashFlowReport.tsx
@@ -22,6 +22,7 @@ import {
   IncomeSourceItem,
 } from "@/types/built-in-reports";
 import { useNumberFormat } from "@/hooks/useNumberFormat";
+import { useChartDateFormat } from "@/hooks/useChartDateFormat";
 import { useDateRange } from "@/hooks/useDateRange";
 import { useReportData } from "@/hooks/useReportData";
 import { DateRangeSelector } from "@/components/ui/DateRangeSelector";
@@ -47,6 +48,7 @@ export function CashFlowReport() {
   const chartRef = useRef<HTMLDivElement>(null);
   const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis } =
     useNumberFormat();
+  const formatChartDate = useChartDateFormat();
   const {
     dateRange,
     setDateRange,
@@ -86,7 +88,7 @@ export function CashFlowReport() {
         const monthDate = parseISO(item.month + "-01");
         return {
           name: item.month,
-          fullName: format(monthDate, "MMM yyyy"),
+          fullName: formatChartDate(monthDate, "MMM yyyy"),
           Income: Math.round(item.income),
           Expenses: Math.round(item.expenses),
           Net: Math.round(item.net),
@@ -94,7 +96,7 @@ export function CashFlowReport() {
           monthEnd: format(endOfMonth(monthDate), "yyyy-MM-dd"),
         };
       }),
-    [response],
+    [response, formatChartDate],
   );
 
   const incomeItems = useMemo<IncomeSourceItem[]>(
@@ -305,7 +307,7 @@ export function CashFlowReport() {
                 dataKey="name"
                 tick={{ fontSize: 12 }}
                 tickFormatter={(value: string) =>
-                  format(parseISO(value + "-01"), "MMM")
+                  formatChartDate(`${value}-01`, "MMM")
                 }
               />
               <YAxis

--- a/frontend/src/components/reports/DebtPayoffTimelineReport.tsx
+++ b/frontend/src/components/reports/DebtPayoffTimelineReport.tsx
@@ -15,7 +15,7 @@ import {
   Area,
   ReferenceLine,
 } from 'recharts';
-import { format, parseISO } from 'date-fns';
+import { format } from 'date-fns';
 import { accountsApi } from '@/lib/accounts';
 import { transactionsApi } from '@/lib/transactions';
 import { Transaction } from '@/types/transaction';
@@ -24,6 +24,7 @@ import { useReportData } from '@/hooks/useReportData';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
 import { ReportError } from '@/components/reports/ReportError';
 import { chartColors } from '@/lib/chart-colors';
+import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { useTranslations } from 'next-intl';
 
 interface PayoffScheduleItem {
@@ -112,6 +113,7 @@ function advanceDate(date: Date, frequency: string): Date {
 
 export function DebtPayoffTimelineReport() {
   const t = useTranslations('reports');
+  const formatChartDate = useChartDateFormat();
   const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis } = useNumberFormat();
   const chartRef = useRef<HTMLDivElement>(null);
   const [selectedAccountIdState, setSelectedAccountId] = useState<string>('');
@@ -229,7 +231,7 @@ export function DebtPayoffTimelineReport() {
 
       schedule.push({
         date: transaction.transactionDate,
-        label: format(parseISO(transaction.transactionDate), 'MMM yyyy'),
+        label: formatChartDate(transaction.transactionDate, 'MMM yyyy'),
         balance: runningBalance,
         principalPaid: principal,
         interestPaid: interest,
@@ -285,7 +287,7 @@ export function DebtPayoffTimelineReport() {
 
         schedule.push({
           date: format(projDate, 'yyyy-MM-dd'),
-          label: format(projDate, 'MMM yyyy'),
+          label: formatChartDate(projDate, 'MMM yyyy'),
           balance: Math.round(projRunningBalance * 100) / 100,
           principalPaid: Math.round(principalPortion * 100) / 100,
           interestPaid: Math.round(interestCharge * 100) / 100,
@@ -354,7 +356,7 @@ export function DebtPayoffTimelineReport() {
     }
 
     return { payoffSchedule: monthlySchedule, projectionStartLabel: startLabel };
-  }, [selectedAccount, transactions]);
+  }, [selectedAccount, transactions, formatChartDate]);
 
   const summary = useMemo(() => {
     if (payoffSchedule.length === 0 || !selectedAccount) return null;

--- a/frontend/src/components/reports/DividendIncomeReport.test.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.test.tsx
@@ -66,7 +66,8 @@ vi.mock('@/hooks/useDateRange', () => ({
   }),
 }));
 
-vi.mock('@/lib/utils', () => ({
+vi.mock('@/lib/utils', async (importActual) => ({
+  ...(await importActual<typeof import('@/lib/utils')>()),
   parseLocalDate: (d: string) => new Date(d + 'T00:00:00'),
   // MultiSelect (used for the account filter) imports `cn` for className
   // composition; a minimal join keeps it from blowing up at render time.

--- a/frontend/src/components/reports/DividendIncomeReport.tsx
+++ b/frontend/src/components/reports/DividendIncomeReport.tsx
@@ -21,6 +21,7 @@ import { investmentsApi } from '@/lib/investments';
 import { InvestmentTransaction, CapitalGainEntry } from '@/types/investment';
 import { Account } from '@/types/account';
 import { parseLocalDate } from '@/lib/utils';
+import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { useDateRange } from '@/hooks/useDateRange';
@@ -79,6 +80,7 @@ const SERIES_COLORS: Record<SeriesKey, { positive: string; negative: string }> =
 
 export function DividendIncomeReport() {
   const t = useTranslations('reports');
+  const formatChartDate = useChartDateFormat();
   const mainAccountName = useMainAccountName();
   const { formatCurrency: formatCurrencyFull, formatCurrencyAxis } = useNumberFormat();
   const { defaultCurrency, convertToDefault } = useExchangeRates();
@@ -355,7 +357,7 @@ export function DividendIncomeReport() {
       const key = format(month, 'yyyy-MM');
       monthMap.set(key, {
         month: key,
-        label: format(month, 'MMM yyyy'),
+        label: formatChartDate(month, 'MMM yyyy'),
         startValue: 0,
         endValue: 0,
         dividends: 0,
@@ -371,7 +373,7 @@ export function DividendIncomeReport() {
       if (!bucket) {
         bucket = {
           month: monthKey,
-          label: format(txDate, 'MMM yyyy'),
+          label: formatChartDate(txDate, 'MMM yyyy'),
           startValue: 0,
           endValue: 0,
           dividends: 0,
@@ -422,7 +424,7 @@ export function DividendIncomeReport() {
     });
 
     return Array.from(monthMap.values()).sort((a, b) => a.month.localeCompare(b.month));
-  }, [filteredTransactions, filteredCapitalGains, dateRange, resolvedRange, getTxAmount, convertCapitalGain, convertFromAccountCurrency]);
+  }, [filteredTransactions, filteredCapitalGains, dateRange, resolvedRange, getTxAmount, convertCapitalGain, convertFromAccountCurrency, formatChartDate]);
 
   // Daily view: mirrors monthlyData but at daily granularity, combining
   // transaction-level income (DIVIDEND, INTEREST, CAPITAL_GAIN) with the
@@ -435,7 +437,7 @@ export function DividendIncomeReport() {
       if (!bucket) {
         bucket = {
           date: dateKey,
-          label: format(txDate, 'MMM d, yyyy'),
+          label: formatChartDate(txDate, 'MMM d, yyyy'),
           startValue: 0,
           endValue: 0,
           dividends: 0,
@@ -481,7 +483,7 @@ export function DividendIncomeReport() {
     });
 
     return Array.from(dayMap.values()).sort((a, b) => a.date.localeCompare(b.date));
-  }, [filteredTransactions, filteredDailyCapitalGains, getTxAmount, convertCapitalGain, convertFromAccountCurrency]);
+  }, [filteredTransactions, filteredDailyCapitalGains, getTxAmount, convertCapitalGain, convertFromAccountCurrency, formatChartDate]);
 
   // When hideInactiveDays is enabled, drop rows with no income and no price
   // movement. On weekends/holidays the market is closed, so capital gains are

--- a/frontend/src/components/reports/IncomeVsExpensesReport.tsx
+++ b/frontend/src/components/reports/IncomeVsExpensesReport.tsx
@@ -29,6 +29,7 @@ import { ChartTooltip } from "@/components/reports/ChartTooltip";
 import { ReportError } from "@/components/reports/ReportError";
 import { exportToCsv } from "@/lib/csv-export";
 import { chartColors } from "@/lib/chart-colors";
+import { useChartDateFormat } from "@/hooks/useChartDateFormat";
 import { useTranslations } from 'next-intl';
 
 type IncomeVsExpensesSortField = 'name' | 'income' | 'expenses' | 'savings' | 'savingsRate';
@@ -46,6 +47,7 @@ interface ChartDataItem {
 
 export function IncomeVsExpensesReport() {
   const t = useTranslations('reports');
+  const formatChartDate = useChartDateFormat();
   const router = useRouter();
   const chartRef = useRef<HTMLDivElement>(null);
   const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis } =
@@ -92,7 +94,7 @@ export function IncomeVsExpensesReport() {
           item.income > 0 ? Math.round((savings / item.income) * 100) : 0;
         return {
           name: item.month,
-          fullName: format(monthDate, "MMM yyyy"),
+          fullName: formatChartDate(monthDate, "MMM yyyy"),
           Income: Math.round(item.income),
           Expenses: Math.round(item.expenses),
           Savings: Math.round(savings),
@@ -101,7 +103,7 @@ export function IncomeVsExpensesReport() {
           monthEnd: format(endOfMonth(monthDate), "yyyy-MM-dd"),
         };
       }),
-    [response],
+    [response, formatChartDate],
   );
 
   const totals = useMemo(() => {
@@ -395,7 +397,7 @@ export function IncomeVsExpensesReport() {
                     dataKey="name"
                     tick={{ fontSize: 12 }}
                     tickFormatter={(value: string) =>
-                      format(parseISO(value + "-01"), "MMM")
+                      formatChartDate(`${value}-01`, "MMM")
                     }
                   />
                   <YAxis

--- a/frontend/src/components/reports/MonthlyComparisonReport.tsx
+++ b/frontend/src/components/reports/MonthlyComparisonReport.tsx
@@ -21,6 +21,7 @@ import {
   CategorySpendingSnapshot,
 } from '@/types/monthly-comparison';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { gainLossColor } from '@/lib/format';
 import { CHART_COLOURS } from '@/lib/chart-colours';
 import { chartColors } from '@/lib/chart-colors';
@@ -66,6 +67,7 @@ function DeltaBadge({ value, percent, invert = false }: { value: number; percent
 export function MonthlyComparisonReport() {
   const t = useTranslations('reports');
   const { formatCurrency, formatCurrencyCompact, formatCurrencyAxis, formatSignedPercent } = useNumberFormat();
+  const formatChartDate = useChartDateFormat();
   const chartRef = useRef<HTMLDivElement>(null);
   const [month, setMonth] = useState(getDefaultMonth);
   const { data, isLoading, error, reload } = useReportData(
@@ -531,7 +533,7 @@ export function MonthlyComparisonReport() {
             <div className="h-72">
               <ResponsiveContainer width="100%" height="100%" minWidth={0}>
                 <BarChart data={nw.monthlyHistory.map(p => ({
-                  name: format(parseMonth(p.month), 'MMM yy'),
+                  name: formatChartDate(parseMonth(p.month), 'MMM yy'),
                   netWorth: Math.round(p.netWorth),
                 }))} margin={{ top: 10, right: 10, left: 0, bottom: 5 }}>
                   <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />

--- a/frontend/src/components/reports/MonthlySpendingTrendReport.tsx
+++ b/frontend/src/components/reports/MonthlySpendingTrendReport.tsx
@@ -19,6 +19,7 @@ import { format, parseISO, startOfMonth, endOfMonth } from "date-fns";
 import { builtInReportsApi } from "@/lib/built-in-reports";
 import { MonthlyIncomeExpenseItem } from "@/types/built-in-reports";
 import { useNumberFormat } from "@/hooks/useNumberFormat";
+import { useChartDateFormat } from "@/hooks/useChartDateFormat";
 import { useDateRange } from "@/hooks/useDateRange";
 import { useReportData } from "@/hooks/useReportData";
 import { useSortableTable, compareValues } from "@/hooks/useSortableTable";
@@ -51,6 +52,7 @@ export function MonthlySpendingTrendReport() {
   const chartRef = useRef<HTMLDivElement>(null);
   const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis } =
     useNumberFormat();
+  const formatChartDate = useChartDateFormat();
   const [viewType, setViewType] = useState<'line' | 'table'>('line');
   const {
     dateRange,
@@ -90,7 +92,7 @@ export function MonthlySpendingTrendReport() {
         const monthDate = parseISO(item.month + "-01");
         return {
           name: item.month,
-          fullName: format(monthDate, "MMM yyyy"),
+          fullName: formatChartDate(monthDate, "MMM yyyy"),
           Expenses: Math.round(item.expenses),
           Income: Math.round(item.income),
           Net: Math.round(item.net),
@@ -98,7 +100,7 @@ export function MonthlySpendingTrendReport() {
           monthEnd: format(endOfMonth(monthDate), "yyyy-MM-dd"),
         };
       }),
-    [response],
+    [response, formatChartDate],
   );
 
   const sortedTableData = useMemo(() => {
@@ -342,7 +344,7 @@ export function MonthlySpendingTrendReport() {
                     dataKey="name"
                     tick={{ fontSize: 12 }}
                     tickFormatter={(value: string) =>
-                      format(parseISO(value + "-01"), "MMM")
+                      formatChartDate(`${value}-01`, "MMM")
                     }
                   />
                   <YAxis

--- a/frontend/src/components/reports/NetWorthReport.test.tsx
+++ b/frontend/src/components/reports/NetWorthReport.test.tsx
@@ -44,7 +44,8 @@ vi.mock('@/hooks/useDateRange', () => ({
   }),
 }));
 
-vi.mock('@/lib/utils', () => ({
+vi.mock('@/lib/utils', async (importActual) => ({
+  ...(await importActual<typeof import('@/lib/utils')>()),
   parseLocalDate: (d: string) => new Date(d + 'T00:00:00'),
   cn: (...args: any[]) => args.filter(Boolean).join(' '),
 }));
@@ -64,7 +65,9 @@ vi.mock('recharts', () => ({
   ),
   XAxis: ({ tickFormatter }: any) => {
     if (tickFormatter) {
-      try { tickFormatter('Jan 2024'); tickFormatter('Jul 2024'); tickFormatter('NoSpace'); } catch {}
+      // The axis is keyed off the raw ISO month (YYYY-MM-DD), so exercise the
+      // formatter with raw values rather than pre-localized labels.
+      try { tickFormatter('2024-01-01'); tickFormatter('2024-07-01'); } catch {}
     }
     return null;
   },

--- a/frontend/src/components/reports/NetWorthReport.tsx
+++ b/frontend/src/components/reports/NetWorthReport.tsx
@@ -18,11 +18,10 @@ import {
   ReferenceDot,
   LabelList,
 } from 'recharts';
-import { format } from 'date-fns';
 import { chartColors } from '@/lib/chart-colors';
 import { netWorthApi } from '@/lib/net-worth';
 import { MonthlyNetWorth } from '@/types/net-worth';
-import { parseLocalDate } from '@/lib/utils';
+import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { gainLossColor } from '@/lib/format';
 import { useDateRange } from '@/hooks/useDateRange';
@@ -44,6 +43,7 @@ type NetWorthSortField = 'name' | 'assets' | 'liabilities' | 'netWorth';
 
 export function NetWorthReport() {
   const t = useTranslations('reports');
+  const formatChartDate = useChartDateFormat();
   const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis, formatCurrencyLabel, formatSignedPercent } = useNumberFormat();
   const isMobile = useIsMobile();
   const [isRecalculating, setIsRecalculating] = useState(false);
@@ -113,14 +113,16 @@ export function NetWorthReport() {
     monthlyData.map((d) => ({
       // `name` is the formatted display label; `sortKey` is the ISO month
       // (YYYY-MM) so the table can sort chronologically rather than
-      // alphabetically by month-name ("Apr 2021" < "Aug 2020" lexically).
-      name: format(parseLocalDate(d.month), 'MMM yyyy'),
+      // alphabetically by month-name ("Apr 2021" < "Aug 2020" lexically) and
+      // so the chart axis can format month markers locale-aware from the raw
+      // value rather than splitting the localized label.
+      name: formatChartDate(d.month, 'MMM yyyy'),
       sortKey: d.month,
       Assets: Math.round(d.assets),
       Liabilities: Math.round(d.liabilities),
       NetWorth: Math.round(d.netWorth),
     })),
-  [monthlyData]);
+  [monthlyData, formatChartDate]);
 
   const summary = useMemo(() => {
     if (chartData.length === 0) return { current: 0, change: 0, changePercent: 0 };
@@ -154,13 +156,15 @@ export function NetWorthReport() {
     return sorted;
   }, [chartData, sortField, sortDirection]);
 
-  // For long ranges, explicitly specify which ticks to show so years don't repeat
+  // For long ranges, explicitly specify which ticks to show so years don't repeat.
+  // Ticks are keyed off the raw ISO month (sortKey, YYYY-MM-DD) so the January
+  // filter and axis formatting stay locale-independent.
   const xAxisTicks = useMemo(() => {
     if (chartData.length <= 36) return undefined; // let Recharts auto-decide for shorter ranges
     // Only show ticks on January of each year
     return chartData
-      .filter(d => d.name.startsWith('Jan '))
-      .map(d => d.name);
+      .filter(d => d.sortKey.slice(5, 7) === '01')
+      .map(d => d.sortKey);
   }, [chartData]);
 
   // Calculate Y-axis domain to avoid starting at 0 when values are significantly higher
@@ -212,15 +216,19 @@ export function NetWorthReport() {
   const barLabelsVertical = showBarLabels && (chartData.length > 14 || isMobile);
 
   // Shared between the area, bar and stacked charts so the month labels stay
-  // consistent as the range widens.
+  // consistent as the range widens. `value` is the raw ISO month (sortKey,
+  // YYYY-MM-DD) so the markers are formatted locale-aware rather than by
+  // splitting an already-localized label string.
   const formatXAxisTick = (value: string) => {
     if (chartData.length > 36) {
-      return value.split(' ')[1] || value;
+      // Long ranges show January ticks only, labelled with the year alone.
+      // Read the year straight off the raw ISO value so it is exact and
+      // locale-independent.
+      return value.slice(0, 4);
     } else if (chartData.length > 18) {
-      const parts = value.split(' ');
-      return parts.length === 2 ? `${parts[0]} '${parts[1].slice(2)}` : value;
+      return formatChartDate(value, 'MMM yy');
     }
-    return value.split(' ')[0];
+    return formatChartDate(value, 'MMM');
   };
 
   // The 100% stacked view normalises each bar to its assets/liabilities split,
@@ -426,7 +434,7 @@ export function NetWorthReport() {
                 </defs>
                 <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
                 <XAxis
-                  dataKey="name"
+                  dataKey="sortKey"
                   tick={{ fontSize: 12 }}
                   {...(xAxisTicks ? { ticks: xAxisTicks } : {})}
                   tickFormatter={formatXAxisTick}
@@ -450,7 +458,7 @@ export function NetWorthReport() {
                 />
                 {minMax && (
                   <ReferenceDot
-                    x={minMax.max.name}
+                    x={minMax.max.sortKey}
                     y={minMax.max.NetWorth}
                     r={6}
                     fill={chartColors.income}
@@ -461,7 +469,7 @@ export function NetWorthReport() {
                 )}
                 {minMax && (
                   <ReferenceDot
-                    x={minMax.min.name}
+                    x={minMax.min.sortKey}
                     y={minMax.min.NetWorth}
                     r={6}
                     fill={chartColors.expense}
@@ -475,7 +483,7 @@ export function NetWorthReport() {
               <BarChart data={chartData} stackOffset="expand" margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} vertical={false} />
                 <XAxis
-                  dataKey="name"
+                  dataKey="sortKey"
                   tick={{ fontSize: 12 }}
                   {...(xAxisTicks ? { ticks: xAxisTicks } : {})}
                   tickFormatter={formatXAxisTick}
@@ -494,7 +502,7 @@ export function NetWorthReport() {
               <BarChart data={chartData} margin={{ top: showBarLabels ? (barLabelsVertical ? 52 : 22) : 10, right: 10, left: 0, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} vertical={false} />
                 <XAxis
-                  dataKey="name"
+                  dataKey="sortKey"
                   tick={{ fontSize: 12 }}
                   {...(xAxisTicks ? { ticks: xAxisTicks } : {})}
                   tickFormatter={formatXAxisTick}

--- a/frontend/src/components/reports/PortfolioValueReport.test.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.test.tsx
@@ -48,7 +48,8 @@ vi.mock('@/hooks/useLocalStorage', () => ({
   useLocalStorage: (_key: string, defaultValue: string) => [defaultValue, vi.fn()],
 }));
 
-vi.mock('@/lib/utils', () => ({
+vi.mock('@/lib/utils', async (importActual) => ({
+  ...(await importActual<typeof import('@/lib/utils')>()),
   parseLocalDate: (d: string) => new Date(d + 'T00:00:00'),
   cn: (...inputs: any[]) => inputs.filter(Boolean).join(' '),
 }));

--- a/frontend/src/components/reports/PortfolioValueReport.tsx
+++ b/frontend/src/components/reports/PortfolioValueReport.tsx
@@ -13,13 +13,12 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
-import { format } from 'date-fns';
 import { chartColors } from '@/lib/chart-colors';
 import { netWorthApi } from '@/lib/net-worth';
 import { investmentsApi } from '@/lib/investments';
 import { PortfolioSummary } from '@/types/investment';
 import { Account } from '@/types/account';
-import { parseLocalDate } from '@/lib/utils';
+import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { gainLossColor } from '@/lib/format';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
@@ -74,6 +73,7 @@ export function PortfolioValueReport() {
   const t = useTranslations('reports');
   const tc = useTranslations('common');
   const mainAccountName = useMainAccountName();
+  const formatChartDate = useChartDateFormat();
   const { formatCurrencyCompact, formatCurrencyAxis, formatCurrencyFlag, formatCurrency: formatCurrencyFull, formatSignedPercent } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
   const chartRef = useRef<HTMLDivElement>(null);
@@ -164,9 +164,9 @@ export function PortfolioValueReport() {
   const formatIntradayLabel = useCallback(
     (iso: string, range: string) => {
       const d = new Date(iso);
-      return range === '1d' ? format(d, 'HH:mm') : format(d, 'MMM d HH:mm');
+      return range === '1d' ? formatChartDate(d, 'HH:mm') : formatChartDate(d, 'MMM d HH:mm');
     },
-    [],
+    [formatChartDate],
   );
 
   useEffect(() => {
@@ -189,7 +189,7 @@ export function PortfolioValueReport() {
         if (loadSeqRef.current !== seq) return;
         setChartPoints(
           data.map((d) => ({
-            name: format(parseLocalDate(d.date), 'MMM d, yyyy'),
+            name: formatChartDate(d.date, 'MMM d, yyyy'),
             Value: d.value,
           })),
         );
@@ -198,7 +198,7 @@ export function PortfolioValueReport() {
         if (loadSeqRef.current !== seq) return;
         setChartPoints(
           data.map((d) => ({
-            name: format(parseLocalDate(d.month), 'MMM yyyy'),
+            name: formatChartDate(d.month, 'MMM yyyy'),
             Value: d.value,
           })),
         );
@@ -321,6 +321,7 @@ export function PortfolioValueReport() {
     isIntraday,
     dateRange,
     formatIntradayLabel,
+    formatChartDate,
   ]);
 
   const summary = useMemo(() => {

--- a/frontend/src/components/reports/SecurityPerformanceReport.test.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.test.tsx
@@ -31,7 +31,8 @@ vi.mock('@/hooks/useExchangeRates', () => ({
   }),
 }));
 
-vi.mock('@/lib/utils', () => ({
+vi.mock('@/lib/utils', async (importActual) => ({
+  ...(await importActual<typeof import('@/lib/utils')>()),
   parseLocalDate: (d: string) => new Date(d + 'T00:00:00'),
   cn: (...inputs: any[]) => inputs.flat(Infinity).filter(Boolean).join(' '),
 }));

--- a/frontend/src/components/reports/SecurityPerformanceReport.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.tsx
@@ -22,7 +22,8 @@ import { chartColors } from '@/lib/chart-colors';
 import { investmentsApi } from '@/lib/investments';
 import { Security, SecurityPrice, InvestmentTransaction, HoldingWithMarketValue } from '@/types/investment';
 import { Account } from '@/types/account';
-import { parseLocalDate } from '@/lib/utils';
+import { parseLocalDate, type ChartDatePattern } from '@/lib/utils';
+import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
 import { ExportDropdown } from '@/components/ui/ExportDropdown';
@@ -80,6 +81,7 @@ interface PriceChartPoint {
 export function SecurityPerformanceReport() {
   const t = useTranslations('reports');
   const tc = useTranslations('common');
+  const formatChartDate = useChartDateFormat();
   const mainAccountName = useMainAccountName();
   const { formatCurrency: formatCurrencyFull, formatCurrencyAxis, formatSignedPercent } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
@@ -247,13 +249,13 @@ export function SecurityPerformanceReport() {
         return {
           date: p.priceDate,
           ts: parsed.getTime(),
-          label: format(parsed, 'MMM d, yyyy'),
+          label: formatChartDate(parsed, 'MMM d, yyyy'),
           close: Number(p.closePrice),
           buyMarker: txInfo?.buys ? Number(p.closePrice) : undefined,
           sellMarker: txInfo?.sells ? Number(p.closePrice) : undefined,
         };
       });
-  }, [prices, transactions]);
+  }, [prices, transactions, formatChartDate]);
 
   // Time-axis ticks: evenly spaced in real time (not by data index), so the
   // horizontal scale is consistent across the whole timeline. Without this the
@@ -264,7 +266,7 @@ export function SecurityPerformanceReport() {
       return {
         ticks: [] as number[],
         domain: ['dataMin', 'dataMax'] as [string, string],
-        tickFormat: 'MMM yyyy',
+        tickFormat: 'MMM yyyy' as ChartDatePattern,
       };
     }
     const minTs = chartData[0].ts;
@@ -273,7 +275,7 @@ export function SecurityPerformanceReport() {
     return {
       ticks,
       domain: [minTs, maxTs] as [number, number],
-      tickFormat: stepMonths >= 12 ? 'yyyy' : 'MMM yyyy',
+      tickFormat: (stepMonths >= 12 ? 'yyyy' : 'MMM yyyy') as ChartDatePattern,
     };
   }, [chartData]);
 
@@ -599,7 +601,7 @@ export function SecurityPerformanceReport() {
                         scale="time"
                         domain={xAxis.domain}
                         ticks={xAxis.ticks}
-                        tickFormatter={(ts: number) => format(ts, xAxis.tickFormat)}
+                        tickFormatter={(ts: number) => formatChartDate(new Date(ts), xAxis.tickFormat)}
                         tick={{ fontSize: 11 }}
                       />
                       <YAxis

--- a/frontend/src/components/transactions/AccountBalancesBarChart.tsx
+++ b/frontend/src/components/transactions/AccountBalancesBarChart.tsx
@@ -290,7 +290,7 @@ export function AccountBalancesBarChart({
               tickLine={false}
               axisLine={false}
               tickFormatter={formatAxis}
-              width={45}
+              width="auto"
               scale={effectiveScale}
               domain={effectiveScale === 'log' ? ['auto', 'auto'] : undefined}
               allowDataOverflow={false}

--- a/frontend/src/components/transactions/BalanceHistoryChart.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.tsx
@@ -19,6 +19,7 @@ import { chartColors } from '@/lib/chart-colors';
 import { parseLocalDate } from '@/lib/utils';
 import { computeBalanceGradient, computeBalanceSummary } from '@/lib/balance-history';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { ChartDownloadButton } from '@/components/ui/ChartDownloadButton';
 import {
   ChartFlagShadowFilter,
@@ -81,6 +82,7 @@ export function BalanceHistoryChart({
   const chartTitle = t('charts.balanceHistory.title');
   const { formatCurrency: formatCurrencyFull, formatCurrencyAxis, formatCurrencyFlag } =
     useNumberFormat();
+  const formatChartDate = useChartDateFormat();
   const chartRef = useRef<HTMLDivElement>(null);
   // High/low value bubbles a user has temporarily dismissed, keyed by the value
   // they marked so a later data change with a new extreme shows its bubble
@@ -119,12 +121,12 @@ export function BalanceHistoryChart({
       }
       return {
         date: d.date,
-        label: format(parsed, 'MMM d, yyyy'),
+        label: formatChartDate(parsed, 'MMM d, yyyy'),
         balance: Math.round(d.balance * 100) / 100,
       };
     });
     return { chartData: points, monthTicks: ticks };
-  }, [data]);
+  }, [data, formatChartDate]);
 
   const summary = useMemo(() => computeBalanceSummary(chartData), [chartData]);
 
@@ -205,7 +207,7 @@ export function BalanceHistoryChart({
               tick={{ fill: chartColors.axis, fontSize: 12 }}
               tickLine={false}
               axisLine={{ stroke: chartColors.grid }}
-              tickFormatter={(value: string) => format(parseLocalDate(value), 'MMM')}
+              tickFormatter={(value: string) => formatChartDate(value, 'MMM')}
             />
             <YAxis
               tick={{ fill: chartColors.axis, fontSize: 11 }}

--- a/frontend/src/components/transactions/BalanceHistoryChart.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.tsx
@@ -209,12 +209,15 @@ export function BalanceHistoryChart({
               axisLine={{ stroke: chartColors.grid }}
               tickFormatter={(value: string) => formatChartDate(value, 'MMM')}
             />
+            {/* width="auto" lets recharts size the axis to its widest tick
+                label so long localized currency values (e.g. "1.234.567 €")
+                are never clipped. */}
             <YAxis
               tick={{ fill: chartColors.axis, fontSize: 11 }}
               tickLine={false}
               axisLine={false}
               tickFormatter={formatAxis}
-              width={45}
+              width="auto"
               domain={['auto', 'auto']}
             />
             <Tooltip content={<BalanceTooltip formatCurrency={formatCurrency} />} />

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
@@ -19,6 +19,7 @@ import { format, lastDayOfMonth } from 'date-fns';
 import { parseLocalDate } from '@/lib/utils';
 import { MonthlyTotal } from '@/types/transaction';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { ChartDownloadButton } from '@/components/ui/ChartDownloadButton';
 
@@ -83,6 +84,7 @@ export function CategoryPayeeBarChart({
   const t = useTranslations('transactions');
   const chartTitle = t('charts.monthlyTotals.title');
   const { formatCurrency, formatCurrencyAxis } = useNumberFormat();
+  const formatChartDate = useChartDateFormat();
   const chartRef = useRef<HTMLDivElement>(null);
   const downloadFilename = filterLabel ? `${chartTitle} - ${filterLabel}` : chartTitle;
   const isMobile = useIsMobile();
@@ -92,13 +94,13 @@ export function CategoryPayeeBarChart({
       const parsed = parseLocalDate(`${d.month}-01`);
       return {
         month: d.month,
-        label: format(parsed, 'MMMM yyyy'),
+        label: formatChartDate(parsed, 'MMMM yyyy'),
         total: d.total,
         absTotal: Math.abs(d.total),
         count: d.count,
       };
     });
-  }, [data]);
+  }, [data, formatChartDate]);
 
   const isCrowded = chartData.length > DESKTOP_CROWDED_THRESHOLD;
   const verticalLabels = isMobile || isCrowded;
@@ -177,7 +179,7 @@ export function CategoryPayeeBarChart({
               tick={{ fill: '#6b7280', fontSize: isMobile ? 10 : 12 }}
               tickLine={false}
               axisLine={{ stroke: '#e5e7eb' }}
-              tickFormatter={(value: string) => format(parseLocalDate(`${value}-01`), 'MMM yy')}
+              tickFormatter={(value: string) => formatChartDate(`${value}-01`, 'MMM yy')}
               interval="preserveStartEnd"
               angle={isMobile ? -35 : 0}
               textAnchor={isMobile ? 'end' : 'middle'}

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
@@ -191,7 +191,7 @@ export function CategoryPayeeBarChart({
               tickLine={false}
               axisLine={false}
               tickFormatter={formatCurrencyAxis}
-              width={45}
+              width="auto"
             />
             <Tooltip content={<MonthlyTotalTooltip formatCurrency={formatCurrency} />} />
             <Bar

--- a/frontend/src/components/transactions/TransactionForm.test.tsx
+++ b/frontend/src/components/transactions/TransactionForm.test.tsx
@@ -795,7 +795,7 @@ describe('TransactionForm', () => {
       expect(mockOnSuccess).toHaveBeenCalledTimes(1);
     });
 
-    it('confirms before saving an edit to a reconciled transaction', async () => {
+    it('confirms before saving a reconciled transaction when the date changes', async () => {
       const existingTransaction = createExistingTransaction({
         status: TransactionStatus.RECONCILED,
         isReconciled: true,
@@ -813,6 +813,8 @@ describe('TransactionForm', () => {
         expect(screen.getByRole('button', { name: /Update Transaction/i })).toBeInTheDocument();
       });
 
+      // Changing the date affects the reconciliation, so the save is gated.
+      fireEvent.change(screen.getByLabelText('Date'), { target: { value: '2024-02-20' } });
       fireEvent.click(screen.getByRole('button', { name: /Update Transaction/i }));
 
       // The edit is gated behind a confirmation; nothing is saved yet.
@@ -830,6 +832,69 @@ describe('TransactionForm', () => {
           expect.any(Object)
         );
       });
+      expect(mockOnSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    it('confirms before saving a reconciled transaction when the amount changes', async () => {
+      const existingTransaction = createExistingTransaction({
+        status: TransactionStatus.RECONCILED,
+        isReconciled: true,
+      });
+
+      render(
+        <TransactionForm
+          transaction={existingTransaction}
+          onSuccess={mockOnSuccess}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Update Transaction/i })).toBeInTheDocument();
+      });
+
+      // Changing the amount affects the reconciliation, so the save is gated.
+      fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '75.00' } });
+      fireEvent.click(screen.getByRole('button', { name: /Update Transaction/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Edit reconciled transaction?')).toBeInTheDocument();
+      });
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('saves a reconciled transaction without confirmation when date and amount are unchanged', async () => {
+      const existingTransaction = createExistingTransaction({
+        status: TransactionStatus.RECONCILED,
+        isReconciled: true,
+      });
+
+      render(
+        <TransactionForm
+          transaction={existingTransaction}
+          onSuccess={mockOnSuccess}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Update Transaction/i })).toBeInTheDocument();
+      });
+
+      // Editing a different field (here, nothing date/amount related) leaves the
+      // reconciliation intact, so the save proceeds without a warning.
+      fireEvent.change(screen.getByLabelText('Reference Number'), {
+        target: { value: 'REF-EDITED' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /Update Transaction/i }));
+
+      await waitFor(() => {
+        expect(mockUpdate).toHaveBeenCalledWith(
+          existingTransaction.id,
+          expect.any(Object)
+        );
+      });
+      expect(screen.queryByText('Edit reconciled transaction?')).not.toBeInTheDocument();
       expect(mockOnSuccess).toHaveBeenCalledTimes(1);
     });
 

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -61,6 +61,30 @@ const buildTransactionSchema = (t: (key: string) => string) => z.object({
 
 type TransactionFormData = z.infer<ReturnType<typeof buildTransactionSchema>>;
 
+/**
+ * A reconciled transaction was matched against a statement during
+ * reconciliation. Only the date and amount feed that match, so editing other
+ * fields (payee, category, notes, reference) leaves the reconciliation intact
+ * and should save without a warning. Returns true only when the submitted date
+ * or amount differs from the original, in which case the edit is gated behind a
+ * confirmation. Amounts are compared in integer cents at the same 2-decimal
+ * precision the form loads them with, so float drift never triggers a warning.
+ */
+function reconciledEditAffectsReconciliation(
+  original: Transaction,
+  data: TransactionFormData,
+): boolean {
+  const dateChanged = data.transactionDate !== original.transactionDate;
+  // Mirror the form's defaultValues normalization: transfers always load an
+  // absolute amount, everything else keeps its sign.
+  const originalAmount = original.isTransfer
+    ? Math.abs(Math.round(Number(original.amount) * 100) / 100)
+    : Math.round(Number(original.amount) * 100) / 100;
+  const amountChanged =
+    Math.round(Number(data.amount) * 100) !== Math.round(originalAmount * 100);
+  return dateChanged || amountChanged;
+}
+
 interface TransactionFormProps {
   transaction?: Transaction;
   duplicateFrom?: Transaction;
@@ -867,11 +891,16 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
     }
   };
 
-  // Editing a reconciled transaction silently changes a record that was matched
-  // against a statement, so confirm before saving. New/duplicated transactions
-  // start UNRECONCILED, so this only gates genuine edits.
+  // Editing a reconciled transaction's date or amount silently changes a record
+  // that was matched against a statement, so confirm before saving. Edits that
+  // leave the date and amount untouched (e.g. fixing a payee or category) don't
+  // affect the reconciliation and save without a prompt. New/duplicated
+  // transactions start UNRECONCILED, so this only gates genuine edits.
   const onSubmit = async (data: TransactionFormData) => {
-    if (transaction?.status === TransactionStatus.RECONCILED) {
+    if (
+      transaction?.status === TransactionStatus.RECONCILED &&
+      reconciledEditAffectsReconciliation(transaction, data)
+    ) {
       setReconciledConfirmData(data);
       return;
     }

--- a/frontend/src/hooks/useChartDateFormat.ts
+++ b/frontend/src/hooks/useChartDateFormat.ts
@@ -1,0 +1,21 @@
+import { useCallback } from 'react';
+import { usePreferencesStore } from '@/store/preferencesStore';
+import { formatChartDate, type ChartDatePattern } from '@/lib/utils';
+
+/**
+ * Hook returning a locale-aware date formatter for chart axes, tooltips, and
+ * series labels. Month markers are rendered in the user's UI language rather
+ * than always in English. The pseudo-locale ('xx') and unset/'browser'
+ * language fall back to the runtime default, mirroring `useDateFormat`.
+ */
+export function useChartDateFormat() {
+  const language = usePreferencesStore((state) => state.preferences?.language);
+  const locale =
+    language && language !== 'xx' && language !== 'browser' ? language : undefined;
+
+  return useCallback(
+    (date: Date | string, pattern: ChartDatePattern) =>
+      formatChartDate(date, pattern, locale),
+    [locale],
+  );
+}

--- a/frontend/src/i18n/messages/en/transactions.json
+++ b/frontend/src/i18n/messages/en/transactions.json
@@ -295,7 +295,7 @@
     "submitUpdate": "Update {mode}",
     "reconciledConfirm": {
       "title": "Edit reconciled transaction?",
-      "message": "This transaction is reconciled. Changing it will affect a completed reconciliation. Do you want to save your changes anyway?",
+      "message": "This transaction is reconciled. Changing its date or amount will affect a completed reconciliation. Do you want to save your changes anyway?",
       "confirm": "Save changes"
     },
     "modeLabel": {

--- a/frontend/src/i18n/messages/xx/transactions.json
+++ b/frontend/src/i18n/messages/xx/transactions.json
@@ -295,7 +295,7 @@
     "submitUpdate": "[XX-Update {mode}-XX]",
     "reconciledConfirm": {
       "title": "[XX-Edit reconciled transaction?-XX]",
-      "message": "[XX-This transaction is reconciled. Changing it will affect a completed reconciliation. Do you want to save your changes anyway?-XX]",
+      "message": "[XX-This transaction is reconciled. Changing its date or amount will affect a completed reconciliation. Do you want to save your changes anyway?-XX]",
       "confirm": "[XX-Save changes-XX]"
     },
     "modeLabel": {

--- a/frontend/src/lib/forecast.test.ts
+++ b/frontend/src/lib/forecast.test.ts
@@ -515,27 +515,6 @@ describe('buildForecast', () => {
     });
   });
 
-  // --- Date formatting for chart labels ---
-  describe('date formatting for chart labels', () => {
-    it('formats labels as short month and day', () => {
-      const accounts = [makeAccount()];
-      const result = buildForecast(accounts, [], 'week', 'all');
-      // Jan 15, 2025 should format as "Jan 15"
-      expect(result[0].label).toBe('Jan 15');
-    });
-
-    it('formats labels correctly across months', () => {
-      vi.setSystemTime(new Date(2025, 0, 28)); // Jan 28
-      const accounts = [makeAccount()];
-      const result = buildForecast(accounts, [], 'week', 'all');
-      // First point: Jan 28
-      expect(result[0].label).toBe('Jan 28');
-      // Some point should be in February
-      const febPoint = result.find(dp => dp.label.startsWith('Feb'));
-      expect(febPoint).toBeDefined();
-    });
-  });
-
   // --- Empty scheduled transactions input ---
   describe('empty scheduled transactions input', () => {
     it('returns flat balance line with empty transactions array', () => {
@@ -1231,9 +1210,9 @@ describe('getForecastSummary', () => {
 
   it('calculates min/max/starting/ending balances', () => {
     const dataPoints = [
-      { date: '2025-01-01', balance: 1000, label: 'Jan 1', transactions: [] },
-      { date: '2025-01-15', balance: 500, label: 'Jan 15', transactions: [] },
-      { date: '2025-01-31', balance: 1500, label: 'Jan 31', transactions: [] },
+      { date: '2025-01-01', balance: 1000, transactions: [] },
+      { date: '2025-01-15', balance: 500, transactions: [] },
+      { date: '2025-01-31', balance: 1500, transactions: [] },
     ];
     const summary = getForecastSummary(dataPoints);
     expect(summary.startingBalance).toBe(1000);
@@ -1245,8 +1224,8 @@ describe('getForecastSummary', () => {
 
   it('detects negative balances', () => {
     const dataPoints = [
-      { date: '2025-01-01', balance: 100, label: 'Jan 1', transactions: [] },
-      { date: '2025-01-15', balance: -50, label: 'Jan 15', transactions: [] },
+      { date: '2025-01-01', balance: 100, transactions: [] },
+      { date: '2025-01-15', balance: -50, transactions: [] },
     ];
     const summary = getForecastSummary(dataPoints);
     expect(summary.goesNegative).toBe(true);
@@ -1254,7 +1233,7 @@ describe('getForecastSummary', () => {
 
   it('handles single data point', () => {
     const dataPoints = [
-      { date: '2025-01-01', balance: 1000, label: 'Jan 1', transactions: [] },
+      { date: '2025-01-01', balance: 1000, transactions: [] },
     ];
     const summary = getForecastSummary(dataPoints);
     expect(summary.startingBalance).toBe(1000);
@@ -1266,8 +1245,8 @@ describe('getForecastSummary', () => {
 
   it('detects goesNegative as false when min balance is exactly zero', () => {
     const dataPoints = [
-      { date: '2025-01-01', balance: 100, label: 'Jan 1', transactions: [] },
-      { date: '2025-01-15', balance: 0, label: 'Jan 15', transactions: [] },
+      { date: '2025-01-01', balance: 100, transactions: [] },
+      { date: '2025-01-15', balance: 0, transactions: [] },
     ];
     const summary = getForecastSummary(dataPoints);
     expect(summary.goesNegative).toBe(false);

--- a/frontend/src/lib/forecast.ts
+++ b/frontend/src/lib/forecast.ts
@@ -21,7 +21,6 @@ export interface ForecastTransaction {
 export interface ForecastDataPoint {
   date: string;
   balance: number;
-  label: string;
   transactions: ForecastTransaction[];
 }
 
@@ -60,10 +59,6 @@ function formatDateKey(date: Date): string {
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
-}
-
-function formatDateLabel(date: Date): string {
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
 /**
@@ -409,7 +404,6 @@ export function buildForecast(
       dataPoints.push({
         date: dateKey,
         balance: Math.round(currentBalance * 100) / 100,
-        label: formatDateLabel(currentDate),
         transactions: dayTransactions,
       });
       lastAddedTime = currentTime;

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -13,6 +13,7 @@ import {
   parseTime,
   getLocalDateString,
   parseDateFromFormat,
+  formatChartDate,
 } from './utils';
 
 describe('cn', () => {
@@ -127,6 +128,43 @@ describe('formatMonth', () => {
 
   it('falls back to browser locale for unknown format', () => {
     const result = formatMonth('2026-01', 'unknown-format');
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+describe('formatChartDate', () => {
+  it('localizes the short month name (en)', () => {
+    expect(formatChartDate('2026-01-15', 'MMM', 'en-US')).toBe('Jan');
+  });
+
+  it('localizes the short month name in another language (de)', () => {
+    // German abbreviates January as "Jan" too, but March differs ("Mär").
+    expect(formatChartDate('2026-03-15', 'MMM', 'de')).toBe('Mär');
+  });
+
+  it('localizes the full month with year (fr)', () => {
+    // French uses lowercase month names and day-month-year ordering.
+    expect(formatChartDate('2026-01-15', 'MMMM yyyy', 'fr')).toBe('janvier 2026');
+  });
+
+  it('parses string dates as local time without shifting', () => {
+    // A naive new Date('2026-01-01') is UTC midnight and can roll back a day
+    // in negative-offset zones; formatChartDate parses parts directly.
+    expect(formatChartDate('2026-01-01', 'MMM yyyy', 'en-US')).toBe('Jan 2026');
+  });
+
+  it('formats Date inputs (intraday timestamps) with time', () => {
+    const d = new Date(2026, 0, 5, 14, 30);
+    expect(formatChartDate(d, 'HH:mm', 'en-GB')).toBe('14:30');
+  });
+
+  it('formats year-only markers', () => {
+    expect(formatChartDate('2026-06-15', 'yyyy', 'en-US')).toBe('2026');
+  });
+
+  it('falls back to the runtime default locale when none is given', () => {
+    const result = formatChartDate('2026-01-15', 'MMM');
     expect(typeof result).toBe('string');
     expect(result.length).toBeGreaterThan(0);
   });

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -130,6 +130,56 @@ export function formatMonth(month: string, format: string = 'browser', locale?: 
 }
 
 /**
+ * date-fns-style tokens used for month markers and date labels on charts,
+ * mapped to locale-aware `Intl.DateTimeFormat` output. Charts historically
+ * formatted these with date-fns `format()`, which is English-only here (no
+ * locale was ever supplied), so month names like "Jan" never followed the
+ * user's UI language. Using Intl localizes both the month name and the
+ * locale-appropriate ordering/separators.
+ */
+export type ChartDatePattern =
+  | 'MMM' // Jan
+  | 'MMM yy' // Jan 25
+  | 'MMM yyyy' // Jan 2025
+  | 'MMMM yyyy' // January 2025
+  | 'MMM d' // Jan 5
+  | 'MMM d, yyyy' // Jan 5, 2025
+  | 'MMM d HH:mm' // Jan 5, 14:30
+  | 'HH:mm' // 14:30
+  | 'yyyy'; // 2025
+
+const CHART_DATE_OPTIONS: Record<ChartDatePattern, Intl.DateTimeFormatOptions> = {
+  MMM: { month: 'short' },
+  'MMM yy': { month: 'short', year: '2-digit' },
+  'MMM yyyy': { month: 'short', year: 'numeric' },
+  'MMMM yyyy': { month: 'long', year: 'numeric' },
+  'MMM d': { month: 'short', day: 'numeric' },
+  'MMM d, yyyy': { month: 'short', day: 'numeric', year: 'numeric' },
+  'MMM d HH:mm': { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false },
+  'HH:mm': { hour: '2-digit', minute: '2-digit', hour12: false },
+  yyyy: { year: 'numeric' },
+};
+
+/**
+ * Format a date for a chart axis tick, tooltip, or series label in the user's
+ * locale. String inputs are parsed as local dates (YYYY-MM-DD) so they do not
+ * shift across timezones; Date inputs (e.g. intraday timestamps) are formatted
+ * as given.
+ * @param date - Date object or local date string (YYYY-MM-DD)
+ * @param pattern - One of the supported chart date patterns
+ * @param locale - Optional BCP 47 locale (typically the user's UI language);
+ *                 falls back to the runtime default when omitted.
+ */
+export function formatChartDate(
+  date: Date | string,
+  pattern: ChartDatePattern,
+  locale?: string,
+): string {
+  const d = typeof date === 'string' ? parseLocalDate(date) : date;
+  return new Intl.DateTimeFormat(locale, CHART_DATE_OPTIONS[pattern]).format(d);
+}
+
+/**
  * Resolve the user's timezone preference to an IANA timezone string.
  * 'browser' (or undefined) falls back to the browser's detected timezone.
  */


### PR DESCRIPTION
Chart axes, tooltips, and series labels formatted month/date markers with
date-fns `format()` and no locale, so month names (Jan, Feb, ...) always
rendered in English regardless of the user's UI language. The cash-flow
forecast additionally hardcoded `toLocaleDateString('en-US')`.

Add a locale-aware `formatChartDate(date, pattern, locale?)` helper in
`lib/utils.ts` (backed by `Intl.DateTimeFormat`) plus a `useChartDateFormat`
hook that binds the user's preferred language (matching `useDateFormat`'s
locale resolution, with the pseudo-locale falling back to the runtime
default). Route every on-screen chart month marker through it across the
transaction, dashboard, investment, bills, and report charts. Non-display
date formatting (grouping keys, CSV/PDF export, table cells) stays on
date-fns. Where an axis derived the month by string-splitting a localized
label, the axis now keys off the raw YYYY-MM(-DD) value so it stays correct
across locales with different date ordering.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014wVvxdpHgkpWiJ2Gz9tzex