### PR TITLE
fix(loans): scrollable rate history + show payments before the configured start date

### DIFF
--- a/frontend/src/components/accounts/loan-detail/RateHistorySidebar.tsx
+++ b/frontend/src/components/accounts/loan-detail/RateHistorySidebar.tsx
@@ -98,11 +98,11 @@ export function RateHistorySidebar({
 
   return (
     <div
-      className={`relative overflow-hidden bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 scroll-mt-4 ${
+      className={`relative flex flex-col overflow-hidden bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 scroll-mt-4 ${
         fillHeight ? 'lg:h-full' : ''
       }`}
     >
-      <div className="relative z-10 p-4 flex flex-col gap-3">
+      <div className="relative z-10 min-h-0 flex-1 p-4 flex flex-col gap-3">
         <div className="flex flex-wrap items-start justify-between gap-2">
           <button
             type="button"
@@ -149,7 +149,11 @@ export function RateHistorySidebar({
               {t('loanDetail.rateHistory.empty')}
             </p>
           ) : (
-            <ul className="max-h-96 overflow-y-auto divide-y divide-gray-200/70 dark:divide-gray-700/70">
+            <ul
+              className={`overflow-y-auto min-h-0 divide-y divide-gray-200/70 dark:divide-gray-700/70 ${
+                fillHeight ? 'max-h-96 lg:max-h-none lg:flex-1' : 'max-h-96'
+              }`}
+            >
               {sorted.map((change) => (
                 <li
                   key={change.id}

--- a/frontend/src/lib/loan-past-impact.test.ts
+++ b/frontend/src/lib/loan-past-impact.test.ts
@@ -27,13 +27,17 @@ function makeAccount(overrides: Partial<Account> = {}): Account {
   } as Account;
 }
 
-function makeHistory(account: Account, principals: number[]): LoanHistoryResult {
+function makeHistory(
+  account: Account,
+  principals: number[],
+  dates?: string[],
+): LoanHistoryResult {
   const transactions = principals.map(
     (amount, i) =>
       ({
         id: `tx-${i}`,
         accountId: account.id,
-        transactionDate: `2025-${String(i + 1).padStart(2, '0')}-15`,
+        transactionDate: dates?.[i] ?? `2025-${String(i + 1).padStart(2, '0')}-15`,
         amount,
         linkedTransaction: null,
       }) as Transaction,
@@ -176,7 +180,14 @@ describe('computePastImpact', () => {
       isCanadianMortgage: true,
       isVariableRate: true,
     });
-    const history = makeHistory(account, [3200, 3200, 3200]);
+    // The schedule now starts at the earliest actual payment, so the recorded
+    // transactions sit on the real installment dates (2022-05-13 onward), not a
+    // synthetic 2025 stub -- otherwise the baseline would start years late.
+    const history = makeHistory(
+      account,
+      [3200, 3200, 3200],
+      ['2022-05-13', '2022-06-24', '2022-08-05'],
+    );
     const rateChanges = [
       { effectiveDate: '2022-05-13', annualRate: 1.75, newPaymentAmount: 3200 },
       { effectiveDate: '2022-06-24', annualRate: 2.25, newPaymentAmount: 3233.04 },

--- a/frontend/src/lib/loan-past-impact.ts
+++ b/frontend/src/lib/loan-past-impact.ts
@@ -87,9 +87,11 @@ export function computePastImpact(
         ? history.startingBalance
         : reconstructedPrincipal;
 
-  // The schedule starts at the configured first-payment date, or the earliest
-  // actual payment when that is unset.
-  const startDate = account.paymentStartDate || history.events[0]?.date || null;
+  // The schedule starts at the earliest actual payment; the configured
+  // first-payment date is only a fallback for when there are no payments yet.
+  // Preferring the real transaction keeps the baseline aligned with the data
+  // the user actually has, rather than a stale configured value.
+  const startDate = history.events[0]?.date || account.paymentStartDate || null;
 
   // The configured repayment period. Prefer the amortization period; fall back
   // to the term. It is required (the loan/mortgage form collects it), so


### PR DESCRIPTION
Two loan-detail fixes, rebased on current `main`.

### 1. Scrollable rate history
With many recorded rate changes the Rate History list grew unbounded, and beside the overpayment simulator (`fillHeight`) the tall panel stretched the whole flex row and broke the page layout. The list now scrolls inside the card: it fills the available height on desktop and keeps a `max-h-96` cap on mobile and in the full-width below-schedule placement.

### 2. Show payments before the configured start date
The "original schedule" baseline in the past-impact chart started at the configured `paymentStartDate`, which can be a stale value predating the earliest recorded payment (e.g. an origination date entered at creation) -- drawing a phantom segment with no data before the real history begins. It now starts at the **earliest actual payment**, falling back to the configured date only when there are no payments yet.

Scope note: I reverted the editable first-payment-date field I'd originally added here. Per the discussion, the interest-only grace-period origination in `loan-history.ts` is intentionally left on `paymentStartDate` (it's the loan origination, not the first-payment date). The Edit-Mortgage scheduled-transaction panel + "recreate" button is left for a separate PR.