### PR TITLE
Standardize startup logging through NestJS Logger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Every user-facing string must be internationalized -- no hardcoded literals in t
 ### Code Style
 - No emojis in code, comments, or documentation
 - Immutability always -- never mutate objects or arrays
-- No `console.log` in production code; use NestJS `Logger` class
+- No `console.log` in production code; use NestJS `Logger` class -- including the scripts that run before the app boots and the `docker-entrypoint.sh` steps, so the whole startup log has one shape (backend `no-console` lint rule + `backend/src/startup-logging.spec.ts`)
 - Use proxy, not middleware (middleware is deprecated in this project)
 
 ### Follow the existing pattern, and pin it down when you miss it

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -234,9 +234,26 @@ Changing what a service computes and seeing every test pass means the change is 
 
 Server-rendered strings (exception messages, email copy) are localized via `nestjs-i18n`. Wrap exception messages in `tr(key, fallback, args)` (`src/i18n/translate.ts`), which resolves against the request locale and returns the English `fallback` outside an HTTP context (jobs, schedulers, tests). Render emails with an `EmailT` translator (`emailTranslator(i18n, recipientLang)` from `src/i18n/email-translator.ts`) so copy matches the recipient's stored locale rather than the request's. Catalogs live in `src/i18n/locales/{locale}/*.json`, one folder per supported locale; the authoritative locale list is `SUPPORTED_LOCALE_CODES` in `src/i18n/config.ts` (root `CLAUDE.md` enumerates them) -- keep it in sync with the frontend's. The `en-*` entries are lean regional variants (declared in `LOCALE_BASES`): they hold only the keys that differ from `en` and fall back to it per key. Adding or changing a string means updating every locale -- the parity test `src/i18n/locales.parity.spec.ts` fails otherwise -- then regenerating the pseudo-locale with `npm run i18n:pseudo`. Full contributor flow: `src/i18n/README.md`.
 
+## Every line in the log has the same shape
+
+`[Nest] pid - date LEVEL [Context] message`, produced by the NestJS `Logger`.
+That includes the lines written before the app exists: `Logger` works outside an
+application context, so `db-init`, `db-migrate`, `db-demo-check` and the seeders
+each construct `new Logger("<Context>")` rather than calling `console`. Backend
+`src/` bans `console` outright (`no-console`, `eslint.config.mjs`); the only
+exception is `oauth/oidc-provider-log-bridge.ts`, which has to hold the real
+console methods in order to forward everything that is not a provider notice.
+
+`docker-entrypoint.sh` prints nothing itself. A shell `echo` is the one line in
+the container log with no timestamp, level or context, and an inline `node -e`
+blob cannot reach the `Logger` without restating its format -- so each step logs
+for itself and the entrypoint just runs the steps.
+`src/startup-logging.spec.ts` scans for both mistakes and for a `console` call in
+any pre-boot script.
+
 ## OAuth / OIDC provider
 
-`node-oidc-provider` prints its own `oidc-provider NOTICE:`/`WARNING:` lines with bare `console.info`/`console.warn`, so they land in the backend logs unformatted, outside the Nest `Logger`. Every such notice means a config option was left at its default -- fix the config rather than the log line. In particular, `ttl` needs an explicit number for every artifact the provider can issue (`AccessToken`, `AuthorizationCode`, `IdToken`, `RefreshToken`, `Grant`, `Interaction`, `Session`); the guard test in `src/oauth/oauth-provider.service.spec.ts` fails when one is missing.
+`node-oidc-provider` prints its own `oidc-provider NOTICE:`/`WARNING:` lines with bare `console.info`/`console.warn`, outside the Nest `Logger`. The library exposes no logger hook, so `oauth/oidc-provider-log-bridge.ts` -- installed at the top of `main.ts`, before anything can instantiate the provider -- re-routes exactly those lines to a `[OidcProvider]` logger and passes any other console output through untouched. That fixes the formatting only: every such notice still means a config option was left at its default, so fix the config rather than treating the bridge as the answer. In particular, `ttl` needs an explicit number for every artifact the provider can issue (`AccessToken`, `AuthorizationCode`, `IdToken`, `RefreshToken`, `Grant`, `Interaction`, `Session`); the guard test in `src/oauth/oauth-provider.service.spec.ts` fails when one is missing.
 
 ## Automatic backups are an operator setting, not a user preference
 

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,35 +1,18 @@
 #!/bin/sh
 set -e
 
-echo "Checking database initialization..."
+# Every step logs for itself, through the Nest Logger, so the whole startup
+# sequence reads in one format. Do not add `echo` here: a shell echo is the one
+# line in the container log without a timestamp, level, or context (guarded by
+# src/startup-logging.spec.ts).
+
 node dist/db-init.js
 
-echo "Running database migrations..."
 node dist/db-migrate.js
 
 # In demo mode, seed the demo user and data if not already present
 if [ "$DEMO_MODE" = "true" ]; then
-  echo "Demo mode detected — checking if demo user exists..."
-  node -e "
-    const { Client } = require('pg');
-    (async () => {
-      const c = new Client({
-        host: process.env.DATABASE_HOST,
-        port: process.env.DATABASE_PORT || 5432,
-        user: process.env.DATABASE_USER,
-        password: process.env.DATABASE_PASSWORD,
-        database: process.env.DATABASE_NAME,
-      });
-      await c.connect();
-      const r = await c.query(\"SELECT id FROM users WHERE email = 'demo@monize.com'\");
-      await c.end();
-      process.exit(r.rows.length > 0 ? 0 : 1);
-    })().catch(() => process.exit(1));
-  " && echo "Demo user already exists, skipping seed." || {
-    echo "Seeding demo data..."
-    node dist/database/seed.js
-  }
+  node dist/db-demo-check.js || node dist/database/seed.js
 fi
 
-echo "Starting application..."
 exec node dist/main.js

--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -125,6 +125,13 @@ export default tseslint.config(
       "src/common/db/scoped-db.ts",
     ],
     rules: {
+      // Every line the server writes goes through the NestJS Logger, so the
+      // whole log carries the same `[Nest] pid - date LEVEL [Context] message`
+      // shape. `Logger` works outside an application context, so the pre-boot
+      // scripts (db-init, db-migrate, seed) use it too. The one sanctioned
+      // exception is the oidc-provider log bridge, which has to hold the real
+      // console methods to forward everything that is not a provider notice.
+      "no-console": "error",
       "no-restricted-imports": [
         "error",
         { paths: [BAN_INJECT_REPOSITORY], patterns: [BAN_WITH_CONTEXT] },

--- a/backend/src/common/db/app-role.spec.ts
+++ b/backend/src/common/db/app-role.spec.ts
@@ -1,3 +1,4 @@
+import { Logger } from "@nestjs/common";
 import {
   APP_ROLE_GRANTS_SQL,
   APP_ROLE_NAME_GUC,
@@ -80,10 +81,14 @@ describe("provisionAppRole", () => {
     expect(logger.log).not.toHaveBeenCalled();
   });
 
-  it("defaults the logger to console when none is provided", async () => {
+  it("defaults to the Nest Logger when none is provided, so the line is formatted like the rest of startup", async () => {
     const { client } = makeClient();
-    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const logSpy = jest
+      .spyOn(Logger.prototype, "log")
+      .mockImplementation(() => {});
+    const warnSpy = jest
+      .spyOn(Logger.prototype, "warn")
+      .mockImplementation(() => {});
     try {
       await provisionAppRole(client, {
         appUser: "monize_app",

--- a/backend/src/common/db/app-role.ts
+++ b/backend/src/common/db/app-role.ts
@@ -1,3 +1,4 @@
+import { Logger } from "@nestjs/common";
 import { DEFAULT_APP_USER } from "./rls-config";
 
 /**
@@ -22,7 +23,7 @@ export interface SqlClient {
   ): Promise<{ rows?: unknown[] } | unknown>;
 }
 
-/** Minimal logger surface (matches both `console` and NestJS `Logger`). */
+/** Minimal logger surface (matches NestJS `Logger` and any test double). */
 export interface RoleProvisionLogger {
   log(message: string): void;
   warn(message: string): void;
@@ -108,7 +109,11 @@ export interface ProvisionAppRoleOptions {
  */
 export async function provisionAppRole(
   client: SqlClient,
-  { appUser, appPassword, logger = console }: ProvisionAppRoleOptions,
+  {
+    appUser,
+    appPassword,
+    logger = new Logger("AppRole"),
+  }: ProvisionAppRoleOptions,
 ): Promise<void> {
   const roleName = appUser || DEFAULT_APP_USER;
 

--- a/backend/src/database/add-skip-price-updates-column.ts
+++ b/backend/src/database/add-skip-price-updates-column.ts
@@ -7,18 +7,21 @@
  * Run with: npx ts-node -r tsconfig-paths/register src/database/add-skip-price-updates-column.ts
  */
 
+import { Logger } from "@nestjs/common";
 import { DataSource } from "typeorm";
 import * as dotenv from "dotenv";
 import * as path from "path";
 
 dotenv.config({ path: path.join(__dirname, "../../../.env") });
 
+const logger = new Logger("AddSkipPriceUpdatesColumn");
+
 function requiredEnv(...names: string[]): string {
   for (const name of names) {
     const value = process.env[name];
     if (value) return value;
   }
-  console.error(`Missing required environment variable: ${names.join(" or ")}`);
+  logger.error(`Missing required environment variable: ${names.join(" or ")}`);
   process.exit(1);
 }
 
@@ -33,7 +36,7 @@ async function addSkipPriceUpdatesColumn() {
   });
 
   await dataSource.initialize();
-  console.log("Database connected");
+  logger.log("Database connected");
 
   try {
     // Check if column already exists
@@ -44,7 +47,7 @@ async function addSkipPriceUpdatesColumn() {
     `);
 
     if (columnExists.length > 0) {
-      console.log("Column skip_price_updates already exists");
+      logger.log("Column skip_price_updates already exists");
       return;
     }
 
@@ -54,10 +57,15 @@ async function addSkipPriceUpdatesColumn() {
       ADD COLUMN skip_price_updates BOOLEAN NOT NULL DEFAULT false
     `);
 
-    console.log("Added skip_price_updates column to securities table");
+    logger.log("Added skip_price_updates column to securities table");
   } finally {
     await dataSource.destroy();
   }
 }
 
-addSkipPriceUpdatesColumn().catch(console.error);
+addSkipPriceUpdatesColumn().catch((error) =>
+  logger.error(
+    "Failed to add skip_price_updates column",
+    error instanceof Error ? error.stack : String(error),
+  ),
+);

--- a/backend/src/database/fix-linked-transactions.ts
+++ b/backend/src/database/fix-linked-transactions.ts
@@ -9,18 +9,21 @@
  * Run with: npx ts-node -r tsconfig-paths/register src/database/fix-linked-transactions.ts
  */
 
+import { Logger } from "@nestjs/common";
 import { DataSource } from "typeorm";
 import * as dotenv from "dotenv";
 import * as path from "path";
 
 dotenv.config({ path: path.join(__dirname, "../../../.env") });
 
+const logger = new Logger("FixLinkedTransactions");
+
 function requiredEnv(...names: string[]): string {
   for (const name of names) {
     const value = process.env[name];
     if (value) return value;
   }
-  console.error(`Missing required environment variable: ${names.join(" or ")}`);
+  logger.error(`Missing required environment variable: ${names.join(" or ")}`);
   process.exit(1);
 }
 
@@ -35,7 +38,7 @@ async function fixLinkedTransactions() {
   });
 
   await dataSource.initialize();
-  console.log("Database connected");
+  logger.log("Database connected");
 
   try {
     // Find all splits that have a linkedTransactionId (these are transfer splits)
@@ -49,7 +52,7 @@ async function fixLinkedTransactions() {
         AND t.is_transfer = true
     `);
 
-    console.log("Fixed linked transactions:", result);
+    logger.log(`Fixed linked transactions: ${JSON.stringify(result)}`);
 
     // Verify the fix
     const verification = await dataSource.query(`
@@ -60,10 +63,15 @@ async function fixLinkedTransactions() {
         AND t.is_transfer = true
     `);
 
-    console.log("Remaining unfixed transactions:", verification[0].count);
+    logger.log(`Remaining unfixed transactions: ${verification[0].count}`);
   } finally {
     await dataSource.destroy();
   }
 }
 
-fixLinkedTransactions().catch(console.error);
+fixLinkedTransactions().catch((error) =>
+  logger.error(
+    "Failed to fix linked transactions",
+    error instanceof Error ? error.stack : String(error),
+  ),
+);

--- a/backend/src/database/seed.ts
+++ b/backend/src/database/seed.ts
@@ -1,7 +1,10 @@
+import { Logger } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { AppModule } from "../app.module";
 import { SeedService } from "./seed.service";
 import { DemoSeedService } from "./demo-seed.service";
+
+const logger = new Logger("Seed");
 
 async function bootstrap() {
   const app = await NestFactory.createApplicationContext(AppModule);
@@ -15,11 +18,14 @@ async function bootstrap() {
       const seedService = app.get(SeedService);
       await seedService.seedAll();
     }
-    console.log("\n🎉 Seeding completed!");
+    logger.log("Seeding completed");
     await app.close();
     process.exit(0);
   } catch (error) {
-    console.error("\n❌ Seeding failed:", error);
+    logger.error(
+      "Seeding failed",
+      error instanceof Error ? error.stack : String(error),
+    );
     await app.close();
     process.exit(1);
   }

--- a/backend/src/db-demo-check.spec.ts
+++ b/backend/src/db-demo-check.spec.ts
@@ -1,0 +1,82 @@
+import { Logger } from "@nestjs/common";
+
+const mockQuery = jest.fn();
+const mockConnect = jest.fn();
+const mockEnd = jest.fn();
+
+jest.mock("pg", () => ({
+  Client: jest.fn().mockImplementation(() => ({
+    connect: mockConnect,
+    query: mockQuery,
+    end: mockEnd,
+  })),
+}));
+
+const mockExit = jest
+  .spyOn(process, "exit")
+  .mockImplementation((() => {}) as never);
+
+import { checkDemoUser } from "./db-demo-check";
+
+describe("db-demo-check", () => {
+  let logSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+    mockEnd.mockResolvedValue(undefined);
+    logSpy = jest.spyOn(Logger.prototype, "log").mockImplementation();
+    warnSpy = jest.spyOn(Logger.prototype, "warn").mockImplementation();
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("exits 0 when the demo user exists, so the entrypoint skips seeding", async () => {
+    mockQuery.mockResolvedValue({ rows: [{ id: "demo-id" }] });
+
+    await checkDemoUser();
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      "SELECT id FROM users WHERE email = $1",
+      ["demo@monize.com"],
+    );
+    expect(mockExit).toHaveBeenCalledWith(0);
+    expect(logSpy).toHaveBeenCalledWith(
+      "Demo user already exists; skipping seed",
+    );
+    expect(mockEnd).toHaveBeenCalled();
+  });
+
+  it("exits 1 when the demo user is absent, so the entrypoint seeds", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await checkDemoUser();
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(logSpy).toHaveBeenCalledWith(
+      "Demo user not found; seeding demo data",
+    );
+  });
+
+  it("exits 1 and warns when the check itself fails -- seeding is idempotent, an empty demo is not", async () => {
+    mockConnect.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    await checkDemoUser();
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/ECONNREFUSED/);
+  });
+
+  it("closes the connection even when the query fails", async () => {
+    mockQuery.mockRejectedValue(new Error("relation does not exist"));
+
+    await checkDemoUser();
+
+    expect(mockEnd).toHaveBeenCalled();
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/backend/src/db-demo-check.ts
+++ b/backend/src/db-demo-check.ts
@@ -1,0 +1,68 @@
+import { Logger } from "@nestjs/common";
+import { Client } from "pg";
+
+/**
+ * Demo-mode startup probe: exits 0 when the demo user already exists (the
+ * entrypoint then skips seeding) and 1 when it does not, or when the check
+ * itself could not run -- seeding is idempotent, so a failed probe re-seeds
+ * rather than leaving a demo deployment empty.
+ *
+ * This used to be a `node -e` blob inside docker-entrypoint.sh with `echo`
+ * around it, which put four unformatted lines at the top of every demo
+ * startup. As a compiled script it logs through the Nest `Logger` like the
+ * rest of the boot sequence.
+ */
+const logger = new Logger("DbDemoCheck");
+
+const DEMO_USER_EMAIL = "demo@monize.com";
+
+export async function demoUserExists(): Promise<boolean> {
+  const client = new Client({
+    host: process.env.DATABASE_HOST,
+    port: parseInt(process.env.DATABASE_PORT || "5432", 10),
+    user: process.env.DATABASE_USER,
+    password: process.env.DATABASE_PASSWORD,
+    database: process.env.DATABASE_NAME,
+  });
+
+  await client.connect();
+  try {
+    const result = await client.query("SELECT id FROM users WHERE email = $1", [
+      DEMO_USER_EMAIL,
+    ]);
+    return result.rows.length > 0;
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Probe entry point. Exported so the spec can drive all three outcomes
+ * (present, absent, unreachable) without spawning the script.
+ */
+export async function checkDemoUser(): Promise<void> {
+  logger.log("Demo mode detected; checking whether the demo user exists");
+  let exists: boolean;
+  try {
+    exists = await demoUserExists();
+  } catch (error) {
+    logger.warn(
+      `Could not check for the demo user (${
+        error instanceof Error ? error.message : String(error)
+      }); seeding will be attempted`,
+    );
+    process.exit(1);
+  }
+
+  if (exists) {
+    logger.log("Demo user already exists; skipping seed");
+    process.exit(0);
+  }
+
+  logger.log("Demo user not found; seeding demo data");
+  process.exit(1);
+}
+
+if (require.main === module) {
+  checkDemoUser();
+}

--- a/backend/src/db-init.ts
+++ b/backend/src/db-init.ts
@@ -1,3 +1,4 @@
+import { Logger } from "@nestjs/common";
 import { Client } from "pg";
 import * as fs from "fs";
 import * as path from "path";
@@ -5,10 +6,18 @@ import { provisionAppRole } from "./common/db/app-role";
 
 const SCHEMA_FILENAME = "schema.sql";
 
+/**
+ * db-init runs as its own process before the Nest app, but its output ends up
+ * in the same container log, so it uses the Nest `Logger` (which works outside
+ * an application context) rather than `console` -- otherwise the first lines of
+ * every startup are the only unformatted ones in the file.
+ */
+const logger = new Logger("DbInit");
+
 function requiredEnv(name: string, fallback?: string): string {
   const value = process.env[name] || fallback;
   if (!value) {
-    console.error(`Missing required environment variable: ${name}`);
+    logger.error(`Missing required environment variable: ${name}`);
     process.exit(1);
   }
   return value;
@@ -30,6 +39,8 @@ function safePath(base: string, relative: string): string | null {
 }
 
 async function initDatabase() {
+  logger.log("Checking database initialization");
+
   const client = new Client({
     host: process.env.DATABASE_HOST || "localhost",
     port: parseInt(process.env.DATABASE_PORT || "5432", 10),
@@ -42,13 +53,13 @@ async function initDatabase() {
   // warning raised when the owner cannot create the runtime role on CNPG).
   client.on("notice", (msg) => {
     if (msg?.message) {
-      console.warn(`Postgres: ${msg.message}`);
+      logger.warn(`Postgres: ${msg.message}`);
     }
   });
 
   try {
     await client.connect();
-    console.log("Connected to database");
+    logger.log("Connected to database");
 
     // RLS role + grants (Phase 1). Runs on EVERY startup, BEFORE the
     // "tables already exist" early return below -- placed after it, the block
@@ -59,6 +70,7 @@ async function initDatabase() {
     await provisionAppRole(client, {
       appUser: process.env.DATABASE_APP_USER,
       appPassword: process.env.DATABASE_APP_PASSWORD,
+      logger,
     });
 
     // Check if tables already exist
@@ -71,11 +83,11 @@ async function initDatabase() {
     `);
 
     if (result.rows[0].exists) {
-      console.log("Database tables already exist. Skipping initialization.");
+      logger.log("Database tables already exist; skipping initialization");
       return;
     }
 
-    console.log("Tables not found. Initializing database...");
+    logger.log("Tables not found; initializing database");
 
     // Try multiple possible locations for schema.sql
     // All base directories are trusted (derived from __dirname or cwd)
@@ -96,18 +108,25 @@ async function initDatabase() {
     }
 
     if (!schemaPath) {
-      console.error("schema.sql not found. Searched directories:");
-      baseDirs.forEach((d) => console.error(`  - ${d}`));
+      logger.error(
+        [
+          "schema.sql not found. Searched directories:",
+          ...baseDirs.map((d) => `  - ${d}`),
+        ].join("\n"),
+      );
       process.exit(1);
     }
 
-    console.log(`Using schema from: ${schemaPath}`);
+    logger.log(`Using schema from: ${schemaPath}`);
     const schema = fs.readFileSync(schemaPath, "utf8");
 
     await client.query(schema);
-    console.log("Database initialized successfully!");
+    logger.log("Database initialized successfully");
   } catch (error) {
-    console.error("Database initialization failed:", error);
+    logger.error(
+      "Database initialization failed",
+      error instanceof Error ? error.stack : String(error),
+    );
     process.exit(1);
   } finally {
     await client.end();

--- a/backend/src/db-migrate.spec.ts
+++ b/backend/src/db-migrate.spec.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import { Logger } from "@nestjs/common";
 
 // Mock pg Client
 const mockQuery = jest.fn();
@@ -36,16 +37,18 @@ describe("db-migrate runMigrations()", () => {
   let statSyncSpy: jest.SpyInstance;
   let readdirSyncSpy: jest.SpyInstance;
   let readFileSyncSpy: jest.SpyInstance;
-  let consoleSpy: jest.SpyInstance;
-  let consoleErrorSpy: jest.SpyInstance;
+  let logSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockConnect.mockResolvedValue(undefined);
     mockEnd.mockResolvedValue(undefined);
 
-    consoleSpy = jest.spyOn(console, "log").mockImplementation();
-    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+    // The runner logs through the Nest Logger so its output matches the rest
+    // of the boot sequence; spying on console here would catch nothing.
+    logSpy = jest.spyOn(Logger.prototype, "log").mockImplementation();
+    errorSpy = jest.spyOn(Logger.prototype, "error").mockImplementation();
 
     // Default: no migrations directory found
     existsSyncSpy = jest.spyOn(fs, "existsSync").mockReturnValue(false);
@@ -61,8 +64,8 @@ describe("db-migrate runMigrations()", () => {
     statSyncSpy.mockRestore();
     readdirSyncSpy.mockRestore();
     readFileSyncSpy.mockRestore();
-    consoleSpy.mockRestore();
-    consoleErrorSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it("skips when no migrations directory is found", async () => {
@@ -70,8 +73,8 @@ describe("db-migrate runMigrations()", () => {
 
     await runMigrations();
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      "No migrations directory found. Skipping migrations.",
+    expect(logSpy).toHaveBeenCalledWith(
+      "No migrations directory found; skipping migrations",
     );
     expect(mockQuery).not.toHaveBeenCalledWith(
       expect.stringContaining("CREATE TABLE IF NOT EXISTS"),
@@ -106,8 +109,8 @@ describe("db-migrate runMigrations()", () => {
 
     await runMigrations();
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      "Database is up to date. No pending migrations.",
+    expect(logSpy).toHaveBeenCalledWith(
+      "Database is up to date; no pending migrations",
     );
     // Should NOT have called BEGIN (no migrations to apply)
     expect(mockQuery).not.toHaveBeenCalledWith("BEGIN");
@@ -149,9 +152,7 @@ describe("db-migrate runMigrations()", () => {
       ["002_add_users.sql"],
     );
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      "Applied 2 migration(s) successfully.",
-    );
+    expect(logSpy).toHaveBeenCalledWith("Applied 2 migration(s) successfully");
   });
 
   it("applies only pending migrations (skips already-applied)", async () => {
@@ -182,9 +183,7 @@ describe("db-migrate runMigrations()", () => {
       ["001_init.sql"],
     );
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      "Applied 1 migration(s) successfully.",
-    );
+    expect(logSpy).toHaveBeenCalledWith("Applied 1 migration(s) successfully");
   });
 
   it("rolls back and exits on migration failure, naming the file and the SQL error", async () => {
@@ -207,7 +206,7 @@ describe("db-migrate runMigrations()", () => {
     await runMigrations();
 
     expect(mockQuery).toHaveBeenCalledWith("ROLLBACK");
-    const report = consoleErrorSpy.mock.calls.map((c) => c[0]).join("\n");
+    const report = errorSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(report).toContain("Migration failed: 001_bad.sql");
     expect(report).toContain('syntax error at or near "INVALID"');
     expect(report).toContain("42601 (syntax_error)");
@@ -233,7 +232,7 @@ describe("db-migrate runMigrations()", () => {
 
     await runMigrations();
 
-    const report = consoleErrorSpy.mock.calls.map((c) => c[0]).join("\n");
+    const report = errorSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(report).toContain("Migration failed: 002_bad.sql");
     expect(report).toContain(
       "1 migration(s) applied successfully before this one",
@@ -245,7 +244,7 @@ describe("db-migrate runMigrations()", () => {
 
     await runMigrations();
 
-    const report = consoleErrorSpy.mock.calls.map((c) => c[0]).join("\n");
+    const report = errorSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(report).toContain(
       "Migration runner failed before or between migrations.",
     );
@@ -275,9 +274,7 @@ describe("db-migrate runMigrations()", () => {
       "INSERT INTO schema_migrations (filename) VALUES ($1)",
       ["001_init.sql"],
     );
-    expect(consoleSpy).toHaveBeenCalledWith(
-      "Applied 1 migration(s) successfully.",
-    );
+    expect(logSpy).toHaveBeenCalledWith("Applied 1 migration(s) successfully");
   });
 
   it("always closes the client connection", async () => {

--- a/backend/src/db-migrate.ts
+++ b/backend/src/db-migrate.ts
@@ -1,8 +1,16 @@
+import { Logger } from "@nestjs/common";
 import { Client } from "pg";
 import * as fs from "fs";
 import * as path from "path";
 
 const MIGRATIONS_DIRNAME = "migrations";
+
+/**
+ * The migration runner is its own process, but its output shares the container
+ * log with the Nest app, so it logs through the Nest `Logger` (usable outside
+ * an application context) instead of `console`.
+ */
+const logger = new Logger("DbMigrate");
 
 /** Where a human goes when a migration fails at startup. */
 const RUNBOOK = "docs/database-migrations.md";
@@ -254,6 +262,8 @@ function safePath(base: string, relative: string): string | null {
 }
 
 export async function runMigrations() {
+  logger.log("Running database migrations");
+
   const client = new Client({
     host: process.env.DATABASE_HOST || "localhost",
     port: parseInt(process.env.DATABASE_PORT || "5432", 10),
@@ -288,7 +298,7 @@ export async function runMigrations() {
     }
 
     if (!migrationsDir) {
-      console.log("No migrations directory found. Skipping migrations.");
+      logger.log("No migrations directory found; skipping migrations");
       return;
     }
 
@@ -321,12 +331,12 @@ export async function runMigrations() {
 
       const filePath = safePath(migrationsDir, file);
       if (!filePath) {
-        console.error(`Skipping invalid migration filename: ${file}`);
+        logger.error(`Skipping invalid migration filename: ${file}`);
         continue;
       }
       const sql = fs.readFileSync(filePath, "utf8");
 
-      console.log(`Applying migration: ${file}`);
+      logger.log(`Applying migration: ${file}`);
       try {
         await client.query("BEGIN");
         await client.query(sql);
@@ -338,7 +348,7 @@ export async function runMigrations() {
         count++;
       } catch (err) {
         await client.query("ROLLBACK");
-        console.error(
+        logger.error(
           formatMigrationFailure({
             file,
             filePath,
@@ -352,12 +362,12 @@ export async function runMigrations() {
     }
 
     if (count > 0) {
-      console.log(`Applied ${count} migration(s) successfully.`);
+      logger.log(`Applied ${count} migration(s) successfully`);
     } else {
-      console.log("Database is up to date. No pending migrations.");
+      logger.log("Database is up to date; no pending migrations");
     }
   } catch (error) {
-    console.error(formatRunnerFailure(error));
+    logger.error(formatRunnerFailure(error));
     process.exit(1);
   } finally {
     await client.end();

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -9,6 +9,14 @@ import { AppModule } from "./app.module";
 import { OAuthProviderService } from "./oauth/oauth-provider.service";
 import { oauthDebugLogger } from "./oauth/oauth-debug-logger.middleware";
 import { isOidcProviderPath } from "./oauth/oidc-provider-paths";
+import { installOidcProviderLogBridge } from "./oauth/oidc-provider-log-bridge";
+
+// node-oidc-provider writes its notices straight to console.info/console.warn,
+// which would otherwise be the only unformatted lines in the log. Installed
+// before anything can import or instantiate the provider.
+installOidcProviderLogBridge();
+
+const logger = new Logger("Bootstrap");
 
 // Configure pg to return DATE types as strings instead of Date objects
 // This prevents timezone-related date shifting issues
@@ -52,12 +60,17 @@ if (process.env.NODE_ENV !== "production") {
     ) {
       return;
     }
-    console.error("Uncaught exception:", err);
+    logger.error(
+      "Uncaught exception",
+      err instanceof Error ? err.stack : String(err),
+    );
     process.exit(1);
   });
 }
 
 async function bootstrap() {
+  logger.log("Starting application");
+
   const app = await NestFactory.create(AppModule);
 
   // Trust first proxy (Docker/nginx) so req.ip reflects the real client IP
@@ -300,7 +313,6 @@ async function bootstrap() {
   server.requestTimeout = 600000; // 10 minutes
   server.headersTimeout = 605000; // must be > requestTimeout
 
-  const logger = new Logger("Bootstrap");
   const port = process.env.PORT || 3001;
   await app.listen(port);
 

--- a/backend/src/oauth/oauth-provider.service.ts
+++ b/backend/src/oauth/oauth-provider.service.ts
@@ -188,9 +188,11 @@ export class OAuthProviderService implements OnModuleInit {
       },
       // Every artifact this provider can issue needs an explicit TTL. Leaving
       // one out does not just inherit a default silently — node-oidc-provider
-      // calls its built-in TTL function and prints a raw
-      // "oidc-provider NOTICE: default ttl.<Model> function called ..." line
-      // straight to console.info, bypassing the Nest Logger and its formatting.
+      // calls its built-in TTL function and emits an
+      // "oidc-provider NOTICE: default ttl.<Model> function called ..." line.
+      // oidc-provider-log-bridge.ts normalizes how such a line is printed, but
+      // the notice itself still means a default was left in place: fix the
+      // config, not the log line.
       // The remaining defaults (ClientCredentials, DeviceCode,
       // BackchannelAuthenticationRequest) belong to grants/features this
       // provider does not enable, so they are never reached.

--- a/backend/src/oauth/oidc-provider-log-bridge.spec.ts
+++ b/backend/src/oauth/oidc-provider-log-bridge.spec.ts
@@ -1,0 +1,118 @@
+import {
+  installOidcProviderLogBridge,
+  parseOidcProviderLine,
+} from "./oidc-provider-log-bridge";
+
+describe("parseOidcProviderLine()", () => {
+  it("routes a NOTICE to log level and strips the library prefix", () => {
+    expect(
+      parseOidcProviderLine(
+        "oidc-provider NOTICE: default ttl.Session function called, you SHOULD change it.",
+      ),
+    ).toEqual({
+      level: "log",
+      message:
+        "default ttl.Session function called, you SHOULD change it.".trim(),
+    });
+  });
+
+  it("routes a WARNING to warn level", () => {
+    expect(
+      parseOidcProviderLine(
+        "oidc-provider WARNING: already parsed request body detected",
+      ),
+    ).toEqual({
+      level: "warn",
+      message: "already parsed request body detected",
+    });
+  });
+
+  it("strips the colour wrapper the library adds on a TTY", () => {
+    // attention.js wraps the whole line in bold yellow/red when stdout is a TTY.
+    const coloured = "\x1b[33;1moidc-provider NOTICE: coloured line\x1b[0m";
+    expect(parseOidcProviderLine(coloured)).toEqual({
+      level: "log",
+      message: "coloured line",
+    });
+  });
+
+  it("keeps a multi-line notice intact", () => {
+    expect(
+      parseOidcProviderLine("oidc-provider NOTICE: first line\n  second line"),
+    ).toEqual({ level: "log", message: "first line\n  second line" });
+  });
+
+  it("ignores anything that is not an oidc-provider attention line", () => {
+    expect(
+      parseOidcProviderLine("some other library said something"),
+    ).toBeNull();
+    expect(parseOidcProviderLine("NOTICE: oidc-provider mentioned")).toBeNull();
+    expect(parseOidcProviderLine(42)).toBeNull();
+    expect(parseOidcProviderLine(undefined)).toBeNull();
+  });
+});
+
+describe("installOidcProviderLogBridge()", () => {
+  let logger: { log: jest.Mock; warn: jest.Mock };
+  let originalInfo: typeof console.info;
+  let originalWarn: typeof console.warn;
+  let restore: () => void;
+
+  beforeEach(() => {
+    logger = { log: jest.fn(), warn: jest.fn() };
+    originalInfo = console.info;
+    originalWarn = console.warn;
+    console.info = jest.fn();
+    console.warn = jest.fn();
+    restore = installOidcProviderLogBridge(logger);
+  });
+
+  afterEach(() => {
+    restore();
+    console.info = originalInfo;
+    console.warn = originalWarn;
+  });
+
+  it("sends an oidc-provider notice to the logger instead of the console", () => {
+    console.info("oidc-provider NOTICE: default ttl.Grant function called");
+
+    expect(logger.log).toHaveBeenCalledWith(
+      "default ttl.Grant function called",
+    );
+    expect(console.info).toBeInstanceOf(Function);
+  });
+
+  it("sends an oidc-provider warning to the logger at warn level", () => {
+    console.warn("oidc-provider WARNING: a quick start adapter is used");
+
+    expect(logger.warn).toHaveBeenCalledWith("a quick start adapter is used");
+  });
+
+  it("passes unrelated console output straight through", () => {
+    console.info("unrelated", { a: 1 });
+    console.warn("also unrelated");
+
+    expect(logger.log).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent -- installing twice does not stack wrappers", () => {
+    const second = installOidcProviderLogBridge(logger);
+    expect(second).toBe(restore);
+
+    console.info("oidc-provider NOTICE: once only");
+    expect(logger.log).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores the original console methods on uninstall", () => {
+    const patchedInfo = console.info;
+    restore();
+    expect(console.info).not.toBe(patchedInfo);
+
+    console.info("oidc-provider NOTICE: after uninstall");
+    expect(logger.log).not.toHaveBeenCalled();
+
+    // The afterEach hook calls restore() again; make it a no-op.
+    restore = () => {};
+  });
+});

--- a/backend/src/oauth/oidc-provider-log-bridge.ts
+++ b/backend/src/oauth/oidc-provider-log-bridge.ts
@@ -1,0 +1,94 @@
+import { Logger } from "@nestjs/common";
+
+/**
+ * `node-oidc-provider` prints its own notices through `console.info` /
+ * `console.warn` (see its `lib/helpers/attention.js`), so they land in the
+ * backend log as bare, unprefixed lines while every other line carries the Nest
+ * `[Nest] pid - date LEVEL [Context] message` shape. The library exposes no
+ * logger hook, so the only place to normalize them is the console itself.
+ *
+ * This bridge re-routes exactly the lines the library emits -- anything else
+ * written to `console.info` / `console.warn` is passed through untouched.
+ *
+ * A notice still means a config option was left at its default; fix the config
+ * rather than silencing the line. The bridge only changes how it is printed.
+ */
+
+/** Matches an attention.js line, with or without its TTY colour wrapper. */
+const OIDC_ATTENTION = /^oidc-provider (NOTICE|WARNING):\s*([\s\S]*)$/;
+
+/** attention.js wraps the line in bold yellow/red when stdout/stderr is a TTY. */
+// eslint-disable-next-line no-control-regex
+const ANSI_SEQUENCE = /\x1b\[[0-9;]*m/g;
+
+export interface OidcProviderLogLine {
+  level: "log" | "warn";
+  message: string;
+}
+
+/**
+ * Recognize an `oidc-provider` attention line and split it into the Nest log
+ * level it belongs at and the message without the library's own prefix (the
+ * `[OidcProvider]` context supplies that). Returns null for anything else, so
+ * the caller can pass it straight through to the real console.
+ */
+export function parseOidcProviderLine(
+  value: unknown,
+): OidcProviderLogLine | null {
+  if (typeof value !== "string") return null;
+  const match = OIDC_ATTENTION.exec(value.replace(ANSI_SEQUENCE, "").trim());
+  if (!match) return null;
+  return {
+    level: match[1] === "WARNING" ? "warn" : "log",
+    message: match[2].trim(),
+  };
+}
+
+/** Minimal logger surface used by the bridge (matches NestJS `Logger`). */
+export interface OidcBridgeLogger {
+  log(message: string): void;
+  warn(message: string): void;
+}
+
+type ConsoleMethod = (...args: unknown[]) => void;
+
+let uninstall: (() => void) | null = null;
+
+/**
+ * Patch `console.info` / `console.warn` so `oidc-provider` lines go through the
+ * Nest logger. Idempotent: calling it twice does not stack wrappers. Returns
+ * the function that restores the original console methods (used by tests; the
+ * server installs the bridge for the life of the process).
+ */
+export function installOidcProviderLogBridge(
+  logger: OidcBridgeLogger = new Logger("OidcProvider"),
+): () => void {
+  if (uninstall) return uninstall;
+
+  /* eslint-disable no-console */
+  const originalInfo = console.info.bind(console) as ConsoleMethod;
+  const originalWarn = console.warn.bind(console) as ConsoleMethod;
+
+  const bridge =
+    (passthrough: ConsoleMethod): ConsoleMethod =>
+    (...args: unknown[]) => {
+      const line = args.length === 1 ? parseOidcProviderLine(args[0]) : null;
+      if (!line) {
+        passthrough(...args);
+        return;
+      }
+      logger[line.level](line.message);
+    };
+
+  console.info = bridge(originalInfo);
+  console.warn = bridge(originalWarn);
+
+  uninstall = () => {
+    console.info = originalInfo;
+    console.warn = originalWarn;
+    uninstall = null;
+  };
+  /* eslint-enable no-console */
+
+  return uninstall;
+}

--- a/backend/src/startup-logging.spec.ts
+++ b/backend/src/startup-logging.spec.ts
@@ -1,0 +1,67 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Startup output is part of the log, so it follows the same format as
+ * everything else: `[Nest] pid - date LEVEL [Context] message`, produced by the
+ * NestJS `Logger` (which works outside an application context, so the
+ * pre-boot scripts can use it too).
+ *
+ * The two ways that convention gets broken are a shell `echo` in the entrypoint
+ * and a `console.*` call in a script that runs before Nest starts. Both are
+ * mechanical, so both are scanned for here rather than left to review; the
+ * `console` half is also an ESLint ban (`no-console`), which this test backs up
+ * for the pre-boot entry points specifically.
+ */
+
+const BACKEND_ROOT = path.resolve(__dirname, "..");
+const ENTRYPOINT = path.join(BACKEND_ROOT, "docker-entrypoint.sh");
+
+/** Scripts the entrypoint runs before (or instead of) the Nest app. */
+const PRE_BOOT_SCRIPTS = [
+  "src/db-init.ts",
+  "src/db-migrate.ts",
+  "src/db-demo-check.ts",
+  "src/database/seed.ts",
+  "src/common/db/app-role.ts",
+];
+
+function sourceLines(file: string): string[] {
+  return fs.readFileSync(path.join(BACKEND_ROOT, file), "utf8").split("\n");
+}
+
+describe("startup logging conventions", () => {
+  describe("docker-entrypoint.sh", () => {
+    const lines = fs.readFileSync(ENTRYPOINT, "utf8").split("\n");
+    const code = lines.filter((line) => !line.trim().startsWith("#"));
+
+    it("prints nothing itself -- a shell echo has no timestamp, level or context", () => {
+      const echoes = code.filter((line) => /(^|[;&|]\s*)echo\s/.test(line));
+      expect(echoes).toEqual([]);
+    });
+
+    it("runs compiled scripts rather than inline node -e blobs", () => {
+      // `node -e` output cannot reach the Nest Logger without duplicating it in
+      // a string, so the demo-user probe lives in src/db-demo-check.ts.
+      const inline = code.filter((line) => /node\s+-e/.test(line));
+      expect(inline).toEqual([]);
+    });
+  });
+
+  describe.each(PRE_BOOT_SCRIPTS)("%s", (file) => {
+    it("logs through the Nest Logger, not console", () => {
+      const offenders = sourceLines(file).filter(
+        (line) =>
+          /\bconsole\.(log|info|warn|error|debug)\s*\(/.test(line) &&
+          !line.trim().startsWith("*") &&
+          !line.trim().startsWith("//"),
+      );
+      expect(offenders).toEqual([]);
+    });
+
+    it("instantiates a Logger with a context", () => {
+      const source = sourceLines(file).join("\n");
+      expect(source).toMatch(/new Logger\("[A-Za-z]+"\)/);
+    });
+  });
+});


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: <!-- discussion/issue link -->

## Summary

Standardizes all startup and pre-boot logging to use NestJS `Logger` instead of `console.*` calls, ensuring every line in the container log carries the same `[Nest] pid - date LEVEL [Context] message` format. This eliminates unformatted lines that previously appeared at the top of every startup sequence.

### Changes

**New modules:**
- `src/oauth/oidc-provider-log-bridge.ts` + spec: Bridges `node-oidc-provider`'s console output (which has no logger hook) through the Nest Logger by patching `console.info` and `console.warn`. Parses the library's ANSI-wrapped attention lines and routes them to the appropriate log level.
- `src/db-demo-check.ts` + spec: Replaces the inline `node -e` blob in the entrypoint with a compiled script that checks whether the demo user exists, exiting 0 to skip seeding or 1 to trigger it. Logs through the Nest Logger.
- `src/startup-logging.spec.ts`: Guard test that scans the entrypoint and pre-boot scripts to enforce the logging convention: no shell `echo` statements, no `console.*` calls, and every script instantiates a Logger with a context.

**Modified files:**
- `docker-entrypoint.sh`: Removed all `echo` statements and the inline `node -e` demo-user probe; now just runs compiled scripts that log for themselves.
- `src/db-init.ts`, `src/db-migrate.ts`, `src/database/seed.ts`, `src/common/db/app-role.ts`: Replaced `console.*` with `new Logger(context)`.
- `src/main.ts`: Installs the oidc-provider log bridge before any other code runs; replaced uncaught exception handler's `console.error` with Logger.
- `src/database/add-skip-price-updates-column.ts`, `src/database/fix-linked-transactions.ts`: Replaced `console.*` with Logger (these are ad-hoc scripts but follow the convention).
- `src/oauth/oauth-provider.service.ts`: Updated comment to reflect the new log bridge.
- `eslint.config.mjs`: Added exception for the oidc-provider log bridge's sanctioned `console` patching.
- `backend/CLAUDE.md`: Documented the logging convention and the oidc-provider bridge.
- `CLAUDE.md`: Added rule against `console.log` in production code.
- Test specs: Updated `src/db-migrate.spec.ts` and `src/common/db/app-role.spec.ts` to spy on `Logger.prototype` instead of `console`.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity). — N/A; no user-facing strings added.
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

<!-- Disclose any AI tools used. Using AI is fine and expected — you remain responsible for correctness, conventions, and tests. -->

https://claude.ai/code/session_01Xq1XBvYEJYGNGMwA1u1Nzi