### PR TITLE
fix(i18n): correct Polish mistranslation of Settings "Security"

### DIFF
--- a/frontend/src/i18n/messages/pl/settings.json
+++ b/frontend/src/i18n/messages/pl/settings.json
@@ -35,7 +35,7 @@
     }
   },
   "security": {
-    "heading": "Papier wartościowy",
+    "heading": "Zabezpieczenia",
     "ssoNotice": "Twoje konto korzysta z logowania jednokrotnego (SSO). Poniższe hasło nie jest używane do logowania, ale można je zachować jako zapasowe na wypadek wyłączenia SSO.",
     "currentPasswordLabel": "Bieżące hasło",
     "currentPasswordPlaceholder": "Wpisz bieżące hasło",
@@ -616,7 +616,7 @@
     "profile": "Profil",
     "preferences": "Preferencje",
     "notifications": "Powiadomienia",
-    "security": "Papier wartościowy",
+    "security": "Zabezpieczenia",
     "sharedAccess": "Dostęp współdzielony",
     "emergencyAccess": "Dostęp awaryjny",
     "apiAccess": "Dostęp do API",


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: N/A -- trivial one-line i18n bugfix (mistranslation), not a change in scope or behavior, so skipping propose-first for this one.

## Summary

The Polish translation of Settings' "Security" section heading and nav label used the financial term for "security" (papier wartościowy, i.e. a stock/bond) instead of "account security" (Zabezpieczenia) -- a plain word-sense mistranslation, now fixed in both spots in `pl/settings.json`.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Written with AI assistance (Claude Code): it located the mistranslation, verified against the English source strings, and made the two-line fix; I reviewed and own the result.