### PR TITLE
fix(ai-chat): render Unicode-bullet (•) lists as real lists, not one line

### DIFF
--- a/frontend/src/components/ai/AssistantMarkdown.test.tsx
+++ b/frontend/src/components/ai/AssistantMarkdown.test.tsx
@@ -42,6 +42,32 @@ describe('AssistantMarkdown', () => {
     expect(items[2].textContent).toBe('Bananas');
   });
 
+  it('renders a Unicode-bullet (•) list as a real list, not one paragraph', () => {
+    // LLMs often emit literal • bullets; without normalisation CommonMark
+    // collapses them into a single paragraph (the "all on one line" bug).
+    const { container } = render(
+      <AssistantMarkdown
+        content={'Rules:\n• Salary → Pay\n• Bonus → Reward\n• Overtime → Extra'}
+      />,
+    );
+    const ul = container.querySelector('ul');
+    expect(ul).not.toBeNull();
+    const items = container.querySelectorAll('li');
+    expect(items).toHaveLength(3);
+    expect(items[0].textContent).toContain('Salary');
+    expect(items[2].textContent).toContain('Overtime');
+    // The literal bullet glyph must not survive into the rendered text.
+    expect(container.textContent).not.toContain('•');
+  });
+
+  it('leaves a mid-sentence bullet glyph untouched', () => {
+    const { container } = render(
+      <AssistantMarkdown content="Use the • symbol carefully" />,
+    );
+    expect(container.querySelector('ul')).toBeNull();
+    expect(container.textContent).toContain('•');
+  });
+
   it('renders an ordered list', () => {
     const { container } = render(
       <AssistantMarkdown content={'1. First\n2. Second\n3. Third'} />,

--- a/frontend/src/components/ai/AssistantMarkdown.tsx
+++ b/frontend/src/components/ai/AssistantMarkdown.tsx
@@ -8,6 +8,20 @@ interface AssistantMarkdownProps {
   content: string;
 }
 
+/**
+ * Normalise Unicode bullet glyphs at the start of a line to a Markdown `-`.
+ * LLMs often format lists with literal bullets (•, ·, ‣, ▪, ◦) instead of
+ * Markdown markers; CommonMark does not treat those as list items, so the whole
+ * block collapses into one paragraph with the line breaks rendered as spaces
+ * (the reported "all on one line" bug). Rewriting the leading glyph to `-` lets
+ * react-markdown build a real list. Only a glyph followed by whitespace at the
+ * line start (after optional indent) is touched, so prose is unaffected; dashes
+ * are deliberately excluded as they are more often legitimate line-start text.
+ */
+function normalizeBulletGlyphs(content: string): string {
+  return content.replace(/^([ \t]*)[•·‣▪◦]\s+/gm, '$1- ');
+}
+
 export function AssistantMarkdown({ content }: AssistantMarkdownProps) {
   return (
     <ReactMarkdown
@@ -95,7 +109,7 @@ export function AssistantMarkdown({ content }: AssistantMarkdownProps) {
         ),
       }}
     >
-      {content}
+      {normalizeBulletGlyphs(content)}
     </ReactMarkdown>
   );
 }


### PR DESCRIPTION
## Linked discussion / issue

Closes #814

## Summary

When the assistant formats a list with literal Unicode bullet glyphs (•, ·, ‣, ▪, ◦) instead of Markdown `-`/`*`, the chat rendered the whole block as a single paragraph with the items run together on one line.

Cause: CommonMark (react-markdown) does not treat `•` as a list marker, so the lines became one paragraph and the single newlines collapsed to spaces.

Fix: in `AssistantMarkdown`, normalise a leading bullet glyph (after optional indent, followed by whitespace) to a Markdown `-` before rendering, so a real `<ul>`/`<li>` list is produced. Only line-start glyphs are touched, so prose is unaffected; dashes are deliberately excluded as they are more often legitimate line-start text. The renderer is shared, so this fixes both the relay and native chat.

## Checklist

- [x] An approved discussion or issue exists and is linked above. (#814)
- [x] This PR addresses a **single concern** (rendering Unicode-bullet lists).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale — **no new user-facing strings** (rendering-only change).
- [x] No shared/core areas were refactored without prior agreement — a small, self-contained preprocessing step in the chat Markdown renderer.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Built with Claude Code (Claude Opus 4.8). I reviewed the diff and tests and own the result.
