### PR TITLE
08: Document system invariants and concurrency contracts (v1.15.0)

### DIFF
--- a/docs/adr/0001-scoped-db-single-database-door.md
+++ b/docs/adr/0001-scoped-db-single-database-door.md
@@ -1,0 +1,88 @@
+# 0001. `withScopedDb` is the only door to the database
+
+Status: accepted
+Date: 2026-08-04 (recorded retrospectively; the decision was made and
+implemented earlier, across RLS tasks R1-R7 and lint task L1)
+
+## Context
+
+Row-level security requires that every database session carry the identity it is
+acting as, in a PostgreSQL GUC the policies read. That is a property of *every*
+query, not of the queries someone remembered to annotate -- one unscoped read is
+enough to return another tenant's rows.
+
+Before this decision the codebase reached the database three ways: injected
+repositories (`@InjectRepository`), manually managed `QueryRunner`s, and bare
+`dataSource.query`. Each carried its own commit, rollback and release
+bookkeeping, and none of them could carry a tenant identity without every call
+site opting in. Around 91 such sites existed.
+
+Two further forces mattered. Multi-table and read-modify-write operations were
+the codebase's most common source of bugs, and a per-call-site transaction
+discipline had already proven insufficient. And a helper that opened its own
+transaction while its caller held one would take a second pooled connection,
+which under load deadlocks the pool rather than merely being wasteful.
+
+## Decision
+
+All database access goes through `withScopedDb` (`backend/src/common/db/scoped-db.ts`).
+
+- Services inject `DataSource`, never a repository. Repositories come from the
+  transaction's `EntityManager`. Helpers take an `EntityManager`, never a
+  `QueryRunner`.
+- `withScopedDb` sets the identity GUCs as the transaction's first statements
+  using `set_config(..., true)`, so they are transaction-local and cannot leak
+  onto a pooled connection.
+- It **throws** without an ambient identity context rather than falling back to
+  `dataSource.manager`. Callers the request interceptor cannot see must seed
+  their own: `withUserContext`, `withSystemContext`, `withDelegateContext`, or
+  `withPreserveTimestamps`.
+- A nested call **joins** the ambient transaction -- same connection, same
+  atomicity -- so a service method calling another is safe.
+- ESLint bans `InjectRepository` and `.createQueryRunner()` in `src/`, and
+  restricts importing `common/db/with-context` to an explicit allowlist.
+
+## Consequences
+
+**Makes easy.** Atomicity is the default rather than something to remember.
+Adding an RLS policy does not require auditing call sites. Refactoring a service
+method into two cannot accidentally split a transaction.
+
+**Makes hard.** Deliberately: a background timer or a progress write that a
+concurrent reader must see now needs `runOutsideActiveScopedManager`, which is
+explicit and reviewable. Genuinely cross-user work needs
+`withSystemContext`, which is logged and allowlisted.
+
+**Forbids.** Any new `@InjectRepository` field, `createQueryRunner()` call, or
+bare `dataSource.query`. A `createQueryRunner()` in a diff is new and wrong --
+there are none left in `src/`.
+
+**Does not provide, and is regularly assumed to.** `withScopedDb` gives
+atomicity and identity. It gives **no** protection against a concurrent writer of
+the same row: the default isolation is READ COMMITTED, so two transactions may
+each read a value, each compute a new one, and each write. This was the single
+most common misreading of the primitive, and it is why
+`docs/concurrency-and-idempotency.md` exists as a separate contract. A callback
+that returns early commits an empty transaction, which is the correct replacement
+for an explicit rollback.
+
+## Alternatives considered
+
+**Keep repositories, add an interceptor that sets the GUC per request.** Rejected
+because it covers only request-scoped work. Crons, bootstrap hooks, seeders and
+bearer-only routes have no request, and those are exactly the surfaces where a
+missing identity is least likely to be noticed -- the `/mcp` transport has no
+`AuthGuard('jwt')`, so an interceptor's scope would carry an undefined user id.
+
+**A repository base class that injects the GUC.** Rejected: it cannot express a
+multi-table transaction, which is the case that most needed fixing, and it leaves
+`dataSource.query` as an open side door.
+
+**Application-level tenant filtering instead of RLS.** Rejected because it is a
+convention rather than a mechanism -- one forgotten `where` clause is a
+cross-tenant leak, and no test can prove the absence of a missing clause across
+a whole codebase.
+
+**Allow nested calls to open independent transactions.** Rejected on pool
+deadlock. Joining also gives the more useful semantics: an inner failure rolls
+back the outer work, which is what a caller almost always wants.

--- a/docs/adr/0002-invariant-catalog-and-enforcement-ranking.md
+++ b/docs/adr/0002-invariant-catalog-and-enforcement-ranking.md
@@ -1,0 +1,108 @@
+# 0002. Invariants are catalogued, and enforced as low in the stack as possible
+
+Status: accepted
+Date: 2026-08-04
+
+## Context
+
+An audit of the codebase produced a large number of findings across many
+subsystems -- imports, balances, holdings, scheduled posting, emergency access,
+attachments, backups, crons, release automation. Read individually they looked
+like unrelated bugs. Read together, most were repeated manifestations of a much
+smaller set of missing cross-layer contracts: no shared serialization protocol
+for a derived value, no lifecycle for a non-transactional external effect, no
+single definition of what a financial field means, and no statement of what kind
+of test a given claim requires.
+
+The repository was not undisciplined. It had `withScopedDb`, atomic balance
+arithmetic, a database-enforced import claim with real two-connection tests,
+RLS enforcement tests, and substantive migration and drift checks. What it did
+not have was those patterns organised into one contract, so adjacent workflows
+used incompatible protocols -- one balance path an atomic delta, another an
+absolute recomputation from a snapshot, each individually transactional and
+unsafe together.
+
+A second observation shaped the decision more than the first. The financial
+contracts in `docs/` had already been read, agreed with, and violated anyway,
+more than once. Prose stating a rule was demonstrably insufficient on its own.
+
+## Decision
+
+**Maintain a catalog of cross-layer invariants** in `docs/system-invariants.md`,
+each with a stable ID, a named enforcement mechanism, a concurrency scope, retry
+and crash semantics, required tests, and an honest status of `enforced`,
+`partial` or `unenforced`.
+
+**State the status truthfully, including when the system violates the
+invariant.** An entry describing a condition the code does not meet, with the
+violation cited, is the useful form. The catalog is a target, not a description.
+
+**Enforce each rule as low in the stack as it will go.** Ranked by how well they
+hold:
+
+1. a type the compiler enforces
+2. a lint rule
+3. a database constraint, index or single atomic statement
+4. a test that scans the source for the mistake anywhere
+5. a test of one call site
+6. a paragraph in a `CLAUDE.md` or a contract document
+
+Reach for the highest the mistake allows. Use prose for the part that genuinely
+needs judgement, not as the first resort.
+
+**Prefer a scanning test wherever the mistake is mechanical.** When a defect can
+appear at many call sites -- a missing-rate fallback of `1`, a `SPLIT` case
+outside the shared reducer, a raw element instead of the shared component -- a
+test that fails for *any* occurrence is the durable form.
+`frontend/src/test/ui-conventions.test.ts` is the pattern.
+
+**Treat a defect found by a human in AI-written code as a missing rule.** Fixing
+it is half the work; the other half is finding how the codebase already solves
+that problem, adding a regression test that fails on the original mistake, and
+writing the rule down.
+
+## Consequences
+
+**Makes easy.** A reviewer can check a diff against a named invariant rather than
+against their memory. A change that closes a gap has one place to update. The
+repeated-rediscovery pattern -- the same FX and stock-split defects independently
+found and fixed in several parallel efforts -- becomes visible as one row instead
+of many bugs.
+
+**Makes hard.** Every invariant-bearing pull request now owes: the IDs it
+touches, the enforcement mechanism, the required test kind, and a status update.
+That is real friction, and it is the point.
+
+**Forbids.** Closing a finding by adding prose. An invariant moves to `enforced`
+only when a mechanism makes the violation fail.
+
+**A specific obligation.** A document that names an identifier is making a claim
+about the source. Renaming or deleting a field, flag or helper means grepping
+`docs/` and every `CLAUDE.md` in the same commit. These contract documents cite
+file paths, job names, script names and flags throughout, so they are subject to
+this rule more than most -- a document describing a model that no longer exists
+gets read, believed, and built on.
+
+## Alternatives considered
+
+**Write more documentation without status fields.** Rejected: a document that
+describes intended behaviour indistinguishably from actual behaviour is how
+comments came to claim atomicity, single-use consumption and locks that the code
+beside them did not implement. Those claims were believed for as long as they
+existed.
+
+**Fix the findings and skip the catalog.** Rejected because the findings were
+manifestations rather than causes. Several were independently rediscovered and
+re-fixed in parallel efforts that did not know about each other, and a
+single-call-site fix repeatedly left siblings live.
+
+**Track invariants in the issue tracker instead.** Rejected: an issue is closed
+and then invisible. An invariant is permanent -- its enforcement must be
+checkable during review years later, which means it belongs in the repository
+beside the code.
+
+**Machine-check everything and write nothing.** Rejected as not achievable
+today. Some rules genuinely need judgement -- which of `null`, `0` and absent a
+new field means; whether an unclaimed cron is idempotent by construction. Those
+need prose. The mistake is using prose for the rules that could have been
+checked.

--- a/docs/concurrency-and-idempotency.md
+++ b/docs/concurrency-and-idempotency.md
@@ -1,0 +1,398 @@
+# Concurrency and Idempotency Contract
+
+A transaction is not a concurrency protocol. `withScopedDb` gives every write
+atomicity and a tenant identity, and that is genuinely valuable -- but two
+transactions that are each individually correct can still corrupt a shared value
+if they disagree about how they serialize against each other. Most of the
+concurrency defects found in this codebase were not missing transactions. They
+were writers of the same value using *different* protocols.
+
+This document defines which protocol to use when, and records which protocol
+each existing writer actually uses. Where two writers of the same value disagree,
+that is recorded as a gap rather than smoothed over -- see section 8.
+
+Related: root `CLAUDE.md` (Transactions, Database Access) states the rules for
+reaching the database at all; `docs/financial-calculation-contract.md` section 7
+states that a rejected command must not already have written.
+
+## 1. The primitive, and what it does and does not give you
+
+```typescript
+withScopedDb<T>(
+  dataSource: DataSource,
+  fn: (manager: EntityManager) => Promise<T>,
+  isolation?: ScopedDbIsolation,
+): Promise<T>
+```
+
+What it guarantees (`backend/src/common/db/scoped-db.ts`):
+
+- One transaction, committed when the callback returns, rolled back when it
+  throws.
+- The tenant GUCs (`app.current_user_id`, `app.real_user_id`, or
+  `app.bypass_rls`) are set as the transaction's first statements using
+  `set_config(..., true)`, so they are transaction-local and cannot leak onto a
+  pooled connection.
+- It **throws** without an ambient identity context rather than silently falling
+  back to `dataSource.manager`.
+- A nested call **joins** the ambient transaction -- same connection, same
+  atomicity -- so a service method calling another does not deadlock the pool.
+  Requesting an `isolation` level while joining throws instead of silently
+  downgrading.
+
+What it does **not** give you:
+
+- **Any protection against a concurrent writer of the same row.** The default
+  isolation is READ COMMITTED. Two transactions may both read a value, both
+  compute a new one from it, and both write; the second overwrites the first.
+  Nothing in `withScopedDb` prevents that, and nothing warns about it.
+- **Any ordering.** Two transactions touching two rows in opposite order can
+  deadlock; the primitive has no lock-ordering opinion.
+
+`runOutsideActiveScopedManager(fn)` deliberately escapes the ambient
+transaction so a write inside becomes visible before the outer transaction
+commits. It costs an extra pooled connection for its duration and is correct
+only for a short statement at a phase boundary -- a progress or heartbeat write
+a concurrent poller must see. It is never correct per row.
+
+## 2. Choosing a mechanism
+
+Work down this list and stop at the first row that applies. The ranking is by
+how much the database enforces rather than the caller.
+
+| # | Situation | Mechanism |
+| --- | --- | --- |
+| 1 | The new value is a function of the old value of **one column** | Atomic SQL arithmetic: `SET col = col + $1` |
+| 2 | At most one row may exist for a key | `UNIQUE` or partial unique index, and handle `23505` |
+| 3 | A state transition must have exactly one winner | `UPDATE ... WHERE <expected state> RETURNING id` |
+| 4 | An upsert whose losing side must still see the winner's rows | `ON CONFLICT ... DO UPDATE`, then re-read inside the same transaction |
+| 5 | Several columns or rows must be read, decided on, and written together | `SELECT ... FOR UPDATE` on the row that owns the decision |
+| 6 | The resource is not a row (a whole computation, a materialization) | `pg_advisory_xact_lock` |
+| 7 | A cross-request business operation must not repeat | A persisted idempotency key, written before the effect |
+
+Rows 1-4 are enforced by the database and survive a caller who forgets. Rows
+5-7 depend on every writer taking part, which is why they need the inventory in
+section 8: a lock that one of three writers skips is not a lock.
+
+### 1 -- atomic arithmetic
+
+```sql
+UPDATE accounts SET current_balance = ROUND(CAST(current_balance AS numeric) + $1, 4) WHERE id = $2
+```
+
+`backend/src/accounts/accounts.service.ts` `updateBalance`. Correct and
+lock-free: the read and the write are one statement, so no other transaction can
+interleave between them. Prefer this whenever the update is expressible as a
+delta.
+
+### 2 -- unique index as the guarantee
+
+```sql
+CREATE UNIQUE INDEX idx_import_jobs_one_active_per_user
+  ON import_jobs (user_id) WHERE status IN ('pending', 'running');
+```
+
+`database/schema.sql`. This is the codebase's best example of the rule in
+CONC-002 below, and `schema.sql` says why in the index's own comment: it is
+enforced there "rather than by a read-then-insert in the service: two concurrent
+starts would otherwise both see no active job."
+
+The application still needs to translate the violation. `MnyImportJobService`
+does it with `isActiveJobConflict()`, matching on both SQLSTATE `23505` and the
+constraint name, and returning the same `409` the advisory pre-check would have
+returned. The pre-check is kept for a good error message and is documented as
+advisory only -- it "answers the question a moment before the answer can change."
+
+### 3 -- conditional update as the claim
+
+```typescript
+// mny-import-job.service.ts, claim()
+UPDATE import_jobs SET status = 'running', ... WHERE id = $1 AND status = 'pending' RETURNING id
+```
+
+The `WHERE status = 'pending'` *is* the concurrency control: whichever statement
+commits first updates one row, the other updates none. The caller decides it won
+by whether a row came back.
+
+**The trap that has already bitten here:** a data-modifying statement with
+`RETURNING` comes back from `manager.query()` as `[rows, rowCount]`, while a
+bare `SELECT` comes back as plain rows. Reading the tuple as `rows.length > 0`
+makes *every* attempt look like a winner. `returnedRows<T>()` in
+`mny-import-job.service.ts` exists for exactly this, and its comment records
+that the bug was found by the real-database concurrency spec -- not by the unit
+tests. Use the helper; never destructure a `RETURNING` result by hand.
+
+### 4 -- upsert on a natural key
+
+```sql
+INSERT INTO exchange_rates (...) VALUES (...)
+ON CONFLICT (from_currency, to_currency, rate_date) DO UPDATE SET rate = EXCLUDED.rate
+```
+
+The cheapest idempotency available, because the uniqueness is a property of the
+data rather than something invented and remembered. A repeated or concurrent
+refresh converges instead of duplicating. `security_prices` uses the same shape
+on `(security_id, price_date)`.
+
+The caveat is about reading afterwards, not writing: an operation that uses
+`ON CONFLICT DO NOTHING` and then returns a read model must re-read the
+authoritative state inside the same transaction. The request that lost the race
+would otherwise return a snapshot taken before the winner's rows existed. See
+`docs/financial-calculation-contract.md` section 6.
+
+### 5 -- pessimistic lock
+
+```typescript
+manager.findOne(RefreshToken, {
+  where: { tokenHash },
+  lock: { mode: "pessimistic_write" },
+});
+```
+
+TypeORM's `pessimistic_write` compiles to `FOR UPDATE`. It is the right tool
+when the decision needs more than one column, or spans rows, and cannot be
+folded into a single conditional statement.
+
+There are exactly five such sites in `backend/src` today (four row locks and one
+advisory lock); they are listed in section 8. That number is small enough that a
+new one is a reviewable decision, and it should stay that way.
+
+### 6 -- advisory lock
+
+```typescript
+await manager.query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", [strategyId]);
+```
+
+`backend/src/strategies/gem-signal.service.ts`. The locked thing is not a row --
+it is "materializing a signal for this strategy". `pg_advisory_xact_lock`
+releases on commit or rollback and is cluster-wide, so unlike a Node-level mutex
+it works across replicas. Use it when the resource is a computation rather than a
+record, and always the `_xact_` variant so a crash cannot hold the lock.
+
+### 7 -- persisted idempotency key
+
+The last resort, for an effect that cannot be folded into one transaction and has
+no natural key to upsert on. It is last because it is the only mechanism on this
+list whose correctness depends on constructing the key well, and a key derived
+from the wrong thing provides no protection while looking like it does. Section 6
+below has the construction rules.
+
+A `Set` in process memory is not a substitute for any of the above. It
+coordinates one replica with itself and silently does nothing across the two or
+more replicas this application actually runs.
+
+## 3. Normative rules
+
+```text
+CONC-001
+A value used to compute a destructive or financial write must be read inside the
+same transaction and under the same lock, statement, or version guard that
+authorizes the write. A value read before the transaction is a snapshot, and a
+write derived from a snapshot silently discards whatever committed in between.
+
+CONC-002
+A check followed by an insert is not an exclusivity mechanism. Exclusivity is
+enforced by a database constraint or a single atomic statement. A pre-check may
+exist for a better error message, and must be commented as advisory.
+
+CONC-003
+All writers of the same derived value must use one serialization protocol. An
+atomic delta and an absolute recomputation are not compatible: the recomputation
+overwrites the whole column, so a delta that commits between its read and its
+write is lost. Either every writer holds the same lock, or every writer is a
+delta, or the recomputation is the only writer.
+
+CONC-004
+Every scheduled or background operation with a persistent, user-visible, or
+external effect must have a durable logical-operation key -- a row whose
+existence means "this effect has happened" -- and must claim it atomically.
+"Two replicas run this and the second one's writes are harmless" is a claim that
+requires proof, not an assumption.
+
+CONC-005
+A worker may write progress, complete, fail, or reap a job only while its claim
+still holds. A stale worker that wakes after being reaped must not be able to
+mark a newer generation of the same job complete.
+
+CONC-006
+A retry after an unknown commit result must reconcile durable state. It may
+repeat an operation only if repeating it is provably idempotent -- because the
+whole effect was one transaction, because the write is an upsert on a natural
+key, or because a persisted key blocks the second attempt.
+
+CONC-007
+A comment claiming atomicity, a lock, or single-use consumption must name the
+mechanism. Two comments in this codebase claimed a guarantee the code beside
+them did not implement, and both were believed for as long as they existed. If
+the mechanism cannot be named, the comment is wrong, not merely vague.
+```
+
+## 4. Retry semantics
+
+The three cases are genuinely different and must be distinguished before writing
+a retry:
+
+| When the failure happened | What a retry means |
+| --- | --- |
+| Before commit | Nothing was written. A retry is a fresh attempt and needs no protection. |
+| After commit, response lost | The effect happened. A blind retry duplicates it. The retry must reconcile: read the durable state and continue from it. |
+| Commit result unknown | Treat as "after commit" until proven otherwise. This is the case CONC-006 exists for. |
+
+Whole-effect-in-one-transaction is the strongest position available for the first
+case, because there is no key to construct wrongly -- prefer it wherever the
+effect genuinely fits in one transaction.
+
+**The trap is the word "genuinely", and the MNY import is the worked example of
+falling into it.** `writeAll` puts every business row in one `withScopedDb`
+transaction, which is real and correct. But the import is not over when that
+transaction commits: post-processing, verification, holdings verification,
+staged-file deletion and the terminal job-status update all follow it. So a
+failure lands in the *first* row of the table above only if it happened inside
+`writeAll`; a failure after that commit is squarely in the second row, and the
+import has no mechanism for it -- no data-committed checkpoint, no import-run id,
+and fresh UUIDs on every parse. A retry replays.
+
+The comment above `runImport` says "The whole write is one transaction, so a
+failure leaves nothing behind and Retry cannot double-import." Read carefully,
+the first clause describes `writeAll` and the second describes the import; the
+inference between them is where the guarantee is lost. That is CONC-007's exact
+failure mode -- a named mechanism that does not cover the scope claimed -- and it
+is worth knowing that this document asserted the same thing in an earlier
+revision, having taken the comment at its word.
+
+So before claiming this pattern: check that the transaction's boundary and the
+operation's boundary are the same boundary. If anything happens after the commit
+that the caller would consider part of the operation, the operation is in the
+second row of the table and needs reconciliation. See INV-IMPORT-002.
+
+The exchange-rate and security-price refreshes are the model for repeatable
+writes: `ON CONFLICT (from_currency, to_currency, rate_date) DO UPDATE` and
+`ON CONFLICT (security_id, price_date) DO UPDATE` make a repeated fetch
+converge instead of duplicating. Note the interaction with
+`docs/financial-calculation-contract.md` section 6: an operation that uses
+`ON CONFLICT DO NOTHING` and then returns a read model must re-read the
+authoritative state inside the same transaction, because the request that lost
+the race would otherwise return data missing the winner's rows.
+
+## 5. Lock ordering
+
+Deadlock is prevented by every transaction taking locks in the same order, and
+the only order that is stable across a codebase is a global one. Where more than
+one row must be locked:
+
+1. Accounts before transactions before splits.
+2. Within one kind, ascending by `id`.
+3. A transfer locks both legs in ascending account id, never "source then
+   destination" -- the two legs of a reciprocal pair would otherwise take them
+   in opposite orders.
+
+This ordering is a rule this document introduces rather than one the code
+currently demonstrates: no existing site locks two rows of the same kind. It
+applies from the first one that does.
+
+## 6. Idempotency keys
+
+When a key is genuinely needed (the effect cannot be folded into one
+transaction, and no natural key exists), it must be:
+
+- **Derived from the logical operation, not the request.** For a scheduled
+  occurrence: `(scheduledTransactionId, occurrenceDate)`. For a daily digest:
+  `(userId, kind, date)`. A UUID generated by the caller identifies a *retry
+  attempt*, not an operation, and two independent retries would get two keys.
+- **Persisted before the effect**, in the same transaction that will be checked
+  by the next attempt.
+- **Unique in the database.** A key checked with a `SELECT` and inserted
+  afterwards is CONC-002 again, one level up.
+
+## 7. Multi-replica cron requirements
+
+Every `@Cron` handler runs in **every** backend replica -- there is no separate
+scheduler process. `docs/cron-jobs.md` states this and lists the jobs; what it
+must also record, per job, is the answer to one question:
+
+> What prevents two healthy replicas from producing the same effect twice?
+
+The acceptable answers are: a conditional claim, a unique constraint, an
+advisory lock, or a proof that the operation is idempotent by construction.
+"The window is small" is not one of them; nor is a process-local `Set`.
+
+Idempotent-by-construction is a real answer and several jobs legitimately use
+it, but it must be argued rather than asserted. `DELETE ... WHERE expired`
+qualifies because the predicate is "already expired", so a second sweep matches
+nothing new. An absolute recomputation qualifies against *another copy of
+itself*, and not against a concurrent delta -- which is CONC-003, and is why
+the account-balance cron appears in the gap register below despite being
+correctly documented as idempotent with respect to re-running.
+
+## 8. Mechanism inventory and gap register
+
+This is the part of the document that goes stale fastest, and the part most
+worth keeping: CONC-003 can only be checked against a list of all writers.
+
+### Locks that exist
+
+| Site | Resource | Why |
+| --- | --- | --- |
+| `auth/token.service.ts` `refreshTokens` | `RefreshToken` row by `tokenHash` | Two concurrent rotations of one token |
+| `auth/two-factor.service.ts` | `User` row during backup-code consumption | Same code consumed twice |
+| `accounts/accounts.service.ts` `update` | `Account` row | Concurrent balance modification |
+| `accounts/accounts.service.ts` `close` | `Account` row | Race between the balance check and the close |
+| `strategies/gem-signal.service.ts` | advisory, per `strategyId` | Materialization interleaving with a settings save |
+
+### Conditional claims that exist
+
+`mny-import-job.service.ts` `claim` and `reapStaleJobs`; the sibling-token
+voiding in the three emergency-access call sites. There is no `@VersionColumn`
+anywhere in the codebase -- conditional `WHERE` is the whole of its optimistic
+concurrency control.
+
+### Gaps
+
+Each row is a place where the rules above are not currently met. A row leaves
+this table when a mechanism lands, not when someone judges the window small.
+
+| Value or operation | Current state | Rule breached |
+| --- | --- | --- |
+| `accounts.current_balance` | Three postures coexist on one column: a lock-free atomic delta (`updateBalance`), an unlocked read-then-write absolute recompute (`recalculateCurrentBalance`, the hourly `applyDueTransactionBalances`, `import-post-processing`, `write-transactions`, `action-history.recalculateBalance`), and a pessimistically locked read-then-write (`update`, `close`). A delta committing between a recompute's SELECT and its UPDATE is silently discarded. | CONC-001, CONC-003 |
+| `holdings.quantity` / `average_cost` | Every mutation path is a JavaScript read-modify-write inside a transaction with no lock and no atomic delta. `UNIQUE(account_id, security_id)` prevents duplicate rows and does nothing about a lost update to the same row. | CONC-001 |
+| `users.failed_login_attempts` | Read in one statement, incremented in JavaScript, written as an absolute value in a later statement with no lock. Two concurrent failures lose an increment, so the counter under-counts and the lockout threshold is reached late. The comment directly above it reads "Atomically increment failed attempts". | CONC-001, CONC-007 |
+| Emergency-access claim consumption | Check-then-act: the in-transaction re-read passes no `lock` option, and the consuming write is an entity `save` by primary key with no `WHERE claim_token_used_at IS NULL`. The code immediately beside it uses the CAS predicate correctly for voiding *sibling* tokens. The comment claims re-validation "under lock". There is no partial unique index on unused tokens to act as a backstop. | CONC-001, CONC-002, CONC-007 |
+| Scheduled auto-posting (`processAutoPostTransactions`, hourly at minute 5 -- `"5 * * * *"`) | Reads due schedules by `nextDueDate <= today`, then posts and advances `nextDueDate` with no row lock, no CAS on the previous `nextDueDate`, and no unique constraint on `(scheduled_transaction_id, transaction_date)`. Two replicas on the same tick can both post the same occurrence. | CONC-004 |
+| `budget-period-cron` monthly rollover | No claim. `UNIQUE(budget_id, period_start)` is the only backstop, and the loser's unique violation is caught by a per-budget `try/catch` that increments an error count -- so the losing replica's period close silently fails rather than converging. | CONC-004, CONC-006 |
+| `demo-reset.service` | Full delete-and-reseed with no lock; two concurrent runs can interleave one's delete with the other's insert. | CONC-004 |
+| Logout vs rotation | Logout's family revoke is an unlocked bulk `UPDATE`. It happens to be safe because `isRevoked = true` is idempotent and the end state is order-independent -- but this is a property of the value, not a protocol, and it stops holding the moment logout writes anything else. | CONC-003 (tolerated; document, do not copy) |
+| MNY import retry after a committed write | `writeAll`'s transaction commits before post-processing, verification, staged-file deletion and the terminal status update. A failure in that window leaves committed rows behind a retryable job, and a retry re-parses with fresh UUIDs. No checkpoint, run id, or per-record key. See INV-IMPORT-002. | CONC-006, CONC-007 |
+
+Refresh-token rotation is worth reading as a positive finding rather than a gap:
+it is correct and subtle -- the loser blocks on the lock, then sees the winner's
+committed `isRevoked`, and takes the reuse-detection branch that revokes the whole
+family, so a concurrent double-rotation ends in revocation rather than two live
+successors.
+
+The MNY import job deserves a more careful verdict than either column allows. It
+has the most complete protocol in the codebase for the races it was built to
+handle -- a partial unique index for exclusivity, a conditional claim for the
+worker, a heartbeat with a reaper for a dead worker -- and it is the only workflow
+with real two-connection tests. Those two facts are related, and the tests are why
+the `returnedRows` bug was found. What it does not have is a protocol for the
+window *after* its own write commits, which is the row added above. A workflow can
+be the best-defended one in a codebase against the failures it anticipated and
+still be undefended against the one it did not.
+
+## 9. Test obligation
+
+A concurrency mechanism that has only unit tests has not been tested. A mocked
+repository can be made to return whatever the "lost the race" branch needs,
+which makes that branch testable, tested, and dead -- the `returnedRows` bug
+above survived exactly that way, and `gem-price.integration.spec.ts` records the
+same lesson: with a mock, "every lost-race branch was dead, tested and
+unreachable."
+
+Anything claiming a property of PostgreSQL -- statement snapshots, row-lock
+ordering, partial-index arbitration, one-winner CAS -- needs a test that opens
+two real connections and interleaves them.
+`backend/test/integration/mny-import-job.integration.spec.ts` is the pattern to
+copy; it states its own rationale: these are "properties of Postgres, not of the
+service". `docs/verification-contract.md` records which invariant requires which
+kind of test, and `docs/testing-contract.md` section on asynchronous and
+concurrent operations lists the interleavings to pick from.

--- a/docs/system-invariants.md
+++ b/docs/system-invariants.md
@@ -1,0 +1,773 @@
+# System Invariants
+
+The conditions that must hold regardless of which controller, service, cron,
+importer, provider or form is involved. An invariant here is a claim about the
+system as a whole, so it cannot be satisfied by one call site behaving
+correctly -- which is the failure mode this catalog exists to prevent. Several
+of the entries below were broken by a change that was locally reasonable and
+globally wrong, and the reviewer had no document to check it against.
+
+**Status is stated honestly.** An invariant marked `enforced` has a mechanism
+named in its entry. One marked `unenforced` describes a condition the system
+currently violates, with the violation cited. This catalog is not a description
+of the code; it is the target the code is measured against, and the gap is the
+useful part. Nothing here is closed by editing this file.
+
+How the statuses are used:
+
+| Status | Meaning |
+| --- | --- |
+| `enforced` | A named mechanism makes the violation fail. Cite it in reviews. |
+| `partial` | Some paths enforce it, others do not. The unenforced paths are listed. |
+| `unenforced` | The system can violate this today. |
+
+## Field template
+
+Each entry carries these fields. Where a field says `--`, it is genuinely not
+applicable, not merely unknown.
+
+```text
+Statement           what must always be true
+Source of truth     the row, ledger, provider object or job state that decides
+Enforcement         constraint, index, lock, CAS, claim, allowlist, or "none"
+Concurrency scope   account, user, holding, occurrence, token, provider key, global
+Retry semantics     which retries are safe, and what prevents duplication
+Crash semantics     expected state before commit, after commit, mid-finalization
+Failure response    409, 404, null, reconcile, refuse, partial
+Required tests      per docs/verification-contract.md
+Status              enforced | partial | unenforced
+```
+
+Two fields a reader might expect are deliberately absent. **CI owner** lives in
+`docs/verification-contract.md` section 4 instead, so the job names appear once
+rather than in thirty entries that would drift independently of the workflow.
+**Subsystem owner** is omitted because this project does not have per-subsystem
+owners; adding a column that would read "maintainer" throughout would be
+ceremony. Reinstate either the moment it would carry real information.
+
+An entry states only what has been checked. Where a field would require a claim
+that was not verified against the source, it says so in the field rather than
+guessing -- see INV-AUTH-004.
+
+## Index
+
+| ID | Invariant | Status |
+| --- | --- | --- |
+| INV-IMPORT-001 | At most one pending or running MNY import per user | enforced |
+| INV-IMPORT-002 | A retry never double-imports | unenforced |
+| INV-IMPORT-003 | A category collision does not abort an import | unenforced |
+| INV-BALANCE-001 | `current_balance` equals opening balance plus included ledger rows | unenforced |
+| INV-HOLDING-001 | A holding equals a deterministic replay of the investment ledger | unenforced |
+| INV-HOLDING-002 | Every view replays the ledger the same way | unenforced |
+| INV-TRANSFER-001 | A transfer's two legs share one status and one balance decision | unenforced |
+| INV-FX-001 | An unavailable rate never becomes 1:1 | unenforced |
+| INV-OCCURRENCE-001 | One scheduled occurrence has at most one financial effect | unenforced |
+| INV-OCCURRENCE-002 | A stored override price survives reopening | unenforced |
+| INV-CLAIM-001 | An emergency-access claim token is consumed exactly once | unenforced |
+| INV-AUTH-001 | A refresh token rotates once, or the family is revoked | enforced |
+| INV-AUTH-002 | A failed-login counter records every failure | unenforced |
+| INV-AUTH-003 | A destructive OIDC action requires a provider round trip | unenforced |
+| INV-AUTH-004 | A logout reports only what it achieved | partial |
+| INV-ACTIVITY-001 | Activity is attributed to whoever acted, not to whoever was acted for | unenforced |
+| INV-PROFILE-001 | A user-profile response is an allowlist | unenforced |
+| INV-MCP-001 | An MCP session is bound to the credential that opened it | unenforced |
+| INV-CURRENCY-001 | A shared currency is deleted only by its creator, on a global count | unenforced |
+| INV-ATTACHMENT-001 | Available metadata resolves to committed bytes | partial |
+| INV-BACKUP-001 | A backup file is complete, verified and owner-namespaced | partial |
+| INV-CRON-001 | One logical cron effect per schedule tick, across replicas | partial |
+| INV-RLS-001 | Enforced mode refuses to run on a role that can bypass RLS | unenforced |
+| INV-CACHE-001 | A money-moving write invalidates every derived cache | unenforced |
+| INV-RELEASE-001 | The tested, imaged and tagged revisions are one revision | partial |
+
+## Imports
+
+### INV-IMPORT-001 -- at most one pending or running MNY import per user
+
+```text
+Statement           For one user, at most one import job may be pending or running.
+Source of truth     import_jobs.status
+Enforcement         Partial unique index idx_import_jobs_one_active_per_user on
+                    import_jobs(user_id) WHERE status IN ('pending','running'),
+                    added by database/migrations/135_import_jobs_single_active.sql.
+                    The service's hasActiveJob() pre-check is advisory only and
+                    is commented as such; isActiveJobConflict() translates
+                    SQLSTATE 23505 into the same 409.
+Concurrency scope   per user
+Retry semantics     A retry after failure is a new job row; safe.
+Crash semantics     A crashed worker leaves status='running' with a stale
+                    heartbeat; reapStaleJobs fails it retryably after 5 minutes.
+Failure response    409 Conflict
+Required tests      Two-connection: two concurrent starts, one winner. Present in
+                    backend/test/integration/mny-import-job.integration.spec.ts
+                    ("has exactly one winner when two starts race over the same
+                    staged file", "has one winner across four concurrent starts",
+                    "lets two users start imports concurrently").
+Status              enforced
+```
+
+This is the reference implementation for the whole catalog. The migration's own
+comment explains why the constraint rather than the check: the service counted
+active jobs and inserted in a second transaction, so two overlapping starts both
+saw zero, and because each parse pre-generates fresh transaction UUIDs nothing
+downstream deduplicated the second run. With `wipeExistingData` both requests
+could also reach the destructive wipe.
+
+### INV-IMPORT-002 -- a retry never double-imports
+
+```text
+Statement           Retrying a failed import must not insert a second copy of
+                    rows a previous attempt may have committed.
+Source of truth     the staged file bytes; import_jobs.status
+Enforcement         None once the business data has committed. writeAll opens its
+                    own withScopedDb transaction and commits when it returns;
+                    post-processing, verification, holdings verification, staged-
+                    file deletion and the terminal status update all run after
+                    that commit. No durable data-committed checkpoint, import-run
+                    identifier, or deterministic per-source-record key exists, and
+                    each parse pre-generates fresh row UUIDs, so nothing
+                    downstream can recognise a row as already imported.
+Concurrency scope   per user
+Retry semantics     Safe when the failure occurred inside writeAll -- nothing
+                    committed. Unsafe when the failure occurred after writeAll
+                    committed, or when the commit result is unknown.
+Crash semantics     A crash between writeAll's commit and terminal completion
+                    leaves committed accounts, transactions, investments and
+                    prices behind a job that is running or failed-retryable. The
+                    reaper marks it retryable, which is correct for the job row
+                    and wrong for the data.
+Failure response    A retry must reconcile: finalize the committed run rather than
+                    replay it, or refuse until the run's state is known.
+Required tests      Failpoint: commit writeAll, then fail before terminal
+                    completion, retry, and assert every imported row exists
+                    exactly once. A test that throws inside the import
+                    transaction does not reach this window. No such test exists.
+Status              unenforced
+```
+
+Worth spelling out how this looked correct. The source comment above `runImport`
+says "The whole write is one transaction, so a failure leaves nothing behind and
+Retry cannot double-import." The first clause is true of `writeAll`. The second
+does not follow from it, because the import is not finished when `writeAll`
+commits -- and the comment's scope ("the whole write") is what makes the
+inference look sound. The numbers:
+
+```text
+Source file transaction:   -25.00
+First attempt commits:     -25.00   writeAll returns, then the worker dies
+Retry re-parses, commits:  -25.00   fresh UUIDs, nothing recognises the first copy
+Resulting effect:          -50.00
+Expected effect:           -25.00
+```
+
+This entry was itself marked `enforced` in an earlier revision of this document,
+on the strength of that comment. It is the catalog's own cautionary tale: a
+status copied from a comment is not a verified status, and CONC-007 exists
+because the mechanism named has to cover the scope claimed. The mechanisms that
+would close it are a `data_committed` checkpoint written in the same transaction
+as the rows, a stable import-run id carried by every imported record, or a
+recovery path that finalizes rather than replays.
+
+Note also that a "start fresh" wipe is applied in `start`, outside the job body,
+so it does not make a retry idempotent: an append-mode import that committed and
+then failed has no wipe to save it.
+
+### INV-IMPORT-003 -- a category collision does not abort an import
+
+```text
+Statement           A category the import needs, created concurrently by the same
+                    user, must not fail the import.
+Source of truth     categories
+Enforcement         None. import.service.ts does findOne then create/save. A
+                    concurrent manual create raises a unique violation that
+                    aborts the whole import transaction.
+Concurrency scope   per user
+Retry semantics     The user must restart the entire import.
+Failure response    Currently a 500 losing the whole import; should be adopting
+                    the winner's row.
+Required tests      Two-connection: manual category create interleaved with an
+                    import needing the same category.
+Status              unenforced
+```
+
+The cost is disproportionate to the cause: an entire `.mny` import is lost
+because one category already existed. `INSERT ... ON CONFLICT DO NOTHING
+RETURNING id` plus adopting the winner's row is the fix, and per
+`docs/financial-calculation-contract.md` section 6 the conflict path must then
+re-read rather than reuse the pre-insert snapshot. Note that no unique index
+currently covers top-level categories (`parent_id IS NULL`), so closing this
+properly needs the index too.
+
+## Ledger and derived values
+
+### INV-BALANCE-001 -- current_balance equals its ledger
+
+```text
+Statement           accounts.current_balance equals opening balance plus every
+                    included, non-void, non-child ledger transaction up to the
+                    applicable date.
+Source of truth     transactions, summed; accounts.opening_balance
+Enforcement         None across writers. Three incompatible protocols coexist on
+                    one column:
+                      - atomic delta: updateBalance's
+                        SET current_balance = ROUND(... + $1, 4)
+                      - unlocked absolute recompute: recalculateCurrentBalance,
+                        the hourly applyDueTransactionBalances,
+                        import-post-processing, write-transactions,
+                        action-history.recalculateBalance
+                      - pessimistically locked read-then-write: accounts update,
+                        accounts close
+                    A delta committing between a recompute's SELECT and its
+                    UPDATE is silently discarded.
+Concurrency scope   per account
+Retry semantics     A recompute is idempotent against another recompute and not
+                    against a concurrent delta.
+Failure response    Currently silent divergence -- the worst available.
+Required tests      Two-connection: delta interleaved with recompute, asserting
+                    the delta survives. No such test exists.
+Status              unenforced
+```
+
+See `docs/concurrency-and-idempotency.md` CONC-003. Also breached by transfers
+created as `VOID`, which update both balances regardless of status.
+
+### INV-HOLDING-001 -- a holding is a deterministic ledger replay
+
+```text
+Statement           holdings.quantity and average_cost equal a deterministic
+                    replay of that account's investment ledger.
+Source of truth     investment_transactions
+Enforcement         None. Every mutation path (createOrUpdate, updateHolding,
+                    applySplit, reverseSplit, adjustQuantity) is a JavaScript
+                    read-modify-write inside a transaction with no lock and no
+                    atomic delta. UNIQUE(account_id, security_id) prevents
+                    duplicate rows and does nothing about a lost update to one.
+Concurrency scope   per (account, security)
+Retry semantics     Not idempotent; a lost update is invisible.
+Failure response    Silent divergence from the ledger.
+Required tests      Two-connection: concurrent trades on one holding, replay
+                    compared against the stored row.
+Status              unenforced
+```
+
+### INV-HOLDING-002 -- every view replays the ledger the same way
+
+```text
+Statement           Every surface that derives a share count from the investment
+                    ledger must apply each action identically.
+Source of truth     one shared reducer, which does not currently exist
+Enforcement         None, and the paths actively disagree:
+                      - holdings.service.ts multiplies on SPLIT
+                        (qty *= txQty; next = current * quantity) and handles
+                        ADD_SHARES/REMOVE_SHARES
+                      - net-worth.service.ts adds on SPLIT at all three of its
+                        reducers, groups SPLIT with BUY/REINVEST/TRANSFER_IN at
+                        one of them, and handles no ADD_SHARES/REMOVE_SHARES at all
+Concurrency scope   --
+Failure response    The holdings page and every historical net-worth chart report
+                    different share counts for the same position after any split.
+Required tests      A source-scanning guard failing on any SPLIT branch outside
+                    the shared reducer, plus a fixture asserting both surfaces
+                    agree after a 2:1 split and an ADD_SHARES.
+Status              unenforced
+```
+
+`docs/financial-semantics.md` FIN-003 has the arithmetic: 90 shares at ratio 2.0
+is 180, and the additive form gives 92. This invariant is separate from
+INV-HOLDING-001 on purpose -- that one is about concurrency, this one about two
+implementations of the same rule, and fixing either leaves the other.
+
+### INV-TRANSFER-001 -- both legs, one decision
+
+```text
+Statement           A transfer's legs share one status, and any balance movement
+                    is decided once for the pair.
+Source of truth     the two linked transactions rows
+Enforcement         Partial and inconsistent. PATCH /:id/transfer mirrors status
+                    to both legs. PATCH /transactions/:id/status, markCleared,
+                    reconcile and unreconcile touch only the row given -- the
+                    reconciliation service references neither isTransfer nor
+                    linkedTransactionId. Bulk update mirrors payeeId, payeeName
+                    and description but not status. Balances are updated
+                    regardless of status, so a transfer created VOID still moves
+                    both.
+Concurrency scope   per transfer pair
+Failure response    Currently silent imbalance: voiding one leg of a 100.00
+                    transfer makes 1,000.00 across two accounts read as 1,100.00.
+Required tests      Per status-changing endpoint, assert both legs moved and both
+                    balances are consistent. Include the split-transfer variant,
+                    which links through the split parent, not a mirror leg.
+Status              unenforced
+```
+
+### INV-FX-001 -- an unavailable rate is not 1:1
+
+```text
+Statement           A cross-currency value must never become a valid-looking 1:1
+                    value, and an unconverted amount must never be returned under
+                    the target currency's label.
+Source of truth     exchange_rates
+Enforcement         None at the consumers. The provider layer is honest --
+                    getRateForDate returns null explicitly "so the caller can
+                    reject or flag the operation rather than silently assuming
+                    1.0" -- and the consumers discard that:
+                      portfolio-calculation.service.ts:
+                        rate = reverseRate !== null ? 1 / reverseRate : 1
+                      net-worth.service.ts:
+                        return result ?? amount
+Concurrency scope   --
+Failure response    Must be null or an explicitly partial figure, per
+                    docs/financial-calculation-contract.md section 1.
+Required tests      Unit per call site with the rate absent; a scanning guard
+                    banning a `: 1` else-branch beside a rate lookup and `??
+                    amount` beside a conversion.
+Status              unenforced
+```
+
+At a real rate of 1.3500, a false 100.00 CAD understates a 135.00 CAD position
+by 35.00 -- and reports it as measured.
+
+## Scheduled occurrences
+
+### INV-OCCURRENCE-001 -- one occurrence, one effect
+
+```text
+Statement           One scheduled occurrence may create at most one financial
+                    effect.
+Source of truth     the posted transaction; scheduled_transactions.next_due_date
+Enforcement         None. processAutoPostTransactions (hourly, at minute 5 --
+                    "5 * * * *") reads due schedules by next_due_date <= today,
+                    then posts and advances next_due_date with no row lock, no
+                    CAS on the previous next_due_date, and no unique constraint
+                    on (scheduled_transaction_id, transaction_date). Every
+                    replica fires every cron.
+Concurrency scope   per (scheduled transaction, occurrence date)
+Retry semantics     Unsafe: a retry cannot tell whether the occurrence posted.
+Crash semantics     A crash between posting and advancing next_due_date reposts
+                    on the next tick.
+Failure response    Should be a durable occurrence key claimed atomically.
+Required tests      Two-instance: two replicas on one tick, exactly one posting.
+Status              unenforced
+```
+
+This is `docs/concurrency-and-idempotency.md` CONC-004's canonical case: the
+logical operation key is obvious (`(scheduledTransactionId, occurrenceDate)`) and
+simply is not persisted.
+
+### INV-OCCURRENCE-002 -- a stored override price survives
+
+```text
+Statement           A stored override price is not replaced by a market quote
+                    without an explicit user action.
+Source of truth     scheduled_transaction_overrides.investment_price
+Enforcement         None. OverrideEditorDialog seeds correctly from the stored
+                    value, then an unconditional effect overwrites
+                    investmentPrice whenever the fetched market price differs
+                    from the last seen one, and recomputes the total from it.
+Concurrency scope   per occurrence
+Failure response    Ten shares stored at 100.00 return as ten at 120.00 with no
+                    money field touched by the user.
+Required tests      Component: reopen with a stored price and a differing quote,
+                    assert the stored price stands.
+Status              unenforced
+```
+
+## Authentication and authorization
+
+### INV-CLAIM-001 -- a claim token is consumed exactly once
+
+```text
+Statement           An emergency-access claim token may be consumed successfully
+                    exactly once.
+Source of truth     emergency_access_contacts.claim_token_used_at
+Enforcement         None. The in-transaction re-read passes no lock option, and
+                    the consuming write is an entity save by primary key with no
+                    WHERE claim_token_used_at IS NULL. No partial unique index on
+                    unused tokens acts as a backstop. The code beside it uses the
+                    CAS predicate correctly for voiding sibling tokens. The
+                    comment claims re-validation "under lock".
+Concurrency scope   per token, per owner
+Retry semantics     Two concurrent completes can both rewrite the owner's
+                    password, to two different hashes, and both return a signed-in
+                    session.
+Failure response    The loser must get 404 or 409, having written nothing --
+                    docs/financial-calculation-contract.md section 7.
+Required tests      Two-connection: one token, two concurrent completes, exactly
+                    one success.
+Status              unenforced
+```
+
+### INV-AUTH-001 -- refresh rotation
+
+```text
+Statement           A presented refresh token rotates once; a second presentation
+                    revokes the family.
+Source of truth     refresh_tokens.is_revoked, per family_id
+Enforcement         Pessimistic write lock on the RefreshToken row by tokenHash,
+                    plus family revocation on a token already revoked. The loser
+                    blocks on the lock, sees the winner's committed isRevoked,
+                    and takes the reuse-detection branch.
+Concurrency scope   per token family
+Retry semantics     A retried rotation of the same token is reuse, not a retry,
+                    and is treated as such by design.
+Crash semantics     A crash before commit leaves the presented token valid; a
+                    crash after leaves the successor valid. Both are consistent.
+Failure response    401, family revoked.
+Required tests      Two-connection: two concurrent rotations of one token; assert
+                    the family ends revoked rather than two live successors.
+Status              enforced
+```
+
+Recorded as enforced because the mechanism is real and correct -- and because it
+is subtle enough that a future refactor could remove the lock without any test
+noticing.
+
+### INV-AUTH-004 -- a logout reports only what it achieved
+
+```text
+Statement           A logout that did not revoke the session must not be presented
+                    to the user as a completed logout.
+Source of truth     refresh_tokens.is_revoked for the family
+Enforcement         Partial and incidental. The family revoke is an unlocked bulk
+                    UPDATE, which is safe against concurrent writers only because
+                    is_revoked = true is order-independent -- a property of the
+                    value, not a protocol, and one that stops holding the moment
+                    logout writes anything else. Whether a failed revoke surfaces
+                    to the user was reported by the audit as a defect; it was not
+                    located in the current code and is unverified here.
+Concurrency scope   per token family
+Retry semantics     Safe: setting is_revoked twice is a no-op.
+Failure response    A revoke that failed must not clear the client's session
+                    silently, or the user believes they signed out and did not.
+Required tests      Integration: force the revoke to fail, assert the response is
+                    not a success.
+Status              partial
+```
+
+Split out from INV-AUTH-001 because the two are different properties that happen
+to touch the same table. Rotation is about exactly-once; this is about truthful
+reporting, and conflating them hid the fact that only the first has a mechanism.
+
+### INV-AUTH-002 -- every failed login is counted
+
+```text
+Statement           A failed login attempt increments the counter the lockout
+                    threshold reads.
+Source of truth     users.failed_login_attempts
+Enforcement         None. The user is read in one statement, incremented in
+                    JavaScript, and written as an absolute value in a later
+                    statement with no lock. Two concurrent failures lose an
+                    increment. The comment above it reads "Atomically increment
+                    failed attempts".
+Concurrency scope   per account
+Failure response    The counter under-counts, so lockout arrives late -- the
+                    direction that favours an attacker.
+Required tests      Two-connection: N concurrent failures, counter equals N.
+Status              unenforced
+```
+
+The reset-on-success path writes a fixed absolute value (`0`, `null`) and is
+therefore safe; only the increment is affected.
+
+### INV-AUTH-003 -- a destructive OIDC action needs a real round trip
+
+```text
+Statement           Restore, delete-account, delete-data and step-up on an OIDC
+                    account require a signed proof of a fresh identity-provider
+                    authentication, bound to the user and the action, single-use
+                    and short-lived.
+Source of truth     the identity provider
+Enforcement         None. The frontend sends the literal string
+                    'oidc-session-confirmed' and the backend checks only that the
+                    field is truthy; step-up takes a client-asserted
+                    oidcConfirmed boolean. No reauth endpoint exists.
+Concurrency scope   per user, per action
+Failure response    Must be 401 until a valid proof is presented.
+Required tests      Integration: a forged or replayed proof is refused; the
+                    artifact is single-use and expires.
+Status              unenforced
+```
+
+Note that the sentinel string is *asserted by tests* in both the frontend and
+backend suites. Those tests are green and protect the defect --
+`docs/verification-contract.md` section on known-wrong tests covers what to do
+with them.
+
+### INV-ACTIVITY-001 -- activity is attributed to whoever acted
+
+```text
+Statement           users.last_activity_at records the authenticated user who
+                    made the request, never the user they are acting as.
+Source of truth     the authenticated principal (req.user.realUserId)
+Enforcement         None, and the wrong value is passed. The request-context
+                    interceptor resolves both identities -- realUserId is derived
+                    as user?.realUserId ?? userId -- and then calls
+                    touchLastActivity(userId), the effective user. A delegate
+                    browsing an owner's data therefore stamps the owner's
+                    last_activity_at.
+Concurrency scope   per user
+Failure response    --
+Required tests      Integration: a delegate request updates the delegate's
+                    last_activity_at and leaves the owner's untouched.
+Status              unenforced
+```
+
+This is not a cosmetic attribution bug. Emergency-access eligibility is computed
+from `lastActivityAt` -- the whole feature is "the owner has not been seen for N
+days". A delegate with routine access keeps resetting that clock, so the grant
+that is supposed to fire never does, and the safeguard fails silently in the
+direction that withholds access from the people it exists for.
+
+### INV-PROFILE-001 -- a profile response is an allowlist
+
+```text
+Statement           Every user-profile response is built by naming the fields to
+                    include, never by removing the fields to hide.
+Source of truth     the User entity
+Enforcement         None. users.controller.ts destructures away exactly four
+                    fields (passwordHash, resetToken, resetTokenExpiry,
+                    twoFactorSecret) and spreads the rest, so
+                    pendingTwoFactorSecret, oidcLinkToken, pendingOidcSubject,
+                    backupPasswordEnc and emailVerificationToken are returned.
+                    The route carries @AllowDelegate().
+Concurrency scope   per user, and per delegate
+Failure response    --
+Required tests      A test that fails when any entity column not on the allowlist
+                    appears in the response, so a new column cannot leak by
+                    default.
+Status              unenforced
+```
+
+A removal list is wrong structurally, not incidentally: the default for a new
+column is "exposed", so the defect is introduced by a change that never touches
+this file. That the route is delegate-accessible means the leak crosses users.
+
+### INV-MCP-001 -- a session is bound to its credential
+
+```text
+Statement           An MCP session is bound to the specific credential that
+                    opened it, and the presented token's current scopes are
+                    re-read on every request.
+Enforcement         None. Only the user id is compared, and scopes are captured
+                    once at session creation and never re-read.
+Concurrency scope   per session, per credential
+Failure response    403 on a mismatched credential.
+Required tests      Integration: a read-only token presenting a write-scoped
+                    session id is refused; a revoked token stops working
+                    immediately rather than at TTL.
+Status              unenforced
+```
+
+### INV-CURRENCY-001 -- shared currency deletion
+
+```text
+Statement           A shared currency row is deleted only by its creator, and only
+                    when a global reference count -- covering every foreign key in
+                    the schema -- is zero, decided under a lock in the deleting
+                    transaction.
+Source of truth     currencies, and every table referencing currency_code
+Enforcement         None sufficient. The authorization check tests
+                    createdByUserId !== null ("is it a system currency") rather
+                    than === userId, so any user who activated another user's
+                    custom currency can trigger its deletion. Both the in-use
+                    checks omit budgets.currency_code and both
+                    exchange_rates.from_currency/to_currency, all real FKs. The
+                    count runs in the caller's tenant scope with no FOR UPDATE on
+                    the currency row.
+Concurrency scope   global -- cross-tenant
+Failure response    403 for a non-creator; 409 while referenced.
+Required tests      A test deriving the reference list from schema.sql so a new
+                    FK cannot be forgotten; two-connection delete-versus-use.
+Status              unenforced
+```
+
+The tenant-scoped count is the part that gets worse rather than better under
+`RLS_MODE=enforce`: a "global" count that sees only the caller's rows reports
+zero for another user's references.
+
+## External effects
+
+### INV-ATTACHMENT-001 -- metadata resolves to committed bytes
+
+```text
+Statement           Attachment metadata that a user can see resolves to bytes
+                    that are durably present, and no bytes exist without
+                    metadata.
+Enforcement         Provider-dependent. The database provider is genuinely atomic
+                    -- its save joins the ambient transaction. Local and S3 write
+                    bytes inside the transaction callback, before the commit, so
+                    a failed commit leaves an orphan that no sweep, no
+                    compensation and no reconciliation job will ever find. The
+                    comment claims joint commit for all providers.
+Concurrency scope   per attachment
+Retry semantics     Deletes are idempotent on a missing key; creates are not.
+Crash semantics     Orphaned bytes accumulate silently.
+Status              partial
+```
+
+### INV-BACKUP-001 -- a backup is complete, verified, owner-namespaced
+
+```text
+Statement           A backup artifact is namespaced by owner, written completely,
+                    and verified before it is reported as done.
+Enforcement         Namespacing: enforced. userFolderPath uses
+                    shardedSegments(userId) for <base>/<ab>/<cd>/<userId>/,
+                    because the filenames carry only a tier and a date -- a flat
+                    folder gave every user the same name for the same day and
+                    whoever's cron ran last overwrote the rest. Folder browse and
+                    validate are admin-gated.
+                    Completeness: none. A single fs.writeFile to the final name,
+                    no temp file, no fsync, no rename, no size check, no
+                    checksum; lastBackupStatus is set to success immediately
+                    after. Retention promotes the daily to weekly and monthly
+                    with copyFileSync, so a truncated file propagates. Restore
+                    validates only the version number and exportedAt.
+Concurrency scope   per user
+Crash semantics     A kill or ENOSPC mid-write leaves a truncated file under the
+                    expected name, indistinguishable from a complete one.
+Required tests      Provider round trip: write, truncate, assert restore refuses.
+Status              partial
+```
+
+Encryption is settled and worth not re-litigating: a support backup is
+unconditionally encrypted because it exists to leave the user's machine, and an
+automatic backup whose stored password cannot be decrypted is *refused* rather
+than written in clear.
+
+### INV-CRON-001 -- one logical effect per tick
+
+```text
+Statement           A scheduled job produces one logical effect per tick,
+                    regardless of replica count.
+Enforcement         Per job, and inconsistent. Real mechanisms: the MNY reaper's
+                    conditional CAS; the price and FX refreshes' natural-key
+                    ON CONFLICT ... DO UPDATE; sweeps that are idempotent by
+                    construction because the predicate is "already expired". No
+                    mechanism: scheduled auto-posting (INV-OCCURRENCE-001);
+                    budget-period rollover, where UNIQUE(budget_id, period_start)
+                    is the only backstop and the loser's violation is swallowed
+                    by a per-budget try/catch that increments an error count;
+                    demo reset, which can interleave one run's delete with
+                    another's insert; the account-balance recompute, idempotent
+                    against itself but not against a concurrent delta.
+                    AI insight generation guards with a process-local Set, which
+                    coordinates one replica with itself and nothing across
+                    replicas.
+Concurrency scope   per job, per logical key
+Required tests      Two-instance per job. Only the MNY job has one.
+Status              partial
+```
+
+`docs/cron-jobs.md` lists schedules; per section 7 of
+`docs/concurrency-and-idempotency.md` it must also record, per job, what prevents
+two replicas from producing the same effect.
+
+## Platform
+
+### INV-RLS-001 -- enforced mode refuses a privileged role
+
+```text
+Statement           Under RLS_MODE=enforce the application refuses to serve
+                    traffic on a role that can bypass row-level security --
+                    including membership reachable via SET ROLE, not only the
+                    role's own attributes.
+Enforcement         None. No startup check exists; no pg_has_role or rolbypassrls
+                    interrogation appears anywhere in backend/src. app-role.ts
+                    provisions and grants but never asks what the connecting role
+                    actually is.
+Concurrency scope   global, at startup
+Failure response    Refuse to boot.
+Required tests      Integration against a superuser and a BYPASSRLS role, and
+                    against a role that merely inherits membership in an exempt
+                    one.
+Status              unenforced
+```
+
+This is the backstop for the entire RLS design: if enforced mode is ever switched
+on with a misconfigured role, nothing notices. It is latent rather than
+exploitable at the `RLS_MODE=off` default -- and the same condition applies to
+delegation's cross-user lookups, which run in the caller's tenant scope today and
+would silently return zero rows under enforcement.
+
+Related and also absent: `db-init` and `db-migrate` are not serialized across
+replicas by an advisory lock, so each pod decides independently from its own read
+of `schema_migrations`.
+
+### INV-CACHE-001 -- a money-moving write invalidates its caches
+
+```text
+Statement           A write that changes money invalidates every client cache
+                    family derived from transactions.
+Enforcement         None. invalidateBalanceCaches drops the 'accounts:' and
+                    'investments:' prefixes only; 'budgets:' is a live prefix and
+                    is not dropped.
+Concurrency scope   per browser tab
+Failure response    A saved transaction leaves the budget progress bar showing
+                    the pre-write figure for up to the cache TTL.
+Required tests      A classification guard requiring every cache prefix in src/
+                    to declare itself transaction-derived or reference data, so a
+                    new family cannot default to stale.
+Status              unenforced
+```
+
+### INV-RELEASE-001 -- one revision
+
+```text
+Statement           The tested commit, the published image's revision, the pushed
+                    release commit and the release tag identify one source
+                    revision, or a later full gate verifies the final revision.
+Source of truth     the git commit SHA
+Enforcement         Partial. The image half is right: prepare-release resolves
+                    the SHA once in a job that creates no commit and threads it
+                    into the build arg and the OCI revision annotation, and
+                    cosign, the SBOM attestation and the Trivy gate all target
+                    the digest. The git half is not: the release job pushes a
+                    "[skip ci]" version-bump commit to protected main with an
+                    admin PAT, nothing re-runs the gate on it, and gh release
+                    create with no --target tags the branch tip.
+Concurrency scope   global -- one release at a time, not currently enforced
+Retry semantics     A re-run after a partial release may bump the version twice;
+                    nothing detects an already-published version.
+Crash semantics     A failure between the image push and the version-bump commit
+                    leaves a published image no tag refers to.
+Failure response    Refuse to tag rather than tag an unverified revision.
+Required tests      A workflow self-test asserting the bump commit's parent is the
+                    tested SHA and its diff touches only version manifests.
+Status              partial
+```
+
+`docs/release-integrity.md` has the full rules and gap register, including the
+unconditional `--passWithNoTests` on the integration suite.
+
+## Candidates not yet admitted
+
+These were raised while assembling the catalog and are **not** entries, because
+each needs a direct reading of the source before it can be stated as an
+invariant. They are listed so the work is not lost and so nobody re-derives them
+from scratch; an unverified entry above the line would undermine every verified
+one.
+
+| Candidate | What to check |
+| --- | --- |
+| Delegation's cross-user lookups run in the caller's tenant scope | `delegation.service.ts` uses plain `withScopedDb` throughout, including `mayManageCredentials`. Inert at `RLS_MODE=off`; under `enforce` a cross-user count would see only the caller's rows. Confirm what each lookup needs before writing the rule. |
+| An export must read every table from one snapshot | Whether `backup.service.ts`'s export methods share a transaction, and whether `REPEATABLE READ` is required for a self-consistent artifact. |
+| Restore must handle self-referential FKs by insertion order | `accounts.linked_loan_account_id` and whether the strip/repair lists are hand-maintained and therefore drift-prone. |
+| `record()` must not run inside an ambient transaction | Whether a failed action-history insert can abort a caller's write, and at what log level a lost undo entry surfaces. |
+| Bootstrap must be serialized across replicas | `db-init` and `db-migrate` have no advisory lock; each pod decides from its own read of `schema_migrations`. The absence is confirmed; the required behaviour is not yet specified. |
+
+## Using this catalog
+
+**In a pull request.** Name the invariant IDs the change touches. If it moves one
+from `unenforced` to `enforced`, update the entry in the same commit and delete
+the citation of the violation -- an entry describing a violation that no longer
+exists is worse than no entry, because it will be read and believed.
+
+**In a review.** An entry marked `enforced` names its mechanism; check the change
+does not remove it. INV-AUTH-001 is the live example -- correct today, and correct
+by a lock whose purpose is not obvious from the call site.
+
+**When adding an invariant.** It belongs here if it is cross-layer. A rule that
+one service can enforce alone belongs in that service, or in a type, or in a lint
+rule -- per root `CLAUDE.md`, prefer the highest enforcement the mistake allows,
+and use prose only for the part that genuinely needs judgement. This document is
+prose, which makes it the weakest of the available options and the one most in
+need of the machine-checkable rules the entries above call for.


### PR DESCRIPTION
## Linked discussion / issue

None. This PR follows an external audit and the documentation review performed after that audit. No repository Discussion or issue was opened beforehand.

## Summary

Adds `docs/system-invariants.md` (773 lines): a catalog of 24 cross-layer invariants — conditions that must hold regardless of which controller, cron or import path is involved — each with a stable ID, a named source of truth, a named enforcement mechanism (or the honest word "none"), concurrency scope, retry and crash semantics, required test kind, and a status of `enforced`, `partial`, or `unenforced`.

Adds `docs/concurrency-and-idempotency.md` (398 lines): the decision procedure for *which* protocol a concurrent write should use (atomic delta, unique index, conditional update, upsert, pessimistic lock, advisory lock, idempotency key — in that preference order), a mechanism inventory of every lock currently taken in `backend/src`, and a gap register of writers whose protocols disagree.

Adds two ADRs:
- `0001-scoped-db-single-database-door.md` records why `withScopedDb` is the only database entry point and — the part most often misunderstood — states plainly what it does *not* give a caller (protection against a concurrent writer of the same row).
- `0002-invariant-catalog-and-enforcement-ranking.md` records the decision to catalog invariants at all and the six-level enforcement ranking (compiler type → lint rule → database constraint → source-scanning test → single-site test → prose) that the whole series follows.

**Why the repository needs this.** The audit that produced this content found the same small set of concurrency defects independently rediscovered in more than one place — an atomic balance delta and an absolute balance recompute both writing `accounts.current_balance` with no shared protocol, a holdings replay implemented two different ways in two files, a comment claiming an atomic increment where the code does a plain read-modify-write. Each of these was locally reasonable and globally wrong, and nothing in the repository stated the cross-layer rule a reviewer could have checked the change against. This PR is that missing document.

**What it defines.** The full text of `docs/system-invariants.md` and `docs/concurrency-and-idempotency.md`, as written, checked line-by-line against the current `backend/src` and `database/schema.sql` (see Documentation verification below). It does not define new behavior; it describes behavior that exists today, including where that behavior is a defect.

**What is currently enforced vs. not.** Of the 24 invariants: 2 are `enforced` (refresh-token rotation via a pessimistic lock; the one-active-MNY-import-per-user partial unique index), 4 are `partial` (a logout's truthful reporting; attachment metadata-resolves-to-bytes; backup completeness; one-cron-effect-per-tick), and the remaining 18 are `unenforced` — meaning the system can violate them today, with the specific violating code cited in the entry. This PR does not change that count. It is the measurement, not the fix.

**Why documentation alone does not close these gaps, stated plainly per this series' shared decision:** an entry marked `unenforced` — for example INV-BALANCE-001, which documents that `accounts.current_balance` has three incompatible writer protocols on one column — remains an open implementation defect after this PR merges. Fixing it is a separate, future PR that would then flip the status field and delete the citation of the violation, per the "Using this catalog" section this document itself specifies.

**Alternatives considered and rejected**, per ADR 0002: writing the same rules as unstatused prose (rejected — a document that doesn't distinguish intended from actual behavior is exactly how the false "atomically increment" and "under lock" comments this audit found came to be believed); fixing the findings without a catalog (rejected — several were independently rediscovered and fixed in parallel efforts that didn't know about each other, which the catalog's existence is meant to prevent going forward); tracking invariants in the issue tracker (rejected — an issue closes and becomes invisible; an invariant's status needs to be checkable during review years later).

## Scope

This PR contains Markdown documentation only:

- `docs/system-invariants.md` (new, 773 lines)
- `docs/concurrency-and-idempotency.md` (new, 398 lines)
- `docs/adr/0001-scoped-db-single-database-door.md` (new, 88 lines)
- `docs/adr/0002-invariant-catalog-and-enforcement-ranking.md` (new, 108 lines)

It does not change:
- application runtime behavior;
- database schema or migrations;
- API contracts;
- frontend components;
- CI workflow execution;
- any other file's content — no existing document is edited by this PR (the `CLAUDE.md`-family pointers to these new documents are PR 4).

## What reviewers should check

1. Confirm every `enforced` invariant (INV-AUTH-001, INV-IMPORT-001) names a real, currently-present mechanism — the pessimistic lock in `backend/src/auth/token.service.ts`, and the partial unique index `idx_import_jobs_one_active_per_user` added by `database/migrations/135_import_jobs_single_active.sql` and mirrored in `database/schema.sql`.
2. Confirm the `partial` and `unenforced` statuses match the current source — in particular INV-BALANCE-001's claim that three incompatible protocols write `accounts.current_balance`, and INV-HOLDING-002's claim that `holdings.service.ts` and `net-worth.service.ts` replay a stock SPLIT differently (multiplicative vs. additive).
3. Confirm the retry/crash-semantics fields for INV-IMPORT-002 accurately describe the window *after* `writeAll`'s transaction commits — this is the entry the branch's own history says was corrected once already ("Correct two invariants the review caught"), and it is the one this series' verification treated as the highest-stakes single claim in the document (see Findings below for one wording nuance worth a second look).
4. Confirm the concurrency mechanism-choice table in `docs/concurrency-and-idempotency.md` §2 and the lock inventory in §8 list only mechanisms that actually exist — five pessimistic/advisory lock sites are named by file and line; confirm no sixth exists that the document should also list, and no listed one has since been removed.
5. Confirm cross-references between `system-invariants.md`, `concurrency-and-idempotency.md`, and the two ADRs resolve to files that exist on this PR's base (they do — both ADRs are in this same PR).

## Findings from documentation verification

Verification against the current source (detailed methodology below) found the mechanism-and-status claims in both documents to be accurate, with **one factual error that recurred in two places, corrected in this PR before opening it:**

- **Cron cadence.** Both `docs/system-invariants.md` (INV-OCCURRENCE-001) and `docs/concurrency-and-idempotency.md` §8's gap register described `processAutoPostTransactions` as running "every 5 minutes." The actual `@Cron` schedule, confirmed at `backend/src/scheduled-transactions/scheduled-transactions.service.ts:152`, is `"5 * * * *"` — minute 5 of every hour, i.e. **once per hour**, not every five minutes. The underlying claim (no lock, no CAS on `next_due_date`, no unique constraint, so two replicas on one tick can double-post) was correct and unaffected; only the cadence phrase needed fixing, in both locations, and has been.

One additional item worth a second look, not a required change: the "comment above `runImport`" quoted in INV-IMPORT-002 and in `concurrency-and-idempotency.md` §4 is, more precisely, a module/class-level doc comment on `MnyImportService` immediately preceding the class declaration in `backend/src/import/mny/mny-import.service.ts`, rather than a comment attached to the `runImport` method signature itself. The comment's text and the argument built on it are both accurate; only its exact location is slightly more specific than "above `runImport`" states. Worth tightening the wording, not blocking.

## Documentation verification

This PR changes documentation only. No application smoke test is required or would verify anything about this change — clicking through the app cannot confirm whether a sentence correctly describes a lock, a transaction boundary, or an index.

Suggested reviewer checks:

1. Open both new documents and both new ADRs; confirm headings, the invariant index table, and every fenced `text`/`typescript`/`sql` block render correctly.
2. Confirm every file path and identifier named in an entry still exists at that name — a renamed service or method would silently invalidate an entry (per root `CLAUDE.md`'s existing rule that a document naming an identifier is making a claim about the source).
3. Re-check the two items under "Findings" above: confirm the cron cadence phrase now reads "5 * * * *" / hourly at minute 5 in both files, and confirm the comment-location nuance is acceptable as left (not a required change).
4. Confirm the "Field template" legend in `system-invariants.md` and the mechanism-ranking table in ADR 0002 are internally consistent with each other (both describe the same six-level ranking; they should not drift into two different orderings over time).
5. Confirm no entry states a target/intended behavior as though it is already enforced — every `unenforced`/`partial` entry should read as a description of a gap, not a description of a fix.

No user-facing or runtime behavior change is expected from this PR.
No manual application test is required.

## Verification performed

No runtime application test was executed because this PR changes documentation only. Verification consisted of:

- Reading both new documents and both new ADRs in full.
- Independently checking every mechanism claim (locks, indexes, conditional updates, comment text) against the current `backend/src` and `database/schema.sql` via targeted source reads and greps, including: `backend/src/common/db/scoped-db.ts`, `database/migrations/135_import_jobs_single_active.sql`, `backend/src/import/mny/mny-import-job.service.ts` and `mny-import.service.ts`, `backend/test/integration/mny-import-job.integration.spec.ts`, the five named lock sites in `token.service.ts`, `two-factor.service.ts`, `accounts.service.ts` (×2), and `gem-signal.service.ts`, and a repository-wide grep confirming no `@VersionColumn` exists.
- Confirming the two ADRs are listed nowhere yet (their index, `docs/adr/README.md`, is PR 4) and that neither ADR's content links to a document outside this PR.
- Confirming this PR's four files contain zero markdown hyperlinks (`[text](path)`) to any document outside this PR (all cross-references are backtick-quoted plain text).

I did not execute the backend test suite for this PR, because this PR contains no code for a test to exercise. `docs/verification-contract.md` (PR 3) is the document that states which tests each invariant *requires* going forward; this PR does not add any of those tests, and does not claim to.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — No; this follows an external audit and post-audit documentation review, not a repository Discussion.
- [x] This PR addresses a single concern. — The invariant catalog and the concurrency-protocol contract, plus the two ADRs that record why each exists.
- [x] New behavior has tests, and the existing suite passes. — Not applicable: no behavior changes. Verification performed was documentation-vs-source consistency checking, detailed above.
- [x] All user-facing strings are translated for every locale. — Not applicable: no user-facing strings changed.
- [x] No shared/core areas were refactored without prior agreement. — No code is touched.
- [x] The branch is rebased on the latest `main`. — Confirmed: 0 commits behind `main` (SHA `1135ec4a`) at last check.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Prepared with Claude Code. The documentation and this PR description were AI-assisted. I reviewed the changes and own the result. Every cited path, identifier, migration, lock site, and comment quoted in `docs/system-invariants.md` and `docs/concurrency-and-idempotency.md` was checked against the current repository tree; the one factual error found (cron cadence, described above) is disclosed and was corrected in this PR before opening it, rather than silently folded in with no record of the mistake. No runtime application verification is claimed because this PR changes documentation only.
