### PR TITLE
docs: record the UI patterns agents keep re-inventing, and guard one of them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,32 @@ Every user-facing string must be internationalized -- no hardcoded literals in t
 - No `console.log` in production code; use NestJS `Logger` class
 - Use proxy, not middleware (middleware is deprecated in this project)
 
+### Follow the existing pattern, and pin it down when you miss it
+
+Before writing a UI control, a data access path, or anything a user interacts
+with, find how the codebase already does that thing and do it the same way. This
+project has one way to make a table row clickable, one date input, one money
+formatter, one door to the database. Reaching for the generic solution -- a raw
+`<input type="date">`, a hand-rolled dropdown, a fresh `overflow-y-auto` -- when
+one already exists produces code that looks fine in isolation and wrong in place.
+
+**When a human points out a defect in code an AI wrote, that is a missing rule,
+not just a bug.** Fixing it is half the work. Also:
+
+1. Find how the codebase already solves that problem, and switch to it -- there
+   is usually an existing helper or hook, and not using it was the actual mistake.
+2. Add a regression test that fails on the original mistake, not merely one that
+   covers the fix. Where the mistake is mechanical (a raw element instead of the
+   shared component), prefer a guard test that scans the source and fails for
+   *any* occurrence, so the next instance is caught wherever it appears --
+   `frontend/src/test/ui-conventions.test.ts` and
+   `frontend/src/lib/tours/anchors.uniqueness.test.ts` are the pattern.
+3. Write the rule down here or in the layer's `CLAUDE.md`, in one or two
+   sentences, naming the thing to use and the thing not to.
+
+The point is that the next agent inherits the correction. A fix that lives only
+in one file will be re-broken in the next one.
+
 ### Code Intelligence
 Prefer LSP over Grep/Read for code navigation — it's faster, precise, and avoids reading entire files:
 - `workspaceSymbol` to find where something is defined

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -58,6 +58,48 @@ This is Next.js middleware (NOT the deprecated middleware pattern from this proj
 - **No `setState` in `useEffect`** — ESLint rule `react-hooks/set-state-in-effect` is enforced. To reset child state when a prop changes (e.g. on a dialog open transition), use the "info from previous render" pattern (track the prop in `useState` and update during render).
 - **Dialogs use `Modal`** (`components/ui/Modal.tsx`) — handles Escape, focus trap, body scroll lock, focus restore, and stacked-modal popstate. Opt into `pushHistory` so the browser back button also closes. `ConfirmDialog` forwards `pushHistory` for stacked confirm flows.
 
+## Reusing existing UI patterns
+
+Each of these exists once. Use it; do not hand-roll a second one. Every rule here
+was added after an agent wrote the generic version and a human had to point it out.
+
+### Date entry -- `DateInput`, never a raw `<input type="date">`
+
+`components/ui/DateInput.tsx` is the only place a raw date input is allowed, and
+`ui-conventions.test.ts` fails the build if another appears. It carries the
+locale-aware parsing, the keyboard shortcuts, and `CalendarPopover` -- the custom
+picker that the `.date-picker-hide` CSS in `globals.css` exists to make room for by
+hiding the browser's own icon. A bare `<input type="date">` gets none of that and
+shows two calendar icons. 32 components use `DateInput`; yours should too.
+
+### A clickable table row -- `useLongPress({ onClick })`
+
+`useLongPress` takes an `onClick` alongside `onLongPress` for exactly this: a plain
+click runs the row's primary action, a 750ms press (or right-click) opens the
+mobile action sheet, and a click that followed a long-press is suppressed. Spread
+`getRowHandlers(item)` on the `<tr>` and add `cursor-pointer`. The accounts,
+payees, tags, categories and securities lists all do this.
+
+Do not put the click on a button around the symbol or the name instead. It looks
+identical and is not: the rest of the row -- all the cell padding, every other
+column -- becomes dead, and clicking a row "does nothing" for the majority of its
+area. Controls *inside* the row (a favourite star, `RowActions`) must
+`stopPropagation` so they act on themselves; both already do.
+
+### A long list -- page it, or bound it with an expander
+
+Two patterns, depending on where it lives:
+
+- A full-page list uses `components/ui/Pagination.tsx`.
+- A list inside a card shows the first few rows and a "Show N more" button.
+
+Do not cap a card's height with `overflow-y-auto`. In a small card that draws a
+full native scrollbar hard against the content, which on Linux is a chunky arrowed
+bar that reads as a rendering fault -- and it hides the rest of the list behind a
+gutter nobody notices. The `overflow-y-auto` regions that do exist are panels,
+modals and sidebars, not cards. `scrollbar-hide` is for a horizontal strip of
+chips, and hiding a scrollbar you need is worse than not needing one.
+
 ## Form Patterns
 
 `useFormModal<T>` (`hooks/useFormModal.ts`) manages create/edit modal state with browser-history integration (back button closes), unsaved-changes detection via `UnsavedChangesDialog`, and form submit exposed via ref. Returns `showForm`, `editingItem`, `openCreate()`, `openEdit(item)`, `close()`, `modalProps`, `unsavedChangesDialog`.

--- a/frontend/src/test/ui-conventions.test.ts
+++ b/frontend/src/test/ui-conventions.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Guard tests for the UI conventions in `frontend/CLAUDE.md`.
+ *
+ * These exist because a documented rule is only as good as its enforcement. Each
+ * one was added after an agent reached for the generic solution, a human spotted
+ * it in the running app, and the fix landed in a single file. A test that scans
+ * the whole source tree catches the next instance wherever it appears, which a
+ * test around the one component that was fixed cannot.
+ *
+ * Add a case here whenever a *mechanical* mistake gets corrected -- a raw element
+ * used where a shared component exists. Judgement calls (is this list long enough
+ * to need paging?) stay in prose; only checkable rules belong here.
+ *
+ * Modelled on `src/lib/tours/anchors.uniqueness.test.ts`, which scans the tree the
+ * same way for detached tour anchors.
+ */
+const sources = import.meta.glob('/src/**/*.{ts,tsx}', {
+  query: '?raw',
+  eager: true,
+  import: 'default',
+}) as Record<string, string>;
+
+/** Source files only: tests legitimately contain the markup they assert on. */
+function productionSources(): [string, string][] {
+  return Object.entries(sources).filter(
+    ([path]) => !/\.test\.tsx?$/.test(path),
+  );
+}
+
+describe('date entry goes through DateInput', () => {
+  /** The one file allowed to hold a raw date input -- it *is* the wrapper. */
+  const WRAPPER = '/src/components/ui/DateInput.tsx';
+  const RAW_DATE_INPUT = /type=["']date["']/;
+
+  it('has no raw <input type="date"> outside the shared component', () => {
+    const offenders = productionSources()
+      .filter(([path]) => path !== WRAPPER)
+      .filter(([, content]) => RAW_DATE_INPUT.test(content))
+      .map(([path]) => path);
+
+    // A bare date input misses the locale-aware parsing and `CalendarPopover`,
+    // and shows the browser's own calendar icon beside Monize's -- the
+    // `.date-picker-hide` rule in globals.css exists to suppress exactly that.
+    expect(offenders).toEqual([]);
+  });
+
+  it('still finds the wrapper, so the rule cannot pass by accident', () => {
+    // Were DateInput renamed, or were it to stop using a native date input, the
+    // check above would trivially pass over an empty set. This fails first and
+    // says what to update.
+    const wrapper = sources[WRAPPER];
+    expect(
+      wrapper,
+      `${WRAPPER} not found -- update WRAPPER in this test`,
+    ).toBeTruthy();
+    expect(RAW_DATE_INPUT.test(wrapper)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: N/A -- documentation of conventions that already exist in the code, plus one guard test. No behaviour change, so no propose-first round; happy to open a discussion if you would rather these were debated first.

## Summary

Writes down three UI patterns Monize already has exactly one implementation of, each of which an AI contributor recently re-invented in a generic form until a human spotted it in the running app: `DateInput` for date entry, `useLongPress({ onClick })` for a clickable table row, and `Pagination` / a "Show N more" button for a long list rather than a height-capped `overflow-y-auto`. Adds a guard test that enforces the first, and a process rule in the root `CLAUDE.md`: when a human points out a defect in AI-written code, treat it as a missing rule -- find the existing pattern, add a test that fails on the original mistake, and record it -- so the correction is inherited instead of re-broken in the next file.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

Notes on the checklist: there are no user-facing strings in this PR (docs and one test). "New behavior has tests" refers to the guard itself -- I verified it fails on a planted `<input type="date">` and names the offending file, and that it fails loudly if `DateInput` is renamed, so the scan cannot pass over an empty set.

## AI assistance disclosure

Written with AI assistance (Claude Code). The rules describe mistakes the same assistant made in this repository and that I caught while testing a build; it then located the existing pattern in each case, wrote these up and added the guard. I reviewed and own the result.