### PR TITLE
02: Boot-time runtime role verification: attributes, ownership, membership (v1.15.0)

### DIFF
--- a/backend/src/common/db/app-role.spec.ts
+++ b/backend/src/common/db/app-role.spec.ts
@@ -9,6 +9,7 @@ import {
   SqlClient,
 } from "./app-role";
 import { DEFAULT_APP_USER } from "./rls-config";
+import { FORBIDDEN_RUNTIME_ATTRIBUTES } from "./runtime-role-check";
 
 function makeClient() {
   const calls: Array<{ text: string; params?: unknown[] }> = [];
@@ -113,6 +114,62 @@ describe("provisionAppRole", () => {
 });
 
 describe("app-role SQL", () => {
+  it("has a runtime check for every forbidden attribute it provisions (RR5-001)", () => {
+    // The parity guard. `APP_ROLE_ATTRIBUTES` strips a set of NO<x> attributes,
+    // and the startup verifier must reject each of them -- provisioning can be
+    // skipped (declarative CNPG), fail soft (no CREATEROLE), or drift, so the
+    // verifier is the real control. REPLICATION was provisioned off and never
+    // checked, so a REPLICATION role passed startup and could hold WAL.
+    //
+    // Derived from the two sources rather than hand-listed, so a new NO<x> in
+    // provisioning without a runtime fact fails here.
+    const provisionedOff = (
+      APP_ROLE_ATTRIBUTES.match(/\bNO[A-Z]+\b/g) ?? []
+    ).map((token) => token.slice(2));
+
+    // NOINHERIT is defence in depth for inherited ownership, not a forbidden
+    // attribute in its own right (a role may legitimately hold INHERIT), so it is
+    // handled by the ownership arms rather than the forbidden-attribute list.
+    const shouldBeChecked = provisionedOff.filter((a) => a !== "INHERIT");
+    const checked = FORBIDDEN_RUNTIME_ATTRIBUTES.map((a) => a.label);
+
+    for (const attr of shouldBeChecked) {
+      expect(checked).toContain(attr);
+    }
+    // ...and nothing checked that provisioning does not also strip, so the two
+    // stay a matched pair.
+    for (const label of checked) {
+      expect(provisionedOff).toContain(label);
+    }
+  });
+
+  it("names every stripped attribute in the insufficient-privilege warning (RR7-002)", () => {
+    // The fallback path for declarative CNPG provisioning: when the owner lacks
+    // CREATEROLE, the ALTER fails soft and this warning is the only instruction
+    // the operator gets. It hand-listed four of the six NO<x> attributes and
+    // dropped NOREPLICATION and NOINHERIT, so an operator following it into
+    // managed.roles rebuilt a role that later failed enforce-mode startup.
+    //
+    // Derived from APP_ROLE_ATTRIBUTES, so the warning cannot drift behind it.
+    const warning = APP_ROLE_UPSERT_SQL.slice(
+      APP_ROLE_UPSERT_SQL.indexOf("RAISE WARNING"),
+    );
+    const stripped = APP_ROLE_ATTRIBUTES.match(/\bNO[A-Z]+\b/g) ?? [];
+    expect(stripped.length).toBeGreaterThan(0);
+    for (const token of stripped) {
+      expect(warning).toContain(token);
+    }
+  });
+
+  it("provisions the role NOINHERIT, so it does not inherit an owner by default", () => {
+    // Defence in depth for RR3-001: an inherited owner bypasses RLS with no SET
+    // ROLE at all. Not the fix -- a per-membership `WITH INHERIT TRUE` overrides
+    // the role default, and declarative provisioning skips this SQL entirely --
+    // which is why the startup check tests reachability rather than trusting it.
+    expect(APP_ROLE_ATTRIBUTES).toContain("NOINHERIT");
+    expect(APP_ROLE_UPSERT_SQL).toContain("NOINHERIT");
+  });
+
   it("uses %I / %L formatting and no FOR ROLE clause", () => {
     expect(APP_ROLE_UPSERT_SQL).toContain(
       `format('CREATE ROLE %I ${APP_ROLE_ATTRIBUTES} PASSWORD %L'`,

--- a/backend/src/common/db/app-role.spec.ts
+++ b/backend/src/common/db/app-role.spec.ts
@@ -1,5 +1,7 @@
 import {
+  APP_ROLE_ATTRIBUTES,
   APP_ROLE_GRANTS_SQL,
+  RUNTIME_READ_ONLY_TABLES,
   APP_ROLE_NAME_GUC,
   APP_ROLE_PASSWORD_GUC,
   APP_ROLE_UPSERT_SQL,
@@ -113,12 +115,48 @@ describe("provisionAppRole", () => {
 describe("app-role SQL", () => {
   it("uses %I / %L formatting and no FOR ROLE clause", () => {
     expect(APP_ROLE_UPSERT_SQL).toContain(
-      "format('CREATE ROLE %I LOGIN PASSWORD %L'",
+      `format('CREATE ROLE %I ${APP_ROLE_ATTRIBUTES} PASSWORD %L'`,
     );
     expect(APP_ROLE_UPSERT_SQL).toContain("insufficient_privilege");
     expect(APP_ROLE_GRANTS_SQL).toContain(
       "ALTER DEFAULT PRIVILEGES IN SCHEMA public",
     );
     expect(APP_ROLE_GRANTS_SQL).not.toMatch(/FOR ROLE/i);
+  });
+});
+
+/**
+ * DR-02. The blanket "all tables in schema public" grant is deliberate -- a new
+ * user-owned table must be reachable the moment a migration creates it -- but it
+ * also handed the runtime role write access to the migration ledger, which no
+ * request touches and no policy protects.
+ */
+describe("runtime grant surface", () => {
+  it("revokes writes on every read-only infrastructure table", () => {
+    for (const table of RUNTIME_READ_ONLY_TABLES) {
+      expect(APP_ROLE_GRANTS_SQL).toContain(`'${table}'`);
+    }
+    expect(APP_ROLE_GRANTS_SQL).toContain(
+      "REVOKE INSERT, UPDATE, DELETE ON public.%I",
+    );
+  });
+
+  it("keeps SELECT, so nothing that reads the ledger breaks", () => {
+    expect(APP_ROLE_GRANTS_SQL).not.toContain("REVOKE ALL");
+    expect(APP_ROLE_GRANTS_SQL).not.toMatch(/REVOKE[^;]*SELECT/);
+  });
+
+  it("guards the revoke on the table existing", () => {
+    // The grants block runs on every startup, including before schema.sql has
+    // created anything. A REVOKE on a missing table aborts the whole DO block
+    // and would take the grants with it.
+    expect(APP_ROLE_GRANTS_SQL).toMatch(/IF EXISTS \(\s*SELECT FROM pg_class/);
+  });
+
+  it("revokes after granting, not before", () => {
+    // "GRANT ON ALL TABLES" would re-add what an earlier revoke took away.
+    expect(APP_ROLE_GRANTS_SQL.indexOf("GRANT SELECT, INSERT")).toBeLessThan(
+      APP_ROLE_GRANTS_SQL.indexOf("REVOKE"),
+    );
   });
 });

--- a/backend/src/common/db/app-role.ts
+++ b/backend/src/common/db/app-role.ts
@@ -60,8 +60,36 @@ export const APP_ROLE_PASSWORD_GUC = "monize.app_password";
  * database what the connection actually is, and refuses to serve traffic on a
  * wrong answer.
  */
+/**
+ * `NOINHERIT` is defence in depth for RR3-001, not the fix.
+ *
+ * PostgreSQL decides table ownership with `has_privs_of_role`, which walks
+ * *inheritable* memberships -- so a role that inherits the owner's privileges is
+ * an owner for the RLS check and bypasses every policy without ever issuing
+ * `SET ROLE`. `NOINHERIT` makes that the role's default, which helps.
+ *
+ * It cannot be the whole answer, for three reasons that all apply here: the
+ * deployment may provision the role declaratively (CNPG `managed.roles`) where
+ * this SQL never runs; PostgreSQL 16 stores inheritance on each membership grant,
+ * so `GRANT owner TO app WITH INHERIT TRUE` overrides the role default; and the
+ * `ALTER` below degrades to a warning without `CREATEROLE`. The startup check is
+ * what actually refuses to serve -- this only narrows the default.
+ */
 export const APP_ROLE_ATTRIBUTES =
-  "LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS NOREPLICATION";
+  "LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS NOREPLICATION NOINHERIT";
+
+/**
+ * The `NO<x>` half of `APP_ROLE_ATTRIBUTES`, i.e. the attributes an operator must
+ * strip when provisioning declaratively. Derived from the one attribute string so
+ * the insufficient-privilege warning below cannot drift behind the contract the
+ * runtime verifier enforces (RR7-002: the warning hand-listed four of these and
+ * silently dropped `NOREPLICATION` and `NOINHERIT`, so an operator who followed it
+ * into `managed.roles` rebuilt a role that later failed enforce-mode startup).
+ * `app-role.spec.ts` asserts every one of these appears in the warning text.
+ */
+export const APP_ROLE_FORBIDDEN_ATTRIBUTE_TOKENS = APP_ROLE_ATTRIBUTES.split(
+  /\s+/,
+).filter((token) => token.startsWith("NO"));
 
 /**
  * Create the role if absent, else converge its attributes and rotate its
@@ -84,7 +112,7 @@ BEGIN
     EXECUTE format('ALTER ROLE %I ${APP_ROLE_ATTRIBUTES} PASSWORD %L', role_name, role_pw);
   END IF;
 EXCEPTION WHEN insufficient_privilege THEN
-  RAISE WARNING 'Insufficient privilege to create/alter role %; provision it declaratively via CNPG managed.roles (spec.managed.roles) with NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS.', role_name;
+  RAISE WARNING 'Insufficient privilege to create/alter role %; provision it declaratively via CNPG managed.roles (spec.managed.roles) with ${APP_ROLE_FORBIDDEN_ATTRIBUTE_TOKENS.join(" ")}.', role_name;
 END $$;
 `.trim();
 

--- a/backend/src/common/db/app-role.ts
+++ b/backend/src/common/db/app-role.ts
@@ -44,12 +44,33 @@ export const APP_ROLE_NAME_GUC = "monize.app_role";
 export const APP_ROLE_PASSWORD_GUC = "monize.app_password";
 
 /**
- * Create the role if absent, else rotate its password. Idempotent and
- * re-applied on every startup so rotating `DATABASE_APP_PASSWORD` and
- * restarting is sufficient. On managed Postgres (CNPG) where the owner lacks
- * `CREATEROLE`, the CREATE/ALTER raises `insufficient_privilege` (42501); we
- * swallow it with a warning and let the role be provisioned declaratively via
- * the CNPG `Cluster` spec (`managed.roles`).
+ * The attribute set that makes the role unprivileged, spelled out on both the
+ * CREATE and the ALTER.
+ *
+ * The ALTER is the load-bearing half. Provisioning used to converge only
+ * `LOGIN PASSWORD`, so a role that already existed kept whatever attributes it
+ * was created with -- `SUPERUSER` or `BYPASSRLS` among them -- and PostgreSQL
+ * exempts both from every policy. `ALTER ROLE` is not additive, so naming the
+ * NO-forms here actually strips them.
+ *
+ * This still cannot be the only defence: the deployment may provision the role
+ * declaratively (CNPG `managed.roles`) where this SQL never runs, the ALTER can
+ * fail with `insufficient_privilege` and degrade to a warning, and an attribute
+ * granted after startup is invisible to it. `runtime-role-check.ts` asks the
+ * database what the connection actually is, and refuses to serve traffic on a
+ * wrong answer.
+ */
+export const APP_ROLE_ATTRIBUTES =
+  "LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS NOREPLICATION";
+
+/**
+ * Create the role if absent, else converge its attributes and rotate its
+ * password. Idempotent and re-applied on every startup so rotating
+ * `DATABASE_APP_PASSWORD` and restarting is sufficient. On managed Postgres
+ * (CNPG) where the owner lacks `CREATEROLE`, the CREATE/ALTER raises
+ * `insufficient_privilege` (42501); we swallow it with a warning and let the
+ * role be provisioned declaratively via the CNPG `Cluster` spec
+ * (`managed.roles`).
  */
 export const APP_ROLE_UPSERT_SQL = `
 DO $$
@@ -58,12 +79,12 @@ DECLARE
   role_pw   text := current_setting('${APP_ROLE_PASSWORD_GUC}');
 BEGIN
   IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = role_name) THEN
-    EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', role_name, role_pw);
+    EXECUTE format('CREATE ROLE %I ${APP_ROLE_ATTRIBUTES} PASSWORD %L', role_name, role_pw);
   ELSE
-    EXECUTE format('ALTER ROLE %I LOGIN PASSWORD %L', role_name, role_pw);
+    EXECUTE format('ALTER ROLE %I ${APP_ROLE_ATTRIBUTES} PASSWORD %L', role_name, role_pw);
   END IF;
 EXCEPTION WHEN insufficient_privilege THEN
-  RAISE WARNING 'Insufficient privilege to create/alter role %; provision it declaratively via CNPG managed.roles (spec.managed.roles).', role_name;
+  RAISE WARNING 'Insufficient privilege to create/alter role %; provision it declaratively via CNPG managed.roles (spec.managed.roles) with NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS.', role_name;
 END $$;
 `.trim();
 
@@ -80,6 +101,7 @@ export const APP_ROLE_GRANTS_SQL = `
 DO $$
 DECLARE
   role_name text := current_setting('${APP_ROLE_NAME_GUC}');
+  infra_table text;
 BEGIN
   IF EXISTS (SELECT FROM pg_roles WHERE rolname = role_name) THEN
     EXECUTE format('GRANT USAGE ON SCHEMA public TO %I', role_name);
@@ -87,11 +109,42 @@ BEGIN
     EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO %I', role_name);
     EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %I', role_name);
     EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO %I', role_name);
+
+    -- Then take back what the blanket grant should never have included.
+    --
+    -- The grant above is deliberately "all tables": a new user-owned table has
+    -- to be reachable the moment a migration creates it, and an allowlist that
+    -- has to be edited per table would be forgotten, leaving the feature broken
+    -- in enforce mode only. But "all tables" also hands the runtime role write
+    -- access to the migration ledger, which no request has any reason to touch
+    -- and which no RLS policy protects -- it is one of the four documented
+    -- exemptions. A mistaken raw query or an application SQL injection could
+    -- rewrite it, and db-migrate reads it to decide what to replay: a forged row
+    -- silently skips a migration, a deleted one replays a migration on top of
+    -- itself. Revoking write while keeping SELECT is a strict narrowing (task
+    -- DR-02); nothing at runtime writes it.
+    FOR infra_table IN SELECT unnest(ARRAY['schema_migrations']) LOOP
+      IF EXISTS (
+        SELECT FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'public' AND c.relname = infra_table
+      ) THEN
+        EXECUTE format('REVOKE INSERT, UPDATE, DELETE ON public.%I FROM %I', infra_table, role_name);
+      END IF;
+    END LOOP;
   END IF;
 EXCEPTION WHEN insufficient_privilege THEN
   RAISE WARNING 'Insufficient privilege to grant DML to role %; grant it manually or via the DB owner.', role_name;
 END $$;
 `.trim();
+
+/**
+ * Tables the runtime role may read but never write: infrastructure with no RLS
+ * policy, where the blanket grant is the only thing standing between a mistaken
+ * query and a corrupted invariant. Exported so the integration harness can
+ * assert the revoke actually took (`app-role.spec.ts` asserts the SQL; only a
+ * live database can assert the privilege).
+ */
+export const RUNTIME_READ_ONLY_TABLES = ["schema_migrations"] as const;
 
 export interface ProvisionAppRoleOptions {
   appUser: string | undefined;

--- a/backend/src/common/db/runtime-role-check.spec.ts
+++ b/backend/src/common/db/runtime-role-check.spec.ts
@@ -1,0 +1,226 @@
+import {
+  RUNTIME_ROLE_FACTS_SQL,
+  RuntimeRoleFacts,
+  assertRuntimeRoleSafe,
+  readRuntimeRoleFacts,
+  runtimeRoleViolations,
+} from "./runtime-role-check";
+import { APP_ROLE_ATTRIBUTES, APP_ROLE_UPSERT_SQL } from "./app-role";
+
+const SAFE: RuntimeRoleFacts = {
+  currentUser: "monize_app",
+  isSuperuser: false,
+  hasBypassRls: false,
+  ownsDatabase: false,
+  ownedPoliciedTables: 0,
+};
+
+/** A querier returning one row, in the `DataSource.query` array shape. */
+const arrayQuerier = (row: Record<string, unknown>) => ({
+  query: jest.fn().mockResolvedValue([row]),
+});
+
+/** ...and in the `pg.Client.query` `{ rows }` shape. Both are used in-tree. */
+const pgQuerier = (row: Record<string, unknown>) => ({
+  query: jest.fn().mockResolvedValue({ rows: [row] }),
+});
+
+const SAFE_ROW = {
+  current_user_name: "monize_app",
+  is_superuser: false,
+  has_bypass_rls: false,
+  owns_database: false,
+  owned_policied_tables: "0",
+};
+
+describe("runtimeRoleViolations", () => {
+  it("accepts an unprivileged non-owner role", () => {
+    expect(runtimeRoleViolations(SAFE, "monize_app")).toEqual([]);
+  });
+
+  // Each of these is a role PostgreSQL exempts from every policy, which is what
+  // made a successful RLS_MODE=enforce boot compatible with zero enforcement.
+  it.each([
+    ["a superuser", { isSuperuser: true }, /SUPERUSER/],
+    ["a BYPASSRLS role", { hasBypassRls: true }, /BYPASSRLS/],
+    ["the database owner", { ownsDatabase: true }, /owns this database/],
+    [
+      "an owner of a policied table",
+      { ownedPoliciedTables: 3 },
+      /owns 3 table\(s\) with RLS enabled/,
+    ],
+  ])("rejects %s", (_label, override, expected) => {
+    const violations = runtimeRoleViolations(
+      { ...SAFE, ...(override as Partial<RuntimeRoleFacts>) },
+      "monize_app",
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatch(expected);
+  });
+
+  it("rejects a connection authenticated as a different role than configured", () => {
+    // The operator asked for monize_app; the pool handed us the owner. Selecting
+    // a username is not the same as connecting under it.
+    const violations = runtimeRoleViolations(
+      { ...SAFE, currentUser: "monize" },
+      "monize_app",
+    );
+
+    expect(violations).toEqual([
+      'connected as "monize" but DATABASE_APP_USER names "monize_app"',
+    ]);
+  });
+
+  it("reports every reason at once", () => {
+    // An operator who fixes one attribute and restarts should not discover the
+    // next one on the following restart.
+    const violations = runtimeRoleViolations(
+      {
+        currentUser: "monize",
+        isSuperuser: true,
+        hasBypassRls: true,
+        ownsDatabase: true,
+        ownedPoliciedTables: 53,
+      },
+      "monize_app",
+    );
+
+    expect(violations).toHaveLength(5);
+  });
+});
+
+describe("readRuntimeRoleFacts", () => {
+  it("reads the array result shape TypeORM returns", async () => {
+    const querier = arrayQuerier(SAFE_ROW);
+
+    await expect(readRuntimeRoleFacts(querier)).resolves.toEqual(SAFE);
+    expect(querier.query).toHaveBeenCalledWith(RUNTIME_ROLE_FACTS_SQL);
+  });
+
+  it("reads the { rows } result shape pg returns", async () => {
+    await expect(readRuntimeRoleFacts(pgQuerier(SAFE_ROW))).resolves.toEqual(
+      SAFE,
+    );
+  });
+
+  it("coerces the bigint count Postgres returns as a string", async () => {
+    const facts = await readRuntimeRoleFacts(
+      arrayQuerier({ ...SAFE_ROW, owned_policied_tables: "7" }),
+    );
+
+    // A string "7" is truthy but `> 0` on a string is a comparison nobody
+    // should have to reason about, so the boundary is crossed here, once.
+    expect(facts.ownedPoliciedTables).toBe(7);
+  });
+
+  it("refuses to guess when pg_roles returns no row", async () => {
+    await expect(
+      readRuntimeRoleFacts({ query: jest.fn().mockResolvedValue([]) }),
+    ).rejects.toThrow(/Refusing to start rather than assume the role is safe/);
+  });
+});
+
+describe("assertRuntimeRoleSafe", () => {
+  it("does not query the database at off or shadow", async () => {
+    for (const mode of ["off", "shadow"] as const) {
+      const querier = arrayQuerier(SAFE_ROW);
+
+      await expect(
+        assertRuntimeRoleSafe(querier, { mode, appUser: "monize_app" }),
+      ).resolves.toBeNull();
+      // Those modes connect as the owner deliberately; a check there would
+      // fail every existing deployment.
+      expect(querier.query).not.toHaveBeenCalled();
+    }
+  });
+
+  it("returns the verified facts at enforce", async () => {
+    await expect(
+      assertRuntimeRoleSafe(arrayQuerier(SAFE_ROW), {
+        mode: "enforce",
+        appUser: "monize_app",
+      }),
+    ).resolves.toEqual(SAFE);
+  });
+
+  it("defaults the expected role name to monize_app", async () => {
+    await expect(
+      assertRuntimeRoleSafe(arrayQuerier(SAFE_ROW), {
+        mode: "enforce",
+        appUser: undefined,
+      }),
+    ).resolves.toEqual(SAFE);
+  });
+
+  it("honours an operator-chosen role name", async () => {
+    await expect(
+      assertRuntimeRoleSafe(arrayQuerier({ ...SAFE_ROW }), {
+        mode: "enforce",
+        appUser: "tenant_runtime",
+      }),
+    ).rejects.toThrow(/DATABASE_APP_USER names "tenant_runtime"/);
+  });
+
+  it("refuses to start on a BYPASSRLS role and says what to do", async () => {
+    await expect(
+      assertRuntimeRoleSafe(
+        arrayQuerier({ ...SAFE_ROW, has_bypass_rls: true }),
+        { mode: "enforce", appUser: "monize_app" },
+      ),
+    ).rejects.toThrow(
+      /RLS_MODE=enforce requires an unprivileged, non-owner runtime role[\s\S]*NOBYPASSRLS/,
+    );
+  });
+
+  it("refuses to start on the database owner", async () => {
+    await expect(
+      assertRuntimeRoleSafe(
+        arrayQuerier({ ...SAFE_ROW, owns_database: true }),
+        {
+          mode: "enforce",
+          appUser: "monize_app",
+        },
+      ),
+    ).rejects.toThrow(/owns this database/);
+  });
+});
+
+describe("APP_ROLE_UPSERT_SQL", () => {
+  it("strips privileged attributes from an already existing role", () => {
+    // The ALTER is the load-bearing half: a role provisioned out of band with
+    // SUPERUSER or BYPASSRLS used to keep those attributes forever, because
+    // provisioning only converged LOGIN PASSWORD.
+    const alter = APP_ROLE_UPSERT_SQL.slice(
+      APP_ROLE_UPSERT_SQL.indexOf("ALTER ROLE"),
+    );
+
+    for (const attribute of [
+      "NOSUPERUSER",
+      "NOCREATEDB",
+      "NOCREATEROLE",
+      "NOBYPASSRLS",
+    ]) {
+      expect(alter).toContain(attribute);
+    }
+  });
+
+  it("creates the role with the same attribute set it converges to", () => {
+    // Two different attribute lists would mean a freshly created role and a
+    // converged one are not the same role.
+    const create = APP_ROLE_UPSERT_SQL.slice(
+      APP_ROLE_UPSERT_SQL.indexOf("CREATE ROLE"),
+      APP_ROLE_UPSERT_SQL.indexOf("ELSE"),
+    );
+
+    expect(create).toContain(APP_ROLE_ATTRIBUTES);
+    expect(
+      APP_ROLE_UPSERT_SQL.slice(APP_ROLE_UPSERT_SQL.indexOf("ALTER ROLE")),
+    ).toContain(APP_ROLE_ATTRIBUTES);
+  });
+
+  it("still passes the password as a quoted literal, never interpolated", () => {
+    expect(APP_ROLE_UPSERT_SQL).toContain("PASSWORD %L");
+    expect(APP_ROLE_UPSERT_SQL).not.toMatch(/PASSWORD\s+'/);
+  });
+});

--- a/backend/src/common/db/runtime-role-check.spec.ts
+++ b/backend/src/common/db/runtime-role-check.spec.ts
@@ -1,4 +1,6 @@
 import {
+  FORBIDDEN_ROLE_MEMBERSHIPS,
+  KNOWN_SAFE_PREDEFINED_ROLES,
   RUNTIME_ROLE_FACTS_SQL,
   RuntimeRoleFacts,
   assertRuntimeRoleSafe,
@@ -9,10 +11,12 @@ import { APP_ROLE_ATTRIBUTES, APP_ROLE_UPSERT_SQL } from "./app-role";
 
 const SAFE: RuntimeRoleFacts = {
   currentUser: "monize_app",
-  isSuperuser: false,
-  hasBypassRls: false,
+  directForbiddenAttributes: [],
   ownsDatabase: false,
   ownedPoliciedTables: 0,
+  exemptReachableContexts: [],
+  inheritedOwnerRoles: [],
+  inheritedForbiddenRoles: [],
 };
 
 /** A querier returning one row, in the `DataSource.query` array shape. */
@@ -27,10 +31,16 @@ const pgQuerier = (row: Record<string, unknown>) => ({
 
 const SAFE_ROW = {
   current_user_name: "monize_app",
-  is_superuser: false,
-  has_bypass_rls: false,
+  rolsuper: false,
+  rolbypassrls: false,
+  rolreplication: false,
+  rolcreaterole: false,
+  rolcreatedb: false,
   owns_database: false,
   owned_policied_tables: "0",
+  exempt_reachable_contexts: [],
+  inherited_owner_roles: [],
+  inherited_forbidden_roles: [],
 };
 
 describe("runtimeRoleViolations", () => {
@@ -41,8 +51,27 @@ describe("runtimeRoleViolations", () => {
   // Each of these is a role PostgreSQL exempts from every policy, which is what
   // made a successful RLS_MODE=enforce boot compatible with zero enforcement.
   it.each([
-    ["a superuser", { isSuperuser: true }, /SUPERUSER/],
-    ["a BYPASSRLS role", { hasBypassRls: true }, /BYPASSRLS/],
+    ["a superuser", { directForbiddenAttributes: ["SUPERUSER"] }, /SUPERUSER/],
+    [
+      "a BYPASSRLS role",
+      { directForbiddenAttributes: ["BYPASSRLS"] },
+      /BYPASSRLS/,
+    ],
+    [
+      "a REPLICATION role",
+      { directForbiddenAttributes: ["REPLICATION"] },
+      /REPLICATION/,
+    ],
+    [
+      "a CREATEROLE role",
+      { directForbiddenAttributes: ["CREATEROLE"] },
+      /CREATEROLE/,
+    ],
+    [
+      "a CREATEDB role",
+      { directForbiddenAttributes: ["CREATEDB"] },
+      /CREATEDB/,
+    ],
     ["the database owner", { ownsDatabase: true }, /owns this database/],
     [
       "an owner of a policied table",
@@ -78,15 +107,284 @@ describe("runtimeRoleViolations", () => {
     const violations = runtimeRoleViolations(
       {
         currentUser: "monize",
-        isSuperuser: true,
-        hasBypassRls: true,
+        directForbiddenAttributes: ["SUPERUSER", "BYPASSRLS", "REPLICATION"],
         ownsDatabase: true,
         ownedPoliciedTables: 53,
+        exemptReachableContexts: ["monize"],
+        inheritedOwnerRoles: ["monize"],
+        inheritedForbiddenRoles: ["pg_execute_server_program"],
       },
       "monize_app",
     );
 
-    expect(violations).toHaveLength(5);
+    // wrong-role + 3 attributes + owns-db + owns-tables + inherited-owner +
+    // inherited-forbidden + reachable.
+    expect(violations).toHaveLength(9);
+  });
+});
+
+describe("runtimeRoleViolations -- exempt role membership (DR-V2)", () => {
+  it("refuses a role that can SET ROLE into an exempt one", () => {
+    // The attribute check reads the LOGIN role only, so a role granted
+    // membership in the owner (or in any BYPASSRLS role) passes every other
+    // check while being one statement away from seeing every tenant.
+    const violations = runtimeRoleViolations(
+      { ...SAFE, exemptReachableContexts: ["monize", "rds_superuser"] },
+      "monize_app",
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain('"monize"');
+    expect(violations[0]).toContain('"rds_superuser"');
+    expect(violations[0]).toContain("SET ROLE");
+  });
+
+  it("refuses a runtime role that holds REPLICATION directly (RR5-001)", () => {
+    // Not an RLS exemption, but the unprivileged-role contract forbids it: a
+    // REPLICATION role can create a WAL-retaining slot and never advance it,
+    // which is a database-wide availability failure. Provisioning strips it; the
+    // verifier used not to read it, so an externally provisioned or drifted role
+    // passed startup.
+    const violations = runtimeRoleViolations(
+      { ...SAFE, directForbiddenAttributes: ["REPLICATION"] },
+      "monize_app",
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain("REPLICATION");
+    expect(violations[0]).toMatch(/WAL|replication/i);
+  });
+
+  it("refuses a role that inherits a server-program membership (RR6-001)", () => {
+    // OS command execution, not an RLS matter -- so the message names the
+    // capability, not policies. Measured on a live server: a NOSUPERUSER member
+    // of pg_execute_server_program ran COPY ... TO PROGRAM and wrote a host file.
+    const violations = runtimeRoleViolations(
+      { ...SAFE, inheritedForbiddenRoles: ["pg_execute_server_program"] },
+      "monize_app",
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain('"pg_execute_server_program"');
+    // The message names the specific capability, drawn from the denylist entry.
+    expect(violations[0]).toContain("COPY");
+    expect(violations[0]).toContain("Revoke the membership");
+    // Not an RLS diagnosis -- RR6-003 is precisely about not saying it is.
+    expect(violations[0]).not.toContain("policies do not apply");
+  });
+
+  it("names the specific capability for each forbidden membership (RR7-001)", () => {
+    // The denylist grew past server-file/server-program to signalling,
+    // cluster-control and broad-data roles, so the message can no longer say
+    // "server-file or server-program" -- it has to describe the role that is
+    // actually granted, from the same list the SQL is generated from.
+    const signal = runtimeRoleViolations(
+      { ...SAFE, inheritedForbiddenRoles: ["pg_signal_backend"] },
+      "monize_app",
+    );
+    expect(signal).toHaveLength(1);
+    expect(signal[0]).toContain('"pg_signal_backend"');
+    expect(signal[0]).toMatch(/terminate sessions/);
+    expect(signal[0]).toContain("Revoke the membership");
+    // It must not misdescribe a signalling role as server-file/program access.
+    expect(signal[0]).not.toContain("server-program");
+    expect(signal[0]).not.toContain("server-file");
+  });
+
+  it("gives a reachable context a truthful, non-RLS-specific reason (RR6-003)", () => {
+    // A reachable context lands here for an RLS exemption, a forbidden attribute,
+    // OR a forbidden membership. The old "policies do not apply" was false for
+    // the last two and sent operators chasing an RLS problem that was not there.
+    const violations = runtimeRoleViolations(
+      { ...SAFE, exemptReachableContexts: ["repl_bridge"] },
+      "monize_app",
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain("SET ROLE");
+    expect(violations[0]).toContain("privileges forbidden to the runtime role");
+    expect(violations[0]).not.toContain("policies do not apply");
+  });
+
+  it("accepts membership in an ordinary role, which grants no exemption", () => {
+    // The query only reports memberships that are themselves exempt, so an
+    // unrelated group grant is not a finding -- reporting it would train the
+    // operator to ignore the message.
+    expect(runtimeRoleViolations(SAFE, "monize_app")).toEqual([]);
+  });
+
+  it("asks the database about membership rather than assuming none", () => {
+    // The first version of this check could not have answered the question at
+    // all -- no role-membership catalog appeared in the query.
+    expect(RUNTIME_ROLE_FACTS_SQL).toContain("h.rolsuper");
+    expect(RUNTIME_ROLE_FACTS_SQL).toContain("h.rolbypassrls");
+    expect(RUNTIME_ROLE_FACTS_SQL).toContain("protected_owners");
+  });
+
+  it("refuses a role that inherits an owner's privileges, SET or not (RR3-001)", () => {
+    // The defect this arm exists for, and the more urgent of the two: an
+    // inherited owner bypasses RLS *now*, with no SET ROLE to detect. Measured on
+    // a live server -- `GRANT owner TO app WITH INHERIT TRUE, SET FALSE` yields
+    // SET=false, USAGE=true, row_security_active=false, and every tenant's rows.
+    const violations = runtimeRoleViolations(
+      { ...SAFE, inheritedOwnerRoles: ["monize_owner"] },
+      "monize_app",
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain('"monize_owner"');
+    expect(violations[0]).toContain("inherits the privileges");
+    // The remedy differs from a revoke, so the message has to say so.
+    expect(violations[0]).toContain("INHERIT FALSE");
+  });
+
+  it("reports the inherited case first, because it is already true", () => {
+    const violations = runtimeRoleViolations(
+      {
+        ...SAFE,
+        inheritedOwnerRoles: ["monize_owner"],
+        exemptReachableContexts: ["some_superuser"],
+      },
+      "monize_app",
+    );
+
+    expect(violations).toHaveLength(2);
+    expect(violations[0]).toContain("inherits the privileges");
+    expect(violations[1]).toContain("SET ROLE");
+  });
+
+  it("never treats an attribute exemption as inheritable", () => {
+    // `rolsuper` and `rolbypassrls` are attributes, and PostgreSQL does not
+    // inherit them: verified on a live server -- a member of a BYPASSRLS role
+    // with INHERIT TRUE still has row_security_active = true. Treating them as
+    // inheritable would refuse to start on a harmless group membership, and an
+    // operator who is told to revoke a harmless grant learns to ignore the check.
+    const inheritedArm = RUNTIME_ROLE_FACTS_SQL.slice(
+      RUNTIME_ROLE_FACTS_SQL.indexOf("AND pg_has_role(r.oid, g.oid, 'USAGE')"),
+    );
+    expect(inheritedArm).toContain("g.oid = d.datdba");
+    expect(inheritedArm).toContain("protected_owners");
+    expect(inheritedArm).not.toContain("rolsuper");
+    expect(inheritedArm).not.toContain("rolbypassrls");
+  });
+
+  it("asks about forbidden predefined-role membership, direct and reachable (RR6-001)", () => {
+    // Membership, not an attribute, so provisioning cannot strip it and the
+    // parity guard is silent -- this predicate is the only defence. Both the
+    // direct-inheritance column and the reachable-context arm consult it, with
+    // USAGE (privileges inherit) exactly like the owner arms.
+    expect(RUNTIME_ROLE_FACTS_SQL).toContain("forbidden_roles");
+    expect(RUNTIME_ROLE_FACTS_SQL).toContain("pg_execute_server_program");
+    expect(RUNTIME_ROLE_FACTS_SQL).toContain("AS inherited_forbidden_roles");
+    // The reachable arm asks the USAGE question of the context h, not of r.
+    const reachableArm = RUNTIME_ROLE_FACTS_SQL.slice(
+      RUNTIME_ROLE_FACTS_SQL.indexOf("AND pg_has_role(r.oid, h.oid, 'SET')"),
+      RUNTIME_ROLE_FACTS_SQL.indexOf("AS exempt_reachable_contexts"),
+    );
+    expect(reachableArm).toContain("FROM forbidden_roles");
+    expect(reachableArm).toContain("pg_has_role(h.oid, fb.oid, 'USAGE')");
+  });
+
+  it("asks both questions of the database, not one", () => {
+    expect(RUNTIME_ROLE_FACTS_SQL).toContain("AS exempt_reachable_contexts");
+    expect(RUNTIME_ROLE_FACTS_SQL).toContain("AS inherited_owner_roles");
+    expect(RUNTIME_ROLE_FACTS_SQL).toContain("'USAGE'");
+  });
+
+  it("judges a reachable context on what IT can reach, not on the catalog (RR4-001)", () => {
+    // The composition the previous version missed. `app --SET--> bridge
+    // --INHERIT--> owner` gives SET=false and USAGE=false from app to owner, and
+    // the bridge owns nothing, so testing a candidate's DIRECT ownership found
+    // nothing while `SET ROLE bridge` reached a context that bypasses every
+    // policy. Measured on a live server: rls_active false, both tenants' rows.
+    //
+    // A source scan, because the fix is the SHAPE of the predicate: the ownership
+    // question has to be asked with the candidate as the subject, not the runtime
+    // role. `rls-elevation-and-role.integration.spec.ts` proves the behaviour.
+    const reachableArm = RUNTIME_ROLE_FACTS_SQL.slice(
+      RUNTIME_ROLE_FACTS_SQL.indexOf("AND pg_has_role(r.oid, h.oid, 'SET')"),
+      RUNTIME_ROLE_FACTS_SQL.indexOf("AS exempt_reachable_contexts"),
+    );
+    // The candidate is the subject of both ownership questions...
+    expect(reachableArm).toContain("pg_has_role(h.oid, d.datdba, 'USAGE')");
+    expect(reachableArm).toContain("pg_has_role(h.oid, po.oid, 'USAGE')");
+    // ...and identity comparison is gone, because owning it directly is only one
+    // of the two ways a context ends up with the owner's privileges.
+    expect(reachableArm).not.toContain("h.oid = d.datdba");
+    expect(reachableArm).not.toContain("po.oid = h.oid");
+  });
+
+  it("keeps the runtime role's own inherited ownership a direct question", () => {
+    // The other arm stays identity-based on purpose: it answers "does THIS role
+    // already have an owner's privileges", so the owner set is the thing being
+    // matched, and widening it to reachability would merge two findings with two
+    // different remedies.
+    const inheritedArm = RUNTIME_ROLE_FACTS_SQL.slice(
+      RUNTIME_ROLE_FACTS_SQL.indexOf("AND pg_has_role(r.oid, g.oid, 'USAGE')"),
+    );
+    expect(inheritedArm).toContain("g.oid = d.datdba");
+    expect(inheritedArm).toContain("po.oid = g.oid");
+  });
+
+  it("asks about SET-ROLE reachability, not one hop of membership (DR-R1)", () => {
+    // `pg_auth_members.member = r.oid` sees only roles granted DIRECTLY, so an
+    // app -> platform_runtime -> owner chain passed startup whenever the
+    // intermediate role was not itself exempt. `pg_has_role(..., 'SET')` is
+    // transitive and evaluates each edge's SET option, which is the actual
+    // question: can this role become that one.
+    expect(RUNTIME_ROLE_FACTS_SQL).toContain(
+      "pg_has_role(r.oid, h.oid, 'SET')",
+    );
+    // ...and the one-hop join is gone, not merely supplemented -- keeping it
+    // would leave a second, weaker answer in the same query.
+    expect(RUNTIME_ROLE_FACTS_SQL).not.toContain("m.member = r.oid");
+    // A role is always "reachable" from itself; excluding it in both arms stops
+    // the check reporting the runtime role as its own escalation path.
+    expect(RUNTIME_ROLE_FACTS_SQL).toContain("h.oid <> r.oid");
+    expect(RUNTIME_ROLE_FACTS_SQL).toContain("g.oid <> r.oid");
+  });
+});
+
+describe("predefined-role classification (DR-RR7-002)", () => {
+  it("forbids pg_signal_backend membership", () => {
+    // RR7-001: a signalling member can pg_terminate_backend other non-superuser
+    // sessions across the cluster -- migrations, backups, other apps. It has no
+    // forbidden attribute and owns nothing, so only the membership arm sees it.
+    expect(FORBIDDEN_ROLE_MEMBERSHIPS.map((m) => m.role)).toContain(
+      "pg_signal_backend",
+    );
+  });
+
+  it("classifies every forbidden role with a capability-specific reason", () => {
+    for (const { role, why } of FORBIDDEN_ROLE_MEMBERSHIPS) {
+      expect(role).toMatch(/^pg_/);
+      // The reason is what the operator reads and what the violation message
+      // quotes, so an empty or placeholder one is a defect.
+      expect(why.length).toBeGreaterThan(20);
+    }
+  });
+
+  it("classifies each predefined role exactly once (no overlap, no omission gap)", () => {
+    // The two lists are a partition: a role is forbidden or deliberately safe,
+    // never both and never neither. The live integration guard proves the union
+    // equals the catalog; here we prove the lists do not contradict each other.
+    const forbidden = new Set<string>(
+      FORBIDDEN_ROLE_MEMBERSHIPS.map((m) => m.role),
+    );
+    const safe = new Set<string>(KNOWN_SAFE_PREDEFINED_ROLES);
+    for (const role of safe) {
+      expect(forbidden.has(role)).toBe(false);
+    }
+    expect(forbidden.size).toBe(FORBIDDEN_ROLE_MEMBERSHIPS.length);
+    expect(safe.size).toBe(KNOWN_SAFE_PREDEFINED_ROLES.length);
+  });
+
+  it("puts every forbidden role into the generated SQL array", () => {
+    // The SQL array is generated from the list, so a new entry reaches both the
+    // direct-inheritance and reachable-context arms with no second edit.
+    for (const { role } of FORBIDDEN_ROLE_MEMBERSHIPS) {
+      expect(RUNTIME_ROLE_FACTS_SQL).toContain(`'${role}'`);
+    }
   });
 });
 
@@ -96,6 +394,52 @@ describe("readRuntimeRoleFacts", () => {
 
     await expect(readRuntimeRoleFacts(querier)).resolves.toEqual(SAFE);
     expect(querier.query).toHaveBeenCalledWith(RUNTIME_ROLE_FACTS_SQL);
+  });
+
+  it("reads the array literal the driver actually sends", async () => {
+    // The shape that broke enforce-mode startup. node-postgres parses text[] into
+    // a JS array and leaves an unrecognized array OID as the literal string, so
+    // `"{}"` -- length 2 -- was read as "one membership" and every boot refused.
+    // A mock returning the array the code wants cannot fail this; the string is
+    // what the driver sends.
+    const empty = await readRuntimeRoleFacts(
+      arrayQuerier({
+        ...SAFE_ROW,
+        exempt_reachable_contexts: "{}",
+        inherited_owner_roles: "{}",
+        inherited_forbidden_roles: "{}",
+      }),
+    );
+    expect(empty.exemptReachableContexts).toEqual([]);
+    expect(empty.inheritedOwnerRoles).toEqual([]);
+    expect(empty.inheritedForbiddenRoles).toEqual([]);
+    expect(runtimeRoleViolations(empty, "monize_app")).toEqual([]);
+
+    const filled = await readRuntimeRoleFacts(
+      arrayQuerier({
+        ...SAFE_ROW,
+        exempt_reachable_contexts: '{monize,"odd role"}',
+      }),
+    );
+    expect(filled.exemptReachableContexts).toEqual(["monize", "odd role"]);
+    expect(runtimeRoleViolations(filled, "monize_app")).toHaveLength(1);
+  });
+
+  it("asks the database for a text[], not the name[] array_agg defaults to", () => {
+    // The cast is what makes the driver hand back an array at all. Without it the
+    // normalizer above is the only thing standing between a fresh deployment and
+    // a boot loop, and a guard that exists twice is cheaper than one that exists
+    // where nobody looks.
+    expect(RUNTIME_ROLE_FACTS_SQL).toContain("g.rolname::text");
+    expect(RUNTIME_ROLE_FACTS_SQL).toContain("'{}'::text[]");
+  });
+
+  it("treats a missing membership array as no memberships", async () => {
+    const { exempt_reachable_contexts: _omitted, ...withoutMemberships } =
+      SAFE_ROW;
+    const facts = await readRuntimeRoleFacts(arrayQuerier(withoutMemberships));
+
+    expect(facts.exemptReachableContexts).toEqual([]);
   });
 
   it("reads the { rows } result shape pg returns", async () => {
@@ -164,10 +508,10 @@ describe("assertRuntimeRoleSafe", () => {
 
   it("refuses to start on a BYPASSRLS role and says what to do", async () => {
     await expect(
-      assertRuntimeRoleSafe(
-        arrayQuerier({ ...SAFE_ROW, has_bypass_rls: true }),
-        { mode: "enforce", appUser: "monize_app" },
-      ),
+      assertRuntimeRoleSafe(arrayQuerier({ ...SAFE_ROW, rolbypassrls: true }), {
+        mode: "enforce",
+        appUser: "monize_app",
+      }),
     ).rejects.toThrow(
       /RLS_MODE=enforce requires an unprivileged, non-owner runtime role[\s\S]*NOBYPASSRLS/,
     );

--- a/backend/src/common/db/runtime-role-check.ts
+++ b/backend/src/common/db/runtime-role-check.ts
@@ -28,11 +28,143 @@ export interface RuntimeRoleQuerier {
   query(sql: string, params?: unknown[]): Promise<unknown>;
 }
 
+/**
+ * Role attributes the unprivileged-role contract forbids, as data.
+ *
+ * These are the `NO<x>` attributes `APP_ROLE_ATTRIBUTES` strips at provisioning
+ * (all but `NOINHERIT`, which is handled by the ownership-inheritance arms
+ * rather than as a forbidden attribute). Kept as one list so the SQL that reads
+ * them, the violation messages, and the parity guard in `app-role.spec.ts` all
+ * derive from a single source -- a `NO<x>` added to provisioning without an
+ * entry here fails that guard, which is what stops the verifier drifting behind
+ * the contract it enforces (RR5-001, where `rolreplication` was provisioned off
+ * but never checked, so a `REPLICATION` role passed startup and could hold WAL).
+ *
+ * None of these are inherited -- PostgreSQL applies role *attributes* only to the
+ * role itself and after `SET ROLE`, never through `INHERIT` -- so each is tested
+ * directly on the runtime role and on every `SET`-reachable context, and never
+ * through `USAGE`.
+ */
+export const FORBIDDEN_RUNTIME_ATTRIBUTES = [
+  {
+    column: "rolsuper",
+    label: "SUPERUSER",
+    why: "is exempt from every row-level-security policy",
+  },
+  {
+    column: "rolbypassrls",
+    label: "BYPASSRLS",
+    why: "is exempt from every row-level-security policy",
+  },
+  {
+    column: "rolreplication",
+    label: "REPLICATION",
+    why: "can create WAL-retaining replication slots and open change streams, outside the tenant model",
+  },
+  {
+    column: "rolcreaterole",
+    label: "CREATEROLE",
+    why: "can create and alter roles, a privilege-escalation surface the unprivileged runtime role must not have",
+  },
+  {
+    column: "rolcreatedb",
+    label: "CREATEDB",
+    why: "can create databases outside the tenant model",
+  },
+] as const;
+
+/**
+ * Predefined roles whose *membership* -- not any attribute -- grants a capability
+ * the application runtime role must never hold.
+ *
+ * These are the server-file and server-program roles: a member of
+ * `pg_execute_server_program` can `COPY ... TO/FROM PROGRAM`, running commands as
+ * the PostgreSQL OS account (RR6-001, measured -- a NOSUPERUSER role wrote a file
+ * on the host), and the file roles read or write anything that account can. They
+ * are reached the same way ownership is, so they are checked the same way:
+ *
+ * - `pg_has_role(role, forbidden, 'USAGE')` -- held now by inheritance, any depth;
+ * - reachable via `SET ROLE` into a context that has that `USAGE`.
+ *
+ * Crucially, provisioning cannot strip these: `ALTER ROLE ... NO<x>` changes
+ * *attributes*, and a membership is a `GRANT`/`REVOKE`. So the parity guard that
+ * covers `FORBIDDEN_RUNTIME_ATTRIBUTES` says nothing here, and the runtime check
+ * is the only line of defence -- which is exactly why it must exist.
+ *
+ * Deliberately a short, named allowlist of the dangerous ones rather than "every
+ * `pg_*` role": `pg_monitor` and friends are not escalation paths, and refusing
+ * to boot on a monitoring grant would train operators to ignore the check.
+ */
+export const FORBIDDEN_ROLE_MEMBERSHIPS = [
+  {
+    role: "pg_execute_server_program",
+    why: "can COPY ... TO/FROM PROGRAM, executing commands as the PostgreSQL OS account",
+  },
+  {
+    role: "pg_read_server_files",
+    why: "can read any file the PostgreSQL OS account can, bypassing database permission checks",
+  },
+  {
+    role: "pg_write_server_files",
+    why: "can write any file the PostgreSQL OS account can, bypassing database permission checks",
+  },
+  {
+    role: "pg_signal_backend",
+    why: "can cancel queries and terminate sessions of other non-superuser roles across the cluster (RR7-001)",
+  },
+  {
+    role: "pg_read_all_settings",
+    why: "can read every configuration variable, including superuser-only values such as a standby's primary_conninfo password",
+  },
+  {
+    role: "pg_read_all_data",
+    why: "holds SELECT on every table in the cluster, reaching data outside the application's own",
+  },
+  {
+    role: "pg_write_all_data",
+    why: "holds INSERT/UPDATE/DELETE on every table in the cluster, reaching data outside the application's own",
+  },
+  {
+    role: "pg_checkpoint",
+    why: "can force immediate checkpoints, which PostgreSQL states are not for normal operation",
+  },
+  {
+    role: "pg_create_subscription",
+    why: "can create logical-replication subscriptions that ingest data outside the tenant model",
+  },
+  {
+    role: "pg_monitor",
+    why: "is an umbrella granting pg_read_all_settings and other monitoring roles, so it reaches forbidden capability",
+  },
+] as const;
+
+/**
+ * The predefined roles a member may safely hold, classified deliberately rather
+ * than allowed by omission (DR-RR7-002). Together with
+ * `FORBIDDEN_ROLE_MEMBERSHIPS` this covers every PostgreSQL 16 `pg_*` role, and
+ * `rls-elevation-and-role.integration.spec.ts` fails when the live catalog holds
+ * a `pg_*` predefined role that appears in neither list -- so a future
+ * PostgreSQL's new predefined role forces a decision instead of defaulting to
+ * safe. These are monitoring or minor-availability capabilities that cross no
+ * tenant, host, or cluster-control boundary.
+ */
+export const KNOWN_SAFE_PREDEFINED_ROLES = [
+  "pg_read_all_stats",
+  "pg_stat_scan_tables",
+  "pg_use_reserved_connections",
+  // Not independently grantable; its sole implicit member is the database owner,
+  // which the ownership arm already refuses.
+  "pg_database_owner",
+] as const;
+
 export interface RuntimeRoleFacts {
   /** The role the connection is actually authenticated as. */
   currentUser: string;
-  isSuperuser: boolean;
-  hasBypassRls: boolean;
+  /**
+   * Labels from `FORBIDDEN_RUNTIME_ATTRIBUTES` the runtime role holds directly,
+   * e.g. `["REPLICATION"]`. Empty for a correctly provisioned role.
+   */
+  directForbiddenAttributes: string[];
   /** True when this role owns the database it is connected to. */
   ownsDatabase: boolean;
   /**
@@ -42,7 +174,69 @@ export interface RuntimeRoleFacts {
    * enforcement by design), so owning even one policied table is a hole.
    */
   ownedPoliciedTables: number;
+  /**
+   * Role contexts this connection can *enter* with `SET ROLE` that are unsafe
+   * once entered -- exempt from RLS, or holding a forbidden attribute.
+   *
+   * "Judged on what it can do once entered" is the whole point, and it is what
+   * the earlier version got wrong (RR4-001): a context is judged on its own
+   * privileges, not on whether the catalog names it as an owner. `bridge` may
+   * own nothing while inheriting the owner, and `SET ROLE bridge` then lands in a
+   * context that bypasses every policy. It also covers a reachable context that
+   * merely holds a forbidden attribute like `REPLICATION` (RR5-001).
+   *
+   * Nothing in this application issues `SET ROLE`, but an injected statement or a
+   * mistaken raw query gets it for free, so it stays a refusal.
+   *
+   * Transitive in both modes, so a chain of any length is covered where a direct
+   * `pg_auth_members` join sees only the first hop (DR-R1).
+   */
+  exemptReachableContexts: string[];
+  /**
+   * Owner roles whose privileges this role **already holds by inheritance**.
+   *
+   * The more dangerous half, and the one `SET` reachability cannot see (RR3-001).
+   * PostgreSQL decides "is the current role the table owner" with
+   * `object_ownercheck` -> `has_privs_of_role`, which walks inheritable
+   * memberships -- so an inherited owner is an owner *now*, with no `SET ROLE` and
+   * nothing to detect at the statement level. Measured on a live server:
+   * `GRANT owner TO app WITH INHERIT TRUE, SET FALSE` gives `SET=false`,
+   * `USAGE=true`, `row_security_active=false`, and both tenants' rows.
+   *
+   * The remedy differs from the list above, which is why it is a separate field:
+   * revoking is one option, `WITH INHERIT FALSE` on the membership is the other.
+   */
+  inheritedOwnerRoles: string[];
+  /**
+   * Forbidden predefined roles (`FORBIDDEN_ROLE_MEMBERSHIPS`) this role holds now
+   * by inheritance -- server-program / server-file capability that is active with
+   * no `SET ROLE` (RR6-001). Reached like inherited ownership, reported
+   * separately because the remedy is `REVOKE`, not `WITH INHERIT FALSE`.
+   */
+  inheritedForbiddenRoles: string[];
 }
+
+/**
+ * Forbidden-attribute columns, as SQL fragments generated from the one list, so
+ * a new entry there reaches the query with no second edit. `r.<col> AS <col>`
+ * for the direct read, and `h.<col> OR ...` for the reachable-context test.
+ */
+const FORBIDDEN_ATTR_DIRECT_COLUMNS = FORBIDDEN_RUNTIME_ATTRIBUTES.map(
+  (a) => `r.${a.column} AS ${a.column}`,
+).join(",\n       ");
+const FORBIDDEN_ATTR_CONTEXT_DISJUNCTION = FORBIDDEN_RUNTIME_ATTRIBUTES.map(
+  (a) => `h.${a.column}`,
+).join("\n                OR ");
+
+/**
+ * The forbidden predefined-role names as a SQL array literal. These come from
+ * our own const list, never from request input, so inlining them is safe -- and
+ * the query takes no parameters, which keeps it runnable through `psql` for the
+ * live checks.
+ */
+const FORBIDDEN_MEMBERSHIP_ARRAY = `ARRAY[${FORBIDDEN_ROLE_MEMBERSHIPS.map(
+  (m) => `'${m.role}'`,
+).join(", ")}]::text[]`;
 
 /**
  * One round trip. `pg_roles` is world-readable, `pg_database.datdba` and
@@ -50,9 +244,24 @@ export interface RuntimeRoleFacts {
  * about itself -- no elevated grant is needed to run the check.
  */
 export const RUNTIME_ROLE_FACTS_SQL = `
+WITH protected_owners AS (
+  -- The roles that own an RLS-enabled public table. Collected once: the
+  -- reachable-context arm below asks a pg_has_role question per owner per
+  -- candidate role, and there are far fewer owners than tables.
+  SELECT DISTINCT c.relowner AS oid
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public'
+     AND c.relkind = 'r'
+     AND c.relrowsecurity
+),
+forbidden_roles AS (
+  -- The dangerous predefined roles that exist in this cluster. Filtering by name
+  -- means a build where one is absent simply yields fewer rows, never an error.
+  SELECT oid FROM pg_roles WHERE rolname = ANY(${FORBIDDEN_MEMBERSHIP_ARRAY})
+)
 SELECT current_user AS current_user_name,
-       r.rolsuper AS is_superuser,
-       r.rolbypassrls AS has_bypass_rls,
+       ${FORBIDDEN_ATTR_DIRECT_COLUMNS},
        (d.datdba = r.oid) AS owns_database,
        (SELECT count(*)
           FROM pg_class c
@@ -60,7 +269,66 @@ SELECT current_user AS current_user_name,
          WHERE n.nspname = 'public'
            AND c.relkind = 'r'
            AND c.relrowsecurity
-           AND c.relowner = r.oid) AS owned_policied_tables
+           AND c.relowner = r.oid) AS owned_policied_tables,
+       -- Every role CONTEXT this connection can enter, judged on what that
+       -- context can do -- not just on what the runtime role directly holds.
+       --
+       -- RR4-001: asking pg_has_role(r, g, 'SET') and then testing whether g
+       -- *directly* owns something misses a mode change partway along the chain.
+       -- app --SET--> bridge --INHERIT--> owner gives SET=false and USAGE=false
+       -- from app to owner, and bridge owns nothing itself, so both arms were
+       -- silent -- while SET ROLE bridge lands in a context that inherits the
+       -- owner and bypasses every policy. Measured: rls_active goes false and
+       -- both tenants' rows appear.
+       --
+       -- So each reachable context is asked the ownership question in its OWN
+       -- right, with USAGE (privileges, which inherit) rather than identity, and
+       -- the forbidden-attribute question directly, because attributes do not
+       -- inherit (RR5-001: a reachable REPLICATION context is unsafe once
+       -- entered). Both pg_has_role calls are transitive, so a chain of any
+       -- length in either mode is covered, and a role is its own SET/USAGE member
+       -- so "owns it directly" needs no separate clause.
+       (SELECT coalesce(array_agg(DISTINCT h.rolname::text), '{}'::text[])
+          FROM pg_roles h
+         WHERE h.oid <> r.oid
+           AND pg_has_role(r.oid, h.oid, 'SET')
+           AND (${FORBIDDEN_ATTR_CONTEXT_DISJUNCTION}
+                OR pg_has_role(h.oid, d.datdba, 'USAGE')
+                OR EXISTS (SELECT 1
+                             FROM protected_owners po
+                            WHERE pg_has_role(h.oid, po.oid, 'USAGE'))
+                -- RR6-001: and whether the context reaches a forbidden
+                -- predefined role. SET ROLE bridge --INHERIT--> server_program
+                -- runs commands on the host; the bridge owns nothing and has no
+                -- forbidden attribute, so only this USAGE question finds it.
+                OR EXISTS (SELECT 1
+                             FROM forbidden_roles fb
+                            WHERE pg_has_role(h.oid, fb.oid, 'USAGE'))))
+         AS exempt_reachable_contexts,
+       -- USAGE from the runtime role itself: ownership is a privilege, and
+       -- PostgreSQL's owner check walks inheritable memberships, so an inherited
+       -- owner bypasses RLS with no SET ROLE at all (RR3-001). Reported
+       -- separately from the contexts above because it is already true rather
+       -- than one statement away, and because the remedy differs.
+       (SELECT coalesce(array_agg(DISTINCT g.rolname::text), '{}'::text[])
+          FROM pg_roles g
+         WHERE g.oid <> r.oid
+           AND pg_has_role(r.oid, g.oid, 'USAGE')
+           AND (g.oid = d.datdba
+                OR EXISTS (SELECT 1
+                             FROM protected_owners po
+                            WHERE po.oid = g.oid)))
+         AS inherited_owner_roles,
+       -- Forbidden predefined roles this role holds NOW by inheritance (RR6-001).
+       -- USAGE, transitive, so a chain of INHERIT grants of any depth is caught;
+       -- the parallel to inherited_owner_roles, for the capability that is active
+       -- with no SET ROLE. Provisioning cannot strip these -- membership is a
+       -- GRANT, not an attribute -- so this predicate is the only defence.
+       (SELECT coalesce(array_agg(DISTINCT fb.rolname::text), '{}'::text[])
+          FROM pg_roles fb
+         WHERE fb.rolname = ANY(${FORBIDDEN_MEMBERSHIP_ARRAY})
+           AND pg_has_role(r.oid, fb.oid, 'USAGE'))
+         AS inherited_forbidden_roles
   FROM pg_roles r
   JOIN pg_database d ON d.datname = current_database()
  WHERE r.rolname = current_user
@@ -68,10 +336,36 @@ SELECT current_user AS current_user_name,
 
 interface RawFactRow {
   current_user_name?: string;
-  is_superuser?: boolean;
-  has_bypass_rls?: boolean;
   owns_database?: boolean;
   owned_policied_tables?: number | string;
+  exempt_reachable_contexts?: string[] | string | null;
+  inherited_owner_roles?: string[] | string | null;
+  inherited_forbidden_roles?: string[] | string | null;
+  // Plus one boolean per FORBIDDEN_RUNTIME_ATTRIBUTES column (rolsuper, ...).
+  [column: string]: unknown;
+}
+
+/**
+ * `text[]` arrives as a JS array from node-postgres and as the literal
+ * `{a,b}` from anything that does not parse the OID -- and `name[]`, which
+ * `array_agg(rolname)` produces without a cast, is one of those.
+ *
+ * This is not defensive noise. The first version of this check aggregated
+ * `rolname` directly, so the field held the two-character string `"{}"`, whose
+ * `.length` is 2: every `RLS_MODE=enforce` boot refused to start, naming a
+ * membership violation that did not exist. The unit test could not see it
+ * because its mock returned the array the code wanted rather than the value the
+ * driver sends.
+ */
+function toRoleNames(value: string[] | string | null | undefined): string[] {
+  if (Array.isArray(value)) return value;
+  if (typeof value !== "string") return [];
+  const inner = value.trim().replace(/^\{|\}$/g, "");
+  if (inner === "") return [];
+  return inner
+    .split(",")
+    .map((name) => name.trim().replace(/^"|"$/g, ""))
+    .filter((name) => name !== "");
 }
 
 /** Normalize what `DataSource.query` / `pg.Client.query` hand back. */
@@ -98,10 +392,14 @@ export async function readRuntimeRoleFacts(
   }
   return {
     currentUser: row.current_user_name,
-    isSuperuser: !!row.is_superuser,
-    hasBypassRls: !!row.has_bypass_rls,
+    directForbiddenAttributes: FORBIDDEN_RUNTIME_ATTRIBUTES.filter(
+      (a) => !!row[a.column],
+    ).map((a) => a.label),
     ownsDatabase: !!row.owns_database,
     ownedPoliciedTables: Number(row.owned_policied_tables ?? 0),
+    exemptReachableContexts: toRoleNames(row.exempt_reachable_contexts),
+    inheritedOwnerRoles: toRoleNames(row.inherited_owner_roles),
+    inheritedForbiddenRoles: toRoleNames(row.inherited_forbidden_roles),
   };
 }
 
@@ -123,16 +421,10 @@ export function runtimeRoleViolations(
         `"${expectedRole}"`,
     );
   }
-  if (facts.isSuperuser) {
+  for (const label of facts.directForbiddenAttributes) {
+    const attr = FORBIDDEN_RUNTIME_ATTRIBUTES.find((a) => a.label === label);
     violations.push(
-      `role "${facts.currentUser}" is a SUPERUSER, which PostgreSQL exempts ` +
-        "from every row-level-security policy",
-    );
-  }
-  if (facts.hasBypassRls) {
-    violations.push(
-      `role "${facts.currentUser}" holds BYPASSRLS, which exempts it from ` +
-        "every row-level-security policy",
+      `role "${facts.currentUser}" holds ${label}, which ${attr?.why ?? "the unprivileged-role contract forbids"}`,
     );
   }
   if (facts.ownsDatabase) {
@@ -145,6 +437,51 @@ export function runtimeRoleViolations(
     violations.push(
       `role "${facts.currentUser}" owns ${facts.ownedPoliciedTables} table(s) ` +
         "with RLS enabled, and a table's owner is exempt from its policies",
+    );
+  }
+  if (facts.inheritedOwnerRoles.length > 0) {
+    // First, because it is the only one that is already true rather than one
+    // statement away, and because the fix is different.
+    violations.push(
+      `role "${facts.currentUser}" inherits the privileges of ${facts.inheritedOwnerRoles
+        .map((r) => `"${r}"`)
+        .join(
+          ", ",
+        )}, which own RLS-protected objects -- PostgreSQL treats an ` +
+        "inherited owner as the owner, so policies are already inactive. Revoke " +
+        "the membership or re-grant it WITH INHERIT FALSE",
+    );
+  }
+  if (facts.inheritedForbiddenRoles.length > 0) {
+    // Also already true, and also a REVOKE remedy -- but not an RLS matter at
+    // all, so it names the specific capability each membership grants, drawn
+    // from the same list the query is generated from (RR7-001: the denylist now
+    // spans host-command, signalling, cluster-control and broad-data roles, so a
+    // single "server-file or server-program" sentence would misdescribe most).
+    const named = facts.inheritedForbiddenRoles
+      .map((r) => {
+        const m = FORBIDDEN_ROLE_MEMBERSHIPS.find((f) => f.role === r);
+        return m ? `"${r}" (${m.why})` : `"${r}"`;
+      })
+      .join(", ");
+    violations.push(
+      `role "${facts.currentUser}" is a member of ${named}, a capability the ` +
+        "unprivileged runtime role must not have. Revoke the membership",
+    );
+  }
+  if (facts.exemptReachableContexts.length > 0) {
+    // RR6-003: worded for every reason a reachable context lands here -- an RLS
+    // exemption, a forbidden attribute like REPLICATION, or a forbidden
+    // predefined-role membership. The old "policies do not apply" was false for
+    // the last two, and a false diagnosis wastes the operator's investigation.
+    violations.push(
+      `role "${facts.currentUser}" can SET ROLE into ${facts.exemptReachableContexts
+        .map((r) => `"${r}"`)
+        .join(
+          ", ",
+        )}, a context with privileges forbidden to the runtime role -- an ` +
+        "RLS exemption, a forbidden attribute, or a dangerous predefined-role " +
+        "membership. Revoke the grant that makes it reachable",
     );
   }
   return violations;
@@ -171,11 +508,17 @@ export async function assertRuntimeRoleSafe(
   const facts = await readRuntimeRoleFacts(querier);
   const violations = runtimeRoleViolations(facts, expectedRole);
   if (violations.length > 0) {
+    // Generated from the forbidden list so it cannot omit an attribute the check
+    // enforces -- RR6-003, where the hand-written sentence had dropped
+    // NOREPLICATION and an operator following it would rebuild an unsafe role.
+    const noAttributes = FORBIDDEN_RUNTIME_ATTRIBUTES.map(
+      (a) => `NO${a.label}`,
+    ).join(" ");
     throw new Error(
       "RLS_MODE=enforce requires an unprivileged, non-owner runtime role, " +
         `but ${violations.join("; ")}. ` +
-        "Point DATABASE_APP_USER at a role created with NOSUPERUSER " +
-        "NOCREATEDB NOCREATEROLE NOBYPASSRLS that owns no application object, " +
+        `Point DATABASE_APP_USER at a role created with ${noAttributes} that ` +
+        "owns no application object and is a member of no privileged role, " +
         "or set RLS_MODE=shadow until it is provisioned.",
     );
   }

--- a/backend/src/common/db/runtime-role-check.ts
+++ b/backend/src/common/db/runtime-role-check.ts
@@ -1,0 +1,183 @@
+import { DEFAULT_APP_USER, RlsMode } from "./rls-config";
+
+/**
+ * Startup verification that `RLS_MODE=enforce` is actually enforcing.
+ *
+ * Selecting the application role and supplying its password is not the same as
+ * connecting under one: PostgreSQL exempts a superuser, a role with `BYPASSRLS`,
+ * and the owner of a table (unless the table is `FORCE ROW LEVEL SECURITY`) from
+ * every policy on it. An operator who points `DATABASE_APP_USER` at the database
+ * owner, or at a pre-existing role that happens to hold `BYPASSRLS`, gets a
+ * successful boot, a log line saying enforce, and no database-level tenant
+ * boundary at all (P2-006). Provisioning cannot substitute for this check: a
+ * role that already exists is only altered, the deployment may provision the
+ * role declaratively (CNPG `managed.roles`) where the application never touches
+ * it, and an attribute granted after startup is invisible either way.
+ *
+ * So the runtime asks the database, over the connection it will actually serve
+ * requests on, what it is -- and refuses to start when the answer is not the
+ * unprivileged role the mode promises. Fail closed: a wrong answer here means
+ * every later query silently sees every tenant.
+ *
+ * At `off`/`shadow` the runtime connects as the owner on purpose, so the check
+ * is skipped by design.
+ */
+
+/** Minimal query surface shared by `DataSource`, `pg.Client` and test doubles. */
+export interface RuntimeRoleQuerier {
+  query(sql: string, params?: unknown[]): Promise<unknown>;
+}
+
+export interface RuntimeRoleFacts {
+  /** The role the connection is actually authenticated as. */
+  currentUser: string;
+  isSuperuser: boolean;
+  hasBypassRls: boolean;
+  /** True when this role owns the database it is connected to. */
+  ownsDatabase: boolean;
+  /**
+   * How many tables with RLS enabled this role owns. A table's owner is exempt
+   * from its policies unless the table is FORCE ROW LEVEL SECURITY, which this
+   * schema deliberately does not use (owner/migration operations run outside
+   * enforcement by design), so owning even one policied table is a hole.
+   */
+  ownedPoliciedTables: number;
+}
+
+/**
+ * One round trip. `pg_roles` is world-readable, `pg_database.datdba` and
+ * `pg_class.relowner` likewise, so an unprivileged role can answer all of this
+ * about itself -- no elevated grant is needed to run the check.
+ */
+export const RUNTIME_ROLE_FACTS_SQL = `
+SELECT current_user AS current_user_name,
+       r.rolsuper AS is_superuser,
+       r.rolbypassrls AS has_bypass_rls,
+       (d.datdba = r.oid) AS owns_database,
+       (SELECT count(*)
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'public'
+           AND c.relkind = 'r'
+           AND c.relrowsecurity
+           AND c.relowner = r.oid) AS owned_policied_tables
+  FROM pg_roles r
+  JOIN pg_database d ON d.datname = current_database()
+ WHERE r.rolname = current_user
+`.trim();
+
+interface RawFactRow {
+  current_user_name?: string;
+  is_superuser?: boolean;
+  has_bypass_rls?: boolean;
+  owns_database?: boolean;
+  owned_policied_tables?: number | string;
+}
+
+/** Normalize what `DataSource.query` / `pg.Client.query` hand back. */
+function firstRow(result: unknown): RawFactRow | undefined {
+  if (Array.isArray(result)) return result[0] as RawFactRow | undefined;
+  if (result && typeof result === "object" && "rows" in result) {
+    const rows = (result as { rows?: unknown[] }).rows;
+    return Array.isArray(rows)
+      ? (rows[0] as RawFactRow | undefined)
+      : undefined;
+  }
+  return undefined;
+}
+
+export async function readRuntimeRoleFacts(
+  querier: RuntimeRoleQuerier,
+): Promise<RuntimeRoleFacts> {
+  const row = firstRow(await querier.query(RUNTIME_ROLE_FACTS_SQL));
+  if (!row?.current_user_name) {
+    throw new Error(
+      "RLS_MODE=enforce: could not read the runtime role's attributes from " +
+        "pg_roles. Refusing to start rather than assume the role is safe.",
+    );
+  }
+  return {
+    currentUser: row.current_user_name,
+    isSuperuser: !!row.is_superuser,
+    hasBypassRls: !!row.has_bypass_rls,
+    ownsDatabase: !!row.owns_database,
+    ownedPoliciedTables: Number(row.owned_policied_tables ?? 0),
+  };
+}
+
+/**
+ * Every reason `facts` disqualifies the connection from serving enforced
+ * traffic, in the operator's words. Empty means the role is safe.
+ *
+ * Returns all of them rather than the first: an operator who fixed one attribute
+ * and restarted should not discover the next one on the following restart.
+ */
+export function runtimeRoleViolations(
+  facts: RuntimeRoleFacts,
+  expectedRole: string,
+): string[] {
+  const violations: string[] = [];
+  if (facts.currentUser !== expectedRole) {
+    violations.push(
+      `connected as "${facts.currentUser}" but DATABASE_APP_USER names ` +
+        `"${expectedRole}"`,
+    );
+  }
+  if (facts.isSuperuser) {
+    violations.push(
+      `role "${facts.currentUser}" is a SUPERUSER, which PostgreSQL exempts ` +
+        "from every row-level-security policy",
+    );
+  }
+  if (facts.hasBypassRls) {
+    violations.push(
+      `role "${facts.currentUser}" holds BYPASSRLS, which exempts it from ` +
+        "every row-level-security policy",
+    );
+  }
+  if (facts.ownsDatabase) {
+    violations.push(
+      `role "${facts.currentUser}" owns this database; owner credentials must ` +
+        "not serve ordinary requests",
+    );
+  }
+  if (facts.ownedPoliciedTables > 0) {
+    violations.push(
+      `role "${facts.currentUser}" owns ${facts.ownedPoliciedTables} table(s) ` +
+        "with RLS enabled, and a table's owner is exempt from its policies",
+    );
+  }
+  return violations;
+}
+
+export interface AssertRuntimeRoleOptions {
+  mode: RlsMode;
+  appUser: string | undefined;
+}
+
+/**
+ * Verify the connection is fit to serve enforced traffic, or throw.
+ *
+ * Call it with the runtime's own connection -- the point is to interrogate the
+ * session that will run requests, not a second one opened as somebody else.
+ */
+export async function assertRuntimeRoleSafe(
+  querier: RuntimeRoleQuerier,
+  { mode, appUser }: AssertRuntimeRoleOptions,
+): Promise<RuntimeRoleFacts | null> {
+  if (mode !== "enforce") return null;
+
+  const expectedRole = appUser || DEFAULT_APP_USER;
+  const facts = await readRuntimeRoleFacts(querier);
+  const violations = runtimeRoleViolations(facts, expectedRole);
+  if (violations.length > 0) {
+    throw new Error(
+      "RLS_MODE=enforce requires an unprivileged, non-owner runtime role, " +
+        `but ${violations.join("; ")}. ` +
+        "Point DATABASE_APP_USER at a role created with NOSUPERUSER " +
+        "NOCREATEDB NOCREATEROLE NOBYPASSRLS that owns no application object, " +
+        "or set RLS_MODE=shadow until it is provisioned.",
+    );
+  }
+  return facts;
+}

--- a/backend/src/currencies/entities/user-currency-preference.entity.ts
+++ b/backend/src/currencies/entities/user-currency-preference.entity.ts
@@ -22,7 +22,17 @@ export class UserCurrencyPreference {
   @CreateDateColumn({ name: "created_at" })
   createdAt: Date;
 
-  @ManyToOne(() => Currency)
+  /**
+   * `onDelete` is declared here because `database/schema.sql` declares it, and an
+   * entity that omits it makes the integration harness -- which builds its schema
+   * from entity metadata -- disagree with production on this exact constraint.
+   *
+   * It is the constraint P2-009 turned dangerous: deleting a shared `currencies`
+   * row cascades another tenant's preference away, silently. A harness whose FK
+   * was NO ACTION instead could only ever have shown a foreign-key error, so the
+   * cross-tenant data loss was not reproducible in a test.
+   */
+  @ManyToOne(() => Currency, { onDelete: "CASCADE" })
   @JoinColumn({ name: "currency_code", referencedColumnName: "code" })
   currency: Currency;
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -9,6 +9,9 @@ import { AppModule } from "./app.module";
 import { OAuthProviderService } from "./oauth/oauth-provider.service";
 import { oauthDebugLogger } from "./oauth/oauth-debug-logger.middleware";
 import { isOidcProviderPath } from "./oauth/oidc-provider-paths";
+import { DataSource } from "typeorm";
+import { parseRlsMode } from "./common/db/rls-config";
+import { assertRuntimeRoleSafe } from "./common/db/runtime-role-check";
 
 // Configure pg to return DATE types as strings instead of Date objects
 // This prevents timezone-related date shifting issues
@@ -57,8 +60,49 @@ if (process.env.NODE_ENV !== "production") {
   });
 }
 
+/**
+ * Verify the runtime DB role is fit to serve enforced traffic, and exit if not.
+ *
+ * Exiting rather than rethrowing: Nest turns a bootstrap rejection into an
+ * unhandled promise warning and a non-zero exit whose cause is buried, and an
+ * operator restarting a crash-looping container needs to read the reason in the
+ * first ten lines of the log.
+ */
+async function assertRuntimeRoleOrExit(dataSource: DataSource): Promise<void> {
+  const logger = new Logger("RlsRuntimeRole");
+  const mode = parseRlsMode(process.env.RLS_MODE);
+  try {
+    const facts = await assertRuntimeRoleSafe(dataSource, {
+      mode,
+      appUser: process.env.DATABASE_APP_USER,
+    });
+    if (facts) {
+      logger.log(
+        `RLS_MODE=enforce verified: connected as "${facts.currentUser}" ` +
+          "(no SUPERUSER, no BYPASSRLS, owns neither the database nor any " +
+          "policied table).",
+      );
+    }
+  } catch (error) {
+    logger.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // RLS_MODE=enforce promises a database-level tenant boundary. Selecting the
+  // application role and supplying its password does not deliver one: a
+  // superuser, a role holding BYPASSRLS, and the owner of a policied table are
+  // each exempt from every policy on it, so an operator who points
+  // DATABASE_APP_USER at the database owner (or at a pre-provisioned role with
+  // BYPASSRLS) used to get a clean boot, a log line saying enforce, and no
+  // enforcement (P2-006). Ask the connection we will actually serve requests on
+  // what it is, and refuse to start on a wrong answer -- before app.listen(),
+  // because the alternative is serving cross-tenant reads while believing the
+  // database is filtering them.
+  await assertRuntimeRoleOrExit(app.get(DataSource));
 
   // Trust first proxy (Docker/nginx) so req.ip reflects the real client IP
   app.getHttpAdapter().getInstance().set("trust proxy", 1);

--- a/backend/test/integration/runtime-role.integration.spec.ts
+++ b/backend/test/integration/runtime-role.integration.spec.ts
@@ -1,0 +1,1064 @@
+import { randomUUID } from "node:crypto";
+import { DataSource } from "typeorm";
+
+import { INTEGRATION_TYPEORM_OPTIONS } from "../helpers/integration-setup";
+import {
+  applyRlsPolicies,
+  TEST_APP_ROLE,
+  TEST_APP_ROLE_PASSWORD,
+} from "../helpers/rls-setup";
+import { withScopedDb } from "@/common/db/scoped-db";
+import { withUserContext } from "@/common/db/with-context";
+import {
+  FORBIDDEN_ROLE_MEMBERSHIPS,
+  KNOWN_SAFE_PREDEFINED_ROLES,
+  readRuntimeRoleFacts,
+  runtimeRoleViolations,
+} from "@/common/db/runtime-role-check";
+
+/**
+ * The scenarios two rounds of independent review asked for and neither party
+ * could execute: they need a live PostgreSQL and a real non-owner role, so a
+ * mocked query double cannot answer them.
+ *
+ *  - MT-13: does the runtime role's grant surface really refuse a write to
+ *    `schema_migrations` while still allowing the read?
+ *  - DR-R1: is `pg_has_role(..., 'SET')` really transitive, so a two-hop
+ *    membership chain through an unremarkable intermediate role is caught?
+ *
+ * This matters most for confidence: it is the only way to establish that the
+ * startup check's central predicate behaves as the documentation says, rather
+ * than as the author read it.
+ *
+ * The elevation/currency scenarios this file's mixed predecessor also carried
+ * (RV-001, FV-003) live in rls-elevation-and-currency.integration.spec.ts.
+ */
+describe("Runtime role verification (real PostgreSQL)", () => {
+  jest.setTimeout(120000);
+
+  let dataSource: DataSource;
+  const USER_A = randomUUID();
+  const USER_B = randomUUID();
+  const previousMode = process.env.RLS_MODE;
+
+  /** A pool of exactly one connection, authenticated as the non-owner role. */
+  async function appRolePool(): Promise<DataSource> {
+    const ds = new DataSource({
+      ...INTEGRATION_TYPEORM_OPTIONS,
+      username: TEST_APP_ROLE,
+      password: TEST_APP_ROLE_PASSWORD,
+      synchronize: false,
+      dropSchema: false,
+      extra: { max: 1 },
+    } as never);
+    await ds.initialize();
+    return ds;
+  }
+
+  /**
+   * Poll a predicate until it holds or the attempts run out. Used where the
+   * database reaches a state asynchronously after a client action -- a backend's
+   * temporary-slot cleanup on session end races the client-side pool close, so
+   * the assertion is "it becomes true", not "it is true this instant".
+   */
+  async function waitFor(
+    predicate: () => Promise<boolean>,
+    { attempts = 50, delayMs = 20 } = {},
+  ): Promise<boolean> {
+    for (let i = 0; i < attempts; i++) {
+      if (await predicate()) return true;
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    return predicate();
+  }
+
+  beforeAll(async () => {
+    dataSource = new DataSource({
+      ...INTEGRATION_TYPEORM_OPTIONS,
+      synchronize: true,
+      dropSchema: true,
+    } as never);
+    await dataSource.initialize();
+    // `synchronize` builds from entity metadata, and `schema_migrations` has no
+    // entity -- it is the migration runner's own ledger. Create it before the role
+    // is provisioned, because the revoke that MT-13 is about is guarded on the
+    // table existing and would otherwise be a silent no-op.
+    await dataSource.query(
+      `CREATE TABLE IF NOT EXISTS schema_migrations (
+         filename VARCHAR(255) PRIMARY KEY,
+         applied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+       )`,
+    );
+    await applyRlsPolicies(dataSource, { includeEnable: true });
+
+    // The runtime role is shared and outlives `dropSchema`, so a membership left
+    // behind by an aborted run (or by a hand-run query against this database)
+    // silently turns every "accepts" case in this file red -- or, worse, could
+    // mask a real finding by making a control look already-broken. Start from a
+    // known graph and assert it, rather than assuming one.
+    const strayMemberships: Array<{ rolname: string }> = await dataSource.query(
+      `SELECT g.rolname
+         FROM pg_auth_members m
+         JOIN pg_roles g ON g.oid = m.roleid
+         JOIN pg_roles r ON r.oid = m.member
+        WHERE r.rolname = $1`,
+      [TEST_APP_ROLE],
+    );
+    for (const { rolname } of strayMemberships) {
+      await dataSource.query(`REVOKE ${rolname} FROM ${TEST_APP_ROLE}`);
+    }
+    const remaining = await dataSource.query(
+      `SELECT count(*)::int AS n
+         FROM pg_auth_members m
+         JOIN pg_roles r ON r.oid = m.member
+        WHERE r.rolname = $1`,
+      [TEST_APP_ROLE],
+    );
+    expect(remaining[0].n).toBe(0);
+
+    await dataSource.query(
+      `INSERT INTO currencies (code, name, symbol, decimal_places, is_active)
+       VALUES ('USD', 'US Dollar', '$', 2, true)
+       ON CONFLICT (code) DO NOTHING`,
+    );
+    for (const id of [USER_A, USER_B]) {
+      await dataSource.query(
+        `INSERT INTO users (id, email, password_hash, first_name, last_name)
+         VALUES ($1, $2, 'x', 'T', 'U')`,
+        [id, `${id}@example.test`],
+      );
+      await dataSource.query(
+        `INSERT INTO accounts (id, user_id, name, account_type, currency_code)
+         VALUES ($1, $2, $3, 'CHEQUING', 'USD')`,
+        [randomUUID(), id, `acct-${id.slice(0, 8)}`],
+      );
+    }
+  });
+
+  afterAll(async () => {
+    if (previousMode === undefined) delete process.env.RLS_MODE;
+    else process.env.RLS_MODE = previousMode;
+    await dataSource?.destroy();
+  });
+
+  describe("MT-13 -- the runtime role's grant surface", () => {
+    it("may read the migration ledger but not write it", async () => {
+      const app = await appRolePool();
+      try {
+        await expect(
+          app.query("SELECT count(*) FROM schema_migrations"),
+        ).resolves.toBeDefined();
+
+        await expect(
+          app.query(
+            "INSERT INTO schema_migrations (filename) VALUES ('999_forged.sql')",
+          ),
+        ).rejects.toThrow(/permission denied/i);
+        await expect(
+          app.query("DELETE FROM schema_migrations"),
+        ).rejects.toThrow(/permission denied/i);
+        await expect(
+          app.query("UPDATE schema_migrations SET filename = filename"),
+        ).rejects.toThrow(/permission denied/i);
+      } finally {
+        await app.destroy();
+      }
+    });
+
+    it("may write an ordinary application table, so the revoke is targeted", async () => {
+      // Negative control: a blanket loss of DML would pass the assertions above
+      // while breaking every request.
+      const app = await appRolePool();
+      process.env.RLS_MODE = "enforce";
+      try {
+        await withUserContext(USER_A, () =>
+          withScopedDb(app, (m) =>
+            m.query(
+              `INSERT INTO accounts (id, user_id, name, account_type, currency_code)
+               VALUES ($1, $2, 'writable', 'CHEQUING', 'USD')`,
+              [randomUUID(), USER_A],
+            ),
+          ),
+        );
+      } finally {
+        await dataSource.query("DELETE FROM accounts WHERE name = 'writable'");
+        await app.destroy();
+      }
+    });
+  });
+
+  describe("DR-V2 / DR-R1 -- what the startup check sees", () => {
+    it("passes the provisioned unprivileged role", async () => {
+      const app = await appRolePool();
+      try {
+        const facts = await readRuntimeRoleFacts(app);
+        expect(facts.currentUser).toBe(TEST_APP_ROLE);
+        expect(facts.directForbiddenAttributes).toEqual([]);
+        expect(facts.ownsDatabase).toBe(false);
+        expect(runtimeRoleViolations(facts, TEST_APP_ROLE)).toEqual([]);
+      } finally {
+        await app.destroy();
+      }
+    });
+
+    it("refuses the owner connection the rest of the suite uses", async () => {
+      // The check has to fail for a real owner, not only for a fabricated fact
+      // object. This connection owns the database and every policied table.
+      const facts = await readRuntimeRoleFacts(dataSource);
+      const violations = runtimeRoleViolations(facts, facts.currentUser);
+
+      expect(violations.length).toBeGreaterThan(0);
+      expect(violations.join(" ")).toMatch(/owns this database|SUPERUSER/i);
+    });
+
+    it("catches a two-hop SET ROLE chain to the database owner (DR-R1)", async () => {
+      // The case a `pg_auth_members.member = r.oid` join cannot see: the runtime
+      // role is granted an unremarkable intermediate role, and only that role is
+      // granted the owner. This is the whole justification for pg_has_role's
+      // transitivity, and a unit test cannot establish it.
+      const intermediate = `mid_role_${Date.now()}`;
+      const owner = (await dataSource.query("SELECT current_user AS u"))[0].u;
+      await dataSource.query(`CREATE ROLE ${intermediate} NOLOGIN`);
+      const app = await appRolePool();
+      try {
+        const before = await readRuntimeRoleFacts(app);
+        expect(before.exemptReachableContexts).toEqual([]);
+
+        await dataSource.query(`GRANT ${owner} TO ${intermediate}`);
+        await dataSource.query(`GRANT ${intermediate} TO ${TEST_APP_ROLE}`);
+
+        const after = await readRuntimeRoleFacts(app);
+        // The OWNER is named, not just the intermediate: reachability, not the
+        // first hop.
+        expect(after.exemptReachableContexts).toContain(owner);
+        const violations = runtimeRoleViolations(after, TEST_APP_ROLE);
+        expect(violations.join(" ")).toMatch(/SET ROLE/);
+      } finally {
+        await app.destroy();
+        await dataSource.query(`REVOKE ${intermediate} FROM ${TEST_APP_ROLE}`);
+        await dataSource.query(`REVOKE ${owner} FROM ${intermediate}`);
+        await dataSource.query(`DROP ROLE ${intermediate}`);
+      }
+    });
+
+    /**
+     * RR3-001. The membership matrix, measured rather than reasoned about.
+     *
+     * PostgreSQL 16 stores `INHERIT` and `SET` independently per grant, and they
+     * answer different questions:
+     *
+     *  - `SET` decides whether the role can *become* the other role. Attribute
+     *    exemptions (`rolsuper`, `rolbypassrls`) are reachable only this way,
+     *    because attributes are not inherited.
+     *  - `INHERIT` decides whether the other role's *privileges* are already in
+     *    force. Ownership is a privilege, and PostgreSQL's owner check
+     *    (`object_ownercheck` -> `has_privs_of_role`) walks inheritable
+     *    memberships -- so an inherited owner bypasses RLS immediately, with no
+     *    statement to detect.
+     *
+     * The previous version of this suite asserted that `WITH SET FALSE` was
+     * harmless. The row below marked "the defect" is what that actually is.
+     */
+    const MEMBERSHIP_MATRIX = [
+      {
+        grant: "WITH INHERIT TRUE, SET FALSE",
+        expectRlsActive: false,
+        expectVisibleRows: 2,
+        expectRejected: true,
+        note: "the defect: inherited ownership, no SET ROLE needed",
+      },
+      {
+        grant: "WITH INHERIT FALSE, SET TRUE",
+        expectRlsActive: true,
+        expectVisibleRows: 1,
+        expectRejected: true,
+        note: "no bypass yet, but one SET ROLE away",
+      },
+      {
+        grant: "WITH INHERIT FALSE, SET FALSE",
+        expectRlsActive: true,
+        expectVisibleRows: 1,
+        expectRejected: false,
+        note: "neither route available: genuinely harmless",
+      },
+    ] as const;
+
+    it.each(MEMBERSHIP_MATRIX)(
+      "owner membership $grant -- $note",
+      async ({ grant, expectRlsActive, expectVisibleRows, expectRejected }) => {
+        const owner = (await dataSource.query("SELECT current_user AS u"))[0].u;
+        const app = await appRolePool();
+        try {
+          await dataSource.query(`GRANT ${owner} TO ${TEST_APP_ROLE} ${grant}`);
+
+          // What the database itself thinks, as the app role, with a tenant GUC
+          // set -- the ground truth the check is supposed to predict.
+          const [observed] = await app.query(
+            `SELECT row_security_active('accounts') AS rls_active,
+                    pg_has_role(current_user, $1, 'SET') AS can_set,
+                    pg_has_role(current_user, $1, 'USAGE') AS has_usage`,
+            [owner],
+          );
+          expect(observed.rls_active).toBe(expectRlsActive);
+
+          const visible = await app.transaction(async (m) => {
+            await m.query(
+              "SELECT set_config('app.current_user_id', $1, true)",
+              [USER_A],
+            );
+            const [{ n }] = await m.query(
+              "SELECT count(*)::int AS n FROM accounts",
+            );
+            return n;
+          });
+          expect(visible).toBe(expectVisibleRows);
+
+          // And what the startup check concludes. It must agree with the row
+          // count: refusing to serve exactly when the boundary is not there.
+          const facts = await readRuntimeRoleFacts(app);
+          const violations = runtimeRoleViolations(facts, TEST_APP_ROLE);
+          if (expectRejected) {
+            expect(violations.length).toBeGreaterThan(0);
+          } else {
+            expect(violations).toEqual([]);
+          }
+
+          if (observed.has_usage && !observed.can_set) {
+            // The precise shape of the finding: reported through the inherited
+            // arm, which `SET` reachability alone could never have seen.
+            expect(facts.inheritedOwnerRoles).toContain(owner);
+            expect(facts.exemptReachableContexts).not.toContain(owner);
+          }
+        } finally {
+          await app.destroy();
+          await dataSource.query(`REVOKE ${owner} FROM ${TEST_APP_ROLE}`);
+        }
+      },
+    );
+
+    it("catches an inherited owner two hops away (RR3-001 + DR-R1)", async () => {
+      // Both defects at once: the membership is indirect AND it is inherited
+      // rather than SET-reachable. A direct-membership join misses the first, and
+      // a SET-only predicate misses the second.
+      const owner = (await dataSource.query("SELECT current_user AS u"))[0].u;
+      const intermediate = `mid_inherit_${Date.now()}`;
+      await dataSource.query(`CREATE ROLE ${intermediate} NOLOGIN`);
+      const app = await appRolePool();
+      try {
+        await dataSource.query(
+          `GRANT ${owner} TO ${intermediate} WITH INHERIT TRUE, SET FALSE`,
+        );
+        await dataSource.query(
+          `GRANT ${intermediate} TO ${TEST_APP_ROLE} WITH INHERIT TRUE, SET FALSE`,
+        );
+
+        const [observed] = await app.query(
+          "SELECT row_security_active('accounts') AS rls_active",
+        );
+        expect(observed.rls_active).toBe(false);
+
+        const facts = await readRuntimeRoleFacts(app);
+        expect(facts.inheritedOwnerRoles).toContain(owner);
+        expect(runtimeRoleViolations(facts, TEST_APP_ROLE).join(" ")).toContain(
+          "inherits the privileges",
+        );
+      } finally {
+        await app.destroy();
+        await dataSource.query(`REVOKE ${intermediate} FROM ${TEST_APP_ROLE}`);
+        await dataSource.query(`REVOKE ${owner} FROM ${intermediate}`);
+        await dataSource.query(`DROP ROLE ${intermediate}`);
+      }
+    });
+
+    /**
+     * RR4-001. A chain that changes mode partway: SET to an ordinary bridge, and
+     * the bridge inherits the owner.
+     *
+     * Neither predicate answered this from the runtime role -- SET to the owner is
+     * false because the bridge->owner edge is SET FALSE, USAGE to the owner is
+     * false because the app->bridge edge is INHERIT FALSE, and the bridge owns
+     * nothing in the catalog. Measured before fixing it: rls_active stays true
+     * until `SET ROLE bridge`, and then goes false with both tenants' rows
+     * visible. So a reachable context has to be judged on what IT can do.
+     */
+    let bridgeSeq = 0;
+
+    async function withBridge<T>(
+      edges: { ownerToBridge: string; bridgeToApp: string },
+      fn: (bridge: string) => Promise<T>,
+    ): Promise<T> {
+      const owner = (await dataSource.query("SELECT current_user AS u"))[0].u;
+      const bridge = `bridge_${Date.now()}_${bridgeSeq++}`;
+      await dataSource.query(`CREATE ROLE ${bridge} NOLOGIN`);
+      try {
+        await dataSource.query(
+          `GRANT ${owner} TO ${bridge} ${edges.ownerToBridge}`,
+        );
+        await dataSource.query(
+          `GRANT ${bridge} TO ${TEST_APP_ROLE} ${edges.bridgeToApp}`,
+        );
+        return await fn(bridge);
+      } finally {
+        await dataSource
+          .query(`REVOKE ${bridge} FROM ${TEST_APP_ROLE}`)
+          .catch(() => undefined);
+        await dataSource
+          .query(`REVOKE ${owner} FROM ${bridge}`)
+          .catch(() => undefined);
+        await dataSource.query(`DROP ROLE ${bridge}`);
+      }
+    }
+
+    it("refuses a SET-reachable bridge that inherits the owner (RR4-001)", async () => {
+      await withBridge(
+        {
+          ownerToBridge: "WITH INHERIT TRUE, SET FALSE",
+          bridgeToApp: "WITH INHERIT FALSE, SET TRUE",
+        },
+        async (bridge) => {
+          const app = await appRolePool();
+          try {
+            const owner = (
+              await dataSource.query("SELECT current_user AS u")
+            )[0].u;
+            // Neither direct predicate sees the owner from here. That is the
+            // finding, asserted rather than described.
+            const [reach] = await app.query(
+              `SELECT pg_has_role(current_user, $1, 'SET') AS owner_set,
+                      pg_has_role(current_user, $1, 'USAGE') AS owner_usage,
+                      pg_has_role(current_user, $2, 'SET') AS bridge_set`,
+              [owner, bridge],
+            );
+            expect(reach.owner_set).toBe(false);
+            expect(reach.owner_usage).toBe(false);
+            expect(reach.bridge_set).toBe(true);
+
+            // Before the statement the boundary is intact...
+            const [before] = await app.query(
+              "SELECT row_security_active('accounts') AS active",
+            );
+            expect(before.active).toBe(true);
+
+            // ...and one statement removes it. `SET LOCAL ROLE`, not `SET ROLE`:
+            // the plain form is SESSION-scoped, so on a one-connection pool it
+            // survives the commit and every later statement -- including the
+            // startup check below -- would run as the bridge and measure the wrong
+            // role entirely. That mistake is what made this test fail while the
+            // SQL was already correct.
+            const entered = await app.transaction(async (m) => {
+              await m.query(
+                "SELECT set_config('app.current_user_id', $1, true)",
+                [USER_A],
+              );
+              await m.query(`SET LOCAL ROLE ${bridge}`);
+              const [{ active }] = await m.query(
+                "SELECT row_security_active('accounts') AS active",
+              );
+              const [{ n }] = await m.query(
+                "SELECT count(*)::int AS n FROM accounts",
+              );
+              return { active, n };
+            });
+            expect(entered.active).toBe(false);
+            expect(entered.n).toBe(2);
+
+            // The demonstration must not have contaminated the measurement.
+            const [{ who }] = await app.query("SELECT current_user AS who");
+            expect(who).toBe(TEST_APP_ROLE);
+
+            // Which the check must now refuse, naming the bridge -- the grant an
+            // operator can actually revoke.
+            const facts = await readRuntimeRoleFacts(app);
+            expect(facts.exemptReachableContexts).toContain(bridge);
+            expect(
+              runtimeRoleViolations(facts, TEST_APP_ROLE).join(" "),
+            ).toContain("SET ROLE");
+          } finally {
+            await app.destroy();
+          }
+        },
+      );
+    });
+
+    it("refuses a mixed chain two bridges long (RR4-001)", async () => {
+      // app --SET--> bridge_a --SET--> bridge_b --INHERIT--> owner. Both
+      // pg_has_role calls are transitive, so the reachable set still contains
+      // bridge_b and the ownership question is asked of it.
+      const owner = (await dataSource.query("SELECT current_user AS u"))[0].u;
+      const a = `bridge_a_${Date.now()}`;
+      const b = `bridge_b_${Date.now()}`;
+      await dataSource.query(`CREATE ROLE ${a} NOLOGIN`);
+      await dataSource.query(`CREATE ROLE ${b} NOLOGIN`);
+      const app = await appRolePool();
+      try {
+        await dataSource.query(
+          `GRANT ${owner} TO ${b} WITH INHERIT TRUE, SET FALSE`,
+        );
+        await dataSource.query(
+          `GRANT ${b} TO ${a} WITH INHERIT FALSE, SET TRUE`,
+        );
+        await dataSource.query(
+          `GRANT ${a} TO ${TEST_APP_ROLE} WITH INHERIT FALSE, SET TRUE`,
+        );
+
+        const facts = await readRuntimeRoleFacts(app);
+        expect(facts.exemptReachableContexts).toContain(b);
+        expect(
+          runtimeRoleViolations(facts, TEST_APP_ROLE).length,
+        ).toBeGreaterThan(0);
+      } finally {
+        await app.destroy();
+        await dataSource.query(`REVOKE ${a} FROM ${TEST_APP_ROLE}`);
+        await dataSource.query(`REVOKE ${b} FROM ${a}`);
+        await dataSource.query(`REVOKE ${owner} FROM ${b}`);
+        await dataSource.query(`DROP ROLE ${a}`);
+        await dataSource.query(`DROP ROLE ${b}`);
+      }
+    });
+
+    it("accepts a bridge that is reachable but not exempt (RR4-001 control)", async () => {
+      // The control that stops the new predicate becoming a blanket rejection of
+      // every membership: a SET-reachable role with no exemption of its own and no
+      // inherited owner is harmless, and the tenant filter must stay on.
+      const plain = `plain_bridge_${Date.now()}`;
+      await dataSource.query(`CREATE ROLE ${plain} NOLOGIN`);
+      const app = await appRolePool();
+      try {
+        await dataSource.query(
+          `GRANT ${plain} TO ${TEST_APP_ROLE} WITH INHERIT TRUE, SET TRUE`,
+        );
+
+        const facts = await readRuntimeRoleFacts(app);
+        expect(facts.exemptReachableContexts).not.toContain(plain);
+        expect(runtimeRoleViolations(facts, TEST_APP_ROLE)).toEqual([]);
+
+        const visible = await app.transaction(async (m) => {
+          await m.query("SELECT set_config('app.current_user_id', $1, true)", [
+            USER_A,
+          ]);
+          const [{ n }] = await m.query(
+            "SELECT count(*)::int AS n FROM accounts",
+          );
+          return n;
+        });
+        expect(visible).toBe(1);
+      } finally {
+        await app.destroy();
+        await dataSource.query(`REVOKE ${plain} FROM ${TEST_APP_ROLE}`);
+        await dataSource.query(`DROP ROLE ${plain}`);
+      }
+    });
+
+    it("accepts an unreachable bridge that inherits the owner (RR4-001 control)", async () => {
+      // The other control: the bridge inherits the owner, but the runtime role can
+      // neither become it nor inherit it, so no route exists and there is nothing
+      // to report. Rejecting here would refuse to start over a graph the
+      // connection cannot use.
+      await withBridge(
+        {
+          ownerToBridge: "WITH INHERIT TRUE, SET FALSE",
+          bridgeToApp: "WITH INHERIT FALSE, SET FALSE",
+        },
+        async (bridge) => {
+          const app = await appRolePool();
+          try {
+            const facts = await readRuntimeRoleFacts(app);
+            expect(facts.exemptReachableContexts).not.toContain(bridge);
+            expect(facts.inheritedOwnerRoles).toEqual([]);
+            expect(runtimeRoleViolations(facts, TEST_APP_ROLE)).toEqual([]);
+
+            const [{ active }] = await app.query(
+              "SELECT row_security_active('accounts') AS active",
+            );
+            expect(active).toBe(true);
+          } finally {
+            await app.destroy();
+          }
+        },
+      );
+    });
+
+    it("does not report an inherited membership in a role that owns nothing policied", async () => {
+      // The negative control for the USAGE arm. Inheriting from an ordinary group
+      // confers no exemption, and reporting it would train the operator to ignore
+      // the message -- the same reasoning that keeps rolsuper/rolbypassrls out of
+      // this arm, since those are not inherited at all.
+      const plain = `plain_group_${Date.now()}`;
+      await dataSource.query(`CREATE ROLE ${plain} NOLOGIN`);
+      const app = await appRolePool();
+      try {
+        await dataSource.query(
+          `GRANT ${plain} TO ${TEST_APP_ROLE} WITH INHERIT TRUE, SET TRUE`,
+        );
+
+        const facts = await readRuntimeRoleFacts(app);
+        expect(facts.inheritedOwnerRoles).not.toContain(plain);
+        expect(facts.exemptReachableContexts).not.toContain(plain);
+        expect(runtimeRoleViolations(facts, TEST_APP_ROLE)).toEqual([]);
+      } finally {
+        await app.destroy();
+        await dataSource.query(`REVOKE ${plain} FROM ${TEST_APP_ROLE}`);
+        await dataSource.query(`DROP ROLE ${plain}`);
+      }
+    });
+
+    it("does not inherit BYPASSRLS, so that stays a SET-only question", async () => {
+      // The assumption the split rests on. Verified rather than read: a member of
+      // a BYPASSRLS role with INHERIT TRUE still has policies applied, because
+      // role attributes are not privileges.
+      const bypasser = `bypass_role_${Date.now()}`;
+      await dataSource.query(`CREATE ROLE ${bypasser} NOLOGIN BYPASSRLS`);
+      const app = await appRolePool();
+      try {
+        await dataSource.query(
+          `GRANT ${bypasser} TO ${TEST_APP_ROLE} WITH INHERIT TRUE, SET FALSE`,
+        );
+
+        const [observed] = await app.query(
+          "SELECT row_security_active('accounts') AS rls_active",
+        );
+        expect(observed.rls_active).toBe(true);
+        const facts = await readRuntimeRoleFacts(app);
+        expect(facts.inheritedOwnerRoles).not.toContain(bypasser);
+        // ...and it is not SET-reachable either, so nothing is reported.
+        expect(facts.exemptReachableContexts).not.toContain(bypasser);
+      } finally {
+        await app.destroy();
+        await dataSource.query(`REVOKE ${bypasser} FROM ${TEST_APP_ROLE}`);
+        await dataSource.query(`DROP ROLE ${bypasser}`);
+      }
+    });
+
+    it("refuses a runtime role that holds REPLICATION, and proves the slot works (RR5-001)", async () => {
+      // The forbidden attribute the verifier used not to read. First prove it is
+      // real -- a NOSUPERUSER role with REPLICATION can create a WAL-retaining
+      // physical slot -- then that the check now rejects it. The proof is what
+      // makes this more than a string assertion: PostgreSQL, not the author,
+      // decides the attribute is dangerous.
+      const replicator = `repl_role_${Date.now()}`;
+      await dataSource.query(
+        `CREATE ROLE ${replicator} LOGIN PASSWORD 'x' NOSUPERUSER NOBYPASSRLS REPLICATION`,
+      );
+      const replPool = new DataSource({
+        ...INTEGRATION_TYPEORM_OPTIONS,
+        username: replicator,
+        password: "x",
+        synchronize: false,
+        dropSchema: false,
+        extra: { max: 1 },
+      } as never);
+      await replPool.initialize();
+      const slot = `rr5_slot_${Date.now()}`;
+      try {
+        // The concrete availability failure: a slot this role creates reserves
+        // WAL. TEMPORARY (third arg true), because a non-temporary slot outlives
+        // the test -- a SIGKILL before the `finally` cleanup would leave it
+        // retaining WAL on a shared cluster until the disk fills, and replication
+        // slots are cluster-wide, untouched by dropSchema (RR6-002). A temporary
+        // slot still proves the capability -- it reserves WAL while the session
+        // lives -- and PostgreSQL drops it automatically when the session ends.
+        const [created] = await replPool.query(
+          "SELECT slot_name FROM pg_create_physical_replication_slot($1, true, true)",
+          [slot],
+        );
+        expect(created.slot_name).toBe(slot);
+        // Temporary and reserving WAL while the session is alive. Read on the
+        // creating connection: a temporary slot is owned by its session, so the
+        // owner pool is where it is reliably visible.
+        const [status] = await replPool.query(
+          "SELECT temporary, wal_status FROM pg_replication_slots WHERE slot_name = $1",
+          [slot],
+        );
+        expect(status?.temporary).toBe(true);
+        expect(status?.wal_status).toBe("reserved");
+
+        const facts = await readRuntimeRoleFacts(replPool);
+        expect(facts.directForbiddenAttributes).toContain("REPLICATION");
+        const violations = runtimeRoleViolations(facts, replicator);
+        expect(violations.join(" ")).toContain("REPLICATION");
+      } finally {
+        // The ONLY cleanup is ending the session -- deliberately no explicit
+        // pg_drop_replication_slot (DOC-RR7-001). An earlier version dropped the
+        // slot here and then asserted absence, which proved nothing: a successful
+        // explicit drop makes the slot disappear whether or not PostgreSQL would
+        // have auto-dropped it. Removing the drop is what turns the assertion
+        // below into evidence that a temporary slot is session-scoped.
+        await replPool.destroy();
+      }
+      // Proven from a SECOND connection, and with nothing having dropped the slot
+      // explicitly: it is gone because its session ended. Polled, because the
+      // backend's slot cleanup races the client-side pool close.
+      const slotGone = await waitFor(async () => {
+        const [{ n }] = await dataSource.query(
+          "SELECT count(*)::int AS n FROM pg_replication_slots WHERE slot_name = $1",
+          [slot],
+        );
+        return n === 0;
+      });
+      expect(slotGone).toBe(true);
+      await dataSource.query(`DROP ROLE ${replicator}`);
+    });
+
+    it("refuses a SET-reachable context that holds REPLICATION (RR5-001)", async () => {
+      // The attribute is not inherited, so it only matters in a context that can
+      // be entered -- but a reachable one is one SET ROLE from creating a slot,
+      // exactly as a reachable exempt role is one SET ROLE from bypassing RLS.
+      const replBridge = `repl_bridge_${Date.now()}`;
+      await dataSource.query(`CREATE ROLE ${replBridge} NOLOGIN REPLICATION`);
+      const app = await appRolePool();
+      try {
+        await dataSource.query(
+          `GRANT ${replBridge} TO ${TEST_APP_ROLE} WITH INHERIT FALSE, SET TRUE`,
+        );
+
+        const facts = await readRuntimeRoleFacts(app);
+        expect(facts.exemptReachableContexts).toContain(replBridge);
+        expect(
+          runtimeRoleViolations(facts, TEST_APP_ROLE).length,
+        ).toBeGreaterThan(0);
+      } finally {
+        await app.destroy();
+        await dataSource.query(`REVOKE ${replBridge} FROM ${TEST_APP_ROLE}`);
+        await dataSource.query(`DROP ROLE ${replBridge}`);
+      }
+    });
+
+    it("refuses an inherited server-program membership, and proves COPY TO PROGRAM (RR6-001)", async () => {
+      // OS command execution, and provisioning cannot strip it -- membership is a
+      // GRANT, not an attribute, so the parity guard is silent and this is the
+      // only defence. First prove the capability is live: a NOSUPERUSER member of
+      // pg_execute_server_program runs a program on the host. Then that the check
+      // rejects it. INHERIT TRUE, SET FALSE -- active now, no SET ROLE, so only a
+      // USAGE question finds it.
+      await dataSource.query(
+        `GRANT pg_execute_server_program TO ${TEST_APP_ROLE} WITH INHERIT TRUE, SET FALSE`,
+      );
+      const app = await appRolePool();
+      const proof = `/tmp/monize-rr6-${Date.now()}`;
+      try {
+        // The harm, demonstrated. `COPY ... TO PROGRAM` runs as the PostgreSQL OS
+        // account; a NOSUPERUSER role could not do this without the membership.
+        await app.query(`COPY (SELECT 'rr6') TO PROGRAM 'cat > ${proof}'`);
+        const [{ proven }] = await dataSource.query(
+          `SELECT pg_read_file($1) AS proven`,
+          [proof],
+        );
+        expect(proven).toContain("rr6");
+
+        const facts = await readRuntimeRoleFacts(app);
+        expect(facts.inheritedForbiddenRoles).toContain(
+          "pg_execute_server_program",
+        );
+        const message = runtimeRoleViolations(facts, TEST_APP_ROLE).join(" ");
+        expect(message).toContain("pg_execute_server_program");
+        expect(message).toContain("COPY");
+        expect(message).toContain("Revoke the membership");
+      } finally {
+        await app.destroy();
+        await dataSource.query(
+          `REVOKE pg_execute_server_program FROM ${TEST_APP_ROLE}`,
+        );
+        await dataSource
+          .query(`COPY (SELECT 1) TO PROGRAM 'rm -f ${proof}'`)
+          .catch(() => undefined);
+      }
+    });
+
+    it("refuses a SET-reachable bridge that inherits a server-program membership (RR6-001)", async () => {
+      // app --SET--> bridge --INHERIT--> pg_execute_server_program. The bridge
+      // owns nothing and has no forbidden attribute; only the forbidden-membership
+      // USAGE question on the reachable context finds it.
+      const bridge = `srvprog_bridge_${Date.now()}`;
+      await dataSource.query(`CREATE ROLE ${bridge} NOLOGIN`);
+      const app = await appRolePool();
+      try {
+        await dataSource.query(
+          `GRANT pg_execute_server_program TO ${bridge} WITH INHERIT TRUE, SET FALSE`,
+        );
+        await dataSource.query(
+          `GRANT ${bridge} TO ${TEST_APP_ROLE} WITH INHERIT FALSE, SET TRUE`,
+        );
+
+        const facts = await readRuntimeRoleFacts(app);
+        // Not held now (the app->bridge edge is INHERIT FALSE)...
+        expect(facts.inheritedForbiddenRoles).toEqual([]);
+        // ...but reachable, and that is a refusal.
+        expect(facts.exemptReachableContexts).toContain(bridge);
+        expect(
+          runtimeRoleViolations(facts, TEST_APP_ROLE).length,
+        ).toBeGreaterThan(0);
+      } finally {
+        await app.destroy();
+        await dataSource.query(`REVOKE ${bridge} FROM ${TEST_APP_ROLE}`);
+        await dataSource.query(
+          `REVOKE pg_execute_server_program FROM ${bridge}`,
+        );
+        await dataSource.query(`DROP ROLE ${bridge}`);
+      }
+    });
+
+    it("refuses an inherited pg_signal_backend membership, and proves it can terminate another role's session (RR7-001)", async () => {
+      // The capability that has nothing to do with RLS, no forbidden attribute,
+      // and no ownership -- so only the membership arm sees it. A member can
+      // pg_terminate_backend a session owned by ANY other non-superuser role
+      // (migrations, backups, other apps), which a bare NOSUPERUSER role cannot.
+      // Prove the capability against a live victim session, then that the check
+      // rejects it. INHERIT TRUE, SET FALSE -- active now, no SET ROLE.
+      const victim = `rr7_victim_${Date.now()}`;
+      await dataSource.query(
+        `CREATE ROLE ${victim} LOGIN PASSWORD 'x' NOSUPERUSER NOBYPASSRLS`,
+      );
+      const victimPool = new DataSource({
+        ...INTEGRATION_TYPEORM_OPTIONS,
+        username: victim,
+        password: "x",
+        synchronize: false,
+        dropSchema: false,
+        extra: { max: 1 },
+      } as never);
+      await victimPool.initialize();
+      const app = await appRolePool();
+      try {
+        const [{ pid }] = await victimPool.query(
+          "SELECT pg_backend_pid()::int AS pid",
+        );
+
+        await dataSource.query(
+          `GRANT pg_signal_backend TO ${TEST_APP_ROLE} WITH INHERIT TRUE, SET FALSE`,
+        );
+
+        // The harm, demonstrated: the app terminates a DIFFERENT role's backend.
+        // A NOSUPERUSER role without this membership gets "must be a member of
+        // pg_signal_backend" instead of a boolean.
+        const [{ terminated }] = await app.query(
+          "SELECT pg_terminate_backend($1) AS terminated",
+          [pid],
+        );
+        expect(terminated).toBe(true);
+        // ...and the victim's session really is gone from the cluster.
+        const victimGone = await waitFor(async () => {
+          const [{ n }] = await dataSource.query(
+            "SELECT count(*)::int AS n FROM pg_stat_activity WHERE pid = $1",
+            [pid],
+          );
+          return n === 0;
+        });
+        expect(victimGone).toBe(true);
+
+        const facts = await readRuntimeRoleFacts(app);
+        expect(facts.inheritedForbiddenRoles).toContain("pg_signal_backend");
+        const message = runtimeRoleViolations(facts, TEST_APP_ROLE).join(" ");
+        expect(message).toContain("pg_signal_backend");
+        expect(message).toContain("terminate sessions");
+        expect(message).toContain("Revoke the membership");
+      } finally {
+        await app.destroy();
+        await victimPool.destroy().catch(() => undefined);
+        await dataSource.query(
+          `REVOKE pg_signal_backend FROM ${TEST_APP_ROLE}`,
+        );
+        await dataSource.query(`DROP ROLE IF EXISTS ${victim}`);
+      }
+    });
+
+    it("refuses a SET-only pg_signal_backend membership (RR7-001)", async () => {
+      // INHERIT FALSE, SET TRUE: not held now, but one SET ROLE away from the
+      // capability, so it is a reachable-context refusal like every other.
+      const app = await appRolePool();
+      try {
+        await dataSource.query(
+          `GRANT pg_signal_backend TO ${TEST_APP_ROLE} WITH INHERIT FALSE, SET TRUE`,
+        );
+
+        const facts = await readRuntimeRoleFacts(app);
+        expect(facts.inheritedForbiddenRoles).toEqual([]);
+        expect(facts.exemptReachableContexts).toContain("pg_signal_backend");
+        expect(
+          runtimeRoleViolations(facts, TEST_APP_ROLE).length,
+        ).toBeGreaterThan(0);
+      } finally {
+        await app.destroy();
+        await dataSource.query(
+          `REVOKE pg_signal_backend FROM ${TEST_APP_ROLE}`,
+        );
+      }
+    });
+
+    it("refuses a SET-reachable bridge that inherits pg_signal_backend (RR7-001)", async () => {
+      // app --SET--> bridge --INHERIT--> pg_signal_backend. The composition arm:
+      // the bridge owns nothing and has no forbidden attribute, so only the
+      // forbidden-membership USAGE question on the reachable context finds it.
+      const bridge = `signal_bridge_${Date.now()}`;
+      await dataSource.query(`CREATE ROLE ${bridge} NOLOGIN`);
+      const app = await appRolePool();
+      try {
+        await dataSource.query(
+          `GRANT pg_signal_backend TO ${bridge} WITH INHERIT TRUE, SET FALSE`,
+        );
+        await dataSource.query(
+          `GRANT ${bridge} TO ${TEST_APP_ROLE} WITH INHERIT FALSE, SET TRUE`,
+        );
+
+        const facts = await readRuntimeRoleFacts(app);
+        expect(facts.inheritedForbiddenRoles).toEqual([]);
+        expect(facts.exemptReachableContexts).toContain(bridge);
+        expect(
+          runtimeRoleViolations(facts, TEST_APP_ROLE).length,
+        ).toBeGreaterThan(0);
+      } finally {
+        await app.destroy();
+        await dataSource.query(`REVOKE ${bridge} FROM ${TEST_APP_ROLE}`);
+        await dataSource.query(`REVOKE pg_signal_backend FROM ${bridge}`);
+        await dataSource.query(`DROP ROLE ${bridge}`);
+      }
+    });
+
+    it("refuses an inherited pg_read_server_files membership, and proves it can read a host file (RR7-001)", async () => {
+      // The read half of the file-role pair. The capability the role actually
+      // grants is `COPY ... FROM '<absolute path>'` -- a bare NOSUPERUSER role is
+      // refused an absolute path outright. Write the file as the owner, then read
+      // it into a temp table as the app to demonstrate what the membership adds.
+      const proof = `/tmp/monize-rr7-read-${Date.now()}`;
+      await dataSource.query(
+        `COPY (SELECT 'rr7-read') TO PROGRAM 'cat > ${proof}'`,
+      );
+      await dataSource.query(
+        `GRANT pg_read_server_files TO ${TEST_APP_ROLE} WITH INHERIT TRUE, SET FALSE`,
+      );
+      const app = await appRolePool();
+      try {
+        const contents = await app.transaction(async (m) => {
+          await m.query("CREATE TEMP TABLE rr7_read_probe (line text)");
+          await m.query(`COPY rr7_read_probe FROM '${proof}'`);
+          const [{ line }] = await m.query("SELECT line FROM rr7_read_probe");
+          return line as string;
+        });
+        expect(contents).toContain("rr7-read");
+
+        const facts = await readRuntimeRoleFacts(app);
+        expect(facts.inheritedForbiddenRoles).toContain("pg_read_server_files");
+        expect(
+          runtimeRoleViolations(facts, TEST_APP_ROLE).length,
+        ).toBeGreaterThan(0);
+      } finally {
+        await app.destroy();
+        await dataSource.query(
+          `REVOKE pg_read_server_files FROM ${TEST_APP_ROLE}`,
+        );
+        await dataSource
+          .query(`COPY (SELECT 1) TO PROGRAM 'rm -f ${proof}'`)
+          .catch(() => undefined);
+      }
+    });
+
+    it("refuses an inherited pg_write_server_files membership, and proves it can write a host file (RR7-001)", async () => {
+      // The write half. A member can COPY ... TO an absolute path; a bare
+      // NOSUPERUSER role gets "absolute path not allowed". Write as the app, then
+      // read it back as the owner to prove the file landed on the host.
+      const proof = `/tmp/monize-rr7-write-${Date.now()}`;
+      await dataSource.query(
+        `GRANT pg_write_server_files TO ${TEST_APP_ROLE} WITH INHERIT TRUE, SET FALSE`,
+      );
+      const app = await appRolePool();
+      try {
+        await app.query(`COPY (SELECT 'rr7-write') TO '${proof}'`);
+        const [{ proven }] = await dataSource.query(
+          "SELECT pg_read_file($1) AS proven",
+          [proof],
+        );
+        expect(proven).toContain("rr7-write");
+
+        const facts = await readRuntimeRoleFacts(app);
+        expect(facts.inheritedForbiddenRoles).toContain(
+          "pg_write_server_files",
+        );
+        expect(
+          runtimeRoleViolations(facts, TEST_APP_ROLE).length,
+        ).toBeGreaterThan(0);
+      } finally {
+        await app.destroy();
+        await dataSource.query(
+          `REVOKE pg_write_server_files FROM ${TEST_APP_ROLE}`,
+        );
+        await dataSource
+          .query(`COPY (SELECT 1) TO PROGRAM 'rm -f ${proof}'`)
+          .catch(() => undefined);
+      }
+    });
+
+    it("refuses an inherited pg_read_all_settings membership (DR-RR7-001)", async () => {
+      // Reclassified from accepted to forbidden: on a standby whose
+      // primary_conninfo carries a replication password, a member can read that
+      // credential through SHOW / current_setting / pg_settings. Forbidding it is
+      // the deployment-independent control.
+      const app = await appRolePool();
+      try {
+        await dataSource.query(
+          `GRANT pg_read_all_settings TO ${TEST_APP_ROLE} WITH INHERIT TRUE, SET FALSE`,
+        );
+
+        const facts = await readRuntimeRoleFacts(app);
+        expect(facts.inheritedForbiddenRoles).toContain("pg_read_all_settings");
+        expect(
+          runtimeRoleViolations(facts, TEST_APP_ROLE).length,
+        ).toBeGreaterThan(0);
+      } finally {
+        await app.destroy();
+        await dataSource.query(
+          `REVOKE pg_read_all_settings FROM ${TEST_APP_ROLE}`,
+        );
+      }
+    });
+
+    it("accepts membership in a deliberately-safe predefined role like pg_read_all_stats", async () => {
+      // The control that keeps the forbidden list an allowlist rather than "every
+      // pg_* role": a role classified KNOWN_SAFE_PREDEFINED_ROLES confers no
+      // escalation and must not stop the app booting. pg_read_all_settings used to
+      // play this role and is now forbidden (DR-RR7-001), so the control moved to a
+      // genuinely inert monitoring role.
+      const app = await appRolePool();
+      try {
+        await dataSource.query(
+          `GRANT pg_read_all_stats TO ${TEST_APP_ROLE} WITH INHERIT TRUE`,
+        );
+
+        const facts = await readRuntimeRoleFacts(app);
+        expect(facts.inheritedForbiddenRoles).toEqual([]);
+        expect(facts.exemptReachableContexts).toEqual([]);
+        expect(runtimeRoleViolations(facts, TEST_APP_ROLE)).toEqual([]);
+      } finally {
+        await app.destroy();
+        await dataSource.query(
+          `REVOKE pg_read_all_stats FROM ${TEST_APP_ROLE}`,
+        );
+      }
+    });
+
+    it("classifies every predefined role in this PostgreSQL, forbidden or safe (DR-RR7-002)", async () => {
+      // The list must not silently fall behind PostgreSQL. Every live pg_* role
+      // that is a member of `pg_read_all_stats` or otherwise a genuine predefined
+      // role has to appear in exactly one of the two documented lists, so a new
+      // PostgreSQL version's new predefined role forces a decision here instead of
+      // defaulting to safe-by-omission. Read the catalog, subtract the two lists,
+      // and require an empty remainder.
+      const rows: Array<{ rolname: string }> = await dataSource.query(
+        // Predefined roles are exactly the pinned system roles: catalog oid below
+        // the first user oid (16384) and a pg_ name.
+        `SELECT rolname FROM pg_roles
+          WHERE rolname LIKE 'pg\\_%' AND oid < 16384
+          ORDER BY rolname`,
+      );
+      const live = rows.map((r) => r.rolname);
+      expect(live.length).toBeGreaterThan(0);
+
+      const classified = new Set<string>([
+        ...FORBIDDEN_ROLE_MEMBERSHIPS.map((m) => m.role),
+        ...KNOWN_SAFE_PREDEFINED_ROLES,
+      ]);
+      const unclassified = live.filter((r) => !classified.has(r));
+      // A failure here means PostgreSQL shipped a predefined role neither list
+      // knows about -- classify it in runtime-role-check.ts before shipping.
+      expect(unclassified).toEqual([]);
+    });
+  });
+});

--- a/backend/test/integration/schema-entity-parity.integration.spec.ts
+++ b/backend/test/integration/schema-entity-parity.integration.spec.ts
@@ -1,0 +1,192 @@
+import { DataSource } from "typeorm";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import { INTEGRATION_TYPEORM_OPTIONS } from "../helpers/integration-setup";
+
+/**
+ * The integration harness builds its schema from entity metadata
+ * (`synchronize: true`); production applies `database/schema.sql`. Where an
+ * entity omits an `onDelete` that schema.sql declares, the two databases behave
+ * differently -- and the difference is invisible until a test asserts a cascade
+ * that only production performs, or fails to reproduce one that only production
+ * performs.
+ *
+ * That is not hypothetical. `user_currency_preferences.currency_code` is
+ * `ON DELETE CASCADE` in schema.sql and was `NO ACTION` here, which is the FK
+ * that made P2-009 a silent cross-tenant deletion: in the harness the same
+ * DELETE could only ever have raised a foreign-key error, so the data loss was
+ * not reproducible in an integration test at all.
+ *
+ * 55 further foreign keys drift the same way today. Correcting them all is an
+ * entity-wide change with its own review, so they are baselined here and the
+ * list may only SHRINK: a new drift fails this test, and a fixed one fails it
+ * too, with a message saying to delete the line. That is the same shrink-only
+ * shape `array-bound-dto.spec.ts` and `messages.punctuation.test.ts` use.
+ *
+ * Production is unaffected either way -- it never runs `synchronize`. What is
+ * affected is whether an integration suite is evidence about production.
+ */
+describe("entity/schema FK delete-rule drift (integration)", () => {
+  jest.setTimeout(60000);
+
+  /**
+   * Foreign keys whose delete rule differs between schema.sql and the
+   * entity-derived schema. Shrink-only: never add to this list.
+   */
+  const KNOWN_DRIFT: string[] = [
+    "account_delegates.delegate_user_id",
+    "account_delegates.owner_user_id",
+    "accounts.linked_account_id",
+    "accounts.source_account_id",
+    "accounts.user_id",
+    "action_history.user_id",
+    "ai_insights.user_id",
+    "ai_provider_configs.user_id",
+    "ai_usage_logs.user_id",
+    "budget_alerts.budget_category_id",
+    "budget_alerts.budget_id",
+    "budget_alerts.user_id",
+    "budget_categories.budget_id",
+    "budget_categories.category_id",
+    "budget_categories.transfer_account_id",
+    "budget_period_categories.budget_category_id",
+    "budget_period_categories.budget_period_id",
+    "budget_period_categories.category_id",
+    "budget_periods.budget_id",
+    "budgets.user_id",
+    "categories.parent_id",
+    "categories.user_id",
+    "custom_reports.user_id",
+    "holdings.account_id",
+    "import_column_mappings.user_id",
+    "institutions.user_id",
+    "investment_reports.user_id",
+    "investment_transactions.account_id",
+    "investment_transactions.funding_account_id",
+    "investment_transactions.transaction_id",
+    "investment_transactions.user_id",
+    "loan_rate_changes.account_id",
+    "loan_rate_changes.user_id",
+    "loan_scenarios.account_id",
+    "loan_scenarios.user_id",
+    "monte_carlo_scenarios.user_id",
+    "monthly_account_balances.account_id",
+    "monthly_account_balances.user_id",
+    "payee_aliases.user_id",
+    "payees.user_id",
+    "personal_access_tokens.user_id",
+    "refresh_tokens.user_id",
+    "scheduled_transaction_overrides.category_id",
+    "scheduled_transactions.account_id",
+    "scheduled_transactions.transfer_account_id",
+    "scheduled_transactions.user_id",
+    "securities.user_id",
+    "security_prices.security_id",
+    "tags.user_id",
+    "transaction_attachments.user_id",
+    "transaction_splits.transaction_id",
+    "transactions.account_id",
+    "transactions.user_id",
+    "trusted_devices.user_id",
+    "user_preferences.user_id",
+  ];
+
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    dataSource = new DataSource({
+      ...INTEGRATION_TYPEORM_OPTIONS,
+      synchronize: true,
+      dropSchema: true,
+    } as never);
+    await dataSource.initialize();
+  });
+
+  afterAll(async () => {
+    await dataSource?.destroy();
+  });
+
+  /** `table.column -> ON DELETE rule`, as schema.sql declares it. */
+  function declaredDeleteRules(): Map<string, string> {
+    const sql = readFileSync(
+      join(__dirname, "../../../database/schema.sql"),
+      "utf8",
+    );
+    const rules = new Map<string, string>();
+    let table: string | null = null;
+    for (const line of sql.split("\n")) {
+      const created = /^CREATE TABLE (?:IF NOT EXISTS )?(\w+)/.exec(line);
+      if (created) table = created[1];
+      const fk =
+        /^\s*(\w+)\s+[A-Za-z0-9_()[\], ]*REFERENCES\s+\w+\s*\(\s*\w+\s*\)([^,]*)/.exec(
+          line,
+        );
+      if (fk && table) {
+        const trailing = fk[2];
+        const rule = /ON DELETE CASCADE/i.test(trailing)
+          ? "CASCADE"
+          : /ON DELETE SET NULL/i.test(trailing)
+            ? "SET NULL"
+            : "NO ACTION";
+        rules.set(`${table}.${fk[1]}`, rule);
+      }
+    }
+    return rules;
+  }
+
+  it("has no foreign key drifting outside the known list", async () => {
+    const declared = declaredDeleteRules();
+    // Sanity: a parser that matched nothing would make this test vacuous.
+    expect(declared.size).toBeGreaterThan(80);
+
+    const live: Array<{
+      table_name: string;
+      column_name: string;
+      delete_rule: string;
+    }> = await dataSource.query(`
+      SELECT tc.table_name, kcu.column_name, rc.delete_rule
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+          ON kcu.constraint_name = tc.constraint_name
+        JOIN information_schema.referential_constraints rc
+          ON rc.constraint_name = tc.constraint_name
+       WHERE tc.constraint_type = 'FOREIGN KEY'
+         AND tc.table_schema = 'public'`);
+    expect(live.length).toBeGreaterThan(80);
+
+    const drifting = live
+      .filter((fk) => {
+        const want = declared.get(`${fk.table_name}.${fk.column_name}`);
+        return want !== undefined && want !== fk.delete_rule;
+      })
+      .map((fk) => `${fk.table_name}.${fk.column_name}`)
+      .sort();
+
+    const unexpected = drifting.filter((k) => !KNOWN_DRIFT.includes(k));
+    const fixed = KNOWN_DRIFT.filter((k) => !drifting.includes(k));
+
+    expect(unexpected).toEqual([]);
+    // A fixed one must leave the list, or the list stops meaning anything.
+    expect(fixed).toEqual([]);
+  });
+
+  it("agrees with schema.sql on the FK P2-009 turns on", async () => {
+    // Named explicitly rather than left to the list above: this is the one whose
+    // rule decides whether deleting a shared currency destroys another tenant's
+    // row or merely fails, so a regression here changes what the currency tests
+    // are able to observe.
+    const [fk] = await dataSource.query(`
+      SELECT rc.delete_rule
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+          ON kcu.constraint_name = tc.constraint_name
+        JOIN information_schema.referential_constraints rc
+          ON rc.constraint_name = tc.constraint_name
+       WHERE tc.constraint_type = 'FOREIGN KEY'
+         AND tc.table_name = 'user_currency_preferences'
+         AND kcu.column_name = 'currency_code'`);
+
+    expect(fk?.delete_rule).toBe("CASCADE");
+  });
+});


### PR DESCRIPTION
## Linked discussion / issue

Approved in: Agreed via email with the project owner.

## Summary

Boot-time verification that the database role serving `RLS_MODE=enforce` traffic actually is unprivileged — attributes, ownership, membership, and every context the connection can reach — with the claims proven against a live PostgreSQL (P2-006, DR-02, DR-V2/DR-R1, RR3–RR7).

Selecting a role name and supplying its password says nothing about `rolsuper`, `rolbypassrls`, or what the role owns — and PostgreSQL exempts all three from every policy. The check asks the connection what it is and refuses to serve enforced traffic on a wrong answer. The predicate set is shipped here in final form, because each intermediate form passed in a case it did not think of, and several of those failures were *measured*, not argued:

- attributes are a `pg_has_role(..., 'SET')` question (not inherited), ownership a `'USAGE'` question (inherited) — a SET-only predicate reported `GRANT owner TO app WITH INHERIT TRUE, SET FALSE` as safe while the connection saw every tenant's rows;
- routes compose: `app --SET--> bridge --INHERIT--> owner` gives SET=false and USAGE=false from `app`, yet `SET ROLE bridge` bypasses every policy — so the check enumerates reachable contexts and asks what each can reach;
- the forbidden-attribute list is derived from the same `APP_ROLE_ATTRIBUTES` the provisioner writes, with a parity guard — `NOREPLICATION` was provisioned and never checked, so a `REPLICATION` role booted clean;
- membership in a predefined role grants what `ALTER ROLE` cannot strip: a `NOSUPERUSER` member of `pg_execute_server_program` wrote a host file, a member of `pg_signal_backend` killed another role's backend — both measured. Every predefined role is classified forbidden or known-safe, and an unclassified one fails the boot rather than defaulting to safe;
- `array_agg(rolname)` returns `name[]`, which node-postgres renders as the literal string `"{}"` — and `"{}".length > 0` is `true`, which refused every enforce-mode boot on a violation that did not exist. Found by the live run, not the unit suite, whose mock returned the array the code wanted.

Two new integration suites run against real PostgreSQL: `runtime-role.integration.spec.ts` (grant surface, transitive reachability, inherited ownership, live capability proofs, complete predefined-role classification) and `schema-entity-parity.integration.spec.ts` (56 of 113 FKs disagreed between entity metadata and `schema.sql` on their delete rule, baselined shrink-only; the one that mattered, `user_currency_preferences.currency_code`, is fixed by declaring the CASCADE the schema has).

Built from current `main` with no dependency on the other PRs in this series (verified by building and testing in isolation, not assumed).

Verified locally: backend typecheck, lint, `runtime-role-check.spec.ts` + `app-role.spec.ts` (58 tests) on this branch alone. The live integration suites need PostgreSQL — expected to run in CI.

## Checklist

- [x] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). <!-- no string changes in this PR -->
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Generated with Claude Code. Reviewed and owned by the PR author.

---
_Generated by [Claude Code](https://claude.ai/code)_
