### PR TITLE
docs: bring the 1.14.0 release notes up to date with every change

### DIFF
--- a/docs/release-notes/1.14.0.md
+++ b/docs/release-notes/1.14.0.md
@@ -6,6 +6,10 @@ Monize now reads Microsoft Money `.mny` files directly — the file itself, not 
 
 There's nothing to install, Money doesn't need to be on the machine, and the file never leaves your server.
 
+It's also the release where Monize stops assuming one person per ledger. An account you own can be shared as a **joint account** that appears natively in someone else's own account list, register and net worth — no context switching — and **transfers can now cross owners**, moving money between your account and one shared with you, in either direction, gated on the access that was actually granted.
+
+Elsewhere: **securities and payees get full detail pages**, a rule-based **GEM strategy report** joins Reports, scheduled transactions can be entered in a **foreign currency**, Settings gains a real **About section**, automatic backups become a **per-user, encrypted, admin-managed** affair, and the multi-release **Row-Level Security** project reaches its final state.
+
 ## Import a whole Money file
 
 ### One upload, the whole profile
@@ -22,7 +26,7 @@ Money 2001 through Money Plus Sunset are supported. Money 97 and 98 files predat
 - **Transactions** with splits, reference numbers, memos and each row's cleared or reconciled status. Voided transactions arrive voided rather than vanishing.
 - **Transfers**, wired from Money's own record of which two rows are the two sides — nothing is matched by name and amount.
 - **Loans and mortgages** with the principal leg attached to the loan account as a transfer split. Where the payment history makes it unambiguous, the funding account, installment and interest category are filled in for you.
-- **Investments**: buys, sells, dividends, reinvestments, share transfers between accounts, and stock splits.
+- **Investments**: buys, sells, dividends, reinvestments, share transfers between accounts, and stock splits. Only the securities your file shows activity for are brought over, so a 30-year file's seeded ticker list stays behind.
 - **Price history and exchange rates**, both additive — importing twice, or importing over prices a quote provider already fetched, converges instead of duplicating.
 
 ### Choose what you actually want
@@ -37,7 +41,7 @@ Closed accounts are included by default and stay closed. They hold history worth
 
 The part that makes a 30-year migration trustworthy. When the import finishes, every account is listed with the balance computed from your Money file, the balance it ended up with in Monize, and the difference. Investment accounts additionally compare share counts against **Money's own open tax lots**, so a position that drifted shows up as a number rather than as a suspicion. It downloads as JSON if you want to keep it.
 
-Anything ambiguous is surfaced rather than silently decided: two securities sharing a ticker, an action code Money never documented, a repeat interval with no exact Monize equivalent. None of it stops the import; all of it is in the report.
+Anything ambiguous is surfaced rather than silently decided: two securities sharing a ticker, an action code Money never documented, a repeat interval with no exact Monize equivalent. None of it stops the import; all of it is in the report — and each warning **names the transactions it flagged**, so you can go back and fix them in Money rather than hunt for them.
 
 ### Starting fresh
 
@@ -47,20 +51,174 @@ Version 1 targets a fresh profile: it does not merge or de-duplicate, so importi
 
 ### Large files
 
-A file with three decades of history takes minutes, not seconds, so the import runs as a background job — leave the page and come back. If the server restarts mid-import nothing is left half-written, your uploaded file is still there, and **Try again** is one click rather than another 200 MB upload.
+A file with three decades of history takes minutes, not seconds, so the import runs as a background job — leave the page and come back. If the server restarts mid-import nothing is left half-written, your uploaded file is still there, and **Try again** is one click rather than another 200 MB upload. Only one import can be active per account, and that is now a database guarantee rather than a check: two overlapping start requests can no longer both get through and write the file's history twice.
 
 Self-hosting note: a Money file is held in memory while it is read, so the backend container needs roughly twice the file size available. The default Helm memory limit is not enough for a large file — see `helm/README.md` for the sizing table, and `MNY_IMPORT_LIMIT_MB` to bound it.
 
-## Elsewhere
+## Sharing accounts with someone else
 
-- **Scheduled transactions** gained two frequencies, **every two months** and **semiannual**, and all four places that project a schedule forward — cash-flow forecast, occurrence picker, bills calendar, upcoming-bills report — now share one implementation. Two of them had quietly stopped handling semimonthly schedules, and one turned 31 January into 3 March where the rest clamped to the 28th.
-- **Database migrations** fail more usefully: the failing file, the SQL error and a pointer to the runbook, instead of a bare non-zero exit. A new lint catches non-idempotent DDL before it reaches a database.
+### Joint accounts
+
+Shared Access used to mean *acting as* the other person: you switched context, saw their ledger, and switched back. That is right for a bookkeeper and wrong for a couple sharing a chequing account.
+
+An account you own can now be marked **joint** for any user you have granted access to. On their side it simply appears — in their **account list** (with a **Shared with me** filter and a **Joint** badge naming who shares it), in their **register**, in their **net worth**, and on its **detail page** with the cash flow, top categories, top payees and balance forecast the owner sees. No context switch, nothing to remember. On your side the account shows how many people it is shared with, and **Manage sharing** is one click away.
+
+Your existing per-user **read / create / edit / delete** grants still decide what they can do. In v1, everyday accounts (chequing, savings, cash, credit card, line of credit) are writable as granted; investment, loan, mortgage and asset accounts are shared read-only regardless of the flags, and the server enforces that rather than trusting the UI. Every transaction stays on the owner's ledger with the owner's categories and payees — a grantee's own reference data never leaks onto your rows, and tags stay personal on both sides.
+
+The grantee decides whether a joint account counts toward **their** net worth; that preference is theirs, invisible to you and never confused with your own "exclude from net worth" setting. And nothing about plain delegation changes: an ordinary grant behaves exactly as it did.
+
+Revoking is a single switch with no data surgery. Visibility, register access, net-worth inclusion and transfer connectivity are all computed from the grants that exist right now, so unsharing takes them all away and re-sharing brings them all back.
+
+### Transfers between two people's accounts
+
+You can now transfer money **between an account you own and an account shared with you**, from either side and in either direction — previously the destination simply wasn't offered. The transfer form's account picker gains the accounts you're allowed to move money into, and the usual write grant (`create` / `edit` / `delete`) on the shared side is what authorizes it.
+
+Each leg belongs to its own account's owner, so both ledgers stay self-contained: balances, net worth, reports and exports keep aggregating only your own rows.
+
+When access is revoked, the link isn't severed — it's **frozen**. Each of you keeps your own leg, the counterpart shows as **Hidden account** rather than leaking the other person's live account details, and neither side can edit through it. Re-share later and the transfer reconnects on its own, with no repair step. The same masking now applies in exports and in what the AI Assistant and MCP server can read.
+
+### Sharing controls
+
+An account someone shared with you can't be re-shared onward: delegated accounts no longer appear in the Edit Access screen, so a joint account can only be shared by the person who owns it. The accounts page's **Shared with me** filter is a slider, matching the other filters on that screen.
+
+## Detail pages
+
+### A page for a security
+
+Clicking a security now opens a full page instead of a modal: the **position** (market value, cost basis, unrealized P/L, units, average cost, and which accounts hold it), a **price / value / return chart** you can pan back through, **key information**, and a **breakdown** by sector, country and asset class drawn against 100%.
+
+The header carries the latest price **with the time it was quoted** and whether that market is currently open, a manual **refresh**, favourite and edit, and a switcher for hopping to another security without going back to the list. If the security is priced in a currency other than yours, the position is shown in **both**.
+
+Two new tabs: **Documents**, for prospectuses, fact sheets and anything else you want kept with the security, and **News**, showing recent headlines with images served from your own origin rather than fetched from a third party by your browser. The About card links out to the company website and its investor-relations page.
+
+A security you have never traded shows an honest empty state rather than a page of zeroes. A short **guided tour** of the page is offered from the What's New digest.
+
+### A page for a payee
+
+Payees get the same treatment at `/payees/:id`: **spent or received this year** with a comparison against last year, average transaction, transaction count, "payee since" (the earlier of when you created it and its first transaction), and the last time you dealt with them.
+
+Below that, **top categories** with a 12-month or all-time toggle, the **accounts** you use with this payee, a **recurring** panel that detects a cadence — weekly, biweekly, monthly, quarterly, yearly — and tells you the usual day, what the amount was last time, and when the next bill is due, plus a **seasonality** view of when in the year you spend with them. The **Transactions** tab is editable in place.
+
+Merge, deactivate, reactivate and edit are all on the header, a payee can carry a **website** you can open from the page, and clicking a payee anywhere in the transactions list takes you here. Uncategorized spending with this payee can be fixed from the summary — apply a category to the lot, or set it as the payee's default.
+
+### Consistent headers
+
+Securities, payees and account details now share one header layout and one **switcher** control, so moving between records works the same way everywhere.
+
+## Investments
+
+### Set your own asset-class allocation
+
+An ETF or fund that is 60% equity and 40% bonds can now be told so. A manual **asset-class allocation editor** lets you split a security across classes you define yourself, and the portfolio's allocation chart groups by those weights instead of treating each fund as a single opaque holding. The **AI Assistant** and **MCP server** can both read the resulting look-through — by asset class and by country — and can set allocations for you.
+
+### GEM strategy report
+
+A new report at **Reports → GEM Strategy** implements Global Equities Momentum, the dual-momentum allocation rule: hold the strongest equity market while equities are beating the risk-free leg, and hold the safe asset when they are not.
+
+Point it at your brokerage accounts, assign a security to each role (US equity, ex-US equity, emerging markets, safe asset, and optionally a separate risk-free yardstick), pick a monthly or quarterly cadence and a lookback window, and it shows the **current signal**, the **next action** with an estimated transfer including your tax and commission assumptions, the **momentum reasoning** behind the call, the **signal history**, a **performance chart** and a **backtest**. Mark a signal executed when you act on it. Multiple named scenarios can be kept side by side and switched between.
+
+The report is careful about what it does not know: a period whose absolute-momentum test can't be run produces **no signal** rather than a guess, an unassigned role is reported as unmapped rather than substituted, a decision renders the instrument it actually named even if you have since swapped funds, and unknown values render as unknown rather than as zero. Warnings on the report say which of those applies. Full rules, calendar and data model are in [`docs/gem-strategy.md`](../gem-strategy.md).
+
+## Scheduled transactions
+
+### Enter one in another currency
+
+Scheduled transactions gain the foreign-currency entry that ordinary transactions got in 1.13: pick the entry currency beside the amount, type the figure as it will be charged, and see the rate and converted total. When the occurrence is posted you can adjust **either side** of the conversion, and a rate is always resolved for the posting date.
+
+### Two more frequencies
+
+**Every two months** and **semiannual** join the frequency list, and all four places that project a schedule forward — cash-flow forecast, occurrence picker, bills calendar, upcoming-bills report — now share one implementation. Two of them had quietly stopped handling semimonthly schedules, and one turned 31 January into 3 March where the rest clamped to the 28th.
+
+## Settings
+
+### About
+
+The grey version line under the last Settings card is replaced by a real **About** section, listed in the section nav between Help and Danger Zone: the running version with the release notes one labelled click away, a link to every release, update status for admins, licence and security-policy links, and a **copy diagnostics** button that puts versions, browser, locale, timezone and theme on the clipboard for pasting into a bug report. The API version is shown only when it disagrees with the UI build — which means a rolling upgrade only half landed.
+
+### Automatic backups
+
+Automatic backups are now an **operator** setting: the schedule lives behind an admin-only section, and the hourly job enrols every other active user on the deployment defaults so hiding the controls doesn't leave anyone without backups.
+
+Each user's backups are written to **their own folder**, fanned out by user id the same way attachment bytes are. Previously the filename carried only a tier and a date, so in a shared folder every user's daily backup had the same name: whoever's job ran last overwrote the rest, and one user's retention pass deleted another's files. Retention now sweeps the user's own folder plus the old flat location, so files written by an earlier version age out instead of being stranded.
+
+Backups are **encrypted with your own password**, with nothing to switch on: the server holds that plaintext only while you type it, so it's captured at registration, login and password change, and the separate Backup Encryption section is gone. A stored copy is checked against your current password before use — encrypting with a password you have since changed produces a file you can't open — and "nothing stored" is distinguished from "stored but unusable", which refuses rather than silently writing plaintext. OIDC accounts have no password of ours, so they keep a dedicated backup-password setting of their own.
+
+## Interface and fixes
+
+- The **Settings** button no longer disappears in **iPad landscape**. The header's nav switched to its compact layout at 1024px while the right-hand icon cluster still needed more room than that, and the overflow was being clipped rather than scrolled. (#1024, #1026)
+- **Account balances** are no longer stale after a write that moves money — every such write now drops the cached balances instead of only some of them.
+- **Attachment counts** stop blanking out when you cycle a transaction's status.
+- **Report account filters** are remembered between visits, on the investment reports and the rest alike.
+- Chart colours across payee, category and monthly-totals views come from the **theme tokens**, so they follow light and dark mode instead of being hardcoded.
+- A long **Monte Carlo** scenario name stays inside the sidebar.
+- The **OIDC** provider no longer prints a raw library notice into the backend log on the first MCP authorization-code exchange.
+- The Polish translation of Settings → **Security** is corrected.
+
+## Under the Hood
+
+- **Row-Level Security is complete.** Every database access in `src/` now goes through the single `withScopedDb` door, every out-of-request path (cron, seeders, bootstrap, MCP's bearer-only transport, delegate acting-context) seeds its own identity, and the enable migration is written. Lint now bans `@InjectRepository` and `createQueryRunner()` outright and restricts who may seed a context, replacing the old counting ratchet, and a catalog-driven spec proves the policy on every table. It remains **off by default** (`RLS_MODE=off`), and turning it on is a two-step operator flip documented in the [runbook](../future-plans/row-level-security-runbook.md) — behaviour is unchanged until then.
+- New database migrations: **115** (security asset weightings), **116** (every-two-months and semiannual frequencies; unit-price precision), **117** (`.mny` import staging and job tables; security documents), **118** (security-document policies), **119** (scheduled investment price precision), **120** (security websites), **121** (quote time and market hours), **122** (payee website), **123** (the RLS enable step), **124–131** (GEM strategies, accounts, risk-free role, scenarios, triggers, config fingerprint, algorithm version and period key; scheduled-transaction currency), **132** (cross-owner transfer policies), **133–134** (joint-account grants, per-grantee net-worth exclusions and native-read policies), and **135** (one active import job per user).
+- **Migration idempotency is gated in CI.** Every migration must replay as a no-op on top of `schema.sql`, because that is how the app boots. Migrations also fail more usefully now: the failing file, the SQL error and a pointer to the runbook, instead of a bare non-zero exit.
+- The **financial calculation**, **time-series** and **testing** contracts are consolidated in `docs/`, with the rules that can be machine-checked converted into tests and lint rather than left as prose. The AI-agent instructions that contradicted each other across `CLAUDE.md` files were reconciled in the same pass, and the UI conventions agents kept re-inventing are now written down and, where possible, guarded by source-scanning tests.
+- Every number entry in the frontend routes through the shared **NumericInput / CurrencyInput** components rather than a raw `<input type="number">`, with a guard test that fails on any new instance.
+- Security hardening: reorder endpoints **bound their input arrays** (CodeQL `js/loop-bound-injection`); the stored backup password is compared in **constant time** — and then not read back at all, since the write it was avoiding always happened anyway; the securities **news cache** no longer keys one user's security id into another user's response; and the `.mny` import's wipe step moved behind the job lock so it can't run twice.
+- `.mny` import correctness, all with regression tests: debits importing as credits, investment action codes read from the wrong table, market suffixes left on symbols, `SEC_SPLIT` ratios applied twice to share counts, a money-market fund classified as a currency, bank-to-investment transfers missing their cash side, loan-payment template families only half removed, scheduled instances Money never posted, Money's encoded `Num` field, void rows leaking into the register's balance anchor, and loan payments arriving VOID.
 
 ## Documentation
 
 - [Importing from Microsoft Money](../import-ms-money.md) — the user guide, including the v1 limitations.
 - [Microsoft Money data model](../ms-money-data-model.md) — the reverse-engineered `.mny` format reference.
+- [GEM strategy](../gem-strategy.md) — the rules, calendar, materialization semantics and API.
+- [Cross-owner transfers](../future-plans/cross-owner-transfers.md) and [joint accounts](../future-plans/joint-accounts.md) — the specs the sharing work was built from.
 
 ## Credit
 
 The Microsoft Money format reference this feature is built on was reverse-engineered by **marksimpson** in PR #192, and the migration it made possible was tested to destruction by **kenlasko** and **gerardfarrell11** against real 25- and 32-year files. Every data-quality problem they reported — loans importing empty, 1,844 scheduled bills, junk payees, investment share counts going negative, a Money 2001 file with no `BILL` table at all — is fixed here, and each has a regression test named after it.
+
+## All Changes
+* RLS R1-R2: route accounts/categories/payees/tags/institutions/transactions/scheduled-transactions through withScopedDb by @kenlasko in https://github.com/kenlasko/monize/pull/983
+* Persist account selections across report visits by @kenlasko in https://github.com/kenlasko/monize/pull/984
+* fix(i18n): correct Polish mistranslation of Settings "Security" by @WMP in https://github.com/kenlasko/monize/pull/985
+* Add About section to Settings with version and update info by @kenlasko in https://github.com/kenlasko/monize/pull/986
+* Add manual asset-class allocation editor for ETFs and funds by @kenlasko in https://github.com/kenlasko/monize/pull/987
+* Preserve enrichment fields when updating transaction status by @kenlasko in https://github.com/kenlasko/monize/pull/988
+* docs: record the UI patterns agents keep re-inventing, and guard one of them by @WMP in https://github.com/kenlasko/monize/pull/989
+* Implement Microsoft Money (.mny) file decryption and table reading (Phase 0) by @kenlasko in https://github.com/kenlasko/monize/pull/990
+* A detail page for a security: position, chart, breakdowns, documents and news by @WMP in https://github.com/kenlasko/monize/pull/992
+* A short guided tour of the security detail page by @WMP in https://github.com/kenlasko/monize/pull/993
+* feat(db): gate migration idempotency in CI (B1) by @kenlasko in https://github.com/kenlasko/monize/pull/994
+* feat(import): staging and job tables for the .mny import (M1.1) by @kenlasko in https://github.com/kenlasko/monize/pull/995
+* Add investment transactions, securities, and price history import by @kenlasko in https://github.com/kenlasko/monize/pull/996
+* docs: correct the long-list rule from #989, and forbid the double hyphen in UI copy by @WMP in https://github.com/kenlasko/monize/pull/998
+* feat(import): scheduled bills, wipe confirmation and loan terms (M3.1-M3.4) by @kenlasko in https://github.com/kenlasko/monize/pull/999
+* Add payee detail page with analytics and management features by @kenlasko in https://github.com/kenlasko/monize/pull/1000
+* Add EntitySwitcher component and refactor detail page headers by @kenlasko in https://github.com/kenlasko/monize/pull/1001
+* Complete Microsoft Money (.mny) import feature by @kenlasko in https://github.com/kenlasko/monize/pull/1003
+* Delete the modal mode the security detail page left behind by @WMP in https://github.com/kenlasko/monize/pull/1004
+* fix(mny): correct transaction signs, investment actions and bill detection in the .mny import by @kenlasko in https://github.com/kenlasko/monize/pull/1005
+* Follow-ups from the review of the security detail page by @WMP in https://github.com/kenlasko/monize/pull/1006
+* fix(mny): loan payments imported VOID, and warnings that name the transactions they flag by @kenlasko in https://github.com/kenlasko/monize/pull/1007
+* Replace hardcoded chart colours with theme tokens by @kenlasko in https://github.com/kenlasko/monize/pull/1009
+* Refactor: migrate services to scoped-db pattern (R3) by @kenlasko in https://github.com/kenlasko/monize/pull/1010
+* refactor(rls): move ai, mcp, import, action-history, currencies, updates and notifications onto withScopedDb (R6) by @kenlasko in https://github.com/kenlasko/monize/pull/1011
+* docs(rls): correct stale migration numbers, M3 target list, T1 glob trap, L1 allowlist by @kenlasko in https://github.com/kenlasko/monize/pull/1012
+* test(rls): catalog-driven enforcement spec covering every table (T2) by @kenlasko in https://github.com/kenlasko/monize/pull/1013
+* fix(frontend): stale balances after a money-moving write, and Monte Carlo name overflow by @kenlasko in https://github.com/kenlasko/monize/pull/1015
+* Fix missing IdToken TTL in OIDC provider config by @kenlasko in https://github.com/kenlasko/monize/pull/1016
+* Resolve conflicting AI-agent documentation and add financial contracts by @kenlasko in https://github.com/kenlasko/monize/pull/1018
+* Update cross-owner transfer plans for the completed RLS implementation by @kenlasko in https://github.com/kenlasko/monize/pull/1019
+* Make the financial contracts checkable, not just correct by @WMP in https://github.com/kenlasko/monize/pull/1020
+* Add foreign-currency support for scheduled transactions by @kenlasko in https://github.com/kenlasko/monize/pull/1021
+* Replace native number inputs with NumericInput component by @kenlasko in https://github.com/kenlasko/monize/pull/1022
+* Bound request arrays to prevent denial-of-service loops by @kenlasko in https://github.com/kenlasko/monize/pull/1023
+* Add a GEM (Global Equities Momentum) strategy report by @WMP in https://github.com/kenlasko/monize/pull/1014
+* Enable cross-owner transfers with delegation-based authorization by @kenlasko in https://github.com/kenlasko/monize/pull/1025
+* Fix missing Settings button in iPad landscape mode (#1024) by @kenlasko in https://github.com/kenlasko/monize/pull/1026
+* Add joint-accounts spec and task list (S1) by @kenlasko in https://github.com/kenlasko/monize/pull/1027
+* Address the full re-review of the GEM branch by @WMP in https://github.com/kenlasko/monize/pull/1028
+* Make one active .mny import per user a database guarantee by @kenlasko in https://github.com/kenlasko/monize/pull/1030
+* Serve a joint account's analytics and hide a joint-only context switcher by @kenlasko in https://github.com/kenlasko/monize/pull/1031
+* Shard automatic backups by user ID to prevent collisions by @kenlasko in https://github.com/kenlasko/monize/pull/1032
+* Prevent re-sharing of jointly-owned accounts in delegation by @kenlasko in https://github.com/kenlasko/monize/pull/1033
+
+**Full Changelog**: https://github.com/kenlasko/monize/compare/v1.13.0...v1.14.0

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -81,6 +81,7 @@ Notes for past releases live alongside this file, one Markdown file per version
 matching [GitHub Release](https://github.com/kenlasko/monize/releases), newest
 first:
 
+- [v1.14.0](1.14.0.md)
 - [v1.13.0](1.13.0.md)
 - [v1.12.1](1.12.1.md)
 - [v1.12.0](1.12.0.md)


### PR DESCRIPTION
The notes were written at the .mny import's Phase 4.5 and covered that
feature plus two "Elsewhere" bullets. Thirty-odd PRs have merged since,
including three user-facing features larger than anything the file
mentions: joint accounts, cross-owner transfers and the security and
payee detail pages.

Adds sections for account sharing (joint accounts, cross-owner
transfers, the re-share restriction), the security and payee detail
pages, manual asset-class allocation, the GEM strategy report,
foreign-currency scheduled transactions, the Settings About section and
the reworked automatic backups; folds the later .mny fixes and the
one-active-import guarantee into the import section; and records the
completed RLS work, the new migrations 115-135, the contract
consolidation and the security fixes under the hood. Ends with the full
PR list and compare link the parser and the What's New digest expect.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M4E2UogTDcoZNJAt6CQ4KS