### PR TITLE
02: Scope maintenance refreshes by the operation, not the caller (v1.15.0)

### DIFF
--- a/backend/src/currencies/currencies.controller.spec.ts
+++ b/backend/src/currencies/currencies.controller.spec.ts
@@ -321,13 +321,48 @@ describe("CurrenciesController", () => {
   });
 
   describe("refreshRates()", () => {
-    it("delegates to exchangeRateService.refreshAllRates", () => {
-      mockExchangeRateService.refreshAllRates!.mockReturnValue("summary");
+    const summary = {
+      totalPairs: 3,
+      updated: 2,
+      failed: 1,
+      lastUpdated: new Date("2026-08-03T00:00:00Z"),
+      results: [
+        { pair: "USDJPY", success: true, rate: 150 },
+        { pair: "CADNOK", success: false, error: "no quote" },
+      ],
+    };
 
-      const result = controller.refreshRates();
+    it("delegates to exchangeRateService.refreshAllRates", async () => {
+      mockExchangeRateService.refreshAllRates!.mockResolvedValue(summary);
 
-      expect(result).toBe("summary");
+      await controller.refreshRates();
+
       expect(mockExchangeRateService.refreshAllRates).toHaveBeenCalledWith();
+    });
+
+    /**
+     * The refresh is global -- the pair set is assembled from every user's
+     * accounts, securities and default currency -- and this endpoint is reachable
+     * by any authenticated user, not just an admin. Returning the per-pair results
+     * told the caller which currencies everybody else on the deployment transacts
+     * in, which on a small self-hosted instance is an inference about named
+     * people's finances.
+     */
+    it("returns counts only, never the per-pair list", async () => {
+      mockExchangeRateService.refreshAllRates!.mockResolvedValue(summary);
+
+      const result = await controller.refreshRates();
+
+      expect(result).toEqual({
+        totalPairs: 3,
+        updated: 2,
+        failed: 1,
+        lastUpdated: summary.lastUpdated,
+      });
+      expect(result).not.toHaveProperty("results");
+      // Belt and braces: no pair name survives anywhere in the payload, which
+      // also catches one copied into a differently named field.
+      expect(JSON.stringify(result)).not.toContain("CADNOK");
     });
   });
 

--- a/backend/src/currencies/currencies.controller.ts
+++ b/backend/src/currencies/currencies.controller.ts
@@ -194,13 +194,26 @@ export class CurrenciesController {
     return { lastUpdated };
   }
 
+  /**
+   * Counts only, deliberately.
+   *
+   * The refresh is global -- the pair set is assembled from every user's accounts,
+   * securities and default currency -- and this endpoint is reachable by any
+   * authenticated user, not just an admin. Returning the per-pair `results` told
+   * the caller which currencies everybody else on the deployment transacts in,
+   * which on a small self-hosted instance is an inference about named people's
+   * finances. The UI shows `updated` and `failed` and nothing else; the per-pair
+   * detail stays in the server log, where the operator can already see everything.
+   */
   @Post("exchange-rates/refresh")
   @ApiOperation({
     summary: "Manually trigger exchange rate refresh",
   })
-  @ApiResponse({ status: 201, description: "Refresh summary" })
-  refreshRates(): Promise<RateRefreshSummary> {
-    return this.exchangeRateService.refreshAllRates();
+  @ApiResponse({ status: 201, description: "Refresh summary (counts only)" })
+  async refreshRates(): Promise<Omit<RateRefreshSummary, "results">> {
+    const { results: _results, ...counts } =
+      await this.exchangeRateService.refreshAllRates();
+    return counts;
   }
 
   @Post("exchange-rates/backfill")

--- a/backend/src/currencies/exchange-rate.service.spec.ts
+++ b/backend/src/currencies/exchange-rate.service.spec.ts
@@ -7,6 +7,10 @@ import { UserPreference } from "../users/entities/user-preference.entity";
 import { YahooFinanceService } from "../securities/yahoo-finance.service";
 import { createScopedDbMocks } from "../test-helpers/scoped-db-testing";
 import { roundFxRate } from "../common/fx-entry.util";
+import {
+  getRequestContext,
+  requestContextStorage,
+} from "../common/request-context";
 
 jest.mock("../common/db/scoped-db", () =>
   jest.requireActual("../test-helpers/scoped-db-testing").scopedDbMockModule(),
@@ -170,6 +174,31 @@ describe("ExchangeRateService", () => {
   });
 
   describe("refreshAllRates", () => {
+    /**
+     * The pair set is assembled from every user's accounts, securities and default
+     * currency, and `exchange_rates` is shared reference data -- so this is global
+     * by definition. The system context used to live only in the cron, which left
+     * the manual endpoint reading those tables in the requesting user's own scope:
+     * identical to global at RLS_MODE=off, silently narrowed to the caller's own
+     * currencies at enforce. A maintenance operation whose reach depends on which
+     * caller reached it is the trap.
+     */
+    it("runs under a system context regardless of the caller", async () => {
+      dataSource.query.mockResolvedValue([{ code: "USD" }]);
+      let ctx: ReturnType<typeof getRequestContext>;
+      dataSource.query.mockImplementation(() => {
+        ctx = getRequestContext();
+        return Promise.resolve([{ code: "USD" }]);
+      });
+
+      await requestContextStorage.run({ userId: "user-1" }, () =>
+        service.refreshAllRates(),
+      );
+
+      expect(ctx).toMatchObject({ system: true });
+      expect(ctx).not.toHaveProperty("userId");
+    });
+
     it("returns empty summary when fewer than 2 currencies are in use", async () => {
       dataSource.query.mockResolvedValue([{ code: "USD" }]);
 

--- a/backend/src/currencies/exchange-rate.service.ts
+++ b/backend/src/currencies/exchange-rate.service.ts
@@ -323,7 +323,22 @@ export class ExchangeRateService implements OnModuleInit {
   /**
    * Refresh exchange rates for all currencies in use
    */
+  /**
+   * Refresh every currency pair in use across the deployment.
+   *
+   * Global by definition: `exchange_rates` is shared reference data, and the pair
+   * set is assembled from every user's accounts, securities and default currency.
+   * The system context therefore belongs here, not at the call sites -- left to the
+   * caller's ambient identity, the manual endpoint spans all users at
+   * RLS_MODE=off and silently narrows to the caller's own currencies at enforce,
+   * so the same button would mean two different things. A nested system context
+   * from the cron is the same identity and joins.
+   */
   async refreshAllRates(): Promise<RateRefreshSummary> {
+    return withSystemContext(() => this.refreshAllRatesGlobally());
+  }
+
+  private async refreshAllRatesGlobally(): Promise<RateRefreshSummary> {
     const startTime = Date.now();
     this.logger.log("Starting exchange rate refresh");
 

--- a/backend/src/securities/rls-context-smoke.spec.ts
+++ b/backend/src/securities/rls-context-smoke.spec.ts
@@ -89,7 +89,31 @@ describe("securities module RLS context smoke (real withScopedDb)", () => {
     });
   });
 
-  it("real withScopedDb still refuses these paths without their context wrappers", async () => {
+  it("refreshAllPrices supplies its own system context", async () => {
+    // It used to depend on the caller's wrapper, which meant the admin
+    // maintenance endpoint read `securities` in the admin's own scope: global at
+    // RLS_MODE=off and silently narrowed to their own holdings at enforce. The
+    // scope is a property of the operation now, so it runs with no ambient
+    // context at all.
+    const { dataSource } = createScopedDbMocks([
+      [Security, { find: jest.fn().mockResolvedValue([]) }],
+    ]);
+    const service = new SecurityPriceService(
+      dataSource as never,
+      {} as never,
+      {} as never,
+    );
+
+    await expect(service.refreshAllPrices()).resolves.toMatchObject({
+      totalSecurities: 0,
+    });
+  });
+
+  it("real withScopedDb still refuses a per-user path without its context", async () => {
+    // The negative control: `refreshPricesForSecurities` is the caller-scoped
+    // counterpart (its controller verifies ownership of every id first), so it
+    // must still fail closed with no ambient identity -- proving the smokes above
+    // pass because of real context wrappers and not because the check is inert.
     const { dataSource } = createScopedDbMocks([
       [Security, { find: jest.fn() }],
     ]);
@@ -99,11 +123,10 @@ describe("securities module RLS context smoke (real withScopedDb)", () => {
       {} as never,
     );
 
-    // Called with no ambient scope at all (no interceptor, no wrapper): the
-    // real withScopedDb must throw, proving the smokes above pass because of
-    // the C2 wrappers and not because the check is inert.
-    await expect(service.refreshAllPrices()).rejects.toThrow(
-      "DB access outside request/user/system context",
-    );
+    await expect(
+      service.refreshPricesForSecurities([
+        "11111111-1111-4111-8111-111111111111",
+      ]),
+    ).rejects.toThrow("DB access outside request/user/system context");
   });
 });

--- a/backend/src/securities/security-price.service.spec.ts
+++ b/backend/src/securities/security-price.service.spec.ts
@@ -9,6 +9,10 @@ import { YahooFinanceService } from "./yahoo-finance.service";
 import { QuoteProviderRegistry } from "./providers/quote-provider.registry";
 import { UserPreference } from "../users/entities/user-preference.entity";
 import { createScopedDbMocks } from "../test-helpers/scoped-db-testing";
+import {
+  getRequestContext,
+  requestContextStorage,
+} from "../common/request-context";
 
 jest.mock("../common/db/scoped-db", () =>
   jest.requireActual("../test-helpers/scoped-db-testing").scopedDbMockModule(),
@@ -373,6 +377,29 @@ describe("SecurityPriceService", () => {
   });
 
   describe("refreshAllPrices", () => {
+    /**
+     * Prices are keyed by symbol, not by owner, so one fetch serves every holder
+     * and this is global by definition. The system context used to live only in the
+     * cron, leaving the admin maintenance endpoint reading `securities` in the
+     * requesting admin's own scope -- global at RLS_MODE=off, and silently narrowed
+     * to "the admin's own holdings" the moment enforcement is switched on, which
+     * would stop the maintenance endpoint doing maintenance.
+     */
+    it("runs under a system context regardless of the caller", async () => {
+      let ctx: ReturnType<typeof getRequestContext>;
+      securitiesRepository.find.mockImplementation(() => {
+        ctx = getRequestContext();
+        return Promise.resolve([]);
+      });
+
+      await requestContextStorage.run({ userId: "admin-1" }, () =>
+        service.refreshAllPrices(),
+      );
+
+      expect(ctx).toMatchObject({ system: true });
+      expect(ctx).not.toHaveProperty("userId");
+    });
+
     it("returns empty summary when no active securities exist", async () => {
       securitiesRepository.find.mockResolvedValue([]);
 

--- a/backend/src/securities/security-price.service.ts
+++ b/backend/src/securities/security-price.service.ts
@@ -412,7 +412,29 @@ export class SecurityPriceService {
    *   (source = 'manual') never count as fresh, so a user-entered intraday
    *   price does not suppress the official close fetch.
    */
+  /**
+   * Refresh prices for EVERY user's active securities.
+   *
+   * Global by definition -- prices are keyed by symbol, not by owner, and one
+   * fetch serves every holder -- so the system context belongs here rather than at
+   * the call sites. It used to live only in the cron, which left the admin
+   * maintenance endpoint reading `securities` in the requesting admin's own scope:
+   * identical to global at RLS_MODE=off, and silently narrowed to "the admin's own
+   * holdings" the moment enforcement is switched on. A maintenance operation whose
+   * reach depends on which caller reached it is the trap; naming the scope in the
+   * method closes it. A nested system context from the cron is the same identity,
+   * so it joins rather than conflicting (see scoped-db's DR-01 check).
+   *
+   * `refreshPricesForSecurities` is the per-user counterpart: its controller
+   * verifies ownership of every id before calling it.
+   */
   async refreshAllPrices(skipFresh = false): Promise<PriceRefreshSummary> {
+    return withSystemContext(() => this.refreshAllPricesGlobally(skipFresh));
+  }
+
+  private async refreshAllPricesGlobally(
+    skipFresh: boolean,
+  ): Promise<PriceRefreshSummary> {
     const startTime = Date.now();
     this.logger.log("Starting price refresh for all securities");
 


### PR DESCRIPTION
## Linked discussion / issue

Approved in: Agreed via email with the project owner.

## Summary

Scopes the two maintenance refreshes by the operation, not the caller, and stops a global sweep from enumerating other tenants.

`refreshAllPrices` and `refreshAllRates` inherited their tenant scope from whoever called them: the cron wrapped them in a system context and the endpoints did not, which read as global at `RLS_MODE=off` and silently narrowed to the requesting user's own rows at `enforce` — a maintenance endpoint that stops doing maintenance the moment enforcement is switched on. Both now seed their own system context, so the reach is a property of the operation rather than of the call site. The scoping tests fail with the system context moved back into the cron only.

And `POST /currencies/exchange-rates/refresh`, which any authenticated user may call, returned the per-pair results: the set of currencies everybody else on the deployment transacts in, which on a small self-hosted instance is an inference about named people's finances. It returns counts now — all the UI ever read; the per-pair detail stays in the operator's log.

Verified locally: backend typecheck, lint, and the currencies + securities suites (33 suites, 1442 tests) on this branch alone against current `main`.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). <!-- no string changes in this PR -->
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Generated with Claude Code. Reviewed and owned by the PR author.

---
_Generated by [Claude Code](https://claude.ai/code)_
