### PR TITLE
Add configurable dashboard widgets for portfolio and spending analytics

### DIFF
--- a/backend/src/users/dto/update-preferences.dto.ts
+++ b/backend/src/users/dto/update-preferences.dto.ts
@@ -5,6 +5,7 @@ import {
   IsBoolean,
   IsInt,
   IsArray,
+  IsObject,
   Min,
   Max,
   MaxLength,
@@ -12,6 +13,7 @@ import {
   Matches,
   IsIn,
 } from "class-validator";
+import { IsDashboardWidgetConfig } from "../validators/is-dashboard-widget-config.validator";
 
 export class UpdatePreferencesDto {
   @ApiPropertyOptional({
@@ -179,6 +181,19 @@ export class UpdatePreferencesDto {
   })
   @ArrayMaxSize(50)
   dashboardWidgets?: string[];
+
+  @ApiPropertyOptional({
+    description:
+      "Per-widget dashboard settings (timeframe, account selection, chart type) keyed by widget id",
+    example: {
+      "spending-by-payee": { range: "3m" },
+      "income-by-source": { range: "1y", chartType: "pie" },
+    },
+  })
+  @IsOptional()
+  @IsObject()
+  @IsDashboardWidgetConfig()
+  dashboardWidgetConfig?: Record<string, unknown>;
 
   @ApiPropertyOptional({
     description: "Show the Created At field in transaction forms",

--- a/backend/src/users/entities/user-preference.entity.ts
+++ b/backend/src/users/entities/user-preference.entity.ts
@@ -76,6 +76,15 @@ export class UserPreference {
   })
   dashboardWidgets: string[];
 
+  // Per-widget settings (timeframe, account selection, chart type, etc.) keyed
+  // by widget id. Empty object = every widget uses its built-in defaults.
+  @Column({
+    name: "dashboard_widget_config",
+    type: "jsonb",
+    default: {},
+  })
+  dashboardWidgetConfig: Record<string, unknown>;
+
   @Column({ name: "show_created_at", default: false })
   showCreatedAt: boolean;
 

--- a/backend/src/users/entities/user-preference.entity.ts
+++ b/backend/src/users/entities/user-preference.entity.ts
@@ -78,12 +78,15 @@ export class UserPreference {
 
   // Per-widget settings (timeframe, account selection, chart type, etc.) keyed
   // by widget id. Empty object = every widget uses its built-in defaults.
+  // Typed as Record<string, any> (matching the other jsonb columns on
+  // relation-reachable entities, e.g. action-history) so TypeORM's DeepPartial
+  // stays satisfiable where UserPreference is reached through the User relation.
   @Column({
     name: "dashboard_widget_config",
     type: "jsonb",
     default: {},
   })
-  dashboardWidgetConfig: Record<string, unknown>;
+  dashboardWidgetConfig: Record<string, any>;
 
   @Column({ name: "show_created_at", default: false })
   showCreatedAt: boolean;

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -442,6 +442,21 @@ describe("UsersService", () => {
       ]);
     });
 
+    it("updates dashboardWidgetConfig", async () => {
+      preferencesRepository.findOne.mockResolvedValue({ ...mockPreferences });
+
+      await service.updatePreferences("user-1", {
+        dashboardWidgetConfig: {
+          "spending-by-payee": { range: "6m" },
+        },
+      });
+
+      const savedData = preferencesRepository.save.mock.calls[0][0];
+      expect(savedData.dashboardWidgetConfig).toEqual({
+        "spending-by-payee": { range: "6m" },
+      });
+    });
+
     it("updates preferredExchanges", async () => {
       preferencesRepository.findOne.mockResolvedValue({ ...mockPreferences });
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -205,6 +205,9 @@ export class UsersService {
     if (dto.dashboardWidgets !== undefined) {
       preferences.dashboardWidgets = dto.dashboardWidgets;
     }
+    if (dto.dashboardWidgetConfig !== undefined) {
+      preferences.dashboardWidgetConfig = dto.dashboardWidgetConfig;
+    }
     if (dto.showCreatedAt !== undefined) {
       preferences.showCreatedAt = dto.showCreatedAt;
     }

--- a/backend/src/users/validators/is-dashboard-widget-config.validator.spec.ts
+++ b/backend/src/users/validators/is-dashboard-widget-config.validator.spec.ts
@@ -1,0 +1,89 @@
+import { IsDashboardWidgetConfigConstraint } from "./is-dashboard-widget-config.validator";
+
+describe("IsDashboardWidgetConfigConstraint", () => {
+  const validator = new IsDashboardWidgetConfigConstraint();
+
+  it("accepts undefined and null (optional)", () => {
+    expect(validator.validate(undefined)).toBe(true);
+    expect(validator.validate(null)).toBe(true);
+  });
+
+  it("accepts an empty object", () => {
+    expect(validator.validate({})).toBe(true);
+  });
+
+  it("accepts a valid widget config map", () => {
+    expect(
+      validator.validate({
+        "spending-by-payee": { range: "3m" },
+        "income-by-source": { range: "1y", chartType: "pie" },
+        "sector-weightings": { accountIds: ["a", "b"] },
+        "recurring-expenses": { minOccurrences: 3 },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects arrays at the top level", () => {
+    expect(validator.validate([])).toBe(false);
+  });
+
+  it("rejects non-object top-level values", () => {
+    expect(validator.validate("nope")).toBe(false);
+    expect(validator.validate(42)).toBe(false);
+  });
+
+  it("rejects widget ids that violate the id pattern", () => {
+    expect(validator.validate({ "Bad Id": { range: "3m" } })).toBe(false);
+    expect(validator.validate({ UPPER: {} })).toBe(false);
+  });
+
+  it("rejects dangerous keys", () => {
+    // Build a real own "__proto__" key (a JSON payload does exactly this);
+    // the literal { __proto__: {} } would set the prototype instead.
+    expect(validator.validate(JSON.parse('{"__proto__": {}}'))).toBe(false);
+    expect(validator.validate({ widget: { constructor: "x" } })).toBe(false);
+  });
+
+  it("rejects a widget value that is not a flat object", () => {
+    expect(validator.validate({ widget: "string" })).toBe(false);
+    expect(validator.validate({ widget: [1, 2, 3] })).toBe(false);
+    expect(validator.validate({ widget: { nested: { deep: 1 } } })).toBe(false);
+  });
+
+  it("rejects arrays of non-primitives inside a widget config", () => {
+    expect(validator.validate({ widget: { accountIds: [{ id: "x" }] } })).toBe(
+      false,
+    );
+  });
+
+  it("rejects over-long strings", () => {
+    expect(validator.validate({ widget: { range: "x".repeat(101) } })).toBe(
+      false,
+    );
+  });
+
+  it("rejects too many widgets", () => {
+    const tooMany: Record<string, unknown> = {};
+    for (let i = 0; i < 51; i++) {
+      tooMany[`widget-${i}`] = {};
+    }
+    expect(validator.validate(tooMany)).toBe(false);
+  });
+
+  it("rejects too many keys within a single widget", () => {
+    const settings: Record<string, unknown> = {};
+    for (let i = 0; i < 21; i++) {
+      settings[`k${i}`] = i;
+    }
+    expect(validator.validate({ widget: settings })).toBe(false);
+  });
+
+  it("rejects over-long arrays", () => {
+    const big = Array.from({ length: 201 }, (_, i) => String(i));
+    expect(validator.validate({ widget: { accountIds: big } })).toBe(false);
+  });
+
+  it("has a helpful default message", () => {
+    expect(validator.defaultMessage()).toContain("dashboardWidgetConfig");
+  });
+});

--- a/backend/src/users/validators/is-dashboard-widget-config.validator.ts
+++ b/backend/src/users/validators/is-dashboard-widget-config.validator.ts
@@ -1,0 +1,103 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from "class-validator";
+
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+// The map is keyed by widget id; each value is that widget's flat settings
+// object. Bounds keep an arbitrary client payload from bloating the row.
+const MAX_WIDGETS = 50;
+const MAX_KEYS_PER_WIDGET = 20;
+const MAX_ARRAY_LENGTH = 200;
+const MAX_STRING_LENGTH = 100;
+const WIDGET_ID_PATTERN = /^[a-z0-9-]+$/;
+
+function isFlatSettings(value: unknown): boolean {
+  if (value === null) return true;
+  if (typeof value !== "object" || Array.isArray(value)) return false;
+
+  const settings = value as Record<string, unknown>;
+  const keys = Object.keys(settings);
+  if (keys.length > MAX_KEYS_PER_WIDGET) return false;
+
+  for (const key of keys) {
+    if (DANGEROUS_KEYS.has(key)) return false;
+    if (key.length > MAX_STRING_LENGTH) return false;
+
+    const val = settings[key];
+    if (val === null || val === undefined) continue;
+
+    if (Array.isArray(val)) {
+      if (val.length > MAX_ARRAY_LENGTH) return false;
+      for (const item of val) {
+        const itemType = typeof item;
+        if (
+          itemType !== "string" &&
+          itemType !== "number" &&
+          itemType !== "boolean"
+        ) {
+          return false;
+        }
+        if (
+          itemType === "string" &&
+          (item as string).length > MAX_STRING_LENGTH
+        ) {
+          return false;
+        }
+      }
+      continue;
+    }
+
+    const type = typeof val;
+    if (type !== "string" && type !== "number" && type !== "boolean") {
+      return false;
+    }
+    if (type === "string" && (val as string).length > MAX_STRING_LENGTH) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+@ValidatorConstraint({ async: false })
+export class IsDashboardWidgetConfigConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    if (value === undefined || value === null) return true;
+    if (typeof value !== "object" || Array.isArray(value)) return false;
+
+    const map = value as Record<string, unknown>;
+    const widgetIds = Object.keys(map);
+    if (widgetIds.length > MAX_WIDGETS) return false;
+
+    for (const widgetId of widgetIds) {
+      if (DANGEROUS_KEYS.has(widgetId)) return false;
+      if (!WIDGET_ID_PATTERN.test(widgetId)) return false;
+      if (widgetId.length > MAX_STRING_LENGTH) return false;
+      if (!isFlatSettings(map[widgetId])) return false;
+    }
+
+    return true;
+  }
+
+  defaultMessage(): string {
+    return "dashboardWidgetConfig must be an object keyed by widget id, each value a flat settings object of primitives or arrays of primitives";
+  }
+}
+
+export function IsDashboardWidgetConfig(
+  validationOptions?: ValidationOptions,
+): PropertyDecorator {
+  return function (object: object, propertyName: string | symbol) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName: String(propertyName),
+      options: validationOptions,
+      constraints: [],
+      validator: IsDashboardWidgetConfigConstraint,
+    });
+  };
+}

--- a/database/migrations/090_user_preferences_dashboard_widget_config.sql
+++ b/database/migrations/090_user_preferences_dashboard_widget_config.sql
@@ -1,0 +1,6 @@
+-- Per-widget dashboard configuration (timeframe, account selection, chart type,
+-- etc.), keyed by widget id. Stored as JSONB so each widget type can persist its
+-- own settings shape. Cross-device by virtue of living on user_preferences.
+-- Empty object = every widget uses its built-in defaults.
+ALTER TABLE user_preferences
+  ADD COLUMN IF NOT EXISTS dashboard_widget_config JSONB NOT NULL DEFAULT '{}';

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -602,6 +602,7 @@ CREATE TABLE user_preferences (
     budget_digest_day VARCHAR(10) DEFAULT 'MONDAY',
     favourite_report_ids TEXT[] DEFAULT '{}',
     dashboard_widgets TEXT[] DEFAULT '{}', -- ordered visible dashboard widget ids; empty = default layout
+    dashboard_widget_config JSONB NOT NULL DEFAULT '{}', -- per-widget settings (timeframe, accounts, chart type), keyed by widget id
     show_created_at BOOLEAN DEFAULT false,
     time_format VARCHAR(10) DEFAULT '24h',
     preferred_exchanges TEXT[] DEFAULT '{}',

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/components/auth/ProtectedRoute.test.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.test.tsx
@@ -158,6 +158,7 @@ describe('ProtectedRoute', () => {
         timeFormat: '24h',
         favouriteReportIds: [],
         dashboardWidgets: [],
+        dashboardWidgetConfig: {},
         preferredExchanges: [],
     defaultQuoteProvider: 'yahoo' as const,
     recentTransactionsLimit: 5,

--- a/frontend/src/components/dashboard/CreditUtilizationAccountsWidget.test.tsx
+++ b/frontend/src/components/dashboard/CreditUtilizationAccountsWidget.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { render } from '@/test/render';
+import { Account } from '@/types/account';
+import { CreditUtilizationAccountsWidget } from './CreditUtilizationAccountsWidget';
+
+vi.mock('recharts', async () => (await import('@/test/recharts-mock')).rechartsMock());
+
+vi.mock('@/hooks/useWidgetConfig', () => ({
+  useWidgetConfig: () => ({ config: { accountIds: [] }, updateConfig: vi.fn() }),
+}));
+vi.mock('@/hooks/useNumberFormat', () => ({
+  useNumberFormat: () => ({ formatCurrency: (n: number) => `$${n}` }),
+}));
+vi.mock('@/hooks/useExchangeRates', () => ({
+  useExchangeRates: () => ({ convert: (n: number) => n, defaultCurrency: 'USD' }),
+}));
+
+const creditCard = (id: string, balance: number): Account =>
+  ({
+    id,
+    name: `Card ${id}`,
+    accountType: 'CREDIT_CARD',
+    accountSubType: 'NONE',
+    currencyCode: 'USD',
+    currentBalance: balance,
+    creditLimit: 1000,
+    isClosed: false,
+  }) as Account;
+
+describe('CreditUtilizationAccountsWidget', () => {
+  it('renders a bar for credit accounts with a limit', () => {
+    render(
+      <CreditUtilizationAccountsWidget
+        accounts={[creditCard('a', -500), creditCard('b', -100)]}
+        isLoading={false}
+      />,
+    );
+    expect(screen.getByText('Credit Utilization by Account')).toBeInTheDocument();
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+  });
+
+  it('shows the empty state with no credit accounts', () => {
+    render(<CreditUtilizationAccountsWidget accounts={[]} isLoading={false} />);
+    expect(screen.getByText('No credit accounts with a limit set.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/CreditUtilizationAccountsWidget.test.tsx
+++ b/frontend/src/components/dashboard/CreditUtilizationAccountsWidget.test.tsx
@@ -26,7 +26,7 @@ const creditCard = (id: string, balance: number): Account =>
     currentBalance: balance,
     creditLimit: 1000,
     isClosed: false,
-  }) as Account;
+  }) as unknown as Account;
 
 describe('CreditUtilizationAccountsWidget', () => {
   it('renders a bar for credit accounts with a limit', () => {

--- a/frontend/src/components/dashboard/CreditUtilizationAccountsWidget.tsx
+++ b/frontend/src/components/dashboard/CreditUtilizationAccountsWidget.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useTranslations } from 'next-intl';
+import {
+  BarChart,
+  Bar,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from 'recharts';
+import { Account } from '@/types/account';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useExchangeRates } from '@/hooks/useExchangeRates';
+import { useWidgetConfig } from '@/hooks/useWidgetConfig';
+import { chartColors } from '@/lib/chart-colors';
+import {
+  isCreditAccount,
+  utilizationColour,
+  computeCreditRows,
+} from '@/lib/credit-utilization';
+import { ChartTooltipPanel } from '@/components/reports/ChartTooltip';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { WidgetCard, WidgetConfigRow, WidgetMessage } from './WidgetCard';
+import { CREDIT_UTILIZATION_ACCOUNTS_DEFAULT, AccountsConfig } from './widget-config';
+
+const WIDGET_ID = 'credit-utilization-accounts';
+
+interface CreditUtilizationAccountsWidgetProps {
+  accounts: Account[];
+  isLoading: boolean;
+}
+
+export function CreditUtilizationAccountsWidget({
+  accounts,
+  isLoading,
+}: CreditUtilizationAccountsWidgetProps) {
+  const t = useTranslations('dashboard');
+  const { formatCurrency } = useNumberFormat();
+  const { convert, defaultCurrency } = useExchangeRates();
+  const { config, updateConfig } = useWidgetConfig<AccountsConfig>(
+    WIDGET_ID,
+    CREDIT_UTILIZATION_ACCOUNTS_DEFAULT,
+  );
+
+  const creditAccounts = useMemo(() => accounts.filter(isCreditAccount), [accounts]);
+
+  const activeAccounts = useMemo(
+    () =>
+      config.accountIds.length > 0
+        ? creditAccounts.filter((a) => config.accountIds.includes(a.id))
+        : creditAccounts,
+    [creditAccounts, config.accountIds],
+  );
+
+  const displayCurrency = useMemo(() => {
+    const currencies = new Set(activeAccounts.map((a) => a.currencyCode));
+    return currencies.size === 1 ? [...currencies][0] : defaultCurrency;
+  }, [activeAccounts, defaultCurrency]);
+
+  const rows = useMemo(
+    () =>
+      computeCreditRows(activeAccounts, convert, displayCurrency).sort(
+        (a, b) => b.utilizationPercent - a.utilizationPercent,
+      ),
+    [activeAccounts, convert, displayCurrency],
+  );
+
+  const configControls = (
+    <WidgetConfigRow label={t('widgets.accounts')}>
+      <ReportAccountMultiSelect
+        accounts={creditAccounts}
+        value={config.accountIds}
+        onChange={(accountIds) => updateConfig({ accountIds })}
+        filter={() => true}
+        className="w-full"
+      />
+    </WidgetConfigRow>
+  );
+
+  const chartMinHeight = Math.max(220, rows.length * 44);
+
+  return (
+    <WidgetCard
+      title={t('creditUtilizationAccounts.title')}
+      configControls={creditAccounts.length > 0 ? configControls : undefined}
+      configTitle={t('creditUtilizationAccounts.title')}
+    >
+      {isLoading ? (
+        <div className="flex-1 min-h-[260px] animate-pulse rounded-md bg-gray-100 dark:bg-gray-700/50" />
+      ) : rows.length === 0 ? (
+        <WidgetMessage>{t('creditUtilizationAccounts.empty')}</WidgetMessage>
+      ) : (
+        <div className="flex-1" style={{ minHeight: Math.min(chartMinHeight, 420) }}>
+          <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+            <BarChart data={rows} layout="vertical" margin={{ left: 8, right: 24 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} horizontal={false} />
+              <XAxis
+                type="number"
+                domain={[0, 100]}
+                tickFormatter={(v: number) => `${v}%`}
+                tick={{ fontSize: 11 }}
+              />
+              <YAxis type="category" dataKey="name" width={110} tick={{ fontSize: 11 }} />
+              <Tooltip
+                content={({ active, payload }) => {
+                  if (!active || !payload?.length) return null;
+                  const row = payload[0].payload as (typeof rows)[number];
+                  return (
+                    <ChartTooltipPanel>
+                      <p className="font-medium text-gray-900 dark:text-gray-100">{row.name}</p>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        {t('creditUtilizationAccounts.utilization')}: {row.utilizationPercent.toFixed(1)}%
+                      </p>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        {t('creditUtilizationAccounts.used')}: {formatCurrency(row.used, displayCurrency)}
+                      </p>
+                    </ChartTooltipPanel>
+                  );
+                }}
+              />
+              <ReferenceLine x={100} stroke={chartColors.axis} strokeDasharray="4 4" />
+              <Bar dataKey="utilizationPercent" radius={[0, 4, 4, 0]} maxBarSize={28}>
+                {rows.map((row) => (
+                  <Cell key={row.id} fill={utilizationColour(row.utilizationPercent)} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </WidgetCard>
+  );
+}

--- a/frontend/src/components/dashboard/CreditUtilizationTotalWidget.test.tsx
+++ b/frontend/src/components/dashboard/CreditUtilizationTotalWidget.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { render } from '@/test/render';
+import { Account } from '@/types/account';
+import { CreditUtilizationTotalWidget } from './CreditUtilizationTotalWidget';
+
+vi.mock('recharts', async () => (await import('@/test/recharts-mock')).rechartsMock());
+
+vi.mock('@/hooks/useWidgetConfig', () => ({
+  useWidgetConfig: () => ({ config: { accountIds: [] }, updateConfig: vi.fn() }),
+}));
+vi.mock('@/hooks/useNumberFormat', () => ({
+  useNumberFormat: () => ({ formatCurrency: (n: number) => `$${n}` }),
+}));
+vi.mock('@/hooks/useExchangeRates', () => ({
+  useExchangeRates: () => ({ convert: (n: number) => n, defaultCurrency: 'USD' }),
+}));
+
+const creditCard = (id: string, balance: number): Account =>
+  ({
+    id,
+    name: `Card ${id}`,
+    accountType: 'CREDIT_CARD',
+    accountSubType: 'NONE',
+    currencyCode: 'USD',
+    currentBalance: balance,
+    creditLimit: 1000,
+    isClosed: false,
+  }) as Account;
+
+describe('CreditUtilizationTotalWidget', () => {
+  it('renders the overall utilization percentage', () => {
+    render(
+      <CreditUtilizationTotalWidget
+        accounts={[creditCard('a', -500), creditCard('b', -100)]}
+        isLoading={false}
+      />,
+    );
+    expect(screen.getByText('Total Credit Utilization')).toBeInTheDocument();
+    // used 600 / limit 2000 = 30.0%
+    expect(screen.getByText('30.0%')).toBeInTheDocument();
+  });
+
+  it('shows the empty state with no credit accounts', () => {
+    render(<CreditUtilizationTotalWidget accounts={[]} isLoading={false} />);
+    expect(screen.getByText('No credit accounts with a limit set.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/CreditUtilizationTotalWidget.test.tsx
+++ b/frontend/src/components/dashboard/CreditUtilizationTotalWidget.test.tsx
@@ -26,7 +26,7 @@ const creditCard = (id: string, balance: number): Account =>
     currentBalance: balance,
     creditLimit: 1000,
     isClosed: false,
-  }) as Account;
+  }) as unknown as Account;
 
 describe('CreditUtilizationTotalWidget', () => {
   it('renders the overall utilization percentage', () => {

--- a/frontend/src/components/dashboard/CreditUtilizationTotalWidget.tsx
+++ b/frontend/src/components/dashboard/CreditUtilizationTotalWidget.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useTranslations } from 'next-intl';
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
+import { Account } from '@/types/account';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useExchangeRates } from '@/hooks/useExchangeRates';
+import { useWidgetConfig } from '@/hooks/useWidgetConfig';
+import { chartColors } from '@/lib/chart-colors';
+import {
+  isCreditAccount,
+  utilizationColour,
+  computeCreditRows,
+  computeCreditTotals,
+} from '@/lib/credit-utilization';
+import { ChartTooltipPanel } from '@/components/reports/ChartTooltip';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { WidgetCard, WidgetConfigRow, WidgetMessage } from './WidgetCard';
+import { CREDIT_UTILIZATION_TOTAL_DEFAULT, AccountsConfig } from './widget-config';
+
+const WIDGET_ID = 'credit-utilization-total';
+
+interface CreditUtilizationTotalWidgetProps {
+  accounts: Account[];
+  isLoading: boolean;
+}
+
+interface TotalSlice {
+  key: 'used' | 'available';
+  name: string;
+  value: number;
+  percent: number;
+  color: string;
+}
+
+export function CreditUtilizationTotalWidget({
+  accounts,
+  isLoading,
+}: CreditUtilizationTotalWidgetProps) {
+  const t = useTranslations('dashboard');
+  const { formatCurrency } = useNumberFormat();
+  const { convert, defaultCurrency } = useExchangeRates();
+  const { config, updateConfig } = useWidgetConfig<AccountsConfig>(
+    WIDGET_ID,
+    CREDIT_UTILIZATION_TOTAL_DEFAULT,
+  );
+
+  const creditAccounts = useMemo(() => accounts.filter(isCreditAccount), [accounts]);
+
+  const activeAccounts = useMemo(
+    () =>
+      config.accountIds.length > 0
+        ? creditAccounts.filter((a) => config.accountIds.includes(a.id))
+        : creditAccounts,
+    [creditAccounts, config.accountIds],
+  );
+
+  const displayCurrency = useMemo(() => {
+    const currencies = new Set(activeAccounts.map((a) => a.currencyCode));
+    return currencies.size === 1 ? [...currencies][0] : defaultCurrency;
+  }, [activeAccounts, defaultCurrency]);
+
+  const totals = useMemo(
+    () => computeCreditTotals(computeCreditRows(activeAccounts, convert, displayCurrency)),
+    [activeAccounts, convert, displayCurrency],
+  );
+
+  const availableForPie = Math.max(totals.available, 0);
+  const pieData: TotalSlice[] = [
+    {
+      key: 'used',
+      name: t('creditUtilizationTotal.used'),
+      value: totals.used,
+      percent: totals.utilizationPercent,
+      color: utilizationColour(totals.utilizationPercent),
+    },
+    {
+      key: 'available',
+      name: t('creditUtilizationTotal.available'),
+      value: availableForPie,
+      percent: totals.limit > 0 ? (availableForPie / totals.limit) * 100 : 0,
+      color: chartColors.grid,
+    },
+  ];
+
+  const configControls = (
+    <WidgetConfigRow label={t('widgets.accounts')}>
+      <ReportAccountMultiSelect
+        accounts={creditAccounts}
+        value={config.accountIds}
+        onChange={(accountIds) => updateConfig({ accountIds })}
+        filter={() => true}
+        className="w-full"
+      />
+    </WidgetConfigRow>
+  );
+
+  return (
+    <WidgetCard
+      title={t('creditUtilizationTotal.title')}
+      configControls={creditAccounts.length > 0 ? configControls : undefined}
+      configTitle={t('creditUtilizationTotal.title')}
+    >
+      {isLoading ? (
+        <div className="flex-1 min-h-[260px] animate-pulse rounded-md bg-gray-100 dark:bg-gray-700/50" />
+      ) : totals.limit === 0 ? (
+        <WidgetMessage>{t('creditUtilizationTotal.empty')}</WidgetMessage>
+      ) : (
+        <>
+          <div className="flex-1 min-h-[220px] relative">
+            <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+              <PieChart>
+                <Pie
+                  data={pieData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius="62%"
+                  outerRadius="90%"
+                  startAngle={90}
+                  endAngle={-270}
+                  paddingAngle={2}
+                  dataKey="value"
+                >
+                  {pieData.map((slice) => (
+                    <Cell key={slice.key} fill={slice.color} />
+                  ))}
+                </Pie>
+                <Tooltip
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null;
+                    const slice = payload[0].payload as TotalSlice;
+                    return (
+                      <ChartTooltipPanel>
+                        <p className="font-medium text-gray-900 dark:text-gray-100">{slice.name}</p>
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
+                          {formatCurrency(slice.value, displayCurrency)} ({slice.percent.toFixed(1)}%)
+                        </p>
+                      </ChartTooltipPanel>
+                    );
+                  }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+            <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+              <span className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                {totals.utilizationPercent.toFixed(1)}%
+              </span>
+            </div>
+          </div>
+          <div className="mt-3 space-y-1.5 text-sm flex-shrink-0">
+            {pieData.map((slice) => (
+              <div key={slice.key} className="flex items-center gap-2">
+                <span className="w-3 h-3 rounded-sm shrink-0" style={{ backgroundColor: slice.color }} />
+                <span className="flex-1 text-gray-500 dark:text-gray-400">{slice.name}</span>
+                <span className="font-medium text-gray-900 dark:text-gray-100">
+                  {formatCurrency(slice.value, displayCurrency)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </WidgetCard>
+  );
+}

--- a/frontend/src/components/dashboard/GeographicAllocationWidget.test.tsx
+++ b/frontend/src/components/dashboard/GeographicAllocationWidget.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, screen } from '@testing-library/react';
+import { render } from '@/test/render';
+import { Account } from '@/types/account';
+import { HoldingWithMarketValue, Security } from '@/types/investment';
+import { GeographicAllocationWidget } from './GeographicAllocationWidget';
+
+vi.mock('recharts', async () => (await import('@/test/recharts-mock')).rechartsMock());
+
+const configState = { current: { accountIds: [] as string[], view: 'region' as 'region' | 'exchange' | 'country' } };
+vi.mock('@/hooks/useWidgetConfig', () => ({
+  useWidgetConfig: () => ({ config: configState.current, updateConfig: vi.fn() }),
+}));
+vi.mock('@/hooks/useNumberFormat', () => ({
+  useNumberFormat: () => ({
+    formatCurrency: (n: number) => `$${n}`,
+    formatCurrencyAxis: (n: number) => `$${n}`,
+  }),
+}));
+vi.mock('@/hooks/useExchangeRates', () => ({
+  useExchangeRates: () => ({ convertToDefault: (n: number) => n }),
+}));
+
+const getPortfolioSummary = vi.fn();
+const getSecurities = vi.fn();
+const getCountryWeightings = vi.fn();
+vi.mock('@/lib/investments', () => ({
+  investmentsApi: {
+    getPortfolioSummary: (...a: unknown[]) => getPortfolioSummary(...a),
+    getSecurities: (...a: unknown[]) => getSecurities(...a),
+    getCountryWeightings: (...a: unknown[]) => getCountryWeightings(...a),
+  },
+}));
+
+const holding = (securityId: string, marketValue: number): HoldingWithMarketValue =>
+  ({ securityId, marketValue, currencyCode: 'USD' }) as HoldingWithMarketValue;
+
+const security = (id: string, exchange: string): Security =>
+  ({ id, exchange }) as Security;
+
+const investmentAccount = { id: 'i1', accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_BROKERAGE', name: 'Brokerage' } as Account;
+
+async function renderWidget() {
+  await act(async () => {
+    render(<GeographicAllocationWidget accounts={[investmentAccount]} isLoading={false} />);
+  });
+}
+
+describe('GeographicAllocationWidget', () => {
+  beforeEach(() => {
+    getPortfolioSummary.mockReset().mockResolvedValue({
+      holdings: [holding('s-nyse', 700), holding('s-lse', 300)],
+      holdingsByAccount: [],
+    });
+    getSecurities.mockReset().mockResolvedValue([
+      security('s-nyse', 'NYSE'),
+      security('s-lse', 'LSE'),
+    ]);
+    getCountryWeightings.mockReset().mockResolvedValue({
+      items: [{ country: 'United States', directValue: 700, etfValue: 0, totalValue: 700, percentage: 70 }],
+      totalPortfolioValue: 1000,
+      totalDirectValue: 700,
+      totalEtfValue: 0,
+      unclassifiedValue: 0,
+    });
+    configState.current = { accountIds: [], view: 'region' };
+  });
+
+  it('renders the region pie with a North America slice', async () => {
+    await renderWidget();
+    expect(screen.getByText('Geographic Allocation')).toBeInTheDocument();
+    expect(screen.getByText('North America')).toBeInTheDocument();
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+  });
+
+  it('renders the exchange bar view', async () => {
+    configState.current = { accountIds: [], view: 'exchange' };
+    await renderWidget();
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+  });
+
+  it('renders the country view from the country weightings endpoint', async () => {
+    configState.current = { accountIds: [], view: 'country' };
+    await renderWidget();
+    expect(screen.getByText('United States')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/GeographicAllocationWidget.tsx
+++ b/frontend/src/components/dashboard/GeographicAllocationWidget.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useTranslations } from 'next-intl';
+import {
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { Account } from '@/types/account';
+import { HoldingWithMarketValue, Security } from '@/types/investment';
+import { investmentsApi } from '@/lib/investments';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useExchangeRates } from '@/hooks/useExchangeRates';
+import { useReportData } from '@/hooks/useReportData';
+import { useWidgetConfig } from '@/hooks/useWidgetConfig';
+import { chartColors, chartSeriesColor } from '@/lib/chart-colors';
+import { computeGeographicAllocation } from '@/lib/geographic-allocation';
+import { ChartTooltipPanel } from '@/components/reports/ChartTooltip';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { WidgetCard, WidgetConfigRow, WidgetMessage } from './WidgetCard';
+import { WidgetSegmentedControl } from './WidgetSegmentedControl';
+import { GEOGRAPHIC_ALLOCATION_DEFAULT, GeographicConfig } from './widget-config';
+
+const WIDGET_ID = 'geographic-allocation';
+const MAX_EXCHANGE_BARS = 8;
+
+const excludeCashAccounts = (a: Account) => a.accountSubType !== 'INVESTMENT_CASH';
+
+interface GeographicAllocationWidgetProps {
+  accounts: Account[];
+  isLoading: boolean;
+}
+
+interface SimpleSlice {
+  name: string;
+  value: number;
+  percentage: number;
+  color: string;
+}
+
+export function GeographicAllocationWidget({
+  accounts,
+  isLoading,
+}: GeographicAllocationWidgetProps) {
+  const t = useTranslations('dashboard');
+  const { formatCurrency, formatCurrencyAxis } = useNumberFormat();
+  const { convertToDefault } = useExchangeRates();
+  const { config, updateConfig } = useWidgetConfig<GeographicConfig>(
+    WIDGET_ID,
+    GEOGRAPHIC_ALLOCATION_DEFAULT,
+  );
+
+  const investmentAccounts = useMemo(
+    () => accounts.filter((a) => a.accountType === 'INVESTMENT'),
+    [accounts],
+  );
+
+  const accountIds = config.accountIds.length > 0 ? config.accountIds : undefined;
+
+  const { data: summary, isLoading: summaryLoading } = useReportData(
+    () => investmentsApi.getPortfolioSummary(accountIds),
+    [config.accountIds],
+  );
+
+  const { data: securities } = useReportData(
+    () => investmentsApi.getSecurities(),
+    [],
+  );
+
+  const { data: countryResp, isLoading: countryLoading } = useReportData(
+    () => investmentsApi.getCountryWeightings(accountIds),
+    [config.accountIds],
+  );
+
+  const holdings = useMemo<HoldingWithMarketValue[]>(
+    () => summary?.holdings ?? [],
+    [summary],
+  );
+
+  const securityExchangeMap = useMemo(() => {
+    const map = new Map<string, string>();
+    (securities ?? []).forEach((s: Security) => {
+      if (s.exchange) map.set(s.id, s.exchange);
+    });
+    return map;
+  }, [securities]);
+
+  const { exchangeData, regionData } = useMemo(
+    () => computeGeographicAllocation(holdings, securityExchangeMap, convertToDefault),
+    [holdings, securityExchangeMap, convertToDefault],
+  );
+
+  const regionSlices = useMemo<SimpleSlice[]>(
+    () =>
+      regionData.map((r) => ({
+        name: r.region,
+        value: r.marketValue,
+        percentage: r.percentage,
+        color: r.color,
+      })),
+    [regionData],
+  );
+
+  const exchangeBars = useMemo(
+    () => exchangeData.slice(0, MAX_EXCHANGE_BARS),
+    [exchangeData],
+  );
+
+  const countrySlices = useMemo<SimpleSlice[]>(
+    () =>
+      (countryResp?.items ?? []).map((item, idx) => ({
+        name: item.country,
+        value: item.totalValue,
+        percentage: item.percentage,
+        color: chartSeriesColor(idx),
+      })),
+    [countryResp],
+  );
+
+  const configControls = (
+    <>
+      <WidgetConfigRow label={t('widgets.accounts')}>
+        <ReportAccountMultiSelect
+          accounts={investmentAccounts}
+          value={config.accountIds}
+          onChange={(ids) => updateConfig({ accountIds: ids })}
+          filter={excludeCashAccounts}
+          className="w-full"
+        />
+      </WidgetConfigRow>
+      <WidgetConfigRow label={t('widgets.view')}>
+        <WidgetSegmentedControl
+          value={config.view}
+          onChange={(view) => updateConfig({ view })}
+          options={[
+            { value: 'region', label: t('geographicAllocation.viewRegion') },
+            { value: 'exchange', label: t('geographicAllocation.viewExchange') },
+            { value: 'country', label: t('geographicAllocation.viewCountry') },
+          ]}
+        />
+      </WidgetConfigRow>
+    </>
+  );
+
+  const loading =
+    isLoading ||
+    (config.view === 'country' ? countryLoading : summaryLoading);
+
+  const activeSlices = config.view === 'country' ? countrySlices : regionSlices;
+  const isEmpty =
+    config.view === 'exchange' ? exchangeBars.length === 0 : activeSlices.length === 0;
+
+  const sliceTooltip = (active: boolean | undefined, rawPayload: unknown) => {
+    const payload = rawPayload as Array<{ payload: SimpleSlice }> | undefined;
+    if (!active || !payload?.length) return null;
+    const d = payload[0].payload;
+    return (
+      <ChartTooltipPanel>
+        <p className="font-medium text-gray-900 dark:text-gray-100">{d.name}</p>
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          {formatCurrency(d.value)} ({d.percentage.toFixed(1)}%)
+        </p>
+      </ChartTooltipPanel>
+    );
+  };
+
+  return (
+    <WidgetCard
+      title={t('geographicAllocation.title')}
+      configControls={configControls}
+      configTitle={t('geographicAllocation.title')}
+    >
+      {loading ? (
+        <div className="flex-1 min-h-[260px] animate-pulse rounded-md bg-gray-100 dark:bg-gray-700/50" />
+      ) : isEmpty ? (
+        <WidgetMessage>{t('geographicAllocation.empty')}</WidgetMessage>
+      ) : config.view === 'exchange' ? (
+        <div className="flex-1 min-h-[260px]">
+          <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+            <BarChart data={exchangeBars} layout="vertical" margin={{ left: 8, right: 16 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} horizontal={false} />
+              <XAxis type="number" tickFormatter={formatCurrencyAxis} tick={{ fontSize: 11 }} />
+              <YAxis type="category" dataKey="exchange" width={80} tick={{ fontSize: 11 }} />
+              <Tooltip
+                content={({ active, payload }) => {
+                  if (!active || !payload?.length) return null;
+                  const d = payload[0].payload as (typeof exchangeBars)[number];
+                  return (
+                    <ChartTooltipPanel>
+                      <p className="font-medium text-gray-900 dark:text-gray-100">{d.exchange}</p>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        {formatCurrency(d.marketValue)} ({d.percentage.toFixed(1)}%)
+                      </p>
+                    </ChartTooltipPanel>
+                  );
+                }}
+              />
+              <Bar dataKey="marketValue" radius={[0, 4, 4, 0]}>
+                {exchangeBars.map((entry, index) => (
+                  <Cell key={entry.exchange} fill={chartSeriesColor(index)} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      ) : (
+        <>
+          <div className="flex-1 min-h-[220px]">
+            <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+              <PieChart>
+                <Pie
+                  data={activeSlices}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius="55%"
+                  outerRadius="85%"
+                  paddingAngle={2}
+                  dataKey="value"
+                  nameKey="name"
+                >
+                  {activeSlices.map((entry) => (
+                    <Cell key={entry.name} fill={entry.color} />
+                  ))}
+                </Pie>
+                <Tooltip content={({ active, payload }) => sliceTooltip(active, payload)} />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1.5 text-sm flex-shrink-0">
+            {activeSlices.slice(0, 6).map((entry) => (
+              <div key={entry.name} className="flex items-center gap-2">
+                <span className="w-3 h-3 rounded-sm shrink-0" style={{ backgroundColor: entry.color }} />
+                <span className="text-gray-500 dark:text-gray-400 truncate">{entry.name}</span>
+                <span className="ml-auto text-gray-900 dark:text-gray-100">
+                  {entry.percentage.toFixed(0)}%
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </WidgetCard>
+  );
+}

--- a/frontend/src/components/dashboard/IncomeBySourceWidget.test.tsx
+++ b/frontend/src/components/dashboard/IncomeBySourceWidget.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, screen } from '@testing-library/react';
+import { render } from '@/test/render';
+import { IncomeBySourceWidget } from './IncomeBySourceWidget';
+
+vi.mock('recharts', async () => (await import('@/test/recharts-mock')).rechartsMock());
+
+vi.mock('@/hooks/useWidgetConfig', () => ({
+  useWidgetConfig: () => ({ config: { range: '1y', chartType: 'pie' }, updateConfig: vi.fn() }),
+}));
+vi.mock('@/hooks/useNumberFormat', () => ({
+  useNumberFormat: () => ({
+    formatCurrencyCompact: (n: number) => `$${n}`,
+    formatCurrencyAxis: (n: number) => `$${n}`,
+  }),
+}));
+
+const getIncomeBySource = vi.fn();
+vi.mock('@/lib/built-in-reports', () => ({
+  builtInReportsApi: { getIncomeBySource: (...a: unknown[]) => getIncomeBySource(...a) },
+}));
+
+async function renderWidget() {
+  await act(async () => {
+    render(<IncomeBySourceWidget isLoading={false} />);
+  });
+}
+
+describe('IncomeBySourceWidget', () => {
+  beforeEach(() => getIncomeBySource.mockReset());
+
+  it('renders income total and chart', async () => {
+    getIncomeBySource.mockResolvedValue({
+      data: [{ categoryId: 'c1', categoryName: 'Salary', color: null, total: 5000 }],
+      totalIncome: 5000,
+    });
+    await renderWidget();
+    expect(screen.getByText('Income by Source')).toBeInTheDocument();
+    expect(screen.getByText('$5000')).toBeInTheDocument();
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+  });
+
+  it('shows the empty state with no income', async () => {
+    getIncomeBySource.mockResolvedValue({ data: [], totalIncome: 0 });
+    await renderWidget();
+    expect(screen.getByText('No income in this period.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/IncomeBySourceWidget.tsx
+++ b/frontend/src/components/dashboard/IncomeBySourceWidget.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useTranslations } from 'next-intl';
+import {
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { builtInReportsApi } from '@/lib/built-in-reports';
+import { IncomeSourceItem } from '@/types/built-in-reports';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useReportData } from '@/hooks/useReportData';
+import { useWidgetConfig } from '@/hooks/useWidgetConfig';
+import { resolveRangePreset } from '@/lib/date-range';
+import { chartColors } from '@/lib/chart-colors';
+import { CHART_COLOURS_INCOME } from '@/lib/chart-colours';
+import { ChartTooltipPanel } from '@/components/reports/ChartTooltip';
+import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
+import { ChartViewToggle } from '@/components/ui/ChartViewToggle';
+import { WidgetCard, WidgetConfigRow, WidgetMessage } from './WidgetCard';
+import {
+  INCOME_BY_SOURCE_DEFAULT,
+  SPENDING_RANGES,
+  IncomeBySourceConfig,
+} from './widget-config';
+
+const WIDGET_ID = 'income-by-source';
+
+interface IncomeBySourceWidgetProps {
+  isLoading: boolean;
+}
+
+interface IncomeSlice {
+  id: string;
+  name: string;
+  value: number;
+  colour: string;
+}
+
+export function IncomeBySourceWidget({ isLoading }: IncomeBySourceWidgetProps) {
+  const t = useTranslations('dashboard');
+  const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis } = useNumberFormat();
+  const { config, updateConfig } = useWidgetConfig<IncomeBySourceConfig>(
+    WIDGET_ID,
+    INCOME_BY_SOURCE_DEFAULT,
+  );
+
+  const { start, end } = useMemo(
+    () => resolveRangePreset(config.range),
+    [config.range],
+  );
+
+  const { data: response, isLoading: dataLoading } = useReportData(
+    () =>
+      builtInReportsApi.getIncomeBySource({
+        startDate: start || undefined,
+        endDate: end,
+      }),
+    [start, end],
+  );
+
+  const chartData = useMemo<IncomeSlice[]>(() => {
+    if (!response) return [];
+    let colourIndex = 0;
+    return response.data.map((item: IncomeSourceItem) => {
+      let colour = item.color || '';
+      if (!colour) {
+        colour = CHART_COLOURS_INCOME[colourIndex % CHART_COLOURS_INCOME.length];
+        colourIndex++;
+      }
+      return {
+        id: item.categoryId || '',
+        name: item.categoryName,
+        value: item.total,
+        colour,
+      };
+    });
+  }, [response]);
+
+  const totalIncome = response?.totalIncome ?? 0;
+
+  const renderTooltip = (active: boolean | undefined, rawPayload: unknown) => {
+    const payload = rawPayload as Array<{ payload: IncomeSlice }> | undefined;
+    if (!active || !payload?.length) return null;
+    const d = payload[0].payload;
+    const pct = totalIncome > 0 ? ((d.value / totalIncome) * 100).toFixed(1) : '0';
+    return (
+      <ChartTooltipPanel>
+        <p className="font-medium text-gray-900 dark:text-gray-100">{d.name}</p>
+        <p className="text-gray-600 dark:text-gray-400">
+          {formatCurrency(d.value)} ({pct}%)
+        </p>
+      </ChartTooltipPanel>
+    );
+  };
+
+  const configControls = (
+    <>
+      <WidgetConfigRow label={t('widgets.timeframe')}>
+        <DateRangeSelector
+          ranges={SPENDING_RANGES}
+          value={config.range}
+          onChange={(range) => updateConfig({ range })}
+          size="sm"
+        />
+      </WidgetConfigRow>
+      <WidgetConfigRow label={t('widgets.chartType')}>
+        <ChartViewToggle
+          value={config.chartType}
+          onChange={(v) => updateConfig({ chartType: v as 'pie' | 'bar' })}
+          options={['pie', 'bar']}
+        />
+      </WidgetConfigRow>
+    </>
+  );
+
+  const loading = isLoading || dataLoading;
+
+  return (
+    <WidgetCard
+      title={t('incomeBySource.title')}
+      configControls={configControls}
+      configTitle={t('incomeBySource.title')}
+    >
+      {loading ? (
+        <div className="flex-1 min-h-[260px] animate-pulse rounded-md bg-gray-100 dark:bg-gray-700/50" />
+      ) : chartData.length === 0 ? (
+        <WidgetMessage>{t('incomeBySource.empty')}</WidgetMessage>
+      ) : (
+        <>
+          <div className="flex-1 min-h-[260px]">
+            <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+              {config.chartType === 'bar' ? (
+                <BarChart data={chartData} layout="vertical" margin={{ left: 10, right: 10 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} horizontal={false} />
+                  <XAxis type="number" tickFormatter={formatCurrencyAxis} tick={{ fontSize: 11 }} />
+                  <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={90} />
+                  <Tooltip content={({ active, payload }) => renderTooltip(active, payload)} />
+                  <Bar dataKey="value" radius={[0, 4, 4, 0]}>
+                    {chartData.map((entry) => (
+                      <Cell key={entry.id || entry.name} fill={entry.colour} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              ) : (
+                <PieChart>
+                  <Pie
+                    data={chartData}
+                    cx="50%"
+                    cy="50%"
+                    innerRadius="55%"
+                    outerRadius="85%"
+                    paddingAngle={2}
+                    dataKey="value"
+                  >
+                    {chartData.map((entry) => (
+                      <Cell key={entry.id || entry.name} fill={entry.colour} />
+                    ))}
+                  </Pie>
+                  <Tooltip content={({ active, payload }) => renderTooltip(active, payload)} />
+                </PieChart>
+              )}
+            </ResponsiveContainer>
+          </div>
+          <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between text-sm flex-shrink-0">
+            <span className="text-gray-500 dark:text-gray-400">{t('incomeBySource.totalLabel')}</span>
+            <span className="font-semibold text-gray-900 dark:text-gray-100">
+              {formatCurrency(totalIncome)}
+            </span>
+          </div>
+        </>
+      )}
+    </WidgetCard>
+  );
+}

--- a/frontend/src/components/dashboard/MonthlySpendingTrendWidget.test.tsx
+++ b/frontend/src/components/dashboard/MonthlySpendingTrendWidget.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, screen } from '@testing-library/react';
+import { render } from '@/test/render';
+import { MonthlySpendingTrendWidget } from './MonthlySpendingTrendWidget';
+
+vi.mock('recharts', async () => (await import('@/test/recharts-mock')).rechartsMock());
+
+vi.mock('@/hooks/useWidgetConfig', () => ({
+  useWidgetConfig: () => ({ config: { range: '1y' }, updateConfig: vi.fn() }),
+}));
+vi.mock('@/hooks/useChartDateFormat', () => ({
+  useChartDateFormat: () => () => 'Jan 2026',
+}));
+vi.mock('@/hooks/useNumberFormat', () => ({
+  useNumberFormat: () => ({
+    formatCurrency: (n: number) => `$${n}`,
+    formatCurrencyAxis: (n: number) => `$${n}`,
+  }),
+}));
+
+const getIncomeVsExpenses = vi.fn();
+vi.mock('@/lib/built-in-reports', () => ({
+  builtInReportsApi: { getIncomeVsExpenses: (...a: unknown[]) => getIncomeVsExpenses(...a) },
+}));
+
+async function renderWidget() {
+  await act(async () => {
+    render(<MonthlySpendingTrendWidget isLoading={false} />);
+  });
+}
+
+describe('MonthlySpendingTrendWidget', () => {
+  beforeEach(() => getIncomeVsExpenses.mockReset());
+
+  it('renders the chart for the configured month range', async () => {
+    getIncomeVsExpenses.mockResolvedValue({
+      data: [{ month: '2026-01', income: 5000, expenses: 3000, net: 2000 }],
+      totals: { income: 5000, expenses: 3000, net: 2000 },
+    });
+    await renderWidget();
+    expect(screen.getByText('Monthly Spending Trend')).toBeInTheDocument();
+    expect(getIncomeVsExpenses).toHaveBeenCalled();
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+  });
+
+  it('shows the empty state with no data', async () => {
+    getIncomeVsExpenses.mockResolvedValue({ data: [], totals: { income: 0, expenses: 0, net: 0 } });
+    await renderWidget();
+    expect(screen.getByText('No data for this period.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/MonthlySpendingTrendWidget.tsx
+++ b/frontend/src/components/dashboard/MonthlySpendingTrendWidget.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useTranslations } from 'next-intl';
+import { parseISO } from 'date-fns';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+import { builtInReportsApi } from '@/lib/built-in-reports';
+import { MonthlyIncomeExpenseItem } from '@/types/built-in-reports';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useReportData } from '@/hooks/useReportData';
+import { useChartDateFormat } from '@/hooks/useChartDateFormat';
+import { useWidgetConfig } from '@/hooks/useWidgetConfig';
+import { resolveRangePreset } from '@/lib/date-range';
+import { chartColors } from '@/lib/chart-colors';
+import { ChartTooltip } from '@/components/reports/ChartTooltip';
+import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
+import { WidgetCard, WidgetConfigRow, WidgetMessage } from './WidgetCard';
+import {
+  MONTHLY_SPENDING_TREND_DEFAULT,
+  TREND_RANGES,
+  RangeConfig,
+} from './widget-config';
+
+const WIDGET_ID = 'monthly-spending-trend';
+
+interface MonthlySpendingTrendWidgetProps {
+  isLoading: boolean;
+}
+
+export function MonthlySpendingTrendWidget({ isLoading }: MonthlySpendingTrendWidgetProps) {
+  const t = useTranslations('dashboard');
+  const { formatCurrency, formatCurrencyAxis } = useNumberFormat();
+  const formatChartDate = useChartDateFormat();
+  const { config, updateConfig } = useWidgetConfig<RangeConfig>(
+    WIDGET_ID,
+    MONTHLY_SPENDING_TREND_DEFAULT,
+  );
+
+  const { start, end } = useMemo(
+    () => resolveRangePreset(config.range, { alignment: 'month' }),
+    [config.range],
+  );
+
+  const { data: response, isLoading: dataLoading } = useReportData(
+    () =>
+      builtInReportsApi.getIncomeVsExpenses({
+        startDate: start || undefined,
+        endDate: end,
+      }),
+    [start, end],
+  );
+
+  const chartData = useMemo(
+    () =>
+      (response?.data ?? []).map((item: MonthlyIncomeExpenseItem) => ({
+        name: item.month,
+        fullName: formatChartDate(parseISO(item.month + '-01'), 'MMM yyyy'),
+        Expenses: Math.round(item.expenses),
+        Income: Math.round(item.income),
+      })),
+    [response, formatChartDate],
+  );
+
+  const configControls = (
+    <WidgetConfigRow label={t('widgets.timeframe')}>
+      <DateRangeSelector
+        ranges={TREND_RANGES}
+        value={config.range}
+        onChange={(range) => updateConfig({ range })}
+        size="sm"
+      />
+    </WidgetConfigRow>
+  );
+
+  const loading = isLoading || dataLoading;
+
+  return (
+    <WidgetCard
+      title={t('monthlySpendingTrend.title')}
+      configControls={configControls}
+      configTitle={t('monthlySpendingTrend.title')}
+    >
+      {loading ? (
+        <div className="flex-1 min-h-[260px] animate-pulse rounded-md bg-gray-100 dark:bg-gray-700/50" />
+      ) : chartData.length === 0 ? (
+        <WidgetMessage>{t('monthlySpendingTrend.empty')}</WidgetMessage>
+      ) : (
+        <div className="flex-1 min-h-[260px]">
+          <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+            <LineChart data={chartData} margin={{ left: 4, right: 8, top: 4 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
+              <XAxis
+                dataKey="name"
+                tickFormatter={(value) => chartData.find((d) => d.name === value)?.fullName ?? String(value)}
+                tick={{ fontSize: 11 }}
+              />
+              <YAxis tickFormatter={formatCurrencyAxis} tick={{ fontSize: 11 }} width={56} />
+              <Tooltip
+                content={({ active, payload }) => (
+                  <ChartTooltip
+                    active={active}
+                    label={
+                      (payload?.[0]?.payload as { fullName?: string } | undefined)?.fullName
+                    }
+                    payload={payload as { name?: string; value?: number; color?: string }[]}
+                    formatValue={(v) => formatCurrency(Number(v))}
+                  />
+                )}
+              />
+              <Legend />
+              <Line
+                type="monotone"
+                dataKey="Expenses"
+                name={t('monthlySpendingTrend.expenses')}
+                stroke={chartColors.expense}
+                strokeWidth={2}
+                dot={false}
+              />
+              <Line
+                type="monotone"
+                dataKey="Income"
+                name={t('monthlySpendingTrend.income')}
+                stroke={chartColors.income}
+                strokeWidth={2}
+                dot={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </WidgetCard>
+  );
+}

--- a/frontend/src/components/dashboard/PortfolioValueWidget.test.tsx
+++ b/frontend/src/components/dashboard/PortfolioValueWidget.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, screen } from '@testing-library/react';
+import { render } from '@/test/render';
+import { Account } from '@/types/account';
+import { PortfolioValueWidget } from './PortfolioValueWidget';
+
+vi.mock('recharts', async () => (await import('@/test/recharts-mock')).rechartsMock());
+
+const configState = { current: { range: '1y', accountIds: [] as string[] } };
+vi.mock('@/hooks/useWidgetConfig', () => ({
+  useWidgetConfig: () => ({ config: configState.current, updateConfig: vi.fn() }),
+}));
+vi.mock('@/hooks/useChartDateFormat', () => ({
+  useChartDateFormat: () => () => 'Jan 2026',
+}));
+vi.mock('@/hooks/useNumberFormat', () => ({
+  useNumberFormat: () => ({
+    formatCurrency: (n: number) => `$${n}`,
+    formatCurrencyAxis: (n: number) => `$${n}`,
+  }),
+}));
+vi.mock('@/hooks/useExchangeRates', () => ({
+  useExchangeRates: () => ({ defaultCurrency: 'USD' }),
+}));
+
+const getInvestmentsMonthly = vi.fn();
+const getInvestmentsDaily = vi.fn();
+vi.mock('@/lib/net-worth', () => ({
+  netWorthApi: {
+    getInvestmentsMonthly: (...a: unknown[]) => getInvestmentsMonthly(...a),
+    getInvestmentsDaily: (...a: unknown[]) => getInvestmentsDaily(...a),
+  },
+}));
+
+const investmentAccount = { id: 'i1', accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_BROKERAGE', name: 'Brokerage' } as Account;
+
+async function renderWidget() {
+  await act(async () => {
+    render(<PortfolioValueWidget accounts={[investmentAccount]} isLoading={false} />);
+  });
+}
+
+describe('PortfolioValueWidget', () => {
+  beforeEach(() => {
+    getInvestmentsMonthly.mockReset();
+    getInvestmentsDaily.mockReset();
+    configState.current = { range: '1y', accountIds: [] };
+  });
+
+  it('renders the area chart and latest value using monthly data for long ranges', async () => {
+    getInvestmentsMonthly.mockResolvedValue([
+      { month: '2026-05', value: 9000 },
+      { month: '2026-06', value: 10000 },
+    ]);
+    await renderWidget();
+    expect(screen.getByText('Portfolio Value')).toBeInTheDocument();
+    expect(getInvestmentsMonthly).toHaveBeenCalled();
+    expect(getInvestmentsDaily).not.toHaveBeenCalled();
+    expect(screen.getByText('$10000')).toBeInTheDocument();
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+  });
+
+  it('uses daily data for short ranges', async () => {
+    configState.current = { range: '3m', accountIds: [] };
+    getInvestmentsDaily.mockResolvedValue([{ date: '2026-07-01', value: 5000 }]);
+    await renderWidget();
+    expect(getInvestmentsDaily).toHaveBeenCalled();
+    expect(getInvestmentsMonthly).not.toHaveBeenCalled();
+  });
+
+  it('shows the empty state with no history', async () => {
+    getInvestmentsMonthly.mockResolvedValue([]);
+    await renderWidget();
+    expect(screen.getByText('No investment history to show yet.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/PortfolioValueWidget.tsx
+++ b/frontend/src/components/dashboard/PortfolioValueWidget.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useTranslations } from 'next-intl';
+import { parseISO } from 'date-fns';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { Account } from '@/types/account';
+import { netWorthApi } from '@/lib/net-worth';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useExchangeRates } from '@/hooks/useExchangeRates';
+import { useReportData } from '@/hooks/useReportData';
+import { useChartDateFormat } from '@/hooks/useChartDateFormat';
+import { useWidgetConfig } from '@/hooks/useWidgetConfig';
+import { resolveRangePreset } from '@/lib/date-range';
+import { chartColors } from '@/lib/chart-colors';
+import { ChartTooltipPanel } from '@/components/reports/ChartTooltip';
+import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { WidgetCard, WidgetConfigRow, WidgetMessage } from './WidgetCard';
+import {
+  PORTFOLIO_VALUE_DEFAULT,
+  PORTFOLIO_RANGES,
+  PortfolioValueConfig,
+} from './widget-config';
+
+const WIDGET_ID = 'portfolio-value';
+
+// Short ranges render at daily resolution; longer ones use monthly snapshots so
+// the series stays readable without thousands of points.
+const DAILY_RANGES = new Set(['3m', '6m']);
+
+const excludeCashAccounts = (a: Account) => a.accountSubType !== 'INVESTMENT_CASH';
+
+interface PortfolioValueWidgetProps {
+  accounts: Account[];
+  isLoading: boolean;
+}
+
+export function PortfolioValueWidget({ accounts, isLoading }: PortfolioValueWidgetProps) {
+  const t = useTranslations('dashboard');
+  const { formatCurrency, formatCurrencyAxis } = useNumberFormat();
+  const { defaultCurrency } = useExchangeRates();
+  const formatChartDate = useChartDateFormat();
+  const { config, updateConfig } = useWidgetConfig<PortfolioValueConfig>(
+    WIDGET_ID,
+    PORTFOLIO_VALUE_DEFAULT,
+  );
+
+  const investmentAccounts = useMemo(
+    () => accounts.filter((a) => a.accountType === 'INVESTMENT'),
+    [accounts],
+  );
+
+  const isDaily = DAILY_RANGES.has(config.range);
+  const { start, end } = useMemo(
+    () => resolveRangePreset(config.range, { alignment: isDaily ? 'day' : 'month' }),
+    [config.range, isDaily],
+  );
+
+  const accountIdsCsv =
+    config.accountIds.length > 0 ? config.accountIds.join(',') : undefined;
+
+  const { data: series, isLoading: dataLoading } = useReportData(() => {
+    const params = {
+      startDate: start || undefined,
+      endDate: end,
+      accountIds: accountIdsCsv,
+      displayCurrency: defaultCurrency,
+    };
+    return isDaily
+      ? netWorthApi
+          .getInvestmentsDaily(params)
+          .then((rows) => rows.map((r) => ({ date: r.date, value: r.value })))
+      : netWorthApi
+          .getInvestmentsMonthly(params)
+          .then((rows) => rows.map((r) => ({ date: r.month, value: r.value })));
+  }, [start, end, accountIdsCsv, defaultCurrency, isDaily]);
+
+  const chartData = useMemo(
+    () =>
+      (series ?? []).map((row) => {
+        const parsed = parseISO(row.date.length === 7 ? `${row.date}-01` : row.date);
+        return {
+          date: row.date,
+          label: formatChartDate(parsed, isDaily ? 'MMM d' : 'MMM yyyy'),
+          value: Math.round(row.value),
+        };
+      }),
+    [series, formatChartDate, isDaily],
+  );
+
+  const latestValue = chartData.length > 0 ? chartData[chartData.length - 1].value : 0;
+
+  const configControls = (
+    <>
+      <WidgetConfigRow label={t('widgets.timeframe')}>
+        <DateRangeSelector
+          ranges={PORTFOLIO_RANGES}
+          value={config.range}
+          onChange={(range) => updateConfig({ range })}
+          size="sm"
+        />
+      </WidgetConfigRow>
+      <WidgetConfigRow label={t('widgets.accounts')}>
+        <ReportAccountMultiSelect
+          accounts={investmentAccounts}
+          value={config.accountIds}
+          onChange={(accountIds) => updateConfig({ accountIds })}
+          filter={excludeCashAccounts}
+          className="w-full"
+        />
+      </WidgetConfigRow>
+    </>
+  );
+
+  const loading = isLoading || dataLoading;
+
+  return (
+    <WidgetCard
+      title={t('portfolioValue.title')}
+      headerRight={
+        !loading && latestValue > 0 ? (
+          <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            {formatCurrency(latestValue, defaultCurrency)}
+          </span>
+        ) : undefined
+      }
+      configControls={configControls}
+      configTitle={t('portfolioValue.title')}
+    >
+      {loading ? (
+        <div className="flex-1 min-h-[260px] animate-pulse rounded-md bg-gray-100 dark:bg-gray-700/50" />
+      ) : chartData.length === 0 ? (
+        <WidgetMessage>{t('portfolioValue.empty')}</WidgetMessage>
+      ) : (
+        <div className="flex-1 min-h-[260px]">
+          <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+            <AreaChart data={chartData} margin={{ left: 4, right: 8, top: 4 }}>
+              <defs>
+                <linearGradient id="portfolioValueGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={chartColors.primary} stopOpacity={0.35} />
+                  <stop offset="95%" stopColor={chartColors.primary} stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
+              <XAxis
+                dataKey="date"
+                tickFormatter={(value) => chartData.find((d) => d.date === value)?.label ?? String(value)}
+                tick={{ fontSize: 11 }}
+                minTickGap={24}
+              />
+              <YAxis tickFormatter={formatCurrencyAxis} tick={{ fontSize: 11 }} width={56} domain={['auto', 'auto']} />
+              <Tooltip
+                content={({ active, payload }) => {
+                  if (!active || !payload?.length) return null;
+                  const d = payload[0].payload as (typeof chartData)[number];
+                  return (
+                    <ChartTooltipPanel>
+                      <p className="font-medium text-gray-900 dark:text-gray-100">{d.label}</p>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        {formatCurrency(d.value, defaultCurrency)}
+                      </p>
+                    </ChartTooltipPanel>
+                  );
+                }}
+              />
+              <Area
+                type="monotone"
+                dataKey="value"
+                stroke={chartColors.primary}
+                strokeWidth={2}
+                fill="url(#portfolioValueGradient)"
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </WidgetCard>
+  );
+}

--- a/frontend/src/components/dashboard/RecurringExpensesWidget.test.tsx
+++ b/frontend/src/components/dashboard/RecurringExpensesWidget.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, screen } from '@testing-library/react';
+import { render } from '@/test/render';
+import { RecurringExpensesWidget } from './RecurringExpensesWidget';
+
+vi.mock('recharts', async () => (await import('@/test/recharts-mock')).rechartsMock());
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+const updateConfig = vi.fn();
+vi.mock('@/hooks/useWidgetConfig', () => ({
+  useWidgetConfig: () => ({ config: { minOccurrences: 3 }, updateConfig }),
+}));
+vi.mock('@/hooks/useNumberFormat', () => ({
+  useNumberFormat: () => ({
+    formatCurrency: (n: number) => `$${n}`,
+    formatCurrencyCompact: (n: number) => `$${n}`,
+  }),
+}));
+
+const getRecurringExpenses = vi.fn();
+vi.mock('@/lib/built-in-reports', () => ({
+  builtInReportsApi: { getRecurringExpenses: (...a: unknown[]) => getRecurringExpenses(...a) },
+}));
+
+async function renderWidget() {
+  await act(async () => {
+    render(<RecurringExpensesWidget isLoading={false} />);
+  });
+}
+
+describe('RecurringExpensesWidget', () => {
+  beforeEach(() => {
+    getRecurringExpenses.mockReset();
+    updateConfig.mockReset();
+  });
+
+  it('fetches with the configured minimum occurrences and renders the estimate', async () => {
+    getRecurringExpenses.mockResolvedValue({
+      data: [
+        { payeeName: 'Netflix', payeeId: 'p1', occurrences: 6, totalAmount: 90, averageAmount: 15, lastTransactionDate: '2026-06-01', frequency: 'monthly', categoryName: 'Streaming' },
+      ],
+      summary: { totalRecurring: 90, monthlyEstimate: 15, uniquePayees: 1 },
+    });
+    await renderWidget();
+    expect(screen.getByText('Top Recurring Expenses')).toBeInTheDocument();
+    expect(getRecurringExpenses).toHaveBeenCalledWith(3);
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+    expect(screen.getByText('$15')).toBeInTheDocument();
+  });
+
+  it('shows the empty state with no recurring expenses', async () => {
+    getRecurringExpenses.mockResolvedValue({
+      data: [],
+      summary: { totalRecurring: 0, monthlyEstimate: 0, uniquePayees: 0 },
+    });
+    await renderWidget();
+    expect(screen.getByText('No recurring expenses found.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/RecurringExpensesWidget.tsx
+++ b/frontend/src/components/dashboard/RecurringExpensesWidget.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
+import { builtInReportsApi } from '@/lib/built-in-reports';
+import { RecurringExpenseItem } from '@/types/built-in-reports';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useReportData } from '@/hooks/useReportData';
+import { useWidgetConfig } from '@/hooks/useWidgetConfig';
+import { chartSeriesColor } from '@/lib/chart-colors';
+import { ChartTooltipPanel } from '@/components/reports/ChartTooltip';
+import { WidgetCard, WidgetConfigRow, WidgetMessage } from './WidgetCard';
+import { RECURRING_EXPENSES_DEFAULT, RecurringConfig } from './widget-config';
+
+const WIDGET_ID = 'recurring-expenses';
+const MIN_OCCURRENCE_OPTIONS = [2, 3, 4, 5, 6];
+
+interface RecurringExpensesWidgetProps {
+  isLoading: boolean;
+}
+
+type RecurringSlice = RecurringExpenseItem & { color: string };
+
+export function RecurringExpensesWidget({ isLoading }: RecurringExpensesWidgetProps) {
+  const t = useTranslations('dashboard');
+  const router = useRouter();
+  const { formatCurrency, formatCurrencyCompact } = useNumberFormat();
+  const { config, updateConfig } = useWidgetConfig<RecurringConfig>(
+    WIDGET_ID,
+    RECURRING_EXPENSES_DEFAULT,
+  );
+
+  const { data: response, isLoading: dataLoading } = useReportData(
+    () => builtInReportsApi.getRecurringExpenses(config.minOccurrences),
+    [config.minOccurrences],
+  );
+
+  const chartData = useMemo<RecurringSlice[]>(
+    () =>
+      (response?.data ?? []).slice(0, 10).map((item, index) => ({
+        ...item,
+        color: chartSeriesColor(index),
+      })),
+    [response],
+  );
+
+  const monthlyEstimate = response?.summary.monthlyEstimate ?? 0;
+
+  const handleSliceClick = (payeeId: string | null) => {
+    if (payeeId) router.push(`/transactions?payeeId=${payeeId}`);
+  };
+
+  const configControls = (
+    <WidgetConfigRow label={t('recurringExpenses.minOccurrences')}>
+      <select
+        value={config.minOccurrences}
+        onChange={(e) => updateConfig({ minOccurrences: Number(e.target.value) })}
+        className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+      >
+        {MIN_OCCURRENCE_OPTIONS.map((n) => (
+          <option key={n} value={n}>
+            {t('recurringExpenses.minOccurrencesOption', { count: n })}
+          </option>
+        ))}
+      </select>
+    </WidgetConfigRow>
+  );
+
+  const loading = isLoading || dataLoading;
+
+  return (
+    <WidgetCard
+      title={t('recurringExpenses.title')}
+      configControls={configControls}
+      configTitle={t('recurringExpenses.title')}
+    >
+      {loading ? (
+        <div className="flex-1 min-h-[260px] animate-pulse rounded-md bg-gray-100 dark:bg-gray-700/50" />
+      ) : chartData.length === 0 ? (
+        <WidgetMessage>{t('recurringExpenses.empty')}</WidgetMessage>
+      ) : (
+        <>
+          <div className="flex-1 min-h-[240px]">
+            <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+              <PieChart>
+                <Pie
+                  data={chartData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius="55%"
+                  outerRadius="85%"
+                  paddingAngle={2}
+                  dataKey="totalAmount"
+                  nameKey="payeeName"
+                  cursor="pointer"
+                  onClick={(d) => handleSliceClick((d as unknown as RecurringSlice).payeeId)}
+                >
+                  {chartData.map((entry) => (
+                    <Cell key={entry.payeeId || entry.payeeName} fill={entry.color} />
+                  ))}
+                </Pie>
+                <Tooltip
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null;
+                    const d = payload[0].payload as RecurringSlice;
+                    return (
+                      <ChartTooltipPanel>
+                        <p className="font-medium text-gray-900 dark:text-gray-100">{d.payeeName}</p>
+                        <p className="text-gray-600 dark:text-gray-400">
+                          {formatCurrency(d.totalAmount)}
+                        </p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          {t('recurringExpenses.occurrences', { count: d.occurrences })}
+                        </p>
+                      </ChartTooltipPanel>
+                    );
+                  }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between text-sm flex-shrink-0">
+            <span className="text-gray-500 dark:text-gray-400">{t('recurringExpenses.monthlyEstimate')}</span>
+            <span className="font-semibold text-gray-900 dark:text-gray-100">
+              {formatCurrencyCompact(monthlyEstimate)}
+            </span>
+          </div>
+        </>
+      )}
+    </WidgetCard>
+  );
+}

--- a/frontend/src/components/dashboard/SectorWeightingsWidget.test.tsx
+++ b/frontend/src/components/dashboard/SectorWeightingsWidget.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, screen } from '@testing-library/react';
+import { render } from '@/test/render';
+import { Account } from '@/types/account';
+import { SectorWeightingsWidget } from './SectorWeightingsWidget';
+
+vi.mock('recharts', async () => (await import('@/test/recharts-mock')).rechartsMock());
+
+// Stable config reference across renders (mirrors the real memoized hook), so
+// useReportData's [config.accountIds] dependency does not change every render.
+const { widgetCfg } = vi.hoisted(() => ({
+  widgetCfg: { config: { accountIds: [] as string[] }, updateConfig: () => {} },
+}));
+vi.mock('@/hooks/useWidgetConfig', () => ({
+  useWidgetConfig: () => widgetCfg,
+}));
+vi.mock('@/hooks/useNumberFormat', () => ({
+  useNumberFormat: () => ({
+    formatCurrency: (n: number) => `$${n}`,
+    formatCurrencyAxis: (n: number) => `$${n}`,
+  }),
+}));
+vi.mock('@/hooks/useExchangeRates', () => ({
+  useExchangeRates: () => ({ defaultCurrency: 'USD' }),
+}));
+
+const getSectorWeightings = vi.fn();
+vi.mock('@/lib/investments', () => ({
+  investmentsApi: { getSectorWeightings: (...a: unknown[]) => getSectorWeightings(...a) },
+}));
+
+const investmentAccount = { id: 'i1', accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_BROKERAGE', name: 'Brokerage' } as Account;
+
+async function renderWidget() {
+  await act(async () => {
+    render(<SectorWeightingsWidget accounts={[investmentAccount]} isLoading={false} />);
+  });
+}
+
+describe('SectorWeightingsWidget', () => {
+  beforeEach(() => getSectorWeightings.mockReset());
+
+  it('renders a stacked bar for sector weightings', async () => {
+    getSectorWeightings.mockResolvedValue({
+      items: [
+        { sector: 'Technology', directValue: 600, etfValue: 400, totalValue: 1000, percentage: 60 },
+        { sector: 'Energy', directValue: 300, etfValue: 100, totalValue: 400, percentage: 40 },
+      ],
+      totalPortfolioValue: 1400,
+      totalDirectValue: 900,
+      totalEtfValue: 500,
+      unclassifiedValue: 0,
+    });
+    await renderWidget();
+    expect(screen.getByText('Sector Allocation')).toBeInTheDocument();
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+  });
+
+  it('shows the empty state with no sectors', async () => {
+    getSectorWeightings.mockResolvedValue({
+      items: [],
+      totalPortfolioValue: 0,
+      totalDirectValue: 0,
+      totalEtfValue: 0,
+      unclassifiedValue: 0,
+    });
+    await renderWidget();
+    expect(screen.getByText('No sector data available.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/SectorWeightingsWidget.tsx
+++ b/frontend/src/components/dashboard/SectorWeightingsWidget.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useTranslations } from 'next-intl';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+import { Account } from '@/types/account';
+import { investmentsApi } from '@/lib/investments';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useExchangeRates } from '@/hooks/useExchangeRates';
+import { useReportData } from '@/hooks/useReportData';
+import { useWidgetConfig } from '@/hooks/useWidgetConfig';
+import { chartColors } from '@/lib/chart-colors';
+import { ChartTooltipPanel } from '@/components/reports/ChartTooltip';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { WidgetCard, WidgetConfigRow, WidgetMessage } from './WidgetCard';
+import { SECTOR_WEIGHTINGS_DEFAULT, AccountsConfig } from './widget-config';
+
+const WIDGET_ID = 'sector-weightings';
+
+// Holdings are keyed off the brokerage sub-account; the sibling cash account is
+// excluded from the picker.
+const excludeCashAccounts = (a: Account) => a.accountSubType !== 'INVESTMENT_CASH';
+
+interface SectorWeightingsWidgetProps {
+  accounts: Account[];
+  isLoading: boolean;
+}
+
+export function SectorWeightingsWidget({ accounts, isLoading }: SectorWeightingsWidgetProps) {
+  const t = useTranslations('dashboard');
+  const { formatCurrency, formatCurrencyAxis } = useNumberFormat();
+  const { defaultCurrency } = useExchangeRates();
+  const { config, updateConfig } = useWidgetConfig<AccountsConfig>(
+    WIDGET_ID,
+    SECTOR_WEIGHTINGS_DEFAULT,
+  );
+
+  const investmentAccounts = useMemo(
+    () => accounts.filter((a) => a.accountType === 'INVESTMENT'),
+    [accounts],
+  );
+
+  const { data, isLoading: dataLoading } = useReportData(
+    () =>
+      investmentsApi.getSectorWeightings(
+        config.accountIds.length > 0 ? config.accountIds : undefined,
+      ),
+    [config.accountIds],
+  );
+
+  const chartData = useMemo(
+    () =>
+      (data?.items ?? []).map((item) => ({
+        sector: item.sector,
+        direct: item.directValue,
+        etf: item.etfValue,
+        total: item.totalValue,
+        percentage: item.percentage,
+      })),
+    [data],
+  );
+
+  const configControls = (
+    <WidgetConfigRow label={t('widgets.accounts')}>
+      <ReportAccountMultiSelect
+        accounts={investmentAccounts}
+        value={config.accountIds}
+        onChange={(accountIds) => updateConfig({ accountIds })}
+        filter={excludeCashAccounts}
+        className="w-full"
+      />
+    </WidgetConfigRow>
+  );
+
+  const loading = isLoading || dataLoading;
+
+  return (
+    <WidgetCard
+      title={t('sectorWeightings.title')}
+      configControls={configControls}
+      configTitle={t('sectorWeightings.title')}
+    >
+      {loading ? (
+        <div className="flex-1 min-h-[260px] animate-pulse rounded-md bg-gray-100 dark:bg-gray-700/50" />
+      ) : chartData.length === 0 ? (
+        <WidgetMessage>{t('sectorWeightings.empty')}</WidgetMessage>
+      ) : (
+        <div
+          className="flex-1"
+          style={{ minHeight: Math.min(Math.max(240, chartData.length * 38 + 40), 420) }}
+        >
+          <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+            <BarChart data={chartData} layout="vertical" margin={{ top: 4, right: 10, left: 0, bottom: 4 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} horizontal={false} />
+              <XAxis type="number" tickFormatter={formatCurrencyAxis} tick={{ fontSize: 11 }} />
+              <YAxis type="category" dataKey="sector" width={100} tick={{ fontSize: 11 }} />
+              <Tooltip
+                content={({ active, payload }) => {
+                  if (!active || !payload?.length) return null;
+                  const d = payload[0].payload as (typeof chartData)[number];
+                  return (
+                    <ChartTooltipPanel>
+                      <p className="font-medium text-gray-900 dark:text-gray-100">{d.sector}</p>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        {t('sectorWeightings.direct')}: {formatCurrency(d.direct, defaultCurrency)}
+                      </p>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        {t('sectorWeightings.etf')}: {formatCurrency(d.etf, defaultCurrency)}
+                      </p>
+                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                        {d.percentage.toFixed(1)}%
+                      </p>
+                    </ChartTooltipPanel>
+                  );
+                }}
+              />
+              <Legend
+                formatter={(value: string) =>
+                  value === 'direct' ? t('sectorWeightings.direct') : t('sectorWeightings.etf')
+                }
+              />
+              <Bar dataKey="direct" stackId="a" fill={chartColors.primary} name="direct" />
+              <Bar dataKey="etf" stackId="a" fill={chartColors.income} name="etf" radius={[0, 4, 4, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </WidgetCard>
+  );
+}

--- a/frontend/src/components/dashboard/SecurityTypeAllocationWidget.test.tsx
+++ b/frontend/src/components/dashboard/SecurityTypeAllocationWidget.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, screen } from '@testing-library/react';
+import { render } from '@/test/render';
+import { Account } from '@/types/account';
+import { HoldingWithMarketValue } from '@/types/investment';
+import { SecurityTypeAllocationWidget } from './SecurityTypeAllocationWidget';
+
+vi.mock('recharts', async () => (await import('@/test/recharts-mock')).rechartsMock());
+
+// Stable config reference across renders (mirrors the real memoized hook), so
+// useReportData's [config.accountIds] dependency does not change every render.
+const { widgetCfg } = vi.hoisted(() => ({
+  widgetCfg: { config: { accountIds: [] as string[] }, updateConfig: () => {} },
+}));
+vi.mock('@/hooks/useWidgetConfig', () => ({
+  useWidgetConfig: () => widgetCfg,
+}));
+vi.mock('@/hooks/useNumberFormat', () => ({
+  useNumberFormat: () => ({ formatCurrency: (n: number) => `$${n}` }),
+}));
+vi.mock('@/hooks/useExchangeRates', () => ({
+  useExchangeRates: () => ({ convertToDefault: (n: number) => n }),
+}));
+
+const getPortfolioSummary = vi.fn();
+vi.mock('@/lib/investments', () => ({
+  investmentsApi: { getPortfolioSummary: (...a: unknown[]) => getPortfolioSummary(...a) },
+}));
+
+const holding = (securityId: string, securityType: string, marketValue: number): HoldingWithMarketValue =>
+  ({
+    securityId,
+    securityType,
+    marketValue,
+    currencyCode: 'USD',
+    quantity: 10,
+    costBasis: marketValue,
+    costBasisAccountCurrency: marketValue,
+    averageCost: marketValue / 10,
+    gainLoss: 0,
+    gainLossPercent: 0,
+  }) as HoldingWithMarketValue;
+
+const investmentAccount = { id: 'i1', accountType: 'INVESTMENT', accountSubType: 'INVESTMENT_BROKERAGE', name: 'Brokerage' } as Account;
+
+async function renderWidget() {
+  await act(async () => {
+    render(<SecurityTypeAllocationWidget accounts={[investmentAccount]} isLoading={false} />);
+  });
+}
+
+describe('SecurityTypeAllocationWidget', () => {
+  beforeEach(() => getPortfolioSummary.mockReset());
+
+  it('groups holdings by security type', async () => {
+    getPortfolioSummary.mockResolvedValue({
+      holdings: [holding('s1', 'STOCK', 700), holding('s2', 'ETF', 300)],
+      holdingsByAccount: [],
+    });
+    await renderWidget();
+    expect(screen.getByText('Security Type Allocation')).toBeInTheDocument();
+    expect(screen.getByText('Stocks')).toBeInTheDocument();
+    expect(screen.getByText('ETFs')).toBeInTheDocument();
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+  });
+
+  it('shows the empty state with no holdings', async () => {
+    getPortfolioSummary.mockResolvedValue({ holdings: [], holdingsByAccount: [] });
+    await renderWidget();
+    expect(screen.getByText('No holdings to show.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/SecurityTypeAllocationWidget.tsx
+++ b/frontend/src/components/dashboard/SecurityTypeAllocationWidget.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useTranslations } from 'next-intl';
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
+import { Account } from '@/types/account';
+import { HoldingWithMarketValue } from '@/types/investment';
+import { investmentsApi } from '@/lib/investments';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useExchangeRates } from '@/hooks/useExchangeRates';
+import { useReportData } from '@/hooks/useReportData';
+import { useWidgetConfig } from '@/hooks/useWidgetConfig';
+import { chartColors, CHART_SERIES, chartSeriesColor } from '@/lib/chart-colors';
+import { aggregateHoldingsBySecurity } from '@/lib/aggregate-holdings';
+import { ChartTooltipPanel } from '@/components/reports/ChartTooltip';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { WidgetCard, WidgetConfigRow, WidgetMessage } from './WidgetCard';
+import { SECURITY_TYPE_ALLOCATION_DEFAULT, AccountsConfig } from './widget-config';
+
+const WIDGET_ID = 'security-type-allocation';
+
+const excludeCashAccounts = (a: Account) => a.accountSubType !== 'INVESTMENT_CASH';
+
+const TYPE_COLOURS: Record<string, string> = {
+  STOCK: CHART_SERIES[0],
+  ETF: CHART_SERIES[1],
+  MUTUAL_FUND: CHART_SERIES[8],
+  BOND: CHART_SERIES[4],
+  CASH: chartColors.axis,
+};
+
+interface SecurityTypeAllocationWidgetProps {
+  accounts: Account[];
+  isLoading: boolean;
+}
+
+interface TypeAllocation {
+  type: string;
+  label: string;
+  totalValue: number;
+  percentage: number;
+  color: string;
+}
+
+export function SecurityTypeAllocationWidget({
+  accounts,
+  isLoading,
+}: SecurityTypeAllocationWidgetProps) {
+  const t = useTranslations('dashboard');
+  const { formatCurrency } = useNumberFormat();
+  const { convertToDefault } = useExchangeRates();
+  const { config, updateConfig } = useWidgetConfig<AccountsConfig>(
+    WIDGET_ID,
+    SECURITY_TYPE_ALLOCATION_DEFAULT,
+  );
+
+  const investmentAccounts = useMemo(
+    () => accounts.filter((a) => a.accountType === 'INVESTMENT'),
+    [accounts],
+  );
+
+  const typeLabel = (type: string): string => {
+    const known = ['STOCK', 'ETF', 'MUTUAL_FUND', 'BOND', 'CASH'];
+    return known.includes(type)
+      ? t(`securityTypeAllocation.types.${type}` as Parameters<typeof t>[0])
+      : type;
+  };
+
+  const { data: summary, isLoading: dataLoading } = useReportData(
+    () =>
+      investmentsApi.getPortfolioSummary(
+        config.accountIds.length > 0 ? config.accountIds : undefined,
+      ),
+    [config.accountIds],
+  );
+
+  const holdings = useMemo<HoldingWithMarketValue[]>(
+    () => summary?.holdings ?? [],
+    [summary],
+  );
+
+  const allocationData = useMemo<TypeAllocation[]>(() => {
+    const aggregated = aggregateHoldingsBySecurity(holdings);
+    const typeMap = new Map<string, number>();
+    aggregated.forEach((h) => {
+      const type = h.securityType || 'OTHER';
+      const converted = convertToDefault(h.marketValue ?? 0, h.currencyCode);
+      typeMap.set(type, (typeMap.get(type) ?? 0) + converted);
+    });
+
+    const totalValue = Array.from(typeMap.values()).reduce((sum, v) => sum + v, 0);
+    let colorIndex = 0;
+
+    return Array.from(typeMap.entries())
+      .map(([type, value]) => ({
+        type,
+        label: typeLabel(type),
+        totalValue: value,
+        percentage: totalValue > 0 ? (value / totalValue) * 100 : 0,
+        color: TYPE_COLOURS[type] || chartSeriesColor(colorIndex++),
+      }))
+      .sort((a, b) => b.totalValue - a.totalValue);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [holdings, convertToDefault, t]);
+
+  const configControls = (
+    <WidgetConfigRow label={t('widgets.accounts')}>
+      <ReportAccountMultiSelect
+        accounts={investmentAccounts}
+        value={config.accountIds}
+        onChange={(accountIds) => updateConfig({ accountIds })}
+        filter={excludeCashAccounts}
+        className="w-full"
+      />
+    </WidgetConfigRow>
+  );
+
+  const loading = isLoading || dataLoading;
+
+  return (
+    <WidgetCard
+      title={t('securityTypeAllocation.title')}
+      configControls={configControls}
+      configTitle={t('securityTypeAllocation.title')}
+    >
+      {loading ? (
+        <div className="flex-1 min-h-[260px] animate-pulse rounded-md bg-gray-100 dark:bg-gray-700/50" />
+      ) : allocationData.length === 0 ? (
+        <WidgetMessage>{t('securityTypeAllocation.empty')}</WidgetMessage>
+      ) : (
+        <>
+          <div className="flex-1 min-h-[240px]">
+            <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+              <PieChart>
+                <Pie
+                  data={allocationData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius="55%"
+                  outerRadius="85%"
+                  paddingAngle={2}
+                  dataKey="totalValue"
+                  nameKey="label"
+                >
+                  {allocationData.map((entry) => (
+                    <Cell key={entry.type} fill={entry.color} />
+                  ))}
+                </Pie>
+                <Tooltip
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null;
+                    const d = payload[0].payload as TypeAllocation;
+                    return (
+                      <ChartTooltipPanel>
+                        <p className="font-medium text-gray-900 dark:text-gray-100">{d.label}</p>
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
+                          {formatCurrency(d.totalValue)} ({d.percentage.toFixed(1)}%)
+                        </p>
+                      </ChartTooltipPanel>
+                    );
+                  }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1.5 text-sm flex-shrink-0">
+            {allocationData.map((entry) => (
+              <div key={entry.type} className="flex items-center gap-2">
+                <span className="w-3 h-3 rounded-sm shrink-0" style={{ backgroundColor: entry.color }} />
+                <span className="text-gray-500 dark:text-gray-400 truncate">{entry.label}</span>
+                <span className="ml-auto text-gray-900 dark:text-gray-100">
+                  {entry.percentage.toFixed(0)}%
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </WidgetCard>
+  );
+}

--- a/frontend/src/components/dashboard/SpendingByPayeeWidget.test.tsx
+++ b/frontend/src/components/dashboard/SpendingByPayeeWidget.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, screen } from '@testing-library/react';
+import { render } from '@/test/render';
+import { SpendingByPayeeWidget } from './SpendingByPayeeWidget';
+
+vi.mock('recharts', async () => (await import('@/test/recharts-mock')).rechartsMock());
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+const updateConfig = vi.fn();
+const configState = { current: { range: '3m' } };
+vi.mock('@/hooks/useWidgetConfig', () => ({
+  useWidgetConfig: () => ({ config: configState.current, updateConfig }),
+}));
+
+vi.mock('@/hooks/useNumberFormat', () => ({
+  useNumberFormat: () => ({
+    formatCurrency: (n: number) => `$${n}`,
+    formatCurrencyCompact: (n: number) => `$${n}`,
+    formatCurrencyAxis: (n: number) => `$${n}`,
+  }),
+}));
+
+const getSpendingByPayee = vi.fn();
+vi.mock('@/lib/built-in-reports', () => ({
+  builtInReportsApi: { getSpendingByPayee: (...a: unknown[]) => getSpendingByPayee(...a) },
+}));
+
+async function renderWidget() {
+  await act(async () => {
+    render(<SpendingByPayeeWidget isLoading={false} />);
+  });
+}
+
+describe('SpendingByPayeeWidget', () => {
+  beforeEach(() => {
+    getSpendingByPayee.mockReset();
+    updateConfig.mockReset();
+    configState.current = { range: '3m' };
+  });
+
+  it('fetches the configured range and renders the total', async () => {
+    getSpendingByPayee.mockResolvedValue({
+      data: [{ payeeId: 'p1', payeeName: 'Grocer', total: 300 }],
+      totalSpending: 300,
+    });
+    await renderWidget();
+    expect(screen.getByText('Spending by Payee')).toBeInTheDocument();
+    expect(getSpendingByPayee).toHaveBeenCalledWith(
+      expect.objectContaining({ endDate: expect.any(String) }),
+    );
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+    expect(screen.getByText('$300')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there is no spending', async () => {
+    getSpendingByPayee.mockResolvedValue({ data: [], totalSpending: 0 });
+    await renderWidget();
+    expect(screen.getByText('No spending in this period.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/SpendingByPayeeWidget.tsx
+++ b/frontend/src/components/dashboard/SpendingByPayeeWidget.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+import { builtInReportsApi } from '@/lib/built-in-reports';
+import { PayeeSpendingItem } from '@/types/built-in-reports';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useReportData } from '@/hooks/useReportData';
+import { useWidgetConfig } from '@/hooks/useWidgetConfig';
+import { resolveRangePreset } from '@/lib/date-range';
+import { chartColors, chartSeriesColor } from '@/lib/chart-colors';
+import { ChartTooltipPanel } from '@/components/reports/ChartTooltip';
+import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
+import { WidgetCard, WidgetConfigRow, WidgetMessage } from './WidgetCard';
+import {
+  SPENDING_BY_PAYEE_DEFAULT,
+  SPENDING_RANGES,
+  RangeConfig,
+} from './widget-config';
+
+const WIDGET_ID = 'spending-by-payee';
+const MAX_BARS = 8;
+
+interface SpendingByPayeeWidgetProps {
+  isLoading: boolean;
+}
+
+export function SpendingByPayeeWidget({ isLoading }: SpendingByPayeeWidgetProps) {
+  const t = useTranslations('dashboard');
+  const router = useRouter();
+  const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis } = useNumberFormat();
+  const { config, updateConfig } = useWidgetConfig<RangeConfig>(
+    WIDGET_ID,
+    SPENDING_BY_PAYEE_DEFAULT,
+  );
+
+  const { start, end } = useMemo(
+    () => resolveRangePreset(config.range),
+    [config.range],
+  );
+
+  const { data: response, isLoading: dataLoading } = useReportData(
+    () =>
+      builtInReportsApi.getSpendingByPayee({
+        startDate: start || undefined,
+        endDate: end,
+      }),
+    [start, end],
+  );
+
+  const chartData = useMemo(
+    () =>
+      (response?.data ?? []).slice(0, MAX_BARS).map((item: PayeeSpendingItem) => ({
+        id: item.payeeId || '',
+        name: item.payeeName,
+        value: item.total,
+      })),
+    [response],
+  );
+
+  const totalExpenses = response?.totalSpending ?? 0;
+
+  const handlePayeeClick = (payeeId: string) => {
+    if (payeeId) {
+      router.push(`/transactions?payeeId=${payeeId}&startDate=${start}&endDate=${end}`);
+    }
+  };
+
+  const configControls = (
+    <WidgetConfigRow label={t('widgets.timeframe')}>
+      <DateRangeSelector
+        ranges={SPENDING_RANGES}
+        value={config.range}
+        onChange={(range) => updateConfig({ range })}
+        size="sm"
+      />
+    </WidgetConfigRow>
+  );
+
+  const loading = isLoading || dataLoading;
+
+  return (
+    <WidgetCard
+      title={t('spendingByPayee.title')}
+      headerRight={
+        <span className="text-sm text-gray-500 dark:text-gray-400">
+          {t(`widgets.rangeLabels.${config.range}` as Parameters<typeof t>[0])}
+        </span>
+      }
+      configControls={configControls}
+      configTitle={t('spendingByPayee.title')}
+    >
+      {loading ? (
+        <div className="flex-1 min-h-[260px] animate-pulse rounded-md bg-gray-100 dark:bg-gray-700/50" />
+      ) : chartData.length === 0 ? (
+        <WidgetMessage>{t('spendingByPayee.empty')}</WidgetMessage>
+      ) : (
+        <>
+          <div className="flex-1 min-h-[260px]">
+            <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+              <BarChart data={chartData} layout="vertical" margin={{ left: 10, right: 10 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} horizontal={false} />
+                <XAxis type="number" tickFormatter={formatCurrencyAxis} tick={{ fontSize: 11 }} />
+                <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={90} />
+                <Tooltip
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null;
+                    const d = payload[0].payload as { name: string; value: number };
+                    const pct = totalExpenses > 0 ? ((d.value / totalExpenses) * 100).toFixed(1) : '0';
+                    return (
+                      <ChartTooltipPanel>
+                        <p className="font-medium text-gray-900 dark:text-gray-100">{d.name}</p>
+                        <p className="text-gray-600 dark:text-gray-400">
+                          {formatCurrency(d.value)} ({pct}%)
+                        </p>
+                      </ChartTooltipPanel>
+                    );
+                  }}
+                />
+                <Bar
+                  dataKey="value"
+                  cursor="pointer"
+                  onClick={(d) => (d as { id?: string }).id && handlePayeeClick((d as { id: string }).id)}
+                  radius={[0, 4, 4, 0]}
+                >
+                  {chartData.map((entry, index) => (
+                    <Cell key={entry.id || index} fill={chartSeriesColor(index)} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between text-sm flex-shrink-0">
+            <span className="text-gray-500 dark:text-gray-400">{t('spendingByPayee.totalLabel')}</span>
+            <span className="font-semibold text-gray-900 dark:text-gray-100">
+              {formatCurrency(totalExpenses)}
+            </span>
+          </div>
+        </>
+      )}
+    </WidgetCard>
+  );
+}

--- a/frontend/src/components/dashboard/WeekendVsWeekdayWidget.test.tsx
+++ b/frontend/src/components/dashboard/WeekendVsWeekdayWidget.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, screen } from '@testing-library/react';
+import { render } from '@/test/render';
+import { WeekendVsWeekdayWidget } from './WeekendVsWeekdayWidget';
+
+vi.mock('recharts', async () => (await import('@/test/recharts-mock')).rechartsMock());
+
+const configState = { current: { range: '3m', view: 'overview' as 'overview' | 'byDay' } };
+vi.mock('@/hooks/useWidgetConfig', () => ({
+  useWidgetConfig: () => ({ config: configState.current, updateConfig: vi.fn() }),
+}));
+vi.mock('@/hooks/useNumberFormat', () => ({
+  useNumberFormat: () => ({
+    formatCurrencyCompact: (n: number) => `$${n}`,
+    formatCurrencyAxis: (n: number) => `$${n}`,
+  }),
+}));
+
+const getWeekendVsWeekday = vi.fn();
+vi.mock('@/lib/built-in-reports', () => ({
+  builtInReportsApi: { getWeekendVsWeekday: (...a: unknown[]) => getWeekendVsWeekday(...a) },
+}));
+
+const RESPONSE = {
+  summary: { weekendTotal: 400, weekdayTotal: 600, weekendCount: 8, weekdayCount: 20 },
+  byDay: [
+    { dayOfWeek: 0, total: 200, count: 4 },
+    { dayOfWeek: 1, total: 150, count: 5 },
+    { dayOfWeek: 6, total: 200, count: 4 },
+  ],
+  byCategory: [],
+};
+
+async function renderWidget() {
+  await act(async () => {
+    render(<WeekendVsWeekdayWidget isLoading={false} />);
+  });
+}
+
+describe('WeekendVsWeekdayWidget', () => {
+  beforeEach(() => {
+    getWeekendVsWeekday.mockReset().mockResolvedValue(RESPONSE);
+    configState.current = { range: '3m', view: 'overview' };
+  });
+
+  it('renders the overview donut with the weekend percentage', async () => {
+    await renderWidget();
+    expect(screen.getByText('Weekend vs Weekday Spending')).toBeInTheDocument();
+    // 400 / 1000 = 40%
+    expect(screen.getByText('40%')).toBeInTheDocument();
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+  });
+
+  it('renders the by-day view', async () => {
+    configState.current = { range: '3m', view: 'byDay' };
+    await renderWidget();
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there is no spending', async () => {
+    getWeekendVsWeekday.mockResolvedValue({
+      summary: { weekendTotal: 0, weekdayTotal: 0, weekendCount: 0, weekdayCount: 0 },
+      byDay: [],
+      byCategory: [],
+    });
+    await renderWidget();
+    expect(screen.getByText('No spending in this period.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/WeekendVsWeekdayWidget.tsx
+++ b/frontend/src/components/dashboard/WeekendVsWeekdayWidget.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useTranslations } from 'next-intl';
+import {
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { builtInReportsApi } from '@/lib/built-in-reports';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
+import { useReportData } from '@/hooks/useReportData';
+import { useWidgetConfig } from '@/hooks/useWidgetConfig';
+import { resolveRangePreset } from '@/lib/date-range';
+import { chartColors, CHART_SERIES } from '@/lib/chart-colors';
+import { ChartTooltipPanel } from '@/components/reports/ChartTooltip';
+import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
+import { WidgetCard, WidgetConfigRow, WidgetMessage } from './WidgetCard';
+import { WidgetSegmentedControl } from './WidgetSegmentedControl';
+import {
+  WEEKEND_WEEKDAY_DEFAULT,
+  WEEKEND_RANGES,
+  WeekendConfig,
+} from './widget-config';
+
+const WIDGET_ID = 'weekend-weekday';
+const WEEKEND_COLOR = CHART_SERIES[4];
+const WEEKDAY_COLOR = CHART_SERIES[0];
+
+interface WeekendVsWeekdayWidgetProps {
+  isLoading: boolean;
+}
+
+export function WeekendVsWeekdayWidget({ isLoading }: WeekendVsWeekdayWidgetProps) {
+  const t = useTranslations('dashboard');
+  const tc = useTranslations('common');
+  const dayNames = tc.raw('weekdaysShort') as string[];
+  const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis } = useNumberFormat();
+  const { config, updateConfig } = useWidgetConfig<WeekendConfig>(
+    WIDGET_ID,
+    WEEKEND_WEEKDAY_DEFAULT,
+  );
+
+  const { start, end } = useMemo(
+    () => resolveRangePreset(config.range),
+    [config.range],
+  );
+
+  const { data: reportData, isLoading: dataLoading } = useReportData(
+    () => builtInReportsApi.getWeekendVsWeekday({ startDate: start, endDate: end }),
+    [start, end],
+  );
+
+  const dayData = useMemo(() => {
+    const byDay = reportData?.byDay ?? [];
+    return dayNames.map((day, index) => {
+      const info = byDay.find((d) => d.dayOfWeek === index);
+      return {
+        day,
+        total: info?.total ?? 0,
+        isWeekend: index === 0 || index === 6,
+      };
+    });
+  }, [reportData, dayNames]);
+
+  const summary = reportData?.summary;
+  const weekendTotal = summary?.weekendTotal ?? 0;
+  const weekdayTotal = summary?.weekdayTotal ?? 0;
+  const totalSpending = weekendTotal + weekdayTotal;
+  const weekendPercent = totalSpending > 0 ? (weekendTotal / totalSpending) * 100 : 0;
+
+  const pieData = [
+    { name: t('weekendVsWeekday.weekendLabel'), value: weekendTotal, color: WEEKEND_COLOR },
+    { name: t('weekendVsWeekday.weekdayLabel'), value: weekdayTotal, color: WEEKDAY_COLOR },
+  ];
+
+  const configControls = (
+    <>
+      <WidgetConfigRow label={t('widgets.timeframe')}>
+        <DateRangeSelector
+          ranges={WEEKEND_RANGES}
+          value={config.range}
+          onChange={(range) => updateConfig({ range })}
+          size="sm"
+        />
+      </WidgetConfigRow>
+      <WidgetConfigRow label={t('widgets.view')}>
+        <WidgetSegmentedControl
+          value={config.view}
+          onChange={(view) => updateConfig({ view })}
+          options={[
+            { value: 'overview', label: t('weekendVsWeekday.viewOverview') },
+            { value: 'byDay', label: t('weekendVsWeekday.viewByDay') },
+          ]}
+        />
+      </WidgetConfigRow>
+    </>
+  );
+
+  const loading = isLoading || dataLoading;
+
+  return (
+    <WidgetCard
+      title={t('weekendVsWeekday.title')}
+      configControls={configControls}
+      configTitle={t('weekendVsWeekday.title')}
+    >
+      {loading ? (
+        <div className="flex-1 min-h-[260px] animate-pulse rounded-md bg-gray-100 dark:bg-gray-700/50" />
+      ) : totalSpending === 0 ? (
+        <WidgetMessage>{t('weekendVsWeekday.empty')}</WidgetMessage>
+      ) : config.view === 'byDay' ? (
+        <div className="flex-1 min-h-[260px]">
+          <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+            <BarChart data={dayData} margin={{ left: 4, right: 8, top: 4 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
+              <XAxis dataKey="day" tick={{ fontSize: 11 }} />
+              <YAxis tickFormatter={formatCurrencyAxis} tick={{ fontSize: 11 }} width={56} />
+              <Tooltip
+                content={({ active, payload }) => {
+                  if (!active || !payload?.length) return null;
+                  const d = payload[0].payload as { day: string; total: number };
+                  return (
+                    <ChartTooltipPanel>
+                      <p className="font-medium text-gray-900 dark:text-gray-100">{d.day}</p>
+                      <p className="text-gray-600 dark:text-gray-400">{formatCurrency(d.total)}</p>
+                    </ChartTooltipPanel>
+                  );
+                }}
+              />
+              <Bar dataKey="total" radius={[4, 4, 0, 0]}>
+                {dayData.map((entry) => (
+                  <Cell key={entry.day} fill={entry.isWeekend ? WEEKEND_COLOR : WEEKDAY_COLOR} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      ) : (
+        <>
+          <div className="flex-1 min-h-[220px] relative">
+            <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+              <PieChart>
+                <Pie
+                  data={pieData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius="60%"
+                  outerRadius="88%"
+                  paddingAngle={2}
+                  dataKey="value"
+                >
+                  {pieData.map((entry) => (
+                    <Cell key={entry.name} fill={entry.color} />
+                  ))}
+                </Pie>
+                <Tooltip
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null;
+                    const d = payload[0].payload as { name: string; value: number };
+                    const pct = totalSpending > 0 ? ((d.value / totalSpending) * 100).toFixed(1) : '0';
+                    return (
+                      <ChartTooltipPanel>
+                        <p className="font-medium text-gray-900 dark:text-gray-100">{d.name}</p>
+                        <p className="text-gray-600 dark:text-gray-400">
+                          {formatCurrency(d.value)} ({pct}%)
+                        </p>
+                      </ChartTooltipPanel>
+                    );
+                  }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+            <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+              <span className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                {weekendPercent.toFixed(0)}%
+              </span>
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                {t('weekendVsWeekday.weekendLabel')}
+              </span>
+            </div>
+          </div>
+          <div className="mt-3 grid grid-cols-2 gap-2 text-sm flex-shrink-0">
+            {pieData.map((slice) => (
+              <div key={slice.name} className="flex items-center gap-2">
+                <span className="w-3 h-3 rounded-sm shrink-0" style={{ backgroundColor: slice.color }} />
+                <span className="text-gray-500 dark:text-gray-400 truncate">{slice.name}</span>
+                <span className="ml-auto font-medium text-gray-900 dark:text-gray-100">
+                  {formatCurrency(slice.value)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </WidgetCard>
+  );
+}

--- a/frontend/src/components/dashboard/WidgetCard.test.tsx
+++ b/frontend/src/components/dashboard/WidgetCard.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { act, screen, fireEvent } from '@testing-library/react';
+import { render } from '@/test/render';
+import { WidgetCard, WidgetConfigRow, WidgetMessage } from './WidgetCard';
+
+describe('WidgetCard', () => {
+  it('renders the title and body', () => {
+    render(<WidgetCard title="My Widget">body content</WidgetCard>);
+    expect(screen.getByText('My Widget')).toBeInTheDocument();
+    expect(screen.getByText('body content')).toBeInTheDocument();
+  });
+
+  it('omits the settings gear when there are no config controls', () => {
+    render(<WidgetCard title="My Widget">body</WidgetCard>);
+    expect(screen.queryByLabelText(/Configure/)).not.toBeInTheDocument();
+  });
+
+  it('opens and closes the settings modal via the gear and Done button', async () => {
+    render(
+      <WidgetCard title="My Widget" configControls={<div>config body</div>}>
+        body
+      </WidgetCard>,
+    );
+
+    // Controls are not shown until the gear is clicked.
+    expect(screen.queryByText('config body')).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Configure My Widget'));
+    });
+    expect(screen.getByText('config body')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Done'));
+    });
+    expect(screen.queryByText('config body')).not.toBeInTheDocument();
+  });
+
+  it('renders headerRight content', () => {
+    render(
+      <WidgetCard title="My Widget" headerRight={<span>3M</span>}>
+        body
+      </WidgetCard>,
+    );
+    expect(screen.getByText('3M')).toBeInTheDocument();
+  });
+});
+
+describe('WidgetConfigRow', () => {
+  it('labels its control', () => {
+    render(
+      <WidgetConfigRow label="Timeframe">
+        <input aria-label="picker" />
+      </WidgetConfigRow>,
+    );
+    expect(screen.getByText('Timeframe')).toBeInTheDocument();
+    expect(screen.getByLabelText('picker')).toBeInTheDocument();
+  });
+});
+
+describe('WidgetMessage', () => {
+  it('renders its message', () => {
+    render(<WidgetMessage>Nothing here</WidgetMessage>);
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/WidgetCard.tsx
+++ b/frontend/src/components/dashboard/WidgetCard.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { ReactNode, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Modal } from '@/components/ui/Modal';
+import { Button } from '@/components/ui/Button';
+
+interface WidgetCardProps {
+  /** Widget heading. */
+  title: string;
+  /** Optional right-aligned header content (subtitle, inline toggle, etc.). */
+  headerRight?: ReactNode;
+  /**
+   * When provided, a gear button appears in the header that opens a settings
+   * modal rendering these controls. Each control persists on change, so the
+   * modal only needs a Done button to dismiss.
+   */
+  configControls?: ReactNode;
+  /** Title shown in the settings modal. Defaults to the widget title. */
+  configTitle?: string;
+  /** Card body (chart, skeleton, or empty state). */
+  children: ReactNode;
+  /** Tailwind min-height for the card. Charts default to a tall card. */
+  minHeightClass?: string;
+  className?: string;
+}
+
+/**
+ * Shared shell for the report-derived dashboard widgets: the standard white/dark
+ * card, a header with the title and an optional settings gear, and a settings
+ * modal that hosts the widget's per-instance controls. Keeping the gear in the
+ * header (rather than inline controls) keeps the compact widgets uncluttered and
+ * works the same on mobile and desktop.
+ */
+export function WidgetCard({
+  title,
+  headerRight,
+  configControls,
+  configTitle,
+  children,
+  minHeightClass = 'lg:min-h-[540px]',
+  className = '',
+}: WidgetCardProps) {
+  const t = useTranslations('dashboard');
+  const [showConfig, setShowConfig] = useState(false);
+
+  return (
+    <div
+      className={`bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 sm:p-6 ${minHeightClass} flex flex-col h-full ${className}`}
+    >
+      <div className="flex items-center justify-between gap-2 mb-4">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 min-w-0 truncate">
+          {title}
+        </h3>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {headerRight}
+          {configControls && (
+            <button
+              type="button"
+              onClick={() => setShowConfig(true)}
+              aria-label={t('widgets.configure', { name: title })}
+              className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 flex flex-col">{children}</div>
+
+      {configControls && (
+        <Modal
+          isOpen={showConfig}
+          onClose={() => setShowConfig(false)}
+          maxWidth="md"
+          className="p-4 sm:p-6"
+          pushHistory
+        >
+          <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
+            {configTitle ?? title}
+          </h3>
+          <div className="space-y-4">{configControls}</div>
+          <div className="mt-6 flex justify-end">
+            <Button onClick={() => setShowConfig(false)}>{t('widgets.done')}</Button>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+/** A labelled row inside a widget settings modal. */
+export function WidgetConfigRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+/** Centered placeholder used for widget loading/empty bodies. */
+export function WidgetMessage({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex-1 flex items-center justify-center py-8">
+      <p className="text-sm text-gray-500 dark:text-gray-400 text-center">{children}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/WidgetSegmentedControl.test.tsx
+++ b/frontend/src/components/dashboard/WidgetSegmentedControl.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { render } from '@/test/render';
+import { WidgetSegmentedControl } from './WidgetSegmentedControl';
+
+const OPTIONS = [
+  { value: 'a', label: 'Alpha' },
+  { value: 'b', label: 'Beta' },
+] as const;
+
+describe('WidgetSegmentedControl', () => {
+  it('renders all options and marks the active one', () => {
+    render(
+      <WidgetSegmentedControl value="a" onChange={() => {}} options={[...OPTIONS]} />,
+    );
+    expect(screen.getByText('Alpha')).toHaveClass('bg-blue-600');
+    expect(screen.getByText('Beta')).not.toHaveClass('bg-blue-600');
+  });
+
+  it('fires onChange with the clicked value', () => {
+    const onChange = vi.fn();
+    render(
+      <WidgetSegmentedControl value="a" onChange={onChange} options={[...OPTIONS]} />,
+    );
+    fireEvent.click(screen.getByText('Beta'));
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+});

--- a/frontend/src/components/dashboard/WidgetSegmentedControl.tsx
+++ b/frontend/src/components/dashboard/WidgetSegmentedControl.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+interface SegmentOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface WidgetSegmentedControlProps<T extends string> {
+  value: T;
+  onChange: (value: T) => void;
+  options: SegmentOption<T>[];
+  className?: string;
+}
+
+/**
+ * A small segmented button group for widget settings that are a mutually
+ * exclusive text choice (e.g. region/exchange/country, overview/by day) rather
+ * than a chart-type icon toggle.
+ */
+export function WidgetSegmentedControl<T extends string>({
+  value,
+  onChange,
+  options,
+  className,
+}: WidgetSegmentedControlProps<T>) {
+  return (
+    <div className={cn('flex flex-wrap gap-2', className)}>
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          onClick={() => onChange(option.value)}
+          className={cn(
+            'px-3 py-1.5 text-sm font-medium rounded-md transition-colors',
+            value === option.value
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600',
+          )}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/widget-config.ts
+++ b/frontend/src/components/dashboard/widget-config.ts
@@ -1,0 +1,87 @@
+/**
+ * Config contract for the report-derived dashboard widgets. Each configurable
+ * widget owns a slice of the cross-device `dashboardWidgetConfig` preference,
+ * keyed by its widget id. Defaults are stable module-level constants (required
+ * by useWidgetConfig, which memoizes on the defaults reference).
+ */
+
+/** Range presets offered by the transaction-based spending/income widgets. */
+export const SPENDING_RANGES = ['1m', '3m', '6m', '1y', 'ytd'] as const;
+/** Range presets for month-trend widgets. */
+export const TREND_RANGES = ['6m', '1y', '2y'] as const;
+/** Range presets for the portfolio value widget. */
+export const PORTFOLIO_RANGES = ['3m', '6m', '1y', '2y', '5y', 'all'] as const;
+/** Range presets for the weekend/weekday widget. */
+export const WEEKEND_RANGES = ['1m', '3m', '6m', '1y'] as const;
+
+export interface RangeConfig {
+  range: string;
+}
+
+export interface PortfolioValueConfig {
+  range: string;
+  accountIds: string[];
+}
+
+export interface IncomeBySourceConfig {
+  range: string;
+  chartType: 'pie' | 'bar';
+}
+
+export interface AccountsConfig {
+  accountIds: string[];
+}
+
+export interface GeographicConfig {
+  accountIds: string[];
+  view: 'region' | 'exchange' | 'country';
+}
+
+export interface RecurringConfig {
+  minOccurrences: number;
+}
+
+export interface WeekendConfig {
+  range: string;
+  view: 'overview' | 'byDay';
+}
+
+export const PORTFOLIO_VALUE_DEFAULT: PortfolioValueConfig = {
+  range: '1y',
+  accountIds: [],
+};
+
+export const SPENDING_BY_PAYEE_DEFAULT: RangeConfig = { range: '3m' };
+
+export const MONTHLY_SPENDING_TREND_DEFAULT: RangeConfig = { range: '1y' };
+
+export const INCOME_BY_SOURCE_DEFAULT: IncomeBySourceConfig = {
+  range: '1y',
+  chartType: 'pie',
+};
+
+export const CREDIT_UTILIZATION_ACCOUNTS_DEFAULT: AccountsConfig = {
+  accountIds: [],
+};
+
+export const CREDIT_UTILIZATION_TOTAL_DEFAULT: AccountsConfig = {
+  accountIds: [],
+};
+
+export const SECTOR_WEIGHTINGS_DEFAULT: AccountsConfig = { accountIds: [] };
+
+export const SECURITY_TYPE_ALLOCATION_DEFAULT: AccountsConfig = {
+  accountIds: [],
+};
+
+export const GEOGRAPHIC_ALLOCATION_DEFAULT: GeographicConfig = {
+  accountIds: [],
+  view: 'region',
+};
+
+export const RECURRING_EXPENSES_DEFAULT: RecurringConfig = { minOccurrences: 3 };
+
+export const WEEKEND_WEEKDAY_DEFAULT: WeekendConfig = {
+  range: '3m',
+  view: 'overview',
+};

--- a/frontend/src/components/dashboard/widget-registry.test.tsx
+++ b/frontend/src/components/dashboard/widget-registry.test.tsx
@@ -81,18 +81,51 @@ describe('widget-registry', () => {
   });
 
   it('gates the securities widgets on data, not the rest', () => {
-    const ctx = { isLoading: false, hasSecurities: false } as Parameters<
+    const ctx = { isLoading: false, hasSecurities: false, hasInvestments: false } as Parameters<
       NonNullable<(typeof DASHBOARD_WIDGETS)[number]['shouldRender']>
     >[0];
+    // Investment chart widgets are hidden until the user has investments.
+    const investmentGated = new Set([
+      'portfolio-value',
+      'sector-weightings',
+      'security-type-allocation',
+      'geographic-allocation',
+    ]);
     for (const w of DASHBOARD_WIDGETS) {
       const rendered = !w.shouldRender || w.shouldRender(ctx);
       if (w.id === 'top-movers' || w.id === 'favourite-securities') {
         expect(rendered).toBe(false);
         expect(w.shouldRender!({ ...ctx, isLoading: true })).toBe(true);
         expect(w.shouldRender!({ ...ctx, hasSecurities: true })).toBe(true);
+      } else if (investmentGated.has(w.id)) {
+        expect(rendered).toBe(false);
+        expect(w.shouldRender!({ ...ctx, isLoading: true })).toBe(true);
+        expect(w.shouldRender!({ ...ctx, hasInvestments: true })).toBe(true);
       } else {
         expect(rendered).toBe(true);
       }
+    }
+  });
+
+  it('registers all report-derived widgets as opt-in (not in the default layout)', () => {
+    const reportWidgetIds = [
+      'portfolio-value',
+      'spending-by-payee',
+      'monthly-spending-trend',
+      'income-by-source',
+      'credit-utilization-accounts',
+      'credit-utilization-total',
+      'sector-weightings',
+      'security-type-allocation',
+      'geographic-allocation',
+      'recurring-expenses',
+      'weekend-weekday',
+    ];
+    for (const id of reportWidgetIds) {
+      const def = DASHBOARD_WIDGETS.find((w) => w.id === id);
+      expect(def, `widget ${id} should be registered`).toBeDefined();
+      expect(def!.defaultEnabled).toBe(false);
+      expect(DEFAULT_DASHBOARD_WIDGET_IDS).not.toContain(id);
     }
   });
 });

--- a/frontend/src/components/dashboard/widget-registry.tsx
+++ b/frontend/src/components/dashboard/widget-registry.tsx
@@ -34,6 +34,24 @@ const AssetsVsLiabilities = dynamic(() => import('./AssetsVsLiabilities').then(m
   loading: () => <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[500px]" />,
 });
 
+// Report-derived chart widgets (opt-in). Each self-fetches from the report APIs
+// and persists its own settings via the cross-device `dashboardWidgetConfig`
+// preference, so they are lazy-loaded to keep them off the default bundle.
+const widgetSkeleton = () => (
+  <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 sm:p-6 lg:min-h-[540px]" />
+);
+const PortfolioValueWidget = dynamic(() => import('./PortfolioValueWidget').then(m => m.PortfolioValueWidget), { ssr: false, loading: widgetSkeleton });
+const SpendingByPayeeWidget = dynamic(() => import('./SpendingByPayeeWidget').then(m => m.SpendingByPayeeWidget), { ssr: false, loading: widgetSkeleton });
+const MonthlySpendingTrendWidget = dynamic(() => import('./MonthlySpendingTrendWidget').then(m => m.MonthlySpendingTrendWidget), { ssr: false, loading: widgetSkeleton });
+const IncomeBySourceWidget = dynamic(() => import('./IncomeBySourceWidget').then(m => m.IncomeBySourceWidget), { ssr: false, loading: widgetSkeleton });
+const CreditUtilizationAccountsWidget = dynamic(() => import('./CreditUtilizationAccountsWidget').then(m => m.CreditUtilizationAccountsWidget), { ssr: false, loading: widgetSkeleton });
+const CreditUtilizationTotalWidget = dynamic(() => import('./CreditUtilizationTotalWidget').then(m => m.CreditUtilizationTotalWidget), { ssr: false, loading: widgetSkeleton });
+const SectorWeightingsWidget = dynamic(() => import('./SectorWeightingsWidget').then(m => m.SectorWeightingsWidget), { ssr: false, loading: widgetSkeleton });
+const SecurityTypeAllocationWidget = dynamic(() => import('./SecurityTypeAllocationWidget').then(m => m.SecurityTypeAllocationWidget), { ssr: false, loading: widgetSkeleton });
+const GeographicAllocationWidget = dynamic(() => import('./GeographicAllocationWidget').then(m => m.GeographicAllocationWidget), { ssr: false, loading: widgetSkeleton });
+const RecurringExpensesWidget = dynamic(() => import('./RecurringExpensesWidget').then(m => m.RecurringExpensesWidget), { ssr: false, loading: widgetSkeleton });
+const WeekendVsWeekdayWidget = dynamic(() => import('./WeekendVsWeekdayWidget').then(m => m.WeekendVsWeekdayWidget), { ssr: false, loading: widgetSkeleton });
+
 export type DashboardWidgetId =
   | 'favourite-accounts'
   | 'upcoming-bills'
@@ -45,7 +63,18 @@ export type DashboardWidgetId =
   | 'income-expenses'
   | 'budget-status'
   | 'insights'
-  | 'favourite-reports';
+  | 'favourite-reports'
+  | 'portfolio-value'
+  | 'spending-by-payee'
+  | 'monthly-spending-trend'
+  | 'income-by-source'
+  | 'credit-utilization-accounts'
+  | 'credit-utilization-total'
+  | 'sector-weightings'
+  | 'security-type-allocation'
+  | 'geographic-allocation'
+  | 'recurring-expenses'
+  | 'weekend-weekday';
 
 /** Everything the dashboard page loads, handed to each widget's render. */
 export interface DashboardWidgetContext {
@@ -193,6 +222,78 @@ export const DASHBOARD_WIDGETS: DashboardWidgetDefinition[] = [
     titleSection: 'favouriteReports',
     defaultEnabled: false,
     render: (ctx) => <FavouriteReportsWidget isLoading={ctx.isLoading} />,
+  },
+  // Report-derived chart widgets: all opt-in, each with its own persisted
+  // settings. Investment widgets are hidden unless the user has investments.
+  {
+    id: 'portfolio-value',
+    titleSection: 'portfolioValue',
+    defaultEnabled: false,
+    shouldRender: (ctx) => ctx.isLoading || ctx.hasInvestments,
+    render: (ctx) => <PortfolioValueWidget accounts={ctx.accounts} isLoading={ctx.isLoading} />,
+  },
+  {
+    id: 'spending-by-payee',
+    titleSection: 'spendingByPayee',
+    defaultEnabled: false,
+    render: (ctx) => <SpendingByPayeeWidget isLoading={ctx.isLoading} />,
+  },
+  {
+    id: 'monthly-spending-trend',
+    titleSection: 'monthlySpendingTrend',
+    defaultEnabled: false,
+    render: (ctx) => <MonthlySpendingTrendWidget isLoading={ctx.isLoading} />,
+  },
+  {
+    id: 'income-by-source',
+    titleSection: 'incomeBySource',
+    defaultEnabled: false,
+    render: (ctx) => <IncomeBySourceWidget isLoading={ctx.isLoading} />,
+  },
+  {
+    id: 'credit-utilization-accounts',
+    titleSection: 'creditUtilizationAccounts',
+    defaultEnabled: false,
+    render: (ctx) => <CreditUtilizationAccountsWidget accounts={ctx.accounts} isLoading={ctx.isLoading} />,
+  },
+  {
+    id: 'credit-utilization-total',
+    titleSection: 'creditUtilizationTotal',
+    defaultEnabled: false,
+    render: (ctx) => <CreditUtilizationTotalWidget accounts={ctx.accounts} isLoading={ctx.isLoading} />,
+  },
+  {
+    id: 'sector-weightings',
+    titleSection: 'sectorWeightings',
+    defaultEnabled: false,
+    shouldRender: (ctx) => ctx.isLoading || ctx.hasInvestments,
+    render: (ctx) => <SectorWeightingsWidget accounts={ctx.accounts} isLoading={ctx.isLoading} />,
+  },
+  {
+    id: 'security-type-allocation',
+    titleSection: 'securityTypeAllocation',
+    defaultEnabled: false,
+    shouldRender: (ctx) => ctx.isLoading || ctx.hasInvestments,
+    render: (ctx) => <SecurityTypeAllocationWidget accounts={ctx.accounts} isLoading={ctx.isLoading} />,
+  },
+  {
+    id: 'geographic-allocation',
+    titleSection: 'geographicAllocation',
+    defaultEnabled: false,
+    shouldRender: (ctx) => ctx.isLoading || ctx.hasInvestments,
+    render: (ctx) => <GeographicAllocationWidget accounts={ctx.accounts} isLoading={ctx.isLoading} />,
+  },
+  {
+    id: 'recurring-expenses',
+    titleSection: 'recurringExpenses',
+    defaultEnabled: false,
+    render: (ctx) => <RecurringExpensesWidget isLoading={ctx.isLoading} />,
+  },
+  {
+    id: 'weekend-weekday',
+    titleSection: 'weekendVsWeekday',
+    defaultEnabled: false,
+    render: (ctx) => <WeekendVsWeekdayWidget isLoading={ctx.isLoading} />,
   },
 ];
 

--- a/frontend/src/components/reports/GeographicAllocationReport.tsx
+++ b/frontend/src/components/reports/GeographicAllocationReport.tsx
@@ -26,7 +26,13 @@ import { SortableHeader } from '@/components/ui/SortableHeader';
 import { useSortableTable, compareValues } from '@/hooks/useSortableTable';
 import { useReportData } from '@/hooks/useReportData';
 import { ReportError } from '@/components/reports/ReportError';
-import { chartColors, CHART_SERIES } from '@/lib/chart-colors';
+import { chartColors } from '@/lib/chart-colors';
+import {
+  COUNTRY_COLOURS,
+  computeGeographicAllocation,
+  ExchangeAllocation,
+  RegionAllocation,
+} from '@/lib/geographic-allocation';
 import { createLogger } from '@/lib/logger';
 import { useTranslations } from 'next-intl';
 import { resolvePdfColor } from '@/components/reports/resolve-pdf-color';
@@ -45,65 +51,6 @@ interface CountryRow {
   country: string;
   marketValue: number;
   percentage: number;
-  color: string;
-}
-
-const EXCHANGE_TO_REGION: Record<string, { country: string; region: string }> = {
-  NYSE: { country: 'United States', region: 'North America' },
-  NASDAQ: { country: 'United States', region: 'North America' },
-  NMS: { country: 'United States', region: 'North America' },
-  NYQ: { country: 'United States', region: 'North America' },
-  NYSEARCA: { country: 'United States', region: 'North America' },
-  AMEX: { country: 'United States', region: 'North America' },
-  BATS: { country: 'United States', region: 'North America' },
-  TSX: { country: 'Canada', region: 'North America' },
-  TSXV: { country: 'Canada', region: 'North America' },
-  TOR: { country: 'Canada', region: 'North America' },
-  NEO: { country: 'Canada', region: 'North America' },
-  LSE: { country: 'United Kingdom', region: 'Europe' },
-  LON: { country: 'United Kingdom', region: 'Europe' },
-  FRA: { country: 'Germany', region: 'Europe' },
-  XETRA: { country: 'Germany', region: 'Europe' },
-  PAR: { country: 'France', region: 'Europe' },
-  AMS: { country: 'Netherlands', region: 'Europe' },
-  MIL: { country: 'Italy', region: 'Europe' },
-  STO: { country: 'Sweden', region: 'Europe' },
-  TYO: { country: 'Japan', region: 'Asia-Pacific' },
-  HKG: { country: 'Hong Kong', region: 'Asia-Pacific' },
-  SHA: { country: 'China', region: 'Asia-Pacific' },
-  SHE: { country: 'China', region: 'Asia-Pacific' },
-  ASX: { country: 'Australia', region: 'Asia-Pacific' },
-  KRX: { country: 'South Korea', region: 'Asia-Pacific' },
-  TAI: { country: 'Taiwan', region: 'Asia-Pacific' },
-  SGX: { country: 'Singapore', region: 'Asia-Pacific' },
-  BSE: { country: 'India', region: 'Asia-Pacific' },
-  NSE: { country: 'India', region: 'Asia-Pacific' },
-};
-
-const REGION_COLOURS: Record<string, string> = {
-  'North America': CHART_SERIES[0],
-  'Europe': CHART_SERIES[1],
-  'Asia-Pacific': CHART_SERIES[2],
-  'Other': CHART_SERIES[3],
-};
-
-const COUNTRY_COLOURS = CHART_SERIES;
-
-
-interface ExchangeAllocation {
-  exchange: string;
-  country: string;
-  region: string;
-  count: number;
-  marketValue: number;
-  percentage: number;
-}
-
-interface RegionAllocation {
-  region: string;
-  marketValue: number;
-  percentage: number;
-  count: number;
   color: string;
 }
 
@@ -197,56 +144,10 @@ export function GeographicAllocationReport() {
     return map;
   }, [securities]);
 
-  const { exchangeData, regionData, totalValue } = useMemo(() => {
-    const exchangeMap = new Map<string, { country: string; region: string; count: number; value: number }>();
-
-    holdings.forEach((h) => {
-      const exchange = securityExchangeMap.get(h.securityId) || 'Unknown';
-      const info = EXCHANGE_TO_REGION[exchange] || { country: 'Other', region: 'Other' };
-      const marketValue = convertToDefault(h.marketValue ?? 0, h.currencyCode);
-
-      const existing = exchangeMap.get(exchange) || { country: info.country, region: info.region, count: 0, value: 0 };
-      exchangeMap.set(exchange, {
-        ...existing,
-        count: existing.count + 1,
-        value: existing.value + marketValue,
-      });
-    });
-
-    const total = Array.from(exchangeMap.values()).reduce((sum, v) => sum + v.value, 0);
-
-    const exchanges: ExchangeAllocation[] = Array.from(exchangeMap.entries())
-      .map(([exchange, data]) => ({
-        exchange,
-        country: data.country,
-        region: data.region,
-        count: data.count,
-        marketValue: data.value,
-        percentage: total > 0 ? (data.value / total) * 100 : 0,
-      }))
-      .sort((a, b) => b.marketValue - a.marketValue);
-
-    const regionMap = new Map<string, { value: number; count: number }>();
-    exchanges.forEach((e) => {
-      const existing = regionMap.get(e.region) || { value: 0, count: 0 };
-      regionMap.set(e.region, {
-        value: existing.value + e.marketValue,
-        count: existing.count + e.count,
-      });
-    });
-
-    const regions: RegionAllocation[] = Array.from(regionMap.entries())
-      .map(([region, data]) => ({
-        region,
-        marketValue: data.value,
-        percentage: total > 0 ? (data.value / total) * 100 : 0,
-        count: data.count,
-        color: REGION_COLOURS[region] || chartColors.axis,
-      }))
-      .sort((a, b) => b.marketValue - a.marketValue);
-
-    return { exchangeData: exchanges, regionData: regions, totalValue: total };
-  }, [holdings, convertToDefault, securityExchangeMap]);
+  const { exchangeData, regionData, totalValue } = useMemo(
+    () => computeGeographicAllocation(holdings, securityExchangeMap, convertToDefault),
+    [holdings, convertToDefault, securityExchangeMap],
+  );
 
   const sortedRegionData = useMemo(() => {
     const sorted = [...regionData];

--- a/frontend/src/components/settings/NotificationsSection.test.tsx
+++ b/frontend/src/components/settings/NotificationsSection.test.tsx
@@ -40,6 +40,7 @@ const mockPreferences: UserPreferences = {
   timeFormat: '24h',
   favouriteReportIds: [],
   dashboardWidgets: [],
+  dashboardWidgetConfig: {},
   preferredExchanges: [],
     defaultQuoteProvider: 'yahoo' as const,
     recentTransactionsLimit: 5,

--- a/frontend/src/components/settings/PreferencesSection.test.tsx
+++ b/frontend/src/components/settings/PreferencesSection.test.tsx
@@ -63,6 +63,7 @@ const mockPreferences: UserPreferences = {
   timeFormat: '24h',
   favouriteReportIds: [],
   dashboardWidgets: [],
+  dashboardWidgetConfig: {},
   preferredExchanges: [],
     defaultQuoteProvider: 'yahoo' as const,
     recentTransactionsLimit: 5,

--- a/frontend/src/components/settings/SecuritySection.test.tsx
+++ b/frontend/src/components/settings/SecuritySection.test.tsx
@@ -84,6 +84,7 @@ const mockPreferences: UserPreferences = {
   timeFormat: '24h',
   favouriteReportIds: [],
   dashboardWidgets: [],
+  dashboardWidgetConfig: {},
   preferredExchanges: [],
     defaultQuoteProvider: 'yahoo' as const,
     recentTransactionsLimit: 5,

--- a/frontend/src/hooks/useDateRange.ts
+++ b/frontend/src/hooks/useDateRange.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, useEffect } from 'react';
-import { format, subMonths, subDays, subYears, subWeeks, startOfMonth } from 'date-fns';
+import { resolveRangePreset } from '@/lib/date-range';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('useDateRange');
@@ -79,74 +79,8 @@ export function useDateRange(options: UseDateRangeOptions): UseDateRangeReturn {
   }, [storageKey, dateRange, startDate, endDate]);
 
   const resolveRange = useCallback(
-    (range: string): { start: string; end: string } => {
-      if (range === 'custom') {
-        return { start: startDate, end: endDate };
-      }
-
-      const now = new Date();
-      const isMonth = alignment === 'month';
-      // End date is always today: data only exists up to today, so snapping
-      // the end to end-of-month (the previous behaviour for long-range
-      // month-aligned presets like 2y/5y) just produced a flat-line tail
-      // from today through the rest of the month. Month alignment now
-      // affects the start date only.
-      const end = format(now, 'yyyy-MM-dd');
-
-      let start: string;
-
-      switch (range) {
-        case '1d':
-          // '1d' is an intraday-only preset; resolvedRange is consumed only
-          // when the chart falls back to the daily-snapshot endpoint. A
-          // single day's snapshot is just one point, so widen to a week so
-          // the fallback chart is still readable.
-          start = format(subWeeks(now, 1), 'yyyy-MM-dd');
-          break;
-        case '1w':
-          start = format(subWeeks(now, 1), 'yyyy-MM-dd');
-          break;
-        case 'mtd':
-          start = format(startOfMonth(now), 'yyyy-MM-dd');
-          break;
-        case '1m':
-          start = format(subDays(now, 30), 'yyyy-MM-dd');
-          break;
-        case '3m':
-          start = format(subDays(now, 90), 'yyyy-MM-dd');
-          break;
-        case '6m':
-          start = isMonth
-            ? format(startOfMonth(subMonths(now, 5)), 'yyyy-MM-dd')
-            : format(subMonths(now, 6), 'yyyy-MM-dd');
-          break;
-        case '1y':
-          start = format(subYears(now, 1), 'yyyy-MM-dd');
-          break;
-        case '2y':
-          // Rolling 2 years = last 730 days. Same shape regardless of
-          // alignment: month alignment on the start was producing partial
-          // history at the leading edge (e.g. mid-month -> chart only
-          // showed 23.5 months back).
-          start = format(subDays(now, 730), 'yyyy-MM-dd');
-          break;
-        case '5y':
-          start = isMonth
-            ? format(startOfMonth(subMonths(now, 59)), 'yyyy-MM-dd')
-            : format(subYears(now, 5), 'yyyy-MM-dd');
-          break;
-        case 'ytd':
-          start = `${now.getFullYear()}-01-01`;
-          break;
-        case 'all':
-          start = '';
-          break;
-        default:
-          start = format(subMonths(now, 3), 'yyyy-MM-dd');
-      }
-
-      return { start, end };
-    },
+    (range: string): { start: string; end: string } =>
+      resolveRangePreset(range, { alignment, startDate, endDate }),
     [alignment, startDate, endDate]
   );
 

--- a/frontend/src/hooks/useWidgetConfig.test.tsx
+++ b/frontend/src/hooks/useWidgetConfig.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import toast from 'react-hot-toast';
+import { useWidgetConfig } from './useWidgetConfig';
+
+const { storeState } = vi.hoisted(() => ({
+  storeState: {
+    preferences: { dashboardWidgetConfig: {} as Record<string, Record<string, unknown>> },
+  },
+}));
+
+const updatePreferencesApi = vi.fn();
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@/store/preferencesStore', () => {
+  const usePreferencesStore = ((selector: (s: unknown) => unknown) =>
+    selector({ preferences: storeState.preferences })) as unknown as {
+    (selector: (s: unknown) => unknown): unknown;
+    getState: () => unknown;
+  };
+  usePreferencesStore.getState = () => ({
+    preferences: storeState.preferences,
+    updatePreferences: (patch: Record<string, unknown>) => {
+      storeState.preferences = { ...storeState.preferences, ...patch } as typeof storeState.preferences;
+    },
+  });
+  return { usePreferencesStore };
+});
+
+vi.mock('@/lib/user-settings', () => ({
+  userSettingsApi: {
+    updatePreferences: (...args: unknown[]) => updatePreferencesApi(...args),
+  },
+}));
+
+const DEFAULTS = { range: '3m', accountIds: [] as string[] };
+
+describe('useWidgetConfig', () => {
+  beforeEach(() => {
+    storeState.preferences = { dashboardWidgetConfig: {} };
+    updatePreferencesApi.mockReset();
+    (toast.error as ReturnType<typeof vi.fn>).mockReset?.();
+  });
+
+  it('returns defaults when nothing is stored', () => {
+    const { result } = renderHook(() => useWidgetConfig('w1', DEFAULTS));
+    expect(result.current.config).toEqual(DEFAULTS);
+  });
+
+  it('merges stored settings over the defaults', () => {
+    storeState.preferences = { dashboardWidgetConfig: { w1: { range: '1y' } } };
+    const { result } = renderHook(() => useWidgetConfig('w1', DEFAULTS));
+    expect(result.current.config).toEqual({ range: '1y', accountIds: [] });
+  });
+
+  it('persists a merged patch for only its own widget id', async () => {
+    storeState.preferences = {
+      dashboardWidgetConfig: { other: { range: '6m' } },
+    };
+    updatePreferencesApi.mockResolvedValue({
+      dashboardWidgetConfig: { other: { range: '6m' }, w1: { range: '1y', accountIds: [] } },
+    });
+
+    const { result } = renderHook(() => useWidgetConfig('w1', DEFAULTS));
+    await act(async () => {
+      await result.current.updateConfig({ range: '1y' });
+    });
+
+    expect(updatePreferencesApi).toHaveBeenCalledWith({
+      dashboardWidgetConfig: {
+        other: { range: '6m' },
+        w1: { range: '1y', accountIds: [] },
+      },
+    });
+    // Store retains the other widget's config.
+    expect(storeState.preferences.dashboardWidgetConfig.other).toEqual({ range: '6m' });
+  });
+
+  it('reverts the optimistic update and toasts on failure', async () => {
+    const before = { w1: { range: '3m', accountIds: [] } };
+    storeState.preferences = { dashboardWidgetConfig: before };
+    updatePreferencesApi.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useWidgetConfig('w1', DEFAULTS));
+    await act(async () => {
+      await result.current.updateConfig({ range: '1y' });
+    });
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    // Reverted to the pre-edit map.
+    expect(storeState.preferences.dashboardWidgetConfig).toEqual(before);
+  });
+});

--- a/frontend/src/hooks/useWidgetConfig.ts
+++ b/frontend/src/hooks/useWidgetConfig.ts
@@ -1,0 +1,82 @@
+import { useCallback, useMemo } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslations } from 'next-intl';
+import { usePreferencesStore } from '@/store/preferencesStore';
+import { userSettingsApi } from '@/lib/user-settings';
+import { getErrorMessage } from '@/lib/errors';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('useWidgetConfig');
+
+export interface UseWidgetConfigResult<T> {
+  /** The widget's settings: stored values merged over the defaults. */
+  config: T;
+  /**
+   * Merge a partial update into this widget's settings and persist the whole
+   * `dashboardWidgetConfig` map to the backend so it follows the user across
+   * devices. Optimistic: the store updates immediately and reverts on failure.
+   */
+  updateConfig: (patch: Partial<T>) => Promise<void>;
+}
+
+/**
+ * Per-widget settings backed by the cross-device `dashboardWidgetConfig`
+ * preference (a map keyed by widget id). Each configurable dashboard widget
+ * calls this with its own id and a stable module-level defaults object.
+ *
+ * Reads and writes go through the preferences store; the persisted map is the
+ * source of truth (loaded from the backend on every session), so a timeframe or
+ * account selection made on desktop shows up identically on mobile.
+ */
+export function useWidgetConfig<T extends object>(
+  widgetId: string,
+  defaults: T,
+): UseWidgetConfigResult<T> {
+  const t = useTranslations('dashboard');
+  const stored = usePreferencesStore(
+    (s) => s.preferences?.dashboardWidgetConfig?.[widgetId],
+  );
+
+  const config = useMemo(
+    () => ({ ...defaults, ...(stored as Partial<T> | undefined) }),
+    [defaults, stored],
+  );
+
+  const updateConfig = useCallback(
+    async (patch: Partial<T>) => {
+      // Read the freshest map straight from the store (not a render-time
+      // closure) so near-simultaneous edits from two widgets don't clobber
+      // each other.
+      const state = usePreferencesStore.getState();
+      const allBefore = state.preferences?.dashboardWidgetConfig ?? {};
+      const nextWidget = {
+        ...defaults,
+        ...(allBefore[widgetId] as Partial<T> | undefined),
+        ...patch,
+      } as Record<string, unknown>;
+      const nextAll = { ...allBefore, [widgetId]: nextWidget };
+
+      // Optimistic update so the chart re-renders immediately.
+      state.updatePreferences({ dashboardWidgetConfig: nextAll });
+
+      try {
+        const saved = await userSettingsApi.updatePreferences({
+          dashboardWidgetConfig: nextAll,
+        });
+        usePreferencesStore.getState().updatePreferences({
+          dashboardWidgetConfig: saved.dashboardWidgetConfig,
+        });
+      } catch (error) {
+        logger.error('Failed to save widget config:', error);
+        // Revert to the pre-edit map.
+        usePreferencesStore.getState().updatePreferences({
+          dashboardWidgetConfig: allBefore,
+        });
+        toast.error(getErrorMessage(error, t('widgets.configSaveFailed')));
+      }
+    },
+    [defaults, widgetId, t],
+  );
+
+  return { config, updateConfig };
+}

--- a/frontend/src/i18n/messages/de/dashboard.json
+++ b/frontend/src/i18n/messages/de/dashboard.json
@@ -154,5 +154,96 @@
     "title": "Favoritenberichte",
     "empty": "Noch keine Favoritenberichte. Markieren Sie Berichte auf der Berichteseite mit einem Stern, um sie hier zu sehen.",
     "browseReports": "Berichte durchsuchen"
+  },
+  "widgets": {
+    "configure": "{name} konfigurieren",
+    "done": "Fertig",
+    "configSaveFailed": "Widget-Einstellungen konnten nicht gespeichert werden. Bitte versuchen Sie es erneut.",
+    "timeframe": "Zeitraum",
+    "accounts": "Konten",
+    "chartType": "Diagrammtyp",
+    "view": "Ansicht",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "Alle"
+    }
+  },
+  "portfolioValue": {
+    "title": "Portfolio-Wert",
+    "empty": "Noch keine Anlagehistorie vorhanden."
+  },
+  "spendingByPayee": {
+    "title": "Ausgaben nach Zahlungsempfänger",
+    "empty": "Keine Ausgaben in diesem Zeitraum.",
+    "totalLabel": "Gesamt"
+  },
+  "monthlySpendingTrend": {
+    "title": "Monatlicher Ausgabentrend",
+    "empty": "Keine Daten für diesen Zeitraum.",
+    "expenses": "Ausgaben",
+    "income": "Einnahmen"
+  },
+  "incomeBySource": {
+    "title": "Einnahmen nach Quelle",
+    "empty": "Keine Einnahmen in diesem Zeitraum.",
+    "totalLabel": "Gesamteinnahmen"
+  },
+  "creditUtilizationAccounts": {
+    "title": "Kreditauslastung nach Konto",
+    "empty": "Keine Kreditkonten mit festgelegtem Limit.",
+    "utilization": "Auslastung",
+    "used": "Genutzt"
+  },
+  "creditUtilizationTotal": {
+    "title": "Gesamte Kreditauslastung",
+    "empty": "Keine Kreditkonten mit festgelegtem Limit.",
+    "used": "Genutzt",
+    "available": "Verfügbar"
+  },
+  "sectorWeightings": {
+    "title": "Sektorallokation",
+    "empty": "Keine Sektordaten verfügbar.",
+    "direct": "Direkt",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "Wertpapiertyp-Allokation",
+    "empty": "Keine Bestände vorhanden.",
+    "types": {
+      "STOCK": "Aktien",
+      "ETF": "ETFs",
+      "MUTUAL_FUND": "Investmentfonds",
+      "BOND": "Anleihen",
+      "CASH": "Bargeld"
+    }
+  },
+  "geographicAllocation": {
+    "title": "Geografische Allokation",
+    "empty": "Keine Bestände vorhanden.",
+    "viewRegion": "Region",
+    "viewExchange": "Börse",
+    "viewCountry": "Land"
+  },
+  "recurringExpenses": {
+    "title": "Top wiederkehrende Ausgaben",
+    "empty": "Keine wiederkehrenden Ausgaben gefunden.",
+    "minOccurrences": "Mindestanzahl Vorkommen",
+    "minOccurrencesOption": "{count} oder mehr",
+    "occurrences": "{count} Vorkommen",
+    "monthlyEstimate": "Monatliche Schätzung"
+  },
+  "weekendVsWeekday": {
+    "title": "Wochenend- vs. Wochentagsausgaben",
+    "empty": "Keine Ausgaben in diesem Zeitraum.",
+    "weekendLabel": "Wochenende",
+    "weekdayLabel": "Wochentag",
+    "viewOverview": "Übersicht",
+    "viewByDay": "Nach Tag"
   }
 }

--- a/frontend/src/i18n/messages/en/dashboard.json
+++ b/frontend/src/i18n/messages/en/dashboard.json
@@ -154,5 +154,96 @@
     "title": "Favourite Reports",
     "empty": "No favourite reports yet. Star reports on the Reports page to see them here.",
     "browseReports": "Browse reports"
+  },
+  "widgets": {
+    "configure": "Configure {name}",
+    "done": "Done",
+    "configSaveFailed": "Couldn't save widget settings. Please try again.",
+    "timeframe": "Timeframe",
+    "accounts": "Accounts",
+    "chartType": "Chart type",
+    "view": "View",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "All"
+    }
+  },
+  "portfolioValue": {
+    "title": "Portfolio Value",
+    "empty": "No investment history to show yet."
+  },
+  "spendingByPayee": {
+    "title": "Spending by Payee",
+    "empty": "No spending in this period.",
+    "totalLabel": "Total"
+  },
+  "monthlySpendingTrend": {
+    "title": "Monthly Spending Trend",
+    "empty": "No data for this period.",
+    "expenses": "Expenses",
+    "income": "Income"
+  },
+  "incomeBySource": {
+    "title": "Income by Source",
+    "empty": "No income in this period.",
+    "totalLabel": "Total income"
+  },
+  "creditUtilizationAccounts": {
+    "title": "Credit Utilization by Account",
+    "empty": "No credit accounts with a limit set.",
+    "utilization": "Utilization",
+    "used": "Used"
+  },
+  "creditUtilizationTotal": {
+    "title": "Total Credit Utilization",
+    "empty": "No credit accounts with a limit set.",
+    "used": "Used",
+    "available": "Available"
+  },
+  "sectorWeightings": {
+    "title": "Sector Allocation",
+    "empty": "No sector data available.",
+    "direct": "Direct",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "Security Type Allocation",
+    "empty": "No holdings to show.",
+    "types": {
+      "STOCK": "Stocks",
+      "ETF": "ETFs",
+      "MUTUAL_FUND": "Mutual Funds",
+      "BOND": "Bonds",
+      "CASH": "Cash"
+    }
+  },
+  "geographicAllocation": {
+    "title": "Geographic Allocation",
+    "empty": "No holdings to show.",
+    "viewRegion": "Region",
+    "viewExchange": "Exchange",
+    "viewCountry": "Country"
+  },
+  "recurringExpenses": {
+    "title": "Top Recurring Expenses",
+    "empty": "No recurring expenses found.",
+    "minOccurrences": "Minimum occurrences",
+    "minOccurrencesOption": "{count} or more",
+    "occurrences": "{count} occurrences",
+    "monthlyEstimate": "Monthly estimate"
+  },
+  "weekendVsWeekday": {
+    "title": "Weekend vs Weekday Spending",
+    "empty": "No spending in this period.",
+    "weekendLabel": "Weekend",
+    "weekdayLabel": "Weekday",
+    "viewOverview": "Overview",
+    "viewByDay": "By day"
   }
 }

--- a/frontend/src/i18n/messages/es/dashboard.json
+++ b/frontend/src/i18n/messages/es/dashboard.json
@@ -154,5 +154,96 @@
     "title": "Informes favoritos",
     "empty": "Aún no hay informes favoritos. Marca informes con una estrella en la página de Informes para verlos aquí.",
     "browseReports": "Explorar informes"
+  },
+  "widgets": {
+    "configure": "Configurar {name}",
+    "done": "Listo",
+    "configSaveFailed": "No se pudieron guardar los ajustes del widget. Inténtalo de nuevo.",
+    "timeframe": "Período",
+    "accounts": "Cuentas",
+    "chartType": "Tipo de gráfico",
+    "view": "Vista",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "Todo"
+    }
+  },
+  "portfolioValue": {
+    "title": "Valor de la cartera",
+    "empty": "Aún no hay historial de inversiones para mostrar."
+  },
+  "spendingByPayee": {
+    "title": "Gastos por beneficiario",
+    "empty": "No hay gastos en este período.",
+    "totalLabel": "Total"
+  },
+  "monthlySpendingTrend": {
+    "title": "Tendencia de gastos mensual",
+    "empty": "No hay datos para este período.",
+    "expenses": "Gastos",
+    "income": "Ingresos"
+  },
+  "incomeBySource": {
+    "title": "Ingresos por fuente",
+    "empty": "No hay ingresos en este período.",
+    "totalLabel": "Total de ingresos"
+  },
+  "creditUtilizationAccounts": {
+    "title": "Utilización del crédito por cuenta",
+    "empty": "No hay cuentas de crédito con un límite establecido.",
+    "utilization": "Utilización",
+    "used": "Utilizado"
+  },
+  "creditUtilizationTotal": {
+    "title": "Utilización total del crédito",
+    "empty": "No hay cuentas de crédito con un límite establecido.",
+    "used": "Utilizado",
+    "available": "Disponible"
+  },
+  "sectorWeightings": {
+    "title": "Asignación sectorial",
+    "empty": "No hay datos de sectores disponibles.",
+    "direct": "Directo",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "Asignación por tipo de valor",
+    "empty": "No hay posiciones para mostrar.",
+    "types": {
+      "STOCK": "Acciones",
+      "ETF": "ETFs",
+      "MUTUAL_FUND": "Fondos de inversión",
+      "BOND": "Bonos",
+      "CASH": "Efectivo"
+    }
+  },
+  "geographicAllocation": {
+    "title": "Asignación geográfica",
+    "empty": "No hay posiciones para mostrar.",
+    "viewRegion": "Región",
+    "viewExchange": "Bolsa",
+    "viewCountry": "País"
+  },
+  "recurringExpenses": {
+    "title": "Principales gastos recurrentes",
+    "empty": "No se encontraron gastos recurrentes.",
+    "minOccurrences": "Ocurrencias mínimas",
+    "minOccurrencesOption": "{count} o más",
+    "occurrences": "{count} ocurrencias",
+    "monthlyEstimate": "Estimado mensual"
+  },
+  "weekendVsWeekday": {
+    "title": "Gastos fin de semana vs días de semana",
+    "empty": "No hay gastos en este período.",
+    "weekendLabel": "Fin de semana",
+    "weekdayLabel": "Día de semana",
+    "viewOverview": "Resumen",
+    "viewByDay": "Por día"
   }
 }

--- a/frontend/src/i18n/messages/fr/dashboard.json
+++ b/frontend/src/i18n/messages/fr/dashboard.json
@@ -154,5 +154,96 @@
     "title": "Rapports favoris",
     "empty": "Aucun rapport favori pour l’instant. Mettez des rapports en favori sur la page Rapports pour les voir ici.",
     "browseReports": "Parcourir les rapports"
+  },
+  "widgets": {
+    "configure": "Configurer {name}",
+    "done": "Terminé",
+    "configSaveFailed": "Impossible d'enregistrer les paramètres du widget. Veuillez réessayer.",
+    "timeframe": "Période",
+    "accounts": "Comptes",
+    "chartType": "Type de graphique",
+    "view": "Vue",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "Tout"
+    }
+  },
+  "portfolioValue": {
+    "title": "Valeur du portefeuille",
+    "empty": "Aucun historique d'investissement à afficher pour l'instant."
+  },
+  "spendingByPayee": {
+    "title": "Dépenses par bénéficiaire",
+    "empty": "Aucune dépense sur cette période.",
+    "totalLabel": "Total"
+  },
+  "monthlySpendingTrend": {
+    "title": "Tendance mensuelle des dépenses",
+    "empty": "Aucune donnée pour cette période.",
+    "expenses": "Dépenses",
+    "income": "Revenus"
+  },
+  "incomeBySource": {
+    "title": "Revenus par source",
+    "empty": "Aucun revenu sur cette période.",
+    "totalLabel": "Revenus totaux"
+  },
+  "creditUtilizationAccounts": {
+    "title": "Utilisation du crédit par compte",
+    "empty": "Aucun compte de crédit avec une limite définie.",
+    "utilization": "Utilisation",
+    "used": "Utilisé"
+  },
+  "creditUtilizationTotal": {
+    "title": "Utilisation totale du crédit",
+    "empty": "Aucun compte de crédit avec une limite définie.",
+    "used": "Utilisé",
+    "available": "Disponible"
+  },
+  "sectorWeightings": {
+    "title": "Répartition sectorielle",
+    "empty": "Aucune donnée sectorielle disponible.",
+    "direct": "Direct",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "Répartition par type de titre",
+    "empty": "Aucune position à afficher.",
+    "types": {
+      "STOCK": "Actions",
+      "ETF": "ETF",
+      "MUTUAL_FUND": "Fonds communs de placement",
+      "BOND": "Obligations",
+      "CASH": "Liquidités"
+    }
+  },
+  "geographicAllocation": {
+    "title": "Répartition géographique",
+    "empty": "Aucune position à afficher.",
+    "viewRegion": "Région",
+    "viewExchange": "Bourse",
+    "viewCountry": "Pays"
+  },
+  "recurringExpenses": {
+    "title": "Principales dépenses récurrentes",
+    "empty": "Aucune dépense récurrente trouvée.",
+    "minOccurrences": "Occurrences minimales",
+    "minOccurrencesOption": "{count} ou plus",
+    "occurrences": "{count} occurrences",
+    "monthlyEstimate": "Estimation mensuelle"
+  },
+  "weekendVsWeekday": {
+    "title": "Dépenses week-end vs semaine",
+    "empty": "Aucune dépense sur cette période.",
+    "weekendLabel": "Week-end",
+    "weekdayLabel": "Semaine",
+    "viewOverview": "Vue d'ensemble",
+    "viewByDay": "Par jour"
   }
 }

--- a/frontend/src/i18n/messages/hi/dashboard.json
+++ b/frontend/src/i18n/messages/hi/dashboard.json
@@ -154,5 +154,96 @@
     "title": "पसंदीदा रिपोर्ट",
     "empty": "अभी कोई पसंदीदा रिपोर्ट नहीं। यहाँ देखने के लिए रिपोर्ट पृष्ठ पर रिपोर्ट को स्टार करें।",
     "browseReports": "रिपोर्ट ब्राउज़ करें"
+  },
+  "widgets": {
+    "configure": "{name} कॉन्फ़िगर करें",
+    "done": "हो गया",
+    "configSaveFailed": "विजेट सेटिंग्स सहेजी नहीं जा सकीं। कृपया पुनः प्रयास करें।",
+    "timeframe": "समय-सीमा",
+    "accounts": "खाते",
+    "chartType": "चार्ट प्रकार",
+    "view": "दृश्य",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "सभी"
+    }
+  },
+  "portfolioValue": {
+    "title": "पोर्टफोलियो मूल्य",
+    "empty": "अभी दिखाने के लिए कोई निवेश इतिहास नहीं।"
+  },
+  "spendingByPayee": {
+    "title": "भुगतानकर्ता के अनुसार व्यय",
+    "empty": "इस अवधि में कोई व्यय नहीं।",
+    "totalLabel": "कुल"
+  },
+  "monthlySpendingTrend": {
+    "title": "मासिक व्यय प्रवृत्ति",
+    "empty": "इस अवधि के लिए कोई डेटा नहीं।",
+    "expenses": "व्यय",
+    "income": "आय"
+  },
+  "incomeBySource": {
+    "title": "स्रोत के अनुसार आय",
+    "empty": "इस अवधि में कोई आय नहीं।",
+    "totalLabel": "कुल आय"
+  },
+  "creditUtilizationAccounts": {
+    "title": "खाते के अनुसार उपयोग",
+    "empty": "सीमा सेट वाला कोई क्रेडिट खाता नहीं।",
+    "utilization": "उपयोग",
+    "used": "उपयोग"
+  },
+  "creditUtilizationTotal": {
+    "title": "कुल उपयोग",
+    "empty": "सीमा सेट वाला कोई क्रेडिट खाता नहीं।",
+    "used": "उपयोग",
+    "available": "उपलब्ध"
+  },
+  "sectorWeightings": {
+    "title": "क्षेत्र आवंटन",
+    "empty": "कोई क्षेत्र डेटा उपलब्ध नहीं।",
+    "direct": "प्रत्यक्ष",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "प्रतिभूति प्रकार आवंटन",
+    "empty": "दिखाने के लिए कोई होल्डिंग नहीं।",
+    "types": {
+      "STOCK": "शेयर",
+      "ETF": "ETFs",
+      "MUTUAL_FUND": "म्यूचुअल फंड",
+      "BOND": "बांड",
+      "CASH": "नकद"
+    }
+  },
+  "geographicAllocation": {
+    "title": "भौगोलिक आवंटन",
+    "empty": "दिखाने के लिए कोई होल्डिंग नहीं।",
+    "viewRegion": "क्षेत्र",
+    "viewExchange": "एक्सचेंज",
+    "viewCountry": "देश"
+  },
+  "recurringExpenses": {
+    "title": "शीर्ष आवर्ती व्यय",
+    "empty": "कोई आवर्ती व्यय नहीं मिला।",
+    "minOccurrences": "न्यूनतम घटनाएँ",
+    "minOccurrencesOption": "{count} या अधिक",
+    "occurrences": "{count} घटनाएँ",
+    "monthlyEstimate": "मासिक अनुमान"
+  },
+  "weekendVsWeekday": {
+    "title": "सप्ताहांत बनाम कार्यदिवस व्यय",
+    "empty": "इस अवधि में कोई व्यय नहीं।",
+    "weekendLabel": "सप्ताहांत",
+    "weekdayLabel": "कार्यदिवस",
+    "viewOverview": "अवलोकन",
+    "viewByDay": "दिन के अनुसार"
   }
 }

--- a/frontend/src/i18n/messages/id/dashboard.json
+++ b/frontend/src/i18n/messages/id/dashboard.json
@@ -154,5 +154,96 @@
     "title": "Laporan Favorit",
     "empty": "Belum ada laporan favorit. Bintangi laporan di halaman Laporan untuk melihatnya di sini.",
     "browseReports": "Jelajahi laporan"
+  },
+  "widgets": {
+    "configure": "Konfigurasikan {name}",
+    "done": "Selesai",
+    "configSaveFailed": "Tidak dapat menyimpan pengaturan widget. Silakan coba lagi.",
+    "timeframe": "Kerangka Waktu",
+    "accounts": "Akun",
+    "chartType": "Tipe Grafik",
+    "view": "Tampilan",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "Semua"
+    }
+  },
+  "portfolioValue": {
+    "title": "Nilai Portofolio",
+    "empty": "Belum ada riwayat investasi untuk ditampilkan."
+  },
+  "spendingByPayee": {
+    "title": "Pengeluaran per Penerima",
+    "empty": "Tidak ada pengeluaran dalam periode ini.",
+    "totalLabel": "Total"
+  },
+  "monthlySpendingTrend": {
+    "title": "Tren Pengeluaran Bulanan",
+    "empty": "Tidak ada data untuk periode ini.",
+    "expenses": "Pengeluaran",
+    "income": "Pendapatan"
+  },
+  "incomeBySource": {
+    "title": "Pendapatan per Sumber",
+    "empty": "Tidak ada pendapatan dalam periode ini.",
+    "totalLabel": "Total Pendapatan"
+  },
+  "creditUtilizationAccounts": {
+    "title": "Utilisasi per Akun",
+    "empty": "Tidak ada akun kredit dengan batas yang ditetapkan.",
+    "utilization": "Utilisasi",
+    "used": "Digunakan"
+  },
+  "creditUtilizationTotal": {
+    "title": "Total Utilisasi",
+    "empty": "Tidak ada akun kredit dengan batas yang ditetapkan.",
+    "used": "Digunakan",
+    "available": "Tersedia"
+  },
+  "sectorWeightings": {
+    "title": "Alokasi Sektor",
+    "empty": "Tidak ada data sektor tersedia.",
+    "direct": "Langsung",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "Alokasi Tipe Keamanan Dokumen",
+    "empty": "Tidak ada kepemilikan untuk ditampilkan.",
+    "types": {
+      "STOCK": "Saham",
+      "ETF": "ETF",
+      "MUTUAL_FUND": "Reksadana",
+      "BOND": "Obligasi",
+      "CASH": "Tunai"
+    }
+  },
+  "geographicAllocation": {
+    "title": "Alokasi Geografis",
+    "empty": "Tidak ada kepemilikan untuk ditampilkan.",
+    "viewRegion": "Wilayah",
+    "viewExchange": "Bursa",
+    "viewCountry": "Negara"
+  },
+  "recurringExpenses": {
+    "title": "Pengeluaran Berulang Teratas",
+    "empty": "Tidak ada pengeluaran berulang ditemukan.",
+    "minOccurrences": "Kejadian minimum",
+    "minOccurrencesOption": "{count} atau lebih",
+    "occurrences": "{count} kejadian",
+    "monthlyEstimate": "Perkiraan Bulanan"
+  },
+  "weekendVsWeekday": {
+    "title": "Pengeluaran Akhir Pekan vs Hari Kerja",
+    "empty": "Tidak ada pengeluaran dalam periode ini.",
+    "weekendLabel": "Akhir Pekan",
+    "weekdayLabel": "Hari Kerja",
+    "viewOverview": "Ikhtisar",
+    "viewByDay": "Per Hari"
   }
 }

--- a/frontend/src/i18n/messages/it/dashboard.json
+++ b/frontend/src/i18n/messages/it/dashboard.json
@@ -154,5 +154,96 @@
     "title": "Report preferiti",
     "empty": "Nessun report preferito. Aggiungi una stella ai report nella pagina Report per vederli qui.",
     "browseReports": "Sfoglia i report"
+  },
+  "widgets": {
+    "configure": "Configura {name}",
+    "done": "Fine",
+    "configSaveFailed": "Impossibile salvare le impostazioni del widget. Riprova.",
+    "timeframe": "Intervallo di tempo",
+    "accounts": "Conti",
+    "chartType": "Tipo di grafico",
+    "view": "Vista",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "Tutti"
+    }
+  },
+  "portfolioValue": {
+    "title": "Valore del portafoglio",
+    "empty": "Nessuno storico investimenti da mostrare per ora."
+  },
+  "spendingByPayee": {
+    "title": "Uscite per beneficiario",
+    "empty": "Nessuna uscita in questo periodo.",
+    "totalLabel": "Totale"
+  },
+  "monthlySpendingTrend": {
+    "title": "Andamento mensile delle uscite",
+    "empty": "Nessun dato per questo periodo.",
+    "expenses": "Uscite",
+    "income": "Entrate"
+  },
+  "incomeBySource": {
+    "title": "Entrate per fonte",
+    "empty": "Nessuna entrata in questo periodo.",
+    "totalLabel": "Totale entrate"
+  },
+  "creditUtilizationAccounts": {
+    "title": "Utilizzo per conto",
+    "empty": "Nessun conto di credito con un limite impostato.",
+    "utilization": "Utilizzo",
+    "used": "Utilizzato"
+  },
+  "creditUtilizationTotal": {
+    "title": "Utilizzo totale",
+    "empty": "Nessun conto di credito con un limite impostato.",
+    "used": "Utilizzato",
+    "available": "Disponibile"
+  },
+  "sectorWeightings": {
+    "title": "Allocazione per settore",
+    "empty": "Nessun dato di settore disponibile.",
+    "direct": "Diretta",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "Allocazione per tipo di titolo",
+    "empty": "Nessuna posizione da mostrare.",
+    "types": {
+      "STOCK": "Azioni",
+      "ETF": "ETF",
+      "MUTUAL_FUND": "Fondi comuni",
+      "BOND": "Obbligazioni",
+      "CASH": "Contanti"
+    }
+  },
+  "geographicAllocation": {
+    "title": "Allocazione geografica",
+    "empty": "Nessuna posizione da mostrare.",
+    "viewRegion": "Regione",
+    "viewExchange": "Borsa",
+    "viewCountry": "Paese"
+  },
+  "recurringExpenses": {
+    "title": "Principali spese ricorrenti",
+    "empty": "Nessuna spesa ricorrente trovata.",
+    "minOccurrences": "Occorrenze minime",
+    "minOccurrencesOption": "{count} o più",
+    "occurrences": "{count} occorrenze",
+    "monthlyEstimate": "Stima mensile"
+  },
+  "weekendVsWeekday": {
+    "title": "Uscite weekend vs giorni feriali",
+    "empty": "Nessuna uscita in questo periodo.",
+    "weekendLabel": "Weekend",
+    "weekdayLabel": "Giorni feriali",
+    "viewOverview": "Panoramica",
+    "viewByDay": "Per giorno"
   }
 }

--- a/frontend/src/i18n/messages/ja/dashboard.json
+++ b/frontend/src/i18n/messages/ja/dashboard.json
@@ -154,5 +154,96 @@
     "title": "お気に入りのレポート",
     "empty": "お気に入りのレポートがまだありません。レポートページでレポートをスターするとここに表示されます。",
     "browseReports": "レポートを見る"
+  },
+  "widgets": {
+    "configure": "{name}を設定",
+    "done": "完了",
+    "configSaveFailed": "ウィジェット設定を保存できませんでした。もう一度お試しください。",
+    "timeframe": "期間",
+    "accounts": "口座",
+    "chartType": "グラフの種類",
+    "view": "表示",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "すべて"
+    }
+  },
+  "portfolioValue": {
+    "title": "ポートフォリオ価値",
+    "empty": "表示する投資履歴がまだありません。"
+  },
+  "spendingByPayee": {
+    "title": "支払先別支出",
+    "empty": "この期間に支出がありません。",
+    "totalLabel": "合計"
+  },
+  "monthlySpendingTrend": {
+    "title": "月次支出トレンド",
+    "empty": "この期間のデータがありません。",
+    "expenses": "支出",
+    "income": "収入"
+  },
+  "incomeBySource": {
+    "title": "収入源別収入",
+    "empty": "この期間に収入がありません。",
+    "totalLabel": "総収入"
+  },
+  "creditUtilizationAccounts": {
+    "title": "口座別使用率",
+    "empty": "限度額が設定されたクレジット口座がありません。",
+    "utilization": "使用率",
+    "used": "使用額"
+  },
+  "creditUtilizationTotal": {
+    "title": "合計使用率",
+    "empty": "限度額が設定されたクレジット口座がありません。",
+    "used": "使用額",
+    "available": "利用可能額"
+  },
+  "sectorWeightings": {
+    "title": "セクター配分",
+    "empty": "セクターデータがありません。",
+    "direct": "直接",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "有価証券タイプ配分",
+    "empty": "表示する保有銘柄がありません。",
+    "types": {
+      "STOCK": "株式",
+      "ETF": "ETF",
+      "MUTUAL_FUND": "投資信託",
+      "BOND": "債券",
+      "CASH": "現金"
+    }
+  },
+  "geographicAllocation": {
+    "title": "地域配分",
+    "empty": "表示する保有銘柄がありません。",
+    "viewRegion": "地域",
+    "viewExchange": "取引所",
+    "viewCountry": "国"
+  },
+  "recurringExpenses": {
+    "title": "上位定期費用",
+    "empty": "定期費用が見つかりません。",
+    "minOccurrences": "最小発生回数",
+    "minOccurrencesOption": "{count} 回以上",
+    "occurrences": "{count} 回",
+    "monthlyEstimate": "月次見積もり"
+  },
+  "weekendVsWeekday": {
+    "title": "週末 vs 平日の支出",
+    "empty": "この期間に支出がありません。",
+    "weekendLabel": "週末",
+    "weekdayLabel": "平日",
+    "viewOverview": "概要",
+    "viewByDay": "曜日別"
   }
 }

--- a/frontend/src/i18n/messages/ko/dashboard.json
+++ b/frontend/src/i18n/messages/ko/dashboard.json
@@ -154,5 +154,96 @@
     "title": "즐겨찾기 보고서",
     "empty": "즐겨찾기 보고서가 없습니다. 보고서 페이지에서 보고서에 별표를 표시하면 여기에 나타납니다.",
     "browseReports": "보고서 둘러보기"
+  },
+  "widgets": {
+    "configure": "{name} 구성",
+    "done": "완료",
+    "configSaveFailed": "위젯 설정을 저장하지 못했습니다. 다시 시도해 주세요.",
+    "timeframe": "기간",
+    "accounts": "계정",
+    "chartType": "차트 유형",
+    "view": "보기",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "전체"
+    }
+  },
+  "portfolioValue": {
+    "title": "포트폴리오 가치",
+    "empty": "아직 표시할 투자 내역이 없습니다."
+  },
+  "spendingByPayee": {
+    "title": "수취인별 지출",
+    "empty": "이 기간에 지출이 없습니다.",
+    "totalLabel": "합계"
+  },
+  "monthlySpendingTrend": {
+    "title": "월별 지출 추세",
+    "empty": "이 기간에 데이터가 없습니다.",
+    "expenses": "지출",
+    "income": "수익"
+  },
+  "incomeBySource": {
+    "title": "출처별 수익",
+    "empty": "이 기간에 수익이 없습니다.",
+    "totalLabel": "총 수익"
+  },
+  "creditUtilizationAccounts": {
+    "title": "계정별 신용 활용도",
+    "empty": "한도가 설정된 신용 계정이 없습니다.",
+    "utilization": "활용도",
+    "used": "사용액"
+  },
+  "creditUtilizationTotal": {
+    "title": "총 신용 활용도",
+    "empty": "한도가 설정된 신용 계정이 없습니다.",
+    "used": "사용액",
+    "available": "가용 한도"
+  },
+  "sectorWeightings": {
+    "title": "섹터 배분",
+    "empty": "이용 가능한 섹터 데이터가 없습니다.",
+    "direct": "직접",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "유가증권 유형 배분",
+    "empty": "표시할 보유 항목이 없습니다.",
+    "types": {
+      "STOCK": "주식",
+      "ETF": "ETF",
+      "MUTUAL_FUND": "뮤추얼 펀드",
+      "BOND": "채권",
+      "CASH": "현금"
+    }
+  },
+  "geographicAllocation": {
+    "title": "지역별 배분",
+    "empty": "표시할 보유 항목이 없습니다.",
+    "viewRegion": "지역",
+    "viewExchange": "거래소",
+    "viewCountry": "국가"
+  },
+  "recurringExpenses": {
+    "title": "주요 반복 지출",
+    "empty": "반복 지출을 찾을 수 없습니다.",
+    "minOccurrences": "최소 발생 횟수",
+    "minOccurrencesOption": "{count}회 이상",
+    "occurrences": "{count}회 발생",
+    "monthlyEstimate": "월 예상액"
+  },
+  "weekendVsWeekday": {
+    "title": "주말 대 평일 지출",
+    "empty": "이 기간에 지출이 없습니다.",
+    "weekendLabel": "주말",
+    "weekdayLabel": "평일",
+    "viewOverview": "개요",
+    "viewByDay": "요일별"
   }
 }

--- a/frontend/src/i18n/messages/nl/dashboard.json
+++ b/frontend/src/i18n/messages/nl/dashboard.json
@@ -154,5 +154,96 @@
     "title": "Favoriete rapporten",
     "empty": "Nog geen favoriete rapporten. Markeer rapporten met een ster op de pagina Rapporten om ze hier te zien.",
     "browseReports": "Rapporten bekijken"
+  },
+  "widgets": {
+    "configure": "{name} configureren",
+    "done": "Klaar",
+    "configSaveFailed": "Kon de widgetinstellingen niet opslaan. Probeer het opnieuw.",
+    "timeframe": "Tijdsbestek",
+    "accounts": "Rekeningen",
+    "chartType": "Grafiektype",
+    "view": "Weergave",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "Alle"
+    }
+  },
+  "portfolioValue": {
+    "title": "Portefeuillewaarde",
+    "empty": "Nog geen beleggingsgeschiedenis om te tonen."
+  },
+  "spendingByPayee": {
+    "title": "Uitgaven per begunstigde",
+    "empty": "Geen uitgaven in deze periode.",
+    "totalLabel": "Totaal"
+  },
+  "monthlySpendingTrend": {
+    "title": "Maandelijkse uitgaventrend",
+    "empty": "Geen gegevens voor deze periode.",
+    "expenses": "Uitgaven",
+    "income": "Inkomsten"
+  },
+  "incomeBySource": {
+    "title": "Inkomsten per bron",
+    "empty": "Geen inkomsten in deze periode.",
+    "totalLabel": "Totale inkomsten"
+  },
+  "creditUtilizationAccounts": {
+    "title": "Benutting per rekening",
+    "empty": "Geen kredietrekeningen met een ingestelde limiet.",
+    "utilization": "Benutting",
+    "used": "Gebruikt"
+  },
+  "creditUtilizationTotal": {
+    "title": "Totale benutting",
+    "empty": "Geen kredietrekeningen met een ingestelde limiet.",
+    "used": "Gebruikt",
+    "available": "Beschikbaar"
+  },
+  "sectorWeightings": {
+    "title": "Sectorallocatie",
+    "empty": "Geen sectorgegevens beschikbaar.",
+    "direct": "Direct",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "Allocatie per type waardepapier",
+    "empty": "Geen posities om te tonen.",
+    "types": {
+      "STOCK": "Aandelen",
+      "ETF": "ETFs",
+      "MUTUAL_FUND": "Beleggingsfondsen",
+      "BOND": "Obligaties",
+      "CASH": "Contanten"
+    }
+  },
+  "geographicAllocation": {
+    "title": "Geografische allocatie",
+    "empty": "Geen posities om te tonen.",
+    "viewRegion": "Regio",
+    "viewExchange": "Beurs",
+    "viewCountry": "Land"
+  },
+  "recurringExpenses": {
+    "title": "Grootste terugkerende uitgaven",
+    "empty": "Geen terugkerende uitgaven gevonden.",
+    "minOccurrences": "Minimaal aantal keer",
+    "minOccurrencesOption": "{count} of meer",
+    "occurrences": "{count} keer",
+    "monthlyEstimate": "Maandelijkse schatting"
+  },
+  "weekendVsWeekday": {
+    "title": "Weekend- vs. weekdaguitgaven",
+    "empty": "Geen uitgaven in deze periode.",
+    "weekendLabel": "Weekend",
+    "weekdayLabel": "Weekdag",
+    "viewOverview": "Overzicht",
+    "viewByDay": "Per dag"
   }
 }

--- a/frontend/src/i18n/messages/pl/dashboard.json
+++ b/frontend/src/i18n/messages/pl/dashboard.json
@@ -154,5 +154,96 @@
     "title": "Ulubione raporty",
     "empty": "Brak ulubionych raportów. Oznacz raporty gwiazdką na stronie Raporty, aby zobaczyć je tutaj.",
     "browseReports": "Przeglądaj raporty"
+  },
+  "widgets": {
+    "configure": "Konfiguruj {name}",
+    "done": "Gotowe",
+    "configSaveFailed": "Nie udało się zapisać ustawień widżetu. Spróbuj ponownie.",
+    "timeframe": "Zakres czasu",
+    "accounts": "Konta",
+    "chartType": "Typ wykresu",
+    "view": "Widok",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "Wszystkie"
+    }
+  },
+  "portfolioValue": {
+    "title": "Wartość portfela",
+    "empty": "Brak historii inwestycji do wyświetlenia."
+  },
+  "spendingByPayee": {
+    "title": "Wydatki według odbiorcy",
+    "empty": "Brak wydatków w tym okresie.",
+    "totalLabel": "Suma"
+  },
+  "monthlySpendingTrend": {
+    "title": "Trend wydatków miesięcznych",
+    "empty": "Brak danych dla tego okresu.",
+    "expenses": "Wydatki",
+    "income": "Przychody"
+  },
+  "incomeBySource": {
+    "title": "Przychody według źródła",
+    "empty": "Brak przychodów w tym okresie.",
+    "totalLabel": "Przychody łącznie"
+  },
+  "creditUtilizationAccounts": {
+    "title": "Wykorzystanie według konta",
+    "empty": "Brak kont kredytowych z ustawionym limitem.",
+    "utilization": "Wykorzystanie",
+    "used": "Wykorzystano"
+  },
+  "creditUtilizationTotal": {
+    "title": "Całkowite wykorzystanie",
+    "empty": "Brak kont kredytowych z ustawionym limitem.",
+    "used": "Wykorzystano",
+    "available": "Dostępne"
+  },
+  "sectorWeightings": {
+    "title": "Alokacja sektorowa",
+    "empty": "Brak dostępnych danych sektorowych.",
+    "direct": "Bezpośrednia",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "Alokacja według typu papieru wartościowego",
+    "empty": "Brak pozycji do wyświetlenia.",
+    "types": {
+      "STOCK": "Akcje",
+      "ETF": "ETF-y",
+      "MUTUAL_FUND": "Fundusze inwestycyjne",
+      "BOND": "Obligacje",
+      "CASH": "Gotówka"
+    }
+  },
+  "geographicAllocation": {
+    "title": "Alokacja geograficzna",
+    "empty": "Brak pozycji do wyświetlenia.",
+    "viewRegion": "Region",
+    "viewExchange": "Giełda",
+    "viewCountry": "Kraj"
+  },
+  "recurringExpenses": {
+    "title": "Największe wydatki cykliczne",
+    "empty": "Nie znaleziono wydatków cyklicznych.",
+    "minOccurrences": "Minimalna liczba wystąpień",
+    "minOccurrencesOption": "{count} lub więcej",
+    "occurrences": "{count} wystąpień",
+    "monthlyEstimate": "Szacunek miesięczny"
+  },
+  "weekendVsWeekday": {
+    "title": "Wydatki w weekend a w dni robocze",
+    "empty": "Brak wydatków w tym okresie.",
+    "weekendLabel": "Weekend",
+    "weekdayLabel": "Dzień powszedni",
+    "viewOverview": "Przegląd",
+    "viewByDay": "Wg dnia"
   }
 }

--- a/frontend/src/i18n/messages/pt-BR/dashboard.json
+++ b/frontend/src/i18n/messages/pt-BR/dashboard.json
@@ -154,5 +154,96 @@
     "title": "Relatórios Favoritos",
     "empty": "Ainda sem relatórios favoritos. Marque relatórios com estrela na página de Relatórios para vê-los aqui.",
     "browseReports": "Explorar relatórios"
+  },
+  "widgets": {
+    "configure": "Configurar {name}",
+    "done": "Concluído",
+    "configSaveFailed": "Não foi possível salvar as configurações do widget. Tente novamente.",
+    "timeframe": "Período",
+    "accounts": "Contas",
+    "chartType": "Tipo de gráfico",
+    "view": "Visualização",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "Tudo"
+    }
+  },
+  "portfolioValue": {
+    "title": "Valor do Portfólio",
+    "empty": "Ainda não há histórico de investimentos para mostrar."
+  },
+  "spendingByPayee": {
+    "title": "Despesas por Beneficiário",
+    "empty": "Sem despesas neste período.",
+    "totalLabel": "Total"
+  },
+  "monthlySpendingTrend": {
+    "title": "Tendência Mensal de Despesas",
+    "empty": "Sem dados para este período.",
+    "expenses": "Despesas",
+    "income": "Receitas"
+  },
+  "incomeBySource": {
+    "title": "Receitas por Fonte",
+    "empty": "Sem receitas neste período.",
+    "totalLabel": "Receita Total"
+  },
+  "creditUtilizationAccounts": {
+    "title": "Utilização por Conta",
+    "empty": "Nenhuma conta de crédito com limite definido.",
+    "utilization": "Utilização",
+    "used": "Utilizado"
+  },
+  "creditUtilizationTotal": {
+    "title": "Utilização Total",
+    "empty": "Nenhuma conta de crédito com limite definido.",
+    "used": "Utilizado",
+    "available": "Disponível"
+  },
+  "sectorWeightings": {
+    "title": "Alocação Setorial",
+    "empty": "Nenhum dado setorial disponível.",
+    "direct": "Direta",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "Alocação por Tipo de Título",
+    "empty": "Nenhuma posição para mostrar.",
+    "types": {
+      "STOCK": "Ações",
+      "ETF": "ETFs",
+      "MUTUAL_FUND": "Fundos de Investimento",
+      "BOND": "Obrigações",
+      "CASH": "Dinheiro"
+    }
+  },
+  "geographicAllocation": {
+    "title": "Alocação Geográfica",
+    "empty": "Nenhuma posição para mostrar.",
+    "viewRegion": "Região",
+    "viewExchange": "Bolsa",
+    "viewCountry": "País"
+  },
+  "recurringExpenses": {
+    "title": "Principais Despesas Recorrentes",
+    "empty": "Nenhuma despesa recorrente encontrada.",
+    "minOccurrences": "Ocorrências mínimas",
+    "minOccurrencesOption": "{count} ou mais",
+    "occurrences": "{count} ocorrências",
+    "monthlyEstimate": "Estimativa Mensal"
+  },
+  "weekendVsWeekday": {
+    "title": "Despesas: Fim de Semana vs Dia de Semana",
+    "empty": "Sem despesas neste período.",
+    "weekendLabel": "Fim de Semana",
+    "weekdayLabel": "Dia de Semana",
+    "viewOverview": "Visão Geral",
+    "viewByDay": "Por Dia"
   }
 }

--- a/frontend/src/i18n/messages/pt/dashboard.json
+++ b/frontend/src/i18n/messages/pt/dashboard.json
@@ -154,5 +154,96 @@
     "title": "Relatórios Favoritos",
     "empty": "Ainda sem relatórios favoritos. Marque relatórios com estrela na página de Relatórios para os ver aqui.",
     "browseReports": "Explorar relatórios"
+  },
+  "widgets": {
+    "configure": "Configurar {name}",
+    "done": "Concluído",
+    "configSaveFailed": "Não foi possível guardar as definições do widget. Tente novamente.",
+    "timeframe": "Período",
+    "accounts": "Contas",
+    "chartType": "Tipo de gráfico",
+    "view": "Vista",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "Tudo"
+    }
+  },
+  "portfolioValue": {
+    "title": "Valor do Portefólio",
+    "empty": "Ainda não há histórico de investimentos para mostrar."
+  },
+  "spendingByPayee": {
+    "title": "Despesas por Beneficiário",
+    "empty": "Sem despesas neste período.",
+    "totalLabel": "Total"
+  },
+  "monthlySpendingTrend": {
+    "title": "Tendência Mensal de Despesas",
+    "empty": "Sem dados para este período.",
+    "expenses": "Despesas",
+    "income": "Receitas"
+  },
+  "incomeBySource": {
+    "title": "Receitas por Fonte",
+    "empty": "Sem receitas neste período.",
+    "totalLabel": "Receita Total"
+  },
+  "creditUtilizationAccounts": {
+    "title": "Utilização por Conta",
+    "empty": "Nenhuma conta de crédito com limite definido.",
+    "utilization": "Utilização",
+    "used": "Utilizado"
+  },
+  "creditUtilizationTotal": {
+    "title": "Utilização Total",
+    "empty": "Nenhuma conta de crédito com limite definido.",
+    "used": "Utilizado",
+    "available": "Disponível"
+  },
+  "sectorWeightings": {
+    "title": "Alocação Setorial",
+    "empty": "Nenhum dado setorial disponível.",
+    "direct": "Direta",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "Alocação por Tipo de Título",
+    "empty": "Nenhuma posição para mostrar.",
+    "types": {
+      "STOCK": "Ações",
+      "ETF": "ETFs",
+      "MUTUAL_FUND": "Fundos de Investimento",
+      "BOND": "Obrigações",
+      "CASH": "Dinheiro"
+    }
+  },
+  "geographicAllocation": {
+    "title": "Alocação Geográfica",
+    "empty": "Nenhuma posição para mostrar.",
+    "viewRegion": "Região",
+    "viewExchange": "Bolsa",
+    "viewCountry": "País"
+  },
+  "recurringExpenses": {
+    "title": "Principais Despesas Recorrentes",
+    "empty": "Nenhuma despesa recorrente encontrada.",
+    "minOccurrences": "Ocorrências mínimas",
+    "minOccurrencesOption": "{count} ou mais",
+    "occurrences": "{count} ocorrências",
+    "monthlyEstimate": "Estimativa Mensal"
+  },
+  "weekendVsWeekday": {
+    "title": "Despesas: Fim de Semana vs Dia de Semana",
+    "empty": "Sem despesas neste período.",
+    "weekendLabel": "Fim de Semana",
+    "weekdayLabel": "Dia de Semana",
+    "viewOverview": "Visão Geral",
+    "viewByDay": "Por Dia"
   }
 }

--- a/frontend/src/i18n/messages/ru/dashboard.json
+++ b/frontend/src/i18n/messages/ru/dashboard.json
@@ -154,5 +154,96 @@
     "title": "Избранные отчёты",
     "empty": "Нет избранных отчётов. Отметьте отчёты звёздочкой на странице отчётов, чтобы видеть их здесь.",
     "browseReports": "Просмотреть отчёты"
+  },
+  "widgets": {
+    "configure": "Настроить {name}",
+    "done": "Готово",
+    "configSaveFailed": "Не удалось сохранить настройки виджета. Повторите попытку.",
+    "timeframe": "Период",
+    "accounts": "Счета",
+    "chartType": "Тип диаграммы",
+    "view": "Вид",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "Всё"
+    }
+  },
+  "portfolioValue": {
+    "title": "Стоимость портфеля",
+    "empty": "Пока нет истории инвестиций для отображения."
+  },
+  "spendingByPayee": {
+    "title": "Расходы по получателям",
+    "empty": "Нет расходов за этот период.",
+    "totalLabel": "Итого"
+  },
+  "monthlySpendingTrend": {
+    "title": "Ежемесячная тенденция расходов",
+    "empty": "Нет данных за этот период.",
+    "expenses": "Расходы",
+    "income": "Доходы"
+  },
+  "incomeBySource": {
+    "title": "Доходы по источникам",
+    "empty": "Нет доходов за этот период.",
+    "totalLabel": "Всего доходов"
+  },
+  "creditUtilizationAccounts": {
+    "title": "Использование кредита по счёту",
+    "empty": "Нет кредитных счетов с установленным лимитом.",
+    "utilization": "Использование",
+    "used": "Использовано"
+  },
+  "creditUtilizationTotal": {
+    "title": "Общее использование кредита",
+    "empty": "Нет кредитных счетов с установленным лимитом.",
+    "used": "Использовано",
+    "available": "Доступно"
+  },
+  "sectorWeightings": {
+    "title": "Отраслевое распределение",
+    "empty": "Нет данных по отраслям.",
+    "direct": "Прямое",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "Распределение по типам ценных бумаг",
+    "empty": "Нет активов для отображения.",
+    "types": {
+      "STOCK": "Акции",
+      "ETF": "ETF",
+      "MUTUAL_FUND": "Паевые фонды",
+      "BOND": "Облигации",
+      "CASH": "Наличные"
+    }
+  },
+  "geographicAllocation": {
+    "title": "Географическое распределение",
+    "empty": "Нет активов для отображения.",
+    "viewRegion": "Регион",
+    "viewExchange": "Биржа",
+    "viewCountry": "Страна"
+  },
+  "recurringExpenses": {
+    "title": "Основные регулярные расходы",
+    "empty": "Регулярные расходы не найдены.",
+    "minOccurrences": "Минимальное количество вхождений",
+    "minOccurrencesOption": "{count} или более",
+    "occurrences": "{count} вхождений",
+    "monthlyEstimate": "Ежемесячная оценка"
+  },
+  "weekendVsWeekday": {
+    "title": "Расходы в выходные против будней",
+    "empty": "Нет расходов за этот период.",
+    "weekendLabel": "Выходные",
+    "weekdayLabel": "Будни",
+    "viewOverview": "Обзор",
+    "viewByDay": "По дням"
   }
 }

--- a/frontend/src/i18n/messages/tr/dashboard.json
+++ b/frontend/src/i18n/messages/tr/dashboard.json
@@ -154,5 +154,96 @@
     "title": "Favori Raporlar",
     "empty": "Henüz favori rapor yok. Burada görmek için Raporlar sayfasında raporları yıldızlayın.",
     "browseReports": "Raporlara göz at"
+  },
+  "widgets": {
+    "configure": "{name} yapılandır",
+    "done": "Tamam",
+    "configSaveFailed": "Widget ayarları kaydedilemedi. Lütfen tekrar deneyin.",
+    "timeframe": "Zaman aralığı",
+    "accounts": "Hesaplar",
+    "chartType": "Grafik türü",
+    "view": "Görünüm",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "Tümü"
+    }
+  },
+  "portfolioValue": {
+    "title": "Portföy Değeri",
+    "empty": "Henüz gösterilecek yatırım geçmişi yok."
+  },
+  "spendingByPayee": {
+    "title": "Alacaklıya Göre Harcama",
+    "empty": "Bu dönemde harcama yok.",
+    "totalLabel": "Toplam"
+  },
+  "monthlySpendingTrend": {
+    "title": "Aylık Harcama Trendi",
+    "empty": "Bu dönem için veri yok.",
+    "expenses": "Giderler",
+    "income": "Gelir"
+  },
+  "incomeBySource": {
+    "title": "Kaynağa Göre Gelir",
+    "empty": "Bu dönemde gelir yok.",
+    "totalLabel": "Toplam Gelir"
+  },
+  "creditUtilizationAccounts": {
+    "title": "Hesaba Göre Kredi Kullanımı",
+    "empty": "Limit belirlenmiş kredi hesabı yok.",
+    "utilization": "Kullanım",
+    "used": "Kullanılan"
+  },
+  "creditUtilizationTotal": {
+    "title": "Toplam Kredi Kullanımı",
+    "empty": "Limit belirlenmiş kredi hesabı yok.",
+    "used": "Kullanılan",
+    "available": "Mevcut"
+  },
+  "sectorWeightings": {
+    "title": "Sektör Dağılımı",
+    "empty": "Kullanılabilir sektör verisi yok.",
+    "direct": "Doğrudan",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "Menkul Kıymet Türü Dağılımı",
+    "empty": "Gösterilecek varlık yok.",
+    "types": {
+      "STOCK": "Hisseler",
+      "ETF": "ETF'ler",
+      "MUTUAL_FUND": "Yatırım Fonları",
+      "BOND": "Tahviller",
+      "CASH": "Nakit"
+    }
+  },
+  "geographicAllocation": {
+    "title": "Coğrafi Dağılım",
+    "empty": "Gösterilecek varlık yok.",
+    "viewRegion": "Bölge",
+    "viewExchange": "Borsa",
+    "viewCountry": "Ülke"
+  },
+  "recurringExpenses": {
+    "title": "En Yüksek Tekrarlayan Giderler",
+    "empty": "Tekrarlayan gider bulunamadı.",
+    "minOccurrences": "Minimum tekrar",
+    "minOccurrencesOption": "{count} veya daha fazla",
+    "occurrences": "{count} tekrar",
+    "monthlyEstimate": "Aylık Tahmin"
+  },
+  "weekendVsWeekday": {
+    "title": "Hafta Sonu - Hafta İçi Harcama",
+    "empty": "Bu dönemde harcama yok.",
+    "weekendLabel": "Hafta Sonu",
+    "weekdayLabel": "Hafta İçi",
+    "viewOverview": "Genel Bakış",
+    "viewByDay": "Güne Göre"
   }
 }

--- a/frontend/src/i18n/messages/uk/dashboard.json
+++ b/frontend/src/i18n/messages/uk/dashboard.json
@@ -154,5 +154,96 @@
     "title": "Обрані звіти",
     "empty": "Ще немає обраних звітів. Позначте звіти зірочкою на сторінці звітів, щоб бачити їх тут.",
     "browseReports": "Переглянути звіти"
+  },
+  "widgets": {
+    "configure": "Налаштувати {name}",
+    "done": "Готово",
+    "configSaveFailed": "Не вдалося зберегти налаштування віджета. Будь ласка, спробуйте ще раз.",
+    "timeframe": "Часовий проміжок",
+    "accounts": "Рахунки",
+    "chartType": "Тип діаграми",
+    "view": "Вигляд",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "Всі"
+    }
+  },
+  "portfolioValue": {
+    "title": "Вартість портфеля",
+    "empty": "Ще немає інвестиційної історії для відображення."
+  },
+  "spendingByPayee": {
+    "title": "Витрати за одержувачами",
+    "empty": "Витрат за цей період немає.",
+    "totalLabel": "Разом"
+  },
+  "monthlySpendingTrend": {
+    "title": "Тенденція місячних витрат",
+    "empty": "Даних за цей період немає.",
+    "expenses": "Витрати",
+    "income": "Дохід"
+  },
+  "incomeBySource": {
+    "title": "Дохід за джерелами",
+    "empty": "Доходу за цей період немає.",
+    "totalLabel": "Загальний дохід"
+  },
+  "creditUtilizationAccounts": {
+    "title": "Використання кредиту за рахунком",
+    "empty": "Немає кредитних рахунків із встановленим лімітом.",
+    "utilization": "Використання",
+    "used": "Використано"
+  },
+  "creditUtilizationTotal": {
+    "title": "Загальне використання кредиту",
+    "empty": "Немає кредитних рахунків із встановленим лімітом.",
+    "used": "Використано",
+    "available": "Доступно"
+  },
+  "sectorWeightings": {
+    "title": "Розподіл за секторами",
+    "empty": "Немає доступних даних за секторами.",
+    "direct": "Прямий",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "Розподіл за типами цінних паперів",
+    "empty": "Немає позицій для відображення.",
+    "types": {
+      "STOCK": "Акції",
+      "ETF": "ETF",
+      "MUTUAL_FUND": "Пайові фонди",
+      "BOND": "Облігації",
+      "CASH": "Готівка"
+    }
+  },
+  "geographicAllocation": {
+    "title": "Географічний розподіл",
+    "empty": "Немає позицій для відображення.",
+    "viewRegion": "Регіон",
+    "viewExchange": "Біржа",
+    "viewCountry": "Країна"
+  },
+  "recurringExpenses": {
+    "title": "Основні регулярні витрати",
+    "empty": "Регулярних витрат не знайдено.",
+    "minOccurrences": "Мінімальна кількість повторень",
+    "minOccurrencesOption": "{count} або більше",
+    "occurrences": "{count} повторень",
+    "monthlyEstimate": "Місячна оцінка"
+  },
+  "weekendVsWeekday": {
+    "title": "Витрати у вихідні проти будніх",
+    "empty": "Витрат за цей період немає.",
+    "weekendLabel": "Вихідні",
+    "weekdayLabel": "Будні",
+    "viewOverview": "Огляд",
+    "viewByDay": "За днем"
   }
 }

--- a/frontend/src/i18n/messages/vi/dashboard.json
+++ b/frontend/src/i18n/messages/vi/dashboard.json
@@ -154,5 +154,96 @@
     "title": "Báo cáo yêu thích",
     "empty": "Chưa có báo cáo yêu thích nào. Gắn sao các báo cáo trên trang Báo cáo để xem tại đây.",
     "browseReports": "Xem các báo cáo"
+  },
+  "widgets": {
+    "configure": "Cấu hình {name}",
+    "done": "Xong",
+    "configSaveFailed": "Không thể lưu cài đặt tiện ích. Vui lòng thử lại.",
+    "timeframe": "Khung thời gian",
+    "accounts": "Tài khoản",
+    "chartType": "Loại biểu đồ",
+    "view": "Chế độ xem",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "Tất cả"
+    }
+  },
+  "portfolioValue": {
+    "title": "Giá trị danh mục đầu tư",
+    "empty": "Chưa có lịch sử đầu tư để hiển thị."
+  },
+  "spendingByPayee": {
+    "title": "Chi tiêu theo người nhận",
+    "empty": "Không có chi tiêu trong kỳ này.",
+    "totalLabel": "Tổng"
+  },
+  "monthlySpendingTrend": {
+    "title": "Xu hướng chi tiêu hàng tháng",
+    "empty": "Không có dữ liệu trong kỳ này.",
+    "expenses": "Chi phí",
+    "income": "Thu nhập"
+  },
+  "incomeBySource": {
+    "title": "Thu nhập theo nguồn",
+    "empty": "Không có thu nhập trong kỳ này.",
+    "totalLabel": "Tổng thu nhập"
+  },
+  "creditUtilizationAccounts": {
+    "title": "Mức sử dụng tín dụng theo tài khoản",
+    "empty": "Không có tài khoản tín dụng nào được đặt hạn mức.",
+    "utilization": "Mức sử dụng",
+    "used": "Đã dùng"
+  },
+  "creditUtilizationTotal": {
+    "title": "Tổng mức sử dụng tín dụng",
+    "empty": "Không có tài khoản tín dụng nào được đặt hạn mức.",
+    "used": "Đã dùng",
+    "available": "Khả dụng"
+  },
+  "sectorWeightings": {
+    "title": "Phân bổ ngành",
+    "empty": "Không có dữ liệu ngành.",
+    "direct": "Trực tiếp",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "Phân bổ theo loại chứng khoán",
+    "empty": "Không có vị thế để hiển thị.",
+    "types": {
+      "STOCK": "Cổ phiếu",
+      "ETF": "ETFs",
+      "MUTUAL_FUND": "Quỹ tương hỗ",
+      "BOND": "Trái phiếu",
+      "CASH": "Tiền mặt"
+    }
+  },
+  "geographicAllocation": {
+    "title": "Phân bổ theo địa lý",
+    "empty": "Không có vị thế để hiển thị.",
+    "viewRegion": "Khu vực",
+    "viewExchange": "Sàn giao dịch",
+    "viewCountry": "Quốc gia"
+  },
+  "recurringExpenses": {
+    "title": "Chi phí định kỳ hàng đầu",
+    "empty": "Không tìm thấy chi phí định kỳ nào.",
+    "minOccurrences": "Số lần xuất hiện tối thiểu",
+    "minOccurrencesOption": "{count} trở lên",
+    "occurrences": "{count} lần xuất hiện",
+    "monthlyEstimate": "Ước tính hàng tháng"
+  },
+  "weekendVsWeekday": {
+    "title": "Chi tiêu cuối tuần so với ngày thường",
+    "empty": "Không có chi tiêu trong kỳ này.",
+    "weekendLabel": "Cuối tuần",
+    "weekdayLabel": "Ngày thường",
+    "viewOverview": "Tổng quan",
+    "viewByDay": "Theo ngày"
   }
 }

--- a/frontend/src/i18n/messages/xx/dashboard.json
+++ b/frontend/src/i18n/messages/xx/dashboard.json
@@ -154,5 +154,96 @@
     "title": "[XX-Favourite Reports-XX]",
     "empty": "[XX-No favourite reports yet. Star reports on the Reports page to see them here.-XX]",
     "browseReports": "[XX-Browse reports-XX]"
+  },
+  "widgets": {
+    "configure": "[XX-Configure {name}-XX]",
+    "done": "[XX-Done-XX]",
+    "configSaveFailed": "[XX-Couldn't save widget settings. Please try again.-XX]",
+    "timeframe": "[XX-Timeframe-XX]",
+    "accounts": "[XX-Accounts-XX]",
+    "chartType": "[XX-Chart type-XX]",
+    "view": "[XX-View-XX]",
+    "rangeLabels": {
+      "1m": "[XX-1M-XX]",
+      "3m": "[XX-3M-XX]",
+      "6m": "[XX-6M-XX]",
+      "1y": "[XX-1Y-XX]",
+      "2y": "[XX-2Y-XX]",
+      "5y": "[XX-5Y-XX]",
+      "ytd": "[XX-YTD-XX]",
+      "all": "[XX-All-XX]"
+    }
+  },
+  "portfolioValue": {
+    "title": "[XX-Portfolio Value-XX]",
+    "empty": "[XX-No investment history to show yet.-XX]"
+  },
+  "spendingByPayee": {
+    "title": "[XX-Spending by Payee-XX]",
+    "empty": "[XX-No spending in this period.-XX]",
+    "totalLabel": "[XX-Total-XX]"
+  },
+  "monthlySpendingTrend": {
+    "title": "[XX-Monthly Spending Trend-XX]",
+    "empty": "[XX-No data for this period.-XX]",
+    "expenses": "[XX-Expenses-XX]",
+    "income": "[XX-Income-XX]"
+  },
+  "incomeBySource": {
+    "title": "[XX-Income by Source-XX]",
+    "empty": "[XX-No income in this period.-XX]",
+    "totalLabel": "[XX-Total income-XX]"
+  },
+  "creditUtilizationAccounts": {
+    "title": "[XX-Credit Utilization by Account-XX]",
+    "empty": "[XX-No credit accounts with a limit set.-XX]",
+    "utilization": "[XX-Utilization-XX]",
+    "used": "[XX-Used-XX]"
+  },
+  "creditUtilizationTotal": {
+    "title": "[XX-Total Credit Utilization-XX]",
+    "empty": "[XX-No credit accounts with a limit set.-XX]",
+    "used": "[XX-Used-XX]",
+    "available": "[XX-Available-XX]"
+  },
+  "sectorWeightings": {
+    "title": "[XX-Sector Allocation-XX]",
+    "empty": "[XX-No sector data available.-XX]",
+    "direct": "[XX-Direct-XX]",
+    "etf": "[XX-ETF-XX]"
+  },
+  "securityTypeAllocation": {
+    "title": "[XX-Security Type Allocation-XX]",
+    "empty": "[XX-No holdings to show.-XX]",
+    "types": {
+      "STOCK": "[XX-Stocks-XX]",
+      "ETF": "[XX-ETFs-XX]",
+      "MUTUAL_FUND": "[XX-Mutual Funds-XX]",
+      "BOND": "[XX-Bonds-XX]",
+      "CASH": "[XX-Cash-XX]"
+    }
+  },
+  "geographicAllocation": {
+    "title": "[XX-Geographic Allocation-XX]",
+    "empty": "[XX-No holdings to show.-XX]",
+    "viewRegion": "[XX-Region-XX]",
+    "viewExchange": "[XX-Exchange-XX]",
+    "viewCountry": "[XX-Country-XX]"
+  },
+  "recurringExpenses": {
+    "title": "[XX-Top Recurring Expenses-XX]",
+    "empty": "[XX-No recurring expenses found.-XX]",
+    "minOccurrences": "[XX-Minimum occurrences-XX]",
+    "minOccurrencesOption": "[XX-{count} or more-XX]",
+    "occurrences": "[XX-{count} occurrences-XX]",
+    "monthlyEstimate": "[XX-Monthly estimate-XX]"
+  },
+  "weekendVsWeekday": {
+    "title": "[XX-Weekend vs Weekday Spending-XX]",
+    "empty": "[XX-No spending in this period.-XX]",
+    "weekendLabel": "[XX-Weekend-XX]",
+    "weekdayLabel": "[XX-Weekday-XX]",
+    "viewOverview": "[XX-Overview-XX]",
+    "viewByDay": "[XX-By day-XX]"
   }
 }

--- a/frontend/src/i18n/messages/zh-CN/dashboard.json
+++ b/frontend/src/i18n/messages/zh-CN/dashboard.json
@@ -154,5 +154,96 @@
     "title": "收藏报告",
     "empty": "暂无收藏报告。在报告页面为报告加星后即可在此查看。",
     "browseReports": "浏览报告"
+  },
+  "widgets": {
+    "configure": "配置{name}",
+    "done": "完成",
+    "configSaveFailed": "无法保存小组件设置。请重试。",
+    "timeframe": "时间范围",
+    "accounts": "账户",
+    "chartType": "图表类型",
+    "view": "视图",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "全部"
+    }
+  },
+  "portfolioValue": {
+    "title": "投资组合价值",
+    "empty": "暂无投资历史可显示。"
+  },
+  "spendingByPayee": {
+    "title": "按收款人支出",
+    "empty": "此期间无支出。",
+    "totalLabel": "合计"
+  },
+  "monthlySpendingTrend": {
+    "title": "月度支出趋势",
+    "empty": "此期间无数据。",
+    "expenses": "支出",
+    "income": "收入"
+  },
+  "incomeBySource": {
+    "title": "按来源收入",
+    "empty": "此期间无收入。",
+    "totalLabel": "总收入"
+  },
+  "creditUtilizationAccounts": {
+    "title": "按账户信用额度使用率",
+    "empty": "没有设置额度的信用账户。",
+    "utilization": "使用率",
+    "used": "已用"
+  },
+  "creditUtilizationTotal": {
+    "title": "总信用额度使用率",
+    "empty": "没有设置额度的信用账户。",
+    "used": "已用",
+    "available": "可用"
+  },
+  "sectorWeightings": {
+    "title": "行业配置",
+    "empty": "暂无行业数据。",
+    "direct": "直接",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "证券类型配置",
+    "empty": "无持仓可显示。",
+    "types": {
+      "STOCK": "股票",
+      "ETF": "ETF",
+      "MUTUAL_FUND": "共同基金",
+      "BOND": "债券",
+      "CASH": "现金"
+    }
+  },
+  "geographicAllocation": {
+    "title": "地理配置",
+    "empty": "无持仓可显示。",
+    "viewRegion": "地区",
+    "viewExchange": "交易所",
+    "viewCountry": "国家/地区"
+  },
+  "recurringExpenses": {
+    "title": "主要定期支出",
+    "empty": "未找到定期支出。",
+    "minOccurrences": "最少发生次数",
+    "minOccurrencesOption": "{count} 次或以上",
+    "occurrences": "发生 {count} 次",
+    "monthlyEstimate": "月度估算"
+  },
+  "weekendVsWeekday": {
+    "title": "周末与工作日支出",
+    "empty": "此期间无支出。",
+    "weekendLabel": "周末",
+    "weekdayLabel": "工作日",
+    "viewOverview": "概览",
+    "viewByDay": "按日"
   }
 }

--- a/frontend/src/i18n/messages/zh-TW/dashboard.json
+++ b/frontend/src/i18n/messages/zh-TW/dashboard.json
@@ -154,5 +154,96 @@
     "title": "我的最愛報表",
     "empty": "尚無我的最愛報表。請在報表頁面為報表加上星號，即可在此顯示。",
     "browseReports": "瀏覽報表"
+  },
+  "widgets": {
+    "configure": "設定{name}",
+    "done": "完成",
+    "configSaveFailed": "無法儲存小工具設定。請再試一次。",
+    "timeframe": "時間範圍",
+    "accounts": "科目",
+    "chartType": "圖表類型",
+    "view": "檢視",
+    "rangeLabels": {
+      "1m": "1M",
+      "3m": "3M",
+      "6m": "6M",
+      "1y": "1Y",
+      "2y": "2Y",
+      "5y": "5Y",
+      "ytd": "YTD",
+      "all": "全部"
+    }
+  },
+  "portfolioValue": {
+    "title": "投資組合價值",
+    "empty": "尚無投資歷史可顯示。"
+  },
+  "spendingByPayee": {
+    "title": "依收款人分析支出",
+    "empty": "此期間無支出。",
+    "totalLabel": "總計"
+  },
+  "monthlySpendingTrend": {
+    "title": "每月支出趨勢",
+    "empty": "此期間無資料。",
+    "expenses": "支出",
+    "income": "收入"
+  },
+  "incomeBySource": {
+    "title": "依來源分析收入",
+    "empty": "此期間無收入。",
+    "totalLabel": "總收入"
+  },
+  "creditUtilizationAccounts": {
+    "title": "依科目信用使用率",
+    "empty": "沒有設定額度的信用科目。",
+    "utilization": "使用率",
+    "used": "已使用"
+  },
+  "creditUtilizationTotal": {
+    "title": "總信用使用率",
+    "empty": "沒有設定額度的信用科目。",
+    "used": "已使用",
+    "available": "可用"
+  },
+  "sectorWeightings": {
+    "title": "類股配置",
+    "empty": "尚無類股資料。",
+    "direct": "直接",
+    "etf": "ETF"
+  },
+  "securityTypeAllocation": {
+    "title": "證券類型配置",
+    "empty": "無持倉可顯示。",
+    "types": {
+      "STOCK": "股票",
+      "ETF": "ETF",
+      "MUTUAL_FUND": "共同基金",
+      "BOND": "債券",
+      "CASH": "現金"
+    }
+  },
+  "geographicAllocation": {
+    "title": "地區配置",
+    "empty": "無持倉可顯示。",
+    "viewRegion": "地區",
+    "viewExchange": "交易所",
+    "viewCountry": "國家/地區"
+  },
+  "recurringExpenses": {
+    "title": "主要固定支出",
+    "empty": "找不到固定支出。",
+    "minOccurrences": "最少出現次數",
+    "minOccurrencesOption": "{count} 次或以上",
+    "occurrences": "出現 {count} 次",
+    "monthlyEstimate": "每月估計"
+  },
+  "weekendVsWeekday": {
+    "title": "假日與平日支出",
+    "empty": "此期間無支出。",
+    "weekendLabel": "假日",
+    "weekdayLabel": "平日",
+    "viewOverview": "概覽",
+    "viewByDay": "依星期幾"
   }
 }

--- a/frontend/src/lib/credit-utilization.test.ts
+++ b/frontend/src/lib/credit-utilization.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { Account } from '@/types/account';
+import { chartColors } from '@/lib/chart-colors';
+import {
+  isCreditAccount,
+  utilizationColour,
+  computeCreditRows,
+  computeCreditTotals,
+} from './credit-utilization';
+
+const account = (overrides: Partial<Account>): Account =>
+  ({
+    id: 'a1',
+    name: 'Card',
+    accountType: 'CREDIT_CARD',
+    accountSubType: 'NONE',
+    currencyCode: 'USD',
+    currentBalance: -500,
+    creditLimit: 2000,
+    isClosed: false,
+    ...overrides,
+  }) as Account;
+
+// Identity converter for tests (no FX).
+const noConvert = (v: number) => v;
+
+describe('isCreditAccount', () => {
+  it('accepts credit cards and lines of credit with a positive limit', () => {
+    expect(isCreditAccount(account({}))).toBe(true);
+    expect(isCreditAccount(account({ accountType: 'LINE_OF_CREDIT' }))).toBe(true);
+  });
+
+  it('rejects non-credit account types', () => {
+    expect(isCreditAccount(account({ accountType: 'CHECKING' }))).toBe(false);
+  });
+
+  it('rejects accounts without a positive limit', () => {
+    expect(isCreditAccount(account({ creditLimit: 0 }))).toBe(false);
+    expect(isCreditAccount(account({ creditLimit: null }))).toBe(false);
+  });
+
+  it('rejects closed accounts', () => {
+    expect(isCreditAccount(account({ isClosed: true }))).toBe(false);
+  });
+});
+
+describe('utilizationColour', () => {
+  it('maps thresholds to income/warning/expense colours', () => {
+    expect(utilizationColour(10)).toBe(chartColors.income);
+    expect(utilizationColour(50)).toBe(chartColors.warning);
+    expect(utilizationColour(90)).toBe(chartColors.expense);
+    expect(utilizationColour(30)).toBe(chartColors.warning);
+    expect(utilizationColour(75)).toBe(chartColors.expense);
+  });
+});
+
+describe('computeCreditRows', () => {
+  it('derives used/available/utilization from balance magnitude', () => {
+    const rows = computeCreditRows([account({})], noConvert, 'USD');
+    expect(rows[0]).toMatchObject({
+      limit: 2000,
+      used: 500,
+      available: 1500,
+      utilizationPercent: 25,
+    });
+  });
+
+  it('treats a zero limit as zero utilization without dividing by zero', () => {
+    const rows = computeCreditRows(
+      [account({ creditLimit: 0, currentBalance: -100 })],
+      noConvert,
+      'USD',
+    );
+    expect(rows[0].utilizationPercent).toBe(0);
+  });
+});
+
+describe('computeCreditTotals', () => {
+  it('sums rows and computes overall utilization', () => {
+    const rows = computeCreditRows(
+      [
+        account({ id: 'a', creditLimit: 1000, currentBalance: -500 }),
+        account({ id: 'b', creditLimit: 1000, currentBalance: -100 }),
+      ],
+      noConvert,
+      'USD',
+    );
+    const totals = computeCreditTotals(rows);
+    expect(totals).toEqual({
+      limit: 2000,
+      used: 600,
+      available: 1400,
+      utilizationPercent: 30,
+    });
+  });
+
+  it('returns zero utilization for an empty set', () => {
+    expect(computeCreditTotals([])).toEqual({
+      limit: 0,
+      used: 0,
+      available: 0,
+      utilizationPercent: 0,
+    });
+  });
+});

--- a/frontend/src/lib/credit-utilization.test.ts
+++ b/frontend/src/lib/credit-utilization.test.ts
@@ -19,7 +19,7 @@ const account = (overrides: Partial<Account>): Account =>
     creditLimit: 2000,
     isClosed: false,
     ...overrides,
-  }) as Account;
+  }) as unknown as Account;
 
 // Identity converter for tests (no FX).
 const noConvert = (v: number) => v;
@@ -31,7 +31,7 @@ describe('isCreditAccount', () => {
   });
 
   it('rejects non-credit account types', () => {
-    expect(isCreditAccount(account({ accountType: 'CHECKING' }))).toBe(false);
+    expect(isCreditAccount(account({ accountType: 'CHEQUING' }))).toBe(false);
   });
 
   it('rejects accounts without a positive limit', () => {

--- a/frontend/src/lib/credit-utilization.ts
+++ b/frontend/src/lib/credit-utilization.ts
@@ -1,0 +1,83 @@
+import { Account } from '@/types/account';
+import { chartColors } from '@/lib/chart-colors';
+
+/**
+ * Only credit cards and lines of credit with a positive credit limit have a
+ * meaningful utilization figure (used / available credit). Shared by the Credit
+ * Utilization report and its dashboard widgets.
+ */
+export const isCreditAccount = (account: Account): boolean =>
+  (account.accountType === 'CREDIT_CARD' || account.accountType === 'LINE_OF_CREDIT') &&
+  account.creditLimit != null &&
+  account.creditLimit > 0 &&
+  !account.isClosed;
+
+/**
+ * Utilization thresholds drive the colour: low (green), moderate (amber), high
+ * (red). 30% / 75% mirror the common "keep utilization under 30%" guidance.
+ */
+export function utilizationColour(percent: number): string {
+  if (percent >= 75) return chartColors.expense;
+  if (percent >= 30) return chartColors.warning;
+  return chartColors.income;
+}
+
+export interface CreditUtilizationRow {
+  id: string;
+  name: string;
+  accountType: Account['accountType'];
+  currencyCode: string;
+  limit: number;
+  used: number;
+  available: number;
+  utilizationPercent: number;
+}
+
+export interface CreditUtilizationTotals {
+  limit: number;
+  used: number;
+  available: number;
+  utilizationPercent: number;
+}
+
+/**
+ * Per-account utilization rows, all amounts converted into `displayCurrency`.
+ * Liability balances are stored negative when money is owed, so the magnitude
+ * of the balance is the amount drawn.
+ */
+export function computeCreditRows(
+  accounts: Account[],
+  convert: (value: number, from: string, to: string) => number,
+  displayCurrency: string,
+): CreditUtilizationRow[] {
+  return accounts.map((account) => {
+    const limitNative = Number(account.creditLimit) || 0;
+    const usedNative = Math.abs(Number(account.currentBalance) || 0);
+    const availableNative = limitNative - usedNative;
+    const utilizationPercent = limitNative > 0 ? (usedNative / limitNative) * 100 : 0;
+    return {
+      id: account.id,
+      name: account.name,
+      accountType: account.accountType,
+      currencyCode: account.currencyCode,
+      limit: convert(limitNative, account.currencyCode, displayCurrency),
+      used: convert(usedNative, account.currencyCode, displayCurrency),
+      available: convert(availableNative, account.currencyCode, displayCurrency),
+      utilizationPercent,
+    };
+  });
+}
+
+export function computeCreditTotals(
+  rows: CreditUtilizationRow[],
+): CreditUtilizationTotals {
+  const limit = rows.reduce((sum, r) => sum + r.limit, 0);
+  const used = rows.reduce((sum, r) => sum + r.used, 0);
+  const available = rows.reduce((sum, r) => sum + r.available, 0);
+  return {
+    limit,
+    used,
+    available,
+    utilizationPercent: limit > 0 ? (used / limit) * 100 : 0,
+  };
+}

--- a/frontend/src/lib/date-range.test.ts
+++ b/frontend/src/lib/date-range.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { resolveRangePreset } from './date-range';
+
+// Fixed reference date so presets resolve deterministically.
+const NOW = new Date('2026-07-07T12:00:00Z');
+
+describe('resolveRangePreset', () => {
+  it('always ends at today', () => {
+    expect(resolveRangePreset('3m', { now: NOW }).end).toBe('2026-07-07');
+    expect(resolveRangePreset('all', { now: NOW }).end).toBe('2026-07-07');
+  });
+
+  it('resolves ytd to Jan 1 of the current year', () => {
+    expect(resolveRangePreset('ytd', { now: NOW }).start).toBe('2026-01-01');
+  });
+
+  it('resolves all to an empty start (no lower bound)', () => {
+    expect(resolveRangePreset('all', { now: NOW }).start).toBe('');
+  });
+
+  it('resolves 3m to 90 days before now', () => {
+    expect(resolveRangePreset('3m', { now: NOW }).start).toBe('2026-04-08');
+  });
+
+  it('resolves 1y to one year before now', () => {
+    expect(resolveRangePreset('1y', { now: NOW }).start).toBe('2025-07-07');
+  });
+
+  it('snaps 6m start to the month start under month alignment', () => {
+    expect(resolveRangePreset('6m', { now: NOW, alignment: 'month' }).start).toBe('2026-02-01');
+    // Day alignment keeps the exact calendar offset.
+    expect(resolveRangePreset('6m', { now: NOW, alignment: 'day' }).start).toBe('2026-01-07');
+  });
+
+  it('passes through custom start/end', () => {
+    const r = resolveRangePreset('custom', {
+      now: NOW,
+      startDate: '2024-01-01',
+      endDate: '2024-06-30',
+    });
+    expect(r).toEqual({ start: '2024-01-01', end: '2024-06-30' });
+  });
+
+  it('falls back to a 3-month window for unknown presets', () => {
+    expect(resolveRangePreset('bogus', { now: NOW }).start).toBe('2026-04-07');
+  });
+});

--- a/frontend/src/lib/date-range.ts
+++ b/frontend/src/lib/date-range.ts
@@ -1,0 +1,93 @@
+import {
+  format,
+  subMonths,
+  subDays,
+  subYears,
+  subWeeks,
+  startOfMonth,
+} from 'date-fns';
+
+export type DateRangeAlignment = 'day' | 'month';
+
+export interface ResolveRangeOptions {
+  /** Whether the start boundary snaps to the start of the month. Default 'day'. */
+  alignment?: DateRangeAlignment;
+  /** Custom start date (YYYY-MM-DD); only used when range === 'custom'. */
+  startDate?: string;
+  /** Custom end date (YYYY-MM-DD); only used when range === 'custom'. */
+  endDate?: string;
+  /** Injectable "now" for deterministic tests. Defaults to the current date. */
+  now?: Date;
+}
+
+/**
+ * Resolve a preset range key (e.g. '3m', '1y', 'ytd', 'all', 'custom') into a
+ * concrete { start, end } pair. Extracted from useDateRange so config-driven
+ * consumers (dashboard widgets) can resolve a stored range without the hook's
+ * localStorage/state machinery. End date is always today, matching the reports:
+ * data only exists up to today, so snapping to end-of-month just produced a
+ * flat-line tail. Month alignment affects the start date only.
+ */
+export function resolveRangePreset(
+  range: string,
+  options: ResolveRangeOptions = {},
+): { start: string; end: string } {
+  const { alignment = 'day', startDate = '', endDate = '', now = new Date() } =
+    options;
+
+  if (range === 'custom') {
+    return { start: startDate, end: endDate };
+  }
+
+  const isMonth = alignment === 'month';
+  const end = format(now, 'yyyy-MM-dd');
+
+  let start: string;
+
+  switch (range) {
+    case '1d':
+      // '1d' is an intraday-only preset; when a chart falls back to daily
+      // snapshots a single day is one point, so widen to a week.
+      start = format(subWeeks(now, 1), 'yyyy-MM-dd');
+      break;
+    case '1w':
+      start = format(subWeeks(now, 1), 'yyyy-MM-dd');
+      break;
+    case 'mtd':
+      start = format(startOfMonth(now), 'yyyy-MM-dd');
+      break;
+    case '1m':
+      start = format(subDays(now, 30), 'yyyy-MM-dd');
+      break;
+    case '3m':
+      start = format(subDays(now, 90), 'yyyy-MM-dd');
+      break;
+    case '6m':
+      start = isMonth
+        ? format(startOfMonth(subMonths(now, 5)), 'yyyy-MM-dd')
+        : format(subMonths(now, 6), 'yyyy-MM-dd');
+      break;
+    case '1y':
+      start = format(subYears(now, 1), 'yyyy-MM-dd');
+      break;
+    case '2y':
+      // Rolling 2 years = last 730 days; same shape regardless of alignment.
+      start = format(subDays(now, 730), 'yyyy-MM-dd');
+      break;
+    case '5y':
+      start = isMonth
+        ? format(startOfMonth(subMonths(now, 59)), 'yyyy-MM-dd')
+        : format(subYears(now, 5), 'yyyy-MM-dd');
+      break;
+    case 'ytd':
+      start = `${now.getFullYear()}-01-01`;
+      break;
+    case 'all':
+      start = '';
+      break;
+    default:
+      start = format(subMonths(now, 3), 'yyyy-MM-dd');
+  }
+
+  return { start, end };
+}

--- a/frontend/src/lib/geographic-allocation.test.ts
+++ b/frontend/src/lib/geographic-allocation.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { HoldingWithMarketValue } from '@/types/investment';
+import {
+  computeGeographicAllocation,
+  EXCHANGE_TO_REGION,
+  REGION_COLOURS,
+} from './geographic-allocation';
+
+const holding = (
+  securityId: string,
+  marketValue: number,
+): HoldingWithMarketValue =>
+  ({
+    securityId,
+    marketValue,
+    currencyCode: 'USD',
+  }) as HoldingWithMarketValue;
+
+const noConvert = (v: number) => v;
+
+describe('EXCHANGE_TO_REGION', () => {
+  it('maps known exchanges to their region', () => {
+    expect(EXCHANGE_TO_REGION.NYSE.region).toBe('North America');
+    expect(EXCHANGE_TO_REGION.LSE.region).toBe('Europe');
+    expect(EXCHANGE_TO_REGION.TYO.region).toBe('Asia-Pacific');
+  });
+});
+
+describe('computeGeographicAllocation', () => {
+  const exchangeMap = new Map<string, string>([
+    ['s-nyse', 'NYSE'],
+    ['s-tsx', 'TSX'],
+    ['s-lse', 'LSE'],
+  ]);
+
+  it('rolls holdings into exchange and region totals', () => {
+    const holdings = [
+      holding('s-nyse', 100),
+      holding('s-tsx', 300),
+      holding('s-lse', 100),
+    ];
+    const { exchangeData, regionData, totalValue } = computeGeographicAllocation(
+      holdings,
+      exchangeMap,
+      noConvert,
+    );
+
+    expect(totalValue).toBe(500);
+
+    // Exchanges are sorted by market value descending.
+    expect(exchangeData.map((e) => e.exchange)).toEqual(['TSX', 'NYSE', 'LSE']);
+    const tsx = exchangeData.find((e) => e.exchange === 'TSX')!;
+    expect(tsx.marketValue).toBe(300);
+    expect(tsx.percentage).toBeCloseTo(60);
+
+    // North America = NYSE (100) + TSX (300) = 400; Europe = LSE (100).
+    const na = regionData.find((r) => r.region === 'North America')!;
+    expect(na.marketValue).toBe(400);
+    expect(na.count).toBe(2);
+    expect(na.color).toBe(REGION_COLOURS['North America']);
+    expect(regionData.find((r) => r.region === 'Europe')!.marketValue).toBe(100);
+  });
+
+  it('classifies unknown exchanges as Other', () => {
+    const { regionData } = computeGeographicAllocation(
+      [holding('mystery', 50)],
+      new Map(),
+      noConvert,
+    );
+    expect(regionData[0].region).toBe('Other');
+    expect(regionData[0].marketValue).toBe(50);
+  });
+
+  it('returns empty structures and zero total for no holdings', () => {
+    const result = computeGeographicAllocation([], new Map(), noConvert);
+    expect(result).toEqual({ exchangeData: [], regionData: [], totalValue: 0 });
+  });
+});

--- a/frontend/src/lib/geographic-allocation.ts
+++ b/frontend/src/lib/geographic-allocation.ts
@@ -1,0 +1,134 @@
+import { HoldingWithMarketValue } from '@/types/investment';
+import { chartColors, CHART_SERIES } from '@/lib/chart-colors';
+
+export interface ExchangeAllocation {
+  exchange: string;
+  country: string;
+  region: string;
+  count: number;
+  marketValue: number;
+  percentage: number;
+}
+
+export interface RegionAllocation {
+  region: string;
+  marketValue: number;
+  percentage: number;
+  count: number;
+  color: string;
+}
+
+/**
+ * Maps a security's listing exchange to a country and broad geographic region.
+ * Shared by the Geographic Allocation report and its dashboard widget so both
+ * classify holdings identically.
+ */
+export const EXCHANGE_TO_REGION: Record<string, { country: string; region: string }> = {
+  NYSE: { country: 'United States', region: 'North America' },
+  NASDAQ: { country: 'United States', region: 'North America' },
+  NMS: { country: 'United States', region: 'North America' },
+  NYQ: { country: 'United States', region: 'North America' },
+  NYSEARCA: { country: 'United States', region: 'North America' },
+  AMEX: { country: 'United States', region: 'North America' },
+  BATS: { country: 'United States', region: 'North America' },
+  TSX: { country: 'Canada', region: 'North America' },
+  TSXV: { country: 'Canada', region: 'North America' },
+  TOR: { country: 'Canada', region: 'North America' },
+  NEO: { country: 'Canada', region: 'North America' },
+  LSE: { country: 'United Kingdom', region: 'Europe' },
+  LON: { country: 'United Kingdom', region: 'Europe' },
+  FRA: { country: 'Germany', region: 'Europe' },
+  XETRA: { country: 'Germany', region: 'Europe' },
+  PAR: { country: 'France', region: 'Europe' },
+  AMS: { country: 'Netherlands', region: 'Europe' },
+  MIL: { country: 'Italy', region: 'Europe' },
+  STO: { country: 'Sweden', region: 'Europe' },
+  TYO: { country: 'Japan', region: 'Asia-Pacific' },
+  HKG: { country: 'Hong Kong', region: 'Asia-Pacific' },
+  SHA: { country: 'China', region: 'Asia-Pacific' },
+  SHE: { country: 'China', region: 'Asia-Pacific' },
+  ASX: { country: 'Australia', region: 'Asia-Pacific' },
+  KRX: { country: 'South Korea', region: 'Asia-Pacific' },
+  TAI: { country: 'Taiwan', region: 'Asia-Pacific' },
+  SGX: { country: 'Singapore', region: 'Asia-Pacific' },
+  BSE: { country: 'India', region: 'Asia-Pacific' },
+  NSE: { country: 'India', region: 'Asia-Pacific' },
+};
+
+export const REGION_COLOURS: Record<string, string> = {
+  'North America': CHART_SERIES[0],
+  Europe: CHART_SERIES[1],
+  'Asia-Pacific': CHART_SERIES[2],
+  Other: CHART_SERIES[3],
+};
+
+export const COUNTRY_COLOURS = CHART_SERIES;
+
+/**
+ * Roll holdings up into per-exchange and per-region allocations, all converted
+ * into the user's display currency via `convertToDefault`. `securityExchangeMap`
+ * maps securityId -> exchange code (from the securities list).
+ */
+export function computeGeographicAllocation(
+  holdings: HoldingWithMarketValue[],
+  securityExchangeMap: Map<string, string>,
+  convertToDefault: (value: number, currency: string) => number,
+): { exchangeData: ExchangeAllocation[]; regionData: RegionAllocation[]; totalValue: number } {
+  const exchangeMap = new Map<
+    string,
+    { country: string; region: string; count: number; value: number }
+  >();
+
+  holdings.forEach((h) => {
+    const exchange = securityExchangeMap.get(h.securityId) || 'Unknown';
+    const info = EXCHANGE_TO_REGION[exchange] || { country: 'Other', region: 'Other' };
+    const marketValue = convertToDefault(h.marketValue ?? 0, h.currencyCode);
+
+    const existing =
+      exchangeMap.get(exchange) || {
+        country: info.country,
+        region: info.region,
+        count: 0,
+        value: 0,
+      };
+    exchangeMap.set(exchange, {
+      ...existing,
+      count: existing.count + 1,
+      value: existing.value + marketValue,
+    });
+  });
+
+  const total = Array.from(exchangeMap.values()).reduce((sum, v) => sum + v.value, 0);
+
+  const exchangeData: ExchangeAllocation[] = Array.from(exchangeMap.entries())
+    .map(([exchange, data]) => ({
+      exchange,
+      country: data.country,
+      region: data.region,
+      count: data.count,
+      marketValue: data.value,
+      percentage: total > 0 ? (data.value / total) * 100 : 0,
+    }))
+    .sort((a, b) => b.marketValue - a.marketValue);
+
+  const regionMap = new Map<string, { value: number; count: number }>();
+  exchangeData.forEach((e) => {
+    const existing = regionMap.get(e.region) || { value: 0, count: 0 };
+    regionMap.set(e.region, {
+      value: existing.value + e.marketValue,
+      count: existing.count + e.count,
+    });
+  });
+
+  const regionData: RegionAllocation[] = Array.from(regionMap.entries())
+    .map(([region, data]) => ({
+      region,
+      marketValue: data.value,
+      percentage: total > 0 ? (data.value / total) * 100 : 0,
+      count: data.count,
+      color: REGION_COLOURS[region] || chartColors.axis,
+    }))
+    .sort((a, b) => b.marketValue - a.marketValue);
+
+  return { exchangeData, regionData, totalValue: total };
+}

--- a/frontend/src/test/recharts-mock.tsx
+++ b/frontend/src/test/recharts-mock.tsx
@@ -1,0 +1,33 @@
+import { ReactNode } from 'react';
+
+/**
+ * Lightweight Recharts stand-in for widget/chart tests. Recharts'
+ * ResponsiveContainer measures its parent (0x0 in jsdom) and renders nothing,
+ * so tests mock it out. Chart containers pass children through; leaf marks are
+ * no-ops. Use via:
+ *   vi.mock('recharts', async () => (await import('@/test/recharts-mock')).rechartsMock());
+ */
+export function rechartsMock() {
+  const Pass = ({ children }: { children?: ReactNode }) => <div>{children}</div>;
+  const Noop = () => null;
+  return {
+    ResponsiveContainer: ({ children }: { children?: ReactNode }) => (
+      <div data-testid="responsive-container">{children}</div>
+    ),
+    AreaChart: Pass,
+    Area: Noop,
+    LineChart: Pass,
+    Line: Noop,
+    BarChart: Pass,
+    Bar: Noop,
+    PieChart: Pass,
+    Pie: Noop,
+    Cell: Noop,
+    XAxis: Noop,
+    YAxis: Noop,
+    CartesianGrid: Noop,
+    Tooltip: Noop,
+    Legend: Noop,
+    ReferenceLine: Noop,
+  };
+}

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -105,6 +105,7 @@ export interface UserPreferences {
   budgetDigestDay: 'MONDAY' | 'FRIDAY';
   favouriteReportIds: string[];
   dashboardWidgets: string[]; // ordered visible widget ids; empty = default layout
+  dashboardWidgetConfig: Record<string, Record<string, unknown>>; // per-widget settings keyed by widget id
   showCreatedAt: boolean;
   timeFormat: '24h' | '12h';
   preferredExchanges: string[];
@@ -167,6 +168,7 @@ export interface UpdatePreferencesData {
   budgetDigestDay?: 'MONDAY' | 'FRIDAY';
   favouriteReportIds?: string[];
   dashboardWidgets?: string[];
+  dashboardWidgetConfig?: Record<string, Record<string, unknown>>;
   showCreatedAt?: boolean;
   timeFormat?: '24h' | '12h';
   preferredExchanges?: string[];


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: <!-- discussion/issue link -->

## Summary

This PR adds a suite of 11 configurable dashboard widgets that surface key financial analytics from existing reports. Each widget is opt-in, self-fetches from the report APIs, and persists its own settings (timeframe, account selection, chart type) via a new `dashboardWidgetConfig` preference that syncs across devices.

**New widgets:**
- Portfolio Value (area chart, investment accounts, date range)
- Spending by Payee (bar chart, transaction-based, date range)
- Monthly Spending Trend (line chart, income vs. expense, date range)
- Income by Source (pie/bar toggle, date range)
- Sector Weightings (bar chart, investment accounts)
- Geographic Allocation (pie/bar/table toggle, region/country/exchange views, investment accounts)
- Security Type Allocation (pie chart, investment accounts)
- Weekend vs. Weekday (pie/bar toggle, date range)
- Recurring Expenses (pie chart, min occurrence threshold)
- Credit Utilization Total (pie chart, credit accounts)
- Credit Utilization by Account (bar chart, credit accounts)

**Infrastructure:**
- New `useWidgetConfig` hook for persistent per-widget settings with optimistic updates
- New `resolveRangePreset` utility extracted from `useDateRange` for config-driven date range resolution
- New `WidgetCard` shell component with settings modal and gear icon
- New `WidgetSegmentedControl` for mutually exclusive text choices in widget settings
- Shared `geographic-allocation` and `credit-utilization` libraries extracted from existing reports
- Backend validation for `dashboardWidgetConfig` JSONB field with size/key/type bounds
- Database migration and schema updates

All widgets are lazy-loaded to keep them off the default bundle. Settings are validated on the backend and persist to the user's preferences table.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [ ] This PR addresses a **single concern** (large work is split into a series).
- [ ] New behavior has tests, and the existing suite passes.
- [ ] All user-facing strings are translated for **every** locale (i18n parity).
- [ ] No shared/core areas were refactored without prior agreement.
- [ ] The branch is rebased on the latest `main`.
- [ ] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

<!-- Disclose any AI tools used. Using AI is fine and expected — you remain responsible for correctness, conventions, and tests. -->

https://claude.ai/code/session_01PBYDKgDVMrTPpvi1sBMd7f