### PR TITLE
Add adaptive granularity to Monthly Totals chart with gap-fill

### DIFF
--- a/backend/src/transactions/transaction-analytics.service.spec.ts
+++ b/backend/src/transactions/transaction-analytics.service.spec.ts
@@ -1242,11 +1242,17 @@ describe("TransactionAnalyticsService", () => {
       );
     });
 
-    it("does not exclude transfers", async () => {
+    it("keeps whole transfers but excludes transfer split lines (matching getSummary)", async () => {
       await service.getMonthlyTotals(userId);
 
+      // Whole transfer transactions are still counted.
       expect(mockQueryBuilder.andWhere).not.toHaveBeenCalledWith(
         "transaction.isTransfer = false",
+      );
+      // Transfer split lines are excluded so the chart totals/counts reconcile
+      // with the category/payee summary, which shares this query builder.
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        "(splits.transferAccountId IS NULL OR splits.id IS NULL)",
       );
     });
 
@@ -1288,9 +1294,9 @@ describe("TransactionAnalyticsService", () => {
       ]);
 
       expect(mockQueryBuilder.where).toHaveBeenCalledWith(
-        "transaction.categoryId IN (:...monthlyCategoryIds)",
+        "transaction.categoryId IN (:...summaryCategoryIds)",
         {
-          monthlyCategoryIds: expect.arrayContaining(["cat-1", "cat-child"]),
+          summaryCategoryIds: expect.arrayContaining(["cat-1", "cat-child"]),
         },
       );
     });
@@ -1316,16 +1322,16 @@ describe("TransactionAnalyticsService", () => {
       );
     });
 
-    it("uses transaction.amount when no category filter is active", async () => {
+    it("always uses split-aware amounts via the shared summary query", async () => {
       await service.getMonthlyTotals(userId);
 
-      // Should NOT use COALESCE
-      const addSelectCalls = mockQueryBuilder.addSelect.mock.calls;
-      const coalesceUsed = addSelectCalls.some(
-        (call: unknown[]) =>
-          typeof call[0] === "string" && call[0].includes("COALESCE"),
+      // The shared query always expands splits, so the per-month total uses
+      // COALESCE(splits.amount, transaction.amount) even with no category
+      // filter -- keeping the chart total consistent with the summary.
+      expect(mockQueryBuilder.addSelect).toHaveBeenCalledWith(
+        expect.stringContaining("COALESCE(splits.amount, transaction.amount)"),
+        "total",
       );
-      expect(coalesceUsed).toBe(false);
     });
 
     it("applies payeeIds filter when provided", async () => {
@@ -1411,12 +1417,12 @@ describe("TransactionAnalyticsService", () => {
           expect.any(Brackets),
         );
         expect(mockQueryBuilder.where).toHaveBeenCalledWith(
-          "filterTags.id IN (:...monthlyTagIds)",
-          { monthlyTagIds: ["tag-1", "tag-2"] },
+          "filterTags.id IN (:...summaryTagIds)",
+          { summaryTagIds: ["tag-1", "tag-2"] },
         );
         expect(mockQueryBuilder.orWhere).toHaveBeenCalledWith(
-          "filterSplitTags.id IN (:...monthlyTagIds)",
-          { monthlyTagIds: ["tag-1", "tag-2"] },
+          "filterSplitTags.id IN (:...summaryTagIds)",
+          { summaryTagIds: ["tag-1", "tag-2"] },
         );
       });
 

--- a/backend/src/transactions/transaction-analytics.service.ts
+++ b/backend/src/transactions/transaction-analytics.service.ts
@@ -802,177 +802,36 @@ export class TransactionAnalyticsService {
     amountTo?: number,
     tagIds?: string[],
   ): Promise<Array<{ month: string; total: number; count: number }>> {
-    const queryBuilder = this.transactionsRepository
-      .createQueryBuilder("transaction")
-      .where("transaction.userId = :userId", { userId });
+    // Reuse the same filtered query builder as getSummary so the chart's
+    // per-month totals and counts reconcile exactly with the category/payee
+    // info widget's headline summary -- identical brokerage exclusion, split
+    // expansion, and transfer-split handling. Previously this method duplicated
+    // the filter logic with slightly different semantics (no transfer-split
+    // exclusion, conditional split join), which let the chart footer count and
+    // the widget count diverge and read as a stale/"caching" mismatch.
+    // getMonthlyTotals is only called when filters are active (the frontend
+    // switches to daily balances otherwise).
+    const queryBuilder = await this.createFilteredAnalyticsQuery(userId, {
+      accountIds,
+      startDate,
+      endDate,
+      categoryIds,
+      payeeIds,
+      search,
+      amountFrom,
+      amountTo,
+      tagIds,
+    });
 
-    // Join account for filtering.  Use the same exclusion logic as
-    // findAll() so the chart counts/totals match the transaction list.
-    // getMonthlyTotals is only called when filters are active (the
-    // frontend switches to daily balances otherwise).
-    queryBuilder.leftJoin("transaction.account", "summaryAccount");
-
-    queryBuilder.andWhere(
-      "(summaryAccount.accountSubType IS NULL OR summaryAccount.accountSubType != 'INVESTMENT_BROKERAGE')",
-    );
-
-    if (accountIds && accountIds.length > 0) {
-      queryBuilder.andWhere("transaction.accountId IN (:...accountIds)", {
-        accountIds,
-      });
-    }
-
-    if (startDate) {
-      queryBuilder.andWhere("transaction.transactionDate >= :startDate", {
-        startDate,
-      });
-    }
-
-    if (endDate) {
-      queryBuilder.andWhere("transaction.transactionDate <= :endDate", {
-        endDate,
-      });
-    }
-
-    let splitsJoined = false;
-
-    if (categoryIds && categoryIds.length > 0) {
-      const hasUncategorized = categoryIds.includes("uncategorized");
-      const hasTransfer = categoryIds.includes("transfer");
-      const regularCategoryIds = categoryIds.filter(
-        (id) => id !== "uncategorized" && id !== "transfer",
-      );
-
-      let hasCondition = false;
-
-      if (hasUncategorized || hasTransfer || regularCategoryIds.length > 0) {
-        const uniqueCategoryIds =
-          regularCategoryIds.length > 0
-            ? await getAllCategoryIdsWithChildren(
-                this.categoriesRepository,
-                userId,
-                regularCategoryIds,
-              )
-            : [];
-
-        if (hasUncategorized || uniqueCategoryIds.length > 0) {
-          queryBuilder.leftJoin("transaction.splits", "splits");
-          splitsJoined = true;
-        }
-
-        queryBuilder.andWhere(
-          new Brackets((qb) => {
-            if (hasUncategorized) {
-              const method = hasCondition ? "orWhere" : "where";
-              hasCondition = true;
-              qb[method](
-                new Brackets((unc) => {
-                  unc
-                    .where(
-                      "transaction.categoryId IS NULL AND transaction.isSplit = false AND transaction.isTransfer = false AND summaryAccount.accountType != 'INVESTMENT'",
-                    )
-                    // A split transaction counts as uncategorised when any of
-                    // its non-transfer split lines has no category, matching the
-                    // category breakdown grouping.
-                    .orWhere(
-                      "transaction.isSplit = true AND transaction.isTransfer = false AND summaryAccount.accountType != 'INVESTMENT' AND splits.categoryId IS NULL AND splits.transferAccountId IS NULL",
-                    );
-                }),
-              );
-            }
-            if (hasTransfer) {
-              const method = hasCondition ? "orWhere" : "where";
-              hasCondition = true;
-              qb[method]("transaction.isTransfer = true");
-            }
-            if (uniqueCategoryIds.length > 0) {
-              const method = hasCondition ? "orWhere" : "where";
-              hasCondition = true;
-              qb[method](
-                new Brackets((inner) => {
-                  inner
-                    .where(
-                      "transaction.categoryId IN (:...monthlyCategoryIds)",
-                      { monthlyCategoryIds: uniqueCategoryIds },
-                    )
-                    .orWhere("splits.categoryId IN (:...monthlyCategoryIds)", {
-                      monthlyCategoryIds: uniqueCategoryIds,
-                    });
-                }),
-              );
-            }
-          }),
-        );
-      }
-    }
-
-    if (payeeIds && payeeIds.length > 0) {
-      queryBuilder.andWhere("transaction.payeeId IN (:...payeeIds)", {
-        payeeIds,
-      });
-    }
-
-    if (search && search.trim()) {
-      const searchPattern = `%${escapeLikePattern(search.trim())}%`;
-      const parsedSearch = await this.resolveSearchTerm(userId, search);
-      if (!splitsJoined) {
-        queryBuilder.leftJoin("transaction.splits", "splits");
-        splitsJoined = true;
-      }
-      queryBuilder.andWhere(
-        buildTransactionSearchClause({
-          transaction: "transaction",
-          splits: "splits",
-        }),
-        {
-          search: searchPattern,
-          searchAmount: parsedSearch.amount,
-          searchDate: parsedSearch.date,
-        },
-      );
-    }
-
-    if (amountFrom !== undefined) {
-      queryBuilder.andWhere("transaction.amount >= :amountFrom", {
-        amountFrom,
-      });
-    }
-
-    if (amountTo !== undefined) {
-      queryBuilder.andWhere("transaction.amount <= :amountTo", { amountTo });
-    }
-
-    if (tagIds && tagIds.length > 0) {
-      if (!splitsJoined) {
-        queryBuilder.leftJoin("transaction.splits", "splits");
-        splitsJoined = true;
-      }
-      queryBuilder.leftJoin("transaction.tags", "filterTags");
-      queryBuilder.leftJoin("splits.tags", "filterSplitTags");
-      queryBuilder.andWhere(
-        new Brackets((qb) => {
-          qb.where("filterTags.id IN (:...monthlyTagIds)", {
-            monthlyTagIds: tagIds,
-          }).orWhere("filterSplitTags.id IN (:...monthlyTagIds)", {
-            monthlyTagIds: tagIds,
-          });
-        }),
-      );
-    }
-
-    // When category or tag filter joins splits, use the split amount for split
-    // transactions so we only count the matching split, not the full parent.
-    const amountExpr = splitsJoined
-      ? "COALESCE(splits.amount, transaction.amount)"
-      : "transaction.amount";
+    // The splits join is always present, so use the split amount for split
+    // transactions (COALESCE falls back to the transaction amount for
+    // non-split rows), keeping the per-month total signed for the bar chart.
+    const amountExpr = "COALESCE(splits.amount, transaction.amount)";
 
     queryBuilder
       .select("TO_CHAR(transaction.transactionDate, 'YYYY-MM')", "month")
       .addSelect(`SUM(${amountExpr})`, "total")
-      .addSelect(
-        splitsJoined ? "COUNT(DISTINCT transaction.id)" : "COUNT(*)",
-        "count",
-      )
+      .addSelect("COUNT(DISTINCT transaction.id)", "count")
       .groupBy("month")
       .orderBy("month", "ASC");
 

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -149,6 +149,12 @@ function TransactionsContent() {
   const [pagination, setPagination] = useState<PaginationInfo | null>(null);
   const [startingBalance, setStartingBalance] = useState<number | undefined>();
 
+  // Bumped after every transaction reload so the entity info widgets (which
+  // fetch their own summaries) refetch in lockstep with the chart and list,
+  // instead of showing a stale count after a mutation, undo/redo, or AI write
+  // until a full page refresh.
+  const [reloadKey, setReloadKey] = useState(0);
+
   // Budget context for category indicators
   const [budgetStatusMap, setBudgetStatusMap] = useState<Record<string, CategoryBudgetStatus>>({});
 
@@ -274,6 +280,9 @@ function TransactionsContent() {
       logger.error(error);
     } finally {
       setIsLoading(false);
+      // Signal the entity info widgets to refetch their summaries in lockstep
+      // with the freshly loaded chart/list data.
+      setReloadKey((k) => k + 1);
     }
   }, [accountIdsForQuery, filters.filterAccountStatus, filters.filterCategoryIds, filters.filterPayeeIds, filters.filterTagIds, filters.filterStartDate, filters.filterEndDate, filters.filterSearch, filters.filterAmountFrom, filters.filterAmountTo, filters.filterStatuses, filters.filterTagKey, filters.filterTagKeyOp, filters.filterTagKeyValue, t]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -956,6 +965,7 @@ function TransactionsContent() {
                       categories={categories}
                       scheduledTransactions={scheduledTransactions}
                       filterParams={widgetFilterParams}
+                      refreshKey={reloadKey}
                       onEdit={() => handlePayeeClick(retainedWidget.payee.id)}
                       onCollapse={() => setPayeeWidgetCollapsed(true)}
                       onCategoryClick={filters.handleCategoryClick}
@@ -967,6 +977,7 @@ function TransactionsContent() {
                       scheduledTransactions={scheduledTransactions}
                       monthlyTotals={monthlyTotals}
                       filterParams={widgetFilterParams}
+                      refreshKey={reloadKey}
                       onEdit={() => categoryModal.openEdit(retainedWidget.category)}
                       onCollapse={() => setCategoryWidgetCollapsed(true)}
                       onSubcategoryClick={filters.handleCategoryClick}

--- a/frontend/src/components/transactions/CategoryInfoWidget.test.tsx
+++ b/frontend/src/components/transactions/CategoryInfoWidget.test.tsx
@@ -193,8 +193,40 @@ describe('CategoryInfoWidget', () => {
 
     // average = 800 / 20
     expect(screen.getByText('CAD 40.00')).toBeInTheDocument();
-    // monthly average = (300+200+300)/3
+    // monthly average = (300+200+300)/3 (3 consecutive, gap-free months)
     expect(screen.getByText('CAD 266.67')).toBeInTheDocument();
+  });
+
+  it('averages spend over elapsed months, including gap months', async () => {
+    await renderWidget({
+      monthlyTotals: [
+        { month: '2026-01', total: -300, count: 4 },
+        { month: '2026-04', total: -300, count: 4 },
+      ],
+    });
+
+    // 4 elapsed months (Jan..Apr): 600 / 4 = 150, not 600 / 2 = 300.
+    expect(screen.getByText('CAD 150.00')).toBeInTheDocument();
+  });
+
+  it('refetches the summary when refreshKey changes', async () => {
+    const { rerender } = await renderWidget({ refreshKey: 0 });
+    expect(mockedTransactions.getSummary).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      rerender(
+        <CategoryInfoWidget
+          category={makeCategory()}
+          categories={categories}
+          filterParams={{}}
+          refreshKey={1}
+          onEdit={vi.fn()}
+          onCollapse={vi.fn()}
+        />,
+      );
+    });
+
+    expect(mockedTransactions.getSummary).toHaveBeenCalledTimes(2);
   });
 
   it('surfaces the next scheduled transaction in the category subtree', async () => {

--- a/frontend/src/components/transactions/CategoryInfoWidget.tsx
+++ b/frontend/src/components/transactions/CategoryInfoWidget.tsx
@@ -9,6 +9,8 @@ import { GroupedTotal, MonthlyTotal, TransactionSummary } from '@/types/transact
 import { CategoryBudgetStatus } from '@/types/budget';
 import { transactionsApi } from '@/lib/transactions';
 import { budgetsApi } from '@/lib/budgets';
+import { countElapsedPeriods } from '@/lib/chart-buckets';
+import { sumMoney } from '@/lib/format';
 import { getNextScheduled } from '@/lib/scheduled-utils';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useDateFormat } from '@/hooks/useDateFormat';
@@ -32,6 +34,8 @@ interface CategoryInfoWidgetProps {
   monthlyTotals?: MonthlyTotal[];
   /** Active page filters (date range, accounts, ...) minus any category ids. */
   filterParams: WidgetFilterParams;
+  /** Bumped by the page on every reload so the summary refetches in lockstep. */
+  refreshKey?: number;
   /** Open the shared category edit modal for this category. */
   onEdit: () => void;
   /** Collapse the widget so the chart can use the full width. */
@@ -54,6 +58,7 @@ export function CategoryInfoWidget({
   scheduledTransactions = [],
   monthlyTotals = [],
   filterParams,
+  refreshKey,
   onEdit,
   onCollapse,
   onSubcategoryClick,
@@ -112,7 +117,7 @@ export function CategoryInfoWidget({
     return () => {
       cancelled = true;
     };
-  }, [category.id, filterKey]);
+  }, [category.id, filterKey, refreshKey]);
 
   const parentCategory = useMemo(
     () => (category.parentId ? categories.find((c) => c.id === category.parentId) : undefined),
@@ -206,12 +211,15 @@ export function CategoryInfoWidget({
   const averageAmount =
     totals && transactionCount > 0 ? (totals.income + totals.expenses) / transactionCount : null;
 
-  // Average of the months the page's chart already covers; the chart data
-  // carries the same filters as this widget, so the figures reconcile.
+  // Average spend per elapsed month over the period the chart covers. Dividing
+  // by elapsed months (including months with no transaction) rather than only
+  // the months that had activity matches the chart's "Monthly Avg" and reads
+  // as the intuitive "total spend / months elapsed".
   const monthlyAverage = useMemo(() => {
     if (monthlyTotals.length === 0) return null;
-    const sum = monthlyTotals.reduce((acc, m) => acc + Math.abs(m.total), 0);
-    return sum / monthlyTotals.length;
+    const sum = sumMoney(monthlyTotals.map((m) => Math.abs(m.total)));
+    const elapsedMonths = countElapsedPeriods(monthlyTotals, 'month');
+    return elapsedMonths > 0 ? sum / elapsedMonths : null;
   }, [monthlyTotals]);
 
   const headlineTotal = totals ? (category.isIncome ? totals.income : totals.expenses) : null;

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
@@ -250,9 +250,16 @@ describe('CategoryPayeeBarChart', () => {
       expect(capturedProps.labelList.offset).toBe(5);
     });
 
-    it('rotates desktop bar-top labels vertical once the (forced monthly) column count crosses 36 and anchors them to sit above the bar', () => {
-      render(<CategoryPayeeBarChart data={buildMonths(48)} isLoading={false} />);
-      forceMonth();
+    it('keeps desktop bar-top labels horizontal at exactly the density threshold', () => {
+      render(<CategoryPayeeBarChart data={buildMonths(10)} isLoading={false} />);
+      expect(capturedProps.barChart.data).toHaveLength(10);
+      expect(capturedProps.labelList.angle).toBe(0);
+    });
+
+    it('rotates desktop bar-top labels vertical once the bars get dense and anchors them to sit above the bar', () => {
+      // 11 monthly bars crosses the desktop density threshold.
+      render(<CategoryPayeeBarChart data={buildMonths(11)} isLoading={false} />);
+      expect(capturedProps.barChart.data).toHaveLength(11);
       expect(capturedProps.labelList.angle).toBe(-90);
       // textAnchor='start' (with angle -90) makes rotated text extend upward
       // from the anchor, so values never overlap the bar they label.

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
@@ -292,6 +292,24 @@ describe('CategoryPayeeBarChart', () => {
       render(<CategoryPayeeBarChart data={buildMonths(6)} isLoading={false} />);
       expect(capturedProps.barChart.margin.top).toBe(20);
     });
+
+    it('still renders bar-top labels at the maximum labeled bar count', () => {
+      render(<CategoryPayeeBarChart data={buildMonths(60)} isLoading={false} />);
+      capturedProps.labelList = null;
+      forceMonth();
+      expect(capturedProps.barChart.data).toHaveLength(60);
+      expect(capturedProps.labelList).not.toBeNull();
+    });
+
+    it('drops bar-top labels entirely once there are more than 60 bars', () => {
+      render(<CategoryPayeeBarChart data={buildMonths(61)} isLoading={false} />);
+      // Clear the capture from the initial (auto, quarterly) render so we only
+      // observe whether the forced-monthly render emits a LabelList.
+      capturedProps.labelList = null;
+      forceMonth();
+      expect(capturedProps.barChart.data).toHaveLength(61);
+      expect(capturedProps.labelList).toBeNull();
+    });
   });
 
   describe('adaptive granularity', () => {

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent } from '@testing-library/react';
 import { render, screen } from '@/test/render';
 import { CategoryPayeeBarChart } from './CategoryPayeeBarChart';
 
@@ -227,6 +228,11 @@ describe('CategoryPayeeBarChart', () => {
   });
 
   describe('label crowding behaviour', () => {
+    // Auto granularity rolls long spans up to quarters/years, so force the
+    // 'month' bucket size to reproduce the many-thin-bars crowding case.
+    const forceMonth = () =>
+      fireEvent.click(screen.getByRole('button', { name: 'Month' }));
+
     it('always lets the X-axis skip ticks when crowded (preserveStartEnd)', () => {
       render(<CategoryPayeeBarChart data={buildMonths(48)} isLoading={false} />);
       expect(capturedProps.xAxis.interval).toBe('preserveStartEnd');
@@ -237,15 +243,16 @@ describe('CategoryPayeeBarChart', () => {
       expect(capturedProps.xAxis.interval).toBe('preserveStartEnd');
     });
 
-    it('keeps desktop bar-top labels horizontal when uncrowded (<= 36 months)', () => {
-      render(<CategoryPayeeBarChart data={buildMonths(36)} isLoading={false} />);
+    it('keeps desktop bar-top labels horizontal when uncrowded', () => {
+      render(<CategoryPayeeBarChart data={buildMonths(6)} isLoading={false} />);
       expect(capturedProps.labelList.angle).toBe(0);
       expect(capturedProps.labelList.textAnchor).toBe('middle');
       expect(capturedProps.labelList.offset).toBe(5);
     });
 
-    it('rotates desktop bar-top labels vertical once column count crosses 36 and anchors them to sit above the bar', () => {
-      render(<CategoryPayeeBarChart data={buildMonths(37)} isLoading={false} />);
+    it('rotates desktop bar-top labels vertical once the (forced monthly) column count crosses 36 and anchors them to sit above the bar', () => {
+      render(<CategoryPayeeBarChart data={buildMonths(48)} isLoading={false} />);
+      forceMonth();
       expect(capturedProps.labelList.angle).toBe(-90);
       // textAnchor='start' (with angle -90) makes rotated text extend upward
       // from the anchor, so values never overlap the bar they label.
@@ -269,8 +276,115 @@ describe('CategoryPayeeBarChart', () => {
     });
 
     it('reserves extra top margin when bar-top labels are vertical', () => {
-      render(<CategoryPayeeBarChart data={buildMonths(40)} isLoading={false} />);
+      render(<CategoryPayeeBarChart data={buildMonths(48)} isLoading={false} />);
+      forceMonth();
+      expect(capturedProps.barChart.margin.top).toBe(28);
+    });
+
+    it('uses a comfortable top margin when labels are horizontal', () => {
+      render(<CategoryPayeeBarChart data={buildMonths(6)} isLoading={false} />);
       expect(capturedProps.barChart.margin.top).toBe(20);
+    });
+  });
+
+  describe('adaptive granularity', () => {
+    it('auto-selects monthly buckets for a short span (Monthly Avg)', () => {
+      render(<CategoryPayeeBarChart data={buildMonths(3)} isLoading={false} />);
+      expect(screen.getByText('Monthly Avg')).toBeInTheDocument();
+      expect(capturedProps.barChart.data).toHaveLength(3);
+    });
+
+    it('auto-selects quarterly buckets for a medium span (Quarterly Avg)', () => {
+      // 2020-01 .. 2023-01 = 37 monthly points -> 13 quarter buckets.
+      render(<CategoryPayeeBarChart data={buildMonths(37)} isLoading={false} />);
+      expect(screen.getByText('Quarterly Avg')).toBeInTheDocument();
+      expect(capturedProps.barChart.data).toHaveLength(13);
+    });
+
+    it('auto-selects yearly buckets for a long, sparse span (Yearly Avg)', () => {
+      render(
+        <CategoryPayeeBarChart
+          data={[
+            { month: '2015-03', total: -1200, count: 1 },
+            { month: '2024-07', total: -1200, count: 1 },
+          ]}
+          isLoading={false}
+        />,
+      );
+      expect(screen.getByText('Yearly Avg')).toBeInTheDocument();
+      // 2015..2024 inclusive = 10 year buckets.
+      expect(capturedProps.barChart.data).toHaveLength(10);
+      expect(capturedProps.barChart.data[0].periodStart).toBe('2015-01-01');
+    });
+  });
+
+  describe('gap-fill and elapsed-period average', () => {
+    it('fills calendar gaps with zero-value bars at their true position', () => {
+      render(
+        <CategoryPayeeBarChart
+          data={[
+            { month: '2020-01', total: -100, count: 1 },
+            { month: '2020-12', total: -100, count: 1 },
+          ]}
+          isLoading={false}
+        />,
+      );
+      // Jan..Dec = 12 bars even though only 2 months had transactions.
+      expect(capturedProps.barChart.data).toHaveLength(12);
+      const interior = capturedProps.barChart.data[5];
+      expect(interior.total).toBe(0);
+      expect(interior.count).toBe(0);
+    });
+
+    it('averages over elapsed periods, not just active ones', () => {
+      render(
+        <CategoryPayeeBarChart
+          data={[
+            { month: '2020-01', total: -100, count: 1 },
+            { month: '2020-04', total: -300, count: 1 },
+          ]}
+          isLoading={false}
+        />,
+      );
+      // 4 elapsed months (Jan..Apr): avg = -400 / 4 = -100 (not -400/2 = -200).
+      expect(screen.getByText('$-100.00')).toBeInTheDocument();
+      expect(capturedProps.barChart.data).toHaveLength(4);
+    });
+  });
+
+  describe('drill-down', () => {
+    it('drills into the clicked bucket range', () => {
+      const onMonthClick = vi.fn();
+      render(
+        <CategoryPayeeBarChart
+          data={buildMonths(37)}
+          isLoading={false}
+          onMonthClick={onMonthClick}
+        />,
+      );
+      // Auto = quarter; the first bucket is 2020-Q1 (Jan 1 - Mar 31).
+      capturedProps.barChart.onClick({ activeLabel: '2020-01-01' });
+      expect(onMonthClick).toHaveBeenCalledWith('2020-01-01', '2020-03-31');
+    });
+  });
+
+  describe('layout and axis', () => {
+    it('positions bars by period start with no negative left margin', () => {
+      render(<CategoryPayeeBarChart data={buildMonths(3)} isLoading={false} />);
+      expect(capturedProps.xAxis.dataKey).toBe('periodStart');
+      expect(capturedProps.barChart.margin.left).toBe(0);
+    });
+  });
+
+  describe('granularity toggle', () => {
+    it('re-buckets when the user overrides the auto granularity', () => {
+      render(<CategoryPayeeBarChart data={buildMonths(48)} isLoading={false} />);
+      // 2020-01..2023-12 auto-rolls into 16 quarters.
+      expect(capturedProps.barChart.data).toHaveLength(16);
+      fireEvent.click(screen.getByRole('button', { name: 'Month' }));
+      expect(capturedProps.barChart.data).toHaveLength(48);
+      fireEvent.click(screen.getByRole('button', { name: 'Year' }));
+      expect(capturedProps.barChart.data).toHaveLength(4);
     });
   });
 });

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.test.tsx
@@ -251,15 +251,15 @@ describe('CategoryPayeeBarChart', () => {
     });
 
     it('keeps desktop bar-top labels horizontal at exactly the density threshold', () => {
-      render(<CategoryPayeeBarChart data={buildMonths(10)} isLoading={false} />);
-      expect(capturedProps.barChart.data).toHaveLength(10);
+      render(<CategoryPayeeBarChart data={buildMonths(20)} isLoading={false} />);
+      expect(capturedProps.barChart.data).toHaveLength(20);
       expect(capturedProps.labelList.angle).toBe(0);
     });
 
     it('rotates desktop bar-top labels vertical once the bars get dense and anchors them to sit above the bar', () => {
-      // 11 monthly bars crosses the desktop density threshold.
-      render(<CategoryPayeeBarChart data={buildMonths(11)} isLoading={false} />);
-      expect(capturedProps.barChart.data).toHaveLength(11);
+      // 21 monthly bars crosses the desktop density threshold.
+      render(<CategoryPayeeBarChart data={buildMonths(21)} isLoading={false} />);
+      expect(capturedProps.barChart.data).toHaveLength(21);
       expect(capturedProps.labelList.angle).toBe(-90);
       // textAnchor='start' (with angle -90) makes rotated text extend upward
       // from the anchor, so values never overlap the bar they label.

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
@@ -27,9 +27,12 @@ import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { ChartDownloadButton } from '@/components/ui/ChartDownloadButton';
 
-// Desktop goes vertical on the bar-top labels and widens the top margin only
-// once the column count crosses this threshold (3 years of monthly buckets).
-const DESKTOP_CROWDED_THRESHOLD = 36;
+// Desktop switches the bar-top value labels to vertical (and widens the top
+// margin) once there are more than this many bars. Kept low because full
+// currency labels are wide and overlap while still horizontal well before the
+// bars themselves look crowded -- especially when the info widget narrows the
+// chart to ~75% width.
+const DESKTOP_CROWDED_THRESHOLD = 10;
 
 // 'auto' follows the data span; the fixed modes let the user override it.
 type GranularityMode = 'auto' | Granularity;

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
@@ -32,6 +32,10 @@ import { ChartDownloadButton } from '@/components/ui/ChartDownloadButton';
 // currency labels start to overlap.
 const DESKTOP_CROWDED_THRESHOLD = 20;
 
+// Above this many bars the value labels are unreadable even when vertical, so
+// drop them entirely and let the axis and tooltip carry the numbers.
+const MAX_LABELED_BARS = 60;
+
 // 'auto' follows the data span; the fixed modes let the user override it.
 type GranularityMode = 'auto' | Granularity;
 const GRANULARITY_MODES: readonly GranularityMode[] = [
@@ -179,6 +183,7 @@ export function CategoryPayeeBarChart({
 
   const isCrowded = chartData.length > DESKTOP_CROWDED_THRESHOLD;
   const verticalLabels = isMobile || isCrowded;
+  const showBarLabels = chartData.length <= MAX_LABELED_BARS;
 
   const summary = useMemo(() => {
     if (chartData.length === 0) return null;
@@ -315,24 +320,26 @@ export function CategoryPayeeBarChart({
                   fill={entry.total >= 0 ? '#22c55e' : '#ef4444'}
                 />
               ))}
-              <LabelList
-                dataKey="total"
-                position="top"
-                angle={verticalLabels ? -90 : 0}
-                offset={verticalLabels ? (isMobile ? 8 : 6) : 5}
-                textAnchor={verticalLabels ? 'start' : 'middle'}
-                formatter={(value: unknown) =>
-                  isMobile
-                    ? formatCurrencyAxis(Number(value))
-                    : formatCurrency(Number(value))
-                }
-                style={{
-                  fill: '#6b7280',
-                  fontSize: isMobile ? 10 : 11,
-                  fontWeight: 500,
-                  ...(verticalLabels && { dominantBaseline: 'central' as const }),
-                }}
-              />
+              {showBarLabels && (
+                <LabelList
+                  dataKey="total"
+                  position="top"
+                  angle={verticalLabels ? -90 : 0}
+                  offset={verticalLabels ? (isMobile ? 8 : 6) : 5}
+                  textAnchor={verticalLabels ? 'start' : 'middle'}
+                  formatter={(value: unknown) =>
+                    isMobile
+                      ? formatCurrencyAxis(Number(value))
+                      : formatCurrency(Number(value))
+                  }
+                  style={{
+                    fill: '#6b7280',
+                    fontSize: isMobile ? 10 : 11,
+                    fontWeight: 500,
+                    ...(verticalLabels && { dominantBaseline: 'central' as const }),
+                  }}
+                />
+              )}
             </Bar>
           </BarChart>
         </ResponsiveContainer>

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useMemo, useRef } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { gainLossColor } from '@/lib/format';
+import { gainLossColor, sumMoney } from '@/lib/format';
 import { Skeleton } from '@/components/ui/LoadingSkeleton';
 import {
   BarChart,
@@ -15,9 +15,13 @@ import {
   LabelList,
   Cell,
 } from 'recharts';
-import { format, lastDayOfMonth } from 'date-fns';
-import { parseLocalDate } from '@/lib/utils';
 import { MonthlyTotal } from '@/types/transaction';
+import {
+  bucketMonthlyTotals,
+  selectGranularity,
+  type BucketedPoint,
+  type Granularity,
+} from '@/lib/chart-buckets';
 import { useNumberFormat } from '@/hooks/useNumberFormat';
 import { useChartDateFormat } from '@/hooks/useChartDateFormat';
 import { useIsMobile } from '@/hooks/useIsMobile';
@@ -27,6 +31,27 @@ import { ChartDownloadButton } from '@/components/ui/ChartDownloadButton';
 // once the column count crosses this threshold (3 years of monthly buckets).
 const DESKTOP_CROWDED_THRESHOLD = 36;
 
+// 'auto' follows the data span; the fixed modes let the user override it.
+type GranularityMode = 'auto' | Granularity;
+const GRANULARITY_MODES: readonly GranularityMode[] = [
+  'auto',
+  'month',
+  'quarter',
+  'year',
+];
+
+// Summary "average" label switches to match the active bucket size.
+const AVG_LABEL_KEY: Record<Granularity, string> = {
+  month: 'monthlyAvg',
+  quarter: 'quarterlyAvg',
+  year: 'yearlyAvg',
+};
+
+// Quarter number (1-4) from a 'YYYY-MM-DD' period start.
+function quarterOf(periodStart: string): number {
+  return Math.floor((Number(periodStart.split('-')[1]) - 1) / 3) + 1;
+}
+
 interface CategoryPayeeBarChartProps {
   data: MonthlyTotal[];
   isLoading: boolean;
@@ -35,11 +60,9 @@ interface CategoryPayeeBarChartProps {
   filterLabel?: string;
 }
 
-interface ChartDataPoint {
-  month: string;
+interface ChartDataPoint extends BucketedPoint {
   label: string;
-  total: number;
-  count: number;
+  absTotal: number;
 }
 
 function MonthlyTotalTooltip({
@@ -89,28 +112,80 @@ export function CategoryPayeeBarChart({
   const downloadFilename = filterLabel ? `${chartTitle} - ${filterLabel}` : chartTitle;
   const isMobile = useIsMobile();
 
-  const chartData = useMemo(() => {
-    return data.map((d) => {
-      const parsed = parseLocalDate(`${d.month}-01`);
-      return {
-        month: d.month,
-        label: formatChartDate(parsed, 'MMMM yyyy'),
-        total: d.total,
-        absTotal: Math.abs(d.total),
-        count: d.count,
-      };
-    });
-  }, [data, formatChartDate]);
+  const [granularityMode, setGranularityMode] = useState<GranularityMode>('auto');
+  const autoGranularity = useMemo(
+    () => selectGranularity(data.map((d) => d.month)),
+    [data],
+  );
+  const granularity: Granularity =
+    granularityMode === 'auto' ? autoGranularity : granularityMode;
+
+  // Full label for the tooltip (e.g. "January 2024", "Q1 2024", "2024").
+  const bucketFullLabel = useCallback(
+    (bucket: BucketedPoint): string => {
+      if (bucket.granularity === 'year') {
+        return formatChartDate(bucket.periodStart, 'yyyy');
+      }
+      if (bucket.granularity === 'quarter') {
+        return t('charts.monthlyTotals.quarterLabel', {
+          quarter: String(quarterOf(bucket.periodStart)),
+          year: formatChartDate(bucket.periodStart, 'yyyy'),
+        });
+      }
+      return formatChartDate(bucket.periodStart, 'MMMM yyyy');
+    },
+    [formatChartDate, t],
+  );
+
+  // Compact axis tick (e.g. "Jan 24", "Q1 24", "2024").
+  const axisTick = useCallback(
+    (periodStart: string): string => {
+      if (granularity === 'year') return formatChartDate(periodStart, 'yyyy');
+      if (granularity === 'quarter') {
+        return t('charts.monthlyTotals.quarterTick', {
+          quarter: String(quarterOf(periodStart)),
+          year: periodStart.slice(2, 4),
+        });
+      }
+      return formatChartDate(periodStart, 'MMM yy');
+    },
+    [granularity, formatChartDate, t],
+  );
+
+  const buckets = useMemo(
+    () => bucketMonthlyTotals(data, granularity),
+    [data, granularity],
+  );
+
+  const chartData = useMemo<ChartDataPoint[]>(
+    () =>
+      buckets.map((bucket) => ({
+        ...bucket,
+        label: bucketFullLabel(bucket),
+        absTotal: Math.abs(bucket.total),
+      })),
+    [buckets, bucketFullLabel],
+  );
+
+  // Drill-down: map each bar's x value (periodStart) to its [start, end] range.
+  const rangeByStart = useMemo(
+    () =>
+      new Map(
+        buckets.map((b) => [b.periodStart, [b.periodStart, b.periodEnd] as const]),
+      ),
+    [buckets],
+  );
 
   const isCrowded = chartData.length > DESKTOP_CROWDED_THRESHOLD;
   const verticalLabels = isMobile || isCrowded;
 
   const summary = useMemo(() => {
     if (chartData.length === 0) return null;
-    const total = chartData.reduce((sum, d) => sum + d.total, 0);
+    const total = sumMoney(chartData.map((d) => d.total));
     const totalCount = chartData.reduce((sum, d) => sum + d.count, 0);
-    const monthlyAvg = total / chartData.length;
-    return { total, totalCount, monthlyAvg };
+    const periodsElapsed = chartData.length;
+    const periodAvg = periodsElapsed > 0 ? total / periodsElapsed : 0;
+    return { total, totalCount, periodAvg };
   }, [chartData]);
 
   if (isLoading) {
@@ -141,11 +216,47 @@ export function CategoryPayeeBarChart({
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-700/50 p-3 sm:p-6 mb-6 min-h-[420px]">
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center justify-between mb-4 gap-2">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
           {chartTitle}
         </h3>
-        <ChartDownloadButton chartRef={chartRef} filename={downloadFilename} />
+        <div className="flex items-center gap-2">
+          <div
+            className="flex gap-1"
+            role="group"
+            aria-label={t('charts.monthlyTotals.granularityLabel')}
+          >
+            {GRANULARITY_MODES.map((mode) => {
+              const isActive = granularityMode === mode;
+              const label = t(`charts.monthlyTotals.granularity.${mode}`);
+              const title =
+                mode === 'auto'
+                  ? t('charts.monthlyTotals.granularityAutoTitle', {
+                      granularity: t(
+                        `charts.monthlyTotals.granularity.${autoGranularity}`,
+                      ),
+                    })
+                  : t('charts.monthlyTotals.granularityTitle', { label });
+              return (
+                <button
+                  key={mode}
+                  type="button"
+                  onClick={() => setGranularityMode(mode)}
+                  aria-pressed={isActive}
+                  title={title}
+                  className={
+                    isActive
+                      ? 'px-2 py-1 text-xs rounded-md bg-blue-600 text-white transition-colors'
+                      : 'px-2 py-1 text-xs rounded-md bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors'
+                  }
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+          <ChartDownloadButton chartRef={chartRef} filename={downloadFilename} />
+        </div>
       </div>
 
       {/* overflow-hidden: while the account-widget column animates the card's
@@ -159,13 +270,11 @@ export function CategoryPayeeBarChart({
         <ResponsiveContainer width="100%" height="100%" minWidth={0}>
           <BarChart
             data={chartData}
-            margin={{ top: verticalLabels ? 20 : 12, right: isMobile ? 16 : 5, left: -10, bottom: 0 }}
+            margin={{ top: verticalLabels ? 28 : 20, right: isMobile ? 16 : 5, left: 0, bottom: 0 }}
             onClick={onMonthClick ? (state: any) => {
-              const month = state?.activeLabel;
-              if (!month) return;
-              const firstDay = `${month}-01`;
-              const lastDay = format(lastDayOfMonth(parseLocalDate(firstDay)), 'yyyy-MM-dd');
-              onMonthClick(firstDay, lastDay);
+              const start = state?.activeLabel;
+              const range = start ? rangeByStart.get(start) : undefined;
+              if (range) onMonthClick(range[0], range[1]);
             } : undefined}
             style={onMonthClick ? { cursor: 'pointer' } : undefined}
           >
@@ -175,11 +284,11 @@ export function CategoryPayeeBarChart({
               className="dark:stroke-gray-700"
             />
             <XAxis
-              dataKey="month"
+              dataKey="periodStart"
               tick={{ fill: '#6b7280', fontSize: isMobile ? 10 : 12 }}
               tickLine={false}
               axisLine={{ stroke: '#e5e7eb' }}
-              tickFormatter={(value: string) => formatChartDate(`${value}-01`, 'MMM yy')}
+              tickFormatter={axisTick}
               interval="preserveStartEnd"
               angle={isMobile ? -35 : 0}
               textAnchor={isMobile ? 'end' : 'middle'}
@@ -232,13 +341,13 @@ export function CategoryPayeeBarChart({
       {summary && (
         <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700 grid grid-cols-3 gap-4 text-center">
           <div>
-            <div className="text-sm text-gray-500 dark:text-gray-400">{t('charts.monthlyTotals.monthlyAvg')}</div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">{t(`charts.monthlyTotals.${AVG_LABEL_KEY[granularity]}`)}</div>
             <div
               className={`font-semibold ${
-                gainLossColor(summary.monthlyAvg)
+                gainLossColor(summary.periodAvg)
               }`}
             >
-              {formatCurrency(summary.monthlyAvg)}
+              {formatCurrency(summary.periodAvg)}
             </div>
           </div>
           <div>

--- a/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
+++ b/frontend/src/components/transactions/CategoryPayeeBarChart.tsx
@@ -28,11 +28,9 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import { ChartDownloadButton } from '@/components/ui/ChartDownloadButton';
 
 // Desktop switches the bar-top value labels to vertical (and widens the top
-// margin) once there are more than this many bars. Kept low because full
-// currency labels are wide and overlap while still horizontal well before the
-// bars themselves look crowded -- especially when the info widget narrows the
-// chart to ~75% width.
-const DESKTOP_CROWDED_THRESHOLD = 10;
+// margin) once there are more than this many bars, before wide horizontal
+// currency labels start to overlap.
+const DESKTOP_CROWDED_THRESHOLD = 20;
 
 // 'auto' follows the data span; the fixed modes let the user override it.
 type GranularityMode = 'auto' | Granularity;

--- a/frontend/src/components/transactions/PayeeInfoWidget.test.tsx
+++ b/frontend/src/components/transactions/PayeeInfoWidget.test.tsx
@@ -151,6 +151,26 @@ describe('PayeeInfoWidget', () => {
     expect(screen.getByText('Inactive')).toBeInTheDocument();
   });
 
+  it('refetches the summary when refreshKey changes', async () => {
+    const { rerender } = await renderWidget({ refreshKey: 0 });
+    expect(mockedTransactions.getSummary).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      rerender(
+        <PayeeInfoWidget
+          payee={makePayee()}
+          categories={categories}
+          filterParams={{}}
+          refreshKey={1}
+          onEdit={vi.fn()}
+          onCollapse={vi.fn()}
+        />,
+      );
+    });
+
+    expect(mockedTransactions.getSummary).toHaveBeenCalledTimes(2);
+  });
+
   it('renders the top categories with full labels and fires the filter callback', async () => {
     const onCategoryClick = vi.fn();
     await renderWidget({ onCategoryClick });

--- a/frontend/src/components/transactions/PayeeInfoWidget.tsx
+++ b/frontend/src/components/transactions/PayeeInfoWidget.tsx
@@ -35,6 +35,8 @@ interface PayeeInfoWidgetProps {
   scheduledTransactions?: ScheduledTransaction[];
   /** Active page filters (date range, accounts, ...) minus any payee ids. */
   filterParams: WidgetFilterParams;
+  /** Bumped by the page on every reload so the summary refetches in lockstep. */
+  refreshKey?: number;
   /** Open the shared payee edit modal for this payee. */
   onEdit: () => void;
   /** Collapse the widget so the chart can use the full width. */
@@ -54,6 +56,7 @@ export function PayeeInfoWidget({
   categories,
   scheduledTransactions = [],
   filterParams,
+  refreshKey,
   onEdit,
   onCollapse,
   onCategoryClick,
@@ -125,7 +128,7 @@ export function PayeeInfoWidget({
     return () => {
       cancelled = true;
     };
-  }, [payee.id, filterKey]);
+  }, [payee.id, filterKey, refreshKey]);
 
   const nextBill = useMemo(
     () =>

--- a/frontend/src/i18n/messages/de/transactions.json
+++ b/frontend/src/i18n/messages/de/transactions.json
@@ -472,9 +472,22 @@
       "title": "Monatliche Summen",
       "noData": "Keine Buchungsdaten verfügbar",
       "monthlyAvg": "Monatsdurchschnitt",
+      "quarterlyAvg": "Quartalsdurchschnitt",
+      "yearlyAvg": "Jahresdurchschnitt",
       "total": "Gesamt",
       "transactions": "Buchungen",
-      "tooltip": "{count, plural, one {# Buchung} other {# Buchungen}}"
+      "tooltip": "{count, plural, one {# Buchung} other {# Buchungen}}",
+      "quarterLabel": "Q{quarter} {year}",
+      "quarterTick": "Q{quarter} {year}",
+      "granularityLabel": "Gruppierung",
+      "granularity": {
+        "auto": "Auto",
+        "month": "Monat",
+        "quarter": "Quartal",
+        "year": "Jahr"
+      },
+      "granularityAutoTitle": "Auto ({granularity})",
+      "granularityTitle": "{label}-Ansicht"
     },
     "accountBalances": {
       "title": "Kontosalden",

--- a/frontend/src/i18n/messages/en/transactions.json
+++ b/frontend/src/i18n/messages/en/transactions.json
@@ -472,9 +472,22 @@
       "title": "Monthly Totals",
       "noData": "No transaction data available",
       "monthlyAvg": "Monthly Avg",
+      "quarterlyAvg": "Quarterly Avg",
+      "yearlyAvg": "Yearly Avg",
       "total": "Total",
       "transactions": "Transactions",
-      "tooltip": "{count, plural, one {# transaction} other {# transactions}}"
+      "tooltip": "{count, plural, one {# transaction} other {# transactions}}",
+      "quarterLabel": "Q{quarter} {year}",
+      "quarterTick": "Q{quarter} {year}",
+      "granularityLabel": "Bucket size",
+      "granularity": {
+        "auto": "Auto",
+        "month": "Month",
+        "quarter": "Quarter",
+        "year": "Year"
+      },
+      "granularityAutoTitle": "Auto ({granularity})",
+      "granularityTitle": "{label} view"
     },
     "accountBalances": {
       "title": "Account Balances",

--- a/frontend/src/i18n/messages/es/transactions.json
+++ b/frontend/src/i18n/messages/es/transactions.json
@@ -472,9 +472,22 @@
       "title": "Totales mensuales",
       "noData": "No hay datos de transacciones disponibles",
       "monthlyAvg": "Prom. mensual",
+      "quarterlyAvg": "Prom. trimestral",
+      "yearlyAvg": "Prom. anual",
       "total": "Total",
       "transactions": "Transacciones",
-      "tooltip": "{count, plural, one {# transacción} other {# transacciones}}"
+      "tooltip": "{count, plural, one {# transacción} other {# transacciones}}",
+      "quarterLabel": "T{quarter} {year}",
+      "quarterTick": "T{quarter} {year}",
+      "granularityLabel": "Agrupación",
+      "granularity": {
+        "auto": "Auto",
+        "month": "Mes",
+        "quarter": "Trimestre",
+        "year": "Año"
+      },
+      "granularityAutoTitle": "Auto ({granularity})",
+      "granularityTitle": "Vista por {label}"
     },
     "accountBalances": {
       "title": "Saldos de cuentas",

--- a/frontend/src/i18n/messages/fr/transactions.json
+++ b/frontend/src/i18n/messages/fr/transactions.json
@@ -472,9 +472,22 @@
       "title": "Totaux mensuels",
       "noData": "Aucune donnée de transaction disponible",
       "monthlyAvg": "Moy. mensuelle",
+      "quarterlyAvg": "Moy. trimestrielle",
+      "yearlyAvg": "Moy. annuelle",
       "total": "Total",
       "transactions": "Transactions",
-      "tooltip": "{count, plural, one {# transaction} other {# transactions}}"
+      "tooltip": "{count, plural, one {# transaction} other {# transactions}}",
+      "quarterLabel": "T{quarter} {year}",
+      "quarterTick": "T{quarter} {year}",
+      "granularityLabel": "Regroupement",
+      "granularity": {
+        "auto": "Auto",
+        "month": "Mois",
+        "quarter": "Trimestre",
+        "year": "Année"
+      },
+      "granularityAutoTitle": "Auto ({granularity})",
+      "granularityTitle": "Vue par {label}"
     },
     "accountBalances": {
       "title": "Soldes des comptes",

--- a/frontend/src/i18n/messages/hi/transactions.json
+++ b/frontend/src/i18n/messages/hi/transactions.json
@@ -472,9 +472,22 @@
       "title": "मासिक कुल",
       "noData": "कोई लेन-देन डेटा उपलब्ध नहीं",
       "monthlyAvg": "मासिक औसत",
+      "quarterlyAvg": "त्रैमासिक औसत",
+      "yearlyAvg": "वार्षिक औसत",
       "total": "कुल",
       "transactions": "लेन-देन",
-      "tooltip": "{count, plural, one {# लेन-देन} other {# लेन-देन}}"
+      "tooltip": "{count, plural, one {# लेन-देन} other {# लेन-देन}}",
+      "quarterLabel": "Q{quarter} {year}",
+      "quarterTick": "Q{quarter} {year}",
+      "granularityLabel": "समूहन",
+      "granularity": {
+        "auto": "ऑटो",
+        "month": "माह",
+        "quarter": "तिमाही",
+        "year": "वर्ष"
+      },
+      "granularityAutoTitle": "ऑटो ({granularity})",
+      "granularityTitle": "{label} दृश्य"
     },
     "accountBalances": {
       "title": "खाता शेष",

--- a/frontend/src/i18n/messages/id/transactions.json
+++ b/frontend/src/i18n/messages/id/transactions.json
@@ -472,9 +472,22 @@
       "title": "Total Bulanan",
       "noData": "Tidak ada data transaksi yang tersedia",
       "monthlyAvg": "Rata-rata Bulanan",
+      "quarterlyAvg": "Rata-rata Kuartalan",
+      "yearlyAvg": "Rata-rata Tahunan",
       "total": "Total",
       "transactions": "Transaksi",
-      "tooltip": "{count, plural, one {# transaksi} other {# transaksi}}"
+      "tooltip": "{count, plural, one {# transaksi} other {# transaksi}}",
+      "quarterLabel": "K{quarter} {year}",
+      "quarterTick": "K{quarter} {year}",
+      "granularityLabel": "Pengelompokan",
+      "granularity": {
+        "auto": "Otomatis",
+        "month": "Bulan",
+        "quarter": "Kuartal",
+        "year": "Tahun"
+      },
+      "granularityAutoTitle": "Otomatis ({granularity})",
+      "granularityTitle": "Tampilan {label}"
     },
     "accountBalances": {
       "title": "Saldo Akun",

--- a/frontend/src/i18n/messages/it/transactions.json
+++ b/frontend/src/i18n/messages/it/transactions.json
@@ -472,9 +472,22 @@
       "title": "Totali mensili",
       "noData": "Nessun dato transazione disponibile",
       "monthlyAvg": "Media mensile",
+      "quarterlyAvg": "Media trimestrale",
+      "yearlyAvg": "Media annuale",
       "total": "Totale",
       "transactions": "Transazioni",
-      "tooltip": "{count, plural, one {# transazione} other {# transazioni}}"
+      "tooltip": "{count, plural, one {# transazione} other {# transazioni}}",
+      "quarterLabel": "T{quarter} {year}",
+      "quarterTick": "T{quarter} {year}",
+      "granularityLabel": "Raggruppamento",
+      "granularity": {
+        "auto": "Auto",
+        "month": "Mese",
+        "quarter": "Trimestre",
+        "year": "Anno"
+      },
+      "granularityAutoTitle": "Auto ({granularity})",
+      "granularityTitle": "Vista per {label}"
     },
     "accountBalances": {
       "title": "Saldi dei conti",

--- a/frontend/src/i18n/messages/ja/transactions.json
+++ b/frontend/src/i18n/messages/ja/transactions.json
@@ -472,9 +472,22 @@
       "title": "月次合計",
       "noData": "取引データがありません",
       "monthlyAvg": "月次平均",
+      "quarterlyAvg": "四半期平均",
+      "yearlyAvg": "年次平均",
       "total": "合計",
       "transactions": "取引",
-      "tooltip": "{count, plural, one {# 件の取引} other {# 件の取引}}"
+      "tooltip": "{count, plural, one {# 件の取引} other {# 件の取引}}",
+      "quarterLabel": "{year}年Q{quarter}",
+      "quarterTick": "{year}年Q{quarter}",
+      "granularityLabel": "グループ化",
+      "granularity": {
+        "auto": "自動",
+        "month": "月",
+        "quarter": "四半期",
+        "year": "年"
+      },
+      "granularityAutoTitle": "自動（{granularity}）",
+      "granularityTitle": "{label}表示"
     },
     "accountBalances": {
       "title": "口座残高",

--- a/frontend/src/i18n/messages/ko/transactions.json
+++ b/frontend/src/i18n/messages/ko/transactions.json
@@ -472,9 +472,22 @@
       "title": "월별 합계",
       "noData": "거래 데이터가 없습니다",
       "monthlyAvg": "월 평균",
+      "quarterlyAvg": "분기 평균",
+      "yearlyAvg": "연 평균",
       "total": "합계",
       "transactions": "거래",
-      "tooltip": "{count, plural, one {# 건의 거래} other {# 건의 거래}}"
+      "tooltip": "{count, plural, one {# 건의 거래} other {# 건의 거래}}",
+      "quarterLabel": "{year}년 Q{quarter}",
+      "quarterTick": "{year}년 Q{quarter}",
+      "granularityLabel": "그룹화",
+      "granularity": {
+        "auto": "자동",
+        "month": "월",
+        "quarter": "분기",
+        "year": "연"
+      },
+      "granularityAutoTitle": "자동 ({granularity})",
+      "granularityTitle": "{label} 보기"
     },
     "accountBalances": {
       "title": "계정 잔액",

--- a/frontend/src/i18n/messages/nl/transactions.json
+++ b/frontend/src/i18n/messages/nl/transactions.json
@@ -472,9 +472,22 @@
       "title": "Maandtotalen",
       "noData": "Geen transactiegegevens beschikbaar",
       "monthlyAvg": "Maandgemiddelde",
+      "quarterlyAvg": "Kwartaalgemiddelde",
+      "yearlyAvg": "Jaargemiddelde",
       "total": "Totaal",
       "transactions": "Transacties",
-      "tooltip": "{count, plural, one {# transactie} other {# transacties}}"
+      "tooltip": "{count, plural, one {# transactie} other {# transacties}}",
+      "quarterLabel": "K{quarter} {year}",
+      "quarterTick": "K{quarter} {year}",
+      "granularityLabel": "Groepering",
+      "granularity": {
+        "auto": "Auto",
+        "month": "Maand",
+        "quarter": "Kwartaal",
+        "year": "Jaar"
+      },
+      "granularityAutoTitle": "Auto ({granularity})",
+      "granularityTitle": "Weergave per {label}"
     },
     "accountBalances": {
       "title": "Rekeningsaldi",

--- a/frontend/src/i18n/messages/pl/transactions.json
+++ b/frontend/src/i18n/messages/pl/transactions.json
@@ -472,9 +472,22 @@
       "title": "Sumy miesięczne",
       "noData": "Brak danych o transakcjach",
       "monthlyAvg": "Średnia miesięczna",
+      "quarterlyAvg": "Średnia kwartalna",
+      "yearlyAvg": "Średnia roczna",
       "total": "Suma",
       "transactions": "Transakcje",
-      "tooltip": "{count, plural, one {# transakcja} few {# transakcje} many {# transakcji} other {# transakcji}}"
+      "tooltip": "{count, plural, one {# transakcja} few {# transakcje} many {# transakcji} other {# transakcji}}",
+      "quarterLabel": "K{quarter} {year}",
+      "quarterTick": "K{quarter} {year}",
+      "granularityLabel": "Grupowanie",
+      "granularity": {
+        "auto": "Auto",
+        "month": "Miesiąc",
+        "quarter": "Kwartał",
+        "year": "Rok"
+      },
+      "granularityAutoTitle": "Auto ({granularity})",
+      "granularityTitle": "Widok: {label}"
     },
     "accountBalances": {
       "title": "Salda kont",

--- a/frontend/src/i18n/messages/pt-BR/transactions.json
+++ b/frontend/src/i18n/messages/pt-BR/transactions.json
@@ -472,9 +472,22 @@
       "title": "Totais Mensais",
       "noData": "Sem dados de transações disponíveis",
       "monthlyAvg": "Média Mensal",
+      "quarterlyAvg": "Média Trimestral",
+      "yearlyAvg": "Média Anual",
       "total": "Total",
       "transactions": "Transações",
-      "tooltip": "{count, plural, one {# transação} other {# transações}}"
+      "tooltip": "{count, plural, one {# transação} other {# transações}}",
+      "quarterLabel": "T{quarter} {year}",
+      "quarterTick": "T{quarter} {year}",
+      "granularityLabel": "Agrupamento",
+      "granularity": {
+        "auto": "Auto",
+        "month": "Mês",
+        "quarter": "Trimestre",
+        "year": "Ano"
+      },
+      "granularityAutoTitle": "Auto ({granularity})",
+      "granularityTitle": "Ver por {label}"
     },
     "accountBalances": {
       "title": "Saldos das Contas",

--- a/frontend/src/i18n/messages/pt/transactions.json
+++ b/frontend/src/i18n/messages/pt/transactions.json
@@ -472,9 +472,22 @@
       "title": "Totais Mensais",
       "noData": "Sem dados de transações disponíveis",
       "monthlyAvg": "Média Mensal",
+      "quarterlyAvg": "Média Trimestral",
+      "yearlyAvg": "Média Anual",
       "total": "Total",
       "transactions": "Transações",
-      "tooltip": "{count, plural, one {# transação} other {# transações}}"
+      "tooltip": "{count, plural, one {# transação} other {# transações}}",
+      "quarterLabel": "T{quarter} {year}",
+      "quarterTick": "T{quarter} {year}",
+      "granularityLabel": "Agrupamento",
+      "granularity": {
+        "auto": "Auto",
+        "month": "Mês",
+        "quarter": "Trimestre",
+        "year": "Ano"
+      },
+      "granularityAutoTitle": "Auto ({granularity})",
+      "granularityTitle": "Ver por {label}"
     },
     "accountBalances": {
       "title": "Saldos das Contas",

--- a/frontend/src/i18n/messages/ru/transactions.json
+++ b/frontend/src/i18n/messages/ru/transactions.json
@@ -472,9 +472,22 @@
       "title": "Месячные итоги",
       "noData": "Нет данных о проводках",
       "monthlyAvg": "Средн. в месяц",
+      "quarterlyAvg": "Средн. в квартал",
+      "yearlyAvg": "Средн. в год",
       "total": "Итого",
       "transactions": "Проводки",
-      "tooltip": "{count, plural, one {# проводка} other {# проводок}}"
+      "tooltip": "{count, plural, one {# проводка} other {# проводок}}",
+      "quarterLabel": "{quarter} кв. {year}",
+      "quarterTick": "{quarter} кв. {year}",
+      "granularityLabel": "Группировка",
+      "granularity": {
+        "auto": "Авто",
+        "month": "Месяц",
+        "quarter": "Квартал",
+        "year": "Год"
+      },
+      "granularityAutoTitle": "Авто ({granularity})",
+      "granularityTitle": "Вид: {label}"
     },
     "accountBalances": {
       "title": "Остатки по счетам",

--- a/frontend/src/i18n/messages/tr/transactions.json
+++ b/frontend/src/i18n/messages/tr/transactions.json
@@ -472,9 +472,22 @@
       "title": "Aylık Toplamlar",
       "noData": "İşlem verisi mevcut değil",
       "monthlyAvg": "Aylık Ort.",
+      "quarterlyAvg": "Üç Aylık Ort.",
+      "yearlyAvg": "Yıllık Ort.",
       "total": "Toplam",
       "transactions": "İşlemler",
-      "tooltip": "{count, plural, one {# işlem} other {# işlem}}"
+      "tooltip": "{count, plural, one {# işlem} other {# işlem}}",
+      "quarterLabel": "Ç{quarter} {year}",
+      "quarterTick": "Ç{quarter} {year}",
+      "granularityLabel": "Gruplama",
+      "granularity": {
+        "auto": "Otomatik",
+        "month": "Ay",
+        "quarter": "Çeyrek",
+        "year": "Yıl"
+      },
+      "granularityAutoTitle": "Otomatik ({granularity})",
+      "granularityTitle": "{label} görünümü"
     },
     "accountBalances": {
       "title": "Hesap Bakiyeleri",

--- a/frontend/src/i18n/messages/uk/transactions.json
+++ b/frontend/src/i18n/messages/uk/transactions.json
@@ -472,9 +472,22 @@
       "title": "Місячні підсумки",
       "noData": "Немає даних транзакцій",
       "monthlyAvg": "Місячне середнє",
+      "quarterlyAvg": "Квартальне середнє",
+      "yearlyAvg": "Річне середнє",
       "total": "Разом",
       "transactions": "Транзакції",
-      "tooltip": "{count, plural, one {# транзакція} other {# транзакцій}}"
+      "tooltip": "{count, plural, one {# транзакція} other {# транзакцій}}",
+      "quarterLabel": "{quarter} кв. {year}",
+      "quarterTick": "{quarter} кв. {year}",
+      "granularityLabel": "Групування",
+      "granularity": {
+        "auto": "Авто",
+        "month": "Місяць",
+        "quarter": "Квартал",
+        "year": "Рік"
+      },
+      "granularityAutoTitle": "Авто ({granularity})",
+      "granularityTitle": "Вигляд: {label}"
     },
     "accountBalances": {
       "title": "Баланси рахунків",

--- a/frontend/src/i18n/messages/vi/transactions.json
+++ b/frontend/src/i18n/messages/vi/transactions.json
@@ -472,9 +472,22 @@
       "title": "Tổng hàng tháng",
       "noData": "Không có dữ liệu giao tác",
       "monthlyAvg": "Trung bình tháng",
+      "quarterlyAvg": "Trung bình quý",
+      "yearlyAvg": "Trung bình năm",
       "total": "Tổng",
       "transactions": "Giao tác",
-      "tooltip": "{count, plural, one {# giao tác} other {# giao tác}}"
+      "tooltip": "{count, plural, one {# giao tác} other {# giao tác}}",
+      "quarterLabel": "Q{quarter} {year}",
+      "quarterTick": "Q{quarter} {year}",
+      "granularityLabel": "Nhóm theo",
+      "granularity": {
+        "auto": "Tự động",
+        "month": "Tháng",
+        "quarter": "Quý",
+        "year": "Năm"
+      },
+      "granularityAutoTitle": "Tự động ({granularity})",
+      "granularityTitle": "Xem theo {label}"
     },
     "accountBalances": {
       "title": "Số dư tài khoản",

--- a/frontend/src/i18n/messages/xx/transactions.json
+++ b/frontend/src/i18n/messages/xx/transactions.json
@@ -472,9 +472,22 @@
       "title": "[XX-Monthly Totals-XX]",
       "noData": "[XX-No transaction data available-XX]",
       "monthlyAvg": "[XX-Monthly Avg-XX]",
+      "quarterlyAvg": "[XX-Quarterly Avg-XX]",
+      "yearlyAvg": "[XX-Yearly Avg-XX]",
       "total": "[XX-Total-XX]",
       "transactions": "[XX-Transactions-XX]",
-      "tooltip": "[XX-{count, plural, one {# transaction} other {# transactions}}-XX]"
+      "tooltip": "[XX-{count, plural, one {# transaction} other {# transactions}}-XX]",
+      "quarterLabel": "[XX-Q{quarter} {year}-XX]",
+      "quarterTick": "[XX-Q{quarter} {year}-XX]",
+      "granularityLabel": "[XX-Bucket size-XX]",
+      "granularity": {
+        "auto": "[XX-Auto-XX]",
+        "month": "[XX-Month-XX]",
+        "quarter": "[XX-Quarter-XX]",
+        "year": "[XX-Year-XX]"
+      },
+      "granularityAutoTitle": "[XX-Auto ({granularity})-XX]",
+      "granularityTitle": "[XX-{label} view-XX]"
     },
     "accountBalances": {
       "title": "[XX-Account Balances-XX]",

--- a/frontend/src/i18n/messages/zh-CN/transactions.json
+++ b/frontend/src/i18n/messages/zh-CN/transactions.json
@@ -472,9 +472,22 @@
       "title": "月度合计",
       "noData": "无交易数据",
       "monthlyAvg": "月均",
+      "quarterlyAvg": "季均",
+      "yearlyAvg": "年均",
       "total": "合计",
       "transactions": "交易",
-      "tooltip": "{count, plural, one {# 笔交易} other {# 笔交易}}"
+      "tooltip": "{count, plural, one {# 笔交易} other {# 笔交易}}",
+      "quarterLabel": "{year}年Q{quarter}",
+      "quarterTick": "{year}年Q{quarter}",
+      "granularityLabel": "分组方式",
+      "granularity": {
+        "auto": "自动",
+        "month": "月",
+        "quarter": "季度",
+        "year": "年"
+      },
+      "granularityAutoTitle": "自动（{granularity}）",
+      "granularityTitle": "{label}视图"
     },
     "accountBalances": {
       "title": "账户余额",

--- a/frontend/src/i18n/messages/zh-TW/transactions.json
+++ b/frontend/src/i18n/messages/zh-TW/transactions.json
@@ -472,9 +472,22 @@
       "title": "每月總計",
       "noData": "無可用的交易資料",
       "monthlyAvg": "月平均",
+      "quarterlyAvg": "季平均",
+      "yearlyAvg": "年平均",
       "total": "總計",
       "transactions": "交易",
-      "tooltip": "{count, plural, one {# 筆交易} other {# 筆交易}}"
+      "tooltip": "{count, plural, one {# 筆交易} other {# 筆交易}}",
+      "quarterLabel": "{year}年Q{quarter}",
+      "quarterTick": "{year}年Q{quarter}",
+      "granularityLabel": "分組方式",
+      "granularity": {
+        "auto": "自動",
+        "month": "月",
+        "quarter": "季度",
+        "year": "年"
+      },
+      "granularityAutoTitle": "自動（{granularity}）",
+      "granularityTitle": "{label}檢視"
     },
     "accountBalances": {
       "title": "科目結餘",

--- a/frontend/src/lib/chart-buckets.test.ts
+++ b/frontend/src/lib/chart-buckets.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import {
+  selectGranularity,
+  bucketMonthlyTotals,
+  countElapsedPeriods,
+} from './chart-buckets';
+import { MonthlyTotal } from '@/types/transaction';
+
+const m = (month: string, total: number, count = 1): MonthlyTotal => ({
+  month,
+  total,
+  count,
+});
+
+// Build N consecutive month keys starting at 2020-01.
+function months(n: number): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < n; i++) {
+    const year = 2020 + Math.floor(i / 12);
+    const month = (i % 12) + 1;
+    out.push(`${year}-${String(month).padStart(2, '0')}`);
+  }
+  return out;
+}
+
+describe('selectGranularity', () => {
+  it('returns month for empty or single-month input', () => {
+    expect(selectGranularity([])).toBe('month');
+    expect(selectGranularity(['2024-05'])).toBe('month');
+  });
+
+  it('stays monthly for spans up to ~2 years', () => {
+    // span 23 months -> 24 buckets -> still month
+    expect(selectGranularity(['2020-01', '2021-12'])).toBe('month');
+  });
+
+  it('switches to quarter for a medium (2-6 year) span', () => {
+    // span 24 months -> 25 monthly buckets > 24 -> quarter
+    expect(selectGranularity(['2020-01', '2022-01'])).toBe('quarter');
+    expect(selectGranularity(['2020-01', '2025-12'])).toBe('quarter');
+  });
+
+  it('switches to year for a long (> ~6 year) span', () => {
+    // span 72 months -> 25 quarterly buckets > 24 -> year
+    expect(selectGranularity(['2020-01', '2026-02'])).toBe('year');
+    expect(selectGranularity(['2010-01', '2024-01'])).toBe('year');
+  });
+
+  it('ignores input order (uses min/max)', () => {
+    expect(selectGranularity(['2026-02', '2020-01'])).toBe('year');
+  });
+});
+
+describe('bucketMonthlyTotals - month', () => {
+  it('returns [] for empty input', () => {
+    expect(bucketMonthlyTotals([], 'month')).toEqual([]);
+  });
+
+  it('gap-fills missing months with zero totals at their true position', () => {
+    const data = [m('2020-01', 100), m('2020-04', 300), m('2020-12', 1200)];
+    const buckets = bucketMonthlyTotals(data, 'month');
+    // Jan..Dec = 12 buckets, no calendar gaps collapsed.
+    expect(buckets).toHaveLength(12);
+    expect(buckets.map((b) => b.key)).toEqual([
+      '2020-01', '2020-02', '2020-03', '2020-04', '2020-05', '2020-06',
+      '2020-07', '2020-08', '2020-09', '2020-10', '2020-11', '2020-12',
+    ]);
+    expect(buckets[0]).toMatchObject({ total: 100, count: 1, periodStart: '2020-01-01', periodEnd: '2020-01-31' });
+    expect(buckets[1]).toMatchObject({ total: 0, count: 0 }); // gap-filled Feb
+    expect(buckets[3]).toMatchObject({ total: 300, count: 1 });
+    expect(buckets[11]).toMatchObject({ total: 1200, count: 1, periodStart: '2020-12-01', periodEnd: '2020-12-31' });
+  });
+
+  it('sums same-month rows in integer cents (no float drift)', () => {
+    const data = [m('2020-01', 0.1), m('2020-01', 0.2)];
+    const buckets = bucketMonthlyTotals(data, 'month');
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].total).toBe(0.3);
+    expect(buckets[0].count).toBe(2);
+  });
+
+  it('reports a leap-February end date', () => {
+    const buckets = bucketMonthlyTotals([m('2024-02', 50)], 'month');
+    expect(buckets[0].periodEnd).toBe('2024-02-29');
+  });
+
+  it('preserves sign for net-negative periods', () => {
+    const data = [m('2020-01', 100), m('2020-01', -250)];
+    const buckets = bucketMonthlyTotals(data, 'month');
+    expect(buckets[0].total).toBe(-150);
+  });
+});
+
+describe('bucketMonthlyTotals - quarter', () => {
+  it('rolls months into quarter buckets with correct keys and bounds', () => {
+    const data = [m('2020-01', 100), m('2020-02', 100), m('2020-11', 300)];
+    const buckets = bucketMonthlyTotals(data, 'quarter');
+    // Q1..Q4 gap-filled = 4 buckets.
+    expect(buckets.map((b) => b.key)).toEqual(['2020-Q1', '2020-Q2', '2020-Q3', '2020-Q4']);
+    expect(buckets[0]).toMatchObject({ total: 200, count: 2, periodStart: '2020-01-01', periodEnd: '2020-03-31' });
+    expect(buckets[1]).toMatchObject({ total: 0, count: 0, periodStart: '2020-04-01', periodEnd: '2020-06-30' });
+    expect(buckets[3]).toMatchObject({ total: 300, count: 1, periodStart: '2020-10-01', periodEnd: '2020-12-31' });
+  });
+});
+
+describe('bucketMonthlyTotals - year', () => {
+  it('rolls a sparse multi-year series into one bucket per year', () => {
+    const data = [m('2020-03', 1200), m('2022-07', 1200)];
+    const buckets = bucketMonthlyTotals(data, 'year');
+    expect(buckets.map((b) => b.key)).toEqual(['2020', '2021', '2022']);
+    expect(buckets[0]).toMatchObject({ total: 1200, count: 1, periodStart: '2020-01-01', periodEnd: '2020-12-31' });
+    expect(buckets[1]).toMatchObject({ total: 0, count: 0 }); // gap-filled 2021
+    expect(buckets[2]).toMatchObject({ total: 1200, count: 1, periodStart: '2022-01-01', periodEnd: '2022-12-31' });
+  });
+
+  it('handles a single bucket', () => {
+    const buckets = bucketMonthlyTotals([m('2020-06', 500)], 'year');
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0]).toMatchObject({ key: '2020', total: 500 });
+  });
+});
+
+describe('countElapsedPeriods', () => {
+  it('counts every elapsed period including gaps', () => {
+    const data = [m('2020-01', 100), m('2020-12', 100)];
+    expect(countElapsedPeriods(data, 'month')).toBe(12);
+    expect(countElapsedPeriods(data, 'year')).toBe(1);
+  });
+
+  it('returns 0 for empty input', () => {
+    expect(countElapsedPeriods([], 'month')).toBe(0);
+  });
+
+  it('matches the bucket length for a long monthly span', () => {
+    const keys = months(30);
+    const data = keys.map((k) => m(k, 10));
+    expect(countElapsedPeriods(data, 'month')).toBe(30);
+  });
+});

--- a/frontend/src/lib/chart-buckets.ts
+++ b/frontend/src/lib/chart-buckets.ts
@@ -1,0 +1,192 @@
+import { addMonths, format, lastDayOfMonth } from 'date-fns';
+import { MonthlyTotal } from '@/types/transaction';
+
+/**
+ * Time granularity for the transactions "Monthly Totals" bar chart. The chart
+ * rolls the backend's per-month rows up to the coarsest useful bucket so a
+ * sparse, irregular payment series is spaced by real elapsed time rather than
+ * by "successive months that happened to have a transaction".
+ */
+export type Granularity = 'month' | 'quarter' | 'year';
+
+export interface BucketedPoint {
+  granularity: Granularity;
+  /** Stable, sortable id: '2024-03' | '2024-Q1' | '2024'. */
+  key: string;
+  /** First day of the period, local YYYY-MM-DD. */
+  periodStart: string;
+  /** Last day of the period, local YYYY-MM-DD. */
+  periodEnd: string;
+  /** Signed sum for the period (0 for gap-filled empty periods). */
+  total: number;
+  /** Transaction count for the period (0 for gap-filled empty periods). */
+  count: number;
+}
+
+const GRANULARITY_MONTHS: Record<Granularity, number> = {
+  month: 1,
+  quarter: 3,
+  year: 12,
+};
+
+// Finest-first, mirroring the spirit of TICK_STEP_MONTHS in chart-time-axis.ts.
+const GRANULARITY_ORDER: readonly Granularity[] = ['month', 'quarter', 'year'];
+
+/**
+ * Target number of bars. selectGranularity picks the finest granularity whose
+ * estimated bucket count stays at or below this, so long spans collapse to
+ * quarters or years instead of dozens of thin monthly bars.
+ */
+export const TARGET_BUCKETS = 24;
+
+// Integer ten-thousandths, matching the backend roundMoney / decimal(20,4).
+const SCALE = 10000;
+
+function spanMonthsBetween(minMonth: string, maxMonth: string): number {
+  const [minY, minM] = minMonth.split('-').map(Number);
+  const [maxY, maxM] = maxMonth.split('-').map(Number);
+  return (maxY - minY) * 12 + (maxM - minM);
+}
+
+/**
+ * Pick the coarsest-enough granularity for a set of 'YYYY-MM' month keys:
+ * short spans stay monthly, medium spans go quarterly, multi-year spans
+ * collapse to yearly. This is a selection heuristic only -- the exact bucket
+ * count comes from bucketMonthlyTotals, which aligns to period boundaries.
+ */
+export function selectGranularity(
+  months: string[],
+  target: number = TARGET_BUCKETS,
+): Granularity {
+  if (months.length <= 1) return 'month';
+  let min = months[0];
+  let max = months[0];
+  for (const m of months) {
+    if (m < min) min = m;
+    if (m > max) max = m;
+  }
+  const spanMonths = spanMonthsBetween(min, max);
+  for (const granularity of GRANULARITY_ORDER) {
+    const estimatedBuckets =
+      Math.floor(spanMonths / GRANULARITY_MONTHS[granularity]) + 1;
+    if (estimatedBuckets <= target) return granularity;
+  }
+  return 'year';
+}
+
+interface PeriodInfo {
+  key: string;
+  /** Local Date at the first day of the period (midnight). */
+  startDate: Date;
+  periodStart: string;
+}
+
+function periodInfoForMonth(monthKey: string, granularity: Granularity): PeriodInfo {
+  const [year, month] = monthKey.split('-').map(Number); // month is 1-12
+  if (granularity === 'year') {
+    return {
+      key: `${year}`,
+      startDate: new Date(year, 0, 1),
+      periodStart: `${year}-01-01`,
+    };
+  }
+  if (granularity === 'quarter') {
+    const quarterIndex = Math.floor((month - 1) / 3); // 0-3
+    const startDate = new Date(year, quarterIndex * 3, 1);
+    return {
+      key: `${year}-Q${quarterIndex + 1}`,
+      startDate,
+      periodStart: format(startDate, 'yyyy-MM-dd'),
+    };
+  }
+  return {
+    key: monthKey,
+    startDate: new Date(year, month - 1, 1),
+    periodStart: `${monthKey}-01`,
+  };
+}
+
+function periodEndFor(startDate: Date, granularity: Granularity): string {
+  if (granularity === 'year') {
+    return `${startDate.getFullYear()}-12-31`;
+  }
+  if (granularity === 'quarter') {
+    // Last day of the third month of the quarter.
+    return format(lastDayOfMonth(addMonths(startDate, 2)), 'yyyy-MM-dd');
+  }
+  return format(lastDayOfMonth(startDate), 'yyyy-MM-dd');
+}
+
+function monthKeyFor(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+}
+
+/**
+ * Roll per-month totals up to the given granularity and gap-fill every period
+ * from the first populated period to the last, so empty periods render as
+ * zero-height bars at their true time position. Totals are accumulated in
+ * integer ten-thousandths to avoid float drift, then divided back once.
+ */
+export function bucketMonthlyTotals(
+  data: MonthlyTotal[],
+  granularity: Granularity,
+): BucketedPoint[] {
+  if (data.length === 0) return [];
+
+  const accumulator = new Map<
+    string,
+    { startDate: Date; periodStart: string; cents: number; count: number }
+  >();
+
+  for (const datum of data) {
+    const { key, startDate, periodStart } = periodInfoForMonth(datum.month, granularity);
+    const cents = Math.round(datum.total * SCALE);
+    const existing = accumulator.get(key);
+    if (existing) {
+      existing.cents += cents;
+      existing.count += datum.count;
+    } else {
+      accumulator.set(key, { startDate, periodStart, cents, count: datum.count });
+    }
+  }
+
+  const startTimes = [...accumulator.values()].map((v) => v.startDate.getTime());
+  const minStart = new Date(Math.min(...startTimes));
+  const maxStart = new Date(Math.max(...startTimes));
+  const step = GRANULARITY_MONTHS[granularity];
+
+  const points: BucketedPoint[] = [];
+  for (
+    let cursor = minStart;
+    cursor.getTime() <= maxStart.getTime();
+    cursor = addMonths(cursor, step)
+  ) {
+    const { key, startDate, periodStart } = periodInfoForMonth(
+      monthKeyFor(cursor),
+      granularity,
+    );
+    const bucket = accumulator.get(key);
+    points.push({
+      granularity,
+      key,
+      periodStart,
+      periodEnd: periodEndFor(startDate, granularity),
+      total: bucket ? bucket.cents / SCALE : 0,
+      count: bucket ? bucket.count : 0,
+    });
+  }
+
+  return points;
+}
+
+/**
+ * Number of elapsed periods (including empty gap periods) spanned by the data
+ * at the given granularity. Used as the denominator for the "per-period"
+ * average so it reflects time elapsed, not just periods that had activity.
+ */
+export function countElapsedPeriods(
+  data: MonthlyTotal[],
+  granularity: Granularity,
+): number {
+  return bucketMonthlyTotals(data, granularity).length;
+}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -97,6 +97,20 @@ export function roundToCents(value: number): number {
 }
 
 /**
+ * Sum money values without IEEE 754 accumulation drift by accumulating in
+ * integer ten-thousandths (matching the backend `roundMoney` / decimal(20,4)
+ * precision) and dividing back once at the end. Mirrors the backend `sumMoney`
+ * helper so client-side totals reconcile to the same cents as the server.
+ */
+export function sumMoney(values: number[]): number {
+  const totalUnits = values.reduce(
+    (sum, value) => sum + Math.round(value * 10000),
+    0,
+  );
+  return totalUnits / 10000;
+}
+
+/**
  * Pick how many fraction digits to show so a tiny non-zero value doesn't
  * collapse to "0.00". When the value already shows a non-zero figure at the
  * currency's natural precision (baseDigits), baseDigits is returned unchanged.


### PR DESCRIPTION
## Linked discussion / issue

Closes #921 
Approved in: #921 

## Summary

Refactors the Monthly Totals bar chart to intelligently bucket transaction data by time granularity (month/quarter/year) based on the data span, gap-fill empty periods so sparse payment series render at their true time position, and add user controls to override the auto-selected granularity. This fixes a mismatch where the chart's per-month totals and counts diverged from the category/payee summary widget's headline numbers.

### Key Changes

**Frontend:**
- New `chart-buckets.ts` library exports `selectGranularity()` to pick the coarsest-enough bucket size for a data span, and `bucketMonthlyTotals()` to roll per-month data up to the chosen granularity with gap-fill. Totals accumulate in integer ten-thousandths to avoid IEEE 754 drift, matching the backend's `roundMoney` precision.
- `CategoryPayeeBarChart` now renders granularity toggle buttons (Auto/Month/Quarter/Year) and dynamically adjusts the chart, axis labels, and summary "average" label to match the active bucket size.
- Adjusted crowding thresholds: bar-top labels rotate vertical at 20+ bars (down from 36), and drop entirely above 60 bars to keep the chart readable.
- Summary average now divides by elapsed periods (including gap-filled empty periods) rather than just periods with activity, so the per-period average reflects true time elapsed.

**Backend:**
- `getMonthlyTotals()` now reuses the same filtered query builder as `getSummary()` so the chart's per-month totals and counts reconcile exactly with the category/payee info widget's headline summary. Previously the method duplicated filter logic with slightly different semantics (no transfer-split exclusion, conditional split join), which let the counts diverge.
- Transfer split lines are now excluded from the chart (matching the summary widget), while whole transfer transactions are still counted.

**i18n:**
- Added `quarterlyAvg`, `yearlyAvg`, `quarterLabel`, `quarterTick`, `granularityLabel`, and granularity mode labels to all 21 supported locales.

### Testing

- Added comprehensive unit tests for `selectGranularity()` and `bucketMonthlyTotals()` covering span detection, gap-fill, quarter/year bucketing, and float precision.
- Updated `CategoryPayeeBarChart.test.tsx` to verify granularity selection, gap-fill behavior, label crowding thresholds, and the new toggle controls.
- Updated `CategoryInfoWidget.test.tsx` and `PayeeInfoWidget.test.tsx` to verify elapsed-period averaging and refetch on `refreshKey` change.
- Backend tests updated to verify the shared query builder and transfer-split exclusion logic.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (chart bucketing and summary reconciliation).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

<!-- Disclose any AI tools used. Using AI is fine and expected — you remain responsible for correctness, conventions, and tests. -->

https://claude.ai/code/session_011pudKrqKr3HXpn12AxtmEv