### PR TITLE
Add PDF export for security comparison chart and account type/text filters

### DIFF
--- a/frontend/src/components/accounts/AccountList.test.tsx
+++ b/frontend/src/components/accounts/AccountList.test.tsx
@@ -452,6 +452,126 @@ describe('AccountList', () => {
     expect(screen.queryByDisplayValue('Net Worth: All')).not.toBeInTheDocument();
   });
 
+  it('filters accounts by text search on name', () => {
+    const accounts = [
+      createAccount({ id: 'a1', name: 'My Chequing', accountType: 'CHEQUING' }),
+      createAccount({ id: 'a2', name: 'My Savings', accountType: 'SAVINGS' }),
+    ];
+
+    render(
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
+    );
+
+    fireEvent.change(screen.getByLabelText('Search accounts by name'), {
+      target: { value: 'chequing' },
+    });
+
+    expect(screen.getByText('1 of 2 accounts')).toBeInTheDocument();
+    expect(screen.getByText('My Chequing')).toBeInTheDocument();
+    expect(screen.queryByText('My Savings')).not.toBeInTheDocument();
+  });
+
+  it('clears the text search via the clear button', () => {
+    const accounts = [
+      createAccount({ id: 'a1', name: 'My Chequing', accountType: 'CHEQUING' }),
+      createAccount({ id: 'a2', name: 'My Savings', accountType: 'SAVINGS' }),
+    ];
+
+    render(
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
+    );
+
+    fireEvent.change(screen.getByLabelText('Search accounts by name'), {
+      target: { value: 'chequing' },
+    });
+    expect(screen.getByText('1 of 2 accounts')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Clear search'));
+    expect(screen.getByText('2 of 2 accounts')).toBeInTheDocument();
+  });
+
+  it('filters accounts by one or more account types', () => {
+    const accounts = [
+      createAccount({ id: 'a1', name: 'My Chequing', accountType: 'CHEQUING' }),
+      createAccount({ id: 'a2', name: 'My Savings', accountType: 'SAVINGS' }),
+    ];
+
+    render(
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
+    );
+
+    // Open the account-type multi-select. Options render as checkboxes ordered
+    // by ACCOUNT_TYPE_ORDER, so index 1 is SAVINGS (after CHEQUING).
+    fireEvent.click(screen.getByRole('button', { name: 'Filter by account type' }));
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[1]);
+
+    expect(screen.getByText('1 of 2 accounts')).toBeInTheDocument();
+    expect(screen.getByText('My Savings')).toBeInTheDocument();
+    expect(screen.queryByText('My Chequing')).not.toBeInTheDocument();
+  });
+
+  it('persists type and search filters to localStorage', () => {
+    const accounts = [
+      createAccount({ id: 'a1', name: 'My Chequing', accountType: 'CHEQUING' }),
+      createAccount({ id: 'a2', name: 'My Savings', accountType: 'SAVINGS' }),
+    ];
+
+    render(
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filter by account type' }));
+    fireEvent.click(screen.getAllByRole('checkbox')[1]);
+    fireEvent.change(screen.getByLabelText('Search accounts by name'), {
+      target: { value: 'sav' },
+    });
+
+    expect(localStorage.getItem('accounts.filter.types')).toBe(JSON.stringify(['SAVINGS']));
+    expect(localStorage.getItem('accounts.filter.search')).toBe(JSON.stringify('sav'));
+  });
+
+  it('initializes type and search filters from localStorage', () => {
+    localStorage.setItem('accounts.filter.types', JSON.stringify(['SAVINGS']));
+    localStorage.setItem('accounts.filter.search', JSON.stringify(''));
+    const accounts = [
+      createAccount({ id: 'a1', name: 'My Chequing', accountType: 'CHEQUING' }),
+      createAccount({ id: 'a2', name: 'My Savings', accountType: 'SAVINGS' }),
+    ];
+
+    render(
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
+    );
+
+    expect(screen.getByText('1 of 2 accounts')).toBeInTheDocument();
+    expect(screen.getByText('My Savings')).toBeInTheDocument();
+    expect(screen.queryByText('My Chequing')).not.toBeInTheDocument();
+  });
+
+  it('Clear Filters resets the type and search filters', () => {
+    const accounts = [
+      createAccount({ id: 'a1', name: 'My Chequing', accountType: 'CHEQUING' }),
+      createAccount({ id: 'a2', name: 'My Savings', accountType: 'SAVINGS' }),
+    ];
+
+    render(
+      <AccountList accounts={accounts} onEdit={mockOnEdit} defaultCurrency="CAD" convertToDefault={exchangeMocks.convertToDefault} onRefresh={mockOnRefresh} />
+    );
+
+    // A search matching nothing empties the list and surfaces Clear Filters.
+    fireEvent.change(screen.getByLabelText('Search accounts by name'), {
+      target: { value: 'no-such-account' },
+    });
+    expect(screen.getByText('No accounts match your filters.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Clear Filters'));
+
+    expect(screen.getByText('2 of 2 accounts')).toBeInTheDocument();
+    // The persistence effect re-writes the reset (empty) value after clearing.
+    expect(localStorage.getItem('accounts.filter.search')).toBe(JSON.stringify(''));
+    expect(localStorage.getItem('accounts.filter.types')).toBe(JSON.stringify([]));
+  });
+
   it('shows "No accounts match your filters" and Clear Filters button when filters exclude all accounts', () => {
     const accounts = [
       createAccount({ id: 'a1', name: 'Chequing Only', accountType: 'CHEQUING', isClosed: false }),

--- a/frontend/src/components/accounts/AccountList.tsx
+++ b/frontend/src/components/accounts/AccountList.tsx
@@ -16,6 +16,7 @@ import { useLongPress } from '@/hooks/useLongPress';
 import { RowActionSheet } from '@/components/ui/row-actions/RowActionSheet';
 import { useTableDensity, nextDensity, type DensityLevel } from '@/hooks/useTableDensity';
 import { SortIcon } from '@/components/ui/SortIcon';
+import { MultiSelect, MultiSelectOption } from '@/components/ui/MultiSelect';
 import { formatAccountType, countLogicalAccounts } from '@/lib/account-utils';
 
 type SortField = 'name' | 'type' | 'balance' | 'status';
@@ -26,6 +27,8 @@ const STORAGE_KEYS = {
   showFilters: 'accounts.filter.showFilters',
   status: 'accounts.filter.status',
   netWorth: 'accounts.filter.netWorth',
+  types: 'accounts.filter.types',
+  search: 'accounts.filter.search',
   sortField: 'accounts.filter.sortField',
   sortDirection: 'accounts.filter.sortDirection',
   density: 'accounts.filter.density',
@@ -131,6 +134,15 @@ export function AccountList({ accounts, institutions, brokerageMarketValues, def
   const [filterNetWorth, setFilterNetWorth] = useState<'included' | 'excluded' | ''>(() =>
     getStoredValue<'included' | 'excluded' | ''>(STORAGE_KEYS.netWorth, '')
   );
+  // Account-type filter: an empty list means "all types". Persisted so the
+  // chosen types survive navigating away and back to the page.
+  const [filterTypes, setFilterTypes] = useState<AccountType[]>(() =>
+    getStoredValue<AccountType[]>(STORAGE_KEYS.types, [])
+  );
+  // Free-text filter on account name.
+  const [filterSearch, setFilterSearch] = useState<string>(() =>
+    getStoredValue<string>(STORAGE_KEYS.search, '')
+  );
 
   // Density state - initialize from localStorage
   const [density, setDensity] = useState<DensityLevel>(() =>
@@ -167,6 +179,14 @@ export function AccountList({ accounts, institutions, brokerageMarketValues, def
   useEffect(() => {
     localStorage.setItem(STORAGE_KEYS.netWorth, JSON.stringify(filterNetWorth));
   }, [filterNetWorth]);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEYS.types, JSON.stringify(filterTypes));
+  }, [filterTypes]);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEYS.search, JSON.stringify(filterSearch));
+  }, [filterSearch]);
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEYS.sortField, JSON.stringify(sortField));
@@ -238,6 +258,14 @@ export function AccountList({ accounts, institutions, brokerageMarketValues, def
         filterNetWorth === 'excluded' ? a.excludeFromNetWorth : !a.excludeFromNetWorth
       );
     }
+    if (filterTypes.length > 0) {
+      const typeSet = new Set(filterTypes);
+      result = result.filter((a) => typeSet.has(a.accountType));
+    }
+    const search = filterSearch.trim().toLowerCase();
+    if (search) {
+      result = result.filter((a) => a.name.toLowerCase().includes(search));
+    }
 
     // Apply sorting
     result.sort((a, b) => {
@@ -261,7 +289,18 @@ export function AccountList({ accounts, institutions, brokerageMarketValues, def
     });
 
     return result;
-  }, [accounts, favOverrides, filterStatus, filterNetWorth, sortField, sortDirection]);
+  }, [accounts, favOverrides, filterStatus, filterNetWorth, filterTypes, filterSearch, sortField, sortDirection]);
+
+  // Account-type options for the type filter, limited to the types actually
+  // present and ordered to match the grouped list below (unknown types last).
+  const typeOptions = useMemo<MultiSelectOption[]>(() => {
+    const present = new Set(accounts.map((a) => a.accountType));
+    const ordered = ACCOUNT_TYPE_ORDER.filter((type) => present.has(type));
+    for (const type of present) {
+      if (!ordered.includes(type)) ordered.push(type);
+    }
+    return ordered.map((type) => ({ value: type, label: formatAccountType(type, tc) }));
+  }, [accounts, tc]);
 
   // Build a map of account IDs to names for showing linked account pairs
   const accountNameMap = useMemo(() => {
@@ -407,8 +446,12 @@ export function AccountList({ accounts, institutions, brokerageMarketValues, def
   const clearFilters = () => {
     setFilterStatus('');
     setFilterNetWorth('');
+    setFilterTypes([]);
+    setFilterSearch('');
     localStorage.removeItem(STORAGE_KEYS.status);
     localStorage.removeItem(STORAGE_KEYS.netWorth);
+    localStorage.removeItem(STORAGE_KEYS.types);
+    localStorage.removeItem(STORAGE_KEYS.search);
   };
 
 
@@ -569,6 +612,41 @@ export function AccountList({ accounts, institutions, brokerageMarketValues, def
               >
                 {t('list.filter.closed')}
               </button>
+              </div>
+
+              {/* Account-type filter (multi-select) */}
+              <div className="w-full sm:w-52">
+                <MultiSelect
+                  ariaLabel={t('list.filter.typeAriaLabel')}
+                  options={typeOptions}
+                  value={filterTypes}
+                  onChange={(vals) => setFilterTypes(vals as AccountType[])}
+                  placeholder={t('list.filter.typePlaceholder')}
+                />
+              </div>
+
+              {/* Free-text name filter */}
+              <div className="relative w-full sm:w-52">
+                <input
+                  type="text"
+                  value={filterSearch}
+                  onChange={(e) => setFilterSearch(e.target.value)}
+                  placeholder={t('list.filter.searchPlaceholder')}
+                  aria-label={t('list.filter.searchAriaLabel')}
+                  className="w-full text-sm font-sans border border-gray-300 dark:border-gray-600 rounded-md pl-3 pr-8 py-1.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 dark:placeholder-gray-400"
+                />
+                {filterSearch && (
+                  <button
+                    type="button"
+                    onClick={() => setFilterSearch('')}
+                    aria-label={t('list.filter.searchClear')}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                  >
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                )}
               </div>
 
               {/* Net Worth filter -- only shown when at least one account is excluded */}

--- a/frontend/src/components/reports/SecurityComparisonChart.test.tsx
+++ b/frontend/src/components/reports/SecurityComparisonChart.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, act } from '@/test/render';
-import { SecurityComparisonChart, buildPerformanceData } from './SecurityComparisonChart';
+import {
+  SecurityComparisonChart,
+  buildPerformanceData,
+  type SecurityComparisonChartHandle,
+} from './SecurityComparisonChart';
 import type { Security, SecurityPrice } from '@/types/investment';
 
 vi.mock('recharts', () => ({
@@ -21,6 +25,11 @@ vi.mock('@/lib/investments', () => ({
   investmentsApi: {
     getSecurityPrices: (...args: unknown[]) => mockGetSecurityPrices(...args),
   },
+}));
+
+const mockExportToPdf = vi.fn();
+vi.mock('@/lib/pdf-export', () => ({
+  exportToPdf: (...args: unknown[]) => mockExportToPdf(...args),
 }));
 
 vi.mock('@/hooks/useChartDateFormat', () => ({
@@ -109,5 +118,42 @@ describe('SecurityComparisonChart', () => {
         screen.getByText(/No price history is available/i),
       ).toBeInTheDocument(),
     );
+  });
+
+  it('exports the comparison chart to PDF through the export handle', async () => {
+    mockExportToPdf.mockResolvedValue(undefined);
+    mockGetSecurityPrices.mockImplementation((id: string) =>
+      Promise.resolve(
+        id === 's1'
+          ? [price('2024-01-01', 10), price('2024-02-01', 12)]
+          : [price('2024-01-01', 100), price('2024-02-01', 90)],
+      ),
+    );
+    const ref: { current: SecurityComparisonChartHandle | null } = { current: null };
+    await act(async () => {
+      render(
+        <SecurityComparisonChart
+          securities={[sec('s1', 'AAA'), sec('s2', 'BBB')]}
+          exportRef={ref}
+        />,
+      );
+    });
+    await waitFor(() => expect(screen.getAllByTestId('line')).toHaveLength(2));
+
+    await act(async () => {
+      await ref.current!.exportPdf();
+    });
+
+    expect(mockExportToPdf).toHaveBeenCalledTimes(1);
+    const call = mockExportToPdf.mock.calls[0][0];
+    expect(call.title).toBe('Performance Comparison');
+    expect(call.subtitle).toBe('AAA, BBB');
+    expect(call.filename).toBe('security-performance-comparison');
+    expect(call.chartContainer).toBeInstanceOf(HTMLElement);
+    // One legend entry per plotted security, resolved to concrete colours.
+    expect(call.chartLegend).toEqual([
+      { color: expect.stringMatching(/^#/), label: 'AAA - AAA Inc' },
+      { color: expect.stringMatching(/^#/), label: 'BBB - BBB Inc' },
+    ]);
   });
 });

--- a/frontend/src/components/reports/SecurityComparisonChart.tsx
+++ b/frontend/src/components/reports/SecurityComparisonChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useImperativeHandle, useMemo, useRef, type Ref } from 'react';
 import { useTranslations } from 'next-intl';
 import {
   LineChart,
@@ -21,6 +21,7 @@ import { parseLocalDate, type ChartDatePattern } from '@/lib/utils';
 import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { buildTimeAxisTicks } from '@/lib/chart-time-axis';
+import { resolvePdfColor } from '@/components/reports/resolve-pdf-color';
 
 // Match the single-security price chart's window (~3 years of history).
 const PRICE_LIMIT = 1095;
@@ -76,11 +77,23 @@ export function buildPerformanceData(
   return { rows, series };
 }
 
+/** Imperative surface for the parent report's Export dropdown. */
+export interface SecurityComparisonChartHandle {
+  exportPdf: () => Promise<void>;
+}
+
 interface SecurityComparisonChartProps {
   /** The securities the user chose to compare (from the multi-select). */
   securities: Security[];
   /** Bumped by the RefreshPricesButton so a manual price refresh re-fetches. */
   reloadKey?: number;
+  /**
+   * Exposes `exportPdf` so the parent report's Export dropdown (which lives in
+   * the shared toolbar above this component) can export the comparison chart.
+   * The handle lives here because this component owns the fetched series and
+   * the chart DOM the capture needs.
+   */
+  exportRef?: Ref<SecurityComparisonChartHandle>;
 }
 
 /**
@@ -93,10 +106,12 @@ interface SecurityComparisonChartProps {
 export function SecurityComparisonChart({
   securities,
   reloadKey = 0,
+  exportRef,
 }: SecurityComparisonChartProps) {
   const t = useTranslations('reports');
   const formatChartDate = useChartDateFormat();
   const { formatSignedPercent } = useNumberFormat();
+  const chartRef = useRef<HTMLDivElement>(null);
 
   const { data, isLoading, error } = useReportData(async () => {
     const results = await Promise.all(
@@ -141,6 +156,30 @@ export function SecurityComparisonChart({
     };
   }, [rows]);
 
+  // Mirrors the single-security chart export: the on-screen card's title,
+  // subtitle, and chart, plus a drawn legend (the Recharts legend is HTML, not
+  // part of the captured SVG, so the PDF redraws it from the series colours).
+  useImperativeHandle(
+    exportRef,
+    () => ({
+      exportPdf: async () => {
+        const { exportToPdf } = await import('@/lib/pdf-export');
+        await exportToPdf({
+          title: t('securityPerformance.comparisonTitle'),
+          subtitle: series.map((s) => s.symbol).join(', ') || undefined,
+          description: t('securityPerformance.comparisonSubtitle'),
+          chartContainer: chartRef.current,
+          chartLegend: series.map((s) => ({
+            color: resolvePdfColor(s.color),
+            label: `${s.symbol} - ${s.name}`,
+          })),
+          filename: 'security-performance-comparison',
+        });
+      },
+    }),
+    [series, t],
+  );
+
   if (error) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-8 text-center">
@@ -152,7 +191,7 @@ export function SecurityComparisonChart({
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 px-2 py-4 sm:p-6">
+    <div ref={chartRef} className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 px-2 py-4 sm:p-6">
       <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">
         {t('securityPerformance.comparisonTitle')}
       </h3>

--- a/frontend/src/components/reports/SecurityPerformanceReport.test.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.test.tsx
@@ -1038,9 +1038,44 @@ describe('SecurityPerformanceReport', () => {
     await waitFor(() => {
       expect(screen.getByText('Performance Comparison')).toBeInTheDocument();
     });
-    // Single-security controls are hidden in comparison mode.
+    // Per-security view tabs are hidden in comparison mode, but the export
+    // control stays available for the comparison chart.
     expect(screen.queryByText('Price Chart')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('export-pdf')).not.toBeInTheDocument();
+    expect(screen.getByTestId('export-pdf')).toBeInTheDocument();
     expect(screen.getByTestId('line-chart')).toBeInTheDocument();
+  });
+
+  it('exports the comparison chart pdf when 2+ securities are selected', async () => {
+    const { exportToPdf } = await import('@/lib/pdf-export');
+    (exportToPdf as any).mockClear();
+    mockGetSecurities.mockResolvedValue(mockSecurities);
+    mockGetPortfolioSummary.mockResolvedValue({ holdings: mockHoldings });
+    mockGetSecurityPrices.mockResolvedValue([
+      { id: 1, priceDate: '2024-01-01', closePrice: 100, createdAt: '' },
+      { id: 2, priceDate: '2024-02-01', closePrice: 110, createdAt: '' },
+    ]);
+    mockGetTransactions.mockResolvedValue({ data: [], pagination: { hasMore: false } });
+
+    render(<SecurityPerformanceReport />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: SELECT_PLACEHOLDER })).toBeInTheDocument();
+    });
+
+    await selectSecurity('AAPL - Apple Inc.');
+    await selectSecurity('VTI - Vanguard Total Stock');
+
+    await waitFor(() => {
+      expect(screen.getByText('Performance Comparison')).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('export-pdf'));
+    });
+
+    expect(exportToPdf).toHaveBeenCalledTimes(1);
+    const call = (exportToPdf as any).mock.calls[0][0];
+    expect(call.title).toBe('Performance Comparison');
+    expect(call.subtitle).toBe('AAPL, VTI');
+    expect(call.filename).toBe('security-performance-comparison');
+    expect(call.chartLegend).toHaveLength(2);
   });
 });

--- a/frontend/src/components/reports/SecurityPerformanceReport.tsx
+++ b/frontend/src/components/reports/SecurityPerformanceReport.tsx
@@ -33,7 +33,7 @@ import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { aggregateHoldingsBySecurity } from '@/lib/aggregate-holdings';
 import { renderChartFlagDot, ChartFlagShadowFilter } from '@/components/investments/portfolio-chart-utils';
 import { buildTimeAxisTicks } from '@/lib/chart-time-axis';
-import { SecurityComparisonChart } from '@/components/reports/SecurityComparisonChart';
+import { SecurityComparisonChart, SecurityComparisonChartHandle } from '@/components/reports/SecurityComparisonChart';
 import { MultiSelect, MultiSelectOption } from '@/components/ui/MultiSelect';
 
 const MAX_PAGES = 50;
@@ -58,6 +58,8 @@ export function SecurityPerformanceReport() {
   const { formatCurrency: formatCurrencyFull, formatCurrencyAxis, formatSignedPercent } = useNumberFormat();
   const { defaultCurrency } = useExchangeRates();
   const chartRef = useRef<HTMLDivElement>(null);
+  // Export handle for the comparison chart, which owns its own data and DOM.
+  const comparisonExportRef = useRef<SecurityComparisonChartHandle>(null);
   // The securities the user has picked in the multi-select. One selected shows
   // the single-security deep dive (stats, tabs, PDF); two or more switch to the
   // performance-comparison chart. Empty shows the initial prompt.
@@ -346,6 +348,11 @@ export function SecurityPerformanceReport() {
   const displayCurrency = selectedSecurity?.currencyCode || defaultCurrency;
 
   const handleExportPdf = async () => {
+    if (isComparison) {
+      await comparisonExportRef.current?.exportPdf();
+      return;
+    }
+
     const { exportToPdf } = await import('@/lib/pdf-export');
 
     const secLabel = selectedSecurity
@@ -471,7 +478,7 @@ export function SecurityPerformanceReport() {
               </>
             )}
             <RefreshPricesButton onRefreshComplete={() => { reloadBase(); reloadDetail(); setAllRefreshKey((k) => k + 1); }} />
-            {isSingle && <ExportDropdown onExportPdf={handleExportPdf} />}
+            {(isSingle || isComparison) && <ExportDropdown onExportPdf={handleExportPdf} />}
           </div>
         </div>
       </div>
@@ -483,7 +490,11 @@ export function SecurityPerformanceReport() {
           </p>
         </div>
       ) : isComparison ? (
-        <SecurityComparisonChart securities={selectedSecurities} reloadKey={allRefreshKey} />
+        <SecurityComparisonChart
+          securities={selectedSecurities}
+          reloadKey={allRefreshKey}
+          exportRef={comparisonExportRef}
+        />
       ) : isLoadingDetail ? (
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6">
           <div className="space-y-4">

--- a/frontend/src/i18n/messages/de/accounts.json
+++ b/frontend/src/i18n/messages/de/accounts.json
@@ -27,7 +27,12 @@
       "closed": "Geschlossen",
       "netWorthAll": "Reinvermögen: Alle",
       "inNetWorth": "Im Reinvermögen",
-      "excludedFromNetWorth": "Vom Reinvermögen ausgeschlossen"
+      "excludedFromNetWorth": "Vom Reinvermögen ausgeschlossen",
+      "typePlaceholder": "Kontotyp: Alle",
+      "typeAriaLabel": "Nach Kontotyp filtern",
+      "searchPlaceholder": "Konten suchen...",
+      "searchAriaLabel": "Konten nach Namen suchen",
+      "searchClear": "Suche löschen"
     },
     "accountCount": "{filtered} von {total} Konten",
     "groupCount": "{count, plural, one {# Konto} other {# Konten}}",

--- a/frontend/src/i18n/messages/en/accounts.json
+++ b/frontend/src/i18n/messages/en/accounts.json
@@ -27,7 +27,12 @@
       "closed": "Closed",
       "netWorthAll": "Net Worth: All",
       "inNetWorth": "In Net Worth",
-      "excludedFromNetWorth": "Excluded from Net Worth"
+      "excludedFromNetWorth": "Excluded from Net Worth",
+      "typePlaceholder": "Account Type: All",
+      "typeAriaLabel": "Filter by account type",
+      "searchPlaceholder": "Search accounts...",
+      "searchAriaLabel": "Search accounts by name",
+      "searchClear": "Clear search"
     },
     "accountCount": "{filtered} of {total} accounts",
     "groupCount": "{count, plural, one {# account} other {# accounts}}",

--- a/frontend/src/i18n/messages/es/accounts.json
+++ b/frontend/src/i18n/messages/es/accounts.json
@@ -27,7 +27,12 @@
       "closed": "Cerradas",
       "netWorthAll": "Patrimonio neto: Todas",
       "inNetWorth": "En patrimonio neto",
-      "excludedFromNetWorth": "Excluidas del patrimonio neto"
+      "excludedFromNetWorth": "Excluidas del patrimonio neto",
+      "typePlaceholder": "Tipo de cuenta: Todas",
+      "typeAriaLabel": "Filtrar por tipo de cuenta",
+      "searchPlaceholder": "Buscar cuentas...",
+      "searchAriaLabel": "Buscar cuentas por nombre",
+      "searchClear": "Borrar búsqueda"
     },
     "accountCount": "{filtered} de {total} cuentas",
     "groupCount": "{count, plural, one {# cuenta} other {# cuentas}}",

--- a/frontend/src/i18n/messages/fr/accounts.json
+++ b/frontend/src/i18n/messages/fr/accounts.json
@@ -27,7 +27,12 @@
       "closed": "Clôturés",
       "netWorthAll": "Patrimoine net : Tous",
       "inNetWorth": "Inclus dans le valeur nette",
-      "excludedFromNetWorth": "Exclu du valeur nette"
+      "excludedFromNetWorth": "Exclu du valeur nette",
+      "typePlaceholder": "Type de compte : Tous",
+      "typeAriaLabel": "Filtrer par type de compte",
+      "searchPlaceholder": "Rechercher des comptes...",
+      "searchAriaLabel": "Rechercher des comptes par nom",
+      "searchClear": "Effacer la recherche"
     },
     "accountCount": "{filtered} sur {total} comptes",
     "groupCount": "{count, plural, one {# compte} other {# comptes}}",

--- a/frontend/src/i18n/messages/hi/accounts.json
+++ b/frontend/src/i18n/messages/hi/accounts.json
@@ -27,7 +27,12 @@
       "closed": "बंद",
       "netWorthAll": "शुद्ध संपत्ति: सभी",
       "inNetWorth": "शुद्ध संपत्ति में",
-      "excludedFromNetWorth": "शुद्ध संपत्ति से बाहर"
+      "excludedFromNetWorth": "शुद्ध संपत्ति से बाहर",
+      "typePlaceholder": "खाता प्रकार: सभी",
+      "typeAriaLabel": "खाता प्रकार के अनुसार फ़िल्टर करें",
+      "searchPlaceholder": "खाते खोजें...",
+      "searchAriaLabel": "नाम से खाते खोजें",
+      "searchClear": "खोज साफ़ करें"
     },
     "accountCount": "{total} में से {filtered} खाते",
     "groupCount": "{count, plural, one {# खाता} other {# खाते}}",

--- a/frontend/src/i18n/messages/id/accounts.json
+++ b/frontend/src/i18n/messages/id/accounts.json
@@ -27,7 +27,12 @@
       "closed": "Ditutup",
       "netWorthAll": "Nilai Bersih: Semua",
       "inNetWorth": "Dalam Nilai Bersih",
-      "excludedFromNetWorth": "Dikecualikan dari Nilai Bersih"
+      "excludedFromNetWorth": "Dikecualikan dari Nilai Bersih",
+      "typePlaceholder": "Jenis Akun: Semua",
+      "typeAriaLabel": "Filter menurut jenis akun",
+      "searchPlaceholder": "Cari akun...",
+      "searchAriaLabel": "Cari akun berdasarkan nama",
+      "searchClear": "Hapus pencarian"
     },
     "accountCount": "{filtered} dari {total} akun",
     "groupCount": "{count, plural, one {# akun} other {# akun}}",

--- a/frontend/src/i18n/messages/it/accounts.json
+++ b/frontend/src/i18n/messages/it/accounts.json
@@ -27,7 +27,12 @@
       "closed": "Chiusi",
       "netWorthAll": "Patrimonio netto: Tutti",
       "inNetWorth": "Incluso nel patrimonio netto",
-      "excludedFromNetWorth": "Escluso dal patrimonio netto"
+      "excludedFromNetWorth": "Escluso dal patrimonio netto",
+      "typePlaceholder": "Tipo di conto: Tutti",
+      "typeAriaLabel": "Filtra per tipo di conto",
+      "searchPlaceholder": "Cerca conti...",
+      "searchAriaLabel": "Cerca conti per nome",
+      "searchClear": "Cancella ricerca"
     },
     "accountCount": "{filtered} di {total} conti",
     "groupCount": "{count, plural, one {# conto} other {# conti}}",

--- a/frontend/src/i18n/messages/ja/accounts.json
+++ b/frontend/src/i18n/messages/ja/accounts.json
@@ -27,7 +27,12 @@
       "closed": "閉鎖済み",
       "netWorthAll": "純資産：すべて",
       "inNetWorth": "純資産に含む",
-      "excludedFromNetWorth": "純資産から除外"
+      "excludedFromNetWorth": "純資産から除外",
+      "typePlaceholder": "勘定科目の種類：すべて",
+      "typeAriaLabel": "勘定科目の種類で絞り込む",
+      "searchPlaceholder": "勘定科目を検索...",
+      "searchAriaLabel": "名前で勘定科目を検索",
+      "searchClear": "検索をクリア"
     },
     "accountCount": "{total} 件中 {filtered} 件の勘定科目",
     "groupCount": "{count, plural, one {# 件の勘定科目} other {# 件の勘定科目}}",

--- a/frontend/src/i18n/messages/ko/accounts.json
+++ b/frontend/src/i18n/messages/ko/accounts.json
@@ -27,7 +27,12 @@
       "closed": "종료",
       "netWorthAll": "순자산가액: 전체",
       "inNetWorth": "순자산가액 포함",
-      "excludedFromNetWorth": "순자산가액 제외"
+      "excludedFromNetWorth": "순자산가액 제외",
+      "typePlaceholder": "계좌 유형: 전체",
+      "typeAriaLabel": "계좌 유형으로 필터링",
+      "searchPlaceholder": "계좌 검색...",
+      "searchAriaLabel": "이름으로 계좌 검색",
+      "searchClear": "검색 지우기"
     },
     "accountCount": "{total}개 중 {filtered}개 계정",
     "groupCount": "{count, plural, one {계정 #개} other {계정 #개}}",

--- a/frontend/src/i18n/messages/nl/accounts.json
+++ b/frontend/src/i18n/messages/nl/accounts.json
@@ -27,7 +27,12 @@
       "closed": "Gesloten",
       "netWorthAll": "Nettowaarde: alle",
       "inNetWorth": "In nettowaarde",
-      "excludedFromNetWorth": "Uitgesloten van nettowaarde"
+      "excludedFromNetWorth": "Uitgesloten van nettowaarde",
+      "typePlaceholder": "Rekeningtype: Alle",
+      "typeAriaLabel": "Filteren op rekeningtype",
+      "searchPlaceholder": "Rekeningen zoeken...",
+      "searchAriaLabel": "Rekeningen op naam zoeken",
+      "searchClear": "Zoekopdracht wissen"
     },
     "accountCount": "{filtered} van {total} rekeningen",
     "groupCount": "{count, plural, one {# rekening} other {# rekeningen}}",

--- a/frontend/src/i18n/messages/pl/accounts.json
+++ b/frontend/src/i18n/messages/pl/accounts.json
@@ -27,7 +27,12 @@
       "closed": "Zamknięte",
       "netWorthAll": "Wartość netto: wszystkie",
       "inNetWorth": "W wartości netto",
-      "excludedFromNetWorth": "Wykluczone z wartości netto"
+      "excludedFromNetWorth": "Wykluczone z wartości netto",
+      "typePlaceholder": "Typ konta: Wszystkie",
+      "typeAriaLabel": "Filtruj według typu konta",
+      "searchPlaceholder": "Szukaj kont...",
+      "searchAriaLabel": "Szukaj kont według nazwy",
+      "searchClear": "Wyczyść wyszukiwanie"
     },
     "accountCount": "{filtered} z {total} kont",
     "groupCount": "{count, plural, one {# konto} few {# konta} many {# kont} other {# konta}}",

--- a/frontend/src/i18n/messages/pt-BR/accounts.json
+++ b/frontend/src/i18n/messages/pt-BR/accounts.json
@@ -27,7 +27,12 @@
       "closed": "Fechadas",
       "netWorthAll": "Patrimônio Líquido: Todas",
       "inNetWorth": "Incluída no Patrimônio Líquido",
-      "excludedFromNetWorth": "Excluída do Patrimônio Líquido"
+      "excludedFromNetWorth": "Excluída do Patrimônio Líquido",
+      "typePlaceholder": "Tipo de conta: Todas",
+      "typeAriaLabel": "Filtrar por tipo de conta",
+      "searchPlaceholder": "Buscar contas...",
+      "searchAriaLabel": "Buscar contas por nome",
+      "searchClear": "Limpar busca"
     },
     "accountCount": "{filtered} de {total} contas",
     "groupCount": "{count, plural, one {# conta} other {# contas}}",

--- a/frontend/src/i18n/messages/pt/accounts.json
+++ b/frontend/src/i18n/messages/pt/accounts.json
@@ -27,7 +27,12 @@
       "closed": "Fechadas",
       "netWorthAll": "Valor Líquido: Todas",
       "inNetWorth": "Incluída no Valor Líquido",
-      "excludedFromNetWorth": "Excluída do Valor Líquido"
+      "excludedFromNetWorth": "Excluída do Valor Líquido",
+      "typePlaceholder": "Tipo de conta: Todas",
+      "typeAriaLabel": "Filtrar por tipo de conta",
+      "searchPlaceholder": "Pesquisar contas...",
+      "searchAriaLabel": "Pesquisar contas por nome",
+      "searchClear": "Limpar pesquisa"
     },
     "accountCount": "{filtered} de {total} contas",
     "groupCount": "{count, plural, one {# conta} other {# contas}}",

--- a/frontend/src/i18n/messages/ru/accounts.json
+++ b/frontend/src/i18n/messages/ru/accounts.json
@@ -27,7 +27,12 @@
       "closed": "Закрытые",
       "netWorthAll": "Чистая стоимость: все",
       "inNetWorth": "Включён в чистую стоимость",
-      "excludedFromNetWorth": "Исключён из чистой стоимости"
+      "excludedFromNetWorth": "Исключён из чистой стоимости",
+      "typePlaceholder": "Тип счёта: Все",
+      "typeAriaLabel": "Фильтровать по типу счёта",
+      "searchPlaceholder": "Поиск счетов...",
+      "searchAriaLabel": "Поиск счетов по имени",
+      "searchClear": "Очистить поиск"
     },
     "accountCount": "{filtered} из {total} счетов",
     "groupCount": "{count, plural, one {# счёт} other {# счетов}}",

--- a/frontend/src/i18n/messages/tr/accounts.json
+++ b/frontend/src/i18n/messages/tr/accounts.json
@@ -27,7 +27,12 @@
       "closed": "Kapalı",
       "netWorthAll": "Net Değer: Tümü",
       "inNetWorth": "Net Değerde",
-      "excludedFromNetWorth": "Net Değerden Hariç"
+      "excludedFromNetWorth": "Net Değerden Hariç",
+      "typePlaceholder": "Hesap Türü: Tümü",
+      "typeAriaLabel": "Hesap türüne göre filtrele",
+      "searchPlaceholder": "Hesap ara...",
+      "searchAriaLabel": "Hesapları ada göre ara",
+      "searchClear": "Aramayı temizle"
     },
     "accountCount": "{total} hesaptan {filtered} tanesi",
     "groupCount": "{count, plural, one {# hesap} other {# hesap}}",

--- a/frontend/src/i18n/messages/uk/accounts.json
+++ b/frontend/src/i18n/messages/uk/accounts.json
@@ -27,7 +27,12 @@
       "closed": "Закриті",
       "netWorthAll": "Чистий капітал: усі",
       "inNetWorth": "У чистому капіталі",
-      "excludedFromNetWorth": "Виключені з чистого капіталу"
+      "excludedFromNetWorth": "Виключені з чистого капіталу",
+      "typePlaceholder": "Тип рахунку: Усі",
+      "typeAriaLabel": "Фільтрувати за типом рахунку",
+      "searchPlaceholder": "Пошук рахунків...",
+      "searchAriaLabel": "Пошук рахунків за назвою",
+      "searchClear": "Очистити пошук"
     },
     "accountCount": "{filtered} з {total} рахунків",
     "groupCount": "{count, plural, one {# рахунок} other {# рахунків}}",

--- a/frontend/src/i18n/messages/vi/accounts.json
+++ b/frontend/src/i18n/messages/vi/accounts.json
@@ -27,7 +27,12 @@
       "closed": "Đã đóng",
       "netWorthAll": "Tài sản ròng: Tất cả",
       "inNetWorth": "Trong tài sản ròng",
-      "excludedFromNetWorth": "Loại khỏi tài sản ròng"
+      "excludedFromNetWorth": "Loại khỏi tài sản ròng",
+      "typePlaceholder": "Loại tài khoản: Tất cả",
+      "typeAriaLabel": "Lọc theo loại tài khoản",
+      "searchPlaceholder": "Tìm kiếm tài khoản...",
+      "searchAriaLabel": "Tìm kiếm tài khoản theo tên",
+      "searchClear": "Xóa tìm kiếm"
     },
     "accountCount": "{filtered} trong {total} tài khoản",
     "groupCount": "{count, plural, one {# tài khoản} other {# tài khoản}}",

--- a/frontend/src/i18n/messages/xx/accounts.json
+++ b/frontend/src/i18n/messages/xx/accounts.json
@@ -27,7 +27,12 @@
       "closed": "[XX-Closed-XX]",
       "netWorthAll": "[XX-Net Worth: All-XX]",
       "inNetWorth": "[XX-In Net Worth-XX]",
-      "excludedFromNetWorth": "[XX-Excluded from Net Worth-XX]"
+      "excludedFromNetWorth": "[XX-Excluded from Net Worth-XX]",
+      "typePlaceholder": "[XX-Account Type: All-XX]",
+      "typeAriaLabel": "[XX-Filter by account type-XX]",
+      "searchPlaceholder": "[XX-Search accounts...-XX]",
+      "searchAriaLabel": "[XX-Search accounts by name-XX]",
+      "searchClear": "[XX-Clear search-XX]"
     },
     "accountCount": "[XX-{filtered} of {total} accounts-XX]",
     "groupCount": "[XX-{count, plural, one {# account} other {# accounts}}-XX]",

--- a/frontend/src/i18n/messages/zh-CN/accounts.json
+++ b/frontend/src/i18n/messages/zh-CN/accounts.json
@@ -27,7 +27,12 @@
       "closed": "已关闭",
       "netWorthAll": "资产净值：全部",
       "inNetWorth": "计入资产净值",
-      "excludedFromNetWorth": "不计入资产净值"
+      "excludedFromNetWorth": "不计入资产净值",
+      "typePlaceholder": "账户类型：全部",
+      "typeAriaLabel": "按账户类型筛选",
+      "searchPlaceholder": "搜索账户...",
+      "searchAriaLabel": "按名称搜索账户",
+      "searchClear": "清除搜索"
     },
     "accountCount": "{total} 个账户中的 {filtered} 个",
     "groupCount": "{count, plural, one {# 个账户} other {# 个账户}}",

--- a/frontend/src/i18n/messages/zh-TW/accounts.json
+++ b/frontend/src/i18n/messages/zh-TW/accounts.json
@@ -27,7 +27,12 @@
       "closed": "已關閉",
       "netWorthAll": "資產淨值：全部",
       "inNetWorth": "計入資產淨值",
-      "excludedFromNetWorth": "排除於資產淨值外"
+      "excludedFromNetWorth": "排除於資產淨值外",
+      "typePlaceholder": "帳戶類型：全部",
+      "typeAriaLabel": "依帳戶類型篩選",
+      "searchPlaceholder": "搜尋帳戶...",
+      "searchAriaLabel": "依名稱搜尋帳戶",
+      "searchClear": "清除搜尋"
     },
     "accountCount": "{filtered} / {total} 個科目",
     "groupCount": "{count, plural, one {# 個科目} other {# 個科目}}",


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: 

## Summary

This PR bundles two independent frontend changes:

### 1. PDF export for the security performance comparison chart

Adds PDF export capability to the security performance comparison chart. When two or more securities are selected in the SecurityPerformanceReport, the Export dropdown now exports the comparison chart (previously only available for single-security views), bringing the comparison view to parity with the rest of the report. The comparison chart component exposes an imperative `exportPdf()` handle that the parent report's Export dropdown invokes, mirroring the pattern used for single-security chart exports.

- **SecurityComparisonChart**: Added `useImperativeHandle` to expose `exportPdf()` via an `exportRef` prop. The export captures the chart DOM, resolves series colors to PDF-compatible hex values, and builds a legend from the plotted securities.
- **SecurityPerformanceReport**:
  - Created `comparisonExportRef` to hold the comparison chart's export handle.
  - Updated `handleExportPdf()` to delegate to the comparison chart when in comparison mode.
  - Made the Export dropdown visible in both single-security and comparison modes.
  - Passed `exportRef` to `SecurityComparisonChart`.

### 2. Account type and text filters on the Accounts page

The Accounts list already supported status and net-worth filters; this adds two more, both persisted across page views:

- **Account type filter**: a multi-select over the account types actually present in the list, ordered to match the grouped view. Users can filter on one or more types; an empty selection means "all types".
- **Text filter**: a free-text input that matches account name (case-insensitive), with a clear button.
- Both filters persist to `localStorage` (`accounts.filter.types`, `accounts.filter.search`) alongside the existing filter/sort/density state, so they survive navigating away and back. They initialize from storage on mount, are reset by both the "Clear Filters" button and the no-matches empty state, and the "N of M accounts" count reflects them.

### Tests & i18n

- Added test coverage for the comparison-chart export (component and report suites, verifying PDF title, subtitle, filename, and legend).
- Added test coverage for the account filters (text search, clear button, multi-type filtering, persistence, init-from-storage, and Clear Filters reset).
- New user-facing strings for the account filters are internationalized across every supported locale, and the pseudo-locale is regenerated.

## Checklist

- [x] This PR addresses cohesive frontend changes (report export parity + account filtering).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale.
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.

## AI assistance disclosure

Implemented with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkTWjxXKMD3jDE6nD2zCXK