### PR TITLE
Make the financial contracts checkable, not just correct

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,9 @@ The point is that the next agent inherits the correction. A fix that lives only 
 
 **Prefer the rule the machine can check.** A rule in prose gets read, agreed with, and violated anyway; the financial contracts in `docs/` have been all three more than once. Ranked by how well they hold: a type the compiler enforces, a lint rule, a test that scans the source, a paragraph in a `CLAUDE.md`. Reach for the highest one the mistake allows, and use prose for the part that genuinely needs judgement rather than as the first resort.
 
-**A green suite after a behaviour change is a finding.** If you changed what the code produces and nothing failed, either the change is a no-op or the suite had no case for it. Say which, in the change description, and if it is the second, add the case in the same commit. `docs/financial-calculation-contract.md` section 7.1 has the long form; it applies everywhere, not only to money.
+**A green suite after a behaviour change is a finding.** If you changed what the code produces and nothing failed, either the change is a no-op or the suite had no case for it. Say which, in the change description, and if it is the second, add the case in the same commit. `docs/financial-calculation-contract.md` section 8.1 has the long form; it applies everywhere, not only to money.
+
+**Asynchronous data belongs to the request that produced it.** A payload without its request key cannot be told apart from the previous payload, so every action offered beside it may be aimed at the wrong thing. Keep the pair together, adopt a mutation's response only when its captured origin still matches the current selection, and never treat a failed lookup as an empty result. `frontend/CLAUDE.md` has the full rule and the regression matrix.
 
 **A doc that names an identifier is making a claim about the source.** Renaming or deleting a field, flag or helper means grepping `docs/` and every `CLAUDE.md` in the same commit. A document describing a model that no longer exists is worse than none: it gets read, believed, and built on. The same goes for a comment asserting that *every* call site does something -- that is a scanning test, not a comment.
 
@@ -101,6 +103,8 @@ After writing or editing code, check LSP diagnostics and fix errors before proce
 ## Transactions (CRITICAL)
 
 Any operation that touches multiple tables or does read-modify-write MUST run in a single transaction. This is the most common source of bugs in this codebase.
+
+**A rejected command must not already have written.** Every check that can refuse a request -- ownership, tenant or scenario identity, revision, precondition -- runs inside the same transaction as the mutation, and under the same lock where concurrency matters. A `403`, `404`, `409` or validation failure claims the change did not happen, and an HTTP status cannot undo a committed row: validating after a service has saved and committed leaves the client with an error on screen and the write in the database. Pass the caller's expectation down into the operation so it can refuse, rather than letting a higher layer reject something already done. `docs/financial-calculation-contract.md` section 7 has the rule, the forbidden sequence and the test obligation.
 
 ```typescript
 async createSomething(userId: string, dto: CreateDto) {
@@ -179,7 +183,7 @@ A field named `total*`, `portfolioValue`, `transferValue`, `gain`, `tax`, or `es
 
 **`null` is not the safe answer either.** It means "not known", so a state that *is* known must not use it: empty accounts hold zero, move zero, realize zero and owe zero, and reporting those as unknown tells the user a settled question could not be worked out -- while making "nothing to do" indistinguishable from "cannot compute". Decide which of the two each branch is in before writing it.
 
-The full rules -- cost basis and tax truth table, cash, valuation, materialized-result versioning, stale quotes, backtests over incomplete history, and the required adversarial test matrix -- live in `docs/financial-calculation-contract.md` and `docs/time-series-contract.md`. Read both **before** writing or changing any financial calculation, not when a review asks about them: every rule those documents contain has been read, agreed with and broken anyway by someone who reached them afterwards. A financial feature of any substance -- it computes money, materializes a derived result, or reads a time series -- starts from a short approved spec (invariants, truth tables, numerical examples, missing-data policy, test matrix), committed *before* the implementation it guides.
+The full rules -- cost basis and tax truth table, cash, valuation, materialized-result versioning, stale quotes, backtests over incomplete history, and the required adversarial test matrix -- live in `docs/financial-calculation-contract.md` and `docs/time-series-contract.md`. Read both **before** writing or changing any financial calculation, not when a review asks about them: every rule those documents contain has been read, agreed with and broken anyway by someone who reached them afterwards. `docs/testing-contract.md` lists the adversarial inputs that have broken this codebase before -- dates, money precision, aggregation, currency conversion, ownership, concurrency -- so a test author picks from a list rather than recalling edge cases; it is explicitly not a requirement that every test use every value. A financial feature of any substance -- it computes money, materializes a derived result, or reads a time series -- starts from a short approved spec (invariants, truth tables, numerical examples, missing-data policy, test matrix), committed *before* the implementation it guides.
 
 ## Environment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,12 @@ Before writing a UI control, a data access path, or anything a user interacts wi
 
 The point is that the next agent inherits the correction. A fix that lives only in one file will be re-broken in the next one.
 
+**Prefer the rule the machine can check.** A rule in prose gets read, agreed with, and violated anyway; the financial contracts in `docs/` have been all three more than once. Ranked by how well they hold: a type the compiler enforces, a lint rule, a test that scans the source, a paragraph in a `CLAUDE.md`. Reach for the highest one the mistake allows, and use prose for the part that genuinely needs judgement rather than as the first resort.
+
+**A green suite after a behaviour change is a finding.** If you changed what the code produces and nothing failed, either the change is a no-op or the suite had no case for it. Say which, in the change description, and if it is the second, add the case in the same commit. `docs/financial-calculation-contract.md` section 7.1 has the long form; it applies everywhere, not only to money.
+
+**A doc that names an identifier is making a claim about the source.** Renaming or deleting a field, flag or helper means grepping `docs/` and every `CLAUDE.md` in the same commit. A document describing a model that no longer exists is worse than none: it gets read, believed, and built on. The same goes for a comment asserting that *every* call site does something -- that is a scanning test, not a comment.
+
 ### Running the suites locally -- two ways a green branch reads as red
 
 CI runs in UTC with one Playwright worker. A local run does neither, and both differences produce failures that look like regressions and are not.
@@ -171,7 +177,9 @@ Balance updates use atomic SQL: `UPDATE accounts SET current_balance = current_b
 
 A field named `total*`, `portfolioValue`, `transferValue`, `gain`, `tax`, or `estimated*` may only carry a value when **every** component of the calculation is known. Filtering out `null` components and summing the rest produces a subtotal, not a total -- if any component is unknown, the total is `null`, and the partial sum, if returned at all, goes in a separate explicitly named field (`knownMarketValueSubtotal`), never in the total's field. Never default an unknown price, cost basis, or rate to `0` (or an exchange rate to `1`) to keep a formula running, and never treat a missing period price as a 0% return.
 
-The full rules -- cost basis and tax truth table, cash, valuation, materialized-result versioning, stale quotes, backtests over incomplete history, and the required adversarial test matrix -- live in `docs/financial-calculation-contract.md` and `docs/time-series-contract.md`. Read both before writing or changing any financial calculation. A financial feature of any substance starts from a short approved spec (invariants, truth tables, numerical examples, missing-data policy, test matrix) before implementation, not from code.
+**`null` is not the safe answer either.** It means "not known", so a state that *is* known must not use it: empty accounts hold zero, move zero, realize zero and owe zero, and reporting those as unknown tells the user a settled question could not be worked out -- while making "nothing to do" indistinguishable from "cannot compute". Decide which of the two each branch is in before writing it.
+
+The full rules -- cost basis and tax truth table, cash, valuation, materialized-result versioning, stale quotes, backtests over incomplete history, and the required adversarial test matrix -- live in `docs/financial-calculation-contract.md` and `docs/time-series-contract.md`. Read both **before** writing or changing any financial calculation, not when a review asks about them: every rule those documents contain has been read, agreed with and broken anyway by someone who reached them afterwards. A financial feature of any substance -- it computes money, materializes a derived result, or reads a time series -- starts from a short approved spec (invariants, truth tables, numerical examples, missing-data policy, test matrix), committed *before* the implementation it guides.
 
 ## Environment
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -106,6 +106,23 @@ This class of bug is invisible to unit tests, which construct payloads by hand a
 
 Mock repositories use `Record<string, jest.Mock>`; tests use `Test.createTestingModule` with mocks injected via `getRepositoryToken()`. E2E tests live in `test/` with helpers under `test/helpers/` (`auth-helper.ts`, `test-database.ts`, `test-factories.ts`).
 
+### A mock must return what the real collaborator returns
+
+`Record<string, jest.Mock>` is fine for a repository, whose surface the driver defines. For **one of our own services**, type the double -- `jest.Mocked<TheService>`, or a `Partial<jest.Mocked<T>>` cast once -- so `tsc` rejects a return shape the real method cannot produce.
+
+Untyped, a mock quietly becomes fiction, and the branch that reads that fiction is green and unreachable. Two ways it happens:
+
+- **A shape the driver never returns.** A TypeORM insert result mocked as `{ generatedMaps: [] }` made an entire lost-the-race path testable, tested and dead: the real driver signals a conflict elsewhere, so the branch never ran in production and its tests never ran anything else.
+- **A signature that moved.** A service method growing from `Promise<boolean>` to `Promise<string | null>` leaves `mockResolvedValue(true)` behind it -- still truthy, still passing, still describing a contract nothing has any more. When you change a method's return type, grep its mocks in the same commit.
+
+### Fixtures are claims about production data
+
+A fixture is evidence only if the code that writes the real data could have written it. Before adding one, look at the producer: the query's sampling, whether the column is nullable, whether the format guarantees what the fixture assumes. A price series three points a quarter apart proves nothing about code reading daily closes, and weightings that always sum to 1 never exercise the remainder the storage format allows. `docs/financial-calculation-contract.md` section 7.3 has the full rule.
+
+### Do not trust a suite that stayed green
+
+Changing what a service computes and seeing every test pass means the change is a no-op or the suite has a hole -- see `docs/financial-calculation-contract.md` sections 7.1 and 7.2. Establish which before moving on, and break each new invariant on purpose once to confirm its test actually fails.
+
 ## Internationalization (i18n)
 
 Server-rendered strings (exception messages, email copy) are localized via `nestjs-i18n`. Wrap exception messages in `tr(key, fallback, args)` (`src/i18n/translate.ts`), which resolves against the request locale and returns the English `fallback` outside an HTTP context (jobs, schedulers, tests). Render emails with an `EmailT` translator (`emailTranslator(i18n, recipientLang)` from `src/i18n/email-translator.ts`) so copy matches the recipient's stored locale rather than the request's. Catalogs live in `src/i18n/locales/{locale}/*.json`, one folder per supported locale; the authoritative locale list is `SUPPORTED_LOCALE_CODES` in `src/i18n/config.ts` (root `CLAUDE.md` enumerates them) -- keep it in sync with the frontend's. The `en-*` entries are lean regional variants (declared in `LOCALE_BASES`): they hold only the keys that differ from `en` and fall back to it per key. Adding or changing a string means updating every locale -- the parity test `src/i18n/locales.parity.spec.ts` fails otherwise -- then regenerating the pseudo-locale with `npm run i18n:pseudo`. Full contributor flow: `src/i18n/README.md`.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -102,6 +102,12 @@ transactionDate: string;
 
 This class of bug is invisible to unit tests, which construct payloads by hand and never send what the form sends. It surfaces in E2E or in production.
 
+## Rejection happens before the write
+
+A check capable of refusing a command belongs inside the transaction that performs it, and under the same lock when concurrency is in play. A service that mutates, commits, and returns a success-shaped value for a caller to reject afterwards has already done the thing the `409` says it did not do.
+
+Give the operation the caller's precondition as a parameter -- the expected owner, scenario or revision -- and let it refuse before writing. Return the refusal distinguishably: "no such row", "not yours" and "done" are three answers, and folding two into `null` makes the caller guess. Tests assert the rejected response **and** the stored state; see `docs/financial-calculation-contract.md` section 7.
+
 ## Testing Conventions
 
 Mock repositories use `Record<string, jest.Mock>`; tests use `Test.createTestingModule` with mocks injected via `getRepositoryToken()`. E2E tests live in `test/` with helpers under `test/helpers/` (`auth-helper.ts`, `test-database.ts`, `test-factories.ts`).
@@ -117,11 +123,11 @@ Untyped, a mock quietly becomes fiction, and the branch that reads that fiction 
 
 ### Fixtures are claims about production data
 
-A fixture is evidence only if the code that writes the real data could have written it. Before adding one, look at the producer: the query's sampling, whether the column is nullable, whether the format guarantees what the fixture assumes. A price series three points a quarter apart proves nothing about code reading daily closes, and weightings that always sum to 1 never exercise the remainder the storage format allows. `docs/financial-calculation-contract.md` section 7.3 has the full rule.
+`docs/testing-contract.md` is the shared list of adversarial inputs to choose from. A fixture is evidence only if the code that writes the real data could have written it. Before adding one, look at the producer: the query's sampling, whether the column is nullable, whether the format guarantees what the fixture assumes. A price series three points a quarter apart proves nothing about code reading daily closes, and weightings that always sum to 1 never exercise the remainder the storage format allows. `docs/financial-calculation-contract.md` section 8.3 has the full rule.
 
 ### Do not trust a suite that stayed green
 
-Changing what a service computes and seeing every test pass means the change is a no-op or the suite has a hole -- see `docs/financial-calculation-contract.md` sections 7.1 and 7.2. Establish which before moving on, and break each new invariant on purpose once to confirm its test actually fails.
+Changing what a service computes and seeing every test pass means the change is a no-op or the suite has a hole -- see `docs/financial-calculation-contract.md` sections 8.1 and 8.2. Establish which before moving on, and break each new invariant on purpose once to confirm its test actually fails.
 
 ## Internationalization (i18n)
 

--- a/docs/financial-calculation-contract.md
+++ b/docs/financial-calculation-contract.md
@@ -124,7 +124,89 @@ sees:
   -- the request that lost the race would return data missing the rows the
   winning request just inserted.
 
-## 7. Testing requirements
+## 7. A rejected command must not already have written
+
+Every check capable of rejecting a command -- ownership, scenario or tenant
+identity, revision or fingerprint, precondition, request consistency, quota --
+runs **before the mutation is committed, inside the same transaction and under
+the same lock that protect the write**.
+
+A response of `400`, `403`, `404`, `409`, or a validation failure states that
+the change did not happen. It must therefore not have happened. The single
+exception is an API that documents partial success as its contract; such an
+endpoint must return **which** operations committed, and the rejection is then
+not a rejection of the whole command.
+
+The sequence this forbids:
+
+```text
+1. Mark strategy A's signal as executed.
+2. Commit.
+3. Discover that the request named strategy B.
+4. Return 409.
+```
+
+What the caller sees:
+
+```text
+Signal belongs to strategy A.
+The request supplies strategy B.
+The API returns 409 Conflict.
+The signal must remain unmodified.
+```
+
+An HTTP status does not undo a committed row. A client acting on that 409 --
+retrying, showing an error, leaving the operation marked outstanding -- is now
+working against a database that disagrees with it.
+
+In practice:
+
+- A **pre-check outside the transaction is not the check.** State can change
+  between reading it and writing, which is the entire reason the write is in a
+  transaction. Re-read and re-validate inside it.
+- Where concurrency matters, validate **under the same lock** as the write, not
+  merely in the same transaction. A check that ran before the lock was taken
+  describes a world the writer no longer inhabits.
+- A service must not return a success-shaped value, having mutated, and leave
+  the rejection to a layer above it. By then the transaction has committed and
+  the caller's only options are an apology or a compensating write. Push the
+  expectation *down* into the operation instead: give it the caller's
+  precondition as a parameter and let it refuse.
+- Distinguish the refusal from the other outcomes in the return type. "No such
+  row", "not yours" and "done" are different answers and collapsing two of them
+  into `null` invites the caller to guess.
+- When a post-read invariant fails, **rolling the transaction back is the
+  default**, not an exceptional path.
+
+### 7.1 Testing a rejection
+
+A test asserting only the thrown error proves the API's manners, not its
+atomicity. Assert both halves:
+
+```typescript
+await expect(command()).rejects.toMatchObject({ status: 409 });
+
+const reloaded = await repository.findOneByOrFail({ id: signalId });
+expect(reloaded.executed).toBe(false);
+expect(reloaded.executedAt).toBeNull();
+```
+
+Reload through the real persistence path wherever that is practical. An
+assertion against an in-memory mock shows the code did not call `save`; it says
+nothing about whether a transaction committed, which is the invariant when the
+validation and the write are separated by a commit boundary. Where transaction
+or driver behaviour *is* the invariant, the test belongs in the integration
+suite; a unit spec is enough where the question is only ordering.
+
+Where the invariant depends on a lock, add the interleaved case:
+
+```text
+read -> competing write -> validation -> attempted mutation
+```
+
+and assert that the rejected command left nothing behind.
+
+## 8. Testing requirements
 
 "Add tests" is not sufficient for financial code -- a test written by the same
 author as the implementation tends to confirm its assumptions. Every financial
@@ -136,13 +218,16 @@ calculation needs:
   simultaneous gains and losses; configuration changes; deleted or replaced
   instruments; concurrent requests; first-time materialization; and payloads
   that pass through the real validation pipeline (not hand-built objects).
+- **Inputs from `docs/testing-contract.md`**, which names the classes that
+  have broken this codebase before and their canonical values. Select the ones
+  the code can actually receive; it is not a checklist to satisfy in full.
 - **At least one adversarial regression test per formula**: a case where a
   naive implementation using `filter(null)`, a default zero, or stale-value
   carry-forward would produce a plausible but incorrect result -- and the test
   fails on it. If the naive implementation would pass the whole suite, the
   suite is missing its most important case.
 
-### 7.1 A green suite after a behaviour change is a finding
+### 8.1 A green suite after a behaviour change is a finding
 
 If you changed what a calculation produces and **nothing failed**, exactly one
 of two things is true: the change is a no-op, or the suite had no case for
@@ -154,7 +239,7 @@ A rule can be written down, read, agreed with, and violated in code all the
 same; a suite that stays green while the arithmetic changes underneath it is
 evidence rather than opinion.
 
-### 7.2 A test you have never seen fail protects nothing
+### 8.2 A test you have never seen fail protects nothing
 
 For each invariant you add, break it on purpose before trusting the test:
 revert the fix in your working tree, run the named test, watch it fail,
@@ -165,7 +250,7 @@ Doing this is also how you discover that the guard you just wrote is testing a
 misspelled symbol, an interface that no longer exists, or a branch nothing can
 reach.
 
-### 7.3 A fixture is a claim about production data
+### 8.3 A fixture is a claim about production data
 
 Before writing one, find the code that *produces* the data and check that your
 fixture is a shape it can actually emit. Two failure modes, both of which
@@ -183,7 +268,7 @@ leave a suite passing over a defect:
 Where the language can enforce this, let it: type mocked collaborators so the
 compiler rejects a return shape the real method cannot produce.
 
-### 7.4 A second figure inherits the first one's denominator
+### 8.4 A second figure inherits the first one's denominator
 
 Adding a new reported number over an existing base -- another percentage over
 the same total, another total over the same conversion -- adopts every known
@@ -191,7 +276,7 @@ defect of that base and republishes it under a new name the reader has no
 reason to distrust. A pre-existing problem you decided not to fix stops being
 pre-existing the moment you build on it. Fix it, or do not add the figure.
 
-## 8. Specification before implementation
+## 9. Specification before implementation
 
 A financial feature of any substance starts from a short written design
 document, approved before implementation, containing: the invariants, the
@@ -212,7 +297,7 @@ implement them. A design document appended at the end is a summary, and a
 summary cannot be wrong in the way a specification can -- which is the whole
 reason for writing one.
 
-## 9. Keep the prose and the code in step
+## 10. Keep the prose and the code in step
 
 These rules are worth only what the code and the documents agree on.
 

--- a/docs/financial-calculation-contract.md
+++ b/docs/financial-calculation-contract.md
@@ -142,6 +142,55 @@ calculation needs:
   fails on it. If the naive implementation would pass the whole suite, the
   suite is missing its most important case.
 
+### 7.1 A green suite after a behaviour change is a finding
+
+If you changed what a calculation produces and **nothing failed**, exactly one
+of two things is true: the change is a no-op, or the suite had no case for
+that behaviour. Say which, in the change description, before moving on -- and
+if it is the second, add the case in the same commit.
+
+This is the cheapest check in this document and the one that catches the most.
+A rule can be written down, read, agreed with, and violated in code all the
+same; a suite that stays green while the arithmetic changes underneath it is
+evidence rather than opinion.
+
+### 7.2 A test you have never seen fail protects nothing
+
+For each invariant you add, break it on purpose before trusting the test:
+revert the fix in your working tree, run the named test, watch it fail,
+restore the fix. Record in the change description **which test fails on which
+input**.
+
+Doing this is also how you discover that the guard you just wrote is testing a
+misspelled symbol, an interface that no longer exists, or a branch nothing can
+reach.
+
+### 7.3 A fixture is a claim about production data
+
+Before writing one, find the code that *produces* the data and check that your
+fixture is a shape it can actually emit. Two failure modes, both of which
+leave a suite passing over a defect:
+
+- **A fixture the producer could never emit** -- a mock returning a field
+  combination the driver or the collaborator never returns. Every branch that
+  reads it is then green and unreachable.
+- **A fixture that omits a shape the producer *can* emit** -- weightings that
+  always sum to 1 where the storage format explicitly allows a remainder, a
+  price series far sparser or denser than the query supplies, an identifier
+  always present where the column is nullable. The formula is then only ever
+  exercised on the easy half of its input domain.
+
+Where the language can enforce this, let it: type mocked collaborators so the
+compiler rejects a return shape the real method cannot produce.
+
+### 7.4 A second figure inherits the first one's denominator
+
+Adding a new reported number over an existing base -- another percentage over
+the same total, another total over the same conversion -- adopts every known
+defect of that base and republishes it under a new name the reader has no
+reason to distrust. A pre-existing problem you decided not to fix stops being
+pre-existing the moment you build on it. Fix it, or do not add the figure.
+
 ## 8. Specification before implementation
 
 A financial feature of any substance starts from a short written design
@@ -151,3 +200,31 @@ versioning and recomputation rules, concurrency behaviour, and the test
 matrix. A specification written after the code -- or grown out of review
 findings -- documents decisions; it does not guide them. This is the
 domain-level counterpart of the propose-first workflow in `CONTRIBUTING.md`.
+
+**"Of any substance" means**: it computes or reports money, it materializes a
+derived result, or it reads a time series. Not the size of the diff -- a
+twenty-line change that puts a new percentage on a page is in scope, and a
+large mechanical rename is not.
+
+**The specification is the first commit of the change**, so its date is on the
+record and a reviewer can read the invariants before the code meant to
+implement them. A design document appended at the end is a summary, and a
+summary cannot be wrong in the way a specification can -- which is the whole
+reason for writing one.
+
+## 9. Keep the prose and the code in step
+
+These rules are worth only what the code and the documents agree on.
+
+- A document that names an identifier -- a field, a flag, a helper -- is
+  making a claim about the source. When you rename or remove one, grep the
+  `docs/` tree and every `CLAUDE.md` in the same commit. A document describing
+  a model that no longer exists is worse than no document: it gets read,
+  believed, and built on.
+- A comment or docstring asserting that **every** call site does something --
+  "all writes take this lock", "every read goes through this helper" -- is a
+  test, not a comment. Write the scanning test that enumerates them
+  (`backend/src/backup/backup.service.spec.ts` and
+  `frontend/src/test/ui-conventions.test.ts` are the worked examples). Such a
+  claim is true when written and silently false at the first call site added
+  afterwards, which is exactly when nobody re-reads the comment.

--- a/docs/testing-contract.md
+++ b/docs/testing-contract.md
@@ -1,0 +1,202 @@
+# Testing Contract: canonical adversarial inputs
+
+A shared vocabulary of inputs that have broken this codebase before, so that a
+test author picks from a list instead of inventing edge cases from memory and
+missing the ones that matter.
+
+**Tests should share a canonical vocabulary of adversarial inputs, but not
+every test should use every input.** Using 29 February in a function that never
+interprets a date is coverage theatre: it costs a line, proves nothing, and
+makes the suite look more thorough than it is. Pick the classes that apply,
+skip the ones that do not, and say which you skipped when you are documenting a
+matrix.
+
+For a changed formula, parser, validator, date calculation, asynchronous state
+machine, or persistence command:
+
+1. select every input class below that the code can actually receive;
+2. test at least one representative of each selected class;
+3. record the rest as `N/A` when writing out a larger matrix, so a reader can
+   tell "considered and irrelevant" from "not considered";
+4. include at least one adversarial **combination**, not only isolated
+   single-field edges.
+
+Related contracts: `docs/financial-calculation-contract.md` (what a calculation
+may claim, and its testing requirements), `docs/time-series-contract.md` (the
+time dimension).
+
+## Dates and timestamps
+
+| Name | Canonical value | Intended failure |
+| --- | --- | --- |
+| Ordinary date | `2026-06-15` | Normal control case |
+| Leap day | `2024-02-29` | Leap-year handling |
+| Century leap day | `2000-02-29` | Century divisible by 400 is a leap year |
+| Non-leap century boundary | `2100-02-28` | Treating every year divisible by 4 as leap |
+| Invalid non-leap date | `2100-02-29` | Validation must reject, or normalize only by explicit contract |
+| Month end | `2025-01-31` | Month addition and clamping |
+| Year end | `2025-12-31` | Year rollover |
+| Quarter end | `2025-03-31` | Period-boundary logic |
+| Far past supported date | `1970-01-01` | Hidden assumptions that data is recent |
+| Far future supported date | `2099-12-31` | Two-digit years, short horizons |
+| DST spring boundary | `2025-03-30T01:30:00 Europe/Warsaw` | Local time that does not exist |
+| DST autumn boundary | `2025-10-26T02:30:00 Europe/Warsaw` | Local time that happens twice |
+
+- Date-only financial calculations should use the repository's UTC/date-only
+  helpers; the DST rows apply to timestamp or local-time logic, and are `N/A`
+  for a function that only ever sees `YYYY-MM-DD`.
+- Test an invalid date **through the real parser or validator**. Constructing a
+  JavaScript `Date` from `2100-02-29` yields an already-normalized 1 March and
+  tests nothing: the question is what the boundary does with the string.
+- The supported range is whatever the product contract says. `1970-01-01` and
+  `2099-12-31` are stand-ins for "older and newer than anyone thought about",
+  not limits in themselves.
+
+## Numbers and money
+
+Money is `decimal(20,4)`; the values below are chosen against that precision.
+
+| Name | Canonical value | Intended failure |
+| --- | ---: | --- |
+| Zero | `0` | Known zero versus unknown |
+| Negative | `-1` | Sign handling |
+| Smallest stored positive unit | `0.0001` | Precision floor |
+| Half-rounding boundary | `0.00005` | Whether the rounding policy is stated or accidental |
+| Binary floating-point pair | `0.1` and `0.2` | Floating-point accumulation |
+| Ordinary decimal | `1234.5678` | Normal precision |
+| Large valid decimal | `9999999999999999.9999` | The upper shape of `decimal(20,4)` |
+| Just-over-limit decimal | `10000000000000000.0000` | Overflow or validation rejection |
+| Percentage boundary | `100` | Inclusive upper bound |
+| Above the percentage boundary | `100.0001` | Validation where a percentage is capped |
+| Null | `null` | Unknown value |
+| Missing property | omitted | Absent versus explicit `null` |
+
+A value the API domain forbids does not need a calculation test -- it needs a
+test proving the **real validation path** rejects it. Hand-constructing an
+object past the DTO pipeline and asserting the formula copes is the wrong
+question.
+
+## Collections and aggregation
+
+Where applicable: empty; one item; two items; many items; a duplicate; all
+components known; **one component unknown**; several unknown; all unknown; the
+same item held across multiple accounts; mixed positive and negative values.
+
+The one-unknown case is **mandatory** for any field named `total*`,
+`portfolioValue`, `transferValue`, `gain`, `loss`, `tax`, `costBasis`,
+`estimated*`, or any percentage or allocation over an aggregate denominator.
+That is the case the missing-value rule exists for, and the one a naive
+implementation passes by filtering the unknown away.
+
+## Currency conversion
+
+Where applicable: same currency; a direct rate; an inverse rate; a missing
+rate; a stale rate; **historical transaction rates versus a current valuation
+rate**; a zero or negative rate rejected; several currencies where one
+conversion is unknown.
+
+The pair that produces a plausible and wrong answer:
+
+```text
+10 units bought at 100 USD, historical USD/PLN 3.00  -> cost 3,000 PLN
+10 units worth 100 USD today, current USD/PLN 4.00   -> value 4,000 PLN
+
+Correct:  gain 1,000 PLN, tax at 19% = 190 PLN
+Current FX applied to the historical cost:
+          cost 4,000 PLN, gain 0, tax 0
+```
+
+Both sides move with the currency, so an unchanged foreign price reports no
+gain at all. Nothing about the output looks wrong.
+
+## Identifiers and ownership
+
+Where applicable: a valid owned id; a syntactically invalid id; a well-formed
+but unknown id; a valid id owned by **another user**; an id of the right shape
+but the wrong entity type; a stale or deleted id.
+
+## Asynchronous and concurrent operations
+
+Where applicable: duplicate concurrent requests; out-of-order responses; a
+stale revision; the loser of an `ON CONFLICT DO NOTHING` race; a rejection
+arriving after a competing state change; a retry after a transient failure; an
+idempotent repeat; a mutation response landing after the selection changed.
+
+The last two rows connect to the rules they exist for: rejection ordering in
+`docs/financial-calculation-contract.md` section 7, and request-key ownership
+in `frontend/CLAUDE.md`.
+
+## Strings and optional fields
+
+Where applicable: empty string; whitespace only; ordinary Unicode; combining
+characters; the maximum accepted length; one character over it; HTML or
+script-like input **through the real sanitizer**; optional `undefined`;
+optional `null`; optional empty string, which is what a form actually sends for
+a field the user left alone.
+
+## Combinations
+
+Single-axis cases are not enough. A calculation with more than one dimension
+needs at least one pairwise adversarial combination -- the defects that survive
+review are usually the product of two ordinary conditions, each individually
+handled:
+
+```text
+foreign currency + missing cost basis
+leap day + month-end recurrence
+stale response + dirty form
+two accounts + same security + one missing price
+negative value + currency conversion
+duplicate concurrent request + rejected ownership check
+```
+
+An exhaustive Cartesian product is not wanted; one deliberate pair per
+calculation is.
+
+## Fixtures and shared constants
+
+The intended follow-up is a small set of named constants, so the value and the
+reason travel together:
+
+```ts
+TEST_DATES.LEAP_DAY;
+TEST_DATES.MONTH_END;
+TEST_MONEY.ZERO;
+TEST_MONEY.ROUNDING_HALF;
+TEST_MONEY.MAX_DECIMAL_20_4;
+```
+
+They do not exist yet, and this document adds no code. When they arrive they
+must be immutable; named for the property under test rather than the literal;
+free of hidden expected results, so a factory never quietly decides the
+assertion; incapable of constructing a shape production cannot produce; and
+faithful to the real collaborator's return types.
+
+Prefer a builder that starts from a valid production-shaped object and makes
+**one explicit mutation** for the case at hand. One universal fixture that
+every test copies is how a suite comes to exercise a single input shape many
+times over.
+
+## Negative control
+
+For each new invariant, record -- in the change description or beside the test:
+
+```text
+Invariant:
+Canonical adversarial input:
+Minimal mutation that recreates the defect:
+Test that fails under that mutation:
+```
+
+Worked example:
+
+```text
+Invariant: a rejected cross-scenario command commits no state.
+Input:     signal belonging to A, request naming B.
+Mutation:  move the strategy validation to after repository.save().
+Failure:   the rejection test reloads the row and finds executed = true.
+```
+
+This is a note, not a framework. No permanent mutation-testing infrastructure
+is required -- the point is that you performed the check once and wrote down
+what it proved.

--- a/docs/time-series-contract.md
+++ b/docs/time-series-contract.md
@@ -150,7 +150,8 @@ For strategies that materialize periodic signals and simulate acting on them:
 ## 6. Testing
 
 Time-series code inherits the testing requirements of
-`docs/financial-calculation-contract.md` section 7. The adversarial cases
+`docs/financial-calculation-contract.md` section 8, and draw inputs from
+`docs/testing-contract.md`. The adversarial cases
 specific to this contract: a gap in the middle of a backtest, a stale quote
 just outside the boundary window, a first period with no starting price, and
 an instrument whose history starts after the requested range -- each must

--- a/docs/time-series-contract.md
+++ b/docs/time-series-contract.md
@@ -20,6 +20,15 @@ handling.
   and the actual share quantity held.
 - A single calculation must never mix adjusted and raw prices for the same
   instrument. State which series a function consumes in its contract.
+- **Choose the basis per series, never per row.** An adjusted-close column is
+  typically nullable and typically written by one source only, so a per-row
+  `COALESCE(adjusted, raw)` reads like "adjusted, falling back where the
+  provider gave none" and is in fact a splice: every row some other writer
+  inserted -- a transaction-derived price, an import, a seed -- lands raw
+  inside an adjusted history. Around a split that is a several-hundred-percent
+  return and a drawdown that never happened, on any instrument the user has
+  ever traded. Decide once per instrument over the window being read: adjusted
+  rows only where any exist, raw throughout where none do, never both.
 
 ## 2. Quote age and period boundaries
 
@@ -37,6 +46,55 @@ handling.
   boundary value, and every metric derived from it (that period's return, and
   any aggregate including that period) follows the missing-data rules below.
 
+### 2.1 One door, not one constant
+
+A named window constant is not enough on its own. Turning a stored observation
+into a value-for-a-date must go through a **shared helper that applies the
+window**, and every site that needs such a value must use it -- the chart, the
+position valuation, the backfill check, the signal, all of them. Adding a
+second unbounded path beside the bounded one is how the rule ends up with a
+constant, a docstring, and three call sites that ignore both.
+
+In practice that bans, outside the helper itself:
+
+- a nearest-observation lookup with no age test;
+- `ORDER BY <date column> DESC LIMIT 1` (or `DISTINCT ON`) with no lower bound
+  on the date;
+- reading a stored rate or price "latest" and using it in a reported figure.
+
+Where a module has such a helper, a scanning test should fail on a new call
+site that bypasses it, in the manner of
+`frontend/src/test/ui-conventions.test.ts`.
+
+### 2.2 An exchange rate is a price
+
+Everything above applies to currency conversion unchanged. A total built from
+a fresh price and a nine-month-old rate is no more knowable than one built
+from a stale price, and it fails more quietly, because no figure on the page
+is denominated in a rate. A conversion feeding a number the user acts on takes
+a bounded rate or returns unknown.
+
+### 2.3 A boundary needs two observations, not two lookups
+
+When a span's two ends are bounded independently, both can resolve to the
+*same* observation -- necessarily so whenever the span is shorter than the
+window. The arithmetic then returns exactly zero change, which is
+indistinguishable from a market that went nowhere and counts itself as a fully
+covered period. Require the two ends to be **different observations**, and
+distinguish the two reasons a span has none: a gap in the history, versus a
+period that has not yet produced a second close. They are answered differently
+-- the first breaks the chain, the second has simply not happened yet.
+
+### 2.4 Two boundaries say nothing about the interior
+
+A metric that depends on the *path* between boundaries -- drawdown, intraperiod
+extremes, anything "worst" or "peak" -- is only measurable where the
+observations between them are actually consecutive. Boundaries that satisfy
+the window rule are no evidence about the middle: a month-long hole is stepped
+straight over, and the walk reports a calm zero for a period that may have
+halved. Check the spacing of the observations inside the span, and return
+`null` when any stride exceeds the window.
+
 ## 3. Missing returns are never zero
 
 - A period with no usable prices has `return: null`. Never `0`.
@@ -46,6 +104,13 @@ handling.
 - Interpolation across a gap is only acceptable when the calculation
   explicitly documents it, the interpolated span is flagged in the output,
   and the affected periods are identified -- never silently.
+- **The rule survives to the pixel.** A `null` the server took care to produce
+  is undone by a chart that bridges it (`connectNulls` and its equivalents),
+  by a bar rendered at zero width beside an unknown label, or by a row that
+  vanishes instead of showing an unknown marker. A straight segment across
+  four unobserved months is indistinguishable from measured data, and a
+  tooltip admitting "unknown" under the cursor does not undo it. Whoever adds
+  the `null` owns its rendering.
 
 ## 4. Incomplete history: reject or disclose
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -153,6 +153,30 @@ it in the catalog, not in JSX. `"{units} ({share})"` is one string a translator
 can reorder; `{value}{' ('}{share}{')'}` in a component is three fragments they
 cannot reach.
 
+### An unknown value must not render as a measured zero
+
+The server goes to real trouble to send `null` rather than `0` for anything it
+could not work out (`docs/financial-calculation-contract.md`), and the last
+hundred pixels are where that gets thrown away:
+
+- **`connectNulls` on a line chart** draws a straight segment through the gap.
+  It is indistinguishable from measured data, and a tooltip saying "unknown"
+  under the cursor does not undo it. Default to `connectNulls={false}`.
+- **A bar, gauge or meter at zero width** beside an "unknown" label reads as a
+  measured zero to everyone who looks at the shape rather than the number.
+  Draw a distinct no-data treatment, or nothing at all -- not an empty fill.
+- **A row that disappears** when its value is `null` conflates "not
+  applicable" with "could not be computed". Where the payload can tell those
+  apart -- a configured tax rate with an uncomputable tax, say -- render the
+  row with an unknown marker rather than dropping it.
+- **`?? 0`, `|| 0`, `?? 1` on an API value** is the same mistake in arithmetic
+  form. Guard with an `isKnown()`-style check first; a fallback inside a
+  `reduce` that a guard already covers is dead code at best and a silent
+  subtotal at worst.
+
+Whoever adds the `null` on the server owns how it looks. A component test
+asserting the gap, the marker or the absent fill is what keeps it.
+
 ## Form Patterns
 
 `useFormModal<T>` (`hooks/useFormModal.ts`) manages create/edit modal state with browser-history integration (back button closes), unsaved-changes detection via `UnsavedChangesDialog`, and form submit exposed via ref. Returns `showForm`, `editingItem`, `openCreate()`, `openEdit(item)`, `close()`, `modalProps`, `unsavedChangesDialog`.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -153,6 +153,77 @@ it in the catalog, not in JSX. `"{units} ({share})"` is one string a translator
 can reorder; `{value}{' ('}{share}{')'}` in a component is three fragments they
 cannot reach.
 
+### Asynchronous data carries the request that produced it
+
+**Asynchronous data is not only a payload. It is the payload plus the complete
+request key that produced it.** A component holding `data` without knowing
+which request answered cannot tell "the report you are looking at" from "the
+report you were looking at a moment ago", and every action it offers is aimed
+at whichever of the two it happens to read.
+
+The request key is every selector that changes the *meaning* of the response,
+not merely its freshness. Typically: the scenario or strategy id, the account
+id, the date range, the reporting currency, the active filters, the locale
+where the server localizes its output, and the revision or version where one
+exists. If changing it would make the same payload mean something else, it is
+part of the key.
+
+**Stale data may stay on screen; it may not stay actionable.** Keeping the
+previous view during a load is often the better read -- a blank page loses the
+user's place. It is allowed while all of the following hold:
+
+- it is visually marked as stale or loading;
+- editable controls are disabled;
+- mutations are disabled;
+- no action can submit an id taken from the stale payload under the new
+  selection;
+- assistive technology is told the same thing the pixels say (`aria-busy`, or
+  an equivalent that does not rely on the greyed-out styling alone).
+
+Clearing the screen is not required. Non-actionable is.
+
+**A mutation captures an immutable origin key when it starts**, and its
+response is adopted only when
+
+```text
+mutationOriginKey === currentRequestKey
+```
+
+*and* the entity the response describes is the one the mutation targeted. A
+late response from scenario A must never replace scenario B merely by arriving
+last. Derive that origin from the data the component was rendering, not from
+current React state read after the request began -- state has already moved by
+the time the response lands, which is the whole problem.
+
+**A failed lookup is not an empty dataset.** A failed accounts request is not
+`accounts = []`, a failed securities request is not `securities = []`, and a
+failed report is not a report of zeros. Rendering the failure as emptiness
+turns an outage into a plausible answer, and leaves the save button live over
+prerequisites that never loaded. Five states have to stay distinguishable:
+loaded-and-empty, loading, failed, stale-previous, and current. Where a
+prerequisite failed, use the shared retryable error presentation, keep the
+stored ids, and disable the actions that depend on it.
+
+**A dirty keyed form is data.** Changing the request key while a form has
+unsaved edits calls for a confirmation, a preserved draft, or an explicit
+save/discard flow; silently unmounting it is data loss, and remounting it under
+a new key is the same loss with extra steps. A form rendered for scenario A
+must also stop being editable once scenario B is the current selection -- those
+are two obligations, and meeting the second by discarding the first is not
+meeting both.
+
+Regression tests for this class need deferred promises, and must assert on what
+the user *can do*, not only on what is rendered (`docs/testing-contract.md`
+carries the wider list of adversarial inputs, including the asynchronous ones):
+
+| Case | Assertion |
+| --- | --- |
+| A starts, B starts, B resolves, A resolves late | the display is still B |
+| A shown, B selected and loading | A's form cannot submit |
+| Save for A starts, user selects B, A resolves | A's response is discarded and does not retire B's request |
+| A shown, B selected, B fails | the failure is shown; A is not presented as B |
+| Form dirty, user selects B | confirmation is asked for, or the draft survives |
+
 ### An unknown value must not render as a measured zero
 
 The server goes to real trouble to send `null` rather than `0` for anything it


### PR DESCRIPTION
## Linked discussion / issue

**None yet** — flagging this rather than leaving a blank line. This is docs-only and came out of a review of the GEM strategy branch rather than from a proposal, so if the propose-first workflow should apply here too, say so and I will open a Discussion first and hold this.

Closes #

## Summary

Every defect found in a recent multi-pass review of the GEM strategy branch broke a rule these documents **already contained**:

| Defect | Rule it broke |
|---|---|
| exchange rate falling back to 1:1 | `financial-calculation-contract` §3 — verbatim |
| a two-year-old quote valuing a position | `time-series-contract` §2 |
| a dead price feed drawn flat across the chart | `time-series-contract` §2 and §3 |
| adjusted closes spliced with raw ones | `time-series-contract` §1 — verbatim |
| `0` and `null` standing in for each other | `financial-calculation-contract` §1, §2 |
| no specification before implementation | §8 |
| tests confirming the implementation's assumptions | §7 |

Nothing was missing. The rules were read, agreed with, and violated anyway — because prose is checked by whoever remembers to check it and code is checked by the suite. So this PR adds very little new doctrine and a good deal of ways to notice.

**The load-bearing addition is §7.1: a green suite after a behaviour change is a finding, not a confirmation.** Three of the four fixes in that review broke no existing test, which was the loudest available signal that the suite had holes, and nothing was listening for it.

`docs/financial-calculation-contract.md`
- **7.1** green suite after a behaviour change is a finding
- **7.2** one deliberate falsification per invariant — a test never seen failing has not been shown to test anything (doing this once turned up three wrong interface names in a guard written minutes earlier)
- **7.3** fixtures are claims about production data: both a shape the producer can never emit, and a shape it *can* emit that the fixture omits
- **7.4** a second figure over an existing denominator inherits its defects
- **§8** defines "of any substance", and makes the spec the first commit
- **§9** prose and code drift apart silently; "every call site does X" is a scanning test, not a comment

`docs/time-series-contract.md`
- **§1** choose the price basis per series, never per row
- **2.1** one door, not one constant — a named window with three call sites ignoring it is not a rule
- **2.2** an exchange rate is a price
- **2.3** two independently bounded lookups can resolve to one observation
- **2.4** two boundaries say nothing about the interior a drawdown lives in
- **§3** the rule survives to the pixel

`CLAUDE.md` — the ranking that motivates all of it (compiler → lint → scanning test → prose), the general form of the green-suite rule, doc-vs-code drift, and `null` is not the safe default either: empty accounts hold, move, realize and owe a known zero.

`backend/CLAUDE.md` — type doubles of our own services, the one case here where the compiler can do the whole job: `mockResolvedValue(true)` against a method that now returns an id stays truthy, stays passing, and describes a contract nothing has any more.

`frontend/CLAUDE.md` — an unknown value must not render as a measured zero (`connectNulls`, a zero-width bar, a vanishing row, `?? 0` on an API value).

**Not included:** the four guard tests that would enforce some of this mechanically. Three of them only make sense once the GEM branch lands, since that is where the code they would police lives; typed mocks could be done on `main` today. Happy to follow up with either.

## Checklist

- [ ] An approved discussion or issue exists and is linked above — **no**, see the note at the top.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes — **no behaviour change**; documentation only, no code touched.
- [x] All user-facing strings are translated for **every** locale (i18n parity) — **not applicable**; no user-facing strings.
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main` (`0b687ea`).
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

Two deliberate choices worth reviewing:

1. **No identifier is named that does not exist on `main`.** The GEM feature is unmerged, so its helpers and `docs/gem-strategy.md` are not referenced — it would be a poor start to break the new §9 in the commit that introduces it. Only `frontend/src/test/ui-conventions.test.ts` and `backend/src/backup/backup.service.spec.ts` are cited, both present on `main`.
2. **Prettier was not run.** A first pass reformatted unrelated tables and emphasis markers; `docs/support-backup.md` is unformatted on `main`, so markdown is not enforced here. The text matches the surrounding style instead and the diff is purely additive (192 insertions, 1 deletion — one reworded paragraph).

## AI assistance disclosure

Written with Claude Code. The rules were derived from defects found in an adversarial review of the GEM strategy branch, and each one names the concrete failure it came from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgQuCJQbQh7rWjvXHRQyfX
