### PR TITLE
08: Define financial and external-side-effect contracts (v1.15.0)

### DIFF
--- a/docs/adr/0003-filesystem-objects-use-id-sharding.md
+++ b/docs/adr/0003-filesystem-objects-use-id-sharding.md
@@ -1,0 +1,132 @@
+# 0003. Filesystem objects use the shared ID-sharding scheme
+
+Status: accepted
+Date: 2026-08-04 (recorded retrospectively; the decision was made when the
+flat-folder backup collision was fixed, and is already stated as a rule in the
+root `CLAUDE.md`)
+
+## Context
+
+The server writes files in two places: attachment bytes under the local
+filesystem provider, and each user's automatic backups.
+
+Automatic backup filenames carry only a tier and a date --
+`monize-backup-daily-2026-08-03.json.gz`. In a flat shared folder that gave every
+user the same name for the same day. Whoever's cron ran last overwrote the rest,
+and one user's retention pass deleted another user's files. Both effects are
+silent: the backup reports success, and the loss is discovered only when a
+restore is attempted.
+
+A second force is filesystem behaviour rather than correctness. A single
+directory holding one entry per user, or per attachment, degrades on filesystems
+that scan linearly and worse over a network mount, so the layout has to keep any
+one directory small regardless of how many objects exist.
+
+## Decision
+
+Both writers derive their path from one helper, `shardedSegments` in
+`backend/src/common/shard-path.util.ts`, which returns two levels of two hex
+characters taken from an id, followed by the id itself:
+
+```typescript
+shardedSegments(id) // -> [ab, cd, id]
+```
+
+**What is shared is the scheme, not the shard key and not the shape.** The two
+consumers differ in both, deliberately, and conflating them has consequences:
+
+```text
+Automatic backups   -- shard key is the USER id, terminal segment is a DIRECTORY
+<base>/<ab>/<cd>/<userId>/monize-backup-daily-2026-08-03.json.gz
+
+Local attachments   -- shard key is the ATTACHMENT id, terminal segment is a FILE
+<base>/<ab>/<cd>/<attachmentId>
+```
+
+Backups shard by user because the *collision* was per-user: the filename is only
+unique within one user's set. Attachments shard by attachment id because that id
+is already globally unique, so it is the natural key and no per-user grouping is
+needed to avoid a collision.
+
+Rules:
+
+- One sharding scheme, one helper. Do not hand-roll a second.
+- Do not write a file whose name is only unique within some scope into a folder
+  shared beyond that scope. The backup case is the proof: a name that looked
+  unique per user was only unique per user *per day*.
+- A path built from an id must be validated with `isShardableId` and asserted to
+  resolve inside its base before it reaches the filesystem, **even when the id is
+  server-generated** (CWE-22).
+- State which id a new sharded path is keyed on, in the code and in any document
+  that describes it.
+
+## Consequences
+
+**Makes easy.** Directory sizes stay bounded for both writers. For backups
+specifically, retention scoping is correct by construction: a user's retention
+pass sweeps their own directory and cannot reach anyone else's, which is exactly
+the failure that motivated the change.
+
+**Makes hard.** Enumerating every object requires walking two levels.
+`enforceRetention` also still sweeps the pre-sharding flat layout, and the local
+attachment provider still falls back to a flat path on read and delete, so objects
+written before this decision keep resolving without a migration pass. Both
+compatibility paths are expected to remain indefinitely.
+
+**Forbids.** A second sharding scheme; a collision-prone flat write; and an
+unvalidated id reaching a path, including a server-generated one. The "even when
+server-generated" clause is deliberate: an id trusted because of where it came
+from stops being trustworthy the moment a caller passes something else, and the
+validation is cheap.
+
+**Does not provide: ownership from a path.** This is the distinction most likely
+to be misread, so it is stated as a rule rather than left implied:
+
+```text
+A backup's owner is recoverable from its path, because the shard key is the user
+id. An attachment's owner is NOT, because the shard key is the attachment id and
+no user id appears in the path anywhere. Attachment ownership is
+database-authoritative, through the attachment metadata row.
+```
+
+A cleanup, retention, migration or recovery tool for attachments therefore cannot
+work from the filesystem alone -- it must consult PostgreSQL to learn who owns
+what, and it must not read the terminal path segment as a directory or as a user
+id. Authorization is never derived from path structure for either writer:
+sharding is storage distribution, not tenant isolation.
+
+**Does not provide: completeness.** Sharding fixes *which* object belongs to whom.
+It says nothing about whether the bytes are whole -- a truncated write still lands
+under the expected name. See `docs/external-side-effects.md` and INV-BACKUP-001,
+where that remains open.
+
+## Alternatives considered
+
+**Shard attachments by user id too, so both layouts match.** Rejected: it would
+put ownership in the path at the cost of a rename whenever an attachment changes
+owner, and attachment ownership already has an authoritative home in the metadata
+row. Duplicating it into the path creates two sources of truth that can disagree.
+
+**Include the user id in the backup filename, keep one flat directory.** Rejected
+on the filesystem force alone: the collision is solved, but a directory with one
+entry per user per tier per retained date is exactly the shape that scans badly.
+
+**A database-backed blob for everything, no filesystem writes.** This is what the
+database attachment provider does, and it is the strongest option -- metadata and
+bytes commit in one transaction. Rejected as the *only* option because deployments
+want backups on a mounted volume and attachments in object storage, and a backup
+living solely inside the database it backs up is not a backup.
+
+**A single level of sharding.** Rejected as insufficient: one level of two hex
+characters caps at 256 directories, so directory size still grows linearly. Two
+levels give 65,536, which keeps each directory small across any plausible object
+count for this application.
+
+## Verification owed
+
+No test asserts the distinction this ADR turns on. A source or documentation
+consistency check should fail when: backup sharding stops being keyed on
+`userId`; local attachment sharding stops being keyed on the storage key; a
+document claims attachment ownership is derivable from a path; or an
+authorization decision reads path structure. Until that exists this ADR is prose,
+which ranks last per ADR 0002.

--- a/docs/external-side-effects.md
+++ b/docs/external-side-effects.md
@@ -1,0 +1,295 @@
+# External Side Effects
+
+PostgreSQL cannot roll back a file written to disk, an object put to S3, an
+email handed to an SMTP server, or a request already answered by a provider.
+`withScopedDb` makes the database half of every such workflow atomic and gives
+the other half no protection at all -- which is why an external call placed
+inside a transaction callback reads as safe and is not.
+
+This document records, for every provider-backed workflow in the codebase, what
+durable state exists on each side of the external call and what happens when the
+two disagree. Where nothing handles that case, it says so.
+
+Related: `docs/concurrency-and-idempotency.md` for the retry classification this
+builds on (before commit / after commit / commit unknown). The backup format
+and restore semantics themselves are section 3 below, not a separate document.
+
+## 1. The shape of the problem
+
+An external call inside a transaction has two orderings and both leak:
+
+```text
+write bytes, then COMMIT metadata      -- COMMIT fails => orphaned bytes
+INSERT metadata, then write bytes      -- write fails  => rollback saves you
+                                          COMMIT fails after write => orphan again
+```
+
+There is no ordering that makes a non-transactional write transactional. What
+closes the gap is one of:
+
+| Mechanism | What it gives |
+| --- | --- |
+| Natural-key upsert (`ON CONFLICT ... DO UPDATE`) | Repeating the effect converges instead of duplicating |
+| Whole effect inside one transaction | Nothing to reconcile; a failure leaves nothing |
+| Durable state before the call, verified after | An orphan is detectable and attributable |
+| Compensating action | The orphan is removed rather than merely known about |
+| Reconciliation sweep | An orphan nobody noticed is eventually found |
+
+```text
+EXT-001
+An external write must be preceded by durable state that identifies it, or be
+idempotent on a natural key, or be provably reconstructible. "The transaction
+will roll back" is not one of those three.
+
+EXT-002
+"Complete" may be reported only after the external effect has been verified, not
+after the call returned. A write that did not throw is not a write that landed.
+
+EXT-003
+An operation whose external effect cannot be verified must leave its durable
+state in a form that says so, and a later pass must be able to find it. An
+unverifiable effect recorded as success is indistinguishable from a real one.
+
+EXT-004
+A comment asserting that bytes and metadata commit together must name the
+provider it is true for. The claim is true of the database provider and false of
+the other two.
+```
+
+## 2. Attachments
+
+Three providers behind one interface (`save`/`load`/`delete`), selected by
+deployment.
+
+**Database provider.** `save` opens `withScopedDb`, which joins the ambient
+transaction, so bytes and metadata are one PostgreSQL transaction. Genuinely
+atomic, genuinely rollback-safe. The FK cascade removes the blob when the
+metadata row goes.
+
+**Local filesystem and S3.** `save` is an `fs.writeFile` or a `PutObjectCommand`
+executed *inside* the transaction callback, before the commit:
+
+```typescript
+const saved = await repo.save(attachment);   // metadata INSERT, uncommitted
+await this.storage.save(id, file.buffer);    // bytes, durable immediately
+// ...callback returns, then COMMIT
+```
+
+If the byte write throws, the callback throws and the metadata rolls back --
+that direction is safe. If the **commit** then fails (connection loss, process
+kill, DB-side failure), the bytes are already durable and the metadata row is
+gone. That is an orphan, and **no code path ever removes it**: there is no
+reconciliation sweep, no orphan detection, and no cron that compares provider
+contents against `transaction_attachments`.
+
+The comment beside this code says the nested call "joins this transaction, so
+the bytes and the metadata row commit together (or roll back together on
+failure)". That is EXT-004's case: true for the database provider, false for the
+two providers where it matters.
+
+**Deletion** removes the metadata row first, then the bytes, both inside the
+callback. A failing byte delete rolls the metadata delete back, so the row and
+the bytes both survive together -- the better of the two orderings for that
+failure. Both `delete` implementations are explicitly idempotent on a missing
+key, so a retried delete is safe.
+
+It is not fully consistent, though, and the remaining window is the mirror image
+of the create case: if the byte delete succeeds and the **commit** then fails,
+the metadata delete rolls back while the bytes are already gone -- leaving a row
+that resolves to nothing. So both directions of the attachment lifecycle have a
+commit-failure window; create leaks bytes without a row, delete leaks a row
+without bytes. The second is the more visible failure, because a user sees the
+attachment and cannot open it, and INV-ATTACHMENT-001's "no metadata without
+bytes" half is what it breaches.
+
+## 3. Backups
+
+`AutoBackupService` builds the whole payload in memory and writes it in one call
+straight to the final filename:
+
+```typescript
+await fs.writeFile(filepath, payload);
+```
+
+There is no temp file, no `fsync`, no rename, no read-back, and no checksum
+computed or stored anywhere. `lastBackupStatus` is set to `"success"`
+immediately afterwards, with nothing between the write and that claim.
+
+Three consequences follow, and they are separate problems:
+
+- A process killed mid-write, or an `ENOSPC`, leaves a **truncated file under the
+  final, expected name**. Nothing distinguishes it from a complete one, because
+  nothing recorded what complete looks like. This breaches EXT-002.
+- Retention promotes the daily file to weekly and monthly with `copyFileSync`,
+  so a truncated daily becomes a truncated weekly and monthly.
+- Restore cannot detect it either: `validateBackupFormat` checks only that
+  `data` is an object, that `version` equals the hardcoded `BACKUP_VERSION`, and
+  that `exportedAt` is present. There is no content hash to compare against,
+  because none was ever written.
+
+The atomic-write fix is small and standard -- write to a temp name, verify the
+byte count, `fsync`, `rename` -- and `rename` within a filesystem is atomic, so
+a crash leaves either the old file or the new one.
+
+**Per-user namespacing is already correct on `main`,** and worth recording as
+settled: `userFolderPath` uses `shardedSegments(userId)` to build
+`<base>/<ab>/<cd>/<userId>/`, because automatic backup filenames carry only a
+tier and a date. A flat folder gave every user the same name for the same day,
+so whoever's cron ran last overwrote the rest and one user's retention pass
+deleted another's files. `enforceRetention` still sweeps the old flat layout for
+files written before the fix. The folder browse and validate endpoints are
+admin-gated at the controller.
+
+**Encryption.** A support backup is unconditionally encrypted -- the DTO's
+`password` is required, and there is no code path returning an unencrypted
+support buffer, because a support backup exists in order to leave the user's
+machine. An automatic backup is encrypted when a usable password exists; when a
+stored password cannot be decrypted (a rotated key) the backup is **refused**
+rather than silently written in clear. Refusing is the right failure: it is
+visible, and it does not downgrade.
+
+**The writability probe** names its file with `Date.now()`, so two users or two
+replicas probing the same folder in the same millisecond collide, and the
+`unlink` sits inside the `try` that decides the verdict -- so "I could write but
+could not clean up" is reported as "not writable". The probe's answer is whether
+the write succeeded; a failed cleanup is a log line.
+
+**Restore** is the strongest workflow here. The whole thing -- delete existing
+data, insert backup data, fix deferred FKs -- runs inside
+`withPreserveTimestamps(() => withScopedDb(...))`, one transaction, because "a
+half-applied restore would leave the account in a state that is neither the
+backup nor what was there before". Every row's `user_id` is forced to the
+restoring user, every backup id is remapped to a fresh UUID so a backup restored
+into a different account cannot collide with that account's rows, and every table
+and column is checked against an allowlist. What it lacks is integrity
+verification of the payload, per EXT-002 above.
+
+## 4. Email
+
+`EmailService` is a thin `nodemailer` wrapper. It writes nothing to the
+database. There is no outbox, no queue table, no "sent" ledger anywhere.
+
+Every caller is a cron, and each has a different amount of protection:
+
+| Sender | Duplicate protection |
+| --- | --- |
+| `BillReminderService` | None. It recomputes the window from `nextDueDate`/`reminderDaysBefore` daily; there is no "already reminded for this due date" flag. Sending every day the bill is inside the window is intentional, but a crash-restart or a second replica sends the same reminder twice with nothing able to notice. |
+| `MortgageReminderService` | None -- same shape, no dedup state at all. |
+| `BudgetAlertService` | Partial. It creates the `BudgetAlert` row before sending and dedups candidates against existing rows by `(budgetId, alertType, budgetCategoryId, periodStart)`, so a sequential re-run does not re-notify. But the dedup read and the insert are not one atomic unit and no unique constraint backs them, so two replicas can both pass the check and both insert and send. `isEmailSent` is set after the send, so a crash in between leaves it `false` forever without causing a duplicate. |
+| Emergency-access grant | The one deliberate design. See section 5. |
+
+`BudgetAlertService` is a useful illustration of EXT-001: it accidentally has
+most of what the rule asks for -- durable state written before the effect -- and
+still fails, because the state is not *claimed* atomically. Durable-before-effect
+and atomically-claimed are two requirements, not one.
+
+## 5. Emergency access
+
+The grant path is the only place in the codebase that gets the external-effect
+ordering right on purpose. Per contact, it mints and saves a claim token, then
+emails the contact; and it sets `settings.grantedAt` **only if at least one
+contact email actually delivered**:
+
+> Only commit the grant if at least one contact actually received a link.
+> Otherwise leave `grantedAt` null so the next run retries -- a transient SMTP
+> failure must not permanently disable the safeguard.
+
+That is a compensating decision expressed as a state transition: the durable
+"the grant happened" marker is withheld until an external effect is confirmed,
+and withholding it *is* the retry. Copy this shape.
+
+The reminder path is weaker: `lastReminderSentAt` is written after the send, and
+the once-per-day gate reads it, so a crash between send and save re-permits a
+send later the same day. Combined with every replica firing every cron, a
+duplicate reminder is reachable.
+
+Claim consumption itself sends no email, so there is no external-effect question
+there -- but the consumption is a check-then-act with no lock and no conditional
+`WHERE`, which `docs/concurrency-and-idempotency.md` covers.
+
+## 6. Providers: AI, prices, FX
+
+**Price and FX are the good case, and the reason is the mechanism.** Both the
+single-rate and bulk paths write through natural-key upserts --
+`ON CONFLICT (from_currency, to_currency, rate_date) DO UPDATE` and
+`ON CONFLICT (security_id, price_date) DO UPDATE` -- so a repeated or concurrent
+refresh converges rather than duplicating. This is EXT-001's second clause
+satisfied exactly, and it is the cheapest form of idempotency available: the
+uniqueness is a property of the data, so no key has to be invented or
+remembered.
+
+Failures propagate as `null`, deliberately. `getRateForDate`'s own comment says
+it "returns null when no rate can be determined (so the caller can reject or flag
+the operation rather than silently assuming 1.0)". The provider layer is
+therefore *not* where the missing-rate defects in
+`docs/financial-semantics.md` section 9 come from -- it reports honestly and
+callers discard the honesty.
+
+**AI insights are the weak case.** The reentrancy guard is a `Set<userId>` in
+process memory, which coordinates one replica with itself and nothing across
+replicas. The 12-hour cooldown is a plain read of the most recent
+`generatedAt` -- a check-then-act. Rows are inserted with no idempotency key, so
+a manual regenerate racing the daily cron, or two replicas both past the cooldown
+read, produces duplicate insight rows. Ordering is at least correct on failure:
+the provider is called and the response parsed before anything is saved, so a
+failed call leaves no partial rows, and a total provider failure throws rather
+than fabricating a result.
+
+## 7. There is no shared lifecycle, and one workflow shows what it would look like
+
+No generic `pending -> externally_created -> verified -> available` state machine
+exists. Attachments have no state column; backups have a post-hoc
+success/failed string; emergency access has an ad hoc set of timestamp columns;
+AI insights and reminder emails have no state beyond a time-window read.
+
+The nearest thing to a lifecycle belongs to the `.mny` import job. It wraps a
+local parse rather than a provider call, and it is incomplete in one instructive
+way noted below -- but its four ingredients are the template:
+
+- `import_jobs.status` moves `pending -> running -> completed | failed`, with a
+  **partial unique index** on `(user_id) WHERE status IN ('pending','running')`
+  making double-start a database error rather than an application check.
+- The worker claims the job with `UPDATE ... WHERE status = 'pending' RETURNING id`,
+  so exactly one of two workers proceeds.
+- The worker heartbeats, and a reaper cron fails jobs whose heartbeat went
+  stale -- real crash recovery, not a hope that workers do not die.
+- The staged-file sweep is documented as "idempotent by construction -- the
+  predicate is 'already expired'", which is the correct way to justify an
+  unclaimed cron.
+
+None of that machinery is reused for attachments, backups, emails or insights.
+Adopting it does not require building the generic abstraction first: the four
+ingredients (a state column, a uniqueness constraint, a conditional claim, a
+reaper) are independently useful.
+
+**Where it stops short, and why that is the most useful part of the example.**
+The status column has no state between "running" and "completed" -- nothing
+records that the business data has committed. So the reaper, which correctly
+handles a worker that died *before* writing, marks a worker that died *after*
+writing as retryable too, and a retry replays committed rows (INV-IMPORT-002).
+That is precisely the gap EXT-003 describes: an effect that has happened but
+cannot be verified from durable state. A lifecycle needs a state for
+"externally done, not yet finalized", and this one has three states where it
+needs four. Any workflow copying the template should copy it with that state
+added rather than as it stands.
+
+## 8. Gap register
+
+| Workflow | Missing | Rule |
+| --- | --- | --- |
+| Attachment create, local and S3 | Bytes durable before commit; no orphan detection, no reconciliation sweep, no compensation | EXT-001, EXT-003 |
+| Attachment delete, local and S3 | Bytes deleted before commit; a failed commit leaves a metadata row resolving to nothing | EXT-001 |
+| Attachment provider comment | Claims joint commit for all providers; true only of the database provider | EXT-004 |
+| Automatic backup write | Direct write to the final name -- no temp file, fsync, rename, size check or checksum; a truncated file is indistinguishable from a complete one and is promoted to weekly and monthly by `copyFileSync` | EXT-002 |
+| Backup restore validation | Version and `exportedAt` only; no payload integrity check, because nothing was recorded at write time | EXT-002 |
+| Backup folder probe | `Date.now()` in the probe filename; unlink failure reported as "not writable" | EXT-003 |
+| Bill and mortgage reminders | No dedup state of any kind; duplicate sends unbounded across replicas and restarts | EXT-001 |
+| Budget alerts | Durable state written before the send, but the dedup read and insert are not atomic and no unique constraint backs them | EXT-001 |
+| Emergency-access reminder | `lastReminderSentAt` written after the send, and it is the gate | EXT-001 |
+| AI insight generation | Process-local `Set` as the reentrancy guard; cooldown is a check-then-act; inserts carry no idempotency key | EXT-001 |
+
+Two rows are absent from this table on purpose, and both are settled: per-user
+backup sharding with admin-gated folder endpoints, and the FX/price natural-key
+upserts. Section 5's grant-commit-after-delivery belongs in the same category.
+Those three are the patterns the rest of this table should be closed by
+imitating.

--- a/docs/financial-semantics.md
+++ b/docs/financial-semantics.md
@@ -1,0 +1,306 @@
+# Financial Semantics
+
+What the numbers mean: signs, legs, rate direction, precision, and the exact
+arithmetic each derived figure is defined by. This is the narrow reference that
+`docs/financial-calculation-contract.md` and `docs/time-series-contract.md`
+assume. Those two own missing-data propagation, the cost-basis/tax truth table,
+materialized-result versioning, adjusted-versus-raw prices and period
+boundaries; none of that is repeated here. Root `CLAUDE.md` states the
+`decimal(20,4)` and `roundFxRate` rules at a glance -- this document gives the
+full field table and the call sites.
+
+It exists because a semantic that lives in three places drifts in two of them.
+Every gap in section 9 is a place where two code paths currently answer the same
+question differently, and each was found by reading the paths side by side
+rather than by either one failing a test.
+
+## 1. Signs
+
+`transactions.amount` is a single signed `decimal(20,4)`. There is no debit/credit
+column and no type flag:
+
+```text
+positive  = money entering the account (income)
+negative  = money leaving the account (expense)
+```
+
+The sign is supplied by the caller and validated only for range and precision.
+No server rule requires an income category to carry a positive amount, so the
+category and the sign can disagree; code that needs to know direction must read
+the sign, not the category.
+
+For transfers the sign is structural rather than caller-supplied. The DTO's
+`amount` must be non-negative, and `createTransfer` writes the source leg as
+`-amount` and the destination leg as `+toAmount`. Consequently **the sign is
+what identifies a leg**, and the transfer service re-derives it repeatedly:
+
+```typescript
+const isFromTransaction = Number(transaction.amount) < 0;
+```
+
+There is no stored "this is the source leg" flag. A change that could make a
+source leg non-negative breaks leg identification everywhere at once.
+
+For a foreign-currency entry, `normalizeFxEntry` requires `originalAmount` and
+`amount` to share a sign (either may be exactly zero).
+
+## 2. Transfers
+
+A transfer is **two linked `transactions` rows**, each pointing at the other via
+`linkedTransactionId` -- not one row with two accounts. A transfer that is one
+leg of a split is different again: it links through
+`transaction_splits.linkedTransactionId`, and the counterpart's
+`linkedTransactionId` points at the split *parent*, not at a mirror leg. That is
+why the split-transfer paths are separate code from the plain pair throughout
+`transaction-transfer.service.ts`, and why a fix to one has repeatedly missed
+the other.
+
+`toAmount` is:
+
+```text
+toAmount = explicit toAmount, if supplied
+         = roundMoney(amount * exchangeRate), otherwise
+```
+
+An explicitly supplied `toAmount` wins outright. **Nothing cross-checks it
+against `amount * exchangeRate`**, at any tolerance -- a client may state a
+destination amount arbitrarily far from the rate-implied one and it is stored as
+given. If a tolerance is wanted, it does not exist yet; do not write code that
+assumes one.
+
+### Status must move on both legs or neither
+
+A transfer's two legs are one economic fact. Setting one leg to `VOID` while the
+other stays active makes money exist in one account and not the other: a 100.00
+transfer whose source leg alone is voided restores the source balance and leaves
+the destination credited, so 1,000.00 held across two accounts reads as 1,100.00.
+
+```text
+FIN-001
+Any write that changes a transfer leg's `status`, or that moves a balance on the
+strength of a status, must apply to both legs in the same transaction, or to
+neither.
+```
+
+## 3. Exchange rates
+
+**Direction.** `exchangeRate` is *account-currency units per one unit of
+`originalCurrencyCode`* -- the account currency is the quote, the foreign
+currency is the base:
+
+```text
+amount ~= roundMoney(originalAmount * exchangeRate)
+
+Source: 100.00 USD in a CAD account
+Rate:   1.3500 CAD per USD
+Stored: originalAmount 100.00, originalCurrencyCode USD, exchangeRate 1.3500,
+        amount 135.00
+```
+
+**Precision.** A rate is not money. `roundFxRate` rounds to
+`FX_RATE_DECIMALS = 10`, matching the `NUMERIC(20,10)` columns; display uses
+`FX_RATE_DISPLAY_DECIMALS = 6`. `roundMoney(1 / 1.3652)` gives `0.7325`, which
+inverts back to `1.3661` -- four decimal places on a rate is a reconciliation
+error, not a rounding preference.
+
+**Conversion.** `applyFxConversion` folds the account's `fxFeePercent` in as a
+cost, always reducing the magnitude:
+
+```typescript
+const base = roundMoney(originalAmount * rate);
+const fee = fxFeePercent && fxFeePercent > 0
+  ? -roundMoney((Math.abs(base) * fxFeePercent) / 100)
+  : 0;
+return { base, fee, amount: roundMoney(base + fee) };
+```
+
+No separate fee row is written; the Foreign Currency Fees report derives the fee
+back out of `(originalAmount, exchangeRate, amount)`. That derivation is the
+reason all three must stay mutually consistent on every write.
+
+**Validation.** `normalizeFxEntry(input, accountCurrencyCode)` is shared by
+transactions and scheduled transactions so both accept and reject exactly the
+same shapes:
+
+| Input | Result |
+| --- | --- |
+| Neither `originalAmount` nor `originalCurrencyCode` | Both `null` -- an ordinary entry |
+| Exactly one of the pair | Rejected, `fxFieldsIncomplete` |
+| `originalCurrencyCode` equals the account currency | Stripped to both `null`, tolerated |
+| A foreign pair with no `exchangeRate`, or one `<= 0` | Rejected, `fxRateRequired` |
+| `originalAmount` and `amount` with opposite signs | Rejected, `fxSignMismatch` |
+
+### A missing rate is not a rate of 1
+
+```text
+FIN-002
+An unavailable exchange rate makes the converted value unknown. It must
+propagate as unknown. It may never be replaced by 1, and an unconvertible amount
+may never be returned under the target currency's label.
+```
+
+The two forms this violation takes, both present today, are worth naming
+because neither looks wrong locally:
+
+```typescript
+rate = reverseRate !== null ? 1 / reverseRate : 1;   // an else-branch of 1
+return result ?? amount;                             // the unconverted amount, relabelled
+```
+
+The first reports a USD position in CAD at par. The second returns the USD
+figure under a CAD heading, which is worse than an error because it is
+plausible. `docs/financial-calculation-contract.md` section 1 governs what to
+return instead.
+
+## 4. Precision by field
+
+Money is `decimal(20,4)`. Everything below is a deliberate exception; a value
+whose column is wider must not be rounded to money precision on the way in.
+
+| Field | Precision | Note |
+| --- | --- | --- |
+| `transactions.amount`, `transaction_splits.amount`, `accounts.opening_balance`, `accounts.current_balance`, budget amounts, `investment_transactions.total_amount`, `investment_transactions.commission` | `NUMERIC(20,4)` | money |
+| `exchange_rates.rate` and every `exchange_rate` column that mirrors it | `NUMERIC(20,10)` | round with `roundFxRate`, display at 6dp |
+| `investment_transactions.quantity`, `holdings.quantity`, `scheduled_transactions.investment_quantity` | `NUMERIC(20,8)` | share counts -- and the SPLIT ratio, see section 6 |
+| `investment_transactions.price`, `holdings.average_cost`, `security_prices.{open,high,low,close,adjusted_close}_price`, `scheduled_transactions.investment_price` | `NUMERIC(24,10)` | per-share prices are wider than money |
+| `accounts.interest_rate`, `accounts.fx_fee_percent` | `NUMERIC(8,4)` | percentages |
+| Monte Carlo rate inputs | `NUMERIC(8,6)` | |
+
+The MS Money importer narrows investment values to 6dp price / 8dp quantity
+before writing. That is an importer choice about source fidelity, not the
+storage precision, and it is the one place the two legitimately differ.
+
+## 5. Splits
+
+`validateSplitAmountSum` requires at least two splits (unless a single
+transfer/investment pass-through) and that the children sum exactly to the
+parent at full money precision:
+
+```typescript
+const roundedSum = sumMoney(splits.map((s) => Number(s.amount)));
+const roundedAmount = roundMoney(Number(transactionAmount));
+if (roundedSum !== roundedAmount) throw new BadRequestException(...);
+```
+
+`sumMoney` accumulates in integer ten-thousandths rather than adding floats, so
+the canonical case sums exactly:
+
+```text
+-3.3333 - 3.3333 - 3.3334 = -10.0000
+```
+
+Note what makes this work: the comparison happens at 4dp, the storage
+precision. Rounding to cents before comparing -- which a currency input is
+tempted to do -- makes three amounts that do not sum appear to.
+
+## 6. Investments
+
+### Cost basis includes acquisition commission
+
+```text
+Buy: 10 shares at 20.00, commission 5.00
+Total basis:     205.00
+Basis per share:  20.50
+```
+
+`total_amount` is `quantity * price + commission` for a BUY and
+`quantity * price - commission` for a SELL, so a sell's commission reduces
+proceeds. Cash impact mirrors this exactly: `-(qp + c)` on a buy, `qp - c` on a
+sell.
+
+A zero or absent price must not be treated as a free acquisition;
+`portfolio-calculation.service.ts` guards this explicitly, and
+`docs/financial-calculation-contract.md` section 2 has the truth table.
+
+### Average cost, not FIFO
+
+A SELL draws basis down proportionally at the running average cost per share:
+
+```typescript
+const sellQty = Math.min(quantity, entry.quantity);
+const avgCostPerShare = entry.quantity > 0 ? entry.costBasis / entry.quantity : 0;
+const costBasisSold = sellQty * avgCostPerShare;
+const realizedGain = proceeds - costBasisSold;
+```
+
+### A SPLIT multiplies
+
+```text
+FIN-003
+A SPLIT scales the running share count by its ratio and scales per-share cost by
+its reciprocal, preserving total basis. It never adds the ratio to the share
+count, and it is never grouped with BUY, REINVEST or TRANSFER_IN.
+
+Starting quantity: 90 shares
+Split ratio:       2.0
+Correct result:    180 shares
+Additive result:    92 shares   (a difference of -88 shares)
+```
+
+The ratio is stored in the `quantity` column of the `SPLIT` investment
+transaction, validated only as `> 0`. A reverse split is the same operation with
+a ratio below one -- `reverseSplit(ratio)` is literally
+`applySplit(1 / ratio)`, and a 1-for-2 reverse split is `ratio = 0.5`, halving
+shares and doubling per-share cost. There is no separate reverse-split action,
+so any code that special-cases "ratio greater than one" is wrong for half the
+inputs.
+
+`holdings.service.ts` implements this correctly (`qty *= txQty`). Section 9
+records where it is implemented additively instead.
+
+## 7. Scheduled occurrences
+
+An occurrence may carry an override. `scheduled_transaction_overrides` is unique
+on `(scheduled_transaction_id, override_date)`, so one occurrence has at most one
+override.
+
+```text
+FIN-004
+A stored override price is a decision the user made about that occurrence.
+Reopening the editor must not replace it with the current market price. Applying
+a fresh quote is an explicit action, never a side effect of opening a dialog.
+```
+
+Ten shares stored at 100.00 that come back as ten at 120.00 -- with the total
+silently recomputed -- is a money field changed by nobody, and the user has no
+way to tell it happened.
+
+## 8. Import and restore: zero, null, absent
+
+The MS Money importer is deliberately not uniform, and the distinction is worth
+preserving rather than tidying:
+
+- **Investment `price` and `quantity` propagate `null`.** `positiveOrNull`
+  returns `null` for an absent or non-positive value, and the writer stores it
+  as `null`. This is what keeps the zero-price-acquisition guard able to see
+  "unknown" rather than "free".
+- **Cash amounts default to `0`.** `toAmount` returns `0` for a missing or
+  non-finite value, and `total_amount` is `NOT NULL` with no null path. This is
+  defensible because Money's own missing-column semantics already collapse to
+  zero for a cash figure -- an absent `amt` genuinely means zero, not unknown.
+
+The rule that follows is about which of the two a new field is:
+`docs/financial-calculation-contract.md`'s note that `null` means "not known"
+and a settled zero must not be reported as unknown applies in both directions
+here. Decide which the source column actually means before choosing a default.
+
+## 9. Gap register
+
+Places where two paths currently answer the same question differently. Each was
+confirmed by reading `main`; each is a divergence, not a style difference.
+
+| Question | Divergence |
+| --- | --- |
+| What does a SPLIT do to a share count? | `holdings.service.ts` multiplies (`qty *= txQty`, and `next = current * quantity`). `net-worth.service.ts` **adds**, at all three of its reducers -- and at one of them SPLIT is grouped with `BUY`/`REINVEST`/`TRANSFER_IN`. The holdings page and every historical net-worth chart therefore disagree about the same position after any split. `net-worth.service.ts` also handles no `ADD_SHARES`/`REMOVE_SHARES` at all, so those move the share count in one view and not the other. Breaches FIN-003. |
+| What is an unavailable rate worth? | `portfolio-calculation.service.ts` falls back to `rate = 1`; `net-worth.service.ts` returns `result ?? amount`, relabelling an unconverted amount as the target currency. Breaches FIN-002. |
+| Is acquisition commission in the cost basis? | `calculateCostBasisLotsInAccountCurrency` includes it (`quantity * price + commission`); `calculateRealizedGains` does not (`quantity * price`), while still taking proceeds net of the sell commission -- so realized gain is overstated by the buy-side commission relative to every other basis figure in the app. The code comments this discrepancy itself and declines to resolve it, correctly noting that reconciling the two changes every realized-gain figure in the application and so is its own change. Recorded here so the two are not mistaken for one rule. |
+| Does a status change reach both transfer legs? | `PATCH /:id/transfer` mirrors `status` to both legs. `PATCH /transactions/:id/status` (and `markCleared`/`reconcile`/`unreconcile`) touch only the row given -- the reconciliation service references neither `isTransfer` nor `linkedTransactionId`. Bulk update mirrors `payeeId`/`payeeName`/`description` to the linked leg but not `status`. Breaches FIN-001. |
+| Does a cross-currency transfer need a real rate? | `exchangeRate` defaults to `1` with no server-side resolution or rejection, and balances are updated regardless of `status`, so a transfer created as `VOID` still moves both balances. Breaches FIN-001 and FIN-002. |
+| Is a stored override price safe? | `OverrideEditorDialog` seeds from the stored value correctly, then an unconditional effect overwrites `investmentPrice` whenever the fetched market price differs from the last seen one, recomputing the total from it. Breaches FIN-004. |
+
+A note on how these are meant to be closed. FIN-002 and FIN-003 are each
+scattered across several call sites, and every previous attempt fixed one site
+and left the others live. The durable form of these two rules is a scanning
+test, per root `CLAUDE.md`: one that fails on any `: 1` else-branch beside a rate
+lookup, any `?? amount` beside a conversion, and any `SPLIT` case outside the
+single shared reducer. Prose has already been insufficient here more than once.


### PR DESCRIPTION
## Linked discussion / issue

None. This PR follows an external audit and the documentation review performed after that audit. No repository Discussion or issue was opened beforehand.

## Summary

Adds `docs/financial-semantics.md` (306 lines): the exact meaning of every financial field — the sign convention on `transactions.amount`, how a transfer's two legs are identified (by sign, with no stored flag), FX rate direction and precision (`NUMERIC(20,10)`, never money precision), the split-sum validation rule, and the multiplicative arithmetic a stock SPLIT must use.

Adds `docs/external-side-effects.md` (296 lines): for every workflow that writes somewhere PostgreSQL cannot roll back — attachments (local disk, S3, and the genuinely-atomic database provider), automatic backups, email, and price/FX/AI providers — what durable state exists on each side of the external call and what happens when a commit and a write disagree.

Adds ADR `0003-filesystem-objects-use-id-sharding.md`, recording that backups shard by *user* id (terminal segment a directory) while local attachments shard by *attachment* id (terminal segment a file), and the consequence that a backup's owner is recoverable from its path while an attachment's owner is not and must never be inferred from one.

Rewrites `docs/cron-jobs.md`'s job table into a full inventory of every `@Cron` in `backend/src` with a new "coordination across replicas" column, because the previous table gave only schedules with no answer to "what happens if two replicas fire this at once."

**Why the repository needs this.** Two of this PR's own entries are exactly the kind of one-call-site fix followed by a live sibling that the whole series exists to prevent: `holdings.service.ts` replays a stock SPLIT multiplicatively (correct) while `net-worth.service.ts` replays it additively at all three of its own internal reducers (wrong, and inconsistent with itself); `portfolio-calculation.service.ts` falls back to `rate = 1` when no exchange rate is available while `net-worth.service.ts` falls back to `result ?? amount`, silently relabelling an unconverted figure under the target currency. Neither pair was found by a failing test — both were found by reading the two files side by side, which is what a shared reference document is meant to make unnecessary going forward.

**What it defines.** Signed-amount and transfer-leg conventions (FIN-001), the rule that an unavailable exchange rate must propagate as unknown and never as 1:1 (FIN-002), the multiplicative SPLIT rule (FIN-003), and the rule that a stored scheduled-occurrence override price must survive reopening the editor (FIN-004) — plus the external-effect rules (EXT-001 through EXT-004) governing durable state, verified-before-reported completion, and honest comments about which provider a "commits together" claim actually applies to.

**What is currently enforced vs. not.** `docs/financial-semantics.md` §9's gap register lists six places where two code paths answer the same financial question differently, all currently live on `main` — SPLIT replay, unavailable-rate handling, whether acquisition commission is in cost basis (the code's own comment acknowledges this one and declines to resolve it), transfer-leg status mirroring, whether a VOID transfer still moves both balances, and the override-price overwrite. `docs/external-side-effects.md` §8's gap register lists ten workflows with a missing durable-state, orphan-detection, or atomic-claim mechanism, headed by both directions of the attachment lifecycle (create can leak bytes with no metadata row; delete can leak a metadata row with no bytes) and by the automatic-backup write path (a single `fs.writeFile` to the final name, no temp file, no fsync, no checksum, so a truncated file is indistinguishable from a complete one). None of these are new defects; this PR's contribution is stating each precisely enough to be checked and fixed, not fixing any of them.

**Why documentation alone does not close these gaps.** Every gap-register entry named above remains exactly as live in the running application after this PR merges as before it. This PR documents the invariant and its current enforcement status; it does not implement the missing multiplicative reducer, the missing atomic-claim for the exchange-rate fallback, or the missing checksum for backups.

**Alternatives considered and rejected**, per ADR 0003: sharding attachments by user id too, so both layouts match (rejected — it would put ownership in the path at the cost of a rename on every ownership change, duplicating the metadata row's authority); including the user id in the backup filename inside one flat directory (rejected — solves the naming collision but reintroduces a directory that scans badly at scale); a single level of hex sharding (rejected as insufficient — 256 directories still grows linearly; two levels give 65,536).

## Scope

This PR contains Markdown documentation only:

- `docs/financial-semantics.md` (new, 306 lines)
- `docs/external-side-effects.md` (new, 296 lines)
- `docs/adr/0003-filesystem-objects-use-id-sharding.md` (new, 132 lines)
- `docs/cron-jobs.md` (modified, +45/-20 — the job table is rewritten with a new coordination column; no other section changes)

It does not change:
- application runtime behavior — none of the financial-calculation, attachment, or backup code paths this PR describes are touched;
- database schema or migrations;
- API contracts;
- frontend components;
- CI workflow execution.

## What reviewers should check

1. Compare the sign, FX-direction, precision, split-sum, and commission rules in `docs/financial-semantics.md` against the current `transaction-transfer.service.ts`, `fx-entry.util.ts`, `split-amount.util.ts`, `investment-transactions.service.ts`, and `portfolio-calculation.service.ts` — every arithmetic example in the document (e.g. the 90→180-share SPLIT, the `1.3652`→`0.7325`→`1.3661` FX-rounding round-trip) should reproduce from the cited functions.
2. Confirm an unavailable FX rate or price is described as *unknown*, never as a valid-looking `1` or `1:1` value, anywhere in the document — including in the gap register, where the two current violating call sites (`portfolio-calculation.service.ts`, `net-worth.service.ts`) are named as violations, not as the intended behavior.
3. Confirm local filesystem and S3 attachment storage are described as **not** transactionally coupled to PostgreSQL, and that the database attachment provider is correctly identified as the one genuine exception (its `save` joins the ambient transaction).
4. Confirm the backup and attachment path examples use the shard keys ADR 0003 states — `userId` for backups (directory), the attachment's own id for attachments (file) — and that no sentence anywhere claims an attachment's owner can be read off its path.
5. Confirm every `@Cron` decorator currently in `backend/src` appears in `docs/cron-jobs.md`'s inventory table, and that the table contains no job that no longer exists in the source.

## Findings from documentation verification

One broken cross-reference, found by resolving every `docs/*.md` path mentioned across this PR's files and fixed in this PR before opening it: `docs/external-side-effects.md`'s "Related" line near the top cited `docs/backup-restore-contract.md` for "the backup format and restore semantics themselves." **No file of that name exists anywhere in the repository** (confirmed by search; the closest existing file, `docs/support-backup.md`, covers a narrower topic — the support-backup feature specifically, not general backup/restore semantics — and is not an obvious substitute). The reference now points at this same document's own section 3, which is where that content actually lives.

No other broken cross-references or factual discrepancies were found in this PR's four files — see Verification performed below for what was checked and confirmed, including every arithmetic example, every named lock/upsert/write-sequence claim, and the complete `@Cron` inventory (23 decorators found in `backend/src`; all 23 present in the new table; the table introduces none that don't exist and omits none that do).

## Documentation verification

This PR changes documentation only. No application smoke test is required — a tester adding a transaction or an attachment through the UI cannot confirm whether this document correctly describes the commit ordering underneath it.

Suggested reviewer checks:

1. Open all four changed/added files and confirm headings, tables, and fenced code blocks render correctly, including the two multi-line arithmetic examples in `financial-semantics.md` (cost-basis and SPLIT) and the ordering diagrams in `external-side-effects.md` §1.
2. Confirm the fixed reference under Findings above now points at section 3 of the same document rather than a nonexistent file, and re-check that no other `docs/*.md` path mentioned in these four files is missing (all others — `docs/financial-calculation-contract.md`, `docs/time-series-contract.md`, `docs/concurrency-and-idempotency.md`, `docs/system-invariants.md` — were confirmed present).
3. Search the repository for the implementation identifiers this PR names — `roundFxRate`, `applyFxConversion`, `normalizeFxEntry`, `validateSplitAmountSum`, `sumMoney`, `shardedSegments`, `isShardableId` — and confirm each still exists at the cited location.
4. Confirm the gap-register entries in both documents describe current, not intended, behavior — none should read as a claim that the discrepancy is already fixed.
5. Confirm `docs/cron-jobs.md`'s rewritten table still opens with the "every replica fires every cron" statement the previous version had, and that the new coordination column is filled in for every row (a blank cell there is, per the document's own closing note, an unanswered question rather than a formatting gap).

No user-facing or runtime behavior change is expected from this PR.
No manual application test is required.

## Verification performed

No runtime application test was executed because this PR changes documentation only. Verification consisted of:

- Reading both new documents and the new ADR in full, and the complete diff of `docs/cron-jobs.md`.
- Independently checking every arithmetic and mechanism claim against current source, including: `transaction-transfer.service.ts` (leg signs, `toAmount` computation, status-mirroring, the reconciliation service's lack of transfer-awareness, bulk-update's field list), `fx-entry.util.ts` and `exchange-rate.service.ts` (`roundFxRate`, `applyFxConversion`, `getRateForDate`'s comment), `portfolio-calculation.service.ts` and `net-worth.service.ts` (the `rate = ... : 1` and `?? amount` fallbacks, all three SPLIT reducers in `net-worth.service.ts`, `calculateCostBasisLotsInAccountCurrency` vs. `calculateRealizedGains`), `holdings.service.ts` (`reverseSplit`), `database/schema.sql` (every precision column named in the field table), `shard-path.util.ts`, `auto-backup.service.ts`, `local-storage.provider.ts`, `s3-storage.provider.ts`, `database-storage.provider.ts`, `attachments.service.ts`, `backup.service.ts`, `email.service.ts`, `bill-reminder.service.ts`, `mortgage-reminder.service.ts`, `budget-alert.service.ts`, `emergency-access-monitor.service.ts`, and `ai-insights.service.ts`.
- Grepping `backend/src` for every `@Cron(` decorator (23 found) and cross-checking each against the new `docs/cron-jobs.md` table by service, method, and exact schedule expression — full match, no gaps found in either direction.
- Resolving every `docs/*.md` path named in this PR's four files; one target (`docs/backup-restore-contract.md`) did not exist, reported and fixed under Findings.

I did not execute the backend or frontend test suites for this PR, because it contains no code for a test to exercise, and no test currently asserts the documentation's own accuracy (that is a `docs/verification-contract.md`/PR 3 concern, and even there, only for the *invariants*, not for narrative documents like these).

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — No; this follows an external audit and post-audit documentation review, not a repository Discussion.
- [x] This PR addresses a single concern. — Financial-field semantics and non-transactional external-effect lifecycles, plus the ADR and cron inventory that belong beside them.
- [x] New behavior has tests, and the existing suite passes. — Not applicable: no behavior changes. Verification performed was documentation-vs-source consistency checking, detailed above.
- [x] All user-facing strings are translated for every locale. — Not applicable: no user-facing strings changed.
- [x] No shared/core areas were refactored without prior agreement. — No code is touched.
- [x] The branch is rebased on the latest `main`. — Confirmed: 0 commits behind `main` (SHA `1135ec4a`) at last check.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Prepared with Claude Code. The documentation and this PR description were AI-assisted. I reviewed the changes and own the result. Every cited path, identifier, arithmetic example, migration, and cron schedule was checked against the current repository tree; the one broken cross-reference found (`docs/backup-restore-contract.md`, described above) is disclosed and was corrected in this PR before opening it, rather than silently folded in with no record of the mistake. No runtime application verification is claimed because this PR changes documentation only.
