### PR TITLE
Make dashboard customize controls mobile-friendly

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -234,17 +234,19 @@ function DashboardContent() {
             title={user?.firstName ? t('page.welcomeWithName', { name: user.firstName }) : `${t('page.welcomePrefix')}!`}
             subtitle={t('page.subtitle')}
             helpUrl="https://github.com/kenlasko/monize/wiki/Dashboard"
+            compactMobileActions
             actions={
               !isDelegateView ? (
                 <button
                   onClick={() => setShowCustomize(true)}
-                  className="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                  aria-label={t('customize.button')}
+                  className="inline-flex items-center justify-center gap-2 p-2 sm:px-3 sm:py-1.5 text-sm font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
                 >
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                   </svg>
-                  {t('customize.button')}
+                  <span className="hidden sm:inline">{t('customize.button')}</span>
                 </button>
               ) : undefined
             }

--- a/frontend/src/components/dashboard/CustomizeDashboardModal.tsx
+++ b/frontend/src/components/dashboard/CustomizeDashboardModal.tsx
@@ -127,7 +127,11 @@ export function CustomizeDashboardModal({ isOpen, onClose }: CustomizeDashboardM
                 aria-label={t('customize.moveEarlier', { name: widgetName(id) })}
                 className="p-0.5 rounded text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed flex-shrink-0"
               >
-                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                {/* Up on mobile (single-column stack), left on wider screens (two-column grid). */}
+                <svg className="h-3.5 w-3.5 sm:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+                </svg>
+                <svg className="h-3.5 w-3.5 hidden sm:block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
                 </svg>
               </button>
@@ -138,7 +142,11 @@ export function CustomizeDashboardModal({ isOpen, onClose }: CustomizeDashboardM
                 aria-label={t('customize.moveLater', { name: widgetName(id) })}
                 className="p-0.5 rounded text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed flex-shrink-0"
               >
-                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                {/* Down on mobile (single-column stack), right on wider screens (two-column grid). */}
+                <svg className="h-3.5 w-3.5 sm:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+                <svg className="h-3.5 w-3.5 hidden sm:block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                 </svg>
               </button>
@@ -146,7 +154,7 @@ export function CustomizeDashboardModal({ isOpen, onClose }: CustomizeDashboardM
                 type="button"
                 onClick={() => hide(id)}
                 aria-label={t('customize.hide', { name: widgetName(id) })}
-                className="p-0.5 rounded text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700 flex-shrink-0"
+                className="p-0.5 ml-1.5 sm:ml-0 rounded text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700 flex-shrink-0"
               >
                 <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />

--- a/frontend/src/components/layout/PageHeader.test.tsx
+++ b/frontend/src/components/layout/PageHeader.test.tsx
@@ -73,6 +73,31 @@ describe('PageHeader', () => {
     expect(screen.getByRole('button', { name: 'Add New' })).toBeInTheDocument();
   });
 
+  it('stacks actions below the title on mobile by default', () => {
+    const { container } = render(
+      <PageHeader title="My Page" actions={<button>Add New</button>} />,
+    );
+    // Default layout is a column on mobile and the actions span full width.
+    expect(container.querySelector('.flex.flex-col')).not.toBeNull();
+    const actionsContainer = container.querySelector('.flex.flex-wrap');
+    expect(actionsContainer?.className).toContain('w-full');
+  });
+
+  it('keeps actions inline on mobile when compactMobileActions is set', () => {
+    const { container } = render(
+      <PageHeader
+        title="My Page"
+        compactMobileActions
+        actions={<button>Add New</button>}
+      />,
+    );
+    // Row layout even on mobile, and the actions container is not full width.
+    expect(container.querySelector('.flex.flex-col')).toBeNull();
+    expect(container.querySelector('.flex.flex-row')).not.toBeNull();
+    const actionsContainer = container.querySelector('.flex.flex-wrap');
+    expect(actionsContainer?.className).not.toContain('w-full');
+  });
+
   it('renders help link next to title when no other actions are provided', () => {
     const { container } = render(
       <PageHeader title="My Page" helpUrl="https://example.com/help" />,

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -13,17 +13,28 @@ interface PageHeaderProps {
   actions?: ReactNode;
   /** URL to the wiki help page for this feature */
   helpUrl?: string;
+  /**
+   * Keep the actions inline (on the same row as the title) on mobile instead
+   * of stacking them full-width below it. Use for compact, icon-sized actions.
+   */
+  compactMobileActions?: boolean;
 }
 
 /**
  * Inline page header with title, subtitle, and action buttons.
  * Renders directly in the content area without a separate background bar.
  */
-export function PageHeader({ title, subtitle, actions, helpUrl }: PageHeaderProps) {
+export function PageHeader({ title, subtitle, actions, helpUrl, compactMobileActions }: PageHeaderProps) {
   const t = useTranslations('layout');
 
+  const layoutClasses = actions
+    ? compactMobileActions
+      ? 'flex flex-row justify-between items-start sm:items-center gap-4'
+      : 'flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4'
+    : '';
+
   return (
-    <div className={`${actions ? 'flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4' : ''} mb-6`}>
+    <div className={`${layoutClasses} mb-6`}>
       <div>
         <div className="flex items-center gap-2">
           <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
@@ -55,7 +66,17 @@ export function PageHeader({ title, subtitle, actions, helpUrl }: PageHeaderProp
           </p>
         )}
       </div>
-      {actions && <div className="flex flex-wrap items-center gap-3 w-full sm:w-auto [&>*]:w-full [&>*]:sm:w-auto">{actions}</div>}
+      {actions && (
+        <div
+          className={`flex flex-wrap items-center gap-3 ${
+            compactMobileActions
+              ? 'w-auto'
+              : 'w-full sm:w-auto [&>*]:w-full [&>*]:sm:w-auto'
+          }`}
+        >
+          {actions}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: <!-- discussion/issue link -->

## Summary

Refines the dashboard customization controls for small screens:

- **Customize modal reorder arrows** now point up/down on mobile (matching the single-column widget stack) and left/right on wider screens (the two-column mockup grid), using responsive SVGs. The hide (x) button is separated from the arrows with a small left margin on mobile.
- **Customize button in the dashboard header** collapses to just the gear icon on mobile (label hidden, `aria-label` preserved) and stays inline on the same level as the welcome header instead of stacking full-width below it. This is driven by a new opt-in `compactMobileActions` prop on the shared `PageHeader`; default behavior for every other page is unchanged.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). <!-- No new/changed strings; the existing `customize.button` label is reused as the mobile `aria-label`. -->
- [x] No shared/core areas were refactored without prior agreement. <!-- `PageHeader` change is a backward-compatible opt-in prop only. -->
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Implemented with assistance from Claude Code. All changes were reviewed and are owned by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Svx2uMxocwemGd6x11ZwQu