### PR TITLE
02: Refuse a nested identity change on a joined transaction (v1.15.0)

### DIFF
--- a/backend/src/common/db/scoped-db.spec.ts
+++ b/backend/src/common/db/scoped-db.spec.ts
@@ -1,6 +1,7 @@
 import { DataSource, EntityManager } from "typeorm";
 import { requestContextStorage, RequestContext } from "../request-context";
 import {
+  IDENTITY_MISMATCH_MESSAGE,
   MISSING_CONTEXT_MESSAGE,
   getActiveScopedManager,
   runOutsideActiveScopedManager,
@@ -206,6 +207,196 @@ describe("withScopedDb -- re-entrancy", () => {
       withScopedDb(dataSource, async () => undefined),
     );
     expect(getActiveScopedManager()).toBeUndefined();
+  });
+});
+
+/**
+ * DR-01. The GUCs are the transaction's first statement and are
+ * transaction-local, so a nested call that joins under a different ambient
+ * identity runs under the OUTER transaction's GUCs while the code around it
+ * believes it changed identity. That disagreement is silent: it usually fails
+ * closed or writes to the outer identity, and a nested `withSystemContext` reads
+ * as an escape hatch that does not escape.
+ */
+describe("withScopedDb -- nested identity", () => {
+  const withMode = (mode: string) => {
+    process.env.RLS_MODE = mode;
+  };
+
+  it.each(["off", "shadow", "enforce"])(
+    "refuses a nested user change at RLS_MODE=%s",
+    async (mode) => {
+      // Rejected in every mode, not just under enforcement: at `off` the GUCs
+      // are not emitted, so the mistake has no database symptom at all and would
+      // only surface the day an operator flips the flag.
+      withMode(mode);
+      const { dataSource } = makeDataSource();
+
+      await expect(
+        run({ userId: "user-a" }, () =>
+          withScopedDb(dataSource, () =>
+            run({ userId: "user-b" }, () =>
+              withScopedDb(dataSource, async () => "reached"),
+            ),
+          ),
+        ),
+      ).rejects.toThrow(IDENTITY_MISMATCH_MESSAGE);
+    },
+  );
+
+  it("refuses a nested system bypass inside a user transaction", async () => {
+    withMode("enforce");
+    const { dataSource } = makeDataSource();
+
+    await expect(
+      run({ userId: "user-a" }, () =>
+        withScopedDb(dataSource, () =>
+          run({ system: true }, () =>
+            withScopedDb(dataSource, async () => "reached"),
+          ),
+        ),
+      ),
+    ).rejects.toThrow(IDENTITY_MISMATCH_MESSAGE);
+  });
+
+  it("refuses a nested user identity inside a system transaction", async () => {
+    withMode("enforce");
+    const { dataSource } = makeDataSource();
+
+    await expect(
+      run({ system: true }, () =>
+        withScopedDb(dataSource, () =>
+          run({ userId: "user-a" }, () =>
+            withScopedDb(dataSource, async () => "reached"),
+          ),
+        ),
+      ),
+    ).rejects.toThrow(IDENTITY_MISMATCH_MESSAGE);
+  });
+
+  it("refuses a nested delegation change", async () => {
+    // Same effective owner, different authenticated delegate: app.real_user_id
+    // would still name the first one, which decides what the delegate-keyed
+    // policies return.
+    withMode("enforce");
+    const { dataSource } = makeDataSource();
+
+    await expect(
+      run({ userId: "owner", realUserId: "delegate-1" }, () =>
+        withScopedDb(dataSource, () =>
+          run({ userId: "owner", realUserId: "delegate-2" }, () =>
+            withScopedDb(dataSource, async () => "reached"),
+          ),
+        ),
+      ),
+    ).rejects.toThrow(IDENTITY_MISMATCH_MESSAGE);
+  });
+
+  it("refuses a nested preserveTimestamps change", async () => {
+    // The GUC is already set (or not) for the whole transaction, so an inner
+    // scope asking for the other behaviour cannot get it.
+    withMode("off");
+    const { dataSource } = makeDataSource();
+
+    await expect(
+      run({ userId: "user-a" }, () =>
+        withScopedDb(dataSource, () =>
+          run({ userId: "user-a", preserveTimestamps: true }, () =>
+            withScopedDb(dataSource, async () => "reached"),
+          ),
+        ),
+      ),
+    ).rejects.toThrow(IDENTITY_MISMATCH_MESSAGE);
+  });
+
+  it("names both identities in the error", async () => {
+    // The operator (or the next agent) has to be able to tell which of the two
+    // the code meant, so both appear.
+    withMode("enforce");
+    const { dataSource } = makeDataSource();
+
+    await expect(
+      run({ userId: "user-a" }, () =>
+        withScopedDb(dataSource, () =>
+          run({ system: true }, () => withScopedDb(dataSource, async () => 1)),
+        ),
+      ),
+    ).rejects.toThrow(/current=user-a[\s\S]*system bypass/);
+  });
+
+  it("joins on an identical identity spelled out differently", async () => {
+    // `withScopedDb` defaults the real user to the current one, so a context
+    // that omits realUserId is the same identity as one that names it. Rejecting
+    // that would break every ordinary nested service call.
+    withMode("enforce");
+    const { dataSource, transaction, manager } = makeDataSource();
+
+    const joined = await run({ userId: "user-a" }, () =>
+      withScopedDb(dataSource, () =>
+        run({ userId: "user-a", realUserId: "user-a" }, () =>
+          withScopedDb(dataSource, async (m) => m),
+        ),
+      ),
+    );
+
+    expect(joined).toBe(manager);
+    expect(transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("joins when only the timezone differs", async () => {
+    // Timezone is not part of the transaction's identity: it emits no GUC.
+    withMode("enforce");
+    const { dataSource, transaction } = makeDataSource();
+
+    await run({ userId: "user-a", timezone: "UTC" }, () =>
+      withScopedDb(dataSource, () =>
+        run({ userId: "user-a", timezone: "America/Toronto" }, () =>
+          withScopedDb(dataSource, async () => undefined),
+        ),
+      ),
+    );
+
+    expect(transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("joins two system scopes even when one also carries a userId", async () => {
+    // A system transaction emits only app.bypass_rls, so a stray userId beside
+    // `system` does not change what the database is doing.
+    withMode("enforce");
+    const { dataSource, transaction } = makeDataSource();
+
+    await run({ system: true }, () =>
+      withScopedDb(dataSource, () =>
+        run({ system: true, userId: "user-a" }, () =>
+          withScopedDb(dataSource, async () => undefined),
+        ),
+      ),
+    );
+
+    expect(transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a deliberate second transaction change identity", async () => {
+    // The sanctioned escape: runOutsideActiveScopedManager opens its own
+    // transaction, which gets its own GUCs -- at the cost of atomicity, which is
+    // why it has to be asked for explicitly.
+    withMode("enforce");
+    const { dataSource, transaction, queries } = makeDataSource();
+
+    await run({ userId: "user-a" }, () =>
+      withScopedDb(dataSource, async () => {
+        await runOutsideActiveScopedManager(() =>
+          run({ system: true }, () =>
+            withScopedDb(dataSource, async () => undefined),
+          ),
+        );
+      }),
+    );
+
+    expect(transaction).toHaveBeenCalledTimes(2);
+    expect(queries.map((q) => q.text)).toContain(
+      "SELECT set_config('app.bypass_rls', 'on', true)",
+    );
   });
 });
 

--- a/backend/src/common/db/scoped-db.ts
+++ b/backend/src/common/db/scoped-db.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { DataSource, EntityManager } from "typeorm";
-import { getRequestContext } from "../request-context";
+import { getRequestContext, RequestContext } from "../request-context";
 import { getRlsMode } from "./rls-config";
 
 /**
@@ -28,22 +28,89 @@ import { getRlsMode } from "./rls-config";
 // nested withScopedDb can join the ambient transaction instead of opening a
 // second one. A second `dataSource.transaction` would take a second pooled
 // connection inside the first and deadlock the pool under load (design 2b).
-const activeManagerStorage = new AsyncLocalStorage<EntityManager>();
+//
+// The identity that opened the transaction travels with it. The GUCs are set
+// once, as the transaction's first statement, and are transaction-local -- so a
+// nested call that joins under a *different* ambient identity gets the outer
+// transaction's GUCs regardless of what its own context says. That silently
+// disagrees with the application's belief about who it is acting as (DR-01):
+// usually it fails closed or writes to the outer identity, but a caller that
+// uses the nested identity for a non-database decision is then wrong, and a
+// nested `withSystemContext` reads as an escape hatch that does not escape.
+// Recording the identity here is what lets the join refuse instead.
+interface ActiveTransaction {
+  manager: EntityManager;
+  identity: TransactionIdentity;
+}
+
+const activeManagerStorage = new AsyncLocalStorage<ActiveTransaction>();
 
 export function getActiveScopedManager(): EntityManager | undefined {
-  return activeManagerStorage.getStore();
+  return activeManagerStorage.getStore()?.manager;
+}
+
+/**
+ * The identity a transaction's GUCs were set from -- exactly the fields
+ * `withScopedDb` turns into `set_config` calls, normalized so two contexts that
+ * produce identical GUCs compare equal.
+ */
+interface TransactionIdentity {
+  system: boolean;
+  currentUserId?: string;
+  realUserId?: string;
+  preserveTimestamps: boolean;
+}
+
+function identityOf(ctx: RequestContext): TransactionIdentity {
+  return ctx.system
+    ? // A system transaction emits only app.bypass_rls, so a userId in the
+      // context is not part of the transaction's identity and must not make two
+      // otherwise identical system scopes compare unequal.
+      { system: true, preserveTimestamps: !!ctx.preserveTimestamps }
+    : {
+        system: false,
+        currentUserId: ctx.userId,
+        // `withScopedDb` defaults the real user to the current one, so a context
+        // that omits it is the same identity as one that spells it out.
+        realUserId: ctx.realUserId ?? ctx.userId,
+        preserveTimestamps: !!ctx.preserveTimestamps,
+      };
+}
+
+function describeIdentity(identity: TransactionIdentity): string {
+  const parts = identity.system
+    ? ["system bypass"]
+    : [
+        `current=${identity.currentUserId}`,
+        `real=${identity.realUserId ?? identity.currentUserId}`,
+      ];
+  if (identity.preserveTimestamps) parts.push("preserveTimestamps");
+  return parts.join(", ");
+}
+
+function sameIdentity(a: TransactionIdentity, b: TransactionIdentity): boolean {
+  return (
+    a.system === b.system &&
+    a.currentUserId === b.currentUserId &&
+    a.realUserId === b.realUserId &&
+    a.preserveTimestamps === b.preserveTimestamps
+  );
 }
 
 /**
  * Run `fn` while `manager` is registered as the ambient transaction. Exported
  * for tests and for advanced callers that already hold a manager; ordinary code
  * should use `withScopedDb`.
+ *
+ * The registered identity defaults to the current ambient context, which is what
+ * `withScopedDb` passes and what a test double wants.
  */
 export function runWithActiveScopedManager<T>(
   manager: EntityManager,
   fn: () => T,
+  identity: TransactionIdentity = identityOf(getRequestContext() ?? {}),
 ): T {
-  return activeManagerStorage.run(manager, fn);
+  return activeManagerStorage.run({ manager, identity }, fn);
 }
 
 /**
@@ -64,6 +131,9 @@ export function runWithActiveScopedManager<T>(
 export function runOutsideActiveScopedManager<T>(fn: () => T): T {
   return activeManagerStorage.exit(fn);
 }
+
+export const IDENTITY_MISMATCH_MESSAGE =
+  "withScopedDb cannot change identity while joining an ambient transaction";
 
 export const MISSING_CONTEXT_MESSAGE =
   "DB access outside request/user/system context -- wrap the call path in withUserContext/withSystemContext";
@@ -93,8 +163,22 @@ export async function withScopedDb<T>(
     throw new Error(MISSING_CONTEXT_MESSAGE);
   }
 
-  const active = getActiveScopedManager();
+  const active = activeManagerStorage.getStore();
   if (active) {
+    const wanted = identityOf(ctx);
+    if (!sameIdentity(active.identity, wanted)) {
+      // Joining would run `fn` under the OUTER transaction's GUCs while the
+      // caller believes it changed identity. Refuse instead: whichever of the
+      // two the code meant, one of them is not what the database is doing.
+      // Genuinely needing a different identity means a separate transaction --
+      // `runOutsideActiveScopedManager` -- and that is a decision to make
+      // deliberately, because it is no longer atomic with the outer work.
+      throw new Error(
+        `${IDENTITY_MISMATCH_MESSAGE}: transaction opened with ` +
+          `[${describeIdentity(active.identity)}], nested call wants ` +
+          `[${describeIdentity(wanted)}]`,
+      );
+    }
     if (isolation) {
       // A joined transaction already has an isolation level, chosen by whoever
       // opened it. Silently downgrading a SERIALIZABLE request to whatever the
@@ -104,9 +188,9 @@ export async function withScopedDb<T>(
         `withScopedDb cannot apply isolation "${isolation}": it is joining an ambient transaction`,
       );
     }
-    // Re-entrant call: join the ambient transaction (same connection, same
-    // GUCs, same atomicity). Never open a second transaction.
-    return fn(active);
+    // Re-entrant call under the same identity: join the ambient transaction
+    // (same connection, same GUCs, same atomicity). Never open a second one.
+    return fn(active.manager);
   }
 
   const runInTransaction = async (manager: EntityManager) => {
@@ -136,7 +220,11 @@ export async function withScopedDb<T>(
       );
     }
 
-    return runWithActiveScopedManager(manager, () => fn(manager));
+    return runWithActiveScopedManager(
+      manager,
+      () => fn(manager),
+      identityOf(ctx),
+    );
   };
 
   return isolation


### PR DESCRIPTION
## Linked discussion / issue

Approved in: Agreed via email with the project owner.

## Summary

Makes `withScopedDb` refuse a nested identity change on a joined transaction instead of silently honouring the outer identity (DR-01). The identity GUCs are the transaction's first statement and are transaction-local, so a nested `withUserContext`/`withSystemContext` cannot change what the database sees — the nested call joined the outer transaction and ran under *its* GUCs while the application believed it had switched identity. Usually that fails closed or writes to the outer identity; a caller using the nested identity for a non-database decision is simply wrong, and a nested `withSystemContext` reads as an escape hatch that does not escape. The join now compares the registered transaction identity against the requested one and throws on mismatch, naming both. Genuinely needing a different identity means a separate transaction (`runOutsideActiveScopedManager`) — no longer atomic with the outer work, which is a decision to make explicitly.

Verified locally: backend typecheck, lint, and `scoped-db.spec.ts` (31 tests) on this branch alone against current `main`.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). <!-- no string changes in this PR -->
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Generated with Claude Code. Reviewed and owned by the PR author.

---
_Generated by [Claude Code](https://claude.ai/code)_
