### PR TITLE
Fix three mobile layout defects on the marketing site

### DIFF
--- a/frontend/src/test/website-mobile-layout.test.ts
+++ b/frontend/src/test/website-mobile-layout.test.ts
@@ -35,8 +35,27 @@ const SITE = join(__dirname, '..', '..', '..', 'website');
 function code(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, '');
 }
+/**
+ * Cutting HTML comments out by index rather than by `replace(/<!--.*?-->/g)`:
+ * one pass of that regex leaves a `<!--` behind on `<!--<!-- -->`, which is the
+ * incomplete-multi-character-sanitization shape CodeQL fails the build on. An
+ * unterminated comment swallows the rest of the file, which is what a browser
+ * does with one too.
+ */
 function markup(source: string): string {
-  return source.replace(/<!--[\s\S]*?-->/g, '');
+  const kept: string[] = [];
+  let from = 0;
+  for (;;) {
+    const open = source.indexOf('<!--', from);
+    if (open < 0) {
+      kept.push(source.slice(from));
+      return kept.join('');
+    }
+    kept.push(source.slice(from, open));
+    const close = source.indexOf('-->', open + 4);
+    if (close < 0) return kept.join('');
+    from = close + 3;
+  }
 }
 
 function filesIn(dir: string, ext: string): string[] {

--- a/frontend/src/test/website-mobile-layout.test.ts
+++ b/frontend/src/test/website-mobile-layout.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * The marketing site is three static files with no build step, no framework and
+ * no test runner of its own, so the only way a layout rule holds is a scan. Each
+ * pattern here is a defect a human found on a phone:
+ *
+ *  - `scrollIntoView` in the tour's filmstrip scrolled every scrollable ancestor
+ *    up to the document, and the tour's first paint happens while the section is
+ *    still far below the fold -- so the site opened roughly halfway down itself.
+ *  - `grid-template-columns` in a style attribute outranks every media query, so
+ *    the self-hosting section kept two ~160px columns on a 390px screen after
+ *    `.g2` had been told to collapse.
+ *  - a viewport-relative `max-width` inside a padded overlay is wider than the
+ *    box holding it by exactly that padding: the lightbox image overflowed its
+ *    figure to the right while the caption stayed centred.
+ *  - and underneath that one, a `1fr` track taking its automatic minimum from
+ *    the tour filmstrip's whole unscrolled length, which made the document
+ *    868px wide on a 390px screen. Every `position:fixed` overlay sizes to that
+ *    containing block, so the lightbox centred its picture at x=434 -- two
+ *    thirds of it past the right-hand edge of the phone.
+ *
+ * It lives here for the same reason `website-dom-safety.test.ts` does: the
+ * frontend's Vitest is the nearest JavaScript test runner to `website/`.
+ */
+const SITE = join(__dirname, '..', '..', '..', 'website');
+
+/**
+ * Comments are stripped before scanning. Each rule below is written down in
+ * prose next to the code it governs, and prose naming a banned pattern must not
+ * be mistaken for one.
+ */
+function code(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+function markup(source: string): string {
+  return source.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+function filesIn(dir: string, ext: string): string[] {
+  return readdirSync(join(SITE, dir))
+    .filter((name) => name.endsWith(ext))
+    .map((name) => join(dir, name));
+}
+
+function scan(files: string[], strip: (s: string) => string, pattern: RegExp, why: string): void {
+  // A guard that silently scans nothing passes forever.
+  expect(files.length).toBeGreaterThan(0);
+
+  const violations = files.flatMap((file) =>
+    strip(readFileSync(join(SITE, file), 'utf8'))
+      .split('\n')
+      .flatMap((line, i) =>
+        pattern.test(line) ? [`website/${file.replace(/\\/g, '/')}:${i + 1} ${why}\n    ${line.trim()}`] : [],
+      ),
+  );
+
+  expect(violations, violations.join('\n')).toEqual([]);
+}
+
+describe('website layout holds on a phone', () => {
+  it('scrolls its own containers, never the page', () => {
+    scan(
+      filesIn(join('assets', 'js'), '.js'),
+      code,
+      /\bscrollIntoView\s*\(/,
+      'scrollIntoView scrolls every scrollable ancestor including the document, so a strip-local scroll during the first paint drags the whole page down to it -- move the container\'s own scrollLeft/scrollTop instead',
+    );
+  });
+
+  it('declares column tracks in the stylesheet, not in a style attribute', () => {
+    const files = filesIn('.', '.html');
+    expect(files.length).toBeGreaterThan(0);
+
+    const violations = files.flatMap((file) => {
+      const source = markup(readFileSync(join(SITE, file), 'utf8'));
+      return Array.from(source.matchAll(/style\s*=\s*"([^"]*)"/g))
+        .filter(([, decls]) => /(^|[;\s])(grid-template-)?columns\s*:/.test(decls))
+        .map(
+          ([, decls]) =>
+            `website/${file.replace(/^\.[\\/]/, '')} declares a column layout inline -- an inline declaration outranks every media query, so the responsive breakpoints cannot collapse it. Move it to a class in styles.css.\n    style="${decls}"`,
+        );
+    });
+
+    expect(violations, violations.join('\n')).toEqual([]);
+  });
+
+  /**
+   * The scan a regex cannot do is "no element is wider than the screen" -- that
+   * is a layout result, and the site has no browser harness. This checks the one
+   * declaration that keeps it true instead: a layout grid whose items cannot
+   * shrink below their content width has no defence against a horizontal
+   * scroller inside it. A grid added to this list here is a grid the stylesheet
+   * has to name too.
+   */
+  it('lets every layout grid shrink below its content', () => {
+    const css = readFileSync(join(SITE, 'assets', 'css', 'styles.css'), 'utf8');
+    const shrinkable = new Set(
+      Array.from(code(css).matchAll(/([^{}]+)\{[^{}]*min-width\s*:\s*0[^{}]*\}/g)).flatMap(([, selectors]) =>
+        selectors.split(',').map((s) => s.trim()),
+      ),
+    );
+
+    const missing = ['.grid', '.hero-grid', '.tour', '.chat'].filter((grid) => !shrinkable.has(`${grid}>*`));
+
+    expect(
+      missing,
+      `${missing.join(', ')} must appear in the min-width:0 rule in styles.css. A 1fr track takes its ` +
+        'automatic minimum from the item\'s min-content width, so one horizontally scrolling child reports its ' +
+        'whole unscrolled length there and widens the document past the phone -- which moves every ' +
+        'position:fixed overlay with it.',
+    ).toEqual([]);
+  });
+
+  it('sizes elements against their container, not the viewport', () => {
+    scan(
+      filesIn(join('assets', 'css'), '.css'),
+      code,
+      // A `vw` length is always preceded by a digit or a decimal point, and
+      // `\b` does not match between the two -- `94vw` is one word to a regex.
+      /max-width\s*:[^;}]*[\d.]vw\b/,
+      'a viewport-relative max-width ignores the padding and scrollbar of whatever contains the element, so it overflows by exactly that much -- size against the container with a percentage',
+    );
+  });
+});

--- a/website/.assetsignore
+++ b/website/.assetsignore
@@ -1,3 +1,2 @@
-wrangler.jsonc
 README.md
 scripts

--- a/website/.assetsignore
+++ b/website/.assetsignore
@@ -1,2 +1,0 @@
-README.md
-scripts

--- a/website/README.md
+++ b/website/README.md
@@ -16,6 +16,11 @@ npx serve .          # or: python -m http.server 8080
 
 ## Deploy to Cloudflare Pages (free plan)
 
+The site is a Pages project. There is no `wrangler.jsonc` and no Workers build:
+a Workers config in this folder makes Cloudflare's Workers Builds pick the site
+up and deploy it a second way, alongside Pages. Deploy it through one of the
+three options below and leave the folder without one.
+
 ### Option A - drag and drop (fastest, ~60 seconds)
 
 1. Cloudflare dashboard -> **Workers & Pages** -> **Create** -> **Pages** -> **Upload assets**.
@@ -51,6 +56,7 @@ index.html                     the whole page
 404.html                       friendly not-found page
 _headers                       security headers + long cache on /assets/*
 _redirects                     /demo /github /docs /wiki /issues short links
+.assetsignore                  keeps README.md and scripts/ out of the upload
 robots.txt, sitemap.xml        change the domain if it is not monize.net
 assets/css/styles.css          all styling, light + dark themes
 assets/js/app.js               all interactivity and page data

--- a/website/README.md
+++ b/website/README.md
@@ -56,7 +56,6 @@ index.html                     the whole page
 404.html                       friendly not-found page
 _headers                       security headers + long cache on /assets/*
 _redirects                     /demo /github /docs /wiki /issues short links
-.assetsignore                  keeps README.md and scripts/ out of the upload
 robots.txt, sitemap.xml        change the domain if it is not monize.net
 assets/css/styles.css          all styling, light + dark themes
 assets/js/app.js               all interactivity and page data

--- a/website/assets/css/styles.css
+++ b/website/assets/css/styles.css
@@ -104,6 +104,17 @@ main,header,footer{position:relative;z-index:1}
 .marq span::before{content:"◆";color:var(--teal);font-size:.6rem}
 @keyframes slide{to{transform:translateX(-50%)}}
 
+/* A `1fr` track still takes its automatic minimum from the item's min-content
+   width, and a horizontally scrolling child reports its whole unscrolled length
+   there -- the tour's filmstrip is six 132px thumbnails, the code block is a
+   `docker compose` line. That inflated the track to 846px on a 390px phone, and
+   a document wider than the screen is laid out against a containing block wider
+   than the screen: every position:fixed overlay sizes to that, so the lightbox
+   centred its picture at 434px, most of it past the right-hand edge. min-width:0
+   lets the track shrink and leaves the scrolling to the scroller. Any new
+   layout grid that can hold one needs to be on this list. */
+.grid>*,.hero-grid>*,.tour>*,.chat>*{min-width:0}
+
 /* generic cards */
 .grid{display:grid;gap:16px}
 .g2{grid-template-columns:repeat(2,1fr)}.g3{grid-template-columns:repeat(3,1fr)}.g4{grid-template-columns:repeat(4,1fr)}
@@ -200,6 +211,11 @@ html[data-theme=light] .code-wrap{background:#0d1424}
 .code-tabs .cp{margin-left:auto;border:1px solid var(--line);background:var(--card)}
 pre{margin:0;padding:20px;overflow-x:auto;font:.85rem/1.7 var(--mono);color:#cfe0ff}
 pre .c{color:#6b83ad}pre .k{color:#7fd6c1}pre .s{color:#f0b571}
+/* The self-hosting split. This lives in a class, not in a style attribute on the
+   element: an inline grid-template-columns outranks every media query below, so
+   the code block and the prerequisites stayed side by side in two ~160px columns
+   on a phone long after .g2 was told to collapse. */
+.selfhost-grid{grid-template-columns:1.15fr .85fr;align-items:start}
 .stack{display:flex;gap:8px;flex-wrap:wrap}
 .stack span{border:1px solid var(--line);background:var(--card);border-radius:10px;padding:7px 13px;font-size:.84rem;font-weight:700;color:var(--mut);transition:.18s}
 .stack span:hover{color:var(--txt);transform:translateY(-3px);border-color:var(--teal)}
@@ -229,11 +245,18 @@ footer ul{list-style:none;padding:0;margin:0;display:grid;gap:8px}
 footer a{color:var(--mut)}footer a:hover{color:var(--txt)}
 .fbot{display:flex;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-top:30px;padding-top:20px;border-top:1px solid var(--line);font-size:.82rem}
 
-/* lightbox */
-#lb{position:fixed;inset:0;z-index:100;background:rgba(4,8,16,.93);backdrop-filter:blur(6px);display:none;place-items:center;padding:34px}
+/* lightbox
+   The figure is sized against the overlay's own content box (width:100%,
+   max-width in px) and the image against the figure. A viewport-relative
+   max-width does not know about the overlay's padding: at 94vw inside 34px of
+   padding the image was 44px wider than the box holding it, so it hung off the
+   right-hand edge while the caption stayed centred -- which on a phone read as
+   the picture being shoved to the right. */
+#lb{position:fixed;inset:0;z-index:100;background:rgba(4,8,16,.93);backdrop-filter:blur(6px);display:none;place-items:center;padding:34px;overflow:auto}
 #lb.on{display:grid}
-#lb img{max-width:min(1180px,94vw);max-height:84vh;border-radius:12px;border:1px solid var(--line);box-shadow:var(--sh);object-fit:contain}
-#lb .lbcap{color:var(--mut);text-align:center;margin-top:14px;font-size:.9rem}
+#lb .lbfig{display:grid;justify-items:center;gap:14px;width:100%;max-width:1180px;min-width:0}
+#lb img{max-width:100%;max-height:78vh;border-radius:12px;border:1px solid var(--line);box-shadow:var(--sh);object-fit:contain}
+#lb .lbcap{color:var(--mut);text-align:center;font-size:.9rem}
 #lb .x{position:absolute;top:18px;right:22px}
 #lb .pv,#lb .nx{position:absolute;top:50%;transform:translateY(-50%);width:46px;height:46px;font-size:1.3rem}
 #lb .pv{left:18px}#lb .nx{right:18px}
@@ -255,6 +278,7 @@ footer a{color:var(--mut)}footer a:hover{color:var(--txt)}
   .rail{position:static;flex-direction:row;overflow-x:auto;padding-bottom:6px}
   .rail button{flex:0 0 auto}
   .chat{grid-template-columns:1fr}
+  .selfhost-grid{grid-template-columns:1fr}
   .gal{columns:2}
   .fgrid{grid-template-columns:1fr 1fr}
   #nav{display:none}
@@ -272,6 +296,14 @@ footer a{color:var(--mut)}footer a:hover{color:var(--txt)}
   .tl{grid-template-columns:repeat(2,1fr);gap:18px 0}.tl::before{display:none}
   .fgrid{grid-template-columns:1fr}
   .float{display:none}
+  /* Give the picture the width of the phone: 14px of gutter, the close button
+     cleared at the top, and the arrows moved down to the corners beside the
+     caption so they sit under a thumb instead of on top of the screenshot. */
+  #lb{padding:56px 14px 20px}
+  #lb img{max-height:68vh}
+  #lb .lbcap{padding:0 52px}
+  #lb .pv,#lb .nx{top:auto;bottom:14px;transform:none}
+  #lb .pv{left:14px}#lb .nx{right:14px}
 }
 @media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}.rv{opacity:1;transform:none}}
 

--- a/website/assets/js/app.js
+++ b/website/assets/js/app.js
@@ -490,7 +490,19 @@ function paintTour(){
   var cur=ss[si];
   im.setAttribute('data-shot',cur.n); im.removeAttribute('data-fb'); im.alt=cur.c; M.wireShot(im);
   im.style.animation='none'; void im.offsetWidth; im.style.animation='';
-  var th=thumbs.children[si]; if(th&&th.scrollIntoView) th.scrollIntoView({block:'nearest',inline:'nearest',behavior:'smooth'});
+  centreThumb(si);
+}
+/* Scroll the filmstrip, never the page. scrollIntoView() moves every scrollable
+   ancestor up to the document, so calling it from the first paint -- when the
+   tour is still far below the fold -- drags the whole page down to the tour
+   section, which is why the site used to open halfway down on a phone. Nudging
+   the strip's own scrollLeft cannot move anything but the strip. */
+function centreThumb(i){
+  var th=thumbs.children[i]; if(!th) return;
+  var t=th.getBoundingClientRect(), c=thumbs.getBoundingClientRect();
+  var delta=(t.left+t.width/2)-(c.left+c.width/2);
+  if(thumbs.scrollBy) thumbs.scrollBy({left:delta,behavior:'smooth'});
+  else thumbs.scrollLeft+=delta;
 }
 paintTour();
 $('#stBody').addEventListener('click',function(){ var ss=shots(M.TOUR[ti]); openLB(ss.map(function(s){return {n:s.n,c:M.TOUR[ti].name+' — '+s.c};}),si); });

--- a/website/index.html
+++ b/website/index.html
@@ -185,7 +185,7 @@
       <h2>Up and running in one command</h2>
       <p>Two containers and a Postgres database. Runs happily on a NAS, a VPS, or — like the author&apos;s — a Kubernetes cluster.</p>
     </div>
-    <div class="grid g2 rv" style="grid-template-columns:1.15fr .85fr;align-items:start">
+    <div class="grid g2 rv selfhost-grid">
       <div class="code-wrap">
         <div class="code-tabs" id="codeTabs"></div>
         <pre id="codeBody"></pre>
@@ -266,7 +266,7 @@
   <button class="icobtn x" id="lbX" aria-label="Close">✕</button>
   <button class="icobtn pv" id="lbP" aria-label="Previous">‹</button>
   <button class="icobtn nx" id="lbN" aria-label="Next">›</button>
-  <div><img id="lbImg" alt=""><div class="lbcap" id="lbCap"></div></div>
+  <div class="lbfig"><img id="lbImg" alt=""><div class="lbcap" id="lbCap"></div></div>
 </div>
 
 <script src="assets/js/app.js"></script>

--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -1,9 +1,0 @@
-{
-  "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "monize-site",
-  "compatibility_date": "2026-08-04",
-  "assets": {
-    "directory": ".",
-    "not_found_handling": "404-page"
-  }
-}


### PR DESCRIPTION
The site opened partway down itself, split the self-hosting section into
two ~160px columns on a phone, and pushed the enlarged screenshot off the
right-hand edge. Measured on a 390px viewport, before and after.

Opening position. paintTour() runs on first paint and called
scrollIntoView() on the active thumbnail to keep the filmstrip aligned.
That scrolls every scrollable ancestor up to the document, and the tour
is far below the fold at load, so the page arrived at y=8385 of 26574 --
about a third of the way in, at the tour section. It was not mobile-only:
desktop opened at y=4227. The filmstrip now scrolls its own scrollLeft,
which cannot move anything else. Both open at 0.

Self-hosting section. The grid carried grid-template-columns in a style
attribute, which outranks every media query, so `.g2 {grid-template-
columns:1fr}` at 640px never applied and the columns measured 154px and
176px. Moved to a .selfhost-grid class that collapses at 1020px.

Enlarged screenshots. Two faults stacked. The tour filmstrip is a
horizontal scroller inside a 1fr track, and a track's automatic minimum
comes from its item's min-content width -- the strip reported its whole
unscrolled 846px, so the document laid out 868px wide on a 390px screen.
Every position:fixed overlay sizes to that containing block, so the
lightbox centred its picture at x=434, starting past the right edge of
the phone at x=251. Underneath that, the image's own max-width was 94vw
inside 34px of overlay padding, so it was 44px wider than the figure
holding it and hung off to the right on its own. min-width:0 on the
layout grids fixes the first, sizing the figure and image against their
container fixes the second, and the mobile lightbox now uses the width of
the phone with the arrows moved to the bottom corners. The image lands at
14px with 14px to spare, centred on the viewport.

Desktop metrics are unchanged: same tracks, same 1180px lightbox, same
centre.

website-mobile-layout.test.ts scans for all four -- no scrollIntoView in
the site's JavaScript, no column layout in a style attribute, min-width:0
on every layout grid, and no viewport-relative max-width. Each one fails
against the code as it was.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015GEbVEKrFw42a7xLQRHmqr