### PR TITLE
feat(loans): include loan interest by category regardless of date

### DIFF
--- a/frontend/src/lib/loan-history.test.ts
+++ b/frontend/src/lib/loan-history.test.ts
@@ -815,6 +815,10 @@ describe('deriveLoanPaymentHistory with paired separate interest expenses', () =
     expect(events.some((e) => e.date.startsWith('2012'))).toBe(true);
     expect(events.some((e) => e.date.startsWith('2020'))).toBe(true);
     expect(events.some((e) => e.date.startsWith('2022'))).toBe(true);
+    // ...and this loan's own interest is still attributed to the right date,
+    // so a pairing regression can't slip through the date-presence checks.
+    const aug = events.find((e) => e.date.startsWith('2022-08'));
+    expect(aug?.interest).toBeCloseTo(1250, 0);
   });
 
   it('excludes interest booked after the final payment once the loan is paid off', () => {

--- a/frontend/src/lib/loan-history.test.ts
+++ b/frontend/src/lib/loan-history.test.ts
@@ -758,10 +758,39 @@ describe('deriveLoanPaymentHistory with paired separate interest expenses', () =
     expect(cumulativeInterest).toBeCloseTo(388.14 + 286.49 + 335.92, 2);
   });
 
-  it('scopes separate interest to the loan lifetime, ignoring an earlier loan that shares the category', () => {
-    // Sequential refinanced mortgages share the interest category and source
-    // account. A loan that started in 2022 must not show interest-only rows
-    // from a previous mortgage (2012-2021).
+  it('includes interest booked before the configured start date (interest-only grace period)', () => {
+    // Real dataset shape: the interest-only grace period starts 2019-08, but
+    // paymentStartDate was set later (2020-04, e.g. guessed at setup). Interest
+    // is scoped by category, not date, so the pre-start grace interest still
+    // shows and counts instead of being truncated at the configured start.
+    const account = makeAccount({
+      accountType: 'MORTGAGE',
+      openingBalance: -206718.35,
+      currentBalance: -142332.03,
+      interestRate: 5.5,
+      paymentStartDate: '2020-04-05',
+    });
+    const transactions = [makeTransaction({ transactionDate: '2021-07-05', amount: 469.58 })];
+    const interestTransactions = [
+      { transactionDate: '2019-08-05', amount: -388.14, isTransfer: false } as Transaction,
+      { transactionDate: '2019-09-05', amount: -286.49, isTransfer: false } as Transaction,
+      { transactionDate: '2021-07-05', amount: -335.92, isTransfer: false } as Transaction,
+    ];
+
+    const { events } = deriveLoanPaymentHistory(account, transactions, [], interestTransactions);
+
+    // Grace interest from 2019-08 appears, ahead of the 2020-04 start date.
+    expect(events[0].date).toContain('2019-08');
+    expect(events.some((e) => e.date.startsWith('2019-09'))).toBe(true);
+    expect(events[0].interest).toBeCloseTo(388.14, 2);
+  });
+
+  it('includes all category interest regardless of date; refinances need distinct categories', () => {
+    // Interest is scoped by the configured interest category and source account,
+    // not by date, so an active loan shows every payment in that category. The
+    // flip side, called out for reviewers: sequential refinanced mortgages that
+    // reuse ONE interest category can no longer be separated by date -- give
+    // each refinance its own interest category to keep them apart.
     const account = makeAccount({
       accountType: 'MORTGAGE',
       openingBalance: -300000,
@@ -774,21 +803,38 @@ describe('deriveLoanPaymentHistory with paired separate interest expenses', () =
       makeTransaction({ transactionDate: '2022-09-05', amount: 500 }),
     ];
     const interestTransactions = [
-      // Previous mortgage on the same category/source, years earlier:
       { transactionDate: '2012-06-05', amount: -900, isTransfer: false } as Transaction,
       { transactionDate: '2020-06-05', amount: -800, isTransfer: false } as Transaction,
-      // This loan's interest:
       { transactionDate: '2022-08-05', amount: -1250, isTransfer: false } as Transaction,
       { transactionDate: '2022-09-05', amount: -1245, isTransfer: false } as Transaction,
     ];
 
     const { events } = deriveLoanPaymentHistory(account, transactions, [], interestTransactions);
 
-    // Only this loan's two payments -- no phantom rows from 2012-2020.
-    expect(events).toHaveLength(2);
-    expect(events.every((e) => e.date >= '2022-08-01')).toBe(true);
-    // This loan's own interest is still attributed.
-    expect(events[0].interest).toBeCloseTo(1250, 0);
+    // All category interest is now included, including the earlier dates.
+    expect(events.some((e) => e.date.startsWith('2012'))).toBe(true);
+    expect(events.some((e) => e.date.startsWith('2020'))).toBe(true);
+    expect(events.some((e) => e.date.startsWith('2022'))).toBe(true);
+  });
+
+  it('excludes interest booked after the final payment once the loan is paid off', () => {
+    // A paid-off loan should not absorb interest later booked in the same
+    // category (e.g. a subsequent loan). Active loans keep accruing to today.
+    const account = makeAccount({
+      accountType: 'MORTGAGE',
+      openingBalance: -100000,
+      currentBalance: 0,
+      interestRate: 5,
+    });
+    const transactions = [makeTransaction({ transactionDate: '2023-01-05', amount: 100000 })];
+    const interestTransactions = [
+      { transactionDate: '2023-01-05', amount: -400, isTransfer: false } as Transaction,
+      { transactionDate: '2024-06-05', amount: -300, isTransfer: false } as Transaction,
+    ];
+
+    const { events } = deriveLoanPaymentHistory(account, transactions, [], interestTransactions);
+
+    expect(events.some((e) => e.date.startsWith('2024'))).toBe(false);
   });
 
   it('derives the observed rate from the actual days between payments', () => {

--- a/frontend/src/lib/loan-history.ts
+++ b/frontend/src/lib/loan-history.ts
@@ -820,14 +820,17 @@ export async function fetchAllAccountTransactions(accountId: string): Promise<Tr
  * Only genuinely standalone interest expenses are returned. The category filter
  * also matches interest booked as a *split leg* of a payment (the backend
  * matches `splits.categoryId`), but that interest is already attributed to its
- * own loan through the payment's recorded interest split -- and a run of
- * sequential loans that share one interest category and funding account (e.g.
- * a mortgage refinanced every few years, each paid from the same chequing
- * account) would otherwise each pull in every sibling loan's split-leg
- * interest, producing phantom interest-only rows and a bogus payoff timeline.
- * A standalone expense carries the interest category at the top level
- * (split parents have a null top-level category) and is not a transfer, so
- * filtering on that keeps only interest this path is meant to handle.
+ * payment through the recorded interest split (path 2 of
+ * `deriveLoanPaymentHistory`); returning it here as well would double-count it.
+ * A standalone expense carries the interest category at the top level (split
+ * parents have a null top-level category) and is not a transfer, so filtering
+ * on that keeps only the interest this separate-expense path is meant to handle.
+ *
+ * Scoping to this loan is by the configured interest category + source account:
+ * `deriveLoanPaymentHistory` no longer date-bounds the result, so all of it
+ * counts (an interest-only grace period or migrated history included). Pointing
+ * two loans at one interest category would therefore merge them -- give each
+ * loan its own interest category to keep them apart.
  */
 export async function fetchLoanInterestTransactions(
   account: Account,

--- a/frontend/src/lib/loan-history.ts
+++ b/frontend/src/lib/loan-history.ts
@@ -112,29 +112,24 @@ export function deriveLoanPaymentHistory(
   let cumulativePrincipal = 0;
   let cumulativeInterest = 0;
 
-  // Scope separately-booked interest to this loan's own lifetime. Sequential
-  // refinanced mortgages often share one interest category and source account
-  // (e.g. Canadian mortgages re-financed every few years), so an unrelated
-  // earlier or later loan's interest would otherwise be pulled in and shown as
-  // phantom interest-only rows. Bound it below by the configured first-payment
-  // date -- the loan's origination, which precedes the first principal payment
-  // during an interest-only grace period -- and above by the final payment once
-  // the loan is paid off (an active loan still accrues interest to today).
-  const originationDate =
-    account.paymentStartDate ||
-    (sortedTransactions.length > 0
-      ? sortedTransactions[0].transactionDate.split('T')[0]
-      : null);
+  // Separately-booked interest is already scoped to this loan by its configured
+  // interest category and source account (see fetchLoanInterestTransactions), so
+  // include all of it regardless of date. A loan account legitimately has
+  // activity before its configured start date -- an interest-only grace period,
+  // or history migrated from another tool -- and those payments must still show
+  // and count in the schedule and every figure derived from it, rather than
+  // being truncated at a start date that is often set later than the real first
+  // payment. The only bound kept is the upper one for a fully paid-off loan, so
+  // interest later booked in the same category (e.g. a subsequent loan) is not
+  // absorbed after this one is gone; an active loan still accrues to today.
   const lastTransactionDate =
     sortedTransactions.length > 0
       ? sortedTransactions[sortedTransactions.length - 1].transactionDate.split('T')[0]
       : null;
   const loanPaidOff = currentBalance <= 0.01;
   const scopedInterestTransactions = interestTransactions.filter((tx) => {
-    const date = tx.transactionDate.split('T')[0];
-    if (originationDate && date < originationDate) return false;
-    if (loanPaidOff && lastTransactionDate && date > lastTransactionDate) return false;
-    return true;
+    if (!loanPaidOff || !lastTransactionDate) return true;
+    return tx.transactionDate.split('T')[0] <= lastTransactionDate;
   });
 
   // A source-account payment covering multiple loan transfers (e.g. regular +


### PR DESCRIPTION
Follow-up to #885 (now merged) and the reports in #889: the loan detail should show a loan's real history even when it began before the configured `paymentStartDate`.

### Problem
Everything on the loan detail -- schedule, summary cards, payoff timeline, overpayment simulator, rate history -- derives from `deriveLoanPaymentHistory`, which scoped separately-booked interest by a **lower date bound of the configured `paymentStartDate`**. When `paymentStartDate` is set later than the real first payment (common after a Quicken/MS-Money migration, or when an origination date was guessed at setup), every payment before it was silently hidden:

- An **interest-only grace period** (interest dated before the first principal payment) disappeared.
- A migrated mortgage's **pre-migration history** showed only the payments entered in Monize (the "shows from #49" report in #889).

### Fix
Separately-booked interest is already scoped to this loan by its **configured interest category and source account** (`fetchLoanInterestTransactions`), so the date lower bound is unnecessary -- include all of it. A loan account legitimately has activity before its configured start date, and it must show and count in the schedule and every derived figure. The only bound kept is the **upper** one for a fully paid-off loan, so interest later booked in the same category (a subsequent loan) is not absorbed after this one is gone; an active loan still accrues to today.

This drops the previous account-number/description heuristic idea in favour of trusting the configured categories, which is the intended per-loan scoping mechanism.

### Trade-off (needs your call)
The old behaviour used `paymentStartDate` as a lower bound specifically to keep an **earlier refinanced mortgage** that reuses one interest category/source account out of the current loan. With date scoping gone, sequential refinances sharing a single interest category can no longer be separated by date -- the guidance becomes **give each refinance its own interest category**. That relied on `paymentStartDate` being correct, which is exactly the value that is often wrong here, so I think trusting categories is the more robust contract -- but flagging it since it affects Canadian refinancers.

### Tests
Pre-start-date grace interest now shows; all-category inclusion and the paid-off upper bound are covered; the old date-scoping ("ignore earlier loan") test is replaced with one documenting the new inclusive behaviour + the distinct-category guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)