### PR TITLE
fix(mny): correct transaction signs, investment actions and bill detection in the .mny import

### DIFF
--- a/backend/src/import/mny/README.md
+++ b/backend/src/import/mny/README.md
@@ -121,7 +121,21 @@ not the cause -- see `helm/README.md` for the sizing table.
 - **`act` 16 removes shares; it is not a sale.** Mapping it to SELL closes lots against a
   fabricated price and corrupts average cost. Direction always comes from `act` -- `TRN_INV.qty`
   is stored positive, so a quantity sign proves nothing.
-- **`act` 4 (cash dividend) has no `TRN_INV` row.** Drive the investment mapper from `TRN`;
+- **Read `act` off `LOT`, never off a format reference.** `LOT.htrnBuy` and `LOT.htrnSell` name
+  the transactions that opened and closed each tax lot, so whatever `act` those rows carry
+  acquires and disposes *by definition*. PR #192's reference had `act` 1 as SELL; in both Money
+  Plus files available (the maintainer's, 4,616 lots, and the `sample.mny` shipped with Money
+  Plus) `act` 1 opens lots and closes none. Every purchase imported as a sale, so no cash ever
+  left a brokerage sleeve and holdings replayed negative. Money Plus uses
+  1/2/3/4/9/12/13/32/33; codes 0, 5, 14, 15 and 16 appear only in the older fixtures.
+- **Investment `TRN.amt` is signed the opposite way to a banking row.** A buy is positive and a
+  sale negative -- it is what you paid, not the effect on the sleeve. Take the magnitude from
+  `amt` and the direction from `act`, which is what `totalAmountOf`/`cashAmountOf` do.
+- **Money qualifies a symbol with its market**: `US:VTI`, and `$US:INDU` for an index, where
+  `$` is Money's index marker rather than part of the prefix. `stripMarketPrefix` removes only
+  the market segment. Left on, `writeSecurities` matches existing holdings by symbol, so
+  `US:VTI` creates a second security beside the user's own `VTI` and every quote lookup 404s.
+- **`act` 3 and `act` 4 (cash distributions) have no `TRN_INV` row.** Drive the investment mapper from `TRN`;
   iterating `TRN_INV` drops every dividend.
 - **`SEC.sct` codes shift between releases** (the same index securities are `sct` 6 in Money
   2001/2002 and `sct` 7 in Money Plus), so the `sct = 4` currency test is not enough on its own.

--- a/backend/src/import/mny/README.md
+++ b/backend/src/import/mny/README.md
@@ -143,6 +143,20 @@ not the cause -- see `helm/README.md` for the sizing table.
   shape.
 - **`CAT.lType` says income or expense directly** -- `{2, 3}` income, `{0, 1}` expense, `-1` the
   two roots. Use `isIncomeCategoryType` and fall back to the root ancestor only for the roots.
+- **A `.mny` is a snapshot, so bill activity is measured from the file, not the clock.**
+  `billActivityAnchor` anchors the horizon to the newest `BILL` instance the file holds,
+  falling back to `asOf` for a file still in use. Judging against `todayIsoDate()` meant the
+  same file imported differently depending on the day it was run, and a file a quarter old
+  lost *every* bill -- 292 series reduced to one candidate.
+- **A series is judged against its own cadence.** The window is
+  `max(BILL_FUTURE_HORIZON_DAYS, one cycle + BILL_PAST_HORIZON_DAYS)`. A flat quarter declared
+  a yearly bill dead 100 days after its last occurrence, on a current file. Detection erring
+  generous is recoverable -- the wizard's checkbox list unticks it -- while erring strict drops
+  the series with no UI that ever mentions it.
+- **Money's newest instance is where the series stood when the file was last used**, which is
+  in the past for any real import. `rollForward` advances it through its own cadence to the
+  next occurrence at or after `asOf`, so a bill arrives due next month rather than a year
+  overdue. Rolling is step-bounded; a stale daily series would otherwise iterate for ever.
 - **`BILL` is an accumulation of instances, not a list of bills.** One row per occurrence, so a
   long history holds thousands (1,844 in the maintainer's file for ~20 real bills). Group by
   `hbillHead` and reduce each series to one representative before doing anything else.

--- a/backend/src/import/mny/README.md
+++ b/backend/src/import/mny/README.md
@@ -54,7 +54,8 @@ committed here, so the pipeline measures itself and the run is what gets recorde
 
 ## Memory
 
-An upload is buffered whole and decrypted in place, so peak usage is roughly **twice the file
+An upload is buffered whole and decrypted in place, and the reader works on its own copy of
+those bytes (see the `mdb-reader` trap below), so peak usage is roughly **twice the file
 size** above baseline. `MNY_IMPORT_LIMIT_MB` (default 300) bounds it; the pod needs at least
 `2x` that plus headroom, which the default Helm limit of `150Mi` is nowhere near. A pod that hits
 its limit mid-import is OOM-killed and the wizard reports a *stalled job*, naming the symptom and
@@ -91,6 +92,15 @@ not the cause -- see `helm/README.md` for the sizing table.
 - **`decryptMsisamInPlace` takes ownership of its buffer.** It mutates and returns the same
   buffer, deliberately (ADR-6). Tests must read a fresh fixture per assertion --
   `readMnyFixture` does that.
+- **`mdb-reader` writes into the bytes it reads, and the corruption is silent and specific.**
+  A second read of the same buffer returns every currency value with its sign stripped
+  (`-20.0000` reads back as `20.0000`) while row counts, dates and text stay correct, so
+  nothing looks wrong until a ledger of pure credits arrives. The wizard reads a buffer twice
+  by design -- `POST /parse` reads the upload and stages *those same bytes*, and the job reads
+  them again -- so this made every imported transaction a credit, both sides of every transfer
+  positive, and account opening balances absolute (they share `toAmount`). `openDatabase` hands
+  the reader its own copy, which is what makes `openMnyFile` a door you may walk through twice.
+  Do not "optimise" that copy away.
 - **Decrypt each buffer exactly once; RC4 is symmetric.** A second pass re-encrypts pages
   1..0xE, and the only symptom is `MnyUnreadableDatabaseError` from a layer that looks
   unrelated. Staged bytes are stored *decrypted* so the password is spent on the parse request

--- a/backend/src/import/mny/map/map-bills.spec.ts
+++ b/backend/src/import/mny/map/map-bills.spec.ts
@@ -18,7 +18,6 @@ import { MappedAccounts, MappedSecurities } from "../model/mny-import-model";
 import { mapSecurities } from "./map-securities";
 import {
   BILL_FUTURE_HORIZON_DAYS,
-  BILL_PAST_HORIZON_DAYS,
   MapBillsInput,
   billReferences,
   mapBills,
@@ -235,18 +234,88 @@ describe("mapBills", () => {
     });
 
     it("keeps a recently-overdue series and drops one past the grace period", () => {
+      // A monthly series is judged over max(400, 31 + 92) = 400 days. Handle 1
+      // is current and so pins the file's present at AS_OF.
       const result = mapBills(
         input({
           bills: billData({
             bills: [
+              mnyBill({ handle: 1, nextDue: AS_OF, templateTransaction: 500 }),
+              mnyBill({
+                handle: 2,
+                nextDue: shiftIsoDate(AS_OF, -BILL_FUTURE_HORIZON_DAYS),
+                templateTransaction: 501,
+              }),
+              mnyBill({
+                handle: 3,
+                nextDue: shiftIsoDate(AS_OF, -(BILL_FUTURE_HORIZON_DAYS + 1)),
+                templateTransaction: 502,
+              }),
+            ],
+          }),
+          transactions: transactionData({
+            transactions: [
+              template({ handle: 500, account: 1 }),
+              template({ handle: 501, account: 1 }),
+              template({ handle: 502, account: 1 }),
+            ],
+          }),
+        }),
+      );
+
+      expect(result.bills.map((bill) => bill.handle).sort()).toEqual([1, 2]);
+    });
+
+    it("judges a series against its own cadence, not a flat quarter", () => {
+      // The defect this guards: a flat 92-day window declared a yearly bill
+      // dead 100 days after its last occurrence, when it had missed nothing.
+      const yearly = (handle: number, daysAgo: number) =>
+        mnyBill({
+          handle,
+          frequency: 6,
+          nextDue: shiftIsoDate(AS_OF, -daysAgo),
+          templateTransaction: 500 + handle,
+        });
+
+      const result = mapBills(
+        input({
+          bills: billData({
+            bills: [
+              mnyBill({ handle: 1, nextDue: AS_OF, templateTransaction: 500 }),
+              yearly(2, 100),
+            ],
+          }),
+          transactions: transactionData({
+            transactions: [
+              template({ handle: 500, account: 1 }),
+              template({ handle: 502, account: 1 }),
+            ],
+          }),
+        }),
+      );
+
+      expect(result.bills.map((bill) => bill.handle)).toContain(2);
+    });
+
+    it("measures the horizon from the file's own present, not the clock", () => {
+      // A .mny is a snapshot. Judging it against the wall clock meant that the
+      // longer a user waited before importing, the fewer bills survived -- and
+      // at a quarter old, none did. This file was last used a year ago and its
+      // bills are still its bills.
+      const lastUsed = shiftIsoDate(AS_OF, -365);
+      const result = mapBills(
+        input({
+          asOf: AS_OF,
+          bills: billData({
+            bills: [
               mnyBill({
                 handle: 1,
-                nextDue: shiftIsoDate(AS_OF, -BILL_PAST_HORIZON_DAYS),
+                nextDue: lastUsed,
                 templateTransaction: 500,
               }),
               mnyBill({
                 handle: 2,
-                nextDue: shiftIsoDate(AS_OF, -(BILL_PAST_HORIZON_DAYS + 1)),
+                nextDue: shiftIsoDate(lastUsed, -30),
                 templateTransaction: 501,
               }),
             ],
@@ -260,7 +329,38 @@ describe("mapBills", () => {
         }),
       );
 
-      expect(result.bills.map((bill) => bill.handle)).toEqual([1]);
+      expect(result.bills.map((bill) => bill.handle).sort()).toEqual([1, 2]);
+    });
+
+    it("rolls a stale due date forward to the next occurrence", () => {
+      // Money's newest instance is where the series stood when the file was
+      // last used. Written through unchanged, a monthly bill arrives in Monize
+      // a year overdue instead of due next month.
+      const result = mapBills(
+        input({
+          asOf: AS_OF,
+          bills: billData({
+            bills: [
+              mnyBill({
+                handle: 1,
+                nextDue: shiftIsoDate(AS_OF, -365),
+                templateTransaction: 500,
+              }),
+            ],
+          }),
+          transactions: transactionData({
+            transactions: [template({ handle: 500, account: 1 })],
+          }),
+        }),
+      );
+
+      expect(result.bills[0].frequency).toBe("MONTHLY");
+      // The next occurrence, not merely some future date: one cycle's worth of
+      // slack and no more. (The shared helper clamps a 30th onto a short
+      // February and keeps the earlier day thereafter, which is the
+      // scheduler's own behaviour, so the day of month is not asserted.)
+      expect(result.bills[0].nextDueDate >= AS_OF).toBe(true);
+      expect(result.bills[0].nextDueDate <= shiftIsoDate(AS_OF, 31)).toBe(true);
     });
 
     it("drops a series whose next due date is implausibly far out", () => {

--- a/backend/src/import/mny/map/map-bills.ts
+++ b/backend/src/import/mny/map/map-bills.ts
@@ -7,7 +7,15 @@ import {
   MappedBills,
   MappedSecurities,
 } from "../model/mny-import-model";
-import { mapFrequency, mapInvestmentAction } from "../model/mny-model";
+import {
+  MnyFrequencyMapping,
+  mapFrequency,
+  mapInvestmentAction,
+} from "../model/mny-model";
+import {
+  FrequencyType,
+  calculateNextDueDate,
+} from "../../../common/recurrence";
 import { MnyBill, MnyPayee, MnyTransaction } from "../model/mny-rows";
 import { MnyWarning } from "../model/mny-warnings";
 import { isDegeneratePayeeName } from "./map-reference";
@@ -33,11 +41,58 @@ import { MnyTransactionData } from "../tables/read-transactions";
  */
 
 /**
- * How long past its next due date a series stays an active candidate. A bill
- * the user is a few weeks behind on is still a bill; one silent for a quarter
- * is a dead series left in the table.
+ * Grace on top of a series' own cadence before it counts as dead. A bill the
+ * user is a few weeks behind on is still a bill.
+ *
+ * This is added to one full cycle rather than used on its own: a yearly bill
+ * observed 100 days after its last occurrence has not missed anything, and the
+ * flat 92-day rule this replaces declared it dead -- on a *current* file, not
+ * just a stale one.
  */
 export const BILL_PAST_HORIZON_DAYS = 92;
+
+/** One cycle of each frequency, in days, rounded up. */
+const CYCLE_DAYS: Record<FrequencyType, number> = {
+  ONCE: 0,
+  DAILY: 1,
+  WEEKLY: 7,
+  BIWEEKLY: 14,
+  EVERY4WEEKS: 28,
+  SEMIMONTHLY: 15,
+  MONTHLY: 31,
+  EVERY2MONTHS: 62,
+  QUARTERLY: 92,
+  SEMIANNUAL: 184,
+  YEARLY: 366,
+};
+
+/**
+ * The date a series' activity is judged against.
+ *
+ * A `.mny` is a **snapshot**, not a live database: the user stops using Money,
+ * exports, and imports whenever they get to it. Measuring "is this series still
+ * live" against the wall clock therefore makes the same file import differently
+ * depending on the day it is run, and once the file is a quarter old every bill
+ * in it is silently dropped -- which is what reduced a file holding ~30 live
+ * bills to a single one.
+ *
+ * So the horizon is anchored to the file's own present: the newest `BILL`
+ * instance it contains. A file still in use has that at or ahead of today, and
+ * `asOf` wins, which is the behaviour a current file always had.
+ */
+export function billActivityAnchor(
+  bills: readonly MnyBill[],
+  asOf: string,
+): string {
+  const newest = bills
+    .map((bill) => bill.nextDue)
+    .filter((due): due is string => due !== null)
+    .reduce<string | null>(
+      (latest, due) => (latest === null || due > latest ? due : latest),
+      null,
+    );
+  return newest !== null && newest < asOf ? newest : asOf;
+}
 
 /**
  * How far into the future a next due date may plausibly sit. A yearly bill's
@@ -193,17 +248,73 @@ function representativeOf(
   );
 }
 
-/** Whether a series' schedule falls inside the active horizon. */
-function isActive(representative: MnyBill, asOf: string): boolean {
+/**
+ * Whether a series' schedule falls inside the active horizon, measured from the
+ * file's own present (`anchor`) rather than the wall clock.
+ *
+ * A series stays a candidate for one full cycle plus `BILL_PAST_HORIZON_DAYS`
+ * of grace, floored at `BILL_FUTURE_HORIZON_DAYS` so nothing is judged over a
+ * window shorter than a year -- a monthly bill that lapsed for two months is
+ * still the bill the user thinks they have, and the wizard's checkbox list is
+ * where it gets unticked. Detection erring generous is recoverable; erring
+ * strict drops the series with no UI that ever mentions it.
+ */
+function isActive(
+  representative: MnyBill,
+  anchor: string,
+  mapping: MnyFrequencyMapping | null,
+): boolean {
   const nextDue = representative.nextDue as string;
-  if (nextDue < shiftIsoDate(asOf, -BILL_PAST_HORIZON_DAYS)) {
+  if (nextDue > shiftIsoDate(anchor, BILL_FUTURE_HORIZON_DAYS)) {
     return false;
   }
-  if (nextDue > shiftIsoDate(asOf, BILL_FUTURE_HORIZON_DAYS)) {
+  if (representative.endsOn !== null && representative.endsOn < anchor) {
     return false;
   }
-  return representative.endsOn === null || representative.endsOn >= asOf;
+
+  // A one-off that has already fallen due is spent, not a schedule.
+  if (mapping === null || mapping.frequency === "ONCE") {
+    return nextDue >= anchor;
+  }
+
+  const window = Math.max(
+    BILL_FUTURE_HORIZON_DAYS,
+    CYCLE_DAYS[mapping.frequency] + BILL_PAST_HORIZON_DAYS,
+  );
+  return nextDue >= shiftIsoDate(anchor, -window);
 }
+
+/**
+ * The series' next occurrence at or after `asOf`, rolled forward through its own
+ * cadence.
+ *
+ * Money's newest instance is where the series stood when the file was last
+ * used, which for any real import is in the past. Writing that date through
+ * unchanged hands Monize a schedule that is months overdue on arrival, so the
+ * bill lands looking like a backlog rather than a schedule. Rolling is bounded:
+ * a daily series twenty years stale would otherwise iterate for ever.
+ */
+export function rollForward(
+  due: string,
+  frequency: FrequencyType,
+  asOf: string,
+): string {
+  if (frequency === "ONCE") {
+    return due;
+  }
+  let next = due;
+  for (let step = 0; step < MAX_ROLL_STEPS && next < asOf; step += 1) {
+    const advanced = calculateNextDueDate(next, frequency);
+    if (advanced <= next) {
+      return next;
+    }
+    next = advanced;
+  }
+  return next;
+}
+
+/** Enough to roll a daily series through a decade, and no further. */
+const MAX_ROLL_STEPS = 4000;
 
 /** The account key a template row's schedule belongs to, or null. */
 function accountKeyOf(
@@ -402,7 +513,14 @@ function mapOne(
         : (context.input.accounts.currencyByHandle.get(template.account) ?? ""),
     frequency: mapping.frequency,
     approximate: mapping.approximate,
-    nextDueDate: representative.nextDue as string,
+    // Rolled to the next occurrence at or after the import's cut-off: Money's
+    // own newest instance is where the series stood when the file was last
+    // used, which is in the past for any real import.
+    nextDueDate: rollForward(
+      representative.nextDue as string,
+      mapping.frequency,
+      context.input.asOf,
+    ),
     endDate: representative.endsOn,
     description: template.memo,
     isTransfer: transferAccountKey !== null,
@@ -483,9 +601,18 @@ export function mapBills(input: MapBillsInput): MappedBills {
   const mapped: MappedBill[] = [];
   const templateByBillHandle = new Map<number, number>();
 
+  const anchor = billActivityAnchor(input.bills.bills, input.asOf);
+
   for (const instances of bySeries.values()) {
-    const representative = representativeOf(instances, input.asOf);
-    if (representative === null || !isActive(representative, input.asOf)) {
+    const representative = representativeOf(instances, anchor);
+    if (
+      representative === null ||
+      !isActive(
+        representative,
+        anchor,
+        mapFrequency(representative.frequency, representative.interval),
+      )
+    ) {
       continue;
     }
     const bill = mapOne(representative, context);

--- a/backend/src/import/mny/map/map-securities.spec.ts
+++ b/backend/src/import/mny/map/map-securities.spec.ts
@@ -3,6 +3,7 @@ import {
   MAX_SECURITY_SYMBOL_LENGTH,
   mapSecurities,
   placeholderSymbol,
+  stripMarketPrefix,
 } from "./map-securities";
 
 describe("mapSecurities", () => {
@@ -238,5 +239,77 @@ describe("placeholderSymbol", () => {
   it("stays inside the column width", () => {
     const symbol = placeholderSymbol("A B C D E F G H I J K L M N O P Q R S T");
     expect(symbol.length).toBeLessThanOrEqual(MAX_SECURITY_SYMBOL_LENGTH);
+  });
+});
+
+describe("stripMarketPrefix", () => {
+  // Money qualifies a symbol with the market it trades on. Real Money Plus
+  // files hold both shapes side by side: `US:VTI` for a holding and
+  // `$US:INDU`, `$DE:DAX` for an index, where `$` is Money's index marker.
+  it("removes the market a holding trades on", () => {
+    expect(stripMarketPrefix("US:VTI")).toBe("VTI");
+    expect(stripMarketPrefix("US:GLDM")).toBe("GLDM");
+  });
+
+  it("keeps an index an index, dropping only the market", () => {
+    expect(stripMarketPrefix("$US:INDU")).toBe("$INDU");
+    expect(stripMarketPrefix("$DE:DAX")).toBe("$DAX");
+    expect(stripMarketPrefix("$JP:NI225")).toBe("$NI225");
+  });
+
+  it("leaves a symbol Money never qualified alone", () => {
+    expect(stripMarketPrefix("XIU")).toBe("XIU");
+    expect(stripMarketPrefix("$OSPTX")).toBe("$OSPTX");
+    expect(stripMarketPrefix("BMO146")).toBe("BMO146");
+    // A currency pseudo-security, which must survive to be recognised as one.
+    expect(stripMarketPrefix("/GBPUS")).toBe("/GBPUS");
+  });
+
+  it("does not treat a longer prefix as a market", () => {
+    expect(stripMarketPrefix("NYSE:VTI")).toBe("NYSE:VTI");
+  });
+
+  it("keeps what Money stored when stripping would leave nothing", () => {
+    expect(stripMarketPrefix("US:")).toBe("US:");
+    expect(stripMarketPrefix("$US:")).toBe("$US:");
+  });
+});
+
+describe("mapSecurities market prefixes", () => {
+  const base = {
+    currencyByHandle: new Map<number, string>([[1, "USD"]]),
+    baseCurrency: "USD",
+  };
+
+  it("imports a qualified symbol under its bare ticker", () => {
+    // The defect this guards: `writeSecurities` matches existing holdings by
+    // symbol, so an imported `US:VTI` sat beside the user's own `VTI` as a
+    // second security and asked the quote providers for a symbol that does
+    // not exist.
+    const result = mapSecurities({
+      ...base,
+      securities: [
+        mnySecurity({ handle: 1, symbol: "US:VTI", name: "Vanguard" }),
+      ],
+    });
+
+    expect(result.securities[0].symbol).toBe("VTI");
+    // The file's own spelling is still recorded.
+    expect(result.securities[0].moneySymbol).toBe("US:VTI");
+  });
+
+  it("suffixes rather than merges when stripping collides", () => {
+    const result = mapSecurities({
+      ...base,
+      securities: [
+        mnySecurity({ handle: 1, symbol: "VTI", name: "Held directly" }),
+        mnySecurity({ handle: 2, symbol: "US:VTI", name: "Held in the US" }),
+      ],
+    });
+
+    expect(result.securities.map((s) => s.symbol)).toEqual(["VTI", "VTI-2"]);
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({ code: "duplicateSecuritySymbol" }),
+    );
   });
 });

--- a/backend/src/import/mny/map/map-securities.ts
+++ b/backend/src/import/mny/map/map-securities.ts
@@ -58,6 +58,29 @@ export function placeholderSymbol(name: string): string {
 }
 
 /**
+ * Removes the market Money qualifies a symbol with: `US:VTI` is the ticker
+ * `VTI` held on a US market, and `$US:INDU` is an index, where the leading `$`
+ * is Money's own index marker rather than part of the prefix.
+ *
+ * The qualifier is Money's bookkeeping, not the ticker. Left on, it costs twice:
+ * `writeSecurities` matches existing holdings by symbol, so `US:VTI` creates a
+ * second security beside the user's own `VTI` instead of reusing it, and every
+ * price lookup for the imported one asks the quote providers for a symbol that
+ * does not exist.
+ *
+ * Only the market segment goes, so an index stays an index (`$US:INDU` ->
+ * `$INDU`) and a symbol Money never qualified is untouched. The qualifier is an
+ * ISO country code, hence exactly two letters -- `$OSPTX` keeps its shape and a
+ * ticker that merely contains a colon is not a market prefix.
+ */
+export function stripMarketPrefix(symbol: string): string {
+  const stripped = symbol.replace(/^(\$?)[A-Za-z]{2}:/, "$1");
+  // "US:" with nothing after it is not a ticker worth preferring over what
+  // Money actually stored.
+  return stripped === "" || stripped === "$" ? symbol : stripped;
+}
+
+/**
  * Makes a symbol unique within the import, staying inside the column width.
  * The base is trimmed back before suffixing so `-2` never pushes the result
  * over the limit and truncates two distinct securities back onto each other.
@@ -121,7 +144,9 @@ export function mapSecurities(input: MapSecuritiesInput): MappedSecurities {
     }
 
     const generated = moneySymbol === "";
-    const requested = generated ? placeholderSymbol(name) : moneySymbol;
+    const requested = generated
+      ? placeholderSymbol(name)
+      : stripMarketPrefix(moneySymbol);
     const { symbol, collided } = uniqueSymbol(requested, taken);
 
     if (generated) {

--- a/backend/src/import/mny/model/mny-model.spec.ts
+++ b/backend/src/import/mny/model/mny-model.spec.ts
@@ -120,13 +120,18 @@ describe("isRecurrenceTemplate", () => {
 
 describe("mapInvestmentAction", () => {
   it.each([
+    [MNY_ACTION.BUY_LEGACY, InvestmentAction.BUY],
     [MNY_ACTION.BUY, InvestmentAction.BUY],
     [MNY_ACTION.SELL, InvestmentAction.SELL],
-    [MNY_ACTION.REINVEST, InvestmentAction.REINVEST],
     [MNY_ACTION.DIVIDEND, InvestmentAction.DIVIDEND],
+    [MNY_ACTION.DISTRIBUTION, InvestmentAction.DIVIDEND],
+    [MNY_ACTION.REINVEST, InvestmentAction.REINVEST],
+    [MNY_ACTION.BUY_ALT, InvestmentAction.BUY],
     [MNY_ACTION.REINVEST_ALT, InvestmentAction.REINVEST],
     [MNY_ACTION.CAPITAL_GAIN, InvestmentAction.CAPITAL_GAIN],
     [MNY_ACTION.ADD_SHARES, InvestmentAction.ADD_SHARES],
+    [MNY_ACTION.TRANSFER_IN, InvestmentAction.TRANSFER_IN],
+    [MNY_ACTION.TRANSFER_OUT, InvestmentAction.TRANSFER_OUT],
   ])("maps act %p to %s", (act, expected) => {
     expect(mapInvestmentAction(act)).toBe(expected);
   });
@@ -134,21 +139,70 @@ describe("mapInvestmentAction", () => {
   it("maps act 16 to REMOVE_SHARES, never SELL", () => {
     // Mapping it to SELL closes lots against a fabricated sale price and
     // corrupts average cost -- PR #192 issue 4.
-    expect(mapInvestmentAction(MNY_ACTION.REMOVE_SHARES)).toBe(
+    expect(mapInvestmentAction(MNY_ACTION.REMOVE_SHARES_LEGACY)).toBe(
       InvestmentAction.REMOVE_SHARES,
     );
-    expect(mapInvestmentAction(MNY_ACTION.REMOVE_SHARES)).not.toBe(
+    expect(mapInvestmentAction(MNY_ACTION.REMOVE_SHARES_LEGACY)).not.toBe(
       InvestmentAction.SELL,
     );
   });
 
-  it.each([[2], [6], [99]])("returns null for the unknown act %p", (act) => {
-    expect(mapInvestmentAction(act)).toBeNull();
+  it.each([[6], [10], [17], [18], [20], [99]])(
+    "returns null for the unknown act %p",
+    (act) => {
+      // 10, 17, 18 and 20 all occur in real Money Plus files but open and
+      // close no lot, so nothing says what they do to a position. They are
+      // skipped and warned about rather than guessed at.
+      expect(mapInvestmentAction(act)).toBeNull();
+    },
+  );
+
+  it("maps act 1 to BUY, never SELL", () => {
+    // The defect this guards: PR #192's format reference had act 1 as SELL.
+    // LOT disagrees -- act 1 opens 3,520 lots in the maintainer's file and
+    // closes none -- so every purchase imported as a sale, no cash ever left
+    // a brokerage sleeve, and holdings replayed negative.
+    expect(mapInvestmentAction(MNY_ACTION.BUY)).toBe(InvestmentAction.BUY);
+    expect(mapInvestmentAction(MNY_ACTION.BUY)).not.toBe(InvestmentAction.SELL);
+  });
+
+  it("maps the codes LOT proves acquire shares onto acquisitions", () => {
+    // Whatever act a LOT.htrnBuy row carries opens a position, by definition.
+    for (const act of [
+      MNY_ACTION.BUY,
+      MNY_ACTION.REINVEST,
+      MNY_ACTION.BUY_ALT,
+      MNY_ACTION.TRANSFER_IN,
+    ]) {
+      expect(mapInvestmentAction(act)).not.toBeNull();
+      expect([
+        InvestmentAction.BUY,
+        InvestmentAction.REINVEST,
+        InvestmentAction.TRANSFER_IN,
+        InvestmentAction.ADD_SHARES,
+      ]).toContain(mapInvestmentAction(act));
+    }
+  });
+
+  it("maps the codes LOT proves dispose of shares onto disposals", () => {
+    for (const act of [
+      MNY_ACTION.SELL,
+      MNY_ACTION.REMOVE_SHARES,
+      MNY_ACTION.TRANSFER_OUT,
+    ]) {
+      expect([
+        InvestmentAction.SELL,
+        InvestmentAction.REMOVE_SHARES,
+        InvestmentAction.TRANSFER_OUT,
+      ]).toContain(mapInvestmentAction(act));
+    }
   });
 
   it("flags the inferred action codes so mappers can warn", () => {
     expect([...MNY_UNCONFIRMED_ACTIONS].sort((a, b) => a - b)).toEqual([
+      MNY_ACTION.DISTRIBUTION,
       MNY_ACTION.REINVEST_ALT,
+      MNY_ACTION.BUY_ALT,
       MNY_ACTION.CAPITAL_GAIN,
     ]);
   });
@@ -156,7 +210,9 @@ describe("mapInvestmentAction", () => {
   it("knows that dividends carry no TRN_INV row", () => {
     // Iterating TRN_INV instead of TRN drops every cash dividend.
     expect(hasInvestmentDetail(MNY_ACTION.DIVIDEND)).toBe(false);
+    expect(hasInvestmentDetail(MNY_ACTION.DISTRIBUTION)).toBe(false);
     expect(hasInvestmentDetail(MNY_ACTION.BUY)).toBe(true);
+    expect(hasInvestmentDetail(MNY_ACTION.SELL)).toBe(true);
   });
 });
 

--- a/backend/src/import/mny/model/mny-model.ts
+++ b/backend/src/import/mny/model/mny-model.ts
@@ -126,47 +126,103 @@ export function mapTransactionStatus(
 // ---------------------------------------------------------------------------
 
 /**
- * Money investment action codes. Confirmed in the fixtures: 0, 1 and 15. The
- * rest come from PR #192's format reference, corrected by this design -- most
- * importantly 16, which the proof of concept mapped to SELL and which actually
- * removes shares.
+ * Money investment action codes.
+ *
+ * These are read off `LOT`, which is Money's own record of which transaction
+ * opened and closed each tax lot and therefore settles direction without
+ * inference: whatever `act` a `LOT.htrnBuy` row carries acquires shares, and
+ * whatever `LOT.htrnSell` carries disposes of them. Two independent Money Plus
+ * files agree -- the maintainer's (4,616 lots) and the `sample.mny` shipped
+ * with Money Plus (41 lots).
+ *
+ * The previous table came from PR #192's format reference and had **`act` 1 as
+ * SELL**, which is backwards: `act` 1 opens 3,520 lots in the maintainer's file
+ * and closes none. Every purchase imported as a sale, so no cash ever left a
+ * brokerage sleeve, holdings replayed negative, and the investment half of the
+ * ledger was pure credit.
+ *
+ * `act` 0, 5, 14, 15 and 16 appear in no Money Plus file and keep their
+ * reference meanings; the fixtures are the only evidence for them (`act` 15
+ * opens all 60 of money2002's lots, which is consistent with ADD_SHARES).
+ * Where the two schemes disagree the lot evidence wins, because it is
+ * measured rather than assumed.
  */
 export const MNY_ACTION = {
-  BUY: 0,
-  SELL: 1,
-  /** Reinvested distribution. */
-  REINVEST: 3,
+  /** Money 2001-era buy. No Money Plus file uses it. */
+  BUY_LEGACY: 0,
+  /** Opens lots, `TRN.amt` positive: the money went out. */
+  BUY: 1,
+  /** Closes lots, `TRN.amt` negative: the money came in. */
+  SELL: 2,
   /** Cash dividend. Has **no** `TRN_INV` row -- the amount is on `TRN.amt`. */
-  DIVIDEND: 4,
+  DIVIDEND: 3,
+  /** A second cash distribution, also without a `TRN_INV` row. */
+  DISTRIBUTION: 4,
   /** Second reinvestment variant; the 3-versus-5 distinction is unconfirmed. */
   REINVEST_ALT: 5,
+  /** Reinvested distribution: opens lots, and the cash never lands. */
+  REINVEST: 9,
+  /** Opens lots with `TRN.amt` set, exactly like `BUY`. */
+  BUY_ALT: 12,
+  /** Closes lots with no cash. */
+  REMOVE_SHARES: 13,
   /** Cash corporate action. Real-world meaning unconfirmed. */
   CAPITAL_GAIN: 14,
   /** Opens lots without a cash leg. Half of a cross-account transfer. */
   ADD_SHARES: 15,
   /** Closes lots without a cash leg. **Never** a sale. */
-  REMOVE_SHARES: 16,
+  REMOVE_SHARES_LEGACY: 16,
+  /** Opens lots with no cash: the receiving half of a share transfer. */
+  TRANSFER_IN: 32,
+  /** Closes lots with no cash: the sending half of a share transfer. */
+  TRANSFER_OUT: 33,
 } as const;
 
 const ACTION_BY_CODE: ReadonlyMap<number, InvestmentAction> = new Map([
+  [MNY_ACTION.BUY_LEGACY, InvestmentAction.BUY],
   [MNY_ACTION.BUY, InvestmentAction.BUY],
   [MNY_ACTION.SELL, InvestmentAction.SELL],
-  [MNY_ACTION.REINVEST, InvestmentAction.REINVEST],
   [MNY_ACTION.DIVIDEND, InvestmentAction.DIVIDEND],
+  [MNY_ACTION.DISTRIBUTION, InvestmentAction.DIVIDEND],
   [MNY_ACTION.REINVEST_ALT, InvestmentAction.REINVEST],
+  [MNY_ACTION.REINVEST, InvestmentAction.REINVEST],
+  [MNY_ACTION.BUY_ALT, InvestmentAction.BUY],
+  [MNY_ACTION.REMOVE_SHARES, InvestmentAction.REMOVE_SHARES],
   [MNY_ACTION.CAPITAL_GAIN, InvestmentAction.CAPITAL_GAIN],
   [MNY_ACTION.ADD_SHARES, InvestmentAction.ADD_SHARES],
-  [MNY_ACTION.REMOVE_SHARES, InvestmentAction.REMOVE_SHARES],
+  [MNY_ACTION.REMOVE_SHARES_LEGACY, InvestmentAction.REMOVE_SHARES],
+  [MNY_ACTION.TRANSFER_IN, InvestmentAction.TRANSFER_IN],
+  [MNY_ACTION.TRANSFER_OUT, InvestmentAction.TRANSFER_OUT],
 ]);
 
 /**
  * Codes whose meaning is inferred rather than observed. A mapper must attach a
  * warning to every transaction it maps through one of these, so the
  * verification report shows the user what was assumed.
+ *
+ * `DISTRIBUTION` and `BUY_ALT` are here because the lots prove what they do to
+ * a position but not what Money calls them: `act` 4 is some cash distribution
+ * that is not the dividend `act` 3 already is, and `act` 12 opens lots with a
+ * cash amount exactly as `act` 1 does. Both are mapped to their observed
+ * effect and reported, which is the rule -- codes 10, 17, 18 and 20 turn up in
+ * real files with no lot to explain them, so they stay unmapped and are
+ * skipped with a warning rather than guessed at.
  */
 export const MNY_UNCONFIRMED_ACTIONS: ReadonlySet<number> = new Set([
   MNY_ACTION.REINVEST_ALT,
   MNY_ACTION.CAPITAL_GAIN,
+  MNY_ACTION.DISTRIBUTION,
+  MNY_ACTION.BUY_ALT,
+]);
+
+/**
+ * Codes that carry their amount on `TRN.amt` alone, with no `TRN_INV` row.
+ * Iterating `TRN_INV` instead of `TRN` drops every one of them, which is
+ * PR #192 issue 4.
+ */
+const CASH_ONLY_ACTIONS: ReadonlySet<number> = new Set([
+  MNY_ACTION.DIVIDEND,
+  MNY_ACTION.DISTRIBUTION,
 ]);
 
 /**
@@ -182,11 +238,12 @@ export function mapInvestmentAction(act: number): InvestmentAction | null {
 }
 
 /**
- * False for the one action that carries no `TRN_INV` row. Iterating `TRN_INV`
- * instead of `TRN` drops every cash dividend, which is PR #192 issue 4.
+ * False for the actions that carry no `TRN_INV` row -- the cash distributions.
+ * Both Money Plus files confirm it: every `act` 3 and `act` 4 row is absent
+ * from `TRN_INV`, and every other action has a row there.
  */
 export function hasInvestmentDetail(act: number): boolean {
-  return act !== MNY_ACTION.DIVIDEND;
+  return !CASH_ONLY_ACTIONS.has(act);
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/import/mny/msisam/open-mny.spec.ts
+++ b/backend/src/import/mny/msisam/open-mny.spec.ts
@@ -8,6 +8,7 @@ import {
   MnyUnreadableDatabaseError,
 } from "../mny-errors";
 import { JET_PAGE_SIZE } from "./jet-header";
+import { decryptMsisamInPlace } from "./msisam-decrypt";
 import { openDecryptedMnyFile, openMnyFile } from "./open-mny";
 
 function open(fixture: MnyFixtureName) {
@@ -200,5 +201,73 @@ describe("MnyTable", () => {
 
     expect(db.getTableOrNull("ACCT")?.rowCount).toBe(3);
     expect(db.getTableOrNull("TRN")?.rowCount).toBe(60);
+  });
+});
+
+/**
+ * `mdb-reader` writes into the buffer it reads, and a second read of those
+ * bytes returns every currency value with its sign stripped -- row counts,
+ * dates and text all stay correct, so nothing downstream looks wrong until a
+ * ledger of pure credits arrives.
+ *
+ * The wizard reads a buffer twice by design: `POST /parse` reads the upload
+ * and stages those same bytes, and the background job reads them again. That
+ * shipped as "every imported transaction is a credit, including both sides of
+ * a transfer", with account opening balances absolute too because they share
+ * `toAmount`.
+ *
+ * These guard the mechanism rather than the symptom: no committed fixture has
+ * a negative currency value, so an amount assertion would pass on the broken
+ * reader. Buffer identity would not.
+ */
+describe("reading a .mny buffer leaves it reusable", () => {
+  const TABLES = ["ACCT", "TRN", "CRNC", "PAY", "CAT"];
+
+  function readEverything(db: ReturnType<typeof openDecryptedMnyFile>) {
+    return TABLES.map((name) => db.getTableOrNull(name)?.rows() ?? null);
+  }
+
+  it.each(Object.keys(MNY_FIXTURES) as MnyFixtureName[])(
+    "does not modify the bytes of %s while reading them",
+    (fixture) => {
+      const buffer = readMnyFixture(fixture);
+      decryptMsisamInPlace(buffer, MNY_FIXTURES[fixture].password);
+      const pristine = Buffer.from(buffer);
+
+      readEverything(openDecryptedMnyFile(buffer));
+
+      expect(Buffer.compare(buffer, pristine)).toBe(0);
+    },
+  );
+
+  it.each(Object.keys(MNY_FIXTURES) as MnyFixtureName[])(
+    "returns identical rows when %s is read a second time",
+    (fixture) => {
+      const buffer = readMnyFixture(fixture);
+      decryptMsisamInPlace(buffer, MNY_FIXTURES[fixture].password);
+
+      const first = readEverything(openDecryptedMnyFile(buffer));
+      const second = readEverything(openDecryptedMnyFile(buffer));
+
+      expect(second).toEqual(first);
+    },
+  );
+
+  it("keeps the sign of a negative currency value on a re-read", () => {
+    // Built here rather than taken from a fixture: the sample files happen to
+    // hold no negative amount, which is exactly why this went unnoticed.
+    const buffer = readMnyFixture("money2002");
+    decryptMsisamInPlace(buffer, MNY_FIXTURES.money2002.password);
+
+    const amounts = (db: ReturnType<typeof openDecryptedMnyFile>) =>
+      (db.getTableOrNull("TRN")?.rows(["amt"]) ?? []).map((row) =>
+        Number(row.amt),
+      );
+
+    const first = amounts(openDecryptedMnyFile(buffer));
+    const second = amounts(openDecryptedMnyFile(buffer));
+
+    expect(first.some((amount) => amount !== 0)).toBe(true);
+    expect(second).toEqual(first);
   });
 });

--- a/backend/src/import/mny/msisam/open-mny.ts
+++ b/backend/src/import/mny/msisam/open-mny.ts
@@ -133,7 +133,20 @@ function openDatabase(
   let reader: MDBReader;
   let tableNames: string[];
   try {
-    reader = new MDBReader(buffer);
+    // `mdb-reader` writes into the bytes it reads, and the damage is silent:
+    // a second read of the same buffer returns every currency value with its
+    // sign stripped (-20.0000 reads back as 20.0000) while row counts, dates
+    // and text all stay correct. The wizard hits this on every import --
+    // `POST /parse` reads the upload and then stages those same bytes, so the
+    // background job's re-read saw an all-positive ledger: every debit became
+    // a credit, both sides of a transfer came out positive, and account
+    // opening balances were absolute too, because they share `toAmount`.
+    //
+    // The reader therefore gets its own copy and the caller's buffer stays
+    // readable plaintext. That costs one extra file-size of peak memory (see
+    // the README's Memory section) and is the price of `openMnyFile` being a
+    // door you may walk through twice.
+    reader = new MDBReader(Buffer.from(buffer));
     tableNames = reader.getTableNames();
   } catch (error) {
     throw new MnyUnreadableDatabaseError(error);


### PR DESCRIPTION
Three defects found while investigating "every imported transaction is a credit". Each is a separate commit with its own regression tests and README traps.

All findings are measured against a real 62 MB Money Plus file (4,616 lots, 53,079 `TRN` rows) and, where possible, cross-checked against the `sample.mny` shipped with Money Plus.

## 1. `mdb-reader` mutates the buffer it reads (`0de7d1fe`)

The reader writes into its input, and the corruption is silent and specific: a second read of the same bytes returns every currency value with its **sign stripped**, while row counts, dates, payees and text all stay correct.

The wizard reads a buffer twice by design — `POST /parse` reads the upload and then stages *those same bytes*; the background job reads them again. So the job saw an all-positive ledger: every debit became a credit, both sides of every transfer came out positive, and account opening balances were absolute too, because they share `toAmount`.

Same buffer, read twice:

```
read #1:                 14219 pos, 38606 neg   raw: ["-20.0000","-8.0000"]
buffer mutated by read #1: true
read #2 (same buffer):   52825 pos,     0 neg   raw: [ "20.0000", "8.0000"]
read #3 (pristine copy): 14219 pos, 38606 neg
```

`openDatabase` now hands the reader its own copy. Costs one extra file-size of peak memory, noted in the README's Memory section.

## 2. Investment action codes were backwards (`5b73cb96`)

The action table came from PR #192's format reference, which has `act 1` as SELL. `LOT.htrnBuy`/`LOT.htrnSell` are Money's own record of which transaction opened and closed each tax lot, so whatever `act` those rows carry acquires and disposes **by definition** — and `act 1` opens 3,520 lots and closes none. Every purchase was importing as a sale.

Neither Money Plus file contains a single `act 0`, the code the old table called BUY.

Retabled from lot evidence: `1` BUY, `2` SELL, `3`/`4` cash distributions with no `TRN_INV` row, `9` REINVEST, `12` buy-like, `13` remove, `32`/`33` transfer in/out. Codes `10`, `17`, `18`, `20` occur in real files but touch no lot, so they stay unmapped and are skipped with a warning rather than guessed at.

Also strips the market qualifier from symbols (`US:VTI` → `VTI`, `$US:INDU` → `$INDU`). Left on, `writeSecurities` matched existing holdings by symbol and created a second security beside the user's own `VTI`, while every quote lookup 404'd.

| | before | after |
|---|---|---|
| buys / sells | 0 / 1,835 | 1,926 / 102 |
| investment cash negative | 0 | 1,906 |
| rows mapped | 2,944 | 3,617 |
| holdings mismatches | 20+ | 5 |

The US RRSP VEA/VTI/VWO positions now reconcile exactly against Money's lots.

## 3. Bills judged against the wall clock (`e1e2bb8b`)

One scheduled transaction imported out of several dozen. `isActive` measured "is this series still live" against `todayIsoDate()`, but a `.mny` is a snapshot. The file's newest `BILL` instance is 2026-04-30 and it was imported on 2026-07-31, so every series read as more than 92 days overdue and was dropped. The same file imported differently depending on the day it was run.

The grouping was never at fault — 1,845 rows reduce correctly to 292 series, and the median series last occurred in 2013.

- `billActivityAnchor` anchors the horizon to the file's own present, falling back to `asOf` for a file still in use.
- The window becomes `max(BILL_FUTURE_HORIZON_DAYS, one cycle + BILL_PAST_HORIZON_DAYS)`. A flat quarter declared a yearly bill dead 100 days after its last occurrence — on a *current* file. Erring generous is deliberate: an extra candidate is one untick in the wizard, a missed one is dropped with no UI that mentions it.
- `rollForward` advances to the next occurrence at or after `asOf` via the shared `calculateNextDueDate`, so bills no longer arrive months overdue.

End to end: 25 candidates of 292 series, 23 written, none overdue.

## Testing

- 10,114 backend unit tests pass; lint and typecheck clean.
- Three end-to-end imports of the real file through the actual job path (stage → background job → verification), each into a throwaway user.
- The `open-mny` guards assert the **mechanism** — buffer identity and read-twice equality — not the symptom: no committed fixture holds a negative currency value, so an amount assertion passes on the broken reader. That is exactly why this shipped. Reverting the copy fails four of them.

## Reviewer notes

- **Least-covered path:** the action retable changes constants previously labelled "confirmed". Codes `0`, `5`, `14`, `15`, `16` are evidenced only by the small older fixtures (money2002 has 60 rows of `act 15`), so Money 2001/2002 imports deserve a look from someone holding such a file.
- **Not fixed here:** `start()` passes *resolved* options to the job, so `bills: []` overwrites "absent" and the documented "absent means every candidate" contract is unreachable via the API — an API/PAT caller omitting `bills` silently gets zero. The wizard always sends the list explicitly, so the UI path is unaffected. Fixing it means changing what the job row persists.
- **Not fixed here:** share transfers still pair as 0, leaving small residues on 5 securities in one fully-closed legacy account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdFLFoipQj2MG4jmhPWodr