### PR TITLE
01: Stop a stale exchange-rate lookup from overwriting a hand-typed rate (v.1.15.0)

### DIFF
--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx
@@ -1931,6 +1931,64 @@ describe('PostTransactionDialog - editing the converted total', () => {
     );
   });
 
+  it('does not let a stale rate lookup overwrite a manually derived rate', async () => {
+    // The lookup that was already in flight when the user typed a total
+    // resolves *after* the override -- its answer must not un-derive the
+    // rate the user just entered.
+    let resolveRate!: (rate: number | null) => void;
+    mockGetRateForDate.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRate = resolve;
+      }),
+    );
+    await renderDialog();
+
+    const total = screen.getByLabelText('Total in CAD');
+    await act(async () => {
+      fireEvent.change(total, { target: { value: '-60' } });
+      fireEvent.blur(total);
+    });
+
+    await act(async () => {
+      resolveRate(1.4);
+    });
+    await post();
+
+    await waitFor(() => expect(mockPostApi).toHaveBeenCalled());
+    expect(mockPostApi).toHaveBeenCalledWith(
+      's-fx2',
+      expect.objectContaining({ originalAmount: -40, exchangeRate: 1.5 }),
+    );
+  });
+
+  it('does not let a stale lookup failure clear a manually derived rate', async () => {
+    let rejectRate!: (error: Error) => void;
+    mockGetRateForDate.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectRate = reject;
+      }),
+    );
+    await renderDialog();
+
+    const total = screen.getByLabelText('Total in CAD');
+    await act(async () => {
+      fireEvent.change(total, { target: { value: '-60' } });
+      fireEvent.blur(total);
+    });
+
+    await act(async () => {
+      rejectRate(new Error('late lookup failure'));
+      await Promise.resolve();
+    });
+    await post();
+
+    await waitFor(() => expect(mockPostApi).toHaveBeenCalled());
+    expect(mockPostApi).toHaveBeenCalledWith(
+      's-fx2',
+      expect.objectContaining({ originalAmount: -40, exchangeRate: 1.5 }),
+    );
+  });
+
   it('keeps a hand-typed rate when the posting date moves', async () => {
     await renderDialog();
     const total = screen.getByLabelText('Total in CAD');

--- a/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
+++ b/frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx
@@ -218,7 +218,12 @@ export function PostTransactionDialog({
       exchangeRatesApi
         .getRateForDate(entryCurrency, scheduledTransaction.currencyCode, transactionDate)
         .then((rate) => {
-          if (cancelled) return;
+          // `cancelled` only trips when this effect's own deps change; typing
+          // a converted total does not, so a lookup started before the user
+          // overrode the rate is still in flight when it resolves. Without
+          // this check its answer -- for a rate the request itself made
+          // stale -- overwrote the one the user just derived.
+          if (cancelled || rateOverriddenRef.current) return;
           setPostFxRate(rate);
           // The server answered: `null` here really does mean no rate exists
           // for this pair and date, so the warning is a fact.
@@ -226,7 +231,7 @@ export function PostTransactionDialog({
           setPostFxRateLoading(false);
         })
         .catch(() => {
-          if (cancelled) return;
+          if (cancelled || rateOverriddenRef.current) return;
           // The request itself failed (offline, throttled, timed out). That is
           // not evidence about the rate, so the preview goes blank rather than
           // claiming none exists -- and posting still works, because the
@@ -274,6 +279,12 @@ export function PostTransactionDialog({
       base = roundToCents(total >= 0 ? total / (1 - p) : total / (1 + p));
     }
     rateOverriddenRef.current = true;
+    // A lookup can still be in flight -- its own .then/.catch now checks the
+    // ref above, but the loading spinner and any earlier failure banner are
+    // this render's problem, not that request's, and must clear the moment
+    // the manual value becomes authoritative.
+    setPostFxRateLoading(false);
+    setRateLookupFailed(false);
     setPostFxRate(roundToDecimals(base / foreignAmount, 10));
     setAmount(roundToCents(total));
   };


### PR DESCRIPTION
## Linked discussion / issue

None. This is a pre-existing race condition surfaced by a red CI run on an
unrelated PR (`#1047`), not a feature proposal — there was nothing to propose
in advance. Happy to open a Discussion and let this wait behind it if you'd
rather.

## Summary

`PostTransactionDialog` looks up the posting-date exchange rate
asynchronously and debounces it 300ms. Editing the converted total directly
derives a rate from what the user typed and sets `rateOverriddenRef.current`
— but the lookup's own `.then`/`.catch` checked only `cancelled`, which trips
when the *effect's* dependencies change (posting date, currency, etc.), not
when the user types a total. A lookup already in flight when the override
happened was therefore still live, and its answer — for a rate the user had
already superseded — landed after it and overwrote `postFxRate`.

```text
Foreign amount:        -40 USD
Typed converted total: -60 CAD
Correct rate:          1.5   (-60 / -40)
Stale lookup answer:   1.4   (fetched before the override, resolved after it)
```

This is not only a CI timing accident: a real user editing the converted
total while the rate request is still in the air hits the same sequence, and
the wrong rate is what gets posted.

**Fix.** Both the success and failure branches of the lookup now also check
`rateOverriddenRef.current` before writing state. `handleConvertedTotalChange`
additionally clears the loading and failure flags itself, since a lookup a
manual override has already superseded should not leave the dialog showing
its spinner or an error banner for a request that no longer matters.

**Tests.** Two new cases drive the race with a manually controlled `Promise`
— resolving and rejecting the stale lookup only *after* the override — rather
than adding a longer `waitFor()` to the existing test, which would only have
made the window less likely to be hit in this suite, not closed it. Both were
confirmed to fail against the unguarded code (mutation: reverting the
`rateOverriddenRef.current` check in both callbacks fails both new tests) and
pass against the fix.

## Scope

- `frontend/src/components/scheduled-transactions/PostTransactionDialog.tsx`
- `frontend/src/components/scheduled-transactions/PostTransactionDialog.test.tsx`

Does not touch backend exchange-rate resolution, the scheduled-transaction
posting API, or any other component. `TransactionForm`'s own
`rateOverriddenRef` (same pattern, different file) is not in scope here and
was not checked for the same gap.

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — **no**, see below
- [x] This PR addresses a **single concern**. — one race, one component
- [x] New behavior has tests, and the existing suite passes. — 122/122 in `PostTransactionDialog.test.tsx`, including the 2 new cases; both confirmed to fail against the unguarded code
- [x] All user-facing strings are translated for every locale. — no new strings
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below.

## AI assistance disclosure

Written with Claude Code. A separately-produced diagnosis document was
reviewed against the actual source before acting on it — the described race
(stale `.then`/`.catch` writing state after a manual override, guarded only by
an effect-level `cancelled` flag that doesn't trip on the override) was
confirmed to match `PostTransactionDialog.tsx` exactly. The fix and both new
tests are AI-produced; I reviewed them and own the result. Verified locally:
`vitest run PostTransactionDialog.test.tsx` (122/122), `tsc --noEmit` and
ESLint clean on both touched files. Both new tests were confirmed to fail
when the `rateOverriddenRef.current` check is reverted in either callback.
