### PR TITLE
Fix backup restore for OIDC users: re-authenticate via the live session, not an unobtainable ID token

### DIFF
--- a/backend/src/backup/backup.service.spec.ts
+++ b/backend/src/backup/backup.service.spec.ts
@@ -1748,7 +1748,10 @@ describe("BackupService", () => {
       expect(enableIdx).toBeGreaterThan(updateIdx);
     });
 
-    it("rejects OIDC users whose ID token does not match the user's oidcSubject", async () => {
+    it("accepts the session-confirmed sentinel for OIDC users (soft re-auth)", async () => {
+      // OIDC restore mirrors account deletion: the live JWT session is the
+      // re-authentication, so any present confirmation token is accepted -- the
+      // frontend sends a non-JWT sentinel it cannot cryptographically sign.
       const oidcModule = {
         ...mockUser,
         authProvider: "oidc",
@@ -1756,17 +1759,13 @@ describe("BackupService", () => {
         oidcSubject: "sub-1",
       };
       mockUserRepo.findOne.mockResolvedValue(oidcModule);
-      // Re-resolve OidcService from the testing module and flip verify to false.
-      const oidc = (
-        service as unknown as {
-          oidcService: { verifyIdTokenClaims: jest.Mock };
-        }
-      ).oidcService;
-      oidc.verifyIdTokenClaims = jest.fn().mockReturnValue(false);
 
-      await expect(
-        service.restoreData(userId, makeInput({ oidcIdToken: "bad-token" })),
-      ).rejects.toThrow(UnauthorizedException);
+      const result = await service.restoreData(
+        userId,
+        makeInput({ oidcIdToken: "oidc-session-confirmed" }),
+      );
+
+      expect(result.message).toBe("Backup restored successfully");
     });
 
     it("rejects backup files that decompress to a non-object", async () => {

--- a/backend/src/backup/backup.service.ts
+++ b/backend/src/backup/backup.service.ts
@@ -11,7 +11,6 @@ import * as bcrypt from "bcryptjs";
 import { randomUUID } from "crypto";
 import { createGzip, gunzipSync, gzipSync } from "zlib";
 import { User } from "../users/entities/user.entity";
-import { OidcService } from "../auth/oidc/oidc.service";
 import { AiEncryptionService } from "../ai/ai-encryption.service";
 import {
   encryptBackup,
@@ -164,7 +163,6 @@ export class BackupService {
     @InjectRepository(User)
     private readonly usersRepository: Repository<User>,
     private readonly dataSource: DataSource,
-    private readonly oidcService: OidcService,
     private readonly aiEncryption: AiEncryptionService,
   ) {}
 
@@ -838,26 +836,18 @@ export class BackupService {
     input: RestoreBackupInput,
   ): Promise<void> {
     if (user.authProvider === "oidc") {
+      // Re-confirm via the authenticated session, mirroring account deletion
+      // (users.service.deleteAccount). The request already passed the JWT
+      // AuthGuard, so a live OIDC session IS the re-authentication. OIDC users
+      // have no local password and cannot mint a fresh signed ID token in the
+      // browser (the login id_token lives only in backend httpOnly cookies), so
+      // the client sends a "session confirmed" sentinel. Cryptographically
+      // verifying that sentinel as an ID token here made OIDC restore impossible.
       if (!input.oidcIdToken) {
         throw new UnauthorizedException(
           tr(
             "errors.backup.oidcReauthRequired",
             "OIDC re-authentication is required to confirm restore",
-          ),
-        );
-      }
-      if (
-        !user.oidcSubject ||
-        !this.oidcService.enabled ||
-        !this.oidcService.verifyIdTokenClaims(
-          input.oidcIdToken,
-          user.oidcSubject,
-        )
-      ) {
-        throw new UnauthorizedException(
-          tr(
-            "errors.backup.oidcTokenInvalid",
-            "Invalid OIDC token: the token must be a valid ID token from your SSO provider",
           ),
         );
       }


### PR DESCRIPTION
## Linked discussion / issue

Closes #881
Approved in: https://github.com/kenlasko/monize/issues/881

## Summary

Backup restore re-authenticates the user before proceeding. For OIDC users it demanded a fresh, cryptographically valid ID token and verified its claims against `user.oidcSubject` — but the browser can never supply one: the login `id_token` lives only in backend httpOnly cookies, and the SPA has no way to mint a new signed ID token. Restore was therefore **impossible** for every OIDC account.

This mirrors the approach account deletion (`users.service.deleteAccount`) already uses: the request has passed the JWT `AuthGuard`, so a live OIDC session *is* the re-authentication, and the client sends a session-confirmed sentinel. The presence check on `oidcIdToken` stays; the cryptographic claim verification (and the now-unused `OidcService` dependency) is removed, with a comment documenting why. Password-based restore is unchanged.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity — no string changes in this PR).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Implemented with Claude Code (Claude Fable 5). I reviewed the diff and ran the backend `src/backup` suites in the dev container — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)