### PR TITLE
fix(ai-relay): cap conversation history sent to the agent

### DIFF
--- a/backend/src/ai/relay/ai-relay.service.spec.ts
+++ b/backend/src/ai/relay/ai-relay.service.spec.ts
@@ -1,4 +1,8 @@
-import { AiRelayService, INACTIVITY_TIMEOUT_MS } from "./ai-relay.service";
+import {
+  AiRelayService,
+  INACTIVITY_TIMEOUT_MS,
+  trimRelayHistory,
+} from "./ai-relay.service";
 import { RelayAttachmentStore } from "./relay-attachment.store";
 
 const USER = "user-1";
@@ -72,6 +76,20 @@ describe("AiRelayService", () => {
     service.enqueuePrompt(USER, "q", history);
     const claimed = await service.waitForPrompt(USER);
     expect(claimed?.history).toEqual(history);
+  });
+
+  it("trims a long history before handing it to the agent", async () => {
+    // 30 short turns -> only the most recent 10 reach the agent.
+    const history = Array.from({ length: 30 }, (_, i) => ({
+      role: (i % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
+      content: `turn ${i}`,
+    }));
+    service.enqueuePrompt(USER, "q", history);
+    const claimed = await service.waitForPrompt(USER);
+    expect(claimed?.history).toHaveLength(10);
+    // Newest kept, oldest-first order preserved.
+    expect(claimed?.history[0].content).toBe("turn 20");
+    expect(claimed?.history[9].content).toBe("turn 29");
   });
 
   it("rejects post_response for an unknown or foreign prompt", async () => {
@@ -555,6 +573,51 @@ describe("AiRelayService", () => {
       jest.advanceTimersByTime(INACTIVITY_TIMEOUT_MS - 1000);
       // First empty poll after the claim only starts the clock again.
       expect(service.shouldStopForIdle(USER)).toBe(false);
+    });
+  });
+
+  describe("trimRelayHistory", () => {
+    it("returns a short history unchanged", () => {
+      const history = [
+        { role: "user" as const, content: "hi" },
+        { role: "assistant" as const, content: "hello" },
+      ];
+      expect(trimRelayHistory(history)).toEqual(history);
+    });
+
+    it("keeps only the most recent turns, oldest first", () => {
+      const history = Array.from({ length: 25 }, (_, i) => ({
+        role: "user" as const,
+        content: `m${i}`,
+      }));
+      const trimmed = trimRelayHistory(history);
+      expect(trimmed).toHaveLength(10);
+      expect(trimmed[0].content).toBe("m15");
+      expect(trimmed[9].content).toBe("m24");
+    });
+
+    it("drops older turns once the char budget is exhausted", () => {
+      // Three 5000-char turns: only the two newest fit the 12000 budget.
+      const big = (n: number) => ({
+        role: "assistant" as const,
+        content: String(n).repeat(5000),
+      });
+      const trimmed = trimRelayHistory([big(1), big(2), big(3)]);
+      expect(trimmed).toHaveLength(2);
+      expect(trimmed[0].content[0]).toBe("2");
+      expect(trimmed[1].content[0]).toBe("3");
+    });
+
+    it("keeps but truncates a single newest turn that exceeds the budget", () => {
+      const huge = { role: "assistant" as const, content: "x".repeat(20000) };
+      const trimmed = trimRelayHistory([huge]);
+      expect(trimmed).toHaveLength(1);
+      expect(trimmed[0].content.length).toBeLessThan(20000);
+      expect(trimmed[0].content.endsWith("[truncated]")).toBe(true);
+    });
+
+    it("returns an empty array for an empty history", () => {
+      expect(trimRelayHistory([])).toEqual([]);
     });
   });
 });

--- a/backend/src/ai/relay/ai-relay.service.ts
+++ b/backend/src/ai/relay/ai-relay.service.ts
@@ -85,6 +85,54 @@ const CONNECTED_WINDOW_MS = 45 * 1000; // 45 seconds
  */
 export const INACTIVITY_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 
+/**
+ * Most recent conversation turns carried into a relayed prompt. The browser
+ * sends the whole conversation, but `get_next_prompt` returns it to the agent on
+ * EVERY prompt, and the agent runs the relay loop in one long-lived session that
+ * also accumulates its own context. Returning an unbounded history therefore
+ * grows the agent's context until the model degrades (multi-minute "thinking",
+ * malformed tool calls, no answer). Keep only the newest turns, within a char
+ * budget, so continuity survives without the bloat.
+ */
+const MAX_HISTORY_TURNS = 10;
+const MAX_HISTORY_CHARS = 12000;
+const HISTORY_TRUNCATION_MARKER = " … [truncated]";
+
+/**
+ * Trim a conversation history to the most recent turns within the char budget,
+ * preserving order (oldest first). Older turns that do not fit are dropped; if
+ * the single newest turn alone exceeds the budget it is kept but truncated, so
+ * the result is always bounded regardless of how long the conversation grew.
+ */
+export function trimRelayHistory(
+  history: Array<{ role: "user" | "assistant"; content: string }>,
+): Array<{ role: "user" | "assistant"; content: string }> {
+  const kept: Array<{ role: "user" | "assistant"; content: string }> = [];
+  let budget = MAX_HISTORY_CHARS;
+  for (
+    let i = history.length - 1;
+    i >= 0 && kept.length < MAX_HISTORY_TURNS && budget > 0;
+    i--
+  ) {
+    const { role, content } = history[i];
+    if (content.length <= budget) {
+      kept.push({ role, content });
+      budget -= content.length;
+    } else {
+      // Only the newest kept turn may be truncated to fit; once anything is
+      // kept, an over-budget older turn (and everything before it) is dropped.
+      if (kept.length === 0) {
+        kept.push({
+          role,
+          content: content.slice(0, budget) + HISTORY_TRUNCATION_MARKER,
+        });
+      }
+      break;
+    }
+  }
+  return kept.reverse();
+}
+
 interface PendingPrompt {
   id: string;
   prompt: string;
@@ -243,7 +291,9 @@ export class AiRelayService {
       const entry: PendingPrompt = {
         id: randomUUID(),
         prompt,
-        history,
+        // Bound the history handed to the agent: get_next_prompt returns it on
+        // every prompt, so an unbounded conversation bloats the agent's context.
+        history: trimRelayHistory(history),
         resolve,
         reject,
         settled: false,

--- a/backend/src/ai/relay/dto/relay-query.dto.ts
+++ b/backend/src/ai/relay/dto/relay-query.dto.ts
@@ -35,8 +35,12 @@ export class RelayQueryDto {
   @SanitizeHtml()
   query: string;
 
+  // Generous upper bound: the client trims history to a handful of recent turns
+  // and the server trims again before handing it to the agent, so this only
+  // guards against an abusive client sending an unbounded array.
   @IsOptional()
   @IsArray()
+  @ArrayMaxSize(500)
   @ValidateNested({ each: true })
   @Type(() => RelayMessageDto)
   conversationHistory?: RelayMessageDto[];

--- a/frontend/src/store/aiChatStore.test.ts
+++ b/frontend/src/store/aiChatStore.test.ts
@@ -108,6 +108,50 @@ describe('aiChatStore', () => {
       expect(serialized).not.toContain('r.png');
     });
 
+    it('caps conversation history in relay mode to the most recent turns', async () => {
+      const { aiApi } = await import('@/lib/ai');
+      // A long prior conversation: relay must not ship all of it to the agent.
+      const seeded = Array.from({ length: 24 }, (_, i) => ({
+        id: `seed-${i}`,
+        role: (i % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+        content: `seeded turn ${i}`,
+      }));
+      useAiChatStore.setState({ messages: seeded });
+
+      useAiChatStore.getState().submit('newest question', undefined, {
+        relay: true,
+      });
+
+      const history = vi.mocked(aiApi.queryStream).mock.calls[0][2] as Array<{
+        role: string;
+        content: string;
+      }>;
+      expect(history.length).toBeLessThanOrEqual(10);
+      const serialized = JSON.stringify(history);
+      expect(serialized).not.toContain('seeded turn 0');
+      expect(serialized).toContain('newest question');
+    });
+
+    it('keeps the full conversation history on the native (non-relay) path', async () => {
+      const { aiApi } = await import('@/lib/ai');
+      const seeded = Array.from({ length: 24 }, (_, i) => ({
+        id: `seed-${i}`,
+        role: (i % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+        content: `seeded turn ${i}`,
+      }));
+      useAiChatStore.setState({ messages: seeded });
+
+      useAiChatStore.getState().submit('newest question');
+
+      const history = vi.mocked(aiApi.queryStream).mock.calls[0][2] as Array<{
+        role: string;
+        content: string;
+      }>;
+      // 24 seeded + the new user turn, untrimmed.
+      expect(history.length).toBe(25);
+      expect(JSON.stringify(history)).toContain('seeded turn 0');
+    });
+
     it('ignores empty/whitespace queries', async () => {
       const { aiApi } = await import('@/lib/ai');
       useAiChatStore.getState().submit('   ');

--- a/frontend/src/store/aiChatStore.ts
+++ b/frontend/src/store/aiChatStore.ts
@@ -72,6 +72,38 @@ const IDLE_THINKING: ThinkingState = {
 const RELAY_PICKUP_POLL_MS = 4000;
 const RELAY_PICKUP_DEADLINE_MS = 9 * 60 * 1000;
 
+// Bound the conversation history sent in relay mode. The agent receives it on
+// every prompt via get_next_prompt and runs the loop in one long-lived session,
+// so an unbounded history bloats its context until the model degrades. Keep the
+// newest turns within a char budget (the backend trims again as the source of
+// truth). The native LLM path is unaffected.
+const RELAY_MAX_HISTORY_TURNS = 10;
+const RELAY_MAX_HISTORY_CHARS = 12000;
+
+function trimRelayHistory(
+  history: Array<{ role: 'user' | 'assistant'; content: string }>,
+): Array<{ role: 'user' | 'assistant'; content: string }> {
+  const kept: Array<{ role: 'user' | 'assistant'; content: string }> = [];
+  let budget = RELAY_MAX_HISTORY_CHARS;
+  for (
+    let i = history.length - 1;
+    i >= 0 && kept.length < RELAY_MAX_HISTORY_TURNS && budget > 0;
+    i--
+  ) {
+    const { role, content } = history[i];
+    if (content.length <= budget) {
+      kept.push({ role, content });
+      budget -= content.length;
+    } else {
+      if (kept.length === 0) {
+        kept.push({ role, content: content.slice(0, budget) + ' … [truncated]' });
+      }
+      break;
+    }
+  }
+  return kept.reverse();
+}
+
 interface AiChatState {
   messages: ChatMessage[];
   isLoading: boolean;
@@ -445,7 +477,7 @@ export const useAiChatStore = create<AiChatState>()(
         // Build conversation history from existing messages for context.
         // Only include completed (non-streaming, non-error) messages with
         // actual content so the AI can reference prior turns.
-        const history = get()
+        const fullHistory = get()
           .messages.filter(
             (m) =>
               !m.isStreaming &&
@@ -453,6 +485,9 @@ export const useAiChatStore = create<AiChatState>()(
               m.content.length > 0,
           )
           .map((m) => ({ role: m.role, content: m.content }));
+        // In relay mode, cap history so the user's agent isn't overwhelmed by an
+        // ever-growing context; the native LLM path keeps the full history.
+        const history = relay ? trimRelayHistory(fullHistory) : fullHistory;
 
         const controller = aiApi.queryStream(trimmed, {
           onEvent: (event: StreamEvent) => {


### PR DESCRIPTION
## Linked discussion / issue

Relates to #793 (same relay reliability area)
Approved in: #686 (Extending the Native AI Assistant with Write Actions — Human-in-the-Loop)

## Summary

Caps the conversation history carried into a relayed prompt so a long chat doesn't degrade the user's MCP agent. `get_next_prompt` returned the **entire** history on every prompt, and the agent runs the relay loop in one long-lived session that also accumulates its own context — so an unbounded history bloated the model until it degraded (multi-minute "thinking", tool calls emitted as plain text, no answer).

- Trim history to the most recent ~10 turns within a ~12000-char budget in `AiRelayService.enqueuePrompt` (server-side source of truth); the newest turn is truncated rather than dropped if it alone exceeds the budget.
- Cap the history the chat sends in relay mode to the same budget; the native (non-relay) path keeps the full history.
- Add `@ArrayMaxSize(500)` to `conversationHistory` as an abuse bound.

> Sibling of #803 (both relay fixes off `main`); they touch `ai-relay.service.ts` and `aiChatStore.ts` and merge cleanly together, but will need ordering if reviewed in isolation.

## Checklist

- [x] An approved discussion or issue exists and is linked above. (#793 / #686)
- [x] This PR addresses a **single concern** (bounding relayed conversation history).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale — **no new user-facing strings** in this PR.
- [x] No shared/core areas were refactored without prior agreement — confined to the relay feature area from #686.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Built with Claude Code (Claude Opus 4.8). I reviewed the diff and tests and own the result.
