### PR TITLE
Disable long-lived caching of website assets

### DIFF
--- a/frontend/src/test/website-mobile-layout.test.ts
+++ b/frontend/src/test/website-mobile-layout.test.ts
@@ -83,11 +83,11 @@ function rules(css: string): Rule[] {
 }
 
 /**
- * The rules that apply at the phone breakpoint. A regex cannot match a nested
- * brace pair, so the body of each `@media` is taken by counting braces out from
- * the one that opened it.
+ * The rules inside every `@media` whose `max-width` the caller accepts. A regex
+ * cannot match a nested brace pair, so the body of each `@media` is taken by
+ * counting braces out from the one that opened it.
  */
-function phoneRules(css: string): Rule[] {
+function mediaRules(css: string, accepts: (maxWidth: number) => boolean): Rule[] {
   const stripped = code(css);
   const opener = /@media([^{]*)\{/g;
   const found: Rule[] = [];
@@ -99,11 +99,21 @@ function phoneRules(css: string): Rule[] {
       if (stripped[end] === '{') depth++;
       else if (stripped[end] === '}') depth--;
     }
-    if (/max-width\s*:\s*640px/.test(at[1])) found.push(...rules(stripped.slice(start, end - 1)));
+    const max = at[1].match(/max-width\s*:\s*(\d+)px/);
+    if (max && accepts(Number(max[1]))) found.push(...rules(stripped.slice(start, end - 1)));
     opener.lastIndex = end;
   }
 
   return found;
+}
+
+/** The rules that apply at the phone breakpoint. */
+function phoneRules(css: string): Rule[] {
+  return mediaRules(css, (maxWidth) => maxWidth === 640);
+}
+
+function styles(): string {
+  return readFileSync(join(SITE, 'assets', 'css', 'styles.css'), 'utf8');
 }
 
 /** Track count for a `grid-template-rows` value, `repeat(n, ...)` included. */
@@ -288,6 +298,64 @@ describe('website layout holds on a phone', () => {
       `the reports strip lays out ${deepest} row(s) of reports (${declared.join(', ')}) -- one row per column is the ` +
         'shape this guard exists to catch',
     ).toBeGreaterThan(1);
+  });
+
+  /**
+   * The header is a brand, a theme toggle, a demo button and a menu button on
+   * one flex line, and below about 380px that line is wider than the screen.
+   * Nothing in it gives -- `.btn` is `white-space:nowrap` and `.icobtn` is a
+   * fixed square -- so the whole shortfall came out of `.brand`, which does not
+   * reflow: it slid its own text under the theme toggle. At 320px the wordmark
+   * read "Moniz" and the menu button, the only way to reach the nav once `#nav`
+   * is `display:none`, hung 11px past the right edge. Not merely scrolled off:
+   * `body` sets `overflow-x:hidden` and, with `html` at visible, that propagates
+   * to the viewport, so the button was clipped away entirely. Measured in
+   * Chromium, the header held a hard 331px floor at every viewport below it.
+   *
+   * The layout result cannot be scanned, so these are the three declarations
+   * that keep it true. The third is the one that is easy to get wrong twice:
+   * the lightbox's close and arrow buttons carry `.icobtn` too, and they are
+   * thumb targets over a photo, so a header-sized override has to name the
+   * header.
+   */
+  it('keeps the whole header inside the narrowest phone', () => {
+    const css = styles();
+    const narrow = mediaRules(css, (maxWidth) => maxWidth <= 560);
+
+    const brandHolds = narrow.some(
+      ({ selectors, declarations }) =>
+        selectors.split(',').some((selector) => selector.trim() === '.brand') &&
+        (/(^|[;\s])flex\s*:\s*0\s+0\b/.test(declarations) || /(^|[;\s])flex-shrink\s*:\s*0/.test(declarations)),
+    );
+    expect(
+      brandHolds,
+      '.brand must stop shrinking at the phone breakpoint (flex:0 0 auto, or flex-shrink:0). It is the only ' +
+        'flexible item on the header line, so without this every pixel the header is over budget is taken out of ' +
+        'the wordmark -- which does not wrap, it slides under the control beside it and renders as "Moniz".',
+    ).toBe(true);
+
+    const wordmarkGoes = mediaRules(css, (maxWidth) => maxWidth <= 400).some(
+      ({ selectors, declarations }) =>
+        /\.brand\s+span\b/.test(selectors) && /(^|[;\s])display\s*:\s*none/.test(declarations),
+    );
+    expect(
+      wordmarkGoes,
+      'no breakpoint at or below 400px hides .brand span. Even with the gutters tightened the wordmark does not ' +
+        'fit beside the demo button and the two icon buttons on a 320-360px screen, and it is the element whose ' +
+        'loss costs least -- the logo is still the link home and still carries the accessible name.',
+    ).toBe(true);
+
+    const unscoped = narrow
+      .filter(({ declarations }) => /(^|[;\s])(width|height)\s*:/.test(declarations))
+      .flatMap(({ selectors }) => selectors.split(','))
+      .map((selector) => selector.trim())
+      .filter((selector) => /(^|[\s>+~])\.icobtn\b/.test(selector) && !/#hdr|\.hdr-cta/.test(selector));
+    expect(
+      unscoped,
+      `${unscoped.join(', ')} resizes an icon button at a phone breakpoint without naming the header. The lightbox's ` +
+        'close and previous/next buttons carry that class as well, and they are thumb targets sitting over a ' +
+        'photo -- shrink the header pair with .hdr-cta .icobtn instead.',
+    ).toEqual([]);
   });
 
   /**

--- a/frontend/src/test/website-mobile-layout.test.ts
+++ b/frontend/src/test/website-mobile-layout.test.ts
@@ -31,6 +31,7 @@ const SITE = join(__dirname, '..', '..', '..', 'website');
 const STRIPS = [
   { id: 'fgrid', what: 'the feature list' },
   { id: 'gal', what: 'the screenshot gallery' },
+  { id: 'repGrid', what: 'the reports list' },
 ];
 
 /**
@@ -103,6 +104,13 @@ function phoneRules(css: string): Rule[] {
   }
 
   return found;
+}
+
+/** Track count for a `grid-template-rows` value, `repeat(n, ...)` included. */
+function trackCount(value: string): number {
+  const repeat = value.match(/repeat\(\s*(\d+)\s*,([^)]*)\)/);
+  const list = (repeat ? repeat[2] : value).trim().split(/\s+/).filter(Boolean).length;
+  return repeat ? Number(repeat[1]) * list : list;
 }
 
 function filesIn(dir: string, ext: string): string[] {
@@ -181,9 +189,10 @@ describe('website layout holds on a phone', () => {
   });
 
   /**
-   * Two lists here are long -- twenty-eight feature cards and forty-two gallery
-   * screenshots -- and one column of either is a couple of screens of
-   * thumb-scrolling to reach the next section, so on a phone both are horizontal
+   * Three lists here are long -- twenty-eight feature cards, forty-two gallery
+   * screenshots and forty-six report rows -- and one column of any of them is a
+   * couple of screens of thumb-scrolling to reach the next section, so on a
+   * phone all three are horizontal
    * strips. Three things have to line up, and any one of them alone leaves the
    * long column in place, which looks like nothing was changed rather than like
    * something is broken: the class in the markup, the rule in the phone
@@ -246,6 +255,39 @@ describe('website layout holds on a phone', () => {
     });
 
     expect(unstyled, unstyled.join('\n')).toEqual([]);
+  });
+
+  /**
+   * A report row is one line of text and a category, not a card with a picture
+   * in it, so the shared strip rule on its own -- a single row of 82%-wide
+   * columns -- leaves most of the strip's height empty and still costs one swipe
+   * per report. Stacking them four to a column is the difference between twelve
+   * swipes and forty-six, and it is the declaration a browser needs told
+   * explicitly: with `grid-auto-flow:column` the implicit grid grows sideways,
+   * so without a row track list every item lands in row one. That arrangement
+   * satisfies every assertion above, which is why it needs its own.
+   */
+  it('stacks the reports strip several rows deep', () => {
+    const declared = phoneRules(readFileSync(join(SITE, 'assets', 'css', 'styles.css'), 'utf8'))
+      .filter(({ selectors }) =>
+        selectors.split(',').some((s) => /\.rep-grid\b/.test(s) && /\bstrip\b/.test(s) && !/[\s>+~]/.test(s.trim())),
+      )
+      .flatMap(({ declarations }) =>
+        Array.from(declarations.matchAll(/grid-template-rows\s*:([^;}]*)/g)).map(([, value]) => value.trim()),
+      );
+
+    expect(
+      declared,
+      'the reports strip declares no grid-template-rows inside the phone breakpoint -- under grid-auto-flow:column ' +
+        'that puts all forty-six reports in a single row, one swipe each, with the rest of the strip blank',
+    ).not.toEqual([]);
+
+    const deepest = Math.max(...declared.map(trackCount));
+    expect(
+      deepest,
+      `the reports strip lays out ${deepest} row(s) of reports (${declared.join(', ')}) -- one row per column is the ` +
+        'shape this guard exists to catch',
+    ).toBeGreaterThan(1);
   });
 
   /**

--- a/website/README.md
+++ b/website/README.md
@@ -54,7 +54,7 @@ There is nothing to compile, so builds finish instantly and stay inside the free
 ```
 index.html                     the whole page
 404.html                       friendly not-found page
-_headers                       security headers + long cache on /assets/*
+_headers                       security headers + revalidate-always caching
 _redirects                     /demo /github /docs /wiki /issues short links
 robots.txt, sitemap.xml        change the domain if it is not monize.net
 assets/css/styles.css          all styling, light + dark themes

--- a/website/README.md
+++ b/website/README.md
@@ -77,7 +77,7 @@ instead of a broken image. Dropping the PNG into `assets/img/screenshots/` fixes
 ## Editing
 
 All copy and data live in plain arrays near the top of `assets/js/app.js`:
-`TIMELINE`, `FEATURES`, `TOUR`, `REPORTS`, `QA`, `CODE`, `STACK`, `SECURITY`, `FORMATS`, `FAQ`, `GALLERY`, `MARQUEE`, `BUDGET`.
+`FEATURES`, `TOUR`, `REPORTS`, `QA`, `CODE`, `STACK`, `SECURITY`, `FORMATS`, `FAQ`, `GALLERY`, `MARQUEE`, `BUDGET`.
 Add a feature card or a gallery image by adding one line - no rebuild, just refresh.
 
 The content arrays hold **text, never markup.** Nothing in `app.js` assigns a

--- a/website/_headers
+++ b/website/_headers
@@ -6,7 +6,7 @@
   Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; img-src 'self' data: https://raw.githubusercontent.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self' https://api.github.com
 
 /assets/*
-  Cache-Control: public, max-age=31536000, immutable
+  Cache-Control: public, max-age=0, must-revalidate
 
 /index.html
   Cache-Control: public, max-age=0, must-revalidate

--- a/website/assets/css/styles.css
+++ b/website/assets/css/styles.css
@@ -279,16 +279,23 @@ footer a{color:var(--mut)}footer a:hover{color:var(--txt)}
 @media (max-width:640px){
   .sec{padding:60px 0}
   .g4,.g3,.g2,.rep-grid{grid-template-columns:1fr}
-  /* Two lists here are long -- twenty-eight feature cards and forty-two gallery
-     screenshots -- and one column of either is a couple of screens of
-     thumb-scrolling to get past a section nobody has to read in full. Both
-     become a snapping horizontal strip on a phone, the shape the tour rail and
-     the filmstrip above already use.
+  /* Three lists here are long -- twenty-eight feature cards, forty-two gallery
+     screenshots and forty-six report rows -- and one column of any of them is a
+     couple of screens of thumb-scrolling to get past a section nobody has to
+     read in full. All three become a snapping horizontal strip on a phone, the
+     shape the tour rail and the filmstrip above already use.
+     Sideways rather than a capped box with its own vertical scrollbar, which is
+     the obvious alternative for the reports: a vertical scroller inside a
+     vertically scrolling page traps the gesture that was trying to get past it,
+     and on a touch screen there is no pointer position to tell the two apart.
+     Scrolling across is unambiguous -- a downward swipe anywhere still moves the
+     page.
      - the selector names its consumers instead of being a bare `.strip`: the
        collapse rule a line up sets grid-template-columns at the same
        specificity, and .gal sets columns further down, so a single class would
-       win on source order alone. Putting a third list in a strip means adding it
-       here as well as in the markup, which website-mobile-layout.test.ts checks.
+       win on source order alone. Putting a fourth list in a strip means adding
+       it here as well as in the markup, which website-mobile-layout.test.ts
+       checks.
      - display:grid is what turns the gallery's masonry off. A multi-column
        container is not a grid container, so nothing else here would reach it.
      - grid-template-columns has to be cleared, not just overridden: an explicit
@@ -300,12 +307,35 @@ footer a{color:var(--mut)}footer a:hover{color:var(--txt)}
        scroller inside a 1fr track does (see the min-width:0 note above).
      - the reveal slides up 24px, which reads as a card entering from below a row
        it is not in, and overflow-y clips it besides. In a strip it is a fade. */
-  .grid.strip,.gal.strip{
+  .grid.strip,.gal.strip,.rep-grid.strip{
     display:grid;columns:auto;grid-template-columns:none;grid-auto-flow:column;grid-auto-columns:82%;
     overflow-x:auto;overflow-y:hidden;overscroll-behavior-x:contain;
     scroll-snap-type:x mandatory;scrollbar-width:thin;padding:4px 0 12px}
   .strip>*{scroll-snap-align:start;min-width:0}
   .strip>.rv{transform:none}
+  /* A report is one line of text and a category, not a card with a picture in
+     it, so a single row of them would leave most of the strip's height empty and
+     still take forty-six swipes to cross. Four to a column is roughly the height
+     of the feature cards beside it and turns the same list into twelve, and a
+     category chip or a search term usually cuts it to one or two. Rows have to
+     be given explicitly: with grid-auto-flow:column the implicit grid grows
+     sideways, so without this every item lands in row one. */
+  .rep-grid.strip{grid-template-rows:repeat(4,auto)}
+  /* The filter chips wrap to four or five centred rows on a phone -- eleven
+     report categories, ten feature ones -- so the control costs more height than
+     the strip it filters, and the reports section pushed its own list off the
+     screen before a thumb reached it. One scrolling row instead, the shape the
+     tour rail already takes at the tablet breakpoint.
+     - justify-content has to leave centre: a centred flex line that overflows
+       puts its first item at a negative offset, and a scroller cannot reach it
+       because scrollLeft has no values below zero.
+     - overflow-y is set because a box with overflow-x:auto and overflow-y
+       visible computes the second to auto as well, and the chips' 2px hover lift
+       is then enough to raise a vertical scrollbar over a one-line row. The
+       padding is what gives that lift somewhere to go. */
+  .tagrow{flex-wrap:nowrap;justify-content:flex-start;overflow-x:auto;overflow-y:hidden;
+    overscroll-behavior-x:contain;scrollbar-width:thin;margin-bottom:18px;padding:2px 0 6px}
+  .tagrow .chip{flex:0 0 auto}
   /* The gallery's pictures are its content, so they crop to one height rather
      than making every figure as tall as the tallest screenshot -- the trade the
      filmstrip already makes, and the shot is a click away from full size. Both

--- a/website/assets/css/styles.css
+++ b/website/assets/css/styles.css
@@ -275,6 +275,29 @@ footer a{color:var(--mut)}footer a:hover{color:var(--txt)}
 }
 @media (max-width:560px){
   .hdr-cta .btn.ghost{display:none}
+  /* Below this the header is four controls and a wordmark on a line that is not
+     wide enough for them, and nothing in it gives: .btn is white-space:nowrap
+     and .icobtn is a fixed square, so every pixel of the shortfall is taken out
+     of .brand -- which does not reflow, it just slides its own text under the
+     theme toggle. At 320px that read "Moniz", and the menu button, the only way
+     to reach the nav once #nav is display:none, hung 11px off the right-hand
+     edge. Not scrolled off: body sets overflow-x:hidden and, with html at
+     visible, that propagates to the viewport, so the button was clipped away.
+     Tightening the gutters and the gaps buys back roughly thirty of those
+     pixels, and .brand stops shrinking so the wordmark is whole or absent and
+     never half of itself. The icobtn size is scoped to the header because the
+     lightbox's close and arrow buttons carry the same class and are thumb
+     targets over a photo. */
+  #hdr{gap:10px;padding:12px 14px}
+  .hdr-cta .btn{padding:9px 13px}
+  .hdr-cta .icobtn{width:34px;height:34px}
+  .brand{flex:0 0 auto}
+}
+@media (max-width:360px){
+  /* Even tightened, the wordmark does not fit beside the demo button and the two
+     icons here, and of the five it is the one whose loss costs least: the logo
+     is still the link home and still carries the accessible name. */
+  .brand span{display:none}
 }
 @media (max-width:640px){
   .sec{padding:60px 0}

--- a/website/assets/css/styles.css
+++ b/website/assets/css/styles.css
@@ -127,18 +127,6 @@ main,header,footer{position:relative;z-index:1}
 .chip:hover{color:var(--txt);transform:translateY(-2px)}
 .chip.on{background:linear-gradient(135deg,var(--acc),#2563eb);border-color:transparent;color:#fff}
 
-/* timeline */
-.tl{display:grid;grid-template-columns:repeat(4,1fr);gap:0;position:relative;margin:0 0 26px}
-.tl::before{content:"";position:absolute;left:6%;right:6%;top:19px;height:2px;background:var(--line)}
-.tl-i{text-align:center;cursor:pointer;position:relative;padding-top:0}
-.tl-i .dot{width:40px;height:40px;margin:0 auto 12px;border-radius:50%;background:var(--card);border:2px solid var(--line);display:grid;place-items:center;font-size:1rem;transition:.25s;position:relative;z-index:1}
-.tl-i.on .dot{border-color:var(--teal);background:color-mix(in srgb,var(--teal) 25%,var(--card));transform:scale(1.12);box-shadow:0 0 0 8px color-mix(in srgb,var(--teal) 12%,transparent)}
-.tl-i .yr{font-weight:800;font-size:.95rem}
-.tl-i .lb{font-size:.8rem;color:var(--mut)}
-.tl-card{background:var(--card);border:1px solid var(--line);border-radius:var(--r);padding:26px;min-height:120px}
-.tl-card h3{margin-bottom:6px}
-.tl-card p{color:var(--mut);margin:0}
-
 /* tour */
 .tour{display:grid;grid-template-columns:230px 1fr;gap:22px;align-items:start}
 .rail{display:flex;flex-direction:column;gap:6px;position:sticky;top:96px}
@@ -331,7 +319,6 @@ footer a{color:var(--mut)}footer a:hover{color:var(--txt)}
   .gal.strip figure .shotmiss{padding:14px}
   .stats{grid-template-columns:repeat(2,auto);gap:16px 22px}
   .gal{columns:1}
-  .tl{grid-template-columns:repeat(2,1fr);gap:18px 0}.tl::before{display:none}
   .fgrid{grid-template-columns:1fr}
   .float{display:none}
   /* Give the picture the width of the phone: 14px of gutter, the close button

--- a/website/assets/js/app.js
+++ b/website/assets/js/app.js
@@ -103,17 +103,6 @@ function shot(name,alt){
 function full(name){ var i=$('[data-shot="'+name+'"]'); return (i&&i.dataset.fb)? WIKI+name+'.png' : LOCAL+name+'.png'; }
 
 /* ---------- content ---------- */
-var TIMELINE = [
- {yr:'1995', lb:'Microsoft Money', em:'💾', t:'One job, one ledger',
-  d:'A first job in tech support, a credit-card balance to kill, and a copy of Microsoft Money. Every single transaction typed in by hand — which meant knowing exactly where every penny went.'},
- {yr:'2010', lb:'End of the line', em:'⚠️', t:'The last version ships',
-  d:'Microsoft Money is discontinued. Thirty years of history is now trapped in software that runs on exactly one machine, with no mobile app and no automation.'},
- {yr:'2025', lb:'Vibe-coded', em:'🤖', t:'Nothing else measured up',
-  d:'Every hosted and self-hosted alternative had a deal-breaker: no mortgages, no brokerage accounts, no multi-currency, no QIF import. So Monize got built from a requirements list instead of a roadmap.'},
- {yr:'Today', lb:'Retired at last', em:'🏁', t:'30+ years imported, zero discrepancies',
-  d:'A full .mny file import brought across every account, split, transfer, investment and price — then reconciled each balance against the original. Microsoft Money is finally switched off.'}
-];
-
 var FCATS = [['all','Everything'],['accounts','Accounts'],['tx','Transactions'],['inv','Investments'],
  ['budget','Budgets'],['reports','Reports'],['ai','AI'],['sec','Security'],['import','Import'],['host','Self-hosting']];
 
@@ -327,7 +316,7 @@ var BUDGET=[
 ];
 
 window.__MZ = {LOCAL:LOCAL,WIKI:WIKI,REPORAW:REPORAW,DEMO:DEMO,GH:GH,$:$,$$:$$,el:el,clear:clear,fill:fill,rich:rich,rnd:rnd,wireShot:wireShot,shot:shot,full:full,
- TIMELINE:TIMELINE,FCATS:FCATS,FEATURES:FEATURES,TOUR:TOUR,REPORTS:REPORTS,RCOLOR:RCOLOR,QA:QA,CODE:CODE,
+ FCATS:FCATS,FEATURES:FEATURES,TOUR:TOUR,REPORTS:REPORTS,RCOLOR:RCOLOR,QA:QA,CODE:CODE,
  STACK:STACK,STACK2:STACK2,SECURITY:SECURITY,FORMATS:FORMATS,FAQ:FAQ,GALCATS:GALCATS,GALLERY:GALLERY,MARQUEE:MARQUEE,BUDGET:BUDGET};
 })();
 
@@ -431,20 +420,6 @@ mtxt.forEach(function(t){ mq.appendChild(el('span',null,t)); });
 fetch('https://api.github.com/repos/kenlasko/monize').then(function(r){ return r.json(); }).then(function(d){
   if(d && d.stargazers_count) $('#stars').textContent='★ '+d.stargazers_count;
 }).catch(function(){});
-
-/* ---------- timeline ---------- */
-var tl=$('#tl'), tlCard=$('#tlCard');
-M.TIMELINE.forEach(function(s,i){
-  var n=el('div','tl-i'+(i===0?' on':''),
-    el('div','dot',s.em), el('div','yr',s.yr), el('div','lb',s.lb));
-  n.addEventListener('click',function(){ $$('.tl-i',tl).forEach(function(x){x.classList.remove('on');}); n.classList.add('on'); paintTl(i); });
-  tl.appendChild(n);
-});
-function paintTl(i){
-  var s=M.TIMELINE[i];
-  fill(tlCard, el('h3',null,s.yr+' — '+s.t), el('p',null,s.d));
-}
-paintTl(0);
 
 /* ---------- features ---------- */
 var fchips=$('#fchips'), fgrid=asStrip($('#fgrid'),'Features — scroll sideways for more'), fcat='all';

--- a/website/assets/js/app.js
+++ b/website/assets/js/app.js
@@ -533,6 +533,7 @@ addEventListener('keydown',function(e){
 
 /* ---------- reports explorer ---------- */
 var reps=M.REPORTS.split(';').map(function(r){ var p=r.split('|'); return {n:p[0],c:p[1]}; });
+var repGrid=asStrip($('#repGrid'),'Reports — scroll sideways for more');
 var rcats=['All'].concat(Object.keys(M.RCOLOR)), rcat='All', rq='';
 $('#repCount').textContent=reps.length;
 rcats.forEach(function(c){
@@ -542,7 +543,7 @@ rcats.forEach(function(c){
 });
 $('#repSearch').addEventListener('input',function(){ rq=this.value.toLowerCase().trim(); paintR(); });
 function paintR(){
-  var g=clear($('#repGrid'));
+  var g=clear(repGrid);
   var list=reps.filter(function(r){
     return (rcat==='All'||r.c===rcat) && (!rq || r.n.toLowerCase().indexOf(rq)>-1 || r.c.toLowerCase().indexOf(rq)>-1);
   });
@@ -552,6 +553,7 @@ function paintR(){
     g.appendChild(n);
   });
   $('#repMsg').textContent = list.length ? 'Showing '+list.length+' of '+reps.length+' reports' : 'No report matches that — but the custom report builder will.';
+  rewind(repGrid);
 }
 paintR();
 

--- a/website/index.html
+++ b/website/index.html
@@ -114,7 +114,7 @@
       <label class="search">🔍<input id="repSearch" type="search" placeholder="Try “dividend”, “budget”, “net worth”…" aria-label="Search reports"></label>
     </div>
     <div class="tagrow rv" id="repChips"></div>
-    <div class="rep-grid" id="repGrid"></div>
+    <div class="rep-grid strip" id="repGrid"></div>
     <p class="count" id="repMsg"></p>
     <div class="grid g3 rv" style="margin-top:34px">
       <figure class="card" style="padding:0;overflow:hidden"><img data-shot="report-net-worth" alt="Net worth report"><figcaption style="padding:12px 16px;color:var(--mut);font-size:.85rem">Net worth over time</figcaption></figure>

--- a/website/index.html
+++ b/website/index.html
@@ -28,7 +28,7 @@
 <header id="hdr">
   <a class="brand" href="#top" id="brand"><img class="logo" src="assets/img/monize-logo.svg" alt="Monize logo" data-fallback="repo:frontend/public/icons/monize-logo.svg"><span>Monize</span></a>
   <nav id="nav">
-    <a href="#why">Why</a><a href="#features">Features</a><a href="#tour">Screens</a><a href="#reports">Reports</a>
+    <a href="#features">Features</a><a href="#tour">Screens</a><a href="#reports">Reports</a>
     <a href="#ai">AI</a><a href="#migrate">Migrate</a><a href="#selfhost">Self-host</a><a href="#faq">FAQ</a>
   </nav>
   <div class="hdr-cta">
@@ -71,17 +71,6 @@
 </section>
 
 <div class="marq" aria-hidden="true"><div class="marq-in" id="marq"></div></div>
-
-<section class="sec" id="why">
-  <div class="wrap">
-    <div class="sec-h rv"><span class="eyebrow">Why Monize exists</span>
-      <h2>Thirty years of data. <span class="grad">Zero discrepancies.</span></h2>
-      <p>Monize started as one stubborn requirement: retire Microsoft Money without losing a single penny of history. Click through the story.</p>
-    </div>
-    <div class="tl rv" id="tl"></div>
-    <div class="tl-card rv" id="tlCard"></div>
-  </div>
-</section>
 
 <section class="sec" id="features">
   <div class="wrap">


### PR DESCRIPTION
The static site references its assets by unversioned paths
(assets/css/styles.css, assets/js/app.js), so no content hash changes
when they do. Serving them with max-age=31536000, immutable pinned
returning visitors to whatever CSS and JS they first downloaded, with
no way to invalidate short of renaming the files.

Serve /assets/* with max-age=0, must-revalidate, matching what / and
/index.html already use. Revalidation is a conditional request, so
unchanged assets still come back 304 rather than re-downloading.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013BEpAcWmCVo954rse6zbrE