### PR TITLE
fix(deps): bump typeorm and override @hono/node-server

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -42,7 +42,7 @@
         "qrcode": "^1.5.4",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
-        "typeorm": "^0.3.30",
+        "typeorm": "^0.3.31",
         "ua-parser-js": "^2.0.10",
         "undici": "^8.5.0",
         "zod": "^4.3.6"
@@ -970,12 +970,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -3762,6 +3762,7 @@
     },
     "node_modules/ansis": {
       "version": "4.2.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -9884,16 +9885,16 @@
       "license": "MIT"
     },
     "node_modules/typeorm": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
-      "integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.31.tgz",
+      "integrity": "sha512-6u9EFtdLBgHjnPm78NStVeM+I/1MolTzKykDDcydzKUkh6E++YS6XViU/fePJbvDvEGU4Xq34KOM/CLeer9I2A==",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
-        "ansis": "^4.2.0",
+        "ansis": "^4.3.1",
         "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "dayjs": "^1.11.20",
+        "dayjs": "^1.11.21",
         "debug": "^4.4.3",
         "dedent": "^1.7.2",
         "dotenv": "^16.6.1",
@@ -9903,7 +9904,7 @@
         "sql-highlight": "^6.1.0",
         "tslib": "^2.8.1",
         "uuid": "^11.1.1",
-        "yargs": "^17.7.2"
+        "yargs": "^17.7.3"
       },
       "bin": {
         "typeorm": "cli.js",
@@ -9924,13 +9925,13 @@
         "mongodb": "^5.8.0 || ^6.0.0",
         "mssql": "^9.1.1 || ^10.0.0 || ^11.0.0 || ^12.0.0",
         "mysql2": "^2.2.5 || ^3.0.1",
-        "oracledb": "^6.3.0",
+        "oracledb": "^6.3.0 || ^7.0.0",
         "pg": "^8.5.1",
         "pg-native": "^3.0.0",
         "pg-query-stream": "^4.0.0",
         "redis": "^3.1.1 || ^4.0.0 || ^5.0.14",
         "sql.js": "^1.4.0",
-        "sqlite3": "^5.0.3",
+        "sqlite3": "^5.0.3 || ^6.0.0",
         "ts-node": "^10.7.0",
         "typeorm-aurora-data-api-driver": "^2.0.0 || ^3.0.0"
       },
@@ -9983,6 +9984,15 @@
         "typeorm-aurora-data-api-driver": {
           "optional": true
         }
+      }
+    },
+    "node_modules/typeorm/node_modules/ansis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/typeorm/node_modules/buffer": {
@@ -10583,7 +10593,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -65,7 +65,7 @@
     "qrcode": "^1.5.4",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
-    "typeorm": "^0.3.30",
+    "typeorm": "^0.3.31",
     "ua-parser-js": "^2.0.10",
     "undici": "^8.5.0",
     "zod": "^4.3.6"
@@ -103,6 +103,7 @@
     "typescript-eslint": "^8.63.0"
   },
   "overrides": {
+    "@hono/node-server": "^2.0.5",
     "lodash": "4.18.1",
     "ajv@>=7": "8.18.0",
     "js-yaml": ">=4.2.0",


### PR DESCRIPTION
## Linked discussion / issue

Maintainer-initiated security fix; no discussion (scope is two dependency bumps only).
Addresses both moderate alerts at: https://github.com/kenlasko/monize/security/dependabot

## Summary

Resolves the two moderate Dependabot alerts on the default branch:

- `typeorm` `^0.3.30` -> `^0.3.31`
- `@hono/node-server` forced to `^2.0.5` via `overrides` (transitive dependency)

Lockfile regenerated accordingly. No code changes.

## Checklist

- [x] An approved discussion or issue exists and is linked above. (N/A: maintainer security fix; Dependabot alerts linked.)
- [x] This PR addresses a **single concern** (large work is split into a series).
- [ ] New behavior has tests, and the existing suite passes. (No new behavior; relying on CI to run the suite.)
- [x] All user-facing strings are translated for **every** locale (i18n parity). (No string changes.)
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

PR prepared and pushed with Claude Code; dependency version selections reviewed by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)