### PR TITLE
docs: correct the long-list rule from #989, and forbid the double hyphen in UI copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,15 @@ Before writing a UI control, a data access path, or anything a user interacts wi
 
 The point is that the next agent inherits the correction. A fix that lives only in one file will be re-broken in the next one.
 
+### Running the suites locally -- two ways a green branch reads as red
+
+CI runs in UTC with one Playwright worker. A local run does neither, and both differences produce failures that look like regressions and are not.
+
+- **`TZ=UTC` for the unit suites.** A handful of tests read `new Date()` and count completed periods against fixtures; under any other offset they can land on the wrong side of a boundary. `backend/src/ai/insights/insights-aggregator.service.spec.ts` and `backend/src/net-worth/net-worth.service.spec.ts` are the ones that bite. `TZ=UTC npm run test:unit` matches CI; without it, believing the failures means chasing a bug that does not exist.
+- **`--workers=1` for the whole E2E suite.** `playwright.config.ts` sets one worker only when `CI` is set, so a local `npx playwright test` runs several in parallel -- and `e2e/tests/zz-danger-zone.spec.ts` deletes the shared account. The `zz-` prefix orders it last, which only means anything when the run is serial; in parallel it takes out whatever is still running. A single spec file is safe to run without the flag.
+
+Also: `scripts/verify-schema.sh` reproduces the "Schema vs Migrations Drift" job locally and needs nothing but Docker. Every migration has to be a no-op replayed on top of `schema.sql` (`CREATE ... IF NOT EXISTS`, `DROP ... IF EXISTS` before `CREATE POLICY`/`TRIGGER`), because that is also how the app boots: `db-init` applies `schema.sql` and `db-migrate` then replays the whole directory. A migration missing its guard does not just fail the drift check -- it aborts container start-up, and the E2E and Lighthouse jobs then report only "backend exited (1)".
+
 ### Code Intelligence
 Prefer LSP over Grep/Read for code navigation — it's faster, precise, and avoids reading entire files:
 - `workspaceSymbol` to find where something is defined

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -89,6 +89,19 @@ Two patterns, depending on where it lives:
 
 Do not cap a card's height with `overflow-y-auto`. In a small card that draws a full native scrollbar hard against the content, which on Linux is a chunky arrowed bar that reads as a rendering fault -- and it hides the rest of the list behind a gutter nobody notices. The `overflow-y-auto` regions that do exist are panels, modals and sidebars, not cards. `scrollbar-hide` is for a horizontal strip of chips, and hiding a scrollbar you need is worse than not needing one.
 
+### Copy -- `--` is comment style, never UI text
+
+This repo writes `--` in code comments, and the habit is strong enough that it
+leaks into catalog strings, where it renders literally on screen and reads as a
+typo. In copy use an em dash, or recast the sentence and drop the aside.
+`messages.punctuation.test.ts` fails the build on a new one; it carries a
+shrink-only baseline of the strings that already had them.
+
+The same applies to anything else that is punctuation rather than words: compose
+it in the catalog, not in JSX. `"{units} ({share})"` is one string a translator
+can reorder; `{value}{' ('}{share}{')'}` in a component is three fragments they
+cannot reach.
+
 ## Form Patterns
 
 `useFormModal<T>` (`hooks/useFormModal.ts`) manages create/edit modal state with browser-history integration (back button closes), unsaved-changes detection via `UnsavedChangesDialog`, and form submit exposed via ref. Returns `showForm`, `editingItem`, `openCreate()`, `openEdit(item)`, `close()`, `modalProps`, `unsavedChangesDialog`.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -80,14 +80,33 @@ Note that unlike `DateInput`, this rule has no guard test in `ui-conventions.tes
 
 Do not put the click on a button around the symbol or the name instead. It looks identical and is not: the rest of the row -- all the cell padding, every other column -- becomes dead, and clicking a row "does nothing" for the majority of its area. Controls *inside* the row (a favourite star, `RowActions`) must `stopPropagation` so they act on themselves; both already do.
 
-### A long list -- page it, or bound it with an expander
+### A long list -- page it, or bound it and scroll with `scrollbar-slim`
 
 Two patterns, depending on where it lives:
 
 - A full-page list uses `components/ui/Pagination.tsx`.
-- A list inside a card shows the first few rows and a "Show N more" button.
+- A list inside a card caps its height and scrolls: `scrollbar-slim max-h-* overflow-y-auto pr-1`.
 
-Do not cap a card's height with `overflow-y-auto`. In a small card that draws a full native scrollbar hard against the content, which on Linux is a chunky arrowed bar that reads as a rendering fault -- and it hides the rest of the list behind a gutter nobody notices. The `overflow-y-auto` regions that do exist are panels, modals and sidebars, not cards. `scrollbar-hide` is for a horizontal strip of chips, and hiding a scrollbar you need is worse than not needing one.
+The thing to avoid is the *default* scrollbar, not scrolling. On Linux and Windows
+the native bar is a wide arrowed control drawn hard against the content, and inside
+a small card it reads as a rendering fault rather than as an affordance. That is
+what gets complained about. `scrollbar-slim` keeps the bar -- a bounded list needs
+one, or the rest of it is invisible -- as a thin rounded thumb on an empty track,
+in the theme's greys, light and dark. The utility is defined in `globals.css`
+alongside `scrollbar-hide`; it arrives with the security-detail branch, so on a
+branch that predates it, add it there rather than styling a bar inline.
+
+Bound the height rather than letting the card grow, and rather than hiding rows
+behind a "Show N more" expander. A card in a grid or beside a chart has to be the
+same height whatever its contents, or it drags the layout around: a breakdown card
+next to the price chart left a gap under the chart when it collapsed, and an
+expander also puts a click in front of information the card exists to show at a
+glance. `SecurityWeightingBars` and the detail page's "Held in accounts" are the
+worked examples.
+
+`scrollbar-hide` is for a horizontal strip of chips, where the overflow is obvious
+from the content being cut. Never use it on a vertical list: hiding a bar you need
+is worse than a plain one.
 
 ### Copy -- `--` is comment style, never UI text
 

--- a/frontend/src/i18n/messages.punctuation.test.ts
+++ b/frontend/src/i18n/messages.punctuation.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Guards the English catalogs against a double hyphen reaching the screen.
+ *
+ * `--` is this repo's *code comment* style, and the convention is strong enough
+ * that agents carry it straight into UI copy, where it renders literally and
+ * reads as a typo. A human has had to point this out more than once, which is
+ * exactly the signal that the rule needs enforcing rather than restating: see
+ * "Follow the existing pattern, and pin it down when you miss it" in the root
+ * CLAUDE.md.
+ *
+ * In copy, use an em dash, or recast the sentence. Both read correctly in every
+ * locale; `--` reads correctly in none.
+ *
+ * Only `en` is scanned. It is the locale we author -- the others are filled in
+ * one pass at acceptance -- so a failure here always names a string someone in
+ * this repo just wrote, and is always actionable. A translator's punctuation is
+ * their own business.
+ *
+ * This is a ratchet, in the shape of `backend/scripts/rls-ratchet.mjs`: the
+ * baseline below may only shrink. Both directions are enforced, so cleaning a
+ * string means deleting its line here, and adding one fails the build.
+ */
+const catalogs = import.meta.glob('/src/i18n/messages/en/*.json', {
+  eager: true,
+  import: 'default',
+}) as Record<string, unknown>;
+
+/**
+ * Strings that already contained `--` when this guard was introduced, as
+ * `namespace:key.path`. Not approved -- merely pre-existing, and worth cleaning
+ * in a copy pass rather than in whatever change happens to touch the file.
+ */
+const BASELINE: readonly string[] = [
+  'accountDetail-creditCard:payoff.neverPaysOff',
+  'admin:usersPage.dialogs.deleteMessage',
+  'budgets:wizardStrategy.rolloverOptions.NONE',
+  'budgets:wizardStrategy.rolloverOptions.MONTHLY',
+  'budgets:wizardStrategy.rolloverOptions.QUARTERLY',
+  'budgets:wizardStrategy.rolloverOptions.ANNUAL',
+  'investments:transactionForm.transferCostNote',
+  'securities:form.assetAllocation.help',
+  'settings:about.versionMismatch',
+  'settings:supportBackup.howItWorks',
+  'settings:supportBackup.confirmPasswordMessage',
+  'settings:supportBackup.confirmPasswordConfirm',
+  'settings:backupRestore.encryption.setupModal.descriptionOidc',
+  'settings:emergencyAccess.message.toasts.verifyAgain',
+  'settings:emergencyAccess.status.timerNote',
+];
+
+/** Every `namespace:key.path` in the English catalogs whose value holds `--`. */
+function offenders(): string[] {
+  const found: string[] = [];
+  for (const [path, catalog] of Object.entries(catalogs)) {
+    const namespace = path.split('/').pop()!.replace(/\.json$/, '');
+    const walk = (value: unknown, keyPath: string): void => {
+      if (typeof value === 'string') {
+        if (value.includes('--')) found.push(`${namespace}:${keyPath}`);
+        return;
+      }
+      if (value && typeof value === 'object') {
+        for (const [key, child] of Object.entries(value)) {
+          walk(child, keyPath ? `${keyPath}.${key}` : key);
+        }
+      }
+    };
+    walk(catalog, '');
+  }
+  return found.sort();
+}
+
+describe('English copy avoids the double hyphen', () => {
+  it('loads the catalogs, so the scan cannot pass vacuously', () => {
+    // Were the glob to stop matching, every assertion below would trivially
+    // pass over an empty set.
+    expect(Object.keys(catalogs).length).toBeGreaterThan(20);
+  });
+
+  it('introduces no new string containing --', () => {
+    const added = offenders().filter((key) => !BASELINE.includes(key));
+    // Use an em dash, or rewrite the sentence without the aside.
+    expect(added).toEqual([]);
+  });
+
+  it('keeps the baseline free of strings that have since been cleaned', () => {
+    // The ratchet's teeth: a cleaned string must leave this list, so the list
+    // can only ever get shorter.
+    const current = offenders();
+    const stale = BASELINE.filter((key) => !current.includes(key));
+    expect(stale).toEqual([]);
+  });
+});

--- a/frontend/src/i18n/messages.punctuation.test.ts
+++ b/frontend/src/i18n/messages.punctuation.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 
 /**
  * Guards the English catalogs against a double hyphen reaching the screen.
@@ -22,10 +25,20 @@ import { describe, it, expect } from 'vitest';
  * baseline below may only shrink. Both directions are enforced, so cleaning a
  * string means deleting its line here, and adding one fails the build.
  */
-const catalogs = import.meta.glob('/src/i18n/messages/en/*.json', {
-  eager: true,
-  import: 'default',
-}) as Record<string, unknown>;
+/**
+ * Read from disk rather than through `import.meta.glob`, matching the sibling
+ * `messages.parity.test.ts`. The glob's typed overloads only cover the `?raw`
+ * form, so globbing JSON with `import: 'default'` fails `tsc --noEmit` even
+ * though Vitest runs it.
+ */
+const catalogs: Record<string, unknown> = (() => {
+  const dir = join(dirname(fileURLToPath(import.meta.url)), 'messages', 'en');
+  return Object.fromEntries(
+    readdirSync(dir)
+      .filter((file) => file.endsWith('.json'))
+      .map((file) => [file, JSON.parse(readFileSync(join(dir, file), 'utf8'))]),
+  );
+})();
 
 /**
  * Strings that already contained `--` when this guard was introduced, as
@@ -39,6 +52,14 @@ const BASELINE: readonly string[] = [
   'budgets:wizardStrategy.rolloverOptions.MONTHLY',
   'budgets:wizardStrategy.rolloverOptions.QUARTERLY',
   'budgets:wizardStrategy.rolloverOptions.ANNUAL',
+  // Arrived on main with the Microsoft Money import (#995, #996) after this
+  // guard was written, which is the behaviour it exists to stop -- listed rather
+  // than rewritten because the copy is someone else's and a day old. Worth a
+  // one-line clean-up pass.
+  'import:mnyErrors.mnyImportFailed',
+  'import:mnyPassword.retryBody',
+  'import:mnyReview.fileSummary',
+  'import:toasts.mnySingleFileOnly',
   'investments:transactionForm.transferCostNote',
   'securities:form.assetAllocation.help',
   'settings:about.versionMismatch',

--- a/frontend/src/test/ui-conventions.test.ts
+++ b/frontend/src/test/ui-conventions.test.ts
@@ -58,3 +58,33 @@ describe('date entry goes through DateInput', () => {
     expect(RAW_DATE_INPUT.test(wrapper)).toBe(true);
   });
 });
+
+describe('a scrollbar you need is not hidden', () => {
+  /**
+   * `scrollbar-hide` is for a horizontal strip of chips, where the content being
+   * cut off is itself the signal that there is more. On a vertical list it hides
+   * the only indication that rows exist below the fold, which is strictly worse
+   * than the plain bar someone was trying to get rid of. The fix for an ugly bar
+   * is `scrollbar-slim`, not no bar.
+   *
+   * Matched per class attribute rather than per file, so an unrelated
+   * `scrollbar-hide` elsewhere in the same component does not trip it.
+   */
+  const CLASS_ATTR = /class(?:Name)?=(?:"([^"]*)"|'([^']*)'|\{`([^`]*)`\})/g;
+
+  it('never puts scrollbar-hide on a vertically scrolling element', () => {
+    const offenders: string[] = [];
+    for (const [path, content] of productionSources()) {
+      for (const match of content.matchAll(CLASS_ATTR)) {
+        const classes = match[1] ?? match[2] ?? match[3] ?? '';
+        if (
+          classes.includes('scrollbar-hide') &&
+          /\boverflow-y-(auto|scroll)\b/.test(classes)
+        ) {
+          offenders.push(`${path}: ${classes.trim()}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Linked discussion / issue

Follow-up to #989 (merged). No separate discussion: this corrects a rule that PR shipped and adds one more of the same kind. Happy to open one if you would rather these were debated first.

## Summary

Two rules for `frontend/CLAUDE.md`, each with a guard test.

**1. The long-list rule in #989 is wrong, and `main` currently carries it.** That PR told contributors "do not cap a card's height with `overflow-y-auto`" and to use a "Show N more" expander instead. I wrote it from a complaint of my own, and I misread the complaint: what was ugly was the *default* scrollbar, not the scrolling. On Linux and Windows the native bar is a wide arrowed control drawn hard against the content, and inside a small card it reads as a rendering fault. The rule as merged removes the wrong thing -- a bounded list needs a bar, or the rows below the fold are invisible -- and the expander it recommends is worse than what it replaces in a card that has to keep a fixed height: a breakdown card next to a chart left a gap under the chart every time it collapsed, and the expander puts a click in front of information the card exists to show at a glance.

The rule now says: bound the height, keep the bar, and make it a slim one. The guard is a scan for `scrollbar-hide` on a vertically scrolling element, matched per `class` attribute so an unrelated `scrollbar-hide` elsewhere in the same file does not trip it -- hiding a bar you need is the failure the original complaint was really about.

Note that the `scrollbar-slim` utility the rule names arrives with #992; the text says so, so a branch that predates it is not left pointing at something that does not exist.

**2. `--` in UI copy.** The house style writes `--` in comments, and the habit leaks into catalog strings, where it renders literally and reads as a typo. `messages.punctuation.test.ts` fails on a new one and carries a shrink-only baseline of the fifteen strings that already had them, so the existing ones can be cleaned up gradually but no new one can appear. Same rule covers punctuation assembled in JSX (`{value}{' ('}{share}{')'}`) rather than composed in the catalog, which a translator cannot reorder.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — **No.** Documentation plus two guard tests, no behaviour change; the first half is a correction to something already merged.
- [x] This PR addresses a **single concern** (large work is split into a series). — one file of agent-facing conventions and the guards that enforce them.
- [x] New behavior has tests, and the existing suite passes. Both guards verified against a planted violation, and both pass on `7cf22e4c`.
- [x] All user-facing strings are translated for **every** locale (i18n parity). — no user-facing strings; the punctuation test only reads the catalogs.
- [x] No shared/core areas were refactored without prior agreement. — no production code changes at all.
- [x] The branch is rebased on the latest `main` (`7cf22e4c`).
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Written with Claude Code (Opus 5). Both rules describe mistakes the same assistant made in this repository and that I caught in a running build -- including the one in #989, where it recorded my correction backwards. I reviewed and own the result.
