### PR TITLE
Make the website feature list a horizontal strip on a phone

### DIFF
--- a/frontend/src/test/website-mobile-layout.test.ts
+++ b/frontend/src/test/website-mobile-layout.test.ts
@@ -58,6 +58,47 @@ function markup(source: string): string {
   }
 }
 
+interface Rule {
+  selectors: string;
+  declarations: string;
+}
+
+/**
+ * Every `selector { declarations }` pair in a stylesheet, at-rule bodies
+ * included: `[^{}]+` cannot cross a brace, so an `@media` opener never matches
+ * as a selector and the rules nested inside it are found on their own.
+ */
+function rules(css: string): Rule[] {
+  return Array.from(css.matchAll(/([^{}]+)\{([^{}]*)\}/g)).map(([, selectors, declarations]) => ({
+    selectors: selectors.trim(),
+    declarations,
+  }));
+}
+
+/**
+ * The rules that apply at the phone breakpoint. A regex cannot match a nested
+ * brace pair, so the body of each `@media` is taken by counting braces out from
+ * the one that opened it.
+ */
+function phoneRules(css: string): Rule[] {
+  const stripped = code(css);
+  const opener = /@media([^{]*)\{/g;
+  const found: Rule[] = [];
+
+  for (let at = opener.exec(stripped); at; at = opener.exec(stripped)) {
+    const start = at.index + at[0].length;
+    let end = start;
+    for (let depth = 1; end < stripped.length && depth > 0; end++) {
+      if (stripped[end] === '{') depth++;
+      else if (stripped[end] === '}') depth--;
+    }
+    if (/max-width\s*:\s*640px/.test(at[1])) found.push(...rules(stripped.slice(start, end - 1)));
+    opener.lastIndex = end;
+  }
+
+  return found;
+}
+
 function filesIn(dir: string, ext: string): string[] {
   return readdirSync(join(SITE, dir))
     .filter((name) => name.endsWith(ext))
@@ -131,6 +172,69 @@ describe('website layout holds on a phone', () => {
         'whole unscrolled length there and widens the document past the phone -- which moves every ' +
         'position:fixed overlay with it.',
     ).toEqual([]);
+  });
+
+  /**
+   * The features section is twenty-eight cards. Collapsed to a single column it
+   * is a screen and a half of thumb-scrolling to reach the next section, so on a
+   * phone it is a horizontal strip instead. Two files have to agree for that to
+   * happen -- the class in the markup and the rule in the phone breakpoint --
+   * and either one alone leaves the long column back in place, looking like
+   * nothing was changed rather than like something is broken.
+   */
+  it('turns the feature list into a horizontal strip on a phone', () => {
+    const tag = markup(readFileSync(join(SITE, 'index.html'), 'utf8')).match(/<div[^>]*\bid="fgrid"[^>]*>/);
+    expect(tag, 'the feature list (#fgrid) is gone from index.html -- update this guard with it').not.toBeNull();
+    expect(
+      tag![0],
+      '#fgrid must carry the feat-strip class, which is what the phone breakpoint styles as a scroller',
+    ).toMatch(/class="[^"]*\bfeat-strip\b/);
+
+    const declared = phoneRules(readFileSync(join(SITE, 'assets', 'css', 'styles.css'), 'utf8'))
+      .filter(({ selectors }) => /\bfeat-strip\b/.test(selectors))
+      .map(({ declarations }) => declarations)
+      .join(';');
+
+    const required: Array<[RegExp, string]> = [
+      [/grid-auto-flow\s*:\s*column/, 'grid-auto-flow:column -- lays the cards along one row instead of one per row'],
+      [
+        /grid-template-columns\s*:\s*none/,
+        'grid-template-columns:none -- an explicit track list sizes the leading items and grid-auto-columns only ' +
+          'picks up the implicit ones after it, so the collapsed 1fr would keep the first card full width',
+      ],
+      [
+        /overflow-x\s*:\s*(auto|scroll)/,
+        'overflow-x:auto -- without it the row is an overflow, not a scroller, and the cards are simply unreachable',
+      ],
+      [/scroll-snap-type\s*:\s*x/, 'scroll-snap-type:x -- a swipe lands on a card rather than between two'],
+    ];
+
+    const missing = required.flatMap(([pattern, why]) => (pattern.test(declared) ? [] : [why]));
+    expect(missing, `the .feat-strip rule in the phone breakpoint is missing:\n  ${missing.join('\n  ')}`).toEqual([]);
+  });
+
+  /**
+   * A horizontal scroller that reaches its end hands the rest of the gesture to
+   * its ancestors, and on a phone the ancestor that takes it is the browser: a
+   * swipe past the last feature card is a back-navigation off the site. Every
+   * sideways scroller on the page has to keep its own overscroll.
+   */
+  it('keeps a sideways swipe inside the strip that receives it', () => {
+    const css = code(readFileSync(join(SITE, 'assets', 'css', 'styles.css'), 'utf8'));
+    const scrollers = rules(css).filter(({ declarations }) => /overflow-x\s*:\s*(auto|scroll)/.test(declarations));
+
+    // A guard that silently scans nothing passes forever.
+    expect(scrollers.length).toBeGreaterThan(0);
+
+    const leaky = scrollers
+      .filter(({ declarations }) => !/overscroll-behavior(-x)?\s*:\s*(contain|none)/.test(declarations))
+      .map(
+        ({ selectors }) =>
+          `${selectors} scrolls horizontally without overscroll-behavior-x:contain -- a swipe past its end ` +
+          'chains to the page and then to the browser gesture, which navigates away from the site',
+      );
+
+    expect(leaky, leaky.join('\n')).toEqual([]);
   });
 
   it('sizes elements against their container, not the viewport', () => {

--- a/frontend/src/test/website-mobile-layout.test.ts
+++ b/frontend/src/test/website-mobile-layout.test.ts
@@ -27,6 +27,12 @@ import { join } from 'node:path';
  */
 const SITE = join(__dirname, '..', '..', '..', 'website');
 
+/** The lists that are a horizontal strip on a phone rather than a long column. */
+const STRIPS = [
+  { id: 'fgrid', what: 'the feature list' },
+  { id: 'gal', what: 'the screenshot gallery' },
+];
+
 /**
  * Comments are stripped before scanning. Each rule below is written down in
  * prose next to the code it governs, and prose naming a banned pattern must not
@@ -175,42 +181,71 @@ describe('website layout holds on a phone', () => {
   });
 
   /**
-   * The features section is twenty-eight cards. Collapsed to a single column it
-   * is a screen and a half of thumb-scrolling to reach the next section, so on a
-   * phone it is a horizontal strip instead. Two files have to agree for that to
-   * happen -- the class in the markup and the rule in the phone breakpoint --
-   * and either one alone leaves the long column back in place, looking like
-   * nothing was changed rather than like something is broken.
+   * Two lists here are long -- twenty-eight feature cards and forty-two gallery
+   * screenshots -- and one column of either is a couple of screens of
+   * thumb-scrolling to reach the next section, so on a phone both are horizontal
+   * strips. Three things have to line up, and any one of them alone leaves the
+   * long column in place, which looks like nothing was changed rather than like
+   * something is broken: the class in the markup, the rule in the phone
+   * breakpoint, and that rule's selector actually reaching the element carrying
+   * the class. The third is the one only a scan catches -- the rule names its
+   * consumers (`.grid.strip,.gal.strip`) because a bare `.strip` would only beat
+   * the collapse rules on source order, so a third list added to the markup is
+   * styled by nothing until the selector grows to meet it.
    */
-  it('turns the feature list into a horizontal strip on a phone', () => {
-    const tag = markup(readFileSync(join(SITE, 'index.html'), 'utf8')).match(/<div[^>]*\bid="fgrid"[^>]*>/);
-    expect(tag, 'the feature list (#fgrid) is gone from index.html -- update this guard with it').not.toBeNull();
-    expect(
-      tag![0],
-      '#fgrid must carry the feat-strip class, which is what the phone breakpoint styles as a scroller',
-    ).toMatch(/class="[^"]*\bfeat-strip\b/);
-
-    const declared = phoneRules(readFileSync(join(SITE, 'assets', 'css', 'styles.css'), 'utf8'))
-      .filter(({ selectors }) => /\bfeat-strip\b/.test(selectors))
-      .map(({ declarations }) => declarations)
-      .join(';');
+  it('turns its long lists into horizontal strips on a phone', () => {
+    const html = markup(readFileSync(join(SITE, 'index.html'), 'utf8'));
+    const strips = phoneRules(readFileSync(join(SITE, 'assets', 'css', 'styles.css'), 'utf8')).filter(({ selectors }) =>
+      /(^|[\s,>+~])\.[A-Za-z0-9_.-]*\bstrip\b/.test(selectors),
+    );
+    const scrollers = strips.filter(({ declarations }) => /overflow-x\s*:\s*(auto|scroll)/.test(declarations));
 
     const required: Array<[RegExp, string]> = [
-      [/grid-auto-flow\s*:\s*column/, 'grid-auto-flow:column -- lays the cards along one row instead of one per row'],
+      [
+        /display\s*:\s*grid/,
+        'display:grid -- a multi-column container is not a grid container, so nothing else in the rule reaches the ' +
+          "gallery's masonry",
+      ],
+      [/grid-auto-flow\s*:\s*column/, 'grid-auto-flow:column -- lays the items along one row instead of one per row'],
       [
         /grid-template-columns\s*:\s*none/,
         'grid-template-columns:none -- an explicit track list sizes the leading items and grid-auto-columns only ' +
-          'picks up the implicit ones after it, so the collapsed 1fr would keep the first card full width',
+          'picks up the implicit ones after it, so the collapsed 1fr would keep the first item full width',
       ],
       [
         /overflow-x\s*:\s*(auto|scroll)/,
-        'overflow-x:auto -- without it the row is an overflow, not a scroller, and the cards are simply unreachable',
+        'overflow-x:auto -- without it the row is an overflow, not a scroller, and the items are simply unreachable',
       ],
-      [/scroll-snap-type\s*:\s*x/, 'scroll-snap-type:x -- a swipe lands on a card rather than between two'],
+      [/scroll-snap-type\s*:\s*x/, 'scroll-snap-type:x -- a swipe lands on an item rather than between two'],
     ];
-
+    const declared = strips.map(({ declarations }) => declarations).join(';');
     const missing = required.flatMap(([pattern, why]) => (pattern.test(declared) ? [] : [why]));
-    expect(missing, `the .feat-strip rule in the phone breakpoint is missing:\n  ${missing.join('\n  ')}`).toEqual([]);
+    expect(missing, `the strip rule in the phone breakpoint is missing:\n  ${missing.join('\n  ')}`).toEqual([]);
+
+    // Class-only selectors from the rule that makes a strip scroll, e.g.
+    // `.grid.strip` -> ['grid', 'strip']. Anything with a combinator or an
+    // element in it styles the items, not the container, and is skipped.
+    const reaches = scrollers
+      .flatMap(({ selectors }) => selectors.split(','))
+      .map((selector) => selector.trim())
+      .filter((selector) => /^(\.[A-Za-z0-9_-]+)+$/.test(selector))
+      .map((selector) => selector.slice(1).split('.'));
+
+    const unstyled = STRIPS.flatMap(({ id, what }) => {
+      const tag = html.match(new RegExp(`<[a-z]+[^>]*\\bid="${id}"[^>]*>`));
+      if (!tag) return [`${what} (#${id}) is gone from index.html -- update this guard with it`];
+
+      const classes = new Set((tag[0].match(/class="([^"]*)"/)?.[1] ?? '').split(/\s+/).filter(Boolean));
+      if (!classes.has('strip')) return [`${what} (#${id}) must carry the strip class`];
+      if (reaches.some((needed) => needed.every((name) => classes.has(name)))) return [];
+
+      return [
+        `${what} (#${id}) carries the strip class but no selector on the scrolling rule matches it -- it has ` +
+          `${[...classes].join(', ')}, and the rule reaches ${reaches.map((n) => n.join('.')).join(' / ')}`,
+      ];
+    });
+
+    expect(unstyled, unstyled.join('\n')).toEqual([]);
   });
 
   /**

--- a/website/README.md
+++ b/website/README.md
@@ -110,6 +110,32 @@ shape is the whole defence - and Bearer fails the pipeline on the alternative.
 
 Brand colour is `--brand` in `styles.css` (teal `#4fa091`, taken from the app logo).
 
+## Layout on a phone
+
+A long list of cards does not collapse to one column below the phone breakpoint --
+it becomes a horizontal strip. The features section is twenty-eight cards, and
+stacked that is a screen and a half of thumb-scrolling to reach the next section.
+`.feat-strip` in the `max-width:640px` block is the shape to copy: clear
+`grid-template-columns`, `grid-auto-flow:column` with a `grid-auto-columns` under
+100% so the next card peeks, `overflow-x:auto`, and `scroll-snap-type:x`.
+
+Two rules come with it, and both are scanned by
+`frontend/src/test/website-mobile-layout.test.ts`:
+
+- **Every sideways scroller sets `overscroll-behavior-x:contain`.** A swipe that
+  reaches the end of a strip otherwise chains outward until the browser takes it
+  as a back-navigation gesture, off the site.
+- **A strip whose contents are replaced rewinds its own `scrollLeft`.** A scroll
+  offset survives a repaint, clamped to the new content, so filtering the features
+  down to two cards left the strip parked at the end of the two. Move the
+  container's own `scrollLeft` -- never `scrollIntoView`, which scrolls every
+  scrollable ancestor up to the document.
+
+Nothing inside a feature card is focusable, so the strip takes a `tabindex` and a
+name while it can scroll -- asked of the element (`scrollWidth > clientWidth`)
+rather than by repeating the breakpoint in JavaScript, so the two files cannot
+disagree after a breakpoint moves.
+
 ## Licence
 
 Same spirit as the app: AGPL-3.0. Screenshots and the Monize name belong to the Monize project.

--- a/website/README.md
+++ b/website/README.md
@@ -112,15 +112,34 @@ Brand colour is `--brand` in `styles.css` (teal `#4fa091`, taken from the app lo
 
 ## Layout on a phone
 
-A long list of cards does not collapse to one column below the phone breakpoint --
-it becomes a horizontal strip. The features section is twenty-eight cards, and
-stacked that is a screen and a half of thumb-scrolling to reach the next section.
-`.feat-strip` in the `max-width:640px` block is the shape to copy: clear
-`grid-template-columns`, `grid-auto-flow:column` with a `grid-auto-columns` under
-100% so the next card peeks, `overflow-x:auto`, and `scroll-snap-type:x`.
+A long list does not collapse to one column below the phone breakpoint -- it
+becomes a horizontal strip. The features section is twenty-eight cards and the
+gallery is forty-two screenshots; stacked, either is a couple of screens of
+thumb-scrolling to reach the next section. `.strip` in the `max-width:640px`
+block is the shape: `display:grid` (which is also what turns the gallery's
+masonry off), cleared `grid-template-columns`, `grid-auto-flow:column` with a
+`grid-auto-columns` under 100% so the next item peeks, `overflow-x:auto`, and
+`scroll-snap-type:x`.
 
-Two rules come with it, and both are scanned by
+The rule names its consumers -- `.grid.strip,.gal.strip` -- rather than being a
+bare `.strip`, because the collapse rules in the same block set
+`grid-template-columns` and `columns` at the same specificity and a single class
+would win on source order alone. **Putting a third list in a strip means adding
+it to that selector as well as to the markup**; the class on its own is styled by
+nothing.
+
+Where the pictures are the content, as in the gallery, give them a width *and* a
+height so they crop to a common size. `object-fit` crops the picture to the
+element's box, but a height alone leaves the box at whatever the aspect ratio
+makes it, so a portrait screenshot sits in a narrow box with the card blank
+beside it.
+
+Three rules come with all this, and each is scanned by
 `frontend/src/test/website-mobile-layout.test.ts`:
+
+- **Markup, rule and selector have to agree.** The scan fails if a listed strip
+  is missing the class, if the rule is missing any of the declarations that make
+  it a strip, or if no selector on that rule actually reaches the element.
 
 - **Every sideways scroller sets `overscroll-behavior-x:contain`.** A swipe that
   reaches the end of a strip otherwise chains outward until the browser takes it
@@ -131,10 +150,13 @@ Two rules come with it, and both are scanned by
   container's own `scrollLeft` -- never `scrollIntoView`, which scrolls every
   scrollable ancestor up to the document.
 
-Nothing inside a feature card is focusable, so the strip takes a `tabindex` and a
-name while it can scroll -- asked of the element (`scrollWidth > clientWidth`)
-rather than by repeating the breakpoint in JavaScript, so the two files cannot
-disagree after a breakpoint moves.
+Both of those live in `asStrip()` / `rewind()` in `app.js`: register the list
+once with the name a screen reader should announce, and call `rewind()` at the
+end of its paint function. Nothing inside a feature card or a gallery figure is
+focusable, so the strip takes a `tabindex` and that name while it can scroll --
+asked of the element (`scrollWidth > clientWidth`) rather than by repeating the
+breakpoint in JavaScript, so the two files cannot disagree after a breakpoint
+moves.
 
 ## Licence
 

--- a/website/assets/css/styles.css
+++ b/website/assets/css/styles.css
@@ -291,25 +291,44 @@ footer a{color:var(--mut)}footer a:hover{color:var(--txt)}
 @media (max-width:640px){
   .sec{padding:60px 0}
   .g4,.g3,.g2,.rep-grid{grid-template-columns:1fr}
-  /* The feature list is twenty-eight cards. Collapsed to one column that is a
-     screen and a half of thumb-scrolling to get past a section nobody has to
-     read in full, so on a phone it becomes a snapping horizontal strip -- the
-     shape the tour rail and the filmstrip above already use. Notes:
+  /* Two lists here are long -- twenty-eight feature cards and forty-two gallery
+     screenshots -- and one column of either is a couple of screens of
+     thumb-scrolling to get past a section nobody has to read in full. Both
+     become a snapping horizontal strip on a phone, the shape the tour rail and
+     the filmstrip above already use.
+     - the selector names its consumers instead of being a bare `.strip`: the
+       collapse rule a line up sets grid-template-columns at the same
+       specificity, and .gal sets columns further down, so a single class would
+       win on source order alone. Putting a third list in a strip means adding it
+       here as well as in the markup, which website-mobile-layout.test.ts checks.
+     - display:grid is what turns the gallery's masonry off. A multi-column
+       container is not a grid container, so nothing else here would reach it.
      - grid-template-columns has to be cleared, not just overridden: an explicit
        track list sizes the first items and grid-auto-columns only picks up the
-       implicit ones after it, so `1fr` two lines up would keep card one full
-       width and put the strip's own width behind it.
-     - the scroller is the grid itself, which is a block child of .wrap, so it is
-       exactly as wide as the gutter allows and cannot widen the document the way
-       a scroller inside a 1fr track does (see the min-width:0 note above).
+       implicit ones after it, so `1fr` would keep card one full width and put
+       the strip's own width behind it.
+     - the scroller is the list itself, a block child of .wrap, so it is exactly
+       as wide as the gutter allows and cannot widen the document the way a
+       scroller inside a 1fr track does (see the min-width:0 note above).
      - the reveal slides up 24px, which reads as a card entering from below a row
-       it is not in, and overflow-y clips it besides. In the strip it is a fade. */
-  .grid.feat-strip{
-    grid-template-columns:none;grid-auto-flow:column;grid-auto-columns:82%;
+       it is not in, and overflow-y clips it besides. In a strip it is a fade. */
+  .grid.strip,.gal.strip{
+    display:grid;columns:auto;grid-template-columns:none;grid-auto-flow:column;grid-auto-columns:82%;
     overflow-x:auto;overflow-y:hidden;overscroll-behavior-x:contain;
     scroll-snap-type:x mandatory;scrollbar-width:thin;padding:4px 0 12px}
-  .grid.feat-strip>.card{scroll-snap-align:start}
-  .grid.feat-strip>.rv{transform:none}
+  .strip>*{scroll-snap-align:start;min-width:0}
+  .strip>.rv{transform:none}
+  /* The gallery's pictures are its content, so they crop to one height rather
+     than making every figure as tall as the tallest screenshot -- the trade the
+     filmstrip already makes, and the shot is a click away from full size. Both
+     axes have to be given: object-fit crops the picture to the element's box,
+     but a height alone leaves the box itself at whatever the aspect ratio makes
+     it, so a portrait screenshot sat in a 106px-wide box with the rest of the
+     card blank beside it. The missing-shot placeholder takes the same height, or
+     a category with no local copies yet is a different shape from one with. */
+  .gal.strip figure{margin:0}
+  .gal.strip figure img,.gal.strip figure .shotmiss{width:100%;height:186px;object-fit:cover;object-position:top}
+  .gal.strip figure .shotmiss{padding:14px}
   .stats{grid-template-columns:repeat(2,auto);gap:16px 22px}
   .gal{columns:1}
   .tl{grid-template-columns:repeat(2,1fr);gap:18px 0}.tl::before{display:none}

--- a/website/assets/css/styles.css
+++ b/website/assets/css/styles.css
@@ -154,7 +154,7 @@ main,header,footer{position:relative;z-index:1}
 .stage-cap{display:flex;gap:14px;align-items:flex-start;justify-content:space-between;margin:16px 0 12px}
 .stage-cap h3{margin:0 0 4px}
 .stage-cap p{margin:0;color:var(--mut);font-size:.93rem}
-.thumbs{display:flex;gap:10px;overflow-x:auto;padding:4px 2px 10px;scrollbar-width:thin}
+.thumbs{display:flex;gap:10px;overflow-x:auto;overscroll-behavior-x:contain;padding:4px 2px 10px;scrollbar-width:thin}
 .thumbs button{flex:0 0 132px;border:1px solid var(--line);background:var(--card2);border-radius:10px;overflow:hidden;cursor:pointer;padding:0;transition:.18s;position:relative;height:84px}
 .thumbs button img{width:100%;height:100%;object-fit:cover;object-position:top}
 .thumbs button.on{border-color:var(--teal);box-shadow:0 0 0 3px color-mix(in srgb,var(--teal) 22%,transparent)}
@@ -209,7 +209,7 @@ html[data-theme=light] .code-wrap{background:#0d1424}
 .code-tabs button{border:0;background:transparent;color:var(--mut);padding:7px 13px;border-radius:8px;font:700 .84rem var(--ff);cursor:pointer}
 .code-tabs button.on{background:var(--card);color:var(--txt)}
 .code-tabs .cp{margin-left:auto;border:1px solid var(--line);background:var(--card)}
-pre{margin:0;padding:20px;overflow-x:auto;font:.85rem/1.7 var(--mono);color:#cfe0ff}
+pre{margin:0;padding:20px;overflow-x:auto;overscroll-behavior-x:contain;font:.85rem/1.7 var(--mono);color:#cfe0ff}
 pre .c{color:#6b83ad}pre .k{color:#7fd6c1}pre .s{color:#f0b571}
 /* The self-hosting split. This lives in a class, not in a style attribute on the
    element: an inline grid-template-columns outranks every media query below, so
@@ -275,7 +275,7 @@ footer a{color:var(--mut)}footer a:hover{color:var(--txt)}
   .g4{grid-template-columns:repeat(2,1fr)}.g3{grid-template-columns:repeat(2,1fr)}
   .rep-grid{grid-template-columns:repeat(2,1fr)}
   .tour{grid-template-columns:1fr}
-  .rail{position:static;flex-direction:row;overflow-x:auto;padding-bottom:6px}
+  .rail{position:static;flex-direction:row;overflow-x:auto;overscroll-behavior-x:contain;padding-bottom:6px}
   .rail button{flex:0 0 auto}
   .chat{grid-template-columns:1fr}
   .selfhost-grid{grid-template-columns:1fr}
@@ -291,6 +291,25 @@ footer a{color:var(--mut)}footer a:hover{color:var(--txt)}
 @media (max-width:640px){
   .sec{padding:60px 0}
   .g4,.g3,.g2,.rep-grid{grid-template-columns:1fr}
+  /* The feature list is twenty-eight cards. Collapsed to one column that is a
+     screen and a half of thumb-scrolling to get past a section nobody has to
+     read in full, so on a phone it becomes a snapping horizontal strip -- the
+     shape the tour rail and the filmstrip above already use. Notes:
+     - grid-template-columns has to be cleared, not just overridden: an explicit
+       track list sizes the first items and grid-auto-columns only picks up the
+       implicit ones after it, so `1fr` two lines up would keep card one full
+       width and put the strip's own width behind it.
+     - the scroller is the grid itself, which is a block child of .wrap, so it is
+       exactly as wide as the gutter allows and cannot widen the document the way
+       a scroller inside a 1fr track does (see the min-width:0 note above).
+     - the reveal slides up 24px, which reads as a card entering from below a row
+       it is not in, and overflow-y clips it besides. In the strip it is a fade. */
+  .grid.feat-strip{
+    grid-template-columns:none;grid-auto-flow:column;grid-auto-columns:82%;
+    overflow-x:auto;overflow-y:hidden;overscroll-behavior-x:contain;
+    scroll-snap-type:x mandatory;scrollbar-width:thin;padding:4px 0 12px}
+  .grid.feat-strip>.card{scroll-snap-align:start}
+  .grid.feat-strip>.rv{transform:none}
   .stats{grid-template-columns:repeat(2,auto);gap:16px 22px}
   .gal{columns:1}
   .tl{grid-template-columns:repeat(2,1fr);gap:18px 0}.tl::before{display:none}

--- a/website/assets/js/app.js
+++ b/website/assets/js/app.js
@@ -375,6 +375,39 @@ var io = ('IntersectionObserver' in window) ? new IntersectionObserver(function(
 function watch(n){ if(io) io.observe(n); else n.classList.add('in'); }
 $$('.rv').forEach(watch);
 
+/* ---------- lists that become a horizontal strip on a phone ----------
+   The layout is .strip in styles.css. Two things follow from it that CSS cannot
+   do, so every strip is registered here and repainted through rewind():
+
+   - a scroll offset survives its contents being replaced, clamped to whatever
+     the new content allows, so filtering twenty-eight cards down to two left the
+     strip parked at the end of the two. Moving the strip's own scrollLeft cannot
+     move anything but the strip, which is why this is not scrollIntoView.
+   - nothing inside a feature card or a gallery figure is focusable, so on the
+     browsers that do not make a scroller focusable by themselves the strip is
+     unreachable from a keyboard: it takes a tab stop and a name while there is
+     something to scroll to. Asking the element whether it can scroll, rather
+     than repeating `640px` here, keeps the two files from disagreeing after a
+     breakpoint moves. */
+var strips=[];
+function asStrip(node,label){ strips.push([node,label]); return node; }
+function syncStrips(){
+  strips.forEach(function(s){
+    var n=s[0];
+    if(n.scrollWidth-n.clientWidth>1){
+      n.setAttribute('tabindex','0');
+      n.setAttribute('role','group');
+      n.setAttribute('aria-label',s[1]);
+    }else{
+      n.removeAttribute('tabindex');
+      n.removeAttribute('role');
+      n.removeAttribute('aria-label');
+    }
+  });
+}
+function rewind(node){ node.scrollLeft=0; syncStrips(); }
+addEventListener('resize',syncStrips,{passive:true});
+
 /* count-up stats */
 var statsDone=false;
 function runStats(){
@@ -414,30 +447,12 @@ function paintTl(i){
 paintTl(0);
 
 /* ---------- features ---------- */
-var fchips=$('#fchips'), fgrid=$('#fgrid'), fcat='all';
+var fchips=$('#fchips'), fgrid=asStrip($('#fgrid'),'Features — scroll sideways for more'), fcat='all';
 M.FCATS.forEach(function(c){
   var b=el('button','chip'+(c[0]==='all'?' on':''),c[1]);
   b.addEventListener('click',function(){ fcat=c[0]; $$('.chip',fchips).forEach(function(x){x.classList.remove('on');}); b.classList.add('on'); paintF(); });
   fchips.appendChild(b);
 });
-/* Below the phone breakpoint the grid is a horizontal strip (see .feat-strip in
-   styles.css). Nothing inside a feature card is focusable, so on the browsers
-   that do not make a scroller focusable by themselves the strip is unreachable
-   from a keyboard -- it takes a tab stop and a name. Asking the element whether
-   it can scroll, rather than repeating `640px` here, keeps the two files from
-   disagreeing after a breakpoint moves: the strip is focusable exactly while
-   there is something to scroll to. */
-function syncFStrip(){
-  if(fgrid.scrollWidth-fgrid.clientWidth>1){
-    fgrid.setAttribute('tabindex','0');
-    fgrid.setAttribute('role','group');
-    fgrid.setAttribute('aria-label','Features — scroll sideways for more');
-  }else{
-    fgrid.removeAttribute('tabindex');
-    fgrid.removeAttribute('role');
-    fgrid.removeAttribute('aria-label');
-  }
-}
 function paintF(){
   clear(fgrid);
   M.FEATURES.filter(function(f){ return fcat==='all'||f[0]===fcat; }).forEach(function(f,i){
@@ -445,16 +460,9 @@ function paintF(){
     c.style.transitionDelay=Math.min(i*35,420)+'ms';
     fgrid.appendChild(c); watch(c);
   });
-  /* A scroll offset survives its contents being replaced, clamped to whatever
-     the new content allows -- so filtering twenty-eight cards down to two left
-     the strip parked at the end of the two. Rewind it. Moving the strip's own
-     scrollLeft cannot move anything but the strip, which is why this is not
-     scrollIntoView. */
-  fgrid.scrollLeft=0;
-  syncFStrip();
+  rewind(fgrid);
 }
 paintF();
-addEventListener('resize',syncFStrip,{passive:true});
 
 /* ---------- interactive tour ---------- */
 var rail=$('#rail'), thumbs=$('#thumbs'), stImg=$('#stImg'), ti=0, si=0, timer=null;
@@ -644,20 +652,21 @@ M.FAQ.forEach(function(f){
 });
 
 /* ---------- gallery ---------- */
-var gcat='all';
+var gal=asStrip($('#gal'),'Screenshots — scroll sideways for more'), gcat='all';
 M.GALCATS.forEach(function(c){
   var b=el('button','chip'+(c[0]==='all'?' on':''),c[1]);
   b.addEventListener('click',function(){ gcat=c[0]; $$('.chip',$('#galChips')).forEach(function(x){x.classList.remove('on');}); b.classList.add('on'); paintG(); });
   $('#galChips').appendChild(b);
 });
 function paintG(){
-  var g=clear($('#gal'));
+  var g=clear(gal);
   var list=M.GALLERY.filter(function(x){ return gcat==='all'||x[0]===gcat; });
   list.forEach(function(x,i){
     var f=el('figure'); f.appendChild(shot(x[1],x[2])); f.appendChild(el('figcaption',null,x[2]));
     f.addEventListener('click',function(){ openLB(list.map(function(y){return {n:y[1],c:y[2]};}),i); });
     g.appendChild(f);
   });
+  rewind(gal);
 }
 paintG();
 

--- a/website/assets/js/app.js
+++ b/website/assets/js/app.js
@@ -420,6 +420,24 @@ M.FCATS.forEach(function(c){
   b.addEventListener('click',function(){ fcat=c[0]; $$('.chip',fchips).forEach(function(x){x.classList.remove('on');}); b.classList.add('on'); paintF(); });
   fchips.appendChild(b);
 });
+/* Below the phone breakpoint the grid is a horizontal strip (see .feat-strip in
+   styles.css). Nothing inside a feature card is focusable, so on the browsers
+   that do not make a scroller focusable by themselves the strip is unreachable
+   from a keyboard -- it takes a tab stop and a name. Asking the element whether
+   it can scroll, rather than repeating `640px` here, keeps the two files from
+   disagreeing after a breakpoint moves: the strip is focusable exactly while
+   there is something to scroll to. */
+function syncFStrip(){
+  if(fgrid.scrollWidth-fgrid.clientWidth>1){
+    fgrid.setAttribute('tabindex','0');
+    fgrid.setAttribute('role','group');
+    fgrid.setAttribute('aria-label','Features — scroll sideways for more');
+  }else{
+    fgrid.removeAttribute('tabindex');
+    fgrid.removeAttribute('role');
+    fgrid.removeAttribute('aria-label');
+  }
+}
 function paintF(){
   clear(fgrid);
   M.FEATURES.filter(function(f){ return fcat==='all'||f[0]===fcat; }).forEach(function(f,i){
@@ -427,8 +445,16 @@ function paintF(){
     c.style.transitionDelay=Math.min(i*35,420)+'ms';
     fgrid.appendChild(c); watch(c);
   });
+  /* A scroll offset survives its contents being replaced, clamped to whatever
+     the new content allows -- so filtering twenty-eight cards down to two left
+     the strip parked at the end of the two. Rewind it. Moving the strip's own
+     scrollLeft cannot move anything but the strip, which is why this is not
+     scrollIntoView. */
+  fgrid.scrollLeft=0;
+  syncFStrip();
 }
 paintF();
+addEventListener('resize',syncFStrip,{passive:true});
 
 /* ---------- interactive tour ---------- */
 var rail=$('#rail'), thumbs=$('#thumbs'), stImg=$('#stImg'), ti=0, si=0, timer=null;

--- a/website/index.html
+++ b/website/index.html
@@ -90,7 +90,7 @@
       <p>Filter by what you care about — Monize was built feature-by-feature against a 30-year Microsoft Money wishlist.</p>
     </div>
     <div class="tagrow rv" id="fchips"></div>
-    <div class="grid g3" id="fgrid"></div>
+    <div class="grid g3 feat-strip" id="fgrid"></div>
   </div>
 </section>
 

--- a/website/index.html
+++ b/website/index.html
@@ -90,7 +90,7 @@
       <p>Filter by what you care about — Monize was built feature-by-feature against a 30-year Microsoft Money wishlist.</p>
     </div>
     <div class="tagrow rv" id="fchips"></div>
-    <div class="grid g3 feat-strip" id="fgrid"></div>
+    <div class="grid g3 strip" id="fgrid"></div>
   </div>
 </section>
 
@@ -210,7 +210,7 @@
       <p>Because feature lists lie and screenshots don&apos;t. Click any image to enlarge.</p>
     </div>
     <div class="tagrow rv" id="galChips"></div>
-    <div class="gal" id="gal"></div>
+    <div class="gal strip" id="gal"></div>
   </div>
 </section>
 


### PR DESCRIPTION
The features section is twenty-eight cards. Collapsed to a single column
below the phone breakpoint it was roughly a screen and a half of
thumb-scrolling to get past a section nobody has to read in full, so on a
phone it is now a snapping horizontal strip -- the shape the tour rail and
the filmstrip above it already use.

Notes on the rule:

- grid-template-columns is cleared, not just overridden. An explicit track
  list sizes the leading items and grid-auto-columns only picks up the
  implicit ones after it, so the collapsed `1fr` would have kept the first
  card full width with the rest of the strip behind it.
- The scroller is the grid itself, a block child of .wrap, so it is exactly
  as wide as the gutter allows and cannot widen the document the way a
  scroller inside a 1fr track does.
- Cards fade in rather than sliding up: a 24px vertical slide reads as a
  card entering from a row it is not in, and overflow-y clips it anyway.
- The strip rewinds its own scrollLeft on a repaint. A scroll offset
  survives its contents being replaced, clamped to the new content, so
  filtering twenty-eight cards down to two left the strip parked at the end
  of the two.
- Nothing inside a card is focusable, so the strip takes a tab stop and a
  name while it can actually scroll -- asked of the element rather than by
  repeating the breakpoint in JavaScript.

Every sideways scroller on the page now contains its overscroll: a swipe
past the end of one otherwise chains outward until the browser takes it as
a back-navigation gesture, off the site. That covers the tour rail, the
filmstrip and the code block as well as the new strip.

Both rules are scanned by website-mobile-layout.test.ts, which fails on the
markup and the stylesheet disagreeing about the class, on a .feat-strip rule
missing any of the four declarations that make it a strip, and on any
horizontal scroller without overscroll-behavior. Verified in Chromium at
390x844: 28 cards in a 346px scroller, document width unchanged at 390,
no vertical overflow, and the desktop grid still three equal columns with
no stray tab stop.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KuZR197ormfjX1NCyJT18n