### PR TITLE
04: Add concurrency foundations for safe database writes (v1.15.0)

### DIFF
--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -64,6 +64,9 @@ const WITH_CONTEXT_ALLOWLIST = [
   // Joint accounts (N1): refreshing a stale joint account's current-month
   // snapshot runs recalculateAccount under withUserContext(ownerUserId) so
   // the owner-keyed mab rows are written with the correct identity.
+  // The stale-snapshot sweep is likewise a cross-user cron fan-out (system
+  // context) whose per-account body runs as the owning user -- there is no
+  // request to inherit an identity from (DR-04-03).
   "src/net-worth/net-worth.service.ts",
   "src/notifications/bill-reminder.service.ts",
   "src/oauth/oauth-interaction.controller.ts",

--- a/backend/src/common/db/locks.spec.ts
+++ b/backend/src/common/db/locks.spec.ts
@@ -1,0 +1,265 @@
+import { EntityManager } from "typeorm";
+import {
+  LockScope,
+  acquireAdvisoryLock,
+  acquireAdvisoryLocks,
+  lockAccountsForBalanceWrite,
+  lockHoldingScope,
+  lockTokenFamily,
+  lockTransactionRow,
+  lockTransactionRows,
+} from "./locks";
+import { locksMockModule } from "../../test-helpers/locks-testing";
+
+/**
+ * These specs assert the SQL each helper emits and the order it emits it in.
+ *
+ * Whether the locks actually exclude anything is a question only two real
+ * connections can answer, and the integration suites cover that. What a unit
+ * spec can pin down is the part that goes wrong silently: a lock that ends up
+ * *after* the read it was meant to protect, or a set of ids locked in whatever
+ * order the query returned them, which is how two writers deadlock on each
+ * other's second lock.
+ */
+describe("common/db/locks", () => {
+  let manager: { query: jest.Mock };
+
+  beforeEach(() => {
+    manager = { query: jest.fn().mockResolvedValue([]) };
+  });
+
+  const asManager = () => manager as unknown as EntityManager;
+
+  describe("advisory locks", () => {
+    it("keys the lock on a namespace and a hashed id", async () => {
+      await acquireAdvisoryLock(asManager(), LockScope.Holdings, "acc-1");
+
+      expect(manager.query).toHaveBeenCalledWith(
+        "SELECT pg_advisory_xact_lock($1::int, hashtext($2))",
+        [LockScope.Holdings, "acc-1"],
+      );
+    });
+
+    it("locks a set in ascending order, de-duplicated", async () => {
+      // The deadlock guard: a transfer locking two accounts and a rebuild
+      // locking the same two must take them in the same order, or each can end
+      // up holding the other's next lock.
+      await acquireAdvisoryLocks(asManager(), LockScope.Holdings, [
+        "acc-c",
+        "acc-a",
+        "acc-b",
+        "acc-a",
+      ]);
+
+      expect(manager.query.mock.calls.map((c) => c[1][1])).toEqual([
+        "acc-a",
+        "acc-b",
+        "acc-c",
+      ]);
+    });
+
+    it("gives each kind of lock its own namespace", async () => {
+      // Two different kinds of lock must not be able to collide on a hashed id.
+      await lockHoldingScope(asManager(), ["x"]);
+      await lockTokenFamily(asManager(), "x");
+
+      const namespaces = manager.query.mock.calls.map((c) => c[1][0]);
+      expect(new Set(namespaces).size).toBe(2);
+    });
+  });
+
+  describe("lockAccountsForBalanceWrite", () => {
+    it("row-locks the accounts in ascending id order, scoped to the owner", async () => {
+      await lockAccountsForBalanceWrite(asManager(), ["b", "a", "b"], "user-1");
+
+      const [sql, params] = manager.query.mock.calls[0];
+      expect(sql).toContain("FROM accounts");
+      expect(sql).toContain("ORDER BY id");
+      expect(sql).toContain("FOR UPDATE");
+      // Owner-scoped like the transaction lock helpers, so a balance-write lock
+      // can never land on an account that is not the caller's.
+      expect(sql).toContain("user_id = $2");
+      expect(params).toEqual([["a", "b"], "user-1"]);
+    });
+
+    it("locks without an owner predicate for a genuinely cross-user caller", async () => {
+      // The hourly future-dated fold runs under withSystemContext across every
+      // owner in a timezone bucket and passes no userId; it must still lock, just
+      // unscoped -- the one deliberate exception to owner-scoping.
+      await lockAccountsForBalanceWrite(asManager(), ["b", "a"]);
+
+      const [sql, params] = manager.query.mock.calls[0];
+      expect(sql).toContain("FOR UPDATE");
+      expect(sql).not.toContain("user_id");
+      expect(params).toEqual([["a", "b"]]);
+    });
+
+    it("issues nothing for an empty set", async () => {
+      await lockAccountsForBalanceWrite(asManager(), [], "user-1");
+
+      expect(manager.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("lockTransactionRow", () => {
+    it("selects FOR UPDATE, scoped to the owner", async () => {
+      manager.query.mockResolvedValue([
+        {
+          id: "tx-1",
+          account_id: "acc-1",
+          amount: "-20.0000",
+          transaction_date: "2026-01-15",
+          status: "CLEARED",
+          is_split: false,
+          linked_transaction_id: null,
+          parent_transaction_id: null,
+          payee_id: "payee-1",
+          payee_name: "Corner Store",
+        },
+      ]);
+
+      const row = await lockTransactionRow(asManager(), "tx-1", "user-1");
+
+      const [sql, params] = manager.query.mock.calls[0];
+      expect(sql).toContain("FOR UPDATE");
+      expect(sql).toContain("user_id = $2");
+      expect(sql).toContain("payee_id");
+      expect(sql).toContain("payee_name");
+      expect(params).toEqual(["tx-1", "user-1"]);
+      // The amount arrives as a decimal string from the driver and must reach
+      // the caller as a number -- a balance delta computed from a string
+      // concatenates. payee_id/payee_name are carried so a split's counterpart
+      // and embedded investment rows are built from the locked parent, not a
+      // stale snapshot (audit FV4-002).
+      expect(row).toEqual({
+        id: "tx-1",
+        accountId: "acc-1",
+        amount: -20,
+        transactionDate: "2026-01-15",
+        status: "CLEARED",
+        isSplit: false,
+        linkedTransactionId: null,
+        parentTransactionId: null,
+        payeeId: "payee-1",
+        payeeName: "Corner Store",
+      });
+    });
+
+    it("selects the date as text, not as a Date", async () => {
+      // A raw select bypasses the entity transformer, so a DATE column comes back
+      // as a JS Date parsed in UTC -- and reading it can shift the day. See the
+      // raw-select rule in backend/CLAUDE.md.
+      await lockTransactionRow(asManager(), "tx-1", "user-1");
+
+      expect(manager.query.mock.calls[0][0]).toContain(
+        "TO_CHAR(transaction_date, 'YYYY-MM-DD')",
+      );
+    });
+
+    it("returns null when no row matched", async () => {
+      manager.query.mockResolvedValue([]);
+
+      expect(
+        await lockTransactionRow(asManager(), "tx-1", "user-1"),
+      ).toBeNull();
+    });
+  });
+
+  describe("lockTransactionRows", () => {
+    it("locks in ascending id order and returns what it found", async () => {
+      manager.query.mockResolvedValue([
+        {
+          id: "tx-a",
+          account_id: "acc-1",
+          amount: "10.0000",
+          transaction_date: "2026-01-15",
+          status: null,
+          is_split: false,
+          linked_transaction_id: null,
+          parent_transaction_id: null,
+          payee_id: "payee-a",
+          payee_name: "Store A",
+        },
+      ]);
+
+      const found = await lockTransactionRows(
+        asManager(),
+        ["tx-b", "tx-a", "tx-b"],
+        "user-1",
+      );
+
+      const [sql, params] = manager.query.mock.calls[0];
+      expect(sql).toContain("ORDER BY id");
+      expect(sql).toContain("FOR UPDATE");
+      expect(sql).toContain("payee_id");
+      expect(sql).toContain("payee_name");
+      expect(params).toEqual([["tx-a", "tx-b"], "user-1"]);
+      // A row that is gone is absent, not zero-valued: a caller must be able to
+      // tell "no longer there" from "there with amount 0", because reversing a
+      // balance for a row another request already deleted is the double-delete
+      // corruption in P4-003.
+      expect([...found.keys()]).toEqual(["tx-a"]);
+      expect(found.get("tx-a")!.amount).toBe(10);
+      // The parent's payee travels with the locked row so a split counterpart is
+      // built from it and not a stale snapshot (audit FV4-002).
+      expect(found.get("tx-a")!.payeeId).toBe("payee-a");
+      expect(found.get("tx-a")!.payeeName).toBe("Store A");
+    });
+
+    it("refuses a batch that mixes a split parent with its own leg", async () => {
+      // Ascending-id order cannot honour "parent before leg" (audit RV4-005): if
+      // the leg's UUID sorts first, this call would take them in the forbidden
+      // order and deadlock against a lockTransactionRow parent-then-leg path. The
+      // misuse must fail fast rather than deadlock in production.
+      manager.query.mockResolvedValue([
+        {
+          id: "parent-tx",
+          account_id: "acc-1",
+          amount: "0",
+          transaction_date: "2026-01-15",
+          status: null,
+          is_split: true,
+          linked_transaction_id: null,
+          parent_transaction_id: null,
+          payee_id: null,
+          payee_name: null,
+        },
+        {
+          id: "leg-tx",
+          account_id: "acc-1",
+          amount: "10.0000",
+          transaction_date: "2026-01-15",
+          status: null,
+          is_split: false,
+          linked_transaction_id: null,
+          parent_transaction_id: "parent-tx",
+          payee_id: null,
+          payee_name: null,
+        },
+      ]);
+
+      await expect(
+        lockTransactionRows(asManager(), ["parent-tx", "leg-tx"], "user-1"),
+      ).rejects.toThrow(/split parent and its leg/);
+    });
+
+    it("issues nothing for an empty set", async () => {
+      const found = await lockTransactionRows(asManager(), [], "user-1");
+
+      expect(manager.query).not.toHaveBeenCalled();
+      expect(found.size).toBe(0);
+    });
+  });
+
+  describe("locksMockModule (test-double drift guard)", () => {
+    it("exposes exactly the runtime module's exports", () => {
+      // A new export added to locks.ts but not to the mock factory would resolve
+      // to `undefined` in every spec that mocks this module -- a silent hole. Pin
+      // the mock's key set to the real module's runtime exports so the two cannot
+      // drift.
+      const real = jest.requireActual("./locks") as Record<string, unknown>;
+      const mock = locksMockModule() as Record<string, unknown>;
+      expect(Object.keys(mock).sort()).toEqual(Object.keys(real).sort());
+    });
+  });
+});

--- a/backend/src/common/db/locks.ts
+++ b/backend/src/common/db/locks.ts
@@ -1,0 +1,334 @@
+import { EntityManager } from "typeorm";
+
+/**
+ * The serialization primitives every writer of derived financial state shares.
+ *
+ * Two protocols maintain derived state in this codebase and they are not
+ * compatible with each other:
+ *
+ *   1. an atomic delta -- `current_balance = current_balance + $1`;
+ *   2. an absolute recomputation -- read the ledger, write the total.
+ *
+ * (1) is safe against another (1): the `UPDATE` re-reads the row after it wins
+ * the row lock, so two deltas compose. (1) is *not* safe against (2): under
+ * `READ COMMITTED` the recomputation's `SELECT` and its `UPDATE` are separate
+ * statement snapshots, so a delta that commits between them is silently
+ * overwritten with a total that never saw it (audit P4-005).
+ *
+ * The fix is not to pick one protocol -- it is to make every writer take the
+ * same lock before it reads the inputs it will write back:
+ *
+ *   - `lockAccountsForBalanceWrite` for `accounts.current_balance`. A real row
+ *     lock, which is what makes (1) and (2) compose: an absolute writer holding
+ *     it forces a concurrent delta to wait, and the delta's `+ $1` then applies
+ *     to the total the recomputation just committed. Conversely a recomputation
+ *     that arrives second blocks on the row, and its ledger `SELECT` -- issued
+ *     after the lock, so on a fresh snapshot -- sees the delta's ledger row.
+ *
+ *   - `lockHoldingScope` for `holdings`. A holding cannot always be row-locked
+ *     (the row may not exist yet) and a rebuild must serialize against
+ *     *investment_transactions inserts*, not just against holding rows, so the
+ *     lock is an advisory one keyed by account.
+ *
+ *   - `lockTokenFamily` for a refresh-token family, whose members are inserted
+ *     concurrently with the revocation that has to cover them (P4-011).
+ *
+ * Ordering rule, to keep these deadlock-free: **advisory locks are always taken
+ * before row locks**, and a set of ids is always locked in ascending order.
+ * `lockHoldingScope` and `lockAccountsForBalanceWrite` both sort; a caller that
+ * needs both takes the advisory one first.
+ *
+ * **For `transactions` rows there is one more rule, and it is by role rather than
+ * by id: a split parent is locked before any of its legs.** Ascending-id order
+ * cannot be the whole answer here, because a caller cannot know a leg id until it
+ * has read the split -- `removeSplit` necessarily locks the parent and only then
+ * the leg. A batch that sorted parent and leg together would take them in the
+ * opposite order whenever the leg's UUID sorts first, and two requests in
+ * opposite orders is a `40P01` for both (audit RV4-005). With the parent always
+ * first it becomes the serialization point: any two paths touching the same
+ * parent's legs have already queued behind it, so their order among the legs
+ * cannot matter. Legs are still batched ascending, which covers the paths that
+ * lock several with no parent involved -- the two legs of an ordinary transfer,
+ * including the cross-owner pair, where each side names its own leg and so must
+ * sort rather than start from the one it was given.
+ *
+ * Every helper takes an `EntityManager` and must be called inside a
+ * `withScopedDb` callback -- `pg_advisory_xact_lock` and `FOR UPDATE` are both
+ * released by the enclosing transaction, which is the point: there is no
+ * unlock to forget.
+ */
+
+/**
+ * Advisory-lock namespaces. The first `pg_advisory_xact_lock` argument, so two
+ * different kinds of lock cannot collide on a hashed id.
+ *
+ * Values are permanent: changing one silently stops serializing against every
+ * other replica still running the old code during a rolling deploy.
+ */
+export enum LockScope {
+  /** All holdings and investment-ledger work for one account. */
+  Holdings = 1,
+  /** One refresh-token family (rotation vs. revocation). */
+  TokenFamily = 2,
+  /** One user's import slot, held across a destructive wipe + import. */
+  UserImport = 3,
+}
+
+/**
+ * Take a transaction-scoped advisory lock on `(scope, id)`.
+ *
+ * `hashtext` maps the uuid onto the int4 the second lock argument needs. A hash
+ * collision costs two unrelated ids one shared lock -- extra waiting, never a
+ * missed exclusion -- which is the right direction for the failure to go.
+ */
+export async function acquireAdvisoryLock(
+  manager: EntityManager,
+  scope: LockScope,
+  id: string,
+): Promise<void> {
+  await manager.query("SELECT pg_advisory_xact_lock($1::int, hashtext($2))", [
+    scope,
+    id,
+  ]);
+}
+
+/**
+ * Take advisory locks on every id, in ascending order.
+ *
+ * The ordering is the deadlock guard: a transfer locking two accounts and a
+ * rebuild locking the same two in the order the query returned them would
+ * otherwise be able to hold one another's next lock.
+ */
+export async function acquireAdvisoryLocks(
+  manager: EntityManager,
+  scope: LockScope,
+  ids: readonly string[],
+): Promise<void> {
+  const ordered = [...new Set(ids)].sort();
+  for (const id of ordered) {
+    await acquireAdvisoryLock(manager, scope, id);
+  }
+}
+
+/**
+ * Serialize all holdings work for these accounts against every other holdings
+ * writer -- incremental trades, splits, transfers and full rebuilds alike.
+ *
+ * A rebuild reads the investment ledger and then replaces the holdings derived
+ * from it. A row lock on `holdings` cannot protect that: the trade it must not
+ * lose inserts an `investment_transactions` row, which no holdings row locks.
+ * So both sides take this lock before their first read instead.
+ */
+export function lockHoldingScope(
+  manager: EntityManager,
+  accountIds: readonly string[],
+): Promise<void> {
+  return acquireAdvisoryLocks(manager, LockScope.Holdings, accountIds);
+}
+
+/** Serialize refresh-token rotation against family revocation. */
+export function lockTokenFamily(
+  manager: EntityManager,
+  familyId: string,
+): Promise<void> {
+  return acquireAdvisoryLock(manager, LockScope.TokenFamily, familyId);
+}
+
+/**
+ * Row-lock these accounts for a balance write, in ascending id order.
+ *
+ * Call this as the first statement of a transaction that will compute a balance
+ * from the ledger and write it back absolutely. Holding it from before the
+ * ledger `SELECT` until commit is what stops an atomic delta committing into
+ * the gap; see the protocol note at the top of this file.
+ *
+ * Returns nothing: the lock is the effect. Rows that do not exist -- or that
+ * are not `userId`'s when one is given -- are simply not locked, and the
+ * caller's own `NotFound` handling still applies.
+ *
+ * Pass `userId` for an own-context balance write. It scopes the lock the same
+ * way `lockTransactionRow`/`lockTransactionRows` do -- owner-scoping that holds
+ * at every `RLS_MODE`, not only under enforcement, so a caller can never take a
+ * balance-write lock on an account that is not the one it is authorised for.
+ * Pass the id that owns the account (the account's own `user_id`); for a joint
+ * account written in the owner's scope that is the owner, exactly as the
+ * surrounding read uses.
+ *
+ * `userId` is omitted only by a *genuinely* cross-user caller: the hourly
+ * future-dated fold runs under `withSystemContext` over every user in a
+ * timezone bucket, so it locks accounts across owners by construction and cannot
+ * name one. That is the sole exception; every own-context call site passes its
+ * `userId`.
+ */
+export async function lockAccountsForBalanceWrite(
+  manager: EntityManager,
+  accountIds: readonly string[],
+  userId?: string,
+): Promise<void> {
+  const ordered = [...new Set(accountIds)].sort();
+  if (ordered.length === 0) return;
+  if (userId === undefined) {
+    await manager.query(
+      `SELECT id FROM accounts WHERE id = ANY($1) ORDER BY id FOR UPDATE`,
+      [ordered],
+    );
+    return;
+  }
+  await manager.query(
+    `SELECT id FROM accounts WHERE id = ANY($1) AND user_id = $2 ORDER BY id FOR UPDATE`,
+    [ordered, userId],
+  );
+}
+
+/**
+ * Row-lock one transaction and return the columns a balance delta is derived
+ * from, or null when it is gone or not this user's.
+ *
+ * The whole point of this helper is *where* it is called: inside the write
+ * transaction, so the "old" amount a delta reverses is the version the write
+ * actually replaces. A snapshot loaded before the transaction is a different
+ * claim -- that nothing changed in between -- and two concurrent updates each
+ * reversing the same stale amount is the corruption in P4-003.
+ */
+export interface LockedTransactionRow {
+  id: string;
+  accountId: string;
+  amount: number;
+  transactionDate: string;
+  status: string | null;
+  isSplit: boolean;
+  linkedTransactionId: string | null;
+  parentTransactionId: string | null;
+  /**
+   * The parent's payee, carried for the same reason as `accountId` and
+   * `transactionDate`: a split's transfer counterpart and its embedded
+   * investment rows are *built* from the parent's fields, so building them from
+   * the caller's snapshot writes a counterpart describing a parent that has
+   * since moved account, date or payee (audit FV4-002).
+   */
+  payeeId: string | null;
+  payeeName: string | null;
+}
+
+export async function lockTransactionRow(
+  manager: EntityManager,
+  id: string,
+  userId: string,
+): Promise<LockedTransactionRow | null> {
+  const rows: {
+    id: string;
+    account_id: string;
+    amount: string;
+    transaction_date: string;
+    status: string | null;
+    is_split: boolean;
+    linked_transaction_id: string | null;
+    parent_transaction_id: string | null;
+    payee_id: string | null;
+    payee_name: string | null;
+  }[] = await manager.query(
+    `SELECT id,
+            account_id,
+            amount,
+            TO_CHAR(transaction_date, 'YYYY-MM-DD') AS transaction_date,
+            status,
+            COALESCE(is_split, false) AS is_split,
+            linked_transaction_id,
+            parent_transaction_id,
+            payee_id,
+            payee_name
+       FROM transactions
+      WHERE id = $1 AND user_id = $2
+        FOR UPDATE`,
+    [id, userId],
+  );
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    id: row.id,
+    accountId: row.account_id,
+    amount: Number(row.amount),
+    transactionDate: row.transaction_date,
+    status: row.status,
+    isSplit: row.is_split,
+    linkedTransactionId: row.linked_transaction_id,
+    parentTransactionId: row.parent_transaction_id,
+    payeeId: row.payee_id,
+    payeeName: row.payee_name,
+  };
+}
+
+/**
+ * Row-lock several transactions at once, ascending by id, and return what was
+ * found keyed by id. Missing ids are simply absent -- a bulk caller has to
+ * decide whether that is a 404 or a row another request already deleted.
+ */
+export async function lockTransactionRows(
+  manager: EntityManager,
+  ids: readonly string[],
+  userId: string,
+): Promise<Map<string, LockedTransactionRow>> {
+  const ordered = [...new Set(ids)].sort();
+  const found = new Map<string, LockedTransactionRow>();
+  if (ordered.length === 0) return found;
+  const rows: {
+    id: string;
+    account_id: string;
+    amount: string;
+    transaction_date: string;
+    status: string | null;
+    is_split: boolean;
+    linked_transaction_id: string | null;
+    parent_transaction_id: string | null;
+    payee_id: string | null;
+    payee_name: string | null;
+  }[] = await manager.query(
+    `SELECT id,
+            account_id,
+            amount,
+            TO_CHAR(transaction_date, 'YYYY-MM-DD') AS transaction_date,
+            status,
+            COALESCE(is_split, false) AS is_split,
+            linked_transaction_id,
+            parent_transaction_id,
+            payee_id,
+            payee_name
+       FROM transactions
+      WHERE id = ANY($1) AND user_id = $2
+      ORDER BY id
+        FOR UPDATE`,
+    [ordered, userId],
+  );
+  for (const row of rows) {
+    found.set(row.id, {
+      id: row.id,
+      accountId: row.account_id,
+      amount: Number(row.amount),
+      transactionDate: row.transaction_date,
+      status: row.status,
+      isSplit: row.is_split,
+      linkedTransactionId: row.linked_transaction_id,
+      parentTransactionId: row.parent_transaction_id,
+      payeeId: row.payee_id,
+      payeeName: row.payee_name,
+    });
+  }
+  // A split parent must be locked before any of its legs (see the ordering rule
+  // at the top of this file), and a single id-sorted batch cannot honour that:
+  // if a leg's UUID sorts before its parent's, this call takes them in the
+  // forbidden order and deadlocks against a `lockTransactionRow` parent-then-leg
+  // path (audit RV4-005). So refuse a batch that mixes a parent with one of its
+  // own legs -- such a caller must lock the parent first with
+  // `lockTransactionRow`, then the leg. The throw rolls back the transaction,
+  // releasing the locks this statement just took.
+  for (const row of found.values()) {
+    if (row.parentTransactionId && found.has(row.parentTransactionId)) {
+      throw new Error(
+        `lockTransactionRows must not lock a split parent and its leg in one ` +
+          `call (parent ${row.parentTransactionId}, leg ${row.id}); lock the ` +
+          `parent first with lockTransactionRow`,
+      );
+    }
+  }
+  return found;
+}

--- a/backend/src/common/db/query-result.spec.ts
+++ b/backend/src/common/db/query-result.spec.ts
@@ -1,0 +1,96 @@
+import { affectedRowCount, returnedRows } from "./query-result";
+
+/**
+ * These two helpers exist because TypeORM's postgres driver returns two shapes
+ * and which one you get depends on the command tag, not on the presence of a
+ * `RETURNING` clause: `UPDATE`/`DELETE` give `[rows, rowCount]`, and everything
+ * else -- **`INSERT` included** -- gives bare rows.
+ *
+ * Every case below is a shape the driver actually produces, named by the
+ * statement that produces it. Reading one of them wrong does not throw; it
+ * quietly reports the opposite of the truth, which is how a guarded statement
+ * turns every caller into a winner.
+ */
+describe("common/db/query-result", () => {
+  // The shapes, exactly as PostgresQueryRunner.query hands them over.
+  const selectRows = [{ id: "a" }, { id: "b" }];
+  const selectEmpty: unknown[] = [];
+  const insertReturning = [{ id: "a" }];
+  const insertOnConflictSkipped: unknown[] = [];
+  const updateReturningMatched = [[{ id: "a" }], 1];
+  const updateReturningRefused = [[], 0];
+  const deleteWithoutReturning = [[], 3];
+  const deleteWithoutReturningNoop = [[], 0];
+
+  describe("returnedRows", () => {
+    it("reads a SELECT's bare rows", () => {
+      expect(returnedRows(selectRows)).toEqual(selectRows);
+      expect(returnedRows(selectEmpty)).toEqual([]);
+    });
+
+    it("reads an INSERT ... RETURNING as bare rows, not as a tuple", () => {
+      // The trap: treating this as `[rows, rowCount]` would make `result[0]` the
+      // first row rather than the row list, so `result[0].id` would be undefined
+      // and every seeded id would come back missing.
+      expect(returnedRows<{ id: string }>(insertReturning)).toEqual([
+        { id: "a" },
+      ]);
+      expect(returnedRows(insertOnConflictSkipped)).toEqual([]);
+    });
+
+    it("unwraps an UPDATE/DELETE tuple", () => {
+      expect(returnedRows(updateReturningMatched)).toEqual([{ id: "a" }]);
+      expect(returnedRows(updateReturningRefused)).toEqual([]);
+    });
+
+    it("returns nothing for a non-array result", () => {
+      // A statement with no result set at all (`SET`, `BEGIN`) must not throw
+      // here -- a caller that reads it is asking a meaningless question, and
+      // "no rows" is the honest answer to it.
+      for (const value of [undefined, null, 0, "", {}]) {
+        expect(returnedRows(value)).toEqual([]);
+      }
+    });
+  });
+
+  describe("affectedRowCount", () => {
+    it("counts a matched guarded UPDATE and a refused one", () => {
+      // The whole point of a compare-and-set: zero is the answer, not an error.
+      expect(affectedRowCount(updateReturningMatched)).toBe(1);
+      expect(affectedRowCount(updateReturningRefused)).toBe(0);
+    });
+
+    it("does not report a tuple's length as a row count", () => {
+      // `[[], 0].length` is 2. An open-coded `result.length > 0` here makes every
+      // replica the winner of every claim -- the exact bug the guards prevent.
+      expect(affectedRowCount(updateReturningRefused)).not.toBe(
+        (updateReturningRefused as unknown[]).length,
+      );
+    });
+
+    it("counts an INSERT ... ON CONFLICT DO NOTHING RETURNING honestly", () => {
+      expect(affectedRowCount(insertReturning)).toBe(1);
+      expect(affectedRowCount(insertOnConflictSkipped)).toBe(0);
+    });
+
+    it("uses the driver's count for an UPDATE/DELETE with no RETURNING", () => {
+      // `[[], 3]`: the rows are empty because nothing was asked for, but three
+      // rows changed. Counting the row list would report zero -- a delete that
+      // did work looking like a no-op, which is how a reversal gets skipped.
+      expect(affectedRowCount(deleteWithoutReturning)).toBe(3);
+      expect(affectedRowCount(deleteWithoutReturningNoop)).toBe(0);
+    });
+
+    it("agrees with returnedRows wherever both are meaningful", () => {
+      for (const shape of [
+        selectRows,
+        insertReturning,
+        insertOnConflictSkipped,
+        updateReturningMatched,
+        updateReturningRefused,
+      ]) {
+        expect(affectedRowCount(shape)).toBe(returnedRows(shape).length);
+      }
+    });
+  });
+});

--- a/backend/src/common/db/query-result.ts
+++ b/backend/src/common/db/query-result.ts
@@ -1,0 +1,69 @@
+/**
+ * Reading a raw `manager.query()` result correctly, in one place.
+ *
+ * TypeORM's postgres driver returns **two different shapes**, and which one you
+ * get depends on the statement's command tag, not on whether it has a
+ * `RETURNING` clause (`PostgresQueryRunner.query`, the `switch (raw.command)`):
+ *
+ * - `UPDATE` and `DELETE` -> the tuple `[rows, rowCount]`, always, with or
+ *   without `RETURNING`;
+ * - **everything else, `INSERT` included** -> bare rows, `[{...}, {...}]`.
+ *
+ * That `INSERT` sits with `SELECT` rather than with its fellow data-modifying
+ * statements is the part that catches people out, and getting it backwards fails
+ * silently in the worst possible direction. On the tuple `result.length > 0` is
+ * *always* true, so a guarded `UPDATE ... WHERE ... RETURNING` looks like it
+ * matched a row and `length === 0` never fires -- which is exactly how
+ * `TourService.saveProgress` ended up with a missing-row fallback that could not
+ * run. The reading is therefore not open-coded per call site.
+ *
+ * `returnedRows` and `affectedRowCount` are correct for both shapes, so a call
+ * site does not have to know which one it is looking at -- which is the point,
+ * because the command tag is not visible where the result is consumed.
+ *
+ * The `.mny` job service found this the hard way; its concurrency spec is what
+ * keeps it honest.
+ */
+
+/**
+ * The rows a `query()` returned, whichever of the two shapes it used.
+ *
+ * A row is always an object, so an array in position 0 can only be the
+ * `UPDATE`/`DELETE` tuple's row list -- there is no ambiguity to resolve.
+ */
+export function returnedRows<T>(result: unknown): T[] {
+  if (!Array.isArray(result)) {
+    return [];
+  }
+  return Array.isArray(result[0]) ? (result[0] as T[]) : (result as T[]);
+}
+
+/**
+ * How many rows a statement actually matched.
+ *
+ * Use this for a guarded `UPDATE`/`DELETE` (with or without `RETURNING`) or an
+ * `INSERT ... ON CONFLICT ... RETURNING`. Zero means the predicate refused,
+ * which for a compare-and-set is the answer, not an error to ignore.
+ *
+ * The driver's own `rowCount` is preferred when it is there, because it is the
+ * only truthful answer for an `UPDATE`/`DELETE` **without** a `RETURNING`
+ * clause: that comes back as `[[], 3]`, and counting the (empty) row list would
+ * report zero rows changed for a statement that changed three.
+ *
+ * **An `INSERT` must carry a `RETURNING`.** The driver discards `rowCount` for
+ * `INSERT` (see the shape note above: `INSERT` comes back as bare rows, never
+ * the `[rows, rowCount]` tuple), so a bare `INSERT ... ON CONFLICT DO NOTHING`
+ * with no `RETURNING` yields `[]` whether it inserted a row or hit the conflict
+ * -- and this reports 0 for both. Every guarded insert here therefore ends in
+ * `RETURNING`, so the count reflects the row it actually wrote.
+ */
+export function affectedRowCount(result: unknown): number {
+  if (
+    Array.isArray(result) &&
+    Array.isArray(result[0]) &&
+    typeof result[1] === "number"
+  ) {
+    return result[1];
+  }
+  return returnedRows(result).length;
+}

--- a/backend/src/common/db/scoped-db.spec.ts
+++ b/backend/src/common/db/scoped-db.spec.ts
@@ -398,6 +398,74 @@ describe("withScopedDb -- nested identity", () => {
       "SELECT set_config('app.bypass_rls', 'on', true)",
     );
   });
+
+  it("propagates an inner refusal out of the outer transaction when nobody catches it", async () => {
+    // The other half of the case below: uncaught, the refusal has to take the
+    // outer transaction down rather than being absorbed into a partial success.
+    withMode("off");
+    const { dataSource } = makeDataSource();
+
+    await expect(
+      run({ userId: "user-a" }, () =>
+        withScopedDb(dataSource, async () =>
+          run({ system: true }, () =>
+            withScopedDb(dataSource, async () => undefined),
+          ),
+        ),
+      ),
+    ).rejects.toThrow(IDENTITY_MISMATCH_MESSAGE);
+  });
+
+  it("clears the ambient scope after a callback throws something that is not an Error", async () => {
+    // A thrown string still unwinds the ALS scope; if it did not, the next
+    // request on this async chain would join a transaction that no longer
+    // exists.
+    withMode("enforce");
+    const { dataSource, transaction } = makeDataSource();
+
+    await expect(
+      run({ userId: "user-a" }, () =>
+        withScopedDb(dataSource, async () => {
+          throw "not an Error";
+        }),
+      ),
+    ).rejects.toBe("not an Error");
+
+    expect(getActiveScopedManager()).toBeUndefined();
+
+    // And the connection is usable again for a different identity.
+    await run({ system: true }, () =>
+      withScopedDb(dataSource, async () => undefined),
+    );
+    expect(transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps an inner throw catchable by the outer body", async () => {
+    // Refusing is an ordinary throw, so an outer body that already handles
+    // failures keeps handling it -- the guard must not become an unrecoverable
+    // state.
+    withMode("off");
+    const { dataSource, transaction } = makeDataSource();
+
+    const result = await run({ userId: "user-a" }, () =>
+      withScopedDb(dataSource, async (outer) => {
+        try {
+          await run({ system: true }, () =>
+            withScopedDb(dataSource, async () => "never"),
+          );
+          return "no refusal";
+        } catch {
+          // The outer transaction is still usable: the refusal happened before
+          // any statement was issued.
+          await outer.query("SELECT 1");
+          return "refused and recovered";
+        }
+      }),
+    );
+
+    expect(result).toBe("refused and recovered");
+    expect(transaction).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("runOutsideActiveScopedManager", () => {

--- a/backend/src/common/db/scoped-db.ts
+++ b/backend/src/common/db/scoped-db.ts
@@ -139,9 +139,11 @@ export const MISSING_CONTEXT_MESSAGE =
   "DB access outside request/user/system context -- wrap the call path in withUserContext/withSystemContext";
 
 /**
- * Isolation levels callers may request. Only the registration paths need one
- * (SERIALIZABLE, to close the first-user-admin race); everything else uses the
- * connection default, exactly as before.
+ * Isolation levels callers may request. Two paths need one: registration
+ * (SERIALIZABLE, to close the first-user-admin race) and the backup export
+ * (REPEATABLE READ, so every table in one file comes from the same snapshot --
+ * `BackupService.withExportSnapshot`). Everything else uses the connection
+ * default, exactly as before.
  *
  * Spelled out rather than imported from `typeorm/driver/types/IsolationLevel`:
  * that deep path type-checks under tsc but does not resolve under ts-jest, so

--- a/backend/src/import/mny/mny-import-job.service.ts
+++ b/backend/src/import/mny/mny-import-job.service.ts
@@ -6,6 +6,7 @@ import {
   runOutsideActiveScopedManager,
   withScopedDb,
 } from "../../common/db/scoped-db";
+import { returnedRows } from "../../common/db/query-result";
 import {
   withSystemContext,
   withUserContext,
@@ -167,20 +168,12 @@ export interface JobRunContext {
 export type JobBody = (context: JobRunContext) => Promise<MnyImportResult>;
 
 /**
- * The rows a `query()` returned, whichever shape TypeORM chose.
- *
- * A data-modifying statement with `RETURNING` comes back as `[rows, rowCount]`,
- * while a `SELECT` comes back as bare rows. Reading that wrong fails silently in
- * the worst possible direction: `result.length > 0` on the tuple is always true,
- * so every conditional claim would look like a winner and two workers would
- * import the same file. Found by the concurrency spec, kept honest by it.
+ * `returnedRows` lives in exactly one place -- `common/db/query-result` -- so
+ * the two driver-shape readers this module found the hard way cannot drift
+ * apart. Re-exported here because the concurrency spec imports it from this
+ * module, and the internal call sites below use it too.
  */
-export function returnedRows<T>(result: unknown): T[] {
-  if (!Array.isArray(result)) {
-    return [];
-  }
-  return Array.isArray(result[0]) ? (result[0] as T[]) : (result as T[]);
-}
+export { returnedRows };
 
 @Injectable()
 export class MnyImportJobService {

--- a/backend/src/test-helpers/locks-testing.ts
+++ b/backend/src/test-helpers/locks-testing.ts
@@ -1,0 +1,91 @@
+import type { LockedTransactionRow } from "../common/db/locks";
+
+/**
+ * Unit-test harness for the row/advisory locks in `common/db/locks`.
+ *
+ * The real helpers issue `SELECT pg_advisory_xact_lock(...)` and
+ * `SELECT ... FOR UPDATE` through the manager. In a unit test that manager is a
+ * jest mock whose `query` is usually driven by a `mockResolvedValueOnce` chain,
+ * so a lock statement would silently eat one of the spec's queued answers and
+ * shift every assertion after it -- a failure that looks like a logic bug and is
+ * not one.
+ *
+ * So specs mock the module instead:
+ *
+ *   jest.mock("../common/db/locks", () =>
+ *     jest.requireActual("../test-helpers/locks-testing").locksMockModule(),
+ *   );
+ *
+ * and stub the readers they depend on with `stubLockedTransaction`. Whether the
+ * locks are actually *taken* is not a question a mocked manager can answer -- the
+ * two-connection integration specs cover that, and `locks.spec.ts` covers the
+ * SQL each helper emits.
+ */
+
+/** A `LockedTransactionRow` with sensible defaults; override what matters. */
+export function lockedTransactionRow(
+  overrides: Partial<LockedTransactionRow> = {},
+): LockedTransactionRow {
+  return {
+    id: "tx-1",
+    accountId: "acc-1",
+    amount: 0,
+    transactionDate: "2026-01-15",
+    status: "UNRECONCILED",
+    isSplit: false,
+    linkedTransactionId: null,
+    parentTransactionId: null,
+    payeeId: null,
+    payeeName: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Module factory for `jest.mock` of `src/common/db/locks`.
+ *
+ * The advisory/row-lock acquirers resolve to nothing, which is what they do for
+ * real. The two readers default to "row not found" so a spec that forgets to
+ * stub them fails loudly with the service's own NotFound rather than proceeding
+ * on `undefined`.
+ */
+export function locksMockModule() {
+  const actual = jest.requireActual("../common/db/locks");
+  return {
+    LockScope: actual.LockScope,
+    acquireAdvisoryLock: jest.fn().mockResolvedValue(undefined),
+    acquireAdvisoryLocks: jest.fn().mockResolvedValue(undefined),
+    lockHoldingScope: jest.fn().mockResolvedValue(undefined),
+    lockTokenFamily: jest.fn().mockResolvedValue(undefined),
+    lockAccountsForBalanceWrite: jest.fn().mockResolvedValue(undefined),
+    lockTransactionRow: jest.fn().mockResolvedValue(null),
+    lockTransactionRows: jest.fn().mockResolvedValue(new Map()),
+  };
+}
+
+/**
+ * Point the mocked `lockTransactionRow`/`lockTransactionRows` at these rows.
+ *
+ * Pass the rows a spec's scenario has; both readers are stubbed together because
+ * a service usually uses whichever fits and a spec should not have to know which.
+ */
+export function stubLockedTransactions(
+  locks: {
+    lockTransactionRow: jest.Mock;
+    lockTransactionRows: jest.Mock;
+  },
+  rows: LockedTransactionRow[],
+): void {
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  locks.lockTransactionRow.mockImplementation(
+    async (_m, id: string) => byId.get(id) ?? null,
+  );
+  locks.lockTransactionRows.mockImplementation(
+    async (_m, ids: readonly string[]) =>
+      new Map(
+        [...new Set(ids)]
+          .filter((id) => byId.has(id))
+          .map((id) => [id, byId.get(id)!]),
+      ),
+  );
+}

--- a/backend/src/test-helpers/scoped-db-testing.ts
+++ b/backend/src/test-helpers/scoped-db-testing.ts
@@ -58,6 +58,19 @@ export function scopedDbMockModule() {
           ? dataSource.transaction(isolation, fn)
           : dataSource.transaction(fn),
     ),
+    /**
+     * Calls straight through and **returns the callback's value**, like the real
+     * one does.
+     *
+     * Worth spelling out: a double that swallowed the return value would make
+     * every `await runOutsideActiveScopedManager(...)` resolve to `undefined`, so
+     * a caller reading the result -- a conditional claim's row count, a promise it
+     * attaches a `.catch` to -- would fail with a `TypeError` about `undefined`
+     * rather than anything resembling its cause. Whether the callback really got
+     * its own connection is not a question a mock can answer; `scoped-db.spec.ts`
+     * covers that.
+     */
+    runOutsideActiveScopedManager: jest.fn((fn: () => unknown) => fn()),
   };
 }
 

--- a/backend/test/helpers/rls-catalog.ts
+++ b/backend/test/helpers/rls-catalog.ts
@@ -231,7 +231,13 @@ export class RlsRowSeeder {
         const entry = this.entry(table);
         return entry.columns.every((col) => {
           const fk = this.effectiveFk(table, col);
-          if (!fk || col.nullable) return true;
+          // A nullable ownership column is filled by `buildInsert` (the policy
+          // keys on it), so it is a real dependency here too -- otherwise the row
+          // can be ordered before the user it points at and the insert dies on
+          // the foreign key.
+          if (!fk || (col.nullable && !USER_REF_COLUMNS.has(col.name))) {
+            return true;
+          }
           if (fk.refTable === table) return true;
           if (!inSet.has(fk.refTable)) return true;
           return !remaining.has(fk.refTable);
@@ -282,7 +288,15 @@ export class RlsRowSeeder {
 
       const fk = this.effectiveFk(table, col);
       if (fk) {
-        if (col.nullable) continue;
+        // A nullable *ownership* column is still the row's ownership, and the
+        // policy keys on it -- so it gets the owner even though it may be NULL in
+        // production. `attachment_blob_tombstones.user_id` is nullable on purpose
+        // (ON DELETE SET NULL: a tombstone has to outlive its owner, because that
+        // is exactly when the bytes most need removing), and skipping it left an
+        // ownerless row that neither user could see. The sweep then reported
+        // "saw 0 rows" for a table whose policy is fine.
+        const isOwnership = USER_REF_COLUMNS.has(col.name);
+        if (col.nullable && !isOwnership) continue;
         columns.push(col.name);
         values.push(this.resolveForeignKey(table, fk, ownerId));
         continue;


### PR DESCRIPTION
> **Stacked on #1078, which is still open.**
> This branch is exactly one commit above #1078's current head (`8d57c16ff04c28bafb971978d3d455cc594e01e2`).
> Until #1078 merges, GitHub's combined diff will also contain that PR. Review the unique commit
> `187b555236fdc3d577dab7f397867994736763e2` for this PR's own work.
>
> After #1078 merges, this branch should be rebased onto the resulting `main` merge commit before
> final review, in accordance with `CONTRIBUTING.md`.

**Phase 4 merge order: 1**, after #1078. Targets `main`.

## What this changes

This PR adds the shared database-access primitives that the later Phase 4 concurrency fixes use. It deliberately contains no business-domain rewrite and no migration.

**Deterministic lock helpers.** `backend/src/common/db/locks.ts` introduces the common lock vocabulary for later writers:

- transaction-scoped advisory locks with separate namespaces;
- sorted, de-duplicated multi-key advisory acquisition;
- sorted account row locks for absolute balance recomputation;
- owner-scoped transaction row locks that re-read the committed amount, date and status under `FOR UPDATE`;
- a documented ordering rule so later services do not invent incompatible lock orders.

The raw transaction-row helpers explicitly select `DATE` values as `YYYY-MM-DD` text and convert numeric driver values before returning them, so callers do not accidentally derive money or calendar logic from raw-driver representations.

**Guarded-query result helpers.** `backend/src/common/db/query-result.ts` centralizes the PostgreSQL/TypeORM result shapes used by guarded `UPDATE`/`DELETE` statements. Later code can ask for `affectedRowCount()` or `returnedRows()` instead of open-coding checks that are correct for one command tag and wrong for another.

**Nested scoped-DB identity safety.** `withScopedDb` remains re-entrant for the same request identity, but now refuses a nested call whose identity differs from the transaction already in progress. That turns an accidental cross-tenant reuse of an ambient manager into an immediate error instead of letting the inner call silently inherit the outer transaction's RLS identity.

`runOutsideActiveScopedManager` is also exposed for the narrow case where work intentionally must not inherit a caller's transaction manager, such as delayed/background work that opens after the originating transaction has committed.

**Test and lint support.** The PR adds focused lock/query-result/scoped-db specs and reusable test doubles for later Phase 4 PRs, and extends the existing RLS/lint support needed by the later cron and attachment writers.

## Deliberate rebase decision

The earlier Phase 4 stack had its own `bootstrap-lock.ts` and edits to `db-init.ts` / `db-migrate.ts`. Those changes are **not** carried here.

The base already contains the newer Phase 3 startup design from #1077/#1078:

- the shared database lifecycle advisory lock;
- runtime-role safety checks under RLS enforcement;
- runtime-role grant convergence after migrations.

This PR keeps those mechanisms unchanged and adds only the concurrency primitives that the base does not already have. There is one startup-lock implementation, not two competing protocols.

## Why

The Phase 4 audit found several different failure modes with the same root cause: code made a decision from an unlocked snapshot and then wrote derived state after another request had changed the source row. Fixing each service independently would make lock ordering, driver result handling and scoped-transaction behavior drift again.

This PR establishes the shared mechanics first so the later domain PRs can be reviewed against one lock and transaction contract.

## Review focus

The most important review points are:

1. advisory locks are transaction-scoped and multi-key acquisition is deterministic;
2. account and transaction row locks are sorted/scoped consistently;
3. raw transaction rows preserve monetary and calendar semantics;
4. guarded-query result helpers match the actual TypeORM/PostgreSQL result shapes;
5. nested `withScopedDb` calls may join only when their transaction identity matches;
6. no Phase 3 startup/RLS behavior is replaced or weakened.

## Test evidence

The branch commit records the following as green on the #1078 base:

- backend typecheck;
- backend lint;
- foundation specs covering `common/db`, `db-init`, `db-migrate`, and startup logging: **249 tests**.

The PR has not yet produced GitHub Actions status checks because it has not been opened. These results are therefore the branch author's reported local verification and should be confirmed by PR CI before merge.

## Risk

**Medium.** The diff is small and has no schema migration, but it changes shared database primitives that later financial and cron writers depend on. The main risk is an incorrect lock-order or scoped-manager contract becoming a common dependency, which is why this PR is separated from the domain changes that consume it.

## What this PR does not do

- no migration or `database/schema.sql` change;
- no replacement of `db-init` / `db-migrate` startup locking;
- no balance, transaction, holdings, cron, import, attachment or emergency-access behavior change yet;
- no user-facing copy.

Those consumers land in later Phase 4 PRs so each behavioral change remains reviewable against these primitives.

## Linked discussion / issue

Approved in: <!-- Add the maintainer-approved Phase 4 discussion or issue carrying the required approval label. -->

## Checklist

- [ ] An approved discussion or issue exists and is linked above.
- [x] This PR addresses a single concern: shared concurrency/database primitives.
- [x] New behavior has focused regression tests; the branch author reports the test set above as green.
- [x] No user-facing strings are introduced, so no localization change is required.
- [ ] Shared/core-area scope has maintainer sign-off in the linked discussion or issue.
- [ ] The branch is rebased on the latest `main`. This becomes actionable after prerequisite #1078 merges.
- [x] AI assistance is disclosed below, and the submitted result remains the contributor's responsibility.

## AI assistance disclosure

Implemented with Claude Code from findings produced by the Phase 4 repository audit. The branch was subsequently reviewed for stack ancestry, preservation of the #1077/#1078 startup/RLS design, lock semantics, scoped-transaction behavior and regression-test coverage before this PR description was prepared.
