### PR TITLE
01: Define the API scope vocabulary once (v.1.15.0)

### DIFF
--- a/backend/src/auth/dto/create-pat.dto.ts
+++ b/backend/src/auth/dto/create-pat.dto.ts
@@ -9,6 +9,7 @@ import {
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { IsFutureDate } from "../../common/validators/is-future-date.validator";
 import { SanitizeHtml } from "../../common/decorators/sanitize-html.decorator";
+import { apiScopesList, apiScopesPattern } from "../scopes";
 
 export class CreatePatDto {
   @ApiProperty({ description: "User-assigned label for the token" })
@@ -18,15 +19,18 @@ export class CreatePatDto {
   @SanitizeHtml()
   name: string;
 
+  // Pattern and message both derived from `API_SCOPES`: a scope named in the
+  // schema comment or a feature plan but missing from the regex is exactly how
+  // `reports` came to be documented and unissuable.
   @ApiPropertyOptional({
-    description: "Comma-separated scopes: read, write",
+    description: `Comma-separated scopes: ${apiScopesList()}`,
     default: "read",
   })
   @IsOptional()
   @IsString()
   @MaxLength(500)
-  @Matches(/^(read|write)(,(read|write))*$/, {
-    message: "Scopes must be comma-separated values of: read, write",
+  @Matches(apiScopesPattern(), {
+    message: `Scopes must be comma-separated values of: ${apiScopesList()}`,
   })
   scopes?: string;
 

--- a/backend/src/auth/scopes.spec.ts
+++ b/backend/src/auth/scopes.spec.ts
@@ -1,0 +1,182 @@
+import * as fs from "fs";
+import * as path from "path";
+import { validate } from "class-validator";
+import { plainToInstance } from "class-transformer";
+import {
+  API_SCOPES,
+  MCP_SCOPE_PREFIX,
+  apiScopesList,
+  apiScopesPattern,
+  isApiScope,
+} from "./scopes";
+import { CreatePatDto } from "./dto/create-pat.dto";
+import { MCP_RESOURCE_SCOPES } from "../oauth/oauth-provider.service";
+import { hasScope, requireScope } from "../mcp/mcp-context";
+
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+
+function collectFiles(dir: string, extension: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return collectFiles(full, extension);
+    return entry.name.endsWith(extension) ? [full] : [];
+  });
+}
+
+const scopesOf = async (scopes: string): Promise<string[]> => {
+  const dto = plainToInstance(CreatePatDto, { name: "t", scopes });
+  const errors = await validate(dto);
+  return errors.flatMap((error) => Object.values(error.constraints ?? {}));
+};
+
+/**
+ * The scope vocabulary lived in four places -- the schema comment, the PAT DTO
+ * regex, the OAuth resource list, and a feature plan -- and they disagreed: two
+ * of them documented a `reports` scope that PAT issuance rejects, so a client
+ * following the schema got a validation error for a scope the repository said
+ * existed.
+ *
+ * These are the checks that keep the four agreeing. They enumerate from
+ * `API_SCOPES` rather than restating the list, so adding a scope there is what
+ * makes them cover it.
+ */
+describe("API scope vocabulary", () => {
+  describe("PAT issuance", () => {
+    it.each(API_SCOPES)("accepts %s on its own", async (scope) => {
+      expect(await scopesOf(scope)).toEqual([]);
+    });
+
+    it("accepts every supported scope at once", async () => {
+      expect(await scopesOf(API_SCOPES.join(","))).toEqual([]);
+    });
+
+    it("rejects a scope that is not in the vocabulary", async () => {
+      // The `reports` case verbatim: documented, never issuable.
+      expect(await scopesOf("reports")).not.toEqual([]);
+      expect(await scopesOf("read,reports")).not.toEqual([]);
+    });
+
+    it("rejects an empty scope list and a trailing separator", async () => {
+      expect(await scopesOf("")).not.toEqual([]);
+      expect(await scopesOf("read,")).not.toEqual([]);
+    });
+
+    it("names every supported scope in the rejection message", async () => {
+      const [message] = await scopesOf("nope");
+      for (const scope of API_SCOPES) {
+        expect(message).toContain(scope);
+      }
+    });
+  });
+
+  describe("guards and tools read the same strings", () => {
+    it.each(API_SCOPES)("hasScope recognises %s", (scope) => {
+      expect(hasScope(API_SCOPES.join(","), scope)).toBe(true);
+      expect(requireScope(API_SCOPES.join(","), scope).error).toBe(false);
+    });
+
+    it("refuses a scope the token does not carry", () => {
+      expect(requireScope("read", "write").error).toBe(true);
+    });
+
+    it("classifies membership consistently with the list", () => {
+      for (const scope of API_SCOPES) {
+        expect(isApiScope(scope)).toBe(true);
+      }
+      expect(isApiScope("reports")).toBe(false);
+    });
+  });
+
+  describe("OAuth advertises exactly the same set, prefixed", () => {
+    it("derives the resource scopes from the vocabulary", () => {
+      expect([...MCP_RESOURCE_SCOPES]).toEqual(
+        API_SCOPES.map((scope) => `${MCP_SCOPE_PREFIX}${scope}`),
+      );
+    });
+
+    it("advertises no scope a PAT could not also be issued", () => {
+      for (const advertised of MCP_RESOURCE_SCOPES) {
+        expect(isApiScope(advertised.slice(MCP_SCOPE_PREFIX.length))).toBe(
+          true,
+        );
+      }
+    });
+  });
+
+  /**
+   * Scanning guards, not unit tests: the defect was a *document* naming a scope
+   * the code did not have, and no amount of prose keeps that from recurring. Both
+   * checks are deliberately narrow -- they read one machine-identifiable
+   * construct each, rather than trying to judge prose, so they cannot be
+   * satisfied by rewording and cannot fire on a sentence that merely mentions a
+   * retired scope by name.
+   */
+  describe("documentation does not advertise an unissuable scope", () => {
+    it("schema.sql enumerates exactly the supported scopes for personal_access_tokens", () => {
+      const source = fs.readFileSync(
+        path.join(REPO_ROOT, "database/schema.sql"),
+        "utf8",
+      );
+      // The trailing comment on the column definition. This is the copy that was
+      // wrong -- it listed 'read', 'write', 'reports'.
+      const line = /^\s*scopes VARCHAR\(500\).*--(.*)$/m.exec(source);
+      expect(line).not.toBeNull();
+
+      const enumerated = [...line![1].matchAll(/'([a-z]+)'/g)].map(
+        (match) => match[1],
+      );
+      expect(enumerated).toEqual([...API_SCOPES]);
+    });
+
+    it("no document requires a scope through requireScope that cannot be issued", () => {
+      // A plan proposing `requireScope(..., "reports")` describes a tool no PAT
+      // client could ever call. The call shape is exact, so this reads it
+      // directly instead of guessing at intent.
+      const docs = collectFiles(path.join(REPO_ROOT, "docs"), ".md");
+      const offenders: string[] = [];
+
+      for (const file of docs) {
+        const source = fs.readFileSync(file, "utf8");
+        for (const match of source.matchAll(
+          /requireScope\([^)]*?['"]([a-z:]+)['"]/g,
+        )) {
+          const scope = match[1].startsWith(MCP_SCOPE_PREFIX)
+            ? match[1].slice(MCP_SCOPE_PREFIX.length)
+            : match[1];
+          if (!isApiScope(scope)) {
+            offenders.push(`${path.relative(REPO_ROOT, file)}: ${match[1]}`);
+          }
+        }
+      }
+
+      expect(offenders).toEqual([]);
+    });
+  });
+
+  describe("the PAT UI offers exactly the issuable scopes", () => {
+    it("keeps SCOPE_OPTIONS in step with API_SCOPES", () => {
+      // A scope the backend accepts but the UI never offers is unreachable for
+      // every user who does not hand-craft the request; the reverse is a control
+      // that fails validation on submit.
+      const source = fs.readFileSync(
+        path.join(
+          REPO_ROOT,
+          "frontend/src/components/settings/ApiAccessSection.tsx",
+        ),
+        "utf8",
+      );
+      const block = /const SCOPE_OPTIONS = \[(.*?)\];/s.exec(source);
+      expect(block).not.toBeNull();
+
+      const offered = [...block![1].matchAll(/value:\s*['"]([a-z]+)['"]/g)].map(
+        (match) => match[1],
+      );
+      expect(offered).toEqual([...API_SCOPES]);
+    });
+  });
+
+  it("exposes the list for messages and documentation", () => {
+    expect(apiScopesList()).toBe(API_SCOPES.join(", "));
+    expect(apiScopesPattern().test(API_SCOPES.join(","))).toBe(true);
+  });
+});

--- a/backend/src/auth/scopes.ts
+++ b/backend/src/auth/scopes.ts
@@ -1,0 +1,46 @@
+/**
+ * The authorization-scope vocabulary, defined once.
+ *
+ * It had four copies: the `personal_access_tokens.scopes` comment in
+ * `schema.sql`, the regex in `CreatePatDto`, the `monize:`-prefixed list the
+ * OAuth provider advertises, and prose in a feature plan. The schema comment and
+ * the plan named a `reports` scope no issuance path had ever accepted, so a
+ * client reading either was told about a scope `POST /auth/pats` rejects. A
+ * vocabulary spread across four files drifts silently; derive from here instead
+ * of restating.
+ *
+ * `read` and `write` are the whole set. A PAT presents them bare; an OAuth client
+ * presents them resource-prefixed (`monize:read`) and `OAuthProviderService`
+ * strips the prefix, so both surfaces reach `requireScope` and `PatScopeGuard`
+ * with the same strings. Adding a scope means adding it here and to
+ * `frontend/src/components/settings/ApiAccessSection.tsx`; `scopes.spec.ts`
+ * checks that every consumer in this repository agrees.
+ */
+export const API_SCOPES = ["read", "write"] as const;
+
+export type ApiScope = (typeof API_SCOPES)[number];
+
+/** The resource-indicator prefix OAuth clients use for these scopes. */
+export const MCP_SCOPE_PREFIX = "monize:";
+
+/**
+ * Matches a non-empty comma-separated list of supported scopes.
+ *
+ * Built from `API_SCOPES` rather than written out, so a new scope cannot be
+ * declared and then rejected by validation -- which is the exact shape of the
+ * `reports` defect.
+ */
+export function apiScopesPattern(): RegExp {
+  const one = `(${API_SCOPES.join("|")})`;
+  return new RegExp(`^${one}(,${one})*$`);
+}
+
+/** Human-readable list for validation messages and API documentation. */
+export function apiScopesList(): string {
+  return API_SCOPES.join(", ");
+}
+
+/** True when `scope` is part of the supported vocabulary. */
+export function isApiScope(scope: string): scope is ApiScope {
+  return (API_SCOPES as readonly string[]).includes(scope);
+}

--- a/backend/src/oauth/oauth-provider.service.ts
+++ b/backend/src/oauth/oauth-provider.service.ts
@@ -13,11 +13,19 @@ import { makeAdapterFactory } from "./postgres.adapter";
 import { derivePurposeKey } from "../auth/crypto.util";
 import { AuthService } from "../auth/auth.service";
 import { checkUserAuthState } from "../auth/user-state.util";
+import { API_SCOPES, ApiScope, MCP_SCOPE_PREFIX } from "../auth/scopes";
 import { withUserContext } from "../common/db/with-context";
 import { OAuthPayload } from "./entities/oauth-payload.entity";
 
-export const MCP_RESOURCE_SCOPES = ["monize:read", "monize:write"] as const;
-export type McpScope = (typeof MCP_RESOURCE_SCOPES)[number];
+/**
+ * The scopes an OAuth client may request, derived from the single vocabulary in
+ * `auth/scopes.ts` rather than restated. `resolveBearer` strips the prefix, so a
+ * PAT and an OAuth token both reach the guards as `read`/`write`.
+ */
+export const MCP_RESOURCE_SCOPES = API_SCOPES.map(
+  (scope) => `${MCP_SCOPE_PREFIX}${scope}` as const,
+);
+export type McpScope = `${typeof MCP_SCOPE_PREFIX}${ApiScope}`;
 
 @Injectable()
 export class OAuthProviderService implements OnModuleInit {

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1136,7 +1136,11 @@ CREATE TABLE personal_access_tokens (
     name VARCHAR(100) NOT NULL,
     token_prefix VARCHAR(8) NOT NULL,     -- First 8 chars (e.g., "pat_xxxx") for display identification
     token_hash VARCHAR(64) NOT NULL,      -- SHA-256 hash of the full token
-    scopes VARCHAR(500) NOT NULL DEFAULT 'read', -- Comma-separated: 'read', 'write', 'reports'
+    -- Comma-separated. The vocabulary is defined once in
+    -- backend/src/auth/scopes.ts (API_SCOPES) and every consumer derives from
+    -- it; do not widen this comment without widening that constant. It used to
+    -- list a third scope, 'reports', that no issuance path ever accepted.
+    scopes VARCHAR(500) NOT NULL DEFAULT 'read', -- 'read', 'write'
     last_used_at TIMESTAMP,
     expires_at TIMESTAMP,                 -- NULL = never expires
     is_revoked BOOLEAN DEFAULT false,

--- a/docs/future-plans/vat-support.md
+++ b/docs/future-plans/vat-support.md
@@ -44,7 +44,7 @@ in `frontend/src/lib/vat.ts`.
 ### New module `backend/src/tax-rates/` (mirror `tags/`)
 - `entities/tax-rate.entity.ts` (decimal `rate` uses `numericTransformer`)
 - `dto/create-tax-rate.dto.ts`, `dto/update-tax-rate.dto.ts` (PartialType) — `@SanitizeHtml` name, `@Min(0)@Max(100)` rate, `@IsEnum` rateKind; whitelist validation like `create-tag.dto.ts`
-- `tax-rates.service.ts` — `userId`-first CRUD; name-conflict check; single-default enforcement via **QueryRunner** (clears other defaults); `remove` relies on `ON DELETE SET NULL` (keep historical `tax_amount`); record `ActionHistoryService`
+- `tax-rates.service.ts` — `userId`-first CRUD; name-conflict check; single-default enforcement inside one `withScopedDb` transaction (clears other defaults) -- **not** a `QueryRunner`, which ESLint rejects in `src/`; see the root `CLAUDE.md`; `remove` relies on `ON DELETE SET NULL` (keep historical `tax_amount`); record `ActionHistoryService`
 - `tax-rates.controller.ts` — `@Controller("tax-rates")`, class-level `AuthGuard('jwt')`, `ParseUUIDPipe` on `:id`
 - `tax-rates.module.ts` — `forFeature([TaxRate])`, import `ActionHistoryModule`, export service
 - Wire into `backend/src/app.module.ts`
@@ -62,11 +62,11 @@ in `frontend/src/lib/vat.ts`.
 
 ### Shared AI tool `get_vat_summary` (BOTH surfaces — hard project rule)
 - AI executor: `ai/query/tool-executor.service.ts` add `case "get_vat_summary"` + private method returning `{ data, summary, sources }` (mirror `getSpendingByCategory`); inject the tax/built-in-reports service; add to `tool-definitions.ts` and `tool-input-schemas.ts` (+ their specs)
-- MCP: new `mcp/tools/vat.tool.ts` (READ_ONLY, `requireScope(..., "reports")`); add `getVatSummaryOutput` to `mcp/tool-output-schemas.ts`; wire into `mcp-server.service.ts` + `mcp.module.ts`; bump `EXPECTED_TOOL_COUNT` and update `mcp-annotations.spec.ts`, `tool-output-schemas.spec.ts`, `mcp-server.service.spec.ts`
+- MCP: new `mcp/tools/vat.tool.ts` (READ_ONLY, `requireScope(..., "read")` -- the vocabulary is `read`/`write` only, defined in `backend/src/auth/scopes.ts`; a `reports` scope would have to be added there and to the PAT UI first); add `getVatSummaryOutput` to `mcp/tool-output-schemas.ts`; wire into `mcp-server.service.ts` + `mcp.module.ts`; bump `EXPECTED_TOOL_COUNT` and update `mcp-annotations.spec.ts`, `tool-output-schemas.spec.ts`, `mcp-server.service.spec.ts`
 
 ### Migrations + schema
-- `database/migrations/086_tax_rates.sql` — `CREATE TABLE IF NOT EXISTS tax_rates` + unique `(user_id, LOWER(name))` index (idempotent)
-- `database/migrations/087_transaction_split_vat.sql` — add `tax_rate_id` (FK `ON DELETE SET NULL`), `tax_amount`, `tax_direction`; index on `tax_rate_id`; `chk_split_vat_category_only CHECK (tax_rate_id IS NULL OR kind = 'category')` via guarded `DO $$` block
+- `database/migrations/<next>_tax_rates.sql` (read the current max from `ls database/migrations | tail`; the numbers below were written when the directory ended at 085) — `CREATE TABLE IF NOT EXISTS tax_rates` + unique `(user_id, LOWER(name))` index (idempotent)
+- `database/migrations/<next+1>_transaction_split_vat.sql` — add `tax_rate_id` (FK `ON DELETE SET NULL`), `tax_amount`, `tax_direction`; index on `tax_rate_id`; `chk_split_vat_category_only CHECK (tax_rate_id IS NULL OR kind = 'category')` via guarded `DO $$` block
 - Mirror both into `database/schema.sql` (after `tags`, and the `transaction_splits` block)
 
 ## Frontend changes


### PR DESCRIPTION
## Linked discussion / issue

None. Addresses audit finding **P1-004**. See the note at the end.

## Summary

`read` and `write` were spelled out in four places: the
`personal_access_tokens.scopes` comment in `schema.sql`, the regex in
`CreatePatDto`, the `monize:`-prefixed list `OAuthProviderService` advertises, and
`docs/future-plans/vat-support.md`.

Two of them named a third scope, `reports`, that no issuance path has ever
accepted. A client that read the schema and asked for it got a validation error
for a scope the repository said existed, and the planned MCP tool guarded by it
would have been unreachable to every PAT client.

`backend/src/auth/scopes.ts` now holds `API_SCOPES`, and the DTO's pattern, its
message, its Swagger description and `MCP_RESOURCE_SCOPES` all derive from it. The
schema comment points at the constant instead of restating it; the VAT plan asks
for `read`.

**Tests.** `scopes.spec.ts` enumerates from `API_SCOPES` rather than restating the
list, so adding a scope there is what makes the checks cover it. Beyond the
per-scope issuance and guard cases, two scanning guards — because the defect was
documents disagreeing with code, and prose does not stay in step on its own:

- `schema.sql`'s column comment must enumerate exactly `API_SCOPES`;
- no scope named as a `requireScope` argument anywhere under `docs/` may be one
  that cannot be issued.

Both fail when the original wording is restored. A third check ties the frontend's
`SCOPE_OPTIONS` to the same list, since a scope the backend accepts but the UI
never offers is unreachable for anyone not hand-crafting requests.

Both scanning guards read one exact construct rather than judging prose. A first
attempt scanned for quoted scope-shaped tokens near the word "scope" and
false-fired on a sentence explaining that `reports` had been removed.

Also clears two further stale claims in the VAT plan: it proposed a `QueryRunner`
that ESLint rejects in `src/`, and migration numbers `086`/`087` from a time when
the directory ended at `085`.

**Observation, not a change:** the DTO's validation message is a plain
`class-validator` string, not wrapped in `tr()`. That is true of every DTO message
in the repository and is left as-is.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — **no**, see below
- [x] This PR addresses a **single concern**.
- [x] New behavior has tests, and the existing suite passes. — 631 tests in the touched areas
- [x] All user-facing strings are translated for every locale. — no new strings
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below.

**On the missing Discussion:** the audit offered a choice — remove `reports`, or
build it out across DTO, OAuth registration, guards, MCP and the PAT UI. This PR
takes the first, since nothing in the tree needs it. If you intend `reports`, say
so and I will do the second instead.

## AI assistance disclosure

Written with Claude Code (Claude Opus 5). AI-produced and reviewed; I own the
result. Verified locally: `auth` and `oauth` suites pass, `tsc`, `typecheck` and
ESLint clean. Both scanning guards were confirmed to fail when the original
`schema.sql` comment and VAT-plan wording were restored.
