### PR TITLE
feat(transactions): search understands amounts and dates in the user's own format

### DIFF
--- a/backend/src/transactions/transaction-analytics.service.spec.ts
+++ b/backend/src/transactions/transaction-analytics.service.spec.ts
@@ -4,12 +4,14 @@ import { Brackets } from "typeorm";
 import { TransactionAnalyticsService } from "./transaction-analytics.service";
 import { Transaction } from "./entities/transaction.entity";
 import { Category } from "../categories/entities/category.entity";
+import { UserPreference } from "../users/entities/user-preference.entity";
 import { buildTransactionSearchClause } from "./transaction-search.util";
 
 describe("TransactionAnalyticsService", () => {
   let service: TransactionAnalyticsService;
   let transactionsRepository: Record<string, jest.Mock>;
   let categoriesRepository: Record<string, jest.Mock>;
+  let userPreferenceRepository: Record<string, jest.Mock>;
 
   const userId = "user-1";
 
@@ -56,6 +58,10 @@ describe("TransactionAnalyticsService", () => {
       find: jest.fn().mockResolvedValue([]),
     };
 
+    userPreferenceRepository = {
+      findOne: jest.fn().mockResolvedValue(null),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TransactionAnalyticsService,
@@ -66,6 +72,10 @@ describe("TransactionAnalyticsService", () => {
         {
           provide: getRepositoryToken(Category),
           useValue: categoriesRepository,
+        },
+        {
+          provide: getRepositoryToken(UserPreference),
+          useValue: userPreferenceRepository,
         },
       ],
     }).compile();
@@ -762,7 +772,7 @@ describe("TransactionAnalyticsService", () => {
             transaction: "transaction",
             splits: "splits",
           }),
-          { search: "%grocery%" },
+          { search: "%grocery%", searchAmount: null, searchDate: null },
         );
       });
 
@@ -782,7 +792,7 @@ describe("TransactionAnalyticsService", () => {
             transaction: "transaction",
             splits: "splits",
           }),
-          { search: "%coffee%" },
+          { search: "%coffee%", searchAmount: null, searchDate: null },
         );
       });
 
@@ -899,7 +909,7 @@ describe("TransactionAnalyticsService", () => {
         );
         expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
           expect.stringContaining("ILIKE"),
-          { search: "%rent%" },
+          { search: "%rent%", searchAmount: null, searchDate: null },
         );
       });
 
@@ -1329,7 +1339,7 @@ describe("TransactionAnalyticsService", () => {
           transaction: "transaction",
           splits: "splits",
         }),
-        { search: "%grocery%" },
+        { search: "%grocery%", searchAmount: null, searchDate: null },
       );
     });
 
@@ -2017,7 +2027,7 @@ describe("TransactionAnalyticsService", () => {
           transaction: "transaction",
           splits: "splits",
         }),
-        { search: "%coffee%" },
+        { search: "%coffee%", searchAmount: null, searchDate: null },
       );
     });
 

--- a/backend/src/transactions/transaction-analytics.service.ts
+++ b/backend/src/transactions/transaction-analytics.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { Brackets, Repository } from "typeorm";
 import { Transaction } from "./entities/transaction.entity";
 import { Category } from "../categories/entities/category.entity";
+import { UserPreference } from "../users/entities/user-preference.entity";
 import { getAllCategoryIdsWithChildren } from "../common/category-tree.util";
 import { applyInvestmentTransactionFilters } from "../common/investment-filter.util";
 import {
@@ -15,6 +16,10 @@ import {
   buildTransactionSearchClause,
   escapeLikePattern,
 } from "./transaction-search.util";
+import {
+  parseSearchTerm,
+  ParsedSearchTerm,
+} from "./transaction-search-parse.util";
 import { RecurringCharge, detectFrequency } from "./recurring-charges.util";
 import { roundMoney, sumMoney } from "../common/round.util";
 import { suggestClosestNames } from "../common/name-suggestions.util";
@@ -161,7 +166,27 @@ export class TransactionAnalyticsService {
     private transactionsRepository: Repository<Transaction>,
     @InjectRepository(Category)
     private categoriesRepository: Repository<Category>,
+    @InjectRepository(UserPreference)
+    private userPreferenceRepository: Repository<UserPreference>,
   ) {}
+
+  /**
+   * Interprets the search term as an exact amount and/or date using the user's
+   * number/date-format preferences, so locale-formatted values also match.
+   */
+  private async resolveSearchTerm(
+    userId: string,
+    term?: string,
+  ): Promise<ParsedSearchTerm> {
+    if (!term || !term.trim()) return { amount: null, date: null };
+    const prefs = await this.userPreferenceRepository.findOne({
+      where: { userId },
+    });
+    return parseSearchTerm(term, {
+      numberFormat: prefs?.numberFormat,
+      dateFormat: prefs?.dateFormat,
+    });
+  }
 
   /**
    * Per-account transfer activity between the user's own accounts for a date
@@ -523,12 +548,17 @@ export class TransactionAnalyticsService {
 
     if (search && search.trim()) {
       const searchPattern = `%${escapeLikePattern(search.trim())}%`;
+      const parsedSearch = await this.resolveSearchTerm(userId, search);
       queryBuilder.andWhere(
         buildTransactionSearchClause({
           transaction: "transaction",
           splits: "splits",
         }),
-        { search: searchPattern },
+        {
+          search: searchPattern,
+          searchAmount: parsedSearch.amount,
+          searchDate: parsedSearch.date,
+        },
       );
     }
 
@@ -753,6 +783,7 @@ export class TransactionAnalyticsService {
 
     if (search && search.trim()) {
       const searchPattern = `%${escapeLikePattern(search.trim())}%`;
+      const parsedSearch = await this.resolveSearchTerm(userId, search);
       if (!splitsJoined) {
         queryBuilder.leftJoin("transaction.splits", "splits");
         splitsJoined = true;
@@ -762,7 +793,11 @@ export class TransactionAnalyticsService {
           transaction: "transaction",
           splits: "splits",
         }),
-        { search: searchPattern },
+        {
+          search: searchPattern,
+          searchAmount: parsedSearch.amount,
+          searchDate: parsedSearch.date,
+        },
       );
     }
 
@@ -1111,9 +1146,14 @@ export class TransactionAnalyticsService {
     }
 
     if (safeSearchText) {
+      const parsedSearch = await this.resolveSearchTerm(userId, safeSearchText);
       qb.andWhere(
         buildTransactionSearchClause({ transaction: "t", splits: "ts" }),
-        { search: `%${safeSearchText}%` },
+        {
+          search: `%${safeSearchText}%`,
+          searchAmount: parsedSearch.amount,
+          searchDate: parsedSearch.date,
+        },
       );
     }
 

--- a/backend/src/transactions/transaction-bulk-update.service.spec.ts
+++ b/backend/src/transactions/transaction-bulk-update.service.spec.ts
@@ -6,6 +6,7 @@ import { buildTransactionSearchClause } from "./transaction-search.util";
 import { Transaction, TransactionStatus } from "./entities/transaction.entity";
 import { Category } from "../categories/entities/category.entity";
 import { Payee } from "../payees/entities/payee.entity";
+import { UserPreference } from "../users/entities/user-preference.entity";
 import { AccountsService } from "../accounts/accounts.service";
 import { NetWorthService } from "../net-worth/net-worth.service";
 import { TagsService } from "../tags/tags.service";
@@ -22,6 +23,7 @@ describe("TransactionBulkUpdateService", () => {
   let transactionsRepository: Record<string, jest.Mock>;
   let categoriesRepository: Record<string, jest.Mock>;
   let payeesRepository: Record<string, jest.Mock>;
+  let userPreferenceRepository: Record<string, jest.Mock>;
   let accountsService: Record<string, jest.Mock>;
   let netWorthService: Record<string, jest.Mock>;
   let tagsService: Record<string, jest.Mock>;
@@ -95,6 +97,10 @@ describe("TransactionBulkUpdateService", () => {
       findOne: jest.fn().mockResolvedValue(null),
     };
 
+    userPreferenceRepository = {
+      findOne: jest.fn().mockResolvedValue(null),
+    };
+
     accountsService = {
       updateBalance: jest.fn().mockResolvedValue(undefined),
       recalculateCurrentBalance: jest.fn().mockResolvedValue(undefined),
@@ -150,6 +156,10 @@ describe("TransactionBulkUpdateService", () => {
         {
           provide: getRepositoryToken(Payee),
           useValue: payeesRepository,
+        },
+        {
+          provide: getRepositoryToken(UserPreference),
+          useValue: userPreferenceRepository,
         },
         { provide: AccountsService, useValue: accountsService },
         { provide: NetWorthService, useValue: netWorthService },
@@ -1676,7 +1686,7 @@ describe("TransactionBulkUpdateService", () => {
           transaction: "transaction",
           splits: "searchSplits",
         }),
-        { search: "%groceries%" },
+        { search: "%groceries%", searchAmount: null, searchDate: null },
       );
     });
 
@@ -1722,7 +1732,7 @@ describe("TransactionBulkUpdateService", () => {
           transaction: "transaction",
           splits: "filterSplits",
         }),
-        { search: "%food%" },
+        { search: "%food%", searchAmount: null, searchDate: null },
       );
     });
 
@@ -1941,7 +1951,11 @@ describe("TransactionBulkUpdateService", () => {
           transaction: "transaction",
           splits: "searchSplits",
         }),
-        { search: "%100\\% off\\_sale\\\\deal%" },
+        {
+          search: "%100\\% off\\_sale\\\\deal%",
+          searchAmount: null,
+          searchDate: null,
+        },
       );
     });
 

--- a/backend/src/transactions/transaction-bulk-update.service.ts
+++ b/backend/src/transactions/transaction-bulk-update.service.ts
@@ -11,6 +11,7 @@ import { Brackets, Repository, SelectQueryBuilder, DataSource } from "typeorm";
 import { Transaction, TransactionStatus } from "./entities/transaction.entity";
 import { Category } from "../categories/entities/category.entity";
 import { Payee } from "../payees/entities/payee.entity";
+import { UserPreference } from "../users/entities/user-preference.entity";
 import { AccountsService } from "../accounts/accounts.service";
 import { NetWorthService } from "../net-worth/net-worth.service";
 import { TagsService } from "../tags/tags.service";
@@ -28,6 +29,10 @@ import {
   buildTransactionSearchClause,
   escapeLikePattern,
 } from "./transaction-search.util";
+import {
+  parseSearchTerm,
+  ParsedSearchTerm,
+} from "./transaction-search-parse.util";
 import { tr } from "../i18n/translate";
 
 export interface BulkDeleteResult {
@@ -51,6 +56,8 @@ export class TransactionBulkUpdateService {
     private categoriesRepository: Repository<Category>,
     @InjectRepository(Payee)
     private payeesRepository: Repository<Payee>,
+    @InjectRepository(UserPreference)
+    private userPreferenceRepository: Repository<UserPreference>,
     @Inject(forwardRef(() => AccountsService))
     private accountsService: AccountsService,
     @Inject(forwardRef(() => NetWorthService))
@@ -58,6 +65,24 @@ export class TransactionBulkUpdateService {
     private tagsService: TagsService,
     private dataSource: DataSource,
   ) {}
+
+  /**
+   * Interprets the search term as an exact amount and/or date using the user's
+   * number/date-format preferences, so locale-formatted values also match.
+   */
+  private async resolveSearchTerm(
+    userId: string,
+    term?: string,
+  ): Promise<ParsedSearchTerm> {
+    if (!term || !term.trim()) return { amount: null, date: null };
+    const prefs = await this.userPreferenceRepository.findOne({
+      where: { userId },
+    });
+    return parseSearchTerm(term, {
+      numberFormat: prefs?.numberFormat,
+      dateFormat: prefs?.dateFormat,
+    });
+  }
 
   async bulkUpdate(
     userId: string,
@@ -587,6 +612,7 @@ export class TransactionBulkUpdateService {
 
     if (filters.search && filters.search.trim()) {
       const searchPattern = `%${escapeLikePattern(filters.search.trim())}%`;
+      const parsedSearch = await this.resolveSearchTerm(userId, filters.search);
       if (!filters.categoryIds || filters.categoryIds.length === 0) {
         queryBuilder.leftJoin("transaction.splits", "searchSplits");
         queryBuilder.andWhere(
@@ -594,7 +620,11 @@ export class TransactionBulkUpdateService {
             transaction: "transaction",
             splits: "searchSplits",
           }),
-          { search: searchPattern },
+          {
+            search: searchPattern,
+            searchAmount: parsedSearch.amount,
+            searchDate: parsedSearch.date,
+          },
         );
       } else {
         queryBuilder.andWhere(
@@ -602,7 +632,11 @@ export class TransactionBulkUpdateService {
             transaction: "transaction",
             splits: "filterSplits",
           }),
-          { search: searchPattern },
+          {
+            search: searchPattern,
+            searchAmount: parsedSearch.amount,
+            searchDate: parsedSearch.date,
+          },
         );
       }
     }

--- a/backend/src/transactions/transaction-search-parse.util.spec.ts
+++ b/backend/src/transactions/transaction-search-parse.util.spec.ts
@@ -1,0 +1,189 @@
+import { parseSearchTerm } from "./transaction-search-parse.util";
+
+describe("parseSearchTerm", () => {
+  describe("amount parsing (en-US: '.' decimal, ',' thousands)", () => {
+    const prefs = { numberFormat: "en-US", dateFormat: "YYYY-MM-DD" };
+
+    it("parses a plain decimal", () => {
+      expect(parseSearchTerm("1234.56", prefs).amount).toBe(1234.56);
+    });
+
+    it("parses a grouped decimal", () => {
+      expect(parseSearchTerm("1,234.56", prefs).amount).toBe(1234.56);
+    });
+
+    it("parses a bare integer", () => {
+      expect(parseSearchTerm("1234", prefs).amount).toBe(1234);
+    });
+
+    it("rounds storage-precision trailing zeros", () => {
+      expect(parseSearchTerm("1234.5600", prefs).amount).toBe(1234.56);
+    });
+
+    it("parses a negative amount", () => {
+      expect(parseSearchTerm("-50", prefs).amount).toBe(-50);
+    });
+
+    it("parses a leading-plus amount", () => {
+      expect(parseSearchTerm("+50", prefs).amount).toBe(50);
+    });
+
+    it("falls back to comma-decimal when the value is not valid en-US", () => {
+      // "1234,56" is not valid comma-thousands (group of 2), so the lenient
+      // fallback reads the comma as a decimal separator.
+      expect(parseSearchTerm("1234,56", prefs).amount).toBe(1234.56);
+    });
+
+    it("handles space-thousands with comma decimal via fallback", () => {
+      expect(parseSearchTerm("1 234,56", prefs).amount).toBe(1234.56);
+    });
+
+    it("resolves the '12,3' ambiguity to the decimal reading (12.3)", () => {
+      // "12,3" is an invalid thousands group, so it reads as 12.3 -- and
+      // exact equality means it must NOT be treated the same as 112.30.
+      expect(parseSearchTerm("12,3", prefs).amount).toBe(12.3);
+      expect(parseSearchTerm("12,3", prefs).amount).not.toBe(112.3);
+    });
+
+    it("returns null for non-numeric text", () => {
+      expect(parseSearchTerm("groceries", prefs).amount).toBeNull();
+    });
+
+    it("returns null for a value with trailing junk", () => {
+      expect(parseSearchTerm("12.5x", prefs).amount).toBeNull();
+    });
+
+    it("returns null for a double decimal separator", () => {
+      expect(parseSearchTerm("1.2.3", prefs).amount).toBeNull();
+    });
+  });
+
+  describe("amount parsing (de-DE: ',' decimal, '.' thousands)", () => {
+    const prefs = { numberFormat: "de-DE", dateFormat: "DD.MM.YYYY" };
+
+    it("parses a grouped decimal", () => {
+      expect(parseSearchTerm("1.234,56", prefs).amount).toBe(1234.56);
+    });
+
+    it("parses a plain comma decimal", () => {
+      expect(parseSearchTerm("1234,56", prefs).amount).toBe(1234.56);
+    });
+
+    it("parses space-thousands with comma decimal", () => {
+      expect(parseSearchTerm("1 234,56", prefs).amount).toBe(1234.56);
+    });
+
+    it("falls back to dot-decimal for a value typed the en-US way", () => {
+      expect(parseSearchTerm("1234.56", prefs).amount).toBe(1234.56);
+    });
+
+    it("parses a short decimal", () => {
+      expect(parseSearchTerm("12,3", prefs).amount).toBe(12.3);
+    });
+  });
+
+  describe("date parsing", () => {
+    it("parses ISO YYYY-MM-DD", () => {
+      expect(
+        parseSearchTerm("2026-07-02", { dateFormat: "YYYY-MM-DD" }).date,
+      ).toBe("2026-07-02");
+    });
+
+    it("parses single-digit ISO parts", () => {
+      expect(
+        parseSearchTerm("2026-7-2", { dateFormat: "YYYY-MM-DD" }).date,
+      ).toBe("2026-07-02");
+    });
+
+    it("parses a display-format DD.MM.YYYY date", () => {
+      expect(
+        parseSearchTerm("02.07.2026", { dateFormat: "DD.MM.YYYY" }).date,
+      ).toBe("2026-07-02");
+    });
+
+    it("parses MM/DD/YYYY", () => {
+      expect(
+        parseSearchTerm("07/02/2026", { dateFormat: "MM/DD/YYYY" }).date,
+      ).toBe("2026-07-02");
+    });
+
+    it("parses DD/MM/YYYY", () => {
+      expect(
+        parseSearchTerm("02/07/2026", { dateFormat: "DD/MM/YYYY" }).date,
+      ).toBe("2026-07-02");
+    });
+
+    it("parses DD-MMM-YYYY with a month abbreviation", () => {
+      expect(
+        parseSearchTerm("02-Jul-2026", { dateFormat: "DD-MMM-YYYY" }).date,
+      ).toBe("2026-07-02");
+    });
+
+    it("always accepts ISO as a universal fallback", () => {
+      expect(
+        parseSearchTerm("2026-07-02", { dateFormat: "DD/MM/YYYY" }).date,
+      ).toBe("2026-07-02");
+    });
+
+    it("resolves the 'browser' format from the number-format locale", () => {
+      expect(
+        parseSearchTerm("02.07.2026", {
+          dateFormat: "browser",
+          numberFormat: "de-DE",
+        }).date,
+      ).toBe("2026-07-02");
+    });
+
+    it("rejects an impossible month", () => {
+      expect(
+        parseSearchTerm("2026-13-01", { dateFormat: "YYYY-MM-DD" }).date,
+      ).toBeNull();
+    });
+
+    it("rejects an impossible day", () => {
+      expect(
+        parseSearchTerm("2026-02-30", { dateFormat: "YYYY-MM-DD" }).date,
+      ).toBeNull();
+    });
+
+    it("does not parse a month-only term", () => {
+      expect(
+        parseSearchTerm("07", { dateFormat: "YYYY-MM-DD" }).date,
+      ).toBeNull();
+    });
+
+    it("does not parse a year-only term as a date", () => {
+      const result = parseSearchTerm("2026", { dateFormat: "YYYY-MM-DD" });
+      expect(result.date).toBeNull();
+      expect(result.amount).toBe(2026);
+    });
+  });
+
+  describe("combined and edge cases", () => {
+    it("returns nulls for an empty term", () => {
+      expect(parseSearchTerm("", {})).toEqual({ amount: null, date: null });
+    });
+
+    it("returns nulls for a whitespace-only term", () => {
+      expect(parseSearchTerm("   ", {})).toEqual({ amount: null, date: null });
+    });
+
+    it("returns nulls for a plain word", () => {
+      expect(parseSearchTerm("coffee", {})).toEqual({
+        amount: null,
+        date: null,
+      });
+    });
+
+    it("defaults to en-US / ISO when preferences are absent", () => {
+      const result = parseSearchTerm("1,234.50");
+      expect(result.amount).toBe(1234.5);
+    });
+
+    it("trims surrounding whitespace before parsing", () => {
+      expect(
+        parseSearchTerm("  1234.56  ", { numberFormat: "en-US" }).amount,
+      ).toBe(1234.56);
+    });
+  });
+});

--- a/backend/src/transactions/transaction-search-parse.util.ts
+++ b/backend/src/transactions/transaction-search-parse.util.ts
@@ -1,0 +1,292 @@
+/**
+ * Interprets the Transactions "Search" box query as an amount and/or a date,
+ * expressed in the user's own locale conventions.
+ *
+ * This is a pure helper (no I/O). It powers the "smart" part of the search:
+ * on top of the existing substring match, callers additionally match on an
+ * exact amount (absolute value) and/or an exact transaction date when the
+ * typed term parses as one. When the term parses as neither, both fields are
+ * `null` and the caller falls back to the plain substring behaviour.
+ *
+ * Amount parsing respects the user's `numberFormat` (a locale such as
+ * "en-US" or "de-DE"): the decimal separator is resolved from the locale,
+ * with a lenient fallback to the other convention so a pasted statement
+ * amount is found regardless of which separator style was used. Equality is
+ * exact (rounded to 4 decimals, the storage precision), so "12,3" (12.3)
+ * never matches "112,30" (112.30).
+ *
+ * Date parsing respects the user's `dateFormat` (e.g. "DD/MM/YYYY"), with ISO
+ * "YYYY-MM-DD" always accepted as a universal fallback. Partial dates
+ * (month-only, year-only) do not parse -- a complete day/month/year is
+ * required.
+ */
+
+export interface SearchTermPreferences {
+  /** User's number-format locale, e.g. "en-US", "de-DE". */
+  numberFormat?: string | null;
+  /** User's date-format pattern, e.g. "YYYY-MM-DD", "DD/MM/YYYY", "browser". */
+  dateFormat?: string | null;
+}
+
+export interface ParsedSearchTerm {
+  /** Exact amount (signed, rounded to 4 decimals) or null when not a number. */
+  amount: number | null;
+  /** ISO date "yyyy-MM-dd" or null when the term is not a complete date. */
+  date: string | null;
+}
+
+// Whitespace / apostrophe characters that some locales use as thousands
+// separators (regular space, no-break, narrow no-break, thin space, Swiss
+// apostrophe).
+const GROUP_SPACE_CHARS = [" ", " ", " ", " ", "'"];
+
+const MONTH_ABBREVS = [
+  "jan",
+  "feb",
+  "mar",
+  "apr",
+  "may",
+  "jun",
+  "jul",
+  "aug",
+  "sep",
+  "oct",
+  "nov",
+  "dec",
+];
+
+function escapeRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Determines the decimal separator ("." or ",") the given locale uses. Falls
+ * back to "." when the locale is unknown to the runtime's Intl data.
+ */
+function decimalSeparatorForLocale(numberFormat: string): "." | "," {
+  try {
+    const parts = new Intl.NumberFormat(numberFormat).formatToParts(1.1);
+    const dec = parts.find((part) => part.type === "decimal")?.value;
+    return dec === "," ? "," : ".";
+  } catch {
+    return ".";
+  }
+}
+
+/**
+ * Attempts to parse `raw` as a number using a specific decimal separator.
+ * Every other recognised separator character is treated as a thousands
+ * (group) separator. Group structure is validated (leading group 1-3 digits,
+ * following groups exactly 3 digits) so ambiguous inputs like "12,3" are
+ * rejected under the thousands interpretation and fall through to the decimal
+ * interpretation. Returns a number rounded to 4 decimals, or null.
+ */
+function parseAmountWithConvention(
+  raw: string,
+  decimalSep: "." | ",",
+): number | null {
+  let s = raw.trim();
+  if (s === "") return null;
+
+  let sign = 1;
+  if (s[0] === "+") {
+    s = s.slice(1);
+  } else if (s[0] === "-") {
+    sign = -1;
+    s = s.slice(1);
+  }
+  s = s.trim();
+  if (s === "") return null;
+
+  const groupChars = new Set<string>(GROUP_SPACE_CHARS);
+  groupChars.add(decimalSep === "." ? "," : ".");
+
+  // Only digits, the decimal separator, and group characters are allowed.
+  for (const ch of s) {
+    if (ch < "0" || ch > "9") {
+      if (ch !== decimalSep && !groupChars.has(ch)) return null;
+    }
+  }
+
+  // At most one decimal separator.
+  const decCount = s.split(decimalSep).length - 1;
+  if (decCount > 1) return null;
+
+  let intPart = s;
+  let fracPart: string | null = null;
+  if (decCount === 1) {
+    const idx = s.indexOf(decimalSep);
+    intPart = s.slice(0, idx);
+    fracPart = s.slice(idx + 1);
+    if (!/^\d+$/.test(fracPart)) return null;
+  }
+
+  if (intPart === "") {
+    if (fracPart === null) return null;
+    intPart = "0";
+  }
+
+  const groupClass = [...groupChars].map(escapeRegex).join("");
+  const segments = intPart.split(new RegExp(`[${groupClass}]`));
+  if (segments.some((seg) => !/^\d+$/.test(seg))) return null;
+  if (segments.length > 1) {
+    if (segments[0].length < 1 || segments[0].length > 3) return null;
+    for (let i = 1; i < segments.length; i++) {
+      if (segments[i].length !== 3) return null;
+    }
+  }
+
+  const digits = segments.join("");
+  const numStr = fracPart !== null ? `${digits}.${fracPart}` : digits;
+  const value = sign * Number(numStr);
+  if (!Number.isFinite(value)) return null;
+  return Math.round(value * 10000) / 10000;
+}
+
+function parseAmount(term: string, numberFormat: string): number | null {
+  const primary = decimalSeparatorForLocale(numberFormat);
+  const other = primary === "." ? "," : ".";
+  const parsed = parseAmountWithConvention(term, primary);
+  if (parsed !== null) return parsed;
+  return parseAmountWithConvention(term, other);
+}
+
+function buildIsoDate(year: string, month: string, day: string): string | null {
+  const y = Number(year);
+  const m = Number(month);
+  const d = Number(day);
+  if (!Number.isInteger(y) || !Number.isInteger(m) || !Number.isInteger(d)) {
+    return null;
+  }
+  if (y < 1 || m < 1 || m > 12 || d < 1 || d > 31) return null;
+  // Reject impossible calendar dates (e.g. Feb 30).
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  if (
+    dt.getUTCFullYear() !== y ||
+    dt.getUTCMonth() !== m - 1 ||
+    dt.getUTCDate() !== d
+  ) {
+    return null;
+  }
+  const pad = (n: number, len: number) => String(n).padStart(len, "0");
+  return `${pad(y, 4)}-${pad(m, 2)}-${pad(d, 2)}`;
+}
+
+/**
+ * Parses `input` against a token-based date pattern (YYYY / MM / DD / MMM with
+ * arbitrary literal separators). Returns ISO "yyyy-MM-dd" or null.
+ */
+function parseDateWithPattern(input: string, pattern: string): string | null {
+  const tokenRe = /YYYY|MMM|MM|DD/g;
+  let regexStr = "^";
+  const order: string[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = tokenRe.exec(pattern)) !== null) {
+    regexStr += escapeRegex(pattern.slice(lastIndex, match.index));
+    const token = match[0];
+    if (token === "YYYY") {
+      regexStr += "(\\d{4})";
+      order.push("Y");
+    } else if (token === "MMM") {
+      regexStr += "([A-Za-z]{3})";
+      order.push("m");
+    } else if (token === "MM") {
+      regexStr += "(\\d{1,2})";
+      order.push("M");
+    } else {
+      regexStr += "(\\d{1,2})";
+      order.push("D");
+    }
+    lastIndex = match.index + token.length;
+  }
+  regexStr += escapeRegex(pattern.slice(lastIndex)) + "$";
+
+  if (order.length === 0) return null;
+
+  const m = input.match(new RegExp(regexStr));
+  if (!m) return null;
+
+  let year = "";
+  let month = "";
+  let day = "";
+  order.forEach((key, i) => {
+    const value = m[i + 1];
+    if (key === "Y") {
+      year = value;
+    } else if (key === "M") {
+      month = value;
+    } else if (key === "D") {
+      day = value;
+    } else {
+      const idx = MONTH_ABBREVS.indexOf(value.toLowerCase());
+      if (idx !== -1) month = String(idx + 1);
+    }
+  });
+
+  if (!year || !month || !day) return null;
+  return buildIsoDate(year, month, day);
+}
+
+/**
+ * Derives a token pattern (e.g. "DD.MM.YYYY") from the numeric date parts a
+ * locale renders, so the "browser" date-format preference can still be parsed.
+ */
+function patternFromLocale(locale: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat(locale || "en-US").formatToParts(
+      new Date(Date.UTC(2024, 11, 31)),
+    );
+    let out = "";
+    for (const part of parts) {
+      if (part.type === "year") out += "YYYY";
+      else if (part.type === "month") out += "MM";
+      else if (part.type === "day") out += "DD";
+      else if (part.type === "literal") out += part.value;
+    }
+    return out || "YYYY-MM-DD";
+  } catch {
+    return "YYYY-MM-DD";
+  }
+}
+
+function parseDate(
+  term: string,
+  dateFormat: string,
+  numberFormat: string,
+): string | null {
+  const pattern =
+    !dateFormat || dateFormat === "browser"
+      ? patternFromLocale(numberFormat)
+      : dateFormat;
+
+  const fromPattern = parseDateWithPattern(term, pattern);
+  if (fromPattern) return fromPattern;
+
+  // Universal ISO fallback, regardless of the user's preferred format.
+  const iso = term.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
+  if (iso) return buildIsoDate(iso[1], iso[2], iso[3]);
+
+  return null;
+}
+
+/**
+ * Interprets a search term as an amount and/or date in the user's format.
+ * Returns `{ amount: null, date: null }` when the term parses as neither.
+ */
+export function parseSearchTerm(
+  term: string,
+  prefs: SearchTermPreferences = {},
+): ParsedSearchTerm {
+  const trimmed = (term ?? "").trim();
+  if (trimmed === "") return { amount: null, date: null };
+
+  const numberFormat = prefs.numberFormat || "en-US";
+  const dateFormat = prefs.dateFormat || "YYYY-MM-DD";
+
+  return {
+    amount: parseAmount(trimmed, numberFormat),
+    date: parseDate(trimmed, dateFormat, numberFormat),
+  };
+}

--- a/backend/src/transactions/transaction-search-parse.util.ts
+++ b/backend/src/transactions/transaction-search-parse.util.ts
@@ -55,8 +55,25 @@ const MONTH_ABBREVS = [
   "dec",
 ];
 
-function escapeRegex(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+/**
+ * Splits `input` on any of the given separator characters. Used instead of a
+ * character-class regex so no regular expression is built from runtime data.
+ * Adjacent/leading/trailing separators yield empty segments, exactly as a
+ * regex split would -- callers reject those via the digit check.
+ */
+function splitOnChars(input: string, separators: Set<string>): string[] {
+  const segments: string[] = [];
+  let current = "";
+  for (const ch of input) {
+    if (separators.has(ch)) {
+      segments.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  segments.push(current);
+  return segments;
 }
 
 /**
@@ -126,8 +143,7 @@ function parseAmountWithConvention(
     intPart = "0";
   }
 
-  const groupClass = [...groupChars].map(escapeRegex).join("");
-  const segments = intPart.split(new RegExp(`[${groupClass}]`));
+  const segments = splitOnChars(intPart, groupChars);
   if (segments.some((seg) => !/^\d+$/.test(seg))) return null;
   if (segments.length > 1) {
     if (segments[0].length < 1 || segments[0].length > 3) return null;
@@ -172,59 +188,120 @@ function buildIsoDate(year: string, month: string, day: string): string | null {
   return `${pad(y, 4)}-${pad(m, 2)}-${pad(d, 2)}`;
 }
 
+type DateToken =
+  | { kind: "literal"; text: string }
+  | { kind: "field"; field: "Y" | "M" | "D" | "m" };
+
+/**
+ * Splits a date pattern into ordered literal and field tokens. `YYYY`, `MMM`,
+ * `MM` and `DD` are fields (longer tokens tested first so `MMM` wins over
+ * `MM`); every other run of characters is a literal separator.
+ */
+function tokenizeDatePattern(pattern: string): DateToken[] {
+  const tokens: DateToken[] = [];
+  let literal = "";
+  const flushLiteral = () => {
+    if (literal !== "") {
+      tokens.push({ kind: "literal", text: literal });
+      literal = "";
+    }
+  };
+
+  let i = 0;
+  while (i < pattern.length) {
+    if (pattern.startsWith("YYYY", i)) {
+      flushLiteral();
+      tokens.push({ kind: "field", field: "Y" });
+      i += 4;
+    } else if (pattern.startsWith("MMM", i)) {
+      flushLiteral();
+      tokens.push({ kind: "field", field: "m" });
+      i += 3;
+    } else if (pattern.startsWith("MM", i)) {
+      flushLiteral();
+      tokens.push({ kind: "field", field: "M" });
+      i += 2;
+    } else if (pattern.startsWith("DD", i)) {
+      flushLiteral();
+      tokens.push({ kind: "field", field: "D" });
+      i += 2;
+    } else {
+      literal += pattern[i];
+      i += 1;
+    }
+  }
+  flushLiteral();
+  return tokens;
+}
+
+/** Consumes between `min` and `max` consecutive digits from `input` at `pos`. */
+function takeDigits(
+  input: string,
+  pos: number,
+  min: number,
+  max: number,
+): string | null {
+  let end = pos;
+  while (end < input.length && end - pos < max) {
+    const ch = input[end];
+    if (ch < "0" || ch > "9") break;
+    end += 1;
+  }
+  return end - pos >= min ? input.slice(pos, end) : null;
+}
+
+function isAlpha(input: string): boolean {
+  for (const ch of input) {
+    const lower = ch.toLowerCase();
+    if (lower < "a" || lower > "z") return false;
+  }
+  return true;
+}
+
 /**
  * Parses `input` against a token-based date pattern (YYYY / MM / DD / MMM with
- * arbitrary literal separators). Returns ISO "yyyy-MM-dd" or null.
+ * arbitrary literal separators). Returns ISO "yyyy-MM-dd" or null. Walks the
+ * pattern and input in lockstep -- no regex is built from the pattern, so a
+ * user-supplied date format can never inject a pathological expression.
  */
 function parseDateWithPattern(input: string, pattern: string): string | null {
-  const tokenRe = /YYYY|MMM|MM|DD/g;
-  let regexStr = "^";
-  const order: string[] = [];
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
+  const tokens = tokenizeDatePattern(pattern);
+  if (!tokens.some((token) => token.kind === "field")) return null;
 
-  while ((match = tokenRe.exec(pattern)) !== null) {
-    regexStr += escapeRegex(pattern.slice(lastIndex, match.index));
-    const token = match[0];
-    if (token === "YYYY") {
-      regexStr += "(\\d{4})";
-      order.push("Y");
-    } else if (token === "MMM") {
-      regexStr += "([A-Za-z]{3})";
-      order.push("m");
-    } else if (token === "MM") {
-      regexStr += "(\\d{1,2})";
-      order.push("M");
-    } else {
-      regexStr += "(\\d{1,2})";
-      order.push("D");
-    }
-    lastIndex = match.index + token.length;
-  }
-  regexStr += escapeRegex(pattern.slice(lastIndex)) + "$";
-
-  if (order.length === 0) return null;
-
-  const m = input.match(new RegExp(regexStr));
-  if (!m) return null;
-
+  let pos = 0;
   let year = "";
   let month = "";
   let day = "";
-  order.forEach((key, i) => {
-    const value = m[i + 1];
-    if (key === "Y") {
-      year = value;
-    } else if (key === "M") {
-      month = value;
-    } else if (key === "D") {
-      day = value;
-    } else {
-      const idx = MONTH_ABBREVS.indexOf(value.toLowerCase());
-      if (idx !== -1) month = String(idx + 1);
-    }
-  });
 
+  for (const token of tokens) {
+    if (token.kind === "literal") {
+      if (input.slice(pos, pos + token.text.length) !== token.text) return null;
+      pos += token.text.length;
+      continue;
+    }
+
+    if (token.field === "Y") {
+      const value = takeDigits(input, pos, 4, 4);
+      if (value === null) return null;
+      year = value;
+      pos += value.length;
+    } else if (token.field === "m") {
+      const abbrev = input.slice(pos, pos + 3);
+      if (abbrev.length !== 3 || !isAlpha(abbrev)) return null;
+      const idx = MONTH_ABBREVS.indexOf(abbrev.toLowerCase());
+      if (idx === -1) return null;
+      month = String(idx + 1);
+      pos += 3;
+    } else {
+      const value = takeDigits(input, pos, 1, 2);
+      if (value === null) return null;
+      if (token.field === "M") month = value;
+      else day = value;
+      pos += value.length;
+    }
+  }
+
+  if (pos !== input.length) return null;
   if (!year || !month || !day) return null;
   return buildIsoDate(year, month, day);
 }

--- a/backend/src/transactions/transaction-search.util.spec.ts
+++ b/backend/src/transactions/transaction-search.util.spec.ts
@@ -42,6 +42,31 @@ describe("buildTransactionSearchClause", () => {
     expect(clause).toContain("transaction_split_tags");
   });
 
+  it("emits guarded, cast exact-amount terms for parent and split", () => {
+    const clause = buildTransactionSearchClause({
+      transaction: "transaction",
+      splits: "splits",
+    });
+
+    expect(clause).toContain(
+      "(CAST(:searchAmount AS numeric) IS NOT NULL AND ABS(transaction.amount) = ABS(CAST(:searchAmount AS numeric)))",
+    );
+    expect(clause).toContain(
+      "(CAST(:searchAmount AS numeric) IS NOT NULL AND ABS(splits.amount) = ABS(CAST(:searchAmount AS numeric)))",
+    );
+  });
+
+  it("emits a guarded, cast exact-date term", () => {
+    const clause = buildTransactionSearchClause({
+      transaction: "transaction",
+      splits: "splits",
+    });
+
+    expect(clause).toContain(
+      "(CAST(:searchDate AS date) IS NOT NULL AND transaction.transactionDate = CAST(:searchDate AS date))",
+    );
+  });
+
   it("respects custom alias and parameter names", () => {
     const clause = buildTransactionSearchClause({
       transaction: "bf",
@@ -57,5 +82,30 @@ describe("buildTransactionSearchClause", () => {
     expect(clause).toContain("bf.id");
     expect(clause).toContain("bfSplits.id");
     expect(clause).not.toContain(":search");
+  });
+
+  it("derives amount/date param names from the search param name", () => {
+    const clause = buildTransactionSearchClause({
+      transaction: "bf",
+      splits: "bfSplits",
+      paramName: "bfSearch",
+    });
+
+    expect(clause).toContain(":bfSearchAmount");
+    expect(clause).toContain(":bfSearchDate");
+    expect(clause).not.toContain(":searchAmount");
+    expect(clause).not.toContain(":searchDate");
+  });
+
+  it("honours explicit amount/date param name overrides", () => {
+    const clause = buildTransactionSearchClause({
+      transaction: "t",
+      splits: "s",
+      amountParamName: "amtParam",
+      dateParamName: "dateParam",
+    });
+
+    expect(clause).toContain("ABS(CAST(:amtParam AS numeric))");
+    expect(clause).toContain("CAST(:dateParam AS date)");
   });
 });

--- a/backend/src/transactions/transaction-search.util.ts
+++ b/backend/src/transactions/transaction-search.util.ts
@@ -17,6 +17,20 @@ export interface TransactionSearchAliases {
   splits: string;
   /** Bound parameter name (default: "search"). The caller binds `%pattern%` to this. */
   paramName?: string;
+  /**
+   * Bound parameter name for the interpreted exact amount (default:
+   * `${paramName}Amount`). The caller ALWAYS binds it -- the parsed amount, or
+   * null when the term did not parse as a number. When non-null the clause
+   * additionally matches rows whose absolute amount equals it exactly.
+   */
+  amountParamName?: string;
+  /**
+   * Bound parameter name for the interpreted exact date (default:
+   * `${paramName}Date`). The caller ALWAYS binds it -- the parsed ISO date, or
+   * null. When non-null the clause additionally matches rows on that
+   * transaction date exactly.
+   */
+  dateParamName?: string;
 }
 
 export function escapeLikePattern(input: string): string {
@@ -29,7 +43,15 @@ export function buildTransactionSearchClause(
   const t = aliases.transaction;
   const s = aliases.splits;
   const p = aliases.paramName ?? "search";
+  const ap = aliases.amountParamName ?? `${p}Amount`;
+  const dp = aliases.dateParamName ?? `${p}Date`;
 
+  // The amount/date params are ALWAYS bound by callers (null when the term did
+  // not parse). They are cast so the null bind type-checks in Postgres, and
+  // guarded so the extra predicates are inert unless the term parsed. This
+  // keeps the original substring behaviour as the base and OR-s the
+  // interpreted matches on top of it. Absolute value on the amount lets a
+  // pasted statement figure find both the debit and credit legs.
   return (
     `(${t}.description ILIKE :${p}` +
     ` OR ${t}.payeeName ILIKE :${p}` +
@@ -37,6 +59,9 @@ export function buildTransactionSearchClause(
     ` OR ${s}.memo ILIKE :${p}` +
     ` OR CAST(${t}.amount AS TEXT) ILIKE :${p}` +
     ` OR CAST(${s}.amount AS TEXT) ILIKE :${p}` +
+    ` OR (CAST(:${ap} AS numeric) IS NOT NULL AND ABS(${t}.amount) = ABS(CAST(:${ap} AS numeric)))` +
+    ` OR (CAST(:${ap} AS numeric) IS NOT NULL AND ABS(${s}.amount) = ABS(CAST(:${ap} AS numeric)))` +
+    ` OR (CAST(:${dp} AS date) IS NOT NULL AND ${t}.transactionDate = CAST(:${dp} AS date))` +
     ` OR EXISTS (SELECT 1 FROM payees search_p WHERE search_p.id = ${t}.payee_id AND search_p.name ILIKE :${p})` +
     ` OR EXISTS (SELECT 1 FROM categories search_c WHERE search_c.id = ${t}.category_id AND search_c.name ILIKE :${p})` +
     ` OR EXISTS (SELECT 1 FROM categories search_sc WHERE search_sc.id = ${s}.category_id AND search_sc.name ILIKE :${p})` +

--- a/backend/src/transactions/transactions.module.ts
+++ b/backend/src/transactions/transactions.module.ts
@@ -5,6 +5,7 @@ import { TransactionSplit } from "./entities/transaction-split.entity";
 import { Category } from "../categories/entities/category.entity";
 import { Payee } from "../payees/entities/payee.entity";
 import { InvestmentTransaction } from "../securities/entities/investment-transaction.entity";
+import { UserPreference } from "../users/entities/user-preference.entity";
 import { TransactionsService } from "./transactions.service";
 import { TransactionSplitService } from "./transaction-split.service";
 import { TransactionTransferService } from "./transaction-transfer.service";
@@ -29,6 +30,7 @@ import { DelegationModule } from "../delegation/delegation.module";
       Category,
       Payee,
       InvestmentTransaction,
+      UserPreference,
     ]),
     forwardRef(() => AccountsModule),
     forwardRef(() => NetWorthModule),

--- a/backend/src/transactions/transactions.service.spec.ts
+++ b/backend/src/transactions/transactions.service.spec.ts
@@ -8,6 +8,7 @@ import { TransactionSplit } from "./entities/transaction-split.entity";
 import { Category } from "../categories/entities/category.entity";
 import { InvestmentTransaction } from "../securities/entities/investment-transaction.entity";
 import { Payee } from "../payees/entities/payee.entity";
+import { UserPreference } from "../users/entities/user-preference.entity";
 import { AccountsService } from "../accounts/accounts.service";
 import { PayeesService } from "../payees/payees.service";
 import { NetWorthService } from "../net-worth/net-worth.service";
@@ -37,6 +38,7 @@ describe("TransactionsService", () => {
   let splitsRepository: Record<string, jest.Mock>;
   let categoriesRepository: Record<string, jest.Mock>;
   let investmentTxRepository: Record<string, jest.Mock>;
+  let userPreferenceRepository: Record<string, jest.Mock>;
   let accountsService: Record<string, jest.Mock>;
   let payeesService: Record<string, jest.Mock>;
   let netWorthService: Record<string, jest.Mock>;
@@ -92,6 +94,10 @@ describe("TransactionsService", () => {
 
     investmentTxRepository = {
       find: jest.fn().mockResolvedValue([]),
+    };
+
+    userPreferenceRepository = {
+      findOne: jest.fn().mockResolvedValue(null),
     };
 
     accountsService = {
@@ -194,6 +200,10 @@ describe("TransactionsService", () => {
         {
           provide: getRepositoryToken(InvestmentTransaction),
           useValue: investmentTxRepository,
+        },
+        {
+          provide: getRepositoryToken(UserPreference),
+          useValue: userPreferenceRepository,
         },
         {
           provide: getRepositoryToken(Payee),
@@ -1814,7 +1824,80 @@ describe("TransactionsService", () => {
           transaction: "transaction",
           splits: "splits",
         }),
-        { search: "%groceries%" },
+        { search: "%groceries%", searchAmount: null, searchDate: null },
+      );
+    });
+
+    it("interprets an amount typed in the user's locale format", async () => {
+      const mockQb = createMockQueryBuilder();
+      mockQb.getManyAndCount.mockResolvedValue([[], 0]);
+      transactionsRepository.createQueryBuilder.mockReturnValue(mockQb);
+      investmentTxRepository.find.mockResolvedValue([]);
+      // de-DE: "." thousands, "," decimal -> "1.234,56" means 1234.56.
+      userPreferenceRepository.findOne.mockResolvedValue({
+        numberFormat: "de-DE",
+        dateFormat: "DD.MM.YYYY",
+      });
+
+      await service.findAll(
+        "user-1",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        1,
+        50,
+        false,
+        "1.234,56",
+      );
+
+      expect(mockQb.andWhere).toHaveBeenCalledWith(
+        buildTransactionSearchClause({
+          transaction: "transaction",
+          splits: "splits",
+        }),
+        {
+          search: "%1.234,56%",
+          searchAmount: 1234.56,
+          searchDate: null,
+        },
+      );
+    });
+
+    it("interprets a date typed in the user's display format", async () => {
+      const mockQb = createMockQueryBuilder();
+      mockQb.getManyAndCount.mockResolvedValue([[], 0]);
+      transactionsRepository.createQueryBuilder.mockReturnValue(mockQb);
+      investmentTxRepository.find.mockResolvedValue([]);
+      userPreferenceRepository.findOne.mockResolvedValue({
+        numberFormat: "de-DE",
+        dateFormat: "DD.MM.YYYY",
+      });
+
+      await service.findAll(
+        "user-1",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        1,
+        50,
+        false,
+        "02.07.2026",
+      );
+
+      expect(mockQb.andWhere).toHaveBeenCalledWith(
+        buildTransactionSearchClause({
+          transaction: "transaction",
+          splits: "splits",
+        }),
+        {
+          search: "%02.07.2026%",
+          searchAmount: null,
+          searchDate: "2026-07-02",
+        },
       );
     });
 
@@ -2690,7 +2773,11 @@ describe("TransactionsService", () => {
             splits: "bfSplits",
             paramName: "bfSearch",
           }),
-          { bfSearch: "%grocery%" },
+          {
+            bfSearch: "%grocery%",
+            bfSearchAmount: null,
+            bfSearchDate: null,
+          },
         );
       });
 
@@ -3737,7 +3824,7 @@ describe("TransactionsService", () => {
           transaction: "transaction",
           splits: "splits",
         }),
-        { search: "%test search%" },
+        { search: "%test search%", searchAmount: null, searchDate: null },
       );
     });
 

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -12,6 +12,7 @@ import { Transaction, TransactionStatus } from "./entities/transaction.entity";
 import { TransactionSplit } from "./entities/transaction-split.entity";
 import { Category } from "../categories/entities/category.entity";
 import { InvestmentTransaction } from "../securities/entities/investment-transaction.entity";
+import { UserPreference } from "../users/entities/user-preference.entity";
 import { CreateTransactionDto } from "./dto/create-transaction.dto";
 import { UpdateTransactionDto } from "./dto/update-transaction.dto";
 import { CreateTransactionSplitDto } from "./dto/create-transaction-split.dto";
@@ -47,6 +48,10 @@ import {
   buildTransactionSearchClause,
   escapeLikePattern,
 } from "./transaction-search.util";
+import {
+  parseSearchTerm,
+  ParsedSearchTerm,
+} from "./transaction-search-parse.util";
 import { tr } from "../i18n/translate";
 import { stripHtml } from "../common/sanitization.util";
 import {
@@ -185,6 +190,8 @@ export class TransactionsService {
     private categoriesRepository: Repository<Category>,
     @InjectRepository(InvestmentTransaction)
     private investmentTransactionsRepository: Repository<InvestmentTransaction>,
+    @InjectRepository(UserPreference)
+    private userPreferenceRepository: Repository<UserPreference>,
     @Inject(forwardRef(() => AccountsService))
     private accountsService: AccountsService,
     private payeesService: PayeesService,
@@ -199,6 +206,26 @@ export class TransactionsService {
     private dataSource: DataSource,
     private actionHistoryService: ActionHistoryService,
   ) {}
+
+  /**
+   * Interprets the search box term as an exact amount and/or date using the
+   * user's number/date-format preferences, so a value typed in the user's own
+   * locale format (e.g. "1 234,56" or "02.07.2026") also matches. Returns
+   * `{ amount: null, date: null }` for a blank/non-parseable term.
+   */
+  private async resolveSearchTerm(
+    userId: string,
+    term?: string,
+  ): Promise<ParsedSearchTerm> {
+    if (!term || !term.trim()) return { amount: null, date: null };
+    const prefs = await this.userPreferenceRepository.findOne({
+      where: { userId },
+    });
+    return parseSearchTerm(term, {
+      numberFormat: prefs?.numberFormat,
+      dateFormat: prefs?.dateFormat,
+    });
+  }
 
   async create(
     userId: string,
@@ -730,6 +757,11 @@ export class TransactionsService {
     const safeLimit = clamped.limit;
     let safePage = clamped.page;
 
+    // Interpret the search term once (amount/date in the user's locale format)
+    // and thread it through the query, the target-page count, and the running
+    // balance so all three match the same rows.
+    const parsedSearch = await this.resolveSearchTerm(userId, search);
+
     const queryBuilder = this.transactionsRepository
       .createQueryBuilder("transaction")
       .leftJoinAndSelect("transaction.account", "account")
@@ -806,7 +838,11 @@ export class TransactionsService {
           transaction: "transaction",
           splits: "splits",
         }),
-        { search: searchPattern },
+        {
+          search: searchPattern,
+          searchAmount: parsedSearch.amount,
+          searchDate: parsedSearch.date,
+        },
       );
     }
 
@@ -852,6 +888,7 @@ export class TransactionsService {
         search,
         includeInvestmentBrokerage,
         safePage,
+        parsedSearch,
       );
     }
 
@@ -886,6 +923,8 @@ export class TransactionsService {
           payeeIds,
           tagIds,
           search,
+          searchAmount: parsedSearch.amount,
+          searchDate: parsedSearch.date,
           amountFrom,
           amountTo,
         },
@@ -908,6 +947,8 @@ export class TransactionsService {
           payeeIds,
           tagIds,
           search,
+          searchAmount: parsedSearch.amount,
+          searchDate: parsedSearch.date,
           amountFrom,
           amountTo,
         },
@@ -929,6 +970,8 @@ export class TransactionsService {
           payeeIds,
           tagIds,
           search,
+          searchAmount: parsedSearch.amount,
+          searchDate: parsedSearch.date,
           amountFrom,
           amountTo,
         },
@@ -1017,6 +1060,7 @@ export class TransactionsService {
     search?: string,
     includeInvestmentBrokerage?: boolean,
     fallbackPage: number = 1,
+    parsedSearch: ParsedSearchTerm = { amount: null, date: null },
   ): Promise<number> {
     try {
       const targetTx = await this.transactionsRepository.findOne({
@@ -1053,7 +1097,11 @@ export class TransactionsService {
         const searchPattern = `%${escapeLikePattern(search.trim())}%`;
         countQuery.andWhere(
           buildTransactionSearchClause({ transaction: "t", splits: "s" }),
-          { search: searchPattern },
+          {
+            search: searchPattern,
+            searchAmount: parsedSearch.amount,
+            searchDate: parsedSearch.date,
+          },
         );
       }
 
@@ -1091,6 +1139,8 @@ export class TransactionsService {
       payeeIds?: string[];
       tagIds?: string[];
       search?: string;
+      searchAmount?: number | null;
+      searchDate?: string | null;
       amountFrom?: number;
       amountTo?: number;
     },
@@ -1231,6 +1281,8 @@ export class TransactionsService {
       payeeIds?: string[];
       tagIds?: string[];
       search?: string;
+      searchAmount?: number | null;
+      searchDate?: string | null;
       amountFrom?: number;
       amountTo?: number;
     },
@@ -1479,6 +1531,8 @@ export class TransactionsService {
       payeeIds?: string[];
       tagIds?: string[];
       search?: string;
+      searchAmount?: number | null;
+      searchDate?: string | null;
       amountFrom?: number;
       amountTo?: number;
     },
@@ -1544,7 +1598,11 @@ export class TransactionsService {
           splits: "bfSplits",
           paramName: "bfSearch",
         }),
-        { bfSearch: searchPattern },
+        {
+          bfSearch: searchPattern,
+          bfSearchAmount: filters.searchAmount ?? null,
+          bfSearchDate: filters.searchDate ?? null,
+        },
       );
     }
 


### PR DESCRIPTION
## Linked discussion / issue

Approved in: https://github.com/kenlasko/monize/discussions/818

## Summary

Makes the Transactions search box understand an amount or a date typed in the user's own locale format, **in addition to** the existing substring search (never replacing it).

Today the search term is matched as a plain substring, and the amount only as `CAST(amount AS TEXT) ILIKE` against the raw storage rendering (`1234.5600`); dates are not searched at all. So pasting `1 234,56` / `1234,56` (comma-decimal, as the app itself displays it) or typing a date as displayed (`02.07.2026`) returns nothing.

This PR interprets the query before matching, keyed off the user's stored `numberFormat` / `dateFormat` preferences:

- **Amount detection** — if the trimmed query parses as a number in the user's number format (thousands separator space/dot/comma/none; decimal separator resolved from the locale via `Intl`, with a lenient fallback to the other convention), the search **also** matches rows where `ABS(amount)` equals the parsed value exactly (transaction and split legs). Absolute value so a pasted statement figure finds both the debit and the credit leg. Exact equality on the parsed decimal (rounded to 4 dp) — `12,3` does **not** match `112,30`.
- **Date detection** — if the query parses as a complete date in the user's date format (or ISO `yyyy-MM-dd` as a universal fallback), the search **also** matches `transaction_date = parsed date`.
- **Fallback unchanged** — when the query parses as neither, behaviour is exactly today's substring search. When it parses, the interpreted match is OR-ed with the substring search, so e.g. a payee literally named "1234" is still found.

### Implementation

- New pure parser `backend/src/transactions/transaction-search-parse.util.ts` — `parseSearchTerm(term, { numberFormat, dateFormat })` -> `{ amount, date }`.
- `buildTransactionSearchClause` (the single source of truth, `transaction-search.util.ts`) gains two optional param names and emits three **parameterized, guarded** OR-terms: `ABS(amount)`/`ABS(split.amount) = :searchAmount` and `transactionDate = :searchDate`. The params are always bound by callers (null when the term didn't parse) and cast so the null bind type-checks; the predicates are inert unless the term parsed. No SQL interpolation of user input.
- All four call sites (`transactions.service`, `transaction-analytics.service`, `transaction-bulk-update.service`) inject the `UserPreference` repo, parse once per request, and bind the extra params. `findAll` threads the parsed result through target-page and running-balance so the list, filters, and reports drill-downs stay consistent.
- No schema change.

### Tests

Parser (locale decimal/thousands variants, negative, ambiguity, ISO/display dates, invalid/partial dates), clause-builder term assertions, and service-level tests proving a `de-DE` amount (`1.234,56` -> `1234.56`) and a display-format date (`02.07.2026` -> `2026-07-02`) now match. Full backend suite passes.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (locale-aware amount/date interpretation in transaction search).
- [x] New behavior has tests, and the existing suite passes.
- [x] No new user-facing strings were added (query logic only), so i18n parity is unaffected.
- [x] The shared `buildTransactionSearchClause` is extended in a backward-compatible way (new optional params; all callers updated) — this is the exact extension point named in the approved proposal.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Built with Claude Code (Claude Opus 4.8). I reviewed the diff and tests and own the result.
