### PR TITLE
Localize all transactional emails to the recipient's language

### DIFF
--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -75,6 +75,7 @@ describe("AdminService", () => {
 
     preferencesRepository = {
       delete: jest.fn(),
+      findOne: jest.fn().mockResolvedValue(null),
     };
 
     refreshTokensRepository = {
@@ -271,6 +272,24 @@ describe("AdminService", () => {
         "Your Monize account is ready",
         expect.stringContaining("reset-password?token="),
       );
+    });
+
+    it("resolves the invite email language from the invitee's stored preference", async () => {
+      transactionManager.findOne.mockResolvedValue(null);
+      preferencesRepository.findOne.mockResolvedValue({
+        userId: "new-user-id",
+        language: "fr",
+      });
+
+      await service.createUser({
+        email: "invitee@example.com",
+        firstName: "Invitee",
+        sendInvite: true,
+      });
+
+      expect(preferencesRepository.findOne).toHaveBeenCalledWith({
+        where: { userId: "new-user-id" },
+      });
     });
 
     it("rejects sendInvite when SMTP is not configured", async () => {

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -14,7 +14,7 @@ import * as crypto from "crypto";
 import { I18nService } from "nestjs-i18n";
 import { tr } from "../i18n/translate";
 import { emailTranslator } from "../i18n/email-translator";
-import { DEFAULT_LOCALE } from "../i18n/config";
+import { resolveUserEmailLocale } from "../i18n/resolve-user-email-locale";
 import { User } from "../users/entities/user.entity";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
@@ -205,7 +205,10 @@ export class AdminService {
         "http://localhost:3000",
       );
       const inviteUrl = `${frontendUrl}/reset-password?token=${inviteToken}`;
-      const lang = DEFAULT_LOCALE;
+      const lang = await resolveUserEmailLocale(
+        this.preferencesRepository,
+        saved.id,
+      );
       const t = emailTranslator(this.i18n, lang);
       this.emailService
         .sendMail(

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1,10 +1,12 @@
 import { Test, TestingModule } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
 import {
   BadRequestException,
   ForbiddenException,
   UnauthorizedException,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
+import { UserPreference } from "../users/entities/user-preference.entity";
 import { AuthController } from "./auth.controller";
 import { AuthService } from "./auth.service";
 import { OidcService } from "./oidc/oidc.service";
@@ -169,6 +171,10 @@ describe("AuthController", () => {
               opts?.defaultValue ?? key,
           },
         },
+        {
+          provide: getRepositoryToken(UserPreference),
+          useValue: { findOne: jest.fn().mockResolvedValue(null) },
+        },
       ],
     }).compile();
 
@@ -225,6 +231,10 @@ describe("AuthController", () => {
               translate: (key: string, opts?: { defaultValue?: string }) =>
                 opts?.defaultValue ?? key,
             },
+          },
+          {
+            provide: getRepositoryToken(UserPreference),
+            useValue: { findOne: jest.fn().mockResolvedValue(null) },
           },
         ],
       }).compile();
@@ -286,6 +296,10 @@ describe("AuthController", () => {
               translate: (key: string, opts?: { defaultValue?: string }) =>
                 opts?.defaultValue ?? key,
             },
+          },
+          {
+            provide: getRepositoryToken(UserPreference),
+            useValue: { findOne: jest.fn().mockResolvedValue(null) },
           },
         ],
       }).compile();
@@ -403,6 +417,10 @@ describe("AuthController", () => {
               translate: (key: string, opts?: { defaultValue?: string }) =>
                 opts?.defaultValue ?? key,
             },
+          },
+          {
+            provide: getRepositoryToken(UserPreference),
+            useValue: { findOne: jest.fn().mockResolvedValue(null) },
           },
         ],
       }).compile();
@@ -683,6 +701,10 @@ describe("AuthController", () => {
                 opts?.defaultValue ?? key,
             },
           },
+          {
+            provide: getRepositoryToken(UserPreference),
+            useValue: { findOne: jest.fn().mockResolvedValue(null) },
+          },
         ],
       }).compile();
 
@@ -845,6 +867,10 @@ describe("AuthController", () => {
               translate: (key: string, opts?: { defaultValue?: string }) =>
                 opts?.defaultValue ?? key,
             },
+          },
+          {
+            provide: getRepositoryToken(UserPreference),
+            useValue: { findOne: jest.fn().mockResolvedValue(null) },
           },
         ],
       }).compile();
@@ -1743,6 +1769,10 @@ describe("AuthController", () => {
                 opts?.defaultValue ?? key,
             },
           },
+          {
+            provide: getRepositoryToken(UserPreference),
+            useValue: { findOne: jest.fn().mockResolvedValue(null) },
+          },
         ],
       }).compile();
 
@@ -1813,6 +1843,10 @@ describe("AuthController", () => {
               translate: (key: string, opts?: { defaultValue?: string }) =>
                 opts?.defaultValue ?? key,
             },
+          },
+          {
+            provide: getRepositoryToken(UserPreference),
+            useValue: { findOne: jest.fn().mockResolvedValue(null) },
           },
         ],
       }).compile();
@@ -1908,6 +1942,10 @@ describe("AuthController", () => {
                 opts?.defaultValue ?? key,
             },
           },
+          {
+            provide: getRepositoryToken(UserPreference),
+            useValue: { findOne: jest.fn().mockResolvedValue(null) },
+          },
         ],
       }).compile();
       const c = force2faModule.get<AuthController>(AuthController);
@@ -1989,6 +2027,10 @@ describe("AuthController", () => {
               translate: (key: string, opts?: { defaultValue?: string }) =>
                 opts?.defaultValue ?? key,
             },
+          },
+          {
+            provide: getRepositoryToken(UserPreference),
+            useValue: { findOne: jest.fn().mockResolvedValue(null) },
           },
         ],
       }).compile();
@@ -2074,6 +2116,10 @@ describe("AuthController", () => {
                   opts?.defaultValue ?? key,
               },
             },
+            {
+              provide: getRepositoryToken(UserPreference),
+              useValue: { findOne: jest.fn().mockResolvedValue(null) },
+            },
           ],
         }).compile();
         const c = m.get<AuthController>(AuthController);
@@ -2129,6 +2175,10 @@ describe("AuthController", () => {
               translate: (key: string, opts?: { defaultValue?: string }) =>
                 opts?.defaultValue ?? key,
             },
+          },
+          {
+            provide: getRepositoryToken(UserPreference),
+            useValue: { findOne: jest.fn().mockResolvedValue(null) },
           },
         ],
       }).compile();
@@ -2186,6 +2236,10 @@ describe("AuthController", () => {
               translate: (key: string, opts?: { defaultValue?: string }) =>
                 opts?.defaultValue ?? key,
             },
+          },
+          {
+            provide: getRepositoryToken(UserPreference),
+            useValue: { findOne: jest.fn().mockResolvedValue(null) },
           },
         ],
       }).compile();
@@ -2254,6 +2308,10 @@ describe("AuthController", () => {
                 opts?.defaultValue ?? key,
             },
           },
+          {
+            provide: getRepositoryToken(UserPreference),
+            useValue: { findOne: jest.fn().mockResolvedValue(null) },
+          },
         ],
       }).compile();
       const c = m.get<AuthController>(AuthController);
@@ -2306,6 +2364,10 @@ describe("AuthController", () => {
               translate: (key: string, opts?: { defaultValue?: string }) =>
                 opts?.defaultValue ?? key,
             },
+          },
+          {
+            provide: getRepositoryToken(UserPreference),
+            useValue: { findOne: jest.fn().mockResolvedValue(null) },
           },
         ],
       }).compile();
@@ -2497,6 +2559,10 @@ describe("AuthController", () => {
               translate: (key: string, opts?: { defaultValue?: string }) =>
                 opts?.defaultValue ?? key,
             },
+          },
+          {
+            provide: getRepositoryToken(UserPreference),
+            useValue: { findOne: jest.fn().mockResolvedValue(null) },
           },
         ],
       }).compile();

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -46,8 +46,11 @@ import {
 } from "../notifications/email-templates";
 import { SwitchContextDto } from "./dto/switch-context.dto";
 import { I18nService } from "nestjs-i18n";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { UserPreference } from "../users/entities/user-preference.entity";
 import { emailTranslator } from "../i18n/email-translator";
-import { DEFAULT_LOCALE } from "../i18n/config";
+import { resolveUserEmailLocale } from "../i18n/resolve-user-email-locale";
 import { DelegationService } from "../delegation/delegation.service";
 import { AllowDelegate } from "../delegation/decorators/delegate-access.decorator";
 import { SkipCsrf } from "../common/decorators/skip-csrf.decorator";
@@ -78,6 +81,8 @@ export class AuthController {
     private tokenService: TokenService,
     private delegationService: DelegationService,
     private readonly i18n: I18nService,
+    @InjectRepository(UserPreference)
+    private readonly preferencesRepository: Repository<UserPreference>,
   ) {
     // Default to true if not explicitly set to 'false'
     const localAuthSetting = this.configService.get<string>(
@@ -267,6 +272,7 @@ export class AuthController {
     // the client to show its "check your email" state.
     if (result.verificationRequired) {
       await this.sendVerificationEmail(
+        result.user.id,
         result.user.email!,
         result.user.firstName ?? "",
         result.verificationToken,
@@ -289,6 +295,7 @@ export class AuthController {
    * does not reveal whether delivery succeeded (mirrors password-reset).
    */
   private async sendVerificationEmail(
+    userId: string,
     email: string,
     firstName: string,
     token: string,
@@ -298,7 +305,10 @@ export class AuthController {
       "http://localhost:3000",
     );
     const verifyUrl = `${frontendUrl}/verify-email?token=${token}`;
-    const lang = DEFAULT_LOCALE;
+    const lang = await resolveUserEmailLocale(
+      this.preferencesRepository,
+      userId,
+    );
     const t = emailTranslator(this.i18n, lang);
     const html = emailVerificationTemplate(firstName, verifyUrl, t);
 
@@ -686,7 +696,10 @@ export class AuthController {
         "http://localhost:3000",
       );
       const resetUrl = `${frontendUrl}/reset-password?token=${result.token}`;
-      const lang = DEFAULT_LOCALE;
+      const lang = await resolveUserEmailLocale(
+        this.preferencesRepository,
+        result.user.id,
+      );
       const t = emailTranslator(this.i18n, lang);
       const html = passwordResetTemplate(
         result.user.firstName || "",
@@ -772,6 +785,7 @@ export class AuthController {
       );
       if (result) {
         await this.sendVerificationEmail(
+          result.user.id,
           result.user.email!,
           result.user.firstName ?? "",
           result.token,

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -35,7 +35,7 @@ import { tr } from "../i18n/translate";
 import { currentRequestLocale } from "../i18n/request-locale";
 import { I18nService } from "nestjs-i18n";
 import { emailTranslator } from "../i18n/email-translator";
-import { DEFAULT_LOCALE } from "../i18n/config";
+import { resolveUserEmailLocale } from "../i18n/resolve-user-email-locale";
 
 @Injectable()
 export class AuthService {
@@ -323,7 +323,10 @@ export class AuthService {
         );
         // Fire-and-forget lockout email
         if (user.email) {
-          const lang = DEFAULT_LOCALE;
+          const lang = await resolveUserEmailLocale(
+            this.preferencesRepository,
+            user.id,
+          );
           const t = emailTranslator(this.i18n, lang);
           this.emailService
             .sendMail(
@@ -697,7 +700,10 @@ export class AuthService {
         this.configService.get<string>("PUBLIC_APP_URL") ||
         "http://localhost:3000";
       const confirmUrl = `${frontendUrl}/api/v1/auth/oidc/confirm-link?token=${linkToken}`;
-      const lang = DEFAULT_LOCALE;
+      const lang = await resolveUserEmailLocale(
+        this.preferencesRepository,
+        user.id,
+      );
       const t = emailTranslator(this.i18n, lang);
       const html = oidcLinkTemplate(user.firstName || "", confirmUrl, t);
       await this.emailService.sendMail(

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -1189,6 +1189,26 @@ describe("DelegationService", () => {
       expect(emailService.sendMail).toHaveBeenCalled();
     });
 
+    it("resolves the invite email language from the delegate's stored preference", async () => {
+      usersRepo.findOne.mockResolvedValue({ id: "o1", email: "own@x.y" });
+      emailService.getStatus.mockReturnValue({ configured: true });
+      emailService.sendMail.mockResolvedValue(undefined);
+      configService.get.mockReturnValue("http://app");
+      prefsRepo.findOne.mockResolvedValue({ userId: "g-new", language: "fr" });
+      const manager = makeManager();
+      manager.findOne.mockResolvedValue(null);
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+
+      await service.createDelegate("o1", {
+        email: "new@x.y",
+        sendInvite: true,
+      } as any);
+
+      expect(prefsRepo.findOne).toHaveBeenCalledWith({
+        where: { userId: "g-new" },
+      });
+    });
+
     it("rejects an invite when SMTP is not configured", async () => {
       usersRepo.findOne.mockResolvedValue({ id: "o1", email: "own@x.y" });
       emailService.getStatus.mockReturnValue({ configured: false });

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -29,7 +29,7 @@ import { generateReadablePassword } from "../admin/utils/password-generator";
 import { I18nService } from "nestjs-i18n";
 import { tr } from "../i18n/translate";
 import { emailTranslator } from "../i18n/email-translator";
-import { DEFAULT_LOCALE } from "../i18n/config";
+import { resolveUserEmailLocale } from "../i18n/resolve-user-email-locale";
 import { EmailService } from "../notifications/email.service";
 import { delegateInviteTemplate } from "../notifications/email-templates";
 import { ConfigService } from "@nestjs/config";
@@ -901,7 +901,10 @@ export class DelegationService {
           "http://localhost:3000",
         );
         const inviteUrl = `${frontendUrl}/reset-password?token=${inviteToken}`;
-        const lang = DEFAULT_LOCALE;
+        const lang = await resolveUserEmailLocale(
+          this.preferencesRepository,
+          delegateUser.id,
+        );
         const t = emailTranslator(this.i18n, lang);
         this.emailService
           .sendMail(

--- a/backend/src/emergency-access/emergency-access-monitor.service.spec.ts
+++ b/backend/src/emergency-access/emergency-access-monitor.service.spec.ts
@@ -8,12 +8,14 @@ import { EmergencyAccessContact } from "./entities/emergency-access-contact.enti
 import { AiEncryptionService } from "../ai/ai-encryption.service";
 import { EmailService } from "../notifications/email.service";
 import { User } from "../users/entities/user.entity";
+import { UserPreference } from "../users/entities/user-preference.entity";
 
 describe("EmergencyAccessMonitorService", () => {
   let service: EmergencyAccessMonitorService;
   let settingsRepo: Record<string, jest.Mock>;
   let contactsRepo: Record<string, jest.Mock>;
   let usersRepo: Record<string, jest.Mock>;
+  let prefsRepo: Record<string, jest.Mock>;
   let emailService: Record<string, jest.Mock>;
   let encryption: Record<string, jest.Mock>;
   let configService: Record<string, jest.Mock>;
@@ -41,6 +43,7 @@ describe("EmergencyAccessMonitorService", () => {
       })),
     };
     usersRepo = { findOne: jest.fn() };
+    prefsRepo = { findOne: jest.fn().mockResolvedValue(null) };
     emailService = {
       getStatus: jest.fn().mockReturnValue({ configured: true }),
       sendMail: jest.fn().mockResolvedValue(undefined),
@@ -65,6 +68,10 @@ describe("EmergencyAccessMonitorService", () => {
           useValue: contactsRepo,
         },
         { provide: getRepositoryToken(User), useValue: usersRepo },
+        {
+          provide: getRepositoryToken(UserPreference),
+          useValue: prefsRepo,
+        },
         { provide: EmailService, useValue: emailService },
         { provide: AiEncryptionService, useValue: encryption },
         { provide: ConfigService, useValue: configService },
@@ -291,6 +298,48 @@ describe("EmergencyAccessMonitorService", () => {
     await service.runDailyCheck();
 
     expect(emailService.sendMail).toHaveBeenCalledTimes(2);
+  });
+
+  it("localizes the grant email to the contact's own account language when they are a Monize user", async () => {
+    settingsRepo.find.mockResolvedValue([
+      {
+        ownerUserId: userId,
+        enabled: true,
+        grantAfterDays: 14,
+        reminderAfterDays: 7,
+        messageCiphertext: null,
+        lastReminderSentAt: null,
+        grantedAt: null,
+      },
+    ]);
+    usersRepo.findOne.mockImplementation((opts) =>
+      opts?.where?.email === "carol@example.com"
+        ? Promise.resolve({ id: "contact-1", email: "carol@example.com" })
+        : Promise.resolve({
+            id: userId,
+            email: "owner@example.com",
+            firstName: "Owner",
+            isActive: true,
+            lastActivityAt: daysAgo(20),
+          }),
+    );
+    contactsRepo.find.mockResolvedValue([
+      { id: "c1", firstName: "Carol", email: "carol@example.com" },
+    ]);
+    prefsRepo.findOne.mockResolvedValue({
+      userId: "contact-1",
+      language: "fr",
+    });
+
+    await service.runDailyCheck();
+
+    expect(usersRepo.findOne).toHaveBeenCalledWith({
+      where: { email: "carol@example.com" },
+    });
+    expect(prefsRepo.findOne).toHaveBeenCalledWith({
+      where: { userId: "contact-1" },
+    });
+    expect(emailService.sendMail).toHaveBeenCalledTimes(1);
   });
 
   it("skips a user gracefully when their settings row is inactive (no email)", async () => {

--- a/backend/src/emergency-access/emergency-access-monitor.service.ts
+++ b/backend/src/emergency-access/emergency-access-monitor.service.ts
@@ -15,9 +15,10 @@ import {
   emergencyAccessReminderTemplate,
 } from "../notifications/email-templates";
 import { emailTranslator } from "../i18n/email-translator";
-import { DEFAULT_LOCALE } from "../i18n/config";
+import { resolveUserEmailLocale } from "../i18n/resolve-user-email-locale";
 import { hashToken } from "../auth/crypto.util";
 import { User } from "../users/entities/user.entity";
+import { UserPreference } from "../users/entities/user-preference.entity";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const CLAIM_TOKEN_BYTES = 32;
@@ -34,6 +35,8 @@ export class EmergencyAccessMonitorService {
     private readonly contactsRepo: Repository<EmergencyAccessContact>,
     @InjectRepository(User)
     private readonly usersRepo: Repository<User>,
+    @InjectRepository(UserPreference)
+    private readonly preferencesRepo: Repository<UserPreference>,
     private readonly emailService: EmailService,
     private readonly encryption: AiEncryptionService,
     private readonly configService: ConfigService,
@@ -147,7 +150,15 @@ export class EmergencyAccessMonitorService {
           await this.contactsRepo.save(contact);
 
           const claimUrl = `${appUrl}/emergency-access/claim?token=${rawToken}`;
-          const lang = DEFAULT_LOCALE;
+          // The contact may or may not be a Monize user; localize to their own
+          // account language when they have one, otherwise fall back to default.
+          const contactUser = await this.usersRepo.findOne({
+            where: { email: contact.email },
+          });
+          const lang = await resolveUserEmailLocale(
+            this.preferencesRepo,
+            contactUser?.id ?? null,
+          );
           const t = emailTranslator(this.i18n, lang);
           const html = emergencyAccessGrantTemplate(
             {
@@ -216,7 +227,10 @@ export class EmergencyAccessMonitorService {
         0,
         settings.grantAfterDays - daysSinceLogin,
       );
-      const reminderLang = DEFAULT_LOCALE;
+      const reminderLang = await resolveUserEmailLocale(
+        this.preferencesRepo,
+        settings.ownerUserId,
+      );
       const reminderT = emailTranslator(this.i18n, reminderLang);
       const html = emergencyAccessReminderTemplate(
         {
@@ -289,7 +303,10 @@ export class EmergencyAccessMonitorService {
 
     if (!owner.email) return;
     try {
-      const revokedLang = DEFAULT_LOCALE;
+      const revokedLang = await resolveUserEmailLocale(
+        this.preferencesRepo,
+        settings.ownerUserId,
+      );
       const revokedT = emailTranslator(this.i18n, revokedLang);
       const html = emergencyAccessGrantRevokedTemplate(
         {

--- a/backend/src/i18n/resolve-user-email-locale.spec.ts
+++ b/backend/src/i18n/resolve-user-email-locale.spec.ts
@@ -1,0 +1,49 @@
+import { Repository } from "typeorm";
+import { UserPreference } from "../users/entities/user-preference.entity";
+import { resolveUserEmailLocale } from "./resolve-user-email-locale";
+
+describe("resolveUserEmailLocale", () => {
+  const makeRepo = (language: string | null | undefined) =>
+    ({
+      findOne: jest
+        .fn()
+        .mockResolvedValue(
+          language === undefined ? null : { userId: "u1", language },
+        ),
+    }) as unknown as Repository<UserPreference> & {
+      findOne: jest.Mock;
+    };
+
+  it("returns the recipient's stored concrete language", async () => {
+    const repo = makeRepo("fr");
+    await expect(resolveUserEmailLocale(repo, "u1")).resolves.toBe("fr");
+    expect(repo.findOne).toHaveBeenCalledWith({ where: { userId: "u1" } });
+  });
+
+  it("returns a regional variant when stored", async () => {
+    const repo = makeRepo("pt-BR");
+    await expect(resolveUserEmailLocale(repo, "u1")).resolves.toBe("pt-BR");
+  });
+
+  it("falls back to the default locale when the user has no preferences row", async () => {
+    const repo = makeRepo(undefined);
+    await expect(resolveUserEmailLocale(repo, "u1")).resolves.toBe("en");
+  });
+
+  it("ignores the 'browser' follow-the-browser sentinel", async () => {
+    const repo = makeRepo("browser");
+    // No HTTP context in a unit test, so this resolves to the default locale.
+    await expect(resolveUserEmailLocale(repo, "u1")).resolves.toBe("en");
+  });
+
+  it("ignores an unsupported stored value", async () => {
+    const repo = makeRepo("klingon");
+    await expect(resolveUserEmailLocale(repo, "u1")).resolves.toBe("en");
+  });
+
+  it("does not query when there is no recipient user id", async () => {
+    const repo = makeRepo("fr");
+    await expect(resolveUserEmailLocale(repo, null)).resolves.toBe("en");
+    expect(repo.findOne).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/i18n/resolve-user-email-locale.ts
+++ b/backend/src/i18n/resolve-user-email-locale.ts
@@ -1,0 +1,39 @@
+import { Repository } from "typeorm";
+import { UserPreference } from "../users/entities/user-preference.entity";
+import { isSupportedLocale } from "./config";
+import { currentRequestLocale } from "./request-locale";
+
+/**
+ * Resolve the locale an email addressed to `userId` should be rendered in.
+ *
+ * Email copy must match the recipient's own language, not the request locale of
+ * whoever triggered the send (an admin provisioning an account, a scheduler, or
+ * an attacker tripping the failed-login lockout). Precedence:
+ *
+ * 1. the recipient's stored, concrete `user_preferences.language`;
+ * 2. otherwise -- when the user has no row, no preference, or the "browser"
+ *    follow-the-browser sentinel -- the current request/browser locale;
+ * 3. otherwise the default locale (what {@link currentRequestLocale} returns
+ *    outside an HTTP context, e.g. cron jobs and fire-and-forget sends).
+ *
+ * The "browser" sentinel and any unsupported value are treated as "no concrete
+ * stored preference" so they fall through rather than being handed to the
+ * translator verbatim.
+ *
+ * @param preferencesRepo repository for {@link UserPreference}
+ * @param userId the recipient's user id, or null/undefined when the recipient
+ *   is not a known Monize user (e.g. an emergency contact without an account)
+ */
+export async function resolveUserEmailLocale(
+  preferencesRepo: Repository<UserPreference>,
+  userId: string | null | undefined,
+): Promise<string> {
+  if (userId) {
+    const prefs = await preferencesRepo.findOne({ where: { userId } });
+    const stored = prefs?.language;
+    if (stored && stored !== "browser" && isSupportedLocale(stored)) {
+      return stored;
+    }
+  }
+  return currentRequestLocale();
+}

--- a/backend/src/notifications/notifications.controller.spec.ts
+++ b/backend/src/notifications/notifications.controller.spec.ts
@@ -1,14 +1,17 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { BadRequestException } from "@nestjs/common";
+import { getRepositoryToken } from "@nestjs/typeorm";
 import { I18nService } from "nestjs-i18n";
 import { NotificationsController } from "./notifications.controller";
 import { EmailService } from "./email.service";
 import { UsersService } from "../users/users.service";
+import { UserPreference } from "../users/entities/user-preference.entity";
 
 describe("NotificationsController", () => {
   let controller: NotificationsController;
   let mockEmailService: Partial<Record<keyof EmailService, jest.Mock>>;
   let mockUsersService: Partial<Record<keyof UsersService, jest.Mock>>;
+  let mockPreferencesRepo: Record<string, jest.Mock>;
   const mockReq = { user: { id: "user-1" } };
 
   beforeEach(async () => {
@@ -19,6 +22,10 @@ describe("NotificationsController", () => {
 
     mockUsersService = {
       findById: jest.fn(),
+    };
+
+    mockPreferencesRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -35,9 +42,18 @@ describe("NotificationsController", () => {
         {
           provide: I18nService,
           useValue: {
-            translate: (key: string, opts?: { defaultValue?: string }) =>
-              opts?.defaultValue ?? key,
+            translate: (
+              key: string,
+              opts?: { lang?: string; defaultValue?: string },
+            ) =>
+              opts?.lang === "fr" && key === "emails.test.subject"
+                ? "Monize Test Email (fr)"
+                : (opts?.defaultValue ?? key),
           },
+        },
+        {
+          provide: getRepositoryToken(UserPreference),
+          useValue: mockPreferencesRepo,
         },
       ],
     }).compile();
@@ -61,6 +77,7 @@ describe("NotificationsController", () => {
     it("sends test email when SMTP is configured and user has email", async () => {
       mockEmailService.getStatus!.mockReturnValue({ configured: true });
       mockUsersService.findById!.mockResolvedValue({
+        id: "user-1",
         email: "test@example.com",
         firstName: "John",
       });
@@ -73,6 +90,31 @@ describe("NotificationsController", () => {
       expect(mockEmailService.sendMail).toHaveBeenCalledWith(
         "test@example.com",
         "Monize Test Email",
+        expect.any(String),
+      );
+    });
+
+    it("renders the test email in the recipient's stored language", async () => {
+      mockEmailService.getStatus!.mockReturnValue({ configured: true });
+      mockUsersService.findById!.mockResolvedValue({
+        id: "user-1",
+        email: "test@example.com",
+        firstName: "John",
+      });
+      mockPreferencesRepo.findOne.mockResolvedValue({
+        userId: "user-1",
+        language: "fr",
+      });
+      mockEmailService.sendMail!.mockResolvedValue(undefined);
+
+      await controller.sendTestEmail(mockReq);
+
+      expect(mockPreferencesRepo.findOne).toHaveBeenCalledWith({
+        where: { userId: "user-1" },
+      });
+      expect(mockEmailService.sendMail).toHaveBeenCalledWith(
+        "test@example.com",
+        "Monize Test Email (fr)",
         expect.any(String),
       );
     });

--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -7,14 +7,17 @@ import {
   BadRequestException,
 } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
 import { I18nService } from "nestjs-i18n";
 import { tr } from "../i18n/translate";
 import { ApiTags, ApiOperation, ApiBearerAuth } from "@nestjs/swagger";
 import { EmailService } from "./email.service";
 import { UsersService } from "../users/users.service";
+import { UserPreference } from "../users/entities/user-preference.entity";
 import { testEmailTemplate } from "./email-templates";
 import { emailTranslator } from "../i18n/email-translator";
-import { DEFAULT_LOCALE } from "../i18n/config";
+import { resolveUserEmailLocale } from "../i18n/resolve-user-email-locale";
 
 @ApiTags("Notifications")
 @Controller("notifications")
@@ -25,6 +28,8 @@ export class NotificationsController {
     private readonly emailService: EmailService,
     private readonly usersService: UsersService,
     private readonly i18n: I18nService,
+    @InjectRepository(UserPreference)
+    private readonly preferencesRepository: Repository<UserPreference>,
   ) {}
 
   @Get("smtp-status")
@@ -56,7 +61,10 @@ export class NotificationsController {
       );
     }
 
-    const lang = DEFAULT_LOCALE;
+    const lang = await resolveUserEmailLocale(
+      this.preferencesRepository,
+      user.id,
+    );
     const t = emailTranslator(this.i18n, lang);
     const html = testEmailTemplate(user.firstName || "", t);
     const subject = t("emails.test.subject", "Monize Test Email");


### PR DESCRIPTION
<!-- Before opening this PR, please read CONTRIBUTING.md. Monize follows a propose-first workflow: open a Discussion and get the approach approved before writing code. -->

## Linked discussion / issue

<!-- Required. Paste the link to the approved discussion or issue that agreed on this change's scope and approach. -->

Closes #
Approved in: _No linked discussion — this started as a request to verify that all email content is localized to the user's language. The audit found gaps, so this PR completes the localization. Please link/adjust before merging if a discussion is required._

## Summary

<!-- What does this PR do, and why? Keep it to a single concern. -->

Email templates and subjects were already translatable, but only the cron notification emails (bill/mortgage reminders, budget alerts and digests) resolved the recipient's stored `user_preferences.language`. The auth, admin, delegation, and emergency-access emails hardcoded `DEFAULT_LOCALE`, so they always went out in English regardless of the user's chosen language.

This PR adds a shared `resolveUserEmailLocale()` helper (`backend/src/i18n/resolve-user-email-locale.ts`) that resolves a recipient's stored concrete language, falling back to the current request/browser locale and then the default. The `"browser"` follow-the-browser sentinel and unsupported values fall through rather than being handed to the translator verbatim. It is wired into every remaining send site:

- test email (notifications controller)
- account-locked and OIDC-link (auth service)
- email verification and password reset (auth controller)
- admin account invite
- delegate invite
- emergency-access reminder and revoked notices (owner's language) and the grant email (contact's account language when they are a Monize user, looked up by email)

The `UserPreference` repository is injected where it was not already available (notifications and auth controllers, emergency-access monitor); the modules already registered the entity.

No message catalogs changed — every subject/body key already existed and is translated in all locales, so i18n parity is unaffected.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity) — no new strings were added; all keys already existed and were translated.
- [ ] No shared/core areas were refactored without prior agreement — adds a shared `src/i18n` helper and injects `UserPreference` into three more providers; flagging for review.
- [ ] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

<!-- Disclose any AI tools used. Using AI is fine and expected — you remain responsible for correctness, conventions, and tests. -->

Implemented with Claude Code. Changes and tests were reviewed by the author, who owns correctness, conventions, and test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012U9fGqkYo2pikRgpjkTUCn