### PR TITLE
01: Decode the file:// URL these scripts derive REPO_ROOT from (v.1.15.0)

### DIFF
--- a/backend/scripts/migration-lint.test.mjs
+++ b/backend/scripts/migration-lint.test.mjs
@@ -7,6 +7,7 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
 import {
   RULES,
   stripComments,
@@ -255,8 +256,10 @@ test("every rule has a unique id", () => {
 });
 
 test("the repository's migrations lint clean", () => {
+  // fileURLToPath, not `.pathname` -- a file:// URL percent-encodes a space,
+  // and lintDirectory hands that straight to `fs`, which does not decode it.
   const { files, findings } = lintDirectory(
-    new URL("../../database/migrations", import.meta.url).pathname,
+    fileURLToPath(new URL("../../database/migrations", import.meta.url)),
   );
   assert.ok(files.length > 0, "expected migrations to be found");
   assert.deepEqual(

--- a/scripts/check-docs-manifests.mjs
+++ b/scripts/check-docs-manifests.mjs
@@ -25,8 +25,13 @@
 
 import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const REPO_ROOT = new URL('..', import.meta.url).pathname;
+// `.pathname` on a file:// URL is percent-encoded (a space becomes `%20`) and
+// `fs` wants a real OS path, not a URL component -- `fileURLToPath` decodes
+// it. A repo checked out under a path with a space (not exotic: "My Drive")
+// reads that literal `%20` as a directory name and fails on the first read.
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
 /** Documents whose commands and tables are treated as canonical instructions. */
 const DOCS = [

--- a/scripts/check-env-docs.mjs
+++ b/scripts/check-env-docs.mjs
@@ -11,8 +11,13 @@
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const REPO_ROOT = new URL('..', import.meta.url).pathname;
+// `.pathname` on a file:// URL is percent-encoded (a space becomes `%20`) and
+// `fs` wants a real OS path, not a URL component -- `fileURLToPath` decodes
+// it. A repo checked out under a path with a space (not exotic: "My Drive")
+// reads that literal `%20` as a directory name and fails on the first read.
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 const ENV_EXAMPLE = join(REPO_ROOT, '.env.example');
 const SOURCE_DIRS = [
   join(REPO_ROOT, 'backend', 'src'),


### PR DESCRIPTION
## Linked discussion / issue

None. This is a portability bug, not a feature proposal — found while resolving
a rebase conflict on `#1046`, which had the identical line and the identical
bug. There was nothing to propose in advance.

## Summary

Three scripts derive their repository root the same way:

```js
const REPO_ROOT = new URL('..', import.meta.url).pathname;
```

`.pathname` on a `file://` URL is percent-encoded — a space becomes a literal
`%20` — and every `fs` call downstream (`readdirSync`, `join`, ...) reads that
as part of a directory name rather than decoding it. A repository checked out
under a path containing a space fails on the script's own first read. Not
exotic: `My Drive`, `Moje glupoty` — anything a sync client or a non-English
locale routinely produces.

CI never hits this, because the runner's checkout path has no such character,
which is exactly why three separate copies of the same mistake went
unnoticed: `scripts/check-docs-manifests.mjs` and `scripts/check-env-docs.mjs`
(both introduced by the recent docs/CI audit series) reproduce it verbatim,
and `backend/scripts/migration-lint.test.mjs` carries an older, independent
instance of the same anti-pattern (`new URL(...).pathname` used directly as a
path in `lintDirectory`).

`fileURLToPath` (from `node:url`) decodes the URL into a real OS path. All
three now use it.

**Not included:** `scripts/check-migration-prefixes.mjs`. It has the same
line, found and fixed while resolving `#1046`'s rebase conflict — a fourth
copy, but already fixed on that branch, so redoing it here would just conflict
with that PR instead of this one.

## Scope

- `scripts/check-docs-manifests.mjs`
- `scripts/check-env-docs.mjs`
- `backend/scripts/migration-lint.test.mjs`

No behavior change for a checkout path without special characters (the
overwhelming majority, including every CI run to date) — `fileURLToPath` and
`.pathname` agree exactly there. Does not touch anything these scripts check
*against* (env docs, Helm manifests, migration idempotency rules).

## Checklist

- [ ] An approved discussion or issue exists and is linked above. — **no**, see below
- [x] This PR addresses a **single concern**. — one bug, three copies of it
- [x] New behavior has tests, and the existing suite passes. — no new behavior to test; all three scripts run clean against this branch (verified below), and `migration-lint.test.mjs` is itself a test file — its 24 cases, including the fixed one, pass
- [x] All user-facing strings are translated for every locale. — no strings
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below.

**On the missing Discussion:** this is a one-line portability fix repeated
three times, not a design decision — happy to open one if you'd rather.

## AI assistance disclosure

Written with Claude Code. AI-produced and reviewed; I own the result. Verified
locally by reproducing the failure first (a real checkout path containing a
space ENOENTs on all three, before the fix) and then confirming each script
runs clean after it: `node scripts/check-docs-manifests.mjs`, `node
scripts/check-env-docs.mjs`, and `node --test
backend/scripts/migration-lint.test.mjs` (24/24 passing, including "the
repository's migrations lint clean").
