### PR TITLE
Fix PDF export capturing legend icon instead of main chart

### DIFF
--- a/frontend/src/lib/pdf-export-charts.test.ts
+++ b/frontend/src/lib/pdf-export-charts.test.ts
@@ -124,6 +124,40 @@ describe('captureSingleSvg via captureSvgAsImage (with mocked Image)', () => {
     (global as any).Image = originalImage;
   });
 
+  it('captures the main chart surface, not a legend-icon surface that precedes it', async () => {
+    // Recharts v3 renders legend-item icon SVGs (svg.recharts-surface, ~14x14)
+    // BEFORE the main chart surface in the DOM. A loose `svg.recharts-surface`
+    // query would grab the legend icon and produce a near-blank export sized to
+    // the container (issue #886). The main surface must win.
+    const container = document.createElement('div');
+
+    // Legend icon surface first in DOM, nested in a legend item.
+    const legendItem = document.createElement('div');
+    legendItem.classList.add('recharts-legend-item');
+    const legendSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    legendSvg.classList.add('recharts-surface');
+    legendSvg.setAttribute('width', '14');
+    legendSvg.setAttribute('height', '14');
+    legendItem.appendChild(legendSvg);
+    container.appendChild(legendItem);
+
+    // Main chart surface, a direct child of .recharts-wrapper.
+    const wrapper = document.createElement('div');
+    wrapper.classList.add('recharts-wrapper');
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.classList.add('recharts-surface');
+    svg.setAttribute('width', '800');
+    svg.setAttribute('height', '400');
+    wrapper.appendChild(svg);
+    container.appendChild(wrapper);
+
+    const result = await captureSvgAsImage(container);
+    expect(result).not.toBeNull();
+    // 800x400 proves the main surface was captured, not the 14x14 legend icon.
+    expect(result?.width).toBe(800);
+    expect(result?.height).toBe(400);
+  });
+
   it('captures an SVG with width/height attributes', async () => {
     const container = document.createElement('div');
     const wrapper = document.createElement('div');

--- a/frontend/src/lib/pdf-export-charts.ts
+++ b/frontend/src/lib/pdf-export-charts.ts
@@ -226,7 +226,15 @@ export async function captureSvgAsImage(
   container: HTMLElement,
   scale: number = 3,
 ): Promise<CapturedChart | null> {
-  const svg = container.querySelector('svg.recharts-surface') as SVGSVGElement | null;
+  // Target the main chart SVG (a direct child of .recharts-wrapper). Recharts
+  // also renders tiny svg.recharts-surface elements for legend icons, and in
+  // recharts v3 those appear BEFORE the main surface in the DOM -- so a bare
+  // `svg.recharts-surface` query grabs a 14x14 legend icon instead of the chart
+  // whenever the chart has a <Legend>, producing a near-blank export sized to
+  // the container (issue #886). Fall back to the loose selector for any
+  // container that isn't wrapped (e.g. a bare test fixture).
+  const svg = (container.querySelector('.recharts-wrapper > svg.recharts-surface') ??
+    container.querySelector('svg.recharts-surface')) as SVGSVGElement | null;
   if (!svg) return null;
 
   try {


### PR DESCRIPTION
## Linked discussion / issue

Closes #886

## Summary

Fixes a bug in PDF chart export where Recharts v3 legend icon SVGs (tiny 14x14 surfaces rendered before the main chart in the DOM) were being captured instead of the actual chart surface, resulting in near-blank exports.

The fix uses a more specific selector (`.recharts-wrapper > svg.recharts-surface`) to target the main chart surface as a direct child of the wrapper, with a fallback to the loose selector for unwrapped containers (e.g., test fixtures).

## Changes

- **`pdf-export-charts.ts`**: Updated `captureSvgAsImage()` to prioritize the main chart surface over legend icon surfaces by using a child combinator selector, with detailed comments explaining the Recharts v3 DOM structure issue.
- **`pdf-export-charts.test.ts`**: Added test case that verifies the correct surface is captured when both a legend icon and main chart surface are present in the DOM.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (fixing legend icon capture bug).
- [x] New behavior has tests, and the existing suite passes.
- [x] No user-facing strings added.
- [x] No shared/core areas refactored.
- [x] The branch is rebased on the latest `main`.

## Test Plan

The new test case `captures the main chart surface, not a legend-icon surface that precedes it` verifies that when both a legend icon surface (14x14) and main chart surface (800x400) are present, the export captures the correct dimensions (800x400), proving the main surface was selected. Existing tests continue to pass.

https://claude.ai/code/session_01WZ5DEn1kCZfuzzSxjScAWW