### PR TITLE
01: Gate migration prefix uniqueness and ordering in CI (v.1.15.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,6 +314,10 @@ jobs:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
+          # The migration-prefix check compares this branch's migrations against
+          # the base branch's; a shallow clone has no base ref and the check
+          # reports that it skipped rather than passing silently.
+          fetch-depth: 0
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 24
@@ -325,6 +329,13 @@ jobs:
       # install command at a chart directory that does not exist.
       - name: Verify documented paths and Helm defaults match the manifests
         run: node scripts/check-docs-manifests.mjs
+      # A migration prefix that collides with, or sorts below, one already on the
+      # base branch is applied out of order on every database that recorded the
+      # newer filename -- and `database/CLAUDE.md` stating the rule in prose did
+      # not stop a branch from taking a prefix main had meanwhile used. The
+      # ordering half needs the base ref, hence fetch-depth 0.
+      - name: Verify migration prefixes are unique and sort last
+        run: node scripts/check-migration-prefixes.mjs
 
   zizmor-scan:
     name: Workflow Security Scan (zizmor)

--- a/scripts/check-migration-prefixes.mjs
+++ b/scripts/check-migration-prefixes.mjs
@@ -27,8 +27,14 @@
 import { readdirSync, existsSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const REPO_ROOT = new URL('..', import.meta.url).pathname;
+// `.pathname` on a file:// URL is percent-encoded (a space becomes `%20`) and
+// `fs` wants a real OS path, not a URL component -- `fileURLToPath` decodes it.
+// A repo checked out under a path with a space (not exotic: "My Drive", "Moje
+// glupoty") reads that literal `%20` as a directory name and ENOENTs on the
+// very first `readdirSync`.
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 const MIGRATIONS = join(REPO_ROOT, 'database', 'migrations');
 
 /**

--- a/scripts/check-migration-prefixes.mjs
+++ b/scripts/check-migration-prefixes.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+// Verify migration filename prefixes are unique, and that a newly added
+// migration sorts after everything already on the base branch.
+//
+// `database/CLAUDE.md` states both rules in prose. Prose did not stop this from
+// happening: a remediation branch added `133_import_jobs_one_active_per_user.sql`
+// while `main` had meanwhile taken `133` for `133_joint_account_grants.sql` and
+// shipped the same fix as `135_import_jobs_single_active.sql`. Migrations are
+// applied and tracked **by full filename**, so on a database that had already
+// recorded `135`, the newly introduced `133_*` would be seen as pending and
+// applied *after* it -- an obsolete body running against a schema the newer
+// migration had already corrected, with the apply order between the two `133_*`
+// files decided by alphabetical tie-breaking.
+//
+// Two checks:
+//
+//   1. no numeric prefix is used twice, except the historical pairs below;
+//   2. when a base ref is available, every migration this branch adds has a
+//      prefix strictly greater than the highest prefix on that base.
+//
+// Check 2 needs git history. It reports and skips rather than failing when the
+// base ref is absent (shallow clone, detached build), because a check that
+// cannot run must not look like a check that passed.
+//
+// Requires nothing but Node and, for check 2, git.
+
+import { readdirSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const REPO_ROOT = new URL('..', import.meta.url).pathname;
+const MIGRATIONS = join(REPO_ROOT, 'database', 'migrations');
+
+/**
+ * Prefixes already shared by two files when this check was written. Every one
+ * predates the rule and is recorded in `database/CLAUDE.md`. **This list may
+ * only shrink** -- adding to it is choosing the ambiguous apply order the check
+ * exists to prevent.
+ */
+const GRANDFATHERED_DUPLICATES = new Set([
+  '022',
+  '068',
+  '075',
+  '116',
+  '117',
+  '124',
+]);
+
+/** Base refs tried, in order, for the "must sort last" check. */
+const BASE_REFS = ['origin/main', 'main'];
+
+const failures = [];
+const notes = [];
+
+function prefixOf(name) {
+  const match = /^(\d+)_/.exec(name);
+  return match ? match[1] : null;
+}
+
+function migrationNames(list) {
+  return list.filter((name) => name.endsWith('.sql'));
+}
+
+// ---------------------------------------------------------------------------
+// Check 1: unique numeric prefixes
+// ---------------------------------------------------------------------------
+
+const names = migrationNames(readdirSync(MIGRATIONS)).sort();
+
+if (names.length === 0) {
+  failures.push('database/migrations contains no .sql files -- the check would be vacuous');
+}
+
+const byPrefix = new Map();
+for (const name of names) {
+  const prefix = prefixOf(name);
+  if (!prefix) {
+    failures.push(`${name}: filename does not start with a numeric prefix (NNN_description.sql)`);
+    continue;
+  }
+  byPrefix.set(prefix, [...(byPrefix.get(prefix) ?? []), name]);
+}
+
+const staleGrandfathers = [];
+for (const prefix of GRANDFATHERED_DUPLICATES) {
+  if ((byPrefix.get(prefix) ?? []).length < 2) staleGrandfathers.push(prefix);
+}
+if (staleGrandfathers.length) {
+  // The list may only shrink, so a prefix that is no longer duplicated must be
+  // removed from it -- otherwise it silently re-permits a future collision.
+  failures.push(
+    `GRANDFATHERED_DUPLICATES lists prefixes that are no longer duplicated: ` +
+      `${staleGrandfathers.join(', ')}. Remove them from ${'scripts/check-migration-prefixes.mjs'}.`,
+  );
+}
+
+for (const [prefix, files] of byPrefix) {
+  if (files.length > 1 && !GRANDFATHERED_DUPLICATES.has(prefix)) {
+    failures.push(
+      `duplicate migration prefix ${prefix}: ${files.join(', ')} -- ` +
+        'apply order falls back to alphabetical tie-breaking. Renumber the new file to the next free prefix.',
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Check 2: an added migration sorts after everything on the base branch
+// ---------------------------------------------------------------------------
+
+function git(args) {
+  return execFileSync('git', args, {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+}
+
+function resolveBase() {
+  for (const ref of BASE_REFS) {
+    try {
+      git(['rev-parse', '--verify', `${ref}^{commit}`]);
+      return ref;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+const base = existsSync(join(REPO_ROOT, '.git')) ? resolveBase() : null;
+
+if (!base) {
+  notes.push(
+    'no base ref (origin/main or main) resolved, so the "new migration sorts last" ' +
+      'check did not run. Prefix uniqueness was still verified.',
+  );
+} else {
+  let baseNames = [];
+  try {
+    baseNames = migrationNames(
+      git(['ls-tree', '--name-only', base, 'database/migrations/']).split('\n'),
+    ).map((path) => path.replace(/^database\/migrations\//, ''));
+  } catch {
+    notes.push(`could not list database/migrations at ${base}; skipped the ordering check.`);
+  }
+
+  if (baseNames.length > 0) {
+    const baseMax = baseNames
+      .map(prefixOf)
+      .filter(Boolean)
+      .reduce((max, prefix) => (prefix > max ? prefix : max), '000');
+    const baseSet = new Set(baseNames);
+    const added = names.filter((name) => !baseSet.has(name));
+
+    for (const name of added) {
+      const prefix = prefixOf(name);
+      if (prefix && prefix <= baseMax) {
+        failures.push(
+          `${name} is new on this branch but its prefix ${prefix} is not above the highest ` +
+            `prefix on ${base} (${baseMax}). Deployed databases track migrations by full ` +
+            'filename, so a lower-numbered new file is applied after migrations that already ' +
+            'ran. Renumber it.',
+        );
+      }
+    }
+    notes.push(
+      `compared against ${base}: ${added.length} migration(s) added on this branch, ` +
+        `base maximum prefix ${baseMax}.`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+for (const note of notes) console.log(`note: ${note}`);
+
+if (failures.length) {
+  console.error('\nMigration prefix check failed:\n');
+  for (const failure of failures) console.error(`  ${failure}`);
+  console.error('\nSee database/CLAUDE.md, "Creating a New Migration".');
+  process.exit(1);
+}
+
+console.log(`Migration prefix check: OK (${names.length} migrations)`);


### PR DESCRIPTION
## Linked discussion / issue

None. This is the regression gate recommended by **RFR-002** of the follow-up
review. See the note at the end.

## Summary

`database/CLAUDE.md` states both rules in prose. Prose did not hold, and I am the
worked example: a branch of mine added `133_import_jobs_one_active_per_user.sql`
while `main` had meanwhile taken `133` for `133_joint_account_grants.sql` and
shipped the same fix as `135_import_jobs_single_active.sql`.

Migrations are applied and tracked **by full filename**. On a database that had
already recorded `135`, the newly introduced `133_*` would be seen as pending and
applied *after* it — an obsolete body running against a schema the newer migration
had already corrected, with the order between the two `133_*` files decided by
alphabetical tie-breaking.

`scripts/check-migration-prefixes.mjs` checks two things:

1. no numeric prefix is used twice, except the historical pairs already recorded
   in `database/CLAUDE.md` (`022`, `068`, `075`, `116`, `117`, `124`). That list
   **may only shrink** — the script fails if an entry in it is no longer
   duplicated, so it cannot quietly re-permit a future collision;
2. when a base ref resolves, every migration the branch adds has a prefix
   strictly above the highest prefix on that base.

Restoring the `133_*` collision trips both. A synthetic `090_test_low.sql` trips
both as well.

Check 2 needs git history, hence `fetch-depth: 0` on that job's checkout. When no
base ref resolves it prints that it skipped rather than reporting OK — a check
that cannot run must not look like a check that passed.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — **no**, see below
- [x] This PR addresses a **single concern**.
- [x] New behavior has tests, and the existing suite passes. — the script is the test; both rules confirmed to fire
- [x] All user-facing strings are translated for every locale. — no new strings
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below.

**Merge order:** PR 5 adds another step to the same `env-doc-check` job.
Whichever lands second needs a two-line rebase in `.github/workflows/ci.yml`.

**On `fetch-depth: 0`:** this makes that one job's checkout a full clone. If you
would rather not, the check still runs — it just skips its second half and says
so.

## AI assistance disclosure

Written with Claude Code (Claude Opus 5). AI-produced and reviewed; I own the
result. Verified locally: passes on this branch (125 migrations, base maximum
`135`), and fails on both a restored `133` collision and a synthetic
low-numbered file.
