### PR TITLE
fix(reports): pass separate interest into the loan reports

### DIFF
--- a/frontend/src/components/reports/DebtPayoffTimelineReport.test.tsx
+++ b/frontend/src/components/reports/DebtPayoffTimelineReport.test.tsx
@@ -131,6 +131,53 @@ describe('DebtPayoffTimelineReport', () => {
     );
   });
 
+  it('stays in the loading state until the interest fetch resolves (no analytic-estimate flicker)', async () => {
+    mockGetAllAccounts.mockResolvedValue([
+      {
+        id: 'loan-1',
+        name: 'Mortgage',
+        accountType: 'MORTGAGE',
+        currentBalance: -100000,
+        openingBalance: -120000,
+        interestRate: 5.0,
+        paymentAmount: 800,
+        paymentFrequency: 'MONTHLY',
+        interestCategoryId: 'cat-int',
+        sourceAccountId: 'src-1',
+        isCanadianMortgage: false,
+        isVariableRate: false,
+        isClosed: false,
+      },
+    ]);
+    mockGetAllTransactions.mockResolvedValue({
+      data: [{ id: 'tx-1', transactionDate: '2024-06-01', amount: 800, linkedTransaction: null }],
+      pagination: { hasMore: false },
+    });
+    let resolveInterest!: (value: unknown[]) => void;
+    mockGetAllPages.mockReturnValue(
+      new Promise((resolve) => {
+        resolveInterest = resolve;
+      }),
+    );
+
+    render(<DebtPayoffTimelineReport />);
+
+    // Accounts and transactions have resolved, but the separate-interest fetch
+    // is still in flight: the report must keep the skeleton instead of painting
+    // the schedule with the analytic interest estimate.
+    await act(async () => {});
+    await act(async () => {});
+    expect(document.querySelector('.animate-pulse')).toBeTruthy();
+    expect(screen.queryByText('Current Balance')).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveInterest([]);
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Current Balance')).toBeInTheDocument();
+    });
+  });
+
   it('renders controls with account selector when accounts exist', async () => {
     mockGetAllAccounts.mockResolvedValue([
       {

--- a/frontend/src/components/reports/DebtPayoffTimelineReport.test.tsx
+++ b/frontend/src/components/reports/DebtPayoffTimelineReport.test.tsx
@@ -46,6 +46,7 @@ vi.mock('recharts', () => ({
 
 const mockGetAllAccounts = vi.fn();
 const mockGetAllTransactions = vi.fn();
+const mockGetAllPages = vi.fn();
 
 vi.mock('@/lib/accounts', () => ({
   accountsApi: {
@@ -56,6 +57,7 @@ vi.mock('@/lib/accounts', () => ({
 vi.mock('@/lib/transactions', () => ({
   transactionsApi: {
     getAll: (...args: any[]) => mockGetAllTransactions(...args),
+    getAllPages: (...args: any[]) => mockGetAllPages(...args),
   },
 }));
 
@@ -95,6 +97,38 @@ describe('DebtPayoffTimelineReport', () => {
     await waitFor(() => {
       expect(screen.getByText(/No debt accounts found/)).toBeInTheDocument();
     });
+  });
+
+  it('fetches the loan\'s separately-booked interest expenses (issue #893)', async () => {
+    mockGetAllAccounts.mockResolvedValue([
+      {
+        id: 'loan-1',
+        name: 'Mortgage',
+        accountType: 'MORTGAGE',
+        currentBalance: -100000,
+        openingBalance: -120000,
+        interestRate: 5.0,
+        paymentAmount: 800,
+        paymentFrequency: 'MONTHLY',
+        interestCategoryId: 'cat-int',
+        sourceAccountId: 'src-1',
+        isCanadianMortgage: false,
+        isVariableRate: false,
+        isClosed: false,
+      },
+    ]);
+    mockGetAllPages.mockResolvedValue([
+      { id: 'i1', transactionDate: '2024-06-01', amount: -300, categoryId: 'cat-int', isTransfer: false },
+    ]);
+
+    render(<DebtPayoffTimelineReport />);
+
+    await waitFor(() =>
+      expect(mockGetAllPages).toHaveBeenCalledWith({
+        categoryIds: ['cat-int'],
+        accountIds: ['src-1'],
+      }),
+    );
   });
 
   it('renders controls with account selector when accounts exist', async () => {

--- a/frontend/src/components/reports/DebtPayoffTimelineReport.tsx
+++ b/frontend/src/components/reports/DebtPayoffTimelineReport.tsx
@@ -96,8 +96,15 @@ export function DebtPayoffTimelineReport() {
   const transactions = useMemo<Transaction[]>(() => transactionsData ?? [], [transactionsData]);
 
   // The loan's separately-booked interest expenses, so derived interest matches
-  // the loan detail page (see #893).
-  const { data: interestData } = useReportData(
+  // the loan detail page (see #893). Folded into the combined isLoading/error/
+  // reload below like the other loaders, so the schedule never paints with the
+  // analytic interest estimate and then snaps to the booked interest.
+  const {
+    data: interestData,
+    isLoading: interestLoading,
+    error: interestError,
+    reload: reloadInterest,
+  } = useReportData(
     async () => {
       const account = accounts.find((a) => a.id === selectedAccountId);
       if (!account) return [] as Transaction[];
@@ -107,11 +114,12 @@ export function DebtPayoffTimelineReport() {
   );
   const interestTransactions = useMemo<Transaction[]>(() => interestData ?? [], [interestData]);
 
-  const isLoading = accountsLoading || transactionsLoading;
-  const error = accountsError || transactionsError;
+  const isLoading = accountsLoading || transactionsLoading || interestLoading;
+  const error = accountsError || transactionsError || interestError;
   const reload = () => {
     reloadAccounts();
     reloadTransactions();
+    reloadInterest();
   };
 
   // Build payment timeline from actual transactions + projected future payments

--- a/frontend/src/components/reports/DebtPayoffTimelineReport.tsx
+++ b/frontend/src/components/reports/DebtPayoffTimelineReport.tsx
@@ -22,6 +22,7 @@ import {
   buildLoanProjectionInput,
   deriveLoanPaymentHistory,
   fetchAllAccountTransactions,
+  fetchLoanInterestTransactions,
 } from '@/lib/loan-history';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useReportData } from '@/hooks/useReportData';
@@ -93,6 +94,19 @@ export function DebtPayoffTimelineReport() {
   );
 
   const transactions = useMemo<Transaction[]>(() => transactionsData ?? [], [transactionsData]);
+
+  // The loan's separately-booked interest expenses, so derived interest matches
+  // the loan detail page (see #893).
+  const { data: interestData } = useReportData(
+    async () => {
+      const account = accounts.find((a) => a.id === selectedAccountId);
+      if (!account) return [] as Transaction[];
+      return fetchLoanInterestTransactions(account);
+    },
+    [selectedAccountId, accounts],
+  );
+  const interestTransactions = useMemo<Transaction[]>(() => interestData ?? [], [interestData]);
+
   const isLoading = accountsLoading || transactionsLoading;
   const error = accountsError || transactionsError;
   const reload = () => {
@@ -108,7 +122,7 @@ export function DebtPayoffTimelineReport() {
     if (!selectedAccount) return { payoffSchedule: [], projectionStartLabel: null };
 
     // --- Historical payments from actual transactions ---
-    const history = deriveLoanPaymentHistory(selectedAccount, transactions);
+    const history = deriveLoanPaymentHistory(selectedAccount, transactions, [], interestTransactions);
     const schedule: PayoffScheduleItem[] = history.events.map((event) => ({
       date: event.date,
       label: formatChartDate(event.date, 'MMM yyyy'),
@@ -199,7 +213,7 @@ export function DebtPayoffTimelineReport() {
     }
 
     return { payoffSchedule: monthlySchedule, projectionStartLabel: startLabel };
-  }, [selectedAccount, transactions, formatChartDate]);
+  }, [selectedAccount, transactions, interestTransactions, formatChartDate]);
 
   const summary = useMemo(() => {
     if (payoffSchedule.length === 0 || !selectedAccount) return null;

--- a/frontend/src/components/reports/LoanAmortizationReport.test.tsx
+++ b/frontend/src/components/reports/LoanAmortizationReport.test.tsx
@@ -20,6 +20,7 @@ vi.mock('@/hooks/useNumberFormat', () => ({
 
 const mockGetAllAccounts = vi.fn();
 const mockGetAllTransactions = vi.fn();
+const mockGetAllPages = vi.fn();
 
 vi.mock('@/lib/accounts', () => ({
   accountsApi: {
@@ -30,6 +31,7 @@ vi.mock('@/lib/accounts', () => ({
 vi.mock('@/lib/transactions', () => ({
   transactionsApi: {
     getAll: (...args: any[]) => mockGetAllTransactions(...args),
+    getAllPages: (...args: any[]) => mockGetAllPages(...args),
   },
 }));
 
@@ -59,6 +61,44 @@ describe('LoanAmortizationReport', () => {
     await waitFor(() => {
       expect(screen.getByText(/No loan or mortgage accounts found/)).toBeInTheDocument();
     });
+  });
+
+  it('fetches the loan\'s separately-booked interest expenses (issue #893)', async () => {
+    mockGetAllAccounts.mockResolvedValue([
+      {
+        id: 'loan-1',
+        name: 'Mortgage',
+        accountType: 'MORTGAGE',
+        currentBalance: -100000,
+        openingBalance: -120000,
+        interestRate: 5.0,
+        paymentAmount: 800,
+        paymentFrequency: 'MONTHLY',
+        interestCategoryId: 'cat-int',
+        sourceAccountId: 'src-1',
+        isCanadianMortgage: false,
+        isVariableRate: false,
+        isClosed: false,
+      },
+    ]);
+    mockGetAllTransactions.mockResolvedValue({
+      data: [{ id: 'p1', transactionDate: '2024-06-01', amount: 500, linkedTransaction: null }],
+    });
+    mockGetAllPages.mockResolvedValue([
+      { id: 'i1', transactionDate: '2024-06-01', amount: -300, categoryId: 'cat-int', isTransfer: false },
+    ]);
+
+    render(<LoanAmortizationReport />);
+
+    // The report now pulls the loan's interest expenses, scoped to its
+    // configured interest category + source account, so its interest matches
+    // the loan detail page instead of an analytic estimate.
+    await waitFor(() =>
+      expect(mockGetAllPages).toHaveBeenCalledWith({
+        categoryIds: ['cat-int'],
+        accountIds: ['src-1'],
+      }),
+    );
   });
 
   it('renders account selector and summary with data', async () => {

--- a/frontend/src/components/reports/LoanAmortizationReport.tsx
+++ b/frontend/src/components/reports/LoanAmortizationReport.tsx
@@ -10,6 +10,7 @@ import {
   buildLoanProjectionInput,
   deriveLoanPaymentHistory,
   fetchAllAccountTransactions,
+  fetchLoanInterestTransactions,
 } from '@/lib/loan-history';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { exportToCsv } from '@/lib/csv-export';
@@ -49,6 +50,7 @@ export function LoanAmortizationReport() {
   };
   const [selectedAccountId, setSelectedAccountId] = useState<string>('');
   const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [interestTransactions, setInterestTransactions] = useState<Transaction[]>([]);
   const [showAllRows, setShowAllRows] = useState(false);
   const { sortField, sortDirection, handleSort } = useSortableTable<AmortizationSortField>(
     'reports.loan-amortization.sort',
@@ -79,31 +81,40 @@ export function LoanAmortizationReport() {
 
   const selectedAccount = accounts.find((a) => a.id === selectedAccountId);
 
-  // Load transactions from the loan account
+  // Load the loan account's transactions plus its separately-booked interest
+  // expenses, so the derived interest matches the loan detail page (see #893).
   useEffect(() => {
     const loadTransactions = async () => {
       if (!selectedAccountId) {
         setTransactions([]);
+        setInterestTransactions([]);
         return;
       }
 
+      const account = accounts.find((a) => a.id === selectedAccountId);
       try {
-        setTransactions(await fetchAllAccountTransactions(selectedAccountId));
+        const [txns, interest] = await Promise.all([
+          fetchAllAccountTransactions(selectedAccountId),
+          account ? fetchLoanInterestTransactions(account) : Promise.resolve([]),
+        ]);
+        setTransactions(txns);
+        setInterestTransactions(interest);
       } catch (error) {
         logger.error('Failed to load transactions:', error);
         setTransactions([]);
+        setInterestTransactions([]);
       }
     };
 
     loadTransactions();
-  }, [selectedAccountId]);
+  }, [selectedAccountId, accounts]);
 
   // Build payment history from actual transactions + projected future payments
   const paymentHistory = useMemo((): PaymentRow[] => {
     if (!selectedAccount) return [];
 
     // --- Historical payments from actual transactions ---
-    const history = deriveLoanPaymentHistory(selectedAccount, transactions);
+    const history = deriveLoanPaymentHistory(selectedAccount, transactions, [], interestTransactions);
     const payments: PaymentRow[] = history.events.map((event, index) => ({
       paymentNumber: index + 1,
       date: event.date,
@@ -133,7 +144,7 @@ export function LoanAmortizationReport() {
     }
 
     return payments;
-  }, [selectedAccount, transactions]);
+  }, [selectedAccount, transactions, interestTransactions]);
 
   const historicalCount = useMemo(() => paymentHistory.filter((r) => !r.isProjected).length, [paymentHistory]);
   const hasProjection = useMemo(() => paymentHistory.some((r) => r.isProjected), [paymentHistory]);


### PR DESCRIPTION
## Linked discussion / issue

Closes #893
Approved in: surfaced in the review of #892 (https://github.com/kenlasko/monize/pull/892)

## Summary

`LoanAmortizationReport` and `DebtPayoffTimelineReport` called `deriveLoanPaymentHistory(account, transactions)` **without** `interestTransactions`, so `hasSeparateInterest` was always false there. Two consequences:
- the #891 over-count (an analytic interest estimate on a same-date principal-only leg) still happened in the reports even after #892 fixed it on the loan detail page;
- the reports and the loan detail page showed **different interest** for the same loan.

Both reports now load `fetchLoanInterestTransactions(account)` — scoped to the loan's configured interest category + source account — and pass it into `deriveLoanPaymentHistory`, matching the loan detail container. `LoanAmortizationReport` fetches it alongside the transactions; `DebtPayoffTimelineReport` adds a parallel `useReportData` loader.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). — no new strings added; parity unaffected.
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Written with Claude Code (Opus 4.8). I reviewed the diff and own its correctness, conventions, and tests.