### PR TITLE
Fix portfolio value discrepancy between daily and monthly ranges

### DIFF
--- a/backend/src/net-worth/net-worth.service.spec.ts
+++ b/backend/src/net-worth/net-worth.service.spec.ts
@@ -2110,7 +2110,7 @@ describe("NetWorthService", () => {
       ]);
 
       // security prices query (includes a price from the prior trading day so
-      // the first chart point can be valued using yesterday's close)
+      // a first chart point with no same-day close can still fall back to it)
       dataSource.query.mockResolvedValueOnce([
         {
           security_id: "sec-1",
@@ -2140,12 +2140,13 @@ describe("NetWorthService", () => {
         "2025-03-03",
       );
 
-      // Each point uses the previous day's close: 03-01 -> 02-28, 03-02 ->
-      // 03-01, 03-03 -> 03-02. Matches the Gain/Dividend report's convention.
+      // Each point uses that day's close (end-of-day convention): 03-01 ->
+      // 03-01, 03-02 -> 03-02, 03-03 -> 03-03. This lines the daily series up
+      // with the month-end-valued monthly snapshots.
       expect(result).toHaveLength(3);
-      expect(result[0]).toEqual({ date: "2025-03-01", value: 990 });
-      expect(result[1]).toEqual({ date: "2025-03-02", value: 1000 });
-      expect(result[2]).toEqual({ date: "2025-03-03", value: 1020 });
+      expect(result[0]).toEqual({ date: "2025-03-01", value: 1000 });
+      expect(result[1]).toEqual({ date: "2025-03-02", value: 1020 });
+      expect(result[2]).toEqual({ date: "2025-03-03", value: 1010 });
     });
 
     it("includes cash balances from INVESTMENT_CASH accounts", async () => {
@@ -2833,7 +2834,7 @@ describe("NetWorthService", () => {
       });
     });
 
-    it("values each daily point at the latest close before the date", async () => {
+    it("values each daily point at the latest close on or before the date", async () => {
       prefRepository.findOne.mockResolvedValue({ defaultCurrency: "USD" });
 
       dataSource.query.mockResolvedValueOnce([
@@ -2878,7 +2879,7 @@ describe("NetWorthService", () => {
         { key: "sec-1", type: "security", symbol: "MSFT", name: "Microsoft" },
       ]);
       expect(result.points).toEqual([
-        { date: "2025-03-01", total: 990, values: { "sec-1": 990 } },
+        { date: "2025-03-01", total: 1000, values: { "sec-1": 1000 } },
         { date: "2025-03-02", total: 1000, values: { "sec-1": 1000 } },
       ]);
     });

--- a/backend/src/net-worth/net-worth.service.ts
+++ b/backend/src/net-worth/net-worth.service.ts
@@ -952,22 +952,22 @@ export class NetWorthService {
           const security = securityMap.get(secId);
           let price: number | undefined;
 
-          // Use the previous day's close to value each point on the series,
-          // matching the convention used by the Gain/Dividends/Interest report
-          // (which looks up the close on `periodStart - 1` for opening values).
-          // The chart point at date X therefore represents the portfolio's
-          // value as of the start of day X, i.e. the latest close strictly
-          // before X.
+          // Value each point at the latest close on or before that day
+          // (end-of-day convention). The chart point at date X therefore
+          // represents the portfolio's value as of the close of day X, so the
+          // series lines up with the month-end-valued monthly snapshots and the
+          // final point reflects the most recent available close rather than
+          // lagging a trading day behind it.
           if (security?.skipPriceUpdates) {
             const txPrices = txPricesBySec.get(secId) || [];
             for (const tp of txPrices) {
-              if (tp.date < dateStr) price = tp.price;
+              if (tp.date <= dateStr) price = tp.price;
               else break;
             }
           } else {
             const secPrices = pricesBySec.get(secId) || [];
             for (const sp of secPrices) {
-              if (sp.date < dateStr) price = sp.price;
+              if (sp.date <= dateStr) price = sp.price;
               else break;
             }
           }
@@ -1111,10 +1111,11 @@ export class NetWorthService {
     if (sampleDates.length === 0) return empty;
 
     // --- Price lookups -------------------------------------------------------
-    // Daily values each point at the latest close strictly before the date
-    // (start-of-day convention, matching getDailyInvestments). Monthly values
+    // Daily values each point at the latest close on or before the date
+    // (end-of-day convention, matching getDailyInvestments). Monthly values
     // each point at the latest close on or before the month end (matching the
-    // stored monthly snapshots).
+    // stored monthly snapshots). Both are inclusive of their period end so the
+    // daily and monthly series line up at overlapping dates.
     const pricesBySec = new Map<
       string,
       Array<{ date: string; price: number }>
@@ -1396,7 +1397,7 @@ export class NetWorthService {
     if (!series) return undefined;
     let price: number | undefined;
     for (const p of series) {
-      if (p.date < sampleDate) price = p.price;
+      if (p.date <= sampleDate) price = p.price;
       else break;
     }
     return price;


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: _No prior discussion/issue exists for this change — opened directly from a reported bug on the dashboard Portfolio Value widget. Happy to file a discussion first if that is preferred._

## Summary

The Portfolio Value dashboard widget serves its ranges from two different backend endpoints that used opposite price-timing conventions:

| Widget range | Endpoint | Valued each point at… |
|---|---|---|
| 3m, 6m | `getInvestmentsDaily` | latest close **strictly before** that day (start-of-day) |
| 1y, 2y, 5y, all | `getInvestmentsMonthly` | latest close **on or before** the month end (end-of-day) |

Because of this mismatch, the daily (3m/6m) series — including the headline "current value" in the widget header — read **one trading day behind** the monthly ranges. Switching from 1y to 6m visibly changed the displayed portfolio value.

This aligns the daily endpoint to the same end-of-day convention as the monthly one by making its price lookup inclusive of the sample date (`<` → `<=`) in three places in `net-worth.service.ts`:

- `getInvestmentsDaily` — market prices and transaction (skip-price-update) prices
- `getInvestmentBreakdown`'s daily path (`priceForSample`) — keeps the per-security stacked view consistent

Each daily point now represents the value as of that day's close, so the daily and monthly series line up at overlapping dates and the latest point reflects the most recent available close. No frontend change was needed — the widget already routes ranges to the correct endpoints. As a side benefit the Portfolio Value **report**'s daily/monthly boundary is now consistent too.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. _(none exists yet — see note above)_
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes. _(updated the two convention-pinning tests; `net-worth.service.spec.ts` 85/85 pass)_
- [x] All user-facing strings are translated for **every** locale (i18n parity). _(no user-facing strings changed)_
- [x] No shared/core areas were refactored without prior agreement. _(touches the shared `net-worth.service` valuation convention, also used by the Portfolio Value report — flagging for review)_
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Diagnosed and implemented with Claude Code. The change is a targeted, reviewed fix to the daily price-lookup boundary; correctness, conventions, and tests have been verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QviYHUoHQG9GsEmK9nZpEB