### PR TITLE
Serve a joint account's analytics and hide a joint-only context switcher

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -128,6 +128,32 @@ grew a column selects more than one row now; a query still written against the
 old key returns whichever the database offers first. Grep for reads of a
 unique key in the migration that widens it.
 
+## A joint account is only shared where somebody remembered to share it
+
+`transaction.userId = :userId` is the wrong ownership predicate for any
+own-context read a delegate can reach: a jointly shared account's rows belong
+to the **owner**, so the grantee matches none of them and the endpoint returns
+a confident empty answer rather than an error. That is how the register got the
+joint scope on day one while the summary, grouped totals and monthly totals
+beside it did not -- a joint account's detail page drew a full balance chart
+with an empty cash flow, no top categories and no top payees under it.
+
+Own-context reads resolve their scope through
+`TransactionsController.resolveOwnContextJointScope` (the accounts controller's
+equivalents are `jointAccountIdSetFor` for list reads and a `NotFoundException`
+fallback through `jointAccessFor` for `:id` reads, as on `getBalance` and
+`getBalanceForecast`). Filtered to exactly one joint account, the query runs as
+the owner so every derived value -- category descendant expansion, the search
+term parsed in the user's number/date format, the money math -- is byte-identical
+to the owner's own view; anything else keeps the caller's scope and widens it by
+the already-authorized joint ids, never by raw request input. The widened
+predicate itself is written once per service (`registerScope`,
+`analyticsScope`).
+
+An endpoint that deliberately stays owner-only says so where it is skipped:
+`tag-key-breakdown` does, because tags are personal and a joint row never
+carries the grantee's.
+
 ## A money value carries the currency it was calculated into
 
 Not the currency of the account it is filed under. `InvestmentTransaction.exchangeRate`

--- a/backend/src/accounts/accounts.controller.spec.ts
+++ b/backend/src/accounts/accounts.controller.spec.ts
@@ -417,10 +417,14 @@ describe("AccountsController", () => {
   });
 
   describe("getBalanceForecast()", () => {
-    it("delegates to balanceForecastService with a clamped horizon", () => {
+    it("delegates to balanceForecastService with a clamped horizon", async () => {
       mockBalanceForecastService.getBalanceForecast.mockReturnValue("forecast");
 
-      const result = controller.getBalanceForecast(mockReq, "account-1", 30);
+      const result = await controller.getBalanceForecast(
+        mockReq,
+        "account-1",
+        30,
+      );
 
       expect(result).toBe("forecast");
       expect(
@@ -428,16 +432,57 @@ describe("AccountsController", () => {
       ).toHaveBeenCalledWith("user-1", "account-1", 30);
     });
 
-    it("defaults the horizon to 90 days and clamps to 730", () => {
-      controller.getBalanceForecast(mockReq, "account-1", undefined);
+    it("defaults the horizon to 90 days and clamps to 730", async () => {
+      await controller.getBalanceForecast(mockReq, "account-1", undefined);
       expect(
         mockBalanceForecastService.getBalanceForecast,
       ).toHaveBeenLastCalledWith("user-1", "account-1", 90);
 
-      controller.getBalanceForecast(mockReq, "account-1", 5000);
+      await controller.getBalanceForecast(mockReq, "account-1", 5000);
       expect(
         mockBalanceForecastService.getBalanceForecast,
       ).toHaveBeenLastCalledWith("user-1", "account-1", 730);
+    });
+
+    it("falls back to the owner's scope for a joint account after authorization", async () => {
+      // Without this the grantee's balance chart stops at today while the
+      // owner's carries a forward line, and the projected-balance card
+      // silently reports today's balance as the projection.
+      const { NotFoundException } = jest.requireActual("@nestjs/common");
+      mockBalanceForecastService.getBalanceForecast
+        .mockRejectedValueOnce(new NotFoundException())
+        .mockResolvedValueOnce({ points: [] });
+      mockJointAccounts.jointAccessFor.mockResolvedValue({
+        ownerUserId: "owner-9",
+        via: "delegation",
+      });
+
+      const result = await controller.getBalanceForecast(mockReq, "joint-1");
+
+      expect(result).toEqual({ points: [] });
+      expect(mockJointAccounts.jointAccessFor).toHaveBeenCalledWith(
+        "user-1",
+        "joint-1",
+        "read",
+      );
+      expect(
+        mockBalanceForecastService.getBalanceForecast,
+      ).toHaveBeenLastCalledWith("owner-9", "joint-1", 90);
+    });
+
+    it("re-raises the 404 while acting, never taking the joint path", async () => {
+      const { NotFoundException } = jest.requireActual("@nestjs/common");
+      mockBalanceForecastService.getBalanceForecast.mockRejectedValueOnce(
+        new NotFoundException(),
+      );
+
+      await expect(
+        controller.getBalanceForecast(
+          { user: { id: "owner-1", realUserId: "d1", isActing: true } },
+          "joint-1",
+        ),
+      ).rejects.toThrow(NotFoundException);
+      expect(mockJointAccounts.jointAccessFor).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/accounts/accounts.controller.ts
+++ b/backend/src/accounts/accounts.controller.ts
@@ -692,17 +692,34 @@ export class AccountsController {
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
   @ApiResponse({ status: 404, description: "Account not found" })
-  getBalanceForecast(
+  async getBalanceForecast(
     @Request() req,
     @Param("id", ParseUUIDPipe) id: string,
     @Query("days", new ParseIntPipe({ optional: true })) days?: number,
   ) {
     const horizon = Math.min(Math.max(days ?? 90, 1), 730);
-    return this.balanceForecastService.getBalanceForecast(
-      req.user.id,
-      id,
-      horizon,
-    );
+    try {
+      return await this.balanceForecastService.getBalanceForecast(
+        req.user.id,
+        id,
+        horizon,
+      );
+    } catch (err) {
+      if (!(err instanceof NotFoundException) || req.user.isActing) throw err;
+      // Joint fallback (same shape as getBalance): authorize, then project
+      // with the owner's scope so the grantee's balance chart carries the
+      // same forward line the owner's does instead of stopping at today.
+      const access = await this.jointAccounts.jointAccessFor(
+        req.user.realUserId ?? req.user.id,
+        id,
+        "read",
+      );
+      return this.balanceForecastService.getBalanceForecast(
+        access.ownerUserId,
+        id,
+        horizon,
+      );
+    }
   }
 
   @Get(":id/interest-paid")

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -2674,6 +2674,9 @@ describe("AuthController", () => {
       expect(delegation.getSections).toHaveBeenCalledWith("g1");
       expect(delegation.hasTransactionalAccess).toHaveBeenCalledWith("g1");
       expect(delegation.hasAnyAccountAccess).toHaveBeenCalledWith("g1");
+      // The acting owner is named so a joint-only context the caller is
+      // standing in is not filtered out from under them.
+      expect(delegation.getAvailableContexts).toHaveBeenCalledWith("d1", "o1");
     });
 
     it("returns null capabilities and sections when not acting", async () => {
@@ -2693,6 +2696,7 @@ describe("AuthController", () => {
         sections: null,
       });
       expect(delegation.getSections).not.toHaveBeenCalled();
+      expect(delegation.getAvailableContexts).toHaveBeenCalledWith("d1", null);
     });
   });
 

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -608,6 +608,7 @@ export class AuthController {
       actingAsUserId: req.user.isActing ? req.user.id : null,
       contexts: await this.delegationService.getAvailableContexts(
         req.user.realUserId,
+        req.user.isActing ? req.user.id : null,
       ),
       capabilities:
         req.user.isActing && req.user.delegationId

--- a/backend/src/delegation/delegation.service.spec.ts
+++ b/backend/src/delegation/delegation.service.spec.ts
@@ -515,6 +515,12 @@ describe("DelegationService", () => {
   });
 
   describe("getAvailableContexts", () => {
+    beforeEach(() => {
+      // No grants assigned unless a case says otherwise; the joint-only
+      // filter reads them for every delegation.
+      grantsRepo.find.mockResolvedValue([]);
+    });
+
     it("returns [] when the user does not exist", async () => {
       usersRepo.findOne.mockResolvedValue(null);
       await expect(service.getAvailableContexts("u1")).resolves.toEqual([]);
@@ -600,6 +606,146 @@ describe("DelegationService", () => {
       expect(res).toHaveLength(1);
       expect(res[0].isSelf).toBe(false);
       expect(res[0].label).toBe("o1");
+    });
+
+    describe("joint-only delegations", () => {
+      /** A full-account grantee with one active delegation from "o1". */
+      function arrangeGrantee(delegation: Record<string, unknown> = {}) {
+        usersRepo.findOne.mockImplementation(({ where }: any) =>
+          where.id === "u1"
+            ? { id: "u1", firstName: "Del", isDelegateOnly: false }
+            : { id: "o1", firstName: "Own", twoFactorSecret: null },
+        );
+        delegatesRepo.find.mockResolvedValue([
+          {
+            id: "g1",
+            ownerUserId: "o1",
+            owner: { id: "o1", firstName: "Own" },
+            ...delegation,
+          },
+        ]);
+        accountsRepo.exists.mockResolvedValue(true);
+        prefsRepo.findOne.mockResolvedValue({ twoFactorEnabled: false });
+      }
+
+      it("drops the owner context when every readable grant is joint", async () => {
+        arrangeGrantee();
+        grantsRepo.find.mockResolvedValue([
+          { delegationId: "g1", accountId: "a1", canRead: true, isJoint: true },
+          { delegationId: "g1", accountId: "a2", canRead: true, isJoint: true },
+        ]);
+
+        // Nothing to switch between: both accounts are already native.
+        await expect(service.getAvailableContexts("u1")).resolves.toEqual([]);
+      });
+
+      it("keeps the owner context when a readable grant is not joint", async () => {
+        arrangeGrantee();
+        grantsRepo.find.mockResolvedValue([
+          { delegationId: "g1", accountId: "a1", canRead: true, isJoint: true },
+          {
+            delegationId: "g1",
+            accountId: "a2",
+            canRead: true,
+            isJoint: false,
+          },
+        ]);
+
+        const res = await service.getAvailableContexts("u1");
+        expect(res.map((c) => c.userId)).toEqual(["u1", "o1"]);
+      });
+
+      it.each([
+        ["billsCanRead"],
+        ["investmentsCanRead"],
+        ["budgetsCanRead"],
+        ["reportsCanRead"],
+        ["aiCanRead"],
+      ])("keeps the owner context when %s is granted", async (field) => {
+        arrangeGrantee({ [field]: true });
+        grantsRepo.find.mockResolvedValue([
+          { delegationId: "g1", accountId: "a1", canRead: true, isJoint: true },
+        ]);
+
+        const res = await service.getAvailableContexts("u1");
+        expect(res.map((c) => c.userId)).toEqual(["u1", "o1"]);
+      });
+
+      it.each([
+        ["payeesCanCreate"],
+        ["payeesCanEdit"],
+        ["payeesCanDelete"],
+        ["categoriesCanCreate"],
+        ["categoriesCanEdit"],
+        ["categoriesCanDelete"],
+        ["tagsCanCreate"],
+        ["tagsCanEdit"],
+        ["tagsCanDelete"],
+      ])(
+        "keeps the owner context when the %s capability is granted",
+        async (field) => {
+          arrangeGrantee({ [field]: true });
+          grantsRepo.find.mockResolvedValue([
+            {
+              delegationId: "g1",
+              accountId: "a1",
+              canRead: true,
+              isJoint: true,
+            },
+          ]);
+
+          const res = await service.getAvailableContexts("u1");
+          expect(res.map((c) => c.userId)).toEqual(["u1", "o1"]);
+        },
+      );
+
+      it("keeps a delegation whose grants are not assigned yet", async () => {
+        // No joint share stands in for the context, so hiding it would leave
+        // the delegate unable to switch in once the owner grants something.
+        arrangeGrantee();
+        grantsRepo.find.mockResolvedValue([]);
+
+        const res = await service.getAvailableContexts("u1");
+        expect(res.map((c) => c.userId)).toEqual(["u1", "o1"]);
+      });
+
+      it("keeps a joint-only owner the caller is currently acting as", async () => {
+        // Hiding the context the user is standing in would strip the only
+        // control that gets them back to their own account.
+        arrangeGrantee();
+        grantsRepo.find.mockResolvedValue([
+          { delegationId: "g1", accountId: "a1", canRead: true, isJoint: true },
+        ]);
+
+        const res = await service.getAvailableContexts("u1", "o1");
+        expect(res.map((c) => c.userId)).toEqual(["u1", "o1"]);
+      });
+
+      it("drops only the joint-only owner, keeping the other owner's context", async () => {
+        usersRepo.findOne.mockImplementation(({ where }: any) =>
+          where.id === "u1"
+            ? { id: "u1", firstName: "Del", isDelegateOnly: false }
+            : { id: where.id, firstName: where.id, twoFactorSecret: null },
+        );
+        delegatesRepo.find.mockResolvedValue([
+          { id: "g1", ownerUserId: "o1", owner: { id: "o1", firstName: "O1" } },
+          { id: "g2", ownerUserId: "o2", owner: { id: "o2", firstName: "O2" } },
+        ]);
+        accountsRepo.exists.mockResolvedValue(true);
+        prefsRepo.findOne.mockResolvedValue({ twoFactorEnabled: false });
+        grantsRepo.find.mockResolvedValue([
+          { delegationId: "g1", accountId: "a1", canRead: true, isJoint: true },
+          {
+            delegationId: "g2",
+            accountId: "a2",
+            canRead: true,
+            isJoint: false,
+          },
+        ]);
+
+        const res = await service.getAvailableContexts("u1");
+        expect(res.map((c) => c.userId)).toEqual(["u1", "o2"]);
+      });
     });
   });
 

--- a/backend/src/delegation/delegation.service.ts
+++ b/backend/src/delegation/delegation.service.ts
@@ -75,6 +75,25 @@ const SECTION_FIELD: Record<DelegateSection, keyof AccountDelegate> = {
   ai: "aiCanRead",
 };
 
+/**
+ * Every boolean on a delegation that makes the owner's context worth entering:
+ * the section reads, and the reference-data manage capabilities that put a
+ * Tools entry in the delegate's nav. Both are derived rather than listed --
+ * SECTION_FIELDS from the SECTION_FIELD map, CAPABILITY_FIELDS from the
+ * resource x operation product the entity's columns already follow -- so a new
+ * grantable flag cannot be missed by the joint-only check.
+ */
+const SECTION_FIELDS: ReadonlyArray<keyof AccountDelegate> =
+  Object.values(SECTION_FIELD);
+
+const CAPABILITY_FIELDS: ReadonlyArray<keyof AccountDelegate> = (
+  ["payees", "categories", "tags"] as const
+).flatMap((resource) =>
+  (["Create", "Edit", "Delete"] as const).map(
+    (op) => `${resource}Can${op}` as keyof AccountDelegate,
+  ),
+);
+
 export type DelegateOperation = "read" | "create" | "edit" | "delete";
 
 /**
@@ -414,20 +433,73 @@ export class DelegationService {
   // --- Login / switch context ---
 
   /**
+   * Whether switching into this delegation's owner context would show the
+   * grantee anything they do not already have natively. A purely joint share
+   * offers nothing: every readable account already appears in the grantee's
+   * own context, no whole-section read was granted, and no reference-data
+   * manage capability was granted -- so the owner context is dropped from the
+   * switcher rather than offering a switch between two views of the same
+   * accounts. A grant that is readable but not joint, any section, or any
+   * manage capability makes the context reachable only by switching, so it
+   * stays.
+   *
+   * A delegation with nothing readable yet (freshly invited, grants not
+   * assigned) is NOT joint-only: it has no joint share to stand in for the
+   * context, and hiding it would leave the delegate unable to switch in at
+   * all once the owner grants something.
+   */
+  private isJointOnlyDelegation(
+    delegation: AccountDelegate,
+    grants: AccountDelegateGrant[],
+  ): boolean {
+    if (SECTION_FIELDS.some((f) => !!delegation[f])) return false;
+    if (CAPABILITY_FIELDS.some((f) => !!delegation[f])) return false;
+    const readable = grants.filter((g) => g.canRead);
+    return readable.length > 0 && readable.every((g) => g.isJoint);
+  }
+
+  /**
    * Contexts the authenticated user can operate in. Returns an empty array
    * for a normal user with no delegations (so login behaviour is unchanged).
+   *
+   * `actingAsUserId` is the owner the caller is currently acting as, if any.
+   * Its context is never filtered out: a switcher that hides the context the
+   * user is standing in is a one-way door, and the way back to their own
+   * account is the switcher.
    */
-  async getAvailableContexts(userId: string): Promise<AvailableContext[]> {
+  async getAvailableContexts(
+    userId: string,
+    actingAsUserId?: string | null,
+  ): Promise<AvailableContext[]> {
     const user = await this.scoped(User, (repo) =>
       repo.findOne({ where: { id: userId } }),
     );
     if (!user) return [];
 
-    const delegations = await this.scoped(AccountDelegate, (repo) =>
+    const allDelegations = await this.scoped(AccountDelegate, (repo) =>
       repo.find({
         where: { delegateUserId: user.id, status: "active" },
         relations: ["owner"],
       }),
+    );
+
+    if (allDelegations.length === 0) return [];
+
+    // Drop the owner contexts that are purely joint shares: those accounts are
+    // already in the grantee's own context, so offering a switch to them
+    // presents a chooser whose two sides show the same thing.
+    const grantsByDelegation = await this.scoped(AccountDelegateGrant, (repo) =>
+      repo.find({
+        where: { delegationId: In(allDelegations.map((d) => d.id)) },
+      }),
+    );
+    const delegations = allDelegations.filter(
+      (d) =>
+        d.ownerUserId === actingAsUserId ||
+        !this.isJointOnlyDelegation(
+          d,
+          grantsByDelegation.filter((g) => g.delegationId === d.id),
+        ),
     );
 
     if (delegations.length === 0) return [];

--- a/backend/src/transactions/transaction-analytics.service.spec.ts
+++ b/backend/src/transactions/transaction-analytics.service.spec.ts
@@ -294,8 +294,47 @@ describe("TransactionAnalyticsService", () => {
       await service.getSummary(userId);
 
       expect(mockQueryBuilder.where).toHaveBeenCalledWith(
-        "transaction.userId = :userId",
-        { userId },
+        "transaction.userId = :analyticsScopeUserId",
+        { analyticsScopeUserId: userId },
+      );
+    });
+
+    // Joint accounts: the grantee owns none of the rows, so without the
+    // widened ownership predicate every total came back zero while the same
+    // account's register (which has always had it) showed the transactions.
+    it("widens the ownership predicate by the authorized joint ids", async () => {
+      await service.getSummary(
+        userId,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        ["acc-joint-1", "acc-joint-2"],
+      );
+
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+        "transaction.userId = :analyticsScopeUserId",
+        { analyticsScopeUserId: userId },
+      );
+      expect(mockQueryBuilder.orWhere).toHaveBeenCalledWith(
+        "transaction.accountId IN (:...analyticsScopeJointIds)",
+        { analyticsScopeJointIds: ["acc-joint-1", "acc-joint-2"] },
+      );
+    });
+
+    it("leaves the predicate owner-only when no joint ids are authorized", async () => {
+      await service.getSummary(userId);
+
+      expect(mockQueryBuilder.orWhere).not.toHaveBeenCalledWith(
+        "transaction.accountId IN (:...analyticsScopeJointIds)",
+        expect.anything(),
       );
     });
 
@@ -909,8 +948,8 @@ describe("TransactionAnalyticsService", () => {
         );
 
         expect(mockQueryBuilder.where).toHaveBeenCalledWith(
-          "transaction.userId = :userId",
-          { userId },
+          "transaction.userId = :analyticsScopeUserId",
+          { analyticsScopeUserId: userId },
         );
         expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
           "transaction.accountId IN (:...accountIds)",
@@ -1222,8 +1261,29 @@ describe("TransactionAnalyticsService", () => {
       await service.getMonthlyTotals(userId);
 
       expect(mockQueryBuilder.where).toHaveBeenCalledWith(
-        "transaction.userId = :userId",
-        { userId },
+        "transaction.userId = :analyticsScopeUserId",
+        { analyticsScopeUserId: userId },
+      );
+    });
+
+    it("widens the ownership predicate by the authorized joint ids", async () => {
+      await service.getMonthlyTotals(
+        userId,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        ["acc-joint-1"],
+      );
+
+      expect(mockQueryBuilder.orWhere).toHaveBeenCalledWith(
+        "transaction.accountId IN (:...analyticsScopeJointIds)",
+        { analyticsScopeJointIds: ["acc-joint-1"] },
       );
     });
 
@@ -2522,6 +2582,18 @@ describe("TransactionAnalyticsService", () => {
   });
 
   describe("getGroupedTotals", () => {
+    it("widens the ownership predicate by the authorized joint ids", async () => {
+      await service.getGroupedTotals(userId, {
+        groupBy: "payee",
+        jointAccountIds: ["acc-joint-1"],
+      });
+
+      expect(mockQueryBuilder.orWhere).toHaveBeenCalledWith(
+        "transaction.accountId IN (:...analyticsScopeJointIds)",
+        { analyticsScopeJointIds: ["acc-joint-1"] },
+      );
+    });
+
     it("groups by category with split-aware id and name expressions", async () => {
       mockQueryBuilder.getRawMany.mockResolvedValue([
         {

--- a/backend/src/transactions/transaction-analytics.service.ts
+++ b/backend/src/transactions/transaction-analytics.service.ts
@@ -278,6 +278,7 @@ export class TransactionAnalyticsService {
     excludeInvestmentLinked?: boolean,
     excludeTransfers?: boolean,
     tagIds?: string[],
+    jointAccountIds?: string[],
   ): Promise<{
     totalIncome: number;
     totalExpenses: number;
@@ -308,6 +309,7 @@ export class TransactionAnalyticsService {
         excludeInvestmentLinked,
         excludeTransfers,
         tagIds,
+        jointAccountIds,
       });
 
       // Use the split amount when the row came from the splits join;
@@ -398,12 +400,37 @@ export class TransactionAnalyticsService {
   }
 
   /**
+   * The analytics read scope, mirroring the register's (joint-accounts spec):
+   * the user's own rows plus rows in accounts jointly shared to them.
+   * `jointAccountIds` is the already-authorized joint set computed by the
+   * controller, never raw request input. An empty joint set reproduces the old
+   * owner-only predicate exactly, so non-joint traffic is untouched.
+   */
+  private analyticsScope(userId: string, jointAccountIds: string[]): Brackets {
+    return new Brackets((qb) => {
+      qb.where("transaction.userId = :analyticsScopeUserId", {
+        analyticsScopeUserId: userId,
+      });
+      if (jointAccountIds.length > 0) {
+        qb.orWhere("transaction.accountId IN (:...analyticsScopeJointIds)", {
+          analyticsScopeJointIds: jointAccountIds,
+        });
+      }
+    });
+  }
+
+  /**
    * Base query shared by {@link getSummary} and {@link getGroupedTotals}:
    * applies the full transaction-list filter surface (accounts incl. the
    * brokerage exclusion, dates, categories with descendant expansion and
    * the `uncategorized`/`transfer` pseudo-ids, payees, search, amount
    * range, tags) with splits always joined so split transactions count
    * per matching split via `COALESCE(splits.amount, transaction.amount)`.
+   *
+   * `jointAccountIds` widens the ownership predicate only; category
+   * descendant expansion still resolves against `userId`'s own tree, so a
+   * caller that both filters by category and widens by joint ids must pass
+   * the owning user (which is what the single-joint-account path does).
    */
   private async createFilteredAnalyticsQuery(
     m: EntityManager,
@@ -421,6 +448,7 @@ export class TransactionAnalyticsService {
       excludeTransfers?: boolean;
       tagIds?: string[];
       includeUnreconciledBeforeStart?: boolean;
+      jointAccountIds?: string[];
     },
   ) {
     const {
@@ -436,12 +464,13 @@ export class TransactionAnalyticsService {
       excludeTransfers,
       tagIds,
       includeUnreconciledBeforeStart,
+      jointAccountIds,
     } = filters;
 
     const queryBuilder = m
       .getRepository(Transaction)
       .createQueryBuilder("transaction")
-      .where("transaction.userId = :userId", { userId });
+      .where(this.analyticsScope(userId, jointAccountIds ?? []));
 
     // Join account for filtering and uncategorized conditions.
     // Use the same exclusion logic as findAll() so the summary
@@ -658,6 +687,7 @@ export class TransactionAnalyticsService {
       amountTo?: number;
       limit?: number;
       includeUnreconciledBeforeStart?: boolean;
+      jointAccountIds?: string[];
     },
   ): Promise<
     Array<{
@@ -820,6 +850,7 @@ export class TransactionAnalyticsService {
     amountFrom?: number,
     amountTo?: number,
     tagIds?: string[],
+    jointAccountIds?: string[],
   ): Promise<Array<{ month: string; total: number; count: number }>> {
     return withScopedDb(this.dataSource, async (m) => {
       // Reuse the same filtered query builder as getSummary so the chart's
@@ -841,6 +872,7 @@ export class TransactionAnalyticsService {
         amountFrom,
         amountTo,
         tagIds,
+        jointAccountIds,
       });
 
       // The splits join is always present, so use the split amount for split

--- a/backend/src/transactions/transactions.controller.spec.ts
+++ b/backend/src/transactions/transactions.controller.spec.ts
@@ -11,6 +11,7 @@ describe("TransactionsController", () => {
   let mockJointAccounts: Record<string, jest.Mock>;
   let mockJointRegister: Record<string, jest.Mock>;
   let mockCrossOwnerAccess: Record<string, jest.Mock>;
+  let mockDelegationService: Record<string, jest.Mock>;
   const mockReq = { user: { id: "user-1" } };
 
   // Valid UUIDs for testing
@@ -41,6 +42,7 @@ describe("TransactionsController", () => {
       updateTransfer: jest.fn(),
       getSummary: jest.fn(),
       getGroupedTotals: jest.fn(),
+      getMonthlyTotals: jest.fn(),
       getTagKeyBreakdown: jest.fn(),
       getRecurringCharges: jest.fn(),
       bulkUpdate: jest.fn(),
@@ -63,6 +65,10 @@ describe("TransactionsController", () => {
       markCleared: jest.fn(),
     };
 
+    mockDelegationService = {
+      readableAccountIds: jest.fn().mockResolvedValue([]),
+    };
+
     mockCrossOwnerAccess = {
       readableAccountIdSetFor: jest.fn().mockResolvedValue(new Set()),
       // Own accounts by default, matching mockJointRegister.ownsRow above.
@@ -79,7 +85,7 @@ describe("TransactionsController", () => {
         DelegateTransferMaskInterceptor,
         {
           provide: DelegationService,
-          useValue: { readableAccountIds: jest.fn().mockResolvedValue([]) },
+          useValue: mockDelegationService,
         },
         {
           // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -1062,6 +1068,7 @@ describe("TransactionsController", () => {
         undefined,
         undefined,
         undefined,
+        [],
       );
     });
 
@@ -1087,6 +1094,7 @@ describe("TransactionsController", () => {
         undefined,
         undefined,
         undefined,
+        [],
       );
     });
 
@@ -1120,19 +1128,20 @@ describe("TransactionsController", () => {
         undefined,
         undefined,
         [uuid1, uuid2],
+        [],
       );
     });
 
-    it("rejects invalid date in summary startDate", () => {
-      expect(() =>
+    it("rejects invalid date in summary startDate", async () => {
+      await expect(
         controller.getSummary(mockReq, undefined, undefined, "notadate"),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects invalid UUID in summary accountIds", () => {
-      expect(() =>
+    it("rejects invalid UUID in summary accountIds", async () => {
+      await expect(
         controller.getSummary(mockReq, undefined, "bad-uuid"),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
     it("parses amountFrom and amountTo as floats for summary", async () => {
@@ -1164,11 +1173,12 @@ describe("TransactionsController", () => {
         10.5,
         99.99,
         undefined,
+        [],
       );
     });
 
-    it("rejects non-numeric amountFrom in summary", () => {
-      expect(() =>
+    it("rejects non-numeric amountFrom in summary", async () => {
+      await expect(
         controller.getSummary(
           mockReq,
           undefined,
@@ -1182,11 +1192,11 @@ describe("TransactionsController", () => {
           undefined,
           "abc",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects non-numeric amountTo in summary", () => {
-      expect(() =>
+    it("rejects non-numeric amountTo in summary", async () => {
+      await expect(
         controller.getSummary(
           mockReq,
           undefined,
@@ -1201,7 +1211,7 @@ describe("TransactionsController", () => {
           undefined,
           "xyz",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
     });
   });
 
@@ -1247,6 +1257,7 @@ describe("TransactionsController", () => {
         amountTo: 0,
         limit: 25,
         includeUnreconciledBeforeStart: false,
+        jointAccountIds: [],
       });
     });
 
@@ -1275,20 +1286,20 @@ describe("TransactionsController", () => {
       );
     });
 
-    it("rejects a missing or invalid groupBy", () => {
-      expect(() => controller.getGroupedTotals(mockReq)).toThrow(
+    it("rejects a missing or invalid groupBy", async () => {
+      await expect(controller.getGroupedTotals(mockReq)).rejects.toThrow(
         BadRequestException,
       );
-      expect(() => controller.getGroupedTotals(mockReq, "month")).toThrow(
-        BadRequestException,
-      );
+      await expect(
+        controller.getGroupedTotals(mockReq, "month"),
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it("rejects an invalid date and a non-positive limit", () => {
-      expect(() =>
+    it("rejects an invalid date and a non-positive limit", async () => {
+      await expect(
         controller.getGroupedTotals(mockReq, "payee", undefined, "notadate"),
-      ).toThrow(BadRequestException);
-      expect(() =>
+      ).rejects.toThrow(BadRequestException);
+      await expect(
         controller.getGroupedTotals(
           mockReq,
           "payee",
@@ -1303,7 +1314,111 @@ describe("TransactionsController", () => {
           undefined,
           "0",
         ),
-      ).toThrow(BadRequestException);
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // A joint account's detail page draws its cash flow, top categories and top
+  // payees from these three endpoints. Before they resolved the joint scope
+  // they ran under the grantee's own user id, which owns none of the rows, so
+  // the panels rendered empty beside a populated balance chart.
+  describe("joint accounts in analytics endpoints", () => {
+    beforeEach(() => {
+      mockService.getSummary.mockResolvedValue({});
+      mockService.getGroupedTotals.mockResolvedValue([]);
+      mockService.getMonthlyTotals.mockResolvedValue([]);
+      mockJointAccounts.jointAccountIdSetFor.mockResolvedValue(
+        new Set([uuid1]),
+      );
+      mockJointAccounts.jointAccessFor.mockResolvedValue({
+        ownerUserId: "owner-9",
+        via: "delegation",
+      });
+    });
+
+    it("runs the summary as the owner for a single joint account", async () => {
+      await controller.getSummary(mockReq, uuid1);
+
+      expect(mockJointAccounts.jointAccessFor).toHaveBeenCalledWith(
+        "user-1",
+        uuid1,
+        "read",
+      );
+      const call = mockService.getSummary.mock.calls[0];
+      expect(call[0]).toBe("owner-9");
+      expect(call[1]).toEqual([uuid1]);
+      expect(call[10]).toEqual([]);
+    });
+
+    it("runs grouped totals as the owner for a single joint account", async () => {
+      await controller.getGroupedTotals(mockReq, "category", uuid1);
+
+      expect(mockService.getGroupedTotals).toHaveBeenCalledWith(
+        "owner-9",
+        expect.objectContaining({
+          accountIds: [uuid1],
+          jointAccountIds: [],
+        }),
+      );
+    });
+
+    it("runs monthly totals as the owner for a single joint account", async () => {
+      await controller.getMonthlyTotals(mockReq, uuid1);
+
+      const call = mockService.getMonthlyTotals.mock.calls[0];
+      expect(call[0]).toBe("owner-9");
+      expect(call[1]).toEqual([uuid1]);
+      expect(call[10]).toEqual([]);
+    });
+
+    it("widens an unfiltered query by the authorized joint ids instead", async () => {
+      await controller.getMonthlyTotals(mockReq);
+
+      const call = mockService.getMonthlyTotals.mock.calls[0];
+      expect(call[0]).toBe("user-1");
+      expect(call[10]).toEqual([uuid1]);
+      expect(mockJointAccounts.jointAccessFor).not.toHaveBeenCalled();
+    });
+
+    it("intersects a mixed account filter with the authorized joint ids", async () => {
+      await controller.getGroupedTotals(mockReq, "payee", `${uuid1},${uuid2}`);
+
+      expect(mockService.getGroupedTotals).toHaveBeenCalledWith(
+        "user-1",
+        expect.objectContaining({
+          accountIds: [uuid1, uuid2],
+          jointAccountIds: [uuid1],
+        }),
+      );
+      expect(mockJointAccounts.jointAccessFor).not.toHaveBeenCalled();
+    });
+
+    it("never widens for an account that was not jointly granted", async () => {
+      await controller.getSummary(mockReq, uuid2);
+
+      const call = mockService.getSummary.mock.calls[0];
+      expect(call[0]).toBe("user-1");
+      expect(call[10]).toEqual([]);
+      expect(mockJointAccounts.jointAccessFor).not.toHaveBeenCalled();
+    });
+
+    it("keeps the acting delegate's readable set out of the joint path", async () => {
+      mockDelegationService.readableAccountIds.mockResolvedValue([uuid2]);
+
+      await controller.getMonthlyTotals({
+        user: {
+          id: "owner-1",
+          realUserId: "user-1",
+          isActing: true,
+          delegationId: "del-1",
+        },
+      } as never);
+
+      const call = mockService.getMonthlyTotals.mock.calls[0];
+      expect(call[0]).toBe("owner-1");
+      expect(call[1]).toEqual([uuid2]);
+      expect(call[10]).toEqual([]);
+      expect(mockJointAccounts.jointAccountIdSetFor).not.toHaveBeenCalled();
     });
   });
 
@@ -1668,6 +1783,7 @@ describe("TransactionsController", () => {
         -50,
         1000,
         undefined,
+        [],
       );
     });
 

--- a/backend/src/transactions/transactions.controller.ts
+++ b/backend/src/transactions/transactions.controller.ts
@@ -171,6 +171,57 @@ export class TransactionsController {
     private readonly jointRegister: JointRegisterService,
   ) {}
 
+  /**
+   * The own-context read scope for a transaction query (joint-accounts spec):
+   * which user id the query runs as, and the already-authorized joint account
+   * ids its ownership predicate may be widened by. One definition on purpose
+   * -- the register, its summary, its grouped totals and its monthly totals
+   * must see the same rows, or a joint account's detail page shows a balance
+   * chart with no cash flow, categories or payees beside it.
+   *
+   * A query filtered to exactly one joint account runs entirely as the OWNER,
+   * so every derived value (category descendant expansion, number/date-format
+   * parsing of the search term, the money math) behaves byte-identically to
+   * the owner's own view. A mixed or unfiltered query keeps the caller's own
+   * scope and widens it by exactly the authorized joint ids.
+   *
+   * Acting delegates never take this path: their scope is the delegation's
+   * readable set, resolved by each endpoint that allows delegate access. The
+   * guard is here rather than only at the call sites because widening an
+   * OWNER-scoped query by the delegate's own joint ids would mix two ledgers.
+   */
+  private async resolveOwnContextJointScope(
+    req: { user: { id: string; realUserId?: string; isActing?: boolean } },
+    requestedAccountIds?: string[],
+  ): Promise<{ userId: string; jointAccountIds: string[] }> {
+    if (req.user.isActing) {
+      return { userId: req.user.id, jointAccountIds: [] };
+    }
+    const realUserId = req.user.realUserId ?? req.user.id;
+    const jointSet = await this.jointAccounts.jointAccountIdSetFor(realUserId);
+    if (jointSet.size === 0) {
+      return { userId: req.user.id, jointAccountIds: [] };
+    }
+    if (
+      requestedAccountIds?.length === 1 &&
+      jointSet.has(requestedAccountIds[0])
+    ) {
+      const access = await this.jointAccounts.jointAccessFor(
+        realUserId,
+        requestedAccountIds[0],
+        "read",
+      );
+      return { userId: access.ownerUserId, jointAccountIds: [] };
+    }
+    return {
+      userId: req.user.id,
+      jointAccountIds:
+        requestedAccountIds && requestedAccountIds.length > 0
+          ? requestedAccountIds.filter((id) => jointSet.has(id))
+          : [...jointSet],
+    };
+  }
+
   @Post()
   @ApiOperation({ summary: "Create a new transaction" })
   @ApiResponse({ status: 201, description: "Transaction created successfully" })
@@ -441,33 +492,12 @@ export class TransactionsController {
       }
     } else {
       // Own context: joint accounts read natively (joint-accounts spec).
-      const realUserId = req.user.realUserId ?? req.user.id;
-      const jointSet =
-        await this.jointAccounts.jointAccountIdSetFor(realUserId);
-      if (jointSet.size > 0) {
-        if (
-          effectiveAccountIds?.length === 1 &&
-          jointSet.has(effectiveAccountIds[0])
-        ) {
-          // A single joint account's register: authorize, then serve the
-          // OWNER's register for that account. Every count, target-page and
-          // running-balance path then behaves byte-identically to the
-          // owner's own view -- no widened predicates in the money math.
-          const access = await this.jointAccounts.jointAccessFor(
-            realUserId,
-            effectiveAccountIds[0],
-            "read",
-          );
-          registerUserId = access.ownerUserId;
-        } else {
-          // Mixed or unfiltered list: widen the register scope by exactly
-          // the authorized joint ids (intersected with any explicit filter).
-          jointAccountIds =
-            effectiveAccountIds && effectiveAccountIds.length > 0
-              ? effectiveAccountIds.filter((id) => jointSet.has(id))
-              : [...jointSet];
-        }
-      }
+      const scope = await this.resolveOwnContextJointScope(
+        req,
+        effectiveAccountIds,
+      );
+      registerUserId = scope.userId;
+      jointAccountIds = scope.jointAccountIds;
     }
 
     return this.transactionsService.findAll(
@@ -558,7 +588,7 @@ export class TransactionsController {
     description: "Transaction summary retrieved successfully",
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  getSummary(
+  async getSummary(
     @Request() req,
     @Query("accountId") accountId?: string,
     @Query("accountIds") accountIds?: string,
@@ -598,9 +628,17 @@ export class TransactionsController {
       );
     }
 
+    const effectiveAccountIds = parseIds(accountIds, accountId);
+    // Own context: a jointly shared account's money-in/money-out reads the
+    // same rows its register does.
+    const scope = await this.resolveOwnContextJointScope(
+      req,
+      effectiveAccountIds,
+    );
+
     return this.transactionsService.getSummary(
-      req.user.id,
-      parseIds(accountIds, accountId),
+      scope.userId,
+      effectiveAccountIds,
       startDate,
       endDate,
       parseCategoryIds(categoryIds ?? categoryId),
@@ -609,6 +647,7 @@ export class TransactionsController {
       parsedAmountFrom,
       parsedAmountTo,
       parseUuids(tagIdsParam),
+      scope.jointAccountIds,
     );
   }
 
@@ -685,7 +724,7 @@ export class TransactionsController {
     description: "Grouped totals retrieved successfully",
   })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  getGroupedTotals(
+  async getGroupedTotals(
     @Request() req,
     @Query("groupBy") groupBy?: string,
     @Query("accountIds") accountIds?: string,
@@ -745,9 +784,17 @@ export class TransactionsController {
       );
     }
 
-    return this.transactionsService.getGroupedTotals(req.user.id, {
+    const effectiveAccountIds = parseUuids(accountIds);
+    // Own context: a jointly shared account's top categories / top payees
+    // read the same rows its register does.
+    const scope = await this.resolveOwnContextJointScope(
+      req,
+      effectiveAccountIds,
+    );
+
+    return this.transactionsService.getGroupedTotals(scope.userId, {
       groupBy,
-      accountIds: parseUuids(accountIds),
+      accountIds: effectiveAccountIds,
       startDate,
       endDate,
       categoryIds: parseCategoryIds(categoryIds),
@@ -758,6 +805,7 @@ export class TransactionsController {
       amountTo: parsedAmountTo,
       limit: parsedLimit,
       includeUnreconciledBeforeStart: includeUnreconciledBeforeStart === "true",
+      jointAccountIds: scope.jointAccountIds,
     });
   }
 
@@ -1009,6 +1057,8 @@ export class TransactionsController {
     }
 
     let effectiveAccountIds = parseUuids(accountIds);
+    let totalsUserId = req.user.id;
+    let jointAccountIds: string[] = [];
     if (req.user.isActing) {
       const readable = await this.delegationService.readableAccountIds(
         req.user.delegationId,
@@ -1019,10 +1069,19 @@ export class TransactionsController {
           ? effectiveAccountIds.filter((id) => readableSet.has(id))
           : readable;
       if (effectiveAccountIds.length === 0) return [];
+    } else {
+      // Own context: a jointly shared account's cash flow reads the same rows
+      // its register does.
+      const scope = await this.resolveOwnContextJointScope(
+        req,
+        effectiveAccountIds,
+      );
+      totalsUserId = scope.userId;
+      jointAccountIds = scope.jointAccountIds;
     }
 
     return this.transactionsService.getMonthlyTotals(
-      req.user.id,
+      totalsUserId,
       effectiveAccountIds,
       startDate,
       endDate,
@@ -1032,6 +1091,7 @@ export class TransactionsController {
       parsedAmountFrom,
       parsedAmountTo,
       parseUuids(tagIdsParam),
+      jointAccountIds,
     );
   }
 

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -2415,6 +2415,7 @@ export class TransactionsService {
     amountFrom?: number,
     amountTo?: number,
     tagIds?: string[],
+    jointAccountIds?: string[],
   ) {
     return this.analyticsService.getSummary(
       userId,
@@ -2429,6 +2430,7 @@ export class TransactionsService {
       undefined,
       undefined,
       tagIds,
+      jointAccountIds,
     );
   }
 
@@ -2447,6 +2449,7 @@ export class TransactionsService {
       amountTo?: number;
       limit?: number;
       includeUnreconciledBeforeStart?: boolean;
+      jointAccountIds?: string[];
     },
   ) {
     return this.analyticsService.getGroupedTotals(userId, params);
@@ -2500,6 +2503,7 @@ export class TransactionsService {
     amountFrom?: number,
     amountTo?: number,
     tagIds?: string[],
+    jointAccountIds?: string[],
   ) {
     return this.analyticsService.getMonthlyTotals(
       userId,
@@ -2512,6 +2516,7 @@ export class TransactionsService {
       amountFrom,
       amountTo,
       tagIds,
+      jointAccountIds,
     );
   }
 

--- a/docs/future-plans/joint-accounts-tasks.md
+++ b/docs/future-plans/joint-accounts-tasks.md
@@ -92,6 +92,12 @@ One scoping helper in `transactions.service.ts` -- own-context predicate
 count, page-for-transaction and running/projected balances. Mask interceptor spec proves a joint
 counterpart is not masked and the same payload is masked post-revoke.
 
+The same predicate lives once more in `transaction-analytics.service.ts` (`analyticsScope`), and
+`TransactionsController.resolveOwnContextJointScope` is the single decision that feeds both: a
+query filtered to exactly one joint account runs as the OWNER, anything else keeps the caller's
+scope and widens it by the authorized joint ids. Any new own-context endpoint that scopes reads by
+`transaction.userId` calls that helper -- the register and its analytics have to see the same rows.
+
 ### B5 -- Reference data
 
 `GET /delegation/joint-accounts/:accountId/reference-data`: owner's categories + payees (picker

--- a/docs/future-plans/joint-accounts.md
+++ b/docs/future-plans/joint-accounts.md
@@ -120,11 +120,18 @@ reappears. The joint flag itself is not auto-restored by a plain re-share; the o
 
 Non-banking joint types read-only; no grantee tags/splits/attachments on joint rows; attachments,
 scheduled transactions and holdings on joint accounts not natively visible; no native category
-creation; transaction analytics, built-in/custom reports and **all AI Assistant + MCP tools**
-exclude joint rows (the two AI layers change together or not at all -- "not at all" in v1);
-investment breakdowns exclude joint INVESTMENT accounts (the plain net-worth total includes
-them); grantee CSV/QIF export deferred; the joint toggle is offered only for delegates who are
-full Monize accounts (`isFullAccount`), never owner-managed credential identities.
+creation; built-in/custom reports and **all AI Assistant + MCP tools** exclude joint rows (the two
+AI layers change together or not at all -- "not at all" in v1); investment breakdowns exclude
+joint INVESTMENT accounts (the plain net-worth total includes them); grantee CSV/QIF export
+deferred; the joint toggle is offered only for delegates who are full Monize accounts
+(`isFullAccount`), never owner-managed credential identities.
+
+The account-scoped transaction analytics -- `GET /transactions/summary`, `/grouped-totals` and
+`/monthly-totals` -- were a v1 cut and are no longer: they take the same own-context joint scope
+as the register (see B4), because a joint account's detail page draws its cash-flow, top-categories
+and top-payees panels from them and rendered all three empty beside a populated balance chart.
+`/transactions/tag-key-breakdown` stays owner-only on purpose -- tags are personal, and a joint row
+never carries the grantee's.
 
 ## Companion task list
 

--- a/e2e/tests/joint-accounts.spec.ts
+++ b/e2e/tests/joint-accounts.spec.ts
@@ -73,17 +73,21 @@ test.describe('Joint accounts', () => {
       // The page needs a UI login, not the API-only one above: the auth store
       // persists `isAuthenticated` to localStorage, so a context authenticated
       // by cookies alone still fails ProtectedRoute's check and bounces to
-      // /login. Logging in here (rather than at the top) also keeps the
-      // grantee a full account by the time the delegation banner reads its
-      // contexts -- with no account of their own they would have exactly one
-      // context and be auto-switched into the owner's, which is the opposite
-      // of what this test is about.
+      // /login.
       const granteePage = await granteeContext.newPage();
       await loginUser(granteePage, email, password);
       await gotoStable(granteePage, '/accounts');
       const row = granteePage.locator('tr', { hasText: jointName });
       await expect(row).toBeVisible({ timeout: 15000 });
       await expect(row.getByText('Joint', { exact: true })).toBeVisible();
+
+      // No context switcher: this delegation is purely joint (no section read,
+      // no manage capability), so the owner's context would show exactly the
+      // account already sitting in this list. /auth/contexts drops it, and the
+      // banner has nothing to offer.
+      await expect(
+        granteePage.locator('#delegation-context-select'),
+      ).toHaveCount(0);
       await granteePage.close();
 
       // Native create lands on the OWNER's ledger and moves their balance.

--- a/frontend/src/components/accounts/banking-detail/BankingDetailView.test.tsx
+++ b/frontend/src/components/accounts/banking-detail/BankingDetailView.test.tsx
@@ -158,6 +158,23 @@ describe('BankingDetailView', () => {
     expect(mockPush).toHaveBeenCalledWith('/payees/p1');
   });
 
+  it('links a top payee on a joint account to the register, not the payee page', async () => {
+    // The payee belongs to the owner's ledger, so /payees/:id 404s in this
+    // user's context; the register does serve the owner's rows for a joint
+    // account, so the row has to go there instead.
+    await renderView(makeAccount({ isJoint: true }));
+    await waitFor(() => expect(screen.getByText('Corner Store')).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.click(screen.getByText('Corner Store'));
+    });
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^\/transactions\?accountId=chq-1&payeeId=p1&startDate=.+&endDate=.+$/,
+      ),
+    );
+    expect(mockPush).not.toHaveBeenCalledWith('/payees/p1');
+  });
+
   it('links Money In and Money Out to amount-filtered transactions', async () => {
     await renderView();
     await waitFor(() => expect(screen.getByText('Money In')).toBeInTheDocument());

--- a/frontend/src/components/accounts/banking-detail/BankingDetailView.tsx
+++ b/frontend/src/components/accounts/banking-detail/BankingDetailView.tsx
@@ -241,8 +241,18 @@ export function BankingDetailView({ account }: BankingDetailViewProps) {
           currencyCode={currency}
           isLoading={isLoading}
           // A payee row opens the payee's own page; the account+month-scoped
-          // register is one click further, from that page's breakdowns.
-          onSelect={(payeeId) => payeeId && router.push(`/payees/${payeeId}`)}
+          // register is one click further, from that page's breakdowns. On a
+          // jointly shared account the payee belongs to the OWNER's ledger and
+          // has no page in this user's context, so go straight to the register
+          // -- which does serve the owner's rows for a joint account.
+          onSelect={(payeeId) => {
+            if (!payeeId) return;
+            router.push(
+              account.isJoint
+                ? `/transactions?accountId=${account.id}&payeeId=${payeeId}&${monthRangeQuery}`
+                : `/payees/${payeeId}`,
+            );
+          }}
         />
       </div>
 


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: _not linked — this change was requested directly rather than through a discussion. Please attach the discussion or issue link before merging._

## Summary

Two joint-account gaps, both visible on a grantee's own screen and both rooted in the same omission: the joint scope was applied to the register and to nothing beside it.

**Cash flow, top categories and top payees rendered empty on a joint account's detail page**, next to a fully populated balance chart. The register got the own-context joint scope when joint accounts shipped; the three analytics endpoints feeding the same page did not, so they still asked for `transaction.userId = <grantee>` and matched none of the owner's rows — a confident empty answer rather than an error.

- `/transactions/summary`, `/grouped-totals` and `/monthly-totals` now resolve the scope through one controller helper, `resolveOwnContextJointScope`, extracted from the copy that was inline in `findAll`. Filtered to exactly one joint account the query runs **as the owner**, so category descendant expansion, search-term parsing and the money math are byte-identical to the owner's own view; anything else keeps the caller's scope and widens it by the already-authorized joint ids, never by raw request input.
- `analyticsScope` is the widened predicate, written once beside the register's `registerScope`. An empty joint set reproduces the previous owner-only predicate exactly, so non-joint traffic is untouched.
- `/accounts/:id/balance-forecast` gets the same 404-then-authorize fallback `getBalance` already had, so the chart carries its forward line and the projected-balance card stops reporting today's balance as a projection.
- A top-payee row on a joint account now opens the account+month-scoped register instead of `/payees/:id` — that payee is on the owner's ledger and has no page in the grantee's context, so the newly-visible rows would otherwise have led to a 404.

**The context switcher no longer offers an owner whose delegation is purely joint.** Every readable account is already native, no section read and no manage capability was granted, so both sides of the chooser showed the same thing. Two guards: a delegation with nothing readable yet stays listed (hiding it would strip the only way in once the owner grants something), and the context the caller is currently acting as is never filtered out from under them.

Deliberately left owner-only: `/transactions/tag-key-breakdown` (tags are personal; a joint row never carries the grantee's), and reports / AI / MCP tools, which the spec cuts as a set.

`docs/future-plans/joint-accounts.md` recorded "transaction analytics exclude joint rows" as a v1 scope cut; that is no longer true and is updated in the same commit, along with the task list and a new rule in `backend/CLAUDE.md` so the next own-context endpoint does not repeat the omission.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — **not linked**, see above.
- [x] This PR addresses a **single concern** (large work is split into a series). — both halves are the joint-account grantee's own-context view; happy to split if a reviewer disagrees.
- [x] New behavior has tests, and the existing suite passes.
  - Backend unit: 401 suites / 10,777 tests pass (`TZ=UTC npm run test:unit`).
  - Frontend: 627 files / 12,289 tests pass (`npx vitest run`).
  - New regressions: controller scope resolution across all five branches (single joint / unfiltered widen / mixed intersect / non-granted / acting), the widened predicate per analytics endpoint, the joint balance-forecast fallback, and the joint-only context filter parameterised over all 5 section flags and all 9 capability flags.
  - Integration and E2E were **not run** — they need a Docker daemon, which the authoring environment did not have. The E2E banner-absence assertion added to `e2e/tests/joint-accounts.spec.ts` is therefore unexecuted locally and needs CI.
- [x] All user-facing strings are translated for **every** locale (i18n parity). — no strings were added or changed, so no catalog or pseudo-locale work was needed.
- [ ] No shared/core areas were refactored without prior agreement. — one refactor to flag: the own-context joint branch inside `TransactionsController.findAll` was extracted into `resolveOwnContextJointScope` so the register and its analytics cannot drift apart. Behaviour-preserving, and the existing `findAll` joint tests cover it, but it is shared code and worth a look.
- [ ] The branch is rebased on the latest `main`. — currently 7 commits behind `origin/main` (up to `11edb1f`). Say the word and I will rebase.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Written by Claude Code (Claude Opus 5) from a direct description of the two symptoms. The investigation, the fix, the tests and the doc updates are all AI-authored; the human author is responsible for reviewing correctness, conventions and test coverage before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4HMin8tu6saWRQSww2ako