### PR TITLE
01: Acquire counted caps and the last-admin guard atomically (v.1.15.0)

### DIFF
--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -35,6 +35,20 @@ describe("AdminService", () => {
   let transactionManager: Record<string, jest.Mock>;
   let dataSource: Record<string, jest.Mock>;
 
+  /**
+   * The admin set a test posits. The last-admin guard locks it with a raw
+   * `SELECT id FROM users WHERE role = 'admin' FOR UPDATE`, because a count
+   * cannot refuse two concurrent demotions of two different admins -- so the set
+   * is driven through the manager's `query`, not through `usersRepository.count`.
+   */
+  const lockedAdmins = (...ids: string[]): void => {
+    transactionManager.query.mockImplementation((sql: unknown) =>
+      Promise.resolve(
+        /FOR UPDATE/.test(String(sql)) ? ids.map((id) => ({ id })) : [],
+      ),
+    );
+  };
+
   const mockAdmin = {
     id: "admin-1",
     email: "admin@example.com",
@@ -131,6 +145,10 @@ describe("AdminService", () => {
     Object.assign(scoped.manager, transactionManager);
     transactionManager = scoped.manager;
     dataSource = scoped.dataSource as unknown as Record<string, jest.Mock>;
+
+    // Three admins by default, so tests that are not about the guard are not
+    // refused by it.
+    lockedAdmins("admin-1", "admin-9", "user-2");
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -403,7 +421,7 @@ describe("AdminService", () => {
         ...mockTargetUser,
         role: "admin",
       });
-      usersRepository.count.mockResolvedValue(1);
+      lockedAdmins("user-2");
 
       await expect(
         service.updateUserRole("admin-1", "user-2", "user"),
@@ -415,7 +433,7 @@ describe("AdminService", () => {
         ...mockTargetUser,
         role: "admin",
       });
-      usersRepository.count.mockResolvedValue(3);
+      lockedAdmins("user-2", "admin-9");
 
       const result = await service.updateUserRole("admin-1", "user-2", "user");
 
@@ -526,7 +544,7 @@ describe("AdminService", () => {
         ...mockTargetUser,
         role: "admin",
       });
-      usersRepository.count.mockResolvedValue(1);
+      lockedAdmins("user-2");
 
       await expect(service.deleteUser("admin-1", "user-2")).rejects.toThrow(
         BadRequestException,
@@ -538,11 +556,53 @@ describe("AdminService", () => {
         ...mockTargetUser,
         role: "admin",
       });
-      usersRepository.count.mockResolvedValue(2);
+      lockedAdmins("user-2", "admin-9");
 
       await service.deleteUser("admin-1", "user-2");
 
       expect(usersRepository.remove).toHaveBeenCalled();
+    });
+
+    it("locks the admin set again in the transaction that removes the row", async () => {
+      // The guard used to run in its own transaction and commit before the
+      // delete began, so the lock protected nothing by the time the row went.
+      // Two admins deleted concurrently could each pass and leave none.
+      usersRepository.findOne.mockResolvedValue({
+        ...mockTargetUser,
+        role: "admin",
+      });
+      lockedAdmins("user-2", "admin-9");
+
+      await service.deleteUser("admin-1", "user-2");
+
+      const locks = transactionManager.query.mock.calls.filter((call) =>
+        /FOR UPDATE/.test(String(call[0])),
+      );
+      expect(locks.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("refuses in the delete transaction when the admin set shrank after the pre-flight", async () => {
+      // The pre-flight sees two admins; by the time the delete transaction takes
+      // the lock the other admin is gone. The row must survive.
+      usersRepository.findOne.mockResolvedValue({
+        ...mockTargetUser,
+        role: "admin",
+      });
+      let seen = 0;
+      transactionManager.query.mockImplementation((sql: unknown) => {
+        if (!/FOR UPDATE/.test(String(sql))) return Promise.resolve([]);
+        seen += 1;
+        return Promise.resolve(
+          seen === 1
+            ? [{ id: "user-2" }, { id: "admin-9" }]
+            : [{ id: "user-2" }],
+        );
+      });
+
+      await expect(service.deleteUser("admin-1", "user-2")).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(usersRepository.remove).not.toHaveBeenCalled();
     });
 
     it("revokes all OIDC artifacts on delete", async () => {

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -24,6 +24,10 @@ import { generateReadablePassword } from "./utils/password-generator";
 import { hashToken } from "../auth/crypto.util";
 import { OAuthProviderService } from "../oauth/oauth-provider.service";
 import { UsersService } from "../users/users.service";
+import {
+  lockAdminsForUpdate,
+  wouldRemoveLastAdmin,
+} from "../users/last-admin.util";
 import { EmailService } from "../notifications/email.service";
 import { accountInviteTemplate } from "../notifications/email-templates";
 import { CreateUserDto } from "./dto/create-user.dto";
@@ -256,10 +260,19 @@ export class AdminService {
       );
     }
 
-    // One transaction: the last-admin check and the demotion are a
-    // read-modify-write over the same set of rows.
+    // One transaction, and the admin set locked inside it: the last-admin check
+    // and the demotion are a read-modify-write over the same set of rows. A
+    // count would let two concurrent demotions of two *different* admins both
+    // see two and both proceed, leaving nobody able to administer the instance
+    // -- one transaction is not enough on its own, because neither sees the
+    // other's uncommitted change.
     const saved = await withScopedDb(this.dataSource, async (manager) => {
       const repo = manager.getRepository(User);
+
+      // Locked before the target is read, so this read also reflects a
+      // concurrent role change that has since committed.
+      const adminIds = await lockAdminsForUpdate(manager);
+
       const targetUser = await repo.findOne({
         where: { id: targetUserId },
       });
@@ -270,18 +283,17 @@ export class AdminService {
       }
 
       // Prevent removing the last admin
-      if (targetUser.role === "admin" && role === "user") {
-        const adminCount = await repo.count({
-          where: { role: "admin" },
-        });
-        if (adminCount <= 1) {
-          throw new BadRequestException(
-            tr(
-              "errors.admin.removeLastAdmin",
-              "Cannot remove the last admin. Promote another user first.",
-            ),
-          );
-        }
+      if (
+        targetUser.role === "admin" &&
+        role === "user" &&
+        wouldRemoveLastAdmin(adminIds, targetUserId)
+      ) {
+        throw new BadRequestException(
+          tr(
+            "errors.admin.removeLastAdmin",
+            "Cannot remove the last admin. Promote another user first.",
+          ),
+        );
       }
 
       targetUser.role = role;
@@ -369,6 +381,10 @@ export class AdminService {
       );
     }
 
+    // Pre-flight, so an obviously refused delete does not first revoke the
+    // target's sessions. The authoritative check is in the delete transaction
+    // below, under the admin lock -- a guard that commits before the delete
+    // starts holds nothing by the time the row is removed.
     const targetUser = await withScopedDb(this.dataSource, async (manager) => {
       const repo = manager.getRepository(User);
       const found = await repo.findOne({
@@ -380,19 +396,16 @@ export class AdminService {
         );
       }
 
-      // Prevent deleting the last admin
-      if (found.role === "admin") {
-        const adminCount = await repo.count({
-          where: { role: "admin" },
-        });
-        if (adminCount <= 1) {
-          throw new BadRequestException(
-            tr(
-              "errors.admin.deleteLastAdmin",
-              "Cannot delete the last admin account.",
-            ),
-          );
-        }
+      if (
+        found.role === "admin" &&
+        wouldRemoveLastAdmin(await lockAdminsForUpdate(manager), targetUserId)
+      ) {
+        throw new BadRequestException(
+          tr(
+            "errors.admin.deleteLastAdmin",
+            "Cannot delete the last admin account.",
+          ),
+        );
       }
       return found;
     });
@@ -419,6 +432,20 @@ export class AdminService {
     // One transaction: a partially cleared account would leave live sessions
     // pointing at a user row that is about to disappear.
     await withScopedDb(this.dataSource, async (manager) => {
+      // The authoritative last-admin check: taken here, in the transaction that
+      // actually removes the row, so the lock is still held when it commits.
+      if (
+        targetUser.role === "admin" &&
+        wouldRemoveLastAdmin(await lockAdminsForUpdate(manager), targetUserId)
+      ) {
+        throw new BadRequestException(
+          tr(
+            "errors.admin.deleteLastAdmin",
+            "Cannot delete the last admin account.",
+          ),
+        );
+      }
+
       const refreshTokens = manager.getRepository(RefreshToken);
       await refreshTokens.delete({ userId: targetUserId });
       await refreshTokens.delete({ actingAsUserId: targetUserId });

--- a/backend/src/ai/ai.service.spec.ts
+++ b/backend/src/ai/ai.service.spec.ts
@@ -16,6 +16,7 @@ jest.mock("../common/db/scoped-db", () =>
 
 describe("AiService", () => {
   let service: AiService;
+  let scopedManager: Record<string, jest.Mock>;
   let mockConfigRepository: Record<string, jest.Mock>;
   let mockEncryptionService: Partial<
     Record<keyof AiEncryptionService, jest.Mock>
@@ -108,14 +109,18 @@ describe("AiService", () => {
       enqueuePrompt: jest.fn().mockResolvedValue({ text: "Relay answer" }),
     };
 
+    const scoped = createScopedDbMocks([
+      [AiProviderConfig, mockConfigRepository],
+    ]);
+    scopedManager = scoped.manager as unknown as Record<string, jest.Mock>;
+    scopedManager.query.mockResolvedValue([{ id: userId }]);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AiService,
         {
           provide: DataSource,
-          useValue: createScopedDbMocks([
-            [AiProviderConfig, mockConfigRepository],
-          ]).dataSource,
+          useValue: scoped.dataSource,
         },
         { provide: AiEncryptionService, useValue: mockEncryptionService },
         { provide: AiProviderFactory, useValue: mockProviderFactory },
@@ -248,6 +253,22 @@ describe("AiService", () => {
           baseUrl: "ftp://localhost:11434",
         }),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it("serializes on the owner's row before counting against the per-user cap", async () => {
+      // One transaction is not the fix on its own: two concurrent creates each
+      // count the rows committed before either started, so neither sees the
+      // other's insert and both pass the cap. The lock is what makes the count
+      // binding.
+      await service.createConfig(userId, { provider: "ollama" });
+
+      expect(scopedManager.query).toHaveBeenCalledWith(
+        expect.stringMatching(/FROM users WHERE id = \$1 FOR UPDATE/),
+        [userId],
+      );
+      expect(scopedManager.query.mock.invocationCallOrder[0]).toBeLessThan(
+        mockConfigRepository.count.mock.invocationCallOrder[0],
+      );
     });
   });
 

--- a/backend/src/ai/ai.service.ts
+++ b/backend/src/ai/ai.service.ts
@@ -152,10 +152,16 @@ export class AiService {
       await this.validateBaseUrl(dto.baseUrl, dto.provider);
     }
 
-    // One transaction: the per-user cap is a read-modify-write, so counting on
-    // one connection and inserting on another would let two concurrent creates
-    // both pass the check.
+    // One transaction, and the owner's row locked inside it. The per-user cap is
+    // a read-modify-write, and the transaction alone is not the fix: two
+    // concurrent creates each count the rows committed before either started, so
+    // neither sees the other's insert and both pass. Serializing on the `users`
+    // row is what makes the count binding.
     const saved = await withScopedDb(this.dataSource, async (manager) => {
+      await manager.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [
+        userId,
+      ]);
+
       const repo = manager.getRepository(AiProviderConfig);
 
       const existingCount = await repo.count({

--- a/backend/src/auth/pat.service.spec.ts
+++ b/backend/src/auth/pat.service.spec.ts
@@ -20,6 +20,7 @@ describe("PatService", () => {
   let service: PatService;
   let repository: Record<string, jest.Mock>;
   let userRepository: Record<string, jest.Mock>;
+  let manager: Record<string, jest.Mock>;
 
   const mockToken = {
     id: "token-1",
@@ -49,14 +50,18 @@ describe("PatService", () => {
       findOne: jest.fn(),
     };
 
+    const scoped = createScopedDbMocks([
+      [PersonalAccessToken, repository as never],
+      [User, userRepository as never],
+    ]);
+    manager = scoped.manager as unknown as Record<string, jest.Mock>;
+    manager.query.mockResolvedValue([{ id: "user-1" }]);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         {
           provide: DataSource,
-          useValue: createScopedDbMocks([
-            [PersonalAccessToken, repository as never],
-            [User, userRepository as never],
-          ]).dataSource,
+          useValue: scoped.dataSource,
         },
         PatService,
       ],
@@ -157,6 +162,41 @@ describe("PatService", () => {
       await expect(
         service.create("user-1", { name: "Too Many" }),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it("serializes on the owner's row before counting against the cap", async () => {
+      // The cap is a read-modify-write with no unique constraint behind it, so
+      // nothing catches a breach after the fact. Counting on one connection and
+      // inserting on another let two concurrent creates both pass; so would
+      // counting and inserting in one transaction, since neither sees the
+      // other's uncommitted row. The lock is the whole guard.
+      repository.count.mockResolvedValue(0);
+      repository.create.mockImplementation((data) => ({ ...data }));
+      repository.save.mockImplementation((token) =>
+        Promise.resolve({ ...token }),
+      );
+
+      await service.create("user-1", { name: "My Token" });
+
+      expect(manager.query).toHaveBeenCalledWith(
+        expect.stringMatching(/FROM users WHERE id = \$1 FOR UPDATE/),
+        ["user-1"],
+      );
+      expect(manager.query.mock.invocationCallOrder[0]).toBeLessThan(
+        repository.count.mock.invocationCallOrder[0],
+      );
+      expect(repository.count.mock.invocationCallOrder[0]).toBeLessThan(
+        repository.save.mock.invocationCallOrder[0],
+      );
+    });
+
+    it("does not insert the token when the cap refuses it", async () => {
+      repository.count.mockResolvedValue(10);
+
+      await expect(
+        service.create("user-1", { name: "Too Many" }),
+      ).rejects.toThrow(BadRequestException);
+      expect(repository.save).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/auth/pat.service.ts
+++ b/backend/src/auth/pat.service.ts
@@ -44,27 +44,35 @@ export class PatService {
     userId: string,
     dto: CreatePatDto,
   ): Promise<{ token: PersonalAccessToken; rawToken: string }> {
-    const count = await this.scoped(PersonalAccessToken, (repo) =>
-      repo.count({
-        where: { userId, isRevoked: false },
-      }),
-    );
-    if (count >= MAX_TOKENS_PER_USER) {
-      throw new BadRequestException(
-        tr(
-          "errors.auth.maxTokensExceeded",
-          `Maximum of ${MAX_TOKENS_PER_USER} active tokens per user`,
-          { MAX_TOKENS_PER_USER },
-        ),
-      );
-    }
-
     const rawToken = "pat_" + crypto.randomBytes(32).toString("hex");
     const tokenHash = hashToken(rawToken);
     const tokenPrefix = rawToken.substring(0, 8);
 
-    const saved = await withScopedDb(this.dataSource, (manager) => {
+    // One transaction, and the owner's row locked inside it. The cap is a
+    // read-modify-write: counting on one connection and inserting on another let
+    // two concurrent creates both pass, and moving the count into the same
+    // transaction would not have helped -- neither sees the other's uncommitted
+    // insert. Serializing on the `users` row is what makes the count binding, and
+    // there is no unique constraint that could catch it afterwards.
+    const saved = await withScopedDb(this.dataSource, async (manager) => {
+      await manager.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [
+        userId,
+      ]);
+
       const repo = manager.getRepository(PersonalAccessToken);
+      const count = await repo.count({
+        where: { userId, isRevoked: false },
+      });
+      if (count >= MAX_TOKENS_PER_USER) {
+        throw new BadRequestException(
+          tr(
+            "errors.auth.maxTokensExceeded",
+            `Maximum of ${MAX_TOKENS_PER_USER} active tokens per user`,
+            { MAX_TOKENS_PER_USER },
+          ),
+        );
+      }
+
       return repo.save(
         repo.create({
           userId,

--- a/backend/src/users/last-admin.util.spec.ts
+++ b/backend/src/users/last-admin.util.spec.ts
@@ -1,0 +1,58 @@
+import { EntityManager } from "typeorm";
+import { lockAdminsForUpdate, wouldRemoveLastAdmin } from "./last-admin.util";
+
+describe("lockAdminsForUpdate", () => {
+  const managerWith = (
+    rows: unknown,
+  ): { manager: EntityManager; query: jest.Mock } => {
+    const query = jest.fn().mockResolvedValue(rows);
+    return { manager: { query } as unknown as EntityManager, query };
+  };
+
+  it("locks the admin rows rather than counting them", async () => {
+    // A plain count cannot refuse two concurrent demotions of two different
+    // admins -- neither transaction sees the other's uncommitted change. The
+    // `FOR UPDATE` is the entire guard, so its absence is the defect.
+    const { manager, query } = managerWith([{ id: "a" }, { id: "b" }]);
+
+    await lockAdminsForUpdate(manager);
+
+    const sql = String(query.mock.calls[0][0]);
+    expect(sql).toMatch(/FOR UPDATE/);
+    expect(sql).toMatch(/role = 'admin'/);
+  });
+
+  it("returns the locked administrator ids", async () => {
+    const { manager } = managerWith([{ id: "a" }, { id: "b" }]);
+
+    expect(await lockAdminsForUpdate(manager)).toEqual(["a", "b"]);
+  });
+
+  it("returns an empty list when there are none", async () => {
+    const { manager } = managerWith([]);
+
+    expect(await lockAdminsForUpdate(manager)).toEqual([]);
+  });
+});
+
+describe("wouldRemoveLastAdmin", () => {
+  it("refuses when the target is the only administrator", () => {
+    expect(wouldRemoveLastAdmin(["a"], "a")).toBe(true);
+  });
+
+  it("allows when another administrator remains", () => {
+    expect(wouldRemoveLastAdmin(["a", "b"], "a")).toBe(false);
+  });
+
+  it("allows when the target is not an administrator at all", () => {
+    // The sole admin is someone else; demoting a non-admin cannot empty the set,
+    // and a bare length check would have refused this.
+    expect(wouldRemoveLastAdmin(["a"], "b")).toBe(false);
+  });
+
+  it("allows when the set is already empty", () => {
+    // Nothing to protect: refusing here would make an instance with no admin
+    // permanently unable to delete anyone.
+    expect(wouldRemoveLastAdmin([], "a")).toBe(false);
+  });
+});

--- a/backend/src/users/last-admin.util.ts
+++ b/backend/src/users/last-admin.util.ts
@@ -1,0 +1,49 @@
+import { EntityManager } from "typeorm";
+
+/**
+ * The administrators that exist right now, with their rows locked for the rest
+ * of the caller's transaction.
+ *
+ * "Never leave the instance with zero administrators" is an invariant over a
+ * *set* of rows, and counting cannot enforce it. Two transactions each demoting
+ * or deleting a different admin both count two and both proceed -- at any
+ * isolation level below serializable, because neither sees the other's
+ * uncommitted change. Putting the count in the same transaction as the mutation
+ * does not help; only contending over the rows does.
+ *
+ * `FOR UPDATE` gives that contention. The second transaction blocks until the
+ * first commits, and PostgreSQL then re-evaluates `role = 'admin'` against the
+ * committed row, so a just-demoted or just-deleted admin drops out of the result
+ * and the count the caller checks is the real one. A concurrently *added* admin
+ * is a phantom this does not block, which is safe in the only direction that
+ * matters: another administrator can never turn an allowed operation into one
+ * that empties the set.
+ *
+ * Call this before reading the row being changed, so that read also sees the
+ * committed outcome of whatever the lock waited for, and hold the transaction
+ * until the mutation is written. A guard in one transaction and the delete in
+ * the next is the same defect with extra steps: the lock is gone by then.
+ *
+ * @param manager the EntityManager of the ACTIVE transaction performing the
+ *   mutation -- a lock taken in a transaction that then commits protects nothing.
+ */
+export async function lockAdminsForUpdate(
+  manager: EntityManager,
+): Promise<string[]> {
+  const rows: Array<{ id: string }> = await manager.query(
+    `SELECT id FROM users WHERE role = 'admin' FOR UPDATE`,
+  );
+  return rows.map((row) => row.id);
+}
+
+/**
+ * True when removing this user's administrator status would leave none, given
+ * the locked admin set. `adminIds` must come from `lockAdminsForUpdate` in the
+ * same transaction.
+ */
+export function wouldRemoveLastAdmin(
+  adminIds: string[],
+  targetUserId: string,
+): boolean {
+  return adminIds.length <= 1 && adminIds.includes(targetUserId);
+}

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -908,6 +908,31 @@ describe("UsersService", () => {
       expect(usersRepository.remove).toHaveBeenCalled();
     });
 
+    it("refuses under the admin lock even when the pre-flight count allowed it", async () => {
+      // The real race: two admins self-delete at the same instant, both count
+      // two, both proceed, and the instance ends up with no administrator. The
+      // pre-flight count is deliberately permissive here; only the locked read in
+      // the delete transaction can refuse.
+      const hashedPassword = await bcrypt.hash("CorrectPass123!", 10);
+      usersRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        role: "admin",
+        passwordHash: hashedPassword,
+      });
+      usersRepository.count.mockResolvedValue(2);
+      // Same jest.fn as the scoped manager's `query` (wired in beforeEach).
+      mockQueryRunner.query.mockImplementation((sql: unknown) =>
+        Promise.resolve(
+          /FOR UPDATE/.test(String(sql)) ? [{ id: "user-1" }] : [],
+        ),
+      );
+
+      await expect(
+        service.deleteAccount("user-1", { password: "CorrectPass123!" }),
+      ).rejects.toThrow(ForbiddenException);
+      expect(usersRepository.remove).not.toHaveBeenCalled();
+    });
+
     it("accepts OIDC token for OIDC-only users", async () => {
       usersRepository.findOne.mockResolvedValue({
         ...mockUser,

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -21,6 +21,7 @@ import { currentRequestLocale } from "../i18n/request-locale";
 import { User } from "./entities/user.entity";
 import { UserPreference } from "./entities/user-preference.entity";
 import { buildDefaultPreferences } from "./user-preference.factory";
+import { lockAdminsForUpdate, wouldRemoveLastAdmin } from "./last-admin.util";
 import { TrustedDevice } from "./entities/trusted-device.entity";
 import { RefreshToken } from "../auth/entities/refresh-token.entity";
 import { PersonalAccessToken } from "../auth/entities/personal-access-token.entity";
@@ -421,7 +422,13 @@ export class UsersService {
     }
 
     // SECURITY: Prevent the last admin from self-deleting, which would leave
-    // the system with no administrator
+    // the system with no administrator.
+    //
+    // Pre-flight only, so an obviously refused deletion does not first revoke
+    // the caller's own sessions. The authoritative check is under the admin lock
+    // in the transaction that removes the row -- two admins self-deleting at the
+    // same instant each counted two here and each proceeded, and the instance
+    // ended up with none.
     if (user.role === "admin") {
       const adminCount = await this.scoped(User, (repo) =>
         repo.count({
@@ -461,13 +468,28 @@ export class UsersService {
     // and preferences are worthless once the account is gone either way.
     // Delegate sessions acting *as* this user go too -- the owner they point
     // at is about to disappear.
-    await this.scoped(RefreshToken, (repo) => repo.delete({ userId }));
-    await this.scoped(RefreshToken, (repo) =>
-      repo.delete({ actingAsUserId: userId }),
-    );
-    await this.scoped(PersonalAccessToken, (repo) => repo.delete({ userId }));
-    await this.scoped(UserPreference, (repo) => repo.delete({ userId }));
-    await this.scoped(User, (repo) => repo.remove(user));
+    await withScopedDb(this.dataSource, async (manager) => {
+      // The authoritative last-admin check, in the transaction that removes the
+      // row and while the lock over the admin set is still held.
+      if (
+        user.role === "admin" &&
+        wouldRemoveLastAdmin(await lockAdminsForUpdate(manager), userId)
+      ) {
+        throw new ForbiddenException(
+          tr(
+            "errors.users.deleteLastAdmin",
+            "Cannot delete the last admin account. Promote another user first.",
+          ),
+        );
+      }
+
+      const refreshTokens = manager.getRepository(RefreshToken);
+      await refreshTokens.delete({ userId });
+      await refreshTokens.delete({ actingAsUserId: userId });
+      await manager.getRepository(PersonalAccessToken).delete({ userId });
+      await manager.getRepository(UserPreference).delete({ userId });
+      await manager.getRepository(User).remove(user);
+    });
     return { downgraded: false };
   }
 


### PR DESCRIPTION
## Linked discussion / issue

None. Found while reviewing the class of defect behind audit finding **P1-001**
(decide from a count, then act); not itself an audit finding. See the note at the
end.

## Summary

Three places decided from a count and then acted, and in each the count cannot see
the transaction it needs to lose to.

**Last administrator** (`admin.updateUserRole`, `admin.deleteUser`,
`users.deleteAccount`). "Never leave the instance with zero administrators" is an
invariant over a *set* of rows. Two requests each demoting or deleting a
*different* admin both counted two and both proceeded, leaving nobody able to
administer the instance — recoverable only with database access. Putting the count
in the mutation's transaction, which `updateUserRole` already did, does not help:
neither transaction sees the other's uncommitted change.

The set is now locked with `SELECT id FROM users WHERE role = 'admin' FOR UPDATE`,
so the second transaction blocks and PostgreSQL re-evaluates the predicate against
the committed row, dropping the just-demoted admin out of the count. A
concurrently *added* admin is a phantom this does not block, which is safe in the
only direction that matters.

`admin.deleteUser` had a further problem: its guard ran in its own transaction and
committed before the delete transaction opened, so any lock it took was already
released when the row was removed. It and `users.deleteAccount` now check twice —
a pre-flight, so an obviously refused request does not first revoke the target's
sessions, and the authoritative locked check inside the transaction that writes.

**PAT cap** (`pat.service.create`). Ten active tokens per user, counted on one
connection and inserted on another, with no unique constraint that could catch a
breach afterwards. Now one transaction that first locks the owner's `users` row.

**AI provider cap** (`ai.service.createConfig`). Already one transaction, with a
comment claiming that was the fix. It was not, for the same reason; it now takes
the same owner-row lock.

**Tests.** `lockAdminsForUpdate` / `wouldRemoveLastAdmin` unit cases including the
two a bare length check gets wrong (target is not an admin; set already empty);
three service cases that fail with the locked checks removed, one driving a set
that *shrinks* between the pre-flight and the delete; lock-ordering assertions for
both caps.

Note for review: the admin specs drove the admin set through `count`, which the
guard no longer reads, so they now drive it through the locked query. The mock had
to change to keep describing something the real collaborator can produce.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — **no**, see below
- [x] This PR addresses a **single concern**. — one defect class, three call sites
- [x] New behavior has tests, and the existing suite passes. — 273 tests in the touched areas
- [x] All user-facing strings are translated for every locale. — no new strings
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below.

**On the missing Discussion:** happy to open one if you would rather agree the
approach (row-set locking vs. a database constraint) before merging. A constraint
is not available here — "at least one admin exists" is not expressible as one.

## AI assistance disclosure

Written with Claude Code (Claude Opus 5). AI-produced and reviewed; I own the
result. Verified locally: touched unit suites pass, `tsc`, `typecheck` and ESLint
clean. The three service-level assertions were mutation-tested by neutering each
locked check in turn.
