### PR TITLE
08: Document verification and release-integrity requirements (v1.15.0)

### DIFF
--- a/docs/release-integrity.md
+++ b/docs/release-integrity.md
@@ -1,0 +1,229 @@
+# Release Integrity Contract
+
+The rules that make a released artifact traceable to a verified source
+revision. They exist because a green pipeline proves something only about the
+commit it actually ran on, and both halves of that sentence have already been
+weaker here than they looked: a test job that discovers no tests reports
+success, and a release that commits after its gates have run publishes a
+revision no gate ever saw.
+
+This document covers the release and verification boundary.
+`docs/verification-contract.md` covers which tests an invariant requires;
+this one covers whether those tests ran, on what, and whether the thing
+shipped is the thing tested.
+
+Every rule below names the mechanism that enforces it or states plainly that
+nothing does. Where the current pipeline does not satisfy a rule, the gap is
+recorded as a gap rather than described as a guarantee -- see section 6.
+
+## 1. Zero discovered tests is a failure, never a pass
+
+A test runner that finds no tests has not verified anything. It must exit
+non-zero.
+
+The failure mode is not a runner bug; it is that the *set of tests* is itself
+untested state. A renamed directory, an edited glob, a suite moved during a
+refactor, or a `testPathPatterns` regex that no longer matches all silently
+reduce the discovered set -- possibly to nothing -- and a runner told to
+tolerate an empty set converts that into a green check. The pipeline then
+reports "Backend Integration Tests: passed" on a run that executed no
+integration test at all.
+
+```text
+REL-001
+No test command may carry a blanket "succeed if nothing was discovered" flag
+(`--passWithNoTests` or equivalent). A suite that legitimately has no tests
+must be removed from the pipeline, not made unfailable.
+
+REL-002
+A suite whose absence would be a release-blocking regression must be asserted
+present by name before the runner starts, and the discovered count must be
+printed in the job log so a shrinking suite is visible in the diff of two runs.
+```
+
+REL-002 is the stronger of the two, and the reason is worth stating: removing
+the flag makes *zero* tests fail, but it does nothing about twenty tests
+silently becoming three. Only an explicit inventory catches partial loss.
+
+**Current state:** `backend/package.json` runs integration tests with an
+unconditional `--passWithNoTests`:
+
+```json
+"test:integration": "jest --config ./test/jest-e2e.json --testPathPatterns='test/integration/.*\\.spec\\.ts$' --runInBand --passWithNoTests",
+```
+
+There are 21 real suites under `backend/test/integration/`, so the flag is not
+covering a package that has no tests by design -- it is a blanket net under a
+populated suite, which is exactly the case REL-001 forbids. `.github/workflows/ci.yml`
+invokes it unconditionally in the `backend-integration-tests` job. No other
+runner in the pipeline has an equivalent flag: `test:unit` and the frontend's
+`vitest run --coverage` have none, and Playwright fails by default when it
+discovers no spec files.
+
+## 2. The tested revision and the released revision must be the same
+
+A gate result is a statement about one commit. It does not extend to a commit
+created afterwards, however mechanical the change.
+
+```text
+REL-003
+The commit identified by a release tag, a published image's
+`org.opencontainers.image.revision`, and the commit the required gates ran on
+must be one revision -- or a later run of the complete gate must verify the
+final revision before it is tagged.
+
+REL-004
+A commit pushed after the gates have run must either be verified by an
+equivalent full gate, or be proven to differ from the tested revision only in
+ways the gate could not have covered. "Proven" means a check in the workflow,
+not a reviewer's expectation about what `npm version` touches.
+
+REL-005
+A version-bump or release-automation commit may not be pushed with `[skip ci]`
+unless REL-004's proof is in place. `[skip ci]` on a commit that becomes the
+head of a protected branch means the branch head is a revision no workflow has
+ever evaluated.
+```
+
+**Current state -- the image half is right.** The release path resolves the git
+SHA once, in `prepare-release`, a job that creates no commit, and threads that
+single value downstream as a job output. `build-and-push` stamps it into the
+build as `GIT_SHA` and into the manifest as
+`index:org.opencontainers.image.revision`, then signs with cosign, attaches an
+SBOM attestation, and gates a Trivy scan -- all against
+`${{ steps.build.outputs.digest }}`, a digest rather than a moving tag. The
+published image is therefore provably built from the revision the
+`needs:`-listed gates tested. This is the pattern to copy whenever an artifact
+must be tied to a verified revision.
+
+**Current state -- the git half is not.** The `release` job checks out with an
+admin PAT and then:
+
+```yaml
+git commit -m "chore: bump version to ${VERSION} [skip ci]"
+git pull --rebase
+git push
+```
+
+That creates a new commit, pushes it to protected `main` past branch
+protection, and nothing re-runs the gate on it. `gh release create "v${VERSION}"`
+then runs with no `--target`, so the tag resolves to the default branch tip --
+the bump commit, not the tested-and-imaged revision. The result is a split
+identity: the image points at the verified revision, the tag and the branch head
+point at an unverified one.
+
+The `git pull --rebase` widens this. If `main` moved during the release, the
+bump commit is rebased onto whatever arrived, and the pushed head then contains
+changes that were never part of any release gate -- with `[skip ci]` suppressing
+the push-triggered run that would have caught them.
+
+## 3. Bypass is a recovery procedure, not a release step
+
+A branch protection rule that the normal release path routinely circumvents is
+not a control; it is a comment.
+
+```text
+REL-006
+Administrator bypass of a required check must be an exceptional, recorded
+recovery action. A standing credential whose purpose is to push past protection
+on every release means the protected branch is unprotected for the one class of
+commit that reaches it most predictably.
+```
+
+**Current state:** the bypass is by design and documented in the workflow
+itself. `ci.yml` explains that `RELEASE_TOKEN` is an admin-owned fine-grained
+PAT used because the default `GITHUB_TOKEN` acts as a non-admin bot that cannot
+bypass protection, and that this "lets the `[skip ci]` version-bump commit
+through the required 'Verify PR checklist' check on main". The workflow is
+candid that it bypasses rather than forges a check, which is the honest
+framing -- but the bypass is on the standard path, not an exception.
+
+There is a second-order effect worth naming. `pr-checklist.yml` carries a
+`push: branches: [main]` trigger whose stated purpose is to satisfy the required
+check for commits the release job pushes. `[skip ci]` on the bump commit
+suppresses push-triggered runs, so the trigger added to cover this case cannot
+fire for it. The push succeeds regardless, via the PAT -- which is why the
+contradiction has been invisible.
+
+The fix direction REL-006 implies is a release-PR flow: the bump lands through
+the same gate every other change does, and no standing bypass credential is
+needed. Short of that, REL-004's proof is the minimum.
+
+## 4. Required checks are policy, and policy belongs in the repository
+
+```text
+REL-007
+The set of required status checks and the branch protection posture must be
+readable from the repository. A control that exists only in a web UI cannot be
+reviewed in a diff, cannot be restored after an accidental change, and cannot
+be verified by anyone without administrator access.
+```
+
+**Current state:** no in-repo policy exists. `.github/` contains workflows plus
+`lighthouse/`, `zap/`, `zizmor.yml`, a PR template and a discussion template --
+no `settings.yml`, no ruleset export, no `CODEOWNERS`. Branch protection is
+described only in workflow comments, including a comment asserting that "Do not
+allow bypassing the above settings" is unchecked on the `main` rule. That
+assertion may be true, but nothing in the repository can confirm it, and
+nothing notices if it changes.
+
+This is the one rule here that cannot be closed by a test. It needs either an
+exported ruleset committed to the repository, or a scheduled job that reads the
+protection API and fails when the live configuration diverges from a committed
+expectation.
+
+## 5. What the pipeline already does well
+
+Recording these matters as much as recording the gaps: they are the patterns a
+change should imitate, and a reviewer should notice when a new workflow step
+does not.
+
+| Control | Where | Why it is right |
+| --- | --- | --- |
+| SHA resolved once, threaded as an output | `prepare-release` to `build-and-push` | The artifact cannot drift from the tested revision, because no step re-reads a moving ref |
+| Scans and signatures target a digest | cosign, `actions/attest-sbom`, Trivy | A tag can be moved after a scan; a digest cannot |
+| CVE gate fails the build | Trivy with `exit-code: '1'` on CRITICAL | The scan is a gate, not a report |
+| Every third-party action pinned to a full commit SHA | all workflows | A tag-pinned action is a supply-chain write primitive for whoever controls the tag |
+| Workflows themselves are scanned | `zizmor-scan`, SARIF uploaded | Workflow security is machine-checked rather than reviewed by eye |
+| Schema drift is a required gate | `schema-drift` running `scripts/verify-schema.sh` | Gates both the release and preview publish paths, and reproduces locally with only Docker |
+| Bearer scan exceptions expire | `bearer-exceptions-review.yml` | A suppression with a `review-by` date that lapses opens an issue, so exceptions cannot become permanent silently |
+
+The last two are the model this whole document is arguing for: a rule with an
+expiry date and a job that enforces it, rather than a paragraph asking people to
+remember.
+
+## 6. Gap register
+
+The rules above are normative. This table records where the pipeline stands
+against them today, so no reader mistakes an intention for a control. A row
+moves to "enforced" only when a workflow step or committed policy makes it
+fail, not when a document describes it.
+
+| Rule | Status on `main` | Blocking evidence |
+| --- | --- | --- |
+| REL-001 no blanket pass-with-no-tests | **not enforced** | `--passWithNoTests` in `backend/package.json` `test:integration` |
+| REL-002 mandatory suites asserted by name | **not enforced** | no inventory step precedes the runner |
+| REL-003 one revision across tag, image, gate | **partially enforced** | image bound to tested SHA; release tag resolves to the untested bump commit |
+| REL-004 post-gate commit proven or verified | **not enforced** | nothing checks the bump commit's parent or diff scope |
+| REL-005 no `[skip ci]` without that proof | **not enforced** | bump commit carries `[skip ci]` |
+| REL-006 bypass is exceptional | **not enforced** | admin PAT bypass is the standard release path |
+| REL-007 protection policy in-repo | **not enforced** | no `settings.yml` or ruleset export exists |
+
+## 7. Definition of done for a change to the release path
+
+A change to any workflow that builds, tags, publishes or pushes must state, in
+the pull request:
+
+1. which revision each produced artifact is bound to, and how that binding is
+   enforced rather than assumed;
+2. whether the change adds any commit created after the gates run, and if so
+   what verifies it;
+3. whether it introduces a new bypass, standing credential, or `[skip ci]`, and
+   why the alternative was rejected;
+4. which rows of section 6 the change moves, in either direction.
+
+A change that moves a row from "not enforced" to "enforced" should delete the
+row's blocking evidence in the same commit, so this table cannot quietly
+describe a pipeline that no longer exists. `CLAUDE.md`'s rule applies here in
+full: a doc that names an identifier is making a claim about the source, and
+this document names workflow jobs, script names and flags throughout.

--- a/docs/verification-contract.md
+++ b/docs/verification-contract.md
@@ -1,0 +1,284 @@
+# Verification Contract
+
+Which kind of test each invariant requires, and which CI job enforces it. The
+repository has many tests, including real PostgreSQL suites; what it has not had
+is a normative statement of *what kind* of test a given claim needs. That gap is
+why several defects lived behind green suites, and why six tests were found
+asserting the wrong outcome.
+
+Related: `docs/testing-contract.md` lists the adversarial inputs to pick from
+(dates, money precision, aggregation, currency conversion, ownership,
+concurrency) so an author chooses from a list rather than recalling edge cases.
+This document is about test *kind* and *placement*, not input selection.
+`docs/system-invariants.md` defines the IDs used below.
+
+## 1. The test kinds
+
+| Kind | What it can prove | Where it lives |
+| --- | --- | --- |
+| Unit | Pure logic, arithmetic, sign and precision rules, validation branches | `backend/src/**/*.spec.ts`, `frontend/src/**/*.test.ts` |
+| Source scan | That a mistake appears nowhere, rather than not in the one place tested | any suite; see `frontend/src/test/ui-conventions.test.ts` |
+| PostgreSQL integration | Real constraints, cascades, triggers, RLS policies, SQL semantics | `backend/test/integration/*.integration.spec.ts` |
+| Two connections | Lock ordering, statement snapshots, one-winner CAS, partial-index arbitration | same, with two `DataSource` connections and `Promise.all` |
+| Two instances | Process-local state failing across replicas; cron claim mechanisms | same, two service instances over one database |
+| Failpoint | Crash between an external effect and its commit | same, by throwing at the boundary |
+| Provider round trip | Bytes actually written and readable; a truncated artifact refused | same, against local filesystem and S3 |
+| E2E | The user-visible outcome, and browser/cache state | `e2e/tests/*.spec.ts` |
+
+## 2. What a mock cannot prove
+
+A mocked repository can be made to return whatever a branch needs, which makes
+that branch testable, tested, and dead. This is not hypothetical here:
+
+- `mny-import-job.service.ts` carries a helper, `returnedRows`, that exists
+  because a data-modifying statement with `RETURNING` comes back from
+  `manager.query()` as `[rows, rowCount]` while a bare `SELECT` returns plain
+  rows. Reading the tuple as `rows.length > 0` made **every** CAS attempt look
+  like a winner. Its comment records that this was found by the concurrency
+  spec -- the real-database one. No unit test could have found it, because the
+  mock returned whatever shape the test author assumed.
+- `gem-price.integration.spec.ts` states the same lesson about its own subject:
+  with a mock, "every lost-race branch was dead, tested and unreachable."
+
+So mocks are supporting evidence only for anything claiming a property of
+PostgreSQL, of multiple processes, of a provider, or of browser state:
+
+```text
+VER-001
+A test asserting that a service called `save`, `update` or `transaction` proves
+the call, not the property. Where the invariant is a property of PostgreSQL,
+multiple processes, a provider or the browser, a mock-based test is supporting
+evidence and a production-boundary test is mandatory.
+
+VER-002
+A concurrency mechanism with only unit tests is untested. Two-connection means
+two real connections interleaved, not two sequential calls on one.
+
+VER-003
+An invariant's entry in docs/system-invariants.md names its required tests. A
+change that adds enforcement adds the required test in the same commit; a change
+that cannot must say so in the pull request.
+```
+
+## 3. The matrix
+
+`required` means the invariant is not verified without it. `supporting` means it
+adds value but proves nothing on its own. `--` means not applicable.
+
+| Invariant | Unit | Source scan | PG integration | Two connections | Two instances | Failpoint | Provider | E2E |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| INV-IMPORT-001 one active import | supporting | -- | required | **required** | required | supporting | -- | optional |
+| INV-IMPORT-002 retry never doubles | supporting | -- | required | required | -- | **required** | -- | required |
+| INV-IMPORT-003 category collision | supporting | -- | required | **required** | -- | -- | -- | -- |
+| INV-BALANCE-001 balance equals ledger | supporting | -- | required | **required** | optional | required | -- | required |
+| INV-HOLDING-001 holding replay | supporting | -- | required | **required** | optional | required | -- | optional |
+| INV-HOLDING-002 one reducer | required | **required** | supporting | -- | -- | -- | -- | required |
+| INV-TRANSFER-001 both legs | required | -- | required | optional | -- | -- | -- | required |
+| INV-FX-001 no 1:1 fallback | **required** | **required** | required | -- | -- | required | optional | required |
+| INV-OCCURRENCE-001 one effect | supporting | -- | required | required | **required** | required | -- | required |
+| INV-OCCURRENCE-002 override price | required | -- | -- | -- | -- | -- | -- | required |
+| INV-CLAIM-001 single-use claim | supporting | -- | required | **required** | optional | optional | -- | required |
+| INV-AUTH-001 refresh rotation | supporting | -- | required | **required** | -- | -- | -- | optional |
+| INV-AUTH-002 login counter | supporting | -- | required | **required** | -- | -- | -- | -- |
+| INV-AUTH-003 OIDC round trip | required | -- | required | -- | -- | -- | required | required |
+| INV-AUTH-004 truthful logout | supporting | -- | required | -- | -- | **required** | -- | required |
+| INV-ACTIVITY-001 activity attribution | supporting | -- | **required** | -- | -- | -- | -- | -- |
+| INV-PROFILE-001 allowlist | required | **required** | supporting | -- | -- | -- | -- | -- |
+| INV-MCP-001 credential binding | supporting | -- | required | -- | -- | -- | -- | -- |
+| INV-CURRENCY-001 currency delete | supporting | **required** | required | required | -- | -- | -- | optional |
+| INV-ATTACHMENT-001 bytes present | supporting | -- | required | optional | -- | **required** | **required** | required |
+| INV-BACKUP-001 backup complete | supporting | -- | required | -- | optional | **required** | **required** | required |
+| INV-CRON-001 one effect per tick | supporting | -- | required | required | **required** | optional | -- | -- |
+| INV-RLS-001 role privilege | supporting | -- | **required** | -- | required | -- | -- | -- |
+| INV-CACHE-001 cache invalidation | required | **required** | -- | -- | -- | -- | -- | required |
+| INV-RELEASE-001 one revision | required | -- | -- | -- | -- | -- | -- | workflow self-test |
+
+Bold marks the kind that is load-bearing -- the one whose absence means the
+invariant is unverified no matter how many others pass. `INV-PROFILE-001`'s is a
+source scan rather than a unit test because the defect arrives via a change to a
+different file: a new entity column. `INV-FX-001` and `INV-HOLDING-002` need
+scans for the same reason -- both are scattered across call sites, and every
+previous fix corrected one and left the others.
+
+`INV-IMPORT-002`'s load-bearing kind is a **failpoint**, and it is worth
+understanding why the other columns cannot substitute. The MNY import has real
+two-connection tests -- more than any other workflow -- and they all interleave
+*starts* and *claims*. None of them commits the business write and then fails, so
+none of them enters the window where a retry duplicates data. A suite can be
+genuinely strong at one failure mode and blind to the neighbouring one, and
+counting tests will not reveal it. The failpoint that would:
+
+```text
+1. let writeAll() commit
+2. throw immediately after, before terminal job completion
+3. retry the job against the same staged file
+4. assert every imported row exists exactly once
+5. assert the job state distinguishes committed-but-unfinalized from retryable
+```
+
+A test that throws *inside* the import transaction passes today and proves
+nothing about this.
+
+## 4. CI ownership
+
+Every required test must be reachable by a named job. The jobs that exist in
+`.github/workflows/ci.yml`:
+
+| Job | Runs | Owns |
+| --- | --- | --- |
+| `Backend Lint & Type Check` | eslint, tsc | the RLS lint bans, ban lists |
+| `Backend Unit Tests` | `npm run test:unit -- --coverage` | unit, source scans in `backend/src` |
+| `Backend Integration Tests` | `npm run test:integration` | PG integration, two-connection, two-instance, failpoint, provider round trip |
+| `Frontend Unit Tests` | `npm run test:cov` | unit, source scans in `frontend/src` |
+| `Frontend Lint & Type Check` | eslint, tsc | frontend conventions |
+| `Schema vs Migrations Drift` | `scripts/verify-schema.sh` | migration replay is a no-op on `schema.sql` |
+| `E2E Tests (shard N/4)` | Playwright, 4 shards | user-visible outcomes, browser cache state |
+| `Lighthouse audit` | Lighthouse CI | accessibility and performance budgets |
+
+Two structural points about this table:
+
+**One job owns six test kinds.** `Backend Integration Tests` is where
+two-connection, two-instance, failpoint and provider round-trip tests all live,
+because they all need a real database. That makes it the single most important
+job in the pipeline and the one whose silent failure is most costly -- which
+brings us to the next point.
+
+**That job can currently pass having run nothing.** `test:integration` carries an
+unconditional `--passWithNoTests`, so a renamed directory or an edited
+`testPathPatterns` regex turns a discovery failure into a green check across all
+six kinds at once. `docs/release-integrity.md` REL-001 and REL-002 cover this;
+it is repeated here because the consequence is a verification consequence, not
+merely a CI hygiene one. There are 21 suites under
+`backend/test/integration/` today, and nothing asserts that number does not
+shrink.
+
+## 5. Known-wrong tests
+
+A green test is evidence only for the behaviour it asserts. If the assertion
+encodes the defect, the test is a regression protector for the wrong outcome --
+and it is worse than no test, because it will be cited as coverage.
+
+```text
+VER-004
+A test that asserts current behaviour without a reason to believe it correct is
+not coverage. When an invariant is found violated, search the suites for tests
+asserting the violation and correct them in the same change -- they are why the
+defect survived.
+```
+
+### Located in the current suites
+
+These were found by reading the suites, and each is cited so it can be checked
+rather than taken on trust. Correcting the invariant means correcting these in
+the same change.
+
+| Test | Asserts | Protects the violation of |
+| --- | --- | --- |
+| `backend/src/net-worth/net-worth.service.spec.ts` around lines 516 and 2664 | Additive stock-split replay. The comment spells the arithmetic out: `95 - TRANSFER_OUT 5 + SPLIT 90 = 180 shares`, and a second case `BUY 100, SELL 30, TRANSFER_OUT 20, SPLIT 50 = 100 shares`. Under the correct multiplicative rule a SPLIT row of 90 applied to 90 shares is 8,100, not 180. | INV-HOLDING-002 |
+| `frontend/src/components/settings/BackupRestoreSection.test.tsx`, `frontend/src/components/settings/DangerZoneSection.test.tsx`, `backend/src/users/users.service.spec.ts`, `backend/src/backup/backup.service.spec.ts` | `oidcIdToken: 'oidc-session-confirmed'` accepted as proof of re-authentication. | INV-AUTH-003 |
+
+The second is the clearest case of the category: the sentinel string is asserted
+on both sides, so the tests do not merely tolerate the defect -- they specify it.
+Implementing a real OIDC round trip must change them, and that friction is what
+makes the defect look like a decision.
+
+The first is the more instructive one. It reads as a careful test: five actions,
+three months, arithmetic worked out in a comment. The arithmetic is simply the
+wrong rule, applied consistently. A reviewer checking whether the code matches
+the test would find that it does.
+
+### Reported but not located
+
+The audit that prompted this document also reported tests asserting a missing
+exchange rate as 1:1, an overwritten scheduled override price, a failed logout
+presented as successful, and unsafe backup naming expectations. **Searching the
+current suites did not find them.** Each is one of three things, and they are
+worth distinguishing before acting:
+
+- already corrected on `main` since the audit -- the backup-naming case is
+  probably this, since per-user sharding landed and the remaining filename
+  assertions are about the filename, which is correct; the sharding is in the
+  directory;
+- present but not matched by the searches used;
+- or never precisely located by the audit either.
+
+They are recorded here as unconfirmed rather than dropped, because a reader
+closing INV-FX-001 or INV-OCCURRENCE-002 should search once more before assuming
+no test stands in the way. They are deliberately not in the table above: a
+citation that cannot be checked is the thing this document exists to discourage.
+
+Per root `CLAUDE.md`, each corrected unit test needs a production-boundary
+companion wherever the defect depends on PostgreSQL, multiple processes,
+providers or browser state. Correcting the assertion alone leaves the class open.
+
+## 6. A green suite after a behaviour change is a finding
+
+Restating `docs/financial-calculation-contract.md` section 8.1 because it is the
+rule most often skipped: if you changed what the code produces and nothing
+failed, either the change is a no-op or the suite had no case for it. Say which
+in the change description, and if it is the second, add the case in the same
+commit.
+
+### The scans this document requires do not exist yet
+
+Section 3 marks a source scan as load-bearing for INV-FX-001, INV-HOLDING-002,
+INV-PROFILE-001, INV-CURRENCY-001 and INV-CACHE-001. **None of them is written.**
+Each would be a handful of lines in the pattern of
+`frontend/src/test/ui-conventions.test.ts`:
+
+| Scan owed | Fails on |
+| --- | --- |
+| FX fallback | a `: 1` else-branch beside a rate lookup, or `?? amount` beside a conversion |
+| Share replay | a `SPLIT` case outside the single shared reducer |
+| Profile response | an entity column absent from the response allowlist |
+| Currency references | an FK to `currency_code` in `schema.sql` that the in-use check does not cover |
+| Cache families | a cache prefix in `src/` that declares itself neither transaction-derived nor reference data |
+
+They are not written here because each would fail immediately against `main` --
+the defects they scan for are present, which is the point of the scan. A guard
+introduced in the same change that fixes its violations is verifiable; one
+introduced alone either breaks the suite or has to be born with a
+baseline-exception list, which is a decision about how much known-wrong code to
+bless and belongs to whoever fixes the underlying invariant.
+
+That is a reason for sequencing, not an excuse. Until these exist, INV-FX-001 and
+INV-HOLDING-002 in particular are guarded only by prose, and both have already
+been fixed at one call site while siblings stayed live.
+
+The corollary for this document: a test you have never seen fail protects
+nothing. When adding a required test from section 3, run it against the
+unfixed code first and confirm it fails for the right reason.
+
+## 7. Running the suites so a green branch does not read as red
+
+CI runs in UTC with one Playwright worker; a local run does neither, and both
+differences produce failures that look like regressions and are not.
+
+- `TZ=UTC npm run test:unit` matches CI. Some tests read `new Date()` and count
+  completed periods against fixtures; under another offset they land on the wrong
+  side of a boundary. `insights-aggregator.service.spec.ts` and
+  `net-worth.service.spec.ts` are the ones that bite.
+- `--workers=1` for the whole E2E suite. `playwright.config.ts` sets one worker
+  only when `CI` is set, and `e2e/tests/zz-danger-zone.spec.ts` deletes the
+  shared account -- the `zz-` prefix orders it last, which only means anything
+  serially. A single spec file is safe without the flag.
+- `scripts/verify-schema.sh` reproduces the drift job locally and needs only
+  Docker.
+
+Believing an unqualified local failure means chasing a bug that does not exist;
+root `CLAUDE.md` has the longer form.
+
+## 8. Definition of done
+
+For a change that touches an invariant:
+
+1. the invariant IDs are named in the pull request;
+2. each required test from section 3 is added, or an existing one is cited by
+   path and test name;
+3. the load-bearing kind (bold in the matrix) is present, not substituted with a
+   mock;
+4. each new test was seen to fail against the unfixed code;
+5. any test asserting the old, wrong behaviour is corrected in the same change;
+6. the CI job from section 4 that enforces it is named;
+7. the invariant's status in `docs/system-invariants.md` is updated, and the
+   citation of the violation deleted if it no longer exists.


### PR DESCRIPTION
## Linked discussion / issue

None. This PR follows an external audit and the documentation review performed after that audit. No repository Discussion or issue was opened beforehand.

## Summary

Adds `docs/verification-contract.md` (284 lines): which of eight test kinds (unit, source scan, PostgreSQL integration, two connections, two instances, failpoint, provider round trip, E2E) each of the 24 invariants from PR 1 actually requires, a matrix marking which kind is *load-bearing* for each, a named list of tests already located in the current suites that assert the **wrong** outcome (two in `net-worth.service.spec.ts` that encode the additive SPLIT defect; four across frontend and backend that assert an OIDC re-authentication sentinel string as valid proof), and the CI job that owns each test kind.

Adds `docs/release-integrity.md` (229 lines): the rules that make a released container image traceable to a verified source revision, what the current pipeline already does correctly (SHA resolved once and threaded as a job output; cosign, SBOM attestation and a Trivy CVE gate all targeting an immutable digest, not a moving tag), and where it currently does not (`test:integration` runs with an unconditional `--passWithNoTests`; the version-bump commit is pushed past branch protection with an admin PAT and carries `[skip ci]`, so nothing re-runs the gate on the commit a release tag ultimately points at).

**Why the repository needs this.** The audit that produced this content found tests that pass and protect a documented defect rather than catching it — a stock-split test whose own inline comment works out the additive arithmetic and asserts exactly that wrong figure, and four tests across two layers that assert a hardcoded string is accepted as OIDC re-authentication proof. A green suite told the reviewer nothing here, because the suite's own expectation was wrong. This document exists so the next reviewer knows *what kind* of test would have caught each class of defect (a mock cannot prove a property of PostgreSQL or of multiple processes; the `returnedRows` bug in the MNY import path was found only by a real two-connection test, and the document says so by name) rather than counting green checkmarks.

**What it defines.** VER-001 through VER-004 (a mock proves the call, not the property; a concurrency mechanism with only unit tests is untested; each invariant's required test kind is named in its catalog entry; a test asserting the current wrong behavior is not coverage and must be corrected in the same change that fixes the invariant) and REL-001 through REL-007 (no test runner may have a blanket pass-on-empty flag; a mandatory suite's presence must be asserted by name; the tested, imaged, and tagged revision must be one revision or a later gate must verify the final one; a post-gate commit needs proof or an equivalent re-run; `[skip ci]` on such a commit needs that same proof; administrator bypass is a recovery action, not a standing release step; the required-checks policy itself belongs in the repository, not only in a web UI).

**What is currently enforced vs. not.** All seven release-integrity rules have a stated current status in §6's gap register, and only one (REL-003, the image-to-tested-SHA binding) is even partially enforced — the other six are explicitly "not enforced," each with the exact blocking evidence (the `--passWithNoTests` flag; the absence of a `settings.yml` or ruleset export; the admin-PAT push itself) named and quoted. Two of the required source-scanning tests `verification-contract.md` says are load-bearing for PR 1's and PR 2's invariants — for FX-fallback and for SPLIT-replay — do not exist yet anywhere in the suites; the document says this plainly rather than describing them as already written.

**Why documentation alone does not close these gaps.** This PR does not add the missing failpoint test for INV-IMPORT-002, does not remove `--passWithNoTests` from `backend/package.json`, and does not touch the release workflow's `[skip ci]` push. It documents exactly what is missing and what already works well (§5 of `release-integrity.md` is deliberately as long as the gap register, because a future workflow change should imitate the patterns that are already right — SHA-once-as-output, digest-not-tag scanning — as much as it closes the gaps).

**Alternatives considered and rejected.** Treating a discovered-but-uncorrected known-wrong test as "coverage that happens to need updating" (rejected — VER-004 states explicitly that such a test is worse than no test, because it will be cited as protection for the very defect it encodes); silently correcting the two located known-wrong tests as part of this documentation PR (rejected as out of scope for a docs-only PR per this series' shared decision — and per `docs/testing-contract.md`'s existing rule that a corrected assertion needs a production-boundary companion, which is real code work, not a one-line fix).

## Scope

This PR contains Markdown documentation only:

- `docs/verification-contract.md` (new, 284 lines)
- `docs/release-integrity.md` (new, 229 lines)

It does not change:
- application runtime behavior;
- any test file — the two located known-wrong tests (`net-worth.service.spec.ts`, and the four OIDC-sentinel tests) are named and cited by path and line, not edited;
- CI workflow YAML — `--passWithNoTests` remains in `backend/package.json`'s `test:integration` script, and the release job's `[skip ci]` push is described, not modified;
- database schema or migrations;
- API contracts;
- frontend components.

## What reviewers should check

1. Confirm every named CI job (`Backend Lint & Type Check`, `Backend Unit Tests`, `Backend Integration Tests`, `Frontend Unit Tests`, `Frontend Lint & Type Check`, `Schema vs Migrations Drift`, `E2E Tests (shard N/4)`, `Lighthouse audit`) exists with that exact `name:` in `.github/workflows/ci.yml` or `.github/workflows/lighthouse.yml`, and runs the command the document says it does.
2. Confirm `docs/verification-contract.md` §3's matrix distinguishes tests that are *required* (not yet written, in several cases) from tests that already exist — in particular, confirm the two source-scanning tests it calls owed-but-missing (FX fallback, SPLIT replay) are in fact absent from the current suites, not merely uncited.
3. Confirm the two located known-wrong tests still exist at the cited path and assert what the document says — `backend/src/net-worth/net-worth.service.spec.ts` (the additive-SPLIT assertions) and the four OIDC-sentinel tests across `BackupRestoreSection.test.tsx`, `DangerZoneSection.test.tsx`, `users.service.spec.ts`, `backup.service.spec.ts` — and that the four "reported but not located" tests (missing exchange-rate 1:1, overwritten override price, failed-logout-as-success, unsafe backup naming) are genuinely absent from a fresh search rather than merely unsearched, since the document itself flags these as unconfirmed.
4. Re-read the current `.github/workflows/ci.yml`'s release job before accepting any release-provenance claim — confirm the exact git commands quoted (`git commit -m "chore: bump version to ${VERSION} [skip ci]"`, `git pull --rebase`, `git push`, `gh release create "v${VERSION}"` with no `--target`) and the `RELEASE_TOKEN` comment are unchanged from what this document quotes.
5. Confirm the document distinguishes what is committed workflow fact (quoted YAML) from what is a workflow *comment's claim* about live GitHub settings (e.g. "Do not allow bypassing... is unchecked on the main rule") that this repository cannot itself verify — the document should not present the comment's claim as a confirmed setting.

## Findings from documentation verification

No discrepancies were found in either document against the current repository state. Every CI job name and the command it runs, every npm script quoted (including the exact `--passWithNoTests` flag and `--testPathPatterns` regex), the count of integration suites (21, matching exactly), the four named known-wrong test files and their assertions, and every release-workflow step (SHA resolution, build-arg and OCI-annotation names, cosign/SBOM/Trivy steps, the exact bump-commit and `gh release create` commands, the `RELEASE_TOKEN` comment, and the `pr-checklist.yml` push trigger and its own comment) were checked and matched. See Verification performed below for the full list of what was checked.

One thing worth a maintainer's attention even though it is not a documentation defect: `release-integrity.md` notes, correctly, that the bump commit's `[skip ci]` would normally suppress the very push-triggered `pr-checklist.yml` run that exists specifically to satisfy the required check for that commit — meaning the mechanism intended to cover this case may not actually fire for it. This is a live pipeline question the document raises rather than answers, and is exactly the kind of thing a docs-only PR should surface, not resolve.

## Documentation verification

This PR changes documentation only. No application smoke test is required — nothing about test-kind classification or release-pipeline structure is observable by using the running application.

Suggested reviewer checks:

1. Open both files and confirm headings, the two matrices (test-kind-by-invariant in `verification-contract.md`, rule-status-by-row in `release-integrity.md`), and every quoted YAML/JSON/shell fragment render correctly.
2. Confirm every job, script, and workflow file path named resolves against the current `.github/workflows/` and `package.json` files.
3. Confirm the integration-test discovery command is quoted character-for-character, including the regex: `--testPathPatterns='test/integration/.*\.spec\.ts$'`.
4. Confirm every workflow statement describes the *current* `ci.yml`, not a snapshot from when the underlying audit was performed — re-read the live file rather than trusting the document's quotes at face value.
5. Confirm the document distinguishes repository-committed policy (a workflow file, a script) from live GitHub configuration this repository cannot itself expose (branch-protection settings, required-check lists) — §4 of `release-integrity.md` should read as "this cannot be verified from the repository," not as an assertion about the live setting.

No user-facing or runtime behavior change is expected from this PR.
No manual application test is required.

## Verification performed

No runtime application test was executed and no CI run was triggered or observed for this verification; "CI passed" is not claimed anywhere in this PR. Verification consisted of:

- Reading both new documents in full.
- Reading the current `.github/workflows/ci.yml` and `.github/workflows/lighthouse.yml` and confirming every named job's exact `name:` field and the commands in its steps.
- Reading `backend/package.json` and `frontend/package.json` and confirming the exact text of `test:unit`, `test:integration` (including `--passWithNoTests` and the exact `--testPathPatterns` regex), and `test:cov`.
- Counting `backend/test/integration/*.integration.spec.ts` (21 files, matching the document's claim exactly) and listing them.
- Confirming `scripts/verify-schema.sh` exists and matches its described purpose.
- Opening the four cited known-wrong test files and quoting the exact asserting lines, confirming each currently asserts what the document says it does.
- Reading the release-related jobs in `ci.yml` (`prepare-release`, `build-and-push`, the version-bump/release job) and quoting the exact git and `gh` commands, the `RELEASE_TOKEN` comment, and the `pr-checklist.yml` push trigger and its comment.
- Confirming `.github/` contains no `settings.yml`, no ruleset export, and no `CODEOWNERS` file (checked both `.github/CODEOWNERS` and repository-root `CODEOWNERS`), consistent with §4's claim that no in-repo branch-protection policy exists.
- Spot-checking that third-party GitHub Actions are pinned to full commit SHAs rather than floating tags across five different workflow files.

## Checklist

- [x] An approved discussion or issue exists and is linked above. — No; this follows an external audit and post-audit documentation review, not a repository Discussion.
- [x] This PR addresses a single concern. — Which test kind each invariant requires, and whether the tested/imaged/tagged/released revisions are provably one revision.
- [x] New behavior has tests, and the existing suite passes. — Not applicable: no behavior changes, and this PR does not add or modify any test file itself; it documents which tests are required and which existing ones are known-wrong.
- [x] All user-facing strings are translated for every locale. — Not applicable: no user-facing strings changed.
- [x] No shared/core areas were refactored without prior agreement. — No code, test, or workflow file is touched.
- [x] The branch is rebased on the latest `main`. — Confirmed: 0 commits behind `main` (SHA `1135ec4a`) at last check.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Prepared with Claude Code. The documentation and this PR description were AI-assisted. I reviewed the changes and own the result. Every named CI job, npm script, workflow step, and test file citation was checked against the current repository tree; no discrepancy was found in either document. No runtime application verification and no CI execution is claimed anywhere in this PR — every workflow claim was verified by reading the committed YAML, not by running it.
