### PR TITLE
feat(dashboard): open a mover's price history from Top Movers, and chart it

### DIFF
--- a/frontend/src/app/securities/page.test.tsx
+++ b/frontend/src/app/securities/page.test.tsx
@@ -4,6 +4,20 @@ import { render, screen, waitFor, fireEvent, act } from '@/test/render';
 import SecuritiesPage from './page';
 import toast from 'react-hot-toast';
 
+// Per-test query string, so the `?price=<id>` deep link can be exercised.
+const nav = vi.hoisted(() => ({ params: new URLSearchParams() }));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    prefetch: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  usePathname: () => '/securities',
+  useSearchParams: () => nav.params,
+}));
+
 // Mock next/image
 vi.mock('next/image', () => ({
   default: ({ priority, fill, ...props }: any) => <img alt="" {...props} />,
@@ -217,6 +231,7 @@ vi.mock('@/hooks/useLocalStorage', () => ({
 describe('SecuritiesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    nav.params = new URLSearchParams();
     mockGetSecurities.mockResolvedValue([
       { id: 's1', symbol: 'AAPL', name: 'Apple Inc.', securityType: 'STOCK', exchange: 'NASDAQ', currencyCode: 'USD', isActive: true, skipPriceUpdates: false, createdAt: '2026-01-01', updatedAt: '2026-01-01' },
       { id: 's2', symbol: 'XEQT', name: 'iShares Core Equity', securityType: 'ETF', exchange: 'TSX', currencyCode: 'CAD', isActive: true, skipPriceUpdates: false, createdAt: '2026-01-01', updatedAt: '2026-01-01' },
@@ -782,5 +797,38 @@ describe('SecuritiesPage', () => {
     mockGetSecurities.mockResolvedValue(many);
     render(<SecuritiesPage />);
     await waitFor(() => expect(screen.getByTestId('pagination')).toBeInTheDocument());
+  });
+
+  describe('price history deep link', () => {
+    it('opens the price history the ?price= link asks for', async () => {
+      // The dashboard's Top Movers sends the user here rather than growing its
+      // own copy of this view.
+      nav.params = new URLSearchParams('price=s1');
+      render(<SecuritiesPage />);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('price-history')).toBeInTheDocument(),
+      );
+    });
+
+    it('does not reopen it once closed', async () => {
+      nav.params = new URLSearchParams('price=s1');
+      render(<SecuritiesPage />);
+      await waitFor(() =>
+        expect(screen.getByTestId('price-history')).toBeInTheDocument(),
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('price-history-close'));
+      });
+      expect(screen.queryByTestId('price-history')).not.toBeInTheDocument();
+    });
+
+    it('ignores an id that is not in the list', async () => {
+      nav.params = new URLSearchParams('price=nope');
+      render(<SecuritiesPage />);
+
+      expect(screen.queryByTestId('price-history')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/app/securities/page.tsx
+++ b/frontend/src/app/securities/page.tsx
@@ -29,6 +29,7 @@ import { useOnUndoRedo } from '@/hooks/useOnUndoRedo';
 import { useOnAiAction } from '@/hooks/useOnAiAction';
 import { PAGE_SIZE } from '@/lib/constants';
 import { useHighlightParam } from '@/hooks/useHighlightTarget';
+import { useSearchParams } from 'next/navigation';
 
 const logger = createLogger('Securities');
 
@@ -52,6 +53,13 @@ function SecuritiesContent() {
   });
   const { showForm, editingItem: editingSecurity, openCreate, openEdit, close, isEditing, modalProps, setFormDirty, unsavedChangesDialog, formSubmitRef } = useFormModal<Security>();
   const [priceSecurity, setPriceSecurity] = useState<Security | undefined>();
+  // Deep link: `?price=<securityId>` opens this page's price history for that
+  // security, so other screens (the dashboard's Top Movers) can send the user
+  // straight to it instead of growing their own copy of the view. Captured once
+  // on mount, then resolved against the loaded list by plain derivation -- no
+  // effect, so nothing re-opens after the user closes it.
+  const priceParamId = useSearchParams().get('price');
+  const [priceParamConsumed, setPriceParamConsumed] = useState(false);
   const [historySecurity, setHistorySecurity] = useState<Security | undefined>();
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<'all' | 'active' | 'inactive'>('active');
@@ -268,6 +276,19 @@ function SecuritiesContent() {
     }
   }, [highlightId, sortedSecurities]);
 
+  // The deep-linked security, until the user closes the modal. Derived rather
+  // than pushed into state by an effect, so it needs no setState-in-effect and
+  // survives the list arriving after mount.
+  const deepLinkedPriceSecurity =
+    priceParamId && !priceParamConsumed
+      ? allSecurities.find((security) => security.id === priceParamId)
+      : undefined;
+  const shownPriceSecurity = priceSecurity ?? deepLinkedPriceSecurity;
+  const closePriceHistory = () => {
+    setPriceSecurity(undefined);
+    setPriceParamConsumed(true);
+  };
+
   const activeCount = allSecurities.filter((s) => s.isActive).length;
   const inactiveCount = allSecurities.filter((s) => !s.isActive).length;
 
@@ -342,11 +363,11 @@ function SecuritiesContent() {
         <UnsavedChangesDialog {...unsavedChangesDialog} />
 
         {/* Price History Modal */}
-        <Modal isOpen={!!priceSecurity} onClose={() => setPriceSecurity(undefined)} maxWidth="5xl" className="p-6" pushHistory>
-          {priceSecurity && (
+        <Modal isOpen={!!shownPriceSecurity} onClose={closePriceHistory} maxWidth="5xl" className="p-6" pushHistory>
+          {shownPriceSecurity && (
             <SecurityPriceHistory
-              security={priceSecurity}
-              onClose={() => setPriceSecurity(undefined)}
+              security={shownPriceSecurity}
+              onClose={closePriceHistory}
             />
           )}
         </Modal>

--- a/frontend/src/components/dashboard/TopMovers.test.tsx
+++ b/frontend/src/components/dashboard/TopMovers.test.tsx
@@ -225,7 +225,12 @@ describe('TopMovers', () => {
     ] as any[];
 
     render(<TopMovers movers={movers} isLoading={false} hasInvestmentAccounts={true} />);
-    fireEvent.click(screen.getByRole('button', { name: 'Price history for AAPL' }));
+    // The row names itself with its own content; the action is screen-reader
+    // text inside it, not an aria-label that would hide the price and change.
+    const row = screen.getByRole('button', { name: /Price history for AAPL/ });
+    expect(row).toHaveAccessibleName(expect.stringContaining('Apple'));
+    expect(row).toHaveAccessibleName(expect.stringContaining('$180.00'));
+    fireEvent.click(row);
 
     // The same view the securities page opens from its Prices action, reached
     // by deep link rather than by a second copy of it on the dashboard.

--- a/frontend/src/components/dashboard/TopMovers.test.tsx
+++ b/frontend/src/components/dashboard/TopMovers.test.tsx
@@ -219,6 +219,19 @@ describe('TopMovers', () => {
     expect(screen.getByText('$95.00 EUR')).toBeInTheDocument();
   });
 
+  it('opens the security\'s price history when a row is clicked', () => {
+    const movers = [
+      { securityId: 'sec-1', symbol: 'AAPL', name: 'Apple', currentPrice: 180, dailyChange: 5, dailyChangePercent: 2.8, currencyCode: 'USD' },
+    ] as any[];
+
+    render(<TopMovers movers={movers} isLoading={false} hasInvestmentAccounts={true} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Price history for AAPL' }));
+
+    // The same view the securities page opens from its Prices action, reached
+    // by deep link rather than by a second copy of it on the dashboard.
+    expect(mockPush).toHaveBeenCalledWith('/securities?price=sec-1');
+  });
+
   it('does not show currency code for default currency securities', () => {
     const movers = [
       { securityId: '1', symbol: 'AAPL', name: 'Apple', currentPrice: 180, dailyChange: 5, dailyChangePercent: 2.8, currencyCode: 'USD' },

--- a/frontend/src/components/dashboard/TopMovers.tsx
+++ b/frontend/src/components/dashboard/TopMovers.tsx
@@ -192,10 +192,17 @@ export function TopMovers({ movers, isLoading, hasInvestmentAccounts, onRefresh,
               key={mover.securityId}
               type="button"
               onClick={() => router.push(`/securities?price=${mover.securityId}`)}
-              aria-label={t('topMovers.openPriceHistory', { symbol: mover.symbol })}
+              title={t('topMovers.openPriceHistory', { symbol: mover.symbol })}
               className="flex w-full items-center justify-between p-2 sm:p-3 rounded-lg border border-gray-200 dark:border-gray-700 text-left transition-colors hover:border-blue-400 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:border-blue-500 dark:hover:bg-gray-700/50"
             >
               <div className="min-w-0">
+                {/* The row's content is its accessible name -- symbol, name,
+                    price and change -- so the action is added as screen-reader
+                    text rather than an aria-label that would replace all of
+                    it. */}
+                <span className="sr-only">
+                  {t('topMovers.openPriceHistory', { symbol: mover.symbol })}
+                </span>
                 <div className="font-medium text-gray-900 dark:text-gray-100">
                   {mover.symbol}
                 </div>

--- a/frontend/src/components/dashboard/TopMovers.tsx
+++ b/frontend/src/components/dashboard/TopMovers.tsx
@@ -188,9 +188,12 @@ export function TopMovers({ movers, isLoading, hasInvestmentAccounts, onRefresh,
             return isForeign ? `${formatted} ${mover.currencyCode}` : formatted;
           };
           return (
-            <div
+            <button
               key={mover.securityId}
-              className="flex items-center justify-between p-2 sm:p-3 rounded-lg border border-gray-200 dark:border-gray-700"
+              type="button"
+              onClick={() => router.push(`/securities?price=${mover.securityId}`)}
+              aria-label={t('topMovers.openPriceHistory', { symbol: mover.symbol })}
+              className="flex w-full items-center justify-between p-2 sm:p-3 rounded-lg border border-gray-200 dark:border-gray-700 text-left transition-colors hover:border-blue-400 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:border-blue-500 dark:hover:bg-gray-700/50"
             >
               <div className="min-w-0">
                 <div className="font-medium text-gray-900 dark:text-gray-100">
@@ -214,7 +217,7 @@ export function TopMovers({ movers, isLoading, hasInvestmentAccounts, onRefresh,
                   {isPositive ? '+' : ''}{formatCurrencyPrecise(mover.dailyChange, mover.currencyCode)} ({isPositive ? '+' : ''}{formatPercent(mover.dailyChangePercent)})
                 </div>
               </div>
-            </div>
+            </button>
           );
         })}
       </div>

--- a/frontend/src/components/securities/SecurityPriceHistory.test.tsx
+++ b/frontend/src/components/securities/SecurityPriceHistory.test.tsx
@@ -373,6 +373,27 @@ describe('SecurityPriceHistory', () => {
     expect(screen.getAllByText('Edit')).toHaveLength(3);
   });
 
+  describe('price chart', () => {
+    it('charts the price series above the table', async () => {
+      await renderComponent();
+
+      // Deliberately the account balance-history chart, so the two screens
+      // read the same way; only the title and the neutral colouring differ.
+      expect(screen.getByText('Price History')).toBeInTheDocument();
+      expect(screen.getByText(/AAPL/)).toBeInTheDocument();
+    });
+
+    it('leaves the chart out when there is nothing to plot', async () => {
+      (investmentsApi.getSecurityPrices as ReturnType<typeof vi.fn>).mockResolvedValue([
+        mockPrices[0],
+      ]);
+      await renderComponent();
+
+      // A single point is a dot, not a history.
+      expect(screen.queryByText('Price History')).not.toBeInTheDocument();
+    });
+  });
+
   describe('Force Update Prices', () => {
     it('force-updates prices, shows a success toast with the count, and reloads', async () => {
       const toast = (await import('react-hot-toast')).default;

--- a/frontend/src/components/securities/SecurityPriceHistory.test.tsx
+++ b/frontend/src/components/securities/SecurityPriceHistory.test.tsx
@@ -2,9 +2,26 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@/test/render';
 import { SecurityPriceHistory } from './SecurityPriceHistory';
 
+// The chart itself is covered by BalanceHistoryChart.test; here it stands in
+// for itself so the props the modal builds -- the title and the trade markers
+// -- can be asserted directly.
+vi.mock('@/components/transactions/BalanceHistoryChart', () => ({
+  BalanceHistoryChart: ({ title, markers }: any) => (
+    <div data-testid="price-chart">
+      {title}
+      {(markers ?? []).map((marker: any, i: number) => (
+        <span key={i} data-testid="chart-marker">
+          {marker.direction}: {marker.label}
+        </span>
+      ))}
+    </div>
+  ),
+}));
+
 vi.mock('@/lib/investments', () => ({
   investmentsApi: {
     getSecurityPrices: vi.fn(),
+    getSecurityTransactionHistory: vi.fn(),
     createSecurityPrice: vi.fn(),
     updateSecurityPrice: vi.fn(),
     deleteSecurityPrice: vi.fn(),
@@ -98,6 +115,16 @@ describe('SecurityPriceHistory', () => {
     vi.clearAllMocks();
     window.addEventListener('unhandledrejection', swallowExpected);
     (investmentsApi.getSecurityPrices as ReturnType<typeof vi.fn>).mockResolvedValue(mockPrices);
+    (investmentsApi.getSecurityTransactionHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
+      securityId: 'sec-1',
+      symbol: 'AAPL',
+      name: 'Apple Inc.',
+      currencyCode: 'USD',
+      isActive: true,
+      accounts: [],
+      transactions: [],
+      currentQuantityAll: 0,
+    });
   });
 
   afterEach(() => {
@@ -381,6 +408,42 @@ describe('SecurityPriceHistory', () => {
       // read the same way; only the title and the neutral colouring differ.
       expect(screen.getByText('Price History')).toBeInTheDocument();
       expect(screen.getByText(/AAPL/)).toBeInTheDocument();
+    });
+
+    it('marks the days shares moved, and how many', async () => {
+      (investmentsApi.getSecurityTransactionHistory as ReturnType<typeof vi.fn>).mockResolvedValue({
+        securityId: 'sec-1',
+        symbol: 'AAPL',
+        name: 'Apple Inc.',
+        currencyCode: 'USD',
+        isActive: true,
+        accounts: [],
+        currentQuantityAll: 8,
+        transactions: [
+          { id: 't1', transactionDate: '2025-05-30', accountId: 'a1', accountName: 'RRSP', action: 'BUY', quantity: 10, price: 150, commission: 0, totalAmount: 1500, description: null, runningQuantityAccount: 10, runningQuantityAll: 10 },
+          { id: 't2', transactionDate: '2025-06-01', accountId: 'a1', accountName: 'RRSP', action: 'SELL', quantity: 2, price: 193, commission: 0, totalAmount: 386, description: null, runningQuantityAccount: 8, runningQuantityAll: 8 },
+          // No shares moved, so nothing to pin on the chart.
+          { id: 't3', transactionDate: '2025-06-01', accountId: 'a1', accountName: 'RRSP', action: 'DIVIDEND', quantity: null, price: null, commission: 0, totalAmount: 12, description: null, runningQuantityAccount: 8, runningQuantityAll: 8 },
+        ],
+      });
+
+      await renderComponent();
+
+      const markers = screen.getAllByTestId('chart-marker');
+      expect(markers).toHaveLength(2);
+      expect(markers[0]).toHaveTextContent('in: Bought 10 · RRSP');
+      expect(markers[1]).toHaveTextContent('out: Sold 2 · RRSP');
+    });
+
+    it('keeps the chart when the trade lookup fails', async () => {
+      (investmentsApi.getSecurityTransactionHistory as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('nope'),
+      );
+      await renderComponent();
+
+      // Markers are a nicety; the price history is the point of the modal.
+      expect(screen.getByTestId('price-chart')).toBeInTheDocument();
+      expect(screen.queryAllByTestId('chart-marker')).toHaveLength(0);
     });
 
     it('leaves the chart out when there is nothing to plot', async () => {

--- a/frontend/src/components/securities/SecurityPriceHistory.tsx
+++ b/frontend/src/components/securities/SecurityPriceHistory.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import toast from 'react-hot-toast';
 import { Button } from '@/components/ui/Button';
@@ -11,6 +11,7 @@ import { investmentsApi } from '@/lib/investments';
 import { useDateFormat } from '@/hooks/useDateFormat';
 import { getErrorMessage } from '@/lib/errors';
 import { SecurityPriceForm } from './SecurityPriceForm';
+import { BalanceHistoryChart } from '@/components/transactions/BalanceHistoryChart';
 
 interface SecurityPriceHistoryProps {
   security: Security;
@@ -117,6 +118,20 @@ export function SecurityPriceHistory({ security, onClose }: SecurityPriceHistory
     }
   }, [security.id, deletingPrice, loadPrices, t]);
 
+  // The same shape the account balance chart takes, so the price history can
+  // reuse it: oldest first (the API returns newest first) and the close price as
+  // the series value.
+  const chartData = useMemo(
+    () =>
+      prices
+        .map((price) => ({
+          date: price.priceDate.slice(0, 10),
+          balance: Number(price.closePrice),
+        }))
+        .sort((a, b) => a.date.localeCompare(b.date)),
+    [prices],
+  );
+
   const handleForceUpdate = useCallback(async () => {
     setIsUpdating(true);
     try {
@@ -189,6 +204,21 @@ export function SecurityPriceHistory({ security, onClose }: SecurityPriceHistory
             onCancel={() => setEditingPrice(undefined)}
           />
         </div>
+      )}
+
+      {/* Price chart. Deliberately the account balance-history chart: same
+          shape of data, so the two screens read the same way -- title and
+          neutral colouring are the only differences (a price has no good or
+          bad sign). */}
+      {!isLoading && chartData.length > 1 && (
+        <BalanceHistoryChart
+          data={chartData}
+          isLoading={false}
+          currencyCode={security.currencyCode}
+          accountName={security.symbol}
+          title={t('priceHistory.chartTitle')}
+          neutralValues
+        />
       )}
 
       {/* Price Table */}

--- a/frontend/src/components/securities/SecurityPriceHistory.tsx
+++ b/frontend/src/components/securities/SecurityPriceHistory.tsx
@@ -281,6 +281,7 @@ export function SecurityPriceHistory({ security, onClose }: SecurityPriceHistory
           accountName={security.symbol}
           title={t('priceHistory.chartTitle')}
           neutralValues
+          precise
           markers={chartMarkers}
         />
       )}

--- a/frontend/src/components/securities/SecurityPriceHistory.tsx
+++ b/frontend/src/components/securities/SecurityPriceHistory.tsx
@@ -6,12 +6,21 @@ import toast from 'react-hot-toast';
 import { Button } from '@/components/ui/Button';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
-import { Security, SecurityPrice, CreateSecurityPriceData } from '@/types/investment';
+import {
+  Security,
+  SecurityPrice,
+  CreateSecurityPriceData,
+  SecurityHistoryTransaction,
+} from '@/types/investment';
 import { investmentsApi } from '@/lib/investments';
 import { useDateFormat } from '@/hooks/useDateFormat';
 import { getErrorMessage } from '@/lib/errors';
 import { SecurityPriceForm } from './SecurityPriceForm';
-import { BalanceHistoryChart } from '@/components/transactions/BalanceHistoryChart';
+import {
+  BalanceHistoryChart,
+  type ChartMarker,
+} from '@/components/transactions/BalanceHistoryChart';
+import { useNumberFormat } from '@/hooks/useNumberFormat';
 
 interface SecurityPriceHistoryProps {
   security: Security;
@@ -59,11 +68,16 @@ export function SecurityPriceHistory({ security, onClose }: SecurityPriceHistory
   const t = useTranslations('securities');
   const { formatDate } = useDateFormat();
   const [prices, setPrices] = useState<SecurityPrice[]>([]);
+  // Trades, only for the chart's markers. A failed lookup costs the markers,
+  // never the price list the modal is actually for.
+  const [trades, setTrades] = useState<SecurityHistoryTransaction[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [showAddForm, setShowAddForm] = useState(false);
   const [editingPrice, setEditingPrice] = useState<SecurityPrice | undefined>();
   const [deletingPrice, setDeletingPrice] = useState<SecurityPrice | undefined>();
   const [isUpdating, setIsUpdating] = useState(false);
+
+  const { formatQuantity } = useNumberFormat();
 
   const loadPrices = useCallback(async () => {
     setIsLoading(true);
@@ -80,6 +94,23 @@ export function SecurityPriceHistory({ security, onClose }: SecurityPriceHistory
   useEffect(() => {
     loadPrices();
   }, [loadPrices]);
+
+  useEffect(() => {
+    let cancelled = false;
+    investmentsApi
+      .getSecurityTransactionHistory(security.id)
+      .then((history) => {
+        if (!cancelled) setTrades(history.transactions);
+      })
+      // Markers are a nicety: without them the chart still reads, so a failed
+      // lookup stays silent rather than raising a toast over the price list.
+      .catch(() => {
+        if (!cancelled) setTrades([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [security.id]);
 
   const handleAdd = useCallback(async (data: CreateSecurityPriceData) => {
     try {
@@ -131,6 +162,38 @@ export function SecurityPriceHistory({ security, onClose }: SecurityPriceHistory
         .sort((a, b) => a.date.localeCompare(b.date)),
     [prices],
   );
+
+  // Which way each action moved the position. Actions with no share movement
+  // (dividends, interest, capital gains) carry no quantity and are left off the
+  // chart -- a dot with nothing to say is noise.
+  const chartMarkers = useMemo<ChartMarker[]>(() => {
+    const direction: Partial<Record<SecurityHistoryTransaction['action'], 'in' | 'out'>> = {
+      BUY: 'in',
+      REINVEST: 'in',
+      TRANSFER_IN: 'in',
+      ADD_SHARES: 'in',
+      SELL: 'out',
+      TRANSFER_OUT: 'out',
+      REMOVE_SHARES: 'out',
+    };
+    return trades.flatMap((trade) => {
+      const way = direction[trade.action];
+      if (!way || trade.quantity === null) return [];
+      const quantity = formatQuantity(Math.abs(Number(trade.quantity)));
+      return [
+        {
+          date: trade.transactionDate.slice(0, 10),
+          direction: way,
+          label: t(
+            way === 'in'
+              ? 'priceHistory.markers.bought'
+              : 'priceHistory.markers.sold',
+            { quantity, account: trade.accountName },
+          ),
+        },
+      ];
+    });
+  }, [trades, formatQuantity, t]);
 
   const handleForceUpdate = useCallback(async () => {
     setIsUpdating(true);
@@ -218,6 +281,7 @@ export function SecurityPriceHistory({ security, onClose }: SecurityPriceHistory
           accountName={security.symbol}
           title={t('priceHistory.chartTitle')}
           neutralValues
+          markers={chartMarkers}
         />
       )}
 

--- a/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
@@ -50,9 +50,14 @@ const mockFormatCurrency = vi.fn((n: number, _code?: string) => `$${n.toFixed(2)
 const mockFormatCurrencyAxis = vi.fn((n: number, _code?: string) => `$${n}`);
 const mockFormatCurrencyFlag = vi.fn((n: number, _code?: string) => `$${n}`);
 
+const mockFormatCurrencyPrecise = vi.fn(
+  (n: number, _code?: string) => `$${n.toFixed(6)}`,
+);
+
 vi.mock('@/hooks/useNumberFormat', () => ({
   useNumberFormat: () => ({
     formatCurrency: mockFormatCurrency,
+    formatCurrencyPrecise: mockFormatCurrencyPrecise,
     formatCurrencyAxis: mockFormatCurrencyAxis,
     formatCurrencyFlag: mockFormatCurrencyFlag,
   }),
@@ -481,11 +486,17 @@ describe('computeBalanceGradient', () => {
         <BalanceHistoryChart
           data={series}
           isLoading={false}
-          markers={[{ date: '2026-01-04', direction: 'out', label: 'Sold 2' }]}
+          markers={[
+            { date: '2025-12-31', direction: 'in', label: 'Bought 100' },
+            { date: '2026-01-04', direction: 'out', label: 'Sold 2' },
+          ]}
         />,
       );
-      // Later than every point: pinned to the last one, not dropped.
-      expect(screen.getByTestId('reference-dot')).toHaveAttribute('data-x', '2026-01-03');
+      // Outside the series entirely: dropped, not clamped onto its ends. A
+      // migration carries decades of trades against a couple of years of
+      // backfilled prices, and clamping would claim they all happened on the
+      // first day it has a price for.
+      expect(screen.queryByTestId('reference-dot')).toBeNull();
     });
 
     it('lists the events for the hovered day in the tooltip', () => {
@@ -507,6 +518,38 @@ describe('computeBalanceGradient', () => {
     it('draws no dots without markers', () => {
       render(<BalanceHistoryChart data={series} isLoading={false} />);
       expect(screen.queryByTestId('reference-dot')).toBeNull();
+    });
+  });
+
+  describe('precise mode', () => {
+    const subCent = [
+      { date: '2026-01-01', balance: 0.000342 },
+      { date: '2026-01-02', balance: 0.000411 },
+    ];
+
+    it('keeps sub-cent values and formats them precisely', () => {
+      render(
+        <BalanceHistoryChart data={subCent} isLoading={false} precise />
+      );
+
+      // Rounding a price to cents would flatten the series to zero and print
+      // "$0.00" beside a table showing 0.000342.
+      expect(mockFormatCurrencyPrecise).toHaveBeenCalled();
+      const rounded = mockFormatCurrency.mock.calls.map((call) => call[0]);
+      expect(rounded).not.toContain(0);
+    });
+
+    it('still rounds a balance series to cents', () => {
+      render(
+        <BalanceHistoryChart
+          data={[
+            { date: '2026-01-01', balance: 10.005 },
+            { date: '2026-01-02', balance: 12.344 },
+          ]}
+          isLoading={false}
+        />,
+      );
+      expect(mockFormatCurrency).toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/render';
+import { render, screen, fireEvent, cleanup } from '@/test/render';
 import { BalanceHistoryChart } from './BalanceHistoryChart';
 import { computeBalanceGradient } from '@/lib/balance-history';
 
@@ -22,8 +22,28 @@ vi.mock('recharts', () => ({
   XAxis: () => <div data-testid="x-axis" />,
   YAxis: () => <div data-testid="y-axis" />,
   CartesianGrid: () => <div data-testid="cartesian-grid" />,
-  Tooltip: () => <div data-testid="tooltip" />,
+  // Render the tooltip's content with a hovered point, so the marker lines
+  // under the value are exercised.
+  Tooltip: ({ content }: any) => (
+    <div data-testid="tooltip">
+      {content
+        ? {
+            ...content,
+            props: {
+              ...content.props,
+              active: true,
+              payload: [
+                { payload: { date: '2026-01-02', label: 'Jan 2, 2026', balance: 120 } },
+              ],
+            },
+          }
+        : null}
+    </div>
+  ),
   ReferenceLine: () => <div data-testid="reference-line" />,
+  ReferenceDot: ({ x, y, fill }: any) => (
+    <div data-testid="reference-dot" data-x={x} data-y={y} data-fill={fill} />
+  ),
 }));
 
 const mockFormatCurrency = vi.fn((n: number, _code?: string) => `$${n.toFixed(2)}`);
@@ -415,5 +435,78 @@ describe('computeBalanceGradient', () => {
     expect(g.topOpacity).toBe(0);
     expect(g.bottomOpacity).toBe(0.3);
     expect(g.zeroOffset).toBe(0);
+  });
+
+  describe('markers', () => {
+    const series = [
+      { date: '2026-01-01', balance: 100 },
+      { date: '2026-01-02', balance: 120 },
+      { date: '2026-01-03', balance: 110 },
+    ];
+
+    it('pins a dot on the day of each event, green in and red out', () => {
+      render(
+        <BalanceHistoryChart
+          data={series}
+          isLoading={false}
+          markers={[
+            { date: '2026-01-02', direction: 'in', label: 'Bought 10' },
+            { date: '2026-01-03', direction: 'out', label: 'Sold 4' },
+          ]}
+        />,
+      );
+
+      const dots = screen.getAllByTestId('reference-dot');
+      expect(dots).toHaveLength(2);
+      expect(dots[0]).toHaveAttribute('data-x', '2026-01-02');
+      expect(dots[0]).toHaveAttribute('data-y', '120');
+      expect(dots[0].getAttribute('data-fill')).not.toBe(
+        dots[1].getAttribute('data-fill'),
+      );
+    });
+
+    it('snaps an event on a non-trading day back to the last known price', () => {
+      // A trade on a Saturday has no price row of its own.
+      render(
+        <BalanceHistoryChart
+          data={series}
+          isLoading={false}
+          markers={[{ date: '2026-01-02T12:00:00Z'.slice(0, 10), direction: 'in', label: 'Bought 1' }]}
+        />,
+      );
+      expect(screen.getByTestId('reference-dot')).toHaveAttribute('data-x', '2026-01-02');
+
+      cleanup();
+      render(
+        <BalanceHistoryChart
+          data={series}
+          isLoading={false}
+          markers={[{ date: '2026-01-04', direction: 'out', label: 'Sold 2' }]}
+        />,
+      );
+      // Later than every point: pinned to the last one, not dropped.
+      expect(screen.getByTestId('reference-dot')).toHaveAttribute('data-x', '2026-01-03');
+    });
+
+    it('lists the events for the hovered day in the tooltip', () => {
+      render(
+        <BalanceHistoryChart
+          data={series}
+          isLoading={false}
+          markers={[
+            { date: '2026-01-02', direction: 'in', label: 'Bought 10' },
+            { date: '2026-01-02', direction: 'out', label: 'Sold 4' },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText('Bought 10')).toBeInTheDocument();
+      expect(screen.getByText('Sold 4')).toBeInTheDocument();
+    });
+
+    it('draws no dots without markers', () => {
+      render(<BalanceHistoryChart data={series} isLoading={false} />);
+      expect(screen.queryByTestId('reference-dot')).toBeNull();
+    });
   });
 });

--- a/frontend/src/components/transactions/BalanceHistoryChart.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.tsx
@@ -55,6 +55,13 @@ interface BalanceHistoryChartProps {
    */
   title?: string;
   /**
+   * Keep sub-cent precision. A balance is money and rounds to 2dp, but a price
+   * series can be quoted at 4-6dp (a fund NAV, a penny stock, a crypto pair):
+   * rounding those to cents flattens the line to zero and makes every tooltip
+   * read "$0.00" while the table beside it shows 0.000342.
+   */
+  precise?: boolean;
+  /**
    * Events to pin on the line, each snapped to a point in the series. Empty or
    * omitted for a plain balance history.
    */
@@ -144,13 +151,18 @@ export function BalanceHistoryChart({
   hideTitle = false,
   title,
   neutralValues = false,
+  precise = false,
   markers,
 }: BalanceHistoryChartProps) {
   const t = useTranslations('transactions');
   const tc = useTranslations('common');
   const chartTitle = title ?? t('charts.balanceHistory.title');
-  const { formatCurrency: formatCurrencyFull, formatCurrencyAxis, formatCurrencyFlag } =
-    useNumberFormat();
+  const {
+    formatCurrency: formatCurrencyFull,
+    formatCurrencyPrecise,
+    formatCurrencyAxis,
+    formatCurrencyFlag,
+  } = useNumberFormat();
   const formatChartDate = useChartDateFormat();
   const chartRef = useRef<HTMLDivElement>(null);
   // High/low value bubbles a user has temporarily dismissed, keyed by the value
@@ -162,18 +174,27 @@ export function BalanceHistoryChart({
   const downloadFilename = accountName ? `${chartTitle} - ${accountName}` : chartTitle;
 
   const formatCurrency = useCallback(
-    (value: number) => formatCurrencyFull(value, currencyCode),
-    [formatCurrencyFull, currencyCode],
+    (value: number) =>
+      precise
+        ? formatCurrencyPrecise(value, currencyCode)
+        : formatCurrencyFull(value, currencyCode),
+    [precise, formatCurrencyPrecise, formatCurrencyFull, currencyCode],
   );
 
   const formatAxis = useCallback(
-    (value: number) => formatCurrencyAxis(value, currencyCode),
-    [formatCurrencyAxis, currencyCode],
+    (value: number) =>
+      precise
+        ? formatCurrencyPrecise(value, currencyCode)
+        : formatCurrencyAxis(value, currencyCode),
+    [precise, formatCurrencyPrecise, formatCurrencyAxis, currencyCode],
   );
 
   const formatFlag = useCallback(
-    (value: number) => formatCurrencyFlag(value, currencyCode),
-    [formatCurrencyFlag, currencyCode],
+    (value: number) =>
+      precise
+        ? formatCurrencyPrecise(value, currencyCode)
+        : formatCurrencyFlag(value, currencyCode),
+    [precise, formatCurrencyPrecise, formatCurrencyFlag, currencyCode],
   );
 
   const { chartData, axisTicks, axisPattern } = useMemo(() => {
@@ -188,7 +209,8 @@ export function BalanceHistoryChart({
     const points = data.map((d) => ({
       date: d.date,
       label: formatChartDate(parseLocalDate(d.date), 'MMM d, yyyy'),
-      balance: Math.round(d.balance * 100) / 100,
+      // Money rounds to cents; a price keeps what it was quoted at.
+      balance: precise ? d.balance : Math.round(d.balance * 100) / 100,
     }));
 
     // A month tick per month reads well over ~2 years or less; beyond that the
@@ -215,7 +237,7 @@ export function BalanceHistoryChart({
       axisTicks: ticks,
       axisPattern: (useYearTicks ? 'yyyy' : 'MMM') as ChartDatePattern,
     };
-  }, [data, formatChartDate]);
+  }, [data, formatChartDate, precise]);
 
   // The exact span the chart covers, shown under the title so the timeframe is
   // always explicit (e.g. the all-history default is no longer a silent range).
@@ -231,19 +253,23 @@ export function BalanceHistoryChart({
 
   // Markers snapped onto the series: a trade can fall on a day with no price
   // row (a weekend, or a gap in history), so it lands on the nearest earlier
-  // point -- and on the first point when it predates the whole series.
+  // point. Events outside the series are dropped rather than clamped to its
+  // ends: a Microsoft Money migration carries decades of trades against a
+  // couple of years of backfilled prices, and pinning them all to the earliest
+  // point would claim they happened that day.
   const pinnedMarkers = useMemo(() => {
     if (!markers?.length || chartData.length === 0) return [];
-    return markers
-      .map((marker) => {
-        let point = chartData[0];
-        for (const candidate of chartData) {
-          if (candidate.date <= marker.date) point = candidate;
-          else break;
-        }
-        return { marker, point };
-      })
-      .filter(({ point }) => !!point);
+    const first = chartData[0].date;
+    const last = chartData[chartData.length - 1].date;
+    return markers.flatMap((marker) => {
+      if (marker.date < first || marker.date > last) return [];
+      let point = chartData[0];
+      for (const candidate of chartData) {
+        if (candidate.date <= marker.date) point = candidate;
+        else break;
+      }
+      return [{ marker, point }];
+    });
   }, [markers, chartData]);
 
   const markersByDate = useMemo(() => {
@@ -432,6 +458,11 @@ export function BalanceHistoryChart({
                     ? chartColors.income
                     : chartColors.expense
                 }
+                // Same white ring the min/max flag dots use (see
+                // portfolio-chart-utils): it separates the dot from the line
+                // under it on every theme. A themed ring would need a new
+                // `--chart-surface` variable, worth adding for all of them at
+                // once rather than for this one dot.
                 stroke="#fff"
                 strokeWidth={1.5}
                 ifOverflow="extendDomain"

--- a/frontend/src/components/transactions/BalanceHistoryChart.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.tsx
@@ -31,8 +31,20 @@ interface BalanceHistoryChartProps {
   data: Array<{ date: string; balance: number }>;
   isLoading: boolean;
   currencyCode?: string;
-  /** Account name to append to the download filename, e.g. "Checking". */
+  /** Subject to append to the download filename, e.g. "Checking" or "AAPL". */
   accountName?: string;
+  /**
+   * Overrides the in-card title (and the download filename), for series that
+   * are not an account balance -- a security's price history reuses this chart
+   * so the two read identically.
+   */
+  title?: string;
+  /**
+   * Drop the green/red colouring of the footer figures. For a series where the
+   * sign carries no meaning: a security price is always positive, so tinting
+   * every figure green says nothing.
+   */
+  neutralValues?: boolean;
   /**
    * True when the balance belongs to a liability account (credit card, loan,
    * mortgage, line of credit). A negative balance is the normal, expected
@@ -58,10 +70,13 @@ function BalanceTooltip({
   active,
   payload,
   formatCurrency,
+  neutral = false,
 }: {
   active?: boolean;
   payload?: Array<{ payload: ChartPoint }>;
   formatCurrency: (v: number) => string;
+  /** Skip the by-sign colouring, for a series whose sign means nothing. */
+  neutral?: boolean;
 }) {
   if (active && payload?.[0]) {
     const data = payload[0].payload;
@@ -72,7 +87,9 @@ function BalanceTooltip({
         </p>
         <p
           className={`text-lg font-semibold ${
-            gainLossColor(data.balance)
+            neutral
+              ? 'text-gray-900 dark:text-gray-100'
+              : gainLossColor(data.balance)
           }`}
         >
           {formatCurrency(data.balance)}
@@ -90,10 +107,12 @@ export function BalanceHistoryChart({
   accountName,
   isLiability = false,
   hideTitle = false,
+  title,
+  neutralValues = false,
 }: BalanceHistoryChartProps) {
   const t = useTranslations('transactions');
   const tc = useTranslations('common');
-  const chartTitle = t('charts.balanceHistory.title');
+  const chartTitle = title ?? t('charts.balanceHistory.title');
   const { formatCurrency: formatCurrencyFull, formatCurrencyAxis, formatCurrencyFlag } =
     useNumberFormat();
   const formatChartDate = useChartDateFormat();
@@ -175,6 +194,9 @@ export function BalanceHistoryChart({
   }, [chartData, formatChartDate, t]);
 
   const summary = useMemo(() => computeBalanceSummary(chartData), [chartData]);
+  /** Footer figure colour: by sign, unless the sign means nothing here. */
+  const valueColor = (value: number) =>
+    neutralValues ? 'text-gray-900 dark:text-gray-100' : gainLossColor(value);
 
   // Date of the last point on or before today, when future (projected) points
   // follow it -- used to draw the "history vs projection" divider line.
@@ -294,7 +316,14 @@ export function BalanceHistoryChart({
               width="auto"
               domain={['auto', 'auto']}
             />
-            <Tooltip content={<BalanceTooltip formatCurrency={formatCurrency} />} />
+            <Tooltip
+              content={
+                <BalanceTooltip
+                  formatCurrency={formatCurrency}
+                  neutral={neutralValues}
+                />
+              }
+            />
             <ReferenceLine
               y={0}
               stroke={chartColors.expense}
@@ -364,20 +393,20 @@ export function BalanceHistoryChart({
         <div className={`mt-4 pt-4 border-t border-gray-200 dark:border-gray-700 grid ${summary.hasFutureData ? 'grid-cols-2 sm:grid-cols-4' : 'grid-cols-3'} gap-4 text-center`}>
           <div>
             <div className="text-sm text-gray-500 dark:text-gray-400">{t('charts.balanceHistory.starting')}</div>
-            <div className={`font-semibold ${gainLossColor(summary.startBalance)}`}>
+            <div className={`font-semibold ${valueColor(summary.startBalance)}`}>
               {formatCurrency(summary.startBalance)}
             </div>
           </div>
           <div>
             <div className="text-sm text-gray-500 dark:text-gray-400">{t('charts.balanceHistory.current')}</div>
-            <div className={`font-semibold ${gainLossColor(summary.currentBalance)}`}>
+            <div className={`font-semibold ${valueColor(summary.currentBalance)}`}>
               {formatCurrency(summary.currentBalance)}
             </div>
           </div>
           {summary.hasFutureData && (
             <div>
               <div className="text-sm text-gray-500 dark:text-gray-400">{t('charts.balanceHistory.ending')}</div>
-              <div className={`font-semibold ${gainLossColor(summary.endBalance)}`}>
+              <div className={`font-semibold ${valueColor(summary.endBalance)}`}>
                 {formatCurrency(summary.endBalance)}
               </div>
             </div>
@@ -392,7 +421,7 @@ export function BalanceHistoryChart({
                 ? t('charts.balanceHistory.lowest')
                 : t('charts.balanceHistory.minBalance')}
             </div>
-            <div className={`font-semibold ${gainLossColor(summary.minBalance)}`}>
+            <div className={`font-semibold ${valueColor(summary.minBalance)}`}>
               {formatCurrency(summary.minBalance)}
               {summary.goesNegative && !isLiability && (
                 <span className="ml-1 text-xs text-red-500">!</span>

--- a/frontend/src/components/transactions/BalanceHistoryChart.tsx
+++ b/frontend/src/components/transactions/BalanceHistoryChart.tsx
@@ -13,6 +13,7 @@ import {
   Tooltip,
   ResponsiveContainer,
   ReferenceLine,
+  ReferenceDot,
 } from 'recharts';
 import { chartColors } from '@/lib/chart-colors';
 import { parseLocalDate, type ChartDatePattern } from '@/lib/utils';
@@ -27,6 +28,20 @@ import {
 } from '@/components/investments/portfolio-chart-utils';
 
 
+/**
+ * An event to pin on the series: the security price chart marks the days a
+ * holding was bought or sold, so a step in the line has a visible cause.
+ */
+export interface ChartMarker {
+  /** ISO `yyyy-MM-dd`; snapped to the nearest earlier point if the series has
+   *  no value for that exact day (a trade on a non-trading day). */
+  date: string;
+  /** Which way the event moved the position: 'in' reads green, 'out' red. */
+  direction: 'in' | 'out';
+  /** One tooltip line, already formatted, e.g. "Bought 12.5". */
+  label: string;
+}
+
 interface BalanceHistoryChartProps {
   data: Array<{ date: string; balance: number }>;
   isLoading: boolean;
@@ -39,6 +54,11 @@ interface BalanceHistoryChartProps {
    * so the two read identically.
    */
   title?: string;
+  /**
+   * Events to pin on the line, each snapped to a point in the series. Empty or
+   * omitted for a plain balance history.
+   */
+  markers?: readonly ChartMarker[];
   /**
    * Drop the green/red colouring of the footer figures. For a series where the
    * sign carries no meaning: a security price is always positive, so tinting
@@ -71,12 +91,15 @@ function BalanceTooltip({
   payload,
   formatCurrency,
   neutral = false,
+  markersByDate,
 }: {
   active?: boolean;
   payload?: Array<{ payload: ChartPoint }>;
   formatCurrency: (v: number) => string;
   /** Skip the by-sign colouring, for a series whose sign means nothing. */
   neutral?: boolean;
+  /** Events pinned on each day, listed under the value. */
+  markersByDate?: Map<string, ChartMarker[]>;
 }) {
   if (active && payload?.[0]) {
     const data = payload[0].payload;
@@ -94,6 +117,18 @@ function BalanceTooltip({
         >
           {formatCurrency(data.balance)}
         </p>
+        {markersByDate?.get(data.date)?.map((marker, i) => (
+          <p
+            key={i}
+            className={`mt-1 text-sm font-medium ${
+              marker.direction === 'in'
+                ? 'text-green-600 dark:text-green-400'
+                : 'text-red-600 dark:text-red-400'
+            }`}
+          >
+            {marker.label}
+          </p>
+        ))}
       </div>
     );
   }
@@ -109,6 +144,7 @@ export function BalanceHistoryChart({
   hideTitle = false,
   title,
   neutralValues = false,
+  markers,
 }: BalanceHistoryChartProps) {
   const t = useTranslations('transactions');
   const tc = useTranslations('common');
@@ -192,6 +228,33 @@ export function BalanceHistoryChart({
     );
     return t('charts.balanceHistory.range', { start, end });
   }, [chartData, formatChartDate, t]);
+
+  // Markers snapped onto the series: a trade can fall on a day with no price
+  // row (a weekend, or a gap in history), so it lands on the nearest earlier
+  // point -- and on the first point when it predates the whole series.
+  const pinnedMarkers = useMemo(() => {
+    if (!markers?.length || chartData.length === 0) return [];
+    return markers
+      .map((marker) => {
+        let point = chartData[0];
+        for (const candidate of chartData) {
+          if (candidate.date <= marker.date) point = candidate;
+          else break;
+        }
+        return { marker, point };
+      })
+      .filter(({ point }) => !!point);
+  }, [markers, chartData]);
+
+  const markersByDate = useMemo(() => {
+    const byDate = new Map<string, ChartMarker[]>();
+    for (const { marker, point } of pinnedMarkers) {
+      const existing = byDate.get(point.date);
+      if (existing) existing.push(marker);
+      else byDate.set(point.date, [marker]);
+    }
+    return byDate;
+  }, [pinnedMarkers]);
 
   const summary = useMemo(() => computeBalanceSummary(chartData), [chartData]);
   /** Footer figure colour: by sign, unless the sign means nothing here. */
@@ -321,6 +384,7 @@ export function BalanceHistoryChart({
                 <BalanceTooltip
                   formatCurrency={formatCurrency}
                   neutral={neutralValues}
+                  markersByDate={markersByDate}
                 />
               }
             />
@@ -354,6 +418,25 @@ export function BalanceHistoryChart({
                 strokeOpacity={0.4}
               />
             )}
+            {/* Pinned events (buys and sells on a price series): a dot on the
+                line at the day it happened, green in / red out, with the
+                quantity in the tooltip for that day. */}
+            {pinnedMarkers.map(({ marker, point }, i) => (
+              <ReferenceDot
+                key={`${point.date}-${i}`}
+                x={point.date}
+                y={point.balance}
+                r={4}
+                fill={
+                  marker.direction === 'in'
+                    ? chartColors.income
+                    : chartColors.expense
+                }
+                stroke="#fff"
+                strokeWidth={1.5}
+                ifOverflow="extendDomain"
+              />
+            ))}
             <Area
               type="monotone"
               dataKey="balance"

--- a/frontend/src/i18n/messages/de/dashboard.json
+++ b/frontend/src/i18n/messages/de/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "Heute keine Verlierer."
     },
     "dailyChange": "Tagesveränderung",
+    "openPriceHistory": "Kursverlauf für {symbol}",
     "refreshPrices": "Kurse aktualisieren",
     "viewPortfolio": "Portfolio anzeigen",
     "filter": {

--- a/frontend/src/i18n/messages/de/securities.json
+++ b/frontend/src/i18n/messages/de/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "Kurs hinzufügen",
     "editPriceSection": "Kurs bearbeiten",
     "loading": "Kurse werden geladen...",
+    "chartTitle": "Kursverlauf",
     "empty": "Kein Kursverlauf verfügbar",
     "columns": {
       "date": "Datum",

--- a/frontend/src/i18n/messages/de/securities.json
+++ b/frontend/src/i18n/messages/de/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "Kurs bearbeiten",
     "loading": "Kurse werden geladen...",
     "chartTitle": "Kursverlauf",
+    "markers": {
+      "bought": "Kauf {quantity} · {account}",
+      "sold": "Verkauf {quantity} · {account}"
+    },
     "empty": "Kein Kursverlauf verfügbar",
     "columns": {
       "date": "Datum",

--- a/frontend/src/i18n/messages/en/dashboard.json
+++ b/frontend/src/i18n/messages/en/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "No losers today."
     },
     "dailyChange": "Daily change",
+    "openPriceHistory": "Price history for {symbol}",
     "refreshPrices": "Refresh prices",
     "viewPortfolio": "View portfolio",
     "filter": {

--- a/frontend/src/i18n/messages/en/securities.json
+++ b/frontend/src/i18n/messages/en/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "Add Price",
     "editPriceSection": "Edit Price",
     "loading": "Loading prices...",
+    "chartTitle": "Price History",
     "empty": "No price history available",
     "columns": {
       "date": "Date",

--- a/frontend/src/i18n/messages/en/securities.json
+++ b/frontend/src/i18n/messages/en/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "Edit Price",
     "loading": "Loading prices...",
     "chartTitle": "Price History",
+    "markers": {
+      "bought": "Bought {quantity} · {account}",
+      "sold": "Sold {quantity} · {account}"
+    },
     "empty": "No price history available",
     "columns": {
       "date": "Date",

--- a/frontend/src/i18n/messages/es/dashboard.json
+++ b/frontend/src/i18n/messages/es/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "No hay perdedoras hoy."
     },
     "dailyChange": "Cambio diario",
+    "openPriceHistory": "Historial de precios de {symbol}",
     "refreshPrices": "Actualizar precios",
     "viewPortfolio": "Ver cartera",
     "filter": {

--- a/frontend/src/i18n/messages/es/securities.json
+++ b/frontend/src/i18n/messages/es/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "Editar precio",
     "loading": "Cargando precios...",
     "chartTitle": "Historial de precios",
+    "markers": {
+      "bought": "Compra {quantity} · {account}",
+      "sold": "Venta {quantity} · {account}"
+    },
     "empty": "No hay historial de precios disponible",
     "columns": {
       "date": "Fecha",

--- a/frontend/src/i18n/messages/es/securities.json
+++ b/frontend/src/i18n/messages/es/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "Agregar precio",
     "editPriceSection": "Editar precio",
     "loading": "Cargando precios...",
+    "chartTitle": "Historial de precios",
     "empty": "No hay historial de precios disponible",
     "columns": {
       "date": "Fecha",

--- a/frontend/src/i18n/messages/fr/dashboard.json
+++ b/frontend/src/i18n/messages/fr/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "Aucun perdant aujourd'hui."
     },
     "dailyChange": "Variation quotidienne",
+    "openPriceHistory": "Historique du cours de {symbol}",
     "refreshPrices": "Actualiser les cours",
     "viewPortfolio": "Voir le portefeuille",
     "filter": {

--- a/frontend/src/i18n/messages/fr/securities.json
+++ b/frontend/src/i18n/messages/fr/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "Ajouter un cours",
     "editPriceSection": "Modifier le cours",
     "loading": "Chargement des cours...",
+    "chartTitle": "Historique du cours",
     "empty": "Aucun historique des cours disponible",
     "columns": {
       "date": "Date",

--- a/frontend/src/i18n/messages/fr/securities.json
+++ b/frontend/src/i18n/messages/fr/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "Modifier le cours",
     "loading": "Chargement des cours...",
     "chartTitle": "Historique du cours",
+    "markers": {
+      "bought": "Achat {quantity} · {account}",
+      "sold": "Vente {quantity} · {account}"
+    },
     "empty": "Aucun historique des cours disponible",
     "columns": {
       "date": "Date",

--- a/frontend/src/i18n/messages/hi/dashboard.json
+++ b/frontend/src/i18n/messages/hi/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "आज कोई हानिकर्ता नहीं।"
     },
     "dailyChange": "दैनिक परिवर्तन",
+    "openPriceHistory": "{symbol} का मूल्य इतिहास",
     "refreshPrices": "मूल्य रीफ्रेश करें",
     "viewPortfolio": "पोर्टफोलियो देखें",
     "filter": {

--- a/frontend/src/i18n/messages/hi/securities.json
+++ b/frontend/src/i18n/messages/hi/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "मूल्य जोड़ें",
     "editPriceSection": "मूल्य संपादित करें",
     "loading": "मूल्य लोड हो रहे हैं...",
+    "chartTitle": "मूल्य इतिहास",
     "empty": "कोई मूल्य इतिहास उपलब्ध नहीं",
     "columns": {
       "date": "तिथि",

--- a/frontend/src/i18n/messages/hi/securities.json
+++ b/frontend/src/i18n/messages/hi/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "मूल्य संपादित करें",
     "loading": "मूल्य लोड हो रहे हैं...",
     "chartTitle": "मूल्य इतिहास",
+    "markers": {
+      "bought": "खरीद {quantity} · {account}",
+      "sold": "बिक्री {quantity} · {account}"
+    },
     "empty": "कोई मूल्य इतिहास उपलब्ध नहीं",
     "columns": {
       "date": "तिथि",

--- a/frontend/src/i18n/messages/id/dashboard.json
+++ b/frontend/src/i18n/messages/id/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "Tidak ada yang turun hari ini."
     },
     "dailyChange": "Perubahan harian",
+    "openPriceHistory": "Riwayat harga {symbol}",
     "refreshPrices": "Perbarui harga",
     "viewPortfolio": "Lihat portofolio",
     "filter": {

--- a/frontend/src/i18n/messages/id/securities.json
+++ b/frontend/src/i18n/messages/id/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "Edit Harga",
     "loading": "Memuat harga...",
     "chartTitle": "Riwayat harga",
+    "markers": {
+      "bought": "Beli {quantity} · {account}",
+      "sold": "Jual {quantity} · {account}"
+    },
     "empty": "Tidak ada riwayat harga tersedia",
     "columns": {
       "date": "Tanggal",

--- a/frontend/src/i18n/messages/id/securities.json
+++ b/frontend/src/i18n/messages/id/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "Tambah Harga",
     "editPriceSection": "Edit Harga",
     "loading": "Memuat harga...",
+    "chartTitle": "Riwayat harga",
     "empty": "Tidak ada riwayat harga tersedia",
     "columns": {
       "date": "Tanggal",

--- a/frontend/src/i18n/messages/it/dashboard.json
+++ b/frontend/src/i18n/messages/it/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "Nessuna perdita oggi."
     },
     "dailyChange": "Variazione giornaliera",
+    "openPriceHistory": "Storico prezzi di {symbol}",
     "refreshPrices": "Aggiorna quotazioni",
     "viewPortfolio": "Visualizza portafoglio",
     "filter": {

--- a/frontend/src/i18n/messages/it/securities.json
+++ b/frontend/src/i18n/messages/it/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "Aggiungi prezzo",
     "editPriceSection": "Modifica prezzo",
     "loading": "Caricamento prezzi...",
+    "chartTitle": "Storico prezzi",
     "empty": "Nessuno storico delle quotazioni disponibile",
     "columns": {
       "date": "Data",

--- a/frontend/src/i18n/messages/it/securities.json
+++ b/frontend/src/i18n/messages/it/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "Modifica prezzo",
     "loading": "Caricamento prezzi...",
     "chartTitle": "Storico prezzi",
+    "markers": {
+      "bought": "Acquisto {quantity} · {account}",
+      "sold": "Vendita {quantity} · {account}"
+    },
     "empty": "Nessuno storico delle quotazioni disponibile",
     "columns": {
       "date": "Data",

--- a/frontend/src/i18n/messages/ja/dashboard.json
+++ b/frontend/src/i18n/messages/ja/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "今日の値下がり銘柄はありません。"
     },
     "dailyChange": "日次変動",
+    "openPriceHistory": "{symbol} の価格履歴",
     "refreshPrices": "価格を更新",
     "viewPortfolio": "ポートフォリオを見る",
     "filter": {

--- a/frontend/src/i18n/messages/ja/securities.json
+++ b/frontend/src/i18n/messages/ja/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "株価を追加",
     "editPriceSection": "株価を編集",
     "loading": "株価を読み込み中...",
+    "chartTitle": "価格履歴",
     "empty": "株価履歴がありません",
     "columns": {
       "date": "日付",

--- a/frontend/src/i18n/messages/ja/securities.json
+++ b/frontend/src/i18n/messages/ja/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "株価を編集",
     "loading": "株価を読み込み中...",
     "chartTitle": "価格履歴",
+    "markers": {
+      "bought": "買付 {quantity}・{account}",
+      "sold": "売却 {quantity}・{account}"
+    },
     "empty": "株価履歴がありません",
     "columns": {
       "date": "日付",

--- a/frontend/src/i18n/messages/ko/dashboard.json
+++ b/frontend/src/i18n/messages/ko/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "오늘 하락 종목이 없습니다."
     },
     "dailyChange": "일일 변동",
+    "openPriceHistory": "{symbol} 가격 이력",
     "refreshPrices": "가격 새로고침",
     "viewPortfolio": "포트폴리오 보기",
     "filter": {

--- a/frontend/src/i18n/messages/ko/securities.json
+++ b/frontend/src/i18n/messages/ko/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "가격 편집",
     "loading": "가격 불러오는 중...",
     "chartTitle": "가격 이력",
+    "markers": {
+      "bought": "매수 {quantity} · {account}",
+      "sold": "매도 {quantity} · {account}"
+    },
     "empty": "사용 가능한 가격 이력이 없습니다",
     "columns": {
       "date": "날짜",

--- a/frontend/src/i18n/messages/ko/securities.json
+++ b/frontend/src/i18n/messages/ko/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "가격 추가",
     "editPriceSection": "가격 편집",
     "loading": "가격 불러오는 중...",
+    "chartTitle": "가격 이력",
     "empty": "사용 가능한 가격 이력이 없습니다",
     "columns": {
       "date": "날짜",

--- a/frontend/src/i18n/messages/nl/dashboard.json
+++ b/frontend/src/i18n/messages/nl/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "Vandaag geen dalers."
     },
     "dailyChange": "Dagelijkse wijziging",
+    "openPriceHistory": "Koersgeschiedenis van {symbol}",
     "refreshPrices": "Koersen vernieuwen",
     "viewPortfolio": "Portefeuille bekijken",
     "filter": {

--- a/frontend/src/i18n/messages/nl/securities.json
+++ b/frontend/src/i18n/messages/nl/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "Koers bewerken",
     "loading": "Koersen laden...",
     "chartTitle": "Koersgeschiedenis",
+    "markers": {
+      "bought": "Aankoop {quantity} · {account}",
+      "sold": "Verkoop {quantity} · {account}"
+    },
     "empty": "Geen koershistorie beschikbaar",
     "columns": {
       "date": "Datum",

--- a/frontend/src/i18n/messages/nl/securities.json
+++ b/frontend/src/i18n/messages/nl/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "Koers toevoegen",
     "editPriceSection": "Koers bewerken",
     "loading": "Koersen laden...",
+    "chartTitle": "Koersgeschiedenis",
     "empty": "Geen koershistorie beschikbaar",
     "columns": {
       "date": "Datum",

--- a/frontend/src/i18n/messages/pl/dashboard.json
+++ b/frontend/src/i18n/messages/pl/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "Brak spadków dzisiaj."
     },
     "dailyChange": "Zmiana dzienna",
+    "openPriceHistory": "Historia ceny: {symbol}",
     "refreshPrices": "Odśwież ceny",
     "viewPortfolio": "Zobacz portfel",
     "filter": {

--- a/frontend/src/i18n/messages/pl/securities.json
+++ b/frontend/src/i18n/messages/pl/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "Dodaj cenę",
     "editPriceSection": "Edytuj cenę",
     "loading": "Wczytywanie cen...",
+    "chartTitle": "Historia ceny",
     "empty": "Brak dostępnej historii cen",
     "columns": {
       "date": "Data",

--- a/frontend/src/i18n/messages/pl/securities.json
+++ b/frontend/src/i18n/messages/pl/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "Edytuj cenę",
     "loading": "Wczytywanie cen...",
     "chartTitle": "Historia ceny",
+    "markers": {
+      "bought": "Kupno {quantity} · {account}",
+      "sold": "Sprzedaż {quantity} · {account}"
+    },
     "empty": "Brak dostępnej historii cen",
     "columns": {
       "date": "Data",

--- a/frontend/src/i18n/messages/pt-BR/dashboard.json
+++ b/frontend/src/i18n/messages/pt-BR/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "Sem descidas hoje."
     },
     "dailyChange": "Variação diária",
+    "openPriceHistory": "Histórico de preços de {symbol}",
     "refreshPrices": "Atualizar cotações",
     "viewPortfolio": "Ver portfólio",
     "filter": {

--- a/frontend/src/i18n/messages/pt-BR/securities.json
+++ b/frontend/src/i18n/messages/pt-BR/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "Adicionar Cotação",
     "editPriceSection": "Editar Cotação",
     "loading": "Carregando cotações...",
+    "chartTitle": "Histórico de preços",
     "empty": "Sem histórico de cotações disponível",
     "columns": {
       "date": "Data",

--- a/frontend/src/i18n/messages/pt-BR/securities.json
+++ b/frontend/src/i18n/messages/pt-BR/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "Editar Cotação",
     "loading": "Carregando cotações...",
     "chartTitle": "Histórico de preços",
+    "markers": {
+      "bought": "Compra {quantity} · {account}",
+      "sold": "Venda {quantity} · {account}"
+    },
     "empty": "Sem histórico de cotações disponível",
     "columns": {
       "date": "Data",

--- a/frontend/src/i18n/messages/pt/dashboard.json
+++ b/frontend/src/i18n/messages/pt/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "Sem descidas hoje."
     },
     "dailyChange": "Variação diária",
+    "openPriceHistory": "Histórico de preços de {symbol}",
     "refreshPrices": "Atualizar cotações",
     "viewPortfolio": "Ver portefólio",
     "filter": {

--- a/frontend/src/i18n/messages/pt/securities.json
+++ b/frontend/src/i18n/messages/pt/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "Adicionar Cotação",
     "editPriceSection": "Editar Cotação",
     "loading": "A carregar cotações...",
+    "chartTitle": "Histórico de preços",
     "empty": "Sem histórico de cotações disponível",
     "columns": {
       "date": "Data",

--- a/frontend/src/i18n/messages/pt/securities.json
+++ b/frontend/src/i18n/messages/pt/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "Editar Cotação",
     "loading": "A carregar cotações...",
     "chartTitle": "Histórico de preços",
+    "markers": {
+      "bought": "Compra {quantity} · {account}",
+      "sold": "Venda {quantity} · {account}"
+    },
     "empty": "Sem histórico de cotações disponível",
     "columns": {
       "date": "Data",

--- a/frontend/src/i18n/messages/ru/dashboard.json
+++ b/frontend/src/i18n/messages/ru/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "Сегодня нет падающих активов."
     },
     "dailyChange": "Изменение за день",
+    "openPriceHistory": "История цены: {symbol}",
     "refreshPrices": "Обновить цены",
     "viewPortfolio": "Просмотреть портфель",
     "filter": {

--- a/frontend/src/i18n/messages/ru/securities.json
+++ b/frontend/src/i18n/messages/ru/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "Редактировать цену",
     "loading": "Загрузка цен...",
     "chartTitle": "История цены",
+    "markers": {
+      "bought": "Покупка {quantity} · {account}",
+      "sold": "Продажа {quantity} · {account}"
+    },
     "empty": "История цен недоступна",
     "columns": {
       "date": "Дата",

--- a/frontend/src/i18n/messages/ru/securities.json
+++ b/frontend/src/i18n/messages/ru/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "Добавить цену",
     "editPriceSection": "Редактировать цену",
     "loading": "Загрузка цен...",
+    "chartTitle": "История цены",
     "empty": "История цен недоступна",
     "columns": {
       "date": "Дата",

--- a/frontend/src/i18n/messages/tr/dashboard.json
+++ b/frontend/src/i18n/messages/tr/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "Bugün kaybedenler yok."
     },
     "dailyChange": "Günlük değişim",
+    "openPriceHistory": "{symbol} fiyat geçmişi",
     "refreshPrices": "Fiyatları yenile",
     "viewPortfolio": "Portföyü görüntüle",
     "filter": {

--- a/frontend/src/i18n/messages/tr/securities.json
+++ b/frontend/src/i18n/messages/tr/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "Fiyatı Düzenle",
     "loading": "Fiyatlar yükleniyor...",
     "chartTitle": "Fiyat geçmişi",
+    "markers": {
+      "bought": "Alım {quantity} · {account}",
+      "sold": "Satım {quantity} · {account}"
+    },
     "empty": "Fiyat geçmişi mevcut değil",
     "columns": {
       "date": "Tarih",

--- a/frontend/src/i18n/messages/tr/securities.json
+++ b/frontend/src/i18n/messages/tr/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "Fiyat Ekle",
     "editPriceSection": "Fiyatı Düzenle",
     "loading": "Fiyatlar yükleniyor...",
+    "chartTitle": "Fiyat geçmişi",
     "empty": "Fiyat geçmişi mevcut değil",
     "columns": {
       "date": "Tarih",

--- a/frontend/src/i18n/messages/uk/dashboard.json
+++ b/frontend/src/i18n/messages/uk/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "Сьогодні немає падіння."
     },
     "dailyChange": "Денна зміна",
+    "openPriceHistory": "Історія ціни: {symbol}",
     "refreshPrices": "Оновити ціни",
     "viewPortfolio": "Переглянути портфель",
     "filter": {

--- a/frontend/src/i18n/messages/uk/securities.json
+++ b/frontend/src/i18n/messages/uk/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "Редагувати ціну",
     "loading": "Завантаження цін...",
     "chartTitle": "Історія ціни",
+    "markers": {
+      "bought": "Купівля {quantity} · {account}",
+      "sold": "Продаж {quantity} · {account}"
+    },
     "empty": "Histórico цін відсутня",
     "columns": {
       "date": "Дата",

--- a/frontend/src/i18n/messages/uk/securities.json
+++ b/frontend/src/i18n/messages/uk/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "Додати ціну",
     "editPriceSection": "Редагувати ціну",
     "loading": "Завантаження цін...",
+    "chartTitle": "Історія ціни",
     "empty": "Histórico цін відсутня",
     "columns": {
       "date": "Дата",

--- a/frontend/src/i18n/messages/vi/dashboard.json
+++ b/frontend/src/i18n/messages/vi/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "Không có cổ phiếu giảm hôm nay."
     },
     "dailyChange": "Thay đổi hàng ngày",
+    "openPriceHistory": "Lịch sử giá của {symbol}",
     "refreshPrices": "Làm mới giá",
     "viewPortfolio": "Xem danh mục đầu tư",
     "filter": {

--- a/frontend/src/i18n/messages/vi/securities.json
+++ b/frontend/src/i18n/messages/vi/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "Chỉnh sửa giá",
     "loading": "Đang tải giá...",
     "chartTitle": "Lịch sử giá",
+    "markers": {
+      "bought": "Mua {quantity} · {account}",
+      "sold": "Bán {quantity} · {account}"
+    },
     "empty": "Không có lịch sử giá",
     "columns": {
       "date": "Ngày",

--- a/frontend/src/i18n/messages/vi/securities.json
+++ b/frontend/src/i18n/messages/vi/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "Thêm giá",
     "editPriceSection": "Chỉnh sửa giá",
     "loading": "Đang tải giá...",
+    "chartTitle": "Lịch sử giá",
     "empty": "Không có lịch sử giá",
     "columns": {
       "date": "Ngày",

--- a/frontend/src/i18n/messages/xx/dashboard.json
+++ b/frontend/src/i18n/messages/xx/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "[XX-No losers today.-XX]"
     },
     "dailyChange": "[XX-Daily change-XX]",
+    "openPriceHistory": "[XX-Price history for {symbol}-XX]",
     "refreshPrices": "[XX-Refresh prices-XX]",
     "viewPortfolio": "[XX-View portfolio-XX]",
     "filter": {

--- a/frontend/src/i18n/messages/xx/securities.json
+++ b/frontend/src/i18n/messages/xx/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "[XX-Add Price-XX]",
     "editPriceSection": "[XX-Edit Price-XX]",
     "loading": "[XX-Loading prices...-XX]",
+    "chartTitle": "[XX-Price History-XX]",
     "empty": "[XX-No price history available-XX]",
     "columns": {
       "date": "[XX-Date-XX]",

--- a/frontend/src/i18n/messages/xx/securities.json
+++ b/frontend/src/i18n/messages/xx/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "[XX-Edit Price-XX]",
     "loading": "[XX-Loading prices...-XX]",
     "chartTitle": "[XX-Price History-XX]",
+    "markers": {
+      "bought": "[XX-Bought {quantity} · {account}-XX]",
+      "sold": "[XX-Sold {quantity} · {account}-XX]"
+    },
     "empty": "[XX-No price history available-XX]",
     "columns": {
       "date": "[XX-Date-XX]",

--- a/frontend/src/i18n/messages/zh-CN/dashboard.json
+++ b/frontend/src/i18n/messages/zh-CN/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "今日无下跌。"
     },
     "dailyChange": "日涨跌",
+    "openPriceHistory": "{symbol} 的价格历史",
     "refreshPrices": "刷新价格",
     "viewPortfolio": "查看投资组合",
     "filter": {

--- a/frontend/src/i18n/messages/zh-CN/securities.json
+++ b/frontend/src/i18n/messages/zh-CN/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "编辑价格",
     "loading": "正在加载价格...",
     "chartTitle": "价格历史",
+    "markers": {
+      "bought": "买入 {quantity} · {account}",
+      "sold": "卖出 {quantity} · {account}"
+    },
     "empty": "暂无价格历史",
     "columns": {
       "date": "日期",

--- a/frontend/src/i18n/messages/zh-CN/securities.json
+++ b/frontend/src/i18n/messages/zh-CN/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "添加价格",
     "editPriceSection": "编辑价格",
     "loading": "正在加载价格...",
+    "chartTitle": "价格历史",
     "empty": "暂无价格历史",
     "columns": {
       "date": "日期",

--- a/frontend/src/i18n/messages/zh-TW/dashboard.json
+++ b/frontend/src/i18n/messages/zh-TW/dashboard.json
@@ -88,6 +88,7 @@
       "noLosers": "今日無下跌標的。"
     },
     "dailyChange": "每日變動",
+    "openPriceHistory": "{symbol} 的價格歷史",
     "refreshPrices": "更新價格",
     "viewPortfolio": "查看投資組合",
     "filter": {

--- a/frontend/src/i18n/messages/zh-TW/securities.json
+++ b/frontend/src/i18n/messages/zh-TW/securities.json
@@ -204,6 +204,10 @@
     "editPriceSection": "編輯價格",
     "loading": "載入價格中...",
     "chartTitle": "價格歷史",
+    "markers": {
+      "bought": "買入 {quantity} · {account}",
+      "sold": "賣出 {quantity} · {account}"
+    },
     "empty": "無可用的價格歷史",
     "columns": {
       "date": "日期",

--- a/frontend/src/i18n/messages/zh-TW/securities.json
+++ b/frontend/src/i18n/messages/zh-TW/securities.json
@@ -203,6 +203,7 @@
     "addPriceSection": "新增價格",
     "editPriceSection": "編輯價格",
     "loading": "載入價格中...",
+    "chartTitle": "價格歷史",
     "empty": "無可用的價格歷史",
     "columns": {
       "date": "日期",


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: (none yet -- opening this one for the approach; happy to move it to a discussion first if you would rather agree the deep-link shape before the code)

## Summary

The **Top Movers** widget lists a security's symbol, price and daily change, and then goes nowhere -- the rows are plain `div`s. The daily change is exactly the hook that raises the next question ("what has it been doing?"), and the answer already exists on the securities page.

- **Each row is a button** that deep-links to `/securities?price=<securityId>`, which opens that page's existing price-history view. The dashboard grows no second copy of the view, and the link works from anywhere else that wants it. Rows are keyboard-reachable and labelled ("Price history for AAPL").
- **The securities page** reads `?price=` once and resolves it against the loaded list by plain derivation -- no `setState` in an effect, and nothing re-opens after the user closes the modal.
- **The price history gains a chart.** Deliberately the account balance-history chart (`BalanceHistoryChart`), so the two screens read the same way rather than growing a second chart style: same area/gradient, same min/max flags, same download button, same summary footer. It takes two new optional props -- `title` (a price history is not a balance history) and `neutralValues` (a price has no good or bad sign, so tinting every footer figure green says nothing). Existing callers are untouched.

**Buys and sells are marked on it.** A price line answers "what has it been doing"; the next question is "what did I do about it", and the trades were already loaded one modal over. Every action that moved shares (buy, sell, reinvest, transfers, share adjustments) becomes a dot on the line at its date -- green in, red out -- with the quantity and the account in that day's tooltip. Actions that move no shares (dividends, interest, capital gains) carry no quantity and are left off: a dot with nothing to say is noise.

Two details worth knowing: a trade can fall on a day with no price row (a weekend, a gap in history), so markers snap to the nearest earlier point -- and to the first point when they predate the series; and the trade lookup is best-effort, so a failure costs the markers, never the price list the modal is actually for.

The chart only renders with more than one price point: a single point is a dot, not a history.

Verified: `npm run lint` clean, `tsc --noEmit` clean, `vitest run` 540 files / 10885 tests pass (new cases for the row click, the deep link opening/closing/ignoring an unknown id, the chart, and the markers -- placement, snapping, tooltip, and the failed lookup), `i18n:check` clean, four new strings translated for every locale.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement. `BalanceHistoryChart` gains three optional props (`title`, `neutralValues`, `markers`) with unchanged defaults.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Implemented with Claude Code; I reviewed the diff and ran the suite locally.
