### PR TITLE
Fix for "exchangeRate must be a number conforming to the specified constraints" error

### DIFF
--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -14,7 +14,7 @@ import { SplitTransactionFields } from './SplitTransactionFields';
 import { CurrencyPickerButton } from './CurrencyPickerButton';
 import { CurrencyInput } from '@/components/ui/CurrencyInput';
 import { exchangeRatesApi } from '@/lib/exchange-rates';
-import { getCurrencySymbol, roundToCents } from '@/lib/format';
+import { getCurrencySymbol, roundToCents, roundToDecimals } from '@/lib/format';
 import {
   getRememberedTransactionCurrency,
   rememberTransactionCurrency,
@@ -777,7 +777,7 @@ export function TransactionForm({ transaction, duplicateFrom, defaultAccountId, 
       const p = feePercent / 100;
       base = roundToCents(total >= 0 ? total / (1 - p) : total / (1 + p));
     }
-    const newRate = Math.round((base / foreignAmount) * 1e10) / 1e10;
+    const newRate = roundToDecimals(base / foreignAmount, 10);
     rateOverriddenRef.current = true;
     setFxRate(newRate);
     recomputeFx(foreignAmount, newRate, base);


### PR DESCRIPTION
## Linked discussion / issue

Closes #938 
Approved in: #938 

## Summary

Exchange rate rounding was overly complicated and may have led to errors.  This ensures the exchange rate is always rounded to exactly 10 decimal places.

## Checklist

- [X] An approved discussion or issue exists and is linked above.
- [X] This PR addresses a **single concern** (large work is split into a series).
- [X] New behavior has tests, and the existing suite passes.
- [X] All user-facing strings are translated for **every** locale (i18n parity).
- [X] No shared/core areas were refactored without prior agreement.
- [X] The branch is rebased on the latest `main`.
- [X] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Co-authored with AI; reviewed and tested by a human.
