### PR TITLE
fix(loans): don't fabricate analytic interest for a principal-only payment

### DIFF
--- a/frontend/src/lib/loan-history.test.ts
+++ b/frontend/src/lib/loan-history.test.ts
@@ -758,6 +758,51 @@ describe('deriveLoanPaymentHistory with paired separate interest expenses', () =
     expect(cumulativeInterest).toBeCloseTo(388.14 + 286.49 + 335.92, 2);
   });
 
+  it('does not fabricate analytic interest for a principal-only payment sharing a date (interest booked separately)', () => {
+    // Real case (2023-09-05): two principal payments land on the same day -- an
+    // overpayment (973.11, whose interest is booked separately) and the regular
+    // installment (1097.78, booked with zero interest). The day's two booked
+    // interest expenses (596.89 + 28.28 = 625.17) are the whole month's
+    // interest. The overpayment consumes the paired interest; the principal-only
+    // installment must be left at 0, not given an analytic estimate -- otherwise
+    // the month over-counts interest (previously ~+860).
+    const account = makeAccount({
+      accountType: 'MORTGAGE',
+      openingBalance: -206718.35,
+      currentBalance: -142332.03,
+      interestRate: 5.5,
+    });
+    const transactions = [
+      makeTransaction({
+        id: 'over',
+        transactionDate: '2023-09-05',
+        amount: 973.11,
+        description: 'Nadpłata 2023-09-05 (kapitał z 1 570; odsetki osobno)',
+      }),
+      makeTransaction({
+        id: 'reg',
+        transactionDate: '2023-09-05',
+        amount: 1097.78,
+        description: 'Kapitał raty 2023-09 (KAPITAL: 1097.78 ODSETKI: 0.00)',
+      }),
+    ];
+    const interestTransactions = [
+      { transactionDate: '2023-09-05', amount: -596.89, isTransfer: false, description: 'Odsetki z nadpłaty 2023-09-05' } as Transaction,
+      { transactionDate: '2023-09-05', amount: -28.28, isTransfer: false } as Transaction,
+    ];
+
+    const { events } = deriveLoanPaymentHistory(account, transactions, [], interestTransactions);
+    const sept = events.filter((e) => e.date.startsWith('2023-09'));
+    const septInterest = sept.reduce((s, e) => s + e.interest, 0);
+
+    // Whole-month interest equals the booked expenses, with no analytic top-up.
+    expect(septInterest).toBeCloseTo(625.17, 2);
+    // The principal-only installment row carries zero interest.
+    const regRow = sept.find((e) => Math.abs(e.principal - 1097.78) < 0.01);
+    expect(regRow).toBeDefined();
+    expect(regRow!.interest).toBe(0);
+  });
+
   it('scopes separate interest to the loan lifetime, ignoring an earlier loan that shares the category', () => {
     // Sequential refinanced mortgages share the interest category and source
     // account. A loan that started in 2022 must not show interest-only rows

--- a/frontend/src/lib/loan-history.ts
+++ b/frontend/src/lib/loan-history.ts
@@ -139,11 +139,6 @@ export function deriveLoanPaymentHistory(
     if (loanPaidOff && lastTransactionDate && date > lastTransactionDate) return false;
     return true;
   });
-  // Whether this loan books interest as separate expenses. When it does, a
-  // payment with no paired interest carried none of its own (the interest for
-  // its date is already represented by the booked expenses), so it must not
-  // receive an analytic estimate -- see classifyPayment.
-  const hasSeparateInterest = scopedInterestTransactions.length > 0;
 
   // A source-account payment covering multiple loan transfers (e.g. regular +
   // extra principal) carries one interest split; count it once.
@@ -157,6 +152,15 @@ export function deriveLoanPaymentHistory(
       scopedInterestTransactions,
       repayments.map((t) => t.transactionDate.split('T')[0]),
     );
+  // Whether this loan books interest as separate expenses. When it does, a
+  // payment with no paired interest carried none of its own (the interest for
+  // its date is already represented by the booked expenses), so it must not
+  // receive an analytic estimate -- see classifyPayment. Derived from the
+  // pairing output (not the raw list) so all-transfer / zero-amount inputs,
+  // which pairSeparateInterestByDate discards, don't falsely disable the
+  // analytic fallback.
+  const hasSeparateInterest =
+    separateInterestByDate.size > 0 || orphanInterest.length > 0;
   const usedInterestDates = new Set<string>();
   const events: LoanPaymentEvent[] = [];
 

--- a/frontend/src/lib/loan-history.ts
+++ b/frontend/src/lib/loan-history.ts
@@ -26,11 +26,14 @@ import {
  *   2. otherwise, if the linked source-account transaction carries an interest
  *      split (the shape ScheduledTransactionLoanService builds), that recorded
  *      interest is used -- exact even on variable-rate loans;
- *   3. otherwise the interest is derived analytically from the running balance
- *      at the rate in effect on that date (`balance * periodicRate`, using the
- *      rate timeline when supplied), so a payment recorded without an interest
- *      split -- including loans whose interest is booked separately -- shows a
- *      realistic interest that tracks the bank rather than 100% principal.
+ *   3. otherwise, for a loan with no separately-booked interest at all, the
+ *      interest is derived analytically from the running balance at the rate in
+ *      effect on that date (`balance * periodicRate`, using the rate timeline
+ *      when supplied), so a plain principal-only transfer shows a realistic
+ *      interest that tracks the bank rather than 100% principal. When the loan
+ *      DOES book interest as separate expenses, a payment with no paired expense
+ *      carried no interest of its own (it is already represented by the booked
+ *      expenses), so it is left at 0 rather than given an analytic estimate.
  *
  * The balance walk is unchanged -- it always tracks the actual ledger amount,
  * so the projected balance still ends at the account's current balance.
@@ -136,6 +139,11 @@ export function deriveLoanPaymentHistory(
     if (loanPaidOff && lastTransactionDate && date > lastTransactionDate) return false;
     return true;
   });
+  // Whether this loan books interest as separate expenses. When it does, a
+  // payment with no paired interest carried none of its own (the interest for
+  // its date is already represented by the booked expenses), so it must not
+  // receive an analytic estimate -- see classifyPayment.
+  const hasSeparateInterest = scopedInterestTransactions.length > 0;
 
   // A source-account payment covering multiple loan transfers (e.g. regular +
   // extra principal) carries one interest split; count it once.
@@ -173,6 +181,7 @@ export function deriveLoanPaymentHistory(
         rateChanges,
         separateInterestByDate,
         usedInterestDates,
+        hasSeparateInterest,
       );
       runningBalance = Math.max(0, runningBalance - principal);
       cumulativePrincipal += principal;
@@ -206,6 +215,7 @@ export function deriveLoanPaymentHistory(
         rateChanges,
         separateInterestByDate,
         usedInterestDates,
+        hasSeparateInterest,
       );
       cumulativePrincipal += principal;
       cumulativeInterest += interest;
@@ -382,6 +392,7 @@ function classifyPayment(
   rateChanges: RateTimelineRow[],
   separateInterestByDate: Map<string, number>,
   usedInterestDates: Set<string>,
+  hasSeparateInterest: boolean,
 ): { interest: number; type: LoanPaymentType } {
   const dateKey = transaction.transactionDate.split('T')[0];
   // The actual interest expense paired to this date, consumed once.
@@ -416,6 +427,16 @@ function classifyPayment(
   const paired = takeSeparateInterest();
   if (paired != null) {
     return { interest: paired, type: 'REGULAR' };
+  }
+  // A loan that books interest as separate expenses has this payment's interest
+  // (if any) already captured by those expenses. When none is paired to this
+  // payment -- e.g. a principal-only leg sharing a date with another payment
+  // that already consumed the date's interest, like an overpayment and a
+  // regular installment on the same day -- it genuinely carried no interest.
+  // Only fall back to an analytic estimate for loans with no separate interest
+  // booking at all, where the interest is not recorded anywhere else.
+  if (hasSeparateInterest) {
+    return { interest: 0, type: 'REGULAR' };
   }
   return {
     interest: analyticInterest(balanceBefore, account, transaction, rateChanges),


### PR DESCRIPTION
Fixes #891.

### Problem
`deriveLoanPaymentHistory` resolves each payment's interest from a paired separately-booked interest expense, then falls back to an analytic estimate (`balance x periodicRate`) when none is paired. That fallback fired even for loans that **do** book interest separately: when a single date has more principal payments than interest expenses (e.g. an overpayment and a regular installment on the same day), the first payment consumes the date's booked interest and the second -- left unpaired -- was given invented analytic interest.

### Real case (from #891)
`2023-09-05`: an overpayment (973.11 principal, 596.89 interest booked separately) and a regular installment (1097.78 principal, booked `ODSETKI: 0.00`), plus a 28.28 interest expense. Real month interest = 596.89 + 28.28 = **625.17**, but the principal-only 1097.78 row got an analytic **~860**, so the Loan Schedule reported **1485.25** for the month -- inflating cumulative interest and everything derived from it (saved-interest, payoff comparison). Verified against the source bank statement: the imported transactions match exactly; only the fabricated interest differed.

### Fix
The analytic estimate is only meaningful for loans with **no separately-booked interest at all** (a plain principal-only transfer whose interest is recorded nowhere). When the loan books interest as separate expenses, a payment with no paired expense carried none of its own -- the date's interest is already represented by the booked expenses -- so leave it at 0 instead of estimating.

`classifyPayment` now takes a `hasSeparateInterest` flag (`scopedInterestTransactions.length > 0`); when set and no expense pairs to the payment, it returns 0 rather than an analytic value. Loans with no separate interest are unaffected -- the analytic path still runs for them (existing test covers it).

### Tests
Added a test with the exact 2023-09-05 data: two same-day principal payments + two interest expenses; asserts the month's interest is 625.17 and the principal-only installment row is 0. Existing analytic-fallback and separate-interest tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Behavior note
Beyond the #891 inflation, this changes one adjacent case: for a loan whose separate-interest booking only starts partway through its history (e.g. a migration where the earliest interest was never imported), early *unpaired* payments now show **0 interest** instead of an analytic estimate. Months whose interest was actually booked but did not pair still surface as orphan interest-only rows, so nothing booked is lost — only genuinely unbooked months go to zero, which is more honest than fabricating an estimate.

Follow-up (separate): the loan reports (`LoanAmortizationReport`, `DebtPayoffTimelineReport`) call `deriveLoanPaymentHistory` without `interestTransactions`, so `hasSeparateInterest` is always false there and the #891 inflation persists in those reports — tracked in a follow-up issue.