### PR TITLE
Fix hero image placement on mobile by splitting copy into two blocks

### DIFF
--- a/frontend/src/test/website-mobile-layout.test.ts
+++ b/frontend/src/test/website-mobile-layout.test.ts
@@ -21,6 +21,9 @@ import { join } from 'node:path';
  *    868px wide on a 390px screen. Every `position:fixed` overlay sizes to that
  *    containing block, so the lightbox centred its picture at x=434 -- two
  *    thirds of it past the right-hand edge of the phone.
+ *  - a two-column hero collapsing to one put its screenshot last, below four
+ *    stat tiles and roughly a screen and a half down. Reported as the site
+ *    having no picture on mobile, which is what a picture nobody reaches is.
  *
  * It lives here for the same reason `website-dom-safety.test.ts` does: the
  * frontend's Vitest is the nearest JavaScript test runner to `website/`.
@@ -110,6 +113,33 @@ function mediaRules(css: string, accepts: (maxWidth: number) => boolean): Rule[]
 /** The rules that apply at the phone breakpoint. */
 function phoneRules(css: string): Rule[] {
   return mediaRules(css, (maxWidth) => maxWidth === 640);
+}
+
+/**
+ * The rules outside every at-rule, i.e. the ones that apply at any width. A
+ * bare `rules()` over the whole sheet reaches inside `@media` bodies too --
+ * `[^{}]+` never matches the `@media` opener itself, so its children are
+ * indistinguishable from top-level rules once they are in the list.
+ */
+function topLevelRules(css: string): Rule[] {
+  const stripped = code(css);
+  const opener = /@[a-z-]+[^{;]*\{/gi;
+  const kept: string[] = [];
+  let from = 0;
+
+  for (let at = opener.exec(stripped); at; at = opener.exec(stripped)) {
+    kept.push(stripped.slice(from, at.index));
+    let end = at.index + at[0].length;
+    for (let depth = 1; end < stripped.length && depth > 0; end++) {
+      if (stripped[end] === '{') depth++;
+      else if (stripped[end] === '}') depth--;
+    }
+    from = end;
+    opener.lastIndex = end;
+  }
+  kept.push(stripped.slice(from));
+
+  return rules(kept.join('\n'));
 }
 
 function styles(): string {
@@ -380,6 +410,87 @@ describe('website layout holds on a phone', () => {
       );
 
     expect(leaky, leaky.join('\n')).toEqual([]);
+  });
+
+  /**
+   * The hero is two columns of copy and screenshot on a desktop and one column
+   * on a phone, and stacking it put the picture last -- under the badge, the
+   * headline, the lede, both buttons, the fine print and four stat tiles, about
+   * a screen and a half below the fold. A hero image nobody scrolls to is a
+   * hero image nobody sees, and the report it produced was that the marketing
+   * site has no picture on mobile rather than that it is in the wrong place.
+   *
+   * So the copy is two blocks with the art between them, and the fix is only
+   * held by the named areas: drop `grid-template-areas` from either breakpoint
+   * and the three children fall straight back into document order, which looks
+   * deliberate and is the original defect at the desktop end. Both orders are
+   * checked here -- the phone's, because that is the bug, and the desktop's,
+   * because the split is invisible there only while the art spans both rows.
+   */
+  it('puts the hero screenshot between the lede and the buttons on a phone', () => {
+    const html = markup(readFileSync(join(SITE, 'index.html'), 'utf8'));
+    const hero = html.match(/<div class="wrap hero-grid">([\s\S]*?)\n {2}<\/div>/);
+    expect(hero, 'the hero grid is gone from index.html -- update this guard with it').not.toBeNull();
+
+    const regions = ['hero-copy-top', 'hero-art', 'hero-copy-bottom'];
+    const inMarkup = regions.filter((region) => new RegExp(`class="${region}"`).test(hero![1]));
+    expect(
+      inMarkup,
+      `the hero must be ${regions.join(', ')} -- one block of copy cannot have the picture inserted into the ` +
+        'middle of it, and splitting the copy is what lets the phone layout place the picture after the lede',
+    ).toEqual(regions);
+
+    /** The area names of a `grid-template-areas` value, row by row. */
+    const areaRows = (declarations: string): string[][] =>
+      Array.from(declarations.match(/grid-template-areas\s*:([^;}]*)/)?.[1].matchAll(/"([^"]*)"/g) ?? []).map(
+        ([, row]) => row.trim().split(/\s+/),
+      );
+
+    /** The last `grid-template-areas` `.hero-grid` is given among `candidates`. */
+    const heroAreas = (candidates: Rule[], where: string): string[][] => {
+      const declared = candidates
+        .filter(({ selectors }) => selectors.split(',').some((s) => s.trim() === '.hero-grid'))
+        .map(({ declarations }) => areaRows(declarations))
+        .filter((rows) => rows.length > 0);
+
+      expect(
+        declared.length,
+        `.hero-grid declares no grid-template-areas ${where}. Without it the three hero blocks fall back to ` +
+          'document order, and the copy split silently does nothing.',
+      ).toBeGreaterThan(0);
+      return declared[declared.length - 1];
+    };
+
+    // The stacking breakpoint: one column, the picture in the middle row.
+    const phone = heroAreas(
+      mediaRules(styles(), (maxWidth) => maxWidth === 1020),
+      'at the 1020px stacking breakpoint',
+    );
+    expect(
+      phone.map((row) => row.join(' ')),
+      'stacked, the hero must read copyTop / art / copyBottom -- the picture belongs after the headline and lede ' +
+        'and before the call-to-action row, not below the stats where it started',
+    ).toEqual(['copyTop', 'art', 'copyBottom']);
+
+    // Wide: both copy rows in column one, the art spanning them in column two.
+    const wide = heroAreas(topLevelRules(styles()), 'outside a media query (the desktop layout)');
+    expect(
+      wide.map((row) => row.join(' ')),
+      'side by side, the copy stacks in the first column and the art spans both rows of the second -- anything ' +
+        'else leaves a gap beside one of the two copy blocks',
+    ).toEqual(['copyTop art', 'copyBottom art']);
+
+    // The split must cost nothing where the copy is one column: a row gap
+    // between the two blocks would open a space that was never there before.
+    const gapless = topLevelRules(styles()).some(
+      ({ selectors, declarations }) =>
+        selectors.split(',').some((s) => s.trim() === '.hero-grid') && /(^|[;\s])row-gap\s*:\s*0/.test(declarations),
+    );
+    expect(
+      gapless,
+      '.hero-grid must set row-gap:0 in its base rule. The two copy blocks are one continuous column of text on a ' +
+        'desktop, and a grid gap between them is spacing the single block never had.',
+    ).toBe(true);
   });
 
   it('sizes elements against their container, not the viewport', () => {

--- a/website/assets/css/styles.css
+++ b/website/assets/css/styles.css
@@ -71,7 +71,25 @@ main,header,footer{position:relative;z-index:1}
 
 /* hero */
 .hero{padding:56px 0 40px}
-.hero-grid{display:grid;grid-template-columns:1.02fr .98fr;gap:46px;align-items:center}
+/* The hero copy is split into two blocks either side of the screenshot so that
+   the one-column phone layout can put the picture between them -- straight
+   after the headline and lede, before the call-to-action row. As one block the
+   copy stacked whole and the screenshot landed under the stats, roughly a
+   screen and a half down, which reads on a phone as the hero having no picture
+   at all.
+
+   The document order is the phone order, and named areas move the picture into
+   the second column on desktop rather than the other way round: reordering with
+   grid changes only the visual sequence, so the order that stays true when the
+   areas do not apply is the one worth having in the markup. Two rows with a
+   zero row-gap reproduce the old single-column-of-copy spacing exactly on
+   desktop; the art spans both and stays centred against the pair. */
+.hero-grid{display:grid;grid-template-columns:1.02fr .98fr;
+  grid-template-areas:"copyTop art" "copyBottom art";
+  column-gap:46px;row-gap:0;align-items:center}
+.hero-copy-top{grid-area:copyTop}
+.hero-copy-bottom{grid-area:copyBottom}
+.hero-art{grid-area:art}
 .lede{font-size:1.12rem;color:var(--mut);max-width:56ch}
 .stats{list-style:none;display:grid;grid-template-columns:repeat(4,auto);gap:10px 26px;padding:0;margin:30px 0 0;justify-content:start}
 .stats li{min-width:84px}
@@ -258,7 +276,11 @@ footer a{color:var(--mut)}footer a:hover{color:var(--txt)}
 @keyframes fall{to{transform:translateY(105vh) rotate(720deg);opacity:.1}}
 
 @media (max-width:1020px){
-  .hero-grid{grid-template-columns:1fr;gap:34px}
+  .hero-grid{grid-template-columns:1fr;grid-template-areas:"copyTop" "art" "copyBottom";gap:26px}
+  /* The lede's own bottom margin stacks on top of the row gap and would leave
+     the picture noticeably further from the text above it than from the
+     buttons below. */
+  .hero-copy-top>:last-child{margin-bottom:0}
   #heroArt .frame{transform:none}
   .g4{grid-template-columns:repeat(2,1fr)}.g3{grid-template-columns:repeat(2,1fr)}
   .rep-grid{grid-template-columns:repeat(2,1fr)}

--- a/website/index.html
+++ b/website/index.html
@@ -42,10 +42,21 @@
 <main>
 <section class="hero" id="top">
   <div class="wrap hero-grid">
-    <div>
+    <div class="hero-copy-top">
       <span class="badge">◆ Self-hosted · <b>AGPL-3.0</b> · Docker &amp; Kubernetes ready</span>
       <h1>Every dollar accounted for — <span class="grad">on your own server.</span></h1>
       <p class="lede">Monize is a modern personal finance manager built to finally replace Microsoft&nbsp;Money and Quicken. Accounts, transactions, budgets, investments, bills, 46 reports and an AI assistant — all running on hardware <em>you</em> control.</p>
+    </div>
+    <div class="hero-art" id="heroArt">
+      <div class="frame">
+        <div class="frame-bar"><i></i><i></i><i></i><span class="url">demo.monize.net/dashboard</span></div>
+        <div class="frame-body"><img data-shot="dashboard-overview" alt="The Monize dashboard showing net worth, favourite accounts, upcoming bills and top movers"></div>
+      </div>
+      <div class="float f1"><span class="k">Net worth</span><span class="v">$1,144,810 <small class="up">▲5.66%</small></span></div>
+      <div class="float f2"><span class="k">Safe to spend today</span><span class="v up">$235.52</span></div>
+      <div class="float f3"><span class="k">Due tomorrow</span><span class="v down">−$196.99</span></div>
+    </div>
+    <div class="hero-copy-bottom">
       <div class="row">
         <a class="btn primary big" href="https://demo.monize.net" target="_blank" rel="noopener">▶ Play with the live demo</a>
         <a class="btn ghost big" href="https://github.com/kenlasko/monize" target="_blank" rel="noopener">★ Get it on GitHub</a>
@@ -57,15 +68,6 @@
         <li><b data-to="22" data-suffix="">0</b><span>languages &amp; locales</span></li>
         <li><b data-to="30" data-suffix=" yrs">0</b><span>of data migrated</span></li>
       </ul>
-    </div>
-    <div class="hero-art" id="heroArt">
-      <div class="frame">
-        <div class="frame-bar"><i></i><i></i><i></i><span class="url">demo.monize.net/dashboard</span></div>
-        <div class="frame-body"><img data-shot="dashboard-overview" alt="The Monize dashboard showing net worth, favourite accounts, upcoming bills and top movers"></div>
-      </div>
-      <div class="float f1"><span class="k">Net worth</span><span class="v">$1,144,810 <small class="up">▲5.66%</small></span></div>
-      <div class="float f2"><span class="k">Safe to spend today</span><span class="v up">$235.52</span></div>
-      <div class="float f3"><span class="k">Due tomorrow</span><span class="v down">−$196.99</span></div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: <!-- discussion/issue link -->

## Summary

The hero section's screenshot was rendering below the stats tiles on mobile (roughly a screen and a half down the page), making it effectively invisible and causing reports that the marketing site has no picture on mobile.

This fix restructures the hero grid to split the copy into two blocks (`hero-copy-top` and `hero-copy-bottom`) with the screenshot (`hero-art`) between them. On desktop, CSS Grid's `grid-template-areas` places the copy in one column and the art spanning both rows in the second column. On mobile (≤1020px), the areas reorder to stack as `copyTop / art / copyBottom`, placing the screenshot immediately after the headline and lede, before the call-to-action buttons.

The document order in the markup is the phone order (copy-top, art, copy-bottom), so the layout degrades gracefully if `grid-template-areas` is removed. A `row-gap: 0` on the base rule ensures the two copy blocks read as a single continuous column on desktop, matching the original spacing.

## Changes

- **website/index.html**: Split hero copy into two divs with `hero-copy-top` and `hero-copy-bottom` classes; moved `hero-art` between them in document order.
- **website/assets/css/styles.css**: 
  - Added `grid-template-areas` to `.hero-grid` for desktop layout (copy stacked in column 1, art spanning both rows in column 2).
  - Added `grid-area` assignments to `.hero-copy-top`, `.hero-copy-bottom`, and `.hero-art`.
  - Changed `gap` to `column-gap` and added `row-gap: 0` to preserve single-column spacing on desktop.
  - At the 1020px breakpoint, reordered areas to `"copyTop" "art" "copyBottom"` and suppressed the lede's bottom margin to avoid double spacing.
- **frontend/src/test/website-mobile-layout.test.ts**:
  - Added `topLevelRules()` helper to extract CSS rules outside `@media` queries.
  - Added comprehensive test `'puts the hero screenshot between the lede and the buttons on a phone'` that verifies the copy is split into three regions, the desktop layout uses the correct grid areas, the phone layout reorders them correctly, and `row-gap: 0` is set to avoid spacing issues.
  - Updated file header comment to document the hero layout defect.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [ ] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). — No user-facing strings added.
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [ ] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

<!-- Disclose any AI tools used. Using AI is fine and expected — you remain responsible for correctness, conventions, and tests. -->

https://claude.ai/code/session_01HYb5QNdAoaiGL6i1AeWASh