### PR TITLE
fix(reports): localize sector names in the Sector Weightings report

### DIFF
--- a/frontend/src/components/reports/SectorWeightingsReport.test.tsx
+++ b/frontend/src/components/reports/SectorWeightingsReport.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent, act } from '@/test/render';
-import { SectorWeightingsReport } from './SectorWeightingsReport';
+import { SectorWeightingsReport, sectorNameKey } from './SectorWeightingsReport';
 
 vi.mock('@/lib/pdf-export', () => ({
   exportToPdf: vi.fn().mockResolvedValue(undefined),
@@ -84,6 +84,21 @@ const mockSecurities = [
   { id: 's-2', symbol: 'VTI', name: 'Vanguard Total Stock', isActive: true },
   { id: 's-3', symbol: 'OLD', name: 'Old Stock', isActive: false },
 ];
+
+describe('sectorNameKey', () => {
+  it('maps known provider sector names to i18n keys, case-insensitively', () => {
+    expect(sectorNameKey('Technology')).toBe('technology');
+    expect(sectorNameKey('Financial Services')).toBe('financialServices');
+    expect(sectorNameKey('REAL ESTATE')).toBe('realEstate');
+    expect(sectorNameKey('  communication services ')).toBe('communicationServices');
+    expect(sectorNameKey('Other')).toBe('other');
+  });
+
+  it('returns null for an unrecognised sector so the raw value is shown', () => {
+    expect(sectorNameKey('Quantum Widgets')).toBeNull();
+    expect(sectorNameKey('')).toBeNull();
+  });
+});
 
 describe('SectorWeightingsReport', () => {
   beforeEach(() => {

--- a/frontend/src/components/reports/SectorWeightingsReport.tsx
+++ b/frontend/src/components/reports/SectorWeightingsReport.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useReportData } from '@/hooks/useReportData';
@@ -61,8 +61,46 @@ function CustomTooltip({ active, payload, formatCurrencyFull, defaultCurrency, l
   );
 }
 
+/**
+ * Map a provider-supplied sector name (Yahoo Finance, a fixed taxonomy stored in
+ * English) to its i18n key, or null for an unrecognised value. Matched
+ * case-insensitively so both the stock `sector` strings and the ETF
+ * sector-weighting display names ("Financial Services", "Real Estate", ...)
+ * resolve. Unknown values fall back to the raw string so a new provider sector
+ * still renders rather than showing a missing-key placeholder.
+ */
+const SECTOR_KEY_BY_NAME: Record<string, string> = {
+  technology: 'technology',
+  'financial services': 'financialServices',
+  healthcare: 'healthcare',
+  'consumer cyclical': 'consumerCyclical',
+  'consumer defensive': 'consumerDefensive',
+  industrials: 'industrials',
+  energy: 'energy',
+  utilities: 'utilities',
+  'real estate': 'realEstate',
+  'basic materials': 'basicMaterials',
+  'communication services': 'communicationServices',
+  other: 'other',
+};
+
+export function sectorNameKey(sector: string): string | null {
+  return SECTOR_KEY_BY_NAME[sector.trim().toLowerCase()] ?? null;
+}
+
 export function SectorWeightingsReport() {
   const t = useTranslations('reports');
+  // Localise a sector name when it is a known provider taxonomy value; otherwise
+  // show the raw string unchanged.
+  const sectorLabel = useCallback(
+    (sector: string): string => {
+      const key = sectorNameKey(sector);
+      return key
+        ? t(`sectorWeightings.sectorNames.${key}` as Parameters<typeof t>[0])
+        : sector;
+    },
+    [t],
+  );
   const { formatCurrencyCompact: formatCurrency, formatCurrency: formatCurrencyFull } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
   const [accounts, setAccounts] = useState<Account[]>([]);
@@ -101,7 +139,7 @@ export function SectorWeightingsReport() {
       let comparison = 0;
       switch (sortField) {
         case 'sector':
-          comparison = compareValues(a.sector, b.sector);
+          comparison = compareValues(sectorLabel(a.sector), sectorLabel(b.sector));
           break;
         case 'direct':
           comparison = compareValues(a.directValue, b.directValue);
@@ -119,7 +157,7 @@ export function SectorWeightingsReport() {
       return sortDirection === 'asc' ? comparison : -comparison;
     });
     return items;
-  }, [data, sortField, sortDirection]);
+  }, [data, sortField, sortDirection, sectorLabel]);
 
   // Load accounts and securities once on mount
   useEffect(() => {
@@ -144,7 +182,7 @@ export function SectorWeightingsReport() {
       t('sectorWeightings.pdfColPortfolioPct'),
     ];
     const rows = data ? data.items.map(item => [
-      item.sector,
+      sectorLabel(item.sector),
       formatCurrencyFull(item.directValue, defaultCurrency),
       formatCurrencyFull(item.etfValue, defaultCurrency),
       formatCurrencyFull(item.totalValue, defaultCurrency),
@@ -190,7 +228,7 @@ export function SectorWeightingsReport() {
   }
 
   const chartData = data.items.map((item, idx) => ({
-    sector: item.sector,
+    sector: sectorLabel(item.sector),
     direct: item.directValue,
     etf: item.etfValue,
     total: item.totalValue,
@@ -374,7 +412,7 @@ export function SectorWeightingsReport() {
                         className="w-3 h-3 rounded-full flex-shrink-0"
                         style={{ backgroundColor: chartSeriesColor(idx) }}
                       />
-                      {item.sector}
+                      {sectorLabel(item.sector)}
                     </div>
                   </td>
                   <td className="px-4 py-3 text-sm text-right text-blue-600 dark:text-blue-400">

--- a/frontend/src/i18n/messages/de/reports.json
+++ b/frontend/src/i18n/messages/de/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "Typisch/Mo."
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "Technologie",
+      "financialServices": "Finanzdienstleistungen",
+      "healthcare": "Gesundheitswesen",
+      "consumerCyclical": "Zyklische Konsumgüter",
+      "consumerDefensive": "Defensive Konsumgüter",
+      "industrials": "Industrie",
+      "energy": "Energie",
+      "utilities": "Versorger",
+      "realEstate": "Immobilien",
+      "basicMaterials": "Grundstoffe",
+      "communicationServices": "Kommunikationsdienste",
+      "other": "Sonstige"
+    },
     "noData": "Keine Anlagebestände mit Sektordaten gefunden. Fügen Sie Wertpapiere mit Sektorklassifizierung hinzu, um die Aufschlüsselung zu sehen.",
     "totalPortfolio": "Gesamtportfolio",
     "directExposure": "Direktes Exposure",

--- a/frontend/src/i18n/messages/en/reports.json
+++ b/frontend/src/i18n/messages/en/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "Typical/Mo"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "Technology",
+      "financialServices": "Financial Services",
+      "healthcare": "Healthcare",
+      "consumerCyclical": "Consumer Cyclical",
+      "consumerDefensive": "Consumer Defensive",
+      "industrials": "Industrials",
+      "energy": "Energy",
+      "utilities": "Utilities",
+      "realEstate": "Real Estate",
+      "basicMaterials": "Basic Materials",
+      "communicationServices": "Communication Services",
+      "other": "Other"
+    },
     "noData": "No investment holdings with sector data found. Add securities with sector classification to see the breakdown.",
     "totalPortfolio": "Total Portfolio",
     "directExposure": "Direct Exposure",

--- a/frontend/src/i18n/messages/es/reports.json
+++ b/frontend/src/i18n/messages/es/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "Típico/Mes"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "Tecnología",
+      "financialServices": "Servicios financieros",
+      "healthcare": "Salud",
+      "consumerCyclical": "Consumo cíclico",
+      "consumerDefensive": "Consumo defensivo",
+      "industrials": "Industria",
+      "energy": "Energía",
+      "utilities": "Servicios públicos",
+      "realEstate": "Inmobiliario",
+      "basicMaterials": "Materiales básicos",
+      "communicationServices": "Servicios de comunicación",
+      "other": "Otros"
+    },
     "noData": "No se encontraron posiciones de inversión con datos sectoriales. Agrega valores con clasificación sectorial para ver el desglose.",
     "totalPortfolio": "Total de la cartera",
     "directExposure": "Exposición directa",

--- a/frontend/src/i18n/messages/fr/reports.json
+++ b/frontend/src/i18n/messages/fr/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "Typique/Mois"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "Technologie",
+      "financialServices": "Services financiers",
+      "healthcare": "Santé",
+      "consumerCyclical": "Consommation cyclique",
+      "consumerDefensive": "Consommation de base",
+      "industrials": "Industrie",
+      "energy": "Énergie",
+      "utilities": "Services aux collectivités",
+      "realEstate": "Immobilier",
+      "basicMaterials": "Matériaux de base",
+      "communicationServices": "Services de communication",
+      "other": "Autres"
+    },
     "noData": "Aucune position d'investissement avec données sectorielles trouvée. Ajoutez des titres avec une classification sectorielle pour voir la ventilation.",
     "totalPortfolio": "Total du portefeuille",
     "directExposure": "Exposition directe",

--- a/frontend/src/i18n/messages/hi/reports.json
+++ b/frontend/src/i18n/messages/hi/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "सामान्य/माह"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "प्रौद्योगिकी",
+      "financialServices": "वित्तीय सेवाएँ",
+      "healthcare": "स्वास्थ्य सेवा",
+      "consumerCyclical": "चक्रीय उपभोक्ता",
+      "consumerDefensive": "रक्षात्मक उपभोक्ता",
+      "industrials": "औद्योगिक",
+      "energy": "ऊर्जा",
+      "utilities": "उपयोगिताएँ",
+      "realEstate": "अचल संपत्ति",
+      "basicMaterials": "मूल सामग्री",
+      "communicationServices": "संचार सेवाएँ",
+      "other": "अन्य"
+    },
     "noData": "क्षेत्र डेटा के साथ कोई निवेश होल्डिंग नहीं मिली। विवरण देखने के लिए क्षेत्र वर्गीकरण के साथ प्रतिभूतियाँ जोड़ें।",
     "totalPortfolio": "कुल पोर्टफोलियो",
     "directExposure": "प्रत्यक्ष एक्सपोज़र",

--- a/frontend/src/i18n/messages/id/reports.json
+++ b/frontend/src/i18n/messages/id/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "Khas/Bln"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "Teknologi",
+      "financialServices": "Jasa keuangan",
+      "healthcare": "Kesehatan",
+      "consumerCyclical": "Konsumen siklikal",
+      "consumerDefensive": "Konsumen defensif",
+      "industrials": "Industri",
+      "energy": "Energi",
+      "utilities": "Utilitas",
+      "realEstate": "Properti",
+      "basicMaterials": "Bahan dasar",
+      "communicationServices": "Jasa komunikasi",
+      "other": "Lainnya"
+    },
     "noData": "Tidak ada kepemilikan investasi dengan data sektor ditemukan. Tambah keamanan dokumen dengan klasifikasi sektor untuk melihat rincian.",
     "totalPortfolio": "Total Portofolio",
     "directExposure": "Eksposur Langsung",

--- a/frontend/src/i18n/messages/it/reports.json
+++ b/frontend/src/i18n/messages/it/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "Tipico/Mese"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "Tecnologia",
+      "financialServices": "Servizi finanziari",
+      "healthcare": "Sanità",
+      "consumerCyclical": "Consumi ciclici",
+      "consumerDefensive": "Consumi difensivi",
+      "industrials": "Industria",
+      "energy": "Energia",
+      "utilities": "Servizi di pubblica utilità",
+      "realEstate": "Immobiliare",
+      "basicMaterials": "Materiali di base",
+      "communicationServices": "Servizi di comunicazione",
+      "other": "Altri"
+    },
     "noData": "Nessuna posizione in investimenti con dati di settore trovata. Aggiungi titoli con classificazione settoriale per vedere la ripartizione.",
     "totalPortfolio": "Portafoglio totale",
     "directExposure": "Esposizione diretta",

--- a/frontend/src/i18n/messages/ja/reports.json
+++ b/frontend/src/i18n/messages/ja/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "典型値/月"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "テクノロジー",
+      "financialServices": "金融サービス",
+      "healthcare": "ヘルスケア",
+      "consumerCyclical": "一般消費財",
+      "consumerDefensive": "生活必需品",
+      "industrials": "資本財",
+      "energy": "エネルギー",
+      "utilities": "公益事業",
+      "realEstate": "不動産",
+      "basicMaterials": "素材",
+      "communicationServices": "通信サービス",
+      "other": "その他"
+    },
     "noData": "セクターデータのある投資保有銘柄が見つかりません。内訳を確認するにはセクター分類のある有価証券を追加してください。",
     "totalPortfolio": "ポートフォリオ合計",
     "directExposure": "直接エクスポージャー",

--- a/frontend/src/i18n/messages/ko/reports.json
+++ b/frontend/src/i18n/messages/ko/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "일반/월"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "기술",
+      "financialServices": "금융 서비스",
+      "healthcare": "헬스케어",
+      "consumerCyclical": "경기소비재",
+      "consumerDefensive": "필수소비재",
+      "industrials": "산업재",
+      "energy": "에너지",
+      "utilities": "유틸리티",
+      "realEstate": "부동산",
+      "basicMaterials": "소재",
+      "communicationServices": "커뮤니케이션 서비스",
+      "other": "기타"
+    },
     "noData": "섹터 데이터가 있는 투자 보유 항목을 찾을 수 없습니다. 섹터 분류가 있는 유가증권을 추가하여 분류를 확인하세요.",
     "totalPortfolio": "총 포트폴리오",
     "directExposure": "직접 노출",

--- a/frontend/src/i18n/messages/nl/reports.json
+++ b/frontend/src/i18n/messages/nl/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "Typisch/mnd"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "Technologie",
+      "financialServices": "Financiële diensten",
+      "healthcare": "Gezondheidszorg",
+      "consumerCyclical": "Cyclische consumptiegoederen",
+      "consumerDefensive": "Defensieve consumptiegoederen",
+      "industrials": "Industrie",
+      "energy": "Energie",
+      "utilities": "Nutsbedrijven",
+      "realEstate": "Vastgoed",
+      "basicMaterials": "Basismaterialen",
+      "communicationServices": "Communicatiediensten",
+      "other": "Overig"
+    },
     "noData": "Geen beleggingsposities met sectorgegevens gevonden. Voeg waardepapieren met sectorclassificatie toe om de uitsplitsing te zien.",
     "totalPortfolio": "Totale portefeuille",
     "directExposure": "Directe blootstelling",

--- a/frontend/src/i18n/messages/pl/reports.json
+++ b/frontend/src/i18n/messages/pl/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "Typowo/mies."
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "Technologia",
+      "financialServices": "Usługi finansowe",
+      "healthcare": "Ochrona zdrowia",
+      "consumerCyclical": "Dobra konsumpcyjne cykliczne",
+      "consumerDefensive": "Dobra konsumpcyjne podstawowe",
+      "industrials": "Przemysł",
+      "energy": "Energia",
+      "utilities": "Usługi komunalne",
+      "realEstate": "Nieruchomości",
+      "basicMaterials": "Surowce",
+      "communicationServices": "Usługi komunikacyjne",
+      "other": "Pozostałe"
+    },
     "noData": "Nie znaleziono pozycji inwestycyjnych z danymi sektorowymi. Dodaj papiery wartościowe z klasyfikacją sektorową, aby zobaczyć rozbicie.",
     "totalPortfolio": "Cały portfel",
     "directExposure": "Ekspozycja bezpośrednia",

--- a/frontend/src/i18n/messages/pt-BR/reports.json
+++ b/frontend/src/i18n/messages/pt-BR/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "Típico/Mês"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "Tecnologia",
+      "financialServices": "Serviços financeiros",
+      "healthcare": "Saúde",
+      "consumerCyclical": "Consumo cíclico",
+      "consumerDefensive": "Consumo defensivo",
+      "industrials": "Industriais",
+      "energy": "Energia",
+      "utilities": "Serviços públicos",
+      "realEstate": "Imobiliário",
+      "basicMaterials": "Materiais básicos",
+      "communicationServices": "Serviços de comunicação",
+      "other": "Outros"
+    },
     "noData": "Nenhuma posição de investimento com dados setoriais encontrada. Adicione títulos com classificação setorial para ver a análise.",
     "totalPortfolio": "Total do Portfólio",
     "directExposure": "Exposição Direta",

--- a/frontend/src/i18n/messages/pt/reports.json
+++ b/frontend/src/i18n/messages/pt/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "Típico/Mês"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "Tecnologia",
+      "financialServices": "Serviços financeiros",
+      "healthcare": "Saúde",
+      "consumerCyclical": "Consumo cíclico",
+      "consumerDefensive": "Consumo defensivo",
+      "industrials": "Industriais",
+      "energy": "Energia",
+      "utilities": "Serviços públicos",
+      "realEstate": "Imobiliário",
+      "basicMaterials": "Materiais básicos",
+      "communicationServices": "Serviços de comunicação",
+      "other": "Outros"
+    },
     "noData": "Nenhuma posição de investimento com dados setoriais encontrada. Adicione títulos com classificação setorial para ver a análise.",
     "totalPortfolio": "Total do Portefólio",
     "directExposure": "Exposição Direta",

--- a/frontend/src/i18n/messages/ru/reports.json
+++ b/frontend/src/i18n/messages/ru/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "Типично/мес."
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "Технологии",
+      "financialServices": "Финансовые услуги",
+      "healthcare": "Здравоохранение",
+      "consumerCyclical": "Циклические потребительские товары",
+      "consumerDefensive": "Защитные потребительские товары",
+      "industrials": "Промышленность",
+      "energy": "Энергетика",
+      "utilities": "Коммунальные услуги",
+      "realEstate": "Недвижимость",
+      "basicMaterials": "Сырьё",
+      "communicationServices": "Коммуникационные услуги",
+      "other": "Прочее"
+    },
     "noData": "Инвестиционные активы с данными об отраслях не найдены. Добавьте ценные бумаги с классификацией отраслей для просмотра разбивки.",
     "totalPortfolio": "Всего портфель",
     "directExposure": "Прямая экспозиция",

--- a/frontend/src/i18n/messages/tr/reports.json
+++ b/frontend/src/i18n/messages/tr/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "Tipik/Ay"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "Teknoloji",
+      "financialServices": "Finansal hizmetler",
+      "healthcare": "Sağlık",
+      "consumerCyclical": "Çevrimsel tüketim",
+      "consumerDefensive": "Defansif tüketim",
+      "industrials": "Sanayi",
+      "energy": "Enerji",
+      "utilities": "Kamu hizmetleri",
+      "realEstate": "Gayrimenkul",
+      "basicMaterials": "Temel malzemeler",
+      "communicationServices": "İletişim hizmetleri",
+      "other": "Diğer"
+    },
     "noData": "Sektör verisine sahip yatırım varlığı bulunamadı. Dökümü görmek için sektör sınıflandırmasına sahip menkul kıymet ekleyin.",
     "totalPortfolio": "Toplam Portföy",
     "directExposure": "Doğrudan Risk",

--- a/frontend/src/i18n/messages/uk/reports.json
+++ b/frontend/src/i18n/messages/uk/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "Типово/міс"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "Технології",
+      "financialServices": "Фінансові послуги",
+      "healthcare": "Охорона здоров'я",
+      "consumerCyclical": "Циклічні споживчі товари",
+      "consumerDefensive": "Захисні споживчі товари",
+      "industrials": "Промисловість",
+      "energy": "Енергетика",
+      "utilities": "Комунальні послуги",
+      "realEstate": "Нерухомість",
+      "basicMaterials": "Сировина",
+      "communicationServices": "Комунікаційні послуги",
+      "other": "Інше"
+    },
     "noData": "Інвестиційних позицій із галузевими даними не знайдено. Додайте цінні папери з галузевою класифікацією, щоб побачити розбивку.",
     "totalPortfolio": "Усього портфеля",
     "directExposure": "Пряма експозиція",

--- a/frontend/src/i18n/messages/vi/reports.json
+++ b/frontend/src/i18n/messages/vi/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "Điển hình/Tháng"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "Công nghệ",
+      "financialServices": "Dịch vụ tài chính",
+      "healthcare": "Chăm sóc sức khỏe",
+      "consumerCyclical": "Tiêu dùng không thiết yếu",
+      "consumerDefensive": "Tiêu dùng thiết yếu",
+      "industrials": "Công nghiệp",
+      "energy": "Năng lượng",
+      "utilities": "Tiện ích",
+      "realEstate": "Bất động sản",
+      "basicMaterials": "Vật liệu cơ bản",
+      "communicationServices": "Dịch vụ truyền thông",
+      "other": "Khác"
+    },
     "noData": "Không tìm thấy vị thế đầu tư có dữ liệu ngành. Thêm chứng khoán có phân loại ngành để xem phân tích.",
     "totalPortfolio": "Tổng danh mục",
     "directExposure": "Đầu tư trực tiếp",

--- a/frontend/src/i18n/messages/xx/reports.json
+++ b/frontend/src/i18n/messages/xx/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "[XX-Typical/Mo-XX]"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "[XX-Technology-XX]",
+      "financialServices": "[XX-Financial Services-XX]",
+      "healthcare": "[XX-Healthcare-XX]",
+      "consumerCyclical": "[XX-Consumer Cyclical-XX]",
+      "consumerDefensive": "[XX-Consumer Defensive-XX]",
+      "industrials": "[XX-Industrials-XX]",
+      "energy": "[XX-Energy-XX]",
+      "utilities": "[XX-Utilities-XX]",
+      "realEstate": "[XX-Real Estate-XX]",
+      "basicMaterials": "[XX-Basic Materials-XX]",
+      "communicationServices": "[XX-Communication Services-XX]",
+      "other": "[XX-Other-XX]"
+    },
     "noData": "[XX-No investment holdings with sector data found. Add securities with sector classification to see the breakdown.-XX]",
     "totalPortfolio": "[XX-Total Portfolio-XX]",
     "directExposure": "[XX-Direct Exposure-XX]",

--- a/frontend/src/i18n/messages/zh-CN/reports.json
+++ b/frontend/src/i18n/messages/zh-CN/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "典型/月"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "科技",
+      "financialServices": "金融服务",
+      "healthcare": "医疗保健",
+      "consumerCyclical": "周期性消费",
+      "consumerDefensive": "防御性消费",
+      "industrials": "工业",
+      "energy": "能源",
+      "utilities": "公用事业",
+      "realEstate": "房地产",
+      "basicMaterials": "基础材料",
+      "communicationServices": "通信服务",
+      "other": "其他"
+    },
     "noData": "未找到有行业数据的投资持仓。添加有行业分类的证券以查看明细。",
     "totalPortfolio": "投资组合总计",
     "directExposure": "直接敞口",

--- a/frontend/src/i18n/messages/zh-TW/reports.json
+++ b/frontend/src/i18n/messages/zh-TW/reports.json
@@ -1238,6 +1238,20 @@
     "pdfColTypical": "每月典型金額"
   },
   "sectorWeightings": {
+    "sectorNames": {
+      "technology": "科技",
+      "financialServices": "金融服務",
+      "healthcare": "醫療保健",
+      "consumerCyclical": "非必需消費",
+      "consumerDefensive": "必需消費",
+      "industrials": "工業",
+      "energy": "能源",
+      "utilities": "公用事業",
+      "realEstate": "房地產",
+      "basicMaterials": "基礎材料",
+      "communicationServices": "通訊服務",
+      "other": "其他"
+    },
     "noData": "找不到有類股資料的投資持倉。請新增有類股分類的證券以查看明細。",
     "totalPortfolio": "投資組合總值",
     "directExposure": "直接曝險",


### PR DESCRIPTION
## Linked discussion / issue

Closes #810

## Summary

Sector names in the Sector Weightings report came straight from the provider (Yahoo Finance) in English and were rendered untranslated, so non-English users saw "Technology", "Financial Services", etc. regardless of locale.

- Adds a `sectorNames` catalog (the ~11 fixed Yahoo/GICS sectors + "Other") and a `sectorNameKey` helper that maps a provider sector string to its i18n key **case-insensitively**. Unknown values fall back to the raw string so a new provider sector still renders rather than a missing-key placeholder.
- Applies the localized label in the chart (axis + tooltip), the data table, the PDF export, and the **sector sort** (so sort order matches the displayed text).
- No backend change — the sector taxonomy stays stored in English; only the presentation is localized.

## Checklist

- [x] An approved discussion or issue exists and is linked above. (#810)
- [x] This PR addresses a **single concern** (localizing sector names).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (parity passes; pseudo-locale regenerated).
- [x] No shared/core areas were refactored without prior agreement — confined to the one report component and its catalog.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Built with Claude Code (Claude Opus 4.8). I reviewed the diff and tests and own the result.
