### PR TITLE
Make dashboard widgets configurable with time ranges and account filters

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Fragment, useState, useEffect, useCallback, useMemo } from 'react';
-import { subMonths, subWeeks, startOfWeek, format } from 'date-fns';
+import { subMonths, format } from 'date-fns';
 import { useOnUndoRedo } from '@/hooks/useOnUndoRedo';
 import { useOnAiAction } from '@/hooks/useOnAiAction';
 import { useTranslations } from 'next-intl';
@@ -15,14 +15,12 @@ import {
   resolveDashboardWidgets,
 } from '@/components/dashboard/widget-registry';
 import { accountsApi } from '@/lib/accounts';
-import { transactionsApi } from '@/lib/transactions';
 import { categoriesApi } from '@/lib/categories';
 import { scheduledTransactionsApi } from '@/lib/scheduled-transactions';
 import { investmentsApi } from '@/lib/investments';
 import { netWorthApi } from '@/lib/net-worth';
 import { invalidateCache } from '@/lib/apiCache';
 import { Account } from '@/types/account';
-import { Transaction } from '@/types/transaction';
 import { Category } from '@/types/category';
 import { ScheduledTransaction } from '@/types/scheduled-transaction';
 import { TopMover, PortfolioSummary, FavouriteSecurityQuote } from '@/types/investment';
@@ -55,11 +53,9 @@ function DashboardContent() {
   // delegate on the owner endpoints (and then re-run with the right
   // path), so wait until the store has hydrated before firing.
   const authHydrated = useAuthStore((s) => s._hasHydrated);
-  const weekStartsOn = (usePreferencesStore((s) => s.preferences?.weekStartsOn) ?? 1) as 0 | 1 | 2 | 3 | 4 | 5 | 6;
   const dashboardWidgets = usePreferencesStore((s) => s.preferences?.dashboardWidgets);
 
   const [accounts, setAccounts] = useState<Account[]>([]);
-  const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [scheduledTransactions, setScheduledTransactions] = useState<ScheduledTransaction[]>([]);
   const [topMovers, setTopMovers] = useState<TopMover[]>([]);
@@ -133,16 +129,12 @@ function DashboardContent() {
       }
 
       const now = new Date();
-      const currentWeekStart = startOfWeek(now, { weekStartsOn });
-      const fiveWeeksAgoStart = subWeeks(currentWeekStart, 4);
-      const chartStartDate = format(fiveWeeksAgoStart, 'yyyy-MM-dd');
       const today = format(now, 'yyyy-MM-dd');
 
       const twelveMonthsAgo = format(subMonths(new Date(), 12), 'yyyy-MM-dd');
 
-      const [accountsData, allTransactions, categoriesData, scheduledData, netWorth, favouriteSecs, securitiesList] = await Promise.all([
+      const [accountsData, categoriesData, scheduledData, netWorth, favouriteSecs, securitiesList] = await Promise.all([
         accountsApi.getAll(),
-        transactionsApi.getAllPages({ startDate: chartStartDate, endDate: today }),
         categoriesApi.getAll(),
         scheduledTransactionsApi.getAll(),
         netWorthApi.getMonthly({ startDate: twelveMonthsAgo, endDate: today }).catch(() => [] as MonthlyNetWorth[]),
@@ -151,7 +143,6 @@ function DashboardContent() {
       ]);
 
       setAccounts(accountsData);
-      setTransactions(allTransactions);
       setCategories(categoriesData);
       setScheduledTransactions(scheduledData);
       setNetWorthData(netWorth);
@@ -180,7 +171,7 @@ function DashboardContent() {
     } finally {
       setIsLoading(false);
     }
-  }, [authHydrated, weekStartsOn, isDelegateView, delegateBills]);
+  }, [authHydrated, isDelegateView, delegateBills]);
 
   useEffect(() => {
     loadDashboardData();
@@ -199,7 +190,6 @@ function DashboardContent() {
 
   const widgetContext: DashboardWidgetContext = {
     accounts,
-    transactions,
     categories,
     scheduledTransactions,
     topMovers,

--- a/frontend/src/app/investments/page.tsx
+++ b/frontend/src/app/investments/page.tsx
@@ -261,7 +261,7 @@ function InvestmentsContent() {
           </div>
 
           {/* Portfolio Value Over Time */}
-          <div className="mb-3">
+          <div className="mb-6">
             <InvestmentValueChart
               accountIds={data.selectedAccountIds}
               displayCurrency={

--- a/frontend/src/components/dashboard/CreditUtilizationAccountsWidget.tsx
+++ b/frontend/src/components/dashboard/CreditUtilizationAccountsWidget.tsx
@@ -87,6 +87,7 @@ export function CreditUtilizationAccountsWidget({
   return (
     <WidgetCard
       title={t('creditUtilizationAccounts.title')}
+      widgetId={WIDGET_ID}
       configControls={creditAccounts.length > 0 ? configControls : undefined}
       configTitle={t('creditUtilizationAccounts.title')}
     >

--- a/frontend/src/components/dashboard/CreditUtilizationTotalWidget.tsx
+++ b/frontend/src/components/dashboard/CreditUtilizationTotalWidget.tsx
@@ -99,6 +99,7 @@ export function CreditUtilizationTotalWidget({
   return (
     <WidgetCard
       title={t('creditUtilizationTotal.title')}
+      widgetId={WIDGET_ID}
       configControls={creditAccounts.length > 0 ? configControls : undefined}
       configTitle={t('creditUtilizationTotal.title')}
     >

--- a/frontend/src/components/dashboard/CustomizeDashboardModal.test.tsx
+++ b/frontend/src/components/dashboard/CustomizeDashboardModal.test.tsx
@@ -287,6 +287,16 @@ describe('CustomizeDashboardModal', () => {
     expect(updatePreferencesMock).toHaveBeenCalledWith({ dashboardWidgets: [] });
   });
 
+  it('shows a widget-type icon in each visible tile and hidden chip', async () => {
+    await renderModal();
+    // Expenses by Category is a pie; Income vs Expenses is a bar chart.
+    expect(within(tile('expenses-pie')).getByTestId('widget-type-icon-pie')).toBeInTheDocument();
+    expect(within(tile('income-expenses')).getByTestId('widget-type-icon-bar')).toBeInTheDocument();
+    // Hidden chips carry their type icon too.
+    const chip = screen.getByTestId('widget-hidden-portfolio-value');
+    expect(within(chip).getByTestId('widget-type-icon-line')).toBeInTheDocument();
+  });
+
   it('every registered widget appears exactly once (tile or hidden chip)', async () => {
     await renderModal();
     for (const w of DASHBOARD_WIDGETS) {

--- a/frontend/src/components/dashboard/CustomizeDashboardModal.tsx
+++ b/frontend/src/components/dashboard/CustomizeDashboardModal.tsx
@@ -13,12 +13,78 @@ import {
   DASHBOARD_WIDGETS,
   DEFAULT_DASHBOARD_WIDGET_IDS,
   DashboardWidgetId,
+  WidgetIconType,
   resolveDashboardWidgets,
 } from './widget-registry';
 
 interface CustomizeDashboardModalProps {
   isOpen: boolean;
   onClose: () => void;
+}
+
+/**
+ * Small glyph hinting at the kind of visualization a widget renders (bar, line,
+ * pie, table, or list), so users can tell widgets apart at a glance in the
+ * layout picker.
+ */
+function WidgetTypeIcon({ type }: { type: WidgetIconType }) {
+  const common = {
+    className: 'h-4 w-4 text-gray-400 dark:text-gray-500 flex-shrink-0',
+    fill: 'none',
+    viewBox: '0 0 24 24',
+    stroke: 'currentColor',
+    strokeWidth: 2,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    'aria-hidden': true,
+    'data-testid': `widget-type-icon-${type}`,
+  };
+  switch (type) {
+    case 'bar':
+      return (
+        <svg {...common}>
+          <path d="M3 21h18" />
+          <path d="M6 21v-7" />
+          <path d="M12 21V5" />
+          <path d="M18 21v-11" />
+        </svg>
+      );
+    case 'line':
+      return (
+        <svg {...common}>
+          <path d="M3 21h18" />
+          <path d="M4 15l5-5 4 3 7-8" />
+        </svg>
+      );
+    case 'pie':
+      return (
+        <svg {...common}>
+          <path d="M10.5 6a7.5 7.5 0 107.5 7.5h-7.5V6Z" />
+          <path d="M13.5 10.5H21A7.5 7.5 0 0013.5 3v7.5Z" />
+        </svg>
+      );
+    case 'table':
+      return (
+        <svg {...common}>
+          <rect x="3.5" y="5.5" width="17" height="13" rx="1.5" />
+          <path d="M3.5 10.5h17" />
+          <path d="M3.5 14.5h17" />
+          <path d="M9.5 5.5v13" />
+        </svg>
+      );
+    case 'list':
+    default:
+      return (
+        <svg {...common}>
+          <path d="M8 6.5h12" />
+          <path d="M8 12h12" />
+          <path d="M8 17.5h12" />
+          <path d="M4 6.5h.01" />
+          <path d="M4 12h.01" />
+          <path d="M4 17.5h.01" />
+        </svg>
+      );
+  }
 }
 
 export function CustomizeDashboardModal({ isOpen, onClose }: CustomizeDashboardModalProps) {
@@ -46,6 +112,9 @@ export function CustomizeDashboardModal({ isOpen, onClose }: CustomizeDashboardM
     const section = DASHBOARD_WIDGETS.find((w) => w.id === id)!.titleSection;
     return t(`${section}.title` as Parameters<typeof t>[0]);
   };
+
+  const widgetIcon = (id: DashboardWidgetId): WidgetIconType =>
+    DASHBOARD_WIDGETS.find((w) => w.id === id)!.iconType;
 
   const moveWidget = (from: number, to: number) => {
     setVisible((prev) => {
@@ -92,7 +161,7 @@ export function CustomizeDashboardModal({ isOpen, onClose }: CustomizeDashboardM
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} maxWidth="2xl" className="p-3 sm:p-6" pushHistory>
+    <Modal isOpen={isOpen} onClose={onClose} maxWidth="4xl" className="p-4 sm:p-8" pushHistory>
       <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">
         {t('customize.title')}
       </h3>
@@ -117,6 +186,7 @@ export function CustomizeDashboardModal({ isOpen, onClose }: CustomizeDashboardM
               <span aria-hidden="true" className="select-none text-gray-400 flex-shrink-0">
                 ⠿
               </span>
+              <WidgetTypeIcon type={widgetIcon(id)} />
               <span className="flex-1 min-w-0 truncate text-sm text-gray-900 dark:text-gray-100">
                 {widgetName(id)}
               </span>
@@ -191,6 +261,7 @@ export function CustomizeDashboardModal({ isOpen, onClose }: CustomizeDashboardM
                 <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
                 </svg>
+                <WidgetTypeIcon type={widgetIcon(id)} />
                 {widgetName(id)}
               </button>
             ))}

--- a/frontend/src/components/dashboard/ExpensesPieChart.test.tsx
+++ b/frontend/src/components/dashboard/ExpensesPieChart.test.tsx
@@ -1,10 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@/test/render';
+import { act, render, screen, fireEvent, waitFor } from '@/test/render';
 import { ExpensesPieChart } from './ExpensesPieChart';
 
 const mockPush = vi.fn();
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
+}));
+
+const mockGetAllPages = vi.fn();
+vi.mock('@/lib/transactions', () => ({
+  transactionsApi: {
+    getAllPages: (...args: any[]) => mockGetAllPages(...args),
+  },
+}));
+
+// Fixed config so the widget renders deterministically; WidgetCard reads the
+// same hook for its identity overrides (none here).
+const mockUpdateConfig = vi.fn();
+vi.mock('@/hooks/useWidgetConfig', () => ({
+  useWidgetConfig: () => ({
+    config: { range: '1m', accountIds: [] },
+    updateConfig: mockUpdateConfig,
+  }),
 }));
 
 vi.mock('recharts', () => ({
@@ -37,26 +54,44 @@ vi.mock('@/lib/chart-colours', () => ({
   CHART_COLOURS: ['#3b82f6', '#ef4444', '#22c55e', '#f59e0b', '#8b5cf6'],
 }));
 
+async function renderChart(transactions: any[], categories: any[] = [], isLoading = false) {
+  mockGetAllPages.mockResolvedValue(transactions);
+  let result: ReturnType<typeof render>;
+  await act(async () => {
+    result = render(
+      <ExpensesPieChart accounts={[]} categories={categories} isLoading={isLoading} />,
+    );
+  });
+  return result!;
+}
+
 describe('ExpensesPieChart', () => {
   beforeEach(() => {
     mockPush.mockClear();
+    mockGetAllPages.mockReset();
   });
 
-  it('renders loading state with title and pulse animation', () => {
-    render(<ExpensesPieChart transactions={[]} categories={[]} isLoading={true} />);
+  it('renders loading state with title and pulse animation', async () => {
+    await renderChart([], [], true);
     expect(screen.getByText('Expenses by Category')).toBeInTheDocument();
     expect(document.querySelector('.animate-pulse')).toBeInTheDocument();
     expect(screen.queryByTestId('pie-chart')).not.toBeInTheDocument();
   });
 
-  it('renders empty state when no expenses', () => {
-    render(<ExpensesPieChart transactions={[]} categories={[]} isLoading={false} />);
-    expect(screen.getByText('Expenses by Category')).toBeInTheDocument();
-    expect(screen.getByText('No expense data for this period.')).toBeInTheDocument();
+  it('renders the selected timeframe label', async () => {
+    await renderChart([]);
+    expect(screen.getByText('1M')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no expenses', async () => {
+    await renderChart([]);
+    await waitFor(() => {
+      expect(screen.getByText('No expense data for this period.')).toBeInTheDocument();
+    });
     expect(screen.queryByTestId('pie-chart')).not.toBeInTheDocument();
   });
 
-  it('renders chart with expense data and category legend', () => {
+  it('renders chart with expense data and category legend', async () => {
     const transactions = [
       {
         id: '1', amount: -50, categoryId: 'cat1',
@@ -68,68 +103,57 @@ describe('ExpensesPieChart', () => {
         category: { id: 'cat2', name: 'Transport', color: '#3b82f6' },
         currencyCode: 'CAD', isTransfer: false, isSplit: false, transactionDate: '2024-01-16',
       },
-    ] as any[];
+    ];
     const categories = [
       { id: 'cat1', name: 'Food', color: '#ef4444' },
       { id: 'cat2', name: 'Transport', color: '#3b82f6' },
-    ] as any[];
+    ];
 
-    render(<ExpensesPieChart transactions={transactions} categories={categories} isLoading={false} />);
-    expect(screen.getByText('Expenses by Category')).toBeInTheDocument();
-    expect(screen.getByText('Past 30 days')).toBeInTheDocument();
-    expect(screen.getByTestId('pie-chart')).toBeInTheDocument();
-    // Category names appear in the legend grid
+    await renderChart(transactions, categories);
+    await waitFor(() => expect(screen.getByTestId('pie-chart')).toBeInTheDocument());
     const legendButtons = screen.getAllByRole('button');
-    const foodLegend = legendButtons.find(b => b.textContent?.includes('Food'));
-    const transportLegend = legendButtons.find(b => b.textContent?.includes('Transport'));
-    expect(foodLegend).toBeTruthy();
-    expect(transportLegend).toBeTruthy();
+    expect(legendButtons.some((b) => b.textContent?.includes('Food'))).toBe(true);
+    expect(legendButtons.some((b) => b.textContent?.includes('Transport'))).toBe(true);
   });
 
-  it('shows total expenses amount', () => {
+  it('shows total expenses amount', async () => {
     const transactions = [
       {
         id: '1', amount: -100, categoryId: 'cat1',
         category: { id: 'cat1', name: 'Food', color: '#ef4444' },
         currencyCode: 'CAD', isTransfer: false, isSplit: false, transactionDate: '2024-01-15',
       },
-    ] as any[];
-    const categories = [{ id: 'cat1', name: 'Food', color: '#ef4444' }] as any[];
-
-    render(<ExpensesPieChart transactions={transactions} categories={categories} isLoading={false} />);
-    expect(screen.getByText('Total')).toBeInTheDocument();
+    ];
+    await renderChart(transactions, [{ id: 'cat1', name: 'Food', color: '#ef4444' }]);
+    await waitFor(() => expect(screen.getByText('Total')).toBeInTheDocument());
     expect(screen.getByText('$100.00')).toBeInTheDocument();
   });
 
-  it('skips transfer transactions', () => {
+  it('skips transfer transactions', async () => {
     const transactions = [
       {
         id: '1', amount: -50, categoryId: 'cat1',
         category: { id: 'cat1', name: 'Food', color: '#ef4444' },
         currencyCode: 'CAD', isTransfer: true, isSplit: false, transactionDate: '2024-01-15',
       },
-    ] as any[];
-    const categories = [{ id: 'cat1', name: 'Food', color: '#ef4444' }] as any[];
-
-    render(<ExpensesPieChart transactions={transactions} categories={categories} isLoading={false} />);
-    expect(screen.getByText('No expense data for this period.')).toBeInTheDocument();
+    ];
+    await renderChart(transactions, [{ id: 'cat1', name: 'Food', color: '#ef4444' }]);
+    await waitFor(() => expect(screen.getByText('No expense data for this period.')).toBeInTheDocument());
   });
 
-  it('skips positive amounts (income)', () => {
+  it('skips positive amounts (income)', async () => {
     const transactions = [
       {
         id: '1', amount: 100, categoryId: 'cat1',
         category: { id: 'cat1', name: 'Salary', color: '#22c55e' },
         currencyCode: 'CAD', isTransfer: false, isSplit: false, transactionDate: '2024-01-15',
       },
-    ] as any[];
-    const categories = [{ id: 'cat1', name: 'Salary', color: '#22c55e' }] as any[];
-
-    render(<ExpensesPieChart transactions={transactions} categories={categories} isLoading={false} />);
-    expect(screen.getByText('No expense data for this period.')).toBeInTheDocument();
+    ];
+    await renderChart(transactions, [{ id: 'cat1', name: 'Salary', color: '#22c55e' }]);
+    await waitFor(() => expect(screen.getByText('No expense data for this period.')).toBeInTheDocument());
   });
 
-  it('skips investment account transactions', () => {
+  it('skips investment account transactions', async () => {
     const transactions = [
       {
         id: '1', amount: -50, categoryId: 'cat1',
@@ -137,27 +161,26 @@ describe('ExpensesPieChart', () => {
         account: { accountType: 'INVESTMENT' },
         currencyCode: 'CAD', isTransfer: false, isSplit: false, transactionDate: '2024-01-15',
       },
-    ] as any[];
-    const categories = [{ id: 'cat1', name: 'Food', color: '#ef4444' }] as any[];
-
-    render(<ExpensesPieChart transactions={transactions} categories={categories} isLoading={false} />);
-    expect(screen.getByText('No expense data for this period.')).toBeInTheDocument();
+    ];
+    await renderChart(transactions, [{ id: 'cat1', name: 'Food', color: '#ef4444' }]);
+    await waitFor(() => expect(screen.getByText('No expense data for this period.')).toBeInTheDocument());
   });
 
-  it('groups uncategorized expenses', () => {
+  it('groups uncategorized expenses', async () => {
     const transactions = [
       {
         id: '1', amount: -75, categoryId: null, category: null,
         currencyCode: 'CAD', isTransfer: false, isSplit: false, transactionDate: '2024-01-15',
       },
-    ] as any[];
-
-    render(<ExpensesPieChart transactions={transactions} categories={[]} isLoading={false} />);
-    const legendButtons = screen.getAllByRole('button');
-    expect(legendButtons.some(b => b.textContent?.includes('Uncategorized'))).toBe(true);
+    ];
+    await renderChart(transactions);
+    await waitFor(() => {
+      const legendButtons = screen.getAllByRole('button');
+      expect(legendButtons.some((b) => b.textContent?.includes('Uncategorized'))).toBe(true);
+    });
   });
 
-  it('handles split transactions', () => {
+  it('handles split transactions', async () => {
     const transactions = [
       {
         id: '1', amount: -100, categoryId: null, category: null,
@@ -168,54 +191,35 @@ describe('ExpensesPieChart', () => {
         ],
         transactionDate: '2024-01-15',
       },
-    ] as any[];
+    ];
     const categories = [
       { id: 'cat1', name: 'Food', color: '#ef4444' },
       { id: 'cat2', name: 'Drinks', color: '#3b82f6' },
-    ] as any[];
-
-    render(<ExpensesPieChart transactions={transactions} categories={categories} isLoading={false} />);
-    const legendButtons = screen.getAllByRole('button');
-    expect(legendButtons.some(b => b.textContent?.includes('Food'))).toBe(true);
-    expect(legendButtons.some(b => b.textContent?.includes('Drinks'))).toBe(true);
+    ];
+    await renderChart(transactions, categories);
+    await waitFor(() => {
+      const legendButtons = screen.getAllByRole('button');
+      expect(legendButtons.some((b) => b.textContent?.includes('Food'))).toBe(true);
+      expect(legendButtons.some((b) => b.textContent?.includes('Drinks'))).toBe(true);
+    });
   });
 
-  it('navigates to category transactions on pie click', () => {
+  it('navigates to category transactions on pie click', async () => {
     const transactions = [
       {
         id: '1', amount: -50, categoryId: 'cat1',
         category: { id: 'cat1', name: 'Food', color: '#ef4444' },
         currencyCode: 'CAD', isTransfer: false, isSplit: false, transactionDate: '2024-01-15',
       },
-    ] as any[];
-    const categories = [{ id: 'cat1', name: 'Food', color: '#ef4444' }] as any[];
-
-    render(<ExpensesPieChart transactions={transactions} categories={categories} isLoading={false} />);
+    ];
+    await renderChart(transactions, [{ id: 'cat1', name: 'Food', color: '#ef4444' }]);
+    await waitFor(() => expect(screen.getByTestId('pie-slice-Food')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('pie-slice-Food'));
     expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('/transactions?categoryIds=cat1&startDate='));
-    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('&endDate='));
+    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('endDate='));
   });
 
-  it('navigates on legend button click', () => {
-    const transactions = [
-      {
-        id: '1', amount: -50, categoryId: 'cat1',
-        category: { id: 'cat1', name: 'Food', color: '#ef4444' },
-        currencyCode: 'CAD', isTransfer: false, isSplit: false, transactionDate: '2024-01-15',
-      },
-    ] as any[];
-    const categories = [{ id: 'cat1', name: 'Food', color: '#ef4444' }] as any[];
-
-    render(<ExpensesPieChart transactions={transactions} categories={categories} isLoading={false} />);
-    // The legend buttons in the grid below the chart
-    const legendButtons = screen.getAllByRole('button');
-    const foodButton = legendButtons.find(b => b.textContent?.includes('Food'));
-    if (foodButton) fireEvent.click(foodButton);
-    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('/transactions?categoryIds=cat1&startDate='));
-    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('&endDate='));
-  });
-
-  it('aggregates multiple transactions in the same category', () => {
+  it('aggregates multiple transactions in the same category', async () => {
     const transactions = [
       {
         id: '1', amount: -50, categoryId: 'cat1',
@@ -227,31 +231,26 @@ describe('ExpensesPieChart', () => {
         category: { id: 'cat1', name: 'Food', color: '#ef4444' },
         currencyCode: 'CAD', isTransfer: false, isSplit: false, transactionDate: '2024-01-16',
       },
-    ] as any[];
-    const categories = [{ id: 'cat1', name: 'Food', color: '#ef4444' }] as any[];
-
-    render(<ExpensesPieChart transactions={transactions} categories={categories} isLoading={false} />);
-    expect(screen.getByText('$75.00')).toBeInTheDocument();
+    ];
+    await renderChart(transactions, [{ id: 'cat1', name: 'Food', color: '#ef4444' }]);
+    await waitFor(() => expect(screen.getByText('$75.00')).toBeInTheDocument());
   });
 
-  it('assigns chart colours to categories without a colour', () => {
+  it('assigns chart colours to categories without a colour', async () => {
     const transactions = [
       {
         id: '1', amount: -50, categoryId: 'cat1',
         category: { id: 'cat1', name: 'Food', color: null },
         currencyCode: 'CAD', isTransfer: false, isSplit: false, transactionDate: '2024-01-15',
       },
-    ] as any[];
-    const categories = [{ id: 'cat1', name: 'Food', color: null }] as any[];
-
-    render(<ExpensesPieChart transactions={transactions} categories={categories} isLoading={false} />);
-    // Should still render the chart without errors
-    expect(screen.getByTestId('pie-chart')).toBeInTheDocument();
+    ];
+    await renderChart(transactions, [{ id: 'cat1', name: 'Food', color: null }]);
+    await waitFor(() => expect(screen.getByTestId('pie-chart')).toBeInTheDocument());
     const legendButtons = screen.getAllByRole('button');
-    expect(legendButtons.some(b => b.textContent?.includes('Food'))).toBe(true);
+    expect(legendButtons.some((b) => b.textContent?.includes('Food'))).toBe(true);
   });
 
-  it('handles split transaction with uncategorized split (no transferAccountId)', () => {
+  it('handles split transaction with uncategorized split (no transferAccountId)', async () => {
     const transactions = [
       {
         id: '1', amount: -100, categoryId: null, category: null,
@@ -262,12 +261,12 @@ describe('ExpensesPieChart', () => {
         ],
         transactionDate: '2024-01-15',
       },
-    ] as any[];
-    const categories = [{ id: 'cat1', name: 'Food', color: '#ef4444' }] as any[];
-
-    render(<ExpensesPieChart transactions={transactions} categories={categories} isLoading={false} />);
-    const legendButtons = screen.getAllByRole('button');
-    expect(legendButtons.some(b => b.textContent?.includes('Food'))).toBe(true);
-    expect(legendButtons.some(b => b.textContent?.includes('Uncategorized'))).toBe(true);
+    ];
+    await renderChart(transactions, [{ id: 'cat1', name: 'Food', color: '#ef4444' }]);
+    await waitFor(() => {
+      const legendButtons = screen.getAllByRole('button');
+      expect(legendButtons.some((b) => b.textContent?.includes('Food'))).toBe(true);
+      expect(legendButtons.some((b) => b.textContent?.includes('Uncategorized'))).toBe(true);
+    });
   });
 });

--- a/frontend/src/components/dashboard/ExpensesPieChart.tsx
+++ b/frontend/src/components/dashboard/ExpensesPieChart.tsx
@@ -4,22 +4,36 @@ import { useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
-import { format, subDays } from 'date-fns';
-import { Transaction } from '@/types/transaction';
+import { Account } from '@/types/account';
 import { Category } from '@/types/category';
+import { transactionsApi } from '@/lib/transactions';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
+import { useReportData } from '@/hooks/useReportData';
+import { useWidgetConfig } from '@/hooks/useWidgetConfig';
+import { resolveRangePreset } from '@/lib/date-range';
 import { CHART_COLOURS } from '@/lib/chart-colours';
+import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { WidgetCard, WidgetConfigRow, WidgetMessage } from './WidgetCard';
+import {
+  EXPENSES_PIE_DEFAULT,
+  SPENDING_RANGES,
+  RangeAccountsConfig,
+} from './widget-config';
+
+const WIDGET_ID = 'expenses-pie';
+
+const nonInvestmentAccounts = (a: Account) => a.accountType !== 'INVESTMENT';
 
 interface ExpensesPieChartProps {
-  transactions: Transaction[];
+  accounts: Account[];
   categories: Category[];
   isLoading: boolean;
 }
 
-
 export function ExpensesPieChart({
-  transactions,
+  accounts,
   categories,
   isLoading,
 }: ExpensesPieChartProps) {
@@ -27,6 +41,23 @@ export function ExpensesPieChart({
   const router = useRouter();
   const { formatCurrencyCompact: formatCurrency } = useNumberFormat();
   const { convertToDefault } = useExchangeRates();
+  const { config, updateConfig } = useWidgetConfig<RangeAccountsConfig>(
+    WIDGET_ID,
+    EXPENSES_PIE_DEFAULT,
+  );
+
+  const { start, end } = useMemo(() => resolveRangePreset(config.range), [config.range]);
+  const accountIdsKey = config.accountIds.join(',');
+
+  const { data: transactions, isLoading: dataLoading } = useReportData(
+    () =>
+      transactionsApi.getAllPages({
+        startDate: start || undefined,
+        endDate: end,
+        accountIds: config.accountIds.length > 0 ? config.accountIds : undefined,
+      }),
+    [start, end, accountIdsKey],
+  );
 
   // Calculate spending by category
   const chartData = useMemo(() => {
@@ -36,7 +67,7 @@ export function ExpensesPieChart({
     // Build category lookup
     const categoryLookup = new Map(categories.map((c) => [c.id, c]));
 
-    transactions.forEach((tx) => {
+    (transactions ?? []).forEach((tx) => {
       // Skip transfers and investment account transactions
       if (tx.isTransfer) return;
       if (tx.account?.accountType === 'INVESTMENT') return;
@@ -133,9 +164,10 @@ export function ExpensesPieChart({
 
   const handleCategoryClick = (categoryId: string) => {
     if (categoryId) {
-      const startDate = format(subDays(new Date(), 30), 'yyyy-MM-dd');
-      const endDate = format(new Date(), 'yyyy-MM-dd');
-      router.push(`/transactions?categoryIds=${categoryId}&startDate=${startDate}&endDate=${endDate}`);
+      const params = new URLSearchParams({ categoryIds: categoryId });
+      if (start) params.set('startDate', start);
+      params.set('endDate', end);
+      router.push(`/transactions?${params.toString()}`);
     }
   };
 
@@ -155,84 +187,96 @@ export function ExpensesPieChart({
     return null;
   };
 
-  if (isLoading) {
-    return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6 lg:min-h-[540px]">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-          {t('expensesPieChart.title')}
-        </h3>
+  const configControls = (
+    <>
+      <WidgetConfigRow label={t('widgets.timeframe')}>
+        <DateRangeSelector
+          ranges={SPENDING_RANGES}
+          value={config.range}
+          onChange={(range) => updateConfig({ range })}
+          size="sm"
+        />
+      </WidgetConfigRow>
+      <WidgetConfigRow label={t('widgets.accounts')}>
+        <ReportAccountMultiSelect
+          accounts={accounts}
+          value={config.accountIds}
+          onChange={(accountIds) => updateConfig({ accountIds })}
+          filter={nonInvestmentAccounts}
+          className="w-full"
+        />
+      </WidgetConfigRow>
+    </>
+  );
+
+  const loading = isLoading || dataLoading;
+
+  return (
+    <WidgetCard
+      title={t('expensesPieChart.title')}
+      widgetId={WIDGET_ID}
+      configTitle={t('expensesPieChart.title')}
+      configControls={configControls}
+      headerRight={
+        <span className="text-sm text-gray-500 dark:text-gray-400">
+          {t(`widgets.rangeLabels.${config.range}` as Parameters<typeof t>[0])}
+        </span>
+      }
+    >
+      {loading ? (
         <div className="h-64 flex items-center justify-center">
           <div className="animate-pulse w-48 h-48 rounded-full bg-gray-200 dark:bg-gray-700" />
         </div>
-      </div>
-    );
-  }
-
-  if (chartData.length === 0) {
-    return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6 lg:min-h-[540px]">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-          {t('expensesPieChart.title')}
-        </h3>
-        <p className="text-gray-500 dark:text-gray-400 text-sm">
-          {t('expensesPieChart.empty')}
-        </p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-6 lg:min-h-[540px] flex flex-col h-full">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-          {t('expensesPieChart.title')}
-        </h3>
-        <span className="text-sm text-gray-500 dark:text-gray-400">{t('expensesPieChart.past30Days')}</span>
-      </div>
-      <div className="h-64">
-        <ResponsiveContainer width="100%" height="100%" minWidth={0}>
-          <PieChart>
-            <Pie
-              data={chartData}
-              cx="50%"
-              cy="50%"
-              innerRadius={50}
-              outerRadius={80}
-              paddingAngle={2}
-              dataKey="value"
-              cursor="pointer"
-              onClick={(data) => data.id && handleCategoryClick(data.id)}
-            >
-              {chartData.map((entry, index) => (
-                <Cell key={`cell-${index}`} fill={entry.colour} />
-              ))}
-            </Pie>
-            <Tooltip content={<CustomTooltip />} />
-          </PieChart>
-        </ResponsiveContainer>
-      </div>
-      <div className="mt-4 grid grid-cols-2 sm:grid-cols-3 gap-x-3 gap-y-1.5">
-        {chartData.map((item, index) => (
-          <button
-            key={index}
-            onClick={() => handleCategoryClick(item.id)}
-            className={`flex items-center gap-2 text-sm text-left ${item.id ? 'hover:underline cursor-pointer' : ''}`}
-            disabled={!item.id}
-          >
-            <div
-              className="w-3 h-3 rounded-full flex-shrink-0"
-              style={{ backgroundColor: item.colour }}
-            />
-            <span className="text-gray-600 dark:text-gray-400 truncate">{item.name}</span>
-          </button>
-        ))}
-      </div>
-      <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700 text-center flex-shrink-0">
-        <div className="text-sm text-gray-500 dark:text-gray-400">{t('expensesPieChart.total')}</div>
-        <div className="font-semibold text-gray-900 dark:text-gray-100">
-          {formatCurrency(totalExpenses)}
-        </div>
-      </div>
-    </div>
+      ) : chartData.length === 0 ? (
+        <WidgetMessage>{t('expensesPieChart.empty')}</WidgetMessage>
+      ) : (
+        <>
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+              <PieChart>
+                <Pie
+                  data={chartData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={50}
+                  outerRadius={80}
+                  paddingAngle={2}
+                  dataKey="value"
+                  cursor="pointer"
+                  onClick={(data) => data.id && handleCategoryClick(data.id)}
+                >
+                  {chartData.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={entry.colour} />
+                  ))}
+                </Pie>
+                <Tooltip content={<CustomTooltip />} />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="mt-4 grid grid-cols-2 sm:grid-cols-3 gap-x-3 gap-y-1.5">
+            {chartData.map((item, index) => (
+              <button
+                key={index}
+                onClick={() => handleCategoryClick(item.id)}
+                className={`flex items-center gap-2 text-sm text-left ${item.id ? 'hover:underline cursor-pointer' : ''}`}
+                disabled={!item.id}
+              >
+                <div
+                  className="w-3 h-3 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: item.colour }}
+                />
+                <span className="text-gray-600 dark:text-gray-400 truncate">{item.name}</span>
+              </button>
+            ))}
+          </div>
+          <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700 text-center flex-shrink-0">
+            <div className="text-sm text-gray-500 dark:text-gray-400">{t('expensesPieChart.total')}</div>
+            <div className="font-semibold text-gray-900 dark:text-gray-100">
+              {formatCurrency(totalExpenses)}
+            </div>
+          </div>
+        </>
+      )}
+    </WidgetCard>
   );
 }

--- a/frontend/src/components/dashboard/GeographicAllocationWidget.tsx
+++ b/frontend/src/components/dashboard/GeographicAllocationWidget.tsx
@@ -175,6 +175,7 @@ export function GeographicAllocationWidget({
   return (
     <WidgetCard
       title={t('geographicAllocation.title')}
+      widgetId={WIDGET_ID}
       configControls={configControls}
       configTitle={t('geographicAllocation.title')}
     >

--- a/frontend/src/components/dashboard/IncomeBySourceWidget.tsx
+++ b/frontend/src/components/dashboard/IncomeBySourceWidget.tsx
@@ -127,6 +127,7 @@ export function IncomeBySourceWidget({ isLoading }: IncomeBySourceWidgetProps) {
   return (
     <WidgetCard
       title={t('incomeBySource.title')}
+      widgetId={WIDGET_ID}
       configControls={configControls}
       configTitle={t('incomeBySource.title')}
     >

--- a/frontend/src/components/dashboard/IncomeExpensesBarChart.test.tsx
+++ b/frontend/src/components/dashboard/IncomeExpensesBarChart.test.tsx
@@ -1,10 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@/test/render';
+import { act, render, screen, fireEvent, waitFor } from '@/test/render';
 import { IncomeExpensesBarChart } from './IncomeExpensesBarChart';
 
 const mockPush = vi.fn();
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
+}));
+
+const mockGetAllPages = vi.fn();
+vi.mock('@/lib/transactions', () => ({
+  transactionsApi: {
+    getAllPages: (...args: any[]) => mockGetAllPages(...args),
+  },
+}));
+
+const mockUpdateConfig = vi.fn();
+vi.mock('@/hooks/useWidgetConfig', () => ({
+  useWidgetConfig: () => ({
+    config: { range: '1m', accountIds: [] },
+    updateConfig: mockUpdateConfig,
+  }),
 }));
 
 vi.mock('recharts', () => ({
@@ -22,6 +37,10 @@ vi.mock('recharts', () => ({
 
 vi.mock('@/hooks/useDateFormat', () => ({
   useDateFormat: () => ({ formatDate: (d: any) => typeof d === 'string' ? d : d.toISOString().slice(0, 10) }),
+}));
+
+vi.mock('@/hooks/useChartDateFormat', () => ({
+  useChartDateFormat: () => (d: any) => typeof d === 'string' ? d : d.toISOString().slice(0, 7),
 }));
 
 vi.mock('@/hooks/useNumberFormat', () => ({
@@ -46,264 +65,174 @@ vi.mock('@/store/preferencesStore', () => ({
   usePreferencesStore: vi.fn((selector: any) => selector({ preferences: { weekStartsOn: 1 } })),
 }));
 
+const todayStr = () => {
+  const today = new Date();
+  return `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+};
+
+async function renderChart(transactions: any[], isLoading = false) {
+  mockGetAllPages.mockResolvedValue(transactions);
+  let result: ReturnType<typeof render>;
+  await act(async () => {
+    result = render(<IncomeExpensesBarChart accounts={[]} isLoading={isLoading} />);
+  });
+  return result!;
+}
+
 describe('IncomeExpensesBarChart', () => {
   beforeEach(() => {
     mockPush.mockClear();
+    mockGetAllPages.mockReset();
   });
 
-  it('renders loading state with title and pulse animation', () => {
-    render(<IncomeExpensesBarChart transactions={[]} isLoading={true} />);
+  it('renders loading state with title and pulse animation', async () => {
+    await renderChart([], true);
     expect(screen.getByText('Income vs Expenses')).toBeInTheDocument();
     expect(document.querySelector('.animate-pulse')).toBeInTheDocument();
     expect(screen.queryByTestId('bar-chart')).not.toBeInTheDocument();
   });
 
-  it('renders chart title and date range when not loading', () => {
-    render(<IncomeExpensesBarChart transactions={[]} isLoading={false} />);
+  it('renders chart title and timeframe label when not loading', async () => {
+    await renderChart([]);
+    await waitFor(() => expect(screen.getByTestId('bar-chart')).toBeInTheDocument());
     expect(screen.getByText('Income vs Expenses')).toBeInTheDocument();
-    expect(screen.getByText('Last 5 weeks')).toBeInTheDocument();
-    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+    expect(screen.getByText('1M')).toBeInTheDocument();
   });
 
-  it('shows income, expenses, and net totals in footer', () => {
-    render(<IncomeExpensesBarChart transactions={[]} isLoading={false} />);
+  it('shows income, expenses, and net totals in footer', async () => {
+    await renderChart([]);
+    await waitFor(() => expect(screen.getByTestId('bar-chart')).toBeInTheDocument());
     expect(screen.getByText('Income')).toBeInTheDocument();
     expect(screen.getByText('Expenses')).toBeInTheDocument();
     expect(screen.getByText('Net')).toBeInTheDocument();
   });
 
-  it('calculates income and expenses from transactions', () => {
-    const today = new Date();
-    const dateStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-
+  it('calculates income and expenses from transactions', async () => {
+    const dateStr = todayStr();
     const transactions = [
-      {
-        id: '1', amount: 500, currencyCode: 'CAD', isTransfer: false,
-        transactionDate: dateStr,
-      },
-      {
-        id: '2', amount: -200, currencyCode: 'CAD', isTransfer: false,
-        transactionDate: dateStr,
-      },
-    ] as any[];
-
-    render(<IncomeExpensesBarChart transactions={transactions} isLoading={false} />);
-    // Net = 500 - 200 = 300
-    expect(screen.getByText('$500')).toBeInTheDocument();
+      { id: '1', amount: 500, currencyCode: 'CAD', isTransfer: false, transactionDate: dateStr },
+      { id: '2', amount: -200, currencyCode: 'CAD', isTransfer: false, transactionDate: dateStr },
+    ];
+    await renderChart(transactions);
+    await waitFor(() => expect(screen.getByText('$500')).toBeInTheDocument());
     expect(screen.getByText('$200')).toBeInTheDocument();
     expect(screen.getByText('$300')).toBeInTheDocument();
   });
 
-  it('skips transfer transactions', () => {
-    const today = new Date();
-    const dateStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-
+  it('skips transfer transactions', async () => {
     const transactions = [
-      {
-        id: '1', amount: -100, currencyCode: 'CAD', isTransfer: true,
-        transactionDate: dateStr,
-      },
-    ] as any[];
-
-    render(<IncomeExpensesBarChart transactions={transactions} isLoading={false} />);
-    // All values should be zero since transfer is skipped
-    const zeroValues = screen.getAllByText('$0');
-    expect(zeroValues.length).toBe(3);
+      { id: '1', amount: -100, currencyCode: 'CAD', isTransfer: true, transactionDate: todayStr() },
+    ];
+    await renderChart(transactions);
+    await waitFor(() => expect(screen.getByTestId('bar-chart')).toBeInTheDocument());
+    expect(screen.getAllByText('$0').length).toBe(3);
   });
 
-  it('skips investment account transactions', () => {
-    const today = new Date();
-    const dateStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-
+  it('skips investment account transactions', async () => {
+    const dateStr = todayStr();
     const transactions = [
-      {
-        id: '1', amount: -500, currencyCode: 'CAD', isTransfer: false,
-        transactionDate: dateStr,
-        account: { accountType: 'INVESTMENT' },
-      },
-      {
-        id: '2', amount: 1000, currencyCode: 'CAD', isTransfer: false,
-        transactionDate: dateStr,
-        account: { accountType: 'INVESTMENT' },
-      },
-    ] as any[];
-
-    render(<IncomeExpensesBarChart transactions={transactions} isLoading={false} />);
-    // All values should be zero since investment transactions are skipped
-    const zeroValues = screen.getAllByText('$0');
-    expect(zeroValues.length).toBe(3);
+      { id: '1', amount: -500, currencyCode: 'CAD', isTransfer: false, transactionDate: dateStr, account: { accountType: 'INVESTMENT' } },
+      { id: '2', amount: 1000, currencyCode: 'CAD', isTransfer: false, transactionDate: dateStr, account: { accountType: 'INVESTMENT' } },
+    ];
+    await renderChart(transactions);
+    await waitFor(() => expect(screen.getByTestId('bar-chart')).toBeInTheDocument());
+    expect(screen.getAllByText('$0').length).toBe(3);
   });
 
-  it('includes non-investment account transactions', () => {
-    const today = new Date();
-    const dateStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-
+  it('includes non-investment account transactions', async () => {
+    const dateStr = todayStr();
     const transactions = [
-      {
-        id: '1', amount: -300, currencyCode: 'CAD', isTransfer: false,
-        transactionDate: dateStr,
-        account: { accountType: 'CHECKING' },
-      },
-      {
-        id: '2', amount: -200, currencyCode: 'CAD', isTransfer: false,
-        transactionDate: dateStr,
-        account: { accountType: 'INVESTMENT' },
-      },
-    ] as any[];
-
-    render(<IncomeExpensesBarChart transactions={transactions} isLoading={false} />);
-    // Only the CHECKING transaction ($300 expense) should be counted
-    expect(screen.getByText('$300')).toBeInTheDocument();
+      { id: '1', amount: -300, currencyCode: 'CAD', isTransfer: false, transactionDate: dateStr, account: { accountType: 'CHECKING' } },
+      { id: '2', amount: -200, currencyCode: 'CAD', isTransfer: false, transactionDate: dateStr, account: { accountType: 'INVESTMENT' } },
+    ];
+    await renderChart(transactions);
+    await waitFor(() => expect(screen.getByText('$300')).toBeInTheDocument());
   });
 
-  it('applies green color class for positive net', () => {
-    const today = new Date();
-    const dateStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-
+  it('applies green color class for positive net', async () => {
     const transactions = [
-      { id: '1', amount: 1000, currencyCode: 'CAD', isTransfer: false, transactionDate: dateStr },
-    ] as any[];
-
-    render(<IncomeExpensesBarChart transactions={transactions} isLoading={false} />);
-    // Income = $1000, Expenses = $0, Net = $1000
-    // $1000 appears twice (Income and Net), both green
-    const amountEls = screen.getAllByText('$1000');
-    expect(amountEls.length).toBe(2);
-    // Both should have green text styling
-    amountEls.forEach(el => {
+      { id: '1', amount: 1000, currencyCode: 'CAD', isTransfer: false, transactionDate: todayStr() },
+    ];
+    await renderChart(transactions);
+    await waitFor(() => expect(screen.getAllByText('$1000').length).toBe(2));
+    screen.getAllByText('$1000').forEach((el) => {
       expect(el.className).toContain('text-green');
     });
   });
 
-  it('renders responsive container with bar chart', () => {
-    render(<IncomeExpensesBarChart transactions={[]} isLoading={false} />);
-    expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
-    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
-  });
-
-  it('classifies by category isIncome instead of amount sign', () => {
-    const today = new Date();
-    const dateStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-
+  it('classifies by category isIncome instead of amount sign', async () => {
+    const dateStr = todayStr();
     const transactions = [
-      {
-        id: '1', amount: 5000, currencyCode: 'CAD', isTransfer: false,
-        transactionDate: dateStr,
-        category: { isIncome: true },
-      },
-      {
-        id: '2', amount: -500, currencyCode: 'CAD', isTransfer: false,
-        transactionDate: dateStr,
-        category: { isIncome: false },
-      },
-    ] as any[];
-
-    render(<IncomeExpensesBarChart transactions={transactions} isLoading={false} />);
-    expect(screen.getByText('$5000')).toBeInTheDocument();
+      { id: '1', amount: 5000, currencyCode: 'CAD', isTransfer: false, transactionDate: dateStr, category: { isIncome: true } },
+      { id: '2', amount: -500, currencyCode: 'CAD', isTransfer: false, transactionDate: dateStr, category: { isIncome: false } },
+    ];
+    await renderChart(transactions);
+    await waitFor(() => expect(screen.getByText('$5000')).toBeInTheDocument());
     expect(screen.getByText('$500')).toBeInTheDocument();
     expect(screen.getByText('$4500')).toBeInTheDocument();
   });
 
-  it('counts expense refunds as reducing expenses', () => {
-    const today = new Date();
-    const dateStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-
+  it('counts expense refunds as reducing expenses', async () => {
+    const dateStr = todayStr();
     const transactions = [
-      {
-        id: '1', amount: -500, currencyCode: 'CAD', isTransfer: false,
-        transactionDate: dateStr,
-        category: { isIncome: false },
-      },
-      {
-        id: '2', amount: 400, currencyCode: 'CAD', isTransfer: false,
-        transactionDate: dateStr,
-        category: { isIncome: false },
-      },
-    ] as any[];
-
-    render(<IncomeExpensesBarChart transactions={transactions} isLoading={false} />);
-    // Net expense: 500 - 400 = 100
-    expect(screen.getByText('$100')).toBeInTheDocument();
+      { id: '1', amount: -500, currencyCode: 'CAD', isTransfer: false, transactionDate: dateStr, category: { isIncome: false } },
+      { id: '2', amount: 400, currencyCode: 'CAD', isTransfer: false, transactionDate: dateStr, category: { isIncome: false } },
+    ];
+    await renderChart(transactions);
+    await waitFor(() => expect(screen.getByText('$100')).toBeInTheDocument());
   });
 
-  it('classifies split transactions by split category', () => {
-    const today = new Date();
-    const dateStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-
+  it('classifies split transactions by split category', async () => {
     const transactions = [
       {
-        id: '1', amount: 1000, currencyCode: 'CAD', isTransfer: false,
-        transactionDate: dateStr,
-        category: null,
+        id: '1', amount: 1000, currencyCode: 'CAD', isTransfer: false, transactionDate: todayStr(), category: null,
         splits: [
           { id: 's1', amount: 700, category: { isIncome: true }, transferAccountId: null },
           { id: 's2', amount: 300, category: { isIncome: false }, transferAccountId: null },
         ],
       },
-    ] as any[];
-
-    render(<IncomeExpensesBarChart transactions={transactions} isLoading={false} />);
-    // Income: 700 from income split
-    // Expenses: -300 (positive amount on expense category reduces expenses, so -300)
-    // But since expenses can't go below 0 in display, net = 700 - (-300) = 1000
-    expect(screen.getByText('$700')).toBeInTheDocument();
+    ];
+    await renderChart(transactions);
+    await waitFor(() => expect(screen.getByText('$700')).toBeInTheDocument());
   });
 
-  it('skips transfer splits in split transactions', () => {
-    const today = new Date();
-    const dateStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-
+  it('skips transfer splits in split transactions', async () => {
     const transactions = [
       {
-        id: '1', amount: 1000, currencyCode: 'CAD', isTransfer: false,
-        transactionDate: dateStr,
-        category: null,
+        id: '1', amount: 1000, currencyCode: 'CAD', isTransfer: false, transactionDate: todayStr(), category: null,
         splits: [
           { id: 's1', amount: 600, category: { isIncome: true }, transferAccountId: null },
           { id: 's2', amount: 400, category: { isIncome: true }, transferAccountId: 'acc-123' },
         ],
       },
-    ] as any[];
-
-    render(<IncomeExpensesBarChart transactions={transactions} isLoading={false} />);
-    // Only s1 counted (600 income), s2 skipped due to transferAccountId
-    // $600 appears twice (Income and Net), expenses should be $0
-    const amountEls = screen.getAllByText('$600');
-    expect(amountEls.length).toBe(2);
+    ];
+    await renderChart(transactions);
+    await waitFor(() => expect(screen.getAllByText('$600').length).toBe(2));
     expect(screen.getByText('$0')).toBeInTheDocument();
   });
 
-  it('falls back to sign-based for uncategorized transactions', () => {
-    const today = new Date();
-    const dateStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-
+  it('falls back to sign-based for uncategorized transactions', async () => {
+    const dateStr = todayStr();
     const transactions = [
-      {
-        id: '1', amount: 300, currencyCode: 'CAD', isTransfer: false,
-        transactionDate: dateStr,
-        category: null,
-      },
-      {
-        id: '2', amount: -100, currencyCode: 'CAD', isTransfer: false,
-        transactionDate: dateStr,
-        category: null,
-      },
-    ] as any[];
-
-    render(<IncomeExpensesBarChart transactions={transactions} isLoading={false} />);
-    expect(screen.getByText('$300')).toBeInTheDocument();
+      { id: '1', amount: 300, currencyCode: 'CAD', isTransfer: false, transactionDate: dateStr, category: null },
+      { id: '2', amount: -100, currencyCode: 'CAD', isTransfer: false, transactionDate: dateStr, category: null },
+    ];
+    await renderChart(transactions);
+    await waitFor(() => expect(screen.getByText('$300')).toBeInTheDocument());
     expect(screen.getByText('$100')).toBeInTheDocument();
     expect(screen.getByText('$200')).toBeInTheDocument();
   });
 
-  it('navigates to transactions page with income filter on Income bar click', () => {
-    render(<IncomeExpensesBarChart transactions={[]} isLoading={false} />);
+  it('navigates to transactions page with income filter on Income bar click', async () => {
+    await renderChart([]);
+    await waitFor(() => expect(screen.getByTestId('bar-Income')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('bar-Income'));
     expect(mockPush).toHaveBeenCalledWith('/transactions?startDate=2026-02-17&endDate=2026-02-23&categoryType=income');
   });
 
-  it('navigates to transactions page with expense filter on Expenses bar click', () => {
-    render(<IncomeExpensesBarChart transactions={[]} isLoading={false} />);
+  it('navigates to transactions page with expense filter on Expenses bar click', async () => {
+    await renderChart([]);
+    await waitFor(() => expect(screen.getByTestId('bar-Expenses')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('bar-Expenses'));
     expect(mockPush).toHaveBeenCalledWith('/transactions?startDate=2026-02-17&endDate=2026-02-23&categoryType=expense');
   });

--- a/frontend/src/components/dashboard/IncomeExpensesBarChart.tsx
+++ b/frontend/src/components/dashboard/IncomeExpensesBarChart.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useRef } from 'react';
 import { gainLossColor } from '@/lib/format';
-import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import {
@@ -15,33 +14,62 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
-import { format, startOfWeek, endOfWeek, eachWeekOfInterval, subWeeks } from 'date-fns';
+import {
+  format,
+  startOfWeek,
+  endOfWeek,
+  eachWeekOfInterval,
+  startOfMonth,
+  endOfMonth,
+  eachMonthOfInterval,
+} from 'date-fns';
 import { chartColors } from '@/lib/chart-colors';
-import { Transaction } from '@/types/transaction';
+import { Account } from '@/types/account';
 import { parseLocalDate } from '@/lib/utils';
+import { transactionsApi } from '@/lib/transactions';
 import { useDateFormat } from '@/hooks/useDateFormat';
+import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useExchangeRates } from '@/hooks/useExchangeRates';
+import { useReportData } from '@/hooks/useReportData';
+import { useWidgetConfig } from '@/hooks/useWidgetConfig';
 import { usePreferencesStore } from '@/store/preferencesStore';
+import { resolveRangePreset } from '@/lib/date-range';
+import { DateRangeSelector } from '@/components/ui/DateRangeSelector';
+import { ReportAccountMultiSelect } from '@/components/reports/ReportAccountMultiSelect';
+import { WidgetCard, WidgetConfigRow } from './WidgetCard';
+import {
+  INCOME_EXPENSES_DEFAULT,
+  SPENDING_RANGES,
+  RangeAccountsConfig,
+} from './widget-config';
+
+const WIDGET_ID = 'income-expenses';
+
+// The recent-weeks view stays weekly; longer windows switch to monthly buckets
+// so a year does not render 52 bars in a compact card.
+const WEEKLY_RANGE = '1m';
+
+const nonInvestmentAccounts = (a: Account) => a.accountType !== 'INVESTMENT';
 
 function IncomeExpensesTooltip({
   active,
   payload,
   label,
   formatCurrency,
-  weekOfLabel,
+  periodLabel,
 }: {
   active?: boolean;
   payload?: Array<{ name: string; value: number; color: string }>;
   label?: string;
   formatCurrency: (v: number) => string;
-  weekOfLabel: (date: string) => string;
+  periodLabel: (label: string) => string;
 }) {
   if (active && payload && payload.length) {
     return (
       <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3">
         <p className="font-medium text-gray-900 dark:text-gray-100 mb-1">
-          {weekOfLabel(label ?? '')}
+          {periodLabel(label ?? '')}
         </p>
         {payload.map((entry, index) => (
           <p
@@ -59,93 +87,116 @@ function IncomeExpensesTooltip({
 }
 
 interface IncomeExpensesBarChartProps {
-  transactions: Transaction[];
+  accounts: Account[];
   isLoading: boolean;
 }
 
 export function IncomeExpensesBarChart({
-  transactions,
+  accounts,
   isLoading,
 }: IncomeExpensesBarChartProps) {
   const t = useTranslations('dashboard');
   const router = useRouter();
   const { formatDate } = useDateFormat();
+  const formatChartDate = useChartDateFormat();
   const { formatCurrencyCompact: formatCurrency, formatCurrencyAxis } = useNumberFormat();
   const { convertToDefault } = useExchangeRates();
   const weekStartsOn = (usePreferencesStore((s) => s.preferences?.weekStartsOn) ?? 1) as 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  const { config, updateConfig } = useWidgetConfig<RangeAccountsConfig>(
+    WIDGET_ID,
+    INCOME_EXPENSES_DEFAULT,
+  );
 
-  // Group transactions by week and calculate income/expenses
+  const isWeekly = config.range === WEEKLY_RANGE;
+  const { start, end } = useMemo(
+    () => resolveRangePreset(config.range, { alignment: isWeekly ? 'day' : 'month' }),
+    [config.range, isWeekly],
+  );
+  const accountIdsKey = config.accountIds.join(',');
+
+  const { data: transactions, isLoading: dataLoading } = useReportData(
+    () =>
+      transactionsApi.getAllPages({
+        startDate: start || undefined,
+        endDate: end,
+        accountIds: config.accountIds.length > 0 ? config.accountIds : undefined,
+      }),
+    [start, end, accountIdsKey],
+  );
+
+  // Group transactions into weekly (recent) or monthly (longer) buckets and
+  // split each bucket's activity into income and expenses.
   const chartData = useMemo(() => {
-    const today = new Date();
-    const currentWeekStart = startOfWeek(today, { weekStartsOn });
-    const fiveWeeksAgoStart = subWeeks(currentWeekStart, 4);
+    const txns = transactions ?? [];
+    const startDate = start ? parseLocalDate(start) : parseLocalDate(end);
+    const endDate = parseLocalDate(end);
 
-    // Get 5 weeks: 4 complete past weeks + current partial week
-    const weeks = eachWeekOfInterval(
-      { start: fiveWeeksAgoStart, end: today },
-      { weekStartsOn }
-    );
+    const buckets = isWeekly
+      ? eachWeekOfInterval(
+          { start: startOfWeek(startDate, { weekStartsOn }), end: endDate },
+          { weekStartsOn },
+        ).map((bucketStart) => ({
+          bucketStart,
+          bucketEnd: endOfWeek(bucketStart, { weekStartsOn }),
+          label: formatDate(bucketStart),
+          income: 0,
+          expenses: 0,
+        }))
+      : eachMonthOfInterval({ start: startOfMonth(startDate), end: endDate }).map(
+          (bucketStart) => ({
+            bucketStart,
+            bucketEnd: endOfMonth(bucketStart),
+            label: formatChartDate(bucketStart, 'MMM yyyy'),
+            income: 0,
+            expenses: 0,
+          }),
+        );
 
-    const weekData = weeks.map((weekStart) => {
-      const weekEnd = endOfWeek(weekStart, { weekStartsOn });
-      return {
-        weekStart,
-        weekEnd,
-        label: formatDate(weekStart),
-        income: 0,
-        expenses: 0,
-      };
-    });
-
-    // Aggregate transactions by week
-    transactions.forEach((tx) => {
+    txns.forEach((tx) => {
       // Skip transfers and investment account transactions
       if (tx.isTransfer) return;
       if (tx.account?.accountType === 'INVESTMENT') return;
 
       const txDate = parseLocalDate(tx.transactionDate);
-      const txWeekStart = startOfWeek(txDate, { weekStartsOn });
-
-      const weekBucket = weekData.find(
-        (w) => w.weekStart.getTime() === txWeekStart.getTime()
+      const bucket = buckets.find(
+        (b) => txDate >= b.bucketStart && txDate <= b.bucketEnd,
       );
+      if (!bucket) return;
 
-      if (weekBucket) {
-        const classifyAmount = (rawAmount: number, category: { isIncome: boolean } | null | undefined) => {
-          const amount = convertToDefault(rawAmount, tx.currencyCode);
-          if (category?.isIncome === true) {
-            weekBucket.income += amount;
-          } else if (category?.isIncome === false) {
-            weekBucket.expenses += -1 * amount;
-          } else {
-            // Uncategorized: fall back to sign-based
-            if (amount >= 0) {
-              weekBucket.income += amount;
-            } else {
-              weekBucket.expenses += Math.abs(amount);
-            }
-          }
-        };
-
-        if (tx.splits && tx.splits.length > 0) {
-          tx.splits.forEach((split) => {
-            if (split.transferAccountId) return;
-            classifyAmount(Number(split.amount) || 0, split.category);
-          });
+      const classifyAmount = (rawAmount: number, category: { isIncome: boolean } | null | undefined) => {
+        const amount = convertToDefault(rawAmount, tx.currencyCode);
+        if (category?.isIncome === true) {
+          bucket.income += amount;
+        } else if (category?.isIncome === false) {
+          bucket.expenses += -1 * amount;
         } else {
-          classifyAmount(Number(tx.amount) || 0, tx.category);
+          // Uncategorized: fall back to sign-based
+          if (amount >= 0) {
+            bucket.income += amount;
+          } else {
+            bucket.expenses += Math.abs(amount);
+          }
         }
+      };
+
+      if (tx.splits && tx.splits.length > 0) {
+        tx.splits.forEach((split) => {
+          if (split.transferAccountId) return;
+          classifyAmount(Number(split.amount) || 0, split.category);
+        });
+      } else {
+        classifyAmount(Number(tx.amount) || 0, tx.category);
       }
     });
 
-    return weekData.map((w) => ({
-      name: w.label,
-      Income: Math.round(w.income),
-      Expenses: Math.round(w.expenses),
-      startDate: format(w.weekStart, 'yyyy-MM-dd'),
-      endDate: format(w.weekEnd, 'yyyy-MM-dd'),
+    return buckets.map((b) => ({
+      name: b.label,
+      Income: Math.round(b.income),
+      Expenses: Math.round(b.expenses),
+      startDate: format(b.bucketStart, 'yyyy-MM-dd'),
+      endDate: format(b.bucketEnd, 'yyyy-MM-dd'),
     }));
-  }, [transactions, formatDate, convertToDefault, weekStartsOn]);
+  }, [transactions, start, end, isWeekly, formatDate, formatChartDate, convertToDefault, weekStartsOn]);
 
   const barClickedRef = useRef(false);
 
@@ -173,105 +224,126 @@ export function IncomeExpensesBarChart({
 
   const totals = useMemo(() => {
     return chartData.reduce(
-      (acc, week) => ({
-        income: acc.income + week.Income,
-        expenses: acc.expenses + week.Expenses,
+      (acc, bucket) => ({
+        income: acc.income + bucket.Income,
+        expenses: acc.expenses + bucket.Expenses,
       }),
       { income: 0, expenses: 0 }
     );
   }, [chartData]);
 
-  if (isLoading) {
-    return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[540px]">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-          {t('incomeExpenses.title')}
-        </h3>
-        <div className="h-64 flex items-center justify-center">
-          <Skeleton className="w-full h-full" />
-        </div>
-      </div>
-    );
-  }
+  const configControls = (
+    <>
+      <WidgetConfigRow label={t('widgets.timeframe')}>
+        <DateRangeSelector
+          ranges={SPENDING_RANGES}
+          value={config.range}
+          onChange={(range) => updateConfig({ range })}
+          size="sm"
+        />
+      </WidgetConfigRow>
+      <WidgetConfigRow label={t('widgets.accounts')}>
+        <ReportAccountMultiSelect
+          accounts={accounts}
+          value={config.accountIds}
+          onChange={(accountIds) => updateConfig({ accountIds })}
+          filter={nonInvestmentAccounts}
+          className="w-full"
+        />
+      </WidgetConfigRow>
+    </>
+  );
+
+  const loading = isLoading || dataLoading;
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 lg:min-h-[540px] flex flex-col h-full">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-          {t('incomeExpenses.title')}
-        </h3>
-        <span className="text-sm text-gray-500 dark:text-gray-400">{t('incomeExpenses.last5Weeks')}</span>
-      </div>
-      <div className="flex-1 min-h-[16rem]">
-        <ResponsiveContainer width="100%" height="100%" minWidth={0}>
-          <BarChart
-            data={chartData}
-            barGap={4}
-            margin={{ top: 5, right: 5, left: -10, bottom: 0 }}
-            onClick={handleChartClick}
-            style={{ cursor: 'pointer' }}
-          >
-            <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
-            <XAxis
-              dataKey="name"
-              tick={{ fill: chartColors.axis, fontSize: 12 }}
-              tickLine={false}
-              axisLine={{ stroke: chartColors.grid }}
-            />
-            <YAxis
-              tick={{ fill: chartColors.axis, fontSize: 12 }}
-              tickLine={false}
-              axisLine={{ stroke: chartColors.grid }}
-              tickFormatter={formatCurrencyAxis}
-            />
-            <Tooltip content={<IncomeExpensesTooltip formatCurrency={formatCurrency} weekOfLabel={(date) => t('incomeExpenses.weekOf', { date })} />} />
-            <Legend
-              wrapperStyle={{ paddingTop: '1rem' }}
-              formatter={(value) => (
-                <span className="text-gray-600 dark:text-gray-400">{value}</span>
-              )}
-            />
-            <Bar
-              dataKey="Income"
-              fill={chartColors.income}
-              radius={[4, 4, 0, 0]}
-              maxBarSize={40}
-              cursor="pointer"
-              onClick={handleBarClick('income')}
-            />
-            <Bar
-              dataKey="Expenses"
-              fill={chartColors.expense}
-              radius={[4, 4, 0, 0]}
-              maxBarSize={40}
-              cursor="pointer"
-              onClick={handleBarClick('expense')}
-            />
-          </BarChart>
-        </ResponsiveContainer>
-      </div>
-      <div className="pt-4 border-t border-gray-200 dark:border-gray-700 grid grid-cols-3 gap-4 text-center">
-        <div>
-          <div className="text-sm text-gray-500 dark:text-gray-400">{t('incomeExpenses.income')}</div>
-          <div className="font-semibold text-green-600 dark:text-green-400">
-            {formatCurrency(totals.income)}
+    <WidgetCard
+      title={t('incomeExpenses.title')}
+      widgetId={WIDGET_ID}
+      configTitle={t('incomeExpenses.title')}
+      configControls={configControls}
+      headerRight={
+        <span className="text-sm text-gray-500 dark:text-gray-400">
+          {t(`widgets.rangeLabels.${config.range}` as Parameters<typeof t>[0])}
+        </span>
+      }
+    >
+      {loading ? (
+        <div className="flex-1 min-h-[16rem] animate-pulse rounded-md bg-gray-100 dark:bg-gray-700/50" />
+      ) : (
+        <>
+          <div className="flex-1 min-h-[16rem]">
+            <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+              <BarChart
+                data={chartData}
+                barGap={4}
+                margin={{ top: 5, right: 5, left: -10, bottom: 0 }}
+                onClick={handleChartClick}
+                style={{ cursor: 'pointer' }}
+              >
+                <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
+                <XAxis
+                  dataKey="name"
+                  tick={{ fill: chartColors.axis, fontSize: 12 }}
+                  tickLine={false}
+                  axisLine={{ stroke: chartColors.grid }}
+                />
+                <YAxis
+                  tick={{ fill: chartColors.axis, fontSize: 12 }}
+                  tickLine={false}
+                  axisLine={{ stroke: chartColors.grid }}
+                  tickFormatter={formatCurrencyAxis}
+                />
+                <Tooltip content={<IncomeExpensesTooltip formatCurrency={formatCurrency} periodLabel={(label) => label} />} />
+                <Legend
+                  wrapperStyle={{ paddingTop: '1rem' }}
+                  formatter={(value) => (
+                    <span className="text-gray-600 dark:text-gray-400">{value}</span>
+                  )}
+                />
+                <Bar
+                  dataKey="Income"
+                  fill={chartColors.income}
+                  radius={[4, 4, 0, 0]}
+                  maxBarSize={40}
+                  cursor="pointer"
+                  onClick={handleBarClick('income')}
+                />
+                <Bar
+                  dataKey="Expenses"
+                  fill={chartColors.expense}
+                  radius={[4, 4, 0, 0]}
+                  maxBarSize={40}
+                  cursor="pointer"
+                  onClick={handleBarClick('expense')}
+                />
+              </BarChart>
+            </ResponsiveContainer>
           </div>
-        </div>
-        <div>
-          <div className="text-sm text-gray-500 dark:text-gray-400">{t('incomeExpenses.expenses')}</div>
-          <div className="font-semibold text-red-600 dark:text-red-400">
-            {formatCurrency(totals.expenses)}
+          <div className="pt-4 border-t border-gray-200 dark:border-gray-700 grid grid-cols-3 gap-4 text-center flex-shrink-0">
+            <div>
+              <div className="text-sm text-gray-500 dark:text-gray-400">{t('incomeExpenses.income')}</div>
+              <div className="font-semibold text-green-600 dark:text-green-400">
+                {formatCurrency(totals.income)}
+              </div>
+            </div>
+            <div>
+              <div className="text-sm text-gray-500 dark:text-gray-400">{t('incomeExpenses.expenses')}</div>
+              <div className="font-semibold text-red-600 dark:text-red-400">
+                {formatCurrency(totals.expenses)}
+              </div>
+            </div>
+            <div>
+              <div className="text-sm text-gray-500 dark:text-gray-400">{t('incomeExpenses.net')}</div>
+              <div
+                className={`font-semibold ${gainLossColor(totals.income - totals.expenses)}`}
+              >
+                {formatCurrency(totals.income - totals.expenses)}
+              </div>
+            </div>
           </div>
-        </div>
-        <div>
-          <div className="text-sm text-gray-500 dark:text-gray-400">{t('incomeExpenses.net')}</div>
-          <div
-            className={`font-semibold ${gainLossColor(totals.income - totals.expenses)}`}
-          >
-            {formatCurrency(totals.income - totals.expenses)}
-          </div>
-        </div>
-      </div>
-    </div>
+        </>
+      )}
+    </WidgetCard>
   );
 }

--- a/frontend/src/components/dashboard/MonthlySpendingTrendWidget.tsx
+++ b/frontend/src/components/dashboard/MonthlySpendingTrendWidget.tsx
@@ -86,6 +86,7 @@ export function MonthlySpendingTrendWidget({ isLoading }: MonthlySpendingTrendWi
   return (
     <WidgetCard
       title={t('monthlySpendingTrend.title')}
+      widgetId={WIDGET_ID}
       configControls={configControls}
       configTitle={t('monthlySpendingTrend.title')}
     >

--- a/frontend/src/components/dashboard/PortfolioValueWidget.tsx
+++ b/frontend/src/components/dashboard/PortfolioValueWidget.tsx
@@ -126,6 +126,7 @@ export function PortfolioValueWidget({ accounts, isLoading }: PortfolioValueWidg
   return (
     <WidgetCard
       title={t('portfolioValue.title')}
+      widgetId={WIDGET_ID}
       headerRight={
         !loading && latestValue > 0 ? (
           <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">

--- a/frontend/src/components/dashboard/RecurringExpensesWidget.tsx
+++ b/frontend/src/components/dashboard/RecurringExpensesWidget.tsx
@@ -73,6 +73,7 @@ export function RecurringExpensesWidget({ isLoading }: RecurringExpensesWidgetPr
   return (
     <WidgetCard
       title={t('recurringExpenses.title')}
+      widgetId={WIDGET_ID}
       configControls={configControls}
       configTitle={t('recurringExpenses.title')}
     >

--- a/frontend/src/components/dashboard/SectorWeightingsWidget.tsx
+++ b/frontend/src/components/dashboard/SectorWeightingsWidget.tsx
@@ -86,6 +86,7 @@ export function SectorWeightingsWidget({ accounts, isLoading }: SectorWeightings
   return (
     <WidgetCard
       title={t('sectorWeightings.title')}
+      widgetId={WIDGET_ID}
       configControls={configControls}
       configTitle={t('sectorWeightings.title')}
     >

--- a/frontend/src/components/dashboard/SecurityTypeAllocationWidget.tsx
+++ b/frontend/src/components/dashboard/SecurityTypeAllocationWidget.tsx
@@ -120,6 +120,7 @@ export function SecurityTypeAllocationWidget({
   return (
     <WidgetCard
       title={t('securityTypeAllocation.title')}
+      widgetId={WIDGET_ID}
       configControls={configControls}
       configTitle={t('securityTypeAllocation.title')}
     >

--- a/frontend/src/components/dashboard/SpendingByPayeeWidget.tsx
+++ b/frontend/src/components/dashboard/SpendingByPayeeWidget.tsx
@@ -93,6 +93,7 @@ export function SpendingByPayeeWidget({ isLoading }: SpendingByPayeeWidgetProps)
   return (
     <WidgetCard
       title={t('spendingByPayee.title')}
+      widgetId={WIDGET_ID}
       headerRight={
         <span className="text-sm text-gray-500 dark:text-gray-400">
           {t(`widgets.rangeLabels.${config.range}` as Parameters<typeof t>[0])}

--- a/frontend/src/components/dashboard/WeekendVsWeekdayWidget.tsx
+++ b/frontend/src/components/dashboard/WeekendVsWeekdayWidget.tsx
@@ -109,6 +109,7 @@ export function WeekendVsWeekdayWidget({ isLoading }: WeekendVsWeekdayWidgetProp
   return (
     <WidgetCard
       title={t('weekendVsWeekday.title')}
+      widgetId={WIDGET_ID}
       configControls={configControls}
       configTitle={t('weekendVsWeekday.title')}
     >

--- a/frontend/src/components/dashboard/WidgetCard.test.tsx
+++ b/frontend/src/components/dashboard/WidgetCard.test.tsx
@@ -1,18 +1,75 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act, screen, fireEvent } from '@testing-library/react';
 import { render } from '@/test/render';
 import { WidgetCard, WidgetConfigRow, WidgetMessage } from './WidgetCard';
 
+// Control the identity slice WidgetCard reads/writes for its name + description.
+const { identityState, updateIdentityMock } = vi.hoisted(() => ({
+  identityState: { current: {} as { displayName?: string; description?: string } },
+  updateIdentityMock: vi.fn(),
+}));
+vi.mock('@/hooks/useWidgetConfig', () => ({
+  useWidgetConfig: () => ({
+    config: identityState.current,
+    updateConfig: updateIdentityMock,
+  }),
+}));
+
 describe('WidgetCard', () => {
+  beforeEach(() => {
+    identityState.current = {};
+    updateIdentityMock.mockClear();
+  });
+
   it('renders the title and body', () => {
     render(<WidgetCard title="My Widget">body content</WidgetCard>);
     expect(screen.getByText('My Widget')).toBeInTheDocument();
     expect(screen.getByText('body content')).toBeInTheDocument();
   });
 
-  it('omits the settings gear when there are no config controls', () => {
+  it('omits the settings gear when there are no config controls or widget id', () => {
     render(<WidgetCard title="My Widget">body</WidgetCard>);
     expect(screen.queryByLabelText(/Configure/)).not.toBeInTheDocument();
+  });
+
+  it('shows the gear for a widget id even without config controls', () => {
+    render(<WidgetCard title="My Widget" widgetId="my-widget">body</WidgetCard>);
+    expect(screen.getByLabelText('Configure My Widget')).toBeInTheDocument();
+  });
+
+  it('prefers a custom display name over the title and shows the description', () => {
+    identityState.current = { displayName: 'Renamed', description: 'My notes' };
+    render(<WidgetCard title="My Widget" widgetId="my-widget">body</WidgetCard>);
+    expect(screen.getByText('Renamed')).toBeInTheDocument();
+    expect(screen.queryByText('My Widget')).not.toBeInTheDocument();
+    expect(screen.getByText('My notes')).toBeInTheDocument();
+  });
+
+  it('commits a new display name on blur', async () => {
+    render(<WidgetCard title="My Widget" widgetId="my-widget">body</WidgetCard>);
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Configure My Widget'));
+    });
+    const nameInput = screen.getByPlaceholderText('My Widget');
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: 'Custom name' } });
+      fireEvent.blur(nameInput);
+    });
+    expect(updateIdentityMock).toHaveBeenCalledWith({ displayName: 'Custom name' });
+  });
+
+  it('clears the display name override when blurred empty', async () => {
+    identityState.current = { displayName: 'Renamed' };
+    render(<WidgetCard title="My Widget" widgetId="my-widget">body</WidgetCard>);
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Configure My Widget'));
+    });
+    const nameInput = screen.getByDisplayValue('Renamed');
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: '  ' } });
+      fireEvent.blur(nameInput);
+    });
+    expect(updateIdentityMock).toHaveBeenCalledWith({ displayName: undefined });
   });
 
   it('opens and closes the settings modal via the gear and Done button', async () => {

--- a/frontend/src/components/dashboard/WidgetCard.tsx
+++ b/frontend/src/components/dashboard/WidgetCard.tsx
@@ -4,16 +4,31 @@ import { ReactNode, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Modal } from '@/components/ui/Modal';
 import { Button } from '@/components/ui/Button';
+import { useWidgetConfig } from '@/hooks/useWidgetConfig';
+import {
+  WidgetIdentityConfig,
+  WIDGET_DISPLAY_NAME_MAX,
+  WIDGET_DESCRIPTION_MAX,
+} from './widget-config';
+
+// Stable module-level defaults: useWidgetConfig memoizes on this reference.
+const IDENTITY_DEFAULTS: WidgetIdentityConfig = {};
 
 interface WidgetCardProps {
-  /** Widget heading. */
+  /** Widget heading (the built-in, translated title). */
   title: string;
+  /**
+   * Widget id. When provided, the settings gear also lets the user set a custom
+   * display name (overriding {@link title}) and an optional description, stored
+   * alongside the widget's other settings.
+   */
+  widgetId?: string;
   /** Optional right-aligned header content (subtitle, inline toggle, etc.). */
   headerRight?: ReactNode;
   /**
-   * When provided, a gear button appears in the header that opens a settings
-   * modal rendering these controls. Each control persists on change, so the
-   * modal only needs a Done button to dismiss.
+   * When provided, the settings modal renders these controls above the shared
+   * name/description fields. Each control persists on change, so the modal only
+   * needs a Done button to dismiss.
    */
   configControls?: ReactNode;
   /** Title shown in the settings modal. Defaults to the widget title. */
@@ -28,12 +43,14 @@ interface WidgetCardProps {
 /**
  * Shared shell for the report-derived dashboard widgets: the standard white/dark
  * card, a header with the title and an optional settings gear, and a settings
- * modal that hosts the widget's per-instance controls. Keeping the gear in the
- * header (rather than inline controls) keeps the compact widgets uncluttered and
- * works the same on mobile and desktop.
+ * modal that hosts the widget's per-instance controls plus the shared
+ * name/description overrides. Keeping the gear in the header (rather than inline
+ * controls) keeps the compact widgets uncluttered and works the same on mobile
+ * and desktop.
  */
 export function WidgetCard({
   title,
+  widgetId,
   headerRight,
   configControls,
   configTitle,
@@ -43,18 +60,34 @@ export function WidgetCard({
 }: WidgetCardProps) {
   const t = useTranslations('dashboard');
   const [showConfig, setShowConfig] = useState(false);
+  // Identity lives under the same widget-config slice; a widget without an id
+  // (rare) simply reads an empty slice and never persists anything.
+  const { config: identity, updateConfig: updateIdentity } =
+    useWidgetConfig<WidgetIdentityConfig>(widgetId ?? '', IDENTITY_DEFAULTS);
+
+  const identityEnabled = !!widgetId;
+  const displayTitle = (identityEnabled && identity.displayName?.trim()) || title;
+  const description = identityEnabled ? identity.description?.trim() : undefined;
+  const hasGear = !!configControls || identityEnabled;
 
   return (
     <div
       className={`bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-4 sm:p-6 ${minHeightClass} flex flex-col h-full ${className}`}
     >
-      <div className="flex items-center justify-between gap-2 mb-4">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 min-w-0 truncate">
-          {title}
-        </h3>
+      <div className="flex items-start justify-between gap-2 mb-4">
+        <div className="min-w-0">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">
+            {displayTitle}
+          </h3>
+          {description && (
+            <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400 line-clamp-2">
+              {description}
+            </p>
+          )}
+        </div>
         <div className="flex items-center gap-2 flex-shrink-0">
           {headerRight}
-          {configControls && (
+          {hasGear && (
             <button
               type="button"
               onClick={() => setShowConfig(true)}
@@ -72,7 +105,7 @@ export function WidgetCard({
 
       <div className="flex-1 min-h-0 flex flex-col">{children}</div>
 
-      {configControls && (
+      {hasGear && (
         <Modal
           isOpen={showConfig}
           onClose={() => setShowConfig(false)}
@@ -83,7 +116,18 @@ export function WidgetCard({
           <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
             {configTitle ?? title}
           </h3>
-          <div className="space-y-4">{configControls}</div>
+          <div className="space-y-4">
+            {configControls}
+            {identityEnabled && (
+              <WidgetIdentityEditor
+                displayName={identity.displayName}
+                description={identity.description}
+                placeholder={title}
+                withDivider={!!configControls}
+                onCommit={updateIdentity}
+              />
+            )}
+          </div>
           <div className="mt-6 flex justify-end">
             <Button onClick={() => setShowConfig(false)}>{t('widgets.done')}</Button>
           </div>
@@ -107,6 +151,77 @@ export function WidgetConfigRow({
         {label}
       </label>
       {children}
+    </div>
+  );
+}
+
+/**
+ * Name + description fields shared by every configurable widget. Edits are held
+ * locally and committed on blur so we persist once per edit (not per keystroke).
+ * An empty value clears the override, falling back to the built-in title.
+ */
+function WidgetIdentityEditor({
+  displayName,
+  description,
+  placeholder,
+  withDivider,
+  onCommit,
+}: {
+  displayName?: string;
+  description?: string;
+  placeholder: string;
+  withDivider: boolean;
+  onCommit: (patch: Partial<WidgetIdentityConfig>) => void;
+}) {
+  const t = useTranslations('dashboard');
+  const [nameDraft, setNameDraft] = useState(displayName ?? '');
+  const [descDraft, setDescDraft] = useState(description ?? '');
+  // Adopt external changes (e.g. a reset from another device) without a
+  // setState-in-effect: track the committed values and reseed during render.
+  const [seed, setSeed] = useState({ displayName, description });
+  if (seed.displayName !== displayName || seed.description !== description) {
+    setSeed({ displayName, description });
+    setNameDraft(displayName ?? '');
+    setDescDraft(description ?? '');
+  }
+
+  const commitName = () => {
+    const next = nameDraft.trim();
+    if ((displayName ?? '') !== next) {
+      onCommit({ displayName: next || undefined });
+    }
+  };
+  const commitDescription = () => {
+    const next = descDraft.trim();
+    if ((description ?? '') !== next) {
+      onCommit({ description: next || undefined });
+    }
+  };
+
+  return (
+    <div className={withDivider ? 'space-y-4 border-t border-gray-200 dark:border-gray-700 pt-4' : 'space-y-4'}>
+      <WidgetConfigRow label={t('widgets.displayName')}>
+        <input
+          type="text"
+          value={nameDraft}
+          onChange={(e) => setNameDraft(e.target.value)}
+          onBlur={commitName}
+          maxLength={WIDGET_DISPLAY_NAME_MAX}
+          placeholder={placeholder}
+          className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+      </WidgetConfigRow>
+      <WidgetConfigRow label={t('widgets.description')}>
+        <textarea
+          value={descDraft}
+          onChange={(e) => setDescDraft(e.target.value)}
+          onBlur={commitDescription}
+          maxLength={WIDGET_DESCRIPTION_MAX}
+          rows={2}
+          placeholder={t('widgets.descriptionPlaceholder')}
+          className="w-full resize-none rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+      </WidgetConfigRow>
     </div>
   );
 }

--- a/frontend/src/components/dashboard/widget-config.ts
+++ b/frontend/src/components/dashboard/widget-config.ts
@@ -14,6 +14,22 @@ export const PORTFOLIO_RANGES = ['3m', '6m', '1y', '2y', '5y', 'all'] as const;
 /** Range presets for the weekend/weekday widget. */
 export const WEEKEND_RANGES = ['1m', '3m', '6m', '1y'] as const;
 
+/**
+ * Identity overrides available on every configurable widget: a custom display
+ * name replacing the built-in title, and an optional description shown in
+ * smaller type under the title. Managed centrally by WidgetCard (keyed by the
+ * same widget id as the rest of the widget's settings), so individual widgets
+ * only opt in by passing their `widgetId`.
+ */
+export interface WidgetIdentityConfig {
+  displayName?: string;
+  description?: string;
+}
+
+/** Max lengths for the identity fields (backend caps config strings at 100). */
+export const WIDGET_DISPLAY_NAME_MAX = 60;
+export const WIDGET_DESCRIPTION_MAX = 100;
+
 export interface RangeConfig {
   range: string;
 }
@@ -29,6 +45,12 @@ export interface IncomeBySourceConfig {
 }
 
 export interface AccountsConfig {
+  accountIds: string[];
+}
+
+/** Timeframe + accounts config for the transaction-based summary charts. */
+export interface RangeAccountsConfig {
+  range: string;
   accountIds: string[];
 }
 
@@ -84,4 +106,16 @@ export const RECURRING_EXPENSES_DEFAULT: RecurringConfig = { minOccurrences: 3 }
 export const WEEKEND_WEEKDAY_DEFAULT: WeekendConfig = {
   range: '3m',
   view: 'overview',
+};
+
+// The two default summary charts default to their historical windows: the pie
+// showed the past 30 days, the income/expenses bars the recent weeks.
+export const EXPENSES_PIE_DEFAULT: RangeAccountsConfig = {
+  range: '1m',
+  accountIds: [],
+};
+
+export const INCOME_EXPENSES_DEFAULT: RangeAccountsConfig = {
+  range: '1m',
+  accountIds: [],
 };

--- a/frontend/src/components/dashboard/widget-registry.tsx
+++ b/frontend/src/components/dashboard/widget-registry.tsx
@@ -3,7 +3,6 @@
 import { ReactNode } from 'react';
 import dynamic from 'next/dynamic';
 import { Account } from '@/types/account';
-import { Transaction } from '@/types/transaction';
 import { Category } from '@/types/category';
 import { ScheduledTransaction } from '@/types/scheduled-transaction';
 import { TopMover, FavouriteSecurityQuote } from '@/types/investment';
@@ -76,10 +75,12 @@ export type DashboardWidgetId =
   | 'recurring-expenses'
   | 'weekend-weekday';
 
+/** The kind of visualization a widget renders, shown as an icon in Customize. */
+export type WidgetIconType = 'bar' | 'line' | 'pie' | 'table' | 'list';
+
 /** Everything the dashboard page loads, handed to each widget's render. */
 export interface DashboardWidgetContext {
   accounts: Account[];
-  transactions: Transaction[];
   categories: Category[];
   scheduledTransactions: ScheduledTransaction[];
   topMovers: TopMover[];
@@ -98,6 +99,8 @@ export interface DashboardWidgetDefinition {
   id: DashboardWidgetId;
   /** Key inside the `dashboard` namespace whose `.title` names the widget. */
   titleSection: string;
+  /** Visualization kind, surfaced as an icon in the Customize dashboard modal. */
+  iconType: WidgetIconType;
   /** Part of the default layout shown to users who never customized. */
   defaultEnabled: boolean;
   /** Rendered for a delegate acting on behalf of the account owner. */
@@ -118,6 +121,7 @@ export const DASHBOARD_WIDGETS: DashboardWidgetDefinition[] = [
   {
     id: 'favourite-accounts',
     titleSection: 'favouriteAccounts',
+    iconType: 'table',
     defaultEnabled: true,
     delegateVisible: () => true,
     render: (ctx) => (
@@ -132,6 +136,7 @@ export const DASHBOARD_WIDGETS: DashboardWidgetDefinition[] = [
   {
     id: 'upcoming-bills',
     titleSection: 'upcomingBills',
+    iconType: 'table',
     defaultEnabled: true,
     delegateVisible: (sections) => !!sections?.bills,
     render: (ctx) => (
@@ -146,6 +151,7 @@ export const DASHBOARD_WIDGETS: DashboardWidgetDefinition[] = [
   {
     id: 'top-movers',
     titleSection: 'topMovers',
+    iconType: 'table',
     defaultEnabled: true,
     shouldRender: (ctx) => ctx.isLoading || ctx.hasSecurities,
     render: (ctx) => (
@@ -161,6 +167,7 @@ export const DASHBOARD_WIDGETS: DashboardWidgetDefinition[] = [
   {
     id: 'favourite-securities',
     titleSection: 'favouriteSecurities',
+    iconType: 'table',
     defaultEnabled: true,
     shouldRender: (ctx) => ctx.isLoading || ctx.hasSecurities,
     render: (ctx) => (
@@ -175,22 +182,25 @@ export const DASHBOARD_WIDGETS: DashboardWidgetDefinition[] = [
   {
     id: 'net-worth',
     titleSection: 'netWorth',
+    iconType: 'line',
     defaultEnabled: true,
     render: (ctx) => <NetWorthChart data={ctx.netWorthData} isLoading={ctx.isLoading} />,
   },
   {
     id: 'assets-liabilities',
     titleSection: 'assetsVsLiabilities',
+    iconType: 'bar',
     defaultEnabled: true,
     render: (ctx) => <AssetsVsLiabilities data={ctx.netWorthData} isLoading={ctx.isLoading} />,
   },
   {
     id: 'expenses-pie',
     titleSection: 'expensesPieChart',
+    iconType: 'pie',
     defaultEnabled: true,
     render: (ctx) => (
       <ExpensesPieChart
-        transactions={ctx.transactions}
+        accounts={ctx.accounts}
         categories={ctx.categories}
         isLoading={ctx.isLoading}
       />
@@ -199,20 +209,23 @@ export const DASHBOARD_WIDGETS: DashboardWidgetDefinition[] = [
   {
     id: 'income-expenses',
     titleSection: 'incomeExpenses',
+    iconType: 'bar',
     defaultEnabled: true,
     render: (ctx) => (
-      <IncomeExpensesBarChart transactions={ctx.transactions} isLoading={ctx.isLoading} />
+      <IncomeExpensesBarChart accounts={ctx.accounts} isLoading={ctx.isLoading} />
     ),
   },
   {
     id: 'budget-status',
     titleSection: 'budgetStatus',
+    iconType: 'bar',
     defaultEnabled: true,
     render: (ctx) => <BudgetStatusWidget isLoading={ctx.isLoading} />,
   },
   {
     id: 'insights',
     titleSection: 'insights',
+    iconType: 'list',
     defaultEnabled: true,
     render: (ctx) => <InsightsWidget isLoading={ctx.isLoading} />,
   },
@@ -220,6 +233,7 @@ export const DASHBOARD_WIDGETS: DashboardWidgetDefinition[] = [
   {
     id: 'favourite-reports',
     titleSection: 'favouriteReports',
+    iconType: 'list',
     defaultEnabled: false,
     render: (ctx) => <FavouriteReportsWidget isLoading={ctx.isLoading} />,
   },
@@ -228,6 +242,7 @@ export const DASHBOARD_WIDGETS: DashboardWidgetDefinition[] = [
   {
     id: 'portfolio-value',
     titleSection: 'portfolioValue',
+    iconType: 'line',
     defaultEnabled: false,
     shouldRender: (ctx) => ctx.isLoading || ctx.hasInvestments,
     render: (ctx) => <PortfolioValueWidget accounts={ctx.accounts} isLoading={ctx.isLoading} />,
@@ -235,36 +250,42 @@ export const DASHBOARD_WIDGETS: DashboardWidgetDefinition[] = [
   {
     id: 'spending-by-payee',
     titleSection: 'spendingByPayee',
+    iconType: 'bar',
     defaultEnabled: false,
     render: (ctx) => <SpendingByPayeeWidget isLoading={ctx.isLoading} />,
   },
   {
     id: 'monthly-spending-trend',
     titleSection: 'monthlySpendingTrend',
+    iconType: 'line',
     defaultEnabled: false,
     render: (ctx) => <MonthlySpendingTrendWidget isLoading={ctx.isLoading} />,
   },
   {
     id: 'income-by-source',
     titleSection: 'incomeBySource',
+    iconType: 'pie',
     defaultEnabled: false,
     render: (ctx) => <IncomeBySourceWidget isLoading={ctx.isLoading} />,
   },
   {
     id: 'credit-utilization-accounts',
     titleSection: 'creditUtilizationAccounts',
+    iconType: 'bar',
     defaultEnabled: false,
     render: (ctx) => <CreditUtilizationAccountsWidget accounts={ctx.accounts} isLoading={ctx.isLoading} />,
   },
   {
     id: 'credit-utilization-total',
     titleSection: 'creditUtilizationTotal',
+    iconType: 'pie',
     defaultEnabled: false,
     render: (ctx) => <CreditUtilizationTotalWidget accounts={ctx.accounts} isLoading={ctx.isLoading} />,
   },
   {
     id: 'sector-weightings',
     titleSection: 'sectorWeightings',
+    iconType: 'pie',
     defaultEnabled: false,
     shouldRender: (ctx) => ctx.isLoading || ctx.hasInvestments,
     render: (ctx) => <SectorWeightingsWidget accounts={ctx.accounts} isLoading={ctx.isLoading} />,
@@ -272,6 +293,7 @@ export const DASHBOARD_WIDGETS: DashboardWidgetDefinition[] = [
   {
     id: 'security-type-allocation',
     titleSection: 'securityTypeAllocation',
+    iconType: 'pie',
     defaultEnabled: false,
     shouldRender: (ctx) => ctx.isLoading || ctx.hasInvestments,
     render: (ctx) => <SecurityTypeAllocationWidget accounts={ctx.accounts} isLoading={ctx.isLoading} />,
@@ -279,6 +301,7 @@ export const DASHBOARD_WIDGETS: DashboardWidgetDefinition[] = [
   {
     id: 'geographic-allocation',
     titleSection: 'geographicAllocation',
+    iconType: 'pie',
     defaultEnabled: false,
     shouldRender: (ctx) => ctx.isLoading || ctx.hasInvestments,
     render: (ctx) => <GeographicAllocationWidget accounts={ctx.accounts} isLoading={ctx.isLoading} />,
@@ -286,12 +309,14 @@ export const DASHBOARD_WIDGETS: DashboardWidgetDefinition[] = [
   {
     id: 'recurring-expenses',
     titleSection: 'recurringExpenses',
+    iconType: 'table',
     defaultEnabled: false,
     render: (ctx) => <RecurringExpensesWidget isLoading={ctx.isLoading} />,
   },
   {
     id: 'weekend-weekday',
     titleSection: 'weekendVsWeekday',
+    iconType: 'bar',
     defaultEnabled: false,
     render: (ctx) => <WeekendVsWeekdayWidget isLoading={ctx.isLoading} />,
   },

--- a/frontend/src/i18n/messages/de/dashboard.json
+++ b/frontend/src/i18n/messages/de/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "Konten",
     "chartType": "Diagrammtyp",
     "view": "Ansicht",
+    "displayName": "Anzeigename",
+    "description": "Beschreibung",
+    "descriptionPlaceholder": "Optionale Beschreibung hinzufügen",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/en/dashboard.json
+++ b/frontend/src/i18n/messages/en/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "Accounts",
     "chartType": "Chart type",
     "view": "View",
+    "displayName": "Display name",
+    "description": "Description",
+    "descriptionPlaceholder": "Add an optional description",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/es/dashboard.json
+++ b/frontend/src/i18n/messages/es/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "Cuentas",
     "chartType": "Tipo de gráfico",
     "view": "Vista",
+    "displayName": "Nombre visible",
+    "description": "Descripción",
+    "descriptionPlaceholder": "Añade una descripción opcional",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/fr/dashboard.json
+++ b/frontend/src/i18n/messages/fr/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "Comptes",
     "chartType": "Type de graphique",
     "view": "Vue",
+    "displayName": "Nom d'affichage",
+    "description": "Description",
+    "descriptionPlaceholder": "Ajoutez une description facultative",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/hi/dashboard.json
+++ b/frontend/src/i18n/messages/hi/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "खाते",
     "chartType": "चार्ट प्रकार",
     "view": "दृश्य",
+    "displayName": "प्रदर्शन नाम",
+    "description": "विवरण",
+    "descriptionPlaceholder": "एक वैकल्पिक विवरण जोड़ें",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/id/dashboard.json
+++ b/frontend/src/i18n/messages/id/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "Akun",
     "chartType": "Tipe Grafik",
     "view": "Tampilan",
+    "displayName": "Nama tampilan",
+    "description": "Deskripsi",
+    "descriptionPlaceholder": "Tambahkan deskripsi opsional",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/it/dashboard.json
+++ b/frontend/src/i18n/messages/it/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "Conti",
     "chartType": "Tipo di grafico",
     "view": "Vista",
+    "displayName": "Nome visualizzato",
+    "description": "Descrizione",
+    "descriptionPlaceholder": "Aggiungi una descrizione facoltativa",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/ja/dashboard.json
+++ b/frontend/src/i18n/messages/ja/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "口座",
     "chartType": "グラフの種類",
     "view": "表示",
+    "displayName": "表示名",
+    "description": "説明",
+    "descriptionPlaceholder": "任意の説明を追加",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/ko/dashboard.json
+++ b/frontend/src/i18n/messages/ko/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "계정",
     "chartType": "차트 유형",
     "view": "보기",
+    "displayName": "표시 이름",
+    "description": "설명",
+    "descriptionPlaceholder": "선택적인 설명을 추가하세요",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/nl/dashboard.json
+++ b/frontend/src/i18n/messages/nl/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "Rekeningen",
     "chartType": "Grafiektype",
     "view": "Weergave",
+    "displayName": "Weergavenaam",
+    "description": "Beschrijving",
+    "descriptionPlaceholder": "Voeg een optionele beschrijving toe",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/pl/dashboard.json
+++ b/frontend/src/i18n/messages/pl/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "Konta",
     "chartType": "Typ wykresu",
     "view": "Widok",
+    "displayName": "Nazwa wyświetlana",
+    "description": "Opis",
+    "descriptionPlaceholder": "Dodaj opcjonalny opis",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/pt-BR/dashboard.json
+++ b/frontend/src/i18n/messages/pt-BR/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "Contas",
     "chartType": "Tipo de gráfico",
     "view": "Visualização",
+    "displayName": "Nome de exibição",
+    "description": "Descrição",
+    "descriptionPlaceholder": "Adicione uma descrição opcional",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/pt/dashboard.json
+++ b/frontend/src/i18n/messages/pt/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "Contas",
     "chartType": "Tipo de gráfico",
     "view": "Vista",
+    "displayName": "Nome a apresentar",
+    "description": "Descrição",
+    "descriptionPlaceholder": "Adicione uma descrição opcional",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/ru/dashboard.json
+++ b/frontend/src/i18n/messages/ru/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "Счета",
     "chartType": "Тип диаграммы",
     "view": "Вид",
+    "displayName": "Отображаемое имя",
+    "description": "Описание",
+    "descriptionPlaceholder": "Добавьте необязательное описание",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/tr/dashboard.json
+++ b/frontend/src/i18n/messages/tr/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "Hesaplar",
     "chartType": "Grafik türü",
     "view": "Görünüm",
+    "displayName": "Görünen ad",
+    "description": "Açıklama",
+    "descriptionPlaceholder": "İsteğe bağlı bir açıklama ekleyin",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/uk/dashboard.json
+++ b/frontend/src/i18n/messages/uk/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "Рахунки",
     "chartType": "Тип діаграми",
     "view": "Вигляд",
+    "displayName": "Відображуване ім'я",
+    "description": "Опис",
+    "descriptionPlaceholder": "Додайте необов’язковий опис",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/vi/dashboard.json
+++ b/frontend/src/i18n/messages/vi/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "Tài khoản",
     "chartType": "Loại biểu đồ",
     "view": "Chế độ xem",
+    "displayName": "Tên hiển thị",
+    "description": "Mô tả",
+    "descriptionPlaceholder": "Thêm mô tả tùy chọn",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/xx/dashboard.json
+++ b/frontend/src/i18n/messages/xx/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "[XX-Accounts-XX]",
     "chartType": "[XX-Chart type-XX]",
     "view": "[XX-View-XX]",
+    "displayName": "[XX-Display name-XX]",
+    "description": "[XX-Description-XX]",
+    "descriptionPlaceholder": "[XX-Add an optional description-XX]",
     "rangeLabels": {
       "1m": "[XX-1M-XX]",
       "3m": "[XX-3M-XX]",

--- a/frontend/src/i18n/messages/zh-CN/dashboard.json
+++ b/frontend/src/i18n/messages/zh-CN/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "账户",
     "chartType": "图表类型",
     "view": "视图",
+    "displayName": "显示名称",
+    "description": "描述",
+    "descriptionPlaceholder": "添加可选描述",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",

--- a/frontend/src/i18n/messages/zh-TW/dashboard.json
+++ b/frontend/src/i18n/messages/zh-TW/dashboard.json
@@ -163,6 +163,9 @@
     "accounts": "科目",
     "chartType": "圖表類型",
     "view": "檢視",
+    "displayName": "顯示名稱",
+    "description": "描述",
+    "descriptionPlaceholder": "新增選填的描述",
     "rangeLabels": {
       "1m": "1M",
       "3m": "3M",


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: <!-- discussion/issue link -->

## Summary

Refactors the Income vs Expenses and Expenses by Category dashboard widgets to be fully configurable, allowing users to:
- Select custom time ranges (1M, 3M, 6M, 1Y, All) instead of fixed periods
- Filter by specific accounts instead of showing all non-investment accounts
- Customize widget display names and descriptions via a shared settings modal

The Income vs Expenses widget now intelligently switches between weekly buckets (for recent 1-month views) and monthly buckets (for longer ranges) to keep visualizations compact. Both widgets now fetch their own transaction data on-demand based on the selected filters, rather than relying on pre-loaded dashboard context.

All other configurable widgets (Portfolio Value, Credit Utilization, etc.) are updated to support the new identity override system (custom name + description), and the Customize Dashboard modal now displays visualization-type icons to help users distinguish widgets at a glance.

## Changes

### Core Widget Infrastructure
- **WidgetCard**: Added support for `widgetId` prop to enable custom display names and descriptions. Identity config is stored alongside widget-specific settings and managed centrally.
- **widget-config.ts**: Added `WidgetIdentityConfig` interface and max-length constants for display name (60 chars) and description (100 chars).
- **useWidgetConfig hook**: Already existed; now used by WidgetCard for identity overrides.

### Income vs Expenses Widget
- Replaced fixed 5-week view with configurable time ranges (1M, 3M, 6M, 1Y, All).
- Switched from receiving pre-loaded transactions to fetching on-demand via `transactionsApi.getAllPages()`.
- Added account filtering via `ReportAccountMultiSelect`.
- Implemented intelligent bucketing: weekly for 1-month range, monthly for longer periods.
- Removed `Skeleton` import; loading state now handled by `WidgetCard`.
- Updated tooltip to use generic "periodLabel" instead of "weekOfLabel".

### Expenses by Category Widget
- Replaced fixed 30-day view with configurable time ranges.
- Switched to on-demand transaction fetching with account filtering.
- Updated category click handler to use resolved date range instead of hardcoded 30 days.
- Removed `Skeleton` import; loading state now handled by `WidgetCard`.

### Dashboard Page
- Removed `transactions` from `DashboardWidgetContext` (no longer pre-loaded).
- Removed unused date-fns imports (`subWeeks`, `startOfWeek`).
- Widgets now fetch their own data based on user-selected filters.

### Customize Dashboard Modal
- Added `WidgetTypeIcon` component that renders small SVG glyphs (bar, line, pie, table, list) to help users visually distinguish widget types.
- Updated widget registry to include `WidgetIconType` for each widget.

### All Other Configurable Widgets
- Updated to pass `widgetId` to `WidgetCard` so users can customize their display names and descriptions.
- Affected: Portfolio Value, Credit Utilization (Total & Accounts), Geographic Allocation, Income by Source, Monthly Spending Trend, Recurring Expenses, Sector Weightings, Security Type Allocation, Spending by Payee, Weekend vs Weekday.

### Internationalization
- Added new keys to `dashboard.json` (all locales):
  - `widgets.displayName`: "Display name"
  - `widgets.description`: "Description"
  - `widgets.descriptionPlaceholder`: "Add an optional description"
- Regenerated pseudo-locale (`xx`).

### Tests
- Updated `IncomeExpensesBarChart.test.tsx` and `ExpensesPieChart.test.tsx` to mock the new `useWidgetConfig` and `transactionsApi.getAllPages` hooks.
- Tests now use `act()` and `waitFor()` to handle async data loading.
- Updated assertions to reflect the new configurable UI (e.g., checking for "1M" label instead of "Last 5 weeks").
- Updated `WidgetCard.test.tsx` to test

https://claude.ai/code/session_01J3qNPU7n4uQ6eNviAsRETs