### PR TITLE
Make one active .mny import per user a database guarantee

### DIFF
--- a/backend/src/import/mny/entities/import-job.entity.ts
+++ b/backend/src/import/mny/entities/import-job.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -17,6 +18,14 @@ import {
 import { MnyImportOptions } from "../model/mny-import-options";
 
 /**
+ * The partial unique index enforcing one `pending`/`running` job per user.
+ *
+ * Named here so the constraint the database reports on a losing INSERT and the
+ * constraint the service translates into a 409 are provably the same string.
+ */
+export const ONE_ACTIVE_JOB_INDEX = "idx_import_jobs_one_active_per_user";
+
+/**
  * One background import attempt (design ADR-3).
  *
  * The row is the coordination point: `POST /import/mny/start` inserts it
@@ -24,7 +33,17 @@ import { MnyImportOptions } from "../model/mny-import-options";
  * job writes `progress` and `heartbeat_at` in their own short transactions so a
  * poller can see them, and a reaper cron fails jobs whose heartbeat went stale.
  * A failed job keeps `stagedFileId`, so Retry is a new job over the same bytes.
+ *
+ * The partial unique index is what makes "one import at a time per user" true:
+ * two concurrent starts would otherwise both count zero active jobs and both
+ * insert, importing the same staged bytes twice. Declared here as well as in
+ * migration 135 because test and dev databases are synchronized from the
+ * entities -- a guard that exists only in SQL cannot be tested.
  */
+@Index(ONE_ACTIVE_JOB_INDEX, ["userId"], {
+  unique: true,
+  where: "status IN ('pending', 'running')",
+})
 @Entity("import_jobs")
 export class ImportJob {
   @PrimaryGeneratedColumn("uuid")

--- a/backend/src/import/mny/mny-import-job.service.spec.ts
+++ b/backend/src/import/mny/mny-import-job.service.spec.ts
@@ -1,9 +1,10 @@
-import { DataSource, EntityManager } from "typeorm";
+import { ConflictException } from "@nestjs/common";
+import { DataSource, EntityManager, QueryFailedError } from "typeorm";
 import {
   runOutsideActiveScopedManager,
   withScopedDb,
 } from "../../common/db/scoped-db";
-import { ImportJob } from "./entities/import-job.entity";
+import { ImportJob, ONE_ACTIVE_JOB_INDEX } from "./entities/import-job.entity";
 import { MnyNotAMoneyFileError } from "./mny-errors";
 import {
   JOB_FAILED_ERROR_KEY,
@@ -11,8 +12,10 @@ import {
   JOB_STALE_AFTER_MS,
   JOB_STALLED_ERROR_KEY,
   MnyImportJobService,
+  isActiveJobConflict,
   returnedRows,
 } from "./mny-import-job.service";
+
 import { DEFAULT_MNY_IMPORT_OPTIONS } from "./model/mny-import-options";
 
 jest.mock("../../common/db/scoped-db", () => ({
@@ -29,6 +32,17 @@ const mockedScopedDb = withScopedDb as jest.MockedFunction<typeof withScopedDb>;
 const mockedOutside = runOutsideActiveScopedManager as jest.MockedFunction<
   typeof runOutsideActiveScopedManager
 >;
+
+/**
+ * What `pg` actually raises when the partial unique index refuses an INSERT.
+ * The constraint name is the whole signal, so it comes from the same constant
+ * the entity declares the index with.
+ */
+const activeJobViolation = (): QueryFailedError =>
+  new QueryFailedError("INSERT", [], {
+    code: "23505",
+    constraint: ONE_ACTIVE_JOB_INDEX,
+  } as unknown as Error);
 
 /**
  * The claim's atomicity and the reaper's interval arithmetic are properties of
@@ -122,6 +136,70 @@ describe("MnyImportJobService", () => {
         }),
       );
       expect(job.id).toBe("job-1");
+    });
+
+    it("translates the one-active-job index into the 409 the wizard renders", async () => {
+      repo.save.mockRejectedValue(activeJobViolation());
+
+      await expect(
+        service.create("user-1", "staged-1", DEFAULT_MNY_IMPORT_OPTIONS),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it("rethrows a violation of any other constraint untouched", async () => {
+      // "An import is already running" is a specific claim, and a foreign-key
+      // failure on the staged file is not evidence for it.
+      const other = new QueryFailedError("INSERT", [], {
+        code: "23503",
+        constraint: "import_jobs_staged_file_id_fkey",
+      } as unknown as Error);
+      repo.save.mockRejectedValue(other);
+
+      await expect(
+        service.create("user-1", "staged-1", DEFAULT_MNY_IMPORT_OPTIONS),
+      ).rejects.toBe(other);
+    });
+
+    it("rethrows a plain error, which carries no driver code at all", async () => {
+      const boom = new Error("connection terminated");
+      repo.save.mockRejectedValue(boom);
+
+      await expect(
+        service.create("user-1", "staged-1", DEFAULT_MNY_IMPORT_OPTIONS),
+      ).rejects.toBe(boom);
+    });
+  });
+
+  describe("isActiveJobConflict", () => {
+    it("recognizes the unique violation the partial index raises", () => {
+      expect(isActiveJobConflict(activeJobViolation())).toBe(true);
+    });
+
+    it("rejects a unique violation from a different index", () => {
+      expect(
+        isActiveJobConflict(
+          new QueryFailedError("INSERT", [], {
+            code: "23505",
+            constraint: "some_other_unique_index",
+          } as unknown as Error),
+        ),
+      ).toBe(false);
+    });
+
+    it("rejects anything that is not a query failure", () => {
+      expect(isActiveJobConflict(new Error("nope"))).toBe(false);
+      expect(isActiveJobConflict(undefined)).toBe(false);
+    });
+  });
+
+  describe("discard", () => {
+    it("deletes only this user's job, and only while it is still pending", async () => {
+      await service.discard("user-1", "job-1");
+
+      expect(sql(lastCall())).toContain(
+        "DELETE FROM import_jobs WHERE id = $1 AND user_id = $2 AND status = 'pending'",
+      );
+      expect(lastCall()[1]).toEqual(["job-1", "user-1"]);
     });
   });
 

--- a/backend/src/import/mny/mny-import-job.service.ts
+++ b/backend/src/import/mny/mny-import-job.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { ConflictException, Injectable, Logger } from "@nestjs/common";
 import { Cron, CronExpression } from "@nestjs/schedule";
-import { DataSource } from "typeorm";
+import { DataSource, QueryFailedError } from "typeorm";
+import { tr } from "../../i18n/translate";
 import {
   runOutsideActiveScopedManager,
   withScopedDb,
@@ -9,7 +10,7 @@ import {
   withSystemContext,
   withUserContext,
 } from "../../common/db/with-context";
-import { ImportJob } from "./entities/import-job.entity";
+import { ImportJob, ONE_ACTIVE_JOB_INDEX } from "./entities/import-job.entity";
 import { MnyImportError } from "./mny-errors";
 import { MnyImportProgress, MnyImportResult } from "./model/mny-import-job";
 import { MnyImportOptions } from "./model/mny-import-options";
@@ -22,10 +23,12 @@ import { MnyImportOptions } from "./model/mny-import-options";
  * body runs as an unawaited in-process task under `withUserContext`. The wizard
  * polls the row.
  *
- * Two things make that safe on Kubernetes, where every replica runs the same
- * code: the claim is atomic, so two pods racing to start the same job produce one
- * winner; and a running job heartbeats, so a job whose pod died is reaped into
- * `failed` + retryable instead of appearing to run forever.
+ * Three things make that safe on Kubernetes, where every replica runs the same
+ * code: the insert is guarded by a partial unique index, so two *requests*
+ * racing to start an import produce one job; the claim is atomic, so two pods
+ * racing over that one job produce one winner; and a running job heartbeats, so
+ * a job whose pod died is reaped into `failed` + retryable instead of appearing
+ * to run forever.
  */
 
 /** A job with no heartbeat for this long is presumed dead. */
@@ -39,6 +42,40 @@ export const JOB_STALLED_ERROR_KEY = "mnyJobStalled";
 
 /** i18n key for a failure with no more specific parse error. */
 export const JOB_FAILED_ERROR_KEY = "mnyImportFailed";
+
+/** PostgreSQL SQLSTATE for a unique violation. */
+const UNIQUE_VIOLATION = "23505";
+
+/**
+ * True when this error is the one-active-import-per-user index refusing an
+ * INSERT, rather than any other unique constraint on the table.
+ *
+ * Matching on the constraint name and not merely on the SQLSTATE matters: a
+ * different violation means something the caller has no business reporting as
+ * "an import is already running".
+ */
+export function isActiveJobConflict(error: unknown): boolean {
+  if (!(error instanceof QueryFailedError)) {
+    return false;
+  }
+  const driver = error.driverError as
+    | { code?: string; constraint?: string }
+    | undefined;
+  return (
+    driver?.code === UNIQUE_VIOLATION &&
+    driver?.constraint === ONE_ACTIVE_JOB_INDEX
+  );
+}
+
+/** The 409 the wizard already renders when a second import is refused. */
+export function importAlreadyRunningException(): ConflictException {
+  return new ConflictException(
+    tr(
+      "errors.import.mnyImportAlreadyRunning",
+      "An import is already running. Wait for it to finish before starting another.",
+    ),
+  );
+}
 
 /** What a job body can report while it runs. */
 export interface JobRunContext {
@@ -72,25 +109,61 @@ export class MnyImportJobService {
 
   constructor(private dataSource: DataSource) {}
 
-  /** Creates a `pending` job. Returns the row the wizard will poll. */
+  /**
+   * Creates a `pending` job, or throws 409 when this user already has one in
+   * flight. Returns the row the wizard will poll.
+   *
+   * The refusal is the INSERT itself, not a preceding count: `hasActiveJob`
+   * followed by `create` is two transactions, and two concurrent starts can
+   * both read zero before either writes -- which imported the same staged file
+   * twice, with fresh transaction UUIDs each time so nothing deduplicated the
+   * second run. The partial unique index makes the loser block on the winner
+   * and then fail, so the check and the write are one atomic act.
+   */
   async create(
     userId: string,
     stagedFileId: string,
     options: MnyImportOptions,
   ): Promise<ImportJob> {
-    return withScopedDb(this.dataSource, async (manager) => {
-      const repo = manager.getRepository(ImportJob);
-      return repo.save(
-        repo.create({
-          userId,
-          stagedFileId,
-          sourceFormat: "mny",
-          status: "pending",
-          options,
-          retryable: false,
-        }),
-      );
-    });
+    try {
+      return await withScopedDb(this.dataSource, async (manager) => {
+        const repo = manager.getRepository(ImportJob);
+        return repo.save(
+          repo.create({
+            userId,
+            stagedFileId,
+            sourceFormat: "mny",
+            status: "pending",
+            options,
+            retryable: false,
+          }),
+        );
+      });
+    } catch (error) {
+      if (isActiveJobConflict(error)) {
+        throw importAlreadyRunningException();
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Deletes a job that never started, releasing this user's import slot.
+   *
+   * `start` creates the row *before* the optional destructive wipe, so the wipe
+   * runs under the same lock the import does -- but a wipe that fails
+   * re-authentication must not leave the user holding a slot for a job that
+   * will never run. Restricted to `pending`: a claimed job belongs to its
+   * worker, which reports its own outcome.
+   */
+  async discard(userId: string, jobId: string): Promise<void> {
+    await withScopedDb(this.dataSource, (manager) =>
+      manager.query(
+        `DELETE FROM import_jobs
+          WHERE id = $1 AND user_id = $2 AND status = 'pending'`,
+        [jobId, userId],
+      ),
+    );
   }
 
   /** The job, or null when it never existed or belongs to another user. */
@@ -103,8 +176,11 @@ export class MnyImportJobService {
   }
 
   /**
-   * True when this user already has an import in flight. The wizard's Start
-   * button is guarded by this, so a double-click cannot import a file twice.
+   * True when this user already has an import in flight.
+   *
+   * Advisory only: it answers the question a moment before the answer can
+   * change, so it buys a friendly 409 without an INSERT attempt and nothing
+   * more. The guarantee lives in `create`'s unique index.
    */
   async hasActiveJob(userId: string): Promise<boolean> {
     const count = await withScopedDb(this.dataSource, (manager) =>

--- a/backend/src/import/mny/mny-import.service.spec.ts
+++ b/backend/src/import/mny/mny-import.service.spec.ts
@@ -5,7 +5,11 @@ import { CurrenciesService } from "../../currencies/currencies.service";
 import { UsersService } from "../../users/users.service";
 import { ImportPostProcessingService } from "../import-post-processing.service";
 import { MnyStagedFileMissingError } from "./mny-errors";
-import { JobRunContext, MnyImportJobService } from "./mny-import-job.service";
+import {
+  JobRunContext,
+  MnyImportJobService,
+  importAlreadyRunningException,
+} from "./mny-import-job.service";
 import { MnyImportService } from "./mny-import.service";
 import { MnyParsedFile, MnyParserService } from "./mny-parser.service";
 import { MnyStagingService } from "./mny-staging.service";
@@ -266,6 +270,7 @@ describe("MnyImportService", () => {
     jobs = {
       hasActiveJob: jest.fn().mockResolvedValue(false),
       create: jest.fn().mockResolvedValue({ id: "job-1" }),
+      discard: jest.fn().mockResolvedValue(undefined),
       runClaimed: jest.fn().mockResolvedValue(true),
       fail: jest.fn().mockResolvedValue(undefined),
     };
@@ -368,6 +373,33 @@ describe("MnyImportService", () => {
       expect(jobs.create).not.toHaveBeenCalled();
     });
 
+    it("passes the 409 through when only the insert catches the race", async () => {
+      // The advisory count sees nothing, because the other request has not
+      // committed yet; `create` refuses on the unique index instead. This is
+      // the only path that can distinguish a real concurrent start.
+      jobs.create.mockRejectedValue(importAlreadyRunningException());
+
+      await expect(
+        service.start("user-1", { stagedFileId: "staged-1" }),
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(jobs.runClaimed).not.toHaveBeenCalled();
+    });
+
+    it("does not wipe when the losing request's insert is refused", async () => {
+      // The wipe is behind the lock, so the request that did not get the job
+      // row cannot delete the winner's data out from under it.
+      jobs.create.mockRejectedValue(importAlreadyRunningException());
+
+      await expect(
+        service.start("user-1", {
+          stagedFileId: "staged-1",
+          options: { wipeExistingData: true },
+          wipeCredentials: { password: "hunter2" },
+        }),
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(usersService.deleteData).not.toHaveBeenCalled();
+    });
+
     it("creates the job with resolved options and starts it in the background", async () => {
       const job = await service.start("user-1", { stagedFileId: "staged-1" });
 
@@ -384,7 +416,7 @@ describe("MnyImportService", () => {
       );
     });
 
-    it("wipes before the job exists, and never stores the credentials", async () => {
+    it("wipes only once the job row holds the lock, and never stores the credentials", async () => {
       await service.start("user-1", {
         stagedFileId: "staged-1",
         options: { wipeExistingData: true },
@@ -402,8 +434,14 @@ describe("MnyImportService", () => {
       // import_jobs.options.
       const [, , options] = jobs.create.mock.calls[0];
       expect(JSON.stringify(options)).not.toContain("hunter2");
+      // The row is this user's import lock, so a destructive wipe runs behind
+      // it -- never before it, where two concurrent requests could both wipe.
+      expect(jobs.create.mock.invocationCallOrder[0]).toBeLessThan(
+        usersService.deleteData.mock.invocationCallOrder[0],
+      );
+      // ...and still outside the job body, so the password is never persisted.
       expect(usersService.deleteData.mock.invocationCallOrder[0]).toBeLessThan(
-        jobs.create.mock.invocationCallOrder[0],
+        jobs.runClaimed.mock.invocationCallOrder[0],
       );
     });
 
@@ -416,7 +454,34 @@ describe("MnyImportService", () => {
           options: { wipeExistingData: true },
         }),
       ).rejects.toThrow("bad password");
-      expect(jobs.create).not.toHaveBeenCalled();
+      expect(jobs.runClaimed).not.toHaveBeenCalled();
+    });
+
+    it("gives the import slot back when the wipe is refused", async () => {
+      // Otherwise the pending row it took blocks every import this user starts
+      // until the reaper sweeps it five minutes later -- for a job that will
+      // never run, over a request that already returned an error.
+      usersService.deleteData.mockRejectedValue(new Error("bad password"));
+
+      await expect(
+        service.start("user-1", {
+          stagedFileId: "staged-1",
+          options: { wipeExistingData: true },
+        }),
+      ).rejects.toThrow("bad password");
+      expect(jobs.discard).toHaveBeenCalledWith("user-1", "job-1");
+    });
+
+    it("still reports the wipe failure when the slot cannot be given back", async () => {
+      usersService.deleteData.mockRejectedValue(new Error("bad password"));
+      jobs.discard.mockRejectedValue(new Error("pool exhausted"));
+
+      await expect(
+        service.start("user-1", {
+          stagedFileId: "staged-1",
+          options: { wipeExistingData: true },
+        }),
+      ).rejects.toThrow("bad password");
     });
 
     it("does not wipe when the option is off", async () => {

--- a/backend/src/import/mny/mny-import.service.ts
+++ b/backend/src/import/mny/mny-import.service.ts
@@ -1,5 +1,4 @@
 import {
-  ConflictException,
   Inject,
   Injectable,
   Logger,
@@ -24,6 +23,7 @@ import {
   JOB_FAILED_ERROR_KEY,
   JobRunContext,
   MnyImportJobService,
+  importAlreadyRunningException,
 } from "./mny-import-job.service";
 import { MnyParsedFile, MnyParserService } from "./mny-parser.service";
 import { MnyStagingService } from "./mny-staging.service";
@@ -72,10 +72,13 @@ import {
  * because the job service publishes it on its own connection -- see
  * `runOutsideActiveScopedManager`.
  *
- * The optional "start fresh" wipe happens in `start`, **before** the job exists,
- * for a security reason as much as an ordering one: `UsersService.deleteData`
+ * The optional "start fresh" wipe happens in `start`, outside the job body, for
+ * a security reason as much as an ordering one: `UsersService.deleteData`
  * re-authenticates, and its credentials must never be written into
- * `import_jobs.options`.
+ * `import_jobs.options`. It runs *after* the job row is inserted, though: the
+ * row is this user's import lock, and a destructive operation performed before
+ * the lock is held is one two concurrent requests can both perform. A wipe that
+ * fails takes the row back out with it.
  */
 
 /** `holdings.quantity` is `decimal(20,8)`. */
@@ -126,33 +129,44 @@ export class MnyImportService {
       );
     }
 
+    // Advisory: it saves a doomed INSERT and gives the same 409, but it cannot
+    // decide anything -- two requests can both read false here. `jobs.create`
+    // is what actually refuses, on the database's own unique index.
     if (await this.jobs.hasActiveJob(userId)) {
-      throw new ConflictException(
-        tr(
-          "errors.import.mnyImportAlreadyRunning",
-          "An import is already running. Wait for it to finish before starting another.",
-        ),
-      );
+      throw importAlreadyRunningException();
     }
 
     const options = resolveImportOptions(input.options);
 
-    // Before the job row exists, and never with the credentials in tow: a
-    // failed re-authentication must fail the request, not a background job.
+    // The job row is the lock, so it is taken *before* the destructive wipe:
+    // with the wipe first, two concurrent starts could both pass the advisory
+    // check and both delete the user's data before either row existed.
+    const job = await this.jobs.create(userId, staged.id, options);
+
+    // Still outside the job body, and never with the credentials in tow:
+    // `deleteData` re-authenticates, so running it in the body would mean
+    // writing the user's password into `import_jobs.options`, and a failed
+    // re-authentication must fail the request rather than a background job.
     if (options.wipeExistingData) {
-      await this.usersService.deleteData(userId, {
-        password: input.wipeCredentials?.password,
-        oidcIdToken: input.wipeCredentials?.oidcIdToken,
-        deleteAccounts: true,
-        deleteCategories: true,
-        deletePayees: true,
-      });
+      try {
+        await this.usersService.deleteData(userId, {
+          password: input.wipeCredentials?.password,
+          oidcIdToken: input.wipeCredentials?.oidcIdToken,
+          deleteAccounts: true,
+          deleteCategories: true,
+          deletePayees: true,
+        });
+      } catch (error) {
+        // The request is refused, so the slot it took must go back: leaving the
+        // row pending would block every import this user starts for the five
+        // minutes until the reaper sweeps it.
+        await this.jobs.discard(userId, job.id).catch(() => undefined);
+        throw error;
+      }
       this.logger.log(
         `Wiped existing data for user ${userId} before .mny import`,
       );
     }
-
-    const job = await this.jobs.create(userId, staged.id, options);
 
     // Unawaited on purpose (design ADR-3): the request returns the job id and
     // the wizard polls. `withUserContext` keeps an identity for the async chain

--- a/backend/test/integration/mny-import-job.integration.spec.ts
+++ b/backend/test/integration/mny-import-job.integration.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
+import { ConflictException } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { DataSource } from "typeorm";
@@ -23,9 +24,13 @@ import {
 } from "../helpers/integration-setup";
 
 /**
- * Job concurrency against a real database, because the two properties that
- * matter are properties of Postgres, not of the service: the conditional UPDATE
- * that makes a claim atomic, and the interval arithmetic the reaper depends on.
+ * Job concurrency against a real database, because the properties that matter
+ * are properties of Postgres, not of the service: the partial unique index that
+ * lets only one start per user insert a row, the conditional UPDATE that makes a
+ * claim atomic, and the interval arithmetic the reaper depends on.
+ *
+ * A mocked repository can express any of these and prove none: the losing INSERT
+ * has to actually block on the winner and then fail.
  */
 describe("MnyImportJobService (integration)", () => {
   let module: TestingModule;
@@ -116,6 +121,222 @@ describe("MnyImportJobService (integration)", () => {
       const jobId = await newJob();
 
       expect(await asUser(userB, () => jobs.findOne(userB, jobId))).toBeNull();
+    });
+  });
+
+  describe("one active job per user", () => {
+    /**
+     * A staged file of this user's, inserted directly.
+     *
+     * `MnyStagingService.stage` drops the user's previous file, so it cannot
+     * produce the two-live-files case at all -- and the rule under test is one
+     * import per *user*, which has to hold however many staged rows exist.
+     */
+    async function stage(userId: string): Promise<string> {
+      const row = await asUser(userId, () =>
+        withScopedDb(dataSource, (manager) => {
+          const repo = manager.getRepository(ImportStagedFile);
+          return repo.save(
+            repo.create({
+              userId,
+              filename: "money.mny",
+              sourceFormat: "mny",
+              sizeBytes: 5,
+              sha256: "0".repeat(64),
+              data: Buffer.from("bytes"),
+              expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            }),
+          );
+        }),
+      );
+      return row.id;
+    }
+
+    const activeCount = async (userId: string): Promise<number> => {
+      const rows = await dataSource.query(
+        `SELECT COUNT(*)::int AS count FROM import_jobs
+          WHERE user_id = $1 AND status IN ('pending', 'running')`,
+        [userId],
+      );
+      return rows[0].count;
+    };
+
+    const settle = async (
+      results: PromiseSettledResult<ImportJob>[],
+    ): Promise<{ created: ImportJob[]; refused: unknown[] }> => ({
+      created: results
+        .filter(
+          (result): result is PromiseFulfilledResult<ImportJob> =>
+            result.status === "fulfilled",
+        )
+        .map((result) => result.value),
+      refused: results
+        .filter(
+          (result): result is PromiseRejectedResult =>
+            result.status === "rejected",
+        )
+        .map((result) => result.reason),
+    });
+
+    it("has exactly one winner when two starts race over the same staged file", async () => {
+      // The defect this index exists for: `hasActiveJob` then `create` are two
+      // transactions, so both requests could count zero and both insert. Each
+      // parse generates fresh transaction UUIDs, so the second import would not
+      // deduplicate -- it would double the user's history and balances.
+      const stagedFileId = await stage(userA);
+
+      const { created, refused } = await settle(
+        await Promise.allSettled([
+          asUser(userA, () =>
+            jobs.create(userA, stagedFileId, DEFAULT_MNY_IMPORT_OPTIONS),
+          ),
+          asUser(userA, () =>
+            jobs.create(userA, stagedFileId, DEFAULT_MNY_IMPORT_OPTIONS),
+          ),
+        ]),
+      );
+
+      expect(created).toHaveLength(1);
+      expect(refused).toHaveLength(1);
+      expect(refused[0]).toBeInstanceOf(ConflictException);
+      expect(await activeCount(userA)).toBe(1);
+    });
+
+    it("has one winner across four concurrent starts", async () => {
+      const stagedFileId = await stage(userA);
+
+      const { created, refused } = await settle(
+        await Promise.allSettled(
+          Array.from({ length: 4 }, () =>
+            asUser(userA, () =>
+              jobs.create(userA, stagedFileId, DEFAULT_MNY_IMPORT_OPTIONS),
+            ),
+          ),
+        ),
+      );
+
+      expect(created).toHaveLength(1);
+      expect(refused).toHaveLength(3);
+      for (const error of refused) {
+        expect(error).toBeInstanceOf(ConflictException);
+      }
+      expect(await activeCount(userA)).toBe(1);
+    });
+
+    it("refuses a second start over a different staged file", async () => {
+      // The rule is one import per user, not one import per file: two files
+      // racing write the same accounts, payees and balances.
+      const first = await stage(userA);
+      const second = await stage(userA);
+
+      const { created, refused } = await settle(
+        await Promise.allSettled([
+          asUser(userA, () =>
+            jobs.create(userA, first, DEFAULT_MNY_IMPORT_OPTIONS),
+          ),
+          asUser(userA, () =>
+            jobs.create(userA, second, DEFAULT_MNY_IMPORT_OPTIONS),
+          ),
+        ]),
+      );
+
+      expect(created).toHaveLength(1);
+      expect(refused[0]).toBeInstanceOf(ConflictException);
+      expect(await activeCount(userA)).toBe(1);
+    });
+
+    it("lets two users start imports concurrently", async () => {
+      // The guard is per user. Making it global would mean one user's 200 MB
+      // import locks out everyone else on the deployment.
+      const forA = await stage(userA);
+      const forB = await stage(userB);
+
+      const { created, refused } = await settle(
+        await Promise.allSettled([
+          asUser(userA, () =>
+            jobs.create(userA, forA, DEFAULT_MNY_IMPORT_OPTIONS),
+          ),
+          asUser(userB, () =>
+            jobs.create(userB, forB, DEFAULT_MNY_IMPORT_OPTIONS),
+          ),
+        ]),
+      );
+
+      expect(refused).toHaveLength(0);
+      expect(created).toHaveLength(2);
+      expect(await activeCount(userA)).toBe(1);
+      expect(await activeCount(userB)).toBe(1);
+    });
+
+    it("refuses a start while the first job is running, not merely pending", async () => {
+      const jobId = await newJob(userA);
+      await asUser(userA, () => jobs.claim(jobId));
+      const stagedFileId = await stage(userA);
+
+      await expect(
+        asUser(userA, () =>
+          jobs.create(userA, stagedFileId, DEFAULT_MNY_IMPORT_OPTIONS),
+        ),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it("allows a fresh import once the previous one completed", async () => {
+      const jobId = await newJob(userA);
+      await asUser(userA, () => jobs.claim(jobId));
+      await asUser(userA, () => jobs.complete(jobId, EMPTY_RESULT));
+
+      const stagedFileId = await stage(userA);
+      const next = await asUser(userA, () =>
+        jobs.create(userA, stagedFileId, DEFAULT_MNY_IMPORT_OPTIONS),
+      );
+
+      expect(next.status).toBe("pending");
+    });
+
+    it("allows Retry once the previous job failed", async () => {
+      // Retry is one click on the failure screen, so a failed row must not
+      // count against the slot.
+      const jobId = await newJob(userA);
+      await asUser(userA, () => jobs.claim(jobId));
+      await asUser(userA, () => jobs.fail(jobId, "mnyImportFailed", "x", true));
+
+      const stagedFileId = await stage(userA);
+      await expect(
+        asUser(userA, () =>
+          jobs.create(userA, stagedFileId, DEFAULT_MNY_IMPORT_OPTIONS),
+        ),
+      ).resolves.toMatchObject({ status: "pending" });
+    });
+  });
+
+  describe("discard", () => {
+    it("gives the slot back so the user can start again immediately", async () => {
+      const jobId = await newJob(userA);
+
+      await asUser(userA, () => jobs.discard(userA, jobId));
+
+      expect(await asUser(userA, () => jobs.findOne(userA, jobId))).toBeNull();
+      await expect(asUser(userA, () => newJob(userA))).resolves.toBeDefined();
+    });
+
+    it("leaves a claimed job alone -- it belongs to its worker now", async () => {
+      const jobId = await newJob(userA);
+      await asUser(userA, () => jobs.claim(jobId));
+
+      await asUser(userA, () => jobs.discard(userA, jobId));
+
+      const job = await asUser(userA, () => jobs.findOne(userA, jobId));
+      expect(job!.status).toBe("running");
+    });
+
+    it("cannot discard another user's job", async () => {
+      const jobId = await newJob(userA);
+
+      await asUser(userB, () => jobs.discard(userB, jobId));
+
+      expect(
+        (await asUser(userA, () => jobs.findOne(userA, jobId)))!.status,
+      ).toBe("pending");
     });
   });
 

--- a/backend/test/integration/mny-import.integration.spec.ts
+++ b/backend/test/integration/mny-import.integration.spec.ts
@@ -1220,6 +1220,162 @@ describe("mny writers (integration)", () => {
       ).rejects.toThrow(/already running/i);
     });
 
+    /**
+     * Two `start` calls issued together, as two overlapping HTTP requests are.
+     *
+     * The advisory `hasActiveJob` count cannot separate them -- neither has
+     * committed a row when the other reads -- so what is being exercised is the
+     * partial unique index underneath `jobs.create`. Before it, both requests
+     * created a job and both imported the same bytes; because every parse
+     * generates fresh transaction UUIDs, the second run duplicated the file's
+     * entire history and doubled every balance.
+     */
+    async function raceTwoStarts(
+      stagedFileId: string,
+      options?: Parameters<typeof importService.start>[1]["options"],
+    ) {
+      const settled = await Promise.allSettled([
+        withUserContext(userId, () =>
+          importService.start(userId, { stagedFileId, options }),
+        ),
+        withUserContext(userId, () =>
+          importService.start(userId, { stagedFileId, options }),
+        ),
+      ]);
+
+      return {
+        started: settled
+          .filter((result) => result.status === "fulfilled")
+          .map((result) => (result as PromiseFulfilledResult<ImportJob>).value),
+        refused: settled
+          .filter((result) => result.status === "rejected")
+          .map((result) => (result as PromiseRejectedResult).reason),
+      };
+    }
+
+    /** Polls a job row until it leaves pending/running. */
+    async function awaitJob(jobId: string): Promise<ImportJob> {
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        const current = await withUserContext(userId, () =>
+          jobs.findOne(userId, jobId),
+        );
+        if (
+          current &&
+          current.status !== "pending" &&
+          current.status !== "running"
+        ) {
+          return current;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      throw new Error("import job did not finish");
+    }
+
+    describe("two starts racing", () => {
+      async function stageFixture(): Promise<string> {
+        const staged = await withUserContext(userId, () =>
+          staging.stage(userId, {
+            filename: "money2008.mny",
+            data: stagedBytes("money2008"),
+          }),
+        );
+        return staged.id;
+      }
+
+      it("creates one job and refuses the other", async () => {
+        const { started, refused } = await raceTwoStarts(await stageFixture());
+
+        expect(started).toHaveLength(1);
+        expect(refused).toHaveLength(1);
+        expect(String(refused[0])).toMatch(/already running/i);
+        await awaitJob(started[0].id);
+
+        const rows = await dataSource
+          .getRepository(ImportJob)
+          .find({ where: { userId } });
+        expect(rows).toHaveLength(1);
+      });
+
+      it("imports the file's rows once, not twice", async () => {
+        // The assertion the job-row count cannot make: what actually landed in
+        // the user's ledger.
+        const { started } = await raceTwoStarts(await stageFixture());
+        const job = await awaitJob(started[0].id);
+
+        expect(job.status).toBe("completed");
+        const transactions = await dataSource
+          .getRepository(Transaction)
+          .count({ where: { userId } });
+        const accounts = await dataSource
+          .getRepository(Account)
+          .find({ where: { userId } });
+
+        expect(transactions).toBe(job.result!.transactionsCreated);
+        expect(accounts).toHaveLength(job.result!.accountsCreated);
+        for (const line of job.result!.verification) {
+          const stored = accounts.find(
+            (account) => account.id === line.accountId,
+          );
+          expect(stored).toBeDefined();
+          // A second import over the same file would land here: the balances
+          // reconcile against the file only if every row was written once.
+          expect(Number(stored!.currentBalance)).toBe(line.expectedBalance);
+        }
+      });
+
+      it("wipes at most once, because the wipe is behind the same lock", async () => {
+        // `deleteData` is the destructive path. It used to run before the job
+        // row existed, so both racing requests could reach it.
+        const usersService = module.get(UsersService) as unknown as {
+          deleteData: jest.Mock;
+        };
+        usersService.deleteData.mockClear();
+
+        const { started, refused } = await raceTwoStarts(await stageFixture(), {
+          wipeExistingData: true,
+        });
+
+        expect(started).toHaveLength(1);
+        expect(refused).toHaveLength(1);
+        expect(usersService.deleteData).toHaveBeenCalledTimes(1);
+        await awaitJob(started[0].id);
+      });
+    });
+
+    it("releases the import slot when the wipe is refused", async () => {
+      // A rejected start must not leave the user holding a slot for a job that
+      // will never run -- the reaper would take five minutes to clear it, and
+      // every import started in between would be refused.
+      const usersService = module.get(UsersService) as unknown as {
+        deleteData: jest.Mock;
+      };
+      usersService.deleteData.mockRejectedValueOnce(new Error("bad password"));
+      const staged = await withUserContext(userId, () =>
+        staging.stage(userId, {
+          filename: "money2008.mny",
+          data: stagedBytes("money2008"),
+        }),
+      );
+
+      await expect(
+        withUserContext(userId, () =>
+          importService.start(userId, {
+            stagedFileId: staged.id,
+            options: { wipeExistingData: true },
+          }),
+        ),
+      ).rejects.toThrow("bad password");
+
+      expect(
+        await dataSource.getRepository(ImportJob).count({ where: { userId } }),
+      ).toBe(0);
+      const retried = await withUserContext(userId, () =>
+        importService.start(userId, { stagedFileId: staged.id }),
+      );
+      expect(retried.status).toBe("pending");
+      await awaitJob(retried.id);
+    });
+
     it("refuses to start when the staged file is gone", async () => {
       await expect(
         withUserContext(userId, () =>

--- a/database/migrations/135_import_jobs_single_active.sql
+++ b/database/migrations/135_import_jobs_single_active.sql
@@ -1,0 +1,39 @@
+-- One in-flight import per user, enforced by the database rather than by a
+-- read-then-insert in the service.
+--
+-- `MnyImportService.start` counted the user's active jobs and then inserted a
+-- row in a *second* transaction. Two overlapping start requests could both see
+-- zero and both insert, so the same staged file was imported twice: each parse
+-- pre-generates fresh transaction UUIDs, so nothing downstream deduplicates the
+-- second run's rows and the user ends up with doubled history and balances.
+-- With `wipeExistingData` both requests could also reach the destructive wipe.
+--
+-- The partial unique index is the whole fix: the second INSERT waits on the
+-- first and then fails with 23505, which the job service translates into the
+-- 409 the wizard already renders. `claim(jobId)` stays as it was -- it protects
+-- one row against two workers, which is a different race.
+
+-- Any database that already ran two starts concurrently carries rows the index
+-- would reject, and a migration that fails aborts backend start-up. Keep the
+-- newest active job per user and fail the rest retryably: the staged bytes are
+-- untouched, so the wizard can offer Retry. A no-op on a database that never
+-- raced, and on every re-apply.
+UPDATE import_jobs AS job
+   SET status = 'failed',
+       error_key = 'mnyJobStalled',
+       error_detail = 'Superseded by a concurrent import start',
+       retryable = true,
+       progress = NULL,
+       completed_at = CURRENT_TIMESTAMP
+ WHERE job.status IN ('pending', 'running')
+   AND EXISTS (
+     SELECT 1
+       FROM import_jobs AS newer
+      WHERE newer.user_id = job.user_id
+        AND newer.status IN ('pending', 'running')
+        AND (newer.created_at, newer.id) > (job.created_at, job.id)
+   );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_import_jobs_one_active_per_user
+    ON import_jobs(user_id)
+    WHERE status IN ('pending', 'running');

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1330,6 +1330,10 @@ CREATE TABLE import_jobs (
 CREATE INDEX idx_import_jobs_user ON import_jobs(user_id);
 CREATE INDEX idx_import_jobs_staged_file ON import_jobs(staged_file_id);
 CREATE INDEX idx_import_jobs_running_heartbeat ON import_jobs(heartbeat_at) WHERE status = 'running';
+-- One in-flight import per user, enforced here rather than by a read-then-insert
+-- in the service: two concurrent starts would otherwise both see no active job
+-- and import the same staged file twice.
+CREATE UNIQUE INDEX idx_import_jobs_one_active_per_user ON import_jobs(user_id) WHERE status IN ('pending', 'running');
 
 CREATE TRIGGER update_import_jobs_updated_at BEFORE UPDATE ON import_jobs FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 

--- a/docs/future-plans/mny-import.md
+++ b/docs/future-plans/mny-import.md
@@ -418,9 +418,18 @@ integration spec asserts a poller sees progress from inside an open transaction.
 
 **The wipe cannot happen inside the job.** `UsersService.deleteData`
 re-authenticates, so running it in the job body would mean writing the user's
-password into `import_jobs.options`. It runs in `start()` instead, before the job
-row exists: a failed re-authentication fails the request, and the credentials are
-spent on that one call.
+password into `import_jobs.options`. It runs in `start()` instead: a failed
+re-authentication fails the request, and the credentials are spent on that one
+call.
+
+It runs *after* the job row is inserted, though, not before. The row is the
+user's import lock -- `import_jobs` carries a partial unique index on `user_id`
+where the status is `pending` or `running` (migration 135), so the second of two
+concurrent starts blocks on the first and then fails, and `create` turns that
+into the 409 the wizard already renders. A destructive operation performed
+*before* the lock is held is one both racing requests can perform. A wipe that
+fails takes the row back out with it (`jobs.discard`), so the refused request
+does not leave the user holding a slot for a job that will never run.
 
 **Categories do not route through the QIF entity creator.** ADR-8 hoped to reuse
 `ImportEntityCreatorService` behind a `{manager, query}` shim. Its
@@ -916,8 +925,17 @@ instead.
   localized error that nothing rendered: pressing Start import did nothing at
   all. The review step shows it, and offers the way back to upload when the
   staged bytes are what is gone.
+- *Two concurrent starts imported the same file twice.* `start` counted the
+  user's active jobs and then inserted a row in a second transaction, so two
+  overlapping requests both read zero and both inserted. Each parse
+  pre-generates fresh transaction UUIDs, so nothing downstream deduplicated the
+  loser's rows: the user's history and every balance doubled, and with
+  `wipeExistingData` both requests could reach the destructive wipe. The count
+  is advisory now; the refusal is a partial unique index on
+  `import_jobs(user_id) WHERE status IN ('pending','running')`, and the wipe
+  moved behind it.
 - *Retry after a "start fresh" import asked for the wipe again.* The wipe runs
-  in `start`, before the job row exists, so by the time a job can fail the data
+  in `start`, outside the job body, so by the time a job can fail the data
   is already gone — and Retry deliberately collects no password, being one click
   on a failure screen. The repeat request therefore failed re-authentication and
   left the user on a retryable failure they could not retry.

--- a/frontend/src/hooks/useMnyImport.ts
+++ b/frontend/src/hooks/useMnyImport.ts
@@ -272,8 +272,8 @@ export function useMnyImport(): UseMnyImportResult {
 
     return {
       ...options,
-      // The wipe happens in `start`, before the job row exists, so a Retry after
-      // a failed import must not ask for it again: the data is already gone, and
+      // The wipe happens in `start`, outside the job body, so a Retry after a
+      // failed import must not ask for it again: the data is already gone, and
       // repeating it would fail re-authentication -- Retry collects no password,
       // by design, because it is one click on a failure screen.
       wipeExistingData: wipePerformed.current


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: _none yet — this came from an audit finding (P1-001), not from an approved discussion. Please link one before merging, or confirm the propose-first step is waived for a data-integrity fix._

## Summary

`MnyImportService.start` counted the user's active jobs and then inserted the job row in a **second** transaction, with an optional destructive wipe in between. Two overlapping `POST /import/mny/start` requests could both read zero and both insert. Because every parse pre-generates fresh transaction UUIDs, nothing downstream deduplicated the loser's rows: the file's entire history was written twice and every balance doubled. With `wipeExistingData` both requests could also reach `UsersService.deleteData`, which ran before any job row existed.

The check-and-insert is now one atomic act at the database boundary:

- **`database/migrations/135_import_jobs_single_active.sql`** — partial unique index on `import_jobs(user_id) WHERE status IN ('pending', 'running')`, so the second INSERT blocks on the first and then fails. Includes a backfill failing all but the newest active job per user (retryably — the staged bytes are untouched), because a database that already raced carries rows the index would reject, and a failing migration aborts backend start-up. Mirrored into `schema.sql`, and declared on the `ImportJob` entity as well, since test and dev databases synchronize from the entities — a guard that exists only in SQL cannot be tested.
- **`MnyImportJobService.create`** — translates that one constraint into the 409 the wizard already renders, matched by constraint *name* rather than by SQLSTATE `23505` alone; any other violation rethrows untouched. `hasActiveJob` remains only as an advisory fast path that saves a doomed INSERT and decides nothing.
- **`MnyImportService.start`** — the job row is the user's import lock, so it is inserted **before** the wipe rather than after. The wipe still runs outside the job body, so the re-authentication credentials never reach `import_jobs.options`; a refused wipe hands the slot back through the new `MnyImportJobService.discard` instead of wedging the user until the reaper's five-minute sweep.
- `claim(jobId)` is unchanged — it protects one row against two workers, which is a different race.

Two notes on scope:

- The audit's suggested idempotency key for `(user_id, staged_file_id, request)` was listed as "consider" and is not included. A retried start now gets a clean 409 rather than a second import.
- `MnyStagingService.stage` drops the user's previous staged file, so "two live staged files for one user" cannot arise through the real path. That test inserts the staged rows directly, with the reason in a comment: the rule under test is one import per *user*, and it has to hold however many staged rows exist.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — **not done**, see above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). — no new strings: the 409 reuses `errors.import.mnyImportAlreadyRunning`, and the backfill reuses the existing `mnyJobStalled` error key.
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main` (`bb798b8`).
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

### Tests

Barrier tests against real PostgreSQL in `test/integration/mny-import-job.integration.spec.ts`: two, four and cross-user concurrent starts; a second start over a different staged file; a start against a job already claimed; and that a completed or failed job frees the slot so Retry works. Plus `discard` behaviour — releases the slot, leaves a claimed job alone, cannot touch another user's row.

End-to-end race tests in `test/integration/mny-import.integration.spec.ts` drive two concurrent `start()` calls over a real fixture and assert one job row, one wipe, and that the resulting transaction counts, account counts and per-account balances match a single import.

Every one of those fails with the index removed — 4 job-level tests and all 3 end-to-end race tests — and the doubled-import assertion fails on the account count, which is the original defect reproducing.

Verified: 30/30 job integration specs, 38/38 import integration specs, 259/259 full integration suite, 10,756 unit tests, `npm run migration:lint`, and a local reproduction of the "Schema vs Migrations Drift" job (every migration applied twice on top of `schema.sql`, dumps identical). The backfill was exercised separately against a database seeded with duplicate active rows.

## AI assistance disclosure

Written with Claude Code. The fix, the migration and the tests were produced in that session; the test suites, migration lint and schema-drift check were run against a real PostgreSQL 16 rather than assumed.
