### PR TITLE
fix(ui): never flash raw UUIDs in id-backed comboboxes while options load

### DIFF
--- a/frontend/src/components/accounts/AccountForm.tsx
+++ b/frontend/src/components/accounts/AccountForm.tsx
@@ -708,6 +708,7 @@ export function AccountForm({ account, onSubmit, onCancel, onDirtyChange, submit
           onChange={handleInstitutionChange}
           onCreateNew={handleInstitutionCreate}
           allowCustomValue
+          valueIsId
           usePortal
           alwaysShowSubtitle
           error={errors.institutionId?.message}

--- a/frontend/src/components/accounts/AssetFields.tsx
+++ b/frontend/src/components/accounts/AssetFields.tsx
@@ -54,6 +54,7 @@ export function AssetFields({
         onChange={handleAssetCategoryChange}
         onCreateNew={handleAssetCategoryCreate}
         allowCustomValue={true}
+        valueIsId
       />
       <DateInput
         label={t('assetFields.dateAcquired')}

--- a/frontend/src/components/accounts/LoanPaymentSetupDialog.tsx
+++ b/frontend/src/components/accounts/LoanPaymentSetupDialog.tsx
@@ -440,6 +440,7 @@ export function LoanPaymentSetupDialog({
                   options={payeeOptions}
                   placeholder={t('loanPaymentSetup.selectOrCreatePayee')}
                   allowCustomValue={true}
+                  valueIsId
                 />
               </div>
 

--- a/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx
+++ b/frontend/src/components/scheduled-transactions/ScheduledTransactionForm.tsx
@@ -1056,6 +1056,7 @@ export function ScheduledTransactionForm({
               onInputChange={handlePayeeSearch}
               onCreateNew={handlePayeeCreate}
               allowCustomValue={true}
+              valueIsId
               error={errors.payeeName?.message}
             />
             <div>
@@ -1070,6 +1071,7 @@ export function ScheduledTransactionForm({
                     onChange={handleCategoryChange}
                     onCreateNew={handleCategoryCreate}
                     allowCustomValue={true}
+                    valueIsId
                     error={errors.categoryId?.message}
                   />
                 </div>
@@ -1186,6 +1188,7 @@ export function ScheduledTransactionForm({
               onInputChange={handlePayeeSearch}
               onCreateNew={handlePayeeCreate}
               allowCustomValue={true}
+              valueIsId
               error={errors.payeeName?.message}
             />
             <CurrencyInput
@@ -1351,6 +1354,7 @@ export function ScheduledTransactionForm({
               onInputChange={handlePayeeSearch}
               onCreateNew={handlePayeeCreate}
               allowCustomValue={true}
+              valueIsId
               error={errors.payeeName?.message}
             />
             <div>
@@ -1363,6 +1367,7 @@ export function ScheduledTransactionForm({
                 onChange={handleCategoryChange}
                 onCreateNew={handleCategoryCreate}
                 allowCustomValue={true}
+                valueIsId
                 error={errors.categoryId?.message}
               />
               <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">

--- a/frontend/src/components/transactions/BulkUpdateModal.tsx
+++ b/frontend/src/components/transactions/BulkUpdateModal.tsx
@@ -222,6 +222,7 @@ export function BulkUpdateModal({
                     setValue('payeeName', name);
                   }}
                   allowCustomValue
+                  valueIsId
                 />
               )}
             />

--- a/frontend/src/components/transactions/NormalTransactionFields.tsx
+++ b/frontend/src/components/transactions/NormalTransactionFields.tsx
@@ -116,6 +116,7 @@ export function NormalTransactionFields({
               onChange={handlePayeeChange}
               onCreateNew={handlePayeeCreate}
               allowCustomValue={true}
+              valueIsId
               error={errors.payeeName?.message as string | undefined}
             />
           </div>
@@ -177,6 +178,7 @@ export function NormalTransactionFields({
                 onChange={handleCategoryChange}
                 onCreateNew={handleCategoryCreate}
                 allowCustomValue={true}
+                valueIsId
                 error={errors.categoryId?.message as string | undefined}
               />
             </div>

--- a/frontend/src/components/transactions/SplitTransactionFields.tsx
+++ b/frontend/src/components/transactions/SplitTransactionFields.tsx
@@ -102,6 +102,7 @@ export function SplitTransactionFields({
               onChange={handlePayeeChange}
               onCreateNew={handlePayeeCreate}
               allowCustomValue={true}
+              valueIsId
               error={errors.payeeName?.message as string | undefined}
             />
           </div>

--- a/frontend/src/components/transactions/TransferTransactionFields.tsx
+++ b/frontend/src/components/transactions/TransferTransactionFields.tsx
@@ -197,6 +197,7 @@ export function TransferTransactionFields({
             setTransferPayeeName(payeeName);
           }}
           allowCustomValue={true}
+          valueIsId
         />
         {/* A transfer never counts as income/expense, but a category lets it
             appear in the monthly category breakdown (e.g. investment contributions). */}
@@ -210,6 +211,7 @@ export function TransferTransactionFields({
             onChange={handleCategoryChange}
             onCreateNew={handleCategoryCreate}
             allowCustomValue={true}
+            valueIsId
             error={errors.categoryId?.message as string | undefined}
           />
           <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">

--- a/frontend/src/components/ui/Combobox.test.tsx
+++ b/frontend/src/components/ui/Combobox.test.tsx
@@ -1143,6 +1143,81 @@ describe('Combobox', () => {
 
       expect(screen.getByRole('textbox')).toHaveValue('LSE');
     });
+
+    it('shows initialDisplayValue instead of the raw id while options are still loading', () => {
+      const uuid = 'a1b2c3d4-0000-0000-0000-000000000000';
+      const { rerender } = render(
+        <Combobox
+          options={[]}
+          onChange={onChange}
+          value={uuid}
+          initialDisplayValue="Groceries"
+          allowCustomValue
+        />,
+      );
+
+      // The id must never flash in the input while the options list loads
+      expect(screen.getByRole('textbox')).toHaveValue('Groceries');
+
+      rerender(
+        <Combobox
+          options={[{ value: uuid, label: 'Groceries: Weekly' }]}
+          onChange={onChange}
+          value={uuid}
+          initialDisplayValue="Groceries"
+          allowCustomValue
+        />,
+      );
+
+      expect(screen.getByRole('textbox')).toHaveValue('Groceries: Weekly');
+    });
+
+    it('valueIsId keeps the input blank for an unresolved id, then shows the label once options load', () => {
+      const uuid = 'a1b2c3d4-0000-0000-0000-000000000000';
+      const { rerender } = render(
+        <Combobox
+          options={[]}
+          onChange={onChange}
+          value={uuid}
+          allowCustomValue
+          valueIsId
+        />,
+      );
+
+      // No display name available: blank beats showing the raw id
+      expect(screen.getByRole('textbox')).toHaveValue('');
+
+      rerender(
+        <Combobox
+          options={[{ value: uuid, label: 'Groceries' }]}
+          onChange={onChange}
+          value={uuid}
+          allowCustomValue
+          valueIsId
+        />,
+      );
+
+      expect(screen.getByRole('textbox')).toHaveValue('Groceries');
+    });
+
+    it('valueIsId still allows typing and committing a custom value', () => {
+      render(
+        <Combobox
+          options={options}
+          onChange={onChange}
+          value=""
+          allowCustomValue
+          valueIsId
+        />,
+      );
+
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'My Custom Payee' } });
+      expect(input).toHaveValue('My Custom Payee');
+
+      fireEvent.mouseDown(document.body);
+      expect(onChange).toHaveBeenCalledWith('', 'My Custom Payee');
+    });
   });
 
   describe('usePortal', () => {

--- a/frontend/src/components/ui/Combobox.tsx
+++ b/frontend/src/components/ui/Combobox.tsx
@@ -38,6 +38,15 @@ interface ComboboxProps {
    * in a modal) so the list only opens on an explicit click, keypress, or type.
    */
   openOnFocus?: boolean;
+  /**
+   * The `value` prop is an opaque id (e.g. a UUID), so it must never be
+   * rendered as input text -- when it cannot be resolved to an option label
+   * yet (options still loading), the field shows `initialDisplayValue` or
+   * stays blank instead. Set this on every id-backed combobox that also sets
+   * `allowCustomValue` (whose custom values are reported via
+   * `onChange('', text)`, never through `value`).
+   */
+  valueIsId?: boolean;
   /** Accessible name for the input when there is no visible `label`. */
   'aria-label'?: string;
 }
@@ -58,6 +67,7 @@ export function Combobox({
   alwaysShowSubtitle = false,
   priorityValues,
   openOnFocus = true,
+  valueIsId = false,
   'aria-label': ariaLabel,
 }: ComboboxProps) {
   const t = useTranslations('common');
@@ -125,15 +135,18 @@ export function Combobox({
         setSelectedLabel(option.label);
         setInputValue(option.label);
         setHasInitialized(true);
-      } else if (allowCustomValue) {
-        // Display the raw value for custom values not in options list
+      } else if (initialDisplayValue && !hasInitialized) {
+        // Option not found yet (options list still loading): show the caller's
+        // display name, never the raw value -- for id-backed fields the raw
+        // value is a UUID and must not flash in the input while lists load.
+        setInputValue(initialDisplayValue);
+        setSelectedLabel(initialDisplayValue);
+      } else if (allowCustomValue && !valueIsId) {
+        // Display the raw value for custom values not in options list. An
+        // id-backed value stays blank instead until it resolves to a label.
         setSelectedLabel(value);
         setInputValue(value);
         setHasInitialized(true);
-      } else if (initialDisplayValue && !hasInitialized) {
-        // Use initial display value if option not found yet (still loading)
-        setInputValue(initialDisplayValue);
-        setSelectedLabel(initialDisplayValue);
       }
     } else if (!allowCustomValue) {
       setSelectedLabel('');


### PR DESCRIPTION
## Linked discussion / issue

Closes #925
Approved in: #925 (owner-filed bug report; fix applied directly)

## Summary

Opening a transaction (or account/scheduled-transaction/bulk-update form) briefly flashed raw UUIDs in the payee, category, institution, and asset-category fields before they resolved to names. The form mounts with the entity ids immediately, but the option lists load asynchronously; the shared `Combobox`'s value-sync effect displayed the raw value whenever the id couldn't be resolved yet and `allowCustomValue` was set, checking that fallback *before* the `initialDisplayValue` the forms already pass to cover the loading window.

- Prefer `initialDisplayValue` over the raw value while the id is unresolved.
- Add a `valueIsId` prop to `Combobox` declaring the value an opaque id that must never render as input text: unresolved ids show `initialDisplayValue` or stay blank until the option list resolves. Applied to all 14 id-backed call sites (transaction normal/split/transfer payee + category, scheduled-transaction payee + category, bulk-update payee, loan-payment payee, account institution, asset category). Free-text comboboxes (security type, exchange, allocation name) are untouched and keep the raw-value display.
- This also covers paths with no display name at all (new transaction with a default category) and two further live instances found in audit: `AccountForm` (institution) and `AssetFields` (asset value-change category), whose `initialDisplayValue` derives from async lists.

Audited the other field types for the same class of bug: native `Select`s render blank until options load, `MultiSelect` shows "N selected", and comboboxes without `allowCustomValue` cannot hit the raw-value branch — none display raw ids.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). *(No strings added or changed.)*
- [x] No shared/core areas were refactored without prior agreement. *(`Combobox` change is an additive opt-in prop plus a fallback-order fix; no behavioral change for existing free-text callers, verified by the full test suite for all consumers.)*
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Diagnosed and implemented with Claude Code (Claude Fable 5); reviewed and owned by @kenlasko. Verified with 3 new Combobox tests, the 1,958-test suite covering all consumer components, and `tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)