### PR TITLE
01: Type-check the test tree; four e2e suites had not compiled since 27 July (v.1.15.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,13 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npx tsc --noEmit
+      # tsconfig.json excludes test/ (it drives the build and pins rootDir to
+      # src/), so `tsc --noEmit` above never type-checked the test tree. Four
+      # `test/*.e2e-spec.ts` suites sat uncompilable for over a week as a result
+      # -- ESLint's glob covers the directory but a namespace import called as a
+      # function is a type error, not a lint error, and CI runs neither
+      # `test:e2e` nor a typecheck that reaches them.
+      - run: npm run typecheck
       # Migration idempotency: every migration body must be a no-op when
       # re-applied to an up-to-date database, or a half-applied migration
       # crash-loops the backend at startup (task B1). Self-test first, then lint.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -8,7 +8,8 @@ NestJS API server. All commands run from this directory.
 npm run start:dev          # Dev server with HMR
 npm run build              # Production build
 npm run lint               # ESLint --fix
-npm run test               # All tests (unit + E2E)
+npm run typecheck          # tsc over src AND test (CI gate; plain `tsc --noEmit` skips test/)
+npm run test               # jest with no filter -- see the note below, this is NOT green
 npm run test:unit          # Unit tests only (src/**/*.spec.ts)
 npm run test:cov           # Coverage report (95% lines, 94% stmts, 95% funcs, 85% branches)
 npm run test:e2e           # E2E tests (test/**/*.spec.ts, 30s timeout, sequential)
@@ -17,6 +18,30 @@ npm run i18n:check         # Verify the pseudo-locale is up to date (CI gate)
 npm run migration:lint     # Idempotency lint over database/migrations (CI gate)
 npm run migration:lint:test # Self-test for the migration lint
 ```
+
+### `test/*.e2e-spec.ts` is not a gate, and three of the four suites are broken
+
+CI runs `test:unit` and `test:integration` (the latter filtered to
+`test/integration/*.spec.ts`). Nothing runs `test:e2e`, and `tsconfig.json`
+excludes `test/`, so for over a week four suites did not even compile -- a
+namespace `import * as cookieParser` left behind when `main.ts` moved to a
+default import. ESLint's glob covers the directory, but that is a type error, not
+a lint error. `npm run typecheck` now closes the compile half in CI.
+
+What the compile error was hiding, once removed:
+
+| Suite | State | Why |
+|---|---|---|
+| `test/payee-detail.e2e-spec.ts` | passes (9 tests) | nothing wrong with it; its coverage was simply absent. This is the spec cited below as what caught the raw-select transformer class of bug |
+| `test/payees.e2e-spec.ts` | fails | calls services directly, so there is no request scope; never converted for RLS (`withScopedDb` throws without ambient context) |
+| `test/auth.e2e-spec.ts` | fails | `AuthController` gained a `TokenService` dependency its test module does not provide |
+| `test/transactions.e2e-spec.ts` | fails | `DelegateTransferMaskInterceptor` gained a `CrossOwnerAccessService` dependency its test module does not provide |
+
+Each is separate rot that accumulated *behind* the compile error: the RLS
+conversion, the token-service split and the cross-owner-transfers work each moved
+on without these files and nothing complained. Repair them or delete them --
+what they must not stay is present, cited, and dead. Do not add `test:e2e` to CI
+until the three are fixed; it will be red.
 
 ## Module Structure
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "migration:lint": "node scripts/migration-lint.mjs",
     "migration:lint:test": "node --test scripts/migration-lint.test.mjs",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "test": "jest",
     "test:unit": "jest --testPathPatterns='src/.*\\.spec\\.ts$'",
     "pretest:integration": "node -e \"const{Client}=require('pg');const c=new Client({host:process.env.DATABASE_HOST||'localhost',port:+(process.env.DATABASE_PORT||5432),user:process.env.DATABASE_USER||'monize_user',password:process.env.DATABASE_PASSWORD||'monize_password',database:'postgres'});c.connect().then(()=>c.query(\\\"SELECT 1 FROM pg_database WHERE datname='monize_test'\\\").then(r=>r.rowCount?0:c.query('CREATE DATABASE monize_test')).then(()=>c.end())).catch(e=>{console.error(e.message);process.exit(1)})\"",

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication, ValidationPipe } from "@nestjs/common";
 import * as request from "supertest";
-import * as cookieParser from "cookie-parser";
+import cookieParser from "cookie-parser";
 import { AuthController } from "@/auth/auth.controller";
 import { AuthService } from "@/auth/auth.service";
 import { OidcService } from "@/auth/oidc/oidc.service";

--- a/backend/test/helpers/test-database.ts
+++ b/backend/test/helpers/test-database.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication, ValidationPipe } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { ConfigModule } from "@nestjs/config";
-import * as cookieParser from "cookie-parser";
+import cookieParser from "cookie-parser";
 
 export async function createTestApp(
   modules: any[],

--- a/backend/test/transactions.e2e-spec.ts
+++ b/backend/test/transactions.e2e-spec.ts
@@ -5,7 +5,7 @@ import {
   NotFoundException,
 } from "@nestjs/common";
 import * as request from "supertest";
-import * as cookieParser from "cookie-parser";
+import cookieParser from "cookie-parser";
 import { TransactionsController } from "@/transactions/transactions.controller";
 import { TransactionsService } from "@/transactions/transactions.service";
 import { ThrottlerGuard } from "@nestjs/throttler";

--- a/backend/tsconfig.test.json
+++ b/backend/tsconfig.test.json
@@ -1,0 +1,28 @@
+// Type-check the test tree, which the build config deliberately excludes.
+//
+// `tsconfig.json` sets `rootDir: ./src` and `exclude: [..., "test"]` because it
+// drives the build, and CI's `npx tsc --noEmit` uses it -- so nothing type-checked
+// `test/`. ESLint's glob covers the directory but a namespace import called as a
+// function is a type error, not a lint error, so nothing caught it either.
+//
+// The consequence: when `main.ts` moved to `import cookieParser from
+// "cookie-parser"`, three files under `test/` kept `import * as cookieParser` and
+// stopped compiling. Because CI runs only `test:unit` and `test:integration`
+// (neither of which touches `test/*.e2e-spec.ts`), four suites sat dead for over a
+// week -- one of them cited in `backend/CLAUDE.md` as the safety net for the
+// raw-select transformer rule, and one edited while it was already broken.
+//
+// No `outDir`/`rootDir`: this config never emits, it only checks.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false,
+    // The base config pins rootDir to ./src for the build; keeping it here makes
+    // every test file "not under rootDir". Widening it to the package root is
+    // safe precisely because nothing is emitted.
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Linked discussion / issue

None. Found while reviewing the files the audit listed; belongs to its Phase 7
(tests/CI) scope. See the note at the end.

## Summary

`backend/tsconfig.json` pins `rootDir` to `./src` and excludes `test/` because it
drives the build — and CI's `npx tsc --noEmit` uses it. ESLint's glob does cover
the directory, but a namespace import called as a function is a *type* error, not
a lint error. And CI runs only `test:unit` and `test:integration` (the latter
filtered to `test/integration/`), so nothing executes `test/*.e2e-spec.ts` either.

With no gate of any kind, `main.ts` moving to `import cookieParser from
"cookie-parser"` left three files under `test/` on `import * as cookieParser` and
four suites stopped compiling. `test/payee-detail.e2e-spec.ts` was edited three
days later, still broken, without anyone noticing — and that is the suite
`backend/CLAUDE.md` cites as what caught the raw-select transformer class of bug,
"because a unit spec with mocked query builders cannot".

Imports fixed and `npm run typecheck` (`backend/tsconfig.test.json`, `noEmit`, no
`rootDir` restriction) added to the backend lint job. Restoring the namespace
import fails it.

With the compile error gone, `payee-detail` **passes all 9 of its tests** — that
coverage was simply absent. The other three fail on rot that had accumulated
behind it, each from a different change that moved on without these files:

| Suite | State | Cause |
|---|---|---|
| `test/payee-detail.e2e-spec.ts` | passes (9) | — |
| `test/payees.e2e-spec.ts` | fails | calls services directly; never converted for RLS |
| `test/auth.e2e-spec.ts` | fails | `AuthController` gained a `TokenService` its test module lacks |
| `test/transactions.e2e-spec.ts` | fails | `DelegateTransferMaskInterceptor` gained a `CrossOwnerAccessService` |

Those three are documented in `backend/CLAUDE.md` with their exact causes and are
deliberately **not** fixed here — repairing them is separate work, and `test:e2e`
must stay out of CI until it is done or the job goes red. What they must not remain
is present, cited, and dead. Happy to take that on as a follow-up if you want it.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — **no**, see below
- [x] This PR addresses a **single concern**. — close the compile gap and gate it
- [x] New behavior has tests, and the existing suite passes. — the gate is the test; it fails on the restored import. Restores 9 previously-dead tests
- [x] All user-facing strings are translated for every locale. — no new strings
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below.

**Judgement call for you:** the three broken suites could instead be *deleted* in
this PR. I left them, documented, because `payee-detail`'s history suggests they
encode real knowledge — but they are dead weight until repaired, and deleting them
is a defensible alternative.

## AI assistance disclosure

Written with Claude Code (Claude Opus 5). AI-produced and reviewed; I own the
result. Verified locally: `npm run typecheck` clean, fails when the namespace
import is restored, and `test/payee-detail.e2e-spec.ts` passes 9/9 against a real
PostgreSQL 16.
