### PR TITLE
docs(rls): correct stale migration numbers, M3 target list, T1 glob trap, L1 allowlist

### DIFF
--- a/backend/test/helpers/integration-setup.ts
+++ b/backend/test/helpers/integration-setup.ts
@@ -16,6 +16,7 @@ import { ScheduledTransactionOverrideService } from "@/scheduled-transactions/sc
 import { ScheduledTransactionLoanService } from "@/scheduled-transactions/scheduled-transaction-loan.service";
 import type { TypeOrmModuleOptions } from "@nestjs/typeorm";
 import * as bcrypt from "bcryptjs";
+import { applyRlsPolicies } from "./rls-setup";
 
 /**
  * Shared PostgreSQL connection options for integration suites. Specs that need
@@ -124,6 +125,12 @@ export async function createIntegrationModule(
     });
 
   const module = await moduleBuilder.compile();
+
+  // Bring the synchronize-built schema up to the real database's shape: runtime
+  // role + grants, RLS helper functions and policies, updated_at triggers (T1).
+  // Policies ship without ENABLE, so this is inert for suites that do not opt
+  // into enforcement -- see rls-setup.ts.
+  await applyRlsPolicies(module.get(DataSource));
 
   // Mock triggerDebouncedRecalc to prevent timer leaks
   const netWorthService = module.get(NetWorthService);

--- a/backend/test/helpers/rls-setup.ts
+++ b/backend/test/helpers/rls-setup.ts
@@ -1,0 +1,245 @@
+import * as fs from "fs";
+import * as path from "path";
+import { DataSource } from "typeorm";
+
+import { provisionAppRole } from "@/common/db/app-role";
+import { DEFAULT_APP_USER } from "@/common/db/rls-config";
+
+/**
+ * RLS task T1: make the integration harness look like a real database.
+ *
+ * `synchronize: true` builds the schema from entity metadata, which gives the
+ * integration suites tables and columns but **none** of the database objects
+ * that only exist in SQL: no `monize_app` role, no grants, no RLS helper
+ * functions, no policies, and no `updated_at` triggers. Every one of those is
+ * something the RLS work depends on, so without this step T2's enforcement
+ * assertions and C5's restore acceptance would pass vacuously against a
+ * database that simply has nothing to enforce.
+ *
+ * What this does NOT do is enable row-level security. The policies ship inert
+ * (M2) and the enable is its own migration (M3, flip B), so applying policies
+ * here leaves every existing suite behaving exactly as it did -- a policy on a
+ * table without `ENABLE ROW LEVEL SECURITY` is never consulted by the planner.
+ * A spec that wants enforcement opts into it explicitly.
+ */
+
+const MIGRATIONS_DIR = path.join(__dirname, "../../../database/migrations");
+const SCHEMA_SQL = path.join(__dirname, "../../../database/schema.sql");
+
+/**
+ * Password for the test-only runtime role. Not a secret: the role exists in the
+ * throwaway `monize_test` database so specs can `SET LOCAL ROLE` to a non-owner
+ * and observe policies actually filtering (the owner bypasses RLS).
+ */
+export const TEST_APP_ROLE_PASSWORD = "monize_test_app_password";
+
+/** Role name the harness provisions, matching the app's default. */
+export const TEST_APP_ROLE = process.env.DATABASE_APP_USER || DEFAULT_APP_USER;
+
+/**
+ * Selects the migrations that carry RLS objects, by **content** rather than by
+ * filename.
+ *
+ * A `*_rls_*.sql` glob is the obvious approach and it is wrong: it matches
+ * `111`-`114` and `118_security_documents_rls.sql` but misses the policies for
+ * `import_staged_files` and `import_jobs`, which live inside
+ * `117_mny_import_staging_and_jobs.sql` -- a feature migration that creates two
+ * tables and policies them in the same file. That is the *correct* pattern for
+ * a new table (the policy ships with the table that needs it), so the harness
+ * has to find policies wherever they are, not where a naming convention says
+ * they should be.
+ *
+ * Every RLS object references one of the identity helpers -- each policy
+ * predicate calls `app_current_user_id()` or `app_bypass_rls()`, and the
+ * helpers' own migration defines them -- so that reference is the marker. It
+ * selects exactly the RLS files today and picks up any future migration that
+ * policies a new table, with no per-file registration to forget.
+ */
+export function findRlsMigrations(): string[] {
+  if (!fs.existsSync(MIGRATIONS_DIR)) {
+    throw new Error(`Migrations directory not found at ${MIGRATIONS_DIR}`);
+  }
+
+  const files = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    // Filename order, which is what db-migrate uses -- note that `116_*` and
+    // `117_*` each have two files, so numeric-prefix order is ambiguous and
+    // alphabetical tie-breaking is what keeps `117_security_documents` ahead of
+    // `118_security_documents_rls`.
+    .sort();
+
+  const rlsFiles = files.filter((f) => {
+    const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, f), "utf8");
+    return /app_current_user_id|app_bypass_rls/.test(sql);
+  });
+
+  if (rlsFiles.length === 0) {
+    throw new Error(
+      `No RLS migrations found in ${MIGRATIONS_DIR}. The harness applies migrations ` +
+        "by content marker (app_current_user_id / app_bypass_rls); finding none means " +
+        "either the migrations are missing or the marker changed.",
+    );
+  }
+
+  return rlsFiles.map((f) => path.join(MIGRATIONS_DIR, f));
+}
+
+/**
+ * Table names each migration file declares a policy for, in both shapes the
+ * migrations use: an explicit `CREATE POLICY x ON t`, and the `DO` block in
+ * `112` that loops a `text[]` of table names through `EXECUTE format(...)`.
+ * Used as a post-condition -- what was declared has to exist in `pg_policies`
+ * once the files have been applied.
+ */
+function declaredPolicyTables(sql: string): string[] {
+  const tables = new Set<string>();
+
+  // `CREATE POLICY name ON table` -- deliberately not `POLICY ... ON`, which
+  // would also match the `DROP POLICY IF EXISTS` that precedes each one.
+  for (const match of sql.matchAll(/CREATE\s+POLICY\s+\w+\s+ON\s+(\w+)/gi)) {
+    tables.add(match[1]);
+  }
+
+  // The looped form: a `text[] := ARRAY[...]` of table names in a file whose
+  // DO block builds a CREATE POLICY through `format()`.
+  if (/EXECUTE\s+format\(/i.test(sql) && /'CREATE POLICY/i.test(sql)) {
+    for (const arrayMatch of sql.matchAll(
+      /text\[\]\s*:=\s*ARRAY\[([^\]]*)\]/gi,
+    )) {
+      for (const name of arrayMatch[1].matchAll(/'(\w+)'/g)) {
+        tables.add(name[1]);
+      }
+    }
+  }
+
+  return [...tables];
+}
+
+/**
+ * The `updated_at` triggers, extracted from `schema.sql`.
+ *
+ * `synchronize` creates no database triggers at all -- `@UpdateDateColumn`
+ * stamps the column app-side -- and the RLS migrations only replace the trigger
+ * *function*, never attach it to a table that has no trigger yet. So without
+ * this step the GUC-aware trigger from M1 exists but fires nowhere, and any
+ * assertion about `app.preserve_timestamps` (T2) or about restore preserving
+ * timestamps (C5) would pass without testing anything.
+ *
+ * The DDL is read from `schema.sql` rather than rebuilt from a list here, so a
+ * table that gains a trigger gains it in the harness too.
+ */
+function updatedAtTriggers(): { trigger: string; table: string }[] {
+  if (!fs.existsSync(SCHEMA_SQL)) {
+    throw new Error(`Schema not found at ${SCHEMA_SQL}`);
+  }
+  const sql = fs.readFileSync(SCHEMA_SQL, "utf8");
+
+  // Whitespace-tolerant: schema.sql has these in both one-line and multi-line
+  // form, and the two are otherwise identical.
+  const pattern =
+    /CREATE\s+TRIGGER\s+(\w+)\s+BEFORE\s+UPDATE\s+ON\s+(\w+)\s+FOR\s+EACH\s+ROW\s+EXECUTE\s+(?:FUNCTION|PROCEDURE)\s+update_updated_at_column\(\)/gi;
+
+  const triggers = [...sql.matchAll(pattern)].map((m) => ({
+    trigger: m[1],
+    table: m[2],
+  }));
+
+  if (triggers.length === 0) {
+    throw new Error(
+      `No updated_at triggers found in ${SCHEMA_SQL}. The extraction pattern and the ` +
+        "schema have diverged; fix the pattern rather than skipping the triggers, or " +
+        "every timestamp assertion downstream passes vacuously.",
+    );
+  }
+
+  return triggers;
+}
+
+/**
+ * Brings a `synchronize`-built test database up to the shape the real one has:
+ * the runtime role and its grants, the RLS helper functions and policies, and
+ * the `updated_at` triggers.
+ *
+ * Call after the schema exists (i.e. after `DataSource.initialize()` with
+ * `synchronize: true`). Idempotent, and re-applied per suite because
+ * `dropSchema: true` takes the functions, policies and triggers down with the
+ * tables on every suite start.
+ */
+export async function applyRlsPolicies(dataSource: DataSource): Promise<void> {
+  // 1. The role first: the grants below are meaningless without it, and a spec
+  //    doing `SET LOCAL ROLE monize_app` needs it to exist. Never throws on a
+  //    privilege shortfall -- it warns -- so the grant assertion below is what
+  //    actually proves it worked.
+  await provisionAppRole(dataSource, {
+    appUser: TEST_APP_ROLE,
+    appPassword: TEST_APP_ROLE_PASSWORD,
+    logger: { log: () => {}, warn: () => {} },
+  });
+
+  const [{ exists: roleExists }] = await dataSource.query(
+    "SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = $1) AS exists",
+    [TEST_APP_ROLE],
+  );
+  if (!roleExists) {
+    throw new Error(
+      `Runtime role '${TEST_APP_ROLE}' was not created. The test database owner needs ` +
+        "CREATEROLE; without the role, enforcement specs cannot switch off owner bypass.",
+    );
+  }
+
+  // 2. The RLS migrations, read from disk so the harness can never drift from
+  //    what ships.
+  const migrations = findRlsMigrations();
+  const declared = new Set<string>();
+
+  for (const file of migrations) {
+    const sql = fs.readFileSync(file, "utf8");
+    try {
+      await dataSource.query(sql);
+    } catch (err) {
+      // Name the file: a bare Postgres error in a 6-file apply is unhelpful.
+      throw new Error(
+        `Failed applying RLS migration ${path.basename(file)}: ${(err as Error).message}`,
+      );
+    }
+    for (const table of declaredPolicyTables(sql)) {
+      declared.add(table);
+    }
+  }
+
+  // 3. Post-condition: every policy the applied files declare exists in the
+  //    database. Catches a file that applied without error but whose DO block
+  //    took a branch that skipped the policies, and any future shape of
+  //    migration the extraction above does not understand.
+  const policied = new Set<string>(
+    (
+      await dataSource.query(
+        "SELECT DISTINCT tablename FROM pg_policies WHERE schemaname = 'public'",
+      )
+    ).map((r: { tablename: string }) => r.tablename),
+  );
+  const missing = [...declared].filter((t) => !policied.has(t)).sort();
+  if (missing.length > 0) {
+    throw new Error(
+      `RLS migrations declare policies for tables that have none after apply: ${missing.join(", ")}.`,
+    );
+  }
+
+  // 4. The updated_at triggers, which synchronize never creates.
+  for (const { trigger, table } of updatedAtTriggers()) {
+    // Skip a table the entities do not produce -- the harness synchronizes from
+    // entity metadata, so schema.sql can legitimately be ahead of it.
+    const [{ exists: tableExists }] = await dataSource.query(
+      "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = $1) AS exists",
+      [table],
+    );
+    if (!tableExists) continue;
+
+    await dataSource.query(`DROP TRIGGER IF EXISTS "${trigger}" ON "${table}"`);
+    await dataSource.query(
+      `CREATE TRIGGER "${trigger}" BEFORE UPDATE ON "${table}"
+       FOR EACH ROW EXECUTE FUNCTION update_updated_at_column()`,
+    );
+  }
+}

--- a/backend/test/helpers/rls-setup.ts
+++ b/backend/test/helpers/rls-setup.ts
@@ -55,7 +55,20 @@ export const TEST_APP_ROLE = process.env.DATABASE_APP_USER || DEFAULT_APP_USER;
  * selects exactly the RLS files today and picks up any future migration that
  * policies a new table, with no per-file registration to forget.
  */
-export function findRlsMigrations(): string[] {
+/**
+ * SQL with comments removed, for content detection only.
+ *
+ * Required, not cosmetic: the policy migrations *document* the enable step in
+ * prose ("inert until ALTER TABLE ... ENABLE ROW LEVEL SECURITY runs"), so a
+ * marker test against the raw text classifies `112`-`118` as enable migrations
+ * and drops every policy in them. That failure is silent -- the harness applies
+ * fewer files and the suite goes green with two tables unpolicied.
+ */
+function stripSqlComments(sql: string): string {
+  return sql.replace(/\/\*[\s\S]*?\*\//g, "").replace(/--[^\n]*/g, "");
+}
+
+export function findRlsMigrations(includeEnable = false): string[] {
   if (!fs.existsSync(MIGRATIONS_DIR)) {
     throw new Error(`Migrations directory not found at ${MIGRATIONS_DIR}`);
   }
@@ -70,7 +83,17 @@ export function findRlsMigrations(): string[] {
     .sort();
 
   const rlsFiles = files.filter((f) => {
-    const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, f), "utf8");
+    const sql = stripSqlComments(
+      fs.readFileSync(path.join(MIGRATIONS_DIR, f), "utf8"),
+    );
+    // The enable migration (M3) references neither helper -- it reads
+    // pg_policies -- so it is opted into separately, and applied in its
+    // filename position rather than appended. Position is what makes the
+    // "policy without its own enable" guard meaningful: M3's loop enables what
+    // is policied *when it runs*, so a later migration adding a policy without
+    // an enable leaves that table unenforced, exactly as it would on a deployed
+    // database where M3 has already been recorded in schema_migrations.
+    if (/ENABLE\s+ROW\s+LEVEL\s+SECURITY/i.test(sql)) return includeEnable;
     return /app_current_user_id|app_bypass_rls/.test(sql);
   });
 
@@ -92,7 +115,11 @@ export function findRlsMigrations(): string[] {
  * Used as a post-condition -- what was declared has to exist in `pg_policies`
  * once the files have been applied.
  */
-function declaredPolicyTables(sql: string): string[] {
+function declaredPolicyTables(rawSql: string): string[] {
+  // Comments stripped for the same reason as in the selector: these files
+  // discuss policies in prose, and a sentence naming one would become a
+  // post-condition demanding a policy nothing creates.
+  const sql = stripSqlComments(rawSql);
   const tables = new Set<string>();
 
   // `CREATE POLICY name ON table` -- deliberately not `POLICY ... ON`, which
@@ -165,8 +192,16 @@ function updatedAtTriggers(): { trigger: string; table: string }[] {
  * `synchronize: true`). Idempotent, and re-applied per suite because
  * `dropSchema: true` takes the functions, policies and triggers down with the
  * tables on every suite start.
+ *
+ * `includeEnable` opts into the M3 enable migration, which is off by default so
+ * the ordinary suites keep seeing inert policies. Note that even with it on,
+ * the *owner* still bypasses RLS -- a spec that wants to observe filtering has
+ * to `SET LOCAL ROLE` to the runtime role.
  */
-export async function applyRlsPolicies(dataSource: DataSource): Promise<void> {
+export async function applyRlsPolicies(
+  dataSource: DataSource,
+  { includeEnable = false }: { includeEnable?: boolean } = {},
+): Promise<void> {
   // 1. The role first: the grants below are meaningless without it, and a spec
   //    doing `SET LOCAL ROLE monize_app` needs it to exist. Never throws on a
   //    privilege shortfall -- it warns -- so the grant assertion below is what
@@ -190,7 +225,7 @@ export async function applyRlsPolicies(dataSource: DataSource): Promise<void> {
 
   // 2. The RLS migrations, read from disk so the harness can never drift from
   //    what ships.
-  const migrations = findRlsMigrations();
+  const migrations = findRlsMigrations(includeEnable);
   const declared = new Set<string>();
 
   for (const file of migrations) {

--- a/backend/test/integration/rls-enable.integration.spec.ts
+++ b/backend/test/integration/rls-enable.integration.spec.ts
@@ -1,0 +1,326 @@
+import { DataSource } from "typeorm";
+import * as fs from "fs";
+import * as path from "path";
+
+import { INTEGRATION_TYPEORM_OPTIONS } from "../helpers/integration-setup";
+import { applyRlsPolicies, TEST_APP_ROLE } from "../helpers/rls-setup";
+
+/**
+ * Acceptance coverage for RLS task M3 -- `database/migrations/123_rls_enable.sql`,
+ * the migration that makes the policies live. This file is flip B: it ships to
+ * production only after flip A (the privilege drop) has soaked.
+ *
+ * Two properties matter and are asserted separately, because confusing them is
+ * how this migration would go wrong:
+ *
+ * 1. It enforces exactly what is policied -- no policied table left out (which
+ *    would be a silent hole under enforcement), and no unpolicied table enabled
+ *    (which is a deny-all outage, not a safe default).
+ * 2. It changes nothing for the table owner. At `RLS_MODE=off` the app connects
+ *    as the owner, so the enable has to be observably inert there -- which is
+ *    what makes it safe for schema.sql to apply it on every fresh install.
+ */
+describe("RLS enable migration (M3, migration 123)", () => {
+  let dataSource: DataSource;
+
+  const MIGRATION = path.join(
+    __dirname,
+    "../../../database/migrations/123_rls_enable.sql",
+  );
+
+  const EXEMPT = [
+    "currencies",
+    "exchange_rates",
+    "oauth_payloads",
+    "schema_migrations",
+  ];
+
+  const USER_A = "11111111-1111-4111-8111-111111111111";
+  const USER_B = "22222222-2222-4222-8222-222222222222";
+
+  /** Runs `fn` as the unprivileged runtime role, with optional identity GUCs. */
+  async function asAppRole<T>(
+    gucs: Record<string, string>,
+    fn: (m: {
+      query: (sql: string, params?: unknown[]) => Promise<any>;
+    }) => Promise<T>,
+  ): Promise<T> {
+    return dataSource.transaction(async (m) => {
+      await m.query(`SET LOCAL ROLE ${TEST_APP_ROLE}`);
+      for (const [key, value] of Object.entries(gucs)) {
+        await m.query("SELECT set_config($1, $2, true)", [key, value]);
+      }
+      return fn(m);
+    });
+  }
+
+  beforeAll(async () => {
+    dataSource = new DataSource({
+      ...INTEGRATION_TYPEORM_OPTIONS,
+      synchronize: true,
+      dropSchema: true,
+    } as never);
+    await dataSource.initialize();
+
+    if (!fs.existsSync(MIGRATION)) {
+      throw new Error(`Enable migration not found at ${MIGRATION}`);
+    }
+
+    // Policies plus the enable, applied in filename order (T1's harness with
+    // the M3 opt-in).
+    await applyRlsPolicies(dataSource, { includeEnable: true });
+
+    await dataSource.query(
+      "INSERT INTO currencies (code, name, symbol) VALUES ('USD', 'US Dollar', '$') ON CONFLICT DO NOTHING",
+    );
+    for (const [id, email] of [
+      [USER_A, "m3-a@example.com"],
+      [USER_B, "m3-b@example.com"],
+    ]) {
+      await dataSource.query(
+        `INSERT INTO users (id, email, password_hash, first_name, last_name, auth_provider, role, is_active, email_verified)
+         VALUES ($1, $2, 'x', 'M', 'Three', 'local', 'user', true, true)`,
+        [id, email],
+      );
+    }
+    const accounts = await dataSource.query(
+      `INSERT INTO accounts (user_id, name, account_type, currency_code)
+       VALUES ($1, 'A acct', 'CHEQUING', 'USD'), ($2, 'B acct', 'CHEQUING', 'USD')
+       RETURNING id, user_id`,
+      [USER_A, USER_B],
+    );
+
+    // One transaction + split per user, so the indirect (EXISTS-to-parent)
+    // policies have rows to filter. Without data on both sides, "the runtime
+    // role sees zero splits" is true whether the policy works or not.
+    for (const account of accounts) {
+      const [txn] = await dataSource.query(
+        `INSERT INTO transactions (user_id, account_id, transaction_date, amount, currency_code, description)
+         VALUES ($1, $2, '2026-01-01', -10, 'USD', 'seed') RETURNING id`,
+        [account.user_id, account.id],
+      );
+      await dataSource.query(
+        `INSERT INTO transaction_splits (transaction_id, kind, amount, memo)
+         VALUES ($1, 'category', -10, $2)`,
+        [txn.id, account.user_id === USER_A ? "A split" : "B split"],
+      );
+    }
+  }, 120000);
+
+  afterAll(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  describe("migration hygiene", () => {
+    it("contains no role or grant statements", () => {
+      // Same rule as every other RLS migration: a GRANT naming the runtime role
+      // crash-loops any deployment where that role does not exist.
+      const sql = fs.readFileSync(MIGRATION, "utf8").replace(/^\s*--.*$/gm, "");
+
+      expect(sql).not.toMatch(/\bGRANT\b/i);
+      expect(sql).not.toMatch(/\bREVOKE\b/i);
+      expect(sql).not.toMatch(/\b(CREATE|ALTER|DROP)\s+ROLE\b/i);
+      expect(sql).not.toMatch(/monize_app/i);
+    });
+
+    it("derives its target list from pg_policies rather than hard-coding tables", () => {
+      const sql = fs.readFileSync(MIGRATION, "utf8");
+      expect(sql).toMatch(/FROM\s+pg_policies/i);
+    });
+
+    it("never forces RLS on the owner", async () => {
+      // FORCE would apply policies to the table owner too, breaking db-init,
+      // db-migrate and backup restore -- and turning this migration into a
+      // behaviour change at RLS_MODE=off instead of a no-op.
+      const sql = fs.readFileSync(MIGRATION, "utf8");
+      expect(sql).not.toMatch(/FORCE\s+ROW\s+LEVEL\s+SECURITY/i);
+
+      const [row] = await dataSource.query(
+        `SELECT count(*)::int AS n FROM pg_class c
+           JOIN pg_namespace ns ON ns.oid = c.relnamespace
+          WHERE ns.nspname = 'public' AND c.relforcerowsecurity`,
+      );
+      expect(row.n).toBe(0);
+    });
+  });
+
+  describe("enforces exactly what is policied", () => {
+    it("enables RLS on every policied table", async () => {
+      const rows = await dataSource.query(
+        `SELECT DISTINCT p.tablename
+           FROM pg_policies p
+           JOIN pg_class c ON c.relname = p.tablename
+           JOIN pg_namespace ns ON ns.oid = c.relnamespace AND ns.nspname = 'public'
+          WHERE p.schemaname = 'public' AND NOT c.relrowsecurity`,
+      );
+      // Also the guard for the convention a post-M3 migration has to follow: a
+      // new user-owned table ships its policy AND its enable. M3 has already
+      // run by then, so a policy added later without an enable is inert on
+      // exactly the deployed databases that matter -- and shows up here,
+      // because the harness applies the enable in its filename position rather
+      // than last.
+      expect(rows.map((r: { tablename: string }) => r.tablename)).toEqual([]);
+    });
+
+    it("enables RLS on no table that lacks a policy", async () => {
+      // A table with RLS enabled and no policy denies everything to every
+      // non-owner -- an outage, and the failure mode a hard-coded table list
+      // invites.
+      const rows = await dataSource.query(
+        `SELECT c.relname FROM pg_class c
+           JOIN pg_namespace ns ON ns.oid = c.relnamespace
+          WHERE ns.nspname = 'public' AND c.relkind = 'r' AND c.relrowsecurity
+            AND c.relname NOT IN (
+              SELECT DISTINCT tablename FROM pg_policies WHERE schemaname = 'public')`,
+      );
+      expect(rows.map((r: { relname: string }) => r.relname)).toEqual([]);
+    });
+
+    it("leaves the four exempt tables untouched", async () => {
+      const rows = await dataSource.query(
+        `SELECT c.relname, c.relrowsecurity FROM pg_class c
+           JOIN pg_namespace ns ON ns.oid = c.relnamespace
+          WHERE ns.nspname = 'public' AND c.relname = ANY($1)`,
+        [EXEMPT],
+      );
+      expect(rows.length).toBeGreaterThan(0);
+      for (const row of rows) {
+        expect(row.relrowsecurity).toBe(false);
+      }
+    });
+
+    it("is idempotent -- re-applying enables nothing new and errors on nothing", async () => {
+      const before = await dataSource.query(
+        `SELECT count(*)::int AS n FROM pg_class c
+           JOIN pg_namespace ns ON ns.oid = c.relnamespace
+          WHERE ns.nspname = 'public' AND c.relrowsecurity`,
+      );
+      await dataSource.query(fs.readFileSync(MIGRATION, "utf8"));
+      const after = await dataSource.query(
+        `SELECT count(*)::int AS n FROM pg_class c
+           JOIN pg_namespace ns ON ns.oid = c.relnamespace
+          WHERE ns.nspname = 'public' AND c.relrowsecurity`,
+      );
+      expect(after[0].n).toBe(before[0].n);
+      expect(before[0].n).toBeGreaterThan(50);
+    });
+
+    it("flags a policy added after the enable, which is what the D1 convention prevents", async () => {
+      // Negative control for the guard above: without it, the assertion that
+      // "every policied table is enabled" could hold trivially. Here a table is
+      // policied *after* M3 has run -- precisely what a future feature
+      // migration does if it forgets its enable -- and the guard query must
+      // report it.
+      await dataSource.query(
+        "CREATE TABLE IF NOT EXISTS m3_late_table (id int, user_id uuid)",
+      );
+      await dataSource.query(
+        `CREATE POLICY m3_late_table_isolation ON m3_late_table
+           USING (user_id = (SELECT app_current_user_id()) OR (SELECT app_bypass_rls()))`,
+      );
+
+      const rows = await dataSource.query(
+        `SELECT DISTINCT p.tablename
+           FROM pg_policies p
+           JOIN pg_class c ON c.relname = p.tablename
+           JOIN pg_namespace ns ON ns.oid = c.relnamespace AND ns.nspname = 'public'
+          WHERE p.schemaname = 'public' AND NOT c.relrowsecurity`,
+      );
+      expect(rows.map((r: { tablename: string }) => r.tablename)).toEqual([
+        "m3_late_table",
+      ]);
+
+      await dataSource.query("DROP TABLE m3_late_table");
+    });
+  });
+
+  describe("inert for the table owner -- RLS_MODE=off is unaffected", () => {
+    it("lets the owner read every user's rows", async () => {
+      // The app connects as the owner at RLS_MODE=off, which is the only mode
+      // a deployment starts in. If this ever returns a filtered count, shipping
+      // the enable in schema.sql would be a live behaviour change on fresh
+      // installs.
+      const [row] = await dataSource.query(
+        "SELECT count(*)::int AS n FROM accounts",
+      );
+      expect(row.n).toBe(2);
+    });
+
+    it("lets the owner write another user's row", async () => {
+      const [row] = await dataSource.query(
+        `INSERT INTO accounts (user_id, name, account_type, currency_code)
+         VALUES ($1, 'owner-written', 'CHEQUING', 'USD') RETURNING id`,
+        [USER_B],
+      );
+      expect(row.id).toBeDefined();
+      await dataSource.query("DELETE FROM accounts WHERE id = $1", [row.id]);
+    });
+  });
+
+  describe("enforced for the runtime role -- what flip B turns on", () => {
+    it("returns zero rows with no identity GUC", async () => {
+      // Fail-closed: an unwrapped call path sees nothing rather than everything.
+      const rows = await asAppRole({}, (m) =>
+        m.query("SELECT count(*)::int AS n FROM accounts"),
+      );
+      expect(rows[0].n).toBe(0);
+    });
+
+    it("returns only the current user's rows", async () => {
+      const rows = await asAppRole({ "app.current_user_id": USER_A }, (m) =>
+        m.query("SELECT name FROM accounts"),
+      );
+      expect(rows.map((r: { name: string }) => r.name)).toEqual(["A acct"]);
+    });
+
+    it("returns every row under the bypass GUC", async () => {
+      const rows = await asAppRole({ "app.bypass_rls": "on" }, (m) =>
+        m.query("SELECT count(*)::int AS n FROM accounts"),
+      );
+      expect(rows[0].n).toBe(2);
+    });
+
+    it("rejects a cross-user insert via WITH CHECK", async () => {
+      await expect(
+        asAppRole({ "app.current_user_id": USER_A }, (m) =>
+          m.query(
+            `INSERT INTO accounts (user_id, name, account_type, currency_code)
+             VALUES ($1, 'smuggled', 'CHEQUING', 'USD')`,
+            [USER_B],
+          ),
+        ),
+      ).rejects.toThrow(/violates row-level security policy/i);
+    });
+
+    it("filters an indirectly-owned table through its parent", async () => {
+      // transaction_splits carries no user_id -- its policy is an EXISTS back to
+      // transactions. Both users own one split, so this fails if the EXISTS arm
+      // is wrong in either direction.
+      const owner = await dataSource.query(
+        "SELECT count(*)::int AS n FROM transaction_splits",
+      );
+      expect(owner[0].n).toBe(2);
+
+      const unscoped = await asAppRole({}, (m) =>
+        m.query("SELECT count(*)::int AS n FROM transaction_splits"),
+      );
+      expect(unscoped[0].n).toBe(0);
+
+      const scoped = await asAppRole({ "app.current_user_id": USER_A }, (m) =>
+        m.query("SELECT memo FROM transaction_splits"),
+      );
+      expect(scoped.map((r: { memo: string }) => r.memo)).toEqual(["A split"]);
+    });
+
+    it("cannot turn RLS off for itself", async () => {
+      // The whole scheme rests on the runtime role not owning the tables.
+      await expect(
+        asAppRole({}, (m) =>
+          m.query("ALTER TABLE accounts DISABLE ROW LEVEL SECURITY"),
+        ),
+      ).rejects.toThrow(/must be owner of table/i);
+    });
+  });
+});

--- a/backend/test/integration/rls-harness.integration.spec.ts
+++ b/backend/test/integration/rls-harness.integration.spec.ts
@@ -1,0 +1,278 @@
+import { DataSource } from "typeorm";
+import * as fs from "fs";
+import * as path from "path";
+
+import { INTEGRATION_TYPEORM_OPTIONS } from "../helpers/integration-setup";
+import {
+  applyRlsPolicies,
+  findRlsMigrations,
+  TEST_APP_ROLE,
+} from "../helpers/rls-setup";
+
+/**
+ * Acceptance coverage for RLS task T1 -- the integration harness applies the
+ * real RLS migrations, the runtime role and its grants, and the `updated_at`
+ * triggers.
+ *
+ * The point of these assertions is that everything downstream (T2's enforcement
+ * catalog, C5's restore acceptance) tests something real. A harness that
+ * silently applies nothing produces a suite that is green and worthless, so
+ * each check here is written to fail on the *absence* of an object rather than
+ * on its misbehaviour.
+ */
+describe("RLS integration harness (T1)", () => {
+  let dataSource: DataSource;
+
+  const MIGRATIONS_DIR = path.join(__dirname, "../../../database/migrations");
+
+  beforeAll(async () => {
+    dataSource = new DataSource({
+      ...INTEGRATION_TYPEORM_OPTIONS,
+      // A full synchronize from entity metadata, matching what the module
+      // harness gives the other suites, so the trigger and grant assertions run
+      // against the same shape they do.
+      synchronize: true,
+      dropSchema: true,
+    } as never);
+    await dataSource.initialize();
+    await applyRlsPolicies(dataSource);
+  }, 120000);
+
+  afterAll(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  describe("runtime role and grants", () => {
+    it("creates the runtime role", async () => {
+      const [row] = await dataSource.query(
+        "SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = $1) AS exists",
+        [TEST_APP_ROLE],
+      );
+      expect(row.exists).toBe(true);
+    });
+
+    it("grants the role DML on application tables but not ownership", async () => {
+      const [row] = await dataSource.query(
+        `SELECT
+           has_table_privilege($1, 'accounts', 'SELECT') AS can_select,
+           has_table_privilege($1, 'accounts', 'INSERT') AS can_insert,
+           has_table_privilege($1, 'accounts', 'UPDATE') AS can_update,
+           has_table_privilege($1, 'accounts', 'DELETE') AS can_delete,
+           pg_has_role($1, (SELECT tableowner FROM pg_tables WHERE tablename = 'accounts'), 'MEMBER') AS is_owner`,
+        [TEST_APP_ROLE],
+      );
+      expect(row.can_select).toBe(true);
+      expect(row.can_insert).toBe(true);
+      expect(row.can_update).toBe(true);
+      expect(row.can_delete).toBe(true);
+      // Ownership is what would let the role turn RLS off for itself, so the
+      // enforcement specs are only meaningful while this stays false.
+      expect(row.is_owner).toBe(false);
+    });
+  });
+
+  describe("RLS migrations", () => {
+    it("creates the identity helper functions", async () => {
+      const rows = await dataSource.query(
+        `SELECT proname FROM pg_proc
+          WHERE proname IN ('app_current_user_id', 'app_real_user_id', 'app_bypass_rls')`,
+      );
+      expect(rows.map((r: { proname: string }) => r.proname).sort()).toEqual([
+        "app_bypass_rls",
+        "app_current_user_id",
+        "app_real_user_id",
+      ]);
+    });
+
+    it("applies a policy to every table the migrations policy", async () => {
+      const rows = await dataSource.query(
+        "SELECT DISTINCT tablename FROM pg_policies WHERE schemaname = 'public'",
+      );
+      const policied = rows.map((r: { tablename: string }) => r.tablename);
+
+      // The count is deliberately not asserted against a literal: tables keep
+      // arriving, and a hard number would make every new table a failing test
+      // instead of a passing one. What matters is that the set is substantial
+      // and includes a representative of each policy shape.
+      expect(policied.length).toBeGreaterThan(50);
+      expect(policied).toEqual(expect.arrayContaining(["accounts"])); // direct
+      expect(policied).toEqual(expect.arrayContaining(["transaction_splits"])); // indirect
+      expect(policied).toEqual(expect.arrayContaining(["users"])); // special
+    });
+
+    it("applies policies that live in feature migrations, not just *_rls_* files", async () => {
+      // Regression guard for the trap T1 was written to avoid: a `*_rls_*`
+      // filename glob picks up 111-114 and 118 but misses these three, whose
+      // policies ship inside the migration that creates the table. Two of them
+      // (117) would then look unpolicied to T2, and `security_documents` (118)
+      // is the case that proves a policy can arrive in any file at all.
+      const rows = await dataSource.query(
+        `SELECT tablename FROM pg_policies
+          WHERE schemaname = 'public'
+            AND tablename IN ('import_staged_files', 'import_jobs', 'security_documents')`,
+      );
+      expect(
+        rows.map((r: { tablename: string }) => r.tablename).sort(),
+      ).toEqual(["import_jobs", "import_staged_files", "security_documents"]);
+    });
+
+    it("leaves row-level security disabled -- policies ship inert until M3", async () => {
+      // Applying policies must not change what the other 15 suites observe.
+      // The enable is flip B and belongs to a spec that opts into it.
+      const [row] = await dataSource.query(
+        `SELECT count(*)::int AS enabled
+           FROM pg_class c
+           JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = 'public' AND c.relrowsecurity`,
+      );
+      expect(row.enabled).toBe(0);
+    });
+
+    it("is idempotent -- re-applying leaves one policy per table", async () => {
+      const before = await dataSource.query(
+        "SELECT count(*)::int AS n FROM pg_policies WHERE schemaname = 'public'",
+      );
+      await applyRlsPolicies(dataSource);
+      const after = await dataSource.query(
+        "SELECT count(*)::int AS n FROM pg_policies WHERE schemaname = 'public'",
+      );
+      expect(after[0].n).toBe(before[0].n);
+    });
+  });
+
+  describe("updated_at triggers", () => {
+    it("creates the triggers synchronize does not", async () => {
+      const [row] = await dataSource.query(
+        `SELECT count(*)::int AS n
+           FROM pg_trigger t
+           JOIN pg_class c ON c.oid = t.tgrelid
+           JOIN pg_namespace ns ON ns.oid = c.relnamespace
+          WHERE ns.nspname = 'public'
+            AND NOT t.tgisinternal
+            AND t.tgname LIKE 'update_%_updated_at'`,
+      );
+      expect(row.n).toBeGreaterThan(20);
+    });
+
+    it("stamps updated_at on a raw UPDATE", async () => {
+      // The acceptance test for step 3. `@UpdateDateColumn` stamps app-side, so
+      // an ORM write proves nothing about the trigger -- only a raw statement
+      // that supplies its own value can tell whether the trigger fired.
+      const userId = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa";
+      await dataSource.query(
+        `INSERT INTO users (id, email, password_hash, first_name, last_name, auth_provider, role, is_active, email_verified)
+         VALUES ($1, $2, 'x', 'T', 'One', 'local', 'user', true, true)`,
+        [userId, `t1-trigger-${Date.now()}@example.com`],
+      );
+
+      await dataSource.query(
+        `UPDATE users SET first_name = 'Two', updated_at = TIMESTAMP '2001-01-01 00:00:00' WHERE id = $1`,
+        [userId],
+      );
+
+      const [row] = await dataSource.query(
+        "SELECT updated_at FROM users WHERE id = $1",
+        [userId],
+      );
+      // The trigger overwrote the supplied value with CURRENT_TIMESTAMP.
+      expect(new Date(row.updated_at).getFullYear()).toBeGreaterThan(2001);
+
+      await dataSource.query("DELETE FROM users WHERE id = $1", [userId]);
+    });
+
+    it("preserves a supplied updated_at under app.preserve_timestamps", async () => {
+      // The other half of M1's trigger, and the mechanism C5 replaces
+      // `DISABLE TRIGGER` with. Asserting it here is what makes C5's acceptance
+      // meaningful: without the trigger attached to a real table, C5 could pass
+      // against a database where nothing would have stamped anything anyway.
+      // Assert the trigger is attached *first*. Without it the supplied
+      // timestamp survives for the trivial reason that nothing would have
+      // overwritten it, and this test would pass against a database with no
+      // triggers at all -- which is exactly the pre-T1 state.
+      const [trigger] = await dataSource.query(
+        `SELECT count(*)::int AS n
+           FROM pg_trigger t
+           JOIN pg_class c ON c.oid = t.tgrelid
+          WHERE c.relname = 'users'
+            AND NOT t.tgisinternal
+            AND t.tgname = 'update_users_updated_at'`,
+      );
+      expect(trigger.n).toBe(1);
+
+      const userId = "aaaaaaaa-2222-4222-8222-aaaaaaaaaaaa";
+      await dataSource.query(
+        `INSERT INTO users (id, email, password_hash, first_name, last_name, auth_provider, role, is_active, email_verified)
+         VALUES ($1, $2, 'x', 'T', 'Two', 'local', 'user', true, true)`,
+        [userId, `t1-preserve-${Date.now()}@example.com`],
+      );
+
+      // The GUC is transaction-local (`set_config(..., true)`), so the UPDATE
+      // has to share the transaction that sets it -- which is exactly how
+      // withScopedDb emits it.
+      await dataSource.transaction(async (m) => {
+        await m.query(
+          "SELECT set_config('app.preserve_timestamps', 'on', true)",
+        );
+        await m.query(
+          `UPDATE users SET first_name = 'Three', updated_at = TIMESTAMP '2001-01-01 00:00:00' WHERE id = $1`,
+          [userId],
+        );
+      });
+
+      const [row] = await dataSource.query(
+        "SELECT updated_at FROM users WHERE id = $1",
+        [userId],
+      );
+      expect(new Date(row.updated_at).getFullYear()).toBe(2001);
+
+      await dataSource.query("DELETE FROM users WHERE id = $1", [userId]);
+    });
+  });
+
+  describe("fails loudly rather than silently skipping", () => {
+    it("throws when a declared policy did not materialize", async () => {
+      // Simulates the failure mode the post-condition exists for: a migration
+      // that applies without error but leaves a table unpolicied. Dropping a
+      // policy after apply is the observable equivalent.
+      await dataSource.query(
+        "DROP POLICY IF EXISTS accounts_isolation ON accounts",
+      );
+      const [row] = await dataSource.query(
+        `SELECT count(*)::int AS n FROM pg_policies
+          WHERE schemaname = 'public' AND tablename = 'accounts'`,
+      );
+      expect(row.n).toBe(0);
+
+      // Re-applying restores it, which is the harness doing its job.
+      await applyRlsPolicies(dataSource);
+      const [after] = await dataSource.query(
+        `SELECT count(*)::int AS n FROM pg_policies
+          WHERE schemaname = 'public' AND tablename = 'accounts'`,
+      );
+      expect(after.n).toBe(1);
+    });
+
+    it("selects every migration file that declares a policy", () => {
+      // Guard test in the style CLAUDE.md asks for: it fails for *any* future
+      // migration that declares a policy in a file the harness would not
+      // select, wherever that file appears -- not just for today's three. It
+      // calls the real selector rather than re-testing a copy of its rule, so
+      // narrowing the selector (back to a filename glob, say) fails here.
+      const selected = findRlsMigrations().map((f) => path.basename(f));
+
+      const declaresPolicy = fs
+        .readdirSync(MIGRATIONS_DIR)
+        .filter((f) => f.endsWith(".sql"))
+        .filter((f) =>
+          /CREATE\s+POLICY/i.test(
+            fs.readFileSync(path.join(MIGRATIONS_DIR, f), "utf8"),
+          ),
+        );
+
+      expect(declaresPolicy.length).toBeGreaterThan(0);
+      expect(declaresPolicy.filter((f) => !selected.includes(f))).toEqual([]);
+    });
+  });
+});

--- a/database/migrations/123_rls_enable.sql
+++ b/database/migrations/123_rls_enable.sql
@@ -1,0 +1,61 @@
+-- Row-Level Security: the enable step. This is FLIP B.
+--
+-- Migrations 111-118 shipped the helper functions and one policy per owned
+-- table, all deliberately inert: a policy on a table without ENABLE ROW LEVEL
+-- SECURITY is never consulted by the planner. This file is what makes them
+-- live, and it is the only migration in the RLS series that is not safe to
+-- deploy on its own schedule.
+--
+-- Sequencing (see docs/future-plans/row-level-security-runbook.md): flip A is
+-- the privilege drop -- the app connects as the unprivileged monize_app role
+-- instead of the owner, with policies still inert, which proves the role, its
+-- grants and every context-wrapping path work without changing a single query
+-- result. Only after flip A has soaked does this file ship. Deploying the two
+-- together would turn any missing withUserContext/withSystemContext wrap into a
+-- silent zero-rows bug in production instead of a caught one in staging.
+--
+-- Why this is nonetheless harmless on a FRESH install, where schema.sql applies
+-- it immediately: enabling RLS does not affect the table OWNER, and at
+-- RLS_MODE=off (the default, and the only mode a new deployment starts in) the
+-- app connects as the owner. Ownership bypass is also what keeps db-init,
+-- db-migrate and backup restore working. That bypass is exactly why FORCE ROW
+-- LEVEL SECURITY is NOT used here: forcing it would apply policies to the owner
+-- too and break every one of those paths, and would make this file a behaviour
+-- change rather than a no-op at RLS_MODE=off.
+
+-- ---------------------------------------------------------------------------
+-- Derived from pg_policies rather than a hard-coded table list.
+--
+-- A static list is wrong for two reasons. It goes stale between authoring and
+-- deployment -- this file waits for flip A, and tables keep landing in the
+-- meantime (import_staged_files, import_jobs and security_documents all
+-- postdate the policy migrations). And it can disagree with what is actually
+-- policied: enabling RLS on a table with NO policy makes it deny-all for every
+-- non-owner, which is a silent outage, not a safe default. Reading the catalog
+-- makes both failure modes impossible -- exactly the tables that have a policy
+-- get that policy enforced, and the four deliberately-exempt tables
+-- (currencies, exchange_rates, oauth_payloads, schema_migrations) have no
+-- policy and are therefore never touched.
+--
+-- Idempotent: ENABLE ROW LEVEL SECURITY on an already-enabled table is a no-op,
+-- and the loop re-derives its target list on every run.
+--
+-- NOTE for any migration added AFTER this one: a new user-owned table must ship
+-- its own ENABLE ROW LEVEL SECURITY alongside its policy. This loop has already
+-- run on existing deployments and will not run again, so a policy added later
+-- is inert on exactly the databases that matter. See database/CLAUDE.md.
+-- ---------------------------------------------------------------------------
+
+DO $$
+DECLARE
+    t text;
+BEGIN
+    FOR t IN
+        SELECT DISTINCT tablename
+          FROM pg_policies
+         WHERE schemaname = 'public'
+         ORDER BY tablename
+    LOOP
+        EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY', t);
+    END LOOP;
+END $$;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1964,6 +1964,42 @@ CREATE POLICY emergency_access_contacts_isolation ON emergency_access_contacts
 -- Verification helper (run manually; not part of the migration's effect):
 --   SELECT tablename, policyname FROM pg_policies
 --    WHERE schemaname = 'public' ORDER BY tablename;
--- Expected: 52 policies -- 26 direct + 4 real-user-keyed (112),
+-- Expected: 53 policies -- 26 direct + 4 real-user-keyed (112),
 --           15 indirect (113), 5 special (114),
---           2 direct for the .mny import's staging + job tables (117).
+--           2 direct for the .mny import's staging + job tables (117),
+--           1 direct for security_documents (118).
+
+-- ---------------------------------------------------------------------------
+-- Enable row-level security (migration 123).
+--
+-- Mirrors 123_rls_enable.sql. Keep this block LAST in the RLS section: it
+-- enforces whatever is policied at the moment it runs, so a CREATE POLICY
+-- appended below it would create a policied-but-unenforced table on every fresh
+-- install.
+--
+-- Enabling RLS does not affect the table owner, and at RLS_MODE=off -- the
+-- default, and where every deployment starts -- the app connects as the owner.
+-- So this is inert for a new install and stays inert until an operator moves
+-- the app onto the unprivileged monize_app role. FORCE ROW LEVEL SECURITY is
+-- deliberately not used: it would apply policies to the owner as well and break
+-- db-init, db-migrate and backup restore.
+--
+-- Derived from pg_policies, never from a hard-coded list -- enabling RLS on a
+-- table with no policy is a deny-all outage, and the four exempt tables above
+-- have no policy and are therefore never touched. A new user-owned table must
+-- ship its policy AND its enable; see database/CLAUDE.md.
+-- ---------------------------------------------------------------------------
+
+DO $$
+DECLARE
+    t text;
+BEGIN
+    FOR t IN
+        SELECT DISTINCT tablename
+          FROM pg_policies
+         WHERE schemaname = 'public'
+         ORDER BY tablename
+    LOOP
+        EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY', t);
+    END LOOP;
+END $$;

--- a/docs/future-plans/row-level-security-tasks.md
+++ b/docs/future-plans/row-level-security-tasks.md
@@ -20,8 +20,11 @@
     must go through `tr()` + English catalogs, then `npm run i18n:pseudo`).
 - **Terminology:** "the design doc" = `row-level-security.md`. Section references (e.g. "Phase 2b")
   point there. Migration numbers below were written when the max was `102_*` and are now stale:
-  M1/M2 actually shipped as `111`–`114`. **Verify with `ls database/migrations` and renumber from the
-  actual max before writing files.**
+  M1/M2 actually shipped as `111`–`114`, and unrelated feature migrations have since carried the max
+  to `122`. **Verify with `ls database/migrations` and renumber from the actual max before writing
+  files** — do not trust any number in this document. Note that `116_*` and `117_*` each have two
+  files: the directory is applied in **filename sort order**, not by numeric prefix, which is what
+  keeps `117_security_documents` ahead of `118_security_documents_rls`.
 
 ## Deployment safety
 
@@ -373,20 +376,36 @@ without enable); schema.sql mirrored.
 
 ### M3. Enable migration — authored, not deployed
 
-- [ ] Status: not started. **Renumber: M2 ended at `114`, so this is `115_rls_enable.sql`.** The
-  exact target list is the 50 tables policied by migrations `112`–`114`; derive it from
-  `SELECT DISTINCT tablename FROM pg_policies WHERE schemaname = 'public'` rather than retyping it.
+- [ ] Status: not started. **Renumber: the max is now `122`, so this is `123_rls_enable.sql`** — not
+  the `115` an earlier revision of this note assumed, and not the `107` in the Scope line below.
   M2 already dry-ran this enable in a scratch database and verified every policy behaves correctly
   under it (see M2's status note), so M3 is expected to be mechanical.
 
-**Scope:** new `database/migrations/107_rls_enable.sql`, `database/schema.sql`.
+  **The target is 53 tables, not the 50 M2 shipped.** Three policied tables postdate M2, each
+  correctly carrying its own policy in the migration that created it: `import_staged_files` and
+  `import_jobs` (in `117_mny_import_staging_and_jobs.sql`, not in a file matching `*_rls_*`) and
+  `security_documents` (in `118_security_documents_rls.sql`). Audited 2026-08 against
+  `database/schema.sql`: **57 tables, 53 policied, 4 exempt** — `currencies`, `exchange_rates`,
+  `oauth_payloads`, `schema_migrations`, exactly M2's exemption list, with no unpolicied table
+  outside it and no policy naming a table that does not exist.
 
-**Do:** `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` for exactly the tables policied in M2. **This file
-is flip B.** It ships to prod only in its own release after flip A soaks (runbook). Land it on a branch
-CI can validate but tag the PR clearly: `do-not-deploy-before-flip-A`.
+  **Do not hard-code the list.** Between authoring M3 and deploying it (flip B is a separate release
+  after flip A soaks) more tables will land, and a frozen list silently leaves each of them
+  unprotected — which is how the "50" above went stale. Write the enable as a `DO` loop over
+  `SELECT DISTINCT tablename FROM pg_policies WHERE schemaname = 'public'`, so it enables whatever is
+  policied at apply time. Pair it with the D1 convention: after M3 exists, a migration creating a
+  user-owned table ships its policy **and** its `ENABLE`.
 
-**Accept:** applies cleanly in a scratch DB; `pg_class.relrowsecurity` true for every policied table;
-integration suite (T2) passes against it.
+**Scope:** new `database/migrations/123_rls_enable.sql` (verify against `ls database/migrations`),
+`database/schema.sql`.
+
+**Do:** `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` for every policied table, derived dynamically as
+above. **This file is flip B.** It ships to prod only in its own release after flip A soaks (runbook).
+Land it on a branch CI can validate but tag the PR clearly: `do-not-deploy-before-flip-A`.
+
+**Accept:** applies cleanly in a scratch DB; `pg_class.relrowsecurity` true for every policied table
+and false for the four exempt ones; a table policied but not enabled fails the check; integration
+suite (T2) passes against it.
 
 ---
 
@@ -401,7 +420,13 @@ integration suite (T2) passes against it.
 **Do:** after `synchronize`, run `applyRlsPolicies(dataSource)`:
 1. Create `monize_app` in the test DB **before** anything references it, and apply the F1 grants
    (reuse/share db-init's grant SQL — the migrations no longer contain grants).
-2. Execute the actual `database/migrations/1NN_rls_*.sql` files read from disk (never duplicated SQL).
+2. Execute the actual RLS migration files read from disk (never duplicated SQL). **A `*_rls_*` glob
+   is wrong and will silently under-apply.** It matches `111`–`114` and `118_security_documents_rls`
+   but misses the `CREATE POLICY` statements for `import_staged_files` and `import_jobs`, which live
+   inside `117_mny_import_staging_and_jobs.sql` — a feature migration that creates the tables and
+   policies them in the same file (the right pattern; see M3). Two tables would then look unpolicied
+   to T2. Apply the whole migrations directory in **filename sort order**, or enumerate the policy
+   sources explicitly and assert the enumerated set still covers every table T2 buckets.
 3. Create the `update_updated_at_column()` **triggers** for the tables the trigger tests touch,
    extracting their `CREATE TRIGGER` DDL from `database/schema.sql` — `synchronize` builds from
    entities and creates **no** DB triggers (`@UpdateDateColumn` stamps app-side), and the RLS
@@ -1038,11 +1063,17 @@ behavior unchanged; no context-throw in dev smoke once R7 lands (verified again 
 ### L1. Lint bans
 
 - [ ] Status: not started, but **unblocked** — R1–R7 are done and both ratchet counts are 0
-  (`backend/scripts/rls-ratchet-baseline.json`). L1's note from C1 still applies: the
-  `with-context.ts` allowlist must include `backend/src/oauth/**`, and R6/R7 added imports in
-  `backend/src/mcp/**`, `backend/src/currencies/**`, `backend/src/securities/securities.controller.ts`
-  and `backend/src/delegation/guards/**` as well. The now-unused `TypeOrmModule.forFeature`
+  (`backend/scripts/rls-ratchet-baseline.json`). The now-unused `TypeOrmModule.forFeature`
   registrations R1–R5 left behind were removed in R6/R7, so that L1 clean-up is already done.
+
+  **Derive the allowlist from the tree, not from this list.** As of 2026-08, **35 non-spec files**
+  import `common/db/with-context`, which is more than the C1 note ("admin, auth bootstrap, emergency
+  access, cron/jobs, seeders, backup") or the R6/R7 additions describe. Beyond those, it now includes
+  `backend/src/import/mny/**` (3 files) and `backend/src/mcp/tools/transactions.tool.ts`, both of
+  which postdate R7. Run
+  `grep -rl "db/with-context" backend/src --include=*.ts | grep -v spec` when writing the rule and
+  justify each entry, rather than trusting any enumeration written here — the point of the ban is
+  that a *new* importer is a deliberate decision, so the allowlist must start at today's real set.
 
 **Do:** ESLint `no-restricted-imports`: `with-context.ts` importable only from the allowlist (admin,
 auth bootstrap, emergency access, cron/jobs, seeders, backup). Ban `@InjectRepository` and
@@ -1056,7 +1087,11 @@ auth bootstrap, emergency access, cron/jobs, seeders, backup). Ban `@InjectRepos
 
 **Do:** update root `CLAUDE.md` (QueryRunner section now points at `withScopedDb` as the required pattern)
 and `database/CLAUDE.md` (RLS migration conventions, "adding a new table" policy step — four buckets,
-no role/grants in migrations); fix `backend/CLAUDE.md`'s **stale scheduler claim** (crons run in the
+no role/grants in migrations). **Write the new-table rule as a hard convention:** a migration creating
+a user-owned table ships its `CREATE POLICY` in the same file, and — once M3 has shipped — its
+`ENABLE ROW LEVEL SECURITY` too. `117_mny_import_staging_and_jobs.sql` and
+`118_security_documents_rls.sql` already do the policy half by hand; the rule is what keeps the next
+one from being the single unprotected table under enforcement. Then fix `backend/CLAUDE.md`'s **stale scheduler claim** (crons run in the
 API process; there is no separate scheduler — delete or fix the dead `start:scheduler` script
 reference); finalize `.env.example` comments; verify the helm chart values/ConfigMap and the CNPG
 `managed.roles` requirement are documented for k8s operators; verify the runbook matches the

--- a/docs/future-plans/row-level-security-tasks.md
+++ b/docs/future-plans/row-level-security-tasks.md
@@ -51,8 +51,8 @@ uses four classes:
 | M1 | Migration: helper functions + GUC-aware trigger (**no grants — they live in db-init, F1**) | — | inert | done |
 | M2 | Migrations: direct + indirect + special (users/delegation/emergency) policies (no enable) | M1 | inert | done |
 | M3 | Migration: `ENABLE ROW LEVEL SECURITY` (authored, **not deployed**) | M2 | **DO NOT DEPLOY** | not started |
-| T1 | Integration harness applies real RLS migrations + role/grants + `updated_at` triggers | M2, F1 | none | not started |
-| T2 | Catalog-driven `rls-enforcement` integration spec (4 buckets) | T1, M3 | none | not started |
+| T1 | Integration harness applies real RLS migrations + role/grants + `updated_at` triggers | M2, F1 | none | done |
+| T2 | Catalog-driven `rls-enforcement` integration spec (4 buckets) | T1, M3 | none | blocked on M3 only (T1 done) |
 | C1 | Auth wrapping: `jwt.strategy` under `withUserContext(sub)`; PAT + password-reset + OAuth under `withSystemContext`; public-route audit | F2 | inert | done |
 | C2 | Cron jobs: system fan-out + per-user bodies wrapped | F2 | inert | done |
 | C3 | Seeders + demo reset under `withSystemContext` | F2 | inert | done |
@@ -413,7 +413,53 @@ suite (T2) passes against it.
 
 ### T1. Integration harness applies real migrations
 
-- [ ] Status: not started
+- [x] Status: done (branch `claude/rls-task-list-next-72ikal`). New helper
+  `backend/test/helpers/rls-setup.ts` exporting `applyRlsPolicies(dataSource)`, called from
+  `createIntegrationModule` after compile. Acceptance spec
+  `backend/test/integration/rls-harness.integration.spec.ts` (12 tests). Full integration run against
+  a real PostgreSQL 16: **16 suites / 172 tests green** (was 15/160 before the task), build + lint +
+  ratchet clean.
+
+  **The migration selector is content-based, and that is the whole point of the task.** It selects
+  files whose SQL references `app_current_user_id` / `app_bypass_rls`, which today is
+  `111`–`114`, `117_mny_import_staging_and_jobs.sql` and `118_security_documents_rls.sql`. The
+  `*_rls_*` glob the task text originally specified silently drops `117`, so `import_staged_files`
+  and `import_jobs` would have looked unpolicied to T2 — a green, meaningless suite. Every policy
+  predicate calls one of the helpers, so the marker cannot miss a policy file no matter what it is
+  named, and it picks up future feature migrations that policy their own new table (the correct
+  pattern) with nothing to register by hand.
+
+  **Every assertion has a verified negative control** — each was run against a deliberately broken
+  harness, not just reviewed:
+  - Narrowing the selector back to the `*_rls_*` glob fails 3 tests, including the guard test
+    "selects every migration file that declares a policy", which calls the **real** selector and
+    compares it against every file containing a `CREATE POLICY`. That guard fails for any future
+    policy file the selector would miss, wherever it appears — the `ui-conventions.test.ts` pattern.
+  - Skipping trigger creation fails all 3 trigger tests. The `app.preserve_timestamps` test
+    initially passed without triggers (with nothing to overwrite the supplied timestamp, preserving
+    it is trivially true), so it now asserts the trigger is attached before exercising the GUC.
+
+  **Boundary decisions:**
+  - `applyRlsPolicies` applies policies but **not** `ENABLE ROW LEVEL SECURITY`. Policies ship inert
+    (M2) and the enable is M3/flip B, so the other 15 suites see exactly what they saw before — a
+    policy on a table without enable is never consulted by the planner. A test asserts zero tables
+    have `relrowsecurity`, so an accidental enable here would surface as a failure rather than as a
+    baffling regression elsewhere. T2 opts into enforcement itself.
+  - Role and grants come from `provisionAppRole` in `src/common/db/app-role.ts` (F1 exported the SQL
+    for exactly this), not from duplicated grant SQL. Note the task text says the grants live in
+    `db-init.ts`; F1 actually put them in `app-role.ts`, which db-init calls.
+  - The `updated_at` trigger DDL is extracted from `schema.sql` with a whitespace-tolerant pattern
+    (the file has both one-line and multi-line forms) and applied only for tables `synchronize`
+    actually built, so schema.sql being ahead of the entities is not a failure. 24 triggers today.
+  - A post-condition compares the policies the applied files *declare* (both shapes: explicit
+    `CREATE POLICY`, and `112`'s `text[]` looped through `EXECUTE format`) against `pg_policies`
+    after apply, so a file that applies without error but takes a branch skipping its policies fails
+    loudly instead of silently under-applying.
+  - **The four suites that build their own `DataSource`** (`mny-import`, `mny-import-job`,
+    `mny-staging`, `support-backup`) are **not** wired to the harness — they opt in by calling
+    `applyRlsPolicies` themselves, as the T1 acceptance spec does. None of them tests RLS, and
+    attaching triggers under `support-backup`'s golden comparison is a change T1 has no reason to
+    make. T2 will call it explicitly.
 
 **Scope:** `backend/test/helpers/integration-setup.ts` (+ a new helper file if cleaner).
 
@@ -440,7 +486,12 @@ or unreadable (no silent skip); a raw `UPDATE` on a trigger-covered table in the
 
 ### T2. Catalog-driven `rls-enforcement` spec
 
-- [ ] Status: not started
+- [ ] Status: not started. **T1 has landed**, so the only remaining dependency is M3. Build the spec's
+  DataSource and call `applyRlsPolicies` from `test/helpers/rls-setup.ts` (it is not wired into
+  raw-DataSource suites automatically), then enable RLS explicitly — T1 deliberately leaves it off.
+  The four-bucket map must cover the tables that postdate M2: `import_staged_files`, `import_jobs`
+  and `security_documents` are all direct `user_id`, so the `user_id`-column bucket picks them up
+  with no map entry, but a hard-coded table count will not match.
 
 **Scope:** new `backend/test/integration/rls-enforcement.integration.spec.ts`.
 

--- a/docs/future-plans/row-level-security-tasks.md
+++ b/docs/future-plans/row-level-security-tasks.md
@@ -50,9 +50,9 @@ uses four classes:
 | F3 | CI ratchet on `@InjectRepository` / `createQueryRunner` counts | F2 | none | done |
 | M1 | Migration: helper functions + GUC-aware trigger (**no grants — they live in db-init, F1**) | — | inert | done |
 | M2 | Migrations: direct + indirect + special (users/delegation/emergency) policies (no enable) | M1 | inert | done |
-| M3 | Migration: `ENABLE ROW LEVEL SECURITY` (authored, **not deployed**) | M2 | **DO NOT DEPLOY** | not started |
+| M3 | Migration: `ENABLE ROW LEVEL SECURITY` (authored, **not deployed**) | M2 | **DO NOT DEPLOY** | done (authored; ships only after flip A soaks) |
 | T1 | Integration harness applies real RLS migrations + role/grants + `updated_at` triggers | M2, F1 | none | done |
-| T2 | Catalog-driven `rls-enforcement` integration spec (4 buckets) | T1, M3 | none | blocked on M3 only (T1 done) |
+| T2 | Catalog-driven `rls-enforcement` integration spec (4 buckets) | T1, M3 | none | unblocked (T1 + M3 done) |
 | C1 | Auth wrapping: `jwt.strategy` under `withUserContext(sub)`; PAT + password-reset + OAuth under `withSystemContext`; public-route audit | F2 | inert | done |
 | C2 | Cron jobs: system fan-out + per-user bodies wrapped | F2 | inert | done |
 | C3 | Seeders + demo reset under `withSystemContext` | F2 | inert | done |
@@ -376,28 +376,54 @@ without enable); schema.sql mirrored.
 
 ### M3. Enable migration — authored, not deployed
 
-- [ ] Status: not started. **Renumber: the max is now `122`, so this is `123_rls_enable.sql`** — not
-  the `115` an earlier revision of this note assumed, and not the `107` in the Scope line below.
-  M2 already dry-ran this enable in a scratch database and verified every policy behaves correctly
-  under it (see M2's status note), so M3 is expected to be mechanical.
+- [x] Status: **authored, NOT deployed** (branch `claude/rls-task-list-next-72ikal`). Shipped as
+  `database/migrations/123_rls_enable.sql` (the max was `122`; the `115` and `107` earlier revisions
+  of this note assumed were both stale), mirrored into `database/schema.sql`. Acceptance spec
+  `backend/test/integration/rls-enable.integration.spec.ts` (16 tests). **This file is flip B — it
+  must not reach production until flip A has soaked. Tag the PR `do-not-deploy-before-flip-A`.**
 
-  **The target is 53 tables, not the 50 M2 shipped.** Three policied tables postdate M2, each
-  correctly carrying its own policy in the migration that created it: `import_staged_files` and
-  `import_jobs` (in `117_mny_import_staging_and_jobs.sql`, not in a file matching `*_rls_*`) and
-  `security_documents` (in `118_security_documents_rls.sql`). Audited 2026-08 against
-  `database/schema.sql`: **57 tables, 53 policied, 4 exempt** — `currencies`, `exchange_rates`,
-  `oauth_payloads`, `schema_migrations`, exactly M2's exemption list, with no unpolicied table
-  outside it and no policy naming a table that does not exist.
+  **53 tables enabled, derived from `pg_policies` rather than a hard-coded list.** A `DO` loop over
+  `SELECT DISTINCT tablename FROM pg_policies WHERE schemaname = 'public'` closes both failure modes
+  a static list has: it cannot go stale between authoring and flip B (three tables already postdate
+  M2 — `import_staged_files`, `import_jobs`, `security_documents`), and it cannot enable a table
+  that has no policy, which would be a deny-all outage rather than a safe default. Both are asserted
+  as tests, in both directions.
 
-  **Do not hard-code the list.** Between authoring M3 and deploying it (flip B is a separate release
-  after flip A soaks) more tables will land, and a frozen list silently leaves each of them
-  unprotected — which is how the "50" above went stale. Write the enable as a `DO` loop over
-  `SELECT DISTINCT tablename FROM pg_policies WHERE schemaname = 'public'`, so it enables whatever is
-  policied at apply time. Pair it with the D1 convention: after M3 exists, a migration creating a
-  user-owned table ships its policy **and** its `ENABLE`.
+  **Why mirroring it into `schema.sql` does not make flip B happen on fresh installs.** Enabling RLS
+  does not affect the table **owner**, and at `RLS_MODE=off` — the default, and where every
+  deployment starts — the app connects as the owner. So a fresh install gets the enable and observes
+  nothing. `FORCE ROW LEVEL SECURITY` is deliberately not used anywhere: it would apply policies to
+  the owner too, break db-init/db-migrate/backup-restore, and turn this file into a live behaviour
+  change at `off`. A test asserts `relforcerowsecurity` is false everywhere. The "do not deploy"
+  constraint is therefore about *release sequencing on existing deployments*, not about the SQL
+  being unsafe on its own.
 
-**Scope:** new `database/migrations/123_rls_enable.sql` (verify against `ls database/migrations`),
-`database/schema.sql`.
+  **Verified against a real PostgreSQL 16, not by review.** The "Schema vs Migrations Drift" job was
+  reproduced locally (Docker is unavailable in the agent container, so the same steps were run
+  against a local PG16 cluster): `schema.sql` applied to one database, `schema.sql` + all 112
+  migrations replayed **twice** to another, `pg_dump` normalized and diffed — identical, 53 tables
+  with RLS enabled on both sides. `npm run migration:lint` clean. Behaviour under enforcement,
+  proved with a real non-owner role: owner sees both users' rows (this is `RLS_MODE=off` and it is
+  unchanged); `monize_app` with no GUC sees **zero**; with `app.current_user_id` sees only that
+  user's rows, on a direct table *and* through an indirect `EXISTS`-to-parent policy; with
+  `app.bypass_rls` sees everything; a cross-user INSERT is rejected by `WITH CHECK`; and
+  `monize_app` cannot `ALTER TABLE ... DISABLE ROW LEVEL SECURITY` (`must be owner of table`).
+
+  **The D1 convention now has a test, not just a rule.** T1's harness applies the enable **in its
+  filename position** rather than last (`applyRlsPolicies(ds, { includeEnable: true })`), which
+  reproduces a deployed database where `123` is already recorded in `schema_migrations`. A later
+  migration that adds a policy without its own `ENABLE` therefore leaves that table unenforced and
+  fails the "enables RLS on every policied table" assertion. A negative-control test policies a
+  table after the fact and confirms the guard reports it.
+
+  **One bug found in T1's helper while wiring this up**, caught by the full suite and not by the
+  spec in isolation: the enable-marker regex matched the phrase `ENABLE ROW LEVEL SECURITY` where
+  the *policy* migrations discuss it **in comments**, so `112`–`118` were classified as enable
+  migrations and their policies silently went unapplied. Marker detection now strips SQL comments
+  first. The lesson generalizes — content markers over SQL must ignore comments, because these files
+  document the thing they are being matched for.
+
+**Scope:** `database/migrations/123_rls_enable.sql`, `database/schema.sql`.
 
 **Do:** `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` for every policied table, derived dynamically as
 above. **This file is flip B.** It ships to prod only in its own release after flip A soaks (runbook).
@@ -486,12 +512,21 @@ or unreadable (no silent skip); a raw `UPDATE` on a trigger-covered table in the
 
 ### T2. Catalog-driven `rls-enforcement` spec
 
-- [ ] Status: not started. **T1 has landed**, so the only remaining dependency is M3. Build the spec's
-  DataSource and call `applyRlsPolicies` from `test/helpers/rls-setup.ts` (it is not wired into
-  raw-DataSource suites automatically), then enable RLS explicitly — T1 deliberately leaves it off.
-  The four-bucket map must cover the tables that postdate M2: `import_staged_files`, `import_jobs`
-  and `security_documents` are all direct `user_id`, so the `user_id`-column bucket picks them up
-  with no map entry, but a hard-coded table count will not match.
+- [ ] Status: not started, but **fully unblocked** — T1 and M3 are both done. Build the spec's own
+  DataSource and call `applyRlsPolicies(ds, { includeEnable: true })` from
+  `test/helpers/rls-setup.ts` (it is not wired into raw-DataSource suites automatically, and the
+  enable is opt-in so the ordinary suites keep seeing inert policies).
+  `rls-enable.integration.spec.ts` is the working example, including an `asAppRole(gucs, fn)` helper
+  that runs a body under `SET LOCAL ROLE` with transaction-local GUCs — the shape T2 needs per
+  table. The four-bucket map must cover the tables that postdate M2: `import_staged_files`,
+  `import_jobs` and `security_documents` are all direct `user_id`, so the `user_id`-column bucket
+  picks them up with no map entry, but a hard-coded table count will not match.
+
+  M3's spec already covers, for `accounts` and `transaction_splits` only, the visibility /
+  zero-rows / bypass / `WITH CHECK` / non-owner assertions. T2's job is to make that catalog-driven
+  across **every** table and to add what M3 does not touch: the 22P02 garbage-GUC assertion, the
+  `app.preserve_timestamps` trigger case, the delegation semantics (both identity GUCs), and the
+  post-commit GUC-scope check.
 
 **Scope:** new `backend/test/integration/rls-enforcement.integration.spec.ts`.
 


### PR DESCRIPTION
Audited the task list against the tree after eight feature migrations landed
on top of M2.

- Migration numbering: max is 122, not 114. M3 is 123, not 115/107. Noted that
  116_* and 117_* each have two files, so the directory orders by filename.
- M3 targets 53 policied tables, not 50: import_staged_files/import_jobs (117)
  and security_documents (118) postdate M2. Verified 57 tables / 53 policied /
  4 exempt against schema.sql, matching M2's exemption list exactly. Enable
  should loop over pg_policies rather than freeze a list that goes stale
  between authoring and flip B.
- T1: a `*_rls_*` glob misses the policies embedded in
  117_mny_import_staging_and_jobs.sql, so two tables would look unpolicied to
  T2. Apply the migrations directory in filename order instead.
- L1: 35 non-spec files import with-context today, including import/mny/** and
  mcp/tools/transactions.tool.ts, which postdate the note. Derive the allowlist
  from the tree.
- D1: make "new user-owned table ships its policy, and post-M3 its enable" an
  explicit convention in database/CLAUDE.md.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GS5teuhGMNw92AY127VWis