### PR TITLE
02: Attribute interactive activity to the authenticated user (v1.15.0)

### DIFF
--- a/backend/src/common/interceptors/request-context.interceptor.spec.ts
+++ b/backend/src/common/interceptors/request-context.interceptor.spec.ts
@@ -406,6 +406,58 @@ describe("RequestContextInterceptor", () => {
       expect(usersRepository.update).toHaveBeenCalledTimes(1);
     });
 
+    // P2-008: an acting JWT resolves `id` to the OWNER and `realUserId` to the
+    // delegate. Stamping the owner's row made a delegate's traffic look like the
+    // owner signing in, so a delegate making one request every few days held the
+    // owner's emergency-access waiting period at zero forever.
+    it("stamps the delegate's own row, never the owner's, while acting", async () => {
+      preferencesRepository.findOne.mockResolvedValue(null);
+      const owner = "44444444-4444-4444-4444-44444444000a";
+      const delegate = "44444444-4444-4444-4444-44444444000b";
+      const ctx = makeContext({
+        user: { id: owner, realUserId: delegate },
+      });
+
+      const obs$ = (await interceptor.intercept(ctx, makeNext() as any)) as any;
+      await firstValueFrom(obs$);
+
+      expect(usersRepository.update).toHaveBeenCalledTimes(1);
+      expect(usersRepository.update.mock.calls[0][0]).toEqual({ id: delegate });
+    });
+
+    it("still resets the owner's own clock on the owner's own request", async () => {
+      preferencesRepository.findOne.mockResolvedValue(null);
+      const owner = "44444444-4444-4444-4444-44444444000c";
+      const ctx = makeContext({ user: { id: owner, realUserId: owner } });
+
+      const obs$ = (await interceptor.intercept(ctx, makeNext() as any)) as any;
+      await firstValueFrom(obs$);
+
+      expect(usersRepository.update.mock.calls[0][0]).toEqual({ id: owner });
+    });
+
+    it("throttles per authenticated user, not per acted-on owner", async () => {
+      // Two delegates acting for the same owner are two humans: the throttle
+      // must not let one of them silence the other's activity record.
+      preferencesRepository.findOne.mockResolvedValue(null);
+      const owner = "44444444-4444-4444-4444-44444444000d";
+      const first = "44444444-4444-4444-4444-44444444000e";
+      const second = "44444444-4444-4444-4444-44444444000f";
+
+      for (const realUserId of [first, second]) {
+        const obs$ = (await interceptor.intercept(
+          makeContext({ user: { id: owner, realUserId } }),
+          makeNext() as any,
+        )) as any;
+        await firstValueFrom(obs$);
+      }
+
+      expect(usersRepository.update.mock.calls.map((c) => c[0])).toEqual([
+        { id: first },
+        { id: second },
+      ]);
+    });
+
     it("does not write activity when there is no authenticated user", async () => {
       preferencesRepository.findOne.mockResolvedValue(null);
       const next = makeNext();

--- a/backend/src/common/interceptors/request-context.interceptor.ts
+++ b/backend/src/common/interceptors/request-context.interceptor.ts
@@ -55,27 +55,46 @@ export class RequestContextInterceptor implements NestInterceptor {
     );
   }
 
-  private touchLastActivity(userId: string): void {
+  /**
+   * Record that a human interactively used Monize.
+   *
+   * `realUserId` -- the authenticated identity -- is deliberately the subject,
+   * not the effective user. While a delegate acts, the effective user is the
+   * OWNER, and stamping the owner's row would make the delegate's traffic
+   * indistinguishable from the owner signing in. Emergency access measures
+   * exactly that: an owner who configures a 30-day waiting period and stops
+   * signing in never becomes eligible if a delegate keeps making requests, so a
+   * delegate could suppress the owner's safety mechanism indefinitely, and the
+   * activity record would attribute the delegate's session to the owner (P2-008).
+   *
+   * `users.last_activity_at` therefore answers one question -- when did *this*
+   * person last interact -- and nothing else may be inferred from it. Tracking
+   * "somebody accessed this owner's data" is a different question; it needs its
+   * own column, and the emergency timer must never read it as an owner sign-in.
+   */
+  private touchLastActivity(realUserId: string): void {
     const now = Date.now();
-    const last = this.lastActivityWrite.get(userId) ?? 0;
+    const last = this.lastActivityWrite.get(realUserId) ?? 0;
     if (now - last < ACTIVITY_WRITE_INTERVAL_MS) return;
-    this.lastActivityWrite.set(userId, now);
+    this.lastActivityWrite.set(realUserId, now);
 
     // RLS (task C6): this fire-and-forget write runs BEFORE the interceptor
     // enters its requestContextStorage scope (that scope needs the resolved
     // timezone, which is not known yet). Seed a user context here so the write
     // has ambient identity once this repository moves to withScopedDb (R7). Inert
-    // at RLS_MODE=off; the update writes the same row it always did.
-    withUserContext(userId, () =>
+    // at RLS_MODE=off. The authenticated user always reaches their own `users`
+    // row: withUserContext puts the same id in both identity GUCs, and
+    // `users_self` matches on either.
+    withUserContext(realUserId, () =>
       this.scoped(User, (repo) =>
-        repo.update({ id: userId }, { lastActivityAt: new Date(now) }),
+        repo.update({ id: realUserId }, { lastActivityAt: new Date(now) }),
       ),
     ).catch((err) => {
       // Roll the cached timestamp back so a transient failure does not
       // permanently silence activity tracking for this user.
-      this.lastActivityWrite.delete(userId);
+      this.lastActivityWrite.delete(realUserId);
       this.logger.warn(
-        `Failed to persist last_activity_at for user ${userId}: ${err?.message ?? err}`,
+        `Failed to persist last_activity_at for user ${realUserId}: ${err?.message ?? err}`,
       );
     });
   }
@@ -100,8 +119,8 @@ export class RequestContextInterceptor implements NestInterceptor {
     // app.real_user_id for delegate-keyed rows. jwt.strategy resolves it.
     const realUserId: string | undefined = user?.realUserId ?? userId;
 
-    if (userId) {
-      this.touchLastActivity(userId);
+    if (realUserId) {
+      this.touchLastActivity(realUserId);
     }
 
     const rawHeader = request.headers["x-client-timezone"];


### PR DESCRIPTION
## Linked discussion / issue

Approved in: Agreed via email with the project owner.

## Summary

Records `last_activity_at` against the *authenticated* user (`realUserId`), never the effective owner a delegate is acting as (P2-008). A delegate's traffic recorded as the owner signing in held the owner's emergency-access inactivity timer at zero forever — the exact timer that decides when an emergency contact may claim the account. Any timestamp that answers "is this human still around" has to name the human, not the data they touched.

Verified locally: backend typecheck, lint, and `request-context.interceptor.spec.ts` (28 tests) on this branch alone against current `main`.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). <!-- no string changes in this PR -->
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Generated with Claude Code. Reviewed and owned by the PR author.

---
_Generated by [Claude Code](https://claude.ai/code)_
