### PR TITLE
01: Align setup/deploy documentation with the manifests and gate it in CI (v.1.15.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   env-doc-check:
-    name: Env Var Documentation
+    name: Documentation vs Manifests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
@@ -312,6 +312,12 @@ jobs:
           node-version: 24
       - name: Verify env vars are documented
         run: node scripts/check-env-docs.mjs
+      # The documented setup path must name files that exist and defaults that
+      # match the manifests: the README's Quick Start pointed at a
+      # `docker-compose.yml` this repository has never contained, and the Helm
+      # install command at a chart directory that does not exist.
+      - name: Verify documented paths and Helm defaults match the manifests
+        run: node scripts/check-docs-manifests.mjs
 
   zizmor-scan:
     name: Workflow Security Scan (zizmor)

--- a/README.md
+++ b/README.md
@@ -232,9 +232,11 @@ monize/
 │   └── migrations/            # Incremental schema migrations
 ├── e2e/                       # End-to-end tests
 ├── helm/                      # Helm charts for Kubernetes
-├── docker-compose.yml         # Development environment
+├── docker-compose.dev.yml     # Development environment
 ├── docker-compose.prod.yml    # Production environment
 ├── docker-compose.demo.yml    # Demo environment
+├── docker-compose.e2e.yml     # End-to-end test environment
+├── docker-compose.zap.yml     # ZAP security-scan environment
 ├── .env.example               # Environment variables template
 └── README.md
 ```
@@ -268,8 +270,11 @@ cp .env.example .env
 
 4. Start the application:
 ```bash
-docker-compose up -d
+docker compose -f docker-compose.dev.yml up -d
 ```
+
+   The `-f` is required: every stack in this repository is an explicit target
+   (see the tree above) and there is no default Compose file to fall back on.
 
 5. Access the application:
    - Frontend: http://localhost:3001

--- a/docs/future-plans/row-level-security-tasks.md
+++ b/docs/future-plans/row-level-security-tasks.md
@@ -220,6 +220,11 @@ branch selection; UUID validation in `withUserContext`; filter mapping. LSP diag
   `npm run rls:ratchet`). Exact-match ratchet: a count above baseline fails
   (banned new site), below baseline fails (lower the baseline in the same PR).
 
+  **Superseded (see L1).** The counts reached zero, so the script, its self-test,
+  its baseline and both npm scripts were removed and replaced by outright ESLint
+  bans. Nothing named in the paragraph above still exists -- it is kept as the
+  record of how the sites were driven down, not as a gate you can run.
+
 **Scope:** a script under `backend/scripts/` (or repo `scripts/`), CI workflow wiring, a committed
 baseline file.
 

--- a/docs/future-plans/row-level-security.md
+++ b/docs/future-plans/row-level-security.md
@@ -1,5 +1,16 @@
 # Plan: Database-Enforced Row-Level Security (RLS)
 
+> **Status: implemented, not yet enforced.** This is the original design
+> document, kept for its rationale and its rollout reasoning. Do not read it as
+> a description of future work: every code and migration task in
+> [`row-level-security-tasks.md`](./row-level-security-tasks.md) has landed,
+> including the enable migration (`123_rls_enable.sql`). What remains is the two
+> operational flips in
+> [`row-level-security-runbook.md`](./row-level-security-runbook.md). The
+> `docs/future-plans/` location is historical -- the files move to `docs/` when
+> enforcement ships -- and it has already misled a reviewer into reporting the
+> feature as unbuilt.
+
 ## Goal
 
 Add PostgreSQL Row-Level Security as a database-enforced safety net **beneath** Monize's existing application-level multi-tenancy. Today every service takes `userId` (from JWT `req.user.id`) as its first argument and filters each query with `WHERE user_id = ?`; this is correct and is covered by `backend/test/integration/security-cross-user-isolation.integration.spec.ts`. RLS is defense in depth: a single forgotten `WHERE user_id` clause anywhere -- a new endpoint, a refactor, a raw query -- must not be able to leak one user's financial data to another. The app-level filtering stays in place; RLS is a second wall the database itself enforces.

--- a/helm/README.md
+++ b/helm/README.md
@@ -20,16 +20,16 @@ Only the frontend is exposed externally via HTTPRoute or Ingress. The backend is
 
 ```bash
 # Install with default values (HTTPRoute enabled)
-helm install monize ./helm/monize -n monize --create-namespace
+helm install monize ./helm -n monize --create-namespace
 
 # Install with Ingress instead of HTTPRoute
-helm install monize ./helm/monize -n monize --create-namespace \
+helm install monize ./helm -n monize --create-namespace \
   --set httpRoute.enabled=false \
   --set ingress.enabled=true \
   --set ingress.className=nginx
 
 # Dry-run to preview rendered templates
-helm template monize ./helm/monize -n monize
+helm template monize ./helm -n monize
 ```
 
 ## Routing Options
@@ -93,10 +93,10 @@ ingress:
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `backend.image.registry` | Image registry | `registry.yourdomain.com` |
-| `backend.image.repository` | Image repository | `monize/backend` |
+| `backend.image.registry` | Image registry | `ghcr.io` |
+| `backend.image.repository` | Image repository | `kenlasko/monize/backend` |
 | `backend.image.tag` | Image tag | `latest` |
-| `backend.image.pullPolicy` | Image pull policy | `Always` |
+| `backend.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `backend.replicas` | Number of replicas | `1` |
 | `backend.service.port` | Service port | `3001` |
 | `backend.service.type` | Service type | `ClusterIP` |
@@ -107,10 +107,19 @@ ingress:
 | `backend.env.*` | Backend environment variables | See values.yaml |
 | `backend.mnyImport.MNY_IMPORT_LIMIT_MB` | Largest Microsoft Money (.mny) file the import wizard accepts | `300` |
 
+> **`latest` with `IfNotPresent` does not pick up new builds.** The two defaults
+> combine into a deployment that keeps whatever image the node already cached: a
+> rolling restart re-uses it, so replicas can end up running different builds of
+> the same tag. Pin an immutable tag or a digest (`--set
+> backend.image.tag=v1.13.0`) for anything you intend to upgrade predictably, or
+> set `pullPolicy=Always` if you genuinely want to track `latest`. This is
+> stated rather than changed because flipping either default silently alters
+> upgrade behaviour for existing installs.
+
 #### Memory for Microsoft Money imports
 
-The default `backend.resources.limits.memory` of `150Mi` is sized for ordinary
-use and **cannot import a real `.mny` file**. A Money upload is buffered in
+The default `backend.resources.limits.memory` of `400Mi` is sized for ordinary
+use and **cannot import a real `.mny` file** at the default 300 MB ceiling. A Money upload is buffered in
 memory and decrypted in place, so peak usage is roughly twice the file size on
 top of the baseline. A pod that hits its limit mid-import is OOM-killed, and the
 wizard reports the job as stalled rather than as out of memory.
@@ -141,10 +150,10 @@ otherwise, and truncates rather than rejecting anything larger).
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `frontend.image.registry` | Image registry | `registry.yourdomain.com` |
-| `frontend.image.repository` | Image repository | `monize/frontend` |
+| `frontend.image.registry` | Image registry | `ghcr.io` |
+| `frontend.image.repository` | Image repository | `kenlasko/monize/frontend` |
 | `frontend.image.tag` | Image tag | `latest` |
-| `frontend.image.pullPolicy` | Image pull policy | `Always` |
+| `frontend.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `frontend.replicas` | Number of replicas | `1` |
 | `frontend.service.port` | Service port | `3000` |
 | `frontend.service.type` | Service type | `ClusterIP` |
@@ -231,16 +240,16 @@ All containers enforce the `restricted` Pod Security Standard:
 
 ```bash
 # Lint the chart
-helm lint ./helm/monize
+helm lint ./helm
 
 # Render templates without deploying
-helm template monize ./helm/monize -n monize
+helm template monize ./helm -n monize
 
 # Dry-run install
-helm install monize ./helm/monize -n monize --dry-run
+helm install monize ./helm -n monize --dry-run
 
 # Test with Ingress instead of HTTPRoute
-helm template monize ./helm/monize -n monize \
+helm template monize ./helm -n monize \
   --set httpRoute.enabled=false \
   --set ingress.enabled=true \
   --set ingress.className=nginx

--- a/scripts/check-docs-manifests.mjs
+++ b/scripts/check-docs-manifests.mjs
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+// Verify the setup and deployment documentation describes files that exist and
+// defaults that match the manifests.
+//
+// The root README told readers to run `docker-compose up -d` against a
+// `docker-compose.yml` this repository has never contained, and `helm/README.md`
+// installed `./helm/monize` when the chart root is `helm/` -- so the documented
+// happy path failed before the application started, in both cases. The Helm
+// default-value tables had drifted too: registry, repository, pull policy and
+// the backend memory limit all disagreed with `helm/values.yaml`, while the
+// templates render the real values.
+//
+// Prose cannot be type-checked, so this is the check. Six rules:
+//
+//   1. every repository path a documented command names must exist;
+//   2. no documented `docker compose` command may omit `-f`, because there is no
+//      default Compose file to fall back on;
+//   3. every Helm parameter documented with a default must have that default in
+//      helm/values.yaml;
+//   4. every Compose stack on disk appears in the README's tree;
+//   5. every `npm run <script>` a document offers exists in a package.json;
+//   6. every Markdown table row actually renders inside a table.
+//
+// Exits non-zero with the offending lines. Requires nothing but Node.
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+
+const REPO_ROOT = new URL('..', import.meta.url).pathname;
+
+/** Documents whose commands and tables are treated as canonical instructions. */
+const DOCS = [
+  'README.md',
+  'CONTRIBUTING.md',
+  'CLAUDE.md',
+  'helm/README.md',
+  'database/CLAUDE.md',
+  'backend/CLAUDE.md',
+  'frontend/CLAUDE.md',
+  'CONTAINER_BUILD.md',
+];
+
+/**
+ * Every markdown file under docs/, for the npm-script rule only. Rule 5's
+ * failure was in `docs/future-plans/`, which none of the canonical instruction
+ * files above cover -- limiting the sweep to DOCS would have made the check pass
+ * over the defect that motivated it.
+ */
+function allDocsMarkdown(dir = join(REPO_ROOT, 'docs')) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).flatMap((name) => {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) return allDocsMarkdown(full);
+    return name.endsWith('.md') ? [full.slice(REPO_ROOT.length)] : [];
+  });
+}
+
+const failures = [];
+
+function fail(file, line, message) {
+  failures.push(`${file}${line ? `:${line}` : ''}  ${message}`);
+}
+
+function readDoc(relative) {
+  const full = join(REPO_ROOT, relative);
+  return existsSync(full) ? readFileSync(full, 'utf8').split('\n') : null;
+}
+
+// ---------------------------------------------------------------------------
+// Rule 1 + 2: paths and Compose invocations in documented commands
+// ---------------------------------------------------------------------------
+
+// A `-f <file>` on a docker compose command.
+const COMPOSE_WITH_FILE = /docker[- ]compose\s+(?:[^\n]*?\s)?-f\s+([\w./-]+)/g;
+// A docker compose command with no -f anywhere before the subcommand.
+const COMPOSE_WITHOUT_FILE = /docker[- ]compose\s+(?!.*-f\s)(up|down|build|exec|run|logs|ps|config)\b/;
+// A compose filename mentioned anywhere, including inside a directory tree.
+const COMPOSE_FILENAME = /\bdocker-compose[\w.-]*\.ya?ml\b/g;
+// `helm <verb> ... ./path` -- the chart directory.
+const HELM_CHART = /helm\s+(?:install|upgrade|template|lint)\s+[^\n]*?(\.\/[\w./-]+)/g;
+
+function checkCommands(relative, lines) {
+  lines.forEach((text, index) => {
+    const lineNumber = index + 1;
+
+    for (const [, file] of text.matchAll(COMPOSE_WITH_FILE)) {
+      if (!existsSync(join(REPO_ROOT, file))) {
+        fail(relative, lineNumber, `compose file does not exist: ${file}`);
+      }
+    }
+
+    if (COMPOSE_WITHOUT_FILE.test(text)) {
+      fail(
+        relative,
+        lineNumber,
+        'docker compose without -f: this repository has no default docker-compose.yml',
+      );
+    }
+
+    for (const [name] of text.matchAll(COMPOSE_FILENAME)) {
+      if (!existsSync(join(REPO_ROOT, name))) {
+        fail(relative, lineNumber, `compose file does not exist: ${name}`);
+      }
+    }
+
+    for (const [, chart] of text.matchAll(HELM_CHART)) {
+      const path = join(REPO_ROOT, chart);
+      if (!existsSync(join(path, 'Chart.yaml'))) {
+        fail(
+          relative,
+          lineNumber,
+          `not a Helm chart root (no Chart.yaml): ${chart}`,
+        );
+      }
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Rule 3: documented Helm defaults against helm/values.yaml
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal reader for the subset of YAML `helm/values.yaml` uses: nested plain
+ * mappings, scalar values, `{}`, and comments. Deliberately not a YAML parser --
+ * pulling one in would mean a dependency for a check that must run anywhere, and
+ * the file is committed in this shape. Returns a flat map of dotted path to raw
+ * scalar text; a key whose value is a nested mapping, a list or `{}` is absent,
+ * so a documented row pointing at one is skipped rather than misjudged.
+ */
+function flattenValues(source) {
+  const flat = new Map();
+  /** @type {Array<{ indent: number, key: string }>} */
+  const stack = [];
+
+  for (const raw of source.split('\n')) {
+    if (!raw.trim() || raw.trim().startsWith('#')) continue;
+    if (raw.trim().startsWith('- ')) continue; // list item: not addressable here
+
+    const match = /^(\s*)([\w.-]+):\s*(.*?)\s*(?:#.*)?$/.exec(raw);
+    if (!match) continue;
+
+    const [, indentText, key, value] = match;
+    const indent = indentText.length;
+
+    while (stack.length && stack[stack.length - 1].indent >= indent) stack.pop();
+    stack.push({ indent, key });
+
+    if (value !== '' && value !== '{}' && value !== '[]' && value !== '|') {
+      flat.set(
+        stack.map((entry) => entry.key).join('.'),
+        value.replace(/^["']|["']$/g, ''),
+      );
+    }
+  }
+
+  return flat;
+}
+
+// `| `backend.image.tag` | Image tag | `latest` |`
+const DEFAULTS_ROW = /^\|\s*`([\w.*-]+)`\s*\|[^|]*\|\s*`([^`|]+)`\s*\|/;
+
+function checkHelmDefaults(relative, lines, values) {
+  lines.forEach((text, index) => {
+    const match = DEFAULTS_ROW.exec(text);
+    if (!match) return;
+
+    const [, path, documented] = match;
+    // Rows documenting a whole subtree ("See values.yaml") or a wildcard
+    // (`backend.env.*`) address no single scalar.
+    if (path.includes('*')) return;
+    if (!values.has(path)) return;
+
+    const actual = values.get(path);
+    // An empty value in values.yaml means the effective default is derived in a
+    // template (`global.hostname: ""` becomes `monize.<domain>`), and the table
+    // documents that derivation rather than the literal. Comparing them would
+    // fail on correct documentation.
+    if (actual === '') return;
+    if (actual !== documented) {
+      fail(
+        relative,
+        index + 1,
+        `${path} documented as \`${documented}\` but helm/values.yaml has \`${actual}\``,
+      );
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Rule 4: every Compose stack in the tree is listed in the README's tree
+// ---------------------------------------------------------------------------
+
+function checkComposeInventory() {
+  const onDisk = readdirSync(REPO_ROOT)
+    .filter((name) => /^docker-compose[\w.-]*\.ya?ml$/.test(name))
+    .sort();
+  const readme = readFileSync(join(REPO_ROOT, 'README.md'), 'utf8');
+  const missing = onDisk.filter((name) => !readme.includes(name));
+  if (missing.length) {
+    fail(
+      'README.md',
+      null,
+      `Compose stacks present but undocumented: ${missing.join(', ')}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rule 6: a table row must actually be inside a table
+// ---------------------------------------------------------------------------
+
+// Rule 3 reads pipe-prefixed lines without rendering Markdown, so it happily
+// compared documented Helm defaults in rows that no longer render as a table at
+// all: a blockquote inserted between `backend.image.pullPolicy` and the rest of
+// the backend parameters ended the table, and every row after it displayed as
+// plain text. The checker passed; an operator reading the rendered page lost
+// replicas, ports, resources, probes and the import limit out of the table.
+//
+// A pipe row belongs to a table only if a header separator (`|---|`) appeared
+// since the last block boundary. Blank lines inside a table are already illegal
+// in GitHub-flavoured Markdown, so the boundary set is: blank line, blockquote,
+// heading, fence, or list item.
+const TABLE_SEPARATOR = /^\s*\|?[\s:|-]*-{3,}[\s:|-]*\|?\s*$/;
+const PIPE_ROW = /^\s*\|/;
+const BLOCK_BOUNDARY = /^\s*(?:$|>|#{1,6}\s|```|[-*+]\s|\d+\.\s)/;
+
+function checkTableStructure(relative, lines) {
+  let inTable = false;
+  let fenced = false;
+
+  lines.forEach((text, index) => {
+    if (/^\s*```/.test(text)) {
+      fenced = !fenced;
+      inTable = false;
+      return;
+    }
+    if (fenced) return;
+
+    if (TABLE_SEPARATOR.test(text) && index > 0 && PIPE_ROW.test(lines[index - 1])) {
+      inTable = true;
+      return;
+    }
+    if (PIPE_ROW.test(text)) {
+      // The header row itself precedes the separator; accept it by looking ahead.
+      const isHeader =
+        index + 1 < lines.length && TABLE_SEPARATOR.test(lines[index + 1]);
+      if (!inTable && !isHeader) {
+        fail(
+          relative,
+          index + 1,
+          'table row outside a table -- a block element ended the table above it, ' +
+            'so this row renders as plain text',
+        );
+      }
+      return;
+    }
+    if (BLOCK_BOUNDARY.test(text)) {
+      inTable = false;
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Rule 5: every `npm run <script>` a document offers actually exists
+// ---------------------------------------------------------------------------
+
+// The RLS task list documented `npm run rls:ratchet` as a live CI gate long
+// after the ratchet had reached zero and its script, baseline and npm entries
+// were deleted -- so a reader was pointed at a check that could not be run, let
+// alone fail. A command in a document is a promise; this is the check that it
+// can be kept.
+const NPM_RUN = /npm run ([\w:.-]+)/g;
+
+function collectScriptNames() {
+  const names = new Set();
+  for (const dir of ['', 'backend', 'frontend', 'e2e']) {
+    const manifest = join(REPO_ROOT, dir, 'package.json');
+    if (!existsSync(manifest)) continue;
+    const { scripts = {} } = JSON.parse(readFileSync(manifest, 'utf8'));
+    for (const name of Object.keys(scripts)) names.add(name);
+  }
+  return names;
+}
+
+/**
+ * Wording that marks a named command as historical rather than runnable. A task
+ * list legitimately records "we specified `npm run mny:validate`, shipped as
+ * `npm run mny:inspect`"; what it must not do is present a deleted script as a
+ * gate you can run. The marker has to be written, so the exemption is a decision
+ * rather than an accident, and it is looked for in a window rather than on the
+ * one line -- the correction often sits a paragraph below the command.
+ */
+const SUPERSEDED =
+  /superseded|no longer exists?|(?:was |now )?(?:removed|deleted|dropped|gone)|shipped as|renamed to|replaced by/i;
+const SUPERSEDED_WINDOW = 8;
+
+function checkNpmScripts(relative, lines, scripts) {
+  lines.forEach((text, index) => {
+    for (const [, name] of text.matchAll(NPM_RUN)) {
+      if (scripts.has(name)) continue;
+      const context = lines
+        .slice(
+          Math.max(0, index - SUPERSEDED_WINDOW),
+          index + SUPERSEDED_WINDOW + 1,
+        )
+        .join('\n');
+      if (SUPERSEDED.test(context)) continue;
+      fail(relative, index + 1, `npm script does not exist: ${name}`);
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+
+const valuesPath = join(REPO_ROOT, 'helm/values.yaml');
+const values = existsSync(valuesPath)
+  ? flattenValues(readFileSync(valuesPath, 'utf8'))
+  : new Map();
+
+if (values.size === 0) {
+  fail('helm/values.yaml', null, 'no values parsed -- the defaults check would be vacuous');
+}
+
+const npmScripts = collectScriptNames();
+if (npmScripts.size === 0) {
+  fail('package.json', null, 'no npm scripts parsed -- the script check would be vacuous');
+}
+
+for (const relative of DOCS) {
+  const lines = readDoc(relative);
+  if (!lines) continue;
+  checkCommands(relative, lines);
+  checkTableStructure(relative, lines);
+  if (dirname(relative) === 'helm') checkHelmDefaults(relative, lines, values);
+}
+
+for (const relative of new Set([...DOCS, ...allDocsMarkdown()])) {
+  const lines = readDoc(relative);
+  if (lines) checkNpmScripts(relative, lines, npmScripts);
+}
+
+checkComposeInventory();
+
+if (failures.length) {
+  console.error('Documentation/manifest drift:\n');
+  for (const failure of failures) console.error(`  ${failure}`);
+  console.error(
+    '\nEvery documented path must exist and every documented Helm default must' +
+      '\nmatch helm/values.yaml. See scripts/check-docs-manifests.mjs.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Documentation/manifest check: OK (${values.size} Helm values, ${DOCS.length} documents)`,
+);

--- a/scripts/check-env-docs.mjs
+++ b/scripts/check-env-docs.mjs
@@ -21,12 +21,13 @@ const SOURCE_DIRS = [
 // docker-compose files where service environments declare vars that are
 // derived in-compose (e.g. DATABASE_NAME mapped from POSTGRES_DB). Counts as
 // documentation since self-hosters consume these files alongside .env.example.
-const COMPOSE_FILES = [
-  'docker-compose.yml',
-  'docker-compose.dev.yml',
-  'docker-compose.prod.yml',
-  'docker-compose.e2e.yml',
-];
+// Read from disk rather than listed: the hardcoded list named a
+// `docker-compose.yml` this repository does not have (the loop below skips a
+// missing file silently, so the coverage loss was invisible) and omitted the
+// demo and zap stacks. A new stack is now covered by existing.
+const COMPOSE_FILES = readdirSync(REPO_ROOT)
+  .filter((name) => /^docker-compose[\w.-]*\.ya?ml$/.test(name))
+  .sort();
 
 // Built-ins and runtime-injected vars that don't belong in .env.example.
 const IGNORED = new Set([


### PR DESCRIPTION
## Linked discussion / issue

None. Addresses audit finding **P1-002**, plus **RFR-005** of the follow-up
review. See the note at the end.

## Summary

The documented happy path failed before the application started, twice:

- the README's Quick Start ran `docker-compose up -d` against a
  `docker-compose.yml` this repository has never contained — every stack is an
  explicit `-f` target;
- `helm/README.md` installed `./helm/monize` in seven places when the chart root
  is `helm/`.

The Helm default-value tables had drifted independently: registry, repository and
pull policy for both images, and a backend memory limit of `150Mi` against an
actual `400Mi`. The templates render the real values, so the tables misdescribed
resource and image-pull behaviour rather than changing it.

Corrected, plus the two Compose stacks the README's tree omitted
(`docker-compose.e2e.yml`, `docker-compose.zap.yml`).

**`latest` + `IfNotPresent` is now stated, not changed.** The pair keeps whatever
image a node already cached, so replicas can end up running different builds of
the same tag and a rolling restart re-uses the cache. `helm/README.md` says so and
points at pinning an immutable tag or digest. Flipping either default silently
alters upgrade behaviour for existing installs, which is your call, not a
documentation PR's.

**The gate.** `scripts/check-docs-manifests.mjs`, wired into the CI job now named
"Documentation vs Manifests". No dependencies, six rules:

1. every repository path a documented command names exists;
2. no documented `docker compose` invocation omits `-f`;
3. every documented Helm default matches `helm/values.yaml`;
4. every Compose stack on disk appears in the README's tree;
5. every `npm run <script>` an instruction file or anything under `docs/` offers
   exists in a `package.json`;
6. every Markdown table row actually renders inside a table.

Rule 6 earned its place immediately: while fixing the Helm tables I put a
blockquote *inside* one, which ends the table under standard Markdown, so
replicas, ports, resources, probes and the import limit rendered as plain text —
and rule 3 could not see it, because it reads pipe-prefixed lines without
rendering Markdown. Warning moved below the table; restoring it fails the check on
six rows.

Run against the pre-fix documents the checker reports all four original defects
and nothing else, verified by restoring each in turn.

**Also in scope, same class:**

- `scripts/check-env-docs.mjs` carried the same phantom `docker-compose.yml` in a
  hardcoded list. Its loop skips a missing file silently, so the coverage loss was
  invisible — and the list also omitted the demo and zap stacks. It now reads the
  stacks from disk.
- `docs/future-plans/row-level-security.md` gained the status banner its runbook
  already had. It reads as future work while every task in it has landed,
  including the enable migration, which has already led one reader to report the
  feature as unbuilt.
- `docs/future-plans/row-level-security-tasks.md` no longer presents the deleted
  counting ratchet as a runnable gate.

**Not implemented** from the audit's suggestions for this job: `docker compose
config`, `helm lint`, `helm template`. They need Docker and Helm binaries in the
job, and the failure mode here was drift between text and manifests, which the
static rules catch. Worth adding if a rendering bug ever appears.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — **no**, see below
- [x] This PR addresses a **single concern**. — documentation truthfulness, and the gate for it
- [x] New behavior has tests, and the existing suite passes. — the checker is the test; all four original defects reproduce
- [x] All user-facing strings are translated for every locale. — no new strings
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below.

**Merge order:** PR 6 adds a second step to the same `env-doc-check` job.
Whichever lands second needs a two-line rebase in `.github/workflows/ci.yml`.

## AI assistance disclosure

Written with Claude Code (Claude Opus 5). AI-produced and reviewed; I own the
result. Verified locally: the checker passes on this branch and reports exactly
the four original defects when each is restored, including the blockquote-in-table
case.
