### PR TITLE
01: Refuse a retired .mny import job's writes inside its own transaction (v.1.15.0)

### DIFF
--- a/backend/src/import/mny/mny-import-job.service.ts
+++ b/backend/src/import/mny/mny-import-job.service.ts
@@ -1,6 +1,6 @@
 import { ConflictException, Injectable, Logger } from "@nestjs/common";
 import { Cron, CronExpression } from "@nestjs/schedule";
-import { DataSource, QueryFailedError } from "typeorm";
+import { DataSource, EntityManager, QueryFailedError } from "typeorm";
 import { tr } from "../../i18n/translate";
 import {
   runOutsideActiveScopedManager,
@@ -42,6 +42,20 @@ export const JOB_STALLED_ERROR_KEY = "mnyJobStalled";
 
 /** i18n key for a failure with no more specific parse error. */
 export const JOB_FAILED_ERROR_KEY = "mnyImportFailed";
+
+/**
+ * Thrown when a job discovers, inside its own write transaction, that it no
+ * longer holds its user's import slot. Not a parse failure: retrying is exactly
+ * the right thing to offer, since the staged bytes are untouched.
+ */
+export class MnyImportSlotLostError extends Error {
+  constructor(jobId: string, status: string) {
+    super(
+      `Import job ${jobId} no longer holds the import slot (status ${status})`,
+    );
+    this.name = "MnyImportSlotLostError";
+  }
+}
 
 /** PostgreSQL SQLSTATE for a unique violation. */
 const UNIQUE_VIOLATION = "23505";
@@ -195,6 +209,48 @@ export class MnyImportJobService {
   }
 
   /**
+   * Verifies this job still holds its user's import slot, **inside the caller's
+   * transaction**, and locks the row so the answer cannot change before commit.
+   *
+   * `claim` protects the start of a job; this protects the end of one. A job can
+   * lose its slot after claiming it, and in both cases the row is rewritten by
+   * something that cannot stop the worker:
+   *
+   *  - the one-active-job migration retires older duplicates on a database that
+   *    raced before the index existed. Every backend container runs migrations at
+   *    start-up and the Helm StatefulSet rolls pods one at a time, so a new pod
+   *    can retire a job an *old* pod is still importing;
+   *  - `reapStaleJobs` fails a `running` job whose heartbeat lapsed -- a real
+   *    possibility for a slow import on a loaded pod, not only for a dead one.
+   *
+   * Neither changes what the worker does. Status alone therefore cannot protect
+   * the data: by the time a terminal write happens the financial rows are already
+   * committed. Calling this as the last statement of the transaction that writes
+   * them makes the refusal roll them back instead, which is the repository's
+   * standing rule -- a rejected command must not already have written.
+   *
+   * `FOR UPDATE` matters as much as the predicate: it serializes this check
+   * against a concurrent retirement, so the loser of that race sees the committed
+   * outcome rather than a snapshot taken before it.
+   *
+   * @param manager the EntityManager of the ACTIVE transaction whose writes this
+   *   is guarding -- checked in a separate transaction it guarantees nothing.
+   */
+  async assertStillHoldsSlot(
+    manager: EntityManager,
+    jobId: string,
+  ): Promise<void> {
+    const rows: Array<{ status: string }> = await manager.query(
+      `SELECT status FROM import_jobs WHERE id = $1 FOR UPDATE`,
+      [jobId],
+    );
+    const status = rows[0]?.status ?? "missing";
+    if (status !== "running") {
+      throw new MnyImportSlotLostError(jobId, status);
+    }
+  }
+
+  /**
    * Moves a job from `pending` to `running`, atomically.
    *
    * The `WHERE status = 'pending'` is the whole concurrency control: whichever
@@ -257,13 +313,17 @@ export class MnyImportJobService {
     await runOutsideActiveScopedManager(() =>
       withScopedDb(this.dataSource, (manager) =>
         manager.query(
+          // `AND status = 'running'`: a job retired while its body ran must not
+          // be flipped back to completed. `assertStillHoldsSlot` normally makes
+          // this unreachable by rolling the body back first; this is the second
+          // line of defence, and it keeps the audit trail honest either way.
           `UPDATE import_jobs
               SET status = 'completed',
                   result = $2::jsonb,
                   progress = NULL,
                   completed_at = CURRENT_TIMESTAMP,
                   retryable = false
-            WHERE id = $1`,
+            WHERE id = $1 AND status = 'running'`,
           [jobId, JSON.stringify(result)],
         ),
       ),
@@ -329,6 +389,12 @@ export class MnyImportJobService {
     } catch (error) {
       const isParseFailure = error instanceof MnyImportError;
       const detail = error instanceof Error ? error.message : String(error);
+      if (error instanceof MnyImportSlotLostError) {
+        // The row already says why, written by whatever retired it. Overwriting
+        // it here would replace that explanation with a generic failure.
+        this.logger.warn(detail);
+        return true;
+      }
       await this.fail(
         jobId,
         isParseFailure ? error.code : JOB_FAILED_ERROR_KEY,

--- a/backend/src/import/mny/mny-import.service.spec.ts
+++ b/backend/src/import/mny/mny-import.service.spec.ts
@@ -273,6 +273,10 @@ describe("MnyImportService", () => {
       discard: jest.fn().mockResolvedValue(undefined),
       runClaimed: jest.fn().mockResolvedValue(true),
       fail: jest.fn().mockResolvedValue(undefined),
+      // The lease check the write transaction ends with. Resolving means "still
+      // holds the slot"; the refusal path is a property of real transactions and
+      // is asserted in test/integration/mny-import-job.integration.spec.ts.
+      assertStillHoldsSlot: jest.fn().mockResolvedValue(undefined),
     };
     postProcessing = { run: jest.fn().mockResolvedValue(undefined) };
     usersService = { deleteData: jest.fn().mockResolvedValue(undefined) };

--- a/backend/src/import/mny/mny-import.service.ts
+++ b/backend/src/import/mny/mny-import.service.ts
@@ -115,8 +115,14 @@ export class MnyImportService {
   ) {}
 
   /**
-   * Validates, optionally wipes, creates the job and starts it in the
-   * background. Returns the job row the wizard polls.
+   * In order: validate the staged file, acquire this user's single active-import
+   * slot, then optionally re-authenticate and wipe, then start the background
+   * worker. Returns the job row the wizard polls.
+   *
+   * The order is the safety property, not an implementation detail. The job row
+   * is the lock, so it is taken before anything destructive; a summary that reads
+   * "optionally wipes, creates the job" describes the race this method was
+   * changed to close, and a maintainer following it would reopen it.
    */
   async start(userId: string, input: StartImportInput): Promise<ImportJob> {
     const staged = await this.staging.findInfo(userId, input.stagedFileId);
@@ -571,7 +577,7 @@ export class MnyImportService {
         accounts.idByKey,
       );
 
-      return {
+      const result = {
         accountIdByKey: accounts.idByKey,
         securityIdByHandle: securities.idByHandle,
         accountsCreated: accounts.created,
@@ -590,6 +596,16 @@ export class MnyImportService {
           ...investments.affectedAccountIds,
         ]),
       };
+
+      // Last statement before commit: if this job no longer holds the user's
+      // import slot -- retired by the one-active-job migration on a database that
+      // raced before the index existed, or reaped as stale -- throwing here rolls
+      // every row above back. Checking the status anywhere else, including in
+      // `complete()`, happens after these rows are already committed, which is
+      // how a retired duplicate could still double a user's financial history.
+      await this.jobs.assertStillHoldsSlot(manager, context.jobId);
+
+      return result;
     });
   }
 

--- a/backend/test/integration/mny-import-job.integration.spec.ts
+++ b/backend/test/integration/mny-import-job.integration.spec.ts
@@ -2,13 +2,14 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { ConflictException } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { TypeOrmModule } from "@nestjs/typeorm";
-import { DataSource } from "typeorm";
+import { DataSource, EntityManager } from "typeorm";
 
 import { ImportJob } from "@/import/mny/entities/import-job.entity";
 import { ImportStagedFile } from "@/import/mny/entities/import-staged-file.entity";
 import {
   JOB_STALLED_ERROR_KEY,
   MnyImportJobService,
+  MnyImportSlotLostError,
 } from "@/import/mny/mny-import-job.service";
 import { MnyStagingService } from "@/import/mny/mny-staging.service";
 import { MnyPasswordIncorrectError } from "@/import/mny/mny-errors";
@@ -421,6 +422,153 @@ describe("MnyImportJobService (integration)", () => {
 
       const job = await asUser(userA, () => jobs.findOne(userA, jobId));
       expect(job!.progress).toBeNull();
+    });
+  });
+
+  /**
+   * The slot lease, against real transactions.
+   *
+   * The one-active-job index stops a *new* start from racing. It does not stop a
+   * job that already claimed its slot from losing it mid-flight, and two things
+   * do exactly that: the migration that retires pre-existing duplicates on a
+   * database that raced before the index existed, and `reapStaleJobs` failing a
+   * `running` job whose heartbeat lapsed. Every backend container runs migrations
+   * at start-up and the Helm StatefulSet rolls pods one at a time, so a new pod
+   * can retire a job an old pod is still importing.
+   *
+   * What made that dangerous was where the status was checked. `complete()` runs
+   * *after* the body, so the financial rows are committed by the time anything
+   * notices -- a retired duplicate could still double a user's history. The lease
+   * check runs as the last statement of the writing transaction instead, so the
+   * refusal rolls those rows back.
+   */
+  describe("assertStillHoldsSlot", () => {
+    /** A table the body can write into, standing in for the imported rows. */
+    const writeMarker = (manager: EntityManager, jobId: string) =>
+      manager.query(
+        `UPDATE import_jobs SET error_detail = 'wrote-financial-rows' WHERE id = $1`,
+        [jobId],
+      );
+
+    const detailOf = async (jobId: string): Promise<string | null> => {
+      const rows = await asUser(userA, () =>
+        withScopedDb(dataSource, (manager) =>
+          manager.query(`SELECT error_detail FROM import_jobs WHERE id = $1`, [
+            jobId,
+          ]),
+        ),
+      );
+      return rows[0]?.error_detail ?? null;
+    };
+
+    it("passes while the job is running", async () => {
+      const jobId = await newJob();
+      await asUser(userA, () => jobs.claim(jobId));
+
+      await expect(
+        asUser(userA, () =>
+          withScopedDb(dataSource, (manager) =>
+            jobs.assertStillHoldsSlot(manager, jobId),
+          ),
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    it("rolls the body's writes back when the job was retired mid-flight", async () => {
+      const jobId = await newJob();
+      await asUser(userA, () => jobs.claim(jobId));
+
+      // Retire it the way migration 135 does, from outside the body's transaction.
+      await asUser(userA, () =>
+        withScopedDb(dataSource, (manager) =>
+          manager.query(
+            `UPDATE import_jobs SET status = 'failed', error_key = $2,
+                    retryable = true WHERE id = $1`,
+            [jobId, JOB_STALLED_ERROR_KEY],
+          ),
+        ),
+      );
+
+      await expect(
+        asUser(userA, () =>
+          withScopedDb(dataSource, async (manager) => {
+            await writeMarker(manager, jobId);
+            await jobs.assertStillHoldsSlot(manager, jobId);
+          }),
+        ),
+      ).rejects.toBeInstanceOf(MnyImportSlotLostError);
+
+      // The whole transaction rolled back, so the write is gone. Before the lease
+      // check existed this was the point at which imported rows were committed.
+      expect(await detailOf(jobId)).toBeNull();
+    });
+
+    it("refuses a job that is still pending -- it never claimed the slot", async () => {
+      const jobId = await newJob();
+
+      await expect(
+        asUser(userA, () =>
+          withScopedDb(dataSource, (manager) =>
+            jobs.assertStillHoldsSlot(manager, jobId),
+          ),
+        ),
+      ).rejects.toBeInstanceOf(MnyImportSlotLostError);
+    });
+
+    it("refuses a job row that no longer exists", async () => {
+      // Distinguishable from "not yours": both are a lost slot, and neither may
+      // let the body commit.
+      await expect(
+        asUser(userA, () =>
+          withScopedDb(dataSource, (manager) =>
+            jobs.assertStillHoldsSlot(
+              manager,
+              "00000000-0000-0000-0000-000000000000",
+            ),
+          ),
+        ),
+      ).rejects.toBeInstanceOf(MnyImportSlotLostError);
+    });
+
+    it("does not resurrect a retired job through complete()", async () => {
+      // The second line of defence: `complete` carries AND status = 'running',
+      // so a row the migration marked failed cannot later read as completed.
+      const jobId = await newJob();
+      await asUser(userA, () => jobs.claim(jobId));
+      await asUser(userA, () => jobs.fail(jobId, "x", "retired", true));
+
+      await asUser(userA, () => jobs.complete(jobId, EMPTY_RESULT));
+
+      const job = await asUser(userA, () => jobs.findOne(userA, jobId));
+      expect(job!.status).toBe("failed");
+      expect(job!.result).toBeNull();
+    });
+
+    it("leaves the retiring party's explanation on the row", async () => {
+      // A lost slot must not overwrite error_key with the generic failure key:
+      // the row already says why it was retired.
+      const jobId = await newJob();
+
+      const ran = await asUser(userA, () =>
+        jobs.runClaimed(userA, jobId, async (context) => {
+          await asUser(userA, () =>
+            withScopedDb(dataSource, (manager) =>
+              manager.query(
+                `UPDATE import_jobs SET status = 'failed', error_key = $2,
+                        retryable = true WHERE id = $1`,
+                [context.jobId, JOB_STALLED_ERROR_KEY],
+              ),
+            ),
+          );
+          throw new MnyImportSlotLostError(context.jobId, "failed");
+        }),
+      );
+
+      const job = await asUser(userA, () => jobs.findOne(userA, jobId));
+      expect(ran).toBe(true);
+      expect(job!.status).toBe("failed");
+      expect(job!.errorKey).toBe(JOB_STALLED_ERROR_KEY);
+      expect(job!.retryable).toBe(true);
     });
   });
 

--- a/database/migrations/135_import_jobs_single_active.sql
+++ b/database/migrations/135_import_jobs_single_active.sql
@@ -18,6 +18,16 @@
 -- newest active job per user and fail the rest retryably: the staged bytes are
 -- untouched, so the wizard can offer Retry. A no-op on a database that never
 -- raced, and on every re-apply.
+--
+-- This UPDATE alone does NOT stop a worker. Every backend container runs
+-- migrations at start-up and the Helm StatefulSet rolls pods one at a time, so a
+-- new pod can retire a job an *old* pod is still importing -- and status is not
+-- something the worker consults. What makes the retirement binding is
+-- `MnyImportJobService.assertStillHoldsSlot`, called as the last statement of the
+-- transaction that writes the imported rows: the retired worker sees `failed`
+-- there and its whole write rolls back. Without it this cleanup would rewrite the
+-- coordination row while the duplicate import committed anyway, which is the
+-- doubled history the index exists to prevent.
 UPDATE import_jobs AS job
    SET status = 'failed',
        error_key = 'mnyJobStalled',


### PR DESCRIPTION
## Linked discussion / issue

None. This addresses **RFR-001** of an external remediation review of audit
finding **P1-001**. No Discussion was opened beforehand — see the note at the end
of this body.

## Summary

Migration `135_import_jobs_single_active.sql` retires duplicate active import
jobs on a database that raced before the one-active-job index existed. That
`UPDATE` rewrites the coordination row and nothing else: the import body never
consults `status`, so it runs to completion and its financial transaction commits
anyway.

That matters during the upgrade the migration is part of. Every backend container
runs migrations at start-up and the StatefulSet uses `RollingUpdate`, so a new pod
can retire a job an **old** pod is still importing — and the doubled history the
index exists to prevent still lands. `complete()` then had `WHERE id = $1` with no
status predicate, so the retired row could read `completed` afterwards.

`MnyImportJobService.assertStillHoldsSlot(manager, jobId)` is now the last
statement of the transaction that writes the imported rows. It selects the job's
status `FOR UPDATE` and throws unless it is still `running`, so the refusal rolls
those rows back — the standing rule in `backend/CLAUDE.md` that a rejected command
must not already have written. Checking in `complete()` cannot satisfy it: by
then the rows are committed.

`FOR UPDATE` matters as much as the predicate. It serializes the check against a
concurrent retirement, so of two racing workers exactly one commits and the loser
sees the committed outcome rather than a snapshot taken before it.

It also covers a path with no migration involved: `reapStaleJobs` fails a
`running` job whose heartbeat lapsed, which happens to a slow import on a loaded
pod, not only to a dead one. That had the same problem.

Supporting changes: `complete()` gained `AND status = 'running'` as a second line
of defence; a lost slot logs and returns rather than overwriting the retiring
party's `error_key` with the generic failure key; migration 135 now says the
`UPDATE` alone does not stop a worker and names what makes it binding.

**Not done, deliberately.** The review's alternative was to abort the migration
when duplicate `running` rows exist. A failed migration aborts backend start-up,
so that converts a data edge case into a boot loop on every replica requiring DBA
intervention. With the lease in place the online cleanup is safe.

**Tests.** Six integration cases against real transactions in
`backend/test/integration/mny-import-job.integration.spec.ts`: retired mid-flight
(the body's write is **rolled back**, not merely refused), still `pending`, row
deleted, still `running`, `complete()` after retirement, and the error-key
survival. Mutation-tested in two parts, because one mutation would not have
proved both: neutering the lease check fails three cases, removing only
`complete()`'s predicate fails the resurrection case.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — **no**, see below
- [x] This PR addresses a **single concern**.
- [x] New behavior has tests, and the existing suite passes. — 770 unit + 36 integration in the touched areas
- [x] All user-facing strings are translated for every locale. — no new strings; reuses existing `tr()` keys
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below.

**On the missing Discussion:** this came out of an audit rather than a feature
proposal, so there was nothing to propose in advance. Happy to open a Discussion
and let this PR wait behind it — say the word. The alternative reading is that the
finding itself is the proposal.

## AI assistance disclosure

Written with Claude Code (Claude Opus 5). The finding, the fix, the tests and this
description are AI-produced; I have reviewed them and own the result. Verification
was run locally against PostgreSQL 16 (Docker unavailable in the environment, so a
local server was used): the touched unit suites and the `.mny` integration suite
pass, `tsc --noEmit`, `npm run typecheck`, ESLint and `npm run migration:lint` are
clean. Every new assertion was mutation-tested — the defect restored, the test
confirmed to fail — rather than only confirmed green.
