### PR TITLE
Clear the production advisories the NPM Audit gate now fails on

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4456,9 +4456,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5919,9 +5919,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -6555,9 +6555,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6744,9 +6744,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -10839,9 +10839,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -115,9 +115,9 @@
     "picomatch": "4.0.4",
     "path-to-regexp": "8.4.0",
     "uuid": "^14.0.0",
-    "fast-uri": "^3.1.2",
+    "fast-uri": "^3.1.5",
     "multer": "^2.2.0",
-    "brace-expansion@>=3": "5.0.8",
+    "brace-expansion@>=3": "5.0.9",
     "typeorm": {
       "glob": "13.0.0"
     },


### PR DESCRIPTION
## Linked discussion / issue

No discussion: this is a CI-blocking security fix, not a feature. The trigger is
`main` itself going red — the NPM Audit job passed on run
[30835649751](https://github.com/kenlasko/monize/actions/runs/30835649751) at
17:11 UTC today and failed on
[30854431564](https://github.com/kenlasko/monize/actions/runs/30854431564) at
21:23 with no change to the tree in between. Five advisories were published
against dependencies already present, so every open PR is currently red on a
finding it did not introduce. Happy to open a discussion first if you would
rather these went through the normal route.

## Summary

Clears the five findings that `npm audit --audit-level=high --omit=dev` — the
blocking half of the NPM Audit job — now reports for backend production
dependencies.

**Four are lockfile-only**, within ranges `package.json` already allows:

| Package | Was | Now | Findings |
| --- | --- | --- | --- |
| `undici` (direct, `^8.5.0`) | 8.5.0 | 8.10.0 | 4 high: response desynchronization via the retry interceptor, two cross-user cache disclosures, CRLF injection via a blob body `type`, cookie attribute injection |
| `ip-address` (via `@modelcontextprotocol/sdk` → `express-rate-limit`) | 10.2.0 | 10.4.0 | 3 high: SSRF / trust-boundary bypasses (leading-zero octets, CIDR suffix, IPv4-mapped and NAT64) |
| `hono` | 4.12.31 | 4.12.34 | moderate: ReDoS in the CORS middleware |

**Two are override pins this repo had already made**, now overtaken by the
advisories they were made against:

- `fast-uri` `^3.1.2` → `^3.1.5` — host confusion via a backslash authority introducer.
- `brace-expansion@>=3` `5.0.8` → `5.0.9` — DoS through unbounded intermediate arrays, which bypasses the mitigation that the 5.0.8 pin existed for.

An override that pins a version is a claim about that version, so it has to move
when the claim stops holding.

Untouched: the dev-only `brace-expansion` 1.x finding under `minimatch@3`, which
is still unfixable upstream and which the workflow already runs as
`continue-on-error` with that reasoning in a comment.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

No discussion is linked, for the reason above — that box is left unticked rather
than claimed. There is no new behaviour to test: `undici` is the runtime
dependency behind the AI providers' long-running fetch, and the backend unit
suite covering it is green (403 suites, 10844 tests). Both audit gates exit 0
after the change (backend and frontend, production dependencies).

## AI assistance disclosure

Written with Claude Code: advisories read, versions checked against the ranges
already declared, suite run locally. I have reviewed and own the result.
