### PR TITLE
test(db): guard enum-backed varchar columns against too-narrow widths (fixes recurring_extra_mode)

### DIFF
--- a/backend/src/entity-varchar-capacity.spec.ts
+++ b/backend/src/entity-varchar-capacity.spec.ts
@@ -1,0 +1,234 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as ts from "typescript";
+
+/**
+ * Guards the whole backend against enum-backed varchar columns that are
+ * narrower than a value the code is allowed to store in them.
+ *
+ * The bug class this catches: loan_scenarios' mode columns were VARCHAR(16)
+ * while the property type admitted 'LOWER_INSTALLMENT' (17 chars), so saving
+ * a lower-installment scenario failed only against a real database with
+ * 22001 "value too long for type character varying(16)". Unit tests mock the
+ * repository and never see column widths, so the mismatch is invisible to
+ * them by construction.
+ *
+ * Method: compile every *.entity.ts under src/ and, for each @Column of a
+ * varchar type with a declared length whose TypeScript property type resolves
+ * to a union of string literals (an enum-like column), assert that
+ *   1. the longest admissible literal fits the entity's declared length, and
+ *   2. database/schema.sql declares the same table.column at least that wide
+ *      (the entity drives test databases via synchronize, but production
+ *      schemas come from schema.sql/migrations -- both sides must fit).
+ */
+describe("entity varchar capacities (enum-backed columns)", () => {
+  interface EnumColumn {
+    file: string;
+    className: string;
+    property: string;
+    tableName: string | null;
+    columnName: string;
+    declaredLength: number;
+    literals: string[];
+  }
+
+  const SRC_DIR = __dirname;
+  const SCHEMA_SQL_PATH = path.resolve(__dirname, "../../database/schema.sql");
+
+  function findEntityFiles(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        out.push(...findEntityFiles(full));
+      } else if (entry.name.endsWith(".entity.ts")) {
+        out.push(full);
+      }
+    }
+    return out;
+  }
+
+  /** String value of an object-literal property, for literal initializers. */
+  function literalString(expr: ts.Expression): string | null {
+    return ts.isStringLiteralLike(expr) ? expr.text : null;
+  }
+
+  function literalNumber(expr: ts.Expression): number | null {
+    return ts.isNumericLiteral(expr) ? Number(expr.text) : null;
+  }
+
+  function objectProp(
+    obj: ts.ObjectLiteralExpression,
+    name: string,
+  ): ts.Expression | null {
+    for (const prop of obj.properties) {
+      if (
+        ts.isPropertyAssignment(prop) &&
+        ts.isIdentifier(prop.name) &&
+        prop.name.text === name
+      ) {
+        return prop.initializer;
+      }
+    }
+    return null;
+  }
+
+  function decoratorCall(
+    node: ts.HasDecorators,
+    decoratorName: string,
+  ): ts.CallExpression | null {
+    for (const decorator of ts.getDecorators(node) ?? []) {
+      if (
+        ts.isCallExpression(decorator.expression) &&
+        ts.isIdentifier(decorator.expression.expression) &&
+        decorator.expression.expression.text === decoratorName
+      ) {
+        return decorator.expression;
+      }
+    }
+    return null;
+  }
+
+  /** All string literals of a union type; null when any part is not one. */
+  function unionStringLiterals(type: ts.Type): string[] | null {
+    const parts = type.isUnion() ? type.types : [type];
+    const literals: string[] = [];
+    for (const part of parts) {
+      if (part.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined)) continue;
+      if (part.isStringLiteral()) {
+        literals.push(part.value);
+      } else {
+        return null;
+      }
+    }
+    return literals.length > 0 ? literals : null;
+  }
+
+  function collectEnumColumns(): EnumColumn[] {
+    const files = findEntityFiles(SRC_DIR);
+    expect(files.length).toBeGreaterThan(0);
+
+    const program = ts.createProgram(files, {
+      target: ts.ScriptTarget.ES2021,
+      module: ts.ModuleKind.CommonJS,
+      experimentalDecorators: true,
+      strictNullChecks: true,
+      skipLibCheck: true,
+      baseUrl: SRC_DIR,
+      paths: { "@/*": ["*"] },
+    });
+    const checker = program.getTypeChecker();
+    const columns: EnumColumn[] = [];
+
+    for (const file of files) {
+      const source = program.getSourceFile(file);
+      if (!source) continue;
+      ts.forEachChild(source, (node) => {
+        if (!ts.isClassDeclaration(node) || !node.name) return;
+
+        const entityCall = decoratorCall(node, "Entity");
+        const tableArg = entityCall?.arguments[0];
+        const tableName =
+          tableArg && ts.isStringLiteralLike(tableArg) ? tableArg.text : null;
+
+        for (const member of node.members) {
+          if (!ts.isPropertyDeclaration(member) || !member.type) continue;
+          const columnCall = decoratorCall(member, "Column");
+          const options = columnCall?.arguments[0];
+          if (!options || !ts.isObjectLiteralExpression(options)) continue;
+
+          const columnType = objectProp(options, "type");
+          const isVarchar =
+            columnType !== null &&
+            /^(varchar|character varying)$/i.test(
+              literalString(columnType) ?? "",
+            );
+          const lengthExpr = objectProp(options, "length");
+          const declaredLength = lengthExpr && literalNumber(lengthExpr);
+          if (!isVarchar || !declaredLength) continue;
+
+          const literals = unionStringLiterals(
+            checker.getTypeFromTypeNode(member.type),
+          );
+          if (!literals) continue; // free-form string column, not enum-like
+
+          const nameExpr = objectProp(options, "name");
+          const columnName =
+            (nameExpr && literalString(nameExpr)) ??
+            (ts.isIdentifier(member.name) ? member.name.text : "");
+
+          columns.push({
+            file: path.relative(SRC_DIR, file),
+            className: node.name!.text,
+            property: ts.isIdentifier(member.name)
+              ? member.name.text
+              : columnName,
+            tableName,
+            columnName,
+            declaredLength,
+            literals,
+          });
+        }
+      });
+    }
+    return columns;
+  }
+
+  /** VARCHAR width of table.column in schema.sql, or null when absent. */
+  function schemaWidth(tableName: string, columnName: string): number | null {
+    const schema = fs.readFileSync(SCHEMA_SQL_PATH, "utf8");
+    const tableMatch = new RegExp(
+      `CREATE TABLE (?:IF NOT EXISTS )?${tableName}\\s*\\(([\\s\\S]*?)\\n\\);`,
+      "i",
+    ).exec(schema);
+    if (!tableMatch) return null;
+    const columnMatch = new RegExp(
+      `(?:^|\\n)\\s*${columnName}\\s+(?:VARCHAR|CHARACTER VARYING)\\s*\\((\\d+)\\)`,
+      "i",
+    ).exec(tableMatch[1]);
+    return columnMatch ? Number(columnMatch[1]) : null;
+  }
+
+  const enumColumns = collectEnumColumns();
+
+  it("finds the known enum-backed columns (sanity check)", () => {
+    // If the sweep silently found nothing, every other assertion would
+    // vacuously pass; pin a couple of known columns to keep it honest.
+    const names = enumColumns.map((c) => c.columnName);
+    expect(names).toContain("recurring_extra_mode");
+    expect(names).toContain("recurring_extra_frequency");
+  });
+
+  it("every enum-backed varchar column fits its longest allowed value", () => {
+    const tooNarrow = enumColumns
+      .map((c) => {
+        const widest = [...c.literals].sort((a, b) => b.length - a.length)[0];
+        return { ...c, widest };
+      })
+      .filter((c) => c.widest.length > c.declaredLength)
+      .map(
+        (c) =>
+          `${c.className}.${c.property} (${c.file}): column ${c.columnName} is ` +
+          `varchar(${c.declaredLength}) but '${c.widest}' is ${c.widest.length} chars`,
+      );
+    expect(tooNarrow).toEqual([]);
+  });
+
+  it("schema.sql declares every enum-backed column at least as wide", () => {
+    const mismatches = enumColumns
+      .filter((c) => c.tableName !== null)
+      .map((c) => ({ ...c, schema: schemaWidth(c.tableName!, c.columnName) }))
+      .filter((c) => {
+        if (c.schema === null) return false; // column added by an unmerged path
+        const widest = Math.max(...c.literals.map((l) => l.length));
+        return c.schema < widest || c.schema < c.declaredLength;
+      })
+      .map(
+        (c) =>
+          `${c.tableName}.${c.columnName}: schema.sql has varchar(${c.schema}), ` +
+          `entity declares ${c.declaredLength}, longest value is ` +
+          `${Math.max(...c.literals.map((l) => l.length))} chars`,
+      );
+    expect(mismatches).toEqual([]);
+  });
+});

--- a/backend/src/loan-scenarios/entities/loan-scenario.entity.ts
+++ b/backend/src/loan-scenarios/entities/loan-scenario.entity.ts
@@ -85,7 +85,7 @@ export class LoanScenario {
 
   @Column({
     type: "varchar",
-    length: 16,
+    length: 64,
     name: "recurring_extra_mode",
     nullable: true,
   })

--- a/database/migrations/105_loan_scenarios_widen_recurring_extra_mode.sql
+++ b/database/migrations/105_loan_scenarios_widen_recurring_extra_mode.sql
@@ -1,0 +1,9 @@
+-- 'LOWER_INSTALLMENT' is 17 characters, but recurring_extra_mode was created
+-- as VARCHAR(16) (migration 098), so saving a scenario whose recurring
+-- overpayment uses the lower-installment mode failed with "value too long for
+-- type character varying(16)" (22001). Widen to 64.
+-- Safe on any database: widening a varchar never touches stored data, and
+-- re-running is a no-op in effect.
+-- (Numbered 105: 103/104 are reserved by the in-flight monthly-budget branch.)
+ALTER TABLE loan_scenarios
+    ALTER COLUMN recurring_extra_mode TYPE VARCHAR(64);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1276,7 +1276,7 @@ CREATE TABLE loan_scenarios (
     account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
     name VARCHAR(100) NOT NULL,
     recurring_extra_amount DECIMAL(20,4),
-    recurring_extra_mode VARCHAR(16),
+    recurring_extra_mode VARCHAR(64),
     recurring_extra_frequency VARCHAR(16),
     recurring_extra_start_date DATE,
     recurring_extra_end_date DATE,


### PR DESCRIPTION
## Linked discussion / issue

Closes #942

## Summary

Adds an automated guard for the bug class we just hit live twice: an enum-backed varchar column narrower than a value the code itself stores in it, which no mock-based test can see and which only surfaces against a real database as PG 22001 ("value too long").

**The guard** (`backend/src/entity-varchar-capacity.spec.ts`): sweeps every `*.entity.ts` with the TypeScript compiler; for each varchar `@Column` with a declared `length` whose property type resolves to a union of string literals, it asserts (1) the longest admissible literal fits the entity's declared length and (2) `database/schema.sql` declares the same `table.column` at least that wide. No database needed; runs in the unit suite in ~5 s; failure messages name the exact class, property, column and offending value. A pinned sanity check keeps the sweep honest (it must find the known enum columns, so a silently-empty scan can't vacuously pass).

**The instance it found on `main`**: `loan_scenarios.recurring_extra_mode` is `VARCHAR(16)` while the type admits `'LOWER_INSTALLMENT'` (17 chars) -- saving a recurring lower-installment scenario fails. Fixed minimally here: entity + `schema.sql` widened to 64, plus migration **105** for existing databases. (103/104 are reserved by the in-flight #937 branch, which fixes its own sibling columns the same way; whichever merges second becomes a no-op on the overlap. The migration numbering gap is intentional and harmless -- pending migrations run in filename order.)

Verified: with the fix reverted, the guard fails on exactly the `recurring_extra_mode` instance (both axes); with it applied, the suite, lint, type-check and `scripts/verify-schema.sh` are green.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). *(No user-facing strings in this PR.)*
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Developed with Claude Code; I reviewed the code and verified the guard catches the released bug by reverting the fix locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
