### PR TITLE
Follow-ups from the review of the security detail page

### DIFF
--- a/backend/src/securities/investment-transactions.service.spec.ts
+++ b/backend/src/securities/investment-transactions.service.spec.ts
@@ -5370,6 +5370,25 @@ describe("InvestmentTransactionsService", () => {
       });
     });
 
+    it("reads the history in chronological order, which callers depend on", async () => {
+      // Two readers rely on this ordering and neither can recover it: the
+      // running totals below are computed by replaying the rows in sequence, and
+      // the detail page's chart takes the last row of each day as that day's
+      // closing balance (`buildQuantitySteps`). Same-day order cannot be derived
+      // from the date alone, so sorting on the client is not an option -- the
+      // order is part of this method's contract, and a future change to the
+      // query should fail here rather than quietly skew a chart.
+      investmentTransactionsRepository.find.mockResolvedValue([]);
+
+      await service.getSecurityTransactionHistory(userId, securityId);
+
+      expect(investmentTransactionsRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          order: { transactionDate: "ASC", createdAt: "ASC" },
+        }),
+      );
+    });
+
     it("computes per-account and cross-account running totals without snapping", async () => {
       investmentTransactionsRepository.find.mockResolvedValue([
         tx(

--- a/frontend/src/app/securities/[id]/page.test.tsx
+++ b/frontend/src/app/securities/[id]/page.test.tsx
@@ -6,10 +6,16 @@ import type { Security, SecurityDetail } from '@/types/investment';
 const mockPush = vi.fn();
 /** Mutable so a test can arrive with `?tab=` the way a deep link does. */
 const searchParams = { current: new URLSearchParams() };
+/**
+ * Mutable too: the switcher moves between securities with `router.push` on the
+ * same route, so a test has to be able to change the id under a mounted page the
+ * way the App Router does.
+ */
+const routeParams = { current: { id: 'sec-1' } as { id: string } };
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush, replace: vi.fn() }),
-  usePathname: () => '/securities/sec-1',
-  useParams: () => ({ id: 'sec-1' }),
+  usePathname: () => `/securities/${routeParams.current.id}`,
+  useParams: () => routeParams.current,
   useSearchParams: () => searchParams.current,
 }));
 
@@ -180,6 +186,7 @@ describe('SecurityDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     searchParams.current = new URLSearchParams();
+    routeParams.current = { id: 'sec-1' };
     mockGetSecurityDetail.mockResolvedValue(detailFixture());
     mockGetSecurityPrices.mockResolvedValue([
       {
@@ -237,6 +244,48 @@ describe('SecurityDetailPage', () => {
     expect(
       screen.getByRole('heading', { level: 1, name: 'Apple Inc.' }),
     ).toBeInTheDocument();
+  });
+
+  it('discards a load that resolves after the reader moved to another security', async () => {
+    // The switcher moves between securities on the same route, so this component
+    // stays mounted and a load started for the previous one keeps running. With
+    // nothing discarding the late response, it wrote its own figures over the new
+    // page: another instrument's position under this instrument's URL, with
+    // nothing on screen to say so.
+    let resolveSlowRead: ((detail: SecurityDetail) => void) | undefined;
+    const slowRead = new Promise<SecurityDetail>((resolve) => {
+      resolveSlowRead = resolve;
+    });
+    const microsoft = detailFixture({
+      security: { ...security, id: 'sec-2', symbol: 'MSFT', name: 'Microsoft' },
+    });
+    mockGetSecurityDetail.mockImplementation((id: string) =>
+      id === 'sec-1' ? slowRead : Promise.resolve(microsoft),
+    );
+
+    // Apple's read is still in flight when the reader picks Microsoft.
+    const { rerender } = await renderPage();
+    routeParams.current = { id: 'sec-2' };
+    await act(async () => {
+      rerender(<SecurityDetailPage />);
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { level: 1, name: 'Microsoft' }),
+      ).toBeInTheDocument();
+    });
+
+    // Only now does Apple's response arrive.
+    await act(async () => {
+      resolveSlowRead?.(detailFixture());
+    });
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Microsoft' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { level: 1, name: 'Apple Inc.' }),
+    ).not.toBeInTheDocument();
   });
 
   it('names the currency on the header quote when it is not the reader\'s', async () => {

--- a/frontend/src/app/securities/[id]/page.tsx
+++ b/frontend/src/app/securities/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
@@ -26,6 +26,7 @@ import { useOnAiAction } from '@/hooks/useOnAiAction';
 import { usePriceRefresh } from '@/hooks/usePriceRefresh';
 import { investmentsApi } from '@/lib/investments';
 import { getErrorMessage } from '@/lib/errors';
+import { SECURITY_PRICE_HISTORY_LIMIT } from '@/lib/constants';
 import { TOUR_ANCHORS, tourAnchor } from '@/lib/tours/anchors';
 import { roundToDecimals } from '@/lib/format';
 import {
@@ -147,27 +148,48 @@ function SecurityDetailContent() {
   // Only for the caret beside the name; a failure costs the switcher, not the page.
   const [securities, setSecurities] = useState<Security[]>([]);
 
+  // The security on screen right now, readable from inside an in-flight load.
+  // The switcher moves between securities on the same route (`router.push`
+  // below), so this component stays mounted and a load started for the previous
+  // one can still be running. Assigned during render so it is never a render
+  // behind the id the page is currently showing.
+  const shownIdRef = useRef(securityId);
+  shownIdRef.current = securityId;
+
   const loadData = useCallback(async () => {
+    const requestedId = securityId;
+    // Every write below is guarded on the page still showing the security this
+    // load was started for. Without it a slow response for the previous
+    // security lands after the new one's and paints its figures under the new
+    // URL -- the reader sees another instrument's position, and nothing looks
+    // wrong until they reload.
+    const isStale = () => shownIdRef.current !== requestedId;
+
     setIsLoading(true);
     setError(null);
     try {
       // The detail is the page; prices and trades feed the chart and its
       // markers, so a failure in either costs the chart, never the page.
-      const detailData = await investmentsApi.getSecurityDetail(securityId);
+      const detailData = await investmentsApi.getSecurityDetail(requestedId);
       const [priceData, historyData] = await Promise.all([
-        investmentsApi.getSecurityPrices(securityId, 9999).catch(() => []),
         investmentsApi
-          .getSecurityTransactionHistory(securityId)
+          .getSecurityPrices(requestedId, SECURITY_PRICE_HISTORY_LIMIT)
+          .catch(() => []),
+        investmentsApi
+          .getSecurityTransactionHistory(requestedId)
           .catch(() => null),
       ]);
+      if (isStale()) return;
       setDetail(detailData);
       setPrices(priceData);
       setTrades(historyData?.transactions ?? []);
     } catch (err) {
+      if (isStale()) return;
       const message = getErrorMessage(err, t('loadFailed'));
       setError(message);
     } finally {
-      setIsLoading(false);
+      // A stale load must not clear the spinner the current one put up.
+      if (!isStale()) setIsLoading(false);
     }
   }, [securityId, t]);
 
@@ -175,11 +197,17 @@ function SecurityDetailContent() {
   // the page is already on screen -- reload in place rather than through
   // loadData, whose spinner would blank everything the user was reading.
   const reloadAfterPriceRefresh = useCallback(async () => {
+    const requestedId = securityId;
     try {
       const [detailData, priceData] = await Promise.all([
-        investmentsApi.getSecurityDetail(securityId),
-        investmentsApi.getSecurityPrices(securityId, 9999).catch(() => null),
+        investmentsApi.getSecurityDetail(requestedId),
+        investmentsApi
+          .getSecurityPrices(requestedId, SECURITY_PRICE_HISTORY_LIMIT)
+          .catch(() => null),
       ]);
+      // Same guard as loadData: a refresh that resolves after the reader moved
+      // on must not write the old security's quote onto the new page.
+      if (shownIdRef.current !== requestedId) return;
       setDetail(detailData);
       if (priceData) setPrices(priceData);
     } catch {

--- a/frontend/src/components/securities/SecurityPriceHistory.tsx
+++ b/frontend/src/components/securities/SecurityPriceHistory.tsx
@@ -17,6 +17,7 @@ import { useDateFormat } from '@/hooks/useDateFormat';
 import { useLongPress } from '@/hooks/useLongPress';
 import { RowActionSheet, type RowAction } from '@/components/ui/row-actions';
 import { getErrorMessage } from '@/lib/errors';
+import { SECURITY_PRICE_HISTORY_LIMIT } from '@/lib/constants';
 import {
   groupPricesByPeriod,
   allPriceGroupKeys,
@@ -92,7 +93,10 @@ export function SecurityPriceHistory({ security }: SecurityPriceHistoryProps) {
   const loadPrices = useCallback(async () => {
     setIsLoading(true);
     try {
-      const data = await investmentsApi.getSecurityPrices(security.id, 9999);
+      const data = await investmentsApi.getSecurityPrices(
+        security.id,
+        SECURITY_PRICE_HISTORY_LIMIT,
+      );
       setPrices(data);
       // Open the newest year and month so recent prices need no click.
       setOpenGroups(

--- a/frontend/src/components/securities/detail/SecurityDocumentForm.test.tsx
+++ b/frontend/src/components/securities/detail/SecurityDocumentForm.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render } from '@/test/render';
+import { SecurityDocumentForm } from './SecurityDocumentForm';
+import type { SecurityDocument } from '@/types/investment';
+
+function existingDocument(
+  overrides: Partial<SecurityDocument> = {},
+): SecurityDocument {
+  return {
+    id: 'doc-1',
+    securityId: 'sec-1',
+    documentType: 'FACTSHEET',
+    name: 'Factsheet 2025',
+    documentDate: '2025-06-30',
+    url: 'https://ishares.com/factsheet.pdf',
+    notes: 'Quarterly',
+    createdAt: '2025-07-01T00:00:00.000Z',
+    updatedAt: '2025-07-01T00:00:00.000Z',
+    ...overrides,
+  } as SecurityDocument;
+}
+
+function fill(label: string, value: string) {
+  fireEvent.change(screen.getByLabelText(label), { target: { value } });
+}
+
+async function submit() {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Add document' }));
+  });
+}
+
+describe('SecurityDocumentForm', () => {
+  it('requires a name and an address before it will submit', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <SecurityDocumentForm onSubmit={onSubmit} onCancel={vi.fn()} />,
+    );
+
+    await submit();
+
+    await waitFor(() => {
+      expect(screen.getByText('Give the document a name')).toBeInTheDocument();
+    });
+    expect(screen.getByText('An address is required')).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('rejects an address that is not http or https', async () => {
+    // Client-side twin of the backend's protocol allowlist: the server is the
+    // authority, this just catches a typo before a round trip. A bare host is the
+    // usual mistake, and it would render an Open action that goes nowhere.
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<SecurityDocumentForm onSubmit={onSubmit} onCancel={vi.fn()} />);
+
+    fill('Name', 'Factsheet');
+    fill('Address', 'ishares.com/factsheet.pdf');
+    await submit();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('The address must start with http:// or https://'),
+      ).toBeInTheDocument();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('trims what it sends, and omits empty optional fields on create', async () => {
+    // On create an absent field means "leave it null", so it is left out of the
+    // payload entirely rather than sent as an empty string.
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<SecurityDocumentForm onSubmit={onSubmit} onCancel={vi.fn()} />);
+
+    fill('Name', '  Factsheet 2025  ');
+    fill('Address', '  https://ishares.com/factsheet.pdf  ');
+    await submit();
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith({
+      documentType: 'OTHER',
+      name: 'Factsheet 2025',
+      url: 'https://ishares.com/factsheet.pdf',
+      documentDate: undefined,
+      notes: undefined,
+    });
+  });
+
+  it('sends an explicit null when an edit clears a date or a note', async () => {
+    // Regression guard for the reason `cleared` exists: the server assigns only
+    // what the request carries, so omitting a cleared field left the old value in
+    // place and clearing a date was impossible from the UI.
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <SecurityDocumentForm
+        document={existingDocument()}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fill('Document date', '');
+    fill('Notes', '');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save document' }));
+    });
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ documentDate: null, notes: null }),
+    );
+  });
+
+  it('keeps the form open when the caller rejects', async () => {
+    // The caller surfaces its own error; rethrowing here would leave
+    // react-hook-form with an unhandled rejection.
+    const onSubmit = vi.fn().mockRejectedValue(new Error('taken'));
+    render(<SecurityDocumentForm onSubmit={onSubmit} onCancel={vi.fn()} />);
+
+    fill('Name', 'Factsheet');
+    fill('Address', 'https://ishares.com/f.pdf');
+    await submit();
+    await act(async () => {});
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(screen.getByLabelText('Name')).toBeInTheDocument();
+  });
+
+  it('offers Save rather than Add when editing', async () => {
+    render(
+      <SecurityDocumentForm
+        document={existingDocument()}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Save document' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Add document' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/securities/detail/SecurityKeyInformation.test.tsx
+++ b/frontend/src/components/securities/detail/SecurityKeyInformation.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { render } from '@/test/render';
+import { SecurityKeyInformation } from './SecurityKeyInformation';
+import type { Security } from '@/types/investment';
+import type { SecurityPricePoint } from '@/lib/security-detail';
+
+/** The user's own default provider, which a security without one inherits. */
+const preferences = { current: { defaultQuoteProvider: 'msn' } as { defaultQuoteProvider: string } | null };
+vi.mock('@/store/preferencesStore', () => ({
+  usePreferencesStore: (selector: (state: unknown) => unknown) =>
+    selector({ preferences: preferences.current }),
+}));
+
+function security(overrides: Partial<Security> = {}): Security {
+  return {
+    id: 'sec-1',
+    symbol: 'IUSQ',
+    name: 'All World',
+    securityType: 'ETF',
+    exchange: 'XETRA',
+    currencyCode: 'EUR',
+    description: null,
+    tags: [],
+    isActive: true,
+    isFavourite: false,
+    skipPriceUpdates: false,
+    sector: null,
+    industry: null,
+    sectorWeightings: null,
+    countryWeightings: null,
+    assetWeightings: null,
+    website: null,
+    irWebsite: null,
+    quoteProvider: 'yahoo',
+    msnInstrumentId: null,
+    lastPriceSource: null,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/** Two points that agree: an adjusted series exists and nothing was paid out. */
+const accumulating: SecurityPricePoint[] = [
+  { date: '2024-01-01', close: 100, totalReturnClose: 100 },
+  { date: '2025-01-01', close: 120, totalReturnClose: 120 },
+];
+
+/** No adjusted series at all, as MSN supplies. */
+const noAdjustedSeries: SecurityPricePoint[] = [
+  { date: '2024-01-01', close: 100 },
+  { date: '2025-01-01', close: 120 },
+];
+
+describe('SecurityKeyInformation', () => {
+  beforeEach(() => {
+    preferences.current = { defaultQuoteProvider: 'msn' };
+  });
+
+  it('drops the rows a thinly-filled security has no value for', () => {
+    // A column of dashes says nothing; `KeyValueList` omits an empty row, so this
+    // has to stay true as rows are added.
+    render(
+      <SecurityKeyInformation
+        security={security({ exchange: null, sector: null, industry: null })}
+        latestPrice={null}
+        prices={[]}
+      />,
+    );
+
+    expect(screen.getByText('Symbol')).toBeInTheDocument();
+    expect(screen.queryByText('Exchange')).not.toBeInTheDocument();
+    expect(screen.queryByText('Sector')).not.toBeInTheDocument();
+    expect(screen.queryByText('Industry')).not.toBeInTheDocument();
+    expect(screen.queryByText('Last price')).not.toBeInTheDocument();
+  });
+
+  it('states the distribution behaviour it can read off the price history', () => {
+    render(
+      <SecurityKeyInformation
+        security={security()}
+        latestPrice={null}
+        prices={accumulating}
+      />,
+    );
+
+    expect(screen.getByText('Distributions')).toBeInTheDocument();
+    // Worded as observed from data, not declared by the issuer.
+    expect(screen.getByText('None (accumulating)')).toBeInTheDocument();
+  });
+
+  it('drops the distribution row rather than guessing without an adjusted series', () => {
+    render(
+      <SecurityKeyInformation
+        security={security()}
+        latestPrice={null}
+        prices={noAdjustedSeries}
+      />,
+    );
+
+    expect(screen.queryByText('Distributions')).not.toBeInTheDocument();
+  });
+
+  it('names the effective provider, never a blank row', () => {
+    // A security with no provider of its own uses the user's default, so the
+    // answer here is what will actually be asked for a quote.
+    render(
+      <SecurityKeyInformation
+        security={security({ quoteProvider: null })}
+        latestPrice={null}
+        prices={[]}
+      />,
+    );
+
+    expect(screen.getByText('Provider')).toBeInTheDocument();
+    expect(screen.getByText('MSN')).toBeInTheDocument();
+  });
+
+  it('falls back to Yahoo when the user has no default either', () => {
+    preferences.current = null;
+    render(
+      <SecurityKeyInformation
+        security={security({ quoteProvider: null })}
+        latestPrice={null}
+        prices={[]}
+      />,
+    );
+
+    expect(screen.getByText('Yahoo')).toBeInTheDocument();
+  });
+
+  it('dates the last price, because a stale quote reads as a current one', () => {
+    render(
+      <SecurityKeyInformation
+        security={security()}
+        latestPrice={{ price: 123.45, priceDate: '2026-07-28' }}
+        prices={[]}
+      />,
+    );
+
+    expect(screen.getByText('Last price')).toBeInTheDocument();
+    expect(screen.getByText(/123\.45/)).toBeInTheDocument();
+    expect(screen.getByText(/2026/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/securities/detail/SecurityPerformanceCard.test.tsx
+++ b/frontend/src/components/securities/detail/SecurityPerformanceCard.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { render } from '@/test/render';
+import { SecurityPerformanceCard } from './SecurityPerformanceCard';
+import type { SecurityPricePoint } from '@/lib/security-detail';
+
+/**
+ * Periods are measured against the real clock (`periodStartDate` defaults to
+ * `new Date()`), so fixtures are dated relative to today rather than pinned --
+ * a hard-coded 2024 series would drift out of every window as time passes.
+ */
+const TODAY = new Date();
+
+function isoDaysAgo(days: number): string {
+  const date = new Date(TODAY);
+  date.setDate(date.getDate() - days);
+  return date.toISOString().slice(0, 10);
+}
+
+/** Oldest-first series, as the card documents its input. */
+function series(
+  points: readonly { daysAgo: number; close: number; adjusted?: number }[],
+): SecurityPricePoint[] {
+  return points
+    .map((point) => ({
+      date: isoDaysAgo(point.daysAgo),
+      close: point.close,
+      totalReturnClose: point.adjusted,
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+describe('SecurityPerformanceCard', () => {
+  it('reports the periods the history covers', () => {
+    render(
+      <SecurityPerformanceCard
+        prices={series([
+          { daysAgo: 40, close: 100 },
+          { daysAgo: 0, close: 110 },
+        ])}
+      />,
+    );
+
+    expect(screen.getByText('Security performance')).toBeInTheDocument();
+    // 1M reaches back 30 days, so the 40-day-old point is its baseline: +10%.
+    expect(screen.getByText('+10.00%')).toBeInTheDocument();
+  });
+
+  it('says n/a for a period the history does not reach, rather than 0%', () => {
+    // The distinction the card exists to make: a zero here would be a statement
+    // about the security's performance instead of about our data.
+    render(
+      <SecurityPerformanceCard
+        prices={series([
+          { daysAgo: 40, close: 100 },
+          { daysAgo: 0, close: 110 },
+        ])}
+      />,
+    );
+
+    // 3M, YTD, 1Y, 3Y and 5Y all start before the oldest point. YTD is the one
+    // that depends on the date the test runs, so this counts at least four.
+    expect(screen.getAllByText('n/a').length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('states that dividends are included when an adjusted series exists', () => {
+    render(
+      <SecurityPerformanceCard
+        prices={series([
+          { daysAgo: 40, close: 100, adjusted: 97 },
+          { daysAgo: 0, close: 110, adjusted: 110 },
+        ])}
+      />,
+    );
+
+    expect(screen.getByText('Includes dividends')).toBeInTheDocument();
+    expect(screen.queryByText('Excludes dividends')).not.toBeInTheDocument();
+  });
+
+  it('warns that dividends are excluded when the provider supplies no adjusted close', () => {
+    // MSN supplies none. A distributing fund then looks worse than it was by its
+    // whole yield, which the card has to say rather than leave to be discovered.
+    render(
+      <SecurityPerformanceCard
+        prices={series([
+          { daysAgo: 40, close: 100 },
+          { daysAgo: 0, close: 110 },
+        ])}
+      />,
+    );
+
+    expect(screen.getByText('Excludes dividends')).toBeInTheDocument();
+  });
+
+  it('shows the empty state, and no dividend caption, without enough history', () => {
+    render(<SecurityPerformanceCard prices={series([{ daysAgo: 0, close: 110 }])} />);
+
+    expect(
+      screen.getByText('Not enough price history to measure a return yet.'),
+    ).toBeInTheDocument();
+    // A caption about what the figures include, with no figures, is noise.
+    expect(screen.queryByText('Includes dividends')).not.toBeInTheDocument();
+    expect(screen.queryByText('Excludes dividends')).not.toBeInTheDocument();
+  });
+
+  it('separates the security\'s return from the holder\'s', () => {
+    // Readers take any "Performance" heading on a page about their own holding to
+    // mean their own return; the subtitle is what stops that misreading.
+    render(<SecurityPerformanceCard prices={series([{ daysAgo: 0, close: 110 }])} />);
+
+    expect(screen.getByText(/whether or not you held it/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/securities/detail/SecurityPositionState.test.tsx
+++ b/frontend/src/components/securities/detail/SecurityPositionState.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { render } from '@/test/render';
+import { SecurityPositionState } from './SecurityPositionState';
+import type { SecurityDetail } from '@/types/investment';
+
+function detail(overrides: {
+  hasTransactions?: boolean;
+  activity?: Partial<SecurityDetail['activity']>;
+}): SecurityDetail {
+  return {
+    security: {
+      id: 'sec-1',
+      symbol: 'AAPL',
+      name: 'Apple Inc.',
+      securityType: 'STOCK',
+      exchange: 'NASDAQ',
+      currencyCode: 'USD',
+      description: null,
+      tags: [],
+      isActive: true,
+      isFavourite: false,
+      skipPriceUpdates: false,
+      sector: null,
+      industry: null,
+      sectorWeightings: null,
+      countryWeightings: null,
+      assetWeightings: null,
+      website: null,
+      irWebsite: null,
+      quoteProvider: 'yahoo',
+      msnInstrumentId: null,
+      lastPriceSource: null,
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    },
+    // Nothing is held in either case this panel covers, so every figure is zero.
+    // The panel exists precisely so those zeroes are never rendered as a summary.
+    position: {
+      quantity: 0,
+      averageCost: 0,
+      currentPrice: 0,
+      costBasis: 0,
+      marketValue: 0,
+      gainLoss: 0,
+      gainLossPercent: 0,
+    },
+    accounts: [],
+    activity: {
+      firstTransactionDate: '2022-03-12',
+      lastTransactionDate: '2025-06-20',
+      totalInvested: 5000,
+      totalSold: 6000,
+      dividends: 0,
+      fees: 0,
+      realizedGain: 1000,
+      realizedGainCurrency: 'USD',
+      realizedGainCurrencies: ['USD'],
+      realizedSaleCount: 1,
+      transactionCount: 2,
+      ...overrides.activity,
+    },
+    hasTransactions: overrides.hasTransactions ?? true,
+    isPositionClosed: true,
+  } as SecurityDetail;
+}
+
+describe('SecurityPositionState', () => {
+  it('tells a never-traded security apart from a closed one', () => {
+    // Zero-filled cards would claim a value of zero where the truth is "nothing
+    // here yet", which is why this panel exists instead.
+    render(<SecurityPositionState detail={detail({ hasTransactions: false })} />);
+
+    expect(screen.getByText('No position data')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'You have not recorded any transactions for this security yet.',
+      ),
+    ).toBeInTheDocument();
+    // Nothing was ever sold, so there is no realised result to report.
+    expect(screen.queryByText('Realized P/L')).not.toBeInTheDocument();
+    expect(screen.queryByText('Position closed')).not.toBeInTheDocument();
+  });
+
+  it('reports the realised result and the period it was held once closed', () => {
+    render(<SecurityPositionState detail={detail({})} />);
+
+    expect(screen.getByText('Position closed')).toBeInTheDocument();
+    expect(screen.getByText('Realized P/L')).toBeInTheDocument();
+    // A gain carries its sign explicitly: "1,000.00" alone reads as a balance.
+    expect(screen.getByText(/\+.*1,000\.00/)).toBeInTheDocument();
+    expect(screen.getByText('Held from')).toBeInTheDocument();
+  });
+
+  it('omits the realised figure when sales spanned several currencies', () => {
+    // The backend sends null rather than adding up two currencies; showing a bare
+    // number here would imply a conversion the page never performs.
+    render(
+      <SecurityPositionState
+        detail={detail({
+          activity: { realizedGain: null, realizedGainCurrency: null },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Position closed')).toBeInTheDocument();
+    expect(screen.queryByText('Realized P/L')).not.toBeInTheDocument();
+    // The held period is independent of currency, so it stays.
+    expect(screen.getByText('Held from')).toBeInTheDocument();
+  });
+
+  it('omits the held period when the dates are unknown', () => {
+    render(
+      <SecurityPositionState
+        detail={detail({
+          activity: { firstTransactionDate: null, lastTransactionDate: null },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Position closed')).toBeInTheDocument();
+    expect(screen.queryByText('Held from')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -2,6 +2,19 @@ import { formatDate } from './utils';
 
 export const PAGE_SIZE = 50;
 
+/**
+ * Rows to ask for when a screen wants a security's whole price history: the
+ * detail page's chart, its Performance card and the price table all reason over
+ * the complete series, so a page of prices would give them a partial answer that
+ * still looks like a total.
+ *
+ * It is a cap rather than "everything" because the endpoint requires a limit.
+ * ~40 years of daily closes fits, which is beyond any history a provider
+ * backfills -- but a series longer than this is silently truncated, so a screen
+ * that starts reporting a suspiciously short "all" range should look here first.
+ */
+export const SECURITY_PRICE_HISTORY_LIMIT = 9999;
+
 type DateFormatOption = { value: string; label: string };
 
 /**

--- a/frontend/src/lib/security-detail.test.ts
+++ b/frontend/src/lib/security-detail.test.ts
@@ -142,6 +142,21 @@ describe('inferDistributionPolicy', () => {
     ).toBe('distributing');
   });
 
+  it('ignores an adjusted close above the quoted one, which is bad data', () => {
+    // Back-adjustment only ever pushes the adjusted series *below* the quoted
+    // one, so a point above it says nothing about distributions -- it says the
+    // row is wrong. Reading the gap unsigned let a single such row relabel an
+    // accumulating fund as distributing, and the label then stuck for every
+    // reader of the page.
+    expect(
+      inferDistributionPolicy([
+        { date: '2024-01-01', close: 100, totalReturnClose: 100 },
+        { date: '2024-06-01', close: 101, totalReturnClose: 101 },
+        { date: '2025-01-01', close: 103, totalReturnClose: 103.5 },
+      ]),
+    ).toBe('accumulating');
+  });
+
   it('ignores a gap that is only provider rounding', () => {
     // Six decimal places of storage can leave a hair of difference; that is not
     // a dividend.
@@ -261,6 +276,43 @@ describe('buildChartSeries', () => {
       // The 15 Feb top-up doubles the position before the March point.
       { date: '2024-03-01', balance: 1800 },
     ]);
+  });
+
+  it('walks the steps once and still reads every date as quantityAt does', () => {
+    // Value mode advances a cursor through the steps instead of re-scanning them
+    // per price point. The cases that separate a correct walk from a plausible
+    // one: a price before any trade, several steps between two prices (the last
+    // one wins), and a step landing exactly on a price date (it counts that day).
+    const prices = [
+      { date: '2024-01-01', close: 10 },
+      { date: '2024-06-01', close: 10 },
+      { date: '2024-06-15', close: 10 },
+      { date: '2024-12-01', close: 10 },
+    ];
+    const manySteps = [
+      { date: '2024-03-01', quantity: 5 },
+      { date: '2024-04-01', quantity: 9 },
+      { date: '2024-05-01', quantity: 12 },
+      { date: '2024-06-15', quantity: 20 },
+    ];
+
+    expect(buildChartSeries(prices, manySteps, 'value')).toEqual([
+      // Before the first trade: nothing held, so the position is worth nothing.
+      { date: '2024-01-01', balance: 0 },
+      // Three steps passed between January and June; only the newest holds.
+      { date: '2024-06-01', balance: 120 },
+      // A step dated the same day as the price counts on that day.
+      { date: '2024-06-15', balance: 200 },
+      { date: '2024-12-01', balance: 200 },
+    ]);
+
+    // Same answer the per-point lookup gives, which is the contract the walk
+    // replaced.
+    for (const point of prices) {
+      const viaLookup = point.close * quantityAt(manySteps, point.date);
+      const viaWalk = buildChartSeries([point], manySteps, 'value')[0].balance;
+      expect(viaWalk).toBe(viaLookup);
+    }
   });
 
   it('uses the adjusted series in return mode, matching the Performance card', () => {
@@ -617,6 +669,15 @@ describe('priceDecimals', () => {
 
   it('caps at what the price columns can store', () => {
     expect(priceDecimals([1.23456789012345])).toBe(MAX_PRICE_DECIMALS);
+  });
+
+  it('is not widened by binary float noise in one value', () => {
+    // 0.1 + 0.2 is 0.30000000000000004, seventeen countable decimals. Counting
+    // them took the whole column to the cap, so a table of two-decimal prices
+    // rendered as 93.1800000000 because one value had been through arithmetic.
+    // Storage is NUMERIC(24,10); past the tenth place there is no information to
+    // preserve.
+    expect(priceDecimals([0.1 + 0.2, 93.18])).toBe(2);
   });
 
   it('goes to the cap for a price written in exponent form', () => {

--- a/frontend/src/lib/security-detail.ts
+++ b/frontend/src/lib/security-detail.ts
@@ -161,9 +161,19 @@ export function inferDistributionPolicy(
   // because no distribution has happened since).
   if (comparable.length < 2) return 'unknown';
 
+  // Only a gap in the direction back-adjustment actually produces counts: the
+  // adjusted series runs *below* the quoted one, never above. An adjusted close
+  // above the quoted close is bad provider data, and reading it as a
+  // distribution would relabel an accumulating fund on the strength of the one
+  // thing this model says cannot happen.
+  //
+  // One diverging point is still enough. A distribution back-adjusts every close
+  // before it, so a long history diverges across a stretch -- but a series with
+  // only one point older than the payout has only that one to show it, and
+  // demanding two would read that fund as accumulating.
   const diverges = comparable.some(
     (point) =>
-      Math.abs((point.totalReturnClose as number) - point.close) / point.close >
+      (point.close - (point.totalReturnClose as number)) / point.close >
       DISTRIBUTION_EPSILON,
   );
   return diverges ? 'distributing' : 'accumulating';
@@ -204,10 +214,26 @@ export function buildChartSeries(
   }
 
   if (mode === 'value') {
-    return window.map((point) => ({
-      date: point.date,
-      balance: roundToDecimals(point.close * quantityAt(steps, point.date), 4),
-    }));
+    // Both series are date-ordered, so one walk over the steps serves the whole
+    // window. Calling `quantityAt` per point re-scans the steps from the
+    // beginning each time, which is O(points x steps) -- fine for a month of a
+    // lightly traded holding, wasteful for a decade of daily closes against
+    // years of trades, and this runs on every chart render.
+    let stepIndex = 0;
+    let quantity = 0;
+    return window.map((point) => {
+      while (
+        stepIndex < steps.length &&
+        steps[stepIndex].date <= point.date
+      ) {
+        quantity = steps[stepIndex].quantity;
+        stepIndex += 1;
+      }
+      return {
+        date: point.date,
+        balance: roundToDecimals(point.close * quantity, 4),
+      };
+    });
   }
 
   // Return mode reads the same adjusted series the Performance card does, so the
@@ -467,7 +493,12 @@ const MIN_PRICE_DECIMALS = 2;
 /** Decimal places a single number is written with, or null if not readable. */
 function decimalPlacesOf(value: number): number | null {
   if (!isFinite(value)) return null;
-  const text = Math.abs(value).toString();
+  // Round to the most a column will ever show before counting. Otherwise binary
+  // float noise decides the width of the whole column: a value that arrived as
+  // 0.30000000000000004 rather than 0.3 counts as seventeen decimals and takes
+  // every row to the maximum. Storage is NUMERIC(24,10), so nothing past the
+  // tenth place is information anyway.
+  const text = Math.abs(roundToDecimals(value, MAX_PRICE_DECIMALS)).toString();
   // Exponent form (a very small price): the digits are there but not countable
   // this way, so let the caller fall back to the maximum.
   if (text.includes('e')) return null;


### PR DESCRIPTION
## Linked discussion / issue

Closes # <!-- no separate issue: this hardens work already merged, see below -->
Approved in: #964

#964 scoped the security detail page and #992 implemented it. This PR is hardening
inside that scope: it adds no screen, no endpoint, no user-facing string and no new
behaviour to agree on -- it corrects three defects in what #992 shipped and covers
four of its components that landed without tests. All three findings came from
re-reading that merged code, and each is described below with the way it fails.

## Summary

Three findings from a review of the security detail page (#992), as three
commits.

**1. A load is no longer written after the reader moves to another security.**
The switcher navigates with `router.push` on the same route, so the page stays
mounted and only its id changes -- a load started for the previous security keeps
running, and nothing stopped its response from writing state. A slow read for
AAPL resolving after MSFT's painted Apple's position, accounts and chart under
Microsoft's URL, with nothing on screen to say so. The window is wider than it
looks: the detail is awaited, then prices and trades, and only then is any of it
stored. Every write now checks the page is still showing the security the load
was started for -- including `isLoading`, since a stale load clearing it hid the
current load's own spinner. The test drives the real sequence and fails on the
previous code.

Also names the price-history limit: `9999` sat at three call sites with no
explanation, and a series longer than it is silently truncated.

**2. The distribution inference read a gap in either direction.** It compared the
adjusted and quoted closes with `Math.abs`, but back-adjustment only ever pushes
the adjusted series *below* the quoted one -- the function's own comment says so
and cites the pair it was checked against. An adjusted close above the quoted one
is bad provider data, and a single such row relabelled an accumulating fund as
"Paid (observed)" for every reader. The comparison is now signed. Two smaller
corrections in the same file: `priceDecimals` counted binary float noise as
precision, so one value that arrived as `0.30000000000000004` took a column of
two-decimal prices to ten places; and value mode re-scanned the quantity steps
per price point, which one cursor over the steps replaces.

**3. Four of the fifteen detail components shipped without co-located tests.**
`SecurityDocumentForm` (validation, and the explicit `null` an edit needs to clear
a date), `SecurityPerformanceCard` ("n/a" rather than 0% for an uncovered period),
`SecurityPositionState` (never-traded vs. sold-down-to-nothing), and
`SecurityKeyInformation` (valueless rows dropped, effective provider named). Plus
one contract test on the backend: `getSecurityTransactionHistory` must return rows
in chronological order, because its own running totals replay them in sequence and
the chart takes the last row of each day as that day's balance -- same-day order
cannot be recovered from the date, so this belongs in a test rather than in a
comment.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

Where a tick needs a word:

- **Approved in #964**: no discussion of its own. The scope is #964's, already
  agreed and shipped as #992; this only hardens it, and adds nothing that would
  need agreeing separately. If you would rather see hardening go through
  propose-first as well, say so and I will open one.
- **Single concern**: "the findings from one review of #992". They are three
  separable commits, and I first had them as three branches; tell me if you would
  rather review three PRs and I will split them back out.
- **i18n parity**: no catalog file is touched and no user-facing string is added
  or changed -- the diff is 11 files, none under `i18n/`. `npm run i18n:check`
  passes and `messages.parity.test.ts` is green (1352 assertions), both unchanged
  from `main`.
- **Shared/core areas**: nothing existing is refactored. `lib/constants.ts` is
  purely additive (one new export plus its comment); `lib/security-detail.ts` is
  the detail page's own logic module, used only by the securities screens; the
  remaining nine files are under `securities/` or are new test files.

Verified on this branch, at `origin/main` after #1004:

- `tsc --noEmit` clean, both apps.
- `npm run lint` exits 0. One pre-existing warning remains, in
  `components/ui/Combobox.tsx` -- a file this PR does not touch.
- Frontend suite: 599 files, 11 835 tests, green.
- `investment-transactions.service.spec.ts`, which gains the contract test:
  211/211.
- The stale-load test was also run against the unpatched page and fails there, so
  it is a regression test rather than a description of current behaviour.

## AI assistance disclosure

Written with Claude Code (Opus 5), including the review that found all three
items. The two behavioural fixes were verified to fail before and pass after:
the stale-load test was run against the unpatched page, and the
distribution-direction and float-noise cases were reproduced numerically first.
I have read the result and own it.
