### PR TITLE
fix(ai-chat): detect attachment type by MIME, not just extension (PDF without .pdf)

### DIFF
--- a/frontend/src/lib/ai-attachments.test.ts
+++ b/frontend/src/lib/ai-attachments.test.ts
@@ -40,6 +40,18 @@ describe('ai-attachments', () => {
     it('returns null for unsupported files', () => {
       expect(resolveMediaType(makeFile('a.exe', 'application/octet-stream'))).toBeNull();
     });
+
+    it('resolves a PDF by MIME when it has no extension', () => {
+      expect(resolveMediaType(makeFile('statement', 'application/pdf'))).toBe(
+        'application/pdf',
+      );
+    });
+
+    it('trusts an accepted MIME over a misleading extension (real PDF named .txt)', () => {
+      expect(resolveMediaType(makeFile('report.txt', 'application/pdf'))).toBe(
+        'application/pdf',
+      );
+    });
   });
 
   describe('kindForMediaType', () => {

--- a/frontend/src/lib/ai-attachments.ts
+++ b/frontend/src/lib/ai-attachments.ts
@@ -23,9 +23,9 @@ export const ACCEPTED_MIME_TYPES = [
 ] as const;
 
 /**
- * Extension -> canonical MIME. Browsers report CSV inconsistently
- * (text/csv, application/vnd.ms-excel, or empty), so we normalise by
- * extension first and fall back to the browser-reported type.
+ * Extension -> canonical MIME. Used as a fallback when the browser-reported MIME
+ * is missing or unrecognised -- common for CSV, which browsers report as
+ * text/csv, application/vnd.ms-excel, or empty.
  */
 const EXT_TO_MIME: Record<string, string> = {
   png: 'image/png',
@@ -38,8 +38,16 @@ const EXT_TO_MIME: Record<string, string> = {
   txt: 'text/plain',
 };
 
-/** `accept` attribute for the file input. */
-export const ATTACHMENT_ACCEPT = '.png,.jpg,.jpeg,.gif,.webp,.pdf,.csv,.txt';
+/**
+ * `accept` attribute for the file input. Lists both extensions AND the accepted
+ * MIME types: an extension-only list hides files that carry the right MIME but
+ * no (or a different) extension from the OS picker -- e.g. a real application/pdf
+ * downloaded without a ".pdf" suffix, which is exactly what could not be
+ * attached. The MIME entries let the picker match those by content type.
+ */
+export const ATTACHMENT_ACCEPT =
+  '.png,.jpg,.jpeg,.gif,.webp,.pdf,.csv,.txt,' +
+  'image/png,image/jpeg,image/gif,image/webp,application/pdf,text/csv,text/plain';
 
 /** An i18n error key plus interpolation values, surfaced as a toast. */
 export interface AttachmentError {
@@ -54,11 +62,17 @@ function extensionOf(filename: string): string {
 
 /** Resolve a file to one of the accepted MIME types, or null if unsupported. */
 export function resolveMediaType(file: File): string | null {
-  const byExt = EXT_TO_MIME[extensionOf(file.name)];
-  if (byExt) return byExt;
+  // Trust the browser-reported MIME when it is one we accept: it describes the
+  // file's actual format, whereas the filename extension can be missing or
+  // misleading (e.g. a real application/pdf saved without a ".pdf" suffix, or a
+  // file renamed to the wrong extension). Fall back to the extension only when
+  // the MIME is absent or unrecognised -- common for CSV, which browsers report
+  // as text/csv, application/vnd.ms-excel, or ''.
   if ((ACCEPTED_MIME_TYPES as readonly string[]).includes(file.type)) {
     return file.type;
   }
+  const byExt = EXT_TO_MIME[extensionOf(file.name)];
+  if (byExt) return byExt;
   return null;
 }
 


### PR DESCRIPTION
## Linked discussion / issue

Closes #808

## Summary

Fixes a PDF being un-attachable when it carries the correct `application/pdf` MIME but no `.pdf` filename extension (the reported cause behind #808).

- The file input's `accept` listed only **extensions**, so the OS picker hid an extension-less PDF. `ATTACHMENT_ACCEPT` now also lists the accepted MIME types, so the picker matches such files by content type.
- `resolveMediaType` consulted the **extension before** the browser MIME, so a missing or misleading extension misclassified the file. It now trusts an accepted browser MIME first and falls back to the extension only when the MIME is absent/unrecognised (still covering CSV, which browsers report inconsistently). This also fixes a genuine PDF renamed to a non-`.pdf` extension being mislabelled.

Shared client logic, so it fixes the upload for **both** the relay and native chat paths (reported via the relay chat). No backend change needed — the server already validates the declared MIME against the file's magic bytes.

## Checklist

- [x] An approved discussion or issue exists and is linked above. (#808)
- [x] This PR addresses a **single concern** (attachment type detection for extension-less/mislabelled files).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale — **no new user-facing strings** in this PR.
- [x] No shared/core areas were refactored without prior agreement — a small, targeted fix to the attachment type-resolution helper, no behavioural change for already-working files.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Built with Claude Code (Claude Opus 4.8). I reviewed the diff and tests and own the result.
