### PR TITLE
fix(investments): Asset Allocation percentages reconcile against the drawn slices

### DIFF
--- a/backend/src/securities/portfolio-calculation.service.spec.ts
+++ b/backend/src/securities/portfolio-calculation.service.spec.ts
@@ -9,6 +9,7 @@ import {
 } from "./entities/investment-transaction.entity";
 import { Account } from "../accounts/entities/account.entity";
 import { ExchangeRateService } from "../currencies/exchange-rate.service";
+import { HoldingWithMarketValue } from "./portfolio.service";
 
 describe("PortfolioCalculationService.calculateRealizedGains", () => {
   let service: PortfolioCalculationService;
@@ -1015,7 +1016,7 @@ describe("PortfolioCalculationService.buildAllocationByTag", () => {
       ],
     ]);
 
-    const result = service.buildAllocationByTag(items, tags, 0, 150, "CAD");
+    const result = service.buildAllocationByTag(items, tags, 0, "CAD");
 
     const allWorld = result.find((r) => r.name === "All-World");
     const ai = result.find((r) => r.name === "AI");
@@ -1038,7 +1039,7 @@ describe("PortfolioCalculationService.buildAllocationByTag", () => {
       ["SMH", [{ id: "t-ai", name: "AI", color: null }]],
     ]);
 
-    const result = service.buildAllocationByTag(items, tags, 0, 200, "CAD");
+    const result = service.buildAllocationByTag(items, tags, 0, "CAD");
 
     expect(result.find((r) => r.name === "All-World")?.color).toBe("#abcdef");
     expect(result.find((r) => r.name === "AI")?.color).toMatch(/^#/);
@@ -1050,7 +1051,7 @@ describe("PortfolioCalculationService.buildAllocationByTag", () => {
       ["VWCE", [{ id: "t-aw", name: "All-World", color: null }]],
     ]);
 
-    const result = service.buildAllocationByTag(items, tags, 60, 200, "CAD");
+    const result = service.buildAllocationByTag(items, tags, 60, "CAD");
 
     const cash = result.find((r) => r.type === "cash");
     const untagged = result.find((r) => r.type === "untagged");
@@ -1066,7 +1067,7 @@ describe("PortfolioCalculationService.buildAllocationByTag", () => {
       ["VWCE", [{ id: "t-aw", name: "All-World", color: null }]],
     ]);
 
-    const result = service.buildAllocationByTag(items, tags, 0, 100, "CAD");
+    const result = service.buildAllocationByTag(items, tags, 0, "CAD");
 
     expect(result.some((r) => r.type === "cash")).toBe(false);
     expect(result.some((r) => r.type === "untagged")).toBe(false);
@@ -1080,9 +1081,135 @@ describe("PortfolioCalculationService.buildAllocationByTag", () => {
       ["SMH", [{ id: "t-ai", name: "AI", color: null }]],
     ]);
 
-    const result = service.buildAllocationByTag(items, tags, 0, 100, "CAD");
+    const result = service.buildAllocationByTag(items, tags, 0, "CAD");
 
     expect(result.some((r) => r.name === "All-World")).toBe(false);
     expect(result.find((r) => r.name === "AI")?.value).toBe(100);
+  });
+
+  it("reconciles to ~100% when cash is negative (margin/loan is not in the base)", () => {
+    // Regression for #842: a negative cash balance must not be folded into the
+    // denominator. Here a single tag (Equities) plus the disjoint Untagged
+    // bucket would sum to 139% of the net portfolio value (932 + 458 vs a net
+    // of 1110). The drawn slices must instead share the base 932 + 458 = 1390.
+    const items = [securityItem("AKC", 932), securityItem("XYZ", 458)];
+    const tags = new Map([
+      ["AKC", [{ id: "t-eq", name: "Equities", color: null }]],
+    ]);
+
+    const result = service.buildAllocationByTag(items, tags, -280, "CAD");
+
+    // Negative cash is not drawn as a slice.
+    expect(result.some((r) => r.type === "cash")).toBe(false);
+
+    const equities = result.find((r) => r.name === "Equities");
+    const untagged = result.find((r) => r.type === "untagged");
+    expect(equities?.percentage).toBeCloseTo((932 / 1390) * 100, 5);
+    expect(untagged?.percentage).toBeCloseTo((458 / 1390) * 100, 5);
+    // Disjoint tag + Untagged now reconcile, instead of totalling 139%.
+    expect(
+      (equities?.percentage ?? 0) + (untagged?.percentage ?? 0),
+    ).toBeCloseTo(100, 5);
+  });
+});
+
+describe("PortfolioCalculationService.buildAllocation", () => {
+  let service: PortfolioCalculationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PortfolioCalculationService,
+        { provide: getRepositoryToken(Holding), useValue: {} },
+        { provide: getRepositoryToken(SecurityPrice), useValue: {} },
+        { provide: getRepositoryToken(InvestmentTransaction), useValue: {} },
+        { provide: getRepositoryToken(Account), useValue: {} },
+        { provide: ExchangeRateService, useValue: {} },
+      ],
+    }).compile();
+    service = module.get(PortfolioCalculationService);
+  });
+
+  const holdingWithValue = (
+    id: string,
+    securityId: string,
+    symbol: string,
+    marketValue: number,
+  ): HoldingWithMarketValue =>
+    ({
+      id,
+      accountId: "acct-1",
+      securityId,
+      symbol,
+      name: symbol,
+      securityType: "STOCK",
+      currencyCode: "CAD",
+      quantity: 1,
+      averageCost: 0,
+      costBasis: 0,
+      costBasisAccountCurrency: 0,
+      currentPrice: marketValue,
+      marketValue,
+      gainLoss: null,
+      gainLossPercent: null,
+    }) as HoldingWithMarketValue;
+
+  const holdingRow = (id: string, securityId: string) =>
+    ({
+      id,
+      securityId,
+      security: { currencyCode: "CAD" },
+    }) as unknown as Holding;
+
+  it("measures by-security slices against the drawn total, not the net value when cash is negative", async () => {
+    // Regression for #842 (by-security parity): a negative cash balance must
+    // not shrink the denominator. Slices must share the base 932 + 458 = 1390
+    // and reconcile to ~100%, rather than being inflated against a net 1110.
+    const sortedHoldings = [
+      holdingWithValue("h1", "s1", "AKC", 932),
+      holdingWithValue("h2", "s2", "XYZ", 458),
+    ];
+    const holdings = [holdingRow("h1", "s1"), holdingRow("h2", "s2")];
+
+    const result = await service.buildAllocation(
+      sortedHoldings,
+      holdings,
+      -280,
+      "CAD",
+      new Map<string, number>(),
+    );
+
+    expect(result.some((r) => r.type === "cash")).toBe(false);
+    const securityPctTotal = result
+      .filter((r) => r.type === "security")
+      .reduce((sum, r) => sum + r.percentage, 0);
+    expect(securityPctTotal).toBeCloseTo(100, 5);
+    expect(result.find((r) => r.symbol === "AKC")?.percentage).toBeCloseTo(
+      (932 / 1390) * 100,
+      5,
+    );
+  });
+
+  it("keeps positive cash in the base so slices sum to ~100%", async () => {
+    const sortedHoldings = [holdingWithValue("h1", "s1", "AKC", 140)];
+    const holdings = [holdingRow("h1", "s1")];
+
+    const result = await service.buildAllocation(
+      sortedHoldings,
+      holdings,
+      60,
+      "CAD",
+      new Map<string, number>(),
+    );
+
+    // base = 140 + 60 = 200
+    expect(result.find((r) => r.type === "cash")?.percentage).toBeCloseTo(
+      30,
+      5,
+    );
+    expect(result.find((r) => r.symbol === "AKC")?.percentage).toBeCloseTo(
+      70,
+      5,
+    );
   });
 });

--- a/backend/src/securities/portfolio-calculation.service.ts
+++ b/backend/src/securities/portfolio-calculation.service.ts
@@ -1341,7 +1341,6 @@ export class PortfolioCalculationService {
     sortedHoldings: HoldingWithMarketValue[],
     holdings: Holding[],
     totalCashValue: number,
-    totalPortfolioValue: number,
     defaultCurrency: string,
     rateCache: Map<string, number>,
   ): Promise<AllocationItem[]> {
@@ -1356,21 +1355,6 @@ export class PortfolioCalculationService {
       "#eab308",
       "#ef4444",
     ];
-
-    if (totalCashValue > 0) {
-      allocation.push({
-        name: "Cash",
-        symbol: null,
-        type: "cash",
-        value: totalCashValue,
-        percentage:
-          totalPortfolioValue > 0
-            ? (totalCashValue / totalPortfolioValue) * 100
-            : 0,
-        color: "#6b7280",
-        currencyCode: defaultCurrency,
-      });
-    }
 
     // Consolidate holdings by security so the same security held across
     // multiple accounts appears as a single allocation slice.
@@ -1412,6 +1396,30 @@ export class PortfolioCalculationService {
       (a, b) => b.value - a.value,
     );
 
+    // Percentages are measured against the sum of the slices actually drawn
+    // (positive security values plus positive cash), not the net portfolio
+    // value. Using the net value would let a negative cash balance (margin /
+    // loan) or a short position shrink the denominator and inflate every
+    // slice past 100%; the drawn total always reconciles to ~100%.
+    const positiveCash = totalCashValue > 0 ? totalCashValue : 0;
+    const drawnTotal =
+      consolidatedItems.reduce((sum, item) => sum + item.value, 0) +
+      positiveCash;
+    const pct = (value: number) =>
+      drawnTotal > 0 ? (value / drawnTotal) * 100 : 0;
+
+    if (totalCashValue > 0) {
+      allocation.push({
+        name: "Cash",
+        symbol: null,
+        type: "cash",
+        value: totalCashValue,
+        percentage: pct(totalCashValue),
+        color: "#6b7280",
+        currencyCode: defaultCurrency,
+      });
+    }
+
     let colorIndex = 0;
     for (const item of consolidatedItems) {
       allocation.push({
@@ -1419,10 +1427,7 @@ export class PortfolioCalculationService {
         symbol: item.symbol,
         type: "security",
         value: item.value,
-        percentage:
-          totalPortfolioValue > 0
-            ? (item.value / totalPortfolioValue) * 100
-            : 0,
+        percentage: pct(item.value),
         color: colors[colorIndex % colors.length],
         currencyCode: item.currencyCode,
       });
@@ -1457,7 +1462,6 @@ export class PortfolioCalculationService {
       Array<{ id: string; name: string; color: string | null }>
     >,
     totalCashValue: number,
-    totalPortfolioValue: number,
     defaultCurrency: string,
   ): AllocationItem[] {
     const palette = [
@@ -1477,9 +1481,14 @@ export class PortfolioCalculationService {
       { name: string; color: string | null; value: number }
     >();
     let untaggedValue = 0;
+    // Sum of every security slice that lands on the chart (tagged or not).
+    // This, plus positive cash, is the denominator so tag and Untagged slices
+    // share one base and reconcile to ~100%.
+    let includedSecuritiesValue = 0;
 
     for (const item of securityItems) {
       if (item.type !== "security" || item.value <= 0) continue;
+      includedSecuritiesValue += item.value;
       const tags = item.symbol ? (tagsBySymbol.get(item.symbol) ?? []) : [];
       if (tags.length === 0) {
         untaggedValue += item.value;
@@ -1499,8 +1508,10 @@ export class PortfolioCalculationService {
       }
     }
 
+    const positiveCash = totalCashValue > 0 ? totalCashValue : 0;
+    const drawnTotal = includedSecuritiesValue + positiveCash;
     const pct = (value: number) =>
-      totalPortfolioValue > 0 ? (value / totalPortfolioValue) * 100 : 0;
+      drawnTotal > 0 ? (value / drawnTotal) * 100 : 0;
 
     const allocation: AllocationItem[] = [];
 

--- a/backend/src/securities/portfolio.service.ts
+++ b/backend/src/securities/portfolio.service.ts
@@ -491,7 +491,6 @@ export class PortfolioService {
       sortedHoldings,
       holdingsResult.holdings,
       totalCashValue,
-      totalPortfolioValue,
       defaultCurrency,
       rateCache,
     );
@@ -939,7 +938,6 @@ export class PortfolioService {
       securityItems,
       tagsBySymbol,
       totalCashValue,
-      summary.totalPortfolioValue,
       defaultCurrency,
     );
     return { allocation, totalValue: summary.totalPortfolioValue };


### PR DESCRIPTION
## Linked discussion / issue

Fixes #842 (labelled `approved-to-build`).

## Summary

Asset Allocation percentages were divided by the **net** portfolio value (`totalCashValue + totalHoldingsValue`). When cash is **negative** (a margin / loan balance), that denominator shrinks below the sum of the slices actually drawn -- because a negative cash balance is never rendered as a slice. Every percentage was then inflated and the buckets stopped reconciling.

In the **By tag** view this showed up as a single tag plus the *disjoint* Untagged bucket totalling far more than 100% (the reported `93.2% + 45.8% = 139%`), which the multi-tag-overlap note cannot explain: those two sets do not overlap.

## Implementation

Measure both allocation views against the sum of the **positive slices they actually draw** -- included security values plus positive cash -- instead of the net portfolio value:

- `buildAllocationByTag` accumulates the charted securities value and uses `includedSecuritiesValue + max(cash, 0)` as the denominator. The now-unused `totalPortfolioValue` parameter is dropped.
- `buildAllocation` (by-security) uses the same base, so the two views stay consistent and a negative cash balance or a short position can no longer push slices past 100%. Same parameter dropped.
- Callers in `portfolio.service.ts` updated. The public `getAllocationByTag` is unchanged and still reports `summary.totalPortfolioValue` as the headline total.

**Backward compatible:** in the normal case (cash >= 0, no shorts) the drawn total equals the old net value, so percentages are identical. The behaviour only changes when the old denominator was wrong.

## Tests

Added regression tests for **both** views under a negative cash balance (tag + Untagged reconcile to ~100%; by-security slices reconcile to ~100%) plus a positive-cash base check. Existing `buildAllocationByTag` assertions are unchanged. Full `securities` suite passes (194 tests); ESLint + `tsc` clean.

## Notes

The key:value / weighted-per-dimension allocation idea discussed in #842 is a deliberate **follow-up PR** after this merges -- it touches the same allocation code, so sequencing avoids conflicts and keeps this PR to the single #842 concern.

## Checklist

- [x] An approved issue exists and is linked above (`approved-to-build`).
- [x] Single concern (allocation percentage base reconciliation).
- [x] New behavior has tests, and the existing suite passes.
- [x] No new user-facing strings, so i18n parity is unaffected.
- [x] Branch is rebased on the latest `main`.

## AI assistance disclosure

Built with Claude Code (Claude Opus 4.8). I reviewed the diff and tests and own the result.