### PR TITLE
02: Write automatic backups atomically, with a per-write-unique temporary name (v1.15.0)

### DIFF
--- a/backend/src/backup/auto-backup.service.spec.ts
+++ b/backend/src/backup/auto-backup.service.spec.ts
@@ -30,6 +30,7 @@ jest.mock("fs", () => {
       stat: jest.fn(),
       writeFile: jest.fn(),
       unlink: jest.fn(),
+      rename: jest.fn(),
       readdir: jest.fn(),
       mkdir: jest.fn(),
     },
@@ -85,6 +86,7 @@ describe("AutoBackupService", () => {
     });
     (fsPromises.writeFile as unknown as jest.Mock).mockResolvedValue(undefined);
     (fsPromises.unlink as unknown as jest.Mock).mockResolvedValue(undefined);
+    (fsPromises.rename as unknown as jest.Mock).mockResolvedValue(undefined);
   }
 
   function setupExportMocks() {
@@ -573,11 +575,11 @@ describe("AutoBackupService", () => {
 
       await service.runManualBackup(userId);
 
-      expect(fsPromises.writeFile).toHaveBeenCalledWith(
+      expect(fsPromises.rename).toHaveBeenCalledWith(
+        expect.anything(),
         expect.stringContaining(
           `${DEFAULT_BACKUP_CONTAINER_DIR}/${userShard}/monize-backup-daily-`,
         ),
-        expect.any(Buffer),
       );
     });
 
@@ -589,13 +591,13 @@ describe("AutoBackupService", () => {
 
       const result = await service.runManualBackup(userId);
 
-      expect(fsPromises.writeFile).toHaveBeenCalledWith(
-        `/backups/${userShard}/${result.filename}`,
-        expect.any(Buffer),
-      );
-      expect(fsPromises.writeFile).not.toHaveBeenCalledWith(
-        `/backups/${result.filename}`,
+      expect(fsPromises.rename).toHaveBeenCalledWith(
         expect.anything(),
+        `/backups/${userShard}/${result.filename}`,
+      );
+      expect(fsPromises.rename).not.toHaveBeenCalledWith(
+        expect.anything(),
+        `/backups/${result.filename}`,
       );
     });
 
@@ -657,13 +659,13 @@ describe("AutoBackupService", () => {
       // Identical filenames -- the name carries only a tier and a date -- so
       // only the folder can tell the two backups apart.
       expect(theirs.filename).toBe(mine.filename);
-      expect(fsPromises.writeFile).toHaveBeenCalledWith(
+      expect(fsPromises.rename).toHaveBeenCalledWith(
+        expect.anything(),
         `/backups/${userShard}/${mine.filename}`,
-        expect.any(Buffer),
       );
-      expect(fsPromises.writeFile).toHaveBeenCalledWith(
+      expect(fsPromises.rename).toHaveBeenCalledWith(
+        expect.anything(),
         `/backups/77/77/${otherUserId}/${theirs.filename}`,
-        expect.any(Buffer),
       );
     });
 
@@ -803,12 +805,42 @@ describe("AutoBackupService", () => {
 
       await service.handleAutoBackupCron();
 
-      expect(fsPromises.writeFile).toHaveBeenCalledWith(
+      expect(fsPromises.rename).toHaveBeenCalledWith(
+        expect.anything(),
         expect.stringContaining(
           `${DEFAULT_BACKUP_CONTAINER_DIR}/${userShard}/monize-backup-daily-`,
         ),
-        expect.any(Buffer),
       );
+    });
+
+    it("gives two writes for the same user and day distinct temp files (FV-004)", async () => {
+      // `.<filename>.partial-<pid>` looked unique and was not: a manual backup and
+      // the scheduled one for the same user, day and extension collide inside a
+      // single process, and across replicas sharing a volume PIDs collide outright.
+      // The loser's rename then fails with ENOENT -- or its cleanup unlinks the
+      // temp file the winner is about to rename -- so a legitimate run fails.
+      const settings = createSettings({
+        enabled: true,
+        folderPath: "",
+        nextBackupAt: new Date(Date.now() - 3600000),
+      });
+      mockSettingsRepo.find.mockResolvedValue([settings]);
+      setupExportMocks();
+
+      await service.handleAutoBackupCron();
+      await service.handleAutoBackupCron();
+
+      const tempPaths = (
+        fsPromises.rename as unknown as jest.Mock
+      ).mock.calls.map((c: unknown[]) => c[0] as string);
+      expect(tempPaths).toHaveLength(2);
+      expect(new Set(tempPaths).size).toBe(2);
+      // The FINAL path is still the same file -- replacing our own same-day
+      // backup is intended. It is only the intermediate name that is private.
+      const finalPaths = (
+        fsPromises.rename as unknown as jest.Mock
+      ).mock.calls.map((c: unknown[]) => c[1] as string);
+      expect(new Set(finalPaths).size).toBe(1);
     });
 
     it("should mark status as failed on error and continue", async () => {

--- a/backend/src/backup/auto-backup.service.ts
+++ b/backend/src/backup/auto-backup.service.ts
@@ -13,6 +13,7 @@ import { withScopedDb } from "../common/db/scoped-db";
 import { Cron } from "@nestjs/schedule";
 import { promises as fs, readdirSync, unlinkSync, copyFileSync } from "fs";
 import { resolve } from "path";
+import { randomUUID } from "crypto";
 import { AutoBackupSettings } from "./entities/auto-backup-settings.entity";
 import { BackupService } from "./backup.service";
 import { BackupEncryptionService } from "./backup-encryption.service";
@@ -641,7 +642,30 @@ export class AutoBackupService {
       userId,
       encryptionPassword,
     );
-    await fs.writeFile(filepath, payload);
+    // Write to a temporary name and rename into place. `rename` within a
+    // directory is atomic, so a reader (or a restore) never sees a half-written
+    // backup, and a crash mid-write leaves the previous good file rather than a
+    // truncated one that looks like a successful backup. Replacing our own
+    // same-day file is intended -- the collision that mattered was between
+    // different users, and the per-user directory removes it.
+    // FV-004: unique per write, not per process. `process.pid` looked unique and
+    // is not -- a manual backup and the scheduled one for the same user, day and
+    // extension collide inside a single process, and across replicas sharing a
+    // volume PIDs collide outright. The loser's `rename` then fails with ENOENT,
+    // or its own cleanup unlinks the temp file the winner is about to rename, so a
+    // legitimate backup run reports failure. Replacing our own *final* same-day
+    // file is still intended; it is the intermediate name that has to be private.
+    const tempPath = this.safePath(
+      userFolder,
+      `.${filename}.partial-${process.pid}-${randomUUID()}`,
+    );
+    try {
+      await fs.writeFile(tempPath, payload);
+      await fs.rename(tempPath, filepath);
+    } catch (error) {
+      await fs.unlink(tempPath).catch(() => {});
+      throw error;
+    }
 
     this.logger.log(
       `Backup written to ${filepath}${encryptionPassword ? " (encrypted)" : ""}`,


### PR DESCRIPTION
## Linked discussion / issue

Approved in: Agreed via email with the project owner.

## Summary

Writes automatic backups atomically, with a per-write-unique temporary name (FV-004). `exportToFile` wrote the payload straight to its final path, so a crash mid-write left a truncated file that looks like a successful backup — and a restore trusts it. It now writes to a temporary name and renames into place; `rename` within a directory is atomic, so a reader never sees a half-written backup and a crash leaves the previous good file.

The temporary name carries `randomUUID()`, not just the pid: a manual backup and the scheduled one for the same user, day and extension collide inside a single process, and across replicas sharing a volume PIDs collide outright — the loser's `rename` then fails with ENOENT, or its cleanup unlinks the temp file the winner is about to rename, so a legitimate backup run reports failure. Replacing our own *final* same-day file is still intended; it is the intermediate name that has to be private.

This is the one remaining piece of the audit's backup findings — the per-user sharded folders and admin-only settings landed independently on `main` already (#1032).

Verified locally: backend typecheck, lint, and the full backup module suite (11 suites, 214 tests) on this branch alone against current `main`.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). <!-- no string changes in this PR -->
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Generated with Claude Code. Reviewed and owned by the PR author.

---
_Generated by [Claude Code](https://claude.ai/code)_
