### PR TITLE
Bind relay turns to MCP sessions, not users

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -288,6 +288,18 @@ any pre-boot script.
 
 ## OAuth / OIDC provider
 
+**A page whose form submission must redirect off-origin needs its own CSP.**
+Helmet's app-wide policy merges in the default `form-action 'self'`, and Chrome
+enforces `form-action` against every redirect hop that follows a form submit --
+so the OAuth consent page's Allow/Deny POST (303 to `/oauth/auth` resume, 303 to
+the client's `redirect_uri` with the code) is silently cancelled on the final,
+cross-origin hop. The server logs `authorization.success`, the browser stays
+parked on the consent form, and the MCP client never receives its code. The
+interaction controller therefore sets a per-page policy with
+`form-action 'self' https:` (`setInteractionPageHeaders`); the redirect_uri is
+per-client and dynamic, so it cannot be enumerated. Do not "fix" this by
+loosening the global Helmet `form-action` -- only this page needs it.
+
 `node-oidc-provider` prints its own `oidc-provider NOTICE:`/`WARNING:` lines with bare `console.info`/`console.warn`, outside the Nest `Logger`. The library exposes no logger hook, so `oauth/oidc-provider-log-bridge.ts` -- installed at the top of `main.ts`, before anything can instantiate the provider -- re-routes exactly those lines to a `[OidcProvider]` logger and passes any other console output through untouched. That fixes the formatting only: every such notice still means a config option was left at its default, so fix the config rather than treating the bridge as the answer. In particular, `ttl` needs an explicit number for every artifact the provider can issue (`AccessToken`, `AuthorizationCode`, `IdToken`, `RefreshToken`, `Grant`, `Interaction`, `Session`); the guard test in `src/oauth/oauth-provider.service.spec.ts` fails when one is missing.
 
 ## Automatic backups are an operator setting, not a user preference

--- a/backend/src/ai/relay/ai-relay.service.spec.ts
+++ b/backend/src/ai/relay/ai-relay.service.spec.ts
@@ -188,6 +188,64 @@ describe("AiRelayService", () => {
       expect(service.takeBufferedActions(USER)).toEqual([]);
     });
 
+    it("does not hand one session's relay turn to another session's write", async () => {
+      // The web chat's agent (session A) is mid-prompt. Claude Desktop
+      // (session B) is a different MCP session of the SAME user: its write is
+      // not part of A's turn, so its confirmation must stay in Claude Desktop.
+      const emit = jest.fn();
+      service.enqueuePrompt(USER, "summarize my spending", [], emit);
+      await service.waitForPrompt(USER, "session-A");
+
+      expect(service.emitPendingAction(USER, action, "session-B")).toBe(false);
+      expect(emit).not.toHaveBeenCalled();
+      expect(service.takeBufferedActions(USER)).toEqual([]);
+
+      // The claiming session's own write still routes to the web chat.
+      expect(service.emitPendingAction(USER, action, "session-A")).toBe(true);
+      expect(emit).toHaveBeenCalledWith({ type: "pending_action", action });
+    });
+
+    it("does not let a stale timed-out turn capture a later write forever", async () => {
+      // An abandoned web-chat turn leaves an awaitingLate marker. It stands in
+      // for a live turn only while a late answer would still be retained; past
+      // that the turn is over and a direct write must confirm in its client.
+      const pending = service.enqueuePrompt(USER, "q", [], jest.fn());
+      pending.catch(() => undefined);
+      await service.waitForPrompt(USER, "session-A");
+      jest.advanceTimersByTime(180 * 1000); // idle timeout -> awaitingLate
+
+      // Still within the retention window: the marker stands in for the turn.
+      expect(service.emitPendingAction(USER, action, "session-A")).toBe(true);
+      service.takeBufferedActions(USER);
+
+      // Past the 10-minute buffer TTL: the marker no longer answers for it.
+      jest.advanceTimersByTime(10 * 60 * 1000 + 1000);
+      expect(service.emitPendingAction(USER, action, "session-A")).toBe(false);
+      expect(service.takeBufferedActions(USER)).toEqual([]);
+    });
+
+    it("keeps the turn when the claiming agent reconnects with a new session id", async () => {
+      // An agent whose transport blipped comes back with a fresh MCP session.
+      // It proves ownership by knowing the promptId, so its later card must
+      // still reach the web chat rather than its own client.
+      const emit = jest.fn();
+      service.enqueuePrompt(USER, "q", [], emit);
+      const claimed = await service.waitForPrompt(USER, "session-old");
+
+      service.reportProgress(
+        USER,
+        claimed!.promptId,
+        "still here",
+        "session-new",
+      );
+
+      expect(service.emitPendingAction(USER, action, "session-new")).toBe(true);
+      expect(emit).toHaveBeenCalledWith({ type: "pending_action", action });
+      expect(service.emitPendingAction(USER, action, "session-old")).toBe(
+        false,
+      );
+    });
+
     it("does not route a card to the web chat while a relay agent is merely parked listening", () => {
       // A relay agent polling get_next_prompt with nothing queued has no
       // claimed prompt, so a write arriving now is a direct MCP client's and
@@ -265,6 +323,51 @@ describe("AiRelayService", () => {
       expect(() =>
         service.reportToolActivity(USER, "list_categories", "start"),
       ).not.toThrow();
+    });
+
+    it("does not mirror another session's tool calls into the web chat", async () => {
+      const emit = jest.fn();
+      service.enqueuePrompt(USER, "q", [], emit);
+      await service.waitForPrompt(USER, "session-A");
+
+      // Claude Desktop (session B) working on its own, not on this prompt.
+      service.reportToolActivity(
+        USER,
+        "list_accounts",
+        "start",
+        false,
+        "session-B",
+      );
+
+      expect(emit).not.toHaveBeenCalled();
+    });
+
+    it("does not let another session's tool calls keep an abandoned turn alive", async () => {
+      // The poisoning mechanism: liveness from ANY session reset the claimed
+      // prompt's idle timer, so a relay turn whose browser was long gone never
+      // timed out -- and while it sat in flight it captured every direct write
+      // the user made. Only the claiming session's activity is its liveness.
+      const pending = service.enqueuePrompt(USER, "q", [], jest.fn());
+      const rejection = jest.fn();
+      pending.catch(rejection);
+      await service.waitForPrompt(USER, "session-A");
+
+      // Another session hammers tool calls right through the idle window.
+      for (let i = 0; i < 4; i++) {
+        jest.advanceTimersByTime(60 * 1000);
+        service.reportToolActivity(
+          USER,
+          "list_accounts",
+          "start",
+          false,
+          "session-B",
+        );
+        await Promise.resolve();
+      }
+
+      // The abandoned turn timed out on schedule despite the other session.
+      expect(rejection).toHaveBeenCalled();
+      expect(service.getStatus(USER).state).not.toBe("busy");
     });
   });
 

--- a/backend/src/ai/relay/ai-relay.service.spec.ts
+++ b/backend/src/ai/relay/ai-relay.service.spec.ts
@@ -173,6 +173,31 @@ describe("AiRelayService", () => {
       expect(service.emitPendingAction(USER, action)).toBe(false);
       expect(service.takeBufferedActions(USER)).toEqual([]);
     });
+
+    it("does not treat a direct MCP client's own tool activity as a relay turn", () => {
+      // Every MCP data tool call reports activity before its handler runs --
+      // including manage_transactions itself, called from Claude Desktop with
+      // no relay in sight. That activity must not make the write look like a
+      // relay turn, or the confirmation card lands in the web chat instead of
+      // the client that asked.
+      service.reportToolActivity(USER, "list_accounts", "start");
+      service.reportToolActivity(USER, "list_accounts", "result", false);
+      service.reportToolActivity(USER, "manage_transactions", "start");
+
+      expect(service.emitPendingAction(USER, action)).toBe(false);
+      expect(service.takeBufferedActions(USER)).toEqual([]);
+    });
+
+    it("does not route a card to the web chat while a relay agent is merely parked listening", () => {
+      // A relay agent polling get_next_prompt with nothing queued has no
+      // claimed prompt, so a write arriving now is a direct MCP client's and
+      // must confirm there -- not in the web chat.
+      void service.waitForPrompt(USER);
+      expect(service.getStatus(USER).state).toBe("listening");
+
+      expect(service.emitPendingAction(USER, action)).toBe(false);
+      expect(service.takeBufferedActions(USER)).toEqual([]);
+    });
   });
 
   describe("reportProgress", () => {
@@ -246,6 +271,12 @@ describe("AiRelayService", () => {
   describe("status", () => {
     it("is offline before any agent polls", () => {
       expect(service.getStatus(USER)).toEqual({ state: "offline", queued: 0 });
+    });
+
+    it("stays offline on tool activity alone (a direct MCP client is not a relay agent)", () => {
+      service.reportToolActivity(USER, "list_accounts", "start");
+      service.reportToolActivity(USER, "list_accounts", "result", false);
+      expect(service.getStatus(USER).state).toBe("offline");
     });
 
     it("is busy while a claimed prompt is in flight", async () => {

--- a/backend/src/ai/relay/ai-relay.service.ts
+++ b/backend/src/ai/relay/ai-relay.service.ts
@@ -150,6 +150,19 @@ interface PendingPrompt {
   /** True once an agent has claimed this prompt via get_next_prompt. */
   claimed: boolean;
   /**
+   * MCP session id of the agent that claimed this prompt. A relay turn belongs
+   * to ONE session: writes, tool activity and liveness from any other session
+   * (a direct MCP client the same user has open) are not part of this turn and
+   * must not steer it. Undefined only for a claim made without a session id,
+   * which the MCP tool layer cannot produce (`resolve(extra.sessionId)` is what
+   * yields the user in the first place) -- it occurs in tests, where strict
+   * equality against another `undefined` keeps the unbound behaviour.
+   *
+   * Adopted on a later liveness signal that carries a different session (see
+   * `adoptSession`), so an agent that reconnects mid-prompt keeps its turn.
+   */
+  claimedBy?: string;
+  /**
    * Refs to attachments the user uploaded with this prompt (bytes live in the
    * RelayAttachmentStore). Passed to the agent on claim and released once the
    * prompt definitively settles; the store's TTL is the backstop.
@@ -173,6 +186,8 @@ interface PendingPrompt {
 interface Waiter {
   resolve: (prompt: RelayClaimedPrompt | null) => void;
   timer: ReturnType<typeof setTimeout>;
+  /** MCP session of the parked agent; becomes the claim's owning session. */
+  sessionId?: string;
 }
 
 /** A late agent answer held for pickup after the browser stream gave up. */
@@ -180,6 +195,19 @@ interface BufferedResponse {
   text: string;
   /** Epoch ms the answer was posted; used for TTL pruning and LRU eviction. */
   at: number;
+}
+
+/**
+ * A prompt that was claimed and then timed out before `post_response` arrived.
+ * Carries the claiming session so a late confirmation card is recognised as
+ * belonging to THAT agent's turn and not to some other session's write, and the
+ * timestamp so the marker stops counting as a live turn once it is older than
+ * the buffer would have retained the answer.
+ */
+interface LateMarker {
+  userId: string;
+  at: number;
+  sessionId?: string;
 }
 
 /**
@@ -244,10 +272,7 @@ export class AiRelayService {
    * Entries are evicted when the answer arrives, or after BUFFER_TTL_MS since
    * there is no point waiting longer than the buffer would retain the answer.
    */
-  private readonly awaitingLate = new Map<
-    string,
-    { userId: string; at: number }
-  >();
+  private readonly awaitingLate = new Map<string, LateMarker>();
   /**
    * Write-confirmation cards emitted after the browser stream gave up, keyed by
    * userId then actionId. The browser drains them via the pickup endpoint so a
@@ -326,14 +351,18 @@ export class AiRelayService {
    * for the user, or parks until one arrives or the poll window elapses (then
    * returns null so the agent polls again).
    */
-  waitForPrompt(userId: string): Promise<RelayClaimedPrompt | null> {
+  waitForPrompt(
+    userId: string,
+    sessionId?: string,
+  ): Promise<RelayClaimedPrompt | null> {
     this.lastPollAt.set(userId, Date.now());
     // The agent is polling, so it is connected: clear any stale idle-disconnect
     // notice (e.g. it just reconnected after a quiet spell).
     this.idleDisconnectedAt.delete(userId);
-    // A poll proves the agent is alive: keep any prompt it is mid-task on from
-    // tripping the idle timer.
-    this.bumpInFlight(userId);
+    // A poll proves THIS agent is alive: keep the prompt it is mid-task on from
+    // tripping the idle timer. Scoped to its own session -- another session's
+    // traffic says nothing about whether this agent is still working.
+    this.bumpInFlight(userId, sessionId);
 
     const queue = this.pending.get(userId) ?? [];
     const [next, ...rest] = queue;
@@ -341,12 +370,13 @@ export class AiRelayService {
       this.pending.set(userId, rest);
       // Claiming a prompt is activity: restart the inactivity clock.
       this.idleSince.delete(userId);
-      return Promise.resolve(this.claim(userId, next));
+      return Promise.resolve(this.claim(userId, next, sessionId));
     }
 
     return new Promise<RelayClaimedPrompt | null>((resolve) => {
       const waiter: Waiter = {
         resolve,
+        sessionId,
         timer: setTimeout(() => {
           this.removeWaiter(userId, waiter);
           resolve(null);
@@ -508,15 +538,23 @@ export class AiRelayService {
    * "sending the confirmation card...") instead of a static spinner. Returns
    * false if the prompt is unknown, already settled, or has no stream.
    */
-  reportProgress(userId: string, promptId: string, text: string): boolean {
+  reportProgress(
+    userId: string,
+    promptId: string,
+    text: string,
+    sessionId?: string,
+  ): boolean {
     this.lastPollAt.set(userId, Date.now());
-    // Progress is liveness: keep the idle timer from firing mid-task.
-    this.bumpInFlight(userId);
     const record = this.inFlight.get(promptId);
     if (!record || record.userId !== userId) {
       return false;
     }
     const { prompt } = record;
+    // Knowing the promptId is what proves this caller owns the turn, so a
+    // reconnected agent's new session is adopted here rather than locked out.
+    this.adoptSession(prompt, sessionId);
+    // Progress is liveness: keep the idle timer from firing mid-task.
+    this.scheduleIdleTimeout(userId, prompt);
     if (prompt.settled || !prompt.emit) {
       return false;
     }
@@ -533,9 +571,13 @@ export class AiRelayService {
    * prompt (or its stream is gone). Shared by the progress, tool-activity, and
    * pending-action emitters.
    */
-  private emitToInFlight(userId: string, event: RelayServerEvent): boolean {
+  private emitToInFlight(
+    userId: string,
+    event: RelayServerEvent,
+    sessionId?: string,
+  ): boolean {
     for (const record of this.inFlight.values()) {
-      if (record.userId !== userId) {
+      if (record.userId !== userId || record.prompt.claimedBy !== sessionId) {
         continue;
       }
       const { prompt } = record;
@@ -560,21 +602,22 @@ export class AiRelayService {
     toolName: string,
     phase: "start" | "result",
     isError = false,
+    sessionId?: string,
   ): void {
-    // Deliberately does NOT stamp lastPollAt: every MCP data tool call lands
-    // here, including calls from a direct MCP client (Claude Desktop) that has
-    // nothing to do with the relay. Stamping made the user look
-    // relay-connected the instant any tool ran, which routed the direct
-    // client's own write-confirmation card to the web chat. Only the relay
-    // control tools (get_next_prompt / post_response / report_progress) prove
-    // a relay agent is present.
-    // Tool activity is liveness: keep the idle timer from firing mid-task.
-    this.bumpInFlight(userId);
+    // Deliberately does NOT stamp lastPollAt, and everything below is scoped to
+    // the CALLING session: every MCP data tool call lands here, including calls
+    // from a direct MCP client (Claude Desktop) that has nothing to do with the
+    // relay. Treating that traffic as this user's relay liveness kept an
+    // abandoned relay prompt's idle timer alive indefinitely, so the dead turn
+    // stayed in `inFlight` and captured every later direct write's confirmation
+    // card -- and mirrored the direct client's tool chips into a web chat
+    // nobody was watching.
+    this.bumpInFlight(userId, sessionId);
     const event: RelayServerEvent =
       phase === "start"
         ? { type: "tool_start", name: toolName }
         : { type: "tool_result", name: toolName, isError };
-    this.emitToInFlight(userId, event);
+    this.emitToInFlight(userId, event, sessionId);
   }
 
   /**
@@ -596,15 +639,21 @@ export class AiRelayService {
    * through to an MCP-client elicitation the web-chat user could not answer, and
    * it surfaced as a decline.
    */
-  emitPendingAction(userId: string, action: PendingAiAction): boolean {
-    if (this.emitToInFlight(userId, { type: "pending_action", action })) {
+  emitPendingAction(
+    userId: string,
+    action: PendingAiAction,
+    sessionId?: string,
+  ): boolean {
+    if (
+      this.emitToInFlight(userId, { type: "pending_action", action }, sessionId)
+    ) {
       return true;
     }
-    // No live stream. If the user has a relay turn in progress (or one that just
-    // timed out), the stream was almost certainly killed by the idle timeout
-    // while the agent composed this call -- buffer the card for pickup rather
-    // than telling the caller this is not a relay context.
-    if (this.hasRelayTurn(userId)) {
+    // No live stream. If THIS session has a relay turn in progress (or one that
+    // just timed out), the stream was almost certainly killed by the idle
+    // timeout while the agent composed this call -- buffer the card for pickup
+    // rather than telling the caller this is not a relay context.
+    if (this.hasRelayTurn(userId, sessionId)) {
       this.bufferAction(userId, action);
       return true;
     }
@@ -630,27 +679,38 @@ export class AiRelayService {
   }
 
   /**
-   * Whether the user has a relay agent currently or very recently handling a
-   * prompt: an in-flight prompt, or a prompt that timed out after a claim
-   * (awaiting a late answer). Used to decide whether a card with no live stream
-   * belongs to a relay turn (buffer it) or to a direct MCP client (let the
-   * caller elicit).
+   * Whether THIS session is currently (or was just now) handling a relay
+   * prompt: an in-flight prompt it claimed, or one of its claims that timed out
+   * and is still within the window a late answer would be retained. Used to
+   * decide whether a card with no live stream belongs to a relay turn (buffer
+   * it) or to a direct MCP client (let the caller elicit).
    *
-   * Deliberately keyed to a CLAIMED prompt only -- never to connection
-   * liveness. A relay agent that is merely parked on get_next_prompt has no
-   * prompt to be writing for, so a write arriving then is a direct MCP
-   * client's, and its confirmation must stay in that client. Treating a recent
-   * poll as a relay turn routed direct clients' confirmation cards to the web
-   * chat.
+   * Three things this deliberately is NOT:
+   *  - not connection liveness. An agent merely parked on `get_next_prompt`
+   *    has no prompt to be writing for, so a write arriving then is a direct
+   *    client's and must confirm there.
+   *  - not user-wide. A relay turn belongs to the session that claimed it;
+   *    another session's write is not part of it. Matching on userId alone let
+   *    one abandoned web-chat turn capture every direct write the same user
+   *    made afterwards.
+   *  - not unbounded in time. A late marker only stands in for a live turn for
+   *    as long as the answer buffer would have held the answer; past that the
+   *    turn is over, and an expired marker must not answer for it.
    */
-  private hasRelayTurn(userId: string): boolean {
+  private hasRelayTurn(userId: string, sessionId?: string): boolean {
     for (const record of this.inFlight.values()) {
-      if (record.userId === userId) {
+      if (record.userId === userId && record.prompt.claimedBy === sessionId) {
         return true;
       }
     }
+    this.pruneAwaitingLate();
+    const cutoff = Date.now() - BUFFER_TTL_MS;
     for (const marker of this.awaitingLate.values()) {
-      if (marker.userId === userId) {
+      if (
+        marker.userId === userId &&
+        marker.sessionId === sessionId &&
+        marker.at >= cutoff
+      ) {
         return true;
       }
     }
@@ -719,12 +779,17 @@ export class AiRelayService {
     return parked || recent ? "listening" : "offline";
   }
 
-  private claim(userId: string, entry: PendingPrompt): RelayClaimedPrompt {
+  private claim(
+    userId: string,
+    entry: PendingPrompt,
+    sessionId?: string,
+  ): RelayClaimedPrompt {
     this.inFlight.set(entry.id, { userId, prompt: entry });
     // The prompt is now an agent's responsibility: switch from the queue wait to
     // the idle timer and arm the hard backstop. The claim itself counts as
     // liveness, so the idle window starts fresh here.
     entry.claimed = true;
+    entry.claimedBy = sessionId;
     entry.hardDeadline = Date.now() + HARD_WAIT_MS;
     this.scheduleIdleTimeout(userId, entry);
     return {
@@ -759,17 +824,33 @@ export class AiRelayService {
    * Called from every liveness signal (poll, progress, tool activity) so a slow
    * but alive agent is not timed out mid-task.
    */
-  private bumpInFlight(userId: string): void {
+  private bumpInFlight(userId: string, sessionId?: string): void {
     for (const record of this.inFlight.values()) {
-      if (record.userId === userId && !record.prompt.settled) {
+      if (
+        record.userId === userId &&
+        record.prompt.claimedBy === sessionId &&
+        !record.prompt.settled
+      ) {
         this.scheduleIdleTimeout(userId, record.prompt);
       }
     }
   }
 
+  /**
+   * Adopt a new session for a prompt whose owner proved itself by knowing the
+   * (unguessable) promptId -- an agent that reconnected mid-turn arrives with a
+   * fresh MCP session id. Without this its own later writes would look like a
+   * different session's and confirm in the wrong place.
+   */
+  private adoptSession(prompt: PendingPrompt, sessionId?: string): void {
+    if (sessionId !== undefined) {
+      prompt.claimedBy = sessionId;
+    }
+  }
+
   private handOff(userId: string, entry: PendingPrompt, waiter: Waiter): void {
     clearTimeout(waiter.timer);
-    waiter.resolve(this.claim(userId, entry));
+    waiter.resolve(this.claim(userId, entry, waiter.sessionId));
   }
 
   private takeWaiter(userId: string): Waiter | undefined {
@@ -814,7 +895,11 @@ export class AiRelayService {
       // attachments around (TTL bounds them) in case the recovered agent
       // re-reads them before posting its late answer.
       this.pruneAwaitingLate();
-      this.awaitingLate.set(entry.id, { userId, at: Date.now() });
+      this.awaitingLate.set(entry.id, {
+        userId,
+        at: Date.now(),
+        sessionId: entry.claimedBy,
+      });
       this.logger.warn(
         `Relay prompt ${entry.id} for user ${userId} went quiet after claim; ` +
           `browser gave up (late answer can still be buffered)`,

--- a/backend/src/ai/relay/ai-relay.service.ts
+++ b/backend/src/ai/relay/ai-relay.service.ts
@@ -561,7 +561,13 @@ export class AiRelayService {
     phase: "start" | "result",
     isError = false,
   ): void {
-    this.lastPollAt.set(userId, Date.now());
+    // Deliberately does NOT stamp lastPollAt: every MCP data tool call lands
+    // here, including calls from a direct MCP client (Claude Desktop) that has
+    // nothing to do with the relay. Stamping made the user look
+    // relay-connected the instant any tool ran, which routed the direct
+    // client's own write-confirmation card to the web chat. Only the relay
+    // control tools (get_next_prompt / post_response / report_progress) prove
+    // a relay agent is present.
     // Tool activity is liveness: keep the idle timer from firing mid-task.
     this.bumpInFlight(userId);
     const event: RelayServerEvent =
@@ -625,10 +631,17 @@ export class AiRelayService {
 
   /**
    * Whether the user has a relay agent currently or very recently handling a
-   * prompt: an in-flight prompt, a prompt that timed out after a claim (awaiting
-   * a late answer), or an agent that polled within the connection window. Used
-   * to decide whether a card with no live stream belongs to a relay turn (buffer
-   * it) or to a direct MCP client (let the caller elicit).
+   * prompt: an in-flight prompt, or a prompt that timed out after a claim
+   * (awaiting a late answer). Used to decide whether a card with no live stream
+   * belongs to a relay turn (buffer it) or to a direct MCP client (let the
+   * caller elicit).
+   *
+   * Deliberately keyed to a CLAIMED prompt only -- never to connection
+   * liveness. A relay agent that is merely parked on get_next_prompt has no
+   * prompt to be writing for, so a write arriving then is a direct MCP
+   * client's, and its confirmation must stay in that client. Treating a recent
+   * poll as a relay turn routed direct clients' confirmation cards to the web
+   * chat.
    */
   private hasRelayTurn(userId: string): boolean {
     for (const record of this.inFlight.values()) {
@@ -641,8 +654,7 @@ export class AiRelayService {
         return true;
       }
     }
-    const last = this.lastPollAt.get(userId) ?? 0;
-    return Date.now() - last < CONNECTED_WINDOW_MS;
+    return false;
   }
 
   /** Store a late confirmation card for pickup, enforcing TTL and the per-user cap. */

--- a/backend/src/mcp/CLAUDE.md
+++ b/backend/src/mcp/CLAUDE.md
@@ -109,7 +109,12 @@ Checklist for a new tool:
      the approve/reject card is shown in the browser and committed via
      `/ai/actions/confirm` on approval -- return `RELAY_PREVIEW_SHOWN` and do
      NOT write or `confirmWrite`. If it returns `false` (no in-flight relay
-     prompt), fall through to `confirmWrite` as above.
+     prompt), fall through to `confirmWrite` as above. The relay decision is
+     keyed to a **claimed relay prompt** (in-flight or awaiting a late
+     answer), never to connection liveness: every data tool call -- from a
+     direct MCP client too -- produces tool-activity signals, so "the user
+     looks connected" is not evidence the write serves the web chat, and
+     using it routed direct clients' confirmation cards there.
 6. Update `mcp-server.service.ts` count and `mcp.module.ts` if it's a new
    provider class.
 7. Add/extend tests (below). `mcp-annotations.spec.ts` enforces that every tool

--- a/backend/src/mcp/CLAUDE.md
+++ b/backend/src/mcp/CLAUDE.md
@@ -108,13 +108,30 @@ Checklist for a new tool:
      `AiRelayService.emitPendingAction(userId, action)`. If it returns `true`,
      the approve/reject card is shown in the browser and committed via
      `/ai/actions/confirm` on approval -- return `RELAY_PREVIEW_SHOWN` and do
-     NOT write or `confirmWrite`. If it returns `false` (no in-flight relay
-     prompt), fall through to `confirmWrite` as above. The relay decision is
-     keyed to a **claimed relay prompt** (in-flight or awaiting a late
-     answer), never to connection liveness: every data tool call -- from a
-     direct MCP client too -- produces tool-activity signals, so "the user
-     looks connected" is not evidence the write serves the web chat, and
-     using it routed direct clients' confirmation cards there.
+     NOT write or `confirmWrite`. If it returns `false` (no relay turn for this
+     session), fall through to `confirmWrite` as above.
+
+## A relay turn belongs to one MCP session, for a bounded time
+
+The same user can have two MCP sessions at once -- the agent running the
+web-chat relay loop, and a direct client (Claude Desktop) they are typing at.
+Only one of them is serving a browser prompt, so **"does this write belong to
+the web chat" is a question about the calling session, not about the user**.
+
+- Emit a card with `emitRelayCard(this.relayService, userId, action)`
+  (`mcp-relay-confirm.ts`), never `relayService.emitPendingAction` directly:
+  the helper supplies the ambient MCP session id that the decision depends on.
+  `mcp-relay-confirm.spec.ts` scans the tool sources and fails on a direct call.
+- A relay turn is a prompt **claimed by this session** (`waitForPrompt` records
+  `claimedBy`), or one of its claims that timed out within the late-answer
+  retention window. It is not connection liveness, not user-wide, and not
+  unbounded in time. Each of those three was tried and each routed a direct
+  client's confirmation into a web chat nobody was watching -- the worst
+  version being user-wide + unbounded, where a single abandoned web-chat turn
+  captured every direct write the user made afterwards, permanently.
+- Liveness is session-scoped for the same reason: a direct client's tool calls
+  are not evidence that some other session's agent is still working, and
+  treating them as such kept dead relay prompts alive indefinitely.
 6. Update `mcp-server.service.ts` count and `mcp.module.ts` if it's a new
    provider class.
 7. Add/extend tests (below). `mcp-annotations.spec.ts` enforces that every tool

--- a/backend/src/mcp/mcp-relay-confirm.spec.ts
+++ b/backend/src/mcp/mcp-relay-confirm.spec.ts
@@ -1,0 +1,78 @@
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+import { RELAY_PREVIEW_SHOWN, emitRelayCard } from "./mcp-relay-confirm";
+import { withMcpSession } from "./mcp-session-context";
+import type { AiRelayService } from "../ai/relay/ai-relay.service";
+import type { PendingAiAction } from "../ai/actions/ai-action.types";
+
+const TOOLS_DIR = join(__dirname, "tools");
+
+describe("emitRelayCard", () => {
+  const action = { actionId: "a1" } as PendingAiAction;
+
+  function relayDouble() {
+    return {
+      emitPendingAction: jest.fn().mockReturnValue(false),
+    } as unknown as jest.Mocked<Pick<AiRelayService, "emitPendingAction">>;
+  }
+
+  it("passes the ambient MCP session id through to the relay", () => {
+    const relay = relayDouble();
+
+    withMcpSession("session-abc", () => {
+      emitRelayCard(relay as unknown as AiRelayService, "user-1", action);
+    });
+
+    expect(relay.emitPendingAction).toHaveBeenCalledWith(
+      "user-1",
+      action,
+      "session-abc",
+    );
+  });
+
+  it("passes undefined when there is no ambient session (cannot prove a relay turn)", () => {
+    const relay = relayDouble();
+
+    emitRelayCard(relay as unknown as AiRelayService, "user-1", action);
+
+    expect(relay.emitPendingAction).toHaveBeenCalledWith(
+      "user-1",
+      action,
+      undefined,
+    );
+  });
+
+  it("returns whatever the relay decided", () => {
+    const relay = relayDouble();
+    (relay.emitPendingAction as jest.Mock).mockReturnValue(true);
+    expect(
+      emitRelayCard(relay as unknown as AiRelayService, "user-1", action),
+    ).toBe(true);
+  });
+
+  it("exposes the preview_shown status that says the write has NOT happened", () => {
+    expect(RELAY_PREVIEW_SHOWN.status).toBe("preview_shown");
+  });
+});
+
+/**
+ * A write tool that calls `relayService.emitPendingAction` directly drops the
+ * ambient session id, and the relay then cannot tell this user's relay turn
+ * from a second, direct MCP client of the same user -- which is how a direct
+ * client's confirmation card ended up in a web chat nobody was watching. The
+ * rule is mechanical, so it is checked mechanically rather than left in prose.
+ */
+describe("MCP tools use the shared card emitter", () => {
+  const toolFiles = readdirSync(TOOLS_DIR).filter(
+    (f) => f.endsWith(".tool.ts") && !f.endsWith(".spec.ts"),
+  );
+
+  it("finds the tool sources to scan", () => {
+    expect(toolFiles.length).toBeGreaterThan(0);
+  });
+
+  it.each(toolFiles)("%s never calls emitPendingAction directly", (file) => {
+    const source = readFileSync(join(TOOLS_DIR, file), "utf8");
+    expect(source).not.toMatch(/\.emitPendingAction\s*\(/);
+  });
+});

--- a/backend/src/mcp/mcp-relay-confirm.ts
+++ b/backend/src/mcp/mcp-relay-confirm.ts
@@ -1,3 +1,29 @@
+import type { AiRelayService } from "../ai/relay/ai-relay.service";
+import type { PendingAiAction } from "../ai/actions/ai-action.types";
+import { currentMcpSessionId } from "./mcp-session-context";
+
+/**
+ * The ONE way an MCP write tool offers its confirmation card to the web chat.
+ *
+ * Returns true when the relay took the card (it is shown in the browser and
+ * committed via `/ai/actions/confirm` on approval, so the tool must NOT write);
+ * false when this call is not part of a relay turn, so the tool falls back to
+ * `confirmWrite` in the calling MCP client.
+ *
+ * Tools must not call `relayService.emitPendingAction` directly: the decision
+ * depends on the *calling session*, which lives in the ambient MCP session
+ * context, and a call site that forgets to pass it sends a direct client's
+ * confirmation to a web chat nobody is watching. `mcp-relay-confirm.spec.ts`
+ * scans the tool sources and fails on a direct call.
+ */
+export function emitRelayCard(
+  relayService: AiRelayService,
+  userId: string,
+  action: PendingAiAction,
+): boolean {
+  return relayService.emitPendingAction(userId, action, currentMcpSessionId());
+}
+
 /**
  * LLM-facing result returned by an MCP write tool when it is serving a relayed
  * browser prompt and has handed the confirmation off to the web chat as a

--- a/backend/src/mcp/mcp-relay-tool-activity.spec.ts
+++ b/backend/src/mcp/mcp-relay-tool-activity.spec.ts
@@ -3,6 +3,7 @@ import {
   installRelayToolActivity,
   wrapToolHandlerForRelay,
 } from "./mcp-relay-tool-activity";
+import { currentMcpSessionId } from "./mcp-session-context";
 import type { AiRelayService } from "../ai/relay/ai-relay.service";
 
 describe("wrapToolHandlerForRelay", () => {
@@ -25,10 +26,38 @@ describe("wrapToolHandlerForRelay", () => {
     const result = await wrapped({}, { sessionId: "s1" });
 
     expect(result).toEqual({ ok: true });
+    // The calling session travels with every report: it is what lets the relay
+    // tell this user's relay turn from a second, direct MCP client of theirs.
     expect((relayService as any).reportToolActivity.mock.calls).toEqual([
-      ["u1", "get_accounts", "start"],
-      ["u1", "get_accounts", "result", false],
+      ["u1", "get_accounts", "start", false, "s1"],
+      ["u1", "get_accounts", "result", false, "s1"],
     ]);
+  });
+
+  it("makes the calling session ambient for the duration of the handler", async () => {
+    // emitRelayCard reads this to decide whether a write belongs to a relay
+    // turn; without it every confirmation looks session-less and a direct
+    // client's card could be routed to the web chat.
+    const relayService = relay();
+    const seen: (string | undefined)[] = [];
+    const wrapped = wrapToolHandlerForRelay(
+      "manage_transactions",
+      async () => {
+        seen.push(currentMcpSessionId());
+        await Promise.resolve();
+        // Still ambient after an await -- handlers are async throughout.
+        seen.push(currentMcpSessionId());
+        return { ok: true };
+      },
+      resolveUser,
+      relayService,
+    );
+
+    await wrapped({}, { sessionId: "s1" });
+
+    expect(seen).toEqual(["s1", "s1"]);
+    // And it does not leak outside the call.
+    expect(currentMcpSessionId()).toBeUndefined();
   });
 
   it("reports isError:true when the tool result is an error", async () => {
@@ -47,6 +76,7 @@ describe("wrapToolHandlerForRelay", () => {
       "create_transaction",
       "result",
       true,
+      "s1",
     );
   });
 
@@ -66,6 +96,7 @@ describe("wrapToolHandlerForRelay", () => {
       "get_accounts",
       "result",
       true,
+      "s1",
     );
   });
 

--- a/backend/src/mcp/mcp-relay-tool-activity.ts
+++ b/backend/src/mcp/mcp-relay-tool-activity.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { UserContextResolver } from "./mcp-context";
 import type { AiRelayService } from "../ai/relay/ai-relay.service";
+import { withMcpSession } from "./mcp-session-context";
 
 // Relay control tools are infrastructure (the long-poll and answer channel),
 // not work the user should see as progress.
@@ -31,23 +32,43 @@ export function wrapToolHandlerForRelay(
   relayService: AiRelayService,
 ): ToolHandler {
   return async (args, extra) => {
-    const userId = resolve(extra?.sessionId)?.userId;
-    if (userId) {
-      relayService.reportToolActivity(userId, name, "start");
-    }
-    let isError = false;
-    try {
-      const result = await handler(args, extra);
-      isError = Boolean((result as { isError?: boolean } | undefined)?.isError);
-      return result;
-    } catch (err) {
-      isError = true;
-      throw err;
-    } finally {
+    const sessionId = extra?.sessionId;
+    const userId = resolve(sessionId)?.userId;
+    // Every tool handler runs inside its session's ambient context, so a write
+    // deep inside one can tell whether it is serving this session's relay turn
+    // or is a direct MCP client's own call (see mcp-session-context.ts).
+    return withMcpSession(sessionId, async () => {
       if (userId) {
-        relayService.reportToolActivity(userId, name, "result", isError);
+        relayService.reportToolActivity(
+          userId,
+          name,
+          "start",
+          false,
+          sessionId,
+        );
       }
-    }
+      let isError = false;
+      try {
+        const result = await handler(args, extra);
+        isError = Boolean(
+          (result as { isError?: boolean } | undefined)?.isError,
+        );
+        return result;
+      } catch (err) {
+        isError = true;
+        throw err;
+      } finally {
+        if (userId) {
+          relayService.reportToolActivity(
+            userId,
+            name,
+            "result",
+            isError,
+            sessionId,
+          );
+        }
+      }
+    });
   };
 }
 

--- a/backend/src/mcp/mcp-session-context.ts
+++ b/backend/src/mcp/mcp-session-context.ts
@@ -1,0 +1,30 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * The MCP session id of the tool call currently executing, made ambient by the
+ * per-call wrapper in `mcp-relay-tool-activity.ts` so code deep inside a tool
+ * handler can tell WHICH client is calling without threading the id through
+ * every helper signature.
+ *
+ * This exists because "which session is this" is a correctness question, not a
+ * diagnostic one: a reverse-relay turn belongs to the one session that claimed
+ * the prompt, and a write arriving from any other session of the same user is a
+ * direct MCP client's -- its confirmation belongs in that client, not in the
+ * web chat. Keyed on userId alone, one abandoned web-chat turn captured every
+ * direct write the user made afterwards.
+ *
+ * Absent means "cannot prove which session" -- callers must treat that as a
+ * direct client (confirm locally), never as a relay turn.
+ */
+const sessionStorage = new AsyncLocalStorage<{ sessionId?: string }>();
+
+export function withMcpSession<T>(
+  sessionId: string | undefined,
+  fn: () => T,
+): T {
+  return sessionStorage.run({ sessionId }, fn);
+}
+
+export function currentMcpSessionId(): string | undefined {
+  return sessionStorage.getStore()?.sessionId;
+}

--- a/backend/src/mcp/tools/investments.tool.ts
+++ b/backend/src/mcp/tools/investments.tool.ts
@@ -30,7 +30,7 @@ import {
   MAX_BULK_ACTION_ROWS,
   resolveApprovalMode,
 } from "../../ai/actions/ai-action.types";
-import { RELAY_PREVIEW_SHOWN } from "../mcp-relay-confirm";
+import { RELAY_PREVIEW_SHOWN, emitRelayCard } from "../mcp-relay-confirm";
 import {
   UserContextResolver,
   requireScope,
@@ -724,7 +724,7 @@ export class McpInvestmentsTools {
         userId,
         preview,
       );
-      if (this.relayService.emitPendingAction(userId, action)) {
+      if (emitRelayCard(this.relayService, userId, action)) {
         return toolResult(RELAY_PREVIEW_SHOWN);
       }
       const confirmation = await confirmWrite(
@@ -785,7 +785,7 @@ export class McpInvestmentsTools {
       bulk.okPreviews,
       bulk.previewRows,
     );
-    if (this.relayService.emitPendingAction(userId, action)) {
+    if (emitRelayCard(this.relayService, userId, action)) {
       return toolResult(RELAY_PREVIEW_SHOWN);
     }
     const confirmation = await confirmWrite(
@@ -849,7 +849,7 @@ export class McpInvestmentsTools {
         userId,
         preview,
       );
-      if (this.relayService.emitPendingAction(userId, action)) {
+      if (emitRelayCard(this.relayService, userId, action)) {
         return toolResult(RELAY_PREVIEW_SHOWN);
       }
       const confirmation = await confirmWrite(
@@ -930,7 +930,7 @@ export class McpInvestmentsTools {
       bulk.okRows,
       bulk.previewRows,
     );
-    if (this.relayService.emitPendingAction(userId, action)) {
+    if (emitRelayCard(this.relayService, userId, action)) {
       return toolResult(RELAY_PREVIEW_SHOWN);
     }
     const confirmation = await confirmWrite(
@@ -986,7 +986,7 @@ export class McpInvestmentsTools {
         userId,
         preview,
       );
-      if (this.relayService.emitPendingAction(userId, action)) {
+      if (emitRelayCard(this.relayService, userId, action)) {
         return toolResult(RELAY_PREVIEW_SHOWN);
       }
       const confirmation = await confirmWrite(
@@ -1057,7 +1057,7 @@ export class McpInvestmentsTools {
       bulk.okRows,
       bulk.previewRows,
     );
-    if (this.relayService.emitPendingAction(userId, action)) {
+    if (emitRelayCard(this.relayService, userId, action)) {
       return toolResult(RELAY_PREVIEW_SHOWN);
     }
     const confirmation = await confirmWrite(
@@ -1092,9 +1092,9 @@ export class McpInvestmentsTools {
     requestId: unknown,
     skipped: { index: number; reason: string }[],
   ) {
-    if (this.relayService.emitPendingAction(userId, cards[0])) {
+    if (emitRelayCard(this.relayService, userId, cards[0])) {
       for (let i = 1; i < cards.length; i++) {
-        this.relayService.emitPendingAction(userId, cards[i]);
+        emitRelayCard(this.relayService, userId, cards[i]);
       }
       return toolResult(RELAY_PREVIEW_SHOWN);
     }
@@ -1310,7 +1310,7 @@ export class McpInvestmentsTools {
     confirmMessage: string,
     requestId: unknown,
   ): Promise<"relay" | "accepted" | "declined"> {
-    if (this.relayService.emitPendingAction(userId, pendingAction)) {
+    if (emitRelayCard(this.relayService, userId, pendingAction)) {
       return "relay";
     }
     const confirmation = await confirmWrite(
@@ -1389,7 +1389,7 @@ export class McpInvestmentsTools {
       prep.okRows,
       prep.previewRows,
     );
-    if (this.relayService.emitPendingAction(userId, action)) {
+    if (emitRelayCard(this.relayService, userId, action)) {
       return toolResult(RELAY_PREVIEW_SHOWN);
     }
     const confirmation = await confirmWrite(
@@ -1475,7 +1475,7 @@ export class McpInvestmentsTools {
       prep.okRows,
       prep.previewRows,
     );
-    if (this.relayService.emitPendingAction(userId, action)) {
+    if (emitRelayCard(this.relayService, userId, action)) {
       return toolResult(RELAY_PREVIEW_SHOWN);
     }
     const confirmation = await confirmWrite(
@@ -1557,7 +1557,7 @@ export class McpInvestmentsTools {
       prep.okRows,
       prep.previewRows,
     );
-    if (this.relayService.emitPendingAction(userId, action)) {
+    if (emitRelayCard(this.relayService, userId, action)) {
       return toolResult(RELAY_PREVIEW_SHOWN);
     }
     const confirmation = await confirmWrite(
@@ -1644,9 +1644,9 @@ export class McpInvestmentsTools {
     requestId: unknown,
     skipped: { index: number; reason: string }[],
   ) {
-    if (this.relayService.emitPendingAction(userId, cards[0])) {
+    if (emitRelayCard(this.relayService, userId, cards[0])) {
       for (let i = 1; i < cards.length; i++) {
-        this.relayService.emitPendingAction(userId, cards[i]);
+        emitRelayCard(this.relayService, userId, cards[i]);
       }
       return toolResult(RELAY_PREVIEW_SHOWN);
     }

--- a/backend/src/mcp/tools/payees.tool.ts
+++ b/backend/src/mcp/tools/payees.tool.ts
@@ -14,7 +14,7 @@ import {
   PendingAiAction,
   MAX_BULK_ACTION_ROWS,
 } from "../../ai/actions/ai-action.types";
-import { RELAY_PREVIEW_SHOWN } from "../mcp-relay-confirm";
+import { RELAY_PREVIEW_SHOWN, emitRelayCard } from "../mcp-relay-confirm";
 import {
   UserContextResolver,
   requireScope,
@@ -247,7 +247,7 @@ export class McpPayeesTools {
     confirmMessage: string,
     requestId: unknown,
   ): Promise<"relay" | "accepted" | "declined"> {
-    if (this.relayService.emitPendingAction(userId, pendingAction)) {
+    if (emitRelayCard(this.relayService, userId, pendingAction)) {
       return "relay";
     }
     const confirmation = await confirmWrite(
@@ -318,7 +318,7 @@ export class McpPayeesTools {
       prep.okRows,
       prep.previewRows,
     );
-    if (this.relayService.emitPendingAction(userId, action)) {
+    if (emitRelayCard(this.relayService, userId, action)) {
       return toolResult(RELAY_PREVIEW_SHOWN);
     }
     const confirmation = await confirmWrite(
@@ -400,7 +400,7 @@ export class McpPayeesTools {
       prep.okRows,
       prep.previewRows,
     );
-    if (this.relayService.emitPendingAction(userId, action)) {
+    if (emitRelayCard(this.relayService, userId, action)) {
       return toolResult(RELAY_PREVIEW_SHOWN);
     }
     const confirmation = await confirmWrite(
@@ -479,7 +479,7 @@ export class McpPayeesTools {
       prep.okRows,
       prep.previewRows,
     );
-    if (this.relayService.emitPendingAction(userId, action)) {
+    if (emitRelayCard(this.relayService, userId, action)) {
       return toolResult(RELAY_PREVIEW_SHOWN);
     }
     const confirmation = await confirmWrite(
@@ -511,9 +511,9 @@ export class McpPayeesTools {
     requestId: unknown,
     skipped: { index: number; reason: string }[],
   ) {
-    if (this.relayService.emitPendingAction(userId, cards[0])) {
+    if (emitRelayCard(this.relayService, userId, cards[0])) {
       for (let i = 1; i < cards.length; i++) {
-        this.relayService.emitPendingAction(userId, cards[i]);
+        emitRelayCard(this.relayService, userId, cards[i]);
       }
       return toolResult(RELAY_PREVIEW_SHOWN);
     }

--- a/backend/src/mcp/tools/relay.tool.spec.ts
+++ b/backend/src/mcp/tools/relay.tool.spec.ts
@@ -134,6 +134,9 @@ describe("McpRelayTools", () => {
         "user-1",
         "p1",
         "looking up category",
+        // The calling session, so an agent that reconnected mid-prompt re-binds
+        // its relay turn instead of losing it to the old session id.
+        "s",
       );
     });
 

--- a/backend/src/mcp/tools/relay.tool.ts
+++ b/backend/src/mcp/tools/relay.tool.ts
@@ -50,7 +50,13 @@ export class McpRelayTools {
         if (check.error) return check.result;
 
         try {
-          const claimed = await this.relayService.waitForPrompt(ctx.userId);
+          // The claim is bound to THIS session: it is what makes a later write
+          // from this agent part of the relay turn, and a write from any other
+          // session of the same user a direct client's.
+          const claimed = await this.relayService.waitForPrompt(
+            ctx.userId,
+            extra.sessionId,
+          );
           if (!claimed) {
             // No prompt this window. If the user has gone quiet long enough,
             // tell the agent to stop looping instead of polling forever.
@@ -142,6 +148,9 @@ export class McpRelayTools {
             ctx.userId,
             args.promptId,
             args.text,
+            // Re-binds the turn when an agent reconnects mid-prompt with a
+            // fresh session id; knowing the promptId is what proves ownership.
+            extra.sessionId,
           );
           return toolResult({ delivered });
         } catch (err: unknown) {

--- a/backend/src/mcp/tools/transactions.tool.ts
+++ b/backend/src/mcp/tools/transactions.tool.ts
@@ -32,7 +32,7 @@ import { AttachmentToolPrepService } from "../../attachments/attachment-tool-pre
 import { AttachmentsService } from "../../attachments/attachments.service";
 import { sniffAttachmentMime } from "../../attachments/attachment-mime.util";
 import { withUserContext } from "../../common/db/with-context";
-import { RELAY_PREVIEW_SHOWN } from "../mcp-relay-confirm";
+import { RELAY_PREVIEW_SHOWN, emitRelayCard } from "../mcp-relay-confirm";
 import {
   UserContextResolver,
   requireScope,
@@ -942,7 +942,7 @@ export class McpTransactionsTools {
     confirmMessage: string,
     requestId: unknown,
   ): Promise<"relay" | "accepted" | "declined"> {
-    if (this.relayService.emitPendingAction(userId, pendingAction)) {
+    if (emitRelayCard(this.relayService, userId, pendingAction)) {
       return "relay";
     }
     const confirmation = await confirmWrite(
@@ -1347,9 +1347,9 @@ export class McpTransactionsTools {
       );
     }
     // Relay: emit each card to the web chat.
-    if (this.relayService.emitPendingAction(userId, cards[0])) {
+    if (emitRelayCard(this.relayService, userId, cards[0])) {
       for (let i = 1; i < cards.length; i++) {
-        this.relayService.emitPendingAction(userId, cards[i]);
+        emitRelayCard(this.relayService, userId, cards[i]);
       }
       return toolResult(RELAY_PREVIEW_SHOWN);
     }
@@ -1583,7 +1583,7 @@ export class McpTransactionsTools {
       bulk.okRows,
       bulk.previewRows,
     );
-    if (this.relayService.emitPendingAction(userId, action)) {
+    if (emitRelayCard(this.relayService, userId, action)) {
       return toolResult(RELAY_PREVIEW_SHOWN);
     }
     const confirmation = await confirmWrite(
@@ -1688,7 +1688,7 @@ export class McpTransactionsTools {
       bulk.okRows,
       bulk.previewRows,
     );
-    if (this.relayService.emitPendingAction(userId, action)) {
+    if (emitRelayCard(this.relayService, userId, action)) {
       return toolResult(RELAY_PREVIEW_SHOWN);
     }
     const confirmation = await confirmWrite(
@@ -1721,9 +1721,9 @@ export class McpTransactionsTools {
     skipped: { index: number; reason: string }[],
   ) {
     // Relay path: emit each card; the browser confirms+commits each.
-    if (this.relayService.emitPendingAction(userId, cards[0])) {
+    if (emitRelayCard(this.relayService, userId, cards[0])) {
       for (let i = 1; i < cards.length; i++) {
-        this.relayService.emitPendingAction(userId, cards[i]);
+        emitRelayCard(this.relayService, userId, cards[i]);
       }
       return toolResult(RELAY_PREVIEW_SHOWN);
     }

--- a/backend/src/oauth/oauth-interaction.controller.spec.ts
+++ b/backend/src/oauth/oauth-interaction.controller.spec.ts
@@ -211,7 +211,7 @@ describe("OAuthInteractionController", () => {
       );
     });
 
-    it("renders a friendly completed page when the interaction is stale (consumed/expired)", async () => {
+    it("renders an honest closed-window page when the interaction is stale (consumed/expired)", async () => {
       const { controller } = makeController({
         interactionDetails: jest.fn().mockRejectedValue(
           Object.assign(new Error("invalid_request"), {
@@ -225,8 +225,66 @@ describe("OAuthInteractionController", () => {
       await controller.render(req, res);
 
       expect(res.status).toHaveBeenCalledWith(200);
+      // The page must NOT claim the authorization completed: a superseded
+      // reconnect attempt lands here while the client is still waiting, and
+      // "already complete" told the user to stop when they needed to retry.
       expect(res.send).toHaveBeenCalledWith(
-        expect.stringContaining("authorization is already complete"),
+        expect.stringContaining("no longer active"),
+      );
+      expect(res.send).toHaveBeenCalledWith(
+        expect.stringContaining("start the connection again"),
+      );
+      expect(res.send).not.toHaveBeenCalledWith(
+        expect.stringContaining("already complete"),
+      );
+    });
+
+    it("redirects a stale page to the live interaction's own consent page (uid mismatch)", async () => {
+      // A second authorization attempt moved the single path-'/' interaction
+      // cookie to a new uid while this older page was still open. The page
+      // must not act under its stale uid: send the browser to the live
+      // interaction so the user reviews the attempt the client is waiting on.
+      const { controller } = makeController({
+        interactionDetails: jest.fn().mockResolvedValue({
+          uid: "live-uid",
+          prompt: { name: "consent" },
+          params: { client_id: "claude-desktop", scope: "monize:read" },
+        }),
+      });
+      const req = {
+        cookies: { auth_token: "valid" },
+        params: { uid: "stale-uid" },
+      } as any;
+      const res = makeRes();
+
+      await controller.render(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        302,
+        "https://app.monize.test/api/v1/oauth-consent/live-uid",
+      );
+      expect(res.send).not.toHaveBeenCalled();
+    });
+
+    it("renders normally when the page uid matches the live interaction", async () => {
+      const { controller } = makeController({
+        interactionDetails: jest.fn().mockResolvedValue({
+          uid: "u1",
+          prompt: { name: "consent" },
+          params: { client_id: "claude-desktop", scope: "monize:read" },
+        }),
+      });
+      const req = {
+        cookies: { auth_token: "valid" },
+        params: { uid: "u1" },
+      } as any;
+      const res = makeRes();
+
+      await controller.render(req, res);
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.send).toHaveBeenCalledWith(
+        expect.stringContaining("Claude Desktop"),
       );
     });
 
@@ -255,7 +313,7 @@ describe("OAuthInteractionController", () => {
       },
     };
 
-    it("renders a friendly completed page when the interaction is already consumed", async () => {
+    it("renders an honest closed-window page when the interaction is already consumed", async () => {
       const { controller } = makeController({
         interactionDetails: jest.fn().mockRejectedValue(
           Object.assign(new Error("invalid_request"), {
@@ -270,8 +328,88 @@ describe("OAuthInteractionController", () => {
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.send).toHaveBeenCalledWith(
-        expect.stringContaining("authorization is already complete"),
+        expect.stringContaining("no longer active"),
       );
+      expect(res.send).not.toHaveBeenCalledWith(
+        expect.stringContaining("already complete"),
+      );
+    });
+
+    it("redirects a stale Allow submit to the live interaction instead of completing the wrong attempt", async () => {
+      // Clicking Allow on a superseded page must not grant/finish the
+      // cookie-resolved interaction: the user reviewed a different page's
+      // client and scopes. Re-render the live attempt for a fresh approval.
+      const grant = {
+        addOIDCScope: jest.fn(),
+        addOIDCClaims: jest.fn(),
+        addResourceScope: jest.fn(),
+        save: jest.fn().mockResolvedValue("grant-id-1"),
+      };
+      class GrantMock {
+        constructor() {
+          return grant;
+        }
+        static find = jest.fn().mockResolvedValue(null);
+      }
+      const { controller, interactionFinished } = makeController({
+        interactionDetails: jest.fn().mockResolvedValue({
+          uid: "live-uid",
+          prompt: { name: "consent", details: consentDetails },
+          params: { client_id: "claude-desktop" },
+          session: { accountId: USER_ID },
+        }),
+        Grant: GrantMock as any,
+      });
+      const req = {
+        cookies: { auth_token: "v" },
+        params: { uid: "stale-uid" },
+        body: {},
+      } as any;
+      const res = makeRes();
+
+      await controller.confirm(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        303,
+        "https://app.monize.test/api/v1/oauth-consent/live-uid",
+      );
+      expect(grant.save).not.toHaveBeenCalled();
+      expect(interactionFinished).not.toHaveBeenCalled();
+    });
+
+    it("confirms normally when the page uid matches the live interaction", async () => {
+      const grant = {
+        addOIDCScope: jest.fn(),
+        addOIDCClaims: jest.fn(),
+        addResourceScope: jest.fn(),
+        save: jest.fn().mockResolvedValue("grant-id-1"),
+      };
+      class GrantMock {
+        constructor() {
+          return grant;
+        }
+        static find = jest.fn().mockResolvedValue(null);
+      }
+      const { controller, interactionFinished } = makeController({
+        interactionDetails: jest.fn().mockResolvedValue({
+          uid: "u1",
+          prompt: { name: "consent", details: consentDetails },
+          params: { client_id: "claude-desktop" },
+          session: { accountId: USER_ID },
+        }),
+        Grant: GrantMock as any,
+      });
+      const req = {
+        cookies: { auth_token: "v" },
+        params: { uid: "u1" },
+        body: {},
+      } as any;
+      const res = makeRes();
+
+      await controller.confirm(req, res);
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(interactionFinished).toHaveBeenCalled();
     });
 
     it("returns 401 when user not authenticated", async () => {

--- a/backend/src/oauth/oauth-interaction.controller.spec.ts
+++ b/backend/src/oauth/oauth-interaction.controller.spec.ts
@@ -181,6 +181,32 @@ describe("OAuthInteractionController", () => {
       expect(ctx?.system).toBeUndefined();
     });
 
+    it("sets a page CSP whose form-action lets the submit's redirect chain reach the client's https callback", async () => {
+      // Helmet's app-wide policy carries the default `form-action 'self'`, and
+      // Chrome enforces form-action on every redirect hop after a form submit.
+      // The Allow POST resolves 'self' -> /oauth/auth resume -> the client's
+      // https redirect_uri (cross-origin); without 'self' https: here Chrome
+      // silently cancels the last hop -- the server logs authorization.success
+      // while the browser never delivers the code and the consent page just
+      // sits there. The consent page must therefore ship its own CSP.
+      const { controller } = makeController({
+        interactionDetails: jest.fn().mockResolvedValue({
+          uid: "u",
+          prompt: { name: "consent" },
+          params: { client_id: "claude-desktop", scope: "monize:read" },
+        }),
+      });
+      const req = { cookies: { auth_token: "valid" } } as any;
+      const res = makeRes();
+
+      await controller.render(req, res);
+
+      expect(res.setHeader).toHaveBeenCalledWith(
+        "Content-Security-Policy",
+        expect.stringContaining("form-action 'self' https:"),
+      );
+    });
+
     it("renders consent HTML for authenticated user with valid prompt", async () => {
       const { controller } = makeController({
         interactionDetails: jest.fn().mockResolvedValue({

--- a/backend/src/oauth/oauth-interaction.controller.ts
+++ b/backend/src/oauth/oauth-interaction.controller.ts
@@ -44,12 +44,13 @@ export class OAuthInteractionController {
       // the consent was already submitted). Render a friendly page
       // instead of bubbling SessionNotFound up to a 500.
       this.logger.log(
-        `interaction.render no live interaction (${(err as Error).name}: ${(err as Error).message}) — rendering completed page`,
+        `interaction.render uid=${req.params?.uid} no live interaction (${(err as Error).name}: ${(err as Error).message}) — rendering closed-window page`,
       );
-      this.respondWithCompletedPage(res);
+      this.respondWithStaleInteractionPage(res);
       return;
     }
     const { prompt, params, uid } = interaction;
+    if (this.redirectStalePage(req, res, uid, "render")) return;
     this.logger.log(
       `interaction.render uid=${uid} prompt=${prompt.name} client=${params.client_id} scope="${params.scope}"`,
     );
@@ -135,13 +136,14 @@ export class OAuthInteractionController {
       // Duplicate / stale form submission (back button, double-click,
       // or claude.ai re-prompting after the first submit had already
       // succeeded). The interaction has been consumed; render a
-      // friendly "completed" page instead of a 500.
+      // friendly closed-window page instead of a 500.
       this.logger.log(
-        `interaction.confirm no live interaction (${(err as Error).name}: ${(err as Error).message}) — rendering completed page`,
+        `interaction.confirm uid=${req.params?.uid} no live interaction (${(err as Error).name}: ${(err as Error).message}) — rendering closed-window page`,
       );
-      this.respondWithCompletedPage(res);
+      this.respondWithStaleInteractionPage(res);
       return;
     }
+    if (this.redirectStalePage(req, res, interaction.uid, "confirm")) return;
     const { prompt, params, session } = interaction;
 
     if (prompt.name !== "consent") {
@@ -246,13 +248,61 @@ export class OAuthInteractionController {
       // Stale uid (back button, retry after the original abort already
       // landed). Render a friendly closed-window page instead of 500.
       this.logger.log(
-        `interaction.abort no live interaction (${(err as Error).name}: ${(err as Error).message}) — rendering completed page`,
+        `interaction.abort uid=${req.params?.uid} no live interaction (${(err as Error).name}: ${(err as Error).message}) — rendering closed-window page`,
       );
-      this.respondWithCompletedPage(res);
+      this.respondWithStaleInteractionPage(res);
     }
   }
 
-  private respondWithCompletedPage(res: Response): void {
+  /**
+   * The provider resolves the live interaction from the single `_interaction`
+   * cookie (pinned to path '/'), never from the page URL -- so when an MCP
+   * client fires a second authorization attempt (Claude retries reconnects),
+   * the cookie moves to the new attempt while an older consent page may still
+   * be on screen. Acting on the cookie's interaction from that stale page
+   * would silently complete a DIFFERENT attempt than the one the user
+   * reviewed, and the client is usually waiting on the newest attempt anyway.
+   * Detect the mismatch and send the browser to the live interaction's own
+   * page so the user approves the attempt that can actually finish.
+   *
+   * Returns true when a redirect was issued (the caller must stop). The uid
+   * param is absent only outside the real Express route (unit tests calling
+   * the handler directly); the guard is a self-heal, not an auth boundary --
+   * the session/account checks below remain the security checks.
+   */
+  private redirectStalePage(
+    req: Request,
+    res: Response,
+    liveUid: string,
+    phase: "render" | "confirm",
+  ): boolean {
+    const pageUid = req.params?.uid;
+    if (!pageUid || pageUid === liveUid) return false;
+    this.logger.log(
+      `interaction.${phase} page uid=${pageUid} superseded by live interaction ${liveUid} — redirecting to the live consent page`,
+    );
+    // 303 turns the stale form POST into a GET of the live page (PRG).
+    res.redirect(phase === "confirm" ? 303 : 302, this.consentUrlFor(liveUid));
+    return true;
+  }
+
+  private consentUrlFor(uid: string): string {
+    // Absolute URL for the same reverse-proxy reasons as interactions.url in
+    // oauth-provider.service.ts (Envoy can rewrite/drop relative redirects).
+    const base =
+      this.configService.get<string>("PUBLIC_APP_URL")?.replace(/\/$/, "") ??
+      "";
+    return `${base}/api/v1/oauth-consent/${encodeURIComponent(uid)}`;
+  }
+
+  /**
+   * Rendered when the page's interaction no longer exists. That covers both a
+   * harmless duplicate submit after a success AND a superseded/expired attempt
+   * whose client is still waiting -- the copy must not claim success, or the
+   * waiting case reads as done and the user never retries (the connection then
+   * "never completes"). Say what is knowable and give the retry path.
+   */
+  private respondWithStaleInteractionPage(res: Response): void {
     res.setHeader("Content-Type", "text/html; charset=utf-8");
     res.setHeader("Cache-Control", "no-store");
     res.status(200).send(`<!DOCTYPE html>
@@ -261,7 +311,7 @@ export class OAuthInteractionController {
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <meta name="robots" content="noindex" />
-<title>Authorization complete — Monize</title>
+<title>Authorization window closed — Monize</title>
 <style>
   :root {
     --bg: #f8fafc; --card: #ffffff; --text: #0f172a;
@@ -287,8 +337,9 @@ export class OAuthInteractionController {
 <body>
   <main class="card">
     <div class="brand">Monize</div>
-    <h1>This authorization is already complete</h1>
-    <p>You can safely close this window and return to the application that requested access.</p>
+    <h1>This authorization window is no longer active</h1>
+    <p>The sign-in attempt this window belonged to has already finished or expired.</p>
+    <p style="margin-top:12px">If the application that requested access now shows Monize as connected, you are done — close this window. If it is still waiting, close this window and start the connection again from that application; a fresh approval prompt will appear.</p>
   </main>
 </body>
 </html>`);

--- a/backend/src/oauth/oauth-interaction.controller.ts
+++ b/backend/src/oauth/oauth-interaction.controller.ts
@@ -115,8 +115,7 @@ export class OAuthInteractionController {
             ? params.resource
             : this.providerService.getMcpResourceUrl(),
       });
-      res.setHeader("Content-Type", "text/html; charset=utf-8");
-      res.setHeader("Cache-Control", "no-store");
+      this.setInteractionPageHeaders(res);
       res.send(html);
       return;
     }
@@ -296,6 +295,32 @@ export class OAuthInteractionController {
   }
 
   /**
+   * Headers for the HTML pages this controller serves. The Content-Security-
+   * Policy REPLACES the app-wide Helmet policy on these responses, and it must:
+   * Helmet's defaults (merged under the global config) include
+   * `form-action 'self'`, and Chrome enforces form-action against EVERY hop of
+   * the redirect chain that follows a form submission. The Allow/Deny POST is
+   * answered with a 303 to the provider's /oauth/auth resume endpoint (self),
+   * which 303s again to the OAuth client's redirect_uri (cross-origin, e.g.
+   * claude.ai) carrying the authorization code. Under `form-action 'self'`
+   * Chrome silently cancels that final hop: the server logs
+   * authorization.success, the browser stays parked on the consent form, and
+   * the client never receives its code -- the connection "never completes"
+   * with nothing visibly wrong. So this page's policy allows the chain to end
+   * at any https origin (the redirect_uri is per-client and dynamic, so it
+   * cannot be enumerated statically); everything else stays locked down.
+   */
+  private setInteractionPageHeaders(res: Response): void {
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.setHeader("Cache-Control", "no-store");
+    res.setHeader(
+      "Content-Security-Policy",
+      "default-src 'none'; base-uri 'none'; frame-ancestors 'none'; " +
+        "style-src 'unsafe-inline'; form-action 'self' https:",
+    );
+  }
+
+  /**
    * Rendered when the page's interaction no longer exists. That covers both a
    * harmless duplicate submit after a success AND a superseded/expired attempt
    * whose client is still waiting -- the copy must not claim success, or the
@@ -303,8 +328,7 @@ export class OAuthInteractionController {
    * "never completes"). Say what is knowable and give the retry path.
    */
   private respondWithStaleInteractionPage(res: Response): void {
-    res.setHeader("Content-Type", "text/html; charset=utf-8");
-    res.setHeader("Cache-Control", "no-store");
+    this.setInteractionPageHeaders(res);
     res.status(200).send(`<!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
## Linked discussion / issue

Closes #
Approved in: <!-- discussion/issue link -->

## Summary

Three connected defects reported while connecting Monize to Claude Desktop over MCP. All are backend-only.

**1. A direct MCP client's write-confirmation cards were routed to the Monize web chat** (`7a91adb`, `15e7cb2`)

Creating a transaction from Claude Desktop replied "approve it in the Monize web UI" instead of confirming in Claude Desktop. The relay asked *"does this **user** have a relay turn?"* when the real question is *"is **this session** serving one?"* — a user can have the web-chat relay agent and a direct client connected at the same time. Three separate signals answered the wrong question:

- `reportToolActivity` stamped `lastPollAt`, the relay agent's poll-liveness timestamp. Every data tool call lands there — including the write tool itself, milliseconds earlier — so `hasRelayTurn`'s connection-liveness branch was always true.
- The same call bumped the idle timer of *any* in-flight prompt for the user, so a direct client's traffic kept an abandoned relay prompt alive past its timeout. While it sat in `inFlight` it captured every direct write.
- Past the 20-minute hard deadline the prompt became an `awaitingLate` marker, which `hasRelayTurn` accepted with no TTL check and which was pruned only when some *other* claimed prompt timed out — in practice never. One abandoned web-chat turn therefore poisoned every later direct write until the process restarted.

A claim now records the MCP session that made it (`claimedBy`), and liveness, event mirroring and the relay/direct decision all match on it; a late marker additionally has to be inside the late-answer retention window. An agent that reconnects mid-prompt re-binds its turn through `report_progress`, which proves ownership by knowing the unguessable `promptId`, so the #793 late-card buffering still works. The session travels via an ambient `AsyncLocalStorage` context seeded by the per-call wrapper, so tools call `emitRelayCard(...)` instead of threading the id through every helper.

**2. Reconnecting an MCP client dead-ended on "This authorization is already complete"** (`7bb04d8`)

The provider resolves the live interaction solely from the `_interaction` cookie, never from the page URL. A reconnecting client can fire several authorization attempts; each overwrites that one cookie, and each completed attempt rotates the session identifier. A page from a superseded attempt then either acted on a *different* interaction than the user reviewed, or hit `SessionNotFound` and rendered a page claiming success — telling the user to stop exactly when they needed to retry. `render`/`confirm` now compare the page's `:uid` with the cookie-resolved interaction and redirect to the live one; the fallback page no longer claims success.

**3. Clicking "Allow access" appeared to do nothing** (`b0e1a3e`)

The backend logged a full success (grant saved, `interaction.ended`, `authorization.success`) but the browser stayed on the consent form and the client never exchanged a code. Helmet's app-wide CSP carries the default `form-action 'self'`, and Chrome enforces `form-action` against every redirect hop following a form submission — so the last hop (`/oauth/auth` resume → the client's cross-origin `redirect_uri`) was silently cancelled. The consent page now ships its own policy with `form-action 'self' https:` (the `redirect_uri` is per-client and dynamic, so it cannot be enumerated) while keeping `default-src 'none'`, no scripts and no framing. The global Helmet policy is unchanged.

**Notes for review**

- Each fix's rule is written down where the next change will meet it: `backend/src/mcp/CLAUDE.md` (relay turns belong to one session, for a bounded time) and `backend/CLAUDE.md` (a page whose form submission redirects off-origin needs its own CSP).
- `mcp-relay-confirm.spec.ts` scans the tool sources and fails if any tool calls `relayService.emitPendingAction` directly, since a call site that drops the session id reintroduces defect 1.
- No i18n catalogs changed. The OAuth consent and interaction pages are server-rendered outside `nestjs-i18n` and were already hardcoded English; the reworded stale-window page follows the existing page it replaces.
- No migrations, no schema changes, no frontend changes.

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a **single concern** (large work is split into a series).
- [x] New behavior has tests, and the existing suite passes.
- [x] All user-facing strings are translated for **every** locale (i18n parity).
- [x] No shared/core areas were refactored without prior agreement.
- [x] The branch is rebased on the latest `main`.
- [x] AI assistance is disclosed below, and I have reviewed and own the result.

## AI assistance disclosure

Written with Claude Code, from a report of the misrouted confirmation card; defects 2 and 3 surfaced while reproducing it. Every fix carries a regression test that was confirmed to **fail** against the previous code before being kept — for the session-scoping work that meant temporarily restoring the old predicates and watching each of the five new tests go red, rather than trusting a green suite. Verified locally: full backend unit suite (11,155 tests across 417 suites), `npm run lint`, and `npm run typecheck`. The schema-drift and E2E jobs were not run locally; this PR touches no migrations, schema or frontend code.

https://claude.ai/code/session_01KgE7bQoQp4FvkkCM4gBYgv