### PR TITLE
fix(tests): pin the clock in the date-dependent BalanceHistoryChart test

### DIFF
--- a/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
@@ -134,24 +134,33 @@ describe('BalanceHistoryChart', () => {
   });
 
   it('shows Ending balance when future transactions exist', () => {
-    render(
-      <BalanceHistoryChart
-        data={[
-          { date: '2026-01-01', balance: 1000 },
-          { date: '2026-03-19', balance: 800 },
-          { date: '2026-04-15', balance: 650 },
-          { date: '2026-05-01', balance: 500 },
-          { date: '2026-06-01', balance: 400 },
-          { date: '2026-07-01', balance: 300 },
-        ]}
-        isLoading={false}
-      />
-    );
+    // Lock "today" so the data points after it stay in the future forever;
+    // with a real clock this test started failing the day the last hardcoded
+    // date stopped being in the future.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-04-10T12:00:00Z'));
+    try {
+      render(
+        <BalanceHistoryChart
+          data={[
+            { date: '2026-01-01', balance: 1000 },
+            { date: '2026-03-19', balance: 800 },
+            { date: '2026-04-15', balance: 650 },
+            { date: '2026-05-01', balance: 500 },
+            { date: '2026-06-01', balance: 400 },
+            { date: '2026-07-01', balance: 300 },
+          ]}
+          isLoading={false}
+        />
+      );
 
-    expect(screen.getByText('Starting')).toBeInTheDocument();
-    expect(screen.getByText('Current')).toBeInTheDocument();
-    expect(screen.getByText('Ending')).toBeInTheDocument();
-    expect(screen.getByText('Min Balance')).toBeInTheDocument();
+      expect(screen.getByText('Starting')).toBeInTheDocument();
+      expect(screen.getByText('Current')).toBeInTheDocument();
+      expect(screen.getByText('Ending')).toBeInTheDocument();
+      expect(screen.getByText('Min Balance')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('does not show Ending balance when no future transactions', () => {


### PR DESCRIPTION
## Linked discussion / issue

Closes #816

## Summary

`BalanceHistoryChart > shows Ending balance when future transactions exist` hardcodes data points up to `2026-07-01` and relies on them being in the future relative to the real clock. Since 2026-07-02 they no longer are, so `computeBalanceSummary` reports `hasFutureData=false`, the **Ending** label is not rendered, and `Frontend Unit Tests` fail on every PR (first seen on #807, which does not touch charts).

Fix: pin the system time with `vi.useFakeTimers({ toFake: ['Date'] })` + `vi.setSystemTime('2026-04-10')` -- the exact pattern the neighbouring `shows Current as today balance and Ending as last future data point` test and `src/lib/balance-history.test.ts` already use -- so the post-pin data points stay in the future forever. Test-only change; no product code touched.

I swept the frontend test suite for other hardcoded not-yet-past dates asserted against the real clock and found no other occurrence of this pattern (remaining 2026+ dates are either clock-independent fixtures or already under `setSystemTime`).

## Checklist

- [x] An approved discussion or issue exists and is linked above. (#816)
- [x] This PR addresses a **single concern** (one date-dependent test).
- [x] New behavior has tests, and the existing suite passes -- this IS a test fix; the full frontend suite passes locally.
- [x] All user-facing strings are translated for **every** locale — **no user-facing strings** (test-only change).
- [x] No shared/core areas were refactored without prior agreement — one test file.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Built with Claude Code (Claude Fable 5). I reviewed the diff and own the result.