### PR TITLE
Only clear an account's institution when the user explicitly clears it

### DIFF
--- a/frontend/src/components/accounts/AccountForm.test.tsx
+++ b/frontend/src/components/accounts/AccountForm.test.tsx
@@ -6,6 +6,7 @@ import { Account } from '@/types/account';
 import { exchangeRatesApi } from '@/lib/exchange-rates';
 import { accountsApi } from '@/lib/accounts';
 import { categoriesApi } from '@/lib/categories';
+import { institutionsApi } from '@/lib/institutions';
 
 vi.mock('@/lib/accounts', () => ({
   accountsApi: {
@@ -585,6 +586,62 @@ describe('AccountForm', () => {
       expect(screen.getByText('Lender/Institution (required)')).toBeInTheDocument();
     });
     expect(screen.queryByText('Institution (optional)')).not.toBeInTheDocument();
+  });
+
+  it('keeps the existing institutionId on submit when the field is untouched (issue #806)', async () => {
+    vi.mocked(institutionsApi.getAll).mockResolvedValueOnce([
+      { id: 'inst-1', name: 'RBC', website: 'rbc.com' } as never,
+    ]);
+    const account = createExistingAccount({ institutionId: 'inst-1' });
+
+    render(
+      <AccountForm account={account} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('RBC')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Update Account/i }));
+    });
+
+    await waitFor(() => {
+      expect(mockOnSubmit).toHaveBeenCalled();
+    });
+    expect(mockOnSubmit.mock.calls[0][0].institutionId).toBe('inst-1');
+  });
+
+  it('submits an explicit null when the user clears the institution while editing', async () => {
+    vi.mocked(institutionsApi.getAll).mockResolvedValueOnce([
+      { id: 'inst-1', name: 'RBC', website: 'rbc.com' } as never,
+    ]);
+    const account = createExistingAccount({ institutionId: 'inst-1' });
+
+    render(
+      <AccountForm account={account} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('RBC')).toBeInTheDocument();
+    });
+
+    // Click the combobox's clear (X) button next to the institution input
+    const institutionInput = screen.getByDisplayValue('RBC');
+    const clearButton = institutionInput.parentElement!.querySelector('button');
+    expect(clearButton).not.toBeNull();
+    await act(async () => {
+      fireEvent.mouseDown(clearButton!);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Update Account/i }));
+    });
+
+    await waitFor(() => {
+      expect(mockOnSubmit).toHaveBeenCalled();
+    });
+    expect(mockOnSubmit.mock.calls[0][0].institutionId).toBeNull();
   });
 
   it('blocks new MORTGAGE submit with localized required errors and no raw Zod enum message', async () => {

--- a/frontend/src/components/accounts/AccountForm.tsx
+++ b/frontend/src/components/accounts/AccountForm.tsx
@@ -83,7 +83,7 @@ const buildAccountSchema = (t: (key: string) => string, isEditing: boolean) => z
   interestRate: optionalNumberWithRange(0, 100),
   description: z.string().optional(),
   accountNumber: z.string().optional(),
-  institutionId: z.string().optional(),
+  institutionId: z.string().nullable().optional(),
   isFavourite: z.boolean().optional(),
   excludeFromNetWorth: z.boolean().optional(),
   createInvestmentPair: z.boolean().optional(),
@@ -311,7 +311,15 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
 
   const handleInstitutionChange = (value: string) => {
     setSelectedInstitutionId(value);
-    setValue('institutionId', value || undefined, { shouldDirty: true });
+    // The combobox only reports changes from real user interaction, so an
+    // empty value here means the user explicitly cleared the field. When
+    // editing, encode that as null -- the explicit "clear the stored
+    // institution" signal -- so the submit layer never has to infer a clear
+    // from a merely absent value (issue #806). On create there is nothing to
+    // clear, so an empty selection stays undefined and is stripped on submit.
+    setValue('institutionId', value || (account ? null : undefined), {
+      shouldDirty: true,
+    });
   };
 
   const handleInstitutionCreate = (name: string) => {

--- a/frontend/src/components/accounts/AccountFormModal.test.tsx
+++ b/frontend/src/components/accounts/AccountFormModal.test.tsx
@@ -151,7 +151,7 @@ describe('AccountFormModal', () => {
     );
   });
 
-  it('clears a previously set institution by sending null when removed on edit', async () => {
+  it('clears a previously set institution when the form reports an explicit null', async () => {
     mockUpdate.mockResolvedValue({});
     render(
       <AccountFormModal
@@ -165,13 +165,34 @@ describe('AccountFormModal', () => {
 
     await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
     await act(async () => {
-      await capturedOnSubmit!({ name: 'Renamed', accountType: 'CHEQUING', institutionId: undefined });
+      await capturedOnSubmit!({ name: 'Renamed', accountType: 'CHEQUING', institutionId: null });
     });
 
     expect(mockUpdate).toHaveBeenCalledWith(
       'a-1',
       expect.objectContaining({ institutionId: null }),
     );
+  });
+
+  it('keeps the stored institution when institutionId is merely absent on edit (issue #806)', async () => {
+    mockUpdate.mockResolvedValue({});
+    render(
+      <AccountFormModal
+        formModal={buildFormModal({
+          editingItem: { id: 'a-1', accountType: 'INVESTMENT', institutionId: 'inst-1' } as Account,
+          isEditing: true,
+        })}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(capturedOnSubmit).not.toBeNull());
+    await act(async () => {
+      await capturedOnSubmit!({ name: 'Renamed', accountType: 'INVESTMENT', institutionId: undefined });
+    });
+
+    const [, payload] = mockUpdate.mock.calls[0];
+    expect(payload).not.toHaveProperty('institutionId');
   });
 
   it('omits an empty description when the account never had one', async () => {

--- a/frontend/src/components/accounts/AccountFormModal.tsx
+++ b/frontend/src/components/accounts/AccountFormModal.tsx
@@ -90,13 +90,15 @@ export function AccountFormModal({ formModal, onSaved }: AccountFormModalProps) 
       // When editing, a cleared optional field must reach the backend as null
       // so the stored value is overwritten. Left as '' or undefined it would be
       // stripped by the cleanup below and the field would silently keep its old
-      // value (e.g. removing a description or institution would not save).
+      // value (e.g. removing a description would not save). Only always-rendered
+      // plain text inputs belong here, where an empty submitted value can only
+      // mean the user emptied the field. institutionId must NOT be inferred
+      // from absence: the form submits an explicit null when the user clears
+      // the institution combobox, and force-nulling a merely absent value
+      // wiped the institution from investment cash accounts on unrelated
+      // edits (issue #806).
       if (editingItem) {
-        const clearableFields = [
-          'description',
-          'accountNumber',
-          'institutionId',
-        ] as const;
+        const clearableFields = ['description', 'accountNumber'] as const;
         for (const key of clearableFields) {
           if (
             (cleanedData[key] === '' || cleanedData[key] === undefined) &&


### PR DESCRIPTION
Editing an investment cash account dropped its institution icon because
AccountFormModal force-set institutionId to null whenever the submitted
value was empty or absent while the account had one stored. An absent
value does not mean the user cleared the field, so unrelated edits could
silently wipe the stored institution.

The form now encodes user intent itself: when the institution combobox
reports a user-driven clear while editing, the form value becomes an
explicit null, which flows through to the PATCH payload. A merely absent
or undefined institutionId is stripped from the payload so the backend
keeps the stored value. Description and account number keep the
inferred-clear behaviour since their plain text inputs are always
rendered and an empty value can only mean the user emptied them.

Fixes #806

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E2Ym3qjTCUm4bKBfAy76ZB