### PR TITLE
fix(frontend): stale balances after a money-moving write, and Monte Carlo name overflow

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -40,6 +40,29 @@ npm run i18n:check         # Verify the pseudo-locale is up to date (CI gate)
 
 Feature API modules (one per feature, typed axios wrappers) live alongside `api.ts`. Use the filesystem to discover them.
 
+### A write that moves money calls `invalidateBalanceCaches()`
+
+`accountsApi.getAll` and `investmentsApi.getPortfolioSummary` are cached in
+`apiCache.ts` for two minutes, and the backend computes balances live from
+transactions -- so a write that does not drop those entries leaves the Accounts
+page showing the pre-write number. Navigating away and back does not fix it:
+the page refetches on mount and the refetch is served from the same cache, so
+only a browser reload clears it. Call `invalidateBalanceCaches()` (both
+prefixes at once) after any write that adds, removes, re-dates, re-prices or
+voids a transaction -- and note that "goes through `transactionsApi`" is not the
+test. Posting a scheduled transaction, editing splits (a split can carry a
+`transferAccountId`, so the counterpart lands in an account the parent never
+named), an investment trade hitting its INVESTMENT_CASH account, and a QIF/OFX/
+CSV/MNY import all write transaction rows from their own modules. That omission
+on `scheduledTransactionsApi.post` is the bug this rule came from;
+`src/lib/balance-cache.guard.test.ts` now scans for it.
+
+Where the write can touch anything -- undo/redo, an AI assistant action, a
+backup restore -- use `clearAllCache()` instead; no prefix is narrow enough to
+be correct. This matters most for `notifyUndoRedo`/`notifyAiAction`: they exist
+to make mounted pages refetch, and a refetch served from a stale cache makes
+the whole signal a no-op.
+
 ## Proxy (`src/proxy.ts`)
 
 This is Next.js middleware (NOT the deprecated middleware pattern from this project's conventions). It handles:

--- a/frontend/src/components/reports/MonteCarloReport.test.tsx
+++ b/frontend/src/components/reports/MonteCarloReport.test.tsx
@@ -929,6 +929,20 @@ describe('MonteCarloReport', () => {
       ).toBeInTheDocument();
     });
 
+    it('keeps a long scenario name inside the sidebar', async () => {
+      // Regression: the name sits in a `truncate` div inside a `flex-1`
+      // button. A flex item defaults to min-width:auto, so without `min-w-0`
+      // the button grew to the full name and pushed out of the card -- the
+      // select-mode branch beside it already had `min-w-0`.
+      const longName = 'Aggressive thirty year retirement plan with every option enabled';
+      mockApi.list.mockResolvedValueOnce([scenario({ id: 'long-1', name: longName })]);
+      await renderReport();
+
+      const item = await screen.findByRole('button', { name: new RegExp(longName, 'i') });
+      expect(item.className).toContain('min-w-0');
+      expect(item.querySelector('.truncate')).toHaveTextContent(longName);
+    });
+
     it('clicking New clears active scenario and form fields', async () => {
       mockApi.list.mockResolvedValueOnce([scenario({ name: 'Old plan' })]);
       await renderReport();

--- a/frontend/src/components/reports/MonteCarloReport.tsx
+++ b/frontend/src/components/reports/MonteCarloReport.tsx
@@ -532,9 +532,13 @@ export function MonteCarloReport() {
                     </div>
                   </label>
                 ) : (
+                  /* min-w-0 is what makes the `truncate` inside work: a flex item
+                     defaults to min-width:auto, so without it the button grows to
+                     the name's full width and a long scenario name pushes out of
+                     the sidebar. The select-mode branch above already does this. */
                   <button
                     onClick={() => !reordering && loadScenario(s)}
-                    className={`flex-1 text-left px-2 py-1.5 rounded text-sm ${
+                    className={`min-w-0 flex-1 text-left px-2 py-1.5 rounded text-sm ${
                       reordering ? 'cursor-default' : ''
                     } ${
                       activeId === s.id

--- a/frontend/src/lib/action-history.test.ts
+++ b/frontend/src/lib/action-history.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import apiClient from './api';
 import { actionHistoryApi } from './action-history';
+import { getCached, setCache } from './apiCache';
 
 vi.mock('./api', () => ({
   default: { get: vi.fn(), post: vi.fn() },
@@ -59,5 +60,21 @@ describe('actionHistoryApi', () => {
     const result = await actionHistoryApi.redo();
     expect(apiClient.post).toHaveBeenCalledWith('/action-history/redo');
     expect(result.description).toBe('redid create');
+  });
+
+  // Regression: `notifyUndoRedo` tells every mounted page to refetch, but the
+  // refetch goes through `dedupe`, so without dropping the cache first the
+  // subscriber is handed back the values the undo just reversed.
+  it.each(['undo', 'redo'] as const)('%s empties the API cache', async (op) => {
+    setCache('accounts:all:true', [{ id: 'a-1' }], 120_000);
+    setCache('payees:all', [{ id: 'p-1' }], 120_000);
+    vi.mocked(apiClient.post).mockResolvedValue({
+      data: { action: { id: 'h-1' }, description: 'reversed' },
+    });
+
+    await actionHistoryApi[op]();
+
+    expect(getCached('accounts:all:true')).toBeUndefined();
+    expect(getCached('payees:all')).toBeUndefined();
   });
 });

--- a/frontend/src/lib/action-history.ts
+++ b/frontend/src/lib/action-history.ts
@@ -1,4 +1,5 @@
 import apiClient from './api';
+import { clearAllCache } from './apiCache';
 
 export interface ActionHistoryItem {
   id: string;
@@ -30,13 +31,19 @@ export const actionHistoryApi = {
     return data;
   },
 
+  // Undo/redo can reverse a write to any entity, so there is no prefix narrow
+  // enough to be correct. Clearing everything also keeps the promise made by
+  // `notifyUndoRedo`: subscribers refetch, and without this the refetch is
+  // served from the cache that the reversed write left behind.
   undo: async (): Promise<UndoRedoResult> => {
     const { data } = await apiClient.post<UndoRedoResult>('/action-history/undo');
+    clearAllCache();
     return data;
   },
 
   redo: async (): Promise<UndoRedoResult> => {
     const { data } = await apiClient.post<UndoRedoResult>('/action-history/redo');
+    clearAllCache();
     return data;
   },
 };

--- a/frontend/src/lib/apiCache.ts
+++ b/frontend/src/lib/apiCache.ts
@@ -35,6 +35,26 @@ export function clearAllCache(): void {
   inflight.clear();
 }
 
+/**
+ * Drop every cached view of a balance. Call this from any write that moves
+ * money -- posting a scheduled transaction, editing a split, an investment
+ * trade, an import -- not just the ones that go through `transactionsApi`.
+ *
+ * `accountsApi.getAll` caches for two minutes and the backend computes the
+ * balance live from transactions, so a write that skips this leaves the
+ * Accounts page showing the pre-write number until the entry ages out or the
+ * browser reloads. Navigating back to the page does not help: the page
+ * refetches on mount and the refetch is served from this cache.
+ *
+ * Both prefixes go together because an account balance and a portfolio value
+ * are two views of the same rows: a trade moves the INVESTMENT_CASH balance,
+ * and a split transfer moves an account the parent transaction never named.
+ */
+export function invalidateBalanceCaches(): void {
+  invalidateCache('accounts:');
+  invalidateCache('investments:');
+}
+
 // Cache + in-flight deduplication. When several callers request the same key
 // before the first response arrives, they all await the same promise instead
 // of triggering parallel network requests. Successful responses are cached

--- a/frontend/src/lib/backupApi.ts
+++ b/frontend/src/lib/backupApi.ts
@@ -1,4 +1,5 @@
 import apiClient from './api';
+import { clearAllCache } from './apiCache';
 import { filenameFromContentDisposition } from './download';
 import { AutoBackupSettings, UpdateAutoBackupSettingsData } from '@/types/auth';
 
@@ -231,6 +232,9 @@ export const backupApi = {
       body,
       { headers, timeout: 300000 },
     );
+    // A restore replaces the whole dataset; nothing cached from before it is
+    // still true.
+    clearAllCache();
     return response.data;
   },
 

--- a/frontend/src/lib/balance-cache.guard.test.ts
+++ b/frontend/src/lib/balance-cache.guard.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Guard test for the balance-cache rule in `frontend/CLAUDE.md`.
+ *
+ * `accountsApi.getAll` caches for two minutes, so any write that moves money
+ * has to call `invalidateBalanceCaches()` (or `clearAllCache()`) before it
+ * returns. A write that skips it leaves the Accounts page showing the
+ * pre-write balance until the entry ages out or the browser reloads -- and
+ * navigating back to the page does not fix it, because the page's refetch on
+ * mount is served from that same cache.
+ *
+ * This was originally missed on `scheduledTransactionsApi.post`, which
+ * invalidated only `scheduled:`. A test around that one method would not have
+ * caught the identical omission sitting in `updateSplits`, `addSplit`,
+ * `deleteSplit` and the import endpoints, so this scans the source instead --
+ * the pattern used by `src/test/ui-conventions.test.ts`.
+ *
+ * Modelled on that file: add an endpoint here when a new route starts writing
+ * transaction rows.
+ */
+const sources = import.meta.glob('/src/lib/*.ts', {
+  query: '?raw',
+  eager: true,
+  import: 'default',
+}) as Record<string, string>;
+
+/** Routes whose writes change a balance the Accounts page reads. */
+const BALANCE_WRITING_ROUTES = [
+  /['`]\/transactions/,
+  /['`]\/scheduled-transactions\/\$\{[^}]+\}\/post['`]/,
+  /['`]\/investment-transactions/,
+  /['`]\/import\/(qif|ofx|csv)['`]/,
+];
+
+/**
+ * Sub-routes that hang off a balance-affecting path but write no money. A
+ * receipt attached to a transaction changes nothing any balance sums.
+ */
+const NO_MONEY_ROUTES = [/\/attachments/];
+
+/**
+ * Writes on a balance-affecting route that move no money, so they are allowed
+ * to leave the cache in place. `AccountsService.getProjectedBalance` -- and its
+ * `onlyBalanceAffecting` helper on the backend -- is the definition being
+ * tracked: a balance sums every non-VOID, non-child transaction. Clearing and
+ * reconciling touch neither the amount nor the VOID flag. (Voiding goes through
+ * `updateStatus`, which is *not* on this list and does invalidate.)
+ */
+const NO_MONEY_MOVED = ['markCleared', 'reconcile', 'unreconcile'];
+
+const INVALIDATES = /invalidateBalanceCaches\(\)|clearAllCache\(\)/;
+const MUTATION = /apiClient\.(post|put|patch|delete)/;
+
+/**
+ * Split a feature API module into its `name: async (...) => { ... },` methods.
+ * They are all one indent level inside the exported object literal, so the
+ * two-space `},` that closes one is an unambiguous terminator.
+ */
+function methodsOf(source: string): { name: string; body: string }[] {
+  const lines = source.split('\n');
+  const methods: { name: string; body: string }[] = [];
+  let current: { name: string; body: string[] } | null = null;
+
+  for (const line of lines) {
+    const start = /^ {2}([a-zA-Z][a-zA-Z0-9_]*): async /.exec(line);
+    if (start) {
+      if (current) methods.push({ name: current.name, body: current.body.join('\n') });
+      current = { name: start[1], body: [line] };
+      continue;
+    }
+    if (!current) continue;
+    current.body.push(line);
+    if (/^ {2}\},?$/.test(line)) {
+      methods.push({ name: current.name, body: current.body.join('\n') });
+      current = null;
+    }
+  }
+  if (current) methods.push({ name: current.name, body: current.body.join('\n') });
+  return methods;
+}
+
+describe('a write that moves money drops the cached balances', () => {
+  it('has no balance-writing API method that skips invalidation', () => {
+    const offenders: string[] = [];
+
+    for (const [path, source] of Object.entries(sources)) {
+      if (/\.test\.ts$/.test(path)) continue;
+      for (const { name, body } of methodsOf(source)) {
+        if (NO_MONEY_MOVED.includes(name)) continue;
+        if (!MUTATION.test(body)) continue;
+        if (NO_MONEY_ROUTES.some((route) => route.test(body))) continue;
+        if (!BALANCE_WRITING_ROUTES.some((route) => route.test(body))) continue;
+        if (INVALIDATES.test(body)) continue;
+        offenders.push(`${path} -> ${name}`);
+      }
+    }
+
+    // Each of these writes transaction rows. Add `invalidateBalanceCaches()`
+    // after the await, before the return.
+    expect(offenders).toEqual([]);
+  });
+
+  it('still matches the methods it is meant to police', () => {
+    // Were a module renamed, or the object-literal style replaced, the check
+    // above would pass trivially over an empty set. This fails first and says
+    // what to update.
+    const covered = Object.entries(sources)
+      .filter(([path]) => !/\.test\.ts$/.test(path))
+      .flatMap(([, source]) => methodsOf(source))
+      .filter(({ body }) => BALANCE_WRITING_ROUTES.some((r) => r.test(body)))
+      .filter(({ body }) => MUTATION.test(body))
+      .map(({ name }) => name);
+
+    expect(covered).toContain('post'); // scheduledTransactionsApi.post
+    expect(covered).toContain('updateSplits');
+    expect(covered).toContain('createTransfer');
+    expect(covered).toContain('importCsv');
+    expect(covered).toContain('createTransaction'); // investmentsApi
+  });
+});

--- a/frontend/src/lib/import-mny.ts
+++ b/frontend/src/lib/import-mny.ts
@@ -1,4 +1,5 @@
 import apiClient from './api';
+import { invalidateBalanceCaches } from './apiCache';
 import { AccountType } from '@/types/account';
 
 /**
@@ -314,6 +315,12 @@ export const mnyImportApi = {
       `/import/mny/jobs/${id}`,
       { timeout: POLL_TIMEOUT_MS },
     );
+    // The import runs server-side after `start` returns, so the write lands
+    // here rather than at a mutation call. A failed job can still have written
+    // rows before it stopped, so both terminal states invalidate.
+    if (response.data.status === 'completed' || response.data.status === 'failed') {
+      invalidateBalanceCaches();
+    }
     return response.data;
   },
 

--- a/frontend/src/lib/import.ts
+++ b/frontend/src/lib/import.ts
@@ -1,4 +1,5 @@
 import apiClient from './api';
+import { invalidateBalanceCaches } from './apiCache';
 
 export type DateFormat = 'MM/DD/YYYY' | 'DD/MM/YYYY' | 'YYYY-MM-DD' | 'YYYY-DD-MM';
 
@@ -300,6 +301,7 @@ export const importApi = {
   importQif: async (data: ImportQifRequest): Promise<ImportResult> => {
     // Longer timeout for large imports (5 minutes)
     const response = await apiClient.post('/import/qif', data, { timeout: 300000 });
+    invalidateBalanceCaches();
     return response.data;
   },
 
@@ -311,6 +313,7 @@ export const importApi = {
 
   importQifMultiAccount: async (data: ImportQifMultiAccountRequest): Promise<ImportResult> => {
     const response = await apiClient.post('/import/qif/multi-account', data, { timeout: 300000 });
+    invalidateBalanceCaches();
     return response.data;
   },
 
@@ -322,6 +325,7 @@ export const importApi = {
 
   importOfx: async (data: ImportOfxRequest): Promise<ImportResult> => {
     const response = await apiClient.post('/import/ofx', data, { timeout: 300000 });
+    invalidateBalanceCaches();
     return response.data;
   },
 
@@ -338,6 +342,7 @@ export const importApi = {
 
   importCsv: async (data: ImportCsvRequest): Promise<ImportResult> => {
     const response = await apiClient.post('/import/csv', data, { timeout: 300000 });
+    invalidateBalanceCaches();
     return response.data;
   },
 

--- a/frontend/src/lib/investments.ts
+++ b/frontend/src/lib/investments.ts
@@ -25,7 +25,7 @@ import {
   SecurityDetail,
 } from '@/types/investment';
 import { IntradayBreakdown } from '@/types/net-worth';
-import { getCached, setCache, invalidateCache } from './apiCache';
+import { getCached, setCache, invalidateBalanceCaches, invalidateCache } from './apiCache';
 
 export const investmentsApi = {
   // Get portfolio summary
@@ -279,7 +279,7 @@ export const investmentsApi = {
       '/investment-transactions',
       data,
     );
-    invalidateCache('investments:');
+    invalidateBalanceCaches();
     return response.data;
   },
 
@@ -302,7 +302,7 @@ export const investmentsApi = {
       transferOut: InvestmentTransaction;
       transferIn: InvestmentTransaction;
     }>('/investment-transactions/transfer-security', data);
-    invalidateCache('investments:');
+    invalidateBalanceCaches();
     return response.data;
   },
 
@@ -319,7 +319,7 @@ export const investmentsApi = {
       `/investment-transactions/${id}`,
       data,
     );
-    invalidateCache('investments:');
+    invalidateBalanceCaches();
     return response.data;
   },
 
@@ -345,7 +345,7 @@ export const investmentsApi = {
   // Delete investment transaction
   deleteTransaction: async (id: string): Promise<void> => {
     await apiClient.delete(`/investment-transactions/${id}`);
-    invalidateCache('investments:');
+    invalidateBalanceCaches();
   },
 
   // Get all securities

--- a/frontend/src/lib/scheduled-transactions.test.ts
+++ b/frontend/src/lib/scheduled-transactions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import apiClient from './api';
 import { scheduledTransactionsApi } from './scheduled-transactions';
+import { clearAllCache, getCached, setCache } from './apiCache';
 
 vi.mock('./api', () => ({
   default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -130,5 +131,32 @@ describe('scheduledTransactionsApi', () => {
     const result = await scheduledTransactionsApi.deleteAllOverrides('st-1');
     expect(apiClient.delete).toHaveBeenCalledWith('/scheduled-transactions/st-1/overrides');
     expect(result).toBe(3);
+  });
+
+  // Regression: posting writes a real transaction, so the cached account
+  // balances are stale the moment it returns. They were not being dropped, so
+  // the Accounts page kept showing the pre-post balance for the two-minute TTL
+  // -- navigating away and back did not help, because the page's refetch on
+  // mount was served from the same cache. Only a browser reload cleared it.
+  it('post drops the cached account and portfolio balances', async () => {
+    clearAllCache();
+    setCache('accounts:all:true', [{ id: 'a-1', currentBalance: 100 }], 120_000);
+    setCache('investments:portfolioSummary', { total: 1 }, 120_000);
+
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { id: 'st-1' } });
+    await scheduledTransactionsApi.post('st-1');
+
+    expect(getCached('accounts:all:true')).toBeUndefined();
+    expect(getCached('investments:portfolioSummary')).toBeUndefined();
+  });
+
+  it('skip leaves balance caches alone -- it writes no transaction', async () => {
+    clearAllCache();
+    setCache('accounts:all:true', [{ id: 'a-1' }], 120_000);
+
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { id: 'st-1' } });
+    await scheduledTransactionsApi.skip('st-1');
+
+    expect(getCached('accounts:all:true')).toEqual([{ id: 'a-1' }]);
   });
 });

--- a/frontend/src/lib/scheduled-transactions.ts
+++ b/frontend/src/lib/scheduled-transactions.ts
@@ -9,7 +9,7 @@ import {
   OverrideCheckResult,
   PostScheduledTransactionData,
 } from '@/types/scheduled-transaction';
-import { dedupe, invalidateCache } from './apiCache';
+import { dedupe, invalidateBalanceCaches, invalidateCache } from './apiCache';
 
 export const scheduledTransactionsApi = {
   // Create a new scheduled transaction
@@ -79,6 +79,10 @@ export const scheduledTransactionsApi = {
       data || {},
     );
     invalidateCache('scheduled:');
+    // Posting writes a real transaction, so every balance derived from it is
+    // now stale. Without this the Accounts page shows the pre-post balance for
+    // up to two minutes, including after navigating back to it.
+    invalidateBalanceCaches();
     return response.data;
   },
 

--- a/frontend/src/lib/transactions.ts
+++ b/frontend/src/lib/transactions.ts
@@ -21,7 +21,7 @@ import {
   GroupedTotal,
   RecurringChargeInfo,
 } from '@/types/transaction';
-import { invalidateCache } from './apiCache';
+import { invalidateBalanceCaches } from './apiCache';
 
 /** Convert array filter params to comma-separated strings for the API. */
 function buildFilterParams(params?: {
@@ -98,8 +98,7 @@ export const transactionsApi = {
   // Create a new transaction
   create: async (data: CreateTransactionData): Promise<Transaction> => {
     const response = await apiClient.post<Transaction>('/transactions', data);
-    invalidateCache('accounts:');
-    invalidateCache('investments:');
+    invalidateBalanceCaches();
     return response.data;
   },
 
@@ -191,16 +190,14 @@ export const transactionsApi = {
   // Update transaction
   update: async (id: string, data: UpdateTransactionData): Promise<Transaction> => {
     const response = await apiClient.patch<Transaction>(`/transactions/${id}`, data);
-    invalidateCache('accounts:');
-    invalidateCache('investments:');
+    invalidateBalanceCaches();
     return response.data;
   },
 
   // Delete transaction
   delete: async (id: string): Promise<void> => {
     await apiClient.delete(`/transactions/${id}`);
-    invalidateCache('accounts:');
-    invalidateCache('investments:');
+    invalidateBalanceCaches();
   },
 
   // Mark transaction as cleared/uncleared
@@ -228,8 +225,7 @@ export const transactionsApi = {
     const response = await apiClient.patch<Transaction>(`/transactions/${id}/status`, {
       status,
     });
-    invalidateCache('accounts:');
-    invalidateCache('investments:');
+    invalidateBalanceCaches();
     return response.data;
   },
 
@@ -411,6 +407,10 @@ export const transactionsApi = {
       `/transactions/${transactionId}/splits`,
       splits,
     );
+    // A split can carry a transferAccountId, and the backend writes the
+    // counterpart transaction into that other account -- so editing splits
+    // moves balances the parent transaction never named.
+    invalidateBalanceCaches();
     return response.data;
   },
 
@@ -423,12 +423,14 @@ export const transactionsApi = {
       `/transactions/${transactionId}/splits`,
       split,
     );
+    invalidateBalanceCaches();
     return response.data;
   },
 
   // Remove a split from a transaction
   deleteSplit: async (transactionId: string, splitId: string): Promise<void> => {
     await apiClient.delete(`/transactions/${transactionId}/splits/${splitId}`);
+    invalidateBalanceCaches();
   },
 
   // ==================== Transfer Methods ====================
@@ -436,8 +438,7 @@ export const transactionsApi = {
   // Create a transfer between two accounts
   createTransfer: async (data: CreateTransferData): Promise<TransferResult> => {
     const response = await apiClient.post<TransferResult>('/transactions/transfer', data);
-    invalidateCache('accounts:');
-    invalidateCache('investments:');
+    invalidateBalanceCaches();
     return response.data;
   },
 
@@ -452,8 +453,7 @@ export const transactionsApi = {
   // Delete a transfer (deletes both linked transactions)
   deleteTransfer: async (transactionId: string): Promise<void> => {
     await apiClient.delete(`/transactions/${transactionId}/transfer`);
-    invalidateCache('accounts:');
-    invalidateCache('investments:');
+    invalidateBalanceCaches();
   },
 
   // Update a transfer (updates both linked transactions)
@@ -465,8 +465,7 @@ export const transactionsApi = {
       `/transactions/${transactionId}/transfer`,
       data,
     );
-    invalidateCache('accounts:');
-    invalidateCache('investments:');
+    invalidateBalanceCaches();
     return response.data;
   },
 
@@ -497,8 +496,7 @@ export const transactionsApi = {
       `/transactions/reconcile/${accountId}`,
       { transactionIds, reconciledDate },
     );
-    invalidateCache('accounts:');
-    invalidateCache('investments:');
+    invalidateBalanceCaches();
     return response.data;
   },
 
@@ -508,8 +506,7 @@ export const transactionsApi = {
       '/transactions/bulk-update',
       data,
     );
-    invalidateCache('accounts:');
-    invalidateCache('investments:');
+    invalidateBalanceCaches();
     return response.data;
   },
 
@@ -519,8 +516,7 @@ export const transactionsApi = {
       '/transactions/bulk-delete',
       data,
     );
-    invalidateCache('accounts:');
-    invalidateCache('investments:');
+    invalidateBalanceCaches();
     return response.data;
   },
 };

--- a/frontend/src/store/aiChatStore.ts
+++ b/frontend/src/store/aiChatStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { aiApi } from '@/lib/ai';
 import { notifyAiAction } from '@/lib/aiActionSignal';
+import { clearAllCache } from '@/lib/apiCache';
 import type {
   ChartPayload,
   PendingAction,
@@ -752,7 +753,10 @@ export const useAiChatStore = create<AiChatState>()(
           // The write landed server-side; tell any mounted list page to reload
           // so the new/edited record shows up without a manual refresh (e.g. a
           // transaction created from the chat bubble while on the Transactions
-          // page).
+          // page). Drop the cache first -- the assistant can write any entity,
+          // and a subscriber's refetch would otherwise be served the values
+          // this action just replaced.
+          clearAllCache();
           notifyAiAction();
         } catch (err) {
           const errorMessage =


### PR DESCRIPTION
## Linked discussion / issue

Both fixes were reported directly by the maintainer during use; no separate discussion was opened.

Closes #
Approved in: reported by @kenlasko in-session

## Summary

Two small frontend bugs.

**1. Stale account balances after a write.** After posting a scheduled transaction, returning to the Accounts page still showed the old balance until a browser reload. `accountsApi.getAll` is served from `apiCache` with a two-minute TTL, and navigating back does not help — the page refetches on mount and the refetch comes out of that same cache.

`scheduledTransactionsApi.post` invalidated `scheduled:` and nothing else, and it was not the only offender:

- splits (`updateSplits` / `addSplit` / `deleteSplit`) — a split can carry a `transferAccountId`, so the counterpart lands in an account the parent transaction never names
- investment `createTransaction` / `updateTransaction` / `deleteTransaction` / `transferSecurity` — these move the linked `INVESTMENT_CASH` balance
- QIF / OFX / CSV / MNY imports
- undo/redo and AI assistant writes — worse than stale: `notifyUndoRedo` / `notifyAiAction` tell mounted pages to refetch, and the refetch was answered from the cache the reversed write had left behind, so the signal was a no-op
- backup restore

Adds `invalidateBalanceCaches()` to `apiCache.ts` (clears `accounts:` and `investments:` together, since a balance and a portfolio value are two views of the same rows) and calls it from each of those writes; uses `clearAllCache()` where the write can touch anything.

`markCleared` / `reconcile` / `unreconcile` are deliberately left alone — per the backend's `onlyBalanceAffecting`, a balance sums non-VOID, non-child rows and those touch neither. Voiding goes through `updateStatus`, which does invalidate.

**2. Monte Carlo scenario name overflow.** A long saved scenario name pushed out of the Scenarios card. The name sits in a `truncate` div inside a `flex-1` button, and a flex item defaults to `min-width: auto`, so the button grew to the full name rather than clipping. The select-mode branch beside it already had `min-w-0`.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series). — two one-line-cause bug fixes, one commit each
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). — no user-facing strings changed
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

### Tests

Following the repo rule that a human-reported defect becomes an enforced rule, the cache fix ships a source-scanning guard (`src/lib/balance-cache.guard.test.ts`) that fails on *any* API method writing to a money route without invalidating — a test around `post` alone would have missed the four other sites. Plus behavioural tests on `post`, `skip` (asserting it does *not* invalidate) and undo/redo, and a rendering test pinning `min-w-0` on the scenario button. Each was verified to fail against the unfixed code. The rule is written up in `frontend/CLAUDE.md`.

`type-check` and `lint` are clean. `authStore.test.ts > keeps authenticated state on network error` fails on this branch — it fails identically on unmodified `main`, so it is pre-existing and unrelated.

## AI assistance disclosure

Written with Claude Code (Opus 5). Diagnosis, fixes, tests and this description are AI-authored and maintainer-reviewed.
