### PR TITLE
Fix import completion navigation to show just-imported accounts

### DIFF
--- a/frontend/src/components/import/CompleteStep.test.tsx
+++ b/frontend/src/components/import/CompleteStep.test.tsx
@@ -2,6 +2,45 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@/test/render';
 import { CompleteStep } from './CompleteStep';
 import { Account } from '@/types/account';
+import { ImportFileData } from '@/app/import/import-utils';
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: vi.fn(),
+    back: vi.fn(),
+    prefetch: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+function createImportFile(
+  fileName: string,
+  selectedAccountId: string,
+  accountType = 'CHEQUING',
+): ImportFileData {
+  return {
+    fileName,
+    fileContent: '',
+    fileType: 'qif',
+    parsedData: {
+      accountType,
+      accountName: '',
+      transactionCount: 1,
+      categories: [],
+      transferAccounts: [],
+      securities: [],
+      dateRange: { start: '2024-01-01', end: '2024-01-31' },
+      detectedDateFormat: 'YYYY-MM-DD',
+      sampleDates: [],
+    },
+    selectedAccountId,
+    matchConfidence: 'exact',
+  };
+}
 
 vi.mock('@/lib/accounts', () => ({
   accountsApi: {
@@ -146,6 +185,120 @@ describe('CompleteStep', () => {
     ];
     render(<CompleteStep {...defaultProps} importFiles={importFiles} />);
     expect(screen.getByText(/View Investments/i)).toBeInTheDocument();
+  });
+
+  // --- View destination navigation (issue #911) ---
+
+  it('navigates to the just-imported account, not the last-viewed one', () => {
+    render(
+      <CompleteStep
+        {...defaultProps}
+        importFiles={[createImportFile('b.qif', 'acc-1')]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /View Transactions/i }));
+    expect(mockPush).toHaveBeenCalledWith('/transactions?accountId=acc-1');
+  });
+
+  it('falls back to the selectedAccountId when importFiles is empty', () => {
+    render(<CompleteStep {...defaultProps} selectedAccountId="acc-1" />);
+    fireEvent.click(screen.getByRole('button', { name: /View Transactions/i }));
+    expect(mockPush).toHaveBeenCalledWith('/transactions?accountId=acc-1');
+  });
+
+  it('filters to every account touched by a bulk import', () => {
+    const accounts = [
+      createAccount({ id: 'acc-1', name: 'Chequing' }),
+      createAccount({ id: 'acc-2', name: 'Savings' }),
+    ];
+    render(
+      <CompleteStep
+        {...defaultProps}
+        accounts={accounts}
+        importResult={null}
+        isBulkImport
+        bulkImportResult={{
+          totalImported: 5, totalSkipped: 0, totalErrors: 0,
+          categoriesCreated: 0, accountsCreated: 0, payeesCreated: 0, securitiesCreated: 0,
+          fileResults: [],
+        }}
+        importFiles={[
+          createImportFile('checking.qif', 'acc-1'),
+          createImportFile('savings.qif', 'acc-2'),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /View Transactions/i }));
+    const url = mockPush.mock.calls[0][0] as string;
+    expect(url.startsWith('/transactions?')).toBe(true);
+    const params = new URLSearchParams(url.split('?')[1]);
+    expect(params.get('accountIds')).toBe('acc-1,acc-2');
+  });
+
+  it('deduplicates accounts when a bulk import targets one account twice', () => {
+    render(
+      <CompleteStep
+        {...defaultProps}
+        importResult={null}
+        isBulkImport
+        bulkImportResult={{
+          totalImported: 5, totalSkipped: 0, totalErrors: 0,
+          categoriesCreated: 0, accountsCreated: 0, payeesCreated: 0, securitiesCreated: 0,
+          fileResults: [],
+        }}
+        importFiles={[
+          createImportFile('jan.qif', 'acc-1'),
+          createImportFile('feb.qif', 'acc-1'),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /View Transactions/i }));
+    expect(mockPush).toHaveBeenCalledWith('/transactions?accountId=acc-1');
+  });
+
+  it('forces the Show Accounts filter to All for a closed target account', () => {
+    render(
+      <CompleteStep
+        {...defaultProps}
+        accounts={[createAccount({ id: 'acc-1', isClosed: true })]}
+        importFiles={[createImportFile('b.qif', 'acc-1')]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /View Transactions/i }));
+    expect(mockPush).toHaveBeenCalledWith('/transactions?accountId=acc-1&accountStatus=all');
+  });
+
+  it('filters investments to the imported brokerage account', () => {
+    render(
+      <CompleteStep
+        {...defaultProps}
+        importFiles={[createImportFile('portfolio.qif', 'brokerage-1', 'INVESTMENT')]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /View Investments/i }));
+    expect(mockPush).toHaveBeenCalledWith('/investments?accountId=brokerage-1');
+  });
+
+  it('filters to accounts created by a multi-account QIF import', () => {
+    render(
+      <CompleteStep
+        {...defaultProps}
+        importFiles={[]}
+        selectedAccountId=""
+        importResult={{
+          imported: 20, skipped: 0, errors: 0, errorMessages: [],
+          categoriesCreated: 0, accountsCreated: 2, payeesCreated: 0, securitiesCreated: 0,
+          createdMappings: {
+            categories: {},
+            accounts: { Chequing: 'acc-1' },
+            loans: {},
+            securities: {},
+          },
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /View Transactions/i }));
+    expect(mockPush).toHaveBeenCalledWith('/transactions?accountId=acc-1');
   });
 
   // --- Bulk import results ---

--- a/frontend/src/components/import/CompleteStep.tsx
+++ b/frontend/src/components/import/CompleteStep.tsx
@@ -80,6 +80,56 @@ export function CompleteStep({
     (la) => !completedSetups.has(la.accountId),
   );
 
+  // The Transactions and Investments pages restore their last-viewed account
+  // filter from localStorage, so navigating to a bare path would show a
+  // previously-imported account rather than the one just imported (issue #911).
+  // Build a destination that pins the filter to the account(s) this import
+  // touched -- an explicit URL filter takes precedence over the persisted one.
+  const viewDestination = useMemo(() => {
+    const seen = new Set<string>();
+    const accountIds: string[] = [];
+    const addId = (id: string | undefined | null) => {
+      if (id && !seen.has(id)) {
+        seen.add(id);
+        accountIds.push(id);
+      }
+    };
+    // Accounts explicitly targeted by the imported files (single + bulk).
+    for (const f of importFiles) addId(f.selectedAccountId);
+    addId(selectedAccountId);
+    // Multi-account QIF imports create their accounts during import and leave
+    // importFiles empty, so fall back to the accounts the import created.
+    if (accountIds.length === 0 && importResult?.createdMappings) {
+      for (const id of Object.values(importResult.createdMappings.accounts)) addId(id);
+    }
+
+    if (hasInvestmentFile) {
+      // The Investments page filters by a single brokerage account, so use the
+      // first imported investment account to surface its holdings immediately.
+      const investmentFile = importFiles.find(
+        (f) => f.parsedData?.accountType === 'INVESTMENT' && f.selectedAccountId,
+      );
+      return investmentFile
+        ? `/investments?accountId=${investmentFile.selectedAccountId}`
+        : '/investments';
+    }
+
+    if (accountIds.length === 0) return '/transactions';
+
+    const params = new URLSearchParams();
+    if (accountIds.length === 1) {
+      params.set('accountId', accountIds[0]);
+    } else {
+      params.set('accountIds', accountIds.join(','));
+    }
+    // A closed account is pruned by the persisted "Show Accounts" toggle, so
+    // force it to All to keep the just-imported transactions visible.
+    if (accountIds.some((id) => accounts.find((a) => a.id === id)?.isClosed)) {
+      params.set('accountStatus', 'all');
+    }
+    return `/transactions?${params.toString()}`;
+  }, [importFiles, selectedAccountId, importResult, hasInvestmentFile, accounts]);
+
   return (
     <div className={isBulkImport ? "max-w-4xl mx-auto" : "max-w-xl mx-auto"}>
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
@@ -251,7 +301,7 @@ export function CompleteStep({
         <div className="flex justify-center space-x-4">
           <Button
             variant="outline"
-            onClick={() => router.push(hasInvestmentFile ? '/investments' : '/transactions')}
+            onClick={() => router.push(viewDestination)}
           >
             {hasInvestmentFile ? t('complete.viewInvestments') : t('complete.viewTransactions')}
           </Button>


### PR DESCRIPTION
## Linked discussion / issue

Closes #911

## Summary

When completing a file import, the "View Transactions" and "View Investments" buttons now navigate to the account(s) that were just imported, rather than falling back to the last-viewed account persisted in localStorage. This prevents the confusing experience of importing into one account but seeing transactions from a previously-viewed account.

The fix builds an explicit URL with account filter parameters that take precedence over the persisted filter:
- **Single imports**: pins to the target account via `?accountId=`
- **Bulk imports**: pins to all touched accounts via `?accountIds=`
- **Multi-account QIF imports**: uses accounts created during import (from `importResult.createdMappings`)
- **Closed accounts**: forces `?accountStatus=all` to keep imported transactions visible
- **Investment imports**: routes to `/investments?accountId=` for the brokerage account

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (navigation destination logic).
- [x] New behavior has tests, and the existing suite passes.
- [x] No user-facing strings added (existing i18n keys reused).
- [x] No shared/core areas refactored.
- [x] The branch is rebased on the latest `main`.

## Test coverage

Added 6 new test cases covering:
- Single import navigation to target account
- Fallback to `selectedAccountId` when no import files
- Bulk import filtering to all touched accounts
- Deduplication when bulk import targets same account twice
- Closed account handling (forces `accountStatus=all`)
- Investment account filtering
- Multi-account QIF import account creation fallback

All tests pass with the new `viewDestination` logic.

https://claude.ai/code/session_016sQmBxhkQv2HfMnAr3V1QA